### PR TITLE
Add defensive condition to prevent reported crashes during onboarding

### DIFF
--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -134,7 +134,7 @@ export const FirmwareInitial = ({
         useFirmwareInstallation({
             shouldSwitchFirmwareType,
         });
-    const { updateAnalytics } = useOnboarding();
+    const { isActive: isOnboarding, updateAnalytics } = useOnboarding();
     const devices = useSelector(selectDevices);
     const [bitcoinOnlyOffer, setBitcoinOnlyOffer] = useState(false);
     const [showSkipConfirmation, setShowSkipConfirmation] = useState(false);
@@ -147,7 +147,9 @@ export const FirmwareInitial = ({
     // todo: move to utils device.ts
     const devicesConnected = devices.filter(device => device?.connected);
     const multipleDevicesConnected = [...new Set(devicesConnected.map(d => d.path))].length > 1;
-    const shouldCheckSeed = device?.mode !== 'initialize';
+
+    // The first condition is a defensive measure against https://github.com/trezor/trezor-suite/issues/17246, I could not reproduce the error.
+    const shouldCheckSeed = !isOnboarding && device?.mode !== 'initialize';
 
     let content;
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Suite can crash in the firmware step of onboarding as is apparent from [these Sentry reports](https://satoshilabs.sentry.io/issues/5619729147/events/?project=5193825&referrer=issue-stream&statsPeriod=90d&stream_index=0). Unfortunately, I could not reproduce it. This is my best guest of what could be causing the issue and how it can be preventented.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17246
