### PR TITLE
fix(e2e): Finetune local timeout

### DIFF
--- a/docs/tests/e2e-playwright-suite.md
+++ b/docs/tests/e2e-playwright-suite.md
@@ -70,6 +70,8 @@ Steps:
 
 1. **To enable Electron verbose logging** add env variable LOGLEVEL=debug or any other level
 
+1. **To increase test timeouts** when your local run exceed 1m limit, you can specify test timeout override in `packages/suite-desktop-core/.env`. (UI runner --ui needs to be restarted to reflect the change in `.env`)
+
 ## Contribution
 
 Please follow our general [Playwright contribution guide](e2e-playwright-contribution-guide.md)
@@ -137,7 +139,3 @@ To open last HTML report run:
 ### Currents.dev
 
 Test reports are uploaded to [currents.dev](https://app.currents.dev/)
-
-### Artifacts on CI
-
-Every Playwright test run contains attached artifact of both Playwright report and docker logs. Download, unpack and show with `yarn playwright show-report ./path/to/report`

--- a/packages/suite-desktop-core/.example.env
+++ b/packages/suite-desktop-core/.example.env
@@ -1,3 +1,6 @@
 
-# Secret wallet passphrase dedicated for automated Trading tests
+# Secret wallet passphrase dedicated for automated Trading tests (mandatory)
 PASSPHRASE=
+
+# Custom Test timeout override, for convenient test development (optional)
+TEST_TIMEOUT_OVERRIDE=

--- a/packages/suite-desktop-core/e2e/playwright.config.ts
+++ b/packages/suite-desktop-core/e2e/playwright.config.ts
@@ -10,7 +10,7 @@ export enum PlaywrightProjects {
     Desktop = 'desktop',
 }
 const timeoutCIRun = 1000 * 180;
-const timeoutLocalRun = 1000 * 60;
+const timeoutLocalRun = 1000 * 90;
 
 const config: PlaywrightTestConfig = {
     projects: [
@@ -37,6 +37,7 @@ const config: PlaywrightTestConfig = {
         video: 'on',
         screenshot: 'on',
         testIdAttribute: 'data-testid',
+        actionTimeout: 1000 * 15,
     },
     reportSlowTests: null,
     reporter: process.env.GITHUB_ACTION

--- a/packages/suite-desktop-core/e2e/playwright.config.ts
+++ b/packages/suite-desktop-core/e2e/playwright.config.ts
@@ -9,8 +9,17 @@ export enum PlaywrightProjects {
     Web = 'web',
     Desktop = 'desktop',
 }
-const timeoutCIRun = 1000 * 180;
-const timeoutLocalRun = 1000 * 90;
+
+const CI_TIMEOUT = 1000 * 180;
+const LOCAL_TIMEOUT = 1000 * 90;
+
+function getTimeout(): number {
+    if (process.env.TEST_TIMEOUT_OVERRIDE) {
+        return Number(process.env.TEST_TIMEOUT_OVERRIDE);
+    }
+
+    return process.env.GITHUB_ACTION ? CI_TIMEOUT : LOCAL_TIMEOUT;
+}
 
 const config: PlaywrightTestConfig = {
     projects: [
@@ -43,7 +52,7 @@ const config: PlaywrightTestConfig = {
     reporter: process.env.GITHUB_ACTION
         ? [['list'], ['@currents/playwright']]
         : [['list'], ['html', { open: 'never' }]],
-    timeout: process.env.GITHUB_ACTION ? timeoutCIRun : timeoutLocalRun,
+    timeout: getTimeout(),
     outputDir: path.join(__dirname, 'test-results'),
     snapshotPathTemplate: 'snapshots/{projectName}/{testFilePath}/{arg}{ext}',
 };


### PR DESCRIPTION
We had local test run timeout set to 1m. But some of our tests' runs average on 45s. 
Add to that Solana slower network, busy machine where the test is run and you can get to a point where test timeouts while it didn't encounter any fatal problems

Increasing the local timeout by 30s to 90s but introducing actionTimeout of 15s. That way we wont have to wait way too much time on fail but we provide enough time for the local runs

Additionally adding option to override test timeout by .env variable `TEST_TIMEOUT_OVERRIDE`