### PR TITLE
feat(suite): enable labeling for token transfers

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -115,101 +115,91 @@ export const TransactionTarget = ({
         [amount, historicRate, transaction.symbol],
     );
 
-    const { addressLabel, isBeingEdited } = useMemo(() => {
+    const metadataId = useMemo(() => {
         switch (type) {
-            case 'target': {
-                const targetMetadata =
-                    accountMetadata?.outputLabels?.[transaction.txid]?.[payload.n];
-                const defaultMetadataValue = `${transaction.txid}-${payload.n}`;
-                const isBeingEdited = defaultMetadataValue === labelingValueBeingEdited;
+            case 'target':
+                return payload.n;
+            case 'token':
+                return `token-${payload.contract}`;
+            case 'internal':
+                return `internal-${payload.to}`;
+        }
+    }, [type, payload]);
+    const targetMetadata = accountMetadata?.outputLabels?.[transaction.txid]?.[metadataId];
+    const defaultMetadataValue = `${transaction.txid}-${metadataId}`;
+    const isBeingEdited = defaultMetadataValue === labelingValueBeingEdited;
 
-                const copyAddress = () => {
-                    let toast: ToastPayload = { type: 'copy-to-clipboard' };
-                    if (!payload?.addresses) {
-                        // probably should not happen?
-                        toast = {
-                            type: 'error',
-                            error: 'There is nothing to copy',
-                        };
-                    } else {
-                        const result = copyToClipboard(payload.addresses.join());
-                        if (typeof result === 'string') {
-                            toast = {
-                                type: 'error',
-                                error: result,
-                            };
-                        }
-                    }
-                    dispatch(notificationsActions.addToast(toast));
-                };
-
-                return {
-                    addressLabel: (
-                        <MetadataLabeling
-                            isDisabled={isActionDisabled}
-                            defaultVisibleValue={
-                                <TargetAddressLabel
-                                    symbol={transaction.symbol}
-                                    accountMetadata={accountMetadata}
-                                    target={payload}
-                                    type={transaction.type}
-                                />
-                            }
-                            dropdownOptions={[
-                                {
-                                    onClick: copyAddress,
-                                    label: <Translation id="TR_ADDRESS_MODAL_CLIPBOARD" />,
-                                    'data-testid': 'copy-address', // hack: This will be prefixed in the withDropdown()
-                                },
-                            ]}
-                            payload={{
-                                type: 'outputLabel',
-                                entityKey: accountKey,
-                                txid: transaction.txid,
-                                outputIndex: payload.n,
-                                defaultValue: defaultMetadataValue,
-                                value: targetMetadata,
-                            }}
-                        />
-                    ),
-                    isBeingEdited,
+    const copyAddress = () => {
+        let toast: ToastPayload = { type: 'copy-to-clipboard' };
+        const addresses = type === 'target' ? payload.addresses : [payload.to];
+        if (!addresses) {
+            // probably should not happen?
+            toast = {
+                type: 'error',
+                error: 'There is nothing to copy',
+            };
+        } else {
+            const result = copyToClipboard(addresses.join());
+            if (typeof result === 'string') {
+                toast = {
+                    type: 'error',
+                    error: result,
                 };
             }
-            case 'token':
-                return {
-                    addressLabel: (
-                        <TokenTransferAddressLabel
-                            symbol={transaction.symbol}
-                            isPhishingTransaction={isPhishingTransaction}
-                            transfer={payload}
-                            type={transaction.type}
-                        />
-                    ),
-                };
-            case 'internal':
-                return {
-                    addressLabel: (
-                        <AddressLabeling address={payload.to} symbol={transaction.symbol} />
-                    ),
-                };
         }
-    }, [
-        type,
-        payload,
-        transaction,
-        accountMetadata,
-        accountKey,
-        isActionDisabled,
-        isPhishingTransaction,
-        labelingValueBeingEdited,
-        dispatch,
-    ]);
+        dispatch(notificationsActions.addToast(toast));
+    };
+
+    const label = useMemo(() => {
+        switch (type) {
+            case 'target':
+                return (
+                    <TargetAddressLabel
+                        symbol={transaction.symbol}
+                        accountMetadata={accountMetadata}
+                        target={payload}
+                        type={transaction.type}
+                    />
+                );
+            case 'token':
+                return (
+                    <TokenTransferAddressLabel
+                        symbol={transaction.symbol}
+                        isPhishingTransaction={isPhishingTransaction}
+                        transfer={payload}
+                        type={transaction.type}
+                    />
+                );
+            case 'internal':
+                return <AddressLabeling address={payload.to} symbol={transaction.symbol} />;
+        }
+    }, [type, transaction, payload, accountMetadata, isPhishingTransaction]);
 
     return (
         <TransactionTargetLayout
             {...baseLayoutProps}
             useHiddenPlaceholder={!isBeingEdited}
-            addressLabel={addressLabel}
+            addressLabel={
+                <MetadataLabeling
+                    isDisabled={isActionDisabled}
+                    defaultVisibleValue={label}
+                    dropdownOptions={[
+                        {
+                            onClick: copyAddress,
+                            label: <Translation id="TR_ADDRESS_MODAL_CLIPBOARD" />,
+                            'data-testid': 'copy-address', // hack: This will be prefixed in the withDropdown()
+                        },
+                    ]}
+                    payload={{
+                        type: 'outputLabel',
+                        entityKey: accountKey,
+                        txid: transaction.txid,
+                        outputIndex: metadataId,
+                        defaultValue: defaultMetadataValue,
+                        value: targetMetadata,
+                    }}
+                />
+            }
             amount={amountComponent}
             fiatAmount={fiatAmountComponent}
         />

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -20,7 +20,7 @@ export type MetadataAddPayload = { skipSave?: boolean } & (
           type: 'outputLabel';
           entityKey: string;
           txid: string;
-          outputIndex: number;
+          outputIndex: number | string;
           defaultValue?: string;
           value?: string;
       }


### PR DESCRIPTION
## Description

Enable labeling for token and internal transfers, reusing the same logic as regular transfer, except the indexing is done by contract address, not output number.

## Related Issue

Related to #3545
Depends on PR #17135

## Screenshots:

<img width="1131" alt="Screenshot 2025-02-20 at 14 56 02" src="https://github.com/user-attachments/assets/05e8e00b-9131-4cfe-8b65-eae4941bd6dd" />
