### PR TITLE
fix(suite-native): use react-native-keyboard-controller for bottom sheets

### DIFF
--- a/suite-native/atoms/package.json
+++ b/suite-native/atoms/package.json
@@ -31,6 +31,7 @@
         "react": "18.2.0",
         "react-native": "0.76.1",
         "react-native-gesture-handler": "^2.21.0",
+        "react-native-keyboard-controller": "1.16.5",
         "react-native-reanimated": "^3.16.7",
         "react-native-safe-area-context": "^4.14.0",
         "react-native-svg": "15.9.0"

--- a/suite-native/atoms/src/Sheet/BottomSheet.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheet.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useEffect, useRef, useState } from 'react';
-import { GestureResponderEvent, Pressable } from 'react-native';
+import { GestureResponderEvent, Platform, Pressable } from 'react-native';
 import { PanGestureHandler, ScrollView } from 'react-native-gesture-handler';
 import Animated from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -25,7 +25,7 @@ type WrapperStyleProps = {
     insetBottom: number;
 };
 
-const DEFAULT_INSET_BOTTOM = 50;
+const DEFAULT_INSET_BOTTOM = Platform.OS === 'android' ? 48 : 0;
 
 const sheetWrapperStyle = prepareNativeStyle<WrapperStyleProps>((utils, { insetBottom }) => ({
     backgroundColor: utils.colors.backgroundSurfaceElevation0,

--- a/suite-native/atoms/src/Sheet/BottomSheetContainer.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetContainer.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
-import { KeyboardAvoidingView, Platform, Modal as RNModal } from 'react-native';
+import { Modal as RNModal } from 'react-native';
 import { gestureHandlerRootHOC } from 'react-native-gesture-handler';
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 
 import { getWindowHeight, getWindowWidth } from '@trezor/env-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -37,18 +38,12 @@ export const BottomSheetContainer = ({
 
     return (
         <RNModal transparent visible={isVisible} onRequestClose={onClose}>
-            <>
-                <BottomSheetGestureHandler>
-                    <KeyboardAvoidingView
-                        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-                        style={applyStyle(ContentWrapperStyle)}
-                    >
-                        {children}
-                    </KeyboardAvoidingView>
-                </BottomSheetGestureHandler>
-
-                {ExtraProvider && <ExtraProvider />}
-            </>
+            <BottomSheetGestureHandler>
+                <KeyboardAvoidingView behavior="height" style={applyStyle(ContentWrapperStyle)}>
+                    {children}
+                </KeyboardAvoidingView>
+            </BottomSheetGestureHandler>
+            {ExtraProvider && <ExtraProvider />}
         </RNModal>
     );
 };

--- a/suite-native/navigation/src/hooks/useIsKeyboardShown.ts
+++ b/suite-native/navigation/src/hooks/useIsKeyboardShown.ts
@@ -5,16 +5,17 @@ export const useIsKeyboardShown = () => {
     const [isKeyboardShown, setIsKeyboardShown] = useState(false);
 
     useEffect(() => {
-        const willShowSubscription = KeyboardEvents.addListener('keyboardWillShow', () =>
-            setIsKeyboardShown(true),
-        );
-        const willHideSubscription = KeyboardEvents.addListener('keyboardWillHide', () =>
-            setIsKeyboardShown(false),
-        );
+        const subscriptions = [
+            KeyboardEvents.addListener('keyboardWillShow', () => setIsKeyboardShown(true)),
+            // We need both keyboardWillHide and keyboardDidHide. If the keyboard is closed from
+            // a bottom sheet, keyboardWillHide is not trigger on Android. And if we register only
+            // keyboardDidHide, the closing animation glitches on both platforms.
+            KeyboardEvents.addListener('keyboardWillHide', () => setIsKeyboardShown(false)),
+            KeyboardEvents.addListener('keyboardDidHide', () => setIsKeyboardShown(false)),
+        ];
 
         return () => {
-            willShowSubscription.remove();
-            willHideSubscription.remove();
+            subscriptions.forEach(s => s.remove());
         };
     }, []);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10070,6 +10070,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"
     react-native-gesture-handler: "npm:^2.21.0"
+    react-native-keyboard-controller: "npm:1.16.5"
     react-native-reanimated: "npm:^3.16.7"
     react-native-safe-area-context: "npm:^4.14.0"
     react-native-svg: "npm:15.9.0"


### PR DESCRIPTION
When you confirm/cancel account name change on Android, the UI breaks because the `keyboardWillHide` event is not triggered.

![image](https://github.com/user-attachments/assets/f87d2fbd-1f68-4dbe-80cf-b18f66a6487e)