### PR TITLE
fix: Tooltip graph overflow

### DIFF
--- a/packages/components/src/components/Card/Card.tsx
+++ b/packages/components/src/components/Card/Card.tsx
@@ -36,6 +36,7 @@ export const allowedCardFrameProps = [
     'flex',
 ] as const satisfies FramePropsKeys[];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedCardFrameProps)[number]>;
+type Overflow = FrameProps['overflow'];
 
 type ContainerProps = {
     $fillType: FillType;
@@ -63,22 +64,23 @@ type CardContainerProps = {
     $isClickable: boolean;
     $variant?: CardVariant;
     $hasLabel: boolean;
+    $overflow: Overflow;
 };
 
 const CardContainer = styled.div<CardContainerProps>`
     position: relative;
     border-radius: ${borders.radii.md};
     cursor: ${({ $isClickable }) => ($isClickable ? 'pointer' : 'default')};
-    overflow: hidden;
+    overflow: ${({ $overflow }) => ($overflow)};
     transition:
         background 0.5s,
         border 0.5s,
         box-shadow 0.5s;
 
-    ${({ theme, $variant }) =>
+    ${({ theme, $variant, $overflow }) =>
         $variant &&
         css`
-            overflow: hidden;
+            overflow: ${$overflow};
 
             &::before {
                 content: '';
@@ -99,6 +101,7 @@ export type CardProps = AccessibilityProps &
         label?: ReactNode;
         paddingType?: PaddingType;
         fillType?: FillType;
+        contentOverflow?: Overflow,
         onMouseEnter?: HTMLAttributes<HTMLDivElement>['onMouseEnter'];
         onMouseLeave?: HTMLAttributes<HTMLDivElement>['onMouseLeave'];
         onClick?: HTMLAttributes<HTMLDivElement>['onClick'];
@@ -111,6 +114,7 @@ export type CardProps = AccessibilityProps &
 export const Card = ({
     paddingType = 'normal',
     fillType = 'default',
+    contentOverflow = 'hidden',
     heading,
     label,
     onClick,
@@ -170,6 +174,7 @@ export const Card = ({
                 $fillType={fillType}
                 $isClickable={Boolean(onClick)}
                 $variant={variant}
+                $overflow={contentOverflow}
                 onClick={onClick}
                 onMouseEnter={onMouseEnter}
                 className={className}

--- a/packages/components/src/components/Card/Card.tsx
+++ b/packages/components/src/components/Card/Card.tsx
@@ -114,7 +114,7 @@ export type CardProps = AccessibilityProps &
 export const Card = ({
     paddingType = 'normal',
     fillType = 'default',
-    contentOverflow = 'hidden',
+    overflow = 'hidden',
     heading,
     label,
     onClick,
@@ -129,7 +129,7 @@ export const Card = ({
 }: CardProps) => {
     const { elevation } = useElevation();
     const theme = useTheme();
-    const frameProps = pickAndPrepareFrameProps(rest, allowedCardFrameProps);
+    const frameProps = pickAndPrepareFrameProps({ overflow, ...rest }, allowedCardFrameProps);
 
     const content = (
         <>
@@ -174,7 +174,7 @@ export const Card = ({
                 $fillType={fillType}
                 $isClickable={Boolean(onClick)}
                 $variant={variant}
-                $overflow={contentOverflow}
+                $overflow={frameProps.$overflow}
                 onClick={onClick}
                 onMouseEnter={onMouseEnter}
                 className={className}

--- a/packages/components/src/components/Card/Card.tsx
+++ b/packages/components/src/components/Card/Card.tsx
@@ -101,7 +101,6 @@ export type CardProps = AccessibilityProps &
         label?: ReactNode;
         paddingType?: PaddingType;
         fillType?: FillType;
-        contentOverflow?: Overflow,
         onMouseEnter?: HTMLAttributes<HTMLDivElement>['onMouseEnter'];
         onMouseLeave?: HTMLAttributes<HTMLDivElement>['onMouseLeave'];
         onClick?: HTMLAttributes<HTMLDivElement>['onClick'];

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -139,7 +139,7 @@ export const PortfolioCard = memo(() => {
                 ) : undefined
             }
         >
-            <Card paddingType="none">
+            <Card paddingType="none" contentOverflow="visible">
                 {discoveryStatus && discoveryStatus.status === 'exception' ? null : (
                     <PortfolioCardHeader
                         showGraphControls={showGraphControls}

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -139,7 +139,7 @@ export const PortfolioCard = memo(() => {
                 ) : undefined
             }
         >
-            <Card paddingType="none" contentOverflow="visible">
+            <Card paddingType="none">
                 {discoveryStatus && discoveryStatus.status === 'exception' ? null : (
                     <PortfolioCardHeader
                         showGraphControls={showGraphControls}

--- a/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
@@ -75,9 +75,9 @@ export const TransactionSummary = ({ account }: TransactionSummaryProps) => {
     const dataInterval: [number, number] =
         selectedRange.label === 'all'
             ? [
-                  intervalGraphData[0]?.data[0]?.time,
-                  intervalGraphData[0]?.data[intervalGraphData[0].data.length - 1]?.time,
-              ]
+                intervalGraphData[0]?.data[0]?.time,
+                intervalGraphData[0]?.data[intervalGraphData[0].data.length - 1]?.time,
+            ]
             : [getUnixTime(selectedRange.startDate), getUnixTime(selectedRange.endDate)];
 
     const onRefresh = () => dispatch(updateGraphData([account]));
@@ -113,7 +113,7 @@ export const TransactionSummary = ({ account }: TransactionSummaryProps) => {
                             </Card>
                         ) : (
                             <HiddenPlaceholder enforceIntensity={8}>
-                                <Card>
+                                <Card overflow='visible'>
                                     <Row height={320} overflow="visible" alignItems="stretch">
                                         <TransactionsGraph
                                             hideToolbar


### PR DESCRIPTION
## Description

The tooltip was not visible thanks to "overflow": "hidden" in parent Card.

NOTE: when scrolling, the tooltip stays visible - this might be not desirable, but hardly avoidable with this approach. If not wanted, another solution must be made. (See the screenshot)

![image](https://github.com/user-attachments/assets/c2d8335f-d7d8-49a6-85d4-ed4ea0ad41cc)


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17279

## Screenshots:
