### PR TITLE
fix(trading): fixed swap inputs validation and styling

### DIFF
--- a/packages/components/src/components/form/Switch/Switch.tsx
+++ b/packages/components/src/components/form/Switch/Switch.tsx
@@ -63,7 +63,7 @@ const Container = styled.div<{
                     : theme.backgroundNeutralDisabled};
             }
 
-            :hover {
+            &:hover {
                 background: ${$isChecked
                     ? theme.backgroundPrimaryPressed
                     : theme.backgroundNeutralSubdued};

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.tsx
@@ -166,10 +166,6 @@ const useTradingVerifyAccount = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [accounts]);
 
-    useEffect(() => {
-        methods.trigger();
-    }, [methods]);
-
     return {
         form: {
             ...methods,

--- a/packages/suite/src/views/wallet/trading/common/ConfirmedOnTrezor.tsx
+++ b/packages/suite/src/views/wallet/trading/common/ConfirmedOnTrezor.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { variables } from '@trezor/components';
 import { RotateDeviceImage } from '@trezor/product-components';
+import { borders } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
 
@@ -18,6 +19,7 @@ const Confirmed = styled.div`
     justify-content: center;
     margin-top: 27px;
     gap: 10px;
+    border-radius: ${borders.radii.sm};
 `;
 
 // reason: set size of RotateDeviceImage

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerify.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerify.tsx
@@ -23,6 +23,7 @@ import {
 } from 'src/utils/wallet/trading/tradingTypingUtils';
 import { ConfirmedOnTrezor } from 'src/views/wallet/trading/common/ConfirmedOnTrezor';
 import { TradingAddressOptions } from 'src/views/wallet/trading/common/TradingAddressOptions';
+import { TradingVerifyDestinationTag } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerifyDestinationTag';
 import { TradingVerifyOptions } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerifyOptions';
 
 interface TradingVerifyProps {
@@ -163,25 +164,31 @@ export const TradingVerify = ({ tradingVerifyAccount, cryptoId }: TradingVerifyP
                     />
                 )}
 
+                {exchangeQuote?.extraFieldDescription && (
+                    <TradingVerifyDestinationTag
+                        inputComponent={
+                            <Input
+                                label={
+                                    <Translation
+                                        id="TR_EXCHANGE_EXTRA_FIELD"
+                                        values={extraFieldDescription}
+                                    />
+                                }
+                                inputState={form.formState.errors.extraField ? 'error' : undefined}
+                                bottomText={form.formState.errors.extraField?.message || null}
+                                innerRef={descriptionRef}
+                                {...descriptionField}
+                            />
+                        }
+                        onToggle={() => form.setValue('extraField', '', { shouldValidate: true })}
+                        required={exchangeQuote.extraFieldDescription.required}
+                    />
+                )}
+
                 {device?.connected &&
                     device.available &&
                     addressVerified &&
                     addressVerified === address && <ConfirmedOnTrezor device={device} />}
-
-                {exchangeQuote?.extraFieldDescription && (
-                    <Input
-                        label={
-                            <Translation
-                                id="TR_EXCHANGE_EXTRA_FIELD"
-                                values={extraFieldDescription}
-                            />
-                        }
-                        inputState={form.formState.errors.extraField ? 'error' : undefined}
-                        bottomText={form.formState.errors.extraField?.message || null}
-                        innerRef={descriptionRef}
-                        {...descriptionField}
-                    />
-                )}
             </Column>
             {selectedAccountOption && (
                 <Column>
@@ -226,7 +233,13 @@ export const TradingVerify = ({ tradingVerifyAccount, cryptoId }: TradingVerifyP
                                     confirmTrade(address, extraField);
                                 }
                             }}
-                            isDisabled={!form.formState.isValid || address === '' || callInProgress}
+                            isDisabled={
+                                !form.formState.isValid ||
+                                address === '' ||
+                                callInProgress ||
+                                (exchangeQuote?.extraFieldDescription?.required &&
+                                    extraField === '')
+                            }
                         >
                             <Translation id="TR_BUY_GO_TO_PAYMENT" />
                         </Button>

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerify.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerify.tsx
@@ -124,7 +124,8 @@ export const TradingVerify = ({ tradingVerifyAccount, cryptoId }: TradingVerifyP
                     </Tooltip>
                 }
             />
-            <Column gap={spacings.xxs}>
+
+            <Column gap={spacings.sm}>
                 {selectedAccountOption?.type === 'SUITE' &&
                     selectedAccountOption?.account?.networkType === 'bitcoin' && (
                         <TradingAddressOptions
@@ -169,7 +170,6 @@ export const TradingVerify = ({ tradingVerifyAccount, cryptoId }: TradingVerifyP
 
                 {exchangeQuote?.extraFieldDescription && (
                     <Input
-                        size="small"
                         label={
                             <Translation
                                 id="TR_EXCHANGE_EXTRA_FIELD"
@@ -226,7 +226,7 @@ export const TradingVerify = ({ tradingVerifyAccount, cryptoId }: TradingVerifyP
                                     confirmTrade(address, extraField);
                                 }
                             }}
-                            isDisabled={!form.formState.isValid || callInProgress}
+                            isDisabled={!form.formState.isValid || address === '' || callInProgress}
                         >
                             <Translation id="TR_BUY_GO_TO_PAYMENT" />
                         </Button>

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerifyDestinationTag.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerifyDestinationTag.tsx
@@ -1,0 +1,52 @@
+import { ReactNode, useState } from 'react';
+
+import { Button, Column, Row, Switch } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
+import { Translation } from 'src/components/suite';
+import { useGuideOpenNode } from 'src/hooks/guide';
+import { DESTINATION_TAG_GUIDE_PATH } from 'src/views/wallet/send/Options/RippleOptions/DestinationTag';
+
+export interface TradingVerifyDestinationTagProps {
+    inputComponent: ReactNode;
+    onToggle?: (toggled: boolean) => void;
+    required: boolean;
+}
+
+export const TradingVerifyDestinationTag = ({
+    inputComponent,
+    onToggle,
+    required,
+}: TradingVerifyDestinationTagProps) => {
+    const { openNodeById } = useGuideOpenNode();
+
+    const [enabled, setEnabled] = useState<boolean>(required);
+
+    const handleToggle = (isChecked: boolean) => {
+        setEnabled(isChecked);
+        onToggle?.(isChecked);
+    };
+
+    const handleOpenGuide = (e: React.MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation();
+        openNodeById(DESTINATION_TAG_GUIDE_PATH);
+    };
+
+    return (
+        <Column gap={spacings.md}>
+            <Row justifyContent="space-between">
+                <Switch
+                    isChecked={enabled}
+                    onChange={handleToggle}
+                    label={<Translation id="DESTINATION_TAG_SWITCH" />}
+                    isDisabled={required}
+                />
+                <Button variant="tertiary" type="button" size="tiny" onClick={handleOpenGuide}>
+                    <Translation id="DESTINATION_TAG_GUIDE_LINK" />
+                </Button>
+            </Row>
+
+            {enabled && inputComponent}
+        </Column>
+    );
+};


### PR DESCRIPTION
## Description

- the receive address input and the extra field inputs are displayed only after the user selects whether to create a new account or to use an account that isn't in Suite
- the receive address input shows errors only after the user has interacted with it
- the extra field inputs (memo, destination tag, ...) have better styling for readability

## Related Issue

Resolve #16954 
Resolve #17071 

## Screenshots:

https://github.com/user-attachments/assets/4c33643c-ecf6-407f-b415-b0fcb80534c9
