### PR TITLE
Reenable FW hash check other-error UI

### DIFF
--- a/packages/suite/src/constants/suite/firmware.ts
+++ b/packages/suite/src/constants/suite/firmware.ts
@@ -6,7 +6,7 @@ import { FilterPropertiesByType } from '@trezor/type-utils';
  * see suite-native/device/src/config/firmware.ts for Suite Lite
  */
 
-type BehaviorBaseType = { shouldReport: boolean; debugOnly?: boolean };
+type BehaviorBaseType = { shouldReport: boolean };
 
 // will be ignored completely
 type SkippedBehavior = BehaviorBaseType & { type: 'skipped' };
@@ -45,9 +45,3 @@ export type SkippedHashCheckError = keyof FilterPropertiesByType<
 export const isSkippedHashCheckError = (
     error: FirmwareHashCheckError,
 ): error is SkippedHashCheckError => hashCheckErrorScenarios[error].type === 'skipped';
-
-export const isDebugOnlyRevisionCheckError = (error: FirmwareRevisionCheckError): boolean =>
-    (revisionCheckErrorScenarios[error] as RevisionErrorBehavior).debugOnly ?? false;
-
-export const isDebugOnlyHashCheckError = (error: FirmwareHashCheckError): boolean =>
-    (hashCheckErrorScenarios[error] as HashErrorBehavior).debugOnly ?? false;

--- a/packages/suite/src/constants/suite/firmware.ts
+++ b/packages/suite/src/constants/suite/firmware.ts
@@ -34,8 +34,7 @@ export const hashCheckErrorScenarios = {
     'check-unsupported': { type: 'skipped', shouldReport: false },
     // could mean counterfeit firmware, but it's also caught by revision check, which handles edge-cases better
     'unknown-release': { type: 'skipped', shouldReport: false },
-    // TODO fix FW hash check unreliability & reenable on production (outside of debug mode)
-    'other-error': { type: 'hardModal', shouldReport: true, debugOnly: true },
+    'other-error': { type: 'hardModal', shouldReport: true },
 } satisfies HashCheckErrorScenarios;
 
 export type SkippedHashCheckError = keyof FilterPropertiesByType<

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -568,6 +568,13 @@ export const selectFirmwareHashCheckErrorIfEnabled = (state: AppState) => {
         isDebugOnlyHashCheckError(hashCheckError) && !selectIsDebugModeActive(state);
     if (isHiddenBehindDebug) return null;
 
+    if (
+        hashCheckError === 'other-error' &&
+        selectIsFeatureDisabled(state, Feature.firmwareHashCheckOtherError)
+    ) {
+        return null;
+    }
+
     return hashCheckError;
 };
 

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -21,8 +21,6 @@ import type { Locale } from 'src/config/suite/languages';
 import { ExperimentalFeature } from 'src/constants/suite/experimental';
 import {
     hashCheckErrorScenarios,
-    isDebugOnlyHashCheckError,
-    isDebugOnlyRevisionCheckError,
     isSkippedHashCheckError,
     revisionCheckErrorScenarios,
 } from 'src/constants/suite/firmware';
@@ -531,10 +529,6 @@ export const selectFirmwareRevisionCheckErrorIfEnabled = (state: AppState) => {
     const isDisabledByMessageSystem = selectIsFeatureDisabled(state, Feature.firmwareRevisionCheck);
     if (isDisabledByMessageSystem) return null;
 
-    const isHiddenBehindDebug =
-        isDebugOnlyRevisionCheckError(revisionCheckError) && !selectIsDebugModeActive(state);
-    if (isHiddenBehindDebug) return null;
-
     return revisionCheckError;
 };
 
@@ -563,10 +557,6 @@ export const selectFirmwareHashCheckErrorIfEnabled = (state: AppState) => {
 
     const isDisabledByMessageSystem = selectIsFeatureDisabled(state, Feature.firmwareHashCheck);
     if (isDisabledByMessageSystem) return null;
-
-    const isHiddenBehindDebug =
-        isDebugOnlyHashCheckError(hashCheckError) && !selectIsDebugModeActive(state);
-    if (isHiddenBehindDebug) return null;
 
     if (
         hashCheckError === 'other-error' &&

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -17,6 +17,7 @@ export type MessageSystemRootState = {
     messageSystem: MessageSystemState;
 };
 
+// Note: do not rename the feature flag identifiers (otherwise, both old & new would have to be targetted by a message system release)
 export const Feature = {
     coinjoin: 'coinjoin',
     killswitch: 'killswitch',
@@ -35,6 +36,8 @@ export const Feature = {
     firmwareRevisionCheck: 'security.firmware.revisionCheck',
     firmwareRevisionCheckMobile: 'security.firmware.revisionCheck.mobile',
     firmwareHashCheck: 'security.firmware.hashCheck',
+    // subset of `firmwareHashCheck`: can turn off specifically UI for other-error result
+    firmwareHashCheckOtherError: 'security.firmware.hashCheck.otherError',
     entropyCheck: 'security.entropyCheck',
     // FW update feature flag implemented only for mobile app
     firmwareUpdate: 'device.firmware.update',


### PR DESCRIPTION
## Description

- fully reenable UI for FW hash check `other-error`
  - currently hidden behind debug mode since [#16733](https://github.com/trezor/trezor-suite/pull/16733)
- create & test new `message-system` feature  flag to remotely turn off only that

## Related Issue

Resolve #17379

## QA
[You can check it on this testing branch](https://github.com/trezor/trezor-suite/compare/fully-enable-FW-hash-check...fully-enable-FW-hash-check-TESTING)
- should never show `other-error` :ghost: modal
- but revert `FORCE_LOCAL_JWS` to `false` and it will always show `other-error` :ghost: modal

FYI [:ghost: modal for other-error](https://github.com/user-attachments/assets/1147ee58-bba3-4a7c-88a8-9bb8eaec1674)

