### PR TITLE
fix(blockchain-link-utils): ripple token transaction crash

### DIFF
--- a/packages/blockchain-link-utils/src/ripple.ts
+++ b/packages/blockchain-link-utils/src/ripple.ts
@@ -30,20 +30,21 @@ export const transformTransaction = (
 ): Transaction => {
     const blockTime =
         typeof tx.date === 'number' && tx.date > 0 ? tx.date + BLOCKTIME_OFFSET : tx.date;
+    const isTokenTransaction = tx.Amount && typeof tx.Amount !== 'string';
 
     let txType: Transaction['type'];
 
     // https://xrpl.org/docs/references/protocol/transactions/transaction-results
     if (meta != null && !meta.TransactionResult?.startsWith('tes')) {
         txType = 'failed';
-    } else if (tx.TransactionType !== 'Payment' || !descriptor) {
+    } else if (tx.TransactionType !== 'Payment' || !descriptor || isTokenTransaction) {
         txType = 'unknown';
     } else {
         txType = tx.Account === descriptor ? 'sent' : 'recv';
     }
 
     const addresses = [tx.Destination];
-    const amount = tx.Amount;
+    const amount = !isTokenTransaction ? tx.Amount : undefined;
     const fee = tx.Fee;
     const destinationTag = tx.DestinationTag;
 


### PR DESCRIPTION
## Description

Fix the crash with "Amount is not a number" that happens when encountering Ripple token transfers, where the amount field is an object. 
Now token transfers are shown as unknow transactions.

A Ripple token transfer can be found on old QA seed

## Related Issue

Resolve #17179