### PR TITLE
fix(suite): fixing too high dragable area over sidebar on mac

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx
@@ -34,6 +34,7 @@ export const NavigationItemBase = styled.div.attrs(() => ({
         background 0.15s;
     cursor: pointer;
     border: 1px solid transparent;
+    -webkit-app-region: no-drag;
     ${getFocusShadowStyle()}
 `;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The first navigation item on Mac OS wasn't clickable due to draggable area overlapping it

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
Before:


https://github.com/user-attachments/assets/d6582b18-2f6e-42ae-9ffc-fd98cb13c8f1

Now:

https://github.com/user-attachments/assets/6b79dc61-3d1a-4c7e-969d-5d11c5af0338


