### PR TITLE
Fix SecurityCheck displaying when not initialRun

### DIFF
--- a/packages/suite/src/components/suite/layouts/LoggedOutLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/LoggedOutLayout.tsx
@@ -10,6 +10,7 @@ import { LayoutContext, LayoutContextPayload } from 'src/support/suite/LayoutCon
 import { ModalContextProvider } from 'src/support/suite/ModalContext';
 
 import { Metadata } from '../Metadata';
+import { LoggedOutSidebar } from './LoggedOutSidebar';
 import {
     AppWrapper,
     Body,
@@ -18,7 +19,6 @@ import {
     PageWrapper,
     Wrapper,
 } from './SuiteLayout/SuiteLayout';
-import { LoggedOutSidebar } from './WelcomeLayout/WelcomeLayout';
 import { ModalSwitcher } from '../modals/ModalSwitcher/ModalSwitcher';
 
 interface LoggedOutLayout {

--- a/packages/suite/src/components/suite/layouts/LoggedOutSidebar.tsx
+++ b/packages/suite/src/components/suite/layouts/LoggedOutSidebar.tsx
@@ -1,0 +1,61 @@
+import styled from 'styled-components';
+
+import { Route } from '@suite-common/suite-types';
+import { Column, ElevationUp, useElevation } from '@trezor/components';
+import { Elevation, mapElevationToBackground, mapElevationToBorder } from '@trezor/theme';
+
+import { SIDEBAR_MIN_WIDTH } from './SuiteLayout/Sidebar/Sidebar';
+import { useSelector } from '../../../hooks/suite';
+import { selectIsInitialRun } from '../../../reducers/suite/suiteReducer';
+import { TrafficLightOffset } from '../TrafficLightOffset';
+import { Nav, SETTINGS_ROUTES } from './SuiteLayout/Sidebar/Navigation';
+import { NavItem } from './SuiteLayout/Sidebar/NavigationItem';
+import { QuickActions } from './SuiteLayout/Sidebar/QuickActions/QuickActions';
+
+const SidebarWrapper = styled.div<{ $elevation: Elevation }>`
+    background-color: ${mapElevationToBackground};
+    height: 100%;
+`;
+
+const SidebarNavColumn = styled.div<{ $elevation: Elevation; $minWidth: number }>`
+    border-right: solid 1px ${mapElevationToBorder};
+    min-width: ${({ $minWidth }) => $minWidth}px;
+    height: 100%;
+`;
+
+export const LoggedOutSidebar = () => {
+    const { elevation } = useElevation();
+
+    const isInitialRun = useSelector(selectIsInitialRun);
+    const startRoute: Route['name'] = isInitialRun ? 'suite-start' : 'suite-index';
+
+    return (
+        <SidebarWrapper $elevation={elevation}>
+            <ElevationUp>
+                <SidebarNavColumn $elevation={elevation} $minWidth={SIDEBAR_MIN_WIDTH}>
+                    <TrafficLightOffset>
+                        <Column justifyContent="space-between" height="100%">
+                            <Nav $isSidebarCollapsed>
+                                <NavItem
+                                    nameId="TR_START"
+                                    icon="trezorLogo"
+                                    goToRoute={startRoute}
+                                    routes={[startRoute]}
+                                    data-testid="@suite/menu/suite-start"
+                                />
+                                <NavItem
+                                    nameId="TR_SETTINGS"
+                                    icon="gearSix"
+                                    goToRoute="settings-index"
+                                    routes={SETTINGS_ROUTES}
+                                    data-testid="@suite/menu/settings"
+                                />
+                            </Nav>
+                            <QuickActions hideUpdateStatusBar isSidebarCollapsed />
+                        </Column>
+                    </TrafficLightOffset>
+                </SidebarNavColumn>
+            </ElevationUp>
+        </SidebarWrapper>
+    );
+};

--- a/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { selectBannerMessage } from '@suite-common/message-system';
+import { Route } from '@suite-common/suite-types';
 import {
     Column,
     ElevationDown,
@@ -25,6 +26,7 @@ import { MessageSystemBanner } from 'src/components/suite/banners';
 import { MAX_ONBOARDING_WIDTH } from 'src/constants/suite/layout';
 import { useSelector } from 'src/hooks/suite';
 
+import { selectIsInitialRun } from '../../../../reducers/suite/suiteReducer';
 import { TrafficLightOffset } from '../../TrafficLightOffset';
 import { Nav, SETTINGS_ROUTES } from '../SuiteLayout/Sidebar/Navigation';
 import { NavItem } from '../SuiteLayout/Sidebar/NavigationItem';
@@ -74,6 +76,9 @@ const WelcomeNavColumn = styled.div<{ $elevation: Elevation; $minWidth: number }
 export const LoggedOutSidebar = () => {
     const { elevation } = useElevation();
 
+    const isInitialRun = useSelector(selectIsInitialRun);
+    const startRoute: Route['name'] = isInitialRun ? 'suite-start' : 'suite-index';
+
     return (
         <WelcomeWrapper $elevation={elevation}>
             <ElevationUp>
@@ -84,8 +89,8 @@ export const LoggedOutSidebar = () => {
                                 <NavItem
                                     nameId="TR_START"
                                     icon="trezorLogo"
-                                    goToRoute="suite-start"
-                                    routes={['suite-start']}
+                                    goToRoute={startRoute}
+                                    routes={[startRoute]}
                                     data-testid="@suite/menu/suite-start"
                                 />
                                 <NavItem

--- a/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx
@@ -3,7 +3,6 @@ import { ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { selectBannerMessage } from '@suite-common/message-system';
-import { Route } from '@suite-common/suite-types';
 import {
     Column,
     ElevationDown,
@@ -12,13 +11,7 @@ import {
     useElevation,
     variables,
 } from '@trezor/components';
-import {
-    Elevation,
-    mapElevationToBackground,
-    mapElevationToBorder,
-    spacings,
-    spacingsPx,
-} from '@trezor/theme';
+import { Elevation, spacings, spacingsPx } from '@trezor/theme';
 
 import { GuideButton, GuideRouter } from 'src/components/guide';
 // importing directly, otherwise unit tests fail, seems to be a styled-components issue
@@ -26,17 +19,7 @@ import { MessageSystemBanner } from 'src/components/suite/banners';
 import { MAX_ONBOARDING_WIDTH } from 'src/constants/suite/layout';
 import { useSelector } from 'src/hooks/suite';
 
-import { selectIsInitialRun } from '../../../../reducers/suite/suiteReducer';
-import { TrafficLightOffset } from '../../TrafficLightOffset';
-import { Nav, SETTINGS_ROUTES } from '../SuiteLayout/Sidebar/Navigation';
-import { NavItem } from '../SuiteLayout/Sidebar/NavigationItem';
-import { QuickActions } from '../SuiteLayout/Sidebar/QuickActions/QuickActions';
-import { SIDEBAR_MIN_WIDTH } from '../SuiteLayout/Sidebar/Sidebar';
-
-const WelcomeWrapper = styled.div<{ $elevation: Elevation }>`
-    background-color: ${mapElevationToBackground};
-    height: 100%;
-`;
+import { LoggedOutSidebar } from '../LoggedOutSidebar';
 
 const Content = styled.div<{ $elevation: Elevation }>`
     display: flex;
@@ -66,49 +49,6 @@ const ChildrenWrapper = styled.div`
 interface WelcomeLayoutProps {
     children: ReactNode;
 }
-
-const WelcomeNavColumn = styled.div<{ $elevation: Elevation; $minWidth: number }>`
-    border-right: solid 1px ${mapElevationToBorder};
-    min-width: ${({ $minWidth }) => $minWidth}px;
-    height: 100%;
-`;
-
-export const LoggedOutSidebar = () => {
-    const { elevation } = useElevation();
-
-    const isInitialRun = useSelector(selectIsInitialRun);
-    const startRoute: Route['name'] = isInitialRun ? 'suite-start' : 'suite-index';
-
-    return (
-        <WelcomeWrapper $elevation={elevation}>
-            <ElevationUp>
-                <WelcomeNavColumn $elevation={elevation} $minWidth={SIDEBAR_MIN_WIDTH}>
-                    <TrafficLightOffset>
-                        <Column justifyContent="space-between" height="100%">
-                            <Nav $isSidebarCollapsed>
-                                <NavItem
-                                    nameId="TR_START"
-                                    icon="trezorLogo"
-                                    goToRoute={startRoute}
-                                    routes={[startRoute]}
-                                    data-testid="@suite/menu/suite-start"
-                                />
-                                <NavItem
-                                    nameId="TR_SETTINGS"
-                                    icon="gearSix"
-                                    goToRoute="settings-index"
-                                    routes={SETTINGS_ROUTES}
-                                    data-testid="@suite/menu/settings"
-                                />
-                            </Nav>
-                            <QuickActions hideUpdateStatusBar isSidebarCollapsed />
-                        </Column>
-                    </TrafficLightOffset>
-                </WelcomeNavColumn>
-            </ElevationUp>
-        </WelcomeWrapper>
-    );
-};
 
 const Right = ({ children }: { children: ReactNode }) => {
     const { elevation } = useElevation();

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -482,8 +482,10 @@ export const selectIsUnhideTokenModalShown = (state: SuiteRootState) =>
 export const selectIsCopyAddressModalShown = (state: SuiteRootState) =>
     state.suite.flags.showCopyAddressModal;
 
+export const selectIsInitialRun = (state: SuiteRootState) => state.suite.flags.initialRun;
+
 export const selectIsLoggedOut = (state: SuiteRootState & DeviceRootState) =>
-    state.suite.flags.initialRun || state.device?.selectedDevice?.mode !== 'normal';
+    selectIsInitialRun(state) || state.device?.selectedDevice?.mode !== 'normal';
 
 export const selectSuiteFlags = (state: SuiteRootState) => state.suite.flags;
 


### PR DESCRIPTION
## Description

:eyes: CR recommended commit by commit 

- eb25f5c3 fix root cause, [described in this comment](https://github.com/trezor/trezor-suite/pull/17259/commits/8643f89cb205b8c7c078df656f12dc265638940d#r1971844946)
- eaf52789 extract component `LoggedOutSidebar`, as it is used equally by `WelcomeLayout` & `LoggedOutLayout`

## Related Issue

Resolve #15881

## Screenshots:

The most simple reproduction fixed:
[easier bug fixed.webm](https://github.com/user-attachments/assets/898f61e6-802a-4b47-bfbd-14da6d89c1de)

The whole flow. BTW I noticed unrelated #17261, that's why I need to load `/` path at 0:12)
[fixed.webm](https://github.com/user-attachments/assets/e5149dea-0cd5-44fa-a162-57723c149ce8)