### PR TITLE
Fix/suite dekstop core/e2e fix broken cardano and unstable wallets

### DIFF
--- a/packages/suite-desktop-core/e2e/snapshots/web/wallet/cardano.test.ts/cardano-aria.ts
+++ b/packages/suite-desktop-core/e2e/snapshots/web/wallet/cardano.test.ts/cardano-aria.ts
@@ -17,7 +17,7 @@ export const cardanoAccountDetails = `
 `;
 
 export const cardanoStaking = `
-    - heading "Cardano Staking is NOT Active" [level=2]:
+    - heading "Cardano staking isn't active" [level=2]:
       - img
     - text: Staking Cardano is a great way to earn ADA staking rewards as a form of passive income for holding Cardano. By staking your ADA, you actively support the Cardano network and contribute to the stability of the network. Your stake address stake_test1uqyuj8h935q6panx0klttu026rzam0y9c2v97pv3l56uk3s5v5fjr You don't have enough funds on your account. The deposit fee is 2 ADA and is required to register your address to start staking. If you choose to unstake your Cardano you will get the deposit back.
     - button "Delegate" [disabled]:

--- a/packages/suite-desktop-core/e2e/support/pageObjects/dashboardPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/dashboardPage.ts
@@ -35,6 +35,8 @@ export class DashboardPage {
     readonly passphraseShowButton: Locator;
     readonly loading: Locator;
     readonly notificationNoBackupButton: Locator;
+    readonly openUnusedWalletButton1: Locator;
+    readonly openUnusedWalletButton2: Locator;
 
     constructor(
         private readonly page: Page,
@@ -64,6 +66,12 @@ export class DashboardPage {
         this.passphraseShowButton = this.page.getByTestId('@passphrase/show-toggle');
         this.loading = this.page.getByTestId('@dashboard/loading');
         this.notificationNoBackupButton = this.page.getByTestId('@notification/no-backup/button');
+        this.openUnusedWalletButton1 = this.page.getByTestId(
+            '@passphrase-confirmation/step1-open-unused-wallet-button',
+        );
+        this.openUnusedWalletButton2 = this.page.getByTestId(
+            '@passphrase-confirmation/step2-button',
+        );
     }
 
     @step()
@@ -122,12 +130,20 @@ export class DashboardPage {
     }
 
     @step()
-    async addUnusedHiddenWallet(passphrase: string, options?: { skipDiscovery?: boolean }) {
+    async addUnusedHiddenWallet(
+        passphrase: string,
+        // We are not waiting for discovery by expecting discovery bar to be visible for unused wallet
+        // Because sometime the suite is to fast and the discovery bar is not shown at all
+        // This would cause failure of the test even tho the flow completed successfully
+        options: { skipDiscovery?: boolean } = { skipDiscovery: true },
+    ) {
         await this.addHiddenWallet(passphrase, options);
-        await this.page
-            .getByTestId('@passphrase-confirmation/step1-open-unused-wallet-button')
-            .click({ timeout: 10_000 });
-        await this.page.getByTestId('@passphrase-confirmation/step2-button').click();
+        await expect(
+            this.openUnusedWalletButton1,
+            'Expected "Yes, open" button to be enabled. Unused wallet might not finished Discovery.',
+        ).toBeEnabled({ timeout: 30_000 });
+        await this.openUnusedWalletButton1.click();
+        await this.openUnusedWalletButton2.click();
         await this.passphraseInput.fill(passphrase);
         await this.passphraseSubmitButton.click();
 

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-numbering.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-numbering.test.ts
@@ -14,10 +14,10 @@ test.describe('Passphrase numbering', { tag: ['@group=passphrase'] }, () => {
 
         // Add two hidden wallets
         await dashboardPage.openDeviceSwitcher();
-        await dashboardPage.addUnusedHiddenWallet(passphraseOne, { skipDiscovery: true });
+        await dashboardPage.addUnusedHiddenWallet(passphraseOne);
 
         await dashboardPage.openDeviceSwitcher();
-        await dashboardPage.addUnusedHiddenWallet(passphraseTwo, { skipDiscovery: true });
+        await dashboardPage.addUnusedHiddenWallet(passphraseTwo);
 
         // assert that wallet labels are correct
         await dashboardPage.openDeviceSwitcher();
@@ -32,7 +32,7 @@ test.describe('Passphrase numbering', { tag: ['@group=passphrase'] }, () => {
         // add standard and another hidden wallet
         await dashboardPage.addStandardWallet();
         await dashboardPage.openDeviceSwitcher();
-        await dashboardPage.addUnusedHiddenWallet(passphraseThree, { skipDiscovery: true });
+        await dashboardPage.addUnusedHiddenWallet(passphraseThree);
 
         // assert that wallet labels are correct
         await dashboardPage.openDeviceSwitcher();


### PR DESCRIPTION
Cardano test got broken by Translation 
Wallet and passphrase test are sometime unable to detect discovery because the test is awaiting still promise of pressYes while suite finishes the discovery = that is an issue we will try to address in Tenv but in meantime this should stabilize tests