### PR TITLE
fix(suite-native): remove critical pictograms from send help sheets

### DIFF
--- a/suite-native/module-send/src/components/AddressReviewHelpSheet.tsx
+++ b/suite-native/module-send/src/components/AddressReviewHelpSheet.tsx
@@ -20,7 +20,6 @@ export const AddressReviewHelpSheet = ({ body, title, subtitle }: AddressReviewH
             description: subtitle,
             appendix: body,
             textAlign: 'left',
-            pictogramVariant: 'critical',
             primaryButtonTitle: <Translation id="generic.buttons.gotIt" />,
             titleSpacing: 'sp4',
         });


### PR DESCRIPTION
## Related Issue

Resolve #17352

## Screenshots:
| AddressOriginHelpButton | CompareAddressHelpButton |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/8f5d19a7-95ba-49b2-9a0b-3474e004154c) | ![image](https://github.com/user-attachments/assets/c2098972-0ef0-4ecc-ba66-ab9bb6e244f3) |
