### PR TITLE
docs(suite): don't instruct to build:libs needlessly

### DIFF
--- a/docs/releases/adding-new-firmwares.md
+++ b/docs/releases/adding-new-firmwares.md
@@ -21,7 +21,7 @@ Package `@trezor/connect-common` is a public NPM package used as dependency of `
 
     See [#4262](https://github.com/trezor/trezor-suite/issues/4262) for explanation.
 
-1. Test it locally (at least by running `yarn build:libs` to rebuild connect files and `yarn suite:dev` to use/copy them).
+1. Test it locally by running `yarn suite:dev` and/or `yarn suite:dev:desktop`
 
 1. Freeze Suite. At this moment you are all good to _Freeze_ and forward to QA. They should be able to test Suite in its wholeness along with the new firmwares.
 

--- a/packages/suite-desktop/README.md
+++ b/packages/suite-desktop/README.md
@@ -23,7 +23,7 @@ yarn workspace @trezor/suite-desktop dev
 Prerequisites:
 
 ```
-yarn && yarn build:libs
+yarn
 ```
 
 ### Linux


### PR DESCRIPTION
## Description

Remove instructions to `build:libs` in context of Trezor Suite, because it's relevant only for: 1) initial setup, 2) releasing Connect packages as standalone libs.

@coderabbitai ignore