### PR TITLE
fix(suite): added missing stake buttons to table assets view

### DIFF
--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
@@ -59,6 +59,7 @@ export const AssetRow = memo(
         localCurrency,
         currentFiatRates,
         accounts,
+        isStakeNetwork,
     }: AssetTableRowProps) => {
         const { symbol } = network;
         const dispatch = useDispatch();
@@ -169,6 +170,12 @@ export const AssetRow = memo(
                     </Table.Cell>
                     <Table.Cell align="right" colSpan={2}>
                         <Row gap={spacings.md}>
+                            {isStakeNetwork && (
+                                <TradingButton symbol={symbol} routeName="wallet-staking">
+                                    <Translation id="TR_STAKE_STAKE" />
+                                </TradingButton>
+                            )}
+
                             {!isTestnet(symbol) && (
                                 <TradingButton
                                     symbol={symbol}

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetTable.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetTable.tsx
@@ -60,6 +60,7 @@ export const AssetTable = ({
                     localCurrency={localCurrency}
                     currentFiatRates={currentFiatRates}
                     accounts={asset.accounts}
+                    isStakeNetwork={asset.isStakeNetwork}
                 />
             ))}
             {discoveryInProgress && <AssetRowSkeleton />}


### PR DESCRIPTION
## Description

Added "Stake" button for stakeable networks in the table assets view in the dashboard.

Addition to #17190 

## Related Issue

Resolve #17258 
resolve #16360

## Screenshots:

<img width="1245" alt="Screenshot 2025-02-26 at 16 07 13" src="https://github.com/user-attachments/assets/d6f9ee0c-6fa2-41cc-881b-6a1e69759c03" />
