### PR TITLE
Fix/apply-global-patches-after-focus-install

### DIFF
--- a/.github/actions/release-connect/action.yml
+++ b/.github/actions/release-connect/action.yml
@@ -58,7 +58,7 @@ runs:
       shell: bash
       run: |
         echo -e "\nenableScripts: false" >> .yarnrc.yml
-        yarn workspaces focus @trezor/connect-iframe @trezor/connect-web @trezor/connect-popup @trezor/connect-webextension @trezor/connect-explorer-theme @trezor/connect-explorer
+        yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
 
     - name: Build connect-web
       shell: bash

--- a/.github/workflows/build-suite-native-preview.yml
+++ b/.github/workflows/build-suite-native-preview.yml
@@ -48,7 +48,9 @@ jobs:
           eas-version: 14.7.1
           token: ${{ secrets.EXPO_TOKEN_DEVELOP }}
       - name: Install libs
-        run: yarn workspaces focus @suite-native/app
+        run: |
+          yarn workspaces focus @suite-native/app
+          npx patch-package # Apply global patches.
 
       - name: Check runtimeVersion builds
         run: |

--- a/.github/workflows/release-suite-desktop-web-staging.yml
+++ b/.github/workflows/release-suite-desktop-web-staging.yml
@@ -169,7 +169,7 @@ jobs:
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          yarn workspaces focus @trezor/suite-web @trezor/connect-iframe @trezor/connect-web @trezor/suite-data @trezor/suite-build
+          yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
 
       - name: Build suite-web
         env:

--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -33,7 +33,9 @@ jobs:
           eas-version: 14.7.1
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Install libs
-        run: yarn workspaces focus @suite-native/app
+        run: |
+          yarn workspaces focus @suite-native/app
+          npx patch-package # Apply global patches.
       - name: Build on EAS Android
         run: eas build
           --platform android

--- a/.github/workflows/release-suite-native-production.yml
+++ b/.github/workflows/release-suite-native-production.yml
@@ -37,7 +37,9 @@ jobs:
           eas-version: 14.7.1
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Install libs
-        run: yarn workspaces focus @suite-native/app
+        run: |
+          yarn workspaces focus @suite-native/app
+          npx patch-package # Apply global patches.
       - name: Build on EAS iOS
         run: eas build
           --platform ios
@@ -65,7 +67,9 @@ jobs:
           eas-version: 14.7.1
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Install libs
-        run: yarn workspaces focus @suite-native/app
+        run: |
+          yarn workspaces focus @suite-native/app
+          npx patch-package # Apply global patches.
       - name: Build on EAS Android
         run: eas build
           --platform android
@@ -98,7 +102,9 @@ jobs:
           role-to-assume: arn:aws:iam::538326561891:role/gh_actions_mobile_prod_deploy
           aws-region: eu-central-1
       - name: Install libs
-        run: yarn workspaces focus @suite-native/app
+        run: |
+          yarn workspaces focus @suite-native/app
+          npx patch-package # Apply global patches.
 
       - name: Get Suite version
         id: get_version


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Packages are automatically patched by postinstall script only if `yarn install` is called but not in case of yarn workspaces focus. 

Unfortunately, this cannot be applied globally after every `yarn workspaces focus` because it’s not possible to apply a patch to a package that hasn’t been installed, which results in an error. Therefore, as a safer option for all releases, we run a full yarn install, while for tests and dev builds, we keep the faster focus install.