### PR TITLE
fix(suite): hide solana unstake amount

### DIFF
--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -153,8 +153,7 @@ export interface Transaction {
     };
     solanaSpecific?: {
         status: 'confirmed';
-        stakeType?: StakeType;
-        unstakeAmount?: string;
+        stakeOperation?: { type: StakeType; amount: string };
     };
     details: TransactionDetail;
     vsize?: number;

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -154,6 +154,7 @@ export interface Transaction {
     solanaSpecific?: {
         status: 'confirmed';
         stakeType?: StakeType;
+        unstakeAmount?: string;
     };
     details: TransactionDetail;
     vsize?: number;

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -737,13 +737,16 @@ export const transformTransaction = (
 
     const targets = getTargets(nativeEffects, txType, accountAddress);
 
-    const amount =
-        stakeType === 'unstake'
-            ? getUnstakeAmount(tx)
-            : getAmount(
-                  nativeEffects.find(({ address }) => address === accountAddress),
-                  type,
-              );
+    const isUnstakeTx = stakeType === 'unstake';
+
+    const amount = isUnstakeTx
+        ? '0' // amount for unstake transactions should be hidden
+        : getAmount(
+              nativeEffects.find(({ address }) => address === accountAddress),
+              type,
+          );
+
+    const unstakeAmount = isUnstakeTx ? getUnstakeAmount(tx) : undefined;
 
     const details = getDetails(tx, nativeEffects, accountAddress, type);
 
@@ -763,6 +766,7 @@ export const transformTransaction = (
         solanaSpecific: {
             status: 'confirmed',
             stakeType,
+            unstakeAmount,
         },
     };
 };

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -746,7 +746,7 @@ export const transformTransaction = (
               type,
           );
 
-    const unstakeAmount = isUnstakeTx ? getUnstakeAmount(tx) : undefined;
+    const stakeAmount = isUnstakeTx ? getUnstakeAmount(tx) : amount;
 
     const details = getDetails(tx, nativeEffects, accountAddress, type);
 
@@ -765,8 +765,12 @@ export const transformTransaction = (
         blockHash: tx.transaction.message.recentBlockhash,
         solanaSpecific: {
             status: 'confirmed',
-            stakeType,
-            unstakeAmount,
+            stakeOperation: stakeType
+                ? {
+                      type: stakeType,
+                      amount: stakeAmount,
+                  }
+                : undefined,
         },
     };
 };

--- a/packages/suite/src/components/suite/UnstakingTxAmount.tsx
+++ b/packages/suite/src/components/suite/UnstakingTxAmount.tsx
@@ -16,11 +16,11 @@ interface UnstakingTxAmountProps {
 export const UnstakingTxAmount = ({ transaction }: UnstakingTxAmountProps) => {
     const { ethereumSpecific, solanaSpecific, symbol } = transaction;
 
-    const solanaStakeType = solanaSpecific?.stakeType;
+    const solanaStakeType = solanaSpecific?.stakeOperation?.type;
 
     // Handle Solana unstake transaction
     if (solanaStakeType === 'unstake') {
-        const unstakeAmount = solanaSpecific?.unstakeAmount ?? '0';
+        const unstakeAmount = solanaSpecific?.stakeOperation?.amount ?? '0';
 
         return (
             <FormattedCryptoAmount

--- a/packages/suite/src/components/suite/UnstakingTxAmount.tsx
+++ b/packages/suite/src/components/suite/UnstakingTxAmount.tsx
@@ -14,14 +14,19 @@ interface UnstakingTxAmountProps {
 }
 
 export const UnstakingTxAmount = ({ transaction }: UnstakingTxAmountProps) => {
-    const { ethereumSpecific, solanaSpecific, symbol, amount } = transaction;
+    const { ethereumSpecific, solanaSpecific, symbol } = transaction;
 
     const solanaStakeType = solanaSpecific?.stakeType;
 
     // Handle Solana unstake transaction
     if (solanaStakeType === 'unstake') {
+        const unstakeAmount = solanaSpecific?.unstakeAmount ?? '0';
+
         return (
-            <FormattedCryptoAmount value={formatNetworkAmount(amount, symbol)} symbol={symbol} />
+            <FormattedCryptoAmount
+                value={formatNetworkAmount(unstakeAmount, symbol)}
+                symbol={symbol}
+            />
         );
     }
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
@@ -46,7 +46,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
 
     const txSignature = tx.ethereumSpecific?.parsedData?.methodId;
-    const isStakeType = isStakeTypeTx(txSignature) || tx?.solanaSpecific?.stakeType; // ethereum or solana staking tx
+    const isStakeType = isStakeTypeTx(txSignature) || tx?.solanaSpecific?.stakeOperation?.type; // ethereum or solana staking tx
     const isStakeTypeTxNoAmount = isStakeType && amount.eq(0);
 
     return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
@@ -46,7 +46,8 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
 
     const txSignature = tx.ethereumSpecific?.parsedData?.methodId;
-    const isStakeTypeTxNoAmount = isStakeTypeTx(txSignature) && amount.eq(0);
+    const isStakeType = isStakeTypeTx(txSignature) || tx?.solanaSpecific?.stakeType; // ethereum or solana staking tx
+    const isStakeTypeTxNoAmount = isStakeType && amount.eq(0);
 
     return (
         <Table hasBorders={false} isRowHighlightedOnHover={false} typographyStyle="hint">

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
@@ -99,7 +99,7 @@ export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderP
             </Row>
         );
     }
-    const solanaStakeType = transaction?.solanaSpecific?.stakeType;
+    const solanaStakeType = transaction?.solanaSpecific?.stakeOperation?.type;
     if (solanaStakeType) {
         return (
             <Row gap={spacings.xxs} overflow="hidden">

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
@@ -133,7 +133,7 @@ export const TransactionHeading = ({
         );
     }
     // hide amount for solana unstake transactions
-    if (transaction?.solanaSpecific?.stakeType === 'unstake') {
+    if (transaction?.solanaSpecific?.stakeOperation?.type === 'unstake') {
         amount = null;
     }
 

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -66,8 +66,12 @@ export const TransactionTarget = ({
         selectHistoricFiatRatesByTimestamp(state, fiatRateKey, transaction.blockTime as Timestamp),
     );
     const labelingValueBeingEdited = useSelector(selectLabelingValueBeingEdited);
+    const isSolanaUnstakeTx = transaction?.solanaSpecific?.stakeType === 'unstake';
 
     const amount = useMemo(() => {
+        // hide amount for solana unstake transactions
+        if (isSolanaUnstakeTx) return null;
+
         switch (type) {
             case 'target':
                 return getTargetAmount(payload, transaction);
@@ -76,7 +80,7 @@ export const TransactionTarget = ({
             case 'token':
                 return formatAmount(payload.amount, payload.decimals);
         }
-    }, [type, payload, transaction]);
+    }, [type, payload, transaction, isSolanaUnstakeTx]);
 
     const operation = getTxOperation(type === 'target' ? transaction.type : payload.type);
 

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -66,7 +66,7 @@ export const TransactionTarget = ({
         selectHistoricFiatRatesByTimestamp(state, fiatRateKey, transaction.blockTime as Timestamp),
     );
     const labelingValueBeingEdited = useSelector(selectLabelingValueBeingEdited);
-    const isSolanaUnstakeTx = transaction?.solanaSpecific?.stakeType === 'unstake';
+    const isSolanaUnstakeTx = transaction?.solanaSpecific?.stakeOperation?.type === 'unstake';
 
     const amount = useMemo(() => {
         // hide amount for solana unstake transactions

--- a/suite-common/wallet-core/src/transactions/transactionsReducer.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsReducer.ts
@@ -353,7 +353,7 @@ export const selectAccountStakeTypeTransactions = createMemoizedSelector(
             transactions.filter(
                 tx =>
                     isStakeTypeTx(tx?.ethereumSpecific?.parsedData?.methodId) ||
-                    !!tx?.solanaSpecific?.stakeType,
+                    !!tx?.solanaSpecific?.stakeOperation?.type,
             ),
         ),
 );

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -157,7 +157,7 @@ export const formatCardanoDeposit = (tx: WalletAccountTransaction) =>
         : undefined;
 
 export const isTxFeePaid = (tx: WalletAccountTransaction) => {
-    const showFeeRowForSolClaim = tx?.solanaSpecific?.stakeType === 'claim';
+    const showFeeRowForSolClaim = tx?.solanaSpecific?.stakeOperation?.type === 'claim';
 
     return (
         (!!tx.details.vin.find(vin => vin.isOwn || vin.isAccountOwned) && tx.type !== 'joint') ||


### PR DESCRIPTION
## Description

Fixed an issue where transactions with "Split stake" incorrectly had fiat value and amount.

## Related Issue

Resolve #17222

## Screenshots:
![image](https://github.com/user-attachments/assets/02dead70-5ea7-404b-b745-437d651ea495)
![image](https://github.com/user-attachments/assets/e173ed50-e504-41c0-9022-676e726e0da0)