### PR TITLE
refactor(e2e): add firmware missmatch check to onboarding tests

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/firmwareSection.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/firmwareSection.ts
@@ -1,4 +1,4 @@
-import { Locator, Page } from '@playwright/test';
+import { Locator, Page, expect } from '@playwright/test';
 
 import { step } from '../../common';
 
@@ -6,16 +6,36 @@ export class FirmwareSection {
     readonly continueButton: Locator;
     readonly skipButton: Locator;
     readonly skipConfirmButton: Locator;
+    readonly installFirmwareButton: Locator;
+    readonly onboardingLayout: Locator;
 
     constructor(private readonly page: Page) {
         this.continueButton = this.page.getByTestId('@firmware/continue-button');
         this.skipButton = this.page.getByTestId('@firmware/skip-button');
         this.skipConfirmButton = this.page.getByTestId('@onboarding/skip-button-confirm');
+        this.installFirmwareButton = this.page.getByTestId('@firmware/install-button');
+        this.onboardingLayout = this.page.getByTestId('@onboarding-layout/body');
     }
 
     @step()
     async skip() {
         await this.skipButton.click();
         await this.skipConfirmButton.click();
+    }
+
+    // This methods serves as watchdog for situation where new firmware is released to suite desktop and web
+    // But is not yet available in our TrezorEnv that is used by the test CIs.
+    @step()
+    async continueThroughFirmware() {
+        await expect(this.onboardingLayout).toBeVisible();
+        const isInstallButtonVisible = await this.installFirmwareButton.isVisible();
+        const isInstallTitleVisible = await this.page.getByText('Installing firmware').isVisible();
+        if (isInstallButtonVisible || isInstallTitleVisible) {
+            throw new Error(
+                'New Firmware was released but it was not yet adopted by our test CIs. Please contact @testautomationhelp in #tech_qa.',
+            );
+        }
+        await expect(this.page.getByText('Firmware ready')).toBeVisible();
+        await this.continueButton.click();
     }
 }

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
@@ -19,7 +19,7 @@ test.describe('Onboarding - create wallet', { tag: ['@group=device-management'] 
     }) => {
         // Pass through analytics and firmware steps
         await analyticsSection.passThroughAnalytics();
-        await onboardingPage.firmware.continueButton.click();
+        await onboardingPage.firmware.continueThroughFirmware();
 
         // Start wallet creation
         await page.getByTestId('@onboarding/path-create-button').click();

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts
@@ -20,7 +20,7 @@ test.describe('Onboarding - recover wallet T1B1', { tag: ['@group=device-managem
     }) => {
         // Navigate through onboarding steps
         await analyticsSection.passThroughAnalytics();
-        await onboardingPage.firmware.continueButton.click();
+        await onboardingPage.firmware.continueThroughFirmware();
         await onboardingPage.recoverWalletButton.click();
 
         // Select advanced recovery

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts
@@ -20,7 +20,7 @@ test.describe('Onboarding - recover wallet T1B1', { tag: ['@group=device-managem
         await analyticsSection.passThroughAnalytics();
 
         // Start wallet recovery process
-        await onboardingPage.firmware.continueButton.click();
+        await onboardingPage.firmware.continueThroughFirmware();
         await onboardingPage.recoverWalletButton.click();
         await recoveryModal.selectWordCount(24);
         await recoveryModal.selectBasicRecoveryButton.click();

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts
@@ -25,7 +25,7 @@ test.describe('Onboarding - recover wallet T1B1', { tag: ['@group=device-managem
         await analyticsSection.passThroughAnalytics();
 
         // Start wallet recovery process
-        await onboardingPage.firmware.continueButton.click();
+        await onboardingPage.firmware.continueThroughFirmware();
         await onboardingPage.recoverWalletButton.click();
         await recoveryModal.selectWordCount(24);
         await recoveryModal.selectBasicRecoveryButton.click();

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
@@ -19,7 +19,7 @@ test.describe('Onboarding - create wallet', { tag: ['@group=device-management'] 
         trezorUserEnvLink,
     }) => {
         await analyticsSection.passThroughAnalytics();
-        await onboardingPage.firmware.continueButton.click();
+        await onboardingPage.firmware.continueThroughFirmware();
 
         // Will be clicking on Shamir backup button
         await onboardingPage.createWalletButton.click();

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts
@@ -18,7 +18,7 @@ test.describe('Onboarding - recover wallet T2T1', { tag: ['@group=device-managem
         trezorUserEnvLink,
     }) => {
         await analyticsSection.passThroughAnalytics();
-        await onboardingPage.firmware.continueButton.click();
+        await onboardingPage.firmware.continueThroughFirmware();
 
         // Start wallet recovery process and confirm on device
         await onboardingPage.recoverWalletButton.click();

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts
@@ -57,7 +57,7 @@ test.describe('Onboarding - T2T1 in recovery mode', { tag: ['@group=device-manag
 
         await analyticsSection.passThroughAnalytics();
 
-        await onboardingPage.firmware.continueButton.click();
+        await onboardingPage.firmware.continueThroughFirmware();
         await page.getByTestId('@onboarding/path-recovery-button').click();
     });
 

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts
@@ -17,7 +17,7 @@ test.describe('Onboarding - recover wallet T2T1', { tag: ['@group=device-managem
         trezorUserEnvLink,
     }) => {
         // Start wallet recovery process and confirm on device
-        await onboardingPage.firmware.continueButton.click();
+        await onboardingPage.firmware.continueThroughFirmware();
         await onboardingPage.recoverWalletButton.click();
         await onboardingPage.startRecoveryButton.click();
         await devicePrompt.confirmOnDevicePromptIsShown();

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
@@ -21,7 +21,7 @@ test.describe('Onboarding - create wallet', { tag: ['@group=device-management'] 
         await analyticsSection.passThroughAnalytics();
 
         // Device onboarding steps
-        await onboardingPage.firmware.continueButton.click();
+        await onboardingPage.firmware.continueThroughFirmware();
         await onboardingPage.passThroughAuthenticityCheck();
         await page.waitForTimeout(500);
         await onboardingPage.tutorial.skip();


### PR DESCRIPTION
This PR adds a descriptive error to onboarding tests. For situations when new firmware was released to suite / desktop but  we are still not using Trezor Env with said new firmwares on CI.

This should trivilized troubleshooting and allow us to monitor how often this happen.

Example:
```
  1) [desktop] › e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts:14:9 › Onboarding - create wallet › Success (Shamir backup) @group=device-management › FirmwareSection.continueThroughFirmware 

    Error: New Firmware was released but it was not yet adopted by our test CIs. Please contact @tech_qa.

       at ../support/pageObjects/onboarding/firmwareSection.ts:32

      30 |         const isInstallTitleVisible = await this.page.getByText('Installing firmware').isVisible();
      31 |         if (isInstallButtonVisible || isInstallTitleVisible) {
    > 32 |             throw new Error('New Firmware was released but it was not yet adopted by our test CIs. Please contact @tech_qa.');
         |                   ^
      33 |         }
      34 |         await expect(this.page.getByText('Firmware ready')).toBeVisible();
      35 |         await this.continueButton.click();
        at FirmwareSection.continueThroughFirmware (/home/mcihlar/git/trezor-suite/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/firmwareSection.ts:32:19)
        at /home/mcihlar/git/trezor-suite/packages/suite-desktop-core/e2e/support/common.ts:32:48
        at /home/mcihlar/git/trezor-suite/packages/suite-desktop-core/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts:24:9

```