### PR TITLE
Fix/suite dekstop core/e2e retry partner site link

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
@@ -107,11 +107,14 @@ test.describe('Trading - Swap coins', { tag: ['@group=other', '@webOnly'] }, () 
         });
 
         await test.step('Verify button opens provider support page in new tab', async () => {
-            const partnerPagePromise = page.context().waitForEvent('page');
-            await page.getByRole('link', { name: 'Go to provider support' }).click();
-            const partnerTab = await partnerPagePromise;
-            await expect(partnerTab).toHaveURL(/https:\/\/sideshift\.ai\/orders\//);
-            await partnerTab.close();
+            // There was minor instability, so we are adding retry to this step group
+            await expect(async () => {
+                const partnerPagePromise = page.context().waitForEvent('page', { timeout: 5_000 });
+                await page.getByRole('link', { name: 'Go to provider support' }).click();
+                const partnerTab = await partnerPagePromise;
+                await expect(partnerTab).toHaveURL(/https:\/\/sideshift\.ai\/orders\//);
+                await partnerTab.close();
+            }).toPass({ timeout: 20_000 });
         });
 
         // Statuses: SENDING -> CONVERTING -> CONFIRMING -> SUCCESS


### PR DESCRIPTION
I have seen unstable step of swap coins test on CI. Test was not able to open partner site by clicking on the button. We suspect test was too fast. Solving this by adding retry.
