### PR TITLE
fix(connect): ts requires lib ES2022 even the target is ES2022

### DIFF
--- a/packages/connect/tsconfig.lib.json
+++ b/packages/connect/tsconfig.lib.json
@@ -2,7 +2,7 @@
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
         "outDir": "lib",
-        "lib": ["webworker"]
+        "lib": ["webworker", "ES2022"]
     },
     "include": ["./src"],
     "references": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
It might be a TS caching, not sure, it should not require to add the lib of the target, since according to the TS documentation the lib of the target is added automatically https://www.typescriptlang.org/tsconfig/#target

But still if we add `  throw new Error(response.error, { cause: 'transport-error' });` to the codebase we get TS error, and with lib: ["ES2022"] it does not produce the error.