### PR TITLE
fix(staking): added correct learning links to SOL and ETH staking

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/ConfirmStakeEthModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/ConfirmStakeEthModal.tsx
@@ -1,11 +1,11 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { type NetworkType, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { SOLANA_EPOCH_DAYS } from '@suite-common/wallet-constants';
 import { selectValidatorsQueueData } from '@suite-common/wallet-core';
 import { Banner, Card, Checkbox, Column, NewModal } from '@trezor/components';
 import { spacings } from '@trezor/theme';
-import { HELP_CENTER_ETH_STAKING } from '@trezor/urls';
+import { HELP_CENTER_ETH_STAKING, HELP_CENTER_SOL_STAKING } from '@trezor/urls';
 
 import { openModal } from 'src/actions/suite/modalActions';
 import { Translation } from 'src/components/suite';
@@ -49,6 +49,17 @@ export const ConfirmStakeEthModal = ({
         onConfirm();
     };
 
+    const learnMoreLink = useMemo(() => {
+        switch (account?.networkType) {
+            case 'ethereum':
+                return HELP_CENTER_ETH_STAKING;
+            case 'solana':
+                return HELP_CENTER_SOL_STAKING;
+            default:
+                return undefined;
+        }
+    }, [account]);
+
     if (!account) return null;
 
     return (
@@ -83,7 +94,7 @@ export const ConfirmStakeEthModal = ({
                 <Banner
                     icon="hand"
                     rightContent={
-                        <Banner.Button href={HELP_CENTER_ETH_STAKING}>
+                        <Banner.Button href={learnMoreLink}>
                             <Translation id="TR_LEARN_MORE" />
                         </Banner.Button>
                     }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakingInfoCards/EstimatedGains.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakingInfoCards/EstimatedGains.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { StakeRootState, selectPoolStatsApyData } from '@suite-common/wallet-core';
@@ -41,6 +41,17 @@ export const EstimatedGains = () => {
         },
     ];
 
+    const learnMoreLink = useMemo(() => {
+        switch (account?.networkType) {
+            case 'ethereum':
+                return HELP_CENTER_ETH_STAKING;
+            case 'solana':
+                return HELP_CENTER_SOL_STAKING;
+            default:
+                return undefined;
+        }
+    }, [account]);
+
     return (
         <Column gap={spacings.lg}>
             <Column>
@@ -73,17 +84,7 @@ export const EstimatedGains = () => {
                 <Translation
                     id="TR_STAKING_YOUR_EARNINGS"
                     values={{
-                        a: chunks => (
-                            <TrezorLink
-                                href={
-                                    account.networkType === 'solana'
-                                        ? HELP_CENTER_SOL_STAKING
-                                        : HELP_CENTER_ETH_STAKING
-                                }
-                            >
-                                {chunks}
-                            </TrezorLink>
-                        ),
+                        a: chunks => <TrezorLink href={learnMoreLink}>{chunks}</TrezorLink>,
                     }}
                 />
             </Paragraph>

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EverstakeFooter.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EverstakeFooter.tsx
@@ -1,10 +1,14 @@
+import { useMemo } from 'react';
+
 import styled, { useTheme } from 'styled-components';
 
 import { spacingsPx } from '@trezor/theme';
-import { HELP_CENTER_ETH_STAKING } from '@trezor/urls';
+import { HELP_CENTER_ETH_STAKING, HELP_CENTER_SOL_STAKING } from '@trezor/urls';
 
 import { Translation } from 'src/components/suite';
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
+import { useSelector } from 'src/hooks/suite';
+import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 
 import { EverstakeLogo } from './EverstakeLogo';
 
@@ -30,13 +34,26 @@ export const EverstakeFooter = () => {
     const theme = useTheme();
     const isDarkMode = theme.legacy.THEME === 'dark';
 
+    const account = useSelector(selectSelectedAccount);
+
+    const learnMoreLink = useMemo(() => {
+        switch (account?.networkType) {
+            case 'ethereum':
+                return HELP_CENTER_ETH_STAKING;
+            case 'solana':
+                return HELP_CENTER_SOL_STAKING;
+            default:
+                return undefined;
+        }
+    }, [account]);
+
     return (
         <Wrapper>
             <Left>
                 <Translation id="TR_STAKE_PROVIDED_BY" />{' '}
                 <EverstakeLogo color={isDarkMode ? '#fff' : '#000'} />
             </Left>
-            <LearnMoreButton url={HELP_CENTER_ETH_STAKING} />
+            {learnMoreLink && <LearnMoreButton url={learnMoreLink} />}
         </Wrapper>
     );
 };


### PR DESCRIPTION
## Description

Added correct ETH and SOL staking learning links to respective buttons.

## Related Issue

Resolve #17265 

## Screenshots:

![Screenshot 2025-02-28 at 14 07 00](https://github.com/user-attachments/assets/8b5f175b-9acb-4418-afc7-18be6cec49a5)

![Screenshot 2025-02-28 at 14 06 55](https://github.com/user-attachments/assets/06f09017-9877-462a-9ef2-a0cd9083ba10)

![Screenshot 2025-02-28 at 14 06 48](https://github.com/user-attachments/assets/16661f0e-9b8c-4814-a39f-716b5c3b1cf6)

