### PR TITLE
Fix/script bump version changelog line

### DIFF
--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -9,8 +9,6 @@
 | :----------------: | :----: | :----: |
 | connect.trezor.io/ | 9.5.0  |   -    |
 
-| connect.trezor.io/ | 9.4.7 | 9.5.0-beta.1 |
-
 Use the persistent link [connect.trezor.io/9](https://connect.trezor.io/9/) to access the latest stable version of Connect Explorer.
 
 # 9.5.0

--- a/scripts/ci/connect-bump-versions.ts
+++ b/scripts/ci/connect-bump-versions.ts
@@ -82,7 +82,7 @@ const updateConnectChangelog = async (
         const changelogContent = await readFile(connectChangelogPath, 'utf-8');
         const lines = changelogContent.split('\n');
 
-        const oldContent = lines.slice(9).join('\n');
+        const oldContent = lines.slice(10).join('\n');
 
         const npmTable = [
             { package: 'npm @trezor/connect', stable, canary },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix script that generate Connect changelog so it does not duplicate line of connect.trezor.io version with previous one.
