### PR TITLE
fix: do not show cancel TX for non-bitcoin networks

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -155,7 +155,7 @@ export const TransactionItem = memo(
         const isExpandable = allOutputs.length - DEFAULT_LIMIT > 0;
         const toExpand = allOutputs.length - DEFAULT_LIMIT - limit;
 
-        const isTxCancellable = transaction.type !== 'self';
+        const isTxCancellable = transaction.type !== 'self' && network.networkType === 'bitcoin';
 
         const openTxDetailsModal = ({ flow }: OpenModalParams) => {
             if (isActionDisabled) return; // open explorer


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e05f439b-5524-4681-875e-fff361a461e2)

![image](https://github.com/user-attachments/assets/0cbab002-7586-41bb-8334-c724ace7c0be)


@coderabbitai ignore