### PR TITLE
Connect popup tests 2

### DIFF
--- a/packages/connect-popup/e2e/support/helpers.ts
+++ b/packages/connect-popup/e2e/support/helpers.ts
@@ -116,8 +116,8 @@ export const openPopup = (
     } else {
         triggerPopup.push(explorerPage.waitForEvent('popup'));
     }
-    triggerPopup.push(explorerPage.click("div[data-testid='@api-playground/collapsible-box']"));
-    triggerPopup.push(explorerPage.click("button[data-testid='@submit-button']"));
+    triggerPopup.push(explorerPage.getByTestId('@api-playground/collapsible-box').click());
+    triggerPopup.push(explorerPage.getByTestId('@submit-button').click());
     triggerPopup.push(explorerPage.waitForSelector("[data-testid='@submit-button/spinner']"));
 
     return Promise.all(triggerPopup) as Promise<Page[]>;
@@ -149,7 +149,9 @@ export const setConnectSettings = async (
     { trustedHost = false, connectSrc }: { trustedHost?: boolean; connectSrc?: string },
     _isWebExtension?: boolean,
 ) => {
-    await explorerPage.goto(formatUrl(explorerUrl, `settings/index.html`));
+    await explorerPage.goto(
+        formatUrl(explorerUrl, _isWebExtension ? `settings/index.html` : `settings`),
+    );
     /*if (isWebExtension) {
         // When webextension and using service-worker we need to wait for handshake is confirmed with proxy.
         await explorerPage.waitForSelector("div[data-testid='@settings/handshake-confirmed']");

--- a/packages/connect-popup/e2e/tests/browser-support.test.ts
+++ b/packages/connect-popup/e2e/tests/browser-support.test.ts
@@ -23,7 +23,7 @@ const openPopup = async (page: Page) =>
             // It is important to call waitForEvent before click to set up waiting.
             page.waitForEvent('popup'),
             // Opens popup.
-            page.click("div[data-testid='@api-playground/collapsible-box']"),
+            page.getByTestId('@api-playground/collapsible-box').click(),
             page.click("button[data-testid='@submit-button']"),
         ])
     )[0];

--- a/packages/connect-popup/e2e/tests/popup-close.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close.test.ts
@@ -216,8 +216,13 @@ test('when user cancels permissions in popup it closes automatically', async ({
 
     await popupClosedPromise;
 
-    await explorerPage.goto(formatUrl(explorerUrl, `methods/bitcoin/getAddress/index.html`));
-    await explorerPage.click("[data-testid='@api-playground/collapsible-box']");
+    await explorerPage.goto(
+        formatUrl(
+            explorerUrl,
+            `methods/bitcoin/getAddress` + (isWebExtension ? `/index.html` : ''),
+        ),
+    );
+    await explorerPage.getByTestId('@api-playground/collapsible-box').click();
     await explorerPage.waitForSelector("button[data-testid='@submit-button']", {
         state: 'visible',
     });
@@ -261,7 +266,12 @@ test('device dialogue cancelled IN POPUP by user', async ({ page, context }) => 
 
     await popupClosedPromise;
 
-    await explorerPage.goto(formatUrl(explorerUrl, `methods/bitcoin/getAddress/index.html`));
+    await explorerPage.goto(
+        formatUrl(
+            explorerUrl,
+            `methods/bitcoin/getAddress` + (isWebExtension ? `/index.html` : ''),
+        ),
+    );
     await explorerPage.click("[data-testid='@api-playground/collapsible-box']");
     await explorerPage.waitForSelector("button[data-testid='@submit-button']", {
         state: 'visible',
@@ -336,7 +346,12 @@ test('popup should be focused when a call is in progress and user triggers new c
 
     await popupClosedPromise;
 
-    await explorerPage.goto(formatUrl(explorerUrl, `methods/bitcoin/getAddress/index.html`));
+    await explorerPage.goto(
+        formatUrl(
+            explorerUrl,
+            `methods/bitcoin/getAddress` + (isWebExtension ? `/index.html` : ''),
+        ),
+    );
     await explorerPage.click("[data-testid='@api-playground/collapsible-box']");
     await explorerPage.waitForSelector("button[data-testid='@submit-button']", {
         state: 'visible',
@@ -391,7 +406,12 @@ test('popup should close when third party is closed', async ({ page, context }) 
 
     await popupClosedPromise;
 
-    await explorerPage.goto(formatUrl(explorerUrl, `methods/bitcoin/getAddress/index.html`));
+    await explorerPage.goto(
+        formatUrl(
+            explorerUrl,
+            `methods/bitcoin/getAddress` + (isWebExtension ? `/index.html` : ''),
+        ),
+    );
     await explorerPage.click("[data-testid='@api-playground/collapsible-box']");
     await explorerPage.waitForSelector("button[data-testid='@submit-button']", {
         state: 'visible',
@@ -433,7 +453,7 @@ test.skip('popup should behave properly with subsequent calls', async ({ page, c
     });
     await popupClosedPromise;
 
-    await explorerPage.goto(formatUrl(explorerUrl, `test/index.html`));
+    await explorerPage.goto(formatUrl(explorerUrl, `test` + (isWebExtension ? `/index.html` : '')));
     await waitAndClick(explorerPage, ['@testpage/init']);
     await waitAndClick(explorerPage, ['@testpage/subsequentCalls']);
     log('waiting for popup open');

--- a/packages/connect-popup/e2e/tests/popup-pages.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-pages.test.ts
@@ -75,7 +75,7 @@ test('popup should display error page when device disconnected and debug mode', 
 
     log('waiting for explorer to load');
     await waitAndClick(page, ['@api-playground/collapsible-box']);
-    await page.waitForSelector("div[data-testid='@api-playground/collapsible-box']");
+    await page.getByTestId('@api-playground/collapsible-box').waitFor({ state: 'visible' });
     await explorerPage.waitForSelector("button[data-testid='@submit-button']", {
         state: 'visible',
     });

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -35,7 +35,6 @@
     },
     "dependencies": {
         "@trezor/schema-utils": "workspace:*",
-        "long": "5.2.4",
         "protobufjs": "7.4.0"
     },
     "devDependencies": {

--- a/packages/protobuf/src/index.ts
+++ b/packages/protobuf/src/index.ts
@@ -1,14 +1,3 @@
-// Long.js needed to make protobuf encoding work with numbers over Number.MAX_SAFE_INTEGER
-// Docs claim that it should be enough to only install this dependency and it will be required automatically
-// see: https://github.com/protobufjs/protobuf.js/#compatibility
-// But we found that it does not work in browser environment
-// see: https://github.com/protobufjs/protobuf.js/issues/758
-import Long from 'long';
-import * as protobuf from 'protobufjs/light';
-
-protobuf.util.Long = Long;
-protobuf.configure();
-
 export * from './decode';
 export * from './encode';
 export * as Messages from './messages';

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -67,6 +67,7 @@
         "@trezor/protocol": "workspace:*",
         "@trezor/utils": "workspace:*",
         "cross-fetch": "^4.0.0",
+        "long": "^5.2.0",
         "protobufjs": "7.4.0",
         "usb": "^2.14.0"
     },

--- a/packages/transport/src/index.ts
+++ b/packages/transport/src/index.ts
@@ -1,4 +1,15 @@
+// Long.js needed to make protobuf encoding work with numbers over Number.MAX_SAFE_INTEGER
+// Docs claim that it should be enough to only install this dependency and it will be required automatically
+// see: https://github.com/protobufjs/protobuf.js/#compatibility
+// But we found that it does not work in browser environment
+// see: https://github.com/protobufjs/protobuf.js/issues/758
+import Long from 'long';
+import * as protobuf from 'protobufjs/light';
+
 export * as TRANSPORT_ERROR from './errors';
+
+protobuf.util.Long = Long;
+protobuf.configure();
 
 export type { Descriptor, Session } from './types';
 export { TREZOR_USB_DESCRIPTORS, TRANSPORT } from './constants';

--- a/packages/transport/src/utils/receive.ts
+++ b/packages/transport/src/utils/receive.ts
@@ -1,4 +1,4 @@
-import { type Root } from 'protobufjs/light';
+import { Root } from 'protobufjs/light';
 
 import { createMessageFromType, decode as decodeProtobuf } from '@trezor/protobuf';
 import { TransportProtocol } from '@trezor/protocol';

--- a/packages/transport/src/utils/send.ts
+++ b/packages/transport/src/utils/send.ts
@@ -1,7 +1,7 @@
 // Logic of sending data to trezor
 //
 // Logic of "call" is broken to two parts - sending and receiving
-import { type Root } from 'protobufjs/light';
+import { Root } from 'protobufjs/light';
 
 import { createMessageFromName, encode as encodeProtobuf } from '@trezor/protobuf';
 import { TransportProtocolEncode } from '@trezor/protocol';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12172,7 +12172,6 @@ __metadata:
   resolution: "@trezor/protobuf@workspace:packages/protobuf"
   dependencies:
     "@trezor/schema-utils": "workspace:*"
-    long: "npm:5.2.4"
     protobufjs: "npm:7.4.0"
     protobufjs-cli: "npm:^1.1.3"
     tsx: "npm:^4.16.3"
@@ -12767,6 +12766,7 @@ __metadata:
     cross-fetch: "npm:^4.0.0"
     jest: "npm:29.7.0"
     jest-environment-node: "npm:^29.7.0"
+    long: "npm:^5.2.0"
     protobufjs: "npm:7.4.0"
     ts-node: "npm:^10.9.1"
     tsx: "npm:^4.16.3"
@@ -30039,7 +30039,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"long@npm:5.2.4, long@npm:^5.0.0":
+"long@npm:^5.0.0, long@npm:^5.2.0":
   version: 5.2.4
   resolution: "long@npm:5.2.4"
   checksum: 10/c27c060a683d4d76dc48da12ded0ae49c610aaf10d028ec938829d7bebe916979dcc8b67ed71f8bf6d845a90151b66a9b741a3ee51ec874908e496c2a576697a


### PR DESCRIPTION
- commit 1: 
  - components team changed div to section. we need to adapt
  - it looks like that with update of next probably we cant navigate to something/index.html route with local dev server at least so  I changed it so that it don't use it in case of web. It might still be broken for webextension variant, I havent checked yet.
- ~commit 2 adds simple CI workflow for that runs for changes in components. It could be nicer, there is some duplication but we are abandoning popup anyway so this is sort of  temporary~ I am moving it to a separate PR 
- commit 3 reverts a change that breaks eos and some other coin when used with big numbers. I need some time to investigate the reason why this is happening.