### PR TITLE
feat(connect-web): forward device events in popup mode

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -6,6 +6,7 @@ import { config } from '@trezor/connect/src/data/config';
 import { DEFAULT_DOMAIN } from '@trezor/connect/src/data/version';
 import {
     CoreEventMessage,
+    DEVICE_EVENT,
     IFRAME,
     IFrameCallMessage,
     IFrameLogRequest,
@@ -486,6 +487,9 @@ const initCoreInPopup = async (
         handleUIAffectingMessage(message);
         if (message.type === RESPONSE_EVENT) {
             handleResponseEvent(message);
+        }
+        if (message.event === DEVICE_EVENT) {
+            postMessageToParent(message);
         }
     };
     const coreManager = initCoreState();

--- a/packages/connect-web/src/impl/core-in-popup.ts
+++ b/packages/connect-web/src/impl/core-in-popup.ts
@@ -5,6 +5,7 @@ import * as ERRORS from '@trezor/connect/src/constants/errors';
 import {
     CallMethodAnyResponse,
     CallMethodPayload,
+    DEVICE_EVENT,
     IFRAME,
     POPUP,
     UI_EVENT,
@@ -106,6 +107,9 @@ export class CoreInPopup implements ConnectFactoryDependencies<ConnectSettingsWe
             if (this._popupManager) this._popupManager.close();
             this._popupManager = new popup.PopupManager(this._settings, {
                 logger: this.popupManagerLogger,
+            });
+            this._popupManager.on(DEVICE_EVENT, event => {
+                this.eventEmitter.emit(DEVICE_EVENT, event);
             });
             setLogWriter(() => this.logWriterFactory(this._popupManager!));
         }

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -3,7 +3,14 @@
 import EventEmitter from 'events';
 
 import { CONTENT_SCRIPT_VERSION, VERSION } from '@trezor/connect/src/data/version';
-import { CoreEventMessage, IFRAME, IFrameLoaded, POPUP, UI } from '@trezor/connect/src/events';
+import {
+    CoreEventMessage,
+    DEVICE_EVENT,
+    IFRAME,
+    IFrameLoaded,
+    POPUP,
+    UI,
+} from '@trezor/connect/src/events';
 import type { ConnectSettings } from '@trezor/connect/src/types';
 import { Log } from '@trezor/connect/src/utils/debug';
 import { getOrigin } from '@trezor/connect/src/utils/urlUtils';
@@ -339,6 +346,8 @@ export class PopupManager extends EventEmitter {
                     `Content script version mismatch. Expected ${CONTENT_SCRIPT_VERSION}, got ${contentScriptVersion}`,
                 );
             }
+        } else if (message.event === DEVICE_EVENT) {
+            this.emit(DEVICE_EVENT, message);
         }
     }
 


### PR DESCRIPTION
## Description

3rd parties want to receive device events in popup mode as well. 
The events can be only received when the popup is open, so it cannot be used to track connection/disconnection events, but it's useful to get metadata of the last used device.