### PR TITLE
fix(suite): hide solana unstake amount

### DIFF
--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -154,6 +154,7 @@ export interface Transaction {
     solanaSpecific?: {
         status: 'confirmed';
         stakeType?: StakeType;
+        unstakeAmount?: string;
     };
     details: TransactionDetail;
     vsize?: number;

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -737,13 +737,16 @@ export const transformTransaction = (
 
     const targets = getTargets(nativeEffects, txType, accountAddress);
 
-    const amount =
-        stakeType === 'unstake'
-            ? getUnstakeAmount(tx)
-            : getAmount(
-                  nativeEffects.find(({ address }) => address === accountAddress),
-                  type,
-              );
+    const isUnstakeTx = stakeType === 'unstake';
+
+    const amount = isUnstakeTx
+        ? '0' // amount for unstake transactions should be hidden
+        : getAmount(
+              nativeEffects.find(({ address }) => address === accountAddress),
+              type,
+          );
+
+    const unstakeAmount = isUnstakeTx ? getUnstakeAmount(tx) : undefined;
 
     const details = getDetails(tx, nativeEffects, accountAddress, type);
 
@@ -763,6 +766,7 @@ export const transformTransaction = (
         solanaSpecific: {
             status: 'confirmed',
             stakeType,
+            unstakeAmount,
         },
     };
 };

--- a/packages/suite/src/components/suite/UnstakingTxAmount.tsx
+++ b/packages/suite/src/components/suite/UnstakingTxAmount.tsx
@@ -14,14 +14,19 @@ interface UnstakingTxAmountProps {
 }
 
 export const UnstakingTxAmount = ({ transaction }: UnstakingTxAmountProps) => {
-    const { ethereumSpecific, solanaSpecific, symbol, amount } = transaction;
+    const { ethereumSpecific, solanaSpecific, symbol } = transaction;
 
     const solanaStakeType = solanaSpecific?.stakeType;
 
     // Handle Solana unstake transaction
     if (solanaStakeType === 'unstake') {
+        const unstakeAmount = solanaSpecific?.unstakeAmount ?? '0';
+
         return (
-            <FormattedCryptoAmount value={formatNetworkAmount(amount, symbol)} symbol={symbol} />
+            <FormattedCryptoAmount
+                value={formatNetworkAmount(unstakeAmount, symbol)}
+                symbol={symbol}
+            />
         );
     }
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
@@ -46,7 +46,8 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
 
     const txSignature = tx.ethereumSpecific?.parsedData?.methodId;
-    const isStakeTypeTxNoAmount = isStakeTypeTx(txSignature) && amount.eq(0);
+    const isStakeType = isStakeTypeTx(txSignature) || tx?.solanaSpecific?.stakeType; // ethereum or solana staking tx
+    const isStakeTypeTxNoAmount = isStakeType && amount.eq(0);
 
     return (
         <Table hasBorders={false} isRowHighlightedOnHover={false} typographyStyle="hint">

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -66,8 +66,12 @@ export const TransactionTarget = ({
         selectHistoricFiatRatesByTimestamp(state, fiatRateKey, transaction.blockTime as Timestamp),
     );
     const labelingValueBeingEdited = useSelector(selectLabelingValueBeingEdited);
+    const isSolanaUnstakeTx = transaction?.solanaSpecific?.stakeType === 'unstake';
 
     const amount = useMemo(() => {
+        // hide amount for solana unstake transactions
+        if (isSolanaUnstakeTx) return null;
+
         switch (type) {
             case 'target':
                 return getTargetAmount(payload, transaction);
@@ -76,7 +80,7 @@ export const TransactionTarget = ({
             case 'token':
                 return formatAmount(payload.amount, payload.decimals);
         }
-    }, [type, payload, transaction]);
+    }, [type, payload, transaction, isSolanaUnstakeTx]);
 
     const operation = getTxOperation(type === 'target' ? transaction.type : payload.type);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed an issue where transactions with "Split stake" incorrectly had fiat value and amount.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17222

## Screenshots:
![image](https://github.com/user-attachments/assets/02dead70-5ea7-404b-b745-437d651ea495)
![image](https://github.com/user-attachments/assets/e173ed50-e504-41c0-9022-676e726e0da0)

