### PR TITLE
feat(suite): improved transaction titles for tokens

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
@@ -84,7 +84,12 @@ const getSolTransactionStakeTypeName = (stakeType: StakeType) => {
 export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderProps) => {
     const { translationString } = useTranslation();
 
-    if (transaction?.ethereumSpecific?.parsedData?.name && transaction.type !== 'failed') {
+    if (
+        transaction?.ethereumSpecific?.parsedData?.name &&
+        transaction.type !== 'failed' &&
+        // Exclude Transfer txs, the default messages are more descriptive
+        transaction.ethereumSpecific.parsedData.name !== 'Transfer'
+    ) {
         return (
             <Row gap={spacings.xxs} overflow="hidden">
                 <span>{transaction.ethereumSpecific.parsedData.name}</span>
@@ -104,6 +109,35 @@ export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderP
                 )}
             </Row>
         );
+    }
+
+    // Swap transaction - 2 tokens, token to native or native to token
+    if (
+        transaction.tokens.length === 2 ||
+        (transaction.tokens.length === 1 &&
+            (transaction.internalTransfers.length === 1 || transaction.targets.length === 1))
+    ) {
+        const combined = [
+            ...transaction.tokens,
+            ...transaction.internalTransfers.map(t => ({
+                type: t.type,
+                symbol: getNetworkDisplaySymbol(transaction.symbol),
+            })),
+            ...transaction.targets.map(_ => ({
+                type: 'sent',
+                symbol: getNetworkDisplaySymbol(transaction.symbol),
+            })),
+        ];
+        const fromSymbol = combined.find(t => t.type === 'sent')?.symbol;
+        const toSymbol = combined.find(t => t.type === 'recv')?.symbol;
+
+        if (fromSymbol && toSymbol) {
+            return (
+                <BlurUrls
+                    text={translationString('TR_SWAP_TRANSACTION', { fromSymbol, toSymbol })}
+                />
+            );
+        }
     }
 
     const isMultiTokenTransaction = transaction.tokens.length > 1;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3272,6 +3272,10 @@ export default defineMessages({
         defaultMessage: 'Coinjoin transactions',
         id: 'TR_COINJOIN_TRANSACTION_BATCH',
     },
+    TR_SWAP_TRANSACTION: {
+        defaultMessage: 'Swap from {fromSymbol} to {toSymbol}',
+        id: 'TR_SWAP_TRANSACTION',
+    },
     TR_UNKNOWN_ERROR_SEE_CONSOLE: {
         defaultMessage: 'Unknown error. See console logs for details.',
         id: 'TR_UNKNOWN_ERROR_SEE_CONSOLE',

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -1016,7 +1016,8 @@ export const advancedSearchTransactions = (
  */
 export const getTxHeaderSymbol = (transaction: WalletAccountTransaction) => {
     // check if tx has exactly one token
-    const isSingleTokenTransaction = transaction.tokens.length === 1;
+    const isSingleTokenTransaction =
+        transaction.tokens.length === 1 && transaction.targets.length === 0;
 
     // if there's exactly one token, use its symbol; otherwise, use the main network symbol
     const symbol = isSingleTokenTransaction ? transaction.tokens[0].symbol : transaction.symbol;


### PR DESCRIPTION
## Description

1. Don't use `ethereumSpecific.parsedData` as title for Transfer transactions, since it's less descriptive than our default title.
2. Fix condition for single token transactions to also check target, which would mean it's not really a single token transaction and would have resulted in an inaccurate title.
3. Added support for titles for Swap transactions. These are classified as transactions, where either 2 tokens are exchanged or 1 token is exchanged for the native token.

## Related Issue

Resolve #17141

## Screenshots:

<img width="1121" alt="Screenshot 2025-02-20 at 16 19 55" src="https://github.com/user-attachments/assets/75df94d0-cc23-431c-a307-e94a2e6a67a3" />
