### PR TITLE
chore(suite-native): app version bumped to 25.3.1

### DIFF
--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@suite-native/app",
     "version": "1.0.0",
-    "suiteNativeVersion": "25.2.2",
+    "suiteNativeVersion": "25.3.1",
     "main": "index.js",
     "scripts": {
         "android": "expo run:android",


### PR DESCRIPTION
Automatic bump of suite-native app version.