### PR TITLE
Split `DeviceList`

### DIFF
--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -1,14 +1,6 @@
 // original file https://github.com/trezor/connect/blob/develop/src/js/device/DeviceList.js
 
-import {
-    BridgeTransport,
-    NodeUsbTransport,
-    TRANSPORT,
-    Transport,
-    UdpTransport,
-    WebUsbTransport,
-    isTransportInstance,
-} from '@trezor/transport';
+import { TRANSPORT, Transport } from '@trezor/transport';
 import type { TransportApiType } from '@trezor/transport/src/transports/abstract';
 import { Descriptor, PathPublic } from '@trezor/transport/src/types';
 import {
@@ -25,8 +17,8 @@ import {
 import { ERRORS } from '../constants';
 import { DEVICE, TransportError, TransportInfo } from '../events';
 import { Device } from './Device';
-import { getBridgeInfo } from '../data/transportInfo';
 import { ConnectSettings, DeviceUniquePath, StaticSessionId } from '../types';
+import { createTransportList } from './TransportList';
 import { initLog } from '../utils/debug';
 
 const createAuthPenaltyManager = (priority: number) => {
@@ -153,7 +145,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
     private readonly handshakeLock;
     private readonly authPenaltyManager;
 
-    private transportCommonArgs;
+    private updateTransports;
 
     isConnected(): this is DeviceList {
         return !!Object.keys(this.transport).length;
@@ -218,70 +210,12 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
         this.handshakeLock = getSynchronize();
         this.authPenaltyManager = createAuthPenaltyManager(priority);
-        this.transportCommonArgs = {
+        this.updateTransports = createTransportList({
             messages,
             logger: transportLogger,
             sessionsBackgroundUrl: _sessionsBackgroundUrl,
             id: manifest?.appUrl || 'unknown app',
-        };
-    }
-
-    private tryGetTransport(name: string) {
-        return this.transports.find(t => t.name === name);
-    }
-
-    private getOrCreateTransport(
-        transportType: NonNullable<ConnectSettings['transports']>[number],
-    ) {
-        const { transportCommonArgs } = this;
-
-        if (typeof transportType === 'string') {
-            const existing = this.tryGetTransport(transportType);
-            if (existing) return existing;
-
-            switch (transportType) {
-                case 'WebUsbTransport':
-                    return new WebUsbTransport(transportCommonArgs);
-                case 'NodeUsbTransport':
-                    return new NodeUsbTransport(transportCommonArgs);
-                case 'BridgeTransport':
-                    return new BridgeTransport({
-                        latestVersion: getBridgeInfo().version.join('.'),
-                        ...transportCommonArgs,
-                    });
-                case 'UdpTransport':
-                    return new UdpTransport(transportCommonArgs);
-            }
-        } else if (typeof transportType === 'function' && 'prototype' in transportType) {
-            const transportInstance = new transportType(transportCommonArgs);
-            if (isTransportInstance(transportInstance)) {
-                return this.tryGetTransport(transportInstance.name) ?? transportInstance;
-            }
-        } else if (isTransportInstance(transportType)) {
-            if (this.tryGetTransport(transportType.name)) {
-                return transportType;
-            }
-
-            // custom Transport might be initialized without messages, update them if so
-            if (!transportType.getMessage()) {
-                transportType.updateMessages(transportCommonArgs.messages);
-            }
-
-            return transportType;
-        }
-
-        // runtime check
-        throw ERRORS.TypedError(
-            'Runtime',
-            `DeviceList.init: transports[] of unexpected type: ${transportType}`,
-        );
-    }
-
-    private createTransports(transports: ConnectSettings['transports']) {
-        // BridgeTransport is the ultimate fallback
-        const transportTypes = transports?.length ? transports : ['BridgeTransport' as const];
-
-        return transportTypes.map(this.getOrCreateTransport.bind(this));
+        });
     }
 
     private onDeviceConnected(descriptor: Descriptor, transport: Transport) {
@@ -320,7 +254,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
     async init(initParams: InitParams = {}) {
         // throws when unknown transport is requested, in that case nothing is changed
-        this.transports = this.createTransports(initParams.transports);
+        this.transports = this.updateTransports(this.transports, initParams.transports);
 
         const promises = this.transports
             .map(t => t.apiType)

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -10,7 +10,6 @@ import {
     createDeferred,
     getSynchronize,
     isNotUndefined,
-    resolveAfter,
     typedObjectKeys,
 } from '@trezor/utils';
 
@@ -19,6 +18,7 @@ import { DEVICE, TransportError, TransportInfo } from '../events';
 import { Device } from './Device';
 import { ConnectSettings, DeviceUniquePath, StaticSessionId } from '../types';
 import { createTransportList } from './TransportList';
+import { TransportManager } from './TransportManager';
 import { initLog } from '../utils/debug';
 
 const createAuthPenaltyManager = (priority: number) => {
@@ -131,10 +131,8 @@ type InitParams = Pick<
     'transports' | 'pendingTransportEvent' | 'transportReconnect'
 >;
 
-type ApiTypeMap<T> = Partial<Record<TransportApiType, T>>;
-
 export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDeviceList {
-    private readonly transport: ApiTypeMap<Transport> = {};
+    private readonly transportManagers: Partial<Record<TransportApiType, TransportManager>> = {};
 
     // array of transport that might be used in this environment
     private transports: Transport[] = [];
@@ -147,55 +145,27 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
     private updateTransports;
 
+    private getConnectedTransports() {
+        return Object.values(this.transportManagers)
+            .map(manager => manager.get())
+            .filter(isNotUndefined);
+    }
+
     isConnected(): this is DeviceList {
-        return !!Object.keys(this.transport).length;
+        return !!this.getConnectedTransports().length;
     }
 
     pendingConnection() {
-        const pending = Object.values(this.locks)
-            .map(({ promise }) => promise)
+        const pending = Object.values(this.transportManagers)
+            .map(manager => manager.pending())
             .filter(isNotUndefined);
 
         if (pending.length) return Promise.all(pending).then(() => {});
     }
 
     getActiveTransports() {
-        return Object.values(this.transport).map(getTransportInfo);
+        return this.getConnectedTransports().map(getTransportInfo);
     }
-
-    private readonly locks: ApiTypeMap<{
-        promise?: Promise<void>;
-        abort?: AbortController;
-        abortMessage?: string;
-        sequence: number;
-    }> = {};
-
-    private async transportLock<T extends void>(
-        apiType: TransportApiType,
-        abortMessage: string,
-        action: (signal: AbortSignal) => Promise<T>,
-    ): Promise<T> {
-        const lock = this.locks[apiType] ?? (this.locks[apiType] = { sequence: 0 });
-        lock.abortMessage = abortMessage;
-        const sequence = ++lock.sequence;
-
-        while (lock.promise) {
-            lock.abort?.abort(new Error(abortMessage));
-            await lock.promise.catch(() => {});
-        }
-
-        if (sequence !== lock.sequence) return Promise.reject(new Error(lock.abortMessage));
-
-        lock.abort = new AbortController();
-        lock.promise = action(lock.abort.signal).finally(() => {
-            delete lock.abort;
-            delete lock.promise;
-        });
-
-        return lock.promise as Promise<T>;
-    }
-
-    private readonly scheduledUpgradeChecks: ApiTypeMap<ReturnType<typeof setTimeout>> = {};
 
     constructor({
         messages,
@@ -252,122 +222,57 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         device?.usedElsewhere();
     }
 
-    async init(initParams: InitParams = {}) {
+    private getOrCreateTransportManager(apiType: TransportApiType) {
+        if (!this.transportManagers[apiType]) {
+            const manager = new TransportManager({
+                startTransport: this.startTransport.bind(this),
+                stopTransport: this.stopTransport.bind(this),
+            });
+            manager.on(TRANSPORT.START, transport =>
+                this.emit(TRANSPORT.START, getTransportInfo(transport)),
+            );
+            manager.on(TRANSPORT.ERROR, error => this.emit(TRANSPORT.ERROR, { apiType, error }));
+            this.transportManagers[apiType] = manager;
+        }
+
+        return this.transportManagers[apiType];
+    }
+
+    async init({ transports, transportReconnect, pendingTransportEvent }: InitParams = {}) {
         // throws when unknown transport is requested, in that case nothing is changed
-        this.transports = this.updateTransports(this.transports, initParams.transports);
+        this.transports = this.updateTransports(this.transports, transports);
 
         const promises = this.transports
             .map(t => t.apiType)
-            .concat(typedObjectKeys(this.transport))
-            .concat(typedObjectKeys(this.locks))
+            .concat(typedObjectKeys(this.transportManagers))
             .filter(arrayDistinct)
             .map(apiType =>
-                this.transportLock(apiType, 'New init', signal =>
-                    this.createInitPromise(apiType, initParams, signal),
-                ),
+                this.getOrCreateTransportManager(apiType).init({
+                    transports: this.transports.filter(t => t.apiType === apiType),
+                    transportReconnect,
+                    pendingTransportEvent,
+                }),
             );
 
         await Promise.all(promises);
     }
 
-    private async createInitPromise(
-        apiType: TransportApiType,
-        initParams: InitParams,
-        abortSignal: AbortSignal,
+    private async startTransport(
+        transport: Transport,
+        pendingTransportEvent: boolean,
+        signal: AbortSignal,
     ) {
         try {
-            const transports = this.transports.filter(t => t.apiType === apiType);
-            const transport = transports.length
-                ? await this.selectTransport(transports, abortSignal)
-                : undefined;
-            const oldTransport = this.transport[apiType];
-            if (oldTransport !== transport) {
-                if (oldTransport) {
-                    delete this.transport[apiType];
-                    await this.stopTransport(oldTransport);
-                    if (!transport) {
-                        this.emit(TRANSPORT.ERROR, { apiType, error: 'Transport disabled' });
-                    }
-                }
-
-                if (transport) {
-                    try {
-                        await this.initializeTransport(transport, initParams, abortSignal);
-                    } catch (error) {
-                        await this.stopTransport(transport);
-                        throw error;
-                    }
-
-                    transport.on(TRANSPORT.ERROR, error => {
-                        this.emit(TRANSPORT.ERROR, { apiType, error });
-                        this.transportLock(apiType, 'Transport error', async signal => {
-                            delete this.transport[apiType];
-                            await this.stopTransport(transport);
-                            if (initParams.transportReconnect) {
-                                await this.createReconnectDelay(signal);
-                                await this.createInitPromise(apiType, initParams, signal);
-                            }
-                        }).catch(() => {});
-                    });
-
-                    this.transport[apiType] = transport;
-                    this.emit(TRANSPORT.START, getTransportInfo(transport));
-                }
-            }
-            if (transport && transport !== transports[0]) {
-                // new transport started successfully or present transport kept, and it's not the most preferred one, (re)plan check
-                this.scheduleUpgradeCheck(apiType, initParams);
-            }
-        } catch (error) {
-            this.emit(TRANSPORT.ERROR, { apiType, error: error?.message });
-            if (initParams.transportReconnect && !abortSignal.aborted) {
-                this.transportLock(apiType, 'Reconnecting', async signal => {
-                    await this.createReconnectDelay(signal);
-                    await this.createInitPromise(apiType, initParams, signal);
-                }).catch(() => {});
-            }
+            await this.initializeTransport(transport, pendingTransportEvent, signal);
+        } catch (err) {
+            await this.stopTransport(transport);
+            throw err;
         }
-    }
-
-    private createReconnectDelay(signal: AbortSignal) {
-        return resolveAfter(1000, signal);
-    }
-
-    private scheduleUpgradeCheck(apiType: TransportApiType, initParams: InitParams) {
-        clearTimeout(this.scheduledUpgradeChecks[apiType]);
-        this.scheduledUpgradeChecks[apiType] = setTimeout(async () => {
-            const transport = this.transport[apiType];
-            const transports = this.transports.filter(t => t.apiType === apiType);
-            if (!transport || transport === transports[0]) return;
-            for (const t of transports) {
-                if (t === transport) break;
-                if (await t.ping()) {
-                    this.transportLock(apiType, 'Upgrading', signal =>
-                        this.createInitPromise(apiType, initParams, signal),
-                    ).catch(() => {});
-
-                    return;
-                }
-            }
-            this.scheduleUpgradeCheck(apiType, initParams);
-        }, 1000);
-    }
-
-    private async selectTransport(
-        [transport, ...rest]: Transport[],
-        signal: AbortSignal,
-    ): Promise<Transport> {
-        if (signal.aborted) throw new Error(signal.reason);
-        if (transport === this.transport[transport.apiType]) return transport;
-        const result = await transport.init({ signal });
-        if (result.success) return transport;
-        else if (rest.length) return this.selectTransport(rest, signal);
-        else throw new Error(result.error);
     }
 
     private async initializeTransport(
         transport: Transport,
-        initParams: InitParams,
+        pendingTransportEvent: boolean,
         signal: AbortSignal,
     ) {
         /**
@@ -398,7 +303,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         const descriptors = enumerateResult.payload;
 
         const waitForDevicesPromise =
-            initParams.pendingTransportEvent && descriptors.length
+            pendingTransportEvent && descriptors.length
                 ? this.waitForDevices(transport, descriptors, signal)
                 : Promise.resolve();
 
@@ -482,25 +387,12 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
     async dispose() {
         this.removeAllListeners();
 
-        const promises = typedObjectKeys(this.transport)
-            .concat(typedObjectKeys(this.locks))
-            .filter(arrayDistinct)
-            .map(apiType =>
-                this.transportLock(apiType, 'Disposing', async () => {
-                    const transport = this.transport[apiType];
-                    if (transport) {
-                        delete this.transport[apiType];
-                        await this.stopTransport(transport);
-                    }
-                }),
-            );
+        const promises = Object.values(this.transportManagers).map(manager => manager.dispose());
 
         await Promise.all(promises);
     }
 
     private async stopTransport(transport: Transport) {
-        clearTimeout(this.scheduledUpgradeChecks[transport.apiType]);
-
         const devices = this.devices.clear(transport);
 
         // disconnect devices
@@ -522,7 +414,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
     }
 
     async enumerate() {
-        const promises = Object.values(this.transport).map(async transport => {
+        const promises = this.getConnectedTransports().map(async transport => {
             const res = await transport.enumerate();
 
             if (!res.success) {

--- a/packages/connect/src/device/TransportList.ts
+++ b/packages/connect/src/device/TransportList.ts
@@ -1,0 +1,80 @@
+import {
+    BridgeTransport,
+    NodeUsbTransport,
+    Transport,
+    UdpTransport,
+    WebUsbTransport,
+    isTransportInstance,
+} from '@trezor/transport';
+import type { AbstractTransportParams } from '@trezor/transport/src/transports/abstract';
+
+import { ERRORS } from '../constants';
+import { getBridgeInfo } from '../data/transportInfo';
+import { ConnectSettingsTransport } from '../types';
+
+type Params = AbstractTransportParams & { sessionsBackgroundUrl?: string | null };
+
+const tryGetTransport = (transports: Transport[], name: string) =>
+    transports.find(t => t.name === name);
+
+const getOrCreateTransport = (
+    transports: Transport[],
+    transportType: ConnectSettingsTransport,
+    params: Params,
+) => {
+    if (typeof transportType === 'string') {
+        const existing = tryGetTransport(transports, transportType);
+        if (existing) return existing;
+
+        switch (transportType) {
+            case 'WebUsbTransport':
+                return new WebUsbTransport(params);
+            case 'NodeUsbTransport':
+                return new NodeUsbTransport(params);
+            case 'BridgeTransport':
+                return new BridgeTransport({
+                    latestVersion: getBridgeInfo().version.join('.'),
+                    ...params,
+                });
+            case 'UdpTransport':
+                return new UdpTransport(params);
+        }
+    } else if (typeof transportType === 'function' && 'prototype' in transportType) {
+        const transportInstance = new transportType(params);
+        if (isTransportInstance(transportInstance)) {
+            return tryGetTransport(transports, transportInstance.name) ?? transportInstance;
+        }
+    } else if (isTransportInstance(transportType)) {
+        if (tryGetTransport(transports, transportType.name)) {
+            return transportType;
+        }
+
+        // custom Transport might be initialized without messages, update them if so
+        if (!transportType.getMessage()) {
+            transportType.updateMessages(params.messages);
+        }
+
+        return transportType;
+    }
+
+    // runtime check
+    throw ERRORS.TypedError(
+        'Runtime',
+        `DeviceList.init: transports[] of unexpected type: ${transportType}`,
+    );
+};
+
+const createTransports = (
+    existing: Transport[],
+    transports: ConnectSettingsTransport[] = [],
+    params: Params,
+) => {
+    // BridgeTransport is the ultimate fallback
+    const transportTypes = transports?.length ? transports : ['BridgeTransport' as const];
+
+    return transportTypes.map(type => getOrCreateTransport(existing, type, params));
+};
+
+export const createTransportList =
+    (params: Params) => (existing: Transport[], transports?: ConnectSettingsTransport[]) =>
+        createTransports(existing, transports, params);

--- a/packages/connect/src/device/TransportManager.ts
+++ b/packages/connect/src/device/TransportManager.ts
@@ -1,0 +1,191 @@
+import { TRANSPORT, Transport } from '@trezor/transport';
+import { TypedEmitter, resolveAfter } from '@trezor/utils';
+
+const createOverrideLock = () => {
+    let promise: Promise<void> | undefined;
+    let sequence = 0;
+    let abort: AbortController | undefined;
+    let message: string | undefined;
+
+    const override = async <T extends void>(
+        abortMessage: string,
+        action: (signal: AbortSignal) => Promise<T>,
+    ) => {
+        message = abortMessage;
+        const seq = ++sequence;
+
+        while (promise) {
+            abort?.abort(new Error(abortMessage));
+            await promise.catch(() => {});
+        }
+
+        if (seq !== sequence) return Promise.reject(new Error(message));
+
+        abort = new AbortController();
+        promise = action(abort.signal).finally(() => {
+            abort = undefined;
+            promise = undefined;
+        });
+
+        return promise as Promise<T>;
+    };
+
+    const getPending = () => promise;
+
+    return { override, getPending };
+};
+
+type TransportManagerEvents = {
+    [TRANSPORT.START]: Transport;
+    [TRANSPORT.ERROR]: string;
+};
+
+type TransportManagerParams = {
+    startTransport: (
+        transport: Transport,
+        pendingTransportEvent: boolean,
+        signal: AbortSignal,
+    ) => Promise<void>;
+    stopTransport: (transport: Transport) => Promise<void>;
+};
+
+type InitParams = {
+    transports: Transport[];
+    transportReconnect?: boolean;
+    pendingTransportEvent?: boolean;
+};
+
+export class TransportManager extends TypedEmitter<TransportManagerEvents> {
+    private lock = createOverrideLock();
+    private transports: Transport[] = [];
+    private activeTransport?: Transport;
+    private transportReconnect = false;
+    private upgradeTimeout?: ReturnType<typeof setTimeout>;
+
+    private readonly startTransport;
+    private readonly stopTransport;
+
+    constructor({ startTransport, stopTransport }: TransportManagerParams) {
+        super();
+        this.startTransport = startTransport;
+        this.stopTransport = stopTransport;
+    }
+
+    pending() {
+        return this.lock.getPending();
+    }
+
+    get() {
+        return this.activeTransport;
+    }
+
+    init({ transports, transportReconnect = false, pendingTransportEvent = false }: InitParams) {
+        this.transports = transports;
+        this.transportReconnect = transportReconnect;
+
+        return this.lock.override('New init', signal =>
+            this.createInitPromise(pendingTransportEvent, signal),
+        );
+    }
+
+    dispose() {
+        this.removeAllListeners();
+
+        return this.lock.override('Disposing', async () => {
+            const { activeTransport } = this;
+            if (activeTransport) {
+                clearTimeout(this.upgradeTimeout);
+                delete this.activeTransport;
+                await this.stopTransport(activeTransport);
+            }
+        });
+    }
+
+    private async selectTransport(
+        [transport, ...rest]: Transport[],
+        signal: AbortSignal,
+    ): Promise<Transport> {
+        if (signal.aborted) throw new Error(signal.reason);
+        if (transport === this.activeTransport) return transport;
+        const result = await transport.init({ signal });
+        if (result.success) return transport;
+        else if (rest.length) return this.selectTransport(rest, signal);
+        else throw new Error(result.error);
+    }
+
+    private scheduleUpgradeCheck(pendingTransportEvent: boolean) {
+        clearTimeout(this.upgradeTimeout);
+        this.upgradeTimeout = setTimeout(async () => {
+            if (!this.activeTransport || this.activeTransport === this.transports[0]) return;
+            for (const t of this.transports) {
+                if (t === this.activeTransport) break;
+                if (await t.ping()) {
+                    this.lock
+                        .override('Upgrading', signal =>
+                            this.createInitPromise(pendingTransportEvent, signal),
+                        )
+                        .catch(() => {});
+
+                    return;
+                }
+            }
+            this.scheduleUpgradeCheck(pendingTransportEvent);
+        }, 1000);
+    }
+
+    private async createInitPromise(pendingTransportEvent: boolean, abortSignal: AbortSignal) {
+        try {
+            const { transports, activeTransport } = this;
+            const transport = transports.length
+                ? await this.selectTransport(transports, abortSignal)
+                : undefined;
+
+            if (activeTransport !== transport) {
+                if (activeTransport) {
+                    clearTimeout(this.upgradeTimeout);
+                    delete this.activeTransport;
+                    await this.stopTransport(activeTransport);
+                }
+
+                if (transport) {
+                    await this.startTransport(transport, pendingTransportEvent, abortSignal);
+
+                    transport.on(TRANSPORT.ERROR, error => {
+                        this.emit(TRANSPORT.ERROR, error);
+                        clearTimeout(this.upgradeTimeout);
+                        this.lock
+                            .override('Transport error', async signal => {
+                                delete this.activeTransport;
+                                await this.stopTransport(transport);
+                                if (this.transportReconnect) {
+                                    await resolveAfter(1000, signal);
+                                    await this.createInitPromise(pendingTransportEvent, signal);
+                                }
+                            })
+                            .catch(() => {});
+                    });
+
+                    this.activeTransport = transport;
+                    this.emit(TRANSPORT.START, transport);
+                } else {
+                    this.emit(TRANSPORT.ERROR, 'Transport disabled');
+                }
+            }
+
+            if (transport && transport !== transports[0]) {
+                // new transport started successfully or present transport kept, and it's not the most preferred one, (re)plan check
+                this.scheduleUpgradeCheck(pendingTransportEvent);
+            }
+        } catch (error) {
+            this.emit(TRANSPORT.ERROR, error?.message);
+            if (this.transportReconnect && !abortSignal.aborted) {
+                this.lock
+                    .override('Reconnecting', async signal => {
+                        await resolveAfter(1000, signal);
+                        await this.createInitPromise(pendingTransportEvent, signal);
+                    })
+                    .catch(() => {});
+            }
+        }
+    }
+}

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -12,13 +12,18 @@ export type Proxy = BlockchainSettings['proxy'];
 // omit transports which are not implemented in @trezor/connect
 type KnownTransport = Exclude<Transport['name'], 'NativeUsbTransport' | 'BluetoothTransport'>;
 
+export type ConnectSettingsTransport =
+    | KnownTransport
+    | Transport
+    | (new (...args: any[]) => Transport);
+
 export interface ConnectSettingsPublic {
     manifest?: Manifest;
     connectSrc?: string;
     debug?: boolean;
     popup?: boolean;
     transportReconnect?: boolean;
-    transports?: (KnownTransport | Transport | (new (...args: any[]) => Transport))[];
+    transports?: ConnectSettingsTransport[];
     pendingTransportEvent?: boolean;
     lazyLoad?: boolean;
     interactionTimeout?: number;


### PR DESCRIPTION
`DeviceList` class got a little too chunky, so I extracted some isolated functionalities into separate files. Behavior shouldn't change I hope.

commit 1: Move logic regarding changing allowed transports (creating instances for newly added transports or reusing already existing ones) into `TransportList` file.

commit 2: Move logic regarding transport selection/starting/stopping/reconnecting/upgrading (all of this in a race condition-less manner (oh I wish)) into `TransportManager` file.