### PR TITLE
feat: move reducers into seperate common package, create shared state for mobile

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -129,6 +129,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     public readonly transportPath;
     private readonly transportSessionOwner;
     private readonly transportDescriptorType;
+    private readonly bluetoothProps;
     private session;
     private lastAcquiredHere;
 
@@ -220,6 +221,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         this.transportPath = descriptor.path;
         this.transportSessionOwner = descriptor.sessionOwner;
         this.transportDescriptorType = descriptor.type;
+        this.bluetoothProps = descriptor.id ? { id: descriptor.id } : undefined;
 
         this.session = descriptor.session;
         this.lastAcquiredHere = false;
@@ -1211,6 +1213,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 label: 'Unacquired device',
                 name: this.name,
                 transportSessionOwner: this.transportSessionOwner,
+                bluetoothProps: this.bluetoothProps,
             };
         }
         const defaultLabel = 'My Trezor';
@@ -1236,6 +1239,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
             unavailableCapabilities: this.unavailableCapabilities,
             availableTranslations: this.availableTranslations,
             authenticityChecks: this.authenticityChecks,
+            bluetoothProps: this.bluetoothProps,
         };
     }
 }

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -81,6 +81,10 @@ type BaseDevice = {
     name: string;
 };
 
+export type BluetoothDeviceProps = {
+    id: string;
+};
+
 export type KnownDevice = BaseDevice & {
     type: 'acquired';
     id: string | null;
@@ -105,6 +109,7 @@ export type KnownDevice = BaseDevice & {
     };
     transportSessionOwner?: undefined;
     transportDescriptorType?: typeof undefined;
+    bluetoothProps?: BluetoothDeviceProps;
 };
 
 export type UnknownDevice = BaseDevice & {
@@ -126,6 +131,7 @@ export type UnknownDevice = BaseDevice & {
     availableTranslations?: typeof undefined;
     transportSessionOwner?: string;
     transportDescriptorType?: typeof undefined;
+    bluetoothProps?: BluetoothDeviceProps;
 };
 
 export type UnreadableDevice = BaseDevice & {
@@ -147,6 +153,7 @@ export type UnreadableDevice = BaseDevice & {
     availableTranslations?: typeof undefined;
     transportSessionOwner?: undefined;
     transportDescriptorType: Descriptor['type'];
+    bluetoothProps?: BluetoothDeviceProps;
 };
 
 export type Device = KnownDevice | UnknownDevice | UnreadableDevice;

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -23,6 +23,7 @@ export enum DEVICE_TYPE {
     TypeT2 = 3,
     TypeT2Boot = 4,
     TypeEmulator = 5,
+    TypeBluetooth = 6,
 }
 
 type AccessLock = {

--- a/packages/transport/src/types/index.ts
+++ b/packages/transport/src/types/index.ts
@@ -28,6 +28,8 @@ export type Descriptor = Omit<DescriptorApiLevel, 'path'> & {
     debugSession?: null | Session;
     /** only reported by old bridge */
     debug?: boolean;
+    /** only reported by transport-bluetooth */
+    id?: string;
 };
 
 export interface Logger {

--- a/suite-common/bluetooth/jest.config.js
+++ b/suite-common/bluetooth/jest.config.js
@@ -1,0 +1,6 @@
+const baseConfig = require('../../jest.config.base');
+
+module.exports = {
+    ...baseConfig,
+    roots: ['<rootDir>/src', '<rootDir>/tests', '<rootDir>/../test-utils/__mocks__'],
+};

--- a/suite-common/bluetooth/package.json
+++ b/suite-common/bluetooth/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "@suite-common/bluetooth",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "test:unit": "yarn g:jest -c ./jest.config.js",
+        "depcheck": "yarn g:depcheck",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@reduxjs/toolkit": "1.9.5",
+        "@suite-common/redux-utils": "workspace:*",
+        "@trezor/connect": "workspace:*"
+    }
+}

--- a/suite-common/bluetooth/redux.d.ts
+++ b/suite-common/bluetooth/redux.d.ts
@@ -1,0 +1,11 @@
+import { AsyncThunkAction } from '@reduxjs/toolkit';
+
+declare module 'redux' {
+    export interface Dispatch<A extends Action = AnyAction> {
+        <TThunk extends AsyncThunkAction<any, any, any>>(thunk: TThunk): ReturnType<TThunk>;
+
+        <ReturnType = any, State = any, ExtraThunkArg = any>(
+            thunkAction: ThunkAction<ReturnType, State, ExtraThunkArg, A>,
+        ): ReturnType;
+    }
+}

--- a/suite-common/bluetooth/src/bluetoothActions.ts
+++ b/suite-common/bluetooth/src/bluetoothActions.ts
@@ -1,0 +1,64 @@
+import { createAction } from '@reduxjs/toolkit';
+
+import {
+    BluetoothDeviceCommon,
+    BluetoothScanStatus,
+    DeviceBluetoothStatus,
+} from './bluetoothReducer';
+
+export const BLUETOOTH_PREFIX = '@suite/bluetooth';
+
+const adapterEventAction = createAction(
+    `${BLUETOOTH_PREFIX}/adapter-event`,
+    ({ isPowered }: { isPowered: boolean }) => ({ payload: { isPowered } }),
+);
+
+type BluetoothNearbyDevicesUpdateActionPayload = {
+    nearbyDevices: BluetoothDeviceCommon[];
+};
+
+const nearbyDevicesUpdateAction = createAction(
+    `${BLUETOOTH_PREFIX}/nearby-devices-update`,
+    ({ nearbyDevices }: BluetoothNearbyDevicesUpdateActionPayload) => ({
+        payload: { nearbyDevices },
+    }),
+);
+
+type BluetoothKnownDevicesUpdateActionPayload = {
+    knownDevices: BluetoothDeviceCommon[];
+};
+
+const knownDevicesUpdateAction = createAction(
+    `${BLUETOOTH_PREFIX}/known-devices-update`,
+    ({ knownDevices }: BluetoothKnownDevicesUpdateActionPayload) => ({
+        payload: { knownDevices },
+    }),
+);
+
+const removeKnownDeviceAction = createAction(
+    `${BLUETOOTH_PREFIX}/remove-known-device`,
+    ({ id }: { id: string }) => ({
+        payload: { id },
+    }),
+);
+
+const connectDeviceEventAction = createAction(
+    `${BLUETOOTH_PREFIX}/connect-device-event`,
+    ({ connectionStatus, id }: { id: string; connectionStatus: DeviceBluetoothStatus }) => ({
+        payload: { id, connectionStatus },
+    }),
+);
+
+const scanStatusAction = createAction(
+    `${BLUETOOTH_PREFIX}/scan-status`,
+    ({ status }: { status: BluetoothScanStatus }) => ({ payload: { status } }),
+);
+
+export const bluetoothActions = {
+    adapterEventAction,
+    nearbyDevicesUpdateAction,
+    connectDeviceEventAction,
+    scanStatusAction,
+    knownDevicesUpdateAction,
+    removeKnownDeviceAction,
+};

--- a/suite-common/bluetooth/src/bluetoothReducer.ts
+++ b/suite-common/bluetooth/src/bluetoothReducer.ts
@@ -1,0 +1,146 @@
+import { AnyAction, Draft } from '@reduxjs/toolkit';
+
+import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import { deviceActions } from '@suite-common/wallet-core';
+
+import { bluetoothActions } from './bluetoothActions';
+
+export type BluetoothScanStatus = 'idle' | 'running' | 'error';
+
+export type DeviceBluetoothStatus =
+    | { type: 'pairing'; pin?: string }
+    | { type: 'paired' }
+    | { type: 'connecting' }
+    | { type: 'connected' }
+    | {
+          type: 'error';
+          error: string;
+      };
+
+// Do not export this outside of this suite-common package, Suite uses ist own type
+// from the '@trezor/transport-bluetooth' and mobile (native) have its own type as well.
+export type BluetoothDeviceCommon = {
+    id: string;
+    name: string;
+    data: number[]; // Todo: consider typed data-structure for this
+    lastUpdatedTimestamp: number;
+};
+
+export type DeviceBluetoothStatusType = DeviceBluetoothStatus['type'];
+
+export type BluetoothDeviceState<T extends BluetoothDeviceCommon> = {
+    device: T;
+    status: DeviceBluetoothStatus | null;
+};
+
+export type BluetoothState<T extends BluetoothDeviceCommon> = {
+    adapterStatus: 'unknown' | 'enabled' | 'disabled';
+    scanStatus: BluetoothScanStatus;
+    nearbyDevices: BluetoothDeviceState<T>[];
+
+    // This will be persisted, those are devices we believed that are paired
+    // (because we already successfully paired them in the Suite) in the Operating System
+    knownDevices: T[];
+};
+
+export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>() => {
+    const initialState: BluetoothState<T> = {
+        adapterStatus: 'unknown',
+        scanStatus: 'idle',
+        nearbyDevices: [] as BluetoothDeviceState<T>[],
+        knownDevices: [] as T[],
+    };
+
+    return createReducerWithExtraDeps<BluetoothState<T>>(initialState, (builder, extra) =>
+        builder
+            .addCase(bluetoothActions.adapterEventAction, (state, { payload: { isPowered } }) => {
+                state.adapterStatus = isPowered ? 'enabled' : 'disabled';
+                if (!isPowered) {
+                    state.nearbyDevices = [];
+                    state.scanStatus = 'idle';
+                }
+            })
+            .addCase(
+                bluetoothActions.nearbyDevicesUpdateAction,
+                (state, { payload: { nearbyDevices } }) => {
+                    state.nearbyDevices = nearbyDevices
+                        .sort((a, b) => b.lastUpdatedTimestamp - a.lastUpdatedTimestamp)
+                        .map(
+                            (device): Draft<BluetoothDeviceState<T>> => ({
+                                device: device as Draft<T>,
+                                status:
+                                    state.nearbyDevices.find(it => it.device.id === device.id)
+                                        ?.status ?? null,
+                            }),
+                        );
+                },
+            )
+            .addCase(
+                bluetoothActions.connectDeviceEventAction,
+                (state, { payload: { id, connectionStatus } }) => {
+                    const device = state.nearbyDevices.find(it => it.device.id === id);
+
+                    if (device !== undefined) {
+                        device.status = connectionStatus;
+                    }
+                },
+            )
+            .addCase(
+                bluetoothActions.knownDevicesUpdateAction,
+                (state, { payload: { knownDevices } }) => {
+                    state.knownDevices = knownDevices as Draft<T>[];
+                },
+            )
+            .addCase(bluetoothActions.removeKnownDeviceAction, (state, { payload: { id } }) => {
+                state.knownDevices = state.knownDevices.filter(
+                    knownDevice => knownDevice.id !== id,
+                );
+            })
+            .addCase(bluetoothActions.scanStatusAction, (state, { payload: { status } }) => {
+                state.scanStatus = status;
+            })
+            .addCase(deviceActions.deviceDisconnect, (state, { payload: { bluetoothProps } }) => {
+                if (bluetoothProps !== undefined) {
+                    state.nearbyDevices = state.nearbyDevices.filter(
+                        it => it.device.id !== bluetoothProps.id,
+                    );
+                }
+            })
+            .addCase(
+                deviceActions.connectDevice,
+                (
+                    state,
+                    {
+                        payload: {
+                            device: { bluetoothProps },
+                        },
+                    },
+                ) => {
+                    if (bluetoothProps === undefined) {
+                        return;
+                    }
+
+                    const deviceState = state.nearbyDevices.find(
+                        it => it.device.id === bluetoothProps.id,
+                    );
+
+                    if (deviceState !== undefined) {
+                        // Once device is fully connected, we save it to the list of known devices
+                        // so next time user opens suite we can automatically connect to it.
+                        const foundKnownDevice = state.knownDevices.find(
+                            it => it.id === bluetoothProps.id,
+                        );
+                        if (foundKnownDevice === undefined) {
+                            state.knownDevices.push(deviceState.device);
+                        }
+                    }
+                },
+            )
+            .addMatcher(
+                action => action.type === extra.actionTypes.storageLoad,
+                (state, action: AnyAction) => {
+                    state.knownDevices = action.payload.knownDevices?.bluetooth ?? [];
+                },
+            ),
+    );
+};

--- a/suite-common/bluetooth/src/bluetoothSelectors.ts
+++ b/suite-common/bluetooth/src/bluetoothSelectors.ts
@@ -1,0 +1,47 @@
+import { createWeakMapSelector } from '@suite-common/redux-utils';
+
+import { BluetoothDeviceCommon, BluetoothDeviceState, BluetoothState } from './bluetoothReducer';
+
+export type WithBluetoothState<T extends BluetoothDeviceCommon> = {
+    bluetooth: BluetoothState<T>;
+};
+
+export const selectAdapterStatus = <T extends BluetoothDeviceCommon>(
+    state: WithBluetoothState<T>,
+) => state.bluetooth.adapterStatus;
+
+export const selectKnownDevices = <T extends BluetoothDeviceCommon>(state: WithBluetoothState<T>) =>
+    state.bluetooth.knownDevices;
+
+/**
+ * We need to have generic `createWeakMapSelector.withTypes` so we need to wrap it into Higher Order Function,
+ * but we need to make sure it is called only **once** to not break the memoization. So it is named
+ * `prepareSelectAllDevices` and shall be called **outside** of the component to create a selector with
+ * concrete type:
+ *
+ * For example: `const selectAllDevices = prepareSelectAllDevices<ConcreteBluetoothDevice>();`
+ */
+export const prepareSelectAllDevices = <T extends BluetoothDeviceCommon>() =>
+    createWeakMapSelector.withTypes<WithBluetoothState<T>>()(
+        [state => state.bluetooth.nearbyDevices, state => state.bluetooth.knownDevices],
+        (nearbyDevices, knownDevices) => {
+            const map = new Map<string, BluetoothDeviceState<T>>();
+
+            nearbyDevices.forEach(nearbyDevice => {
+                map.set(nearbyDevice.device.id, nearbyDevice);
+            });
+
+            knownDevices.forEach(knownDevice => {
+                if (!map.has(knownDevice.id)) {
+                    map.set(knownDevice.id, { device: knownDevice, status: null });
+                }
+            });
+
+            return Array.from(map.values()).sort(
+                (a, b) => b.device.lastUpdatedTimestamp - a.device.lastUpdatedTimestamp,
+            );
+        },
+    );
+
+export const selectScanStatus = <T extends BluetoothDeviceCommon>(state: WithBluetoothState<T>) =>
+    state.bluetooth.scanStatus;

--- a/suite-common/bluetooth/src/index.ts
+++ b/suite-common/bluetooth/src/index.ts
@@ -1,0 +1,15 @@
+export { BLUETOOTH_PREFIX, bluetoothActions } from './bluetoothActions';
+
+export { prepareBluetoothReducerCreator } from './bluetoothReducer';
+export type {
+    BluetoothDeviceState,
+    BluetoothScanStatus,
+    DeviceBluetoothStatusType,
+} from './bluetoothReducer';
+
+export {
+    prepareSelectAllDevices,
+    selectKnownDevices,
+    selectAdapterStatus,
+    selectScanStatus,
+} from './bluetoothSelectors';

--- a/suite-common/bluetooth/tests/bluetoothReducer.test.ts
+++ b/suite-common/bluetooth/tests/bluetoothReducer.test.ts
@@ -1,0 +1,182 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { TrezorDevice } from '@suite-common/suite-types';
+import { configureMockStore, extraDependenciesMock } from '@suite-common/test-utils';
+import { deviceActions } from '@suite-common/wallet-core';
+import { Device } from '@trezor/connect';
+
+import { BluetoothDeviceState, bluetoothActions, prepareBluetoothReducerCreator } from '../src';
+import { BluetoothDeviceCommon, BluetoothState } from '../src/bluetoothReducer';
+
+const bluetoothReducer =
+    prepareBluetoothReducerCreator<BluetoothDeviceCommon>()(extraDependenciesMock);
+
+const initialState: BluetoothState<BluetoothDeviceCommon> = {
+    adapterStatus: 'unknown',
+    scanStatus: 'idle',
+    nearbyDevices: [] as BluetoothDeviceState<BluetoothDeviceCommon>[],
+    knownDevices: [] as BluetoothDeviceCommon[],
+};
+
+const bluetoothStateDeviceA: BluetoothDeviceState<BluetoothDeviceCommon> = {
+    device: {
+        id: 'A',
+        data: [],
+        name: 'Trezor A',
+        lastUpdatedTimestamp: 1,
+    },
+    status: { type: 'pairing' },
+};
+
+const bluetoothStateDeviceB: BluetoothDeviceState<BluetoothDeviceCommon> = {
+    device: {
+        id: 'B',
+        data: [],
+        name: 'Trezor B',
+        lastUpdatedTimestamp: 2,
+    },
+    status: null,
+};
+
+const bluetoothStateDeviceC: BluetoothDeviceState<BluetoothDeviceCommon> = {
+    device: {
+        id: 'C',
+        data: [],
+        name: 'Trezor C',
+        lastUpdatedTimestamp: 3,
+    },
+    status: null,
+};
+
+describe('bluetoothReducer', () => {
+    it('sets the bluetooth adapter as enabled/disabled when powered/unpowered', () => {
+        const store = configureMockStore({
+            extra: {},
+            reducer: combineReducers({ bluetooth: bluetoothReducer }),
+            preloadedState: { bluetooth: initialState },
+        });
+
+        expect(store.getState().bluetooth.adapterStatus).toEqual('unknown');
+        store.dispatch(bluetoothActions.adapterEventAction({ isPowered: true }));
+        expect(store.getState().bluetooth.adapterStatus).toEqual('enabled');
+        store.dispatch(bluetoothActions.adapterEventAction({ isPowered: false }));
+        expect(store.getState().bluetooth.adapterStatus).toEqual('disabled');
+    });
+
+    it('sorts the devices based on the `lastUpdatedTimestamp` and keeps the status for already existing device', () => {
+        const store = configureMockStore({
+            extra: {},
+            reducer: combineReducers({ bluetooth: bluetoothReducer }),
+            preloadedState: {
+                bluetooth: {
+                    ...initialState,
+                    nearbyDevices: [bluetoothStateDeviceB, bluetoothStateDeviceA],
+                },
+            },
+        });
+
+        const nearbyDevices: BluetoothDeviceCommon[] = [
+            bluetoothStateDeviceA.device,
+            bluetoothStateDeviceC.device,
+        ];
+
+        store.dispatch(bluetoothActions.nearbyDevicesUpdateAction({ nearbyDevices }));
+        expect(store.getState().bluetooth.nearbyDevices).toEqual([
+            bluetoothStateDeviceC,
+            // No `B` device present, it was dropped
+            {
+                device: bluetoothStateDeviceA.device,
+                status: { type: 'pairing' }, // Keeps the pairing status
+            },
+        ]);
+    });
+
+    it('changes the status of the given device during pairing process', () => {
+        const store = configureMockStore({
+            extra: {},
+            reducer: combineReducers({ bluetooth: bluetoothReducer }),
+            preloadedState: {
+                bluetooth: { ...initialState, nearbyDevices: [bluetoothStateDeviceA] },
+            },
+        });
+
+        store.dispatch(
+            bluetoothActions.connectDeviceEventAction({
+                id: 'A',
+                connectionStatus: { type: 'pairing', pin: '12345' },
+            }),
+        );
+        expect(store.getState().bluetooth.nearbyDevices).toEqual([
+            {
+                device: bluetoothStateDeviceA.device,
+                status: { type: 'pairing', pin: '12345' },
+            },
+        ]);
+    });
+
+    it('updates and removes known devices', () => {
+        const store = configureMockStore({
+            extra: {},
+            reducer: combineReducers({ bluetooth: bluetoothReducer }),
+            preloadedState: { bluetooth: initialState },
+        });
+
+        const knownDeviceToAdd: BluetoothDeviceCommon[] = [
+            bluetoothStateDeviceA.device,
+            bluetoothStateDeviceB.device,
+        ];
+
+        store.dispatch(
+            bluetoothActions.knownDevicesUpdateAction({ knownDevices: knownDeviceToAdd }),
+        );
+        expect(store.getState().bluetooth.knownDevices).toEqual(knownDeviceToAdd);
+
+        store.dispatch(bluetoothActions.removeKnownDeviceAction({ id: 'A' }));
+
+        expect(store.getState().bluetooth.knownDevices).toEqual([bluetoothStateDeviceB.device]);
+    });
+
+    it('removes device from nearbyDevices when the device is disconnected by TrezorConnect', () => {
+        const store = configureMockStore({
+            extra: {},
+            reducer: combineReducers({ bluetooth: bluetoothReducer }),
+            preloadedState: {
+                bluetooth: { ...initialState, nearbyDevices: [bluetoothStateDeviceA] },
+            },
+        });
+
+        const trezorDevice: Pick<TrezorDevice, 'bluetoothProps'> = {
+            bluetoothProps: { id: 'A' },
+        };
+
+        store.dispatch(deviceActions.deviceDisconnect(trezorDevice as TrezorDevice));
+        expect(store.getState().bluetooth.nearbyDevices).toEqual([]);
+    });
+
+    it('stores a device in `knownDevices` when device is connected by TrezorConnect', () => {
+        const nearbyDevice: BluetoothDeviceState<BluetoothDeviceCommon> = {
+            device: bluetoothStateDeviceA.device,
+            status: { type: 'connected' },
+        };
+
+        const store = configureMockStore({
+            extra: {},
+            reducer: combineReducers({ bluetooth: bluetoothReducer }),
+            preloadedState: {
+                bluetooth: { ...initialState, nearbyDevices: [nearbyDevice] },
+            },
+        });
+
+        const trezorDevice: Pick<Device, 'bluetoothProps'> = {
+            bluetoothProps: { id: 'A' },
+        };
+
+        store.dispatch(
+            deviceActions.connectDevice({
+                device: trezorDevice as Device,
+                settings: { defaultWalletLoading: 'passphrase' },
+            }),
+        );
+        expect(store.getState().bluetooth.knownDevices).toEqual([nearbyDevice.device]);
+    });
+});

--- a/suite-common/bluetooth/tests/bluetoothSelectors.test.ts
+++ b/suite-common/bluetooth/tests/bluetoothSelectors.test.ts
@@ -1,0 +1,48 @@
+import { BluetoothDeviceState, prepareSelectAllDevices } from '../src';
+import { BluetoothDeviceCommon, BluetoothState } from '../src/bluetoothReducer';
+import { WithBluetoothState } from '../src/bluetoothSelectors';
+
+const initialState: BluetoothState<BluetoothDeviceCommon> = {
+    adapterStatus: 'unknown',
+    scanStatus: 'idle',
+    nearbyDevices: [] as BluetoothDeviceState<BluetoothDeviceCommon>[],
+    knownDevices: [] as BluetoothDeviceCommon[],
+};
+
+const pairingDeviceStateA: BluetoothDeviceState<BluetoothDeviceCommon> = {
+    device: {
+        id: 'A',
+        data: [],
+        name: 'Trezor A',
+        lastUpdatedTimestamp: 1,
+    },
+    status: { type: 'pairing' },
+};
+
+const deviceB: BluetoothDeviceCommon = {
+    id: 'B',
+    data: [],
+    name: 'Trezor B',
+    lastUpdatedTimestamp: 2,
+};
+
+describe('bluetoothSelectors', () => {
+    it('selects knownDevices and nearbyDevices in one list fot the UI', () => {
+        const selectAllDevices = prepareSelectAllDevices<BluetoothDeviceCommon>();
+
+        const state: WithBluetoothState<BluetoothDeviceCommon> = {
+            bluetooth: {
+                ...initialState,
+                nearbyDevices: [pairingDeviceStateA],
+                knownDevices: [pairingDeviceStateA.device, deviceB],
+            },
+        };
+
+        const devices = selectAllDevices(state);
+
+        expect(devices).toEqual([{ device: deviceB, status: null }, pairingDeviceStateA]);
+
+        const devicesSecondTime = selectAllDevices(state);
+        expect(devices === devicesSecondTime).toBe(true); // Asserts that `reselect` memoization works
+    });
+});

--- a/suite-common/bluetooth/tsconfig.json
+++ b/suite-common/bluetooth/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        { "path": "../redux-utils" },
+        { "path": "../../packages/connect" }
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9400,6 +9400,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite-common/bluetooth@workspace:suite-common/bluetooth":
+  version: 0.0.0-use.local
+  resolution: "@suite-common/bluetooth@workspace:suite-common/bluetooth"
+  dependencies:
+    "@reduxjs/toolkit": "npm:1.9.5"
+    "@suite-common/redux-utils": "workspace:*"
+    "@trezor/connect": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
 "@suite-common/connect-init@workspace:*, @suite-common/connect-init@workspace:suite-common/connect-init":
   version: 0.0.0-use.local
   resolution: "@suite-common/connect-init@workspace:suite-common/connect-init"


### PR DESCRIPTION
Related to: https://github.com/trezor/trezor-suite/issues/15390

This PR adds an shared bluetooth code for redux state (+ actions)

@coderabbitai ignore