### PR TITLE
fix(connect): FW revision check for unknown models

### DIFF
--- a/packages/connect/src/device/checkFirmwareRevision.ts
+++ b/packages/connect/src/device/checkFirmwareRevision.ts
@@ -5,9 +5,13 @@ import { downloadReleasesMetadata } from '../data/downloadReleasesMetadata';
 import { FirmwareRelease, VersionArray } from '../types';
 import { calculateRevisionForDevice } from './calculateRevisionForDevice';
 import { FirmwareRevisionCheckError, FirmwareRevisionCheckResult } from '../types/device';
+import { HttpRequestError } from '../utils/assets-browser';
 
-const isNodeJSNetworkError = (e: Error) => ['FetchError', 'AbortError'].includes(e.name);
-const isReactNativeNetworkError = (e: Error) =>
+const isNotFoundError = (e: unknown): boolean =>
+    e instanceof HttpRequestError && e.response.status === 404;
+
+const isNodeJSOfflineError = (e: Error) => ['FetchError', 'AbortError'].includes(e.name);
+const isReactNativeOfflineError = (e: Error) =>
     e.name === 'TypeError' && e.message.includes('Network request failed');
 
 /**
@@ -16,10 +20,10 @@ const isReactNativeNetworkError = (e: Error) =>
  * In browser runtime (Suite Web), all fetch errors are lumped together as CORS errors, therefore indistinguishable.
  * (even a request that had no response is CORS error, since a non-existent response does not have CORS headers)
  */
-const isNetworkError = (e: unknown): boolean => {
+const isOfflineError = (e: unknown): boolean => {
     if (!(e instanceof Error)) return false;
 
-    return isNodeJSNetworkError(e) || isReactNativeNetworkError(e);
+    return isNodeJSOfflineError(e) || isReactNativeOfflineError(e);
 };
 
 type GetOnlineReleaseMetadataParams = {
@@ -103,7 +107,11 @@ export const checkFirmwareRevision = async ({
 
             return { success: true };
         } catch (e: unknown) {
-            return isNetworkError(e)
+            // 404 means an unrecognized device model, so it cannot be an officially released firmware.
+            // The model might be defined in local files, but important is, if it's been released to data.trezor.io
+            if (isNotFoundError(e)) return failFirmwareRevisionCheck('firmware-version-unknown');
+
+            return isOfflineError(e)
                 ? failFirmwareRevisionCheck('cannot-perform-check-offline')
                 : failFirmwareRevisionCheck('other-error');
         }

--- a/packages/connect/src/utils/assets-browser.ts
+++ b/packages/connect/src/utils/assets-browser.ts
@@ -2,6 +2,16 @@ import fetch from 'cross-fetch';
 
 import { HttpRequestOptions, HttpRequestReturnType, HttpRequestType } from './assetsTypes';
 
+export class HttpRequestError extends Error {
+    response: Response;
+
+    constructor(response: Response) {
+        const message = `${response.status} while fetching ${response.url}`;
+        super(message);
+        this.response = response;
+    }
+}
+
 export const httpRequest = async <T extends HttpRequestType>(
     url: string,
     type: T = 'text' as T,
@@ -23,5 +33,5 @@ export const httpRequest = async <T extends HttpRequestType>(
         return response.text() as Promise<HttpRequestReturnType<T>>;
     }
 
-    throw new Error(`httpRequest error: ${url} ${response.statusText}`);
+    throw new HttpRequestError(response);
 };


### PR DESCRIPTION
## Description

Detect 404 when fetching online `releases.json` during FW revision check, and mark it as `firmware-version-unknown`.

:thought_balloon: this could also happen if the files get deleted on our servers by accident. But IMHO that's negligible; it's much more likely that the servers will be unavailable (leading to either `other-error` or `cannot-perform-check-offline`, depending on response status)

## Related Issue

Resolve #17226

## Screenshots

Display :ghost: modal but that's nothing new.
![image](https://github.com/user-attachments/assets/befa4476-011c-4146-88ff-ee4868a85997)
