### PR TITLE
fix(e2e): remove duplicate trezor confirm from metadata-lifecycle

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/metadata/metadata-lifecycle.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/metadata-lifecycle.test.ts
@@ -59,8 +59,6 @@ test.describe(
             await expect(page.getByTestId('@passphrase/input')).not.toBeVisible();
             await devicePrompt.confirmOnDevicePromptIsShown();
             await trezorUserEnvLink.pressYes();
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await trezorUserEnvLink.pressYes();
 
             // Close connect to data provider modal
             await page.getByTestId('@modal/close-button').click();


### PR DESCRIPTION
Removes duplicate trezor confirm pressYes from metadata-lifecycle test