### PR TITLE
Connect Device stuff refactoring 

### DIFF
--- a/packages/connect/src/api/resetDevice.ts
+++ b/packages/connect/src/api/resetDevice.ts
@@ -1,6 +1,5 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/ResetDevice.js
 import { Assert } from '@trezor/schema-utils';
-import { ERRORS_WITHOUT_DEVICE_INTERACTION } from '@trezor/transport/src/errors-groups';
 import { getRandomInt } from '@trezor/utils';
 
 import { generateEntropy, verifyEntropy } from '../api/firmware/verifyEntropy';
@@ -10,11 +9,7 @@ import { UI } from '../events';
 import { getFirmwareRange } from './common/paramsValidator';
 import { validatePath } from '../utils/pathUtils';
 
-type EntropyRequestData = PROTO.EntropyRequest & { host_entropy: string };
-
 export default class ResetDevice extends AbstractMethod<'resetDevice', PROTO.ResetDevice> {
-    private isEntropyCheckSuccessful: boolean = false;
-
     init() {
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
         this.useDeviceState = false;
@@ -51,95 +46,91 @@ export default class ResetDevice extends AbstractMethod<'resetDevice', PROTO.Res
         };
     }
 
-    // generate host_entropy and then call workflow:
-    // - ResetDevice > EntropyRequest > EntropyAck
-    // - EntropyCheckContinue > EntropyRequest > EntropyAck
-    private async getEntropyData(
-        type: 'ResetDevice' | 'EntropyCheckContinue',
-    ): Promise<EntropyRequestData> {
+    // https://github.com/trezor/trezor-firmware/blob/57868ad48f4c462bb1f4fa57572067e89a039a60/docs/common/message-workflows.md#simple-resetdevice-workflow
+    private async resetDeviceWorkflow() {
         const cmd = this.device.getCommands();
         const entropy = generateEntropy(32).toString('hex');
-        const params = type === 'ResetDevice' ? this.params : {};
-        const entropyRequest = await cmd.typedCall(type, 'EntropyRequest', params);
-        // EntropyAck > Success if this.params.entropy_check === false
-        await cmd.typedCall('EntropyAck', ['EntropyCheckReady', 'Success'], { entropy });
 
-        return {
-            ...entropyRequest.message,
-            host_entropy: entropy,
-        };
+        // ResetDevice > EntropyRequest > EntropyAck > Success (old fw)
+        await cmd.typedCall('ResetDevice', 'EntropyRequest', this.params);
+        await cmd.typedCall('EntropyAck', 'Success', { entropy });
     }
 
-    private async entropyCheck(prevData: EntropyRequestData): Promise<EntropyRequestData> {
+    // https://github.com/trezor/trezor-firmware/blob/57868ad48f4c462bb1f4fa57572067e89a039a60/docs/common/message-workflows.md#entropy-check-workflow
+    private async entropyCheckWorkflow() {
         const cmd = this.device.getCommands();
-        const paths = ["m/84'/0'/0'", "m/44'/60'/0'"];
-        const xpubs: Record<string, string> = {}; // <path, xpub>
-        for (let i = 0; i < paths.length; i++) {
-            const p = paths[i];
-            const pubKey = await cmd.getPublicKey({ address_n: validatePath(p) });
-            xpubs[p] = pubKey.xpub;
+        const paths = ["m/84'/0'/0'", "m/44'/60'/0'"] as const;
+
+        // error.message should be one of these https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/transports/abstract.ts#L59
+        const handleErr = (error: any) => {
+            throw error.cause === 'transport-error'
+                ? error
+                : ERRORS.TypedError('Failure_EntropyCheck', error.message);
+        };
+
+        // steps: 1 - 4
+        // ResetDevice > EntropyRequest > EntropyAck > EntropyCheckReady (new fw)
+        // note: these calls are intentionally excluded from the catch error handling because it is not in the 'critical' phase yet
+        let entropy = generateEntropy(32).toString('hex');
+        let commitment = await cmd
+            .typedCall('ResetDevice', 'EntropyRequest', this.params)
+            .then(response => response.message.entropy_commitment);
+
+        await cmd.typedCall('EntropyAck', 'EntropyCheckReady', { entropy });
+
+        const tries = getRandomInt(1, 5);
+        for (let i = 0; i < tries; i++) {
+            // steps: 5 - 6
+            // GetPublicKey > PublicKey > EntropyCheckContinue > EntropyRequest > EntropyAck > EntropyCheckReady
+
+            const xpubs: Record<string, string> = {}; // <path, xpub>
+            for (const path of paths) {
+                const pubKey = await cmd
+                    .getPublicKey({ address_n: validatePath(path) })
+                    .catch(handleErr);
+                xpubs[path] = pubKey.xpub;
+            }
+
+            const { prev_entropy, entropy_commitment } = await cmd
+                .typedCall('EntropyCheckContinue', 'EntropyRequest', {})
+                .then(response => response.message)
+                .catch(handleErr);
+
+            const res = await verifyEntropy({
+                type: this.params.backup_type,
+                strength: this.params.strength,
+                commitment,
+                hostEntropy: entropy,
+                trezorEntropy: prev_entropy,
+                xpubs,
+            });
+
+            if (res.error) {
+                await this.device.getCurrentSession().cancelCall();
+                throw ERRORS.TypedError('Failure_EntropyCheck', res.error);
+            }
+
+            entropy = generateEntropy(32).toString('hex');
+            commitment = entropy_commitment;
+
+            await cmd.typedCall('EntropyAck', 'EntropyCheckReady', { entropy }).catch(handleErr);
         }
 
-        const currentData = await this.getEntropyData('EntropyCheckContinue');
-        const res = await verifyEntropy({
-            type: this.params.backup_type,
-            strength: this.params.strength,
-            commitment: prevData.entropy_commitment,
-            hostEntropy: prevData.host_entropy,
-            trezorEntropy: currentData.prev_entropy,
-            xpubs,
-        });
-        if (res.error) {
-            await this.device.getCurrentSession().cancelCall();
-            throw new Error(res.error);
-        }
-
-        return currentData;
+        // step 7 EntropyCheckContinue > Success
+        // wallet backup flow may follow after successful entropy check, so don't consider errors thrown there as entropy check failure
+        await cmd.typedCall('EntropyCheckContinue', 'Success', { finish: true });
     }
 
     async run() {
-        const cmd = this.device.getCommands();
-
         if (this.params.entropy_check && this.device.unavailableCapabilities['entropyCheck']) {
             // entropy check requested but not supported by the firmware
             this.params.entropy_check = false;
         }
 
-        // Entropy check workflow:
-        // https://github.com/trezor/trezor-firmware/blob/57868ad48f4c462bb1f4fa57572067e89a039a60/docs/common/message-workflows.md#entropy-check-workflow
-        // steps: 1 - 4
-        // ResetDevice > EntropyRequest > EntropyAck > EntropyCheckReady (new fw) || Success (old fw)
-        let entropyData = await this.getEntropyData('ResetDevice'); // this call is intentionally excluded from the catch error handling below because it is not in the 'critical' phase yet
-
-        try {
-            if (this.params.entropy_check) {
-                const tries = getRandomInt(1, 5);
-                for (let i = 0; i < tries; i++) {
-                    // steps: 5 - 6
-                    // GetPublicKey > ResetDeviceContinue > EntropyRequest > EntropyAck > EntropyCheckReady
-                    entropyData = await this.entropyCheck(entropyData);
-                }
-
-                // if this.entropyCheck hasn't thrown up to now, we may consider it successful
-                this.isEntropyCheckSuccessful = true;
-
-                // step 7 EntropyCheckContinue > Success
-                await cmd.typedCall('EntropyCheckContinue', 'Success', { finish: true });
-            }
-        } catch (error) {
-            // permissible error.message during entropy check should be one of these: see ReadWriteError in packages/transport/src/transports/abstract.ts
-            if (
-                error.cause === 'transport-error' &&
-                ERRORS_WITHOUT_DEVICE_INTERACTION.includes(error.message)
-            ) {
-                throw error;
-            }
-
-            // wallet backup flow may follow after successful entropy check, so don't consider errors thrown there as entropy check failure
-            if (this.isEntropyCheckSuccessful === true) throw error;
-
-            // else consider it an entropy check failure
-            throw ERRORS.TypedError('Failure_EntropyCheck', error.message);
+        if (this.params.entropy_check) {
+            await this.entropyCheckWorkflow();
+        } else {
+            await this.resetDeviceWorkflow();
         }
 
         return { message: 'Success' };

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -3,8 +3,8 @@ import { randomBytes } from 'crypto';
 
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { TransportProtocol, thp as protocolThp, v1 as protocolV1 } from '@trezor/protocol';
-import { Session, TRANSPORT } from '@trezor/transport';
-import { type Descriptor, TRANSPORT_ERROR, type Transport } from '@trezor/transport';
+import { Session, TRANSPORT, TRANSPORT_ERROR } from '@trezor/transport';
+import { type Descriptor, type Transport } from '@trezor/transport';
 import { TransportDeviceEvent } from '@trezor/transport/src/transports/abstract';
 import {
     Deferred,
@@ -212,21 +212,20 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
         this.sessionAcquired = null;
 
+        transport.on(TRANSPORT.STOPPED, this.onTransportStopped);
         transport.deviceEvents.on(this.transportPath, this.onTransportDeviceEvent);
     }
+
+    private readonly onTransportStopped = () => this.disconnect();
 
     private readonly onTransportDeviceEvent = (event: TransportDeviceEvent) => {
         switch (event.type) {
             case TRANSPORT.DEVICE_SESSION_CHANGED:
-                this.updateDescriptor(event.descriptor);
-                break;
+                return this.updateDescriptor(event.descriptor);
             case TRANSPORT.DEVICE_REQUEST_RELEASE:
-                this.usedElsewhere();
-                break;
+                return this.usedElsewhere();
             case TRANSPORT.DEVICE_DISCONNECTED: {
-                this.transport.deviceEvents.off(this.transportPath, this.onTransportDeviceEvent);
-                this.disconnect();
-                break;
+                return this.disconnect();
             }
         }
     };
@@ -1049,12 +1048,18 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     private disconnect() {
-        // TODO: cleanup everything
         _log.debug('Disconnect cleanup');
+
+        this.transport.off(TRANSPORT.STOPPED, this.onTransportStopped);
+        this.transport.deviceEvents.off(this.transportPath, this.onTransportDeviceEvent);
+        this.removeAllListeners();
 
         this.sessionDfd?.reject(new Error());
 
-        this.sessionAcquired = null; // set to null to prevent transport.release and cancelableAction
+        if (this.sessionAcquired) {
+            this.transport.releaseSync(this.sessionAcquired);
+            this.sessionAcquired = null; // set to null to prevent transport.release and cancelableAction
+        }
 
         this.emitLifecycle(DEVICE.DISCONNECT);
         this.emitLifecycle = () => {};
@@ -1138,13 +1143,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
         }
 
         return null;
-    }
-
-    dispose() {
-        this.removeAllListeners();
-        if (this.sessionAcquired) {
-            this.transport.releaseSync(this.sessionAcquired);
-        }
     }
 
     private getMode() {

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -407,7 +407,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         const { signal } = this.runAbort;
 
         this.runPromise = Promise.race([
-            this._runInner(fn, options),
+            this._runInner(fn, options, signal),
             new Promise<never>((_, reject) => {
                 signal.addEventListener('abort', () => reject(signal.reason));
             }),
@@ -467,6 +467,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     private async _runInner<X>(
         fn: (() => Promise<X>) | undefined,
         options: RunOptions,
+        abortSignal: AbortSignal,
     ): Promise<void> {
         // typically when using cancel/override, device might be releasing
         // note: I am tempted to do this check at the beginning of device.acquire but on the other hand I would like
@@ -480,6 +481,8 @@ export class Device extends TypedEmitter<DeviceEvents> {
             // acquire session
             await this.acquire();
         }
+
+        if (abortSignal.aborted) throw abortSignal.reason;
 
         const { staticSessionId, deriveCardano } = this.getState() || {};
         if (acquireNeeded || !staticSessionId || (!deriveCardano && options.useCardanoDerivation)) {

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -3,8 +3,9 @@ import { randomBytes } from 'crypto';
 
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { TransportProtocol, thp as protocolThp, v1 as protocolV1 } from '@trezor/protocol';
-import { Session } from '@trezor/transport';
+import { Session, TRANSPORT } from '@trezor/transport';
 import { type Descriptor, TRANSPORT_ERROR, type Transport } from '@trezor/transport';
+import { TransportDeviceEvent } from '@trezor/transport/src/transports/abstract';
 import {
     Deferred,
     TypedEmitter,
@@ -219,7 +220,25 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
         this.session = descriptor.session;
         this.lastAcquiredHere = false;
+
+        transport.deviceEvents.on(this.transportPath, this.onTransportDeviceEvent);
     }
+
+    private readonly onTransportDeviceEvent = (event: TransportDeviceEvent) => {
+        switch (event.type) {
+            case TRANSPORT.DEVICE_SESSION_CHANGED:
+                this.updateDescriptor(event.descriptor);
+                break;
+            case TRANSPORT.DEVICE_REQUEST_RELEASE:
+                this.usedElsewhere();
+                break;
+            case TRANSPORT.DEVICE_DISCONNECTED: {
+                this.transport.deviceEvents.off(this.transportPath, this.onTransportDeviceEvent);
+                this.disconnect();
+                break;
+            }
+        }
+    };
 
     private getSessionChangePromise() {
         if (!this.sessionDfd) {
@@ -370,7 +389,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         }
     }
 
-    async updateDescriptor(descriptor: Descriptor) {
+    private async updateDescriptor(descriptor: Descriptor) {
         this.sessionDfd?.resolve(descriptor.session);
 
         await Promise.all([this.acquirePromise, this.releasePromise]);
@@ -448,7 +467,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         return this.runPromise?.catch(() => {});
     }
 
-    public usedElsewhere() {
+    private usedElsewhere() {
         // only makes sense to continue when device held by this instance
         if (!this.lastAcquiredHere) {
             return;
@@ -1043,7 +1062,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         return !!this.unreadableError;
     }
 
-    disconnect() {
+    private disconnect() {
         // TODO: cleanup everything
         _log.debug('Disconnect cleanup');
 

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -159,8 +159,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
     private keepTransportSession = false;
     private currentSession?: DeviceCurrentSession;
 
-    private inconsistent = false;
-
     private instance = 0;
 
     // DeviceState list [this.instance]: DeviceState | undefined
@@ -499,9 +497,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
                     await this.initialize(!!options.useCardanoDerivation);
                 } else {
                     const isNative = DataManager.getSettings('env') === 'react-native';
-                    const getFeaturesTimeout = isNative
-                        ? GET_FEATURES_TIMEOUT_REACT_NATIVE
-                        : GET_FEATURES_TIMEOUT;
                     const cancelTimeout = isNative
                         ? GET_FEATURES_TIMEOUT_REACT_NATIVE
                         : CANCEL_TIMEOUT;
@@ -528,45 +523,14 @@ export class Device extends TypedEmitter<DeviceEvents> {
                         ]).catch(() => this.acquire());
                     }
 
-                    let getFeaturesTimeoutId: ReturnType<typeof setTimeout> | undefined;
-
-                    // do not initialize while firstRunPromise otherwise `features.session_id` could be affected
-                    await Promise.race([
-                        this.getFeatures().finally(() => clearTimeout(getFeaturesTimeoutId)),
-                        // note: tested on 24.7.2024 and whatever is written below this line is still valid
-                        // We do not support T1B1 <1.9.0 but we still need Features even from not supported devices to determine your version
-                        // and tell you that update is required.
-                        // Edge-case: T1B1 + bootloader < 1.4.0 doesn't know the "GetFeatures" message yet and it will send no response to its
-                        // transport response is pending endlessly, calling any other message will end up with "device call in progress"
-                        // set the timeout for this call so whenever it happens "unacquired device" will be created instead
-                        // next time device should be called together with "Initialize" (calling "acquireDevice" from the UI)
-                        new Promise((_resolve, reject) => {
-                            getFeaturesTimeoutId = setTimeout(async () => {
-                                await this.getCurrentSession().cancelCall(false);
-                                reject(new Error('GetFeatures timeout'));
-                            }, getFeaturesTimeout);
-                        }),
-                    ]);
+                    await this.getFeatures();
                 }
             } catch (error) {
                 _log.warn('Device._runInner error: ', error.message);
-                if (
-                    !this.inconsistent &&
-                    (error.message === 'GetFeatures timeout' || error.message === 'Unknown message')
-                ) {
-                    // handling corner-case T1B1 + bootloader < 1.4.0 (above)
-                    // if GetFeatures fails try again
-                    // this time add empty "fn" param to force Initialize message
-                    this.inconsistent = true;
-
-                    return this._runInner(() => Promise.resolve({}), options);
-                }
 
                 if (TRANSPORT_ERROR.ABORTED_BY_TIMEOUT === error.message) {
                     this.unreadableError = 'Connection timeout';
                 }
-
-                this.inconsistent = true;
 
                 return Promise.reject(
                     ERRORS.TypedError(
@@ -733,7 +697,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     async getFeatures() {
-        // Please keep the method simple - don't add any async logic
         const { message } = await this.getCurrentSession().typedCall('GetFeatures', 'Features', {});
         this._updateFeatures(message);
     }
@@ -1077,10 +1040,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     isSeedless() {
         return this.features && !!this.features.no_backup;
-    }
-
-    isInconsistent() {
-        return this.inconsistent;
     }
 
     getVersion(): VersionArray | undefined {

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -273,7 +273,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
             .then(result => {
                 if (result.success) {
                     this.sessionAcquired = result.payload;
-                    this.currentSession?.dispose();
                     this.currentSession = new DeviceCurrentSession(
                         this,
                         this.transport,
@@ -293,12 +292,10 @@ export class Device extends TypedEmitter<DeviceEvents> {
         return this.acquirePromise;
     }
 
-    async release() {
+    release() {
         if (!this.sessionAcquired || this.keepTransportSession || this.releasePromise) {
             return;
         }
-
-        await this.currentSession?.dispose();
 
         const sessionPromise = this.getSessionChangePromise();
 
@@ -391,10 +388,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         // Session changed to null
         // -> released
         if (!descriptor.session) {
-            const methodStillRunning = !this.currentSession?.isDisposed();
-            if (methodStillRunning) {
-                this.keepTransportSession = false;
-            }
+            this.keepTransportSession = false;
         }
 
         this.emitLifecycle(DEVICE.CHANGED);
@@ -439,7 +433,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     async interrupt(reason: Error) {
-        await this.currentSession?.abort(reason, true);
+        await this.currentSession?.abort(reason);
 
         // reject inner defer
         this.runAbort?.abort(reason);
@@ -466,8 +460,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
         this._featuresNeedsReload = true;
 
         _log.debug('interruptionFromOutside');
-
-        this.currentSession?.dispose();
 
         this.runAbort?.abort(ERRORS.TypedError('Device_UsedElsewhere'));
     }

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -114,11 +114,6 @@ type DeviceParams = {
     listener: DeviceLifecycleListener;
 };
 
-/**
- * @export
- * @class Device
- * @extends {EventEmitter}
- */
 export class Device extends TypedEmitter<DeviceEvents> {
     public readonly transport: Transport;
     public readonly protocol: TransportProtocol;
@@ -126,9 +121,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     public readonly bluetoothProps;
     private thp: protocolThp.ThpState | undefined;
     private readonly transportDescriptorType;
-    private session;
-    private transportSessionOwner;
-    private lastAcquiredHere;
+    private sessionAcquired: Session | null;
 
     /**
      * descriptor was detected on transport layer but sending any messages (such as GetFeatures) to it failed either
@@ -214,12 +207,10 @@ export class Device extends TypedEmitter<DeviceEvents> {
         this.uniquePath = id;
         this.transport = transport;
         this.transportPath = descriptor.path;
-        this.transportSessionOwner = descriptor.sessionOwner;
         this.transportDescriptorType = descriptor.type;
         this.bluetoothProps = descriptor.id ? { id: descriptor.id } : undefined;
 
-        this.session = descriptor.session;
-        this.lastAcquiredHere = false;
+        this.sessionAcquired = null;
 
         transport.deviceEvents.on(this.transportPath, this.onTransportDeviceEvent);
     }
@@ -277,21 +268,20 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     acquire() {
         const sessionPromise = this.getSessionChangePromise();
+        const previous = this.transport.getDescriptor(this.transportPath)?.session ?? null;
 
         this.acquirePromise = this.transport
-            .acquire({ input: { path: this.transportPath, previous: this.session } })
+            .acquire({ input: { path: this.transportPath, previous } })
             .then(result => this.waitAndCompareSession(result, sessionPromise))
             .then(result => {
                 if (result.success) {
-                    this.session = result.payload;
-                    this.lastAcquiredHere = true;
-
+                    this.sessionAcquired = result.payload;
                     this.currentSession?.dispose();
                     this.currentSession = new DeviceCurrentSession(
                         this,
                         this.transport,
                         this.protocol,
-                        this.session,
+                        this.sessionAcquired,
                     );
 
                     return result;
@@ -307,8 +297,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     async release() {
-        const localSession = this.lastAcquiredHere ? this.session : null;
-        if (!localSession || this.keepTransportSession || this.releasePromise) {
+        if (!this.sessionAcquired || this.keepTransportSession || this.releasePromise) {
             return;
         }
 
@@ -317,11 +306,11 @@ export class Device extends TypedEmitter<DeviceEvents> {
         const sessionPromise = this.getSessionChangePromise();
 
         this.releasePromise = this.transport
-            .release({ session: localSession, path: this.transportPath })
+            .release({ session: this.sessionAcquired, path: this.transportPath })
             .then(result => this.waitAndCompareSession(result, sessionPromise))
             .then(result => {
                 if (result.success) {
-                    this.session = null;
+                    this.sessionAcquired = null;
                 }
 
                 return result;
@@ -398,7 +387,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
         // Session changed to different than the current one
         // -> acquired by someone else
-        if (descriptor.session && descriptor.session !== this.session) {
+        if (descriptor.session && descriptor.session !== this.sessionAcquired) {
             this.usedElsewhere();
         }
 
@@ -411,8 +400,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
             }
         }
 
-        this.session = descriptor.session;
-        this.transportSessionOwner = descriptor.sessionOwner;
         this.emitLifecycle(DEVICE.CHANGED);
     }
 
@@ -469,10 +456,16 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     private usedElsewhere() {
         // only makes sense to continue when device held by this instance
-        if (!this.lastAcquiredHere) {
+        if (!this.sessionAcquired) {
             return;
         }
-        this.lastAcquiredHere = false;
+
+        // session was acquired by another instance. but another might not have power to release interface
+        // so it only notified about its session acquiral and the interrupted instance should cooperate
+        // and release device too.
+        this.transport.releaseDevice(this.sessionAcquired);
+        this.sessionAcquired = null;
+
         this._featuresNeedsReload = true;
 
         _log.debug('interruptionFromOutside');
@@ -480,13 +473,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
         this.currentSession?.dispose();
 
         this.runAbort?.abort(ERRORS.TypedError('Device_UsedElsewhere'));
-
-        // session was acquired by another instance. but another might not have power to release interface
-        // so it only notified about its session acquiral and the interrupted instance should cooperate
-        // and release device too.
-        if (this.session) {
-            this.transport.releaseDevice(this.session);
-        }
     }
 
     private async _runInner<X>(
@@ -657,7 +643,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
             // and device wasn't released in previous call (example: interrupted discovery which set "keepSession" to true but never released)
             // clear "keepTransportSession" and reset "transportSession" to ensure that "initialize" will be called
             if (this.keepTransportSession) {
-                this.lastAcquiredHere = false;
+                this.sessionAcquired = null;
                 this.keepTransportSession = false;
             }
         }
@@ -1068,7 +1054,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
         this.sessionDfd?.reject(new Error());
 
-        this.lastAcquiredHere = false; // set to null to prevent transport.release and cancelableAction
+        this.sessionAcquired = null; // set to null to prevent transport.release and cancelableAction
 
         this.emitLifecycle(DEVICE.DISCONNECT);
         this.emitLifecycle = () => {};
@@ -1112,15 +1098,15 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     isUsed() {
-        return typeof this.session === 'string';
+        return !!this.transport.getDescriptor(this.transportPath)?.session;
     }
 
     isUsedHere() {
-        return this.isUsed() && this.lastAcquiredHere;
+        return !!this.sessionAcquired;
     }
 
     isUsedElsewhere() {
-        return this.isUsed() && !this.lastAcquiredHere;
+        return this.isUsed() && !this.isUsedHere();
     }
 
     getUniquePath() {
@@ -1156,8 +1142,8 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     dispose() {
         this.removeAllListeners();
-        if (this.session && this.lastAcquiredHere) {
-            this.transport.releaseSync(this.session);
+        if (this.sessionAcquired) {
+            this.transport.releaseSync(this.sessionAcquired);
         }
     }
 
@@ -1184,14 +1170,14 @@ export class Device extends TypedEmitter<DeviceEvents> {
             };
         }
         if (this.isUnacquired()) {
+            const sessionOwner = this.transport.getDescriptor(this.transportPath)?.sessionOwner;
+
             return {
                 ...base,
                 type: 'unacquired',
                 label: 'Unacquired device',
                 name: this.name,
-                transportSessionOwner: this.lastAcquiredHere
-                    ? undefined
-                    : this.transportSessionOwner,
+                transportSessionOwner: this.sessionAcquired ? undefined : sessionOwner,
                 bluetoothProps: this.bluetoothProps,
                 thp: this.thp?.serialize(),
             };

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -3,11 +3,12 @@
 import { MessagesSchema as Messages } from '@trezor/protobuf';
 import { TransportProtocol } from '@trezor/protocol';
 import { Assert } from '@trezor/schema-utils';
-import { Session, Transport } from '@trezor/transport';
+import { Session, TRANSPORT_ERROR, Transport } from '@trezor/transport';
 import { resolveAfter, scheduleAction, versionUtils } from '@trezor/utils';
 
 import { ERRORS } from '../constants';
 import { Device } from './Device';
+import { DataManager } from '../data/DataManager';
 import { DEVICE } from '../events';
 import { initLog } from '../utils/debug';
 
@@ -38,6 +39,14 @@ const isExpectedResponse = <Key extends Messages.MessageKey | Messages.MessageKe
 const success = <T>(payload: T) => ({ success: true as const, payload });
 const error = (error: Error) => ({ success: false as const, error });
 const fail = (msg: string) => error(new Error(msg, { cause: 'transport-error' }));
+
+const getFeaturesTimeoutPromise = () =>
+    resolveAfter(
+        // Due to performance issues in suite-native during app start, original timeout is not sufficient.
+        DataManager.getSettings('env') === 'react-native' ? 20_000 : 3_000,
+        undefined,
+        fail(TRANSPORT_ERROR.ABORTED_BY_TIMEOUT),
+    );
 
 export interface TypedCallProvider {
     typedCall: Messages.TypedCall;
@@ -140,9 +149,19 @@ export class DeviceCurrentSession implements TypedCallProvider {
         while (true) {
             const callPromise = this.call(name, data);
 
-            const abortedDuringCall = await Promise.race([
-                callPromise.then(() => false),
-                abortPromise.then(() => true),
+            // note: tested on 24.7.2024 and whatever is written below this line is still valid
+            // We do not support T1B1 <1.9.0 but we still need Features even from not supported devices to determine your version
+            // and tell you that update is required.
+            // Edge-case: T1B1 + bootloader < 1.4.0 doesn't know the "GetFeatures" message yet and it will send no response to its
+            // transport response is pending endlessly, calling any other message will end up with "device call in progress"
+            // set the timeout for this call so whenever it happens "unacquired device" will be created instead
+            // next time device should be called together with "Initialize" (calling "acquireDevice" from the UI)
+            const timeoutPromise = name === 'GetFeatures' ? getFeaturesTimeoutPromise() : undefined;
+
+            const [abortedDuringCall, response] = await Promise.race([
+                callPromise.then(res => [false, res] as const),
+                abortPromise.then(res => [true, res] as const),
+                ...(timeoutPromise ? [timeoutPromise.then(res => [false, res] as const)] : []),
             ]);
 
             if (name === 'ButtonAck' && abortedDuringCall && !this.disposed) {
@@ -161,7 +180,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
                 }
             }
 
-            const response = await callPromise;
+            await callPromise;
 
             if (this.disposed) return error(this.disposed);
 
@@ -172,6 +191,13 @@ export class DeviceCurrentSession implements TypedCallProvider {
             switch (res.type) {
                 case 'Failure': {
                     const { code, message } = res.message;
+
+                    // handling corner-case T1B1 + bootloader < 1.4.0 (above)
+                    // if GetFeatures fails try Initialize instead
+                    if (name === 'GetFeatures' && code === 'Failure_UnexpectedMessage') {
+                        [name, data] = ['Initialize', {}];
+                        break;
+                    }
 
                     const err =
                         message ||

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -4,6 +4,7 @@ import { MessagesSchema as Messages } from '@trezor/protobuf';
 import { TransportProtocol } from '@trezor/protocol';
 import { Assert } from '@trezor/schema-utils';
 import { Session, TRANSPORT_ERROR, Transport } from '@trezor/transport';
+import { isErrorWithoutDeviceInteraction } from '@trezor/transport/src/errors-groups';
 import { resolveAfter, scheduleAction, versionUtils } from '@trezor/utils';
 
 import { ERRORS } from '../constants';
@@ -38,7 +39,13 @@ const isExpectedResponse = <Key extends Messages.MessageKey | Messages.MessageKe
 
 const success = <T>(payload: T) => ({ success: true as const, payload });
 const error = (error: Error) => ({ success: false as const, error });
-const fail = (msg: string) => error(new Error(msg, { cause: 'transport-error' }));
+const fail = (msg: string) =>
+    error(
+        new Error(
+            msg,
+            isErrorWithoutDeviceInteraction(msg) ? { cause: 'transport-error' } : undefined,
+        ),
+    );
 
 const getFeaturesTimeoutPromise = () =>
     resolveAfter(

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -170,13 +170,14 @@ export class DeviceCurrentSession implements TypedCallProvider {
                         // UI_EVENT is send right before ButtonAck, make sure that ButtonAck is sent
                         await resolveAfter(1);
                         await this.device.acquire();
-                        await this.device.getCurrentSession().cancelCall(false);
+                        await this.device.getCurrentSession().cancelCall();
                         await this.device.release();
                     } catch {
                         // ignore whatever happens
                     }
                 } else {
-                    await this.cancelCall(false);
+                    const { session, protocol } = this;
+                    await this.transport.send({ name: 'Cancel', data: {}, session, protocol });
                 }
             }
 
@@ -234,7 +235,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
                     ]);
 
                     if (!promptRes.success) {
-                        const cancelRes = await this.cancelCall();
+                        const cancelRes = await this.call('Cancel', {});
 
                         return cancelRes.success ? promptRes : cancelRes;
                     }
@@ -250,7 +251,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
                     ]);
 
                     if (!promptRes.success) {
-                        const cancelRes = await this.cancelCall();
+                        const cancelRes = await this.call('Cancel', {});
 
                         return cancelRes.success ? promptRes : cancelRes;
                     }
@@ -269,7 +270,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
                     ]);
 
                     if (!promptRes.success) {
-                        const cancelRes = await this.cancelCall();
+                        const cancelRes = await this.call('Cancel', {});
 
                         return cancelRes.success ? promptRes : cancelRes;
                     }
@@ -309,17 +310,8 @@ export class DeviceCurrentSession implements TypedCallProvider {
         return result.success ? success(result.payload) : fail(result.error);
     }
 
-    async cancelCall(expectResponse = true) {
-        if (this.disposed) return Promise.resolve(error(this.disposed));
-
-        const { protocol, session } = this;
-        const cancelArgs = { session, name: 'Cancel', data: {}, protocol };
-
-        const response = expectResponse
-            ? await this.transport.call(cancelArgs)
-            : await this.transport.send(cancelArgs);
-
-        return response.success ? success(response.payload) : fail(response.error);
+    cancelCall() {
+        return this.call('Cancel', {});
     }
 
     async abort(reason: Error, dispose = false) {

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -3,7 +3,7 @@
 import { MessagesSchema as Messages } from '@trezor/protobuf';
 import { TransportProtocol } from '@trezor/protocol';
 import { Assert } from '@trezor/schema-utils';
-import { Session, TRANSPORT_ERROR, Transport } from '@trezor/transport';
+import { Session, TRANSPORT, TRANSPORT_ERROR, Transport } from '@trezor/transport';
 import { isErrorWithoutDeviceInteraction } from '@trezor/transport/src/errors-groups';
 import { resolveAfter, scheduleAction, versionUtils } from '@trezor/utils';
 
@@ -81,6 +81,17 @@ export class DeviceCurrentSession implements TypedCallProvider {
         this.transport = transport;
         this.protocol = protocol;
         this.session = session;
+
+        transport.deviceEvents.once(device.transportPath, e => {
+            if (!this.disposed) {
+                this.disposed = ERRORS.TypedError(
+                    e.type === TRANSPORT.DEVICE_DISCONNECTED
+                        ? 'Device_Disconnected'
+                        : 'Device_UsedElsewhere',
+                );
+                this.abortController?.abort(this.disposed);
+            }
+        });
     }
 
     isDisposed() {
@@ -321,19 +332,9 @@ export class DeviceCurrentSession implements TypedCallProvider {
         return this.call('Cancel', {});
     }
 
-    async abort(reason: Error, dispose = false) {
+    async abort(reason: Error) {
         this.abortController?.abort(reason);
         await this.callPromise;
-        if (dispose) this.disposed = reason;
-    }
-
-    async dispose() {
-        if (!this.disposed) {
-            this.disposed = ERRORS.TypedError(
-                'Runtime',
-                'typedCall: DeviceCommands already disposed',
-            );
-            await this.abort(this.disposed);
-        }
+        this.disposed = reason;
     }
 }

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -29,7 +29,7 @@ const logger = initLog('DeviceCommands');
 
 const success = <T>(payload: T) => ({ success: true as const, payload });
 const error = (error: Error) => ({ success: false as const, error });
-const fail = (msg: string, cause?: string) => error(new Error(msg, cause ? { cause } : undefined));
+const fail = (msg: string) => error(new Error(msg, { cause: 'transport-error' }));
 
 export interface TypedCallProvider {
     typedCall: Messages.TypedCall;
@@ -124,15 +124,12 @@ export class DeviceCurrentSession implements TypedCallProvider {
         type: T,
         msg: Messages.MessagePayload<T>,
         abortPromise: Promise<ReturnType<typeof fail>>,
-    ): Promise<ReturnType<typeof success<Messages.MessageResponse>> | ReturnType<typeof fail>> {
+    ) {
         let [name, data] = [type, msg];
-        const { protocol, session } = this;
         let pinUnlocked = false;
 
         while (true) {
-            if (this.disposed) return error(this.disposed);
-
-            const callPromise = this.call({ session, name, data, protocol });
+            const callPromise = this.call(name, data);
 
             const abortedDuringCall = await Promise.race([
                 callPromise.then(() => false),
@@ -257,10 +254,14 @@ export class DeviceCurrentSession implements TypedCallProvider {
         }
     }
 
-    private async call(params: Parameters<Transport['call']>[0]) {
-        logger.debug('Sending', params.name, filterForLog(params.name, params.data));
+    private async call<T extends Messages.MessageKey>(name: T, data: Messages.MessagePayload<T>) {
+        if (this.disposed) return Promise.resolve(error(this.disposed));
 
-        const result = await this.transport.call(params);
+        logger.debug('Sending', name, filterForLog(name, data));
+
+        const { session, protocol } = this;
+
+        const result = await this.transport.call({ name, data, session, protocol });
 
         if (result.success) {
             const { type, message } = result.payload;
@@ -270,7 +271,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
             logger.warn('Received transport error', result.error, result.message);
         }
 
-        return result.success ? success(result.payload) : fail(result.error, 'transport-error');
+        return result.success ? success(result.payload) : fail(result.error);
     }
 
     async cancelCall(expectResponse = true) {

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -27,6 +27,14 @@ const filterForLog = (type: string, msg: any) =>
 
 const logger = initLog('DeviceCommands');
 
+const isExpectedResponse = <Key extends Messages.MessageKey | Messages.MessageKey[]>(
+    response: Pick<Messages.MessageResponse, 'type'>,
+    expected: Key,
+): response is Extract<
+    Messages.MessageResponse,
+    { type: Key extends Array<any> ? Key[number] : Key }
+> => (Array.isArray(expected) ? expected : expected.split('|')).includes(response.type);
+
 const success = <T>(payload: T) => ({ success: true as const, payload });
 const error = (error: Error) => ({ success: false as const, error });
 const fail = (msg: string) => error(new Error(msg, { cause: 'transport-error' }));
@@ -65,7 +73,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
 
     async typedCall(
         type: Messages.MessageKey,
-        resType: Messages.MessageKey | Messages.MessageKey[],
+        expectedType: Messages.MessageKey | Messages.MessageKey[],
         msg: Messages.MessagePayload = {},
     ) {
         // Assert message type
@@ -86,10 +94,13 @@ export class DeviceCurrentSession implements TypedCallProvider {
         if (!response.success) throw response.error;
 
         const { payload } = response;
+        const receivedType = payload.type;
 
-        if (!(Array.isArray(resType) ? resType : resType.split('|')).includes(payload.type)) {
-            // handle possible race condition
-            // Bridge may have some unread message in buffer, read it
+        if (isExpectedResponse(payload, expectedType)) {
+            return payload;
+        } else {
+            // handle possible race condition - Bridge may have some unread message in buffer, read it
+            // TODO could be possible to remove
             await scheduleAction(
                 abort =>
                     this.transport.receive({
@@ -102,11 +113,9 @@ export class DeviceCurrentSession implements TypedCallProvider {
 
             throw ERRORS.TypedError(
                 'Runtime',
-                `assertType: Response of unexpected type: ${payload.type}. Should be ${resType}`,
+                `assertType: Response of unexpected type: ${receivedType}. Should be ${expectedType}`,
             );
         }
-
-        return payload;
     }
 
     /**

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -6,7 +6,6 @@ import { Descriptor } from '@trezor/transport/src/types';
 import {
     TypedEmitter,
     arrayDistinct,
-    arrayPartition,
     createDeferred,
     getSynchronize,
     isNotUndefined,
@@ -159,6 +158,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
             descriptor,
             listener: lifecycle => {
                 if (lifecycle === DEVICE.DISCONNECT) {
+                    this.authPenaltyManager.remove(device);
                     const index = this.devices.indexOf(device);
                     if (index >= 0) this.devices.splice(index, 1);
                 }
@@ -178,10 +178,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
     private getOrCreateTransportManager(apiType: TransportApiType) {
         if (!this.transportManagers[apiType]) {
-            const manager = new TransportManager({
-                startTransport: this.startTransport.bind(this),
-                stopTransport: this.stopTransport.bind(this),
-            });
+            const manager = new TransportManager(this.initializeTransport.bind(this));
             manager.on(TRANSPORT.START, transport =>
                 this.emit(TRANSPORT.START, getTransportInfo(transport)),
             );
@@ -209,19 +206,6 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
             );
 
         await Promise.all(promises);
-    }
-
-    private async startTransport(
-        transport: Transport,
-        pendingTransportEvent: boolean,
-        signal: AbortSignal,
-    ) {
-        try {
-            await this.initializeTransport(transport, pendingTransportEvent, signal);
-        } catch (err) {
-            this.stopTransport(transport);
-            throw err;
-        }
     }
 
     private async initializeTransport(
@@ -337,26 +321,6 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         const promises = Object.values(this.transportManagers).map(manager => manager.dispose());
 
         await Promise.all(promises);
-    }
-
-    private stopTransport(transport: Transport) {
-        let removed: Device[];
-        [removed, this.devices] = arrayPartition(
-            this.devices,
-            d => !transport || d.transport === transport,
-        );
-
-        // disconnect devices
-        removed.forEach(device => {
-            // device.disconnect();
-            this.emit(DEVICE.DISCONNECT, device);
-            this.authPenaltyManager.remove(device);
-            device.dispose();
-        });
-
-        // now we can be relatively sure that release calls have been dispatched
-        // and we can safely kill all async subscriptions in transport layer
-        transport?.stop();
     }
 
     async enumerate() {

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -411,14 +411,9 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
     async enumerate() {
         const promises = this.getConnectedTransports().map(async transport => {
             const res = await transport.enumerate();
-
-            if (!res.success) {
-                return;
+            if (res.success) {
+                transport.handleDescriptorsChange(res.payload);
             }
-
-            res.payload.forEach(d => {
-                this.devices.get(d.path, transport)?.updateDescriptor(d);
-            });
         });
 
         await Promise.all(promises);

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -2,7 +2,7 @@
 
 import { TRANSPORT, Transport } from '@trezor/transport';
 import type { TransportApiType } from '@trezor/transport/src/transports/abstract';
-import { Descriptor, PathPublic } from '@trezor/transport/src/types';
+import { Descriptor } from '@trezor/transport/src/types';
 import {
     TypedEmitter,
     arrayDistinct,
@@ -47,42 +47,6 @@ const createAuthPenaltyManager = (priority: number) => {
     const clear = () => Object.keys(penalizedDevices).forEach(key => delete penalizedDevices[key]);
 
     return { get, add, remove, clear };
-};
-
-type DeviceTransport = Pick<Device, 'transport' | 'transportPath'>;
-
-const createDeviceCollection = () => {
-    let devices: Device[] = [];
-
-    const isEqual = (a: DeviceTransport) => (b: DeviceTransport) =>
-        a.transport === b.transport && a.transportPath === b.transportPath;
-
-    const get = (transportPath: PathPublic, transport: Transport) =>
-        devices.find(isEqual({ transport, transportPath }));
-
-    const all = (): readonly Device[] => devices;
-
-    const add = (device: Device) => {
-        const index = devices.findIndex(isEqual(device));
-        if (index >= 0) devices[index] = device;
-        else devices.push(device);
-    };
-
-    const remove = (transportPath: PathPublic, transport: Transport) => {
-        const index = devices.findIndex(isEqual({ transport, transportPath }));
-        const [removed] = index >= 0 ? devices.splice(index, 1) : [undefined];
-
-        return removed;
-    };
-
-    const clear = (transport?: Transport) => {
-        let removed: Device[];
-        [removed, devices] = arrayPartition(devices, d => !transport || d.transport === transport);
-
-        return removed;
-    };
-
-    return { get, all, add, remove, clear };
 };
 
 const getTransportInfo = (transport: Transport) => ({
@@ -136,8 +100,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
     // array of transport that might be used in this environment
     private transports: Transport[] = [];
-
-    private readonly devices = createDeviceCollection();
+    private devices: Device[] = [];
     private deviceCounter = Date.now();
 
     private readonly handshakeLock;
@@ -194,32 +157,23 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
             id: DeviceUniquePath(id),
             transport,
             descriptor,
-            listener: lifecycle => this.emit(lifecycle, device),
+            listener: lifecycle => {
+                if (lifecycle === DEVICE.DISCONNECT) {
+                    const index = this.devices.indexOf(device);
+                    if (index >= 0) this.devices.splice(index, 1);
+                }
+                this.emit(lifecycle, device);
+            },
         });
-        this.devices.add(device);
+        this.devices.push(device);
 
         const penalty = this.authPenaltyManager.get();
         this.handshakeLock(async () => {
-            if (this.devices.get(descriptor.path, transport)) {
+            if (this.devices.includes(device)) {
                 // device wasn't removed while waiting for lock
                 await device.handshake(penalty);
             }
         });
-    }
-
-    private onDeviceDisconnected(descriptor: Descriptor, transport: Transport) {
-        const device = this.devices.remove(descriptor.path, transport);
-        device?.disconnect();
-    }
-
-    private onDeviceSessionChanged(descriptor: Descriptor, transport: Transport) {
-        const device = this.devices.get(descriptor.path, transport);
-        device?.updateDescriptor(descriptor);
-    }
-
-    private onDeviceRequestRelease(descriptor: Descriptor, transport: Transport) {
-        const device = this.devices.get(descriptor.path, transport);
-        device?.usedElsewhere();
     }
 
     private getOrCreateTransportManager(apiType: TransportApiType) {
@@ -284,13 +238,6 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
          * where transport.acquire, transport.release is called
          */
         transport.on(TRANSPORT.DEVICE_CONNECTED, d => this.onDeviceConnected(d, transport));
-        transport.on(TRANSPORT.DEVICE_DISCONNECTED, d => this.onDeviceDisconnected(d, transport));
-        transport.on(TRANSPORT.DEVICE_SESSION_CHANGED, d =>
-            this.onDeviceSessionChanged(d, transport),
-        );
-        transport.on(TRANSPORT.DEVICE_REQUEST_RELEASE, d =>
-            this.onDeviceRequestRelease(d, transport),
-        );
 
         // enumerating for the first time. we intentionally postpone emitting TRANSPORT_START
         // event until we read descriptors for the first time
@@ -363,25 +310,25 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
     }
 
     getDeviceCount() {
-        return this.devices.all().length;
+        return this.devices.length;
     }
 
     getAllDevices() {
-        return this.devices.all();
+        return this.devices as readonly Device[];
     }
 
     getOnlyDevice(): Device | undefined {
-        return this.getDeviceCount() === 1 ? this.devices.all()[0] : undefined;
+        return this.devices.length === 1 ? this.devices[0] : undefined;
     }
 
     getDeviceByPath(path: DeviceUniquePath): Device | undefined {
-        return this.devices.all().find(d => d.getUniquePath() === path);
+        return this.devices.find(d => d.getUniquePath() === path);
     }
 
     getDeviceByStaticState(state: StaticSessionId): Device | undefined {
         const deviceId = state.split('@')[1].split(':')[0];
 
-        return this.devices.all().find(d => d.features?.device_id === deviceId);
+        return this.devices.find(d => d.features?.device_id === deviceId);
     }
 
     async dispose() {
@@ -393,10 +340,14 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
     }
 
     private stopTransport(transport: Transport) {
-        const devices = this.devices.clear(transport);
+        let removed: Device[];
+        [removed, this.devices] = arrayPartition(
+            this.devices,
+            d => !transport || d.transport === transport,
+        );
 
         // disconnect devices
-        devices.forEach(device => {
+        removed.forEach(device => {
             // device.disconnect();
             this.emit(DEVICE.DISCONNECT, device);
             this.authPenaltyManager.remove(device);

--- a/packages/connect/src/device/TransportManager.ts
+++ b/packages/connect/src/device/TransportManager.ts
@@ -40,14 +40,11 @@ type TransportManagerEvents = {
     [TRANSPORT.ERROR]: string;
 };
 
-type TransportManagerParams = {
-    startTransport: (
-        transport: Transport,
-        pendingTransportEvent: boolean,
-        signal: AbortSignal,
-    ) => Promise<void>;
-    stopTransport: (transport: Transport) => void;
-};
+type StartTransport = (
+    transport: Transport,
+    pendingTransportEvent: boolean,
+    signal: AbortSignal,
+) => Promise<void>;
 
 type InitParams = {
     transports: Transport[];
@@ -63,12 +60,10 @@ export class TransportManager extends TypedEmitter<TransportManagerEvents> {
     private upgradeTimeout?: ReturnType<typeof setTimeout>;
 
     private readonly startTransport;
-    private readonly stopTransport;
 
-    constructor({ startTransport, stopTransport }: TransportManagerParams) {
+    constructor(startTransport: StartTransport) {
         super();
         this.startTransport = startTransport;
-        this.stopTransport = stopTransport;
     }
 
     pending() {
@@ -96,7 +91,7 @@ export class TransportManager extends TypedEmitter<TransportManagerEvents> {
             if (activeTransport) {
                 clearTimeout(this.upgradeTimeout);
                 delete this.activeTransport;
-                this.stopTransport(activeTransport);
+                activeTransport.stop();
             }
 
             return Promise.resolve();
@@ -146,11 +141,16 @@ export class TransportManager extends TypedEmitter<TransportManagerEvents> {
                 if (activeTransport) {
                     clearTimeout(this.upgradeTimeout);
                     delete this.activeTransport;
-                    this.stopTransport(activeTransport);
+                    activeTransport.stop();
                 }
 
                 if (transport) {
-                    await this.startTransport(transport, pendingTransportEvent, abortSignal);
+                    try {
+                        await this.startTransport(transport, pendingTransportEvent, abortSignal);
+                    } catch (err) {
+                        transport.stop();
+                        throw err;
+                    }
 
                     transport.on(TRANSPORT.ERROR, error => {
                         this.emit(TRANSPORT.ERROR, error);
@@ -158,7 +158,7 @@ export class TransportManager extends TypedEmitter<TransportManagerEvents> {
                         this.lock
                             .override('Transport error', async signal => {
                                 delete this.activeTransport;
-                                this.stopTransport(transport);
+                                transport.stop();
                                 if (this.transportReconnect) {
                                     await resolveAfter(1000, signal);
                                     await this.createInitPromise(pendingTransportEvent, signal);

--- a/packages/transport-test/e2e/bridge/multi-client.test.ts
+++ b/packages/transport-test/e2e/bridge/multi-client.test.ts
@@ -84,8 +84,8 @@ describe('bridge', () => {
     test('2 clients. one acquires and releases, the other one is watching', async () => {
         await enumerateAndListen();
 
-        const bride1spy = jest.spyOn(bridge1, 'emit');
-        const bride2spy = jest.spyOn(bridge2, 'emit');
+        const bride1spy = jest.spyOn(bridge1.deviceEvents, 'emit');
+        const bride2spy = jest.spyOn(bridge2.deviceEvents, 'emit');
 
         const session1 = await bridge1.acquire({
             input: { previous: null, path: descriptors[0].path },
@@ -103,14 +103,14 @@ describe('bridge', () => {
             session: Session('1'),
         });
 
-        expect(bride1spy).toHaveBeenLastCalledWith(
-            'transport-device_session_changed',
-            expectedDescriptor1,
-        );
-        expect(bride2spy).toHaveBeenLastCalledWith(
-            'transport-device_session_changed',
-            expectedDescriptor1,
-        );
+        expect(bride1spy).toHaveBeenLastCalledWith(expectedDescriptor1.path, {
+            type: 'transport-device_session_changed',
+            descriptor: expectedDescriptor1,
+        });
+        expect(bride2spy).toHaveBeenLastCalledWith(expectedDescriptor1.path, {
+            type: 'transport-device_session_changed',
+            descriptor: expectedDescriptor1,
+        });
 
         expect(session1.success).toBe(true);
         if (!session1.success) {
@@ -126,15 +126,15 @@ describe('bridge', () => {
             session: null,
         });
 
-        expect(bride1spy).toHaveBeenLastCalledWith(
-            'transport-device_session_changed',
-            expectedDescriptor2,
-        );
+        expect(bride1spy).toHaveBeenLastCalledWith(expectedDescriptor2.path, {
+            type: 'transport-device_session_changed',
+            descriptor: expectedDescriptor2,
+        });
 
-        expect(bride2spy).toHaveBeenLastCalledWith(
-            'transport-device_session_changed',
-            expectedDescriptor2,
-        );
+        expect(bride2spy).toHaveBeenLastCalledWith(expectedDescriptor2.path, {
+            type: 'transport-device_session_changed',
+            descriptor: expectedDescriptor2,
+        });
 
         const session2 = await bridge2.acquire({
             input: { previous: null, path: descriptors[0].path },
@@ -145,8 +145,8 @@ describe('bridge', () => {
     test('session can be "stolen" by another client', async () => {
         await enumerateAndListen();
 
-        const bride1spy = jest.spyOn(bridge1, 'emit');
-        const bride2spy = jest.spyOn(bridge2, 'emit');
+        const bride1spy = jest.spyOn(bridge1.deviceEvents, 'emit');
+        const bride2spy = jest.spyOn(bridge2.deviceEvents, 'emit');
 
         const session1 = await bridge1.acquire({
             input: { previous: null, path: descriptors[0].path },
@@ -174,15 +174,15 @@ describe('bridge', () => {
 
         await wait(); // wait for event to be propagated
 
-        expect(bride1spy).toHaveBeenLastCalledWith(
-            'transport-device_session_changed',
-            expectedDescriptor,
-        );
+        expect(bride1spy).toHaveBeenLastCalledWith(expectedDescriptor.path, {
+            type: 'transport-device_session_changed',
+            descriptor: expectedDescriptor,
+        });
 
-        expect(bride2spy).toHaveBeenLastCalledWith(
-            'transport-device_session_changed',
-            expectedDescriptor,
-        );
+        expect(bride2spy).toHaveBeenLastCalledWith(expectedDescriptor.path, {
+            type: 'transport-device_session_changed',
+            descriptor: expectedDescriptor,
+        });
     });
 
     // todo: udp not implemented correctly yet in new bridge
@@ -268,30 +268,30 @@ describe('bridge', () => {
     test(`connect/disconnect device - get transport update events`, async () => {
         const eventSpy = jest.fn();
         bridge1.on('transport-device_connected', eventSpy);
-        bridge1.on('transport-device_disconnected', eventSpy);
-        bridge1.on('transport-device_session_changed', eventSpy);
         await TrezorUserEnvLink.stopEmu();
 
         expect(eventSpy).toHaveBeenCalledTimes(0);
 
         bridge1.listen();
 
-        const waitForEvent = (event: Parameters<(typeof bridge1)['once']>[0]) =>
-            new Promise(resolve => {
-                bridge1.once(event, resolve);
-            });
-
-        await Promise.all([
+        const [_, { path }] = await Promise.all([
             TrezorUserEnvLink.startEmu(emulatorStartOpts),
-            waitForEvent('transport-device_connected'),
+            new Promise<Descriptor>(resolve => {
+                bridge1.once('transport-device_connected', resolve);
+            }),
         ]);
         expect(eventSpy).toHaveBeenCalledTimes(1);
 
+        bridge1.deviceEvents.on(path, eventSpy);
+
         await Promise.all([
             TrezorUserEnvLink.stopEmu(),
-            waitForEvent('transport-device_disconnected'),
+            new Promise(resolve => {
+                bridge1.deviceEvents.once(path, resolve);
+            }),
         ]);
 
         expect(eventSpy).toHaveBeenCalledTimes(2);
+        expect(eventSpy.mock.calls[1][0]).toEqual({ type: 'transport-device_disconnected' });
     });
 });

--- a/packages/transport/src/constants.ts
+++ b/packages/transport/src/constants.ts
@@ -29,6 +29,7 @@ export const TRANSPORT = {
     /* events */
     START: 'transport-start',
     ERROR: 'transport-error',
+    STOPPED: 'transport-stopped',
     DEVICE_CONNECTED: 'transport-device_connected',
     DEVICE_DISCONNECTED: 'transport-device_disconnected',
     DEVICE_SESSION_CHANGED: 'transport-device_session_changed',

--- a/packages/transport/src/errors-groups.ts
+++ b/packages/transport/src/errors-groups.ts
@@ -3,7 +3,7 @@ import * as ERRORS from './errors';
 /**
  * list of errors that may originate from the transport layer but are not related to the device interaction
  */
-export const ERRORS_WITHOUT_DEVICE_INTERACTION = [
+const ERRORS_WITHOUT_DEVICE_INTERACTION = [
     ERRORS.HTTP_ERROR,
     ERRORS.OTHER_CALL_IN_PROGRESS,
     ERRORS.WRONG_ENVIRONMENT,
@@ -13,3 +13,8 @@ export const ERRORS_WITHOUT_DEVICE_INTERACTION = [
     ERRORS.SESSION_NOT_FOUND,
     ERRORS.SESSION_WRONG_PREVIOUS,
 ];
+
+export const isErrorWithoutDeviceInteraction = (
+    error: string,
+): error is (typeof ERRORS_WITHOUT_DEVICE_INTERACTION)[number] =>
+    ERRORS_WITHOUT_DEVICE_INTERACTION.includes(error as any);

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -2,6 +2,7 @@ import { Messages, loadDefinitions, parseConfigure } from '@trezor/protobuf';
 import { PROTOCOL_MALFORMED, TransportProtocol } from '@trezor/protocol';
 import { ScheduleActionParams, ScheduledAction, TypedEmitter, scheduleAction } from '@trezor/utils';
 
+import type { BridgeCommonErrors } from './bridge';
 import { ACTION_TIMEOUT, TRANSPORT } from '../constants';
 import * as ERRORS from '../errors';
 import {
@@ -70,22 +71,20 @@ export type ReadWriteError =
     | typeof ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE
     | typeof ERRORS.INTERFACE_DATA_TRANSFER;
 
-class TransportEmitter extends TypedEmitter<{
+type TransportEvents = {
     [TRANSPORT.DEVICE_CONNECTED]: Descriptor;
-    [TRANSPORT.DEVICE_DISCONNECTED]: Descriptor;
-    [TRANSPORT.DEVICE_SESSION_CHANGED]: Descriptor;
-    [TRANSPORT.DEVICE_REQUEST_RELEASE]: Descriptor;
-    [TRANSPORT.ERROR]:
-        | typeof ERRORS.HTTP_ERROR // most common error - bridge was killed
-        | typeof ERRORS.API_DISCONNECTED // BluetoothApi disconnected
-        // probably never happens, wrong shape of data came from bridge
-        | typeof ERRORS.WRONG_RESULT_TYPE
-        | typeof ERRORS.UNEXPECTED_ERROR;
-}> {}
+    [TRANSPORT.ERROR]: BridgeCommonErrors | typeof ERRORS.API_DISCONNECTED; // BluetoothApi disconnected
+    [TRANSPORT.STOPPED]: void;
+};
+
+export type TransportDeviceEvent =
+    | { type: typeof TRANSPORT.DEVICE_DISCONNECTED }
+    | { type: typeof TRANSPORT.DEVICE_REQUEST_RELEASE }
+    | { type: typeof TRANSPORT.DEVICE_SESSION_CHANGED; descriptor: Descriptor };
 
 export type TransportApiType = 'usb' | 'udp' | 'bluetooth';
 
-export abstract class AbstractTransport extends TransportEmitter {
+export abstract class AbstractTransport extends TypedEmitter<TransportEvents> {
     public abstract readonly name:
         | 'BridgeTransport'
         | 'NodeUsbTransport'
@@ -132,6 +131,8 @@ export abstract class AbstractTransport extends TransportEmitter {
      */
     protected id: string;
 
+    public readonly deviceEvents;
+
     constructor({ messages, logger, id }: AbstractTransportParams) {
         super();
         this.descriptors = [];
@@ -139,6 +140,7 @@ export abstract class AbstractTransport extends TransportEmitter {
         this.abortController = new AbortController();
         this.logger = logger;
         this.id = id;
+        this.deviceEvents = new TypedEmitter<{ [path: PathPublic]: TransportDeviceEvent }>();
     }
 
     ping(_params?: AbortableParam) {
@@ -280,7 +282,9 @@ export abstract class AbstractTransport extends TransportEmitter {
      * Stop transport = remove all listeners + try to release session + cancel all requests
      */
     stop() {
+        this.emit(TRANSPORT.STOPPED);
         this.removeAllListeners();
+        this.deviceEvents.removeAllListeners();
         this.stopped = true;
         this.listening = false;
         this.abortController.abort();
@@ -307,7 +311,7 @@ export abstract class AbstractTransport extends TransportEmitter {
             .filter(d => !newDescriptors.has(getKey(d)))
             .forEach(descriptor =>
                 // descriptor in present batch but not in incoming -> disconnected device
-                this.emit(TRANSPORT.DEVICE_DISCONNECTED, descriptor),
+                this.deviceEvents.emit(descriptor.path, { type: TRANSPORT.DEVICE_DISCONNECTED }),
             );
 
         // incoming descriptors
@@ -319,7 +323,10 @@ export abstract class AbstractTransport extends TransportEmitter {
                 this.emit(TRANSPORT.DEVICE_CONNECTED, descriptor);
             } else if (prevDescriptor.session !== descriptor.session) {
                 // present session different than incoming -> device acquired or released
-                this.emit(TRANSPORT.DEVICE_SESSION_CHANGED, descriptor);
+                this.deviceEvents.emit(descriptor.path, {
+                    type: TRANSPORT.DEVICE_SESSION_CHANGED,
+                    descriptor,
+                });
             }
         });
 

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -75,7 +75,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
         });
 
         this.sessionsClient.on('releaseRequest', descriptor => {
-            this.emit(TRANSPORT.DEVICE_REQUEST_RELEASE, descriptor);
+            this.deviceEvents.emit(descriptor.path, { type: TRANSPORT.DEVICE_REQUEST_RELEASE });
         });
 
         return this.success(undefined);

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -11,6 +11,7 @@ import {
     AbstractTransportMethodParams,
     AbstractTransportParams,
 } from './abstract';
+import { TRANSPORT } from '../constants';
 import * as ERRORS from '../errors';
 import {
     AnyError,
@@ -37,7 +38,7 @@ type BridgeEndpoint =
     | '/release'
     | '/read';
 
-type BridgeCommonErrors =
+export type BridgeCommonErrors =
     | typeof ERRORS.HTTP_ERROR
     | typeof ERRORS.WRONG_RESULT_TYPE
     | typeof ERRORS.UNEXPECTED_ERROR;
@@ -142,7 +143,7 @@ export class BridgeTransport extends AbstractTransport {
             if (!response.success) {
                 const time = Date.now() - listenTimestamp;
                 if (time <= 1100) {
-                    this.emit('transport-error', response.error);
+                    this.emit(TRANSPORT.ERROR, response.error);
                     break;
                 }
                 await resolveAfter(1000);

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -115,23 +115,18 @@ describe('Usb', () => {
             const { transport } = await initTest();
             const spy = jest.fn();
             transport.on('transport-device_connected', descriptor =>
-                spy({ type: 'connected', descriptor }),
+                spy({ type: 'transport-device_connected', descriptor }),
             );
-            transport.on('transport-device_disconnected', descriptor =>
-                spy({ type: 'disconnected', descriptor }),
-            );
+            transport.deviceEvents.on(PathPublic('1'), e => spy(e));
 
             transport.handleDescriptorsChange([{ path: PathPublic('1'), session: null, type: 1 }]);
 
             expect(spy).toHaveBeenCalledWith({
-                type: 'connected',
+                type: 'transport-device_connected',
                 descriptor: { path: '1', session: null, type: 1 },
             });
             transport.handleDescriptorsChange([]);
-            expect(spy).toHaveBeenCalledWith({
-                type: 'disconnected',
-                descriptor: { path: '1', session: null, type: 1 },
-            });
+            expect(spy).toHaveBeenCalledWith({ type: 'transport-device_disconnected' });
         });
 
         it('enumerate', async () => {
@@ -163,8 +158,7 @@ describe('Usb', () => {
             jest.useFakeTimers();
             const spy = jest.fn();
             transport.on('transport-device_connected', spy);
-            transport.on('transport-device_disconnected', spy);
-            transport.on('transport-device_session_changed', spy);
+            transport.deviceEvents.on(PathPublic('1'), spy);
 
             await transport.enumerate();
 
@@ -173,10 +167,7 @@ describe('Usb', () => {
             const result = await transport.acquire({
                 input: { path: PathPublic('1'), previous: null },
             });
-            expect(result).toEqual({
-                success: true,
-                payload: '1',
-            });
+            expect(result).toEqual({ success: true, payload: '1' });
 
             expect(spy).toHaveBeenCalledTimes(0);
         });


### PR DESCRIPTION
Some improvements of (mostly) device handling in Connect.

- https://github.com/trezor/trezor-suite/pull/17089/commits/4c37f5c49125d0d984c886b50c87e36d418ad22f - on `DeviceList.enumerate` call, `handleDescriptorsChange` is fired instead of separately update descriptors on devices (it should do the same thing, and even more)
- https://github.com/trezor/trezor-suite/pull/17089/commits/1512841956a288774355a953cea50cb14e4172ab - `TransportEvents` on transports improved, so only `CONNECTED` event (device first seen) is fired 'globally', while `DISCONNECTED`/`SESSION_CHANGED`/`REQUEST_RELEASE` are fired per device path, which allows to subscribe to events specific for a single device (instead of subscribing to all the types and filter them by the path); also `TRANSPORT.STOPPED` event added
- https://github.com/trezor/trezor-suite/pull/17089/commits/9b9ad64a95ebe4a37f6c561de7c680c6639ed19c - based on previous commit, `Device` objects are now handling their own events, instead of passing them from `DeviceList`
- https://github.com/trezor/trezor-suite/pull/17089/commits/4f4468eb35647066e948672834870010c9b29086 - session info for `Device` object is now read from transports (where it's stored anyway) instead of holding a copy of it, which allows to reduce info needed for acquired `Device`s to a single `Session | null`
- https://github.com/trezor/trezor-suite/pull/17089/commits/3d84bdd68f3568045cdc53dfc946fe5eb4d2d566 - `Device`s are listening (apart from their own events) to `TRANSPORT.STOPPED` event as well and disconnecting themselves in that case, which allows to make `TransportManager` easier than before
- https://github.com/trezor/trezor-suite/pull/17089/commits/2c6a8fd0a7290b64b3ed2259d686187916b48b65 - minor improvement of `DeviceCurrentSession` - disposed is handled inside every `call`
- https://github.com/trezor/trezor-suite/pull/17089/commits/58834d53799435335318803dcd4aa45268fd5a46 - response validation in `DeviceCurrentSession` moved to a dedicated typeguard function
- https://github.com/trezor/trezor-suite/pull/17089/commits/28429338a9169327a511581dc6a68905a1b80aeb - `GetFeatures` -> `Initialize` fallback logic moved to `DeviceCurrentSession`, which allows to remove recursion in `Device._runInner`
- https://github.com/trezor/trezor-suite/pull/17089/commits/0e494ab5f9cfdfc4aa363c3d76a044192650fa7e - minor improvement of `DeviceCurrentSession` - the only `transport.send` is moved directly where it was used, so the ordinary `Cancel` logic could've been simplified as it's always `transport.call`
- https://github.com/trezor/trezor-suite/pull/17089/commits/04e230530c136594309b9dbaf01aa923cd142efe - transport errors are identified directly in `DeviceCurrentSession` and `resetDevice` method flow was polished and is now (hopefully) better readable
- https://github.com/trezor/trezor-suite/pull/17089/commits/bfdf67872ad98b3b5ea94b0f3c4cb0510c629cc4 - `DeviceCurrentSession` disposes itself on every device descriptor change instead of depending on `dispose` call from outside
- https://github.com/trezor/trezor-suite/pull/17089/commits/9e5e4ade46a87f2d3f396805556d4416454fc7e1 - this should fix a corner-case inside override e2e test by aborting `_runInner` immediately after the first `acquire` call if needed (but still, abort should be handled in every async call there, not just after the first one)