### PR TITLE
fix(blockchain-link): limit loading signatures for too many solana tokens

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -231,6 +231,8 @@ const getAccountInfo = async (
 
     const getAllTxIds = async (tokenAccountPubkeys: string[]) => {
         const sortedTokenAccountPubkeys = tokenAccountPubkeys.sort();
+        // limit to 100 accounts, loading too many would hit the rpc limit
+        sortedTokenAccountPubkeys.splice(100);
 
         const allAccounts = [payload.descriptor, ...sortedTokenAccountPubkeys];
 


### PR DESCRIPTION
## Description 

This PR introduces a quick fix to resolve discovery errors for users with a high number of token accounts. 
Instead of fetching transaction signatures for all tokens, we limit it to 100. 

The trade-off is that incoming transaction history may not be visible for tokens beyond the limit, however the token itself and its balance are still normally loaded. 

## Related Issue

Resolve #16841