### PR TITLE
Message system - Add context banner to solana staking

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx
@@ -1,5 +1,8 @@
 import { Context } from '@suite-common/message-system';
-import { isSupportedEthStakingNetworkSymbol } from '@suite-common/wallet-utils';
+import {
+    isSupportedEthStakingNetworkSymbol,
+    isSupportedSolStakingNetworkSymbol,
+} from '@suite-common/wallet-utils';
 import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -31,6 +34,9 @@ export const AccountBanners = ({ account }: AccountBannersProps) => {
             {account?.symbol &&
                 isSupportedEthStakingNetworkSymbol(account.symbol) &&
                 route?.name === 'wallet-staking' && <ContextMessage context={Context.ethStaking} />}
+            {account?.symbol &&
+                isSupportedSolStakingNetworkSymbol(account.symbol) &&
+                route?.name === 'wallet-staking' && <ContextMessage context={Context.solStaking} />}
             <AuthConfirmFailed />
             <BackendDisconnected />
             <DeviceUnavailable />

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ContextMessage.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ContextMessage.tsx
@@ -1,8 +1,10 @@
 import { Context, selectContextMessageContent } from '@suite-common/message-system';
-import { Banner } from '@trezor/components';
+import { Banner, Row } from '@trezor/components';
 
-import { useSelector } from 'src/hooks/suite';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { goto } from 'src/actions/suite/routerActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectLanguage, selectTorState } from 'src/reducers/suite/suiteReducer';
+import { getTorUrlIfAvailable } from 'src/utils/suite/tor';
 
 type ContextMessageProps = {
     context: (typeof Context)[keyof typeof Context];
@@ -11,17 +13,43 @@ type ContextMessageProps = {
 export const ContextMessage = ({ context }: ContextMessageProps) => {
     const language = useSelector(selectLanguage);
     const message = useSelector(state => selectContextMessageContent(state, context, language));
+    const { isTorEnabled } = useSelector(selectTorState);
+    const torOnionLinks = useSelector(state => state.suite.settings.torOnionLinks);
+    const dispatch = useDispatch();
 
-    return message ? (
+    if (!message) return null;
+
+    const onCallToAction = ({ action, link, anchor }: NonNullable<(typeof message)['cta']>) => {
+        switch (action) {
+            case 'internal-link':
+                // @ts-expect-error: impossible to add all href options to the message system config json schema
+                return () => dispatch(goto(link, { anchor, preserveParams: true }));
+            case 'external-link':
+                return () =>
+                    window.open(
+                        isTorEnabled && torOnionLinks ? getTorUrlIfAvailable(link) : link,
+                        '_blank',
+                    );
+        }
+    };
+
+    return (
         <Banner
             variant={message.variant === 'critical' ? 'destructive' : message.variant}
             rightContent={
-                message.cta ? (
-                    <Banner.Button href={message.cta.link}>{message.cta.label}</Banner.Button>
-                ) : undefined
+                message.cta && (
+                    <Row gap={8}>
+                        <Banner.Button
+                            onClick={onCallToAction(message.cta)}
+                            data-testid={`@context-message/${context}/cta`}
+                        >
+                            {message.cta.label}
+                        </Banner.Button>
+                    </Row>
+                )
             }
         >
             {message.content}
         </Banner>
-    ) : null;
+    );
 };

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -36,6 +36,7 @@ export type FeatureDomain = (typeof Feature)[keyof typeof Feature];
 export const Context = {
     coinjoin: 'accounts.coinjoin',
     ethStaking: 'accounts.eth.staking',
+    solStaking: 'accounts.sol.staking',
 } as const;
 
 export type ContextDomain = (typeof Context)[keyof typeof Context];


### PR DESCRIPTION
This pull request includes several updates to support Solana staking and improve the context message system. The most important changes include adding support for Solana staking in the wallet layout, enhancing the context message component, updating the message system configuration, and modifying the message system types.

Support for Solana staking:

* [`packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx`](diffhunk://#diff-3ed28da050db15080e5835bcb3310860e4b322cedd5cc6594733c1d223774fd9L2-R5): Added `isSupportedSolStakingNetworkSymbol` check to display Solana staking context messages. [[1]](diffhunk://#diff-3ed28da050db15080e5835bcb3310860e4b322cedd5cc6594733c1d223774fd9L2-R5) [[2]](diffhunk://#diff-3ed28da050db15080e5835bcb3310860e4b322cedd5cc6594733c1d223774fd9R37-R39)

Enhancements to context message component:

* [`packages/suite/src/components/wallet/WalletLayout/AccountBanners/ContextMessage.tsx`](diffhunk://#diff-cd9fabccc48fbdd4cab68ffb0fa3509aa8f10eae6bd7b99721dd9def9f891626R1-R9): Introduced `useMemo` for action configuration, added dispatch for internal and external links, and included Tor URL handling. [[1]](diffhunk://#diff-cd9fabccc48fbdd4cab68ffb0fa3509aa8f10eae6bd7b99721dd9def9f891626R1-R9) [[2]](diffhunk://#diff-cd9fabccc48fbdd4cab68ffb0fa3509aa8f10eae6bd7b99721dd9def9f891626R18-R62)



Modifications to message system types:

* [`suite-common/message-system/src/messageSystemTypes.ts`](diffhunk://#diff-986a62cff972d8e0d2eeb3769eae0afcffa16de1a7ac70fb85988908958edb27R39): Added `solStaking` to the `Context` object.
## Screenshots:
![image](https://github.com/user-attachments/assets/c5b7bf14-0168-4cd6-afcb-7fb2a09ff8c0)


https://github.com/user-attachments/assets/478e84f9-68b2-416e-bbad-9dbc3375a41b

