### PR TITLE
fix(mobile): remove mocked selectors

### DIFF
--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -4,7 +4,11 @@ import * as Device from 'expo-device';
 
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { extraDependenciesMock } from '@suite-common/test-utils';
-import { selectDevices } from '@suite-common/wallet-core';
+import {
+    selectDeviceDiscovery,
+    selectDevices,
+    selectSelectedDevice,
+} from '@suite-common/wallet-core';
 import {
     selectEnabledDiscoveryNetworkSymbols,
     selectTokenDefinitionsEnabledNetworks,
@@ -41,6 +45,8 @@ export const extraDependencies: ExtraDependencies = mergeDeepObject(extraDepende
         selectAreSatsAmountUnit,
         selectLocalCurrency: selectFiatCurrencyCode,
         selectDevices,
+        selectDevice: selectSelectedDevice,
+        selectDeviceDiscovery,
         selectDebugSettings: () => ({
             transports,
         }),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We were using some mocked selectors instead of real ones which already caused some strange bugs in past. This should use real selectors everywhere.

Notes for QA:
- test functionality with device connecting, disconnecting, discovery, fw update etc


## Related Issue

Previously I tried this #15878 but these selectors are used in big number of test and it's significantly harder to mocked them then, so this later solution should be simpler and keeps mocking simple.

## Screenshots:
