### PR TITLE
Rename sentry environments

### DIFF
--- a/suite-common/sentry/package.json
+++ b/suite-common/sentry/package.json
@@ -12,6 +12,7 @@
     "dependencies": {
         "@sentry/core": "^8.47.0",
         "@suite-common/suite-utils": "workspace:*",
+        "@trezor/env-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
     }
 }

--- a/suite-common/sentry/src/index.ts
+++ b/suite-common/sentry/src/index.ts
@@ -1,6 +1,7 @@
 import { Options, Event as SentryEvent, captureConsoleIntegration } from '@sentry/core';
 
 import { isDevEnv } from '@suite-common/suite-utils';
+import { isCodesignBuild } from '@trezor/env-utils';
 import { redactUserPathFromString } from '@trezor/utils';
 
 export const allowReportTag = 'allowReport';
@@ -101,7 +102,7 @@ export const SENTRY_CONFIG: Options = {
     enabled: !isDevEnv,
     maxValueLength: 500, // default 250 is not enough for some errors
     release: process.env.SENTRY_RELEASE,
-    environment: process.env.SUITE_TYPE,
+    environment: isCodesignBuild() ? 'production' : 'develop',
     normalizeDepth: 4,
     maxBreadcrumbs: 40,
     beforeBreadcrumb,

--- a/suite-common/sentry/tsconfig.json
+++ b/suite-common/sentry/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../suite-utils" },
+        { "path": "../../packages/env-utils" },
         { "path": "../../packages/utils" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9609,6 +9609,7 @@ __metadata:
   dependencies:
     "@sentry/core": "npm:^8.47.0"
     "@suite-common/suite-utils": "workspace:*"
+    "@trezor/env-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Change Sentry environments from `web`/`desktop` to `develop`/`production`, according to codesign status.
