### PR TITLE
chore(connect): change `buildMessage` param. `encode` > `protocol`

### DIFF
--- a/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
+++ b/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
@@ -121,7 +121,7 @@ const buildProtobufMessage = (messages: any, override: any = {}) => {
                   revision: LATEST_RELEASE.firmware_revision, // used in calculateFirmwareHashMock
                   ...override.data,
               },
-        encode: protocolV1.encode,
+        protocol: protocolV1,
     }).toString('hex');
 };
 

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -198,7 +198,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     messages: this.messages,
                     name,
                     data,
-                    encode: protocol.encode,
+                    protocol,
                 });
                 const chunks = createChunks(
                     bytes,
@@ -232,7 +232,13 @@ export abstract class AbstractApiTransport extends AbstractTransport {
         );
     }
 
-    public send({ data, session, name, protocol, signal }: AbstractTransportMethodParams<'send'>) {
+    public send({
+        data,
+        session,
+        name,
+        protocol: customProtocol,
+        signal,
+    }: AbstractTransportMethodParams<'send'>) {
         return this.scheduleAction(
             async signal => {
                 const getPathBySessionResponse = await this.sessionsClient.getPathBySession({
@@ -243,14 +249,18 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 }
                 const { path } = getPathBySessionResponse.payload;
 
-                const { encode, getChunkHeader } = protocol || v1Protocol;
+                const protocol = customProtocol || v1Protocol;
                 const bytes = buildMessage({
                     messages: this.messages,
                     name,
                     data,
-                    encode,
+                    protocol,
                 });
-                const chunks = createChunks(bytes, getChunkHeader(bytes), this.api.chunkSize);
+                const chunks = createChunks(
+                    bytes,
+                    protocol.getChunkHeader(bytes),
+                    this.api.chunkSize,
+                );
                 const apiWrite = (chunk: Buffer) => this.api.write(path, chunk, signal);
                 const sendResult = await sendChunks(chunks, apiWrite);
 

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -240,7 +240,7 @@ export class BridgeTransport extends AbstractTransport {
                     messages: this.messages,
                     name,
                     data,
-                    encode: protocol.encode,
+                    protocol,
                 });
                 const response = await this.post(`/call`, {
                     params: session,
@@ -275,7 +275,7 @@ export class BridgeTransport extends AbstractTransport {
                     messages: this.messages,
                     name,
                     data,
-                    encode: protocol.encode,
+                    protocol,
                 });
                 const response = await this.post('/post', {
                     params: session,

--- a/packages/transport/src/utils/send.ts
+++ b/packages/transport/src/utils/send.ts
@@ -1,5 +1,5 @@
 import { encodeMessage } from '@trezor/protobuf';
-import { TransportProtocolEncode } from '@trezor/protocol';
+import { TransportProtocol } from '@trezor/protocol';
 
 import { AsyncResultWithTypedError } from '../types';
 
@@ -30,13 +30,13 @@ interface BuildMessageProps {
     messages: Parameters<typeof encodeMessage>[0];
     name: string;
     data: Record<string, unknown>;
-    encode: TransportProtocolEncode;
+    protocol: TransportProtocol;
 }
 
-export const buildMessage = ({ messages, name, data, encode }: BuildMessageProps) => {
+export const buildMessage = ({ messages, name, data, protocol }: BuildMessageProps) => {
     const { messageType, message } = encodeMessage(messages, name, data);
 
-    return encode(message, { messageType });
+    return protocol.encode(message, { messageType });
 };
 
 export const sendChunks = async <T, E>(

--- a/packages/transport/tests/build-receive.test.ts
+++ b/packages/transport/tests/build-receive.test.ts
@@ -103,7 +103,7 @@ describe('encoding json -> protobuf -> json', () => {
                     messages: parsedMessages,
                     name: f.name,
                     data: f.in,
-                    encode: bridgeProtocol.encode,
+                    protocol: bridgeProtocol,
                 });
                 const { length } = Buffer.from(f.in.source_account);
                 // result length cannot be less than message header/constant (28) + variable source_account length
@@ -128,7 +128,7 @@ describe('encoding json -> protobuf -> json', () => {
                     messages: parsedMessages,
                     name: f.name,
                     data: f.in,
-                    encode: v1Protocol.encode,
+                    protocol: v1Protocol,
                 });
 
                 const chunks = createChunks(result, v1Protocol.getChunkHeader(result), 64);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Another cherry pick from `THP`

Unify params of `utils/send/buildMessage` and `utils/receive/receiveAndParse`

protocol.decode will be used later in THP. i just want to clean incoming diffs a little bit
