### PR TITLE
Feat(suite-native): retry FW revision check if it's stale

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -796,7 +796,11 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
         if (notDoneYet || wasErrorRetriable) {
             const result = await this.checkFirmwareHash();
-            this.authenticityChecks.firmwareHash = result;
+
+            this.authenticityChecks = {
+                ...this.authenticityChecks,
+                firmwareHash: result,
+            };
 
             if (result === null) return;
             result.attemptCount = attemptsDone + 1;
@@ -902,12 +906,16 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
         const release = getRelease(this.features.internal_model, firmwareVersion);
 
-        this.authenticityChecks.firmwareRevision = await checkFirmwareRevision({
+        const result = await checkFirmwareRevision({
             internalModel: this.features.internal_model,
             deviceRevision: this.features.revision,
             firmwareVersion,
             expectedRevision: release?.firmware_revision,
         });
+        this.authenticityChecks = {
+            ...this.authenticityChecks,
+            firmwareRevision: result,
+        };
     }
 
     async changeLanguage({

--- a/suite-native/app/src/hooks/useGlobalHooks.tsx
+++ b/suite-native/app/src/hooks/useGlobalHooks.tsx
@@ -2,6 +2,7 @@ import {
     useDetectDeviceError,
     useHandleDeviceConnection,
     useReportDeviceCompromised,
+    useRetryFwAuthenticityChecks,
 } from '@suite-native/device';
 import { useRenderDeviceCompromisedBanner } from '@suite-native/module-authenticity-checks';
 import { useConnectPopupNavigation } from '@suite-native/module-connect-popup';
@@ -21,4 +22,6 @@ export const useGlobalHooks = () => {
     useDetectDeviceError();
     useReportDeviceCompromised();
     useRenderDeviceCompromisedBanner();
+
+    useRetryFwAuthenticityChecks();
 };

--- a/suite-native/device/package.json
+++ b/suite-native/device/package.json
@@ -33,6 +33,7 @@
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/styles": "workspace:*",
+        "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "lottie-react-native": "^7.1.0",
         "react": "18.2.0",

--- a/suite-native/device/src/hooks/useRetryFwAuthenticityChecks.ts
+++ b/suite-native/device/src/hooks/useRetryFwAuthenticityChecks.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+
+import TrezorConnect, { FIRMWARE } from '@trezor/connect';
+import { TimerId } from '@trezor/type-utils';
+import { isArrayMember } from '@trezor/utils';
+
+import { selectFirmwareRevisionCheckErrorIfEnabled } from '../selectors';
+
+const REFRESH_INTERVAL = 3_000; // [ms]
+
+export const useRetryFwAuthenticityChecks = () => {
+    const firmwareRevisionCheckError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
+
+    const isRetriableError =
+        firmwareRevisionCheckError !== null &&
+        isArrayMember(firmwareRevisionCheckError, FIRMWARE.REVISION_CHECK_RETRIABLE_ERRORS);
+
+    useEffect(() => {
+        let timeoutHandle: TimerId;
+        const recheckFwRevision = () => {
+            if (isRetriableError) {
+                // any device call will cause the tests to be rerun, so getFeatures is used as the most basic one
+                // it'd be useless to await the result; what interests us is the Device state that updates, and gets propagated into redux
+                TrezorConnect.getFeatures({ useEmptyPassphrase: true });
+                timeoutHandle = setTimeout(recheckFwRevision, REFRESH_INTERVAL);
+            }
+        };
+
+        if (isRetriableError) {
+            timeoutHandle = setTimeout(recheckFwRevision, REFRESH_INTERVAL);
+        }
+
+        return () => clearTimeout(timeoutHandle);
+    }, [isRetriableError]);
+};

--- a/suite-native/device/src/index.ts
+++ b/suite-native/device/src/index.ts
@@ -4,6 +4,7 @@ export * from './hooks/useHandleDeviceConnection';
 export * from './hooks/useDetectDeviceError';
 export * from './hooks/useReportDeviceConnectToAnalytics';
 export * from './hooks/useReportDeviceCompromised';
+export * from './hooks/useRetryFwAuthenticityChecks';
 export * from './components/ConnectDeviceAnimation';
 export * from './components/ConfirmOnTrezorImage';
 export * from './components/ConnectorImage';

--- a/suite-native/device/tsconfig.json
+++ b/suite-native/device/tsconfig.json
@@ -31,6 +31,7 @@
         { "path": "../../packages/connect" },
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/styles" },
+        { "path": "../../packages/type-utils" },
         { "path": "../../packages/utils" }
     ],
     "include": [".", "**/*.json"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -10108,6 +10108,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/styles": "workspace:*"
+    "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     lottie-react-native: "npm:^7.1.0"
     react: "npm:18.2.0"


### PR DESCRIPTION
## Description

- add a new Connect method to prompt retrying of FW authenticity checks, if eligible for retry
  - currently, retries happen only during a device call, which'd necessitate a purposeless call just to rerun them
- in mobile, periodically query rerun FW authenticity checks, if eligible for retry

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17133

## Screenshots:

Video demonstrating it [on the testing branch](https://github.com/trezor/trezor-suite/compare/fix-FW-rev-check-persistent-offline..fix-FW-rev-check-persistent-offline-TESTING).
- Using with physical T2B1 via `trezord` mocked with unrecognized version 9,8,7
- It starts with forced NetworkError
- Lots of retries at the beginning (lots of calls to device during handshake & account discovery) 
- Then I let it retry a few times with the given interval
- Then I allowed network requests again, so that FW rev check finally settles

[testing.webm](https://github.com/user-attachments/assets/4b3afd60-8ac7-4e9f-85b4-b7cc10de40a2)
