### PR TITLE
fix(suite-desktop-core): remove obsolete option from notarize call

### DIFF
--- a/packages/suite-desktop-core/scripts/notarize.ts
+++ b/packages/suite-desktop-core/scripts/notarize.ts
@@ -19,13 +19,11 @@ const notarizeAfterSignHook: Hooks['afterSign'] = context => {
 
     return notarize({
         tool: 'notarytool',
-        appBundleId: 'io.trezor.TrezorSuite',
         appPath,
         appleId: process.env.APPLEID,
         appleIdPassword: process.env.APPLEIDPASS,
         teamId: process.env.APPLETEAMID,
-        // TODO fix: notarize tool is known to be working, but TS fails: no overload matches this call
-    } as any);
+    });
 };
 
 export default notarizeAfterSignHook;


### PR DESCRIPTION
## Description

Followup to https://github.com/trezor/trezor-suite/pull/17056, where TS was turned on, and gave error at  `@electron/notarize` interface.

I am sure that `appBundleId` option is useless :heavy_check_mark: 

Based on `tool` option there are [two interfaces: new & legacy](https://github.com/electron/notarize/blob/268fa302d3e8f330fff069729dad8347a15490dd/src/index.ts#L31-L42).
We're on [v2.5.0](https://github.com/electron/notarize/releases/tag/v2.5.0) so I looked at the repo at that commit.
- `'legacy'` is actually not implemented, it just throws error (see link above)
- `appBundleId` is not mentioned anywhere in code but [the legacy type declaration](https://github.com/electron/notarize/blob/268fa302d3e8f330fff069729dad8347a15490dd/src/types.ts#L120)
- in trezor-suite, that option has not been effective since https://github.com/trezor/trezor-suite/commit/52ac30b103956f44f9a28f24792d635d2808c289 (migrated to new interface)

[FYI docs for the new interface](https://github.com/electron/notarize?tab=readme-ov-file#usage-with-app-specific-password)

@coderabbitai ignore