### PR TITLE
chore(suite-desktop-core): typescriptize electron builder hooks

### DIFF
--- a/packages/suite-desktop-core/eslint.config.mjs
+++ b/packages/suite-desktop-core/eslint.config.mjs
@@ -20,4 +20,11 @@ export default [
     {
         ignores: ['**/playwright-report/', '**/test-results/'],
     },
+    {
+        files: ['**/scripts/**'],
+        rules: {
+            'no-console': 'off',
+            'import/no-default-export': 'off',
+        },
+    },
 ];

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -7,7 +7,8 @@
     "homepage": "https://trezor.io/",
     "main": "src/app.ts",
     "scripts": {
-        "build:core": "yarn g:rimraf dist && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/core.webpack.config.ts",
+        "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json",
+        "build:core": "yarn build:lib && yarn g:rimraf dist && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/core.webpack.config.ts",
         "type-check": "yarn g:tsc --build tsconfig.json",
         "test:unit": "yarn g:jest",
         "test:e2e": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts",

--- a/packages/suite-desktop-core/scripts/notarize.ts
+++ b/packages/suite-desktop-core/scripts/notarize.ts
@@ -1,8 +1,7 @@
-/* eslint-disable no-console */
+import { notarize } from '@electron/notarize';
+import type { Hooks } from 'app-builder-lib';
 
-const { notarize } = require('@electron/notarize');
-
-exports.default = context => {
+const notarizeAfterSignHook: Hooks['afterSign'] = context => {
     const { electronPlatformName, appOutDir } = context;
 
     if (electronPlatformName !== 'darwin') {
@@ -25,5 +24,8 @@ exports.default = context => {
         appleId: process.env.APPLEID,
         appleIdPassword: process.env.APPLEIDPASS,
         teamId: process.env.APPLETEAMID,
-    });
+        // TODO fix: notarize tool is known to be working, but TS fails: no overload matches this call
+    } as any);
 };
+
+export default notarizeAfterSignHook;

--- a/packages/suite-desktop-core/scripts/setElectronFuses.ts
+++ b/packages/suite-desktop-core/scripts/setElectronFuses.ts
@@ -1,14 +1,15 @@
-const { flipFuses, FuseV1Options, FuseVersion } = require('@electron/fuses');
-const path = require('path');
+import { FuseV1Options, FuseVersion, flipFuses } from '@electron/fuses';
+import type { Hooks } from 'app-builder-lib';
+import path from 'path';
 
 // copied from https://github.com/electron-userland/electron-builder/blob/04be5699c664e6a93e093b820a16ad516355b5c7/packages/app-builder-lib/src/platformPackager.ts#L430-L434
 const binaryExtensionByPlaformNameMap = {
     darwin: '.app',
     win32: '.exe',
     linux: '',
-};
+} as const;
 
-exports.default = async function afterPack(context) {
+const afterPackHookSetElectronFuses: Hooks['afterPack'] = async context => {
     const { electronPlatformName, appOutDir } = context;
 
     /*
@@ -38,3 +39,5 @@ exports.default = async function afterPack(context) {
 
     console.log('Successfully set electron fuses');
 };
+
+export default afterPackHookSetElectronFuses;

--- a/packages/suite-desktop-core/scripts/sign-windows.ts
+++ b/packages/suite-desktop-core/scripts/sign-windows.ts
@@ -1,19 +1,24 @@
-/* eslint-disable */
-exports.default = async function (configuration) {
+import type { CustomWindowsSign } from 'app-builder-lib';
+
+const signWindows: CustomWindowsSign = async configuration => {
     // Check if IS_CODESIGN_BUILD is set and true
     if (!process.env.IS_CODESIGN_BUILD || process.env.IS_CODESIGN_BUILD.toLowerCase() !== 'true') {
         console.log('This is DEV build, not signing');
+
         return;
     }
+
     // do not include passwords or other sensitive data in the file
     // rather create environment variables with sensitive data
     const CERTIFICATE_NAME = process.env.WINDOWS_SIGN_CERTIFICATE_NAME;
     const TOKEN_PASSWORD = process.env.WINDOWS_SIGN_TOKEN_PASSWORD;
 
-    require('child_process').execSync(
+    await require('child_process').exec(
         `java -jar ../suite-desktop-core/scripts/jsign-6.0.jar --keystore ../suite-desktop-core/scripts/hardwareToken.cfg --storepass '${TOKEN_PASSWORD}' --storetype PKCS11 --tsaurl http://timestamp.digicert.com --alias "${CERTIFICATE_NAME}" "${configuration.path}"`,
         {
             stdio: 'inherit',
         },
     );
 };
+
+export default signWindows;

--- a/packages/suite-desktop-core/tsconfig.json
+++ b/packages/suite-desktop-core/tsconfig.json
@@ -5,7 +5,12 @@
         "moduleResolution": "node",
         "outDir": "libDev"
     },
-    "include": ["src", "e2e", "**/*.json"],
+    "include": [
+        "src",
+        "e2e",
+        "scripts",
+        "**/*.json"
+    ],
     "references": [
         {
             "path": "../../suite-common/message-system"

--- a/packages/suite-desktop-core/tsconfig.lib.json
+++ b/packages/suite-desktop-core/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+    "extends": "../../tsconfig.lib.json",
+    "compilerOptions": {
+        "outDir": "lib"
+    },
+    "include": ["./scripts"],
+    "references": [
+        {
+            "path": "../eslint"
+        }
+    ]
+}

--- a/packages/suite-desktop/electron-builder-config.js
+++ b/packages/suite-desktop/electron-builder-config.js
@@ -134,7 +134,7 @@ module.exports = {
         target: ['nsis'],
         signtoolOptions: {
             publisherName: ['SatoshiLabs, s.r.o.', 'Trezor Company s.r.o.'],
-            sign: '../suite-desktop-core/scripts/sign-windows.ts',
+            sign: '../suite-desktop-core/lib/sign-windows.js',
         },
     },
     linux: {
@@ -162,6 +162,6 @@ module.exports = {
         category: 'Utility',
         target: ['AppImage'],
     },
-    afterPack: '../suite-desktop-core/scripts/setElectronFuses.js',
-    afterSign: '../suite-desktop-core/scripts/notarize.ts',
+    afterPack: '../suite-desktop-core/lib/setElectronFuses.js',
+    afterSign: '../suite-desktop-core/lib/notarize.js',
 };


### PR DESCRIPTION
## Description

Actually use TypeScript for electron-builder hooks - currently they have `.ts` extension, but are written plain JavaScript (CJS, as electron-builder needs), and type checking never ever happens.

- rewrite CJS to TS (ESM)
- include scripts to `type-check`. We don't do it for most JS scripts, but these scripts are built around API of electron-builder & electron/notarize, and IMO they'd really benefit from being typechecked
  - and indeed, there is inconsistent TS in [notarize.ts](https://github.com/trezor/trezor-suite/pull/17056/files#diff-503ee41462b840240200c07b1c391ba370cc013e6782cfc19549ccb294ea0c4b)
    - probably when `@electron/notarize` was bumped by yours truly, but I couldn't have noticed when I believed it was TS, yet didn't know it's not really TS :sweat_smile:  
- add `build:lib` to compile them to CJS for electron-builder right before building
- fix eslint

## Related Issue

Followup to https://github.com/trezor/trezor-suite-private/issues/16 and https://github.com/trezor/trezor-suite/pull/17050 