### PR TITLE
feat(trading): exclude NON_SUITE receive option when noExternalAddress tag

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -126,7 +126,7 @@
         "@testing-library/user-event": "14.5.2",
         "@trezor/eslint": "workspace:*",
         "@types/file-saver": "^2.0.6",
-        "@types/invity-api": "^1.1.2",
+        "@types/invity-api": "^1.1.3",
         "@types/jws": "^3.2.10",
         "@types/pako": "^2.0.3",
         "@types/pdfmake": "^0.2.9",

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.tsx
@@ -29,6 +29,7 @@ const getSelectAccountOptions = (
     suiteReceiveAccounts: Account[] | undefined,
     device: TrezorDevice | undefined,
     isSupportedNetwork: boolean,
+    nonSuiteAccount: boolean,
 ): TradingVerifyFormAccountOptionProps[] => {
     const selectAccountOptions: TradingVerifyFormAccountOptionProps[] = [];
 
@@ -41,7 +42,9 @@ const getSelectAccountOptions = (
         selectAccountOptions.push({ type: 'ADD_SUITE' });
     }
 
-    selectAccountOptions.push({ type: 'NON_SUITE' });
+    if (nonSuiteAccount) {
+        selectAccountOptions.push({ type: 'NON_SUITE' });
+    }
 
     return selectAccountOptions;
 };
@@ -62,6 +65,7 @@ const getTranslationIds = (type: TradingAccountType | undefined): TradingGetTran
 
 const useTradingVerifyAccount = ({
     cryptoId,
+    nonSuiteAccount,
 }: TradingVerifyAccountProps): TradingVerifyAccountReturnProps => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const accounts = useSelector(state => state.wallet.accounts);
@@ -101,8 +105,14 @@ const useTradingVerifyAccount = ({
     }, [accounts, cryptoId, device, isDebug, symbol]);
 
     const selectAccountOptions = useMemo(
-        () => getSelectAccountOptions(suiteReceiveAccounts, device, isSupportedNetwork),
-        [device, suiteReceiveAccounts, isSupportedNetwork],
+        () =>
+            getSelectAccountOptions(
+                suiteReceiveAccounts,
+                device,
+                isSupportedNetwork,
+                nonSuiteAccount,
+            ),
+        [device, suiteReceiveAccounts, isSupportedNetwork, nonSuiteAccount],
     );
     const preselectedAccount = useMemo(
         () =>

--- a/packages/suite/src/types/trading/tradingVerify.ts
+++ b/packages/suite/src/types/trading/tradingVerify.ts
@@ -21,6 +21,7 @@ export interface TradingVerifyFormAccountOptionProps {
 
 export interface TradingVerifyAccountProps {
     cryptoId: CryptoId | undefined;
+    nonSuiteAccount: boolean;
 }
 
 export interface TradingGetTranslationIdsProps {

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferBuy/TradingOfferBuy.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferBuy/TradingOfferBuy.tsx
@@ -15,7 +15,10 @@ export const TradingOfferBuy = ({
     paymentMethodName,
 }: TradingOfferBuyProps) => {
     const cryptoId = selectedQuote?.receiveCurrency;
-    const tradingVerifyAccount = useTradingVerifyAccount({ cryptoId });
+    const tradingVerifyAccount = useTradingVerifyAccount({
+        cryptoId,
+        nonSuiteAccount: !selectedQuote.tags?.includes('noExternalAddress'),
+    });
 
     return (
         <>

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
@@ -26,7 +26,10 @@ export const TradingOfferExchange = ({
 }: TradingOfferExchangeProps) => {
     const { exchangeStep } = useTradingFormContext<TradingExchangeType>();
     const cryptoId = selectedQuote?.receive;
-    const tradingVerifyAccount = useTradingVerifyAccount({ cryptoId });
+    const tradingVerifyAccount = useTradingVerifyAccount({
+        cryptoId,
+        nonSuiteAccount: !selectedQuote.tags?.includes('noExternalAddress'),
+    });
 
     const steps: TradingSelectedOfferStepperItemProps[] = [
         {

--- a/suite-common/trading/package.json
+++ b/suite-common/trading/package.json
@@ -23,6 +23,6 @@
     },
     "devDependencies": {
         "@suite-common/test-utils": "workspace:*",
-        "@types/invity-api": "^1.1.2"
+        "@types/invity-api": "^1.1.3"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9717,7 +9717,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.2"
+    "@types/invity-api": "npm:^1.1.3"
     uuid: "npm:^11.0.5"
   languageName: unknown
   linkType: soft
@@ -12642,7 +12642,7 @@ __metadata:
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/file-saver": "npm:^2.0.6"
-    "@types/invity-api": "npm:^1.1.2"
+    "@types/invity-api": "npm:^1.1.3"
     "@types/jws": "npm:^3.2.10"
     "@types/pako": "npm:^2.0.3"
     "@types/pdfmake": "npm:^0.2.9"
@@ -13552,10 +13552,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/invity-api@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@types/invity-api@npm:1.1.2"
-  checksum: 10/4c3f638c9f6fd674a9bb9360c06dcf5a7d6c1b9750b05b3d70da83277a8145effed660b50c294833c0aef3a22a0511d8459e69ce3cf8d6e618743be2cd2fc1fb
+"@types/invity-api@npm:^1.1.3":
+  version: 1.1.4
+  resolution: "@types/invity-api@npm:1.1.4"
+  checksum: 10/6a17f3d84274c86eb31950cb525b3a0a5bf87a7539e8ac35a011f15d354fd1c0cd7dee88bd3d475d5b973829d71817de2b019bedddd03224be85e51dabac830b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Hide `Use an account that isn’t in Suite` option (NON_SUITE) in receive form, controlled by `noExternalAddress` tag in quote data

## Related Issue

Resolve #17137

## Screenshots:
### Before
![image](https://github.com/user-attachments/assets/a0205b92-85b7-4d3b-93d8-63b723ca8ca0)

### After
#### For multiple accounts:
![image](https://github.com/user-attachments/assets/3287e70c-f76b-4873-99cd-1bb40f3f384e)
#### For single account, the dropdown has only 1 option so it's disabled
![image](https://github.com/user-attachments/assets/1da74340-6766-487d-aaa5-ff6da5ee2979)
