### PR TITLE
fix(suite-native): apply letterSpacing workaround on Connecting title

### DIFF
--- a/suite-native/atoms/src/index.ts
+++ b/suite-native/atoms/src/index.ts
@@ -59,5 +59,6 @@ export * from './useBannerAwareSafeAreaInsets';
 export * from './useIllustrationColors';
 export * from './utils';
 export * from './PriceChangeBadge';
+export * from './resetLetterSpacingOnAndroidStyle';
 
 export { useDebugView } from './DebugView';

--- a/suite-native/atoms/src/resetLetterSpacingOnAndroidStyle.ts
+++ b/suite-native/atoms/src/resetLetterSpacingOnAndroidStyle.ts
@@ -1,0 +1,14 @@
+import { isAndroid } from '@trezor/env-utils';
+import { prepareNativeStyle } from '@trezor/styles';
+
+export const resetLetterSpacingOnAndroidStyle = prepareNativeStyle(_ => ({
+    // Because of this RN issue https://github.com/facebook/react-native/issues/46436
+    // turning off custom letter spacing on Android for selected places only.
+    // This is hopefully temporary solution only for places where it was reported and looks too bad.
+    extend: {
+        condition: isAndroid(),
+        style: {
+            letterSpacing: 0,
+        },
+    },
+}));

--- a/suite-native/formatters/package.json
+++ b/suite-native/formatters/package.json
@@ -21,7 +21,6 @@
         "@suite-native/atoms": "workspace:*",
         "@suite-native/settings": "workspace:*",
         "@suite-native/tokens": "workspace:*",
-        "@trezor/env-utils": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/utils": "workspace:*",
         "react": "18.2.0",

--- a/suite-native/formatters/src/components/AmountText.tsx
+++ b/suite-native/formatters/src/components/AmountText.tsx
@@ -1,6 +1,10 @@
-import { DiscreetText, Text, TextProps } from '@suite-native/atoms';
-import { isAndroid } from '@trezor/env-utils';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import {
+    DiscreetText,
+    Text,
+    TextProps,
+    resetLetterSpacingOnAndroidStyle,
+} from '@suite-native/atoms';
+import { useNativeStyles } from '@trezor/styles';
 
 type AmountTextProps = {
     isDiscreetText?: boolean;
@@ -8,24 +12,13 @@ type AmountTextProps = {
     value: string | null;
 } & TextProps;
 
-const amountTextStyle = prepareNativeStyle(_ => ({
-    // Because of this RN issue https://github.com/facebook/react-native/issues/46436
-    // turning off custom letter spacing for amounts on Android.
-    extend: {
-        condition: isAndroid(),
-        style: {
-            letterSpacing: 0,
-        },
-    },
-}));
-
 export const AmountText = ({ value, isDiscreetText = true, ...otherProps }: AmountTextProps) => {
     const { applyStyle } = useNativeStyles();
 
     const TextComponent = isDiscreetText ? DiscreetText : Text;
 
     return (
-        <TextComponent style={applyStyle(amountTextStyle)} {...otherProps}>
+        <TextComponent style={applyStyle(resetLetterSpacingOnAndroidStyle)} {...otherProps}>
             {value}
         </TextComponent>
     );

--- a/suite-native/formatters/tsconfig.json
+++ b/suite-native/formatters/tsconfig.json
@@ -23,7 +23,6 @@
         { "path": "../atoms" },
         { "path": "../settings" },
         { "path": "../tokens" },
-        { "path": "../../packages/env-utils" },
         { "path": "../../packages/styles" },
         { "path": "../../packages/utils" }
     ]

--- a/suite-native/module-authorize-device/src/screens/connect/ConnectingDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/ConnectingDeviceScreen.tsx
@@ -1,6 +1,6 @@
 import { ActivityIndicator } from 'react-native';
 
-import { Box, Text, VStack } from '@suite-native/atoms';
+import { Box, Text, VStack, resetLetterSpacingOnAndroidStyle } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { useHandleHardwareBackNavigation } from '@suite-native/navigation';
@@ -26,7 +26,10 @@ export const ConnectingDeviceScreen = () => {
             <VStack spacing="sp16" alignItems="center">
                 <ActivityIndicator size="large" />
                 <Box flexDirection="row" alignItems="center">
-                    <Text variant="titleMedium">
+                    <Text
+                        variant="titleMedium"
+                        style={applyStyle(resetLetterSpacingOnAndroidStyle)}
+                    >
                         <Translation id="moduleConnectDevice.connectingDeviceScreen.title" />
                     </Text>
                     <Box paddingBottom="sp8" paddingLeft="sp8">

--- a/yarn.lock
+++ b/yarn.lock
@@ -10562,7 +10562,6 @@ __metadata:
     "@suite-native/atoms": "workspace:*"
     "@suite-native/settings": "workspace:*"
     "@suite-native/tokens": "workspace:*"
-    "@trezor/env-utils": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/utils": "workspace:*"
     react: "npm:18.2.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Apply a workaround on another place where an unexpected line break was reported.

## Related Issue

Resolve [#14729](https://github.com/trezor/trezor-suite/issues/14729)

## Screenshots:
It's hard to reproduce the bug, but with the workaround, it looks almost the same.
<img width="374" alt="image" src="https://github.com/user-attachments/assets/f19976b7-82bd-4a31-b424-dca973bb0f6c" />
