### PR TITLE
fix(e2e): disable HW acceleration in playwright desktop

### DIFF
--- a/packages/suite-desktop-core/e2e/support/electron.ts
+++ b/packages/suite-desktop-core/e2e/support/electron.ts
@@ -44,6 +44,7 @@ export const launchSuiteElectronApp = async (params: LaunchSuiteParams) => {
     const appDir = path.join(__dirname, '../../../suite-desktop');
     const logLevelArgument = `--log-level=${process.env.LOGLEVEL ?? 'error'}`;
     const viewportArgument = `--width=${options.viewport.width} --height=${options.viewport.height}`;
+    const disableHWAccelerationArgument = '--disable-gpu'; // to fix chromium error GetVSyncParametersIfAvailable()
     if (!options.bridgeDaemon) {
         // TODO: #15646 Find out why currently pw fails to see node-bridge so we default to legacy bridge.
         await TrezorUserEnvLink.startBridge(LEGACY_BRIDGE_VERSION);
@@ -56,6 +57,7 @@ export const launchSuiteElectronApp = async (params: LaunchSuiteParams) => {
             showDebugMenuArgument,
             viewportArgument,
             logLevelArgument,
+            disableHWAccelerationArgument,
             ...(options.bridgeLegacyTest ? ['--bridge-legacy', '--bridge-test'] : []),
             ...(options.bridgeDaemon ? ['--bridge-daemon', '--skip-new-bridge-rollout'] : []),
         ],


### PR DESCRIPTION
## Description

Disable hardware acceleration via GPU for Playwright Desktop E2E tests.

Fixes this problem:
```
[110143:0307/144659.650665:ERROR:gl_surface_presentation_helper.cc(260)] GetVSyncParametersIfAvailable() failed for 1 times!
```

:thought_balloon:  Arguably, this makes the test environment different from user environment, as most people with normal operating systems have GPU on.
However, [ubuntu-latest github runner does not have GPU](https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/choosing-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories). So it's questionable what does it even mean to render Chromium with hardware acceleration without it. If it means throwing it back to CPU rendering, than this just simplifies it.