### PR TITLE
fix(suite-native): hide send for portfolio tracker

### DIFF
--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -18,6 +18,7 @@ import {
     selectAccounts,
     selectCurrentFiatRates,
     selectIsAccountUtxoBased,
+    selectIsPortfolioTrackerDevice,
     selectPendingAccountAddresses,
     selectVisibleDeviceAccounts,
 } from '@suite-common/wallet-core';
@@ -223,6 +224,10 @@ export const selectFreshAccountAddress = (
 };
 
 export const selectHasDeviceAnySendAvailableAccount = createMemoizedSelector(
-    [selectVisibleDeviceAccounts],
-    accounts => pipe(accounts, filterSendAvailableAccounts, A.isNotEmpty),
+    [selectIsPortfolioTrackerDevice, selectVisibleDeviceAccounts],
+    (isPortfolioTrackerDevice, accounts) => {
+        if (isPortfolioTrackerDevice) return false;
+
+        return pipe(accounts, filterSendAvailableAccounts, A.isNotEmpty);
+    },
 );


### PR DESCRIPTION
## Description
- hides global send button for portfolio tracker device

## Related Issue

Resolve #16484

## Screenshots:
![Screenshot 2025-02-26 at 12 53 43 PM](https://github.com/user-attachments/assets/f69652c1-b133-4d4b-a5f7-043a068c54e7)
