### PR TITLE
fix: do not show Cancel Transaction button for non-bitcoin network

### DIFF
--- a/packages/suite-data/files/translations/en.json
+++ b/packages/suite-data/files/translations/en.json
@@ -1462,7 +1462,7 @@
   "TR_REMEMBER_WALLET_TITLE": "Remember wallet",
   "TR_REMOVE_WIPE_CODE": "Remove wipe code",
   "TR_REPLACE_BY_FEE_FAILED_ALREADY_MINED": "Replace transaction failed",
-  "TR_REPLACE_BY_FEE_FAILED_ALREADY_MINED_DESCRIPTION": "The transaction couldn’t be replaced as it's just been confirmed on the {network} network.",
+  "TR_REPLACE_BY_FEE_FAILED_ALREADY_MINED_DESCRIPTION": "The transaction couldn’t be replaced as it's just been confirmed on the network.",
   "TR_REPLACE_TX": "Replace transaction",
   "TR_REQUIRED_FIELD": "Required",
   "TR_RESTART_TREZOR_DEVICE_TUTORIAL": "Restart tutorial",

--- a/packages/suite-data/files/translations/en.json
+++ b/packages/suite-data/files/translations/en.json
@@ -1462,7 +1462,7 @@
   "TR_REMEMBER_WALLET_TITLE": "Remember wallet",
   "TR_REMOVE_WIPE_CODE": "Remove wipe code",
   "TR_REPLACE_BY_FEE_FAILED_ALREADY_MINED": "Replace transaction failed",
-  "TR_REPLACE_BY_FEE_FAILED_ALREADY_MINED_DESCRIPTION": "The transaction couldn’t be replaced as it's just been confirmed on the Bitcoin network.",
+  "TR_REPLACE_BY_FEE_FAILED_ALREADY_MINED_DESCRIPTION": "The transaction couldn’t be replaced as it's just been confirmed on the {network} network.",
   "TR_REPLACE_TX": "Replace transaction",
   "TR_REQUIRED_FIELD": "Required",
   "TR_RESTART_TREZOR_DEVICE_TUTORIAL": "Restart tutorial",

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -246,7 +246,6 @@ export const TransactionReviewModalContent = ({
             return (
                 <ReplaceByFeeFailedOriginalTxConfirmed
                     type={precomposedTx.rbfType}
-                    networkSymbol={symbol}
                     networkType={networkType}
                 />
             );

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -243,7 +243,7 @@ export const TransactionReviewModalContent = ({
         }
 
         if (isRbfConfirmedError && isRbfTransaction(precomposedTx)) {
-            return <ReplaceByFeeFailedOriginalTxConfirmed type={precomposedTx.rbfType} />;
+            return <ReplaceByFeeFailedOriginalTxConfirmed type={precomposedTx.rbfType} networkSymbol={symbol}/>;
         }
 
         return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -243,7 +243,13 @@ export const TransactionReviewModalContent = ({
         }
 
         if (isRbfConfirmedError && isRbfTransaction(precomposedTx)) {
-            return <ReplaceByFeeFailedOriginalTxConfirmed type={precomposedTx.rbfType} networkSymbol={symbol}/>;
+            return (
+                <ReplaceByFeeFailedOriginalTxConfirmed
+                    type={precomposedTx.rbfType}
+                    networkSymbol={symbol}
+                    networkType={networkType}
+                />
+            );
         }
 
         return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx
@@ -103,7 +103,10 @@ export const CancelTransactionModal = ({
                 onBackClick={onBackClick}
             >
                 {isTxConfirmed ? (
-                    <ReplaceByFeeFailedOriginalTxConfirmed type="cancel" />
+                    <ReplaceByFeeFailedOriginalTxConfirmed
+                        type="cancel"
+                        networkSymbol={tx.symbol}
+                    />
                 ) : (
                     <Column gap={spacings.md}>
                         <CancelTransaction tx={tx} selectedAccount={selectedAccount} />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx
@@ -106,6 +106,7 @@ export const CancelTransactionModal = ({
                     <ReplaceByFeeFailedOriginalTxConfirmed
                         type="cancel"
                         networkSymbol={tx.symbol}
+                        networkType={account.networkType}
                     />
                 ) : (
                     <Column gap={spacings.md}>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx
@@ -105,7 +105,6 @@ export const CancelTransactionModal = ({
                 {isTxConfirmed ? (
                     <ReplaceByFeeFailedOriginalTxConfirmed
                         type="cancel"
-                        networkSymbol={tx.symbol}
                         networkType={account.networkType}
                     />
                 ) : (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/BumpFeeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/BumpFeeModal.tsx
@@ -61,6 +61,7 @@ export const BumpFeeModal = ({
                     <ReplaceByFeeFailedOriginalTxConfirmed
                         type="bump-fee"
                         networkSymbol={tx.symbol}
+                        networkType={account.networkType}
                     />
                 ) : (
                     <ChangeFee tx={tx} chainedTxs={chainedTxs} showChained={onShowChained} />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/BumpFeeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/BumpFeeModal.tsx
@@ -58,7 +58,10 @@ export const BumpFeeModal = ({
                 onBackClick={onBackClick}
             >
                 {isTxConfirmed ? (
-                    <ReplaceByFeeFailedOriginalTxConfirmed type="bump-fee" />
+                    <ReplaceByFeeFailedOriginalTxConfirmed
+                        type="bump-fee"
+                        networkSymbol={tx.symbol}
+                    />
                 ) : (
                     <ChangeFee tx={tx} chainedTxs={chainedTxs} showChained={onShowChained} />
                 )}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/BumpFeeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/BumpFeeModal.tsx
@@ -60,7 +60,6 @@ export const BumpFeeModal = ({
                 {isTxConfirmed ? (
                     <ReplaceByFeeFailedOriginalTxConfirmed
                         type="bump-fee"
-                        networkSymbol={tx.symbol}
                         networkType={account.networkType}
                     />
                 ) : (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/DetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/DetailModal.tsx
@@ -17,6 +17,7 @@ type DetailModalProps = {
     onCancelTxClick: () => void;
     chainedTxs?: ChainedTransactions;
     canReplaceTransaction: boolean;
+    canCancelTransaction: boolean;
 };
 
 export const DetailModal = ({
@@ -27,6 +28,7 @@ export const DetailModal = ({
     onCancelTxClick,
     chainedTxs,
     canReplaceTransaction,
+    canCancelTransaction,
 }: DetailModalProps) => {
     const accountKey = getAccountKey(tx.descriptor, tx.symbol, tx.deviceState);
     const account = useSelector(state => selectAccountByKey(state, accountKey)) as Account;
@@ -47,9 +49,11 @@ export const DetailModal = ({
                         <NewModal.Button icon="gauge" variant="tertiary" onClick={onChangeFeeClick}>
                             <Translation id="TR_BUMP_FEE" />
                         </NewModal.Button>
-                        <NewModal.Button icon="x" variant="tertiary" onClick={onCancelTxClick}>
-                            <Translation id="TR_CANCEL_TX" />
-                        </NewModal.Button>
+                        {canCancelTransaction && (
+                            <NewModal.Button icon="x" variant="tertiary" onClick={onCancelTxClick}>
+                                <Translation id="TR_CANCEL_TX" />
+                            </NewModal.Button>
+                        )}
                     </>
                 ) : null
             }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ReplaceByFeeFailedOriginalTxConfirmed.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ReplaceByFeeFailedOriginalTxConfirmed.tsx
@@ -1,3 +1,4 @@
+import { NetworkSymbol, networks } from '@suite-common/wallet-config';
 import { RbfTransactionType } from '@suite-common/wallet-types';
 import { Box, Card, Column, IconCircle, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
@@ -12,6 +13,7 @@ import { TrezorLink } from '../../../../TrezorLink';
 
 export type ReplaceByFeeFailedOriginalTxConfirmedProps = {
     type: RbfTransactionType;
+    networkSymbol: NetworkSymbol;
 };
 
 const titleMap: Record<ReplaceByFeeFailedOriginalTxConfirmedProps['type'], TranslationKey> = {
@@ -31,6 +33,7 @@ const helpLink: Record<ReplaceByFeeFailedOriginalTxConfirmedProps['type'], Url> 
 
 export const ReplaceByFeeFailedOriginalTxConfirmed = ({
     type,
+    networkSymbol,
 }: ReplaceByFeeFailedOriginalTxConfirmedProps) => (
     <Card fillType="flat">
         <Column gap={spacings.xs}>
@@ -41,7 +44,10 @@ export const ReplaceByFeeFailedOriginalTxConfirmed = ({
             <Text typographyStyle="titleSmall">
                 <Translation id={titleMap[type]} />
             </Text>
-            <Translation id={descriptionMap[type]} />
+            <Translation
+                id={descriptionMap[type]}
+                values={{ network: networks[networkSymbol].name }}
+            />
 
             <TrezorLink typographyStyle="hint" href={helpLink[type]} icon="arrowUpRight">
                 <Translation id="TR_LEARN_MORE" />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ReplaceByFeeFailedOriginalTxConfirmed.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ReplaceByFeeFailedOriginalTxConfirmed.tsx
@@ -1,4 +1,4 @@
-import { NetworkSymbol, NetworkType, networks } from '@suite-common/wallet-config';
+import { NetworkType } from '@suite-common/wallet-config';
 import { RbfTransactionType } from '@suite-common/wallet-types';
 import { Box, Card, Column, IconCircle, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
@@ -14,7 +14,6 @@ import { TrezorLink } from '../../../../TrezorLink';
 
 export type ReplaceByFeeFailedOriginalTxConfirmedProps = {
     type: RbfTransactionType;
-    networkSymbol: NetworkSymbol;
     networkType: NetworkType;
 };
 
@@ -47,7 +46,6 @@ const helpLink: Record<
 
 export const ReplaceByFeeFailedOriginalTxConfirmed = ({
     type,
-    networkSymbol,
     networkType,
 }: ReplaceByFeeFailedOriginalTxConfirmedProps) => {
     const link = helpLink[networkType]?.[type];
@@ -62,10 +60,7 @@ export const ReplaceByFeeFailedOriginalTxConfirmed = ({
                 <Text typographyStyle="titleSmall">
                     <Translation id={titleMap[type]} />
                 </Text>
-                <Translation
-                    id={descriptionMap[type]}
-                    values={{ network: networks[networkSymbol].name }}
-                />
+                <Translation id={descriptionMap[type]} />
 
                 {link && (
                     <TrezorLink typographyStyle="hint" href={link} icon="arrowUpRight">

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ReplaceByFeeFailedOriginalTxConfirmed.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ReplaceByFeeFailedOriginalTxConfirmed.tsx
@@ -1,10 +1,11 @@
-import { NetworkSymbol, networks } from '@suite-common/wallet-config';
+import { NetworkSymbol, NetworkType, networks } from '@suite-common/wallet-config';
 import { RbfTransactionType } from '@suite-common/wallet-types';
 import { Box, Card, Column, IconCircle, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import {
     HELP_CENTER_CANCEL_TRANSACTION,
     HELP_CENTER_REPLACE_BY_FEE_BITCOIN,
+    HELP_CENTER_REPLACE_BY_FEE_ETHEREUM,
     Url,
 } from '@trezor/urls';
 
@@ -14,6 +15,7 @@ import { TrezorLink } from '../../../../TrezorLink';
 export type ReplaceByFeeFailedOriginalTxConfirmedProps = {
     type: RbfTransactionType;
     networkSymbol: NetworkSymbol;
+    networkType: NetworkType;
 };
 
 const titleMap: Record<ReplaceByFeeFailedOriginalTxConfirmedProps['type'], TranslationKey> = {
@@ -26,32 +28,51 @@ const descriptionMap: Record<ReplaceByFeeFailedOriginalTxConfirmedProps['type'],
     cancel: 'TR_CANCEL_TX_FAILED_ALREADY_MINED_DESCRIPTION',
 };
 
-const helpLink: Record<ReplaceByFeeFailedOriginalTxConfirmedProps['type'], Url> = {
-    'bump-fee': HELP_CENTER_REPLACE_BY_FEE_BITCOIN,
-    cancel: HELP_CENTER_CANCEL_TRANSACTION,
+const helpLink: Record<
+    NetworkType,
+    Record<ReplaceByFeeFailedOriginalTxConfirmedProps['type'], Url | null> | null
+> = {
+    bitcoin: {
+        'bump-fee': HELP_CENTER_REPLACE_BY_FEE_BITCOIN,
+        cancel: HELP_CENTER_CANCEL_TRANSACTION,
+    },
+    cardano: null,
+    ethereum: {
+        'bump-fee': HELP_CENTER_REPLACE_BY_FEE_ETHEREUM,
+        cancel: null,
+    },
+    ripple: null,
+    solana: null,
 };
 
 export const ReplaceByFeeFailedOriginalTxConfirmed = ({
     type,
     networkSymbol,
-}: ReplaceByFeeFailedOriginalTxConfirmedProps) => (
-    <Card fillType="flat">
-        <Column gap={spacings.xs}>
-            <Box margin={{ bottom: spacings.md }}>
-                <IconCircle name="warning" size={110} variant="destructive" />
-            </Box>
+    networkType,
+}: ReplaceByFeeFailedOriginalTxConfirmedProps) => {
+    const link = helpLink[networkType]?.[type];
 
-            <Text typographyStyle="titleSmall">
-                <Translation id={titleMap[type]} />
-            </Text>
-            <Translation
-                id={descriptionMap[type]}
-                values={{ network: networks[networkSymbol].name }}
-            />
+    return (
+        <Card fillType="flat">
+            <Column gap={spacings.xs}>
+                <Box margin={{ bottom: spacings.md }}>
+                    <IconCircle name="warning" size={110} variant="destructive" />
+                </Box>
 
-            <TrezorLink typographyStyle="hint" href={helpLink[type]} icon="arrowUpRight">
-                <Translation id="TR_LEARN_MORE" />
-            </TrezorLink>
-        </Column>
-    </Card>
-);
+                <Text typographyStyle="titleSmall">
+                    <Translation id={titleMap[type]} />
+                </Text>
+                <Translation
+                    id={descriptionMap[type]}
+                    values={{ network: networks[networkSymbol].name }}
+                />
+
+                {link && (
+                    <TrezorLink typographyStyle="hint" href={link} icon="arrowUpRight">
+                        <Translation id="TR_LEARN_MORE" />
+                    </TrezorLink>
+                )}
+            </Column>
+        </Card>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
@@ -69,6 +69,8 @@ export const TxDetailModal = ({ tx, flow, onCancel }: TxDetailModalProps) => {
         !tx.deadline &&
         selectedAccount.status === 'loaded';
 
+    const canCancelTransaction = network.networkType === 'bitcoin';
+
     if (section === 'bump-fee' && canReplaceTransaction) {
         return (
             <BumpFeeModal
@@ -104,6 +106,7 @@ export const TxDetailModal = ({ tx, flow, onCancel }: TxDetailModalProps) => {
             onCancelTxClick={onCancelTxClick}
             chainedTxs={chainedTxs}
             canReplaceTransaction={canReplaceTransaction}
+            canCancelTransaction={canCancelTransaction}
         />
     );
 };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6466,7 +6466,7 @@ export default defineMessages({
     TR_REPLACE_BY_FEE_FAILED_ALREADY_MINED_DESCRIPTION: {
         id: 'TR_REPLACE_BY_FEE_FAILED_ALREADY_MINED_DESCRIPTION',
         defaultMessage:
-            "The transaction couldn’t be replaced as it's just been confirmed on the Bitcoin network.",
+            "The transaction couldn’t be replaced as it's just been confirmed on the {network} network.",
     },
     TR_BUMP_FEE_SUBTEXT: {
         id: 'TR_BUMP_FEE_SUBTEXT',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6466,7 +6466,7 @@ export default defineMessages({
     TR_REPLACE_BY_FEE_FAILED_ALREADY_MINED_DESCRIPTION: {
         id: 'TR_REPLACE_BY_FEE_FAILED_ALREADY_MINED_DESCRIPTION',
         defaultMessage:
-            "The transaction couldn’t be replaced as it's just been confirmed on the {network} network.",
+            "The transaction couldn’t be replaced as it's just been confirmed on the network.",
     },
     TR_BUMP_FEE_SUBTEXT: {
         id: 'TR_BUMP_FEE_SUBTEXT',


### PR DESCRIPTION
- [x] Crowdin changed

## QA
We have RBF for Ethereum as well

1) Create ETH (holesky?) transaction 
2) It will be pending for a while
3) It shall NOT be possible to Cancel it (button nowhere to be seen => TD Detail nor TX Detail Modal)
4) It you attempt to RBF it,  but you wait it out (TX gets confirmed) you get an error screen
5) There shall be no Bitcoin mentioned and Link shall point to Ethereum knowlade Base page

## Screens

![image](https://github.com/user-attachments/assets/878bb9e2-353b-4ce4-9372-8c713757e542)

![image](https://github.com/user-attachments/assets/2495edb7-9144-4112-835d-4f7f185d169b)

