### PR TITLE
fix: incorrect amount formatting for FiatValue in Cancel Transaction flow

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransaction.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransaction.tsx
@@ -36,6 +36,8 @@ export const CancelTransaction = ({ tx, selectedAccount }: CancelTransactionProp
     const feePerByte = new BigNumber(composedCancelTx.feePerByte);
     const fee = formatNetworkAmount(composedCancelTx.fee, tx.symbol);
 
+    const formattedOutputAmount = formatNetworkAmount(output.amount.toString(), tx.symbol);
+
     return (
         <Card
             fillType="flat"
@@ -106,13 +108,13 @@ export const CancelTransaction = ({ tx, selectedAccount }: CancelTransactionProp
                     <Column gap={spacings.md} alignItems="flex-end">
                         <FormattedCryptoAmount
                             disableHiddenPlaceholder
-                            value={formatNetworkAmount(output.amount.toString(), tx.symbol)}
+                            value={formattedOutputAmount}
                             symbol={tx.symbol}
                         />
                         <Text variant="tertiary" typographyStyle="label">
                             <FiatValue
                                 disableHiddenPlaceholder
-                                amount={output.amount.toString()}
+                                amount={formattedOutputAmount}
                                 symbol={tx.symbol}
                             />
                         </Text>


### PR DESCRIPTION
Resolve: https://github.com/trezor/trezor-suite/issues/17171

![image](https://github.com/user-attachments/assets/9d6bc107-4d4f-4fff-a920-15477ecdda97)
