### PR TITLE
fix(suite-native): validate custom fee fields after transforming value

### DIFF
--- a/suite-native/module-send/src/components/CustomFeeInputs.tsx
+++ b/suite-native/module-send/src/components/CustomFeeInputs.tsx
@@ -8,6 +8,7 @@ import { getFeeUnits } from '@suite-common/wallet-utils';
 import { Hint, Text, VStack } from '@suite-native/atoms';
 import { TextInputField, useFormContext } from '@suite-native/forms';
 import { Translation, useTranslate } from '@suite-native/intl';
+import { useDebounce } from '@trezor/react-utils';
 
 import { integerTransformer, useSendAmountTransformers } from '../hooks/useSendAmountTransformers';
 import { SendFeesFormValues } from '../sendFeesFormSchema';
@@ -20,10 +21,14 @@ export const CustomFeeInputs = ({ symbol }: CustomFeeInputsProps) => {
     const { translate } = useTranslate();
     const feeInfo = useSelector((state: FeesRootState) => selectNetworkFeeInfo(state, 'btc'));
     const { cryptoAmountTransformer } = useSendAmountTransformers(symbol);
-
+    const debounce = useDebounce();
     const {
         formState: { errors },
+        setValue,
+        trigger,
     } = useFormContext<SendFeesFormValues>();
+
+    const customFeeLimitName = 'customFeeLimit';
     const feePerUnitFieldName = 'customFeePerUnit';
     const hasFeePerByteError = G.isNotNullable(errors[feePerUnitFieldName]);
 
@@ -31,16 +36,25 @@ export const CustomFeeInputs = ({ symbol }: CustomFeeInputsProps) => {
     const feeUnits = getFeeUnits(networkType);
     const formattedFeePerUnit = `${feeInfo?.minFee} ${feeUnits}`;
 
+    const handleFieldChangeValue =
+        (fieldName: keyof SendFeesFormValues, transformer: (value: string) => string) =>
+        (value: string) => {
+            const transformedValue = transformer(value);
+            setValue(fieldName, transformedValue);
+
+            debounce(() => trigger(fieldName));
+        };
+
     return (
         <VStack spacing="sp8">
             {networkType === 'ethereum' && (
                 <TextInputField
                     label={translate('moduleSend.fees.custom.bottomSheet.label.gasLimit')}
-                    name="customFeeLimit"
-                    testID="customFeeLimit"
+                    name={customFeeLimitName}
+                    testID={`@send/${customFeeLimitName}-input`}
                     accessibilityLabel="address input"
                     keyboardType="number-pad"
-                    valueTransformer={integerTransformer}
+                    onChangeText={handleFieldChangeValue(customFeeLimitName, integerTransformer)}
                 />
             )}
             <TextInputField
@@ -54,7 +68,7 @@ export const CustomFeeInputs = ({ symbol }: CustomFeeInputsProps) => {
                 accessibilityLabel="address input"
                 keyboardType="number-pad"
                 rightIcon={<Text color="textSubdued">{feeUnits}</Text>}
-                valueTransformer={cryptoAmountTransformer}
+                onChangeText={handleFieldChangeValue(feePerUnitFieldName, cryptoAmountTransformer)}
             />
             {networkType !== 'ethereum' && !hasFeePerByteError && (
                 <Hint variant="info">


### PR DESCRIPTION
When setting custom field, the validation was triggered before the value was transformed. This caused odd behaviour in case user inserted non numerical characters.

## Screenshots:

BEFORE:

https://github.com/user-attachments/assets/3ebf838c-5d21-4f56-bc16-805cba69d2b6



AFTER:

https://github.com/user-attachments/assets/fe945592-b14e-4858-aa74-c04c0d8179ac

