### PR TITLE
ci(github): add push branch to intermediery branch creation workflow

### DIFF
--- a/.github/workflows/release-connect-intermediary.yml
+++ b/.github/workflows/release-connect-intermediary.yml
@@ -47,3 +47,10 @@ jobs:
         run: |
           # Cherry-pick the specified range of commits from the fetched develop branch
           git cherry-pick -x ${{ github.event.inputs.cherry_pick_commit_sha_from }}^..${{ github.event.inputs.cherry_pick_commit_sha_to }}
+      
+      - name: Push intermediary branch
+        env:
+          BRANCH_NAME: "intermediary-release-branch-of-release/${{ steps.get-current-branch.outputs.branch_name }}"
+        run: |
+          echo ${{ env.BRANCH_NAME }}
+          git push origin ${{ env.BRANCH_NAME }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The workflow `.github/workflows/release-connect-intermediary.yml` is working properly just missing last step to push the newly created branch so it can be used.