### PR TITLE
Improve device reporting to Sentry

### DIFF
--- a/packages/suite/src/middlewares/suite/sentryMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/sentryMiddleware.ts
@@ -101,18 +101,19 @@ const sentryMiddleware =
                     setSentryContext('suite-ready', payload),
                 );
                 break;
-            case DEVICE.CONNECT: {
-                const { features, mode } = action.payload.device;
+            case deviceActions.selectDevice.type:
+            case deviceActions.updateSelectedDevice.type: {
+                if (action.payload) {
+                    const { features, mode } = action.payload;
 
-                if (!features || !mode) return;
-
-                setSentryContext(deviceContextName, {
-                    mode,
-                    firmware: getFirmwareVersion(action.payload.device),
-                    isBitcoinOnly: hasBitcoinOnlyFirmware(action.payload.device),
-                    bootloader: getBootloaderVersion(action.payload.device),
-                    model: action.payload.device.features.internal_model,
-                });
+                    setSentryContext(deviceContextName, {
+                        mode,
+                        firmware: getFirmwareVersion(action.payload),
+                        isBitcoinOnly: hasBitcoinOnlyFirmware(action.payload),
+                        bootloader: getBootloaderVersion(action.payload),
+                        model: features?.internal_model,
+                    });
+                }
                 break;
             }
             case DEVICE.DISCONNECT:

--- a/packages/suite/src/middlewares/suite/sentryMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/sentryMiddleware.ts
@@ -10,11 +10,7 @@ import {
     discoveryActions,
 } from '@suite-common/wallet-core';
 import { DEVICE, TRANSPORT } from '@trezor/connect';
-import {
-    getBootloaderVersion,
-    getFirmwareVersion,
-    hasBitcoinOnlyFirmware,
-} from '@trezor/device-utils';
+import { getBootloaderVersion, getFirmwareVersion } from '@trezor/device-utils';
 
 import { WALLET_SETTINGS } from 'src/actions/settings/constants';
 import * as walletSettingsActions from 'src/actions/settings/walletSettingsActions';
@@ -103,19 +99,20 @@ const sentryMiddleware =
                 break;
             case deviceActions.selectDevice.type:
             case deviceActions.updateSelectedDevice.type: {
-                if (action.payload) {
-                    const { connected, features, mode, remember } = action.payload;
-
-                    setSentryContext(deviceContextName, {
-                        bootloader: getBootloaderVersion(action.payload),
-                        connected,
-                        firmware: getFirmwareVersion(action.payload),
-                        isBitcoinOnly: hasBitcoinOnlyFirmware(action.payload),
-                        mode,
-                        model: features?.internal_model,
-                        remember: !!remember,
-                    });
-                }
+                setSentryContext(deviceContextName, {
+                    bootloader:
+                        action.payload?.mode === 'bootloader'
+                            ? getBootloaderVersion(action.payload)
+                            : undefined,
+                    connected: action.payload?.connected ?? false, // default to false so that the property is visible in Sentry when device is disconnected
+                    firmwareType: action.payload?.firmwareType, // note that T1B1/T2T1 in bootloader mode report undefined
+                    firmwareVersion: action.payload
+                        ? getFirmwareVersion(action.payload)
+                        : undefined,
+                    mode: action.payload?.mode,
+                    model: action.payload?.features?.internal_model,
+                    remember: action.payload?.remember,
+                });
                 break;
             }
             case ROUTER.LOCATION_CHANGE:

--- a/packages/suite/src/middlewares/suite/sentryMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/sentryMiddleware.ts
@@ -104,23 +104,20 @@ const sentryMiddleware =
             case deviceActions.selectDevice.type:
             case deviceActions.updateSelectedDevice.type: {
                 if (action.payload) {
-                    const { features, mode } = action.payload;
+                    const { connected, features, mode, remember } = action.payload;
 
                     setSentryContext(deviceContextName, {
-                        mode,
+                        bootloader: getBootloaderVersion(action.payload),
+                        connected,
                         firmware: getFirmwareVersion(action.payload),
                         isBitcoinOnly: hasBitcoinOnlyFirmware(action.payload),
-                        bootloader: getBootloaderVersion(action.payload),
+                        mode,
                         model: features?.internal_model,
+                        remember: !!remember,
                     });
                 }
                 break;
             }
-            case DEVICE.DISCONNECT:
-                setSentryContext(deviceContextName, {
-                    disconnected: true,
-                });
-                break;
             case ROUTER.LOCATION_CHANGE:
                 setSentryTag('routerURL', action.payload.url);
                 break;

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -107,7 +107,7 @@ export type ExtraDependencies = {
         lockDevice: ActionCreatorWithPreparedPayload<[payload: boolean], boolean>;
         appChanged: ActionCreatorWithPayload<unknown>;
         setSelectedDevice: ActionCreatorWithPayload<TrezorDevice | undefined>;
-        updateSelectedDevice: ActionCreatorWithPayload<TrezorDevice | undefined>;
+        updateSelectedDevice: ActionCreatorWithPayload<TrezorDevice>;
         requestAuthConfirm: ActionCreatorWithoutPayload;
         onModalCancel: ActionCreatorWithoutPayload;
         openModal: ActionCreatorWithPayload<UserContextPayload>;

--- a/suite-common/sentry/src/index.ts
+++ b/suite-common/sentry/src/index.ts
@@ -99,7 +99,7 @@ export const SENTRY_CONFIG: Options = {
         }),
     ],
     beforeSend,
-    enabled: !isDevEnv,
+    enabled: !isDevEnv, // set to true to enable Sentry logging while testing locally
     maxValueLength: 500, // default 250 is not enough for some errors
     release: process.env.SENTRY_RELEASE,
     environment: isCodesignBuild() ? 'production' : 'develop',

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -81,7 +81,7 @@ const selectDevice = createAction(
 
 const updateSelectedDevice = createAction(
     `${DEVICE_MODULE_PREFIX}/updateSelectedDevice`,
-    (payload?: TrezorDevice) => ({ payload }),
+    (payload: TrezorDevice) => ({ payload }),
 );
 
 // Remove button requests for specific device by button request code or all button requests if no code is provided.

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -67,7 +67,6 @@ export const selectDeviceThunk = createThunk<void, SelectDeviceThunkParams, void
             }
         }
 
-        // 3. select requested device
         dispatch(deviceActions.selectDevice(payload));
     },
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Set device info to Sentry context whenever a device is selected or updated instead of when it is connected or disconnected. This fixes some issues of the original implementation:

1. When a second device was connected (but not selected), the second device was reported. Not what I would expect.
2. When a device would update without reconnecting (a fake device could do that with any property), the context wouldn't change.
3. Property `isBitcoinOnly` was always `false` for T1B1 or T2T1 device in bootloader mode.

I also added properties indicating whether a device is connected and remembered, because that would otherwise be unclear.

**QA:** To test, you can throw an error in debug settings and check that all properties relevant for the device are correctly logged to Sentry.

## Screenshots:
The examples show a report sent when T2T1 and T3T1 are connected. T2T1 is selected, T3T1 was connected last.
[Before](https://satoshilabs.sentry.io/issues/5534264772/events/725f9a5121e744e7aaacf66f9ae9b8b6/)
![Screenshot 2025-02-28 at 14 19 12](https://github.com/user-attachments/assets/393b367c-9eff-4e84-b1d2-1d69c8a93845)
[After](https://satoshilabs.sentry.io/issues/5534264772/events/fd2e549fbea8422babaf5f8b09c15670/)
![Screenshot 2025-02-28 at 14 18 59](https://github.com/user-attachments/assets/6d8fe56a-008e-452a-abe2-b59403b10bc7)
