### PR TITLE
fix(suite-desktop-core): fix async error in Windows signing

### DIFF
--- a/packages/suite-desktop-core/scripts/sign-windows.ts
+++ b/packages/suite-desktop-core/scripts/sign-windows.ts
@@ -1,5 +1,7 @@
 import type { CustomWindowsSign } from 'app-builder-lib';
 
+// electron-builder TS requires the function to return Promise, but jsign MUST be called with execSync!
+// eslint-disable-next-line require-await
 const signWindows: CustomWindowsSign = async configuration => {
     // Check if IS_CODESIGN_BUILD is set and true
     if (!process.env.IS_CODESIGN_BUILD || process.env.IS_CODESIGN_BUILD.toLowerCase() !== 'true') {
@@ -13,7 +15,7 @@ const signWindows: CustomWindowsSign = async configuration => {
     const CERTIFICATE_NAME = process.env.WINDOWS_SIGN_CERTIFICATE_NAME;
     const TOKEN_PASSWORD = process.env.WINDOWS_SIGN_TOKEN_PASSWORD;
 
-    await require('child_process').exec(
+    require('child_process').execSync(
         `java -jar ../suite-desktop-core/scripts/jsign-6.0.jar --keystore ../suite-desktop-core/scripts/hardwareToken.cfg --storepass '${TOKEN_PASSWORD}' --storetype PKCS11 --tsaurl http://timestamp.digicert.com --alias "${CERTIFICATE_NAME}" "${configuration.path}"`,
         {
             stdio: 'inherit',


### PR DESCRIPTION
## Description

In #17056 and  #17234, the electron-builder hook for windows signing was rewritten from CJS to TS.
:arrow_right: fix inconsistent SHA hashes caused by async code.

## Screenshots:

Verified locally by first changing [L19](https://github.com/trezor/trezor-suite/blob/ded0606c8b06d994049bb7158f718e66cad1677f/packages/suite-desktop-core/scripts/sign-windows.ts#L19) to 
```
`java -jar ../suite-desktop-core/scripts/jsign-6.0.jar --keystore /my-folder/cert.pfx --storepass 1234 --storetype PKCS12 --tsaurl http://timestamp.digicert.com "${configuration.path}"`,
```
Using a locally generated `.pfx` file with password 1234.

Then I built and verified that SHA sums are the same (starts with `ajWzamhw`)
```
$ yarn workspace @trezor/suite-build run build:desktop
$ yarn workspace @trezor/suite-desktop build:app
$ yarn workspace @trezor/suite-desktop-core build:app:electron --publish never --win --x64

$ cat latest.yml | head -7
version: 25.4.0
files:
  - url: Trezor-Suite-25.4.0-win-x64.exe
    sha512: ajWzamhw4RD8LMfC5tGkBuSWL9qfTRjqBVx/DDeCVu7Q5TItG6pV/vmUiO3R/+nn/dFtf3hekcqpMY8sJ1tczA==
    size: 156784784
path: Trezor-Suite-25.4.0-win-x64.exe
sha512: ajWzamhw4RD8LMfC5tGkBuSWL9qfTRjqBVx/DDeCVu7Q5TItG6pV/vmUiO3R/+nn/dFtf3hekcqpMY8sJ1tczA==

$ shasum -a 512 Trezor-Suite-25.4.0-win-x64.exe | awk '{print $1}' | xxd -r -p | base64
ajWzamhw4RD8LMfC5tGkBuSWL9qfTRjqBVx/DDeCVu7Q5TItG6pV/vmUiO3R/+nn/dFtf3hekcqpMY8sJ1tczA==
```
