### PR TITLE
chore(suite, urls): add URL to article about entropy check

### DIFF
--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
@@ -1,6 +1,9 @@
 import { deviceActions } from '@suite-common/wallet-core';
 import { Card } from '@trezor/components';
-import { TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL, TREZOR_SUPPORT_URL } from '@trezor/urls';
+import {
+    HELP_CENTER_ENTROPY_CHECK_URL,
+    TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL,
+} from '@trezor/urls';
 
 import { WelcomeLayout } from 'src/components/suite';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
@@ -34,7 +37,7 @@ const useSecurityCheckFailProps = (): SecurityCheckFailProps => {
             text: 'TR_DEVICE_COMPROMISED_ENTROPY_CHECK_TEXT',
             checklistItems: hardFailureChecklistItems,
             goBack: undefined,
-            supportUrl: TREZOR_SUPPORT_URL, // TODO: add specific URL when it is created
+            supportUrl: HELP_CENTER_ENTROPY_CHECK_URL,
         };
     }
     // revision check has precedence over hash check, because it does not have the ambiguous other-error state

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -119,6 +119,7 @@ export const HELP_CENTER_FIRMWARE_REVISION_CHECK: Url =
     'https://trezor.io/learn/a/trezor-firmware-authenticity-check';
 export const HELP_CENTER_FIRMWARE_REVISION_CHECK_MOBILE: Url =
     'https://trezor.io/learn/a/trezor-firmware-authenticity-check-mobile';
+export const HELP_CENTER_ENTROPY_CHECK_URL: Url = 'https://trezor.io/learn/a/entropy-check';
 
 export const HELP_CENTER_REPLACE_BY_FEE_ETHEREUM: Url =
     'https://trezor.io/learn/a/replace-by-fee-rbf-ethereum';


### PR DESCRIPTION
![Screenshot 2025-02-20 at 16 20 46](https://github.com/user-attachments/assets/601716af-3fd6-4a94-a0a9-3504ad5918f7)

**QA:** The button should link to https://trezor.io/learn/a/entropy-check and open chat. This can only be tested by using the fake device available in the office.
