### PR TITLE
feat(suite): Solana staking/unstaking/claiming has a new text

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -29,20 +29,19 @@ const getFeeLabel = (networkType: NetworkType) => {
     }
 };
 
-const getDisplayModeStringsMap = (): Record<
-    StakeType,
-    { value: TranslationKey; label: TranslationKey }
-> => ({
+const getDisplayModeStringsMap = (
+    isEverstake: boolean,
+): Record<StakeType, { value: TranslationKey; label: TranslationKey }> => ({
     stake: {
         value: 'TR_STAKE_ON_EVERSTAKE',
         label: 'TR_STAKE_STAKE',
     },
     unstake: {
-        value: 'TR_UNSTAKE_FROM_EVERSTAKE',
+        value: isEverstake ? 'TR_UNSTAKE_FROM_EVERSTAKE' : 'TR_UNSTAKE_FROM_STAKE_ACCOUNT',
         label: 'TR_STAKE_UNSTAKE',
     },
     claim: {
-        value: 'TR_CLAIM_FROM_EVERSTAKE',
+        value: isEverstake ? 'TR_CLAIM_FROM_EVERSTAKE' : 'TR_CLAIM_FROM_STAKE_ACCOUNT',
         label: 'TR_STAKE_CLAIM',
     },
 });
@@ -54,7 +53,7 @@ const getOutputTitle = (
     isRbf: boolean,
     stakeType: StakeType | undefined,
 ): ReactNode | undefined => {
-    const displayModeStringsMap = getDisplayModeStringsMap();
+    const displayModeStringsMap = getDisplayModeStringsMap(networkType === 'ethereum');
 
     switch (type) {
         case 'locktime': {
@@ -102,6 +101,7 @@ const getOutputTitle = (
 
 const getOutputLines = (
     type: ReviewOutput['type'],
+    networkType: NetworkType,
     value: string,
     value2: string = '',
     label: string = '',
@@ -109,7 +109,7 @@ const getOutputLines = (
     stakeType: StakeType | undefined,
     translationString: (key: TranslationKey, values: any) => string,
 ): OutputElementLine[] => {
-    const displayModeStringsMap = getDisplayModeStringsMap();
+    const displayModeStringsMap = getDisplayModeStringsMap(networkType === 'ethereum');
 
     switch (type) {
         case 'gas':
@@ -256,6 +256,7 @@ export const TransactionReviewOutput = ({
 
     const outputLines = getOutputLines(
         type,
+        networkType,
         value,
         value2,
         label,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7403,9 +7403,17 @@ export default defineMessages({
         id: 'TR_CLAIM_FROM_EVERSTAKE',
         defaultMessage: 'Claim {symbol} from Everstake?',
     },
+    TR_CLAIM_FROM_STAKE_ACCOUNT: {
+        id: 'TR_CLAIM_FROM_STAKE_ACCOUNT',
+        defaultMessage: 'Claim {symbol} from stake account?',
+    },
     TR_UNSTAKE_FROM_EVERSTAKE: {
         id: 'TR_UNSTAKE_FROM_EVERSTAKE',
         defaultMessage: 'Unstake {symbol} from Everstake?',
+    },
+    TR_UNSTAKE_FROM_STAKE_ACCOUNT: {
+        id: 'TR_UNSTAKE_FROM_STAKE_ACCOUNT',
+        defaultMessage: 'Unstake {symbol} from stake account?',
     },
     TR_TX_WITHDRAWAL: {
         id: 'TR_TX_WITHDRAWAL',


### PR DESCRIPTION
## Description

The new fw for Solana has different texts for staking/unstaking/claiming than for Ethereum.

**Everstake -> stake account**

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16363

## Screenshots:

<img width="888" alt="image" src="https://github.com/user-attachments/assets/043e5668-dbeb-4ce8-96b0-f70d963cdc3b" />

![image](https://github.com/user-attachments/assets/5db4d1b6-5b8f-43f1-bd15-46e8a9416226)
