### PR TITLE
feat(blockchain-link-type): change bigint to string in persist

### DIFF
--- a/packages/blockchain-link-types/src/solana.ts
+++ b/packages/blockchain-link-types/src/solana.ts
@@ -72,8 +72,8 @@ export type { Address } from '@solana/web3.js';
 
 export type SolanaStakingAccount = {
     status: string;
-    stake?: bigint;
-    rentExemptReserve: bigint;
+    stake?: string;
+    rentExemptReserve: string;
 };
 
 export type TokenDetailByMint = { [mint: string]: { name: string; symbol: string } };

--- a/packages/blockchain-link/src/workers/solana/stakingAccounts.ts
+++ b/packages/blockchain-link/src/workers/solana/stakingAccounts.ts
@@ -40,8 +40,8 @@ export const getSolanaStakingData = async (
                 if (!EVERSTAKE_VOTER_PUBKEYS.includes(voterPubkey)) return; // filter out non-everstake accounts
 
                 return {
-                    rentExemptReserve: fields[0]?.rentExemptReserve,
-                    stake: fields[1]?.delegation?.stake,
+                    rentExemptReserve: fields[0]?.rentExemptReserve.toString(),
+                    stake: fields[1]?.delegation?.stake.toString(),
                     status: stakeState,
                 };
             }


### PR DESCRIPTION
`BigInt`s in `SolanaStakingAccount` data caused persistence issues on mobile. Changed to `string`
