### PR TITLE
feat(suite-native): release mobile FW revision check

### DIFF
--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -171,9 +171,9 @@ type FwAuthenticityCheckState = NativeDeviceRootState &
 export const selectFirmwareRevisionCheckErrorIfEnabled = (state: FwAuthenticityCheckState) => {
     const revisionCheckError = selectFirmwareRevisionCheckError(state);
     const { isFirmwareRevisionCheckEnabled } = state.appSettings;
-    const isFeatureFlagEnabled = selectIsFeatureFlagEnabled(
+    const isDeviceConnectEnabled = selectIsFeatureFlagEnabled(
         state,
-        FeatureFlag.IsFwRevisionCheckEnabled,
+        FeatureFlag.IsDeviceConnectEnabled,
     );
     const isMessageSystemFeatureEnabled = selectIsFeatureEnabled(
         state,
@@ -181,7 +181,7 @@ export const selectFirmwareRevisionCheckErrorIfEnabled = (state: FwAuthenticityC
         true,
     );
     const isCheckEnabled =
-        isFirmwareRevisionCheckEnabled && isFeatureFlagEnabled && isMessageSystemFeatureEnabled;
+        isFirmwareRevisionCheckEnabled && isDeviceConnectEnabled && isMessageSystemFeatureEnabled;
 
     return isCheckEnabled ? revisionCheckError : null;
 };

--- a/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
+++ b/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
@@ -27,7 +27,6 @@ describe('featureFlagsSlice', () => {
                 isConnectPopupEnabled: true,
                 isTradingEnabled: true,
                 isDeviceOnboardingEnabled: true,
-                IsFwRevisionCheckEnabled: true,
             });
         });
 
@@ -53,7 +52,6 @@ describe('featureFlagsSlice', () => {
                 isConnectPopupEnabled: false,
                 isTradingEnabled: false,
                 isDeviceOnboardingEnabled: false,
-                IsFwRevisionCheckEnabled: false,
             });
         });
 
@@ -79,7 +77,6 @@ describe('featureFlagsSlice', () => {
                 isConnectPopupEnabled: false,
                 isTradingEnabled: false,
                 isDeviceOnboardingEnabled: false,
-                IsFwRevisionCheckEnabled: false,
             });
         });
     });

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -10,7 +10,6 @@ export const FeatureFlag = {
     IsConnectPopupEnabled: 'isConnectPopupEnabled',
     IsDeviceOnboardingEnabled: 'isDeviceOnboardingEnabled',
     IsTradingEnabled: 'isTradingEnabled',
-    IsFwRevisionCheckEnabled: 'IsFwRevisionCheckEnabled',
 } as const;
 
 export type FeatureFlag = (typeof FeatureFlag)[keyof typeof FeatureFlag];
@@ -28,7 +27,6 @@ export const featureFlagsInitialState: FeatureFlagsState = {
     [FeatureFlag.IsConnectPopupEnabled]: isDevelopOrDebugEnv(),
     [FeatureFlag.IsDeviceOnboardingEnabled]: isDebugEnv() && !isDetoxTestBuild(),
     [FeatureFlag.IsTradingEnabled]: isDebugEnv(),
-    [FeatureFlag.IsFwRevisionCheckEnabled]: isDevelopOrDebugEnv(),
 };
 
 export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
@@ -38,7 +36,6 @@ export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsConnectPopupEnabled,
     FeatureFlag.IsDeviceOnboardingEnabled,
     FeatureFlag.IsTradingEnabled,
-    FeatureFlag.IsFwRevisionCheckEnabled,
 ];
 
 export const featureFlagsSlice = createSlice({

--- a/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
@@ -12,7 +12,6 @@ const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsConnectPopupEnabled]: 'Connect Popup',
     [FeatureFlagEnum.IsDeviceOnboardingEnabled]: 'Device onboarding',
     [FeatureFlagEnum.IsTradingEnabled]: 'Trading',
-    [FeatureFlagEnum.IsFwRevisionCheckEnabled]: 'Firmware Revision Check',
 } as const satisfies Record<FeatureFlagEnum, string>;
 
 const FeatureFlag = ({ featureFlag }: { featureFlag: FeatureFlagEnum }) => {

--- a/suite-native/module-settings/src/components/FeaturesSettings.tsx
+++ b/suite-native/module-settings/src/components/FeaturesSettings.tsx
@@ -21,7 +21,6 @@ import { useSettingsNavigateTo } from '../navigation/useSettingsNavigateTo';
 export const FeaturesSettings = () => {
     const isDevButtonVisible = useAtomValue(isDevButtonVisibleAtom);
     const isUsbDeviceConnectFeatureEnabled = useFeatureFlag(FeatureFlag.IsDeviceConnectEnabled);
-    const isFwRevisionCheckEnabled = useFeatureFlag(FeatureFlag.IsFwRevisionCheckEnabled);
 
     const navigation = useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes>>();
     const navigateTo = useSettingsNavigateTo();
@@ -71,18 +70,16 @@ export const FeaturesSettings = () => {
                         isLoading={hasDiscovery}
                         testID="@settings/coin-enabling"
                     />
-                    {isFwRevisionCheckEnabled && (
-                        <SettingsSectionItem
-                            iconName="trezorDevices"
-                            title={
-                                <Translation id="moduleSettings.items.features.deviceChecks.title" />
-                            }
-                            subtitle={
-                                <Translation id="moduleSettings.items.features.deviceChecks.subtitle" />
-                            }
-                            onPress={() => navigateTo(SettingsStackRoutes.SettingsDeviceChecks)}
-                        />
-                    )}
+                    <SettingsSectionItem
+                        iconName="trezorDevices"
+                        title={
+                            <Translation id="moduleSettings.items.features.deviceChecks.title" />
+                        }
+                        subtitle={
+                            <Translation id="moduleSettings.items.features.deviceChecks.subtitle" />
+                        }
+                        onPress={() => navigateTo(SettingsStackRoutes.SettingsDeviceChecks)}
+                    />
                 </>
             )}
         </SettingsSection>


### PR DESCRIPTION
## Description

Remove feature flag `IsFwRevisionCheckEnabled` from mobile, instead using `IsDeviceConnectEnabled`.

This effectively releases mobile FW rev check into production. 

## Related Issue

Resolve #17516

@coderabbitai ignore