### PR TITLE
Report device model to Sentry

### DIFF
--- a/packages/suite/src/middlewares/suite/sentryMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/sentryMiddleware.ts
@@ -8,7 +8,6 @@ import {
     blockchainActions,
     deviceActions,
     discoveryActions,
-    selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { DEVICE, TRANSPORT } from '@trezor/connect';
 import {
@@ -112,7 +111,7 @@ const sentryMiddleware =
                     firmware: getFirmwareVersion(action.payload.device),
                     isBitcoinOnly: hasBitcoinOnlyFirmware(action.payload.device),
                     bootloader: getBootloaderVersion(action.payload.device),
-                    model: selectSelectedDevice(state)?.features?.internal_model,
+                    model: action.payload.device.features.internal_model,
                 });
                 break;
             }


### PR DESCRIPTION
I noticed that device model was not reported to Sentry as it should. I suppose that is because when device connection precedes selecting the device, thus the selector returns `undefined` at that point.

[Example of a Sentry report where device model is indistinguishable
](https://satoshilabs.sentry.io/issues/4555687017/?project=5193825&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20device%20authenticity&referrer=issue-stream&statsPeriod=14d&stream_index=0)
[Example of a Sentry report after this change](https://satoshilabs.sentry.io/issues/6200564641/events/cd1786aaa9d74a348166856fa6178e29/)

## Screenshots:
Before:
![Screenshot 2025-02-27 at 14 24 43](https://github.com/user-attachments/assets/6d59d7d6-6ec3-4cd4-b9ad-4a026ce293bc)
After:
![Screenshot 2025-02-27 at 14 48 45](https://github.com/user-attachments/assets/7a55744c-b92b-43cd-95eb-0307a174860d)

**QA:** must be checked in Sentry