### PR TITLE
rework udp api implementation

### DIFF
--- a/packages/transport-test/e2e/bridge/bridge-complex-cases.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge-complex-cases.test.ts
@@ -20,11 +20,7 @@ describe('restarting bridge', () => {
     let session: Session;
     beforeAll(async () => {
         await TrezorUserEnvLink.connect();
-        await TrezorUserEnvLink.startEmu({
-            // it looks like that any later emulator has trouble recovering from these edge-casey situations
-            version: '2.8.7',
-            model: 'T2T1',
-        });
+        await TrezorUserEnvLink.startEmu();
         await TrezorUserEnvLink.startBridge();
 
         bridge = new BridgeTransport({ messages, id: '' });

--- a/packages/transport/src/api/udp.ts
+++ b/packages/transport/src/api/udp.ts
@@ -20,12 +20,21 @@ export class UdpApi extends AbstractApi {
         type: 'udp4',
         signal: this.listenAbortController.signal,
     });
-    protected communicating = false;
     private debugLink?: boolean;
+    private receivedMessagesBuffer: Buffer[] = [];
 
     constructor({ logger, debugLink }: AbstractApiConstructorParams & { debugLink?: boolean }) {
         super({ logger });
         this.debugLink = debugLink;
+
+        const onMessage = (message: Buffer, _info: UDP.RemoteInfo) => {
+            if (message.toString() === 'PONGPONG') {
+                return;
+            }
+            this.receivedMessagesBuffer.push(message);
+            this.logger?.debug('udp: globalOnMessage log:', message.toString('hex'));
+        };
+        this.interface.addListener('message', onMessage);
     }
 
     listen() {
@@ -78,52 +87,34 @@ export class UdpApi extends AbstractApi {
         });
     }
 
-    public read(_path: string, signal?: AbortSignal) {
-        this.communicating = true;
+    public async read(_path: string, signal?: AbortSignal) {
+        let message = this.receivedMessagesBuffer.shift();
 
-        return new Promise<AbstractApiAwaitedResult<'read'>>(resolve => {
-            /* eslint-disable @typescript-eslint/no-use-before-define */
-            const onClear = () => {
-                this.interface.removeListener('error', onError);
-                this.interface.removeListener('message', onMessage);
-                signal?.removeEventListener('abort', onAbort);
-            };
-            /* eslint-enable @typescript-eslint/no-use-before-define */
-            const onError = (err: Error) => {
-                this.logger?.error(err.message);
+        if (message) {
+            return Promise.resolve(this.success(message));
+        }
 
-                resolve(
-                    this.error({
-                        error: ERRORS.INTERFACE_DATA_TRANSFER,
-                        message: err.message,
-                    }),
-                );
-                onClear();
-            };
-            const onMessage = (message: Buffer, _info: UDP.RemoteInfo) => {
-                if (message.toString() === 'PONGPONG') {
-                    return;
-                }
-                onClear();
+        try {
+            // give emu 500ms to send something
+            this.logger?.debug('udp: read: empty buffer, waiting for messages');
+            await resolveAfter(500, signal);
+        } catch {
+            // signal checked just below
+        }
+        if (signal?.aborted) {
+            return this.error({ error: ERRORS.ABORTED_BY_SIGNAL });
+        }
 
-                resolve(this.success(message));
-            };
-            const onAbort = () => {
-                onClear();
+        message = this.receivedMessagesBuffer.shift();
 
-                return resolve(
-                    this.error({
-                        error: ERRORS.ABORTED_BY_SIGNAL,
-                    }),
-                );
-            };
+        if (!message) {
+            return this.error({
+                error: ERRORS.INTERFACE_DATA_TRANSFER,
+                message: 'no message received',
+            });
+        }
 
-            signal?.addEventListener('abort', onAbort);
-            this.interface.addListener('error', onError);
-            this.interface.addListener('message', onMessage);
-        }).finally(() => {
-            this.communicating = false;
-        });
+        return Promise.resolve(this.success(message));
     }
 
     private async ping(path: string, signal?: AbortSignal) {
@@ -156,7 +147,7 @@ export class UdpApi extends AbstractApi {
             this.interface.addListener('error', onError);
             this.interface.addListener('message', onMessage);
 
-            const timeout = setTimeout(onError, this.communicating ? 10000 : 500);
+            const timeout = setTimeout(onError, 1000);
         });
 
         return pinged;

--- a/packages/transport/tests/apiUdp.test.ts
+++ b/packages/transport/tests/apiUdp.test.ts
@@ -35,7 +35,6 @@ describe('api/udp', () => {
         await api.enumerate(abortController.signal);
         const promise = api.read('1', abortController.signal);
         abortController.abort();
-
         const result = await promise;
         if (result.success) throw new Error('Unexpected success');
         expect(result.error).toContain('Aborted by signal');
@@ -43,7 +42,6 @@ describe('api/udp', () => {
 
     it('write aborted', async () => {
         let listeners = 0;
-
         jest.spyOn(UDP, 'createSocket').mockImplementation(() =>
             createUdpSocketMock({
                 send: (...args: any[]) => {
@@ -68,7 +66,7 @@ describe('api/udp', () => {
         const result = await promise;
         if (result.success) throw new Error('Unexpected success');
         expect(result.error).toContain('Aborted by signal');
-        expect(listeners).toBe(0);
+        expect(listeners).toBe(1); // only the global listener is present
     });
 
     it('enumerate aborted', async () => {


### PR DESCRIPTION
after updating to the latest emulator, our transport e2e tests focusing on the node-bridge - emulator implementation started to fail consistently, namely test that is testing /post and /read endpoints.

After some investigation I found that the issue was caused by emulator responding before /read endpoint was processed which caused data loss and /read hang.

Now udp API is always listening to incoming data and /read can pull them out of a local buffer.