### PR TITLE
fix(urls): add trezor coins url back

### DIFF
--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -5,6 +5,7 @@ export const TREZOR_FORUM_URL: Url = 'https://forum.trezor.io/';
 export const TREZOR_START_URL: Url = 'https://trezor.io/start';
 export const TREZOR_SUPPORT_URL: Url = 'https://trezor.io/support';
 export const TREZOR_RESELLERS_URL: Url = 'https://trezor.io/resellers/';
+export const TREZOR_COINS_URL: Url = 'https://trezor.io/coins';
 
 export const DATA_URL: Url = 'https://data.trezor.io/';
 export const DATA_TOS_URL: Url = 'https://data.trezor.io/legal/wallet-terms.pdf';


### PR DESCRIPTION
## Description

Seems this URL constant was removed some time ago, but it's actually used in popup.html

## Related Issue

Resolve #17115