### PR TITLE
fix(suite-native): staking icon size

### DIFF
--- a/suite-native/accounts/src/components/AccountsList/AccountsListStakingItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListStakingItem.tsx
@@ -2,6 +2,7 @@ import { Account } from '@suite-common/wallet-types';
 import { RoundedIcon } from '@suite-native/atoms';
 import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
+import { useNativeStyles } from '@trezor/styles';
 
 import { AccountsListItemBase } from './AccountsListItemBase';
 
@@ -20,27 +21,37 @@ export const AccountsListStakingItem = ({
     stakingCryptoBalance,
     isLast,
     ...props
-}: AccountsListStakingItemProps) => (
-    <AccountsListItemBase
-        {...props}
-        isLast={isLast}
-        showDivider={!isLast}
-        icon={<RoundedIcon name="piggyBankFilled" color="iconSubdued" />}
-        title={<Translation id="accountList.staking" />}
-        mainValue={
-            <CryptoToFiatAmountFormatter
-                value={stakingCryptoBalance}
-                symbol={account.symbol}
-                isBalance
-            />
-        }
-        secondaryValue={
-            <CryptoAmountFormatter
-                value={stakingCryptoBalance}
-                symbol={account.symbol}
-                numberOfLines={1}
-                adjustsFontSizeToFit
-            />
-        }
-    />
-);
+}: AccountsListStakingItemProps) => {
+    const { utils } = useNativeStyles();
+
+    return (
+        <AccountsListItemBase
+            {...props}
+            isLast={isLast}
+            showDivider={!isLast}
+            icon={
+                <RoundedIcon
+                    name="piggyBankFilled"
+                    color="iconSubdued"
+                    containerSize={utils.spacings.sp32}
+                />
+            }
+            title={<Translation id="accountList.staking" />}
+            mainValue={
+                <CryptoToFiatAmountFormatter
+                    value={stakingCryptoBalance}
+                    symbol={account.symbol}
+                    isBalance
+                />
+            }
+            secondaryValue={
+                <CryptoAmountFormatter
+                    value={stakingCryptoBalance}
+                    symbol={account.symbol}
+                    numberOfLines={1}
+                    adjustsFontSizeToFit
+                />
+            }
+        />
+    );
+};


### PR DESCRIPTION
Changed size of staking icon to fit other icons style

## Related Issue

Resolve #17036

## Screenshots:

before:
<img width=250 src="https://github.com/user-attachments/assets/1ebec439-401f-4562-8e9c-273f56ecd7c3" />
after:
<img width=250 src="https://github.com/user-attachments/assets/7c246e88-5128-4c28-b101-fddc30323020" />
