### PR TITLE
ci: bump github/codeql-action to v3

### DIFF
--- a/.github/workflows/check-codeql-analysis.yml
+++ b/.github/workflows/check-codeql-analysis.yml
@@ -33,9 +33,9 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
to get rid of CI warnings

https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/