### PR TITLE
fix(suite-native): icons size polishing

### DIFF
--- a/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
@@ -3,14 +3,14 @@ import { useSelector } from 'react-redux';
 
 import { AccountsRootState, selectFormattedAccountType } from '@suite-common/wallet-core';
 import { Account, AccountKey } from '@suite-common/wallet-types';
-import { Badge, RoundedIcon } from '@suite-native/atoms';
+import { Badge } from '@suite-native/atoms';
 import {
     CryptoAmountFormatter,
     CryptoToFiatAmountFormatter,
     FiatAmountFormatter,
     NetworkDisplaySymbolNameFormatter,
 } from '@suite-native/formatters';
-import { CryptoIconWithNetwork } from '@suite-native/icons';
+import { CryptoIcon, CryptoIconWithNetwork } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { NativeStakingRootState, selectAccountHasStaking } from '@suite-native/staking';
 import {
@@ -90,7 +90,7 @@ export const AccountsListItem = ({
             isNativeCoinOnly ? (
                 <CryptoIconWithNetwork symbol={account.symbol} />
             ) : (
-                <RoundedIcon symbol={account.symbol} />
+                <CryptoIcon symbol={account.symbol} />
             ),
         [account.symbol, isNativeCoinOnly],
     );

--- a/suite-native/icons/src/CryptoIcon.tsx
+++ b/suite-native/icons/src/CryptoIcon.tsx
@@ -20,6 +20,7 @@ export interface CryptoIconProps {
 }
 
 export const cryptoIconSizes = {
+    tiny: 16,
     extraSmall: 24,
     small: 32,
     large: 48,

--- a/suite-native/icons/src/CryptoIconWithPercentage.tsx
+++ b/suite-native/icons/src/CryptoIconWithPercentage.tsx
@@ -19,7 +19,7 @@ import { useNativeStyles } from '@trezor/styles';
 import { PizzaIcon, usePizzaAnimation } from './PizzaIcon';
 
 const CANVAS_SIZE = 48;
-const ICON_SIZE = 24;
+const ICON_SIZE = 32;
 const RADIUS = 20;
 
 type CryptoIconProps = {
@@ -92,7 +92,7 @@ export const CryptoIconWithPercentage = ({
                                 cy={CANVAS_SIZE / 2}
                                 r={RADIUS}
                                 style="stroke"
-                                strokeWidth={8}
+                                strokeWidth={4}
                                 color={utils.colors.backgroundSurfaceElevation2}
                             />
                             <Path
@@ -100,7 +100,7 @@ export const CryptoIconWithPercentage = ({
                                 start={0}
                                 end={percentageFill}
                                 style="stroke"
-                                strokeWidth={8}
+                                strokeWidth={4}
                                 color={percentageColor}
                                 opacity={0.3}
                             />
@@ -108,8 +108,8 @@ export const CryptoIconWithPercentage = ({
                         {iconSvg && (
                             <ImageSVG
                                 svg={iconSvg}
-                                x={ICON_SIZE / 2}
-                                y={ICON_SIZE / 2}
+                                x={(CANVAS_SIZE - ICON_SIZE) / 2}
+                                y={(CANVAS_SIZE - ICON_SIZE) / 2}
                                 width={ICON_SIZE}
                                 height={ICON_SIZE}
                             />

--- a/suite-native/icons/src/NetworkIcon.tsx
+++ b/suite-native/icons/src/NetworkIcon.tsx
@@ -14,6 +14,7 @@ export interface NetworkIconProps {
 }
 
 export const networkIconSizes = {
+    tiny: 6,
     extraSmall: 9,
     small: 12,
     large: 18,

--- a/suite-native/transactions/src/components/TransactionsList/TransactionIcon.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionIcon.tsx
@@ -76,11 +76,7 @@ export const TransactionIcon = ({
             )}
             {iconSymbol && (
                 <Box style={applyStyle(cryptoIconStyle)}>
-                    <CryptoIcon
-                        symbol={iconSymbol}
-                        contractAddress={contractAddress}
-                        size="extraSmall"
-                    />
+                    <CryptoIcon symbol={iconSymbol} contractAddress={contractAddress} size="tiny" />
                 </Box>
             )}
         </Box>


### PR DESCRIPTION
Crypto icons in transaction list were too big and there was crypto icon size discrepancy between home and assets screen.

This PR resolves both issues


https://github.com/user-attachments/assets/ebffcc1e-d019-478b-b98d-f7f1f8bb9063



