### PR TITLE
chore(components): smaller outline on chosen radiocard

### DIFF
--- a/packages/components/src/components/RadioCard/RadioCard.tsx
+++ b/packages/components/src/components/RadioCard/RadioCard.tsx
@@ -57,9 +57,7 @@ const Wrapper = styled.div<
     ${({ $isActive }) =>
         $isActive &&
         css`
-            outline-width: ${borders.widths.large};
             outline-color: ${({ theme }) => theme.borderSecondary} !important;
-            outline-offset: -${borders.widths.large};
         `}
 
     ${withFrameProps}

--- a/packages/components/src/components/RadioCard/RadioCard.tsx
+++ b/packages/components/src/components/RadioCard/RadioCard.tsx
@@ -2,14 +2,7 @@ import { ReactNode } from 'react';
 
 import styled, { css } from 'styled-components';
 
-import {
-    Elevation,
-    borders,
-    mapElevationToBackground,
-    mapElevationToBorder,
-    palette,
-    spacingsPx,
-} from '@trezor/theme';
+import { Elevation, borders, mapElevationToBorder, palette, spacingsPx } from '@trezor/theme';
 
 import {
     FrameProps,
@@ -45,7 +38,7 @@ const Wrapper = styled.div<
     padding: ${spacingsPx.md};
     outline: ${borders.widths.small} solid ${mapElevationToBorder};
     outline-offset: -${borders.widths.small};
-    background-color: ${mapElevationToBackground};
+    background: ${({ theme }) => theme.backgroundSurfaceElevation1};
 
     ${({ onClick }) => onClick && 'cursor: pointer;'}
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { getStakingDataForNetwork } from '@suite-common/wallet-utils';
-import { Banner, Card, Column, InfoItem, NewModal, Paragraph, Tooltip } from '@trezor/components';
+import { Banner, Column, InfoItem, NewModal, Paragraph, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
@@ -111,20 +111,17 @@ export const ClaimModal = ({ onCancel }: ClaimModalModalProps) => {
                         <Translation id="TR_STAKE_CLAIM_IN_NEXT_BLOCK" />
                     </InfoItem>
 
-                    <Card paddingType="small" margin={{ vertical: spacings.xs }}>
-                        <Fees
-                            control={control}
-                            errors={errors}
-                            register={register}
-                            feeInfo={feeInfo}
-                            setValue={setValue}
-                            getValues={getValues}
-                            account={account}
-                            composedLevels={composedLevels}
-                            changeFeeLevel={changeFeeLevel}
-                            helperText={<Translation id="TR_STAKE_PAID_FROM_BALANCE" />}
-                        />
-                    </Card>
+                    <Fees
+                        control={control}
+                        errors={errors}
+                        register={register}
+                        feeInfo={feeInfo}
+                        setValue={setValue}
+                        getValues={getValues}
+                        account={account}
+                        composedLevels={composedLevels}
+                        changeFeeLevel={changeFeeLevel}
+                    />
 
                     {errors[CRYPTO_INPUT] && (
                         <Banner variant="destructive">{errors[CRYPTO_INPUT]?.message}</Banner>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/StakeEthForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/StakeEthForm.tsx
@@ -1,7 +1,6 @@
-import { Card, Column } from '@trezor/components';
+import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite';
 import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useStakeEthFormContext } from 'src/hooks/wallet/useStakeEthForm';
 
@@ -43,20 +42,17 @@ export const StakeEthForm = () => {
 
                 <Inputs />
 
-                <Card paddingType="small" margin={{ top: spacings.xs }}>
-                    <Fees
-                        control={control}
-                        errors={errors}
-                        register={register}
-                        feeInfo={feeInfo}
-                        setValue={setValue}
-                        getValues={getValues}
-                        account={account}
-                        composedLevels={composedLevels}
-                        changeFeeLevel={changeFeeLevel}
-                        helperText={<Translation id="TR_STAKE_PAID_FROM_BALANCE" />}
-                    />
-                </Card>
+                <Fees
+                    control={control}
+                    errors={errors}
+                    register={register}
+                    feeInfo={feeInfo}
+                    setValue={setValue}
+                    getValues={getValues}
+                    account={account}
+                    composedLevels={composedLevels}
+                    changeFeeLevel={changeFeeLevel}
+                />
             </Column>
         </>
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeEthForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeEthForm.tsx
@@ -1,6 +1,6 @@
 import { selectValidatorsQueueData } from '@suite-common/wallet-core';
 import { getStakingDataForNetwork } from '@suite-common/wallet-utils';
-import { Banner, Card, Column, InfoItem, Tooltip } from '@trezor/components';
+import { Banner, Column, InfoItem, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
@@ -74,20 +74,17 @@ export const UnstakeEthForm = () => {
                     {showError && <Banner variant="destructive">{inputError?.message}</Banner>}
                 </Column>
 
-                <Card paddingType="small" margin={{ vertical: spacings.xs }}>
-                    <Fees
-                        control={control}
-                        errors={errors}
-                        register={register}
-                        feeInfo={feeInfo}
-                        setValue={setValue}
-                        getValues={getValues}
-                        account={account}
-                        composedLevels={composedLevels}
-                        changeFeeLevel={changeFeeLevel}
-                        helperText={<Translation id="TR_STAKE_PAID_FROM_BALANCE" />}
-                    />
-                </Card>
+                <Fees
+                    control={control}
+                    errors={errors}
+                    register={register}
+                    feeInfo={feeInfo}
+                    setValue={setValue}
+                    getValues={getValues}
+                    account={account}
+                    composedLevels={composedLevels}
+                    changeFeeLevel={changeFeeLevel}
+                />
 
                 <InfoItem
                     label={<Translation id="TR_STAKE_UNSTAKING_PERIOD" />}

--- a/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeWrapper.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeWrapper.tsx
@@ -10,7 +10,7 @@ interface CustomFeeWrapperProps {
 }
 
 export const CustomFeeWrapper = ({ children }: CustomFeeWrapperProps) => (
-    <Column gap={spacings.xs} margin={{ bottom: spacings.md }}>
+    <Column gap={spacings.xs}>
         <Banner
             icon
             variant="warning"

--- a/packages/suite/src/components/wallet/Fees/Fees.tsx
+++ b/packages/suite/src/components/wallet/Fees/Fees.tsx
@@ -19,7 +19,7 @@ import {
     PrecomposedTransactionFinal,
 } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
-import { Banner, Column, InfoItem, Note, Row, SelectBar, Text, Tooltip } from '@trezor/components';
+import { Banner, Column, InfoItem, Row, SelectBar, Text, Tooltip } from '@trezor/components';
 import { FeeLevel } from '@trezor/connect';
 import { spacings, spacingsPx } from '@trezor/theme';
 
@@ -63,7 +63,6 @@ export interface FeesProps<TFieldValues extends FormState> {
     composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
     label?: TranslationKey;
     rbfForm?: boolean;
-    helperText?: React.ReactNode;
 }
 
 const buildFeeOptions = (
@@ -134,7 +133,6 @@ export const Fees = <TFieldValues extends FormState>({
     composedLevels,
     label,
     rbfForm,
-    helperText,
     ...props
 }: FeesProps<TFieldValues>) => {
     // Type assertion allowing to make the component reusable, see https://stackoverflow.com/a/73624072.
@@ -271,8 +269,6 @@ export const Fees = <TFieldValues extends FormState>({
                     {error.message}
                 </Banner>
             )}
-
-            {helperText && <Note>{helperText}</Note>}
         </Column>
     );
 };

--- a/packages/suite/src/components/wallet/Fees/StandardFee/FeeCard.tsx
+++ b/packages/suite/src/components/wallet/Fees/StandardFee/FeeCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Column, ElevationUp, RadioCard, Row, Text } from '@trezor/components';
+import { Box, Column, RadioCard, Row, Text } from '@trezor/components';
 import { FeeLevel } from '@trezor/connect';
 
 type FeeCardProps = {
@@ -23,23 +23,21 @@ export const FeeCard = ({
     bottomRightChild,
 }: FeeCardProps) => (
     <Box minWidth={FEE_CARD_MIN_WIDTH}>
-        <ElevationUp>
-            <RadioCard onClick={() => changeFeeLevel(value)} isActive={isSelected}>
-                <Column>
-                    <Row justifyContent="space-between">
-                        <Text typographyStyle="highlight">{topLeftChild}</Text>
-                        <Text variant="tertiary" typographyStyle="hint">
-                            {topRightChild}
-                        </Text>
-                    </Row>
-                    <Row justifyContent="space-between" height={24}>
-                        <Text>{bottomLeftChild}</Text>
-                        <Text variant="tertiary" typographyStyle="hint">
-                            {bottomRightChild}
-                        </Text>
-                    </Row>
-                </Column>
-            </RadioCard>
-        </ElevationUp>
+        <RadioCard onClick={() => changeFeeLevel(value)} isActive={isSelected}>
+            <Column>
+                <Row justifyContent="space-between">
+                    <Text typographyStyle="highlight">{topLeftChild}</Text>
+                    <Text variant="tertiary" typographyStyle="hint">
+                        {topRightChild}
+                    </Text>
+                </Row>
+                <Row justifyContent="space-between" height={24}>
+                    <Text>{bottomLeftChild}</Text>
+                    <Text variant="tertiary" typographyStyle="hint">
+                        {bottomRightChild}
+                    </Text>
+                </Row>
+            </Column>
+        </RadioCard>
     </Box>
 );

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormSwitcherExchangeRates.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormSwitcherExchangeRates.tsx
@@ -1,6 +1,6 @@
 import { UseFormSetValue } from 'react-hook-form';
 
-import { Column, ElevationUp, Grid, Paragraph, RadioCard } from '@trezor/components';
+import { Column, Grid, Paragraph, RadioCard } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
@@ -20,18 +20,16 @@ type ItemProps = {
 };
 
 const Item = ({ isSelected, onClick, title, label }: ItemProps) => (
-    <ElevationUp>
-        <RadioCard isActive={isSelected} onClick={onClick}>
-            <Column alignItems="flex-start" gap={spacings.xxxs}>
-                <Paragraph typographyStyle="highlight">
-                    <Translation id={title} />
-                </Paragraph>
-                <Paragraph typographyStyle="hint">
-                    <Translation id={label} />
-                </Paragraph>
-            </Column>
-        </RadioCard>
-    </ElevationUp>
+    <RadioCard isActive={isSelected} onClick={onClick}>
+        <Column alignItems="flex-start" gap={spacings.xxxs}>
+            <Paragraph typographyStyle="highlight">
+                <Translation id={title} />
+            </Paragraph>
+            <Paragraph typographyStyle="hint">
+                <Translation id={label} />
+            </Paragraph>
+        </Column>
+    </RadioCard>
 );
 
 type TradingFormSwitcherExchangeRatesProps = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- outline on selected fee was too big and it took focus
- staking fee component should not be in card
- remove elevation up for radio card components and changed it's background to be always white


## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
![Screenshot 2025-02-28 at 10 11 46](https://github.com/user-attachments/assets/daac112f-d153-4992-b3d6-7f6a6a220d24)
![Screenshot 2025-02-28 at 10 12 02](https://github.com/user-attachments/assets/eafdf54a-41d6-4cbe-8bc3-d6d7606d68cd)
![Screenshot 2025-02-28 at 10 13 08](https://github.com/user-attachments/assets/6a2397f1-68f5-4346-8f2f-6cb14534164c)
![Screenshot 2025-02-28 at 10 13 17](https://github.com/user-attachments/assets/6437be96-0b30-4d64-bbbb-4905a86b0d8c)

![Screenshot 2025-02-28 at 10 14 09](https://github.com/user-attachments/assets/7dfcee68-fbf5-4b3f-bc16-8d634e1f3f44)

