### PR TITLE
Chore/remove firmware hash invalid dead code

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -456,13 +456,6 @@ export const saveMessageSystem = () => async (_dispatch: Dispatch, getState: Get
     );
 };
 
-export const saveFirmware = () => async (_dispatch: Dispatch, getState: GetState) => {
-    if (!(await db.isAccessible())) return;
-    const { firmware } = getState();
-
-    db.addItem('firmware', { firmwareHashInvalid: firmware.firmwareHashInvalid }, 'firmware', true);
-};
-
 export const saveEntropyCheckFail = () => async (_dispatch: Dispatch, getState: GetState) => {
     if (!(await db.isAccessible())) return;
     const { devicesWithFailedEntropyCheck } = getState().device;

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareHashMismatchOnLastUpdateBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareHashMismatchOnLastUpdateBanner.tsx
@@ -1,9 +1,0 @@
-import { Banner } from '@trezor/components';
-
-import { Translation } from 'src/components/suite';
-
-export const FirmwareHashMismatchOnLastUpdateBanner = () => (
-    <Banner icon variant="destructive">
-        <Translation id="TR_FIRMWARE_HASH_MISMATCH" />
-    </Banner>
-);

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
@@ -19,7 +19,6 @@ import { MessageSystemBanner } from '../MessageSystemBanner';
 import { BridgeDeprecated } from './BridgeDeprecatedBanner';
 import { FailedBackup } from './FailedBackupBanner';
 import { FirmwareAuthenticityCheckBanner } from './FirmwareAuthenticityCheckBanner';
-import { FirmwareHashMismatchOnLastUpdateBanner } from './FirmwareHashMismatchOnLastUpdateBanner';
 import { NoBackup } from './NoBackupBanner';
 import { NoConnectionBanner } from './NoConnectionBanner';
 import { SafetyChecksBanner } from './SafetyChecksBanner';
@@ -39,7 +38,6 @@ export const SuiteBanners = () => {
     const bridge = useSelector(selectTransportOfType('BridgeTransport'));
     const device = useSelector(selectSelectedDevice);
     const isOnline = useSelector(state => state.suite.online);
-    const firmwareHashInvalid = useSelector(state => state.firmware.firmwareHashInvalid);
     const bannerMessage = useSelector(selectBannerMessage);
     const firmwareRevisionError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
     const firmwareHashError = useSelector(selectFirmwareHashCheckErrorIfEnabled);
@@ -52,13 +50,8 @@ export const SuiteBanners = () => {
 
     let banner = null;
     let priority = 0;
-    // this handles firmware hash being invalid after a firmware update, not the regular firmware hash check
-    if (device?.id && firmwareHashInvalid.includes(device.id)) {
-        banner = <FirmwareHashMismatchOnLastUpdateBanner />;
-        priority = 92;
-    }
-    // the regular firmware hash check, and revision id check, either of them may fail
-    else if (firmwareRevisionError || firmwareHashError) {
+    // firmware hash & revision check (performed when connecting a device), either of them may fail
+    if (firmwareRevisionError || firmwareHashError) {
         banner = <FirmwareAuthenticityCheckBanner />;
         priority = 91;
     } else if (device?.features?.unfinished_backup) {

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -311,10 +311,6 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     storageActions.removeFormDraft(action.key);
                     break;
 
-                case deviceActions.connectDevice.type: // so that firmwareReducer.addCase for the same action is persisted
-                    api.dispatch(storageActions.saveFirmware());
-                    break;
-
                 case deviceActions.setEntropyCheckFail.type:
                     api.dispatch(storageActions.saveEntropyCheckFail());
                     break;

--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -20,11 +20,11 @@
 
 -   device state to new object format (`device._state` -> `device.state`)
 
-## 47
+## 47
 
 -   migrate matic to pol
 
-## 46
+## 46
 
 -   added `tokenManagement`
 -   added `device.passwords`
@@ -35,7 +35,7 @@
 -   added `historicRates`
 -   remove rates for all transactions since we are using selectors to get rates
 
-## 44
+## 44
 
 -   remove goerli accounts, txs and settings
 
@@ -71,12 +71,12 @@
 
 -   remove persisted coinjoin sessions
 
-## 36
+## 36
 
 -   token `address` to `contract`
 -   remove ropsten accounts, txs and settings
 
-## 35
+## 35
 
 -   saved ethereum network type txs are removed to be fetched again and obtain internal transfers and token transfer contract and standard
 

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -157,11 +157,6 @@ export const extraDependencies: ExtraDependencies = {
             payload.accounts.map(acc =>
                 acc.backendType === 'coinjoin' ? fixLoadedCoinjoinAccount(acc) : acc,
             ),
-        storageLoadFirmware: (state, { payload }: StorageLoadAction) => {
-            if (payload.firmware?.firmwareHashInvalid) {
-                state.firmwareHashInvalid = payload.firmware.firmwareHashInvalid;
-            }
-        },
         storageLoadDiscovery: (_, { payload }: StorageLoadAction) => payload.discovery,
         addButtonRequestFirmware: (
             state,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7683,11 +7683,6 @@ export default defineMessages({
         id: 'FAILED_TO_DISABLE_TOR',
         defaultMessage: 'Failed to disable Tor',
     },
-    TR_FIRMWARE_HASH_MISMATCH: {
-        id: 'TR_FIRMWARE_HASH_MISMATCH',
-        defaultMessage:
-            'Your Trezor is running unofficial firmware. Contact help@trezor.io immediately.',
-    },
     TR_TO_SATOSHIS: {
         id: 'TR_TO_SATOSHIS',
         defaultMessage: 'To sats',

--- a/packages/suite/src/support/suite/preloadStore.ts
+++ b/packages/suite/src/support/suite/preloadStore.ts
@@ -40,7 +40,6 @@ export const preloadStore = async () => {
     const backendSettings = await db.getItemsWithKeys('backendSettings');
     const sendFormDrafts = await db.getItemsWithKeys('sendFormDrafts');
     const formDrafts = await db.getItemsWithKeys('formDrafts');
-    const firmware = await db.getItemByPK('firmware', 'firmware');
     const coinjoinAccounts = await db.getItemsExtended('coinjoinAccounts');
     const coinjoinDebugSettings = await db.getItemByPK('coinjoinDebugSettings', 'debug');
     const tokenManagement = await db.getItemsWithKeys('tokenManagement');
@@ -64,7 +63,6 @@ export const preloadStore = async () => {
             metadata,
             messageSystem,
             backendSettings,
-            firmware,
             coinjoinAccounts,
             coinjoinDebugSettings,
             tokenManagement,

--- a/suite-common/firmware/src/firmwareReducer.ts
+++ b/suite-common/firmware/src/firmwareReducer.ts
@@ -1,6 +1,5 @@
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { FirmwareStatus, TrezorDevice } from '@suite-common/suite-types';
-import { isDeviceKnown } from '@suite-common/suite-utils';
 import { deviceActions } from '@suite-common/wallet-core';
 import {
     DEVICE,
@@ -18,11 +17,6 @@ type FirmwareUpdateCommon = {
     cachedDevice?: TrezorDevice;
     // Stores firmware type currently being installed so that it can be displayed to the user during installation
     targetType?: FirmwareType;
-    // Array of device ids where suite claims their firmware might have been "hacked". This information is available only after firmware update is finished
-    // and we need to store this information persistently so that it does not disappear after accidental device reconnection.
-    // todo: in the future we might implement additional check that will validate firmware after every connection
-    //  todo: !
-    firmwareHashInvalid: string[];
     useDevkit: boolean;
     uiEvent?: DeviceButtonRequest | FirmwareProgress | FirmwareReconnect;
 };
@@ -42,7 +36,6 @@ const initialState: FirmwareUpdateState = {
     error: undefined,
     cachedDevice: undefined,
     targetType: undefined,
-    firmwareHashInvalid: [],
     useDevkit: false,
     uiEvent: undefined,
 };
@@ -68,7 +61,6 @@ export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, (
         })
         .addCase(firmwareActions.resetReducer, state => ({
             ...initialState,
-            firmwareHashInvalid: state.firmwareHashInvalid,
             useDevkit: state.useDevkit,
         }))
         .addCase(firmwareActions.toggleUseDevkit, (state, { payload }) => {
@@ -78,22 +70,6 @@ export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, (
             state.cachedDevice = payload;
         })
         .addCase(deviceActions.addButtonRequest, extra.reducers.addButtonRequestFirmware)
-        .addCase(deviceActions.connectDevice, (state, { payload: { device } }) => {
-            if (!isDeviceKnown(device)) return;
-
-            // use the automatic hash check to clear device if it hasn't passed hash check done after firmware update
-            // otherwise it'd be stuck in "error" state until next firmware update
-            // in `storageMiddleware` this is persisted into storage (on the same action type)
-            if (device.authenticityChecks?.firmwareHash?.success) {
-                state.firmwareHashInvalid = state.firmwareHashInvalid.filter(
-                    deviceId => deviceId !== device.id,
-                );
-            }
-        })
-        .addMatcher(
-            action => action.type === extra.actionTypes.storageLoad,
-            extra.reducers.storageLoadFirmware,
-        )
         .addMatcher<FirmwareProgress | FirmwareReconnect | DeviceButtonRequest>(
             action =>
                 action.type === UI.FIRMWARE_RECONNECT ||

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -130,7 +130,6 @@ export type ExtraDependencies = {
         storageLoadAccounts: StorageLoadReducer;
         storageLoadTransactions: StorageLoadTransactionsReducer;
         storageLoadHistoricRates: StorageLoadReducer;
-        storageLoadFirmware: StorageLoadReducer;
         storageLoadDiscovery: StorageLoadReducer;
         addButtonRequestFirmware: AddButtonRequestReducer;
         setDeviceMetadataReducer: BaseReducer;

--- a/suite-common/test-utils/src/extraDependenciesMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesMock.ts
@@ -130,7 +130,6 @@ export const extraDependenciesMock: ExtraDependencies = {
         storageLoadAccounts: mockReducer('storageLoadAccounts'),
         storageLoadTransactions: mockReducer('storageLoadTransactions'),
         storageLoadHistoricRates: mockReducer('storageLoadHistoricRates'),
-        storageLoadFirmware: mockReducer('storageLoadFirmware'),
         storageLoadDiscovery: mockReducer('storageLoadDiscovery'),
         addButtonRequestFirmware: mockReducer('addButtonRequestFirmware'),
         setDeviceMetadataReducer: mockReducer('setDeviceMetadataReducer'),


### PR DESCRIPTION
## Description

In https://github.com/trezor/trezor-suite/pull/16949, the FW hash check has been removed from FW upgrade flow, in favor of a combination of version check & FW hash check that happens on each device connection.

Remove dead code:
- banner (reads `firmwareHashInvalid`)
- redux `firmwareHashInvalid` (there is no longer any way to add or remove there)
- persisted `firmware.firmwareHashInvalid`
  - ~create migration there is nothing more on `firmware` persisted, so the migration shall delete entire `firmware`~
  - EDIT: we shall not read/save `firmware.firmwareHashInvalid` to/from storage, but migration shall not be done, as it has no benefits 

## Related Issue

Resolve #17480

@coderabbitai ignore