### PR TITLE
fix(suite): hide non-Everstake Solana staking accounts

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -384,6 +384,7 @@ const getAccountInfo = async (
                 payload.descriptor,
                 isTestnet,
                 solEpoch,
+                api.clusterUrl,
             );
             misc = {
                 owner: accountInfo?.owner,

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -62,8 +62,8 @@ import { IntervalId } from '@trezor/type-utils';
 import { BigNumber, createDeferred, createLazy } from '@trezor/utils';
 
 import { getBaseFee, getPriorityFee } from './fee';
+import { getSolanaStakingData } from './stakingAccounts';
 import { BaseWorker, CONTEXT, ContextType } from '../baseWorker';
-import { getSolanaStakingData } from './utils';
 
 export type SolanaAPI = Readonly<{
     clusterUrl: ClusterUrl;

--- a/packages/blockchain-link/src/workers/solana/stakingAccounts.ts
+++ b/packages/blockchain-link/src/workers/solana/stakingAccounts.ts
@@ -1,12 +1,19 @@
 import { Network, Solana, isStake, stakeAccountState } from '@everstake/wallet-sdk-solana';
 
-import config from '../../ui/config';
+import { SolanaStakingAccount } from '@trezor/blockchain-link-types/src/solana';
+
+import config from './../../ui/config';
+
+const EVERSTAKE_VOTER_PUBKEYS = [
+    '9QU2QSxhb24FUX3Tu2FpczXjpK3VYrvRudywSZaM29mF', // mainnet
+    'GkqYQysEGmuL6V2AJoNnWZUz2ZBGWhzQXsJiXm2CLKAN', // devnet
+];
 
 export const getSolanaStakingData = async (
     descriptor: string,
     isTestnet: boolean,
     epoch: number,
-) => {
+): Promise<SolanaStakingAccount[]> => {
     const blockchainEnvironment = isTestnet ? 'devnet' : 'mainnet';
 
     // Find the blockchain configuration for the specified chain and environment
@@ -36,6 +43,9 @@ export const getSolanaStakingData = async (
 
             if (state && 'fields' in state) {
                 const { fields } = state;
+
+                const voterPubkey = fields[1]?.delegation?.voterPubkey;
+                if (!EVERSTAKE_VOTER_PUBKEYS.includes(voterPubkey)) return; // filter out non-everstake accounts
 
                 return {
                     rentExemptReserve: fields[0]?.rentExemptReserve,

--- a/packages/blockchain-link/src/workers/solana/stakingAccounts.ts
+++ b/packages/blockchain-link/src/workers/solana/stakingAccounts.ts
@@ -2,8 +2,6 @@ import { Network, Solana, isStake, stakeAccountState } from '@everstake/wallet-s
 
 import { SolanaStakingAccount } from '@trezor/blockchain-link-types/src/solana';
 
-import config from './../../ui/config';
-
 const EVERSTAKE_VOTER_PUBKEYS = [
     '9QU2QSxhb24FUX3Tu2FpczXjpK3VYrvRudywSZaM29mF', // mainnet
     'GkqYQysEGmuL6V2AJoNnWZUz2ZBGWhzQXsJiXm2CLKAN', // devnet
@@ -13,14 +11,8 @@ export const getSolanaStakingData = async (
     descriptor: string,
     isTestnet: boolean,
     epoch: number,
+    serverUrl: string,
 ): Promise<SolanaStakingAccount[]> => {
-    const blockchainEnvironment = isTestnet ? 'devnet' : 'mainnet';
-
-    // Find the blockchain configuration for the specified chain and environment
-    const blockchainConfig = config.find(c =>
-        c.blockchain.name.toLowerCase().includes(`solana ${blockchainEnvironment}`),
-    );
-    const serverUrl = blockchainConfig?.blockchain.server[0];
     const network = isTestnet ? Network.Devnet : Network.Mainnet;
 
     const solanaClient = new Solana(network, serverUrl);

--- a/suite-common/wallet-core/src/stake/stakeConstants.ts
+++ b/suite-common/wallet-core/src/stake/stakeConstants.ts
@@ -15,3 +15,5 @@ export const EVERSTAKE_ENDPOINT_PREFIX: Record<
 
 export const EVERSTAKE_REWARDS_SOLANA_ENPOINT =
     'https://stake-sync-api.everstake.one/solana/rewards';
+
+export const EVERSTAKE_VALIDATOR = '9QU2QSxhb24FUX3Tu2FpczXjpK3VYrvRudywSZaM29mF';

--- a/suite-common/wallet-core/src/stake/stakeThunks.ts
+++ b/suite-common/wallet-core/src/stake/stakeThunks.ts
@@ -11,7 +11,11 @@ import {
 import { TimerId } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { EVERSTAKE_ENDPOINT_PREFIX, EVERSTAKE_REWARDS_SOLANA_ENPOINT } from './stakeConstants';
+import {
+    EVERSTAKE_ENDPOINT_PREFIX,
+    EVERSTAKE_REWARDS_SOLANA_ENPOINT,
+    EVERSTAKE_VALIDATOR,
+} from './stakeConstants';
 import { selectEverstakeData } from './stakeSelectors';
 import {
     EVERSTAKE_ASSET_ENDPOINT_TYPES,
@@ -124,7 +128,11 @@ export const fetchEverstakeRewards = createThunk<
         try {
             const response = await fetch(`${EVERSTAKE_REWARDS_SOLANA_ENPOINT}/${address}`, {
                 method: 'POST',
+                body: `validator=${encodeURIComponent(EVERSTAKE_VALIDATOR)}`,
                 signal,
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
             });
 
             if (!response.ok) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hid non-Everstake Solana staking accounts and rewards


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15229

## Screenshots:
