### PR TITLE
fix(e2e): Update disabling of hash check in electron setup

### DIFF
--- a/packages/suite-desktop-core/e2e/support/electron.ts
+++ b/packages/suite-desktop-core/e2e/support/electron.ts
@@ -8,7 +8,7 @@ import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 // specific version of legacy bridge is requested & expected
 export const LEGACY_BRIDGE_VERSION = '2.0.33';
-const disableHashCheckArgument = '--state.suite.settings.isFirmwareHashCheckDisabled=true';
+const disableHashCheckArgument = '--state.suite.settings.enabledSecurityChecks.firmwareHash=false';
 const showDebugMenuArgument = `--state.suite.settings.debug.showDebugMenu=true`;
 
 type LaunchSuiteParams = {

--- a/packages/suite-desktop-core/e2e/support/pageActions/onboarding/onboardingActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/onboarding/onboardingActions.ts
@@ -126,6 +126,8 @@ export class OnboardingActions {
         }
         // eslint-disable-next-line @typescript-eslint/no-shadow
         await this.page.evaluate(SuiteActions => {
+            // WARNING: If this dispatch is changed as part of refactoring. You need to change also:
+            // packages/suite-desktop-core/e2e/support/electron.ts variable disableHashCheckArgument
             window.store.dispatch({
                 type: SuiteActions.TOGGLE_FIRMWARE_HASH_CHECK,
                 payload: false,

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-reconnection.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-reconnection.test.ts
@@ -17,7 +17,8 @@ test.describe('Passphrase reconnection', { tag: ['@group=passphrase'] }, () => {
     // reconnect device
     // go back to 1st hidden wallet
     // check confirm passphrase appears.
-    test('after device is reconnected passphrase needs to be confirmed', async ({
+    // TODO: #17161 Fix unstable test
+    test.skip('after device is reconnected passphrase needs to be confirmed', async ({
         page,
         dashboardPage,
         walletPage,


### PR DESCRIPTION
Some time ago a redux setting  `state.suite.settings.isFirmwareHashCheckDisabled` was changed as part of refactoring, Web was updated because is relays on a Enum. That is not the case of our electron setup so it was forgotten.

Skipping the problematic passphrase reconnect tests - they break in so many steps. It won't be a simple fix. And I don't want this test to lower the thrust worthiness of our suite until we deal with it.

