### PR TITLE
feat(connect-web): enable coreMode auto by default

### DIFF
--- a/packages/connect-web/src/impl/core-in-iframe.ts
+++ b/packages/connect-web/src/impl/core-in-iframe.ts
@@ -170,6 +170,9 @@ export class CoreInIframe implements ConnectFactoryDependencies<ConnectSettingsW
         if (!this._settings.transports?.length) {
             this._settings.transports = ['BridgeTransport', 'WebUsbTransport'];
         }
+        if (!this._settings.coreMode) {
+            this._settings.coreMode = 'auto';
+        }
 
         if (this._settings.lazyLoad) {
             // reset "lazyLoad" after first use


### PR DESCRIPTION
## Description

We've had `coreMode: 'auto'` available for a while, but it was not selected as a default option. 
This will enable websites to use WebUSB automatically. 