### PR TITLE
E2E: Check receive addr on emulator

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/devicePrompt.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/devicePrompt.ts
@@ -89,7 +89,7 @@ export class DevicePrompt {
 
     // Serves to quickly get the text from the device display and end the test
     @step()
-    async debugJSONFromDisplay() {
+    async debugThrowJSONFromDisplay() {
         const debugState = await TrezorUserEnvLinkProxy.getDebugState();
         const json = JSON.parse(debugState.tokens.join(''));
         throw new Error(`Debug JSON: ${JSON.stringify(json, null, 2)}`);
@@ -99,8 +99,13 @@ export class DevicePrompt {
     async getDisplayContent() {
         const debugState = await TrezorUserEnvLinkProxy.getDebugState();
         const json = JSON.parse(debugState.tokens.join(''));
+        if (!json || !json.header || !json.content || !json.footer) {
+            throw new Error(
+                `Display content invalid, should contain header, content, footer: ${JSON.stringify(json)}`,
+            );
+        }
         // The structure of the JSON differs between situations.
-        // We will have to add more logic as start validate more situations
+        // We will have to add more logic as we start validate more situations.
         const header = {
             title: json.header.title.text,
             ...(json.header.subtitle && { subtitle: json.header.subtitle.text }),

--- a/packages/suite-desktop-core/e2e/support/pageObjects/devicePrompt.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/devicePrompt.ts
@@ -111,9 +111,9 @@ export class DevicePrompt {
             ...(json.header.subtitle && { subtitle: json.header.subtitle.text }),
         };
 
-        if (json.content.content.paragraphs.length !== 1) {
+        if (json.content.content.paragraphs.length < 1) {
             throw new Error(
-                `Expected only one paragraph in display JSON, JSON: ${JSON.stringify(json.content.content.paragraphs)}`,
+                `Expected at least one paragraph in display JSON, JSON: ${JSON.stringify(json.content.content.paragraphs)}`,
             );
         }
         const body = json.content.content.paragraphs;

--- a/packages/suite-desktop-core/e2e/support/pageObjects/devicePrompt.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/devicePrompt.ts
@@ -86,4 +86,34 @@ export class DevicePrompt {
 
         return textsArray.map(removeWhitespaces).join('');
     }
+
+    // Serves to quickly get the text from the device display and end the test
+    @step()
+    async debugJSONFromDisplay() {
+        const debugState = await TrezorUserEnvLinkProxy.getDebugState();
+        const json = JSON.parse(debugState.tokens.join(''));
+        throw new Error(`Debug JSON: ${JSON.stringify(json, null, 2)}`);
+    }
+
+    @step()
+    async getDisplayContent() {
+        const debugState = await TrezorUserEnvLinkProxy.getDebugState();
+        const json = JSON.parse(debugState.tokens.join(''));
+        // The structure of the JSON differs between situations.
+        // We will have to add more logic as start validate more situations
+        const header = {
+            title: json.header.title.text,
+            ...(json.header.subtitle && { subtitle: json.header.subtitle.text }),
+        };
+
+        if (json.content.content.paragraphs.length !== 1) {
+            throw new Error(
+                `Expected only one paragraph in display JSON, JSON: ${JSON.stringify(json.content.content.paragraphs)}`,
+            );
+        }
+        const body = json.content.content.paragraphs;
+        const footer = json.footer.instruction;
+
+        return { header, body, footer };
+    }
 }

--- a/packages/suite-desktop-core/e2e/support/pageObjects/tradingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/tradingPage.ts
@@ -366,10 +366,11 @@ export class TradingPage {
         await this.termsConfirmButton.click();
         await this.confirmOnTrezorButton.click();
         await expect(this.devicePrompt.headerParagraph).toHaveText(accountName);
+        await this.devicePrompt.confirmOnDevicePromptIsShown();
         if (addressToCheck) {
             await expect(this.devicePrompt.outputValueOf('address')).toHaveText(addressToCheck);
+            await expect(this.devicePrompt).toDisplayReceiveAddress(addressToCheck);
         }
-        await this.devicePrompt.confirmOnDevicePromptIsShown();
         await TrezorUserEnvLinkProxy.pressYes();
         await this.devicePrompt.confirmOnDevicePromptIsHidden();
         await expect(this.confirmOnTrezorButton).toHaveText('Confirmed on Trezor');

--- a/packages/suite-desktop-core/e2e/support/pageObjects/tradingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/tradingPage.ts
@@ -5,7 +5,7 @@ import { regional } from '@suite-common/trading';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { invityEndpoint } from '../../fixtures/invity';
-import { TrezorUserEnvLinkProxy, step } from '../common';
+import { TrezorUserEnvLinkProxy, formatAddress, step } from '../common';
 import { DevicePrompt } from './devicePrompt';
 import { solanaUrlPattern } from '../mocks/tradingMock';
 import { expect } from '../testExtends/customMatchers';
@@ -368,7 +368,9 @@ export class TradingPage {
         await expect(this.devicePrompt.headerParagraph).toHaveText(accountName);
         await this.devicePrompt.confirmOnDevicePromptIsShown();
         if (addressToCheck) {
-            await expect(this.devicePrompt.outputValueOf('address')).toHaveText(addressToCheck);
+            await expect(this.devicePrompt.outputValueOf('address')).toHaveText(
+                formatAddress(addressToCheck),
+            );
             await expect(this.devicePrompt).toDisplayReceiveAddress(addressToCheck);
         }
         await TrezorUserEnvLinkProxy.pressYes();

--- a/packages/suite-desktop-core/e2e/support/testExtends/customMatchers.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/customMatchers.ts
@@ -1,7 +1,9 @@
 import { Locator, Request, expect as baseExpect } from '@playwright/test';
 import { diff } from 'jest-diff';
+import { isEqual } from 'lodash';
 
 import { isEqualWithOmit } from '../common';
+import { DevicePrompt } from '../pageObjects/devicePrompt';
 
 const compareTextAndNumber = async (
     locator: Locator,
@@ -23,6 +25,27 @@ const compareTextAndNumber = async (
     };
 };
 
+const compareDisplayContent = async (
+    devicePrompt: DevicePrompt,
+    expectedContent: any,
+    errorMessage: string,
+) => {
+    const content = await devicePrompt.getDisplayContent();
+
+    return {
+        pass: isEqual(expectedContent, content),
+        message: () => `${errorMessage}. Diff:\n${diff(expectedContent, content)}`,
+    };
+};
+
+const transformAddressToArrayWithNewlines = (address: string) => {
+    // Address is split to lines of 4 parts on Display so it can fit.
+    // We want to evaluate existence of newlines in the address.
+    const fourPartsOfAddress = /(\S+\s\S+\s\S+\s\S+)/g;
+
+    return address.replace(fourPartsOfAddress, '$1 \n').trim().split(' ');
+};
+
 export const expect = baseExpect.extend({
     async toBeEnabledCoin(locator: Locator) {
         const isActive = await locator.getAttribute('data-active');
@@ -35,6 +58,7 @@ export const expect = baseExpect.extend({
                     : `expected ${locator} to have attribute 'data-active' set to 'true', but got '${isActive}'`,
         };
     },
+
     async toBeDisabledCoin(locator: Locator) {
         const isActive = await locator.getAttribute('data-active');
 
@@ -46,12 +70,15 @@ export const expect = baseExpect.extend({
                     : `expected ${locator} to have attribute 'data-active' set to 'false', but got '${isActive}'`,
         };
     },
+
     async toHaveTextGreaterThan(locator: Locator, expectedValue: number) {
         return await compareTextAndNumber(locator, expectedValue, (a, b) => a > b, 'greater');
     },
+
     async toHaveTextLessThan(locator: Locator, expectedValue: number) {
         return await compareTextAndNumber(locator, expectedValue, (a, b) => a < b, 'less');
     },
+
     async toHavePayload(
         requestPromise: Promise<Request>,
         expectedPayload: any,
@@ -72,5 +99,49 @@ export const expect = baseExpect.extend({
                 \nExpected: ${JSON.stringify(expectedPayload)}
                 \nActual: ${JSON.stringify(requestPayload)}`,
         };
+    },
+
+    async toDisplayReceiveAddress(devicePrompt: DevicePrompt, expectedAddress: string) {
+        const expectedAddressWithNewlines = transformAddressToArrayWithNewlines(expectedAddress);
+        const expectedContent = {
+            header: { title: 'Receive address' },
+            body: [expectedAddressWithNewlines],
+            footer: 'Swipe up',
+        };
+
+        return await compareDisplayContent(
+            devicePrompt,
+            expectedContent,
+            'expect Receive address to match',
+        );
+    },
+
+    async toDisplayRecipientAddress(devicePrompt: DevicePrompt, expectedAddress: string) {
+        const expectedAddressWithNewlines = transformAddressToArrayWithNewlines(expectedAddress);
+        const expectedContent = {
+            header: { title: 'Address', subtitle: 'Recipient #1' },
+            body: [expectedAddressWithNewlines],
+            footer: 'Swipe up',
+        };
+
+        return await compareDisplayContent(
+            devicePrompt,
+            expectedContent,
+            'expect Recipient address to match',
+        );
+    },
+
+    async toDisplaySummary(devicePrompt: DevicePrompt, totalAmount: string, feeAmount: string) {
+        const expectedContent = {
+            header: { title: 'Summary' },
+            body: [['Total amount'], [totalAmount], [' '], ['incl. Transaction fee'], [feeAmount]],
+            footer: 'Swipe up',
+        };
+
+        return await compareDisplayContent(
+            devicePrompt,
+            expectedContent,
+            'expect Summary to match',
+        );
     },
 });

--- a/packages/suite-desktop-core/e2e/support/testExtends/customMatchers.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/customMatchers.ts
@@ -2,8 +2,10 @@ import { Locator, Request, expect as baseExpect } from '@playwright/test';
 import { diff } from 'jest-diff';
 import { isEqual } from 'lodash';
 
-import { isEqualWithOmit } from '../common';
+import { formatAddress, isEqualWithOmit } from '../common';
 import { DevicePrompt } from '../pageObjects/devicePrompt';
+
+type TransformMods = 'fourTetragrams' | 'fullLine';
 
 const compareTextAndNumber = async (
     locator: Locator,
@@ -38,12 +40,33 @@ const compareDisplayContent = async (
     };
 };
 
-const transformAddressToArrayWithNewlines = (address: string) => {
-    // Address is split to lines of 4 parts on Display so it can fit.
-    // We want to evaluate existence of newlines in the address.
-    const fourPartsOfAddress = /(\S+\s\S+\s\S+\s\S+)/g;
+const addNewlinesToAddress = (address: string, regex: RegExp, newLineFormat: string) =>
+    address
+        .replace(regex, match => `${match}${newLineFormat}`)
+        .trim()
+        .split(' ');
 
-    return address.replace(fourPartsOfAddress, '$1 \n').trim().split(' ');
+const transformAddress = (address: string, mode: TransformMods = 'fourTetragrams') => {
+    // Address is split to lines on Display so it can fit. There are different formats:
+    // 1. Four tetragrams of address:
+    // bc1q pyfv fvm5 2zx7
+    // gek8 6ajj 5pkk ne3h
+    // 385a da8r 2y
+    // 1. Full lines (18 chars) of address:
+    // bc1qpyfvfvm52zx7ge
+    // k86ajj5pkkne3h385a
+    // da8r2y
+    // We want to evaluate format and existence of newlines in the address.
+    const fourTetragramsOfAddress = /(\S+\s\S+\s\S+\s\S+)/g; //4 x 4 characters
+    const fullLineOfAddress = /.{18}/g; //18 characters
+
+    if (mode === 'fourTetragrams') {
+        return addNewlinesToAddress(formatAddress(address), fourTetragramsOfAddress, ' \n');
+    }
+
+    if (mode === 'fullLine') {
+        return addNewlinesToAddress(address, fullLineOfAddress, ' \n ');
+    }
 };
 
 export const expect = baseExpect.extend({
@@ -101,11 +124,15 @@ export const expect = baseExpect.extend({
         };
     },
 
-    async toDisplayReceiveAddress(devicePrompt: DevicePrompt, expectedAddress: string) {
-        const expectedAddressWithNewlines = transformAddressToArrayWithNewlines(expectedAddress);
+    async toDisplayReceiveAddress(
+        devicePrompt: DevicePrompt,
+        expectedAddress: string,
+        transformMode: TransformMods = 'fourTetragrams',
+    ) {
+        const transformedExpectedAddress = transformAddress(expectedAddress, transformMode);
         const expectedContent = {
             header: { title: 'Receive address' },
-            body: [expectedAddressWithNewlines],
+            body: [transformedExpectedAddress],
             footer: 'Swipe up',
         };
 
@@ -117,10 +144,10 @@ export const expect = baseExpect.extend({
     },
 
     async toDisplayRecipientAddress(devicePrompt: DevicePrompt, expectedAddress: string) {
-        const expectedAddressWithNewlines = transformAddressToArrayWithNewlines(expectedAddress);
+        const transformedExpectedAddress = transformAddress(expectedAddress);
         const expectedContent = {
             header: { title: 'Address', subtitle: 'Recipient #1' },
-            body: [expectedAddressWithNewlines],
+            body: [transformedExpectedAddress],
             footer: 'Swipe up',
         };
 

--- a/packages/suite-desktop-core/e2e/support/testExtends/customMatchers.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/customMatchers.ts
@@ -5,7 +5,7 @@ import { isEqual } from 'lodash';
 import { formatAddress, isEqualWithOmit } from '../common';
 import { DevicePrompt } from '../pageObjects/devicePrompt';
 
-type TransformMods = 'fourTetragrams' | 'fullLine';
+type LineFormats = 'fourTetragrams' | 'fullLine';
 
 const compareTextAndNumber = async (
     locator: Locator,
@@ -46,7 +46,7 @@ const addNewlinesToAddress = (address: string, regex: RegExp, newLineFormat: str
         .trim()
         .split(' ');
 
-const transformAddress = (address: string, mode: TransformMods = 'fourTetragrams') => {
+const transformAddress = (address: string, lineFormat: LineFormats = 'fourTetragrams') => {
     // Address is split to lines on Display so it can fit. There are different formats:
     // 1. Four tetragrams of address:
     // bc1q pyfv fvm5 2zx7
@@ -60,11 +60,11 @@ const transformAddress = (address: string, mode: TransformMods = 'fourTetragrams
     const fourTetragramsOfAddress = /(\S+\s\S+\s\S+\s\S+)/g; //4 x 4 characters
     const fullLineOfAddress = /.{18}/g; //18 characters
 
-    if (mode === 'fourTetragrams') {
+    if (lineFormat === 'fourTetragrams') {
         return addNewlinesToAddress(formatAddress(address), fourTetragramsOfAddress, ' \n');
     }
 
-    if (mode === 'fullLine') {
+    if (lineFormat === 'fullLine') {
         return addNewlinesToAddress(address, fullLineOfAddress, ' \n ');
     }
 };
@@ -127,14 +127,26 @@ export const expect = baseExpect.extend({
     async toDisplayReceiveAddress(
         devicePrompt: DevicePrompt,
         expectedAddress: string,
-        transformMode: TransformMods = 'fourTetragrams',
+        options: { lineFormat: LineFormats; specialAccountType?: string } = {
+            lineFormat: 'fourTetragrams',
+        },
     ) {
-        const transformedExpectedAddress = transformAddress(expectedAddress, transformMode);
-        const expectedContent = {
-            header: { title: 'Receive address' },
-            body: [transformedExpectedAddress],
-            footer: 'Swipe up',
-        };
+        const transformedExpectedAddress = transformAddress(expectedAddress, options.lineFormat);
+
+        let expectedContent;
+        if (options.specialAccountType) {
+            expectedContent = {
+                header: { title: 'Receive address' },
+                body: [[options.specialAccountType], transformedExpectedAddress],
+                footer: 'Tap to continue',
+            };
+        } else {
+            expectedContent = {
+                header: { title: 'Receive address' },
+                body: [transformedExpectedAddress],
+                footer: 'Swipe up',
+            };
+        }
 
         return await compareDisplayContent(
             devicePrompt,

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-cardano.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-cardano.test.ts
@@ -1,9 +1,8 @@
-import { splitStringEveryNCharacters } from '@trezor/utils';
-
+import { formatAddress } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 const correctPassphraseAddr =
-    'addr1qx3ufjpwcx30ee73a7r29surauze6yt0jvr7c3rnahw0hnppg7qp5xvslcfucsqqayrtjhm4u66x';
+    'addr1qx3ufjpwcx30ee73a7r29surauze6yt0jvr7c3rnahw0hnppg7qp5xvslcfucsqqayrtjhm4u66xsw987ae6ugydlzzsqdsfz4';
 const passphrase = 'secret passphrase A';
 
 test.describe('Passphrase with cardano', { tag: ['@group=passphrase'] }, () => {
@@ -57,10 +56,13 @@ test.describe('Passphrase with cardano', { tag: ['@group=passphrase'] }, () => {
         await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
         await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
 
-        await expect(page.getByTestId('@modal/output-value')).toContainText(
-            splitStringEveryNCharacters(correctPassphraseAddr, 4).join(' '),
+        await expect(page.getByTestId('@modal/output-value')).toHaveText(
+            formatAddress(correctPassphraseAddr),
         );
-        await devicePrompt.waitForPromptAndConfirm(); // Confirm receive address
+
+        await devicePrompt.confirmOnDevicePromptIsShown();
+        await expect(devicePrompt).toDisplayReceiveAddress(correctPassphraseAddr, 'fullLine');
+        await trezorUserEnvLink.pressYes(); // Confirm receive address
 
         await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
         await page.getByTestId('@modal/close-button').click();

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-cardano.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-cardano.test.ts
@@ -61,7 +61,9 @@ test.describe('Passphrase with cardano', { tag: ['@group=passphrase'] }, () => {
         );
 
         await devicePrompt.confirmOnDevicePromptIsShown();
-        await expect(devicePrompt).toDisplayReceiveAddress(correctPassphraseAddr, 'fullLine');
+        await expect(devicePrompt).toDisplayReceiveAddress(correctPassphraseAddr, {
+            lineFormat: 'fullLine',
+        });
         await trezorUserEnvLink.pressYes(); // Confirm receive address
 
         await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-reconnection.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-reconnection.test.ts
@@ -1,5 +1,4 @@
-import { splitStringEveryNCharacters } from '@trezor/utils';
-
+import { formatAddress } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 const abcAddr = 'bc1qpyfvfvm52zx7gek86ajj5pkkne3h385ada8r2y';
@@ -39,9 +38,9 @@ test.describe('Passphrase reconnection', { tag: ['@group=passphrase'] }, () => {
             .click();
         await walletPage.receiveButton.click();
         await walletPage.revealAddressButton.click();
-        await expect(page.getByTestId('@modal/output-value')).toContainText(
-            splitStringEveryNCharacters(abcAddr, 4).join(' '),
-        );
+        await expect(page.getByTestId('@modal/output-value')).toHaveText(formatAddress(abcAddr));
+        await devicePrompt.confirmOnDevicePromptIsShown();
+        await expect(devicePrompt).toDisplayReceiveAddress(abcAddr);
         await trezorUserEnvLink.pressYes(); // confirm address
 
         await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
@@ -68,9 +67,9 @@ test.describe('Passphrase reconnection', { tag: ['@group=passphrase'] }, () => {
         await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
 
         // check address
-        await expect(page.getByTestId('@modal/output-value')).toContainText(
-            splitStringEveryNCharacters(abcAddr, 4).join(' '),
-        );
+        await expect(page.getByTestId('@modal/output-value')).toHaveText(formatAddress(abcAddr));
+        await devicePrompt.confirmOnDevicePromptIsShown();
+        await expect(devicePrompt).toDisplayReceiveAddress(abcAddr);
         await trezorUserEnvLink.pressYes(); // confirm address
 
         await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase.test.ts
@@ -1,6 +1,6 @@
 import { EventType } from '@trezor/suite-analytics';
-import { splitStringEveryNCharacters } from '@trezor/utils';
 
+import { formatAddress } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 import { ExtractByEventType } from '../../support/types';
 
@@ -23,6 +23,7 @@ test.describe('Passphrase', { tag: ['@group=passphrase'] }, () => {
     test('basic flow', async ({
         page,
         analytics,
+        devicePrompt,
         dashboardPage,
         walletPage,
         trezorUserEnvLink,
@@ -42,9 +43,9 @@ test.describe('Passphrase', { tag: ['@group=passphrase'] }, () => {
             .click();
         await walletPage.receiveButton.click();
         await walletPage.revealAddressButton.click();
-        await expect(page.getByTestId('@modal/output-value')).toContainText(
-            splitStringEveryNCharacters(abcAddr, 4).join(' '),
-        );
+        await expect(page.getByTestId('@modal/output-value')).toHaveText(formatAddress(abcAddr));
+        await devicePrompt.confirmOnDevicePromptIsShown();
+        await expect(devicePrompt).toDisplayReceiveAddress(abcAddr);
         await trezorUserEnvLink.pressYes(); // confirm address
 
         await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
@@ -69,9 +70,9 @@ test.describe('Passphrase', { tag: ['@group=passphrase'] }, () => {
         await expect(walletPage.revealAddressButton).not.toBeDisabled();
 
         await walletPage.revealAddressButton.click();
-        await expect(page.getByTestId('@modal/output-value')).toContainText(
-            splitStringEveryNCharacters(defAddr, 4).join(' '),
-        );
+        await expect(page.getByTestId('@modal/output-value')).toHaveText(formatAddress(defAddr));
+        await devicePrompt.confirmOnDevicePromptIsShown();
+        await expect(devicePrompt).toDisplayReceiveAddress(defAddr);
         await trezorUserEnvLink.pressYes(); // confirm address
 
         await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
@@ -89,9 +90,9 @@ test.describe('Passphrase', { tag: ['@group=passphrase'] }, () => {
         await expect(walletPage.revealAddressButton).not.toBeDisabled();
 
         await walletPage.revealAddressButton.click();
-        await expect(page.getByTestId('@modal/output-value')).toContainText(
-            splitStringEveryNCharacters(abcAddr, 4).join(' '),
-        );
+        await expect(page.getByTestId('@modal/output-value')).toHaveText(formatAddress(abcAddr));
+        await devicePrompt.confirmOnDevicePromptIsShown();
+        await expect(devicePrompt).toDisplayReceiveAddress(abcAddr);
         await trezorUserEnvLink.pressYes(); // confirm address
 
         await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-bitcoin.test.ts
@@ -8,7 +8,6 @@ import {
     invityEndpoint,
     invityRequest,
 } from '../../fixtures/invity';
-import { formatAddress } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 // Expected values based on our mocked responses
@@ -66,7 +65,7 @@ test.describe('Trading - Buy BTC', { tag: ['@group=other', '@webOnly'] }, () => 
         });
 
         await test.step('Confirm trade and verifies confirmation summary', async () => {
-            await tradingPage.confirmTrade('Bitcoin #1', formatAddress(receiveAddress));
+            await tradingPage.confirmTrade('Bitcoin #1', receiveAddress);
             await expect(tradingPage.confirmationAddress).toHaveText(receiveAddress);
             await expect(tradingPage.confirmationFiatAmount).toHaveText(formattedUpdateFiatAmount);
             await expect(tradingPage.confirmationCryptoAmount).toHaveText(secondOfferCryptoAmount);
@@ -80,7 +79,7 @@ test.describe('Trading - Buy BTC', { tag: ['@group=other', '@webOnly'] }, () => 
         await test.step('Request a trade', async () => {
             await tradingPage.fillBuyForm(fiatAmount);
             await tradingPage.buyBestOfferButton.click();
-            await tradingPage.confirmTrade('Bitcoin #1', formatAddress(receiveAddress));
+            await tradingPage.confirmTrade('Bitcoin #1', receiveAddress);
         });
 
         await page.clock.install();

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
@@ -7,7 +7,6 @@ import {
     invityEndpoint,
     invityRequest,
 } from '../../fixtures/invity';
-import { formatAddress } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 // Expected values based on our mocked responses
@@ -55,7 +54,7 @@ test.describe('Trading - Buy Solana', { tag: ['@group=other', '@webOnly'] }, () 
         });
 
         await test.step('Confirm the trade', async () => {
-            await tradingPage.confirmTrade('Solana #1', formatAddress(receiveAddress));
+            await tradingPage.confirmTrade('Solana #1', receiveAddress);
             await expect(tradingPage.confirmationAccountDropdown).toContainText('Solana #1');
             await expect(tradingPage.confirmationCryptoAmount).toHaveText(formattedCryptoAmount);
             await expect(tradingPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
@@ -58,7 +58,7 @@ test.describe('Trading - Swap coin to token', { tag: ['@group=other', '@webOnly'
         await test.step('Confirm the Swap trade', async () => {
             await expect(tradingPage.bestOfferAmount).toHaveText(formattedReceiveAmount);
             await tradingPage.clickSwapBestOfferAndWaitForFees();
-            await tradingPage.confirmTrade('Ethereum #1', formatAddress(receiveAddress));
+            await tradingPage.confirmTrade('Ethereum #1', receiveAddress);
         });
 
         await test.step('Verify all confirmation values', async () => {

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
@@ -23,7 +23,6 @@ const formattedSendAmount = `${localizeNumber(sendAmount)} SOL`;
 const formattedReceiveAmount = `${localizeNumber(swapQuotesSolanaBTC[1].receiveStringAmount)} BTC`;
 const { sendAddress, receiveAddress } = swapTradeSolanaBTC;
 const formattedSendAddress = formatAddress(sendAddress);
-const formattedReceiveAddress = formatAddress(receiveAddress);
 const toastText = `${formattedSendAmount} sent from Solana #1`;
 
 test.describe('Trading - Swap coins', { tag: ['@group=other', '@webOnly'] }, () => {
@@ -67,7 +66,7 @@ test.describe('Trading - Swap coins', { tag: ['@group=other', '@webOnly'] }, () 
         await test.step('Confirm the Swap trade', async () => {
             await expect(tradingPage.bestOfferAmount).toHaveText(formattedReceiveAmount);
             await tradingPage.clickSwapBestOfferAndWaitForFees();
-            await tradingPage.confirmTrade('Bitcoin #1', formattedReceiveAddress);
+            await tradingPage.confirmTrade('Bitcoin #1', receiveAddress);
         });
 
         await test.step('Verify all confirmation values', async () => {

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
@@ -17,7 +17,6 @@ const formattedReceiveAmount = `${localizeNumber(swapQuotesTetherBTC[2].receiveS
 const { sendAddress, receiveAddress, send: tetherMint } = swapTradeTetherBTC;
 const tetherRawMintAddress = tetherMint.split('--')[1];
 const formattedSendAddress = formatAddress(sendAddress);
-const formattedReceiveAddress = formatAddress(receiveAddress);
 const toastText = `${formattedSendAmount} sent from Solana #1`;
 
 test.describe('Trading - Swap token to coin', { tag: ['@group=other', '@webOnly'] }, () => {
@@ -58,7 +57,7 @@ test.describe('Trading - Swap token to coin', { tag: ['@group=other', '@webOnly'
         await test.step('Confirm the Swap trade', async () => {
             await expect(tradingPage.bestOfferAmount).toHaveText(formattedReceiveAmount);
             await tradingPage.clickSwapBestOfferAndWaitForFees();
-            await tradingPage.confirmTrade('Bitcoin #1', formattedReceiveAddress);
+            await tradingPage.confirmTrade('Bitcoin #1', receiveAddress);
         });
 
         await test.step('Verify all confirmation values', async () => {

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
@@ -17,7 +17,6 @@ const formattedReceiveAmount = `${localizeNumber(swapQuotesSolanaTokens[0].recei
 const { sendAddress, receiveAddress, send: tetherMint, receive: usdcMint } = swapTradeSolanaTokens;
 const tetherRawMintAddress = tetherMint.split('--')[1];
 const formattedSendAddress = formatAddress(sendAddress);
-const formattedReceiveAddress = formatAddress(receiveAddress);
 const toastText = `${formattedSendAmount} sent from Solana #1`;
 
 test.describe('Trading - Swap tokens', { tag: ['@group=other', '@webOnly'] }, () => {
@@ -58,7 +57,7 @@ test.describe('Trading - Swap tokens', { tag: ['@group=other', '@webOnly'] }, ()
         await test.step('Confirm the Swap trade', async () => {
             await expect(tradingPage.bestOfferAmount).toHaveText(formattedReceiveAmount);
             await tradingPage.clickSwapBestOfferAndWaitForFees();
-            await tradingPage.confirmTrade('Solana #1', formattedReceiveAddress);
+            await tradingPage.confirmTrade('Solana #1', receiveAddress);
         });
 
         await test.step('Verify all confirmation values', async () => {

--- a/packages/suite-desktop-core/e2e/tests/wallet/cardano.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/cardano.test.ts
@@ -24,11 +24,11 @@ test.describe('Cardano', { tag: ['@group=wallet', '@snapshot'] }, () => {
         trezorUserEnvLink,
     }) => {
         await settingsPage.coins.enableNetwork('tada');
-        await settingsPage.coins.openNetworkAdvanceSettings('tada');
+        // await settingsPage.coins.openNetworkAdvanceSettings('tada');
         // await expect(settingsPage.modal).toHaveScreenshot('cardano-advanced-settings.png', {
         //     mask: [settingsPage.coins.coinAddressInput],
         // });
-        await settingsPage.modalCloseButton.click();
+        // await settingsPage.modalCloseButton.click();
 
         await test.step('Verify Cardano account details', async () => {
             await dashboardPage.navigateTo();
@@ -55,7 +55,10 @@ test.describe('Cardano', { tag: ['@group=wallet', '@snapshot'] }, () => {
             await walletPage.receiveButton.click();
             await walletPage.revealAddressButton.click();
             await devicePrompt.confirmOnDevicePromptIsShown();
-            await expect(devicePrompt).toDisplayReceiveAddress(receiveAddress, 'fullLine');
+            await expect(devicePrompt).toDisplayReceiveAddress(receiveAddress, {
+                lineFormat: 'fullLine',
+                specialAccountType: 'Legacy Testnet',
+            });
             await trezorUserEnvLink.pressYes();
             await expect(walletPage.copyAddressButton).toBeEnabled();
             await expect(devicePrompt.outputValue).toHaveText(formatAddress(receiveAddress));

--- a/packages/suite-desktop-core/e2e/tests/wallet/cardano.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/cardano.test.ts
@@ -1,8 +1,9 @@
 import { cardanoAccountDetails } from '../../snapshots/web/wallet/cardano.test.ts/cardano-aria';
+import { formatAddress } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
-const formattedReceiveAddress =
-    'addr _tes t1qp hsv6 vspp 4l3n vmqz w529 teq2 ha08 s0fg jvzg hzh6 28uc cfey 0wtr gp5r mxvl d7kh c745 x9mk 7gts 5ctu zerl f4ed rq5a t0x5';
+const receiveAddress =
+    'addr_test1qphsv6vspp4l3nvmqzw529teq2ha08s0fgjvzghzh628uccfey0wtrgp5rmxvld7khc745x9mk7gts5ctuzerlf4edrq5at0x5';
 
 // todo: setup emu with 24 words mnemonic so that we can test different cardano derivation and its 'auto-discovery; feature
 //mnemonic: 'clot trim improve bag pigeon party wave mechanic beyond clean cake maze protect left assist carry guitar bridge nest faith critic excuse tooth dutch',
@@ -20,6 +21,7 @@ test.describe('Cardano', { tag: ['@group=wallet', '@snapshot'] }, () => {
         devicePrompt,
         settingsPage,
         walletPage,
+        trezorUserEnvLink,
     }) => {
         await settingsPage.coins.enableNetwork('tada');
         await settingsPage.coins.openNetworkAdvanceSettings('tada');
@@ -52,10 +54,12 @@ test.describe('Cardano', { tag: ['@group=wallet', '@snapshot'] }, () => {
         await test.step('Verify Cardano receive form', async () => {
             await walletPage.receiveButton.click();
             await walletPage.revealAddressButton.click();
-            await devicePrompt.waitForPromptAndConfirm();
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await expect(devicePrompt).toDisplayReceiveAddress(receiveAddress, 'fullLine');
+            await trezorUserEnvLink.pressYes();
             await expect(walletPage.copyAddressButton).toBeEnabled();
-            await expect(devicePrompt.outputValue).toHaveText(formattedReceiveAddress);
-            // await expect(settingsPage.modal).toHaveScreenshot('cardano-receive.png');
+            await expect(devicePrompt.outputValue).toHaveText(formatAddress(receiveAddress));
+            await devicePrompt.confirmOnDevicePromptIsShown();
             await settingsPage.modalCloseButton.click();
             await page.getByTestId('@account-subpage/back').click();
         });


### PR DESCRIPTION
This PR introduces first asserts of what is actually displayed on emulator to our e2e tests. So far we checked values only on prompt in the suite. Now we have custom Matcher `toDisplayReceiveAddress` which is to be called on expect(devicePrompt object) and takes parameter of address and optional parameter of tranformMode. The optional parameter is there because I have encountered two ways how address is displayed on the emulator.

```
    // Address is split to lines on Display so it can fit. There are different formats:
    // 1. Four tetragrams of address:
    // bc1q pyfv fvm5 2zx7
    // gek8 6ajj 5pkk ne3h
    // 385a da8r 2y
    // 1. Full lines (18 chars) of address:
    // bc1qpyfvfvm52zx7ge
    // k86ajj5pkkne3h385a
    // da8r2y
```

The assert is used in every test operating with receive address.
I have added also two other asserts but their use would be complicated now. Because of how we resuse some methods in Trading tests. I need rethink that and choose correct approach. Also I dont want this PR to be too big.