### PR TITLE
feat(suite-native): create banner variant for FW rev check other-error

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -39,6 +39,7 @@ export const en = {
                     'Your Trezor may be counterfeit. To ensure your safety, receiving funds has been disabled. Contact Trezor Support immediately.',
                 contactSupportButton: 'Contact Trezor Support',
             },
+            fwRevisionCheckOtherError: "Couldn't perform firmware authenticity check.",
         },
         tokens: '+ Tokens',
     },

--- a/suite-native/module-authenticity-checks/src/DeviceCompromisedBannerAtoms.ts
+++ b/suite-native/module-authenticity-checks/src/DeviceCompromisedBannerAtoms.ts
@@ -5,7 +5,8 @@ import { atom } from 'jotai';
  * - 'none': Banner is hidden
  * - 'brief': Shows banner with only title
  * - 'extended': Shows banner with title, subtitle and CTA
+ * - 'other-error': Shows only a warning banner that check could not be performed
  */
-type DeviceCompromisedBannerVariant = 'none' | 'brief' | 'extended';
+export type DeviceCompromisedBannerVariant = 'none' | 'brief' | 'extended' | 'other-error';
 
 export const deviceCompromisedBannerAtom = atom<DeviceCompromisedBannerVariant>('none');

--- a/suite-native/module-authenticity-checks/src/components/DeviceCompromisedBanner.tsx
+++ b/suite-native/module-authenticity-checks/src/components/DeviceCompromisedBanner.tsx
@@ -9,13 +9,21 @@ import { useOpenLink } from '@suite-native/link';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_MOBILE_URL } from '@trezor/urls';
 
-import { deviceCompromisedBannerAtom } from '../DeviceCompromisedBannerAtoms';
+import {
+    DeviceCompromisedBannerVariant,
+    deviceCompromisedBannerAtom,
+} from '../DeviceCompromisedBannerAtoms';
 
-const containerStyle = prepareNativeStyle(utils => ({
-    backgroundColor: utils.colors.backgroundAlertRedSubtleOnElevation0,
-    // MessageSystemBanner critical variant has the same bgColor, so the margin serves to separate them visually
-    marginBottom: utils.spacings.sp1,
-}));
+const containerStyle = prepareNativeStyle<{ bannerVariant: DeviceCompromisedBannerVariant }>(
+    (utils, { bannerVariant }) => ({
+        backgroundColor:
+            bannerVariant === 'other-error'
+                ? utils.colors.backgroundAlertYellowBold
+                : utils.colors.backgroundAlertRedSubtleOnElevation0,
+        // MessageSystemBanner critical variant has the same bgColor, so the margin serves to separate them visually
+        marginBottom: utils.spacings.sp1,
+    }),
+);
 
 const contentStyle = prepareNativeStyle<{ topSafeAreaInset: number }>(
     (utils, { topSafeAreaInset }) => ({
@@ -55,13 +63,18 @@ export const DeviceCompromisedBanner = ({ topSafeAreaInset }: DeviceCompromisedB
 
     if (bannerVariant === 'none') return null;
 
+    const titleTranslationId =
+        bannerVariant === 'other-error'
+            ? 'generic.banners.fwRevisionCheckOtherError'
+            : 'generic.banners.deviceCompromised.title';
+
     return (
-        <View style={applyStyle(containerStyle)}>
+        <View style={applyStyle(containerStyle, { bannerVariant })}>
             <VStack spacing="sp2" style={applyStyle(contentStyle, { topSafeAreaInset })}>
                 <HStack alignItems="center">
                     <Icon name="warningCircle" size="mediumLarge" />
                     <Text variant="highlight">
-                        <Translation id="generic.banners.deviceCompromised.title" />
+                        <Translation id={titleTranslationId} />
                     </Text>
                 </HStack>
                 {bannerVariant === 'extended' && <ExtendedBannerContent />}

--- a/suite-native/module-authenticity-checks/src/useRenderDeviceCompromisedBanner.ts
+++ b/suite-native/module-authenticity-checks/src/useRenderDeviceCompromisedBanner.ts
@@ -37,6 +37,10 @@ export const useRenderDeviceCompromisedBanner = () => {
             return setBannerVariant('none');
         }
 
+        if (revisionCheckError === 'other-error') {
+            return setBannerVariant('other-error');
+        }
+
         setBannerVariant(isExtendedBanner ? 'extended' : 'brief');
     }, [isRouteExcluded, isExtendedBanner, revisionCheckError, setBannerVariant]);
 };


### PR DESCRIPTION
## Description

In case of FW revision check other-error, display a special softer variant of the Device Compromised banner, to avoid unnecessary alarm because of false positive

- only warning color
- says "Couldn't perform firmware authenticity check." instead of the scary "Unofficial firmware detected" 

## Related Issue

Resolve #17512

## Screenshots:
`other-error` **(NEW)**
![Screenshot from 2025-03-10 12-03-03](https://github.com/user-attachments/assets/6f975ec1-4726-4cc3-8d84-db93845f6f1b)

`hash-mismatch` or `firmware-revision-unknown` **(as is)**
![Screenshot from 2025-03-10 12-03-37](https://github.com/user-attachments/assets/57b55b66-991e-411f-b593-793cc50f8a0e)

`cannot-perform-check-offline` **(as is)**
![Screenshot from 2025-03-10 12-09-23](https://github.com/user-attachments/assets/015a3936-844b-4f53-ba6e-bb0ea3e77275)