### PR TITLE
feat: implement deep-links for anchors

### DIFF
--- a/packages/suite/src/actions/suite/protocolActions.ts
+++ b/packages/suite/src/actions/suite/protocolActions.ts
@@ -2,16 +2,27 @@ import { Protocol } from '@suite-common/suite-constants';
 import { getNetworkSymbolForProtocol } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import * as walletConnectActions from '@suite-common/walletconnect';
-import { SUITE_BRIDGE_DEEPLINK, SUITE_WALLETCONNECT_DEEPLINK } from '@trezor/urls';
+import {
+    SUITE_ANCHOR_DEEPLINK_PREFIX,
+    SUITE_BRIDGE_DEEPLINK,
+    SUITE_WALLETCONNECT_DEEPLINK,
+} from '@trezor/urls';
+import { isArrayMember } from '@trezor/utils';
 
 import * as routerActions from 'src/actions/suite/routerActions';
+import { goto } from 'src/actions/suite/routerActions';
 import type { SendFormState } from 'src/reducers/suite/protocolReducer';
 import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
-import type { Dispatch, GetState } from 'src/types/suite';
+import { Dispatch, GetState } from 'src/types/suite';
 import { parseUri } from 'src/utils/suite/parseUri';
 import { CoinProtocolInfo, getProtocolInfo } from 'src/utils/suite/protocol';
 
 import { PROTOCOL } from './constants';
+import {
+    AnchorSettingSection,
+    SettingsAnchor,
+    mapAnchorToRoute,
+} from '../../constants/suite/anchors';
 
 export type ProtocolAction =
     | {
@@ -61,6 +72,15 @@ export const handleProtocolRequest = (uri: string) => (dispatch: Dispatch, getSt
         const wcUri = parsedUri?.searchParams?.get('uri');
         if (wcUri) {
             dispatch(walletConnectActions.walletConnectPairThunk({ uri: wcUri }));
+        }
+    } else if (uri?.startsWith(SUITE_ANCHOR_DEEPLINK_PREFIX)) {
+        const anchor = uri.replace(SUITE_ANCHOR_DEEPLINK_PREFIX, '');
+
+        if (isArrayMember(anchor, Object.values(SettingsAnchor))) {
+            const [domain] = anchor.split('/');
+
+            const targetRoute = mapAnchorToRoute[domain.replace(/^@/, '') as AnchorSettingSection];
+            dispatch(goto(targetRoute, { anchor }));
         }
     }
 };

--- a/packages/suite/src/components/settings/SettingsSectionItem.tsx
+++ b/packages/suite/src/components/settings/SettingsSectionItem.tsx
@@ -1,11 +1,11 @@
 import { ReactNode } from 'react';
 
 import { SectionItem } from 'src/components/suite';
-import { SettingsAnchor } from 'src/constants/suite/anchors';
+import { SettingsAnchorValue } from 'src/constants/suite/anchors';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 
 interface SettingsSectionItemProps {
-    anchorId: SettingsAnchor;
+    anchorId: SettingsAnchorValue;
     children: ReactNode;
 }
 

--- a/packages/suite/src/constants/suite/anchors.ts
+++ b/packages/suite/src/constants/suite/anchors.ts
@@ -1,55 +1,74 @@
-export const enum SettingsAnchor {
-    Language = '@general-settings/language',
-    Fiat = '@general-settings/fiat',
-    BitcoinAmountUnit = '@general-settings/btc-amount-unit',
-    Labeling = '@general-settings/labeling',
-    LabelingDisconnect = '@general-settings/labeling-disconnect',
-    LabelingConnect = '@general-settings/labeling-connect',
-    Tor = '@general-settings/tor',
-    TorExternal = '@general-settings/tor-external',
-    TorOnionLinks = '@general-settings/tor-onion-links',
-    Theme = '@general-settings/theme',
-    AddressDisplay = '@general-settings/address-display',
-    Analytics = '@general-settings/analytics',
-    ShowLog = '@general-settings/show-log',
-    ClearStorage = '@general-settings/clear-storage',
-    VersionWithUpdate = '@general-settings/version-with-update',
-    EarlyAccess = '@general-settings/early-access',
-    AutoStart = '@general-settings/auto-start',
-    AutomaticUpdate = '@general-settings/automatic-update',
+import { Route } from '@suite-common/suite-types';
 
-    BackupFailed = '@device-settings/backup-failed',
-    BackupRecoverySeed = '@device-settings/backup-recovery-seed',
-    DefaultWalletLoading = '@general-settings/default-wallet-loading',
-    CheckRecoverySeed = '@device-settings/check-recovery-seed',
-    FirmwareVersion = '@device-settings/firmware-version',
-    FirmwareType = '@device-settings/firmware-type',
-    FirmwareLanguage = '@device-settings/firmware-language',
-    PinProtection = '@device-settings/pin-protection',
-    ChangePin = '@device-settings/change-pin',
-    WipeCode = '@device-settings/wipe-code',
-    Passphrase = '@device-settings/passphrase',
-    SafetyChecks = '@device-settings/safety-checks',
-    DeviceLabel = '@device-settings/device-label',
-    Homescreen = '@device-settings/homescreen',
-    DisplayRotation = '@device-settings/display-rotation',
-    Autolock = '@device-settings/autolock',
-    WipeDevice = '@device-settings/wipe-device',
-    CustomFirmware = '@device-settings/custom-firmware',
+export type AnchorSettingSection =
+    | 'general-settings'
+    | 'device-settings'
+    | 'coin-settings'
+    | 'debug-settings';
 
-    Crypto = '@coin-settings/crypto',
-    TestnetCrypto = '@coin-settings/testnet-crypto',
-    UnsupportedCrypto = '@coin-settings/unsupported-crypto',
+type Anchor = `@${AnchorSettingSection}/${string}`;
 
-    TranslationMode = '@debug-settings/translation-mode',
-    GithubIssue = '@debug-settings/github-issue',
-    WipeData = '@debug-settings/wipe-data',
-    InvityApi = '@debug-settings/invity-api',
-    OAuthApi = '@debug-settings/oauth-api',
-}
+export const SettingsAnchor = {
+    Language: '@general-settings/language',
+    Fiat: '@general-settings/fiat',
+    BitcoinAmountUnit: '@general-settings/btc-amount-unit',
+    Labeling: '@general-settings/labeling',
+    LabelingDisconnect: '@general-settings/labeling-disconnect',
+    LabelingConnect: '@general-settings/labeling-connect',
+    Tor: '@general-settings/tor',
+    TorExternal: '@general-settings/tor-external',
+    TorOnionLinks: '@general-settings/tor-onion-links',
+    Theme: '@general-settings/theme',
+    AddressDisplay: '@general-settings/address-display',
+    Analytics: '@general-settings/analytics',
+    ShowLog: '@general-settings/show-log',
+    ClearStorage: '@general-settings/clear-storage',
+    VersionWithUpdate: '@general-settings/version-with-update',
+    EarlyAccess: '@general-settings/early-access',
+    AutoStart: '@general-settings/auto-start',
+    AutomaticUpdate: '@general-settings/automatic-update',
+
+    BackupFailed: '@device-settings/backup-failed',
+    BackupRecoverySeed: '@device-settings/backup-recovery-seed',
+    DefaultWalletLoading: '@general-settings/default-wallet-loading',
+    CheckRecoverySeed: '@device-settings/check-recovery-seed',
+    FirmwareVersion: '@device-settings/firmware-version',
+    FirmwareType: '@device-settings/firmware-type',
+    FirmwareLanguage: '@device-settings/firmware-language',
+    PinProtection: '@device-settings/pin-protection',
+    ChangePin: '@device-settings/change-pin',
+    WipeCode: '@device-settings/wipe-code',
+    Passphrase: '@device-settings/passphrase',
+    SafetyChecks: '@device-settings/safety-checks',
+    DeviceLabel: '@device-settings/device-label',
+    Homescreen: '@device-settings/homescreen',
+    DisplayRotation: '@device-settings/display-rotation',
+    Autolock: '@device-settings/autolock',
+    WipeDevice: '@device-settings/wipe-device',
+    CustomFirmware: '@device-settings/custom-firmware',
+
+    Crypto: '@coin-settings/crypto',
+    TestnetCrypto: '@coin-settings/testnet-crypto',
+    UnsupportedCrypto: '@coin-settings/unsupported-crypto',
+
+    TranslationMode: '@debug-settings/translation-mode',
+    GithubIssue: '@debug-settings/github-issue',
+    WipeData: '@debug-settings/wipe-data',
+    InvityApi: '@debug-settings/invity-api',
+    OAuthApi: '@debug-settings/oauth-api',
+} satisfies { [key: string]: Anchor };
+
+export type SettingsAnchorValue = (typeof SettingsAnchor)[keyof typeof SettingsAnchor];
+
+export const mapAnchorToRoute: Record<AnchorSettingSection, Route['name']> = {
+    'general-settings': 'settings-index',
+    'device-settings': 'settings-device',
+    'coin-settings': 'settings-coins',
+    'debug-settings': 'suite-start',
+};
 
 export const AccountTransactionBaseAnchor = '@account/transaction';
 
 export const CoinjoinLogsAnchor = '@coinjoin/logs';
 
-export type AnchorType = SettingsAnchor | string;
+export type AnchorType = keyof typeof SettingsAnchor | string;

--- a/packages/urls/src/deeplinks.ts
+++ b/packages/urls/src/deeplinks.ts
@@ -1,2 +1,3 @@
 export const SUITE_BRIDGE_DEEPLINK = 'trezorsuite://bridge-requested-by-a-3rd-party';
 export const SUITE_WALLETCONNECT_DEEPLINK = 'trezorsuite://walletconnect';
+export const SUITE_ANCHOR_DEEPLINK_PREFIX = 'trezorsuite://anchor-';


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/16081

--------------


How to test it on linux with AppImage:

1. Compile app: `yarn && yarn workspace @trezor/suite-desktop build:linux`
2. Create `vim ~/.local/share/applications/trezorsuite.desktop` file with **(change `Exec` path for your case)**:  
   ```desktop
   [Desktop Entry]
   Name=Trezor Suite
   Exec=/home/user/workspace/trezor/trezor-suite/packages/suite-desktop/build-electron/Trezor-Suite-25.4.0-linux-x86_64.AppImage %u
   Type=Application
   Terminal=false
   MimeType=x-scheme-handler/trezorsuite;
   ```
3. Register app in linux: `xdg-mime default trezorsuite.desktop x-scheme-handler/trezorsuite`
4. Running `xdg-open trezorsuite://anchor-@device-settings/wipe-code` opens the Suite with the link so it can be tested


@coderabbitai ignore