### PR TITLE
fix(suite): unstake fractions

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -109,10 +109,13 @@ export const TransactionReviewModalContent = ({
         precomposedTx,
     });
 
-    // for bump fee we have to analyze tx data which are in outputs[0]
+    // for bump fee we have to analyze tx data which are in outputs[0], for legacy in outputs[1]
     const stakeType = isStakeForm(precomposedForm)
         ? precomposedForm.stakeType
-        : getTxStakeNameByDataHex(outputs[0]?.value);
+        : outputs
+              .filter(output => output.type === 'data')
+              .map(output => getTxStakeNameByDataHex(output?.value))
+              .find(type => type) || null;
 
     const onCancel = () => {
         if (isRbfConfirmedError) {

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -179,6 +179,16 @@ const getOutputLines = (
                 },
             ];
         case 'regular_legacy':
+            if (stakeType) {
+                return [
+                    {
+                        id: 'data',
+                        type: 'default',
+                        value,
+                    },
+                ];
+            }
+
             return [
                 {
                     id: type,
@@ -258,7 +268,7 @@ export const TransactionReviewOutput = ({
             return {
                 ...line,
                 type:
-                    isTrading || relevantAccounts.length > 0
+                    isTrading || stakeType || relevantAccounts.length > 0
                         ? ('safe-address' as OutputElementLine['type'])
                         : line.type,
             };

--- a/packages/suite/src/hooks/wallet/useUnstakeEthForm.ts
+++ b/packages/suite/src/hooks/wallet/useUnstakeEthForm.ts
@@ -241,7 +241,7 @@ export const useUnstakeEthForm = ({
             setValue(CRYPTO_INPUT, undefined, { shouldDirty: true });
             clearErrors([FIAT_INPUT, CRYPTO_INPUT]);
 
-            const amount = new BigNumber(account.formattedBalance)
+            const amount = new BigNumber(autocompoundBalance)
                 .dividedBy(divisor)
                 .decimalPlaces(network.decimals)
                 .toString();
@@ -249,7 +249,7 @@ export const useUnstakeEthForm = ({
             setValue(CRYPTO_INPUT, amount, { shouldDirty: true, shouldValidate: true });
             await onCryptoAmountChange(amount);
         },
-        [account.formattedBalance, clearErrors, network.decimals, onCryptoAmountChange, setValue],
+        [autocompoundBalance, clearErrors, network.decimals, onCryptoAmountChange, setValue],
     );
 
     const clearForm = useCallback(async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- fix unstake fraction buttons
- replace staking tx is not perfect but better than before

## Related Issue

Resolve #17091
Resolve #17082

## Screenshots:
T1B1 (ignore wrong icon)

Claim
![Screenshot 2025-02-19 at 12 17 49](https://github.com/user-attachments/assets/c399a0cd-dde0-4488-9642-4835ed7095c8)

Claim bump fee
![Screenshot 2025-02-19 at 12 17 39](https://github.com/user-attachments/assets/62d4f28c-a341-4c1a-9b69-0aefd203bb94)

Stake
![Screenshot 2025-02-19 at 11 21 56](https://github.com/user-attachments/assets/466809f4-7908-4111-b7d6-0f674421edff)

Stake bump fee
![Screenshot 2025-02-19 at 11 59 16](https://github.com/user-attachments/assets/8c9eb131-e80c-4b53-9fa5-694aca3bc8a6)

Unstake bump fee
![Screenshot 2025-02-19 at 11 52 55](https://github.com/user-attachments/assets/d8f5e73c-f2a7-4c54-bd4e-8d54a2846fe1)
