### PR TITLE
feat(staking): moved Solana staking out of debug mode

### DIFF
--- a/packages/suite/src/components/suite/CoinList/CoinList.tsx
+++ b/packages/suite/src/components/suite/CoinList/CoinList.tsx
@@ -8,7 +8,6 @@ import { versionUtils } from '@trezor/utils';
 
 import { Translation } from 'src/components/suite';
 import { useDevice, useDiscovery, useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 import { getCoinLabel } from 'src/utils/suite/getCoinLabel';
 
 import { Coin } from './Coin';
@@ -36,7 +35,6 @@ export const CoinList = ({
     onToggle,
 }: CoinListProps) => {
     const { device, isLocked } = useDevice();
-    const isDebug = useSelector(selectIsDebugModeActive);
 
     const blockchain = useSelector(state => state.wallet.blockchain);
     const isDeviceLocked = !!device && isLocked();
@@ -53,14 +51,7 @@ export const CoinList = ({
     return (
         <Wrapper>
             {networks.map(network => {
-                const {
-                    symbol,
-                    name,
-                    support,
-                    features,
-                    testnet: isTestnet,
-                    networkType,
-                } = network;
+                const { symbol, name, support, features, testnet: isTestnet } = network;
                 const hasCustomBackend = !!blockchain[symbol].backends.selected;
 
                 const firmwareSupportRestriction =
@@ -86,13 +77,7 @@ export const CoinList = ({
                     getCoinUnavailabilityMessage(unavailableReason);
                 const tooltipString = discoveryTooltip || lockedTooltip || unavailabilityTooltip;
 
-                const label = getCoinLabel(
-                    features,
-                    isTestnet,
-                    hasCustomBackend,
-                    networkType,
-                    isDebug,
-                );
+                const label = getCoinLabel(features, isTestnet, hasCustomBackend);
 
                 return (
                     <Tooltip

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
@@ -6,7 +6,6 @@ import { CoinLogo } from '@trezor/product-components';
 
 import { Modal, Translation } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 import { getCoinLabel } from 'src/utils/suite/getCoinLabel';
 
 import { CustomBackends } from './CustomBackends/CustomBackends';
@@ -43,13 +42,12 @@ interface AdvancedCoinSettingsModalProps {
 }
 
 export const AdvancedCoinSettingsModal = ({ symbol, onCancel }: AdvancedCoinSettingsModalProps) => {
-    const isDebug = useSelector(selectIsDebugModeActive);
     const blockchain = useSelector(state => state.wallet.blockchain);
     const network = getNetwork(symbol);
 
-    const { name, networkType, features, testnet: isTestnet } = network;
+    const { name, features, testnet: isTestnet } = network;
     const hasCustomBackend = !!blockchain[symbol].backends.selected;
-    const label = getCoinLabel(features, isTestnet, hasCustomBackend, networkType, isDebug);
+    const label = getCoinLabel(features, isTestnet, hasCustomBackend);
 
     return (
         <Modal

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -18,7 +18,7 @@ import { goto } from 'src/actions/suite/routerActions';
 import { setFlag } from 'src/actions/suite/suiteActions';
 import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive, selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
+import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
 
 interface StakingBannerProps {
     account: Account;
@@ -30,8 +30,6 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
     const { route } = useSelector(state => state.router);
     const apy = useSelector(state => selectPoolStatsApyData(state, account.symbol));
     const theme = useTheme();
-    // TODO: remove when solana staking public
-    const isDebug = useSelector(selectIsDebugModeActive);
 
     const closeBanner = () => {
         switch (account.networkType) {
@@ -62,8 +60,9 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
                 return {
                     isStakingBannerClosed: stakeSolBannerClosed,
                     minStakingAmount: MIN_SOL_AMOUNT_FOR_STAKING,
-                    isSupportedStakingNetworkSymbol:
-                        isDebug && isSupportedSolStakingNetworkSymbol(account.symbol),
+                    isSupportedStakingNetworkSymbol: isSupportedSolStakingNetworkSymbol(
+                        account.symbol,
+                    ),
                 };
             default:
                 return {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
@@ -6,10 +6,7 @@ import { goto } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite/Translation';
 import { NavigationItem, SubpageNavigation } from 'src/components/suite/layouts/SuiteLayout';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import {
-    selectHasExperimentalFeature,
-    selectIsDebugModeActive,
-} from 'src/reducers/suite/suiteReducer';
+import { selectHasExperimentalFeature } from 'src/reducers/suite/suiteReducer';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { WalletParams } from 'src/types/wallet';
 
@@ -24,8 +21,6 @@ export const ACCOUNT_TABS = [
 ];
 
 export const AccountNavigation = () => {
-    const isDebugModeActive = useSelector(selectIsDebugModeActive);
-
     const account = useSelector(selectSelectedAccount);
     const routerParams = useSelector(state => state.router.params) as WalletParams;
     const dispatch = useDispatch();
@@ -78,10 +73,7 @@ export const AccountNavigation = () => {
                 goToWithAnalytics('wallet-staking', { preserveParams: true });
             },
             title: <Translation id="TR_NAV_STAKING" />,
-            // TODO: remove 'solana' and debug mode check from the condition when staking will be ready for launch
-            isHidden:
-                !hasNetworkFeatures(account, 'staking') ||
-                (!isDebugModeActive && 'solana' === networkType),
+            isHidden: !hasNetworkFeatures(account, 'staking'),
             'data-testid': '@wallet/menu/staking',
         },
         {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx
@@ -4,7 +4,6 @@ import { Account } from '@suite-common/wallet-types';
 import { isSupportedStakingNetworkSymbol } from '@suite-common/wallet-utils';
 
 import { useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 import { getTokens } from 'src/utils/wallet/tokenUtils';
 
 import { AccountItem } from './AccountItem/AccountItem';
@@ -33,17 +32,11 @@ export const AccountSection = ({
         tokens: accountTokens = [],
     } = account;
 
-    const isDebugModeActive = useSelector(selectIsDebugModeActive);
-
     const coinDefinitions = useSelector(state => selectCoinDefinitions(state, symbol));
     const hasEthStaked = useSelector(state => selectEthAccountHasStaked(state, account.key));
     const hasSolStaked = useSelector(state => selectSolAccountHasStaked(state, account.key));
 
-    // TODO: remove isDebugModeActive when staking will be ready for launch
-    const isSolStakingEnabled = hasSolStaked && isDebugModeActive;
-
-    const isStakeShown =
-        isSupportedStakingNetworkSymbol(symbol) && (hasEthStaked || isSolStakingEnabled);
+    const isStakeShown = isSupportedStakingNetworkSymbol(symbol) && (hasEthStaked || hasSolStaked);
 
     const showGroup = ['ethereum', 'solana', 'cardano'].includes(networkType);
 

--- a/packages/suite/src/utils/suite/getCoinLabel.ts
+++ b/packages/suite/src/utils/suite/getCoinLabel.ts
@@ -1,19 +1,13 @@
 import type { TranslationKey } from '@suite-common/intl-types';
-import type { NetworkFeature, NetworkType } from '@suite-common/wallet-config';
+import type { NetworkFeature } from '@suite-common/wallet-config';
 
 export const getCoinLabel = (
     features: NetworkFeature[],
     isTestnet: boolean,
     isCustomBackend: boolean,
-    networkType?: NetworkType,
-    isDebug?: boolean,
 ): TranslationKey | undefined => {
     const hasTokens = features.includes('tokens');
-    // TODO: Remove this condition when Solana staking is available
-    const hasStaking =
-        networkType === 'solana'
-            ? isDebug && features.includes('staking') // Solana staking only in debug mode
-            : features.includes('staking');
+    const hasStaking = features.includes('staking');
 
     if (isCustomBackend) {
         return 'TR_CUSTOM_BACKEND';

--- a/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
@@ -7,7 +7,6 @@ import { AssetFiatBalance } from '@suite-common/assets';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { selectCoinDefinitions } from '@suite-common/token-definitions';
 import { Network } from '@suite-common/wallet-config';
-import { selectDebugFilteredAssetAccountsThatStaked } from '@suite-common/wallet-core';
 import { Account, RatesByKey } from '@suite-common/wallet-types';
 import { isTestnet } from '@suite-common/wallet-utils';
 import {
@@ -34,7 +33,6 @@ import {
 } from 'src/components/suite';
 import { FiatHeader } from 'src/components/wallet/FiatHeader';
 import { useAccountSearch, useLoadingSkeleton, useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 
 import { AssetCardInfo, AssetCardInfoSkeleton } from './AssetCardInfo';
 import { AssetCardTokensAndStakingInfo } from './AssetCardTokensAndStakingInfo';
@@ -128,20 +126,10 @@ export const AssetCard = ({
     const stakingAccountsForAsset = stakingAccounts.filter(account => account.symbol === symbol);
     const coinDefinitions = useSelector(state => selectCoinDefinitions(state, symbol));
 
-    // TODO: remove this logic when Solana staking is available
-    const isDebugModeActive = useSelector(selectIsDebugModeActive);
-    const debugFilteredStakedAccounts = useSelector(state =>
-        selectDebugFilteredAssetAccountsThatStaked(
-            state,
-            stakingAccountsForAsset,
-            isDebugModeActive,
-        ),
-    );
-
     const { tokensFiatBalance, assetStakingBalance, shouldRenderStakingRow, shouldRenderTokenRow } =
         handleTokensAndStakingData(
             assetTokens,
-            debugFilteredStakedAccounts,
+            stakingAccountsForAsset,
             symbol,
             localCurrency,
             coinDefinitions,

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
@@ -6,7 +6,6 @@ import { AssetFiatBalance } from '@suite-common/assets';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { selectCoinDefinitions } from '@suite-common/token-definitions';
 import { Network } from '@suite-common/wallet-config';
-import { selectDebugFilteredAssetAccountsThatStaked } from '@suite-common/wallet-core';
 import { Account, RatesByKey } from '@suite-common/wallet-types';
 import { isTestnet } from '@suite-common/wallet-utils';
 import { TokenInfo } from '@trezor/blockchain-link-types';
@@ -25,7 +24,6 @@ import {
 } from 'src/components/suite';
 import { TokenIconSetWrapper } from 'src/components/wallet/TokenIconSetWrapper';
 import { useAccountSearch, useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 
 import { AssetCoinLogo } from '../AssetCoinLogo';
 import { AssetCoinName } from '../AssetCoinName';
@@ -85,16 +83,6 @@ export const AssetRow = memo(
             account => account.symbol === network.symbol,
         );
 
-        // TODO: remove this logic when Solana staking is available
-        const isDebugModeActive = useSelector(selectIsDebugModeActive);
-        const debugFilteredStakedAccounts = useSelector(state =>
-            selectDebugFilteredAssetAccountsThatStaked(
-                state,
-                stakingAccountsForAsset,
-                isDebugModeActive,
-            ),
-        );
-
         const {
             tokensFiatBalance,
             assetStakingBalance,
@@ -102,7 +90,7 @@ export const AssetRow = memo(
             shouldRenderTokenRow,
         } = handleTokensAndStakingData(
             assetTokens,
-            debugFilteredStakedAccounts,
+            stakingAccountsForAsset,
             symbol,
             localCurrency,
             coinDefinitions,

--- a/suite-common/wallet-core/src/transactions/transactionsReducer.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsReducer.ts
@@ -401,18 +401,6 @@ export const selectAssetAccountsThatStaked = (
             selectSolAccountHasStaked(state, account.key),
     );
 
-export const selectDebugFilteredAssetAccountsThatStaked = (
-    state: TransactionsRootState & AccountsRootState,
-    accounts: Account[],
-    isDebugModeActive: boolean,
-) => {
-    const accountsThatStaked = selectAssetAccountsThatStaked(state, accounts);
-
-    return !isDebugModeActive
-        ? accountsThatStaked.filter(account => account.networkType !== 'solana')
-        : accountsThatStaked;
-};
-
 export const selectAccountTransactionsFetchStatus = (
     state: TransactionsRootState,
     accountKey: AccountKey,


### PR DESCRIPTION
## Description

Moved Solana staking out of debug mode.

## Related Issue

Resolve #17320 

## Screenshots:

Updated Solana label in settings to include Staking:

<img width="1169" alt="Screenshot 2025-03-04 at 09 46 55" src="https://github.com/user-attachments/assets/f354ab5c-21f3-435b-be0f-356280d0945a" />

Added Staking to left sidebar:

<img width="486" alt="Screenshot 2025-03-04 at 09 47 09" src="https://github.com/user-attachments/assets/8e59f06b-e4c0-4dea-94e3-59cee55f6d12" />

Added Staking tab to account page:

<img width="1449" alt="Screenshot 2025-03-04 at 09 47 27" src="https://github.com/user-attachments/assets/6b66c4f8-f9e4-4196-9b4f-351a81d285fe" />

Added Staking to dashboard card view:

<img width="1167" alt="Screenshot 2025-03-04 at 09 47 38" src="https://github.com/user-attachments/assets/2faae47f-b7ac-4383-8edd-493371409687" />

Added Staking to dashboard table view:

<img width="1169" alt="Screenshot 2025-03-04 at 09 47 46" src="https://github.com/user-attachments/assets/3a425d8b-95f1-4c9e-affc-0a26f7efbab9" />

