### PR TITLE
Fix output labeling bugs, refactor TransactionTarget

### DIFF
--- a/packages/suite/src/components/suite/AccountLabel.tsx
+++ b/packages/suite/src/components/suite/AccountLabel.tsx
@@ -17,6 +17,7 @@ const TabularNums = styled.span`
     font-variant-numeric: tabular-nums;
     text-overflow: ellipsis;
     overflow: hidden;
+    white-space: nowrap;
 `;
 
 interface AccountLabelProps {

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -375,12 +375,12 @@ export const MetadataLabeling = ({
     };
 
     const ButtonLikeLabelWithDropdown = useMemo(() => {
-        if (payload.value) {
+        if (payload.value && !editActive) {
             return withDropdown(ButtonLikeLabel);
         }
 
         return ButtonLikeLabel;
-    }, [payload.value]);
+    }, [payload.value, editActive]);
 
     const labelContainerDataTest = `${dataTestBase}/hover-container`;
 

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -1,6 +1,5 @@
 import { memo, useMemo, useState } from 'react';
 
-import { AnimatePresence } from 'framer-motion';
 import styled from 'styled-components';
 
 import { AccountType, Network } from '@suite-common/wallet-config';
@@ -32,11 +31,7 @@ import { Content, TimestampWrapper, TxTypeIconWrapper } from './CommonComponents
 import { TransactionHeading } from './TransactionHeading';
 import { BlurWrapper } from './TransactionItemBlurWrapper';
 import { CoinjoinRow, DepositRow, FeeRow, WithdrawalRow } from './TransactionRow';
-import {
-    InternalTransfer,
-    TokenTransfer,
-    TransactionTarget,
-} from './TransactionTarget/TransactionTarget';
+import { TransactionTargetsList } from './TransactionTarget/TransactionTargetsList';
 import { TransactionTypeIcon } from './TransactionTypeIcon';
 
 const Wrapper = styled.div<{
@@ -151,7 +146,6 @@ export const TransactionItem = memo(
             ...tokens.map(t => ({ type: 'token' as const, payload: t })),
         ];
 
-        const previewTargets = allOutputs.slice(0, DEFAULT_LIMIT);
         const isExpandable = allOutputs.length - DEFAULT_LIMIT > 0;
         const toExpand = allOutputs.length - DEFAULT_LIMIT - limit;
 
@@ -276,149 +270,18 @@ export const TransactionItem = memo(
                                         <TransactionTimestamp transaction={transaction} />
                                     </TimestampWrapper>
                                     <Column flex="1" overflow="hidden">
-                                        {!isUnknown &&
-                                        type !== 'failed' &&
-                                        previewTargets.length ? (
-                                            <>
-                                                {previewTargets.map((t, i) => (
-                                                    <BlurWrapper
-                                                        $isBlurred={isPhishingTransaction}
-                                                        key={i}
-                                                    >
-                                                        {t.type === 'target' && (
-                                                            <TransactionTarget
-                                                                // render first n targets, n = DEFAULT_LIMIT
-                                                                target={t.payload}
-                                                                transaction={transaction}
-                                                                singleRowLayout={useSingleRowLayout}
-                                                                isFirst={i === 0}
-                                                                isLast={
-                                                                    limit > 0
-                                                                        ? false
-                                                                        : i ===
-                                                                          previewTargets.length - 1
-                                                                } // if list of targets is expanded we won't get last item here
-                                                                accountMetadata={accountMetadata}
-                                                                accountKey={accountKey}
-                                                                isActionDisabled={isActionDisabled}
-                                                                isPhishingTransaction={
-                                                                    isPhishingTransaction
-                                                                }
-                                                            />
-                                                        )}
-                                                        {t.type === 'token' && (
-                                                            <TokenTransfer
-                                                                transfer={t.payload}
-                                                                transaction={transaction}
-                                                                singleRowLayout={useSingleRowLayout}
-                                                                isFirst={i === 0}
-                                                                isLast={
-                                                                    limit > 0
-                                                                        ? false
-                                                                        : i ===
-                                                                          previewTargets.length - 1
-                                                                }
-                                                                isPhishingTransaction={
-                                                                    isPhishingTransaction
-                                                                }
-                                                            />
-                                                        )}
-                                                        {t.type === 'internal' && (
-                                                            <InternalTransfer
-                                                                transfer={t.payload}
-                                                                transaction={transaction}
-                                                                singleRowLayout={useSingleRowLayout}
-                                                                isFirst={i === 0}
-                                                                isLast={
-                                                                    limit > 0
-                                                                        ? false
-                                                                        : i ===
-                                                                          previewTargets.length - 1
-                                                                }
-                                                            />
-                                                        )}
-                                                    </BlurWrapper>
-                                                ))}
-                                                <AnimatePresence initial={false}>
-                                                    {limit > 0 &&
-                                                        allOutputs
-                                                            .slice(
-                                                                DEFAULT_LIMIT,
-                                                                DEFAULT_LIMIT + limit,
-                                                            )
-                                                            .map((t, i) => (
-                                                                <BlurWrapper
-                                                                    $isBlurred={
-                                                                        isPhishingTransaction
-                                                                    }
-                                                                    key={i}
-                                                                >
-                                                                    {t.type === 'target' && (
-                                                                        <TransactionTarget
-                                                                            target={t.payload}
-                                                                            transaction={
-                                                                                transaction
-                                                                            }
-                                                                            useAnimation
-                                                                            isLast={
-                                                                                // if list is not fully expanded, an index of last is limit (num of currently showed items) - 1,
-                                                                                // otherwise the index is calculated as num of all targets - num of targets that are always shown (DEFAULT_LIMIT) - 1
-                                                                                allOutputs.length >
-                                                                                limit +
-                                                                                    DEFAULT_LIMIT
-                                                                                    ? i ===
-                                                                                      limit - 1
-                                                                                    : i ===
-                                                                                      allOutputs.length -
-                                                                                          DEFAULT_LIMIT -
-                                                                                          1
-                                                                            }
-                                                                            accountMetadata={
-                                                                                accountMetadata
-                                                                            }
-                                                                            accountKey={accountKey}
-                                                                            isPhishingTransaction={
-                                                                                isPhishingTransaction
-                                                                            }
-                                                                        />
-                                                                    )}
-                                                                    {t.type === 'token' && (
-                                                                        <TokenTransfer
-                                                                            transfer={t.payload}
-                                                                            transaction={
-                                                                                transaction
-                                                                            }
-                                                                            useAnimation
-                                                                            isLast={
-                                                                                i ===
-                                                                                allOutputs.length -
-                                                                                    DEFAULT_LIMIT -
-                                                                                    1
-                                                                            }
-                                                                            isPhishingTransaction={
-                                                                                isPhishingTransaction
-                                                                            }
-                                                                        />
-                                                                    )}
-                                                                    {t.type === 'internal' && (
-                                                                        <InternalTransfer
-                                                                            transfer={t.payload}
-                                                                            transaction={
-                                                                                transaction
-                                                                            }
-                                                                            useAnimation
-                                                                            isLast={
-                                                                                i ===
-                                                                                allOutputs.length -
-                                                                                    DEFAULT_LIMIT -
-                                                                                    1
-                                                                            }
-                                                                        />
-                                                                    )}
-                                                                </BlurWrapper>
-                                                            ))}
-                                                </AnimatePresence>
-                                            </>
+                                        {!isUnknown && type !== 'failed' && allOutputs.length ? (
+                                            <TransactionTargetsList
+                                                transaction={transaction}
+                                                allOutputs={allOutputs}
+                                                isPhishingTransaction={isPhishingTransaction}
+                                                isActionDisabled={isActionDisabled}
+                                                useSingleRowLayout={useSingleRowLayout}
+                                                accountKey={accountKey}
+                                                accountMetadata={accountMetadata}
+                                                limit={limit}
+                                                defaultLimit={DEFAULT_LIMIT}
+                                            />
                                         ) : null}
 
                                         {type === 'joint' && (

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { ToastPayload, notificationsActions } from '@suite-common/toast-notifications';
 import { selectHistoricFiatRatesByTimestamp } from '@suite-common/wallet-core';
 import { Timestamp, TokenAddress } from '@suite-common/wallet-types';
@@ -10,7 +12,6 @@ import {
     isTestnet,
 } from '@suite-common/wallet-utils';
 import { copyToClipboard } from '@trezor/dom-utils';
-import { ArrayElement } from '@trezor/type-utils';
 
 import {
     AddressLabeling,
@@ -29,126 +30,23 @@ import { TargetAddressLabel } from './TargetAddressLabel';
 import { TokenTransferAddressLabel } from './TokenTransferAddressLabel';
 import { AmountComponent } from '../../AmountComponent';
 import { TransactionTargetLayout } from '../TransactionTargetLayout';
+import { CombinedTarget } from './TransactionTargetsList';
 
-interface BaseTransfer {
-    singleRowLayout?: boolean;
-    useAnimation?: boolean;
-    isFirst?: boolean;
-    isLast?: boolean;
-}
-
-interface TokenTransferProps extends BaseTransfer {
-    transfer: ArrayElement<WalletAccountTransaction['tokens']>;
-    transaction: WalletAccountTransaction;
-    isPhishingTransaction: boolean;
-}
-
-export const TokenTransfer = ({
-    transfer,
-    transaction,
-    isPhishingTransaction,
-    ...baseLayoutProps
-}: TokenTransferProps) => {
-    const fiatCurrencyCode = useSelector(selectLocalCurrency);
-    const fiatRateKey = getFiatRateKey(
-        transaction.symbol,
-        fiatCurrencyCode,
-        transfer.contract as TokenAddress,
-    );
-    const historicRate = useSelector(state =>
-        selectHistoricFiatRatesByTimestamp(state, fiatRateKey, transaction.blockTime as Timestamp),
-    );
-
-    return (
-        <TransactionTargetLayout
-            {...baseLayoutProps}
-            addressLabel={
-                <TokenTransferAddressLabel
-                    symbol={transaction.symbol}
-                    isPhishingTransaction={isPhishingTransaction}
-                    transfer={transfer}
-                    type={transaction.type}
-                />
-            }
-            amount={
-                <AmountComponent
-                    transfer={transfer}
-                    withLink={false}
-                    withSign={true}
-                    alignMultitoken="flex-end"
-                />
-            }
-            fiatAmount={
-                !isTestnet(transaction.symbol) && transfer.amount ? (
-                    <FiatValue
-                        amount={formatAmount(transfer.amount, transfer.decimals)}
-                        symbol={transaction.symbol}
-                        historicRate={historicRate}
-                        useHistoricRate
-                    />
-                ) : undefined
-            }
-        />
-    );
-};
-
-interface InternalTransferProps extends BaseTransfer {
-    transfer: ArrayElement<WalletAccountTransaction['internalTransfers']>;
-    transaction: WalletAccountTransaction;
-}
-
-export const InternalTransfer = ({
-    transfer,
-    transaction,
-    ...baseLayoutProps
-}: InternalTransferProps) => {
-    const fiatCurrencyCode = useSelector(selectLocalCurrency);
-    const fiatRateKey = getFiatRateKey(transaction.symbol, fiatCurrencyCode);
-    const historicRate = useSelector(state =>
-        selectHistoricFiatRatesByTimestamp(state, fiatRateKey, transaction.blockTime as Timestamp),
-    );
-
-    const amount = transfer.amount && formatNetworkAmount(transfer.amount, transaction.symbol);
-    const operation = getTxOperation(transfer.type);
-
-    return (
-        <TransactionTargetLayout
-            {...baseLayoutProps}
-            addressLabel={<AddressLabeling address={transfer.to} symbol={transaction.symbol} />}
-            amount={
-                !baseLayoutProps.singleRowLayout && (
-                    <FormattedCryptoAmount
-                        value={amount}
-                        symbol={transaction.symbol}
-                        signValue={operation}
-                    />
-                )
-            }
-            fiatAmount={
-                !isTestnet(transaction.symbol) && amount ? (
-                    <FiatValue
-                        amount={amount}
-                        symbol={transaction.symbol}
-                        historicRate={historicRate}
-                        useHistoricRate
-                    />
-                ) : undefined
-            }
-        />
-    );
-};
-
-interface TransactionTargetProps extends BaseTransfer {
-    target: ArrayElement<WalletAccountTransaction['targets']>;
+type TransactionTargetProps = CombinedTarget & {
     transaction: WalletAccountTransaction;
     accountKey: string;
     accountMetadata?: AccountLabels;
     isActionDisabled?: boolean;
     isPhishingTransaction: boolean;
-}
+    singleRowLayout?: boolean;
+    useAnimation?: boolean;
+    isFirst?: boolean;
+    isLast?: boolean;
+};
 
 export const TransactionTarget = ({
-    target,
+    type,
+    payload,
     transaction,
     accountMetadata,
     accountKey,
@@ -159,90 +57,161 @@ export const TransactionTarget = ({
     const dispatch = useDispatch();
 
     const fiatCurrencyCode = useSelector(selectLocalCurrency);
-    const fiatRateKey = getFiatRateKey(transaction.symbol, fiatCurrencyCode);
+    const fiatRateKey = getFiatRateKey(
+        transaction.symbol,
+        fiatCurrencyCode,
+        type === 'token' ? (payload.contract as TokenAddress) : undefined,
+    );
     const historicRate = useSelector(state =>
         selectHistoricFiatRatesByTimestamp(state, fiatRateKey, transaction.blockTime as Timestamp),
     );
-
-    const targetAmount = getTargetAmount(target, transaction);
-    const operation = getTxOperation(transaction.type);
-    const targetMetadata = accountMetadata?.outputLabels?.[transaction.txid]?.[target.n];
-
-    const defaultMetadataValue = `${transaction.txid}-${target.n}`;
     const labelingValueBeingEdited = useSelector(selectLabelingValueBeingEdited);
-    const isBeingEdited = defaultMetadataValue === labelingValueBeingEdited;
 
-    const copyAddress = () => {
-        let payload: ToastPayload = { type: 'copy-to-clipboard' };
-        if (!target?.addresses) {
-            // probably should not happen?
-            payload = {
-                type: 'error',
-                error: 'There is nothing to copy',
-            };
-        } else {
-            const result = copyToClipboard(target.addresses.join());
-            if (typeof result === 'string') {
-                payload = {
-                    type: 'error',
-                    error: result,
+    const amount = useMemo(() => {
+        switch (type) {
+            case 'target':
+                return getTargetAmount(payload, transaction);
+            case 'internal':
+                return payload.amount && formatNetworkAmount(payload.amount, transaction.symbol);
+            case 'token':
+                return formatAmount(payload.amount, payload.decimals);
+        }
+    }, [type, payload, transaction]);
+
+    const operation = getTxOperation(type === 'target' ? transaction.type : payload.type);
+
+    const amountComponent = useMemo(() => {
+        switch (type) {
+            case 'target':
+            case 'internal':
+                return amount && !baseLayoutProps.singleRowLayout ? (
+                    <FormattedCryptoAmount
+                        value={amount}
+                        symbol={transaction.symbol}
+                        signValue={operation}
+                    />
+                ) : undefined;
+            case 'token':
+                return (
+                    <AmountComponent
+                        transfer={payload}
+                        withLink={false}
+                        withSign={true}
+                        alignMultitoken="flex-end"
+                    />
+                );
+        }
+    }, [amount, baseLayoutProps.singleRowLayout, operation, transaction.symbol, type, payload]);
+    const fiatAmountComponent = useMemo(
+        () =>
+            !isTestnet(transaction.symbol) && amount ? (
+                <FiatValue
+                    amount={amount}
+                    symbol={transaction.symbol}
+                    historicRate={historicRate}
+                    useHistoricRate
+                />
+            ) : undefined,
+        [amount, historicRate, transaction.symbol],
+    );
+
+    const { addressLabel, isBeingEdited } = useMemo(() => {
+        switch (type) {
+            case 'target': {
+                const targetMetadata =
+                    accountMetadata?.outputLabels?.[transaction.txid]?.[payload.n];
+                const defaultMetadataValue = `${transaction.txid}-${payload.n}`;
+                const isBeingEdited = defaultMetadataValue === labelingValueBeingEdited;
+
+                const copyAddress = () => {
+                    let toast: ToastPayload = { type: 'copy-to-clipboard' };
+                    if (!payload?.addresses) {
+                        // probably should not happen?
+                        toast = {
+                            type: 'error',
+                            error: 'There is nothing to copy',
+                        };
+                    } else {
+                        const result = copyToClipboard(payload.addresses.join());
+                        if (typeof result === 'string') {
+                            toast = {
+                                type: 'error',
+                                error: result,
+                            };
+                        }
+                    }
+                    dispatch(notificationsActions.addToast(toast));
+                };
+
+                return {
+                    addressLabel: (
+                        <MetadataLabeling
+                            isDisabled={isActionDisabled}
+                            defaultVisibleValue={
+                                <TargetAddressLabel
+                                    symbol={transaction.symbol}
+                                    accountMetadata={accountMetadata}
+                                    target={payload}
+                                    type={transaction.type}
+                                />
+                            }
+                            dropdownOptions={[
+                                {
+                                    onClick: copyAddress,
+                                    label: <Translation id="TR_ADDRESS_MODAL_CLIPBOARD" />,
+                                    'data-testid': 'copy-address', // hack: This will be prefixed in the withDropdown()
+                                },
+                            ]}
+                            payload={{
+                                type: 'outputLabel',
+                                entityKey: accountKey,
+                                txid: transaction.txid,
+                                outputIndex: payload.n,
+                                defaultValue: defaultMetadataValue,
+                                value: targetMetadata,
+                            }}
+                        />
+                    ),
+                    isBeingEdited,
                 };
             }
+            case 'token':
+                return {
+                    addressLabel: (
+                        <TokenTransferAddressLabel
+                            symbol={transaction.symbol}
+                            isPhishingTransaction={isPhishingTransaction}
+                            transfer={payload}
+                            type={transaction.type}
+                        />
+                    ),
+                };
+            case 'internal':
+                return {
+                    addressLabel: (
+                        <AddressLabeling address={payload.to} symbol={transaction.symbol} />
+                    ),
+                };
         }
-        dispatch(notificationsActions.addToast(payload));
-    };
+    }, [
+        type,
+        payload,
+        transaction,
+        accountMetadata,
+        accountKey,
+        isActionDisabled,
+        isPhishingTransaction,
+        labelingValueBeingEdited,
+        dispatch,
+    ]);
 
     return (
         <TransactionTargetLayout
             {...baseLayoutProps}
             useHiddenPlaceholder={!isBeingEdited}
-            addressLabel={
-                <MetadataLabeling
-                    isDisabled={isActionDisabled}
-                    defaultVisibleValue={
-                        <TargetAddressLabel
-                            symbol={transaction.symbol}
-                            accountMetadata={accountMetadata}
-                            target={target}
-                            type={transaction.type}
-                        />
-                    }
-                    dropdownOptions={[
-                        {
-                            onClick: copyAddress,
-                            label: <Translation id="TR_ADDRESS_MODAL_CLIPBOARD" />,
-                            'data-testid': 'copy-address', // hack: This will be prefixed in the withDropdown()
-                        },
-                    ]}
-                    payload={{
-                        type: 'outputLabel',
-                        entityKey: accountKey,
-                        txid: transaction.txid,
-                        outputIndex: target.n,
-                        defaultValue: defaultMetadataValue,
-                        value: targetMetadata,
-                    }}
-                />
-            }
-            amount={
-                targetAmount && !baseLayoutProps.singleRowLayout ? (
-                    <FormattedCryptoAmount
-                        value={targetAmount}
-                        symbol={transaction.symbol}
-                        signValue={operation}
-                    />
-                ) : undefined
-            }
-            fiatAmount={
-                !isTestnet(transaction.symbol) && targetAmount ? (
-                    <FiatValue
-                        amount={targetAmount}
-                        symbol={transaction.symbol}
-                        historicRate={historicRate}
-                        useHistoricRate
-                    />
-                ) : undefined
-            }
+            addressLabel={addressLabel}
+            amount={amountComponent}
+            fiatAmount={fiatAmountComponent}
         />
     );
 };

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTargetsList.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTargetsList.tsx
@@ -9,9 +9,9 @@ import { AccountLabels } from 'src/types/suite/metadata';
 import { WalletAccountTransaction } from 'src/types/wallet';
 
 import { BlurWrapper } from '../TransactionItemBlurWrapper';
-import { InternalTransfer, TokenTransfer, TransactionTarget } from './TransactionTarget';
+import { TransactionTarget } from './TransactionTarget';
 
-type CombinedTarget =
+export type CombinedTarget =
     | {
           type: 'token';
           payload: TokenTransferType;
@@ -62,6 +62,7 @@ export const TransactionTargetsList = ({
         useAnimation?: boolean;
     }) => {
         const commonProps = {
+            ...target,
             transaction,
             isFirst: i === 0,
             isLast,
@@ -75,15 +76,7 @@ export const TransactionTargetsList = ({
 
         return (
             <BlurWrapper $isBlurred={isPhishingTransaction} key={i}>
-                {target.type === 'target' && (
-                    <TransactionTarget target={target.payload} {...commonProps} />
-                )}
-                {target.type === 'token' && (
-                    <TokenTransfer transfer={target.payload} {...commonProps} />
-                )}
-                {target.type === 'internal' && (
-                    <InternalTransfer transfer={target.payload} {...commonProps} />
-                )}
+                <TransactionTarget {...commonProps} />
             </BlurWrapper>
         );
     };

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTargetsList.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTargetsList.tsx
@@ -1,0 +1,118 @@
+import { AnimatePresence } from 'framer-motion';
+
+import {
+    InternalTransfer as InternalTransferType,
+    TokenTransfer as TokenTransferType,
+} from '@trezor/blockchain-link-types';
+
+import { AccountLabels } from 'src/types/suite/metadata';
+import { WalletAccountTransaction } from 'src/types/wallet';
+
+import { BlurWrapper } from '../TransactionItemBlurWrapper';
+import { InternalTransfer, TokenTransfer, TransactionTarget } from './TransactionTarget';
+
+type CombinedTarget =
+    | {
+          type: 'token';
+          payload: TokenTransferType;
+      }
+    | {
+          type: 'internal';
+          payload: InternalTransferType;
+      }
+    | {
+          type: 'target';
+          payload: WalletAccountTransaction['targets'][number];
+      };
+
+interface TransactionTargetsListProps {
+    transaction: WalletAccountTransaction;
+    allOutputs: CombinedTarget[];
+    limit: number;
+    defaultLimit: number;
+    accountKey: string;
+    accountMetadata?: AccountLabels;
+    useSingleRowLayout: boolean;
+    isPhishingTransaction: boolean;
+    isActionDisabled?: boolean;
+}
+
+export const TransactionTargetsList = ({
+    transaction,
+    allOutputs,
+    limit,
+    defaultLimit,
+    useSingleRowLayout,
+    accountKey,
+    accountMetadata,
+    isActionDisabled,
+    isPhishingTransaction,
+}: TransactionTargetsListProps) => {
+    const previewTargets = allOutputs.slice(0, defaultLimit);
+
+    const renderTarget = ({
+        target,
+        i,
+        isLast,
+        useAnimation,
+    }: {
+        target: CombinedTarget;
+        i: number;
+        isLast: boolean;
+        useAnimation?: boolean;
+    }) => {
+        const commonProps = {
+            transaction,
+            isFirst: i === 0,
+            isLast,
+            singleRowLayout: useSingleRowLayout,
+            accountMetadata,
+            accountKey,
+            isActionDisabled,
+            isPhishingTransaction,
+            useAnimation,
+        };
+
+        return (
+            <BlurWrapper $isBlurred={isPhishingTransaction} key={i}>
+                {target.type === 'target' && (
+                    <TransactionTarget target={target.payload} {...commonProps} />
+                )}
+                {target.type === 'token' && (
+                    <TokenTransfer transfer={target.payload} {...commonProps} />
+                )}
+                {target.type === 'internal' && (
+                    <InternalTransfer transfer={target.payload} {...commonProps} />
+                )}
+            </BlurWrapper>
+        );
+    };
+
+    return (
+        <>
+            {previewTargets.map((target, i) =>
+                renderTarget({
+                    target,
+                    i,
+                    isLast: limit > 0 ? false : i === previewTargets.length - 1,
+                }),
+            )}
+            <AnimatePresence initial={false}>
+                {limit > 0 &&
+                    allOutputs.slice(defaultLimit, defaultLimit + limit).map((target, i) =>
+                        renderTarget({
+                            target,
+                            i,
+                            // if list is not fully expanded, an index of last is limit (num of currently showed items) - 1,
+                            // otherwise the index is calculated as num of all targets - num of targets that are always shown (DEFAULT_LIMIT) - 1
+                            isLast:
+                                allOutputs.length > limit + defaultLimit
+                                    ? i === limit - 1
+                                    : i === allOutputs.length - defaultLimit - 1,
+                            useAnimation: true,
+                        }),
+                    )}
+            </AnimatePresence>
+        </>
+    );
+};


### PR DESCRIPTION
## Description

Refactoring and fixing several things around transaction labeling. 

chore(suite): extract and refactor TransactionTargetsList from TransactionItem f037748fa8c157f5a4e9d9d3ec083b6a60e9ed5d

- Get rid of duplicated and overly nested code

chore(suite): unify TransactionTarget a840d94d98110229fe0b79c99719f2763d3744f8

- Simplify and deduplicate code of the different transaction types

fix(suite): disable dropdown when editing metadata 748a4be0bdf1a7485d6dcbcde1f019628772b769

- There was an issue typing spaces in labels, since the events would get intercepted by the dropdown

feat(suite): fix graphical glitch in AccountLabel 2763d8c9720cad88332e449023391bee949c412a

- Some labels would wrap the hidden part when animating, causing glitching

<img width="395" alt="Screenshot 2025-02-25 at 18 03 40" src="https://github.com/user-attachments/assets/ee03b9c0-fe69-40ff-9326-ec8d17c77a0f" />
