### PR TITLE
feat(suite-desktop): turn on ASAR integrity check via afterPack hook

### DIFF
--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -47,6 +47,7 @@
     },
     "devDependencies": {
         "@currents/playwright": "^1.3.1",
+        "@electron/fuses": "^1.8.0",
         "@electron/notarize": "2.5.0",
         "@playwright/browser-chromium": "^1.49.1",
         "@playwright/browser-firefox": "^1.49.1",

--- a/packages/suite-desktop-core/scripts/setElectronFuses.js
+++ b/packages/suite-desktop-core/scripts/setElectronFuses.js
@@ -1,0 +1,40 @@
+const { flipFuses, FuseV1Options, FuseVersion } = require('@electron/fuses');
+const path = require('path');
+
+// copied from https://github.com/electron-userland/electron-builder/blob/04be5699c664e6a93e093b820a16ad516355b5c7/packages/app-builder-lib/src/platformPackager.ts#L430-L434
+const binaryExtensionByPlaformNameMap = {
+    darwin: '.app',
+    win32: '.exe',
+    linux: '',
+};
+
+exports.default = async function afterPack(context) {
+    const { electronPlatformName, appOutDir } = context;
+
+    /*
+     As of Electron 34.1.0, ASAR integrity:
+     - is not supported on Linux at all
+     - is supported on macOS, but does not work. TODO investigate & reenable
+     So we only set the appropriate fuses for Windows
+    */
+    if (electronPlatformName !== 'win32') {
+        console.log('Skipping electron fuses ');
+
+        return;
+    }
+
+    const ext = binaryExtensionByPlaformNameMap[electronPlatformName];
+    const appName = context.packager.appInfo.productFilename;
+    const binaryFilename = `${appName}${ext}`;
+    const binaryPath = path.join(appOutDir, binaryFilename);
+
+    console.log(`Setting electron fuses on ${binaryPath}`);
+
+    await flipFuses(binaryPath, {
+        version: FuseVersion.V1,
+        [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
+        [FuseV1Options.OnlyLoadAppFromAsar]: true,
+    });
+
+    console.log('Successfully set electron fuses');
+};

--- a/packages/suite-desktop/electron-builder-config.js
+++ b/packages/suite-desktop/electron-builder-config.js
@@ -162,5 +162,6 @@ module.exports = {
         category: 'Utility',
         target: ['AppImage'],
     },
+    afterPack: '../suite-desktop-core/scripts/setElectronFuses.js',
     afterSign: '../suite-desktop-core/scripts/notarize.ts',
 };

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -30,6 +30,7 @@
         "usb": "^2.14.0"
     },
     "devDependencies": {
+        "@electron/fuses": "^1.8.0",
         "@electron/notarize": "2.5.0",
         "electron": "34.1.0",
         "electron-builder": "26.0.3",

--- a/scripts/list-outdated-dependencies/foundation-dependencies.txt
+++ b/scripts/list-outdated-dependencies/foundation-dependencies.txt
@@ -24,6 +24,7 @@ uuid
 @electron/notarize
 electron
 electron-builder
+@electron/fuses
 electron-localshortcut
 electron-store
 electron-updater

--- a/yarn.lock
+++ b/yarn.lock
@@ -13353,6 +13353,7 @@ __metadata:
   resolution: "@trezor/suite-desktop-core@workspace:packages/suite-desktop-core"
   dependencies:
     "@currents/playwright": "npm:^1.3.1"
+    "@electron/fuses": "npm:^1.8.0"
     "@electron/notarize": "npm:2.5.0"
     "@playwright/browser-chromium": "npm:^1.49.1"
     "@playwright/browser-firefox": "npm:^1.49.1"
@@ -13439,6 +13440,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/suite-desktop@workspace:packages/suite-desktop"
   dependencies:
+    "@electron/fuses": "npm:^1.8.0"
     "@electron/notarize": "npm:2.5.0"
     blake-hash: "npm:^2.0.0"
     electron: "npm:34.1.0"


### PR DESCRIPTION
## Description

After the original implementation #16951 was reverted in #16972 because of failing macOS builds, let's just turn on the ASAR integrity for Windows, for the time being.

The previous attempt was very simple  - just several lines of config for electron-builder, which takes care of flipping the electron fuses during build for **all** platforms (but it takes effect only on macOS & Windows). 

If we want to turn on the fuses only for selected platform(s), we need to do it manually via an `afterPack` hook. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/16

## QA instructions

- build Suite Desktop for all platforms
- see that it installs & runs
- I have personally tested Linux Ubuntu 24 & Windows 10 :heavy_check_mark: 

@coderabbitai ignore