### PR TITLE
fix(suite-native): use correct box size for list icon numbers

### DIFF
--- a/suite-native/atoms/src/BottomSheetListItem.tsx
+++ b/suite-native/atoms/src/BottomSheetListItem.tsx
@@ -6,7 +6,8 @@ import { HStack } from './Stack';
 import { Text } from './Text';
 
 const listItemStyle = prepareNativeStyle(() => ({
-    width: '90%',
+    flexGrow: 1,
+    flexShrink: 1,
 }));
 
 type BottomSheetListItemProps = OrderedListIconProps & {

--- a/suite-native/atoms/src/OrderedListIcon.tsx
+++ b/suite-native/atoms/src/OrderedListIcon.tsx
@@ -1,36 +1,26 @@
-import { G } from '@mobily/ts-belt';
 import { RequireExactlyOne } from 'type-fest';
 
-import { Icon, IconName, IconSize } from '@suite-native/icons';
+import { Icon, IconName, IconSize, getIconSize } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Color } from '@trezor/theme';
 
 import { Box } from './Box';
 import { Text } from './Text';
 
-const iconBackgroundStyle = prepareNativeStyle<{ color: Color; borderColor: Color }>(
-    (utils, { color, borderColor }) => ({
-        alignItems: 'center',
-        justifyContent: 'center',
-        padding: utils.spacings.sp8,
-        borderRadius: utils.borders.radii.r12,
-        extend: [
-            {
-                condition: G.isNotNullable(color),
-                style: {
-                    backgroundColor: utils.colors[color],
-                },
-            },
-            {
-                condition: G.isNotNullable(borderColor),
-                style: {
-                    borderWidth: utils.borders.widths.small,
-                    borderColor: utils.colors[borderColor],
-                },
-            },
-        ],
-    }),
-);
+const iconBackgroundStyle = prepareNativeStyle<{
+    iconSize: number;
+    backgroundColor: Color;
+    borderColor: Color;
+}>((utils, { iconSize, backgroundColor, borderColor }) => ({
+    width: iconSize + 2 * (utils.spacings.sp8 + utils.borders.widths.small),
+    aspectRatio: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: utils.colors[backgroundColor],
+    borderRadius: utils.borders.radii.r12,
+    borderWidth: utils.borders.widths.small,
+    borderColor: utils.colors[borderColor],
+}));
 
 export type OrderedListIconProps = RequireExactlyOne<
     {
@@ -57,7 +47,8 @@ export const OrderedListIcon = ({
     return (
         <Box
             style={applyStyle(iconBackgroundStyle, {
-                color: iconBackgroundColor,
+                iconSize: getIconSize(iconSize),
+                backgroundColor: iconBackgroundColor,
                 borderColor: iconBorderColor,
             })}
         >

--- a/suite-native/module-send/src/components/AddressReviewStep.tsx
+++ b/suite-native/module-send/src/components/AddressReviewStep.tsx
@@ -27,11 +27,9 @@ const getIconProps = (stepNumber: AddressReviewStepProps['stepNumber']): Ordered
               iconBorderColor: 'borderElevation0',
           }
         : {
-              iconBackgroundColor: 'backgroundPrimaryDefault',
-              iconNumber: undefined,
               iconName: 'flagCheckered',
+              iconBackgroundColor: 'backgroundPrimaryDefault',
               iconColor: 'iconDefaultInverted',
-              iconSize: 'medium',
           };
 
 const cardStyle = prepareNativeStyle<{ isFinalStep: boolean }>((utils, { isFinalStep }) => ({


### PR DESCRIPTION
## Related Issue

Resolve #17351

## Screenshots:
| AnalyticsConsentScreen | UninitializedDeviceModalAppendix | AddressReviewStep |
| --- | --- | --- |
| ![image](https://github.com/user-attachments/assets/41f1e0c8-a0ae-4f0f-a8f6-7a607561a1ce) | ![image](https://github.com/user-attachments/assets/7228a162-d148-4f8e-b32f-7ed38b9a2235) | ![image](https://github.com/user-attachments/assets/6d318498-20a8-4ca5-b5bb-f3db61cd839d) | 