### PR TITLE
Make the app usable as early as token defitinions are loaded and token fiat rate loading begins

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx
@@ -42,6 +42,7 @@ interface AccountItemProps {
     isGroup?: boolean;
     tokens?: Account['tokens'];
     dataTestKey?: string;
+    isFiatLoading?: boolean;
     onClick?: () => void;
 }
 
@@ -58,6 +59,7 @@ export const AccountItem = forwardRef(
             customFiatValue,
             isGroup,
             dataTestKey,
+            isFiatLoading,
             onClick,
         }: AccountItemProps,
         ref: Ref<HTMLDivElement>,
@@ -90,6 +92,7 @@ export const AccountItem = forwardRef(
 
         const content = (
             <AccountRow
+                isFiatLoading={Boolean(isFiatLoading)}
                 isSelected={isSelected}
                 isGroup={isGroup}
                 isGroupSelected={isGroupSelected}

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItemContent.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItemContent.tsx
@@ -46,6 +46,7 @@ type ItemContentProps = {
     index?: number;
     formattedBalance: string;
     dataTestKey?: string;
+    isFiatLoading?: boolean;
 };
 
 const FiatValueRenderComponent = ({ value }: { value: JSX.Element | null }) => {
@@ -65,6 +66,7 @@ export const AccountItemContent = ({
     index,
     formattedBalance,
     dataTestKey,
+    isFiatLoading,
 }: ItemContentProps) => {
     const { FiatAmountFormatter } = useFormatters();
     const localCurrency = useSelector(selectLocalCurrency);
@@ -91,12 +93,16 @@ export const AccountItemContent = ({
                 </AccountLabelContainer>
                 {customFiatValue && !isTestnet(symbol) ? (
                     <HiddenPlaceholder>
-                        <FiatAmountFormatter
-                            value={customFiatValue}
-                            currency={localCurrency}
-                            minimumFractionDigits={0}
-                            maximumFractionDigits={0}
-                        />
+                        {isFiatLoading ? (
+                            <SkeletonRectangle animate={shouldAnimate} />
+                        ) : (
+                            <FiatAmountFormatter
+                                value={customFiatValue}
+                                currency={localCurrency}
+                                minimumFractionDigits={0}
+                                maximumFractionDigits={0}
+                            />
+                        )}
                     </HiddenPlaceholder>
                 ) : (
                     <FiatValue

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow.tsx
@@ -25,6 +25,7 @@ type AccountRowProps = {
     accountType: AccountType;
     index?: number;
     formattedBalance: string;
+    isFiatLoading?: boolean;
 };
 
 const Wrapper = styled(NavigationItemBase)<{
@@ -61,6 +62,7 @@ export const AccountRow = forwardRef<HTMLDivElement, AccountRowProps>(
             accountType,
             index,
             formattedBalance,
+            isFiatLoading,
         },
         ref,
     ) => (
@@ -86,6 +88,7 @@ export const AccountRow = forwardRef<HTMLDivElement, AccountRowProps>(
                 index={index}
                 formattedBalance={formattedBalance}
                 dataTestKey={dataTestKey}
+                isFiatLoading={Boolean(isFiatLoading)}
             />
         </Wrapper>
     ),

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 import { selectCurrentFiatRates } from '@suite-common/wallet-core';
 import {
+    areTokenFiatRatesLoading,
     getAccountTokensFiatBalance,
     getAccountTotalStakingBalance,
 } from '@suite-common/wallet-utils';
@@ -61,7 +62,10 @@ export const AccountItemsGroup = ({
     const localCurrency = useSelector(selectLocalCurrency);
     const rates = useSelector(selectCurrentFiatRates);
 
-    const tokensFiatBalance = getAccountTokensFiatBalance(account, localCurrency, rates, tokens);
+    const isFiatLoading = areTokenFiatRatesLoading(account, localCurrency, rates ?? {});
+    const tokensFiatBalance = isFiatLoading
+        ? (0).toFixed()
+        : getAccountTokensFiatBalance(account, localCurrency, rates, tokens);
 
     const tokensRoutes = ['wallet-tokens', 'wallet-tokens-hidden'];
 
@@ -104,6 +108,7 @@ export const AccountItemsGroup = ({
                         customFiatValue={tokensFiatBalance}
                         tokens={tokens}
                         dataTestKey={`${dataTestKey}/tokens`}
+                        isFiatLoading={isFiatLoading}
                     />
                 )}
             </Column>

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -181,7 +181,10 @@ export const fetchFiatRatesThunk = createThunk(
 
         if (tickers.length === 0) return;
 
-        return dispatch(
+        // NOTE: do not await it here, leave it just to return
+        // updateFiatRatesThunk is handled in the reducer and we don't need to wait for
+        // all the token fiat rates to be loaded as it slows down start of the app massively
+        dispatch(
             updateFiatRatesThunk({
                 tickers,
                 localCurrency,
@@ -189,6 +192,8 @@ export const fetchFiatRatesThunk = createThunk(
                 fetchAttemptTimestamp: Date.now() as Timestamp,
             }),
         );
+
+        return;
     },
 );
 

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -184,13 +184,31 @@ export const fetchFiatRatesThunk = createThunk(
         // NOTE: do not await it here, leave it just to return
         // updateFiatRatesThunk is handled in the reducer and we don't need to wait for
         // all the token fiat rates to be loaded as it slows down start of the app massively
-        dispatch(
-            updateFiatRatesThunk({
-                tickers,
-                localCurrency,
-                rateType,
-                fetchAttemptTimestamp: Date.now() as Timestamp,
-            }),
+        // Because of that, let's chunk the number of fiat rates to be loaded
+        // and have then loaded by chunks to not overload the API
+        const FIAT_RATES_FETCH_CHUNK_SIZE = 4;
+        const tickerChunks = Array.from(
+            { length: Math.ceil(tickers.length / FIAT_RATES_FETCH_CHUNK_SIZE) },
+            (_, i) =>
+                tickers.slice(
+                    i * FIAT_RATES_FETCH_CHUNK_SIZE,
+                    (i + 1) * FIAT_RATES_FETCH_CHUNK_SIZE,
+                ),
+        );
+
+        tickerChunks.reduce<Promise<any>>(
+            (chain, chunk) =>
+                chain.then(() =>
+                    dispatch(
+                        updateFiatRatesThunk({
+                            tickers: chunk,
+                            localCurrency,
+                            rateType,
+                            fetchAttemptTimestamp: Date.now() as Timestamp,
+                        }),
+                    ),
+                ),
+            Promise.resolve(),
         );
 
         return;

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -577,33 +577,42 @@ export const enhanceHistory = ({
     txids,
 });
 
+export const areTokenFiatRatesLoading = (
+    account: Account,
+    localCurrency: string,
+    rates: RatesByKey,
+) =>
+    (account.tokens ?? []).some(token => {
+        const tokenFiatRateKey = getFiatRateKey(
+            account.symbol,
+            localCurrency as FiatCurrencyCode,
+            token.contract as TokenAddress,
+        );
+
+        return rates?.[tokenFiatRateKey]?.isLoading;
+    });
+
 export const getAccountTokensFiatBalance = (
     account: Account,
     localCurrency: string,
     rates?: RatesByKey,
     tokens?: Account['tokens'],
-) => {
-    let totalBalance = new BigNumber(0);
+) =>
+    (tokens ?? [])
+        .reduce((total, token) => {
+            const tokenFiatRateKey = getFiatRateKey(
+                account.symbol,
+                localCurrency as FiatCurrencyCode,
+                token.contract as TokenAddress,
+            );
 
-    // sum fiat value of all tokens
-    tokens?.forEach(t => {
-        const tokenFiatRateKey = getFiatRateKey(
-            account.symbol,
-            localCurrency as FiatCurrencyCode,
-            t.contract as TokenAddress,
-        );
+            const tokenFiatRate = rates?.[tokenFiatRateKey];
 
-        const tokenFiatRate = rates?.[tokenFiatRateKey];
-        if (tokenFiatRate?.rate && t.balance) {
-            const tokenBalance = toFiatCurrency(t.balance, tokenFiatRate.rate, 2);
-            if (tokenBalance) {
-                totalBalance = totalBalance.plus(tokenBalance);
-            }
-        }
-    });
-
-    return totalBalance.toFixed();
-};
+            return tokenFiatRate?.rate && token.balance
+                ? total.plus(toFiatCurrency(token.balance, tokenFiatRate.rate, 2) ?? 0)
+                : total;
+        }, new BigNumber(0))
+        .toFixed();
 
 export const getAssetTokensFiatBalance = (
     accounts: Account[],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The support seeds are so large - with so many tokens - that the loading of the rates takes so long that the app loading time times out.

The solution is NOT to wait for all the token fiat rates to be loaded and have the app initialized and usable earlier

## Related Issue

Resolve  - interal slack discussion

## Screenshots:
Before (spoiler alert, it won't dispay the UI of the app)


https://github.com/user-attachments/assets/431bdbac-005e-47c4-9850-4a0d521a0ef6



Now (loaded immeadiatly):


https://github.com/user-attachments/assets/57bb6fd8-7c86-4b30-b83e-f84b2c83a02a

