### PR TITLE
feat(suite-native): add icon to Learn More in FW check settings

### DIFF
--- a/suite-native/module-settings/src/components/TurnOffFirmwareAuthenticityCheckCard.tsx
+++ b/suite-native/module-settings/src/components/TurnOffFirmwareAuthenticityCheckCard.tsx
@@ -25,6 +25,7 @@ const LearnMoreButton = () => {
     return (
         <Button
             size="small"
+            viewLeft="arrowSquareOut"
             onPress={handleButtonPress}
             colorScheme="tertiaryElevation0"
             style={applyStyle(fullWidthButtonStyle)}

--- a/suite-native/module-settings/src/components/TurnOffFirmwareAuthenticityCheckCard.tsx
+++ b/suite-native/module-settings/src/components/TurnOffFirmwareAuthenticityCheckCard.tsx
@@ -16,8 +16,11 @@ import { HELP_CENTER_FIRMWARE_REVISION_CHECK_MOBILE } from '@trezor/urls';
 import { useSettingsNavigateTo } from '../navigation/useSettingsNavigateTo';
 
 const fullWidthButtonStyle = prepareNativeStyle(() => ({ flex: 1 }));
+const shrinkedButtonStyle = prepareNativeStyle(utils => ({
+    paddingHorizontal: utils.spacings.sp16,
+}));
 
-const LearnMoreButton = () => {
+const LearnMoreButton = ({ fullWidth }: { fullWidth?: boolean }) => {
     const { applyStyle } = useNativeStyles();
     const openLink = useOpenLink();
     const handleButtonPress = () => openLink(HELP_CENTER_FIRMWARE_REVISION_CHECK_MOBILE);
@@ -28,7 +31,7 @@ const LearnMoreButton = () => {
             viewLeft="arrowSquareOut"
             onPress={handleButtonPress}
             colorScheme="tertiaryElevation0"
-            style={applyStyle(fullWidthButtonStyle)}
+            style={applyStyle(fullWidth ? fullWidthButtonStyle : shrinkedButtonStyle)}
         >
             <Translation id="moduleSettings.deviceChecks.firmwareAuthenticityCheck.buttonLearnMore" />
         </Button>
@@ -61,6 +64,7 @@ const TurnOnButton = () => {
 };
 
 const TurnOffButton = () => {
+    const { applyStyle } = useNativeStyles();
     const navigateTo = useSettingsNavigateTo();
 
     const handleButtonPress = () => {
@@ -68,7 +72,12 @@ const TurnOffButton = () => {
     };
 
     return (
-        <Button size="small" onPress={handleButtonPress} colorScheme="redElevation0">
+        <Button
+            size="small"
+            onPress={handleButtonPress}
+            colorScheme="redElevation0"
+            style={applyStyle(shrinkedButtonStyle)}
+        >
             <Translation id="moduleSettings.deviceChecks.firmwareAuthenticityCheck.buttonTurnOff" />
         </Button>
     );
@@ -90,7 +99,7 @@ export const TurnOffFirmwareAuthenticityCheckCard = () => {
                     {isFwAuthenticityCheckEnabled ? (
                         <>
                             <TurnOffButton />
-                            <LearnMoreButton />
+                            <LearnMoreButton fullWidth />
                         </>
                     ) : (
                         <>


### PR DESCRIPTION
## Description

Followup to #16435 - add icon to the Learn more button, as the figma design was [updated.](https://www.figma.com/design/eKie94qfryjTHEnR8jfmgk?node-id=4384-15272#1115832371)

## Screenshots:
![image](https://github.com/user-attachments/assets/6cf5c2df-b937-40a5-a51c-e6c49329781c)

@coderabbitai ignore
