### PR TITLE
fix(suite-native): maximum icon enlargement

### DIFF
--- a/suite-native/icons/src/Icon.tsx
+++ b/suite-native/icons/src/Icon.tsx
@@ -15,6 +15,9 @@ export type AnimatedIconColor = Color | CSSColor | SharedValue<CSSColor>;
 
 export const icons = codepoints;
 
+// Limit the maximum font size multiplier to 1.5 to prevent layout issues if the user has accessibility font size settings set to maximum.
+const MAX_FONT_SIZE_MULTIPLIER = 1.5;
+
 /**
  * @description If you need to add a new icon, please follow these steps:
  * 1. Add the icon name to the file `generateIconFont.ts`.
@@ -68,7 +71,11 @@ export const Icon = ({ name, size = 'large', color = 'iconDefault', ...props }: 
     }, [sizeNumber, color, colors]);
 
     return (
-        <DefaultTextComponent style={style} {...props}>
+        <DefaultTextComponent
+            style={style}
+            {...props}
+            maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+        >
             {char}
         </DefaultTextComponent>
     );
@@ -131,7 +138,11 @@ const AnimatedIcon = ({
     }));
 
     return (
-        <Animated.Text style={[baseStyle, style]} {...props}>
+        <Animated.Text
+            style={[baseStyle, style]}
+            {...props}
+            maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+        >
             {char}
         </Animated.Text>
     );


### PR DESCRIPTION
## Related Issue

Resolve #16561 

## Screenshots:
### iOS font enlargement set to maximum:
https://github.com/user-attachments/assets/2f0c5a2c-fc9e-4ca8-a162-02771c04935c


