### PR TITLE
fix(suite-desktop-core): add missing references to tsconfig file

### DIFF
--- a/packages/suite-desktop-core/tsconfig.lib.json
+++ b/packages/suite-desktop-core/tsconfig.lib.json
@@ -6,7 +6,70 @@
     "include": ["./scripts"],
     "references": [
         {
+            "path": "../../suite-common/message-system"
+        },
+        {
+            "path": "../../suite-common/sentry"
+        },
+        {
+            "path": "../../suite-common/suite-constants"
+        },
+        {
+            "path": "../../suite-common/suite-types"
+        },
+        {
+            "path": "../../suite-common/suite-utils"
+        },
+        {
+            "path": "../../suite-common/wallet-config"
+        },
+        {
+            "path": "../coinjoin"
+        },
+        {
+            "path": "../connect"
+        },
+        {
+            "path": "../connect-common"
+        },
+        {
+            "path": "../env-utils"
+        },
+        {
             "path": "../eslint"
+        },
+        {
+            "path": "../ipc-proxy"
+        },
+        {
+            "path": "../node-utils"
+        },
+        {
+            "path": "../request-manager"
+        },
+        {
+            "path": "../suite"
+        },
+        {
+            "path": "../suite-desktop-api"
+        },
+        {
+            "path": "../transport"
+        },
+        {
+            "path": "../transport-bridge"
+        },
+        {
+            "path": "../urls"
+        },
+        {
+            "path": "../utils"
+        },
+        {
+            "path": "../trezor-user-env-link"
+        },
+        {
+            "path": "../type-utils"
         }
     ]
 }


### PR DESCRIPTION
## Description

Fix `suite-desktop-core/tsconfig.lib.json`, because `yarn update-project-references` is unstable; produces diff that is not detected by `yarn verify-project-references`, so it passed CI when I merged it in #17056 :open_mouth: 