### PR TITLE
feat(suite-native): Mobile Trade: add unit test coverage limits

### DIFF
--- a/suite-native/module-trading/jest.config.js
+++ b/suite-native/module-trading/jest.config.js
@@ -2,4 +2,12 @@ const { ...baseConfig } = require('../../jest.config.native');
 
 module.exports = {
     ...baseConfig,
+    coverageThreshold: {
+        global: {
+            statements: 70,
+            branches: 70,
+            functions: 70,
+            lines: 70,
+        },
+    },
 };

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
-        "test:unit": "yarn g:jest"
+        "test:unit": "yarn g:jest --coverage"
     },
     "dependencies": {
         "@mobily/ts-belt": "^3.13.1",

--- a/suite-native/module-trading/src/components/buy/__tests__/LegalSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/LegalSheet.comp.test.tsx
@@ -1,0 +1,37 @@
+import { act, fireEvent, render } from '@suite-native/test-utils';
+
+import { LegalSheet, LegalSheetProps } from '../LegalSheet';
+
+describe('LegalSheet', () => {
+    const renderLegalSheet = (props?: Partial<LegalSheetProps>) =>
+        render(
+            <LegalSheet
+                isVisible
+                onClose={() => {}}
+                tradeProviderName="TEST_PROVIDER"
+                {...props}
+            />,
+        );
+
+    it('should render text info with given tradeProviderName', () => {
+        const { getByText } = renderLegalSheet();
+
+        expect(getByText('Buy with TEST_PROVIDER')).toBeDefined();
+        expect(
+            getByText(
+                "I understand that Invity doesn't provide this service. It's governed by TEST_PROVIDER’s Terms and Conditions.",
+            ),
+        ).toBeDefined();
+    });
+
+    it('should call onClose callback on Continue button press', () => {
+        const onClose = jest.fn();
+        const { getByText } = renderLegalSheet({ onClose });
+
+        act(() => {
+            fireEvent.press(getByText('Continue'));
+        });
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/suite-native/module-trading/src/components/general/AccountSheet/TradeAccountsListFooter.tsx
+++ b/suite-native/module-trading/src/components/general/AccountSheet/TradeAccountsListFooter.tsx
@@ -11,21 +11,23 @@ const footerStyle = prepareNativeStyle(utils => ({
     borderBottomRightRadius: utils.borders.radii.r16,
 }));
 
+export type TradeAccountsListFooterProps = {
+    hasTextualDivider: boolean;
+    onAddAccountTap: () => void;
+};
+
 export const TradeAccountsListFooter = ({
     hasTextualDivider,
     onAddAccountTap,
-}: {
-    hasTextualDivider: boolean;
-    onAddAccountTap: () => void;
-}) => {
+}: TradeAccountsListFooterProps) => {
     const { applyStyle } = useNativeStyles();
 
     return (
         <Box style={applyStyle(footerStyle)}>
             {hasTextualDivider ? (
-                <Divider marginBottom="sp16" />
-            ) : (
                 <TextDivider title="generic.orSeparator" />
+            ) : (
+                <Divider marginBottom="sp16" />
             )}
             <Box paddingTop="sp8" paddingHorizontal="sp16">
                 <Button

--- a/suite-native/module-trading/src/components/general/AccountSheet/__tests__/TradeAccountsListFooter.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountSheet/__tests__/TradeAccountsListFooter.comp.test.tsx
@@ -1,0 +1,33 @@
+import { act, fireEvent, render } from '@suite-native/test-utils';
+
+import { TradeAccountsListFooter, TradeAccountsListFooterProps } from '../TradeAccountsListFooter';
+
+describe('TradeAccountsListFooter', () => {
+    const renderTradeAccountsListFooter = (props: Partial<TradeAccountsListFooterProps>) =>
+        render(
+            <TradeAccountsListFooter hasTextualDivider onAddAccountTap={jest.fn()} {...props} />,
+        );
+
+    it('should not render "OR" when hasTextualDivider props is false', () => {
+        const { queryByText } = renderTradeAccountsListFooter({ hasTextualDivider: false });
+
+        expect(queryByText('OR')).toBeNull();
+    });
+
+    it('should render "OR" when hasTextualDivider props is true', () => {
+        const { getByText } = renderTradeAccountsListFooter({ hasTextualDivider: true });
+
+        expect(getByText('OR')).toBeDefined();
+    });
+
+    it('should call onAddAccountTap callback on "Add new" button press', () => {
+        const onAddAccountTap = jest.fn();
+        const { getByText } = renderTradeAccountsListFooter({ onAddAccountTap });
+
+        act(() => {
+            fireEvent.press(getByText('Add new'));
+        });
+
+        expect(onAddAccountTap).toHaveBeenCalledTimes(1);
+    });
+});

--- a/suite-native/module-trading/src/components/general/CountrySheet/__tests__/CountryListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/CountrySheet/__tests__/CountryListItem.comp.test.tsx
@@ -1,0 +1,34 @@
+import { act, fireEvent, render } from '@suite-native/test-utils';
+
+import { CountryListItem, CountryListItemProps } from '../CountryListItem';
+
+describe('CountryListItem', () => {
+    const renderCountryListItem = (props: Partial<CountryListItemProps>) =>
+        render(
+            <CountryListItem
+                flag="flag"
+                id="US"
+                isSelected={false}
+                name="United States"
+                onPress={jest.fn()}
+                {...props}
+            />,
+        );
+
+    it('should render given name', () => {
+        const { getByText } = renderCountryListItem({ name: 'United States' });
+
+        expect(getByText('United States')).toBeDefined();
+    });
+
+    it('should call onPress callback on item press', () => {
+        const onPress = jest.fn();
+        const { getByText } = renderCountryListItem({ onPress });
+
+        act(() => {
+            fireEvent.press(getByText('United States'));
+        });
+
+        expect(onPress).toHaveBeenCalledTimes(1);
+    });
+});

--- a/suite-native/module-trading/src/components/general/__tests__/TradingEmptyComponent.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingEmptyComponent.comp.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@suite-native/test-utils';
+
+import { TradingEmptyComponent } from '../TradingEmptyComponent';
+
+describe('TradingEmptyComponent', () => {
+    it('should render given title and description', () => {
+        const { getByText } = render(
+            <TradingEmptyComponent title="TITLE" description="DESCRIPTION" />,
+        );
+
+        expect(getByText('TITLE')).toBeDefined();
+        expect(getByText('DESCRIPTION')).toBeDefined();
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Introduce 70% unit test coverage treashold for `suite-native/module-trading` module.
<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
