### PR TITLE
refactor(e2e): improve stability by discovery validation in Trading tests

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum-token.test.ts
@@ -39,6 +39,8 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=other', '@webOnly'] }, 
             await test.step('Enable Ethereum and open its token sell trading', async () => {
                 await settingsPage.navigateTo('coins');
                 await settingsPage.coins.enableNetwork('eth');
+                await settingsPage.coins.activateCoinsButton.click();
+                await dashboardPage.discoveryShouldFinish();
                 await dashboardPage.deviceSwitchingOpenButton.click();
                 await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
                 await walletPage.openSellTradingOfToken('eth', 'USD Coin');

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
@@ -54,6 +54,8 @@ test.describe('Trading - Sell Solana', { tag: ['@group=other', '@webOnly'] }, ()
             await test.step('Enable Solana and open its sell trading', async () => {
                 await settingsPage.navigateTo('coins');
                 await settingsPage.coins.enableNetwork('sol');
+                await settingsPage.coins.activateCoinsButton.click();
+                await dashboardPage.discoveryShouldFinish();
                 await dashboardPage.deviceSwitchingOpenButton.click();
                 await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
                 await walletPage.openTrading({ symbol: 'sol' });

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
@@ -35,6 +35,8 @@ test.describe('Trading - Swap coin to token', { tag: ['@group=other', '@webOnly'
             await settingsPage.coins.enableNetwork('sol');
             await settingsPage.coins.enableNetwork('eth');
             await settingsPage.coins.disableNetwork('btc');
+            await settingsPage.coins.activateCoinsButton.click();
+            await dashboardPage.discoveryShouldFinish();
             await dashboardPage.deviceSwitchingOpenButton.click();
             await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
             await walletPage.openSwapTrading({ symbol: 'sol' });

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
@@ -44,6 +44,8 @@ test.describe('Trading - Swap coins', { tag: ['@group=other', '@webOnly'] }, () 
             await dashboardPage.discoveryShouldFinish();
             await settingsPage.navigateTo('coins');
             await settingsPage.coins.enableNetwork('sol');
+            await settingsPage.coins.activateCoinsButton.click();
+            await dashboardPage.discoveryShouldFinish();
             await dashboardPage.deviceSwitchingOpenButton.click();
             await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
             await walletPage.openSwapTrading({ symbol: 'sol' });

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
@@ -35,6 +35,8 @@ test.describe('Trading - Swap token to coin', { tag: ['@group=other', '@webOnly'
             await dashboardPage.discoveryShouldFinish();
             await settingsPage.navigateTo('coins');
             await settingsPage.coins.enableNetwork('sol');
+            await settingsPage.coins.activateCoinsButton.click();
+            await dashboardPage.discoveryShouldFinish();
             await dashboardPage.deviceSwitchingOpenButton.click();
             await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
             await walletPage.openSwapTrading({ symbol: 'sol' });

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
@@ -35,6 +35,8 @@ test.describe('Trading - Swap tokens', { tag: ['@group=other', '@webOnly'] }, ()
             await dashboardPage.discoveryShouldFinish();
             await settingsPage.navigateTo('coins');
             await settingsPage.coins.enableNetwork('sol');
+            await settingsPage.coins.activateCoinsButton.click();
+            await dashboardPage.discoveryShouldFinish();
             await dashboardPage.deviceSwitchingOpenButton.click();
             await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
             await walletPage.openSwapTrading({ symbol: 'sol' });

--- a/packages/suite-desktop-core/e2e/tests/wallet/cardano.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/cardano.test.ts
@@ -1,7 +1,4 @@
-import {
-    cardanoAccountDetails,
-    cardanoStaking,
-} from '../../snapshots/web/wallet/cardano.test.ts/cardano-aria';
+import { cardanoAccountDetails } from '../../snapshots/web/wallet/cardano.test.ts/cardano-aria';
 import { expect, test } from '../../support/fixtures';
 
 const formattedReceiveAddress =
@@ -65,7 +62,12 @@ test.describe('Cardano', { tag: ['@group=wallet', '@snapshot'] }, () => {
 
         await test.step('Verify Cardano staking', async () => {
             await walletPage.stakingButton.click();
-            await expect(walletPage.stakingCardano).toMatchAriaSnapshot(cardanoStaking);
+            await expect(walletPage.stakeAddress).toHaveText(
+                'stake_test1uqyuj8h935q6panx0klttu026rzam0y9c2v97pv3l56uk3s5v5fjr',
+            );
+            await expect(page.getByRole('button', { name: 'Delegate' })).toBeDisabled();
+            // Recently there were a lot of changes in staking, and the snapshot became problematic
+            // await expect(walletPage.stakingCardano).toMatchAriaSnapshot(cardanoStaking);
         });
     });
 });


### PR DESCRIPTION
I recently found out there was an edge case where discovery would "pause" adding of hidden wallet. This still passed because we didn't have a timeout on action. But recently we introduced a timeout for actions. So we need to properly handle this situation. And that means waiting for discovery between enabling coins and adding hidden wallet

Also improve Cardano staking validation. Recent changes made if unstable. And I was told there will be more changes so switched the validation from Aria snapshot to less broad asserts.
