### PR TITLE
feat(e2e): Log start and end of test in Trezor env

### DIFF
--- a/packages/suite-desktop-core/e2e/support/fixtures.ts
+++ b/packages/suite-desktop-core/e2e/support/fixtures.ts
@@ -91,10 +91,13 @@ const test = base.extend<Fixtures>({
         testInfo,
     ) => {
         // We need to ensure emulator is running before launching the suite
+        await trezorUserEnvLink.logTestDetails(
+            ` - - - STARTING TEST ${testInfo.titlePath.join(' - ')}`,
+        );
+        await trezorUserEnvLink.stopBridge();
+        await trezorUserEnvLink.stopEmu();
+        await trezorUserEnvLink.connect();
         if (startEmulator) {
-            await trezorUserEnvLink.stopBridge();
-            await trezorUserEnvLink.stopEmu();
-            await trezorUserEnvLink.connect();
             await trezorUserEnvLink.startEmu(emulatorStartConf);
         }
 
@@ -117,6 +120,9 @@ const test = base.extend<Fixtures>({
             }
             await use(undefined);
         }
+        await trezorUserEnvLink.logTestDetails(
+            ` - - - FINISHING TEST ${testInfo.titlePath.join(' - ')}`,
+        );
     },
     page: async ({ electronWindow, page: webPage }, use, testInfo) => {
         if (electronWindow) {

--- a/packages/suite-desktop-core/e2e/tests/analytics/events.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/analytics/events.test.ts
@@ -4,12 +4,8 @@ import { ExtractByEventType } from '@trezor/suite-web/e2e/support/types';
 import { expect, test } from '../../support/fixtures';
 
 test.describe('Analytics Events', { tag: ['@group=suite', '@webOnly'] }, () => {
-    test.use({
-        startEmulator: false,
-    });
-    test.beforeEach(async ({ trezorUserEnvLink, onboardingPage }) => {
-        await trezorUserEnvLink.stopBridge();
-        await trezorUserEnvLink.stopEmu();
+    test.use({ startEmulator: false });
+    test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.disableFirmwareHashCheck();
     });
 

--- a/packages/suite-desktop-core/e2e/tests/suite/bridge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/bridge.test.ts
@@ -1,11 +1,6 @@
 import { expect, test } from '../../support/fixtures';
 
 test.describe('Bridge page', { tag: ['@group=suite', '@webOnly'] }, () => {
-    test.beforeEach(async ({ trezorUserEnvLink }) => {
-        await trezorUserEnvLink.stopEmu();
-        await trezorUserEnvLink.stopBridge();
-    });
-
     test.use({ startEmulator: false });
     test('can use webusb', async ({ url, page }) => {
         await page.goto(url + 'bridge');

--- a/packages/suite-desktop-core/e2e/tests/suite/guide.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/guide.test.ts
@@ -1,10 +1,6 @@
 import { expect, test } from '../../support/fixtures';
 
 test.describe('Guide without device', { tag: ['@group=suite', '@webOnly'] }, () => {
-    test.beforeEach(async ({ trezorUserEnvLink }) => {
-        await trezorUserEnvLink.stopEmu();
-        await trezorUserEnvLink.stopBridge();
-    });
     test.use({ startEmulator: false });
     test('open / close guide', async ({ page, suiteGuidePage, settingsPage }) => {
         // Open guide

--- a/packages/suite-desktop-core/e2e/tests/suite/version-page.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/version-page.test.ts
@@ -4,12 +4,7 @@ import { expect, test } from '../../support/fixtures';
 
 //TODO: Fix #17001
 test.describe.skip('Hidden version page', { tag: ['@group=suite', '@webOnly'] }, () => {
-    test.beforeEach(async ({ trezorUserEnvLink }) => {
-        await trezorUserEnvLink.stopEmu();
-        await trezorUserEnvLink.stopBridge();
-    });
     test.use({ startEmulator: false });
-
     test('is accessible via route', async ({ url, page }) => {
         const suiteVersion = getSuiteVersion();
         const suiteCommitHash = getCommitHash();


### PR DESCRIPTION
Also cleans up setup of e2e tests that dont need to start/set emulator

## Description

Improves logging for troubleshooting possible instabilities. These logs are attached to each e2e test build

```
2025-02-18 18:26:16,441 INFO CONTROLLER: Request: {'id': '0', 'type': 'log', 'text': ' - - - STARTING TEST metadata/metadata-lifecycle.test.ts - Metadata - cancel metadata on device - user cancels metadata on device, choice is respected on subsequent runs but only for the cancelled wallet'}
2025-02-18 18:26:16,441 INFO CONTROLLER:  - - - STARTING TEST metadata/metadata-lifecycle.test.ts - Metadata - cancel metadata on device - user cancels metadata on device, choice is respected on subsequent runs but only for the cancelled wallet
....
2025-02-18 18:26:54,691 INFO CONTROLLER: Request: {'id': '10', 'type': 'log', 'text': ' - - - FINISHING TEST metadata/metadata-lifecycle.test.ts - Metadata - cancel metadata on device - user cancels metadata on device, choice is respected on subsequent runs but only for the cancelled wallet'}
2025-02-18 18:26:54,691 INFO CONTROLLER:  - - - FINISHING TEST metadata/metadata-lifecycle.test.ts - Metadata - cancel metadata on device - user cancels metadata on device, choice is respected on subsequent runs but only for the cancelled wallet
2025-02-18 18:26:54,691 INFO CONTROLLER: Response: {'response': 'Text logged', 'id': '10', 'success': True}
```