### PR TITLE
fix(connect-common): revert t3b1 min_bootloader_version bump

### DIFF
--- a/packages/connect-common/files/firmware/t3b1/releases.json
+++ b/packages/connect-common/files/firmware/t3b1/releases.json
@@ -2,7 +2,7 @@
     {
         "required": false,
         "version": [2, 8, 9],
-        "min_bootloader_version": [2, 1, 8],
+        "min_bootloader_version": [2, 1, 7],
         "min_firmware_version": [2, 8, 3],
         "bootloader_version": [2, 1, 8],
         "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR"],


### PR DESCRIPTION
This pull request includes a small change to the `packages/connect-common/files/firmware/t3b1/releases.json` file. The change updates the minimum bootloader version required for a specific firmware release.

* [`packages/connect-common/files/firmware/t3b1/releases.json`](diffhunk://#diff-3312cb44e042b546858d4ec667471d05e3c36eaed12b5d0ac21b2be51a846a9bL5-R5): Changed the `min_bootloader_version` from `[2, 1, 8]` to `[2, 1, 7]`.