### PR TITLE
Sentry reporting for FW revision check other-error

### DIFF
--- a/packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts
+++ b/packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts
@@ -109,7 +109,7 @@ describe.each(DeviceNames)(`${checkFirmwareRevision.name} for device %s`, intern
             params: createDeviceParams({
                 expectedRevision: undefined, // firmware not known by local releases.json file
             }),
-            expected: { success: false, error: 'other-error' },
+            expected: { success: false, error: 'other-error', errorPayload: expect.anything() },
         },
     ])(`$it`, async ({ params, expected, httpRequestMock }) => {
         if (httpRequestMock !== undefined) {

--- a/packages/connect/src/device/checkFirmwareRevision.ts
+++ b/packages/connect/src/device/checkFirmwareRevision.ts
@@ -1,4 +1,4 @@
-import { isEqual } from '@trezor/utils/src/versionUtils';
+import { serializeError, versionUtils } from '@trezor/utils';
 
 import { PROTO } from '../constants';
 import { downloadReleasesMetadata } from '../data/downloadReleasesMetadata';
@@ -37,12 +37,19 @@ const getOnlineReleaseMetadata = async ({
 }: GetOnlineReleaseMetadataParams): Promise<FirmwareRelease | undefined> => {
     const onlineReleases = await downloadReleasesMetadata({ internal_model: internalModel });
 
-    return onlineReleases.find(onlineRelease => isEqual(onlineRelease.version, firmwareVersion));
+    return onlineReleases.find(onlineRelease =>
+        versionUtils.isEqual(onlineRelease.version, firmwareVersion),
+    );
 };
 
 const failFirmwareRevisionCheck = (
     error: FirmwareRevisionCheckError,
-): Extract<FirmwareRevisionCheckResult, { success: false }> => ({ success: false, error });
+    errorPayload?: unknown,
+): Extract<FirmwareRevisionCheckResult, { success: false }> => ({
+    success: false,
+    error,
+    ...(errorPayload ? { errorPayload } : null),
+});
 
 export type CheckFirmwareRevisionParams = {
     firmwareVersion: VersionArray;
@@ -113,7 +120,7 @@ export const checkFirmwareRevision = async ({
 
             return isOfflineError(e)
                 ? failFirmwareRevisionCheck('cannot-perform-check-offline')
-                : failFirmwareRevisionCheck('other-error');
+                : failFirmwareRevisionCheck('other-error', serializeError(e));
         }
     }
 

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -52,6 +52,7 @@ export type FirmwareRevisionCheckResult =
     | {
           success: false;
           error: FirmwareRevisionCheckError;
+          errorPayload?: unknown;
       };
 
 export type FirmwareHashCheckError =

--- a/packages/suite/src/components/suite/SecurityCheck/useReportDeviceCompromised.ts
+++ b/packages/suite/src/components/suite/SecurityCheck/useReportDeviceCompromised.ts
@@ -6,8 +6,7 @@ import { getFirmwareVersion } from '@trezor/device-utils';
 import { isArrayMember } from '@trezor/utils';
 
 import { hashCheckErrorScenarios, revisionCheckErrorScenarios } from 'src/constants/suite/firmware';
-import { useDevice, useSelector } from 'src/hooks/suite';
-import { selectFirmwareRevisionCheckError } from 'src/reducers/suite/suiteReducer';
+import { useDevice } from 'src/hooks/suite';
 import { captureSentryMessage, withSentryScope } from 'src/utils/suite/sentry';
 
 export const reportCheckFail = (
@@ -57,20 +56,25 @@ const useCommonData = () => {
 
 const useReportRevisionCheck = () => {
     const commonData = useCommonData();
-    const errorType = useSelector(selectFirmwareRevisionCheckError);
+    const { device } = useDevice();
+
+    const revCheck = isDeviceAcquired(device) ? device.authenticityChecks?.firmwareRevision : null;
+    const isError = revCheck && !revCheck.success;
+    const errorType = isError ? revCheck.error : null;
+    const errorPayload = isError ? revCheck.errorPayload : null;
 
     useEffect(() => {
-        if (errorType !== null && revisionCheckErrorScenarios[errorType].shouldReport) {
-            reportCheckFail('Firmware revision', { ...commonData, errorType });
+        if (!errorType) return;
+        if (revisionCheckErrorScenarios[errorType].shouldReport) {
+            reportCheckFail('Firmware revision', { ...commonData, errorType }, errorPayload);
         }
-    }, [commonData, errorType]);
+    }, [commonData, errorType, errorPayload]);
 };
 
 const useReportHashCheck = () => {
     const { device } = useDevice();
     const commonData = useCommonData();
 
-    // `errorPayload` must also be extracted, which is why `selectFirmwareHashCheckError` would be impractical
     const hashCheck = isDeviceAcquired(device) ? device.authenticityChecks?.firmwareHash : null;
     const isError = hashCheck && !hashCheck.success;
     const errorType = isError ? hashCheck.error : null;

--- a/suite-native/device/src/hooks/useReportDeviceCompromised.ts
+++ b/suite-native/device/src/hooks/useReportDeviceCompromised.ts
@@ -3,14 +3,24 @@ import { useSelector } from 'react-redux';
 
 import * as Sentry from '@sentry/react-native';
 
+import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { getFirmwareVersion } from '@trezor/device-utils';
 
 import { revisionCheckErrorScenarios } from '../config/firmware';
-import { selectFirmwareRevisionCheckError } from '../selectors';
 
-const reportCheckFail = (checkType: 'Firmware revision', contextData: any) => {
-    Sentry.captureException(`${checkType} check failed! ${JSON.stringify(contextData)}`);
+const reportCheckFail = (
+    checkType: 'Firmware revision',
+    contextData: any,
+    errorPayload?: unknown,
+) => {
+    const payloadLabel = `${checkType} check failed!`;
+    Sentry.withScope(scope => {
+        scope.setExtra('errorPayload', errorPayload);
+        const exceptionForSentry = new Error(`${payloadLabel} ${JSON.stringify(contextData)}`);
+        exceptionForSentry.name = 'reportCheckFail'; // Custom issue title
+        Sentry.captureException(exceptionForSentry, scope);
+    });
 };
 
 const useCommonData = () => {
@@ -28,15 +38,17 @@ const useCommonData = () => {
 
 export const useReportDeviceCompromised = () => {
     const commonData = useCommonData();
+    const device = useSelector(selectSelectedDevice);
 
-    const revisionCheckError = useSelector(selectFirmwareRevisionCheckError);
+    const revCheck = isDeviceAcquired(device) ? device.authenticityChecks?.firmwareRevision : null;
+    const isError = revCheck && !revCheck.success;
+    const errorType = isError ? revCheck.error : null;
+    const errorPayload = isError ? revCheck.errorPayload : null;
 
     useEffect(() => {
-        if (
-            revisionCheckError !== null &&
-            revisionCheckErrorScenarios[revisionCheckError].shouldReport
-        ) {
-            reportCheckFail('Firmware revision', { ...commonData, revisionCheckError });
+        if (!errorType) return;
+        if (revisionCheckErrorScenarios[errorType].shouldReport) {
+            reportCheckFail('Firmware revision', { ...commonData, errorType }, errorPayload);
         }
-    }, [commonData, revisionCheckError]);
+    }, [commonData, errorType, errorPayload]);
 };


### PR DESCRIPTION
## Description

Commits for review:
- Connect: ship `errorPayload` with FW revision check `other-error`, just like FW hash check `other-error`
- Report it in Suite Desktop/Web + cleanup code to be more consistent 
- Report it in Suite Lite + cleanup code to be more consistent

:monocle_face:  Example events from localhost – see that there is an errorPayload: the exception incl. stack trace:
- [Suite Web](https://satoshilabs.sentry.io/issues/6368992271/?project=5193825)
- [Suite Lite](https://satoshilabs.sentry.io/issues/6369070050/?project=4504214699245568)

## Related Issue

Resolve #17484