### PR TITLE
fix(e2e): Buy ethereum - remove invalid assert

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/trading/buy-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-ethereum.test.ts
@@ -46,8 +46,6 @@ test.describe('Trading - Buy Ethereum', { tag: ['@group=other', '@webOnly'] }, (
                 'Select ETHEREUM receive account',
             );
             await expect(tradingPage.confirmationAddress).toHaveText('');
-            await expect(page.getByText('Receive address is required')).toBeVisible();
-
             await tradingPage.confirmationAccountDropdown.click();
             await page.getByRole('option', { name: 'Create a new Ethereum account' }).click();
             await expect(settingsPage.coins.networkButton('eth')).toBeEnabledCoin();


### PR DESCRIPTION
Functionality was changed but test not. This PR fixes that.

The warning label is now shown only if you fill invalid address or remove it. Not when you start the form with empty address.