### PR TITLE
chore(suite-native): improve reliability of the Android E2E tests by …

### DIFF
--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -139,7 +139,7 @@
         "@types/node": "22.10.1",
         "babel-plugin-transform-inline-environment-variables": "^0.4.4",
         "babel-plugin-transform-remove-console": "^6.9.4",
-        "detox": "^20.25.6",
+        "detox": "^20.34.4",
         "expo-atlas": "0.3.27",
         "jest": "^29.7.0",
         "jest-junit": "^16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9973,7 +9973,7 @@ __metadata:
     babel-plugin-transform-inline-environment-variables: "npm:^0.4.4"
     babel-plugin-transform-remove-console: "npm:^6.9.4"
     buffer: "npm:^6.0.3"
-    detox: "npm:^20.25.6"
+    detox: "npm:^20.34.4"
     event-target-shim: "npm:6.0.2"
     expo: "npm:52.0.11"
     expo-atlas: "npm:0.3.27"
@@ -20621,16 +20621,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detox-copilot@npm:^0.0.24":
-  version: 0.0.24
-  resolution: "detox-copilot@npm:0.0.24"
-  checksum: 10/828c6b07200480e29f09cf94fd433858cb99d04f925c673ed8e790deac04736f98372c2bee76a65fdd66cfbdf83689d4ab17797297f11a527831fb4b49401a72
+"detox-copilot@npm:^0.0.27":
+  version: 0.0.27
+  resolution: "detox-copilot@npm:0.0.27"
+  checksum: 10/c8c8488b4d3975ccedc8d10e3179fd95b385459f38f50963291d51734d72ad0f4f529bc8f4a04203f06d457a0091050571a6239fc34845d4acc5ad8c9ebced97
   languageName: node
   linkType: hard
 
-"detox@npm:^20.25.6":
-  version: 20.28.0
-  resolution: "detox@npm:20.28.0"
+"detox@npm:^20.34.4":
+  version: 20.34.4
+  resolution: "detox@npm:20.34.4"
   dependencies:
     ajv: "npm:^8.6.3"
     bunyan: "npm:^1.8.12"
@@ -20638,7 +20638,7 @@ __metadata:
     caf: "npm:^15.0.1"
     chalk: "npm:^4.0.0"
     child-process-promise: "npm:^2.2.0"
-    detox-copilot: "npm:^0.0.24"
+    detox-copilot: "npm:^0.0.27"
     execa: "npm:^5.1.1"
     find-up: "npm:^5.0.0"
     fs-extra: "npm:^11.0.0"
@@ -20675,7 +20675,7 @@ __metadata:
       optional: true
   bin:
     detox: local-cli/cli.js
-  checksum: 10/6ff5e83513376fbdc4010b0f181d66b107f0f4394206794395468f77bbf9e9ec51555ca5319b0d51ea9a1a80f00348d198d51130c2a02d33667f72a70ad91533
+  checksum: 10/6228f0b7fadf264a86f9520d5dae7b2e2e24b9fca47c24ad6ebdd87f6bcc069cc934b56c1d99244d59a481de65ce12692b4778a311d93179d8e579d9ca285aec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
…updating detox@20.34.4

I had my E2E CI rusn crashing on this error mentioned here: https://github.com/wix/Detox/issues/4279#issue-1989332109
in the `✗ Account management Import account and rename it`

Visbile here: https://github.com/trezor/trezor-suite/actions/runs/13589388916/job/37996283394

After adding commit with Detox update the test passed https://github.com/trezor/trezor-suite/actions/runs/13627160836/job/38087130938?pr=17152

The branch wher it was crashing is here https://github.com/trezor/trezor-suite/pull/17152

## Description

- udpated Detox runner as advised here https://github.com/wix/Detox/issues/4279#issuecomment-2662990191

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
