### PR TITLE
fix(suite): keep metal link change to multi share version

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupStep2to4.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupStep2to4.tsx
@@ -15,7 +15,7 @@ import {
     Row,
 } from '@trezor/components';
 import { spacings } from '@trezor/theme';
-import { ESHOP_KEEP_METAL_SINGLE_SHARE_URL, HELP_CENTER_SEED_CARD_URL } from '@trezor/urls';
+import { ESHOP_KEEP_METAL_MULTI_SHARE_URL, HELP_CENTER_SEED_CARD_URL } from '@trezor/urls';
 
 import { Translation, TrezorLink } from 'src/components/suite';
 
@@ -115,7 +115,7 @@ export const MultiShareBackupStep2to4 = ({ step }: MultiShareBackupStep2to4Props
                             ),
                             keepLink: chunks => (
                                 <TrezorLink
-                                    href={ESHOP_KEEP_METAL_SINGLE_SHARE_URL}
+                                    href={ESHOP_KEEP_METAL_MULTI_SHARE_URL}
                                     variant="underline"
                                     typographyStyle="hint"
                                 >

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -168,6 +168,9 @@ export const TREZOR_SAFE_5_URL: Url = 'https://trezor.io/trezor-safe-5';
 export const ESHOP_KEEP_METAL_SINGLE_SHARE_URL: Url =
     'https://trezor.io/trezor-keep-metal-single-share';
 
+export const ESHOP_KEEP_METAL_MULTI_SHARE_URL: Url =
+    'https://trezor.io/trezor-keep-metal-multi-share';
+
 export const TRADING_DOWNLOAD_INVITY_APP_URL: Url = 'https://get.invity.io';
 
 export const UNINSTALL_BRIDGE_URL: Url = 'https://trezor.io/learn/a/what-is-trezor-bridge';


### PR DESCRIPTION
Trezor Keep Metal link change

## Description

- I just changed trezor keep metal link from single share to multi share

## Related Issue

Resolve [#17088](https://github.com/trezor/trezor-suite/issues/17088)

## Screenshots:
