### PR TITLE
Tighten Dispatch type

### DIFF
--- a/packages/suite/src/actions/suite/guideActions.ts
+++ b/packages/suite/src/actions/suite/guideActions.ts
@@ -40,7 +40,7 @@ export const setIndexNode = (payload: GuideCategory) => ({
     payload,
 });
 
-export const unsetNode = () => ({
+export const unsetNode = (): GuideAction => ({
     type: GUIDE.UNSET_NODE,
 });
 

--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -37,7 +37,7 @@ export type MetadataAction =
       }
     | {
           type: typeof METADATA.REMOVE_PROVIDER;
-          payload: MetadataProvider;
+          payload: Pick<MetadataProvider, 'clientId'>;
       }
     | {
           type: typeof METADATA.ADD_PROVIDER;
@@ -46,15 +46,15 @@ export type MetadataAction =
     | {
           type: typeof METADATA.SET_DATA;
           payload: {
-              provider: MetadataProvider;
-              data: Record<string, Labels>;
+              provider: Omit<MetadataProvider, 'data'> & Pick<Partial<MetadataProvider>, 'data'>;
+              data: Record<string, Labels | PasswordManagerState> | undefined;
           };
       }
     | {
           type: typeof METADATA.SET_SELECTED_PROVIDER;
           payload: {
               dataType: DataType;
-              clientId: string;
+              clientId: string | undefined;
           };
       }
     | {
@@ -100,7 +100,7 @@ export const disposeMetadataKeys = () => (dispatch: Dispatch, getState: GetState
     });
 
     devices.forEach(device => {
-        if (device.state) {
+        if (device.state?.staticSessionId) {
             // set metadata as disabled for this device, remove all metadata related information
             dispatch({
                 type: METADATA.SET_DEVICE_METADATA,
@@ -134,7 +134,7 @@ export const setMetadata =
     }: {
         provider: MetadataProvider;
         fileName: string;
-        data: WalletLabels | AccountLabels | PasswordManagerState | undefined;
+        data: WalletLabels | AccountLabels | PasswordManagerState;
     }) =>
     (dispatch: Dispatch) => {
         dispatch({

--- a/packages/suite/src/actions/suite/metadataPasswordsActions.ts
+++ b/packages/suite/src/actions/suite/metadataPasswordsActions.ts
@@ -28,11 +28,11 @@ export const fetchPasswords =
 
         // this triggers renewal of access token if needed. Otherwise multiple requests
         // to renew access token are issued by every provider.getFileContent
-        const response = await provider.getProviderDetails();
-        if (!response.success) {
+        const providerDetails = await provider.getProviderDetails();
+        if (!providerDetails.success) {
             return dispatch(
                 metadataProviderActions.handleProviderError({
-                    error: response,
+                    error: providerDetails,
                     action: ProviderErrorAction.LOAD,
                     clientId: provider.clientId,
                 }),
@@ -55,7 +55,7 @@ export const fetchPasswords =
                         dispatch({
                             type: METADATA.SET_DATA,
                             payload: {
-                                provider,
+                                provider: providerDetails.payload,
                                 data: {
                                     [keys.fileName]: decrypted,
                                 },
@@ -76,7 +76,7 @@ export const fetchPasswords =
 export const init = () => async (dispatch: Dispatch, getState: GetState) => {
     let device = selectSelectedDevice(getState());
 
-    if (!device?.state) {
+    if (!device?.state?.staticSessionId) {
         console.error('no device state!');
 
         return Promise.resolve();

--- a/packages/suite/src/actions/suite/metadataProviderActions.ts
+++ b/packages/suite/src/actions/suite/metadataProviderActions.ts
@@ -130,7 +130,7 @@ export const disconnectProvider =
             // flush reducer
             dispatch({
                 type: METADATA.REMOVE_PROVIDER,
-                payload: provider,
+                payload: { clientId },
             });
             dispatch({
                 type: METADATA.SET_SELECTED_PROVIDER,

--- a/packages/suite/src/actions/suite/metadataProviderActions.ts
+++ b/packages/suite/src/actions/suite/metadataProviderActions.ts
@@ -126,23 +126,24 @@ export const disconnectProvider =
         if (provider) {
             await provider.disconnect();
             providerInstance[dataType] = undefined;
-        }
-        // flush reducer
-        dispatch({
-            type: METADATA.REMOVE_PROVIDER,
-            payload: provider,
-        });
-        dispatch({
-            type: METADATA.SET_SELECTED_PROVIDER,
-            payload: { dataType, clientId: undefined },
-        });
 
-        analytics.report({
-            type: EventType.SettingsGeneralLabelingProvider,
-            payload: {
-                provider: '',
-            },
-        });
+            // flush reducer
+            dispatch({
+                type: METADATA.REMOVE_PROVIDER,
+                payload: provider,
+            });
+            dispatch({
+                type: METADATA.SET_SELECTED_PROVIDER,
+                payload: { dataType, clientId: undefined },
+            });
+
+            analytics.report({
+                type: EventType.SettingsGeneralLabelingProvider,
+                payload: {
+                    provider: '',
+                },
+            });
+        }
     };
 
 /**

--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -79,6 +79,7 @@ export const openDeferredModal =
             type: MODAL.OPEN_USER_CONTEXT,
             payload: {
                 ...payload,
+                // @ts-expect-error: Tightening types, but I don't know how to resolve this.
                 decision: dfd,
             },
         });

--- a/packages/suite/src/actions/suite/routerActions.ts
+++ b/packages/suite/src/actions/suite/routerActions.ts
@@ -33,7 +33,7 @@ export type RouterAction =
       }
     | {
           type: typeof ROUTER.ANCHOR_CHANGE;
-          payload: AnchorType;
+          payload: AnchorType | undefined;
       };
 
 /**

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -95,12 +95,9 @@ export type SuiteAction =
       }
     | { type: typeof SUITE.SET_SIDEBAR_WIDTH; payload: { width: number } };
 
-export const appChanged = createAction(
-    SUITE.APP_CHANGED,
-    (payload: AppState['router']['app'] | unknown) => ({
-        payload,
-    }),
-);
+export const appChanged = createAction(SUITE.APP_CHANGED, (payload: AppState['router']['app']) => ({
+    payload,
+}));
 
 export const desktopHandshake = (payload: HandshakeElectron): SuiteAction => ({
     type: SUITE.DESKTOP_HANDSHAKE,
@@ -305,7 +302,12 @@ export const toggleDeviceAuthenticityCheck = (enable: boolean) => (dispatch: Dis
 export const toggleFirmwareAuthenticityChecks = (enable: boolean) => (dispatch: Dispatch) => {
     dispatch(notificationsActions.addToast({ type: 'settings-applied' }));
 
-    [SUITE.TOGGLE_FIRMWARE_REVISION_CHECK, SUITE.TOGGLE_FIRMWARE_HASH_CHECK].forEach(type => {
+    const firmwareAuthenticityChecks = [
+        SUITE.TOGGLE_FIRMWARE_REVISION_CHECK,
+        SUITE.TOGGLE_FIRMWARE_HASH_CHECK,
+    ] as const;
+
+    firmwareAuthenticityChecks.forEach(type => {
         dispatch({
             type,
             payload: enable,

--- a/packages/suite/src/middlewares/suite/routerMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/routerMiddleware.ts
@@ -20,6 +20,7 @@ const router = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) => (
                         ...action.payload,
                         settingsBackRoute: {
                             name: router.route?.name ?? 'suite-index',
+                            // @ts-expect-error: Tightening types, but I don't know how to resolve this.
                             params: router.params,
                         },
                     },

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -77,6 +77,10 @@ const metadataReducer = (state = initialState, action: Action): MetadataState =>
                 );
                 break;
             case METADATA.SET_SELECTED_PROVIDER:
+                if (!action.payload.clientId) {
+                    delete draft.selectedProvider[action.payload.dataType];
+                    break;
+                }
                 draft.selectedProvider[action.payload.dataType] = action.payload.clientId;
                 break;
             case METADATA.SET_EDITING:

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -4,6 +4,7 @@ import type { ThunkAction as TAction, ThunkDispatch } from 'redux-thunk';
 import { analyticsActions } from '@suite-common/analytics';
 import { deviceAuthenticityActions } from '@suite-common/device-authenticity';
 import { firmwareActions } from '@suite-common/firmware';
+import { addLog } from '@suite-common/logger';
 import { messageSystemActions } from '@suite-common/message-system';
 import type { Route } from '@suite-common/suite-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -83,7 +84,8 @@ export type Action =
     | ProtocolAction
     | DiscoveryAction
     | DeviceAction
-    | DeviceAuthenticityAction;
+    | DeviceAuthenticityAction
+    | ReturnType<typeof addLog>;
 
 export type ThunkAction = TAction<any, AppState, any, Action>;
 
@@ -91,7 +93,7 @@ export type ThunkAction = TAction<any, AppState, any, Action>;
 // export type Dispatch = ThunkDispatch<AppState, any, Action>;
 // fixed return type from `dispatch(A)` in actions
 export interface Dispatch extends ThunkDispatch<AppState, any, Action> {
-    <Action>(action: Action): Action extends (...args: any) => infer R ? R : Action;
+    <A extends Action>(action: A): A extends (...args: any) => infer R ? R : A;
 }
 
 export type GetState = () => AppState;

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -105,7 +105,7 @@ export type ExtraDependencies = {
                   localCurrency: FiatCurrencyCode;
               }>;
         lockDevice: ActionCreatorWithPreparedPayload<[payload: boolean], boolean>;
-        appChanged: ActionCreatorWithPayload<unknown>;
+        appChanged: ActionCreatorWithPayload<any>;
         setSelectedDevice: ActionCreatorWithPayload<TrezorDevice | undefined>;
         updateSelectedDevice: ActionCreatorWithPayload<TrezorDevice>;
         requestAuthConfirm: ActionCreatorWithoutPayload;


### PR DESCRIPTION
Trying to tighten `Dispatch` type so that it provides some type security to our actions, preventing bugs like [this one](https://github.com/trezor/trezor-suite/pull/17188#discussion_r1967543717).

1st commit changes the `Dispatch` type and fixes code wherever I more or less knew what to do.
2nd commit skips type check for lines that I couldn't fix - any help appreciated.
3rd commit fixes types related to metadata, @mroz22, please check.

**QA:** Some cleanup in code related to labelling and password manager. It would be good to test that nothing was broken in the process.