### PR TITLE
fix(suite): hide the update quick action on in the logged out layout …

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/QuickActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/QuickActions.tsx
@@ -24,18 +24,22 @@ const ActionsContainer = styled.div<{ $isSidebarCollapsed: boolean }>`
 `;
 
 type QuickActionsProps = {
+    hideUpdateStatusBar?: boolean;
     isSidebarCollapsed: boolean;
     showUpdateBannerNotification?: boolean;
 };
 
 export const QuickActions = ({
+    hideUpdateStatusBar,
     isSidebarCollapsed,
     showUpdateBannerNotification,
 }: QuickActionsProps) => (
     <ActionsContainer $isSidebarCollapsed={isSidebarCollapsed}>
-        <UpdateStatusActionBarIcon
-            showUpdateBannerNotification={Boolean(showUpdateBannerNotification)}
-        />
+        {!hideUpdateStatusBar && (
+            <UpdateStatusActionBarIcon
+                showUpdateBannerNotification={Boolean(showUpdateBannerNotification)}
+            />
+        )}
         <DebugAndExperimental />
         <CustomBackend />
         <Tor />

--- a/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx
@@ -96,7 +96,7 @@ export const LoggedOutSidebar = () => {
                                     data-testid="@suite/menu/settings"
                                 />
                             </Nav>
-                            <QuickActions isSidebarCollapsed />
+                            <QuickActions hideUpdateStatusBar isSidebarCollapsed />
                         </Column>
                     </TrafficLightOffset>
                 </WelcomeNavColumn>


### PR DESCRIPTION
…and welcome layout

The update quick action doesn't make much sense on the logged out screen / welcome screen

## Description

<!--- Describe your changes in detail -->

## Related Issue

[Resolve](https://github.com/trezor/trezor-suite/issues/17067) 

## Screenshots:
