### PR TITLE
16996 mobile trade make all fiat and crypto balances discreet

### DIFF
--- a/jest.config.native.js
+++ b/jest.config.native.js
@@ -33,5 +33,6 @@ module.exports = {
         '<rootDir>/../../suite-native/firmware/src/jestSetup.js',
         '<rootDir>/../../suite-native/connection-status/src/jestSetup.js',
         '<rootDir>/../../suite-native/react-native-graph/src/jestSetup.js',
+        '<rootDir>/../../suite-native/atoms/src/jestSetup.js',
     ],
 };

--- a/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
@@ -27,6 +27,8 @@ export type CryptoAmountFormatterDataContext = {
     isEllipsisAppended?: boolean;
 };
 
+export const BASE_CRYPTO_MAX_DISPLAYED_DECIMALS = 8;
+
 const truncateDecimals = (value: string, maxDecimals: number, isEllipsisAppended: boolean) => {
     const parts = value.split('.');
     const [integerPart, fractionalPart] = parts;
@@ -63,7 +65,7 @@ const convertToUnit = (
         !isBalance &&
         (bitcoinAmountUnit !== PROTO.AmountUnit.SATOSHI || !areAmountUnitsSupported)
     ) {
-        return formatAmount(value, decimals ?? 8);
+        return formatAmount(value, decimals ?? BASE_CRYPTO_MAX_DISPLAYED_DECIMALS);
     }
 
     return value;
@@ -83,7 +85,7 @@ export const prepareCryptoAmountFormatter = (config: FormatterConfig) =>
                 symbol,
                 isBalance = false,
                 withSymbol = true,
-                maxDisplayedDecimals = 8,
+                maxDisplayedDecimals = BASE_CRYPTO_MAX_DISPLAYED_DECIMALS,
                 isEllipsisAppended = true,
             },
             shouldRedactNumbers,

--- a/suite-common/formatters/src/index.ts
+++ b/suite-common/formatters/src/index.ts
@@ -5,3 +5,4 @@ export * from './types';
 export * from './makeFormatter';
 export * from './utils/sign';
 export * from './utils/convert';
+export { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS } from './formatters/prepareCryptoAmountFormatter';

--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { useFormatters } from '@suite-common/formatters';
+import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS, useFormatters } from '@suite-common/formatters';
 import { useSelectorDeepComparison } from '@suite-common/redux-utils';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountsListItemBase, StakingBadge } from '@suite-native/accounts';
@@ -55,8 +55,7 @@ const CryptoAmount = React.memo(({ symbol }: AssetItemSubComponentProps) => {
             value={cryptoValue}
             symbol={symbol}
             // Every asset crypto amount is rounded to 8 decimals to prevent UI overflow.
-
-            decimals={8}
+            decimals={BASE_CRYPTO_MAX_DISPLAYED_DECIMALS}
             testID={`@assets/cryptoAmount/${symbol}`}
         />
     );

--- a/suite-native/atoms/src/jestSetup.js
+++ b/suite-native/atoms/src/jestSetup.js
@@ -1,0 +1,3 @@
+jest.mock('./Skeleton/BoxSkeleton', () => ({
+    BoxSkeleton: () => null,
+}));

--- a/suite-native/module-staking-management/src/components/StakePendingCard.tsx
+++ b/suite-native/module-staking-management/src/components/StakePendingCard.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { TouchableOpacity } from 'react-native';
 import { useSelector } from 'react-redux';
 
+import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS } from '@suite-common/formatters';
 import { AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { Box, Card, Text } from '@suite-native/atoms';
 import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
@@ -93,7 +94,7 @@ export const StakePendingCard = ({
                         <CryptoAmountFormatter
                             value={totalStakePending}
                             symbol={symbol}
-                            decimals={8}
+                            decimals={BASE_CRYPTO_MAX_DISPLAYED_DECIMALS}
                             color="textDefault"
                             variant="highlight"
                         />

--- a/suite-native/module-trading/src/components/buy/ReceiveAccountCryptoBalance.tsx
+++ b/suite-native/module-trading/src/components/buy/ReceiveAccountCryptoBalance.tsx
@@ -1,6 +1,7 @@
-import { useFormatters } from '@suite-common/formatters';
+import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS } from '@suite-common/formatters';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { Box, Text } from '@suite-native/atoms';
+import { Box, DiscreetTextTrigger } from '@suite-native/atoms';
+import { CryptoAmountFormatter } from '@suite-native/formatters';
 
 export type ReceiveAccountBalanceProps = {
     symbol: NetworkSymbol | undefined;
@@ -10,16 +11,21 @@ export type ReceiveAccountBalanceProps = {
 export const RECEIVE_ACCOUNT_BALANCE_TEST_ID = '@module-trading/receive-account-balance';
 
 export const ReceiveAccountCryptoBalance = ({ symbol, balance }: ReceiveAccountBalanceProps) => {
-    const { CryptoAmountFormatter } = useFormatters();
-
     const shouldDisplayBalance = symbol && balance;
 
     return (
         <Box testID={RECEIVE_ACCOUNT_BALANCE_TEST_ID}>
             {shouldDisplayBalance && (
-                <Text variant="body" color="textSubdued">
-                    <CryptoAmountFormatter value={balance} symbol={symbol} />
-                </Text>
+                <DiscreetTextTrigger>
+                    <CryptoAmountFormatter
+                        value={balance}
+                        symbol={symbol}
+                        variant="body"
+                        color="textSubdued"
+                        isBalance={false}
+                        decimals={BASE_CRYPTO_MAX_DISPLAYED_DECIMALS}
+                    />
+                </DiscreetTextTrigger>
             )}
         </Box>
     );

--- a/suite-native/module-trading/src/components/buy/ReceiveAccountPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/ReceiveAccountPicker.tsx
@@ -7,6 +7,7 @@ import { Color } from '@trezor/theme';
 
 import { useTradeSheetControls } from '../../hooks/useTradeSheetControls';
 import { ReceiveAccount } from '../../types';
+import { AccountAddress } from '../general/AccountAddress';
 import { AccountSheet } from '../general/AccountSheet/AccountSheet';
 import { TradingOverviewRow } from '../general/TradingOverviewRow';
 
@@ -60,9 +61,13 @@ const ReceiveAccountPickerRight = ({
     return (
         <>
             <RightText color="textSubdued">{selectedAccountLabel}</RightText>
-            <RightText color="textSubdued" variant="hint">
-                {selectedAddress}
-            </RightText>
+            <AccountAddress
+                address={selectedAddress}
+                form="short"
+                color="textSubdued"
+                variant="hint"
+                textAlign="right"
+            />
         </>
     );
 };

--- a/suite-native/module-trading/src/components/general/AccountAddress.tsx
+++ b/suite-native/module-trading/src/components/general/AccountAddress.tsx
@@ -1,0 +1,21 @@
+import { Text, TextProps } from '@suite-native/atoms';
+
+type AccountAddressProps = {
+    address: string;
+    form?: 'short' | 'full';
+} & Omit<TextProps, 'numberOfLines' | 'children'>;
+
+const SHORT_ADDRESS_TRUNCATION_LENGTH = 8;
+
+export const AccountAddress = ({ address, form = 'full', ...textProps }: AccountAddressProps) => {
+    const addressToDisplay =
+        form === 'short' && address.length > SHORT_ADDRESS_TRUNCATION_LENGTH
+            ? `${address.substring(0, SHORT_ADDRESS_TRUNCATION_LENGTH)}...`
+            : address;
+
+    return (
+        <Text {...textProps} numberOfLines={1}>
+            {addressToDisplay}
+        </Text>
+    );
+};

--- a/suite-native/module-trading/src/components/general/AccountSheet/AccountListItem.tsx
+++ b/suite-native/module-trading/src/components/general/AccountSheet/AccountListItem.tsx
@@ -9,6 +9,7 @@ import { useTranslate } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { ReceiveAccount } from '../../../types';
+import { AccountAddress } from '../AccountAddress';
 
 export type AccountListItemProps = {
     symbol: NetworkSymbol;
@@ -48,7 +49,16 @@ export const AccountListItem = ({
 
     const shouldDisplayCaret = !isAddressDetail && !!account.addresses;
     const shouldDisplayBalance = !isAddressDetail || address?.balance != null;
-    const label = isAddressDetail ? address.address : account.accountLabel;
+    const label = isAddressDetail ? (
+        <AccountAddress address={address.address} form="full" />
+    ) : (
+        account.accountLabel
+    );
+    const info = isAddressDetail ? (
+        address.path
+    ) : (
+        <DisplaySymbolFormatter value={symbol} areAmountUnitsEnabled={false} />
+    );
 
     return (
         <Pressable
@@ -91,7 +101,7 @@ export const AccountListItem = ({
                             variant="hint"
                             style={applyStyle(labelTextStyle, { textColor: 'textSubdued' })}
                         >
-                            <DisplaySymbolFormatter value={symbol} areAmountUnitsEnabled={false} />
+                            {info}
                         </Text>
                         {shouldDisplayBalance && cryptoValue && (
                             <CryptoToFiatAmountFormatter

--- a/suite-native/module-trading/src/components/general/AccountSheet/AccountListItem.tsx
+++ b/suite-native/module-trading/src/components/general/AccountSheet/AccountListItem.tsx
@@ -1,9 +1,9 @@
 import { Pressable } from 'react-native';
 
-import { useFormatters } from '@suite-common/formatters';
+import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS, useFormatters } from '@suite-common/formatters';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { Box, HStack, RoundedIcon, Text, VStack } from '@suite-native/atoms';
-import { useFiatFromCryptoValue } from '@suite-native/formatters';
+import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
 import { Icon } from '@suite-native/icons';
 import { useTranslate } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -40,12 +40,11 @@ export const AccountListItem = ({
 }: AccountListItemProps) => {
     const { applyStyle } = useNativeStyles();
     const { translate } = useTranslate();
-    const { DisplaySymbolFormatter, FiatAmountFormatter, CryptoAmountFormatter } = useFormatters();
+    const { DisplaySymbolFormatter } = useFormatters();
 
     const isAddressDetail = !!address;
 
     const cryptoValue = isAddressDetail ? address.balance : account.availableBalance;
-    const fiatValue = useFiatFromCryptoValue({ symbol, cryptoValue });
 
     const shouldDisplayCaret = !isAddressDetail && !!account.addresses;
     const shouldDisplayBalance = !isAddressDetail || address?.balance != null;
@@ -72,18 +71,19 @@ export const AccountListItem = ({
                             {label}
                         </Text>
                         {shouldDisplayBalance && (
-                            <Text
+                            <CryptoAmountFormatter
+                                value={cryptoValue}
+                                symbol={account.symbol}
                                 variant="body"
-                                style={applyStyle(amountTextStyle, { textColor: 'textDefault' })}
+                                style={applyStyle(amountTextStyle, {
+                                    textColor: 'textDefault',
+                                })}
                                 accessibilityLabel={translate(
                                     'moduleTrading.accountSheet.balanceCrypto',
                                 )}
-                            >
-                                <CryptoAmountFormatter
-                                    value={cryptoValue}
-                                    symbol={account.symbol}
-                                />
-                            </Text>
+                                isBalance={false}
+                                decimals={BASE_CRYPTO_MAX_DISPLAYED_DECIMALS}
+                            />
                         )}
                     </HStack>
                     <HStack alignItems="center" justifyContent="space-between">
@@ -93,16 +93,16 @@ export const AccountListItem = ({
                         >
                             <DisplaySymbolFormatter value={symbol} areAmountUnitsEnabled={false} />
                         </Text>
-                        {shouldDisplayBalance && fiatValue && (
-                            <Text
+                        {shouldDisplayBalance && cryptoValue && (
+                            <CryptoToFiatAmountFormatter
+                                value={cryptoValue}
+                                symbol={account.symbol}
                                 variant="hint"
-                                style={applyStyle(amountTextStyle, { textColor: 'textSubdued' })}
+                                style={applyStyle(labelTextStyle, { textColor: 'textSubdued' })}
                                 accessibilityLabel={translate(
                                     'moduleTrading.accountSheet.balanceFiat',
                                 )}
-                            >
-                                <FiatAmountFormatter value={fiatValue} />
-                            </Text>
+                            />
                         )}
                     </HStack>
                 </VStack>

--- a/suite-native/module-trading/src/components/general/AccountSheet/__tests__/AccountListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountSheet/__tests__/AccountListItem.comp.test.tsx
@@ -5,8 +5,9 @@ import { Address } from '@trezor/blockchain-link-types';
 import { ReceiveAccount } from '../../../../types';
 import { AccountListItem, AccountListItemProps } from '../AccountListItem';
 
-jest.mock('@suite-native/formatters', () => ({
-    useFiatFromCryptoValue: ({ cryptoValue }: { cryptoValue: string }) => cryptoValue,
+jest.mock('@suite-common/wallet-core', () => ({
+    ...jest.requireActual('@suite-common/wallet-core'),
+    selectFiatRatesByFiatRateKey: () => ({ rate: 1e8 }),
 }));
 
 describe('AccountListItem', () => {
@@ -20,7 +21,7 @@ describe('AccountListItem', () => {
         };
         const result = renderWithStore(<AccountListItem {...props} />);
 
-        await waitFor(() => expect(result.getByText('BTC')).toBeDefined());
+        await waitFor(() => expect(result.getByAccessibilityHint('Crypto Icon')).toBeDefined());
 
         return result;
     };

--- a/suite-native/module-trading/src/components/general/__tests__/AccountAddress.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/AccountAddress.comp.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@suite-native/test-utils';
+
+import { AccountAddress } from '../AccountAddress';
+
+describe('AccountAddress', () => {
+    describe('full form', () => {
+        it('should render full address', () => {
+            const { getByText } = render(<AccountAddress address="0x1234567890abcdef" />);
+
+            expect(getByText('0x1234567890abcdef')).toBeDefined();
+        });
+    });
+
+    describe('short form', () => {
+        it('should render address with ellipsis', () => {
+            const { getByText } = render(
+                <AccountAddress address="0x1234567890abcdef" form="short" />,
+            );
+
+            expect(getByText('0x123456...')).toBeDefined();
+        });
+
+        it('should render full address when it is shorter than 9 characters', () => {
+            const { getByText } = render(<AccountAddress address="0x123456" />);
+
+            expect(getByText('0x123456')).toBeDefined();
+        });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
I also
- updated address picker item to display derivation path (inspired by desktop)
- changed how address is displayed (and introduced `AccountAddress` component)

## Related Issue

Resolve [#16996](https://github.com/trezor/trezor-suite/issues/16996)

## Screenshots:
![Screenshot 2025-02-17 at 17 58 53](https://github.com/user-attachments/assets/f96c0331-4519-4e55-b65c-72b5302a15a6)
![Screenshot 2025-02-17 at 17 59 03](https://github.com/user-attachments/assets/8cfa71f8-8eaf-45e6-bff9-60062fbb5851)

