### PR TITLE
feat(trading): tx id and collapsible box for tx data

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
@@ -1,9 +1,11 @@
 import styled from 'styled-components';
 
-import type { TradingExchangeType } from '@suite-common/trading';
-import { Card } from '@trezor/components';
+import { type TradingExchangeType, cryptoIdToNetwork } from '@suite-common/trading';
+import { Card, InfoItem } from '@trezor/components';
 
 import { goto } from 'src/actions/suite/routerActions';
+import { Translation } from 'src/components/suite';
+import { IOAddress } from 'src/components/suite/copy/IOAddress';
 import { useDispatch } from 'src/hooks/suite';
 import { useTradingDetailContext } from 'src/hooks/wallet/trading/useTradingDetail';
 import { tradeFinalStatuses } from 'src/hooks/wallet/trading/useTradingWatchTrade';
@@ -40,6 +42,9 @@ export const TradingDetailExchange = () => {
         return null;
     }
 
+    const { receiveTxHash, send } = trade.data;
+    const network = send && cryptoIdToNetwork(send);
+
     const tradeStatus = trade?.data?.status || 'CONFIRMING';
     const exchangeTradeFinalStatuses = tradeFinalStatuses['exchange'];
     const showSending =
@@ -61,6 +66,16 @@ export const TradingDetailExchange = () => {
     return (
         <Wrapper>
             <Card>
+                {receiveTxHash && (
+                    <InfoItem label={<Translation id="TR_TXID" />}>
+                        <IOAddress
+                            txAddress={receiveTxHash}
+                            explorerUrl={network?.explorer.tx}
+                            explorerUrlQueryString={network?.explorer.queryString}
+                        />
+                    </InfoItem>
+                )}
+
                 {tradeStatus === 'SUCCESS' && (
                     <TradingDetailExchangePaymentSuccessful account={account} />
                 )}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendApproval.tsx
@@ -9,6 +9,7 @@ import {
     parseCryptoId,
     useTradingInfo,
 } from '@suite-common/trading';
+import { getNetwork } from '@suite-common/wallet-config';
 import {
     Banner,
     Button,
@@ -26,7 +27,7 @@ import { spacings } from '@trezor/theme';
 import { saveSelectedQuote } from 'src/actions/wallet/tradingExchangeActions';
 import { AccountLabeling, Address, Translation } from 'src/components/suite';
 import { IOAddress } from 'src/components/suite/copy/IOAddress';
-import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingExchangeWatchSendApproval } from 'src/hooks/wallet/trading/form/useTradingExchangeWatchSendApproval';
 import { useTradingNavigation } from 'src/hooks/wallet/useTradingNavigation';
@@ -54,7 +55,6 @@ export const TradingOfferExchangeSendApproval = () => {
         selectedQuote?.status === 'CONFIRM' ? 'APPROVED' : 'MINIMAL',
     );
 
-    const blockchain = useSelector(state => state.wallet.blockchain);
     const { navigateToExchangeForm } = useTradingNavigation(account);
 
     useTradingExchangeWatchSendApproval({
@@ -75,7 +75,7 @@ export const TradingOfferExchangeSendApproval = () => {
     if (!selectedQuote.send) return null;
 
     const symbol = cryptoIdToSymbol(selectedQuote.send);
-    const blockchainNetwork = symbol && blockchain[symbol];
+    const network = symbol && getNetwork(symbol);
 
     const isToken = parseCryptoId(selectedQuote.send)?.contractAddress !== undefined;
 
@@ -148,8 +148,8 @@ export const TradingOfferExchangeSendApproval = () => {
                 <InfoItem label={<Translation id="TR_EXCHANGE_APPROVAL_TXID" />}>
                     <IOAddress
                         txAddress={selectedQuote.approvalSendTxHash}
-                        explorerUrl={blockchainNetwork?.explorer.tx}
-                        explorerUrlQueryString={blockchainNetwork?.explorer.queryString}
+                        explorerUrl={network?.explorer.tx}
+                        explorerUrlQueryString={network?.explorer.queryString}
                     />
                 </InfoItem>
             )}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendApproval.tsx
@@ -14,6 +14,7 @@ import {
     Banner,
     Button,
     Card,
+    CollapsibleBox,
     Column,
     Divider,
     InfoItem,
@@ -279,9 +280,9 @@ export const TradingOfferExchangeSendApproval = () => {
             )}
 
             {dexTx.data && (selectedQuote.status !== 'CONFIRM' || approvalType === 'ZERO') && (
-                <InfoItem label={<Translation id="TR_EXCHANGE_APPROVAL_DATA" />}>
+                <CollapsibleBox heading={<Translation id="TR_EXCHANGE_APPROVAL_DATA" />}>
                     <BreakableValue>{dexTx.data}</BreakableValue>
-                </InfoItem>
+                </CollapsibleBox>
             )}
 
             <Column>

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendSwap.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendSwap.tsx
@@ -10,6 +10,7 @@ import { getDisplaySymbol } from '@suite-common/wallet-config';
 import {
     Button,
     Card,
+    CollapsibleBox,
     Column,
     Divider,
     ElevationContext,
@@ -274,9 +275,9 @@ export const TradingOfferExchangeSendSwap = () => {
                 </ElevationContext>
             </Card>
 
-            <InfoItem label={<Translation id="TR_EXCHANGE_SWAP_DATA" />}>
+            <CollapsibleBox heading={<Translation id="TR_EXCHANGE_SWAP_DATA" />}>
                 <BreakableValue>{dexTx.data}</BreakableValue>
-            </InfoItem>
+            </CollapsibleBox>
 
             <Column>
                 <Divider margin={{ top: spacings.xs, bottom: spacings.lg }} />

--- a/packages/suite/src/views/wallet/trading/common/TradingWrapper.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingWrapper.tsx
@@ -4,7 +4,7 @@ import { spacingsPx } from '@trezor/theme';
 export const TradingWrapper = `
     gap: ${spacingsPx.md};
     display: grid;
-    grid-template-columns: 1fr 420px;
+    grid-template-columns: minmax(0, 1fr) 420px;
 
     ${variables.SCREEN_QUERY.BELOW_DESKTOP} {
         display: flex;


### PR DESCRIPTION
## Description

- added tx id with link to blockbook and a copy button to final swap step
- added a collapsible box to approval tx data to second swap step
- added a collapsible box for swap tx data to third swap step

## Related Issue

Resolve #16466 

## Screenshots:

![Screenshot 2025-03-07 at 11 14 34](https://github.com/user-attachments/assets/d9375874-b29a-4a6d-9f64-cee5a8d5d41e)

![Screenshot 2025-03-07 at 11 15 31](https://github.com/user-attachments/assets/6ba8e7e7-b3a3-4e41-857a-f19530f6f2b3)

<img width="706" alt="Screenshot 2025-03-05 at 14 31 56" src="https://github.com/user-attachments/assets/6da45986-3731-40d8-91aa-886ddaa56889" />

<img width="710" alt="Screenshot 2025-03-05 at 14 28 31" src="https://github.com/user-attachments/assets/9b9783f7-7fc4-45fc-83cc-bd65eef1f64c" />

