### PR TITLE
fix(trading): fixed fee padding + fee does not fit the fee card

### DIFF
--- a/packages/suite/src/components/wallet/Fees/FeeDetails.tsx
+++ b/packages/suite/src/components/wallet/Fees/FeeDetails.tsx
@@ -51,7 +51,7 @@ type FeeCardProps = {
     bottomRightChild: React.ReactNode;
 };
 
-const FEE_CARD_MIN_WIDTH = 180;
+const FEE_CARD_MIN_WIDTH = 220;
 
 type ResizeObserverType = (
     feeOptions: FeeOption[],

--- a/packages/suite/src/components/wallet/Fees/FeeDetails.tsx
+++ b/packages/suite/src/components/wallet/Fees/FeeDetails.tsx
@@ -13,7 +13,7 @@ import { getFeeUnits } from '@suite-common/wallet-utils';
 import { Box, Column, ElevationUp, RadioCard, Row, Text } from '@trezor/components';
 import { FeeLevel } from '@trezor/connect';
 import { FeeRate } from '@trezor/product-components';
-import { spacings } from '@trezor/theme';
+import { spacings, spacingsPx } from '@trezor/theme';
 
 import { FiatValue } from 'src/components/suite/FiatValue';
 import { useLocales } from 'src/hooks/suite';
@@ -37,7 +37,7 @@ export const FeeCardsWrapper = styled.div<{ $columns: number }>`
     width: 100%;
     display: grid;
     grid-template-columns: repeat(${({ $columns }) => $columns}, 1fr);
-    gap: ${spacings.xs};
+    gap: ${spacingsPx.sm};
     align-items: stretch;
 `;
 
@@ -83,7 +83,7 @@ const FeeCard = ({
     bottomLeftChild,
     bottomRightChild,
 }: FeeCardProps) => (
-    <Box minWidth={FEE_CARD_MIN_WIDTH} margin={spacings.xxs}>
+    <Box minWidth={FEE_CARD_MIN_WIDTH}>
         <ElevationUp>
             <RadioCard onClick={() => changeFeeLevel(value)} isActive={isSelected}>
                 <Column>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormSwitcherExchangeRates.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormSwitcherExchangeRates.tsx
@@ -48,7 +48,7 @@ export const TradingFormSwitcherExchangeRates = ({
     return (
         <Column gap={spacings.xs}>
             <Translation id="TR_TRADING_RATE" />
-            <Grid columns={2} gap={spacings.md}>
+            <Grid columns={2} gap={spacings.sm}>
                 <Item
                     isSelected={!floatingRateSelected}
                     onClick={() => setValue(FORM_RATE_TYPE, FORM_RATE_FIXED)}


### PR DESCRIPTION
## Description

- removed unnecessary fee grid padding
- unified gaps between items in the fee and rate grids
- fixed fee does not fit the fee card component (tested also with 10x and 100x bigger fiat values, but everything 100x does not fit horizontally - see #17075 discussion)

## Related Issue

Resolve #17069 
Resolve #17075 

## Screenshots:

![Screenshot 2025-02-24 at 16 25 19 (2)](https://github.com/user-attachments/assets/c703cbed-c5bd-403c-9995-afdb1d697cb3)

![Screenshot 2025-02-24 at 16 25 45](https://github.com/user-attachments/assets/8a22b9a6-edf9-4b6e-9d9e-33f9c7ba4b52)

![Screenshot 2025-02-24 at 16 45 59](https://github.com/user-attachments/assets/b1a31a23-d010-4eef-89a9-4b4551491260)

![Screenshot 2025-02-24 at 16 46 08](https://github.com/user-attachments/assets/9d9dad17-a87d-44ca-879a-9bbc9de1b7a2)

