### PR TITLE
Solana tx timer

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -448,7 +448,7 @@ const getInfo = async (request: Request<MessageTypes.GetInfo>, isTestnet: boolea
         network: isTestnet ? 'dsol' : 'sol',
         url: api.clusterUrl,
         name: 'Solana',
-        version: (await api.rpc.getVersion().send())['solana-core'],
+        version: '1', // saving request api.rpc.getVersion().send(), version is not used anyways
         decimals: 9,
     };
 

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -4,9 +4,11 @@ import {
     RpcMainnet,
     RpcSubscriptionsMainnet,
     SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED,
+    SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
     SOLANA_ERROR__RPC_SUBSCRIPTIONS__CHANNEL_CONNECTION_CLOSED,
     SOLANA_ERROR__RPC_SUBSCRIPTIONS__CHANNEL_FAILED_TO_CONNECT,
     SOLANA_ERROR__RPC__TRANSPORT_HTTP_ERROR,
+    SOLANA_ERROR__TRANSACTION_ERROR__BLOCKHASH_NOT_FOUND,
     Signature,
     Slot,
     SolanaRpcApiMainnet,
@@ -194,6 +196,17 @@ const pushTransaction = async (request: Request<MessageTypes.PushTransaction>) =
         ) {
             throw new Error(
                 'Solana backend connection failure. The backend might be inaccessible or the connection is unstable.',
+            );
+        }
+        if (
+            isSolanaError(
+                error,
+                SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
+            ) &&
+            isSolanaError(error.cause, SOLANA_ERROR__TRANSACTION_ERROR__BLOCKHASH_NOT_FOUND)
+        ) {
+            throw new Error(
+                'The transaction has expired because too much time passed between signing and sending. Please try again.',
             );
         }
         if (isSolanaError(error)) {

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -435,9 +435,10 @@ const getAccountInfo = async (
 
 const getInfo = async (request: Request<MessageTypes.GetInfo>, isTestnet: boolean) => {
     const api = await request.connect();
+
     const {
         value: { blockhash: blockHash, lastValidBlockHeight: blockHeight },
-    } = await api.rpc.getLatestBlockhash({ commitment: 'finalized' }).send();
+    } = await api.rpc.getLatestBlockhash({ commitment: 'confirmed' }).send();
 
     const serverInfo = {
         testnet: isTestnet,

--- a/packages/components/src/components/Badge/Badge.stories.tsx
+++ b/packages/components/src/components/Badge/Badge.stories.tsx
@@ -27,6 +27,7 @@ export const Badge: StoryObj<BadgeProps> = {
                 'primary',
                 'tertiary',
                 'destructive',
+                'warning',
                 undefined,
             ] satisfies BadgeProps['variant'][],
         },

--- a/packages/components/src/components/Badge/Badge.tsx
+++ b/packages/components/src/components/Badge/Badge.tsx
@@ -21,7 +21,7 @@ export type BadgeSize = Extract<UISize, (typeof badgeSizes)[number]>;
 export const allowedBadgeFrameProps = ['margin'] as const satisfies FramePropsKeys[];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedBadgeFrameProps)[number]>;
 
-export type BadgeVariant = Extract<UIVariant, 'primary' | 'tertiary' | 'destructive'>;
+export type BadgeVariant = Extract<UIVariant, 'primary' | 'tertiary' | 'destructive' | 'warning'>;
 
 export type BadgeProps = AllowedFrameProps & {
     size?: BadgeSize;
@@ -54,6 +54,7 @@ const mapVariantToBackgroundColor = ({ $variant, $onElevation, theme }: MapArgs)
         primary: 'backgroundPrimarySubtleOnElevation0',
         tertiary: `backgroundNeutralSubtleOnElevation${$onElevation ? 1 : 0}`,
         destructive: 'backgroundAlertRedSubtleOnElevation0',
+        warning: 'backgroundAlertYellowSubtleOnElevation0',
     };
 
     return theme[colorMap[$variant]];
@@ -64,6 +65,7 @@ const mapVariantToTextColor = ({ $variant, theme }: MapArgs): CSSColor => {
         primary: 'textPrimaryDefault',
         tertiary: 'textSubdued',
         destructive: 'textAlertRed',
+        warning: 'textAlertYellow',
     };
 
     return theme[colorMap[$variant]];
@@ -74,6 +76,7 @@ const mapVariantToIconColor = ({ $variant, theme }: MapArgs): CSSColor => {
         primary: 'iconPrimaryDefault',
         tertiary: 'iconSubdued',
         destructive: 'iconAlertRed',
+        warning: 'iconAlertYellow',
     };
 
     return theme[colorMap[$variant]];

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -232,6 +232,11 @@ export const signAndPushSendFormTransactionThunk = createThunk(
                 return;
             }
 
+            // Do not close the modal if the transaction signing timed out
+            if (signResponse.payload?.error === 'sign-transaction-timeout') {
+                return;
+            }
+
             // Close the modal manually since UI.CLOSE_UI.WINDOW was
             // blocked by `modalActions.preserve` above.
             dispatch(modalActions.onCancel());

--- a/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
@@ -195,11 +195,14 @@ export const signTransaction =
             !device ||
             !transactionInfo ||
             transactionInfo.type !== 'final'
-        )
+        ) {
             return;
+        }
 
         const { account } = selectedAccount;
-        if (account.networkType !== 'solana') return;
+        if (account.networkType !== 'solana') {
+            return;
+        }
 
         const addressDisplayType = selectAddressDisplayType(getState());
         const estimatedFee = {
@@ -251,15 +254,20 @@ export const signTransaction =
 
         if (!signedTx.success) {
             // catch manual error from TransactionReviewModal
-            if (signedTx.payload.error === 'tx-cancelled') return;
-            dispatch(
-                notificationsActions.addToast({
-                    type: 'sign-tx-error',
-                    error: signedTx.payload.error,
-                }),
-            );
+            if (signedTx.payload.error === 'tx-cancelled') {
+                return;
+            }
 
-            return;
+            if (signedTx.payload.error !== 'tx-timeout') {
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'sign-tx-error',
+                        error: signedTx.payload.error,
+                    }),
+                );
+            }
+
+            return signedTx;
         }
 
         txData.tx.txShim.addSignature(address(account.descriptor), signedTx.payload.signature);

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -14,7 +14,7 @@ import {
     isSupportedSolStakingNetworkSymbol,
     tryGetAccountIdentity,
 } from '@suite-common/wallet-utils';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { Unsuccessful } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { Dispatch, GetState } from 'src/types/suite';
@@ -178,7 +178,7 @@ export const signTransaction =
         dispatch(modalActions.preserve());
 
         // signTransaction by Trezor
-        let serializedTx: string | undefined;
+        let serializedTx: undefined | string | Unsuccessful;
         if (isSupportedEthStakingNetworkSymbol(account.symbol)) {
             serializedTx = await dispatch(
                 stakeFormEthereumActions.signTransaction(formValues, enhancedTxInfo),
@@ -191,7 +191,10 @@ export const signTransaction =
             );
         }
 
-        if (!serializedTx) {
+        if (typeof serializedTx !== 'string') {
+            if (serializedTx?.payload?.error === 'tx-timeout') {
+                return;
+            }
             // close modal manually since UI.CLOSE_UI.WINDOW was blocked
             dispatch(modalActions.onCancel());
 

--- a/packages/suite/src/components/suite/CountdownTimer.tsx
+++ b/packages/suite/src/components/suite/CountdownTimer.tsx
@@ -85,6 +85,7 @@ export const CountdownTimer = ({
                     id={messageId}
                     values={{
                         value: getValue(),
+                        strong: chunks => <strong>{chunks}</strong>,
                         firstValue,
                     }}
                 />

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
@@ -1,7 +1,17 @@
 import { UserContextPayload } from '@suite-common/suite-types';
-import { cancelSignSendFormTransactionThunk, selectStake } from '@suite-common/wallet-core';
+import {
+    cancelSignSendFormTransactionThunk,
+    selectStake,
+    sendFormActions,
+    stakeActions,
+} from '@suite-common/wallet-core';
+import { PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 
-import { cancelSignTx as cancelSignStakingTx } from 'src/actions/wallet/stakeActions';
+import { signAndPushSendFormTransactionThunk } from 'src/actions/wallet/send/sendFormThunks';
+import {
+    cancelSignTx as cancelSignStakingTx,
+    signTransaction,
+} from 'src/actions/wallet/stakeActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { TransactionReviewModalContent } from './TransactionReviewModalContent';
@@ -19,6 +29,7 @@ type TransactionReviewModalProps =
 export const TransactionReviewModal = ({ type, decision }: TransactionReviewModalProps) => {
     const send = useSelector(state => state.wallet.send);
     const stake = useSelector(selectStake);
+    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const dispatch = useDispatch();
 
     const isSend = Boolean(send?.precomposedTx);
@@ -26,14 +37,39 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa
     const txInfoState = isSend ? send : stake;
 
     const handleCancelSignTx = () => {
-        if (isSend) dispatch(cancelSignSendFormTransactionThunk());
-        else dispatch(cancelSignStakingTx());
+        if (isSend) {
+            dispatch(cancelSignSendFormTransactionThunk());
+        } else {
+            dispatch(cancelSignStakingTx());
+        }
+    };
+
+    const handleTryAgainSignTx = () => {
+        if (send.precomposedForm && send.precomposedTx) {
+            dispatch(sendFormActions.discardTransaction());
+            dispatch(
+                signAndPushSendFormTransactionThunk({
+                    formState: send.precomposedForm,
+                    precomposedTransaction: send.precomposedTx,
+                    selectedAccount: selectedAccount.account,
+                }),
+            );
+        } else if (stake.precomposedForm && stake.precomposedTx) {
+            dispatch(stakeActions.dispose());
+            dispatch(
+                signTransaction(
+                    stake.precomposedForm,
+                    stake.precomposedTx as PrecomposedTransactionFinal,
+                ),
+            );
+        }
     };
 
     return (
         <TransactionReviewModalContent
             decision={decision}
             txInfoState={txInfoState}
+            tryAgainSignTx={handleTryAgainSignTx}
             cancelSignTx={handleCancelSignTx}
             isRbfConfirmedError={type === 'review-transaction-rbf-previous-transaction-mined-error'}
         />

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -1,27 +1,40 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { notificationsActions } from '@suite-common/toast-notifications';
+import { NetworkSymbol, NetworkType } from '@suite-common/wallet-config';
 import {
+    AccountsState,
     DeviceRootState,
     SendState,
+    SerializedTx,
     StakeState,
+    selectAccounts,
     selectPrecomposedSendForm,
     selectSelectedDevice,
     selectSendFormReviewButtonRequestsCount,
     selectStakePrecomposedForm,
 } from '@suite-common/wallet-core';
-import { FormState, RbfTransactionType, StakeFormState } from '@suite-common/wallet-types';
+import {
+    FormState,
+    RbfTransactionType,
+    ReviewOutput,
+    StakeFormState,
+    StakeType,
+} from '@suite-common/wallet-types';
 import {
     constructTransactionReviewOutputs,
+    findAccountsByAddress,
     getTxStakeNameByDataHex,
     isRbfBumpFeeTransaction,
     isRbfCancelTransaction,
     isRbfTransaction,
 } from '@suite-common/wallet-utils';
-import { NewModal } from '@trezor/components';
+import { Column, NewModal, Row } from '@trezor/components';
+import TrezorConnect from '@trezor/connect';
 import { copyToClipboard, download } from '@trezor/dom-utils';
 import { ConfirmOnDevice } from '@trezor/product-components';
 import { EventType, TransactionCreatedEvent, analytics } from '@trezor/suite-analytics';
+import { spacings } from '@trezor/theme';
 import { Deferred } from '@trezor/utils';
 
 import * as modalActions from 'src/actions/suite/modalActions';
@@ -33,9 +46,47 @@ import { getTransactionReviewModalActionText } from 'src/utils/suite/transaction
 
 import { TransactionReviewDetails } from './TransactionReviewDetails';
 import { TransactionReviewOutputList } from './TransactionReviewOutputList/TransactionReviewOutputList';
+import { TransactionReviewOutputTimer } from './TransactionReviewOutputList/TransactionReviewOutputTimer';
 import { TransactionReviewSummary } from './TransactionReviewSummary';
 import { ConfirmActionModal } from '../DeviceContextModal/ConfirmActionModal';
+import { ExpiredTxValidity } from '../UserContextModal/TxDetailModal/ExpiredTxValidity';
 import { ReplaceByFeeFailedOriginalTxConfirmed } from '../UserContextModal/TxDetailModal/ReplaceByFeeFailedOriginalTxConfirmed';
+
+const getTxValidityTimeoutInMs = (networkType?: NetworkType) => {
+    if (networkType === 'solana') {
+        // Blockhash required in Solana tx is valid for 1 minute. Leave 15 seconds for tx confirmation.
+        return 45 * 1000;
+    }
+
+    return 0;
+};
+
+const hasTxValidityExpired = (deadline: number) => deadline <= Date.now();
+
+const shouldShowTxValidityTimer = (
+    deadline: number,
+    outputs: ReviewOutput[],
+    symbol: NetworkSymbol,
+    accounts: AccountsState,
+    buttonRequestsCount: number,
+    serializedTx: SerializedTx | undefined,
+    stakeType: StakeType | null,
+    shouldCheckTxTimeValidity: boolean,
+) => {
+    if (!shouldCheckTxTimeValidity || hasTxValidityExpired(deadline)) {
+        return false;
+    }
+
+    const firstOutput = outputs[0];
+    const isInternalTransfer =
+        firstOutput?.type === 'address' &&
+        findAccountsByAddress(symbol, firstOutput.value, accounts).length > 0;
+
+    const isFirstStep = buttonRequestsCount <= 1;
+    const isStaking = stakeType && !serializedTx;
+
+    return isInternalTransfer || !isFirstStep || serializedTx || isStaking;
+};
 
 const isStakeState = (state: SendState | StakeState): state is StakeState => 'data' in state;
 
@@ -53,6 +104,7 @@ const mapRbfTypeToReporting: Record<
 type TransactionReviewModalContentProps = {
     decision: Deferred<boolean, string | number | undefined> | undefined;
     txInfoState: SendState | StakeState;
+    tryAgainSignTx: () => void;
     cancelSignTx: () => void;
     isRbfConfirmedError?: boolean;
 };
@@ -60,16 +112,17 @@ type TransactionReviewModalContentProps = {
 export const TransactionReviewModalContent = ({
     decision,
     txInfoState,
+    tryAgainSignTx,
     cancelSignTx,
     isRbfConfirmedError,
 }: TransactionReviewModalContentProps) => {
     const dispatch = useDispatch();
     const account = useSelector(selectAccountIncludingChosenInTrading);
+    const accounts = useSelector(selectAccounts);
     const device = useSelector(selectSelectedDevice);
     const isActionAbortable = useSelector(selectIsActionAbortable);
     const [isSending, setIsSending] = useState(false);
     const [areDetailsVisible, setAreDetailsVisible] = useState(false);
-
     const deviceModelInternal = device?.features?.internal_model;
     const { precomposedTx, serializedTx } = txInfoState;
 
@@ -79,7 +132,34 @@ export const TransactionReviewModalContent = ({
             : selectPrecomposedSendForm(state),
     );
 
-    const isTradingAction = !!precomposedForm?.isTrading;
+    const shouldCheckTxTimeValidity =
+        account?.networkType === 'solana' && !precomposedForm?.isTrading;
+
+    const createdTxTimestamp = txInfoState?.precomposedTx?.createdTimestamp || 0;
+    const deadline = createdTxTimestamp + getTxValidityTimeoutInMs(account?.networkType);
+
+    // check if transaction is still valid
+    useEffect(() => {
+        if (!shouldCheckTxTimeValidity) {
+            return;
+        }
+
+        const now = Date.now();
+        const timeLeft = Math.max(deadline - now, 0);
+        let mounted = true;
+
+        const timeoutId = setTimeout(() => {
+            if (mounted && !isSending) {
+                TrezorConnect.cancel('tx-timeout');
+            }
+        }, timeLeft);
+
+        return () => {
+            mounted = false;
+            clearTimeout(timeoutId);
+        };
+    }, [deadline, isSending, shouldCheckTxTimeValidity]);
+
     const isBumpFeeRbfAction =
         precomposedTx !== undefined && isRbfBumpFeeTransaction(precomposedTx);
 
@@ -118,7 +198,7 @@ export const TransactionReviewModalContent = ({
               .find(type => type) || null;
 
     const onCancel = () => {
-        if (isRbfConfirmedError) {
+        if (isRbfConfirmedError || shouldCheckTxTimeValidity) {
             dispatch(modalActions.onCancel());
         }
 
@@ -129,6 +209,19 @@ export const TransactionReviewModalContent = ({
     };
 
     const isCancelRbfAction = isRbfCancelTransaction(precomposedTx);
+
+    const isTxExpired = hasTxValidityExpired(deadline);
+
+    const showTxValidityTimer = shouldShowTxValidityTimer(
+        deadline,
+        outputs,
+        symbol,
+        accounts,
+        buttonRequestsCount,
+        serializedTx,
+        stakeType,
+        shouldCheckTxTimeValidity,
+    );
 
     const actionLabel = getTransactionReviewModalActionText({
         stakeType,
@@ -194,12 +287,33 @@ export const TransactionReviewModalContent = ({
         reportTransactionCreatedEvent('downloaded');
     };
 
+    const handleTryAgain = (cancel: boolean) => {
+        if (cancel) {
+            TrezorConnect.cancel('tx-timeout');
+        }
+
+        tryAgainSignTx();
+    };
+
     const BottomContent = () => {
         if (isRbfConfirmedError) {
             return (
                 <NewModal.Button variant="tertiary" onClick={onCancel}>
                     <Translation id="TR_CLOSE" />
                 </NewModal.Button>
+            );
+        }
+
+        if (shouldCheckTxTimeValidity && isTxExpired && !isSending) {
+            return (
+                <>
+                    <NewModal.Button variant="primary" onClick={() => handleTryAgain(false)}>
+                        <Translation id="TR_TRY_AGAIN" />
+                    </NewModal.Button>
+                    <NewModal.Button variant="tertiary" onClick={onCancel}>
+                        <Translation id="TR_CLOSE" />
+                    </NewModal.Button>
+                </>
             );
         }
 
@@ -254,18 +368,26 @@ export const TransactionReviewModalContent = ({
             );
         }
 
+        if (shouldCheckTxTimeValidity && isTxExpired && !isSending) {
+            return <ExpiredTxValidity symbol={symbol} />;
+        }
+
         return (
-            <TransactionReviewOutputList
-                account={account}
-                precomposedTx={precomposedTx}
-                signedTx={serializedTx}
-                outputs={outputs}
-                buttonRequestsCount={buttonRequestsCount}
-                isRbfAction={isBumpFeeRbfAction}
-                isTradingAction={isTradingAction}
-                isSending={isSending}
-                stakeType={stakeType || undefined}
-            />
+            <Column gap={spacings.md}>
+                <TransactionReviewOutputList
+                    account={account}
+                    precomposedTx={precomposedTx}
+                    signedTx={serializedTx}
+                    outputs={outputs}
+                    buttonRequestsCount={buttonRequestsCount}
+                    isRbfAction={isBumpFeeRbfAction}
+                    isTradingAction={!!precomposedForm.isTrading}
+                    isSending={isSending}
+                    stakeType={stakeType || undefined}
+                    deadline={deadline}
+                    onTryAgain={handleTryAgain}
+                />
+            </Column>
         );
     };
 
@@ -287,15 +409,27 @@ export const TransactionReviewModalContent = ({
                 onBackClick={areDetailsVisible ? () => setAreDetailsVisible(false) : undefined}
                 description={
                     !areDetailsVisible && (
-                        <TransactionReviewSummary
-                            tx={precomposedTx}
-                            account={account}
-                            broadcast={isBroadcastEnabled}
-                            onDetailsClick={() => {
-                                setAreDetailsVisible(!areDetailsVisible);
-                            }}
-                            stakeType={stakeType}
-                        />
+                        <Row justifyContent="space-between">
+                            <TransactionReviewSummary
+                                tx={precomposedTx}
+                                account={account}
+                                broadcast={isBroadcastEnabled}
+                                onDetailsClick={() => {
+                                    setAreDetailsVisible(!areDetailsVisible);
+                                }}
+                                stakeType={stakeType}
+                            />
+                            {showTxValidityTimer && (
+                                <Row gap={spacings.xs}>
+                                    <TransactionReviewOutputTimer
+                                        deadline={deadline}
+                                        onTryAgain={handleTryAgain}
+                                        isMinimal
+                                        isSending={isSending}
+                                    />
+                                </Row>
+                            )}
+                        </Row>
                     )
                 }
                 bottomContent={<BottomContent />}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 import { TranslationKey } from '@suite-common/intl-types';
 import { NetworkSymbol, NetworkType, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { BTC_LOCKTIME_VALUE } from '@suite-common/wallet-constants';
+import { selectAccounts } from '@suite-common/wallet-core';
 import { ReviewOutput, StakeType } from '@suite-common/wallet-types';
 import { findAccountsByAddress, isTestnet } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
@@ -245,7 +246,7 @@ export const TransactionReviewOutput = ({
     isTrading,
 }: TransactionReviewOutputProps) => {
     const { networkType, symbol } = account;
-    const accounts = useSelector(state => state.wallet.accounts);
+    const accounts = useSelector(selectAccounts);
     const { translationString } = useTranslation();
     const isFiatVisible =
         ['fee', 'amount', 'gas', 'fee-replace', 'reduce-output'].includes(type) &&

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import type { GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { ReviewOutput, StakeType } from '@suite-common/wallet-types';
 import { findAccountsByAddress } from '@suite-common/wallet-utils';
-import { Banner, BulletList, Card, Column, H3, H4, Text } from '@trezor/components';
+import { BulletList, Card, Column, H3, H4 } from '@trezor/components';
 import { spacings, spacingsPx } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
@@ -14,6 +14,7 @@ import type { Account } from 'src/types/wallet';
 
 import { TransactionReviewOutput } from './TransactionReviewOutput';
 import type { TransactionReviewOutputElementProps } from './TransactionReviewOutputElement';
+import { TransactionReviewOutputTimer } from './TransactionReviewOutputTimer';
 import { TransactionReviewTotalOutput } from './TransactionReviewTotalOutput';
 
 export type TransactionReviewOutputListProps = {
@@ -26,6 +27,8 @@ export type TransactionReviewOutputListProps = {
     isTradingAction: boolean;
     isSending?: boolean;
     stakeType?: StakeType;
+    deadline?: number;
+    onTryAgain: (close: boolean) => void;
 };
 
 const getState = (
@@ -71,8 +74,10 @@ export const TransactionReviewOutputList = ({
     buttonRequestsCount,
     isRbfAction,
     isTradingAction,
-    isSending,
     stakeType,
+    deadline,
+    onTryAgain,
+    isSending,
 }: TransactionReviewOutputListProps) => {
     const outputRefs = useRef<(HTMLDivElement | null)[]>([]);
     const totalOutputRef = useRef<HTMLDivElement | null>(null);
@@ -80,7 +85,7 @@ export const TransactionReviewOutputList = ({
     const { networkType, symbol } = account;
     const isMultirecipient = outputs.filter(({ type }) => type === 'address').length > 1;
     const isFirstOutputAddress = outputs[0].type === 'address';
-    const isFirstStep = buttonRequestsCount === 1;
+    const isFirstStep = buttonRequestsCount <= 1;
     const isStaking = stakeType;
     const isInternalTransfer =
         isFirstOutputAddress &&
@@ -104,14 +109,24 @@ export const TransactionReviewOutputList = ({
         isFirstStep &&
         !isStaking &&
         !isTradingAction &&
-        !isInternalTransfer
+        !isInternalTransfer &&
+        !signedTx
     ) {
         return (
             <Card>
-                <Column gap={spacings.xxxl}>
-                    <H3>
-                        <Translation id="TR_SEND_ADDRESS_CONFIRMATION_HEADING" />
-                    </H3>
+                <Column gap={spacings.xxl}>
+                    <Column gap={spacings.md}>
+                        <H3>
+                            <Translation id="TR_SEND_ADDRESS_CONFIRMATION_HEADING" />
+                        </H3>
+                        {networkType === 'solana' && deadline && (
+                            <TransactionReviewOutputTimer
+                                deadline={deadline}
+                                onTryAgain={onTryAgain}
+                                isSending={isSending}
+                            />
+                        )}
+                    </Column>
                     <BulletList
                         isOrdered
                         bulletGap={spacings.md}
@@ -191,14 +206,6 @@ export const TransactionReviewOutputList = ({
                     </Column>
                 </Wrapper>
             )}
-            {isSending && networkType === 'solana' ? (
-                <Banner variant="tertiary" icon="info">
-                    <Translation
-                        id="TR_SOLANA_TX_CONFIRMATION_MAY_TAKE_UP_TO_1_MIN"
-                        values={{ nowrap: chunks => <Text textWrap="nowrap">{chunks}</Text> }}
-                    />
-                </Banner>
-            ) : null}
         </Column>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputTimer.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputTimer.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Badge, Banner, Button, Text } from '@trezor/components';
+
+import { CountdownTimer } from 'src/components/suite/CountdownTimer';
+import { Translation } from 'src/components/suite/Translation';
+
+const TimerBox = styled.div`
+    font-variant-numeric: tabular-nums;
+`;
+
+type TransactionReviewOutputTimerProps = {
+    deadline: number;
+    isMinimal?: boolean;
+    onTryAgain: (close: boolean) => void;
+    isSending?: boolean;
+};
+
+export const TransactionReviewOutputTimer = ({
+    deadline,
+    isMinimal,
+    onTryAgain,
+    isSending,
+}: TransactionReviewOutputTimerProps) => {
+    if (isMinimal) {
+        return (
+            <>
+                <Button
+                    icon="arrowClockwise"
+                    variant="tertiary"
+                    type="button"
+                    size="tiny"
+                    isDisabled={isSending}
+                    onClick={() => onTryAgain(true)}
+                >
+                    <Translation id="TR_RETRY" />
+                </Button>
+                <Badge variant="warning">
+                    <TimerBox>
+                        {isSending ? (
+                            <Translation id="TR_CONFIRMING_TX" />
+                        ) : (
+                            <CountdownTimer
+                                deadline={deadline}
+                                unitDisplay="narrow"
+                                message="TR_TX_CONFIRMATION_TIMER_SHORT"
+                                pastDeadlineMessage="TR_TX_SEND_FAILED_TITLE"
+                            />
+                        )}
+                    </TimerBox>
+                </Badge>
+            </>
+        );
+    }
+
+    return (
+        <Banner
+            icon="hourglass"
+            rightContent={
+                <Banner.Button isDisabled={isSending} onClick={() => onTryAgain(true)}>
+                    <Translation id="TR_RETRY" />
+                </Banner.Button>
+            }
+        >
+            <TimerBox>
+                <Text typographyStyle="callout" as="div">
+                    <CountdownTimer
+                        deadline={deadline}
+                        unitDisplay="long"
+                        message="TR_TX_CONFIRMATION_TIMER"
+                        pastDeadlineMessage="TR_TX_SEND_FAILED_TITLE"
+                    />
+                </Text>
+                <Translation id="TR_SOLANA_TX_CONFIRMATION_TIMER_DESCRIPTION" />
+            </TimerBox>
+        </Banner>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/ConfirmStakeEthModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/ConfirmStakeEthModal.tsx
@@ -8,7 +8,7 @@ import { spacings } from '@trezor/theme';
 import { HELP_CENTER_ETH_STAKING } from '@trezor/urls';
 
 import { openModal } from 'src/actions/suite/modalActions';
-import { Translation, TrezorLink } from 'src/components/suite';
+import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { getDaysToAddToPoolInitial } from 'src/utils/suite/ethereumStaking';
@@ -80,19 +80,17 @@ export const ConfirmStakeEthModal = ({
                         }}
                     />
                 </Banner>
-                <Banner icon="hand">
+                <Banner
+                    icon="hand"
+                    rightContent={
+                        <Banner.Button href={HELP_CENTER_ETH_STAKING}>
+                            <Translation id="TR_LEARN_MORE" />
+                        </Banner.Button>
+                    }
+                >
                     <Translation
                         id="TR_STAKE_ETH_WILL_BE_BLOCKED"
                         values={{
-                            a: chunks => (
-                                <TrezorLink
-                                    target="_blank"
-                                    variant="underline"
-                                    href={HELP_CENTER_ETH_STAKING}
-                                >
-                                    {chunks}
-                                </TrezorLink>
-                            ),
                             networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
                         }}
                     />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ExpiredTxValidity.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ExpiredTxValidity.tsx
@@ -1,0 +1,34 @@
+import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { Box, Card, Column, IconCircle, Text } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+import { HELP_CENTER_SOL_SEND } from '@trezor/urls';
+
+import { Translation } from 'src/components/suite/Translation';
+import { TrezorLink } from 'src/components/suite/TrezorLink';
+
+type ExpiredTxValidityProps = {
+    symbol: NetworkSymbol;
+};
+
+export const ExpiredTxValidity = ({ symbol }: ExpiredTxValidityProps) => {
+    const networkName = getNetwork(symbol).name;
+
+    return (
+        <Card fillType="flat">
+            <Column gap={spacings.xs}>
+                <Box margin={{ bottom: spacings.md }}>
+                    <IconCircle name="warning" size={110} variant="destructive" />
+                </Box>
+
+                <Text typographyStyle="titleSmall">
+                    <Translation id="TR_TX_SEND_FAILED_TITLE" />
+                </Text>
+                <Translation id="TR_TX_SEND_FAILED_DESCRIPTION" values={{ networkName }} />
+
+                <TrezorLink typographyStyle="hint" href={HELP_CENTER_SOL_SEND} icon="arrowUpRight">
+                    <Translation id="TR_LEARN_MORE" />
+                </TrezorLink>
+            </Column>
+        </Card>
+    );
+};

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9149,6 +9149,28 @@ export default defineMessages({
         id: 'TR_SOLANA_TX_CONFIRMATION_MAY_TAKE_UP_TO_1_MIN',
         defaultMessage: 'Transaction confirmation may take up to <nowrap>one (1) minute</nowrap>',
     },
+    TR_TX_SEND_FAILED_TITLE: {
+        id: 'TR_TX_SEND_FAILED_TITLE',
+        defaultMessage: 'Send transaction failed',
+    },
+    TR_TX_SEND_FAILED_DESCRIPTION: {
+        id: 'TR_TX_SEND_FAILED_DESCRIPTION',
+        defaultMessage:
+            'The time to sign a {networkName} transaction is limited. It could no longer be submitted because it timed out and is no longer valid.',
+    },
+    TR_TX_CONFIRMATION_TIMER: {
+        id: 'TR_TX_CONFIRMATION_TIMER',
+        defaultMessage: '{value} left',
+    },
+    TR_TX_CONFIRMATION_TIMER_SHORT: {
+        id: 'TR_TX_CONFIRMATION_TIMER_SHORT',
+        defaultMessage: '<strong>{value}</strong> left to confirm',
+    },
+    TR_SOLANA_TX_CONFIRMATION_TIMER_DESCRIPTION: {
+        id: 'TR_SOLANA_TX_CONFIRMATION_TIMER_DESCRIPTION',
+        defaultMessage:
+            'Due to Solana network constraints you have <1 minute to confirm and send the transaction before it times out.',
+    },
     TR_VIEW_ONLY_PROMO_YES: {
         id: 'TR_VIEW_ONLY_PROMO_YES',
         defaultMessage: 'Enable',

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -128,6 +128,9 @@ export const HELP_CENTER_REPLACE_BY_FEE_BITCOIN =
     'https://trezor.io/learn/a/replace-by-fee-rbf-bitcoin';
 export const HELP_CENTER_CANCEL_TRANSACTION: Url =
     'https://trezor.io/support/a/can-i-cancel-or-reverse-a-transaction';
+// TODO: update this link when the article is ready
+export const HELP_CENTER_SOL_SEND: Url =
+    'https://trezor.io/learn/a/solana-sol-on-trezor-safe-5-trezor-safe-3-and-trezor-model-t';
 
 export const INVITY_URL: Url = 'https://invity.io/';
 export const INVITY_SCHEDULE_OF_FEES: Url = 'https://blog.invity.io/schedule-of-fees';

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -64,6 +64,7 @@ import {
     ComposeFeeLevelsError,
     PushTransactionError,
     SignTransactionError,
+    SignTransactionTimeoutError,
 } from './sendFormTypes';
 import { accountsActions } from '../accounts/accountsActions';
 import { selectAccountByKey } from '../accounts/accountsReducer';
@@ -399,7 +400,7 @@ export const signTransactionThunk = createThunk<
         precomposedTransaction: PrecomposedTransactionFinal | PrecomposedTransactionFinalCardano;
         selectedAccount: Account;
     },
-    { rejectValue: SignTransactionError | undefined }
+    { rejectValue: SignTransactionError | SignTransactionTimeoutError | undefined }
 >(
     `${SEND_MODULE_PREFIX}/signTransactionThunk`,
     async (
@@ -457,11 +458,19 @@ export const signTransactionThunk = createThunk<
         if (isRejected(response) || !response?.payload) {
             // catch manual error from TransactionReviewModal
             const message = response?.payload?.message ?? 'unknown-error';
-            if (message === 'tx-cancelled')
+            if (message === 'tx-timeout') {
+                return rejectWithValue({
+                    error: 'sign-transaction-timeout',
+                    message: 'Signing process timed out.',
+                });
+            }
+
+            if (message === 'tx-cancelled') {
                 return rejectWithValue({
                     error: 'sign-transaction-failed',
                     message: 'User canceled the signing process.',
                 });
+            }
 
             dispatch(
                 notificationsActions.addToast({
@@ -576,7 +585,10 @@ export const enhancePrecomposedTransactionThunk = createThunk<
         dispatch(
             sendFormActions.storePrecomposedTransaction({
                 formState: formValues,
-                precomposedTransaction: enhancedPrecomposedTransaction,
+                precomposedTransaction: {
+                    ...enhancedPrecomposedTransaction,
+                    createdTimestamp: new Date().getTime(),
+                },
             }),
         );
 

--- a/suite-common/wallet-core/src/send/sendFormTypes.ts
+++ b/suite-common/wallet-core/src/send/sendFormTypes.ts
@@ -57,9 +57,19 @@ export type SignTransactionError = {
     message?: string;
 };
 
+export type SignTransactionTimeoutError = {
+    error: 'sign-transaction-timeout';
+    errorCode?: CONNECT_ERRORS.ErrorCode;
+    message?: string;
+};
+
 export type PushTransactionError = {
     error: 'push-transaction-failed';
     metadata: Unsuccessful;
 };
 
-export type SendFormError = ComposeFeeLevelsError | SignTransactionError | PushTransactionError;
+export type SendFormError =
+    | ComposeFeeLevelsError
+    | SignTransactionError
+    | SignTransactionTimeoutError
+    | PushTransactionError;

--- a/suite-common/wallet-core/src/stake/stakeReducer.ts
+++ b/suite-common/wallet-core/src/stake/stakeReducer.ts
@@ -58,7 +58,10 @@ export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState,
     builder
         .addCase(stakeActions.requestSignTransaction, (state, action) => {
             if (action.payload) {
-                state.precomposedTx = action.payload.transactionInfo;
+                state.precomposedTx = {
+                    ...action.payload.transactionInfo,
+                    createdTimestamp: new Date().getTime(),
+                };
                 // Deep-cloning to prevent buggy interaction between react-hook-form and immer, see https://github.com/orgs/react-hook-form/discussions/3715#discussioncomment-2151458
                 // Otherwise, whenever the outputs fieldArray is updated after the form draft or precomposedForm is saved, there is na error:
                 // TypeError: Cannot assign to read only property of object '#<Object>'

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -109,6 +109,7 @@ type PrecomposedTransactionBase = PrecomposedTransactionConnectResponseFinal & {
     estimatedFeeLimit?: string;
     token?: TokenInfo;
     isTokenKnown?: boolean;
+    createdTimestamp?: number;
 };
 
 // base of PrecomposedTransactionFinal
@@ -118,6 +119,7 @@ export type PrecomposedTransactionCardanoFinal =
         feeLimit?: string;
         estimatedFeeLimit?: string;
         token?: TokenInfo;
+        createdTimestamp?: number;
     };
 
 export type RbfTransactionType = 'bump-fee' | 'cancel';

--- a/suite-native/module-send/src/sendFormThunks.ts
+++ b/suite-native/module-send/src/sendFormThunks.ts
@@ -5,6 +5,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import { getNetwork } from '@suite-common/wallet-config';
 import {
     SignTransactionError,
+    SignTransactionTimeoutError,
     composeSendFormTransactionFeeLevelsThunk,
     deviceActions,
     enhancePrecomposedTransactionThunk,
@@ -39,7 +40,7 @@ export const signTransactionNativeThunk = createThunk<
         feeLevel: GeneralPrecomposedTransactionFinal;
         tokenContract?: TokenAddress;
     },
-    { rejectValue: SignTransactionError | undefined }
+    { rejectValue: SignTransactionError | SignTransactionTimeoutError | undefined }
 >(
     `${SEND_MODULE_PREFIX}/signTransactionNativeThunk`,
     async (


### PR DESCRIPTION
## Description

A countdown timer has been added to show the remaining time for transaction confirmation. If the blockhash expires, a retry button will be displayed.

- enabled only for:
	- send
	- stake/unstake/claim
- trading is not available
- the timer is set to 45 seconds
- knowns issues: remembered wallet -> passphrase input takes time

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/10906
Resolve [#15434](https://github.com/trezor/trezor-suite/issues/15434)

## Screenshots:
![Screenshot 2025-02-24 at 19 15 54](https://github.com/user-attachments/assets/a6f6f4a4-b33c-4971-ae2f-5f0cd024c5d5)
![Screenshot 2025-02-24 at 19 14 37](https://github.com/user-attachments/assets/db91d71f-7414-45b0-bf07-9787983b0096)
![Screenshot 2025-02-24 at 19 16 51](https://github.com/user-attachments/assets/dc2985c2-29a8-48aa-a137-570f21ff8bd1)
