### PR TITLE
fix(suite): fixed staking in sidebar

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx
@@ -1,7 +1,6 @@
 import { selectCoinDefinitions } from '@suite-common/token-definitions';
-import { selectEthAccountHasStaked, selectSolAccountHasStaked } from '@suite-common/wallet-core';
+import { selectAccountIsStakingActive } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
-import { isSupportedStakingNetworkSymbol } from '@suite-common/wallet-utils';
 
 import { useSelector } from 'src/hooks/suite';
 import { getTokens } from 'src/utils/wallet/tokenUtils';
@@ -33,12 +32,10 @@ export const AccountSection = ({
     } = account;
 
     const coinDefinitions = useSelector(state => selectCoinDefinitions(state, symbol));
-    const hasEthStaked = useSelector(state => selectEthAccountHasStaked(state, account.key));
-    const hasSolStaked = useSelector(state => selectSolAccountHasStaked(state, account.key));
-
-    const isStakeShown = isSupportedStakingNetworkSymbol(symbol) && (hasEthStaked || hasSolStaked);
 
     const showGroup = ['ethereum', 'solana', 'cardano'].includes(networkType);
+
+    const isStakeShown = useSelector(state => selectAccountIsStakingActive(state, account.key));
 
     const tokens = getTokens({
         tokens: accountTokens,

--- a/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
@@ -7,6 +7,7 @@ import { AssetFiatBalance } from '@suite-common/assets';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { selectCoinDefinitions } from '@suite-common/token-definitions';
 import { Network } from '@suite-common/wallet-config';
+import { selectAnyAccountIsStakingActive } from '@suite-common/wallet-core';
 import { Account, RatesByKey } from '@suite-common/wallet-types';
 import { isTestnet } from '@suite-common/wallet-utils';
 import {
@@ -126,10 +127,15 @@ export const AssetCard = ({
     const stakingAccountsForAsset = stakingAccounts.filter(account => account.symbol === symbol);
     const coinDefinitions = useSelector(state => selectCoinDefinitions(state, symbol));
 
+    const isStakingActive = useSelector(state =>
+        selectAnyAccountIsStakingActive(state, stakingAccountsForAsset),
+    );
+
     const { tokensFiatBalance, assetStakingBalance, shouldRenderStakingRow, shouldRenderTokenRow } =
         handleTokensAndStakingData(
             assetTokens,
             stakingAccountsForAsset,
+            isStakingActive,
             symbol,
             localCurrency,
             coinDefinitions,

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
@@ -6,6 +6,7 @@ import { AssetFiatBalance } from '@suite-common/assets';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { selectCoinDefinitions } from '@suite-common/token-definitions';
 import { Network } from '@suite-common/wallet-config';
+import { selectAnyAccountIsStakingActive } from '@suite-common/wallet-core';
 import { Account, RatesByKey } from '@suite-common/wallet-types';
 import { isTestnet } from '@suite-common/wallet-utils';
 import { TokenInfo } from '@trezor/blockchain-link-types';
@@ -83,6 +84,10 @@ export const AssetRow = memo(
             account => account.symbol === network.symbol,
         );
 
+        const isStakingActive = useSelector(state =>
+            selectAnyAccountIsStakingActive(state, stakingAccountsForAsset),
+        );
+
         const {
             tokensFiatBalance,
             assetStakingBalance,
@@ -91,6 +96,7 @@ export const AssetRow = memo(
         } = handleTokensAndStakingData(
             assetTokens,
             stakingAccountsForAsset,
+            isStakingActive,
             symbol,
             localCurrency,
             coinDefinitions,

--- a/packages/suite/src/views/dashboard/AssetsView/assetsViewUtils.ts
+++ b/packages/suite/src/views/dashboard/AssetsView/assetsViewUtils.ts
@@ -15,6 +15,7 @@ import {
 export const handleTokensAndStakingData = (
     assetTokens: TokenInfo[],
     accountsThatStaked: Account[],
+    isStakingActive: boolean,
     symbol: NetworkSymbol,
     localCurrency: FiatCurrencyCode,
     coinDefinitions?: TokenDefinition,
@@ -40,7 +41,9 @@ export const handleTokensAndStakingData = (
         (total, token) => total.plus(token?.fiatValue ?? 0),
         new BigNumber(0),
     );
-    const shouldRenderStakingRow = accountsThatStaked.length > 0 && assetStakingBalance.gt(0);
+
+    const shouldRenderStakingRow =
+        accountsThatStaked.length > 0 && assetStakingBalance.gt(0) && isStakingActive;
     const shouldRenderTokenRow = tokens.shownWithBalance?.length > 0 && tokensFiatBalance.gt(0);
 
     return {

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/EthStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/EthStakingDashboard.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo } from 'react';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
     fetchAllTransactionsForAccountThunk,
+    selectAccountIsStakingActive,
     selectAccountStakeTransactions,
     selectAccountUnstakeTransactions,
     selectPoolStatsApyData,
@@ -23,6 +24,7 @@ import { InstantStakeBanner } from './InstantStakeBanner';
 import { StakingDashboard } from '../../StakingDashboard/StakingDashboard';
 import { ApyCard } from '../../StakingDashboard/components/ApyCard';
 import { ClaimCard } from '../../StakingDashboard/components/ClaimCard';
+import { EmptyStakingCard } from '../../StakingDashboard/components/EmptyStakingCard';
 import { PayoutCard } from '../../StakingDashboard/components/PayoutCard';
 import { StakingCard } from '../../StakingDashboard/components/StakingCard';
 import { Transactions } from '../../StakingDashboard/components/Transactions';
@@ -67,43 +69,52 @@ export const EthStakingDashboard = ({ selectedAccount }: EthStakingDashboardProp
 
     const { canClaim = false } = getStakingDataForNetwork(account) ?? {};
 
+    const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
+
     return (
         <StakingDashboard
             selectedAccount={selectedAccount}
             dashboard={
                 <Column gap={spacings.xxxxl}>
-                    <DashboardSection
-                        heading={
-                            <Translation
-                                id="TR_STAKE_NETWORK"
-                                values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
-                            />
-                        }
-                    >
-                        <Column gap={spacings.sm}>
-                            <InstantStakeBanner
-                                txs={txs}
-                                daysToAddToPool={daysToAddToPool}
-                                daysToUnstake={daysToUnstake}
-                            />
-                            <Grid columns={isBelowLaptop || !canClaim ? 1 : 2} gap={spacings.sm}>
-                                <ClaimCard />
-                                <Flex direction={canClaim ? 'column' : 'row'} gap={spacings.sm}>
-                                    <ApyCard apy={apy} />
-                                    <PayoutCard
-                                        nextRewardPayout={nextRewardPayout}
-                                        daysToAddToPool={daysToAddToPool}
-                                        validatorWithdrawTime={data?.validatorWithdrawTime}
-                                    />
-                                </Flex>
-                            </Grid>
-                            <StakingCard
-                                isValidatorsQueueLoading={isLoading}
-                                daysToAddToPool={daysToAddToPool}
-                                daysToUnstake={daysToUnstake}
-                            />
-                        </Column>
-                    </DashboardSection>
+                    {isStakingActive ? (
+                        <DashboardSection
+                            heading={
+                                <Translation
+                                    id="TR_STAKE_NETWORK"
+                                    values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
+                                />
+                            }
+                        >
+                            <Column gap={spacings.sm}>
+                                <InstantStakeBanner
+                                    txs={txs}
+                                    daysToAddToPool={daysToAddToPool}
+                                    daysToUnstake={daysToUnstake}
+                                />
+                                <Grid
+                                    columns={isBelowLaptop || !canClaim ? 1 : 2}
+                                    gap={spacings.sm}
+                                >
+                                    <ClaimCard />
+                                    <Flex direction={canClaim ? 'column' : 'row'} gap={spacings.sm}>
+                                        <ApyCard apy={apy} />
+                                        <PayoutCard
+                                            nextRewardPayout={nextRewardPayout}
+                                            daysToAddToPool={daysToAddToPool}
+                                            validatorWithdrawTime={data?.validatorWithdrawTime}
+                                        />
+                                    </Flex>
+                                </Grid>
+                                <StakingCard
+                                    isValidatorsQueueLoading={isLoading}
+                                    daysToAddToPool={daysToAddToPool}
+                                    daysToUnstake={daysToUnstake}
+                                />
+                            </Column>
+                        </DashboardSection>
+                    ) : (
+                        <EmptyStakingCard />
+                    )}
 
                     <Transactions />
                 </Column>

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
@@ -1,8 +1,10 @@
-import { useSelector } from 'react-redux';
-
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { SOLANA_EPOCH_DAYS } from '@suite-common/wallet-constants';
-import { StakeRootState, selectPoolStatsApyData } from '@suite-common/wallet-core';
+import {
+    StakeRootState,
+    selectAccountIsStakingActive,
+    selectPoolStatsApyData,
+} from '@suite-common/wallet-core';
 import { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { getStakingDataForNetwork } from '@suite-common/wallet-utils';
 import { Column, Flex, Grid, useMediaQuery, variables } from '@trezor/components';
@@ -10,10 +12,12 @@ import { spacings } from '@trezor/theme';
 
 import { DashboardSection } from 'src/components/dashboard';
 import { Translation } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
 
 import { StakingDashboard } from '../StakingDashboard/StakingDashboard';
 import { ApyCard } from '../StakingDashboard/components/ApyCard';
 import { ClaimCard } from '../StakingDashboard/components/ClaimCard';
+import { EmptyStakingCard } from '../StakingDashboard/components/EmptyStakingCard';
 import { PayoutCard } from '../StakingDashboard/components/PayoutCard';
 import { StakingCard } from '../StakingDashboard/components/StakingCard';
 import { RewardsList } from './components/Rewards/RewardsList';
@@ -33,39 +37,48 @@ export const SolStakingDashboard = ({ selectedAccount }: SolStakingDashboardProp
         selectPoolStatsApyData(state, account?.symbol),
     );
 
+    const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
+
     return (
         <StakingDashboard
             selectedAccount={selectedAccount}
             dashboard={
                 <Column alignItems="normal" gap={spacings.xxxxl}>
-                    <DashboardSection
-                        heading={
-                            <Translation
-                                id="TR_STAKE_NETWORK"
-                                values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
-                            />
-                        }
-                    >
-                        <Column alignItems="normal" gap={spacings.sm}>
-                            <Grid columns={isBelowLaptop || !canClaim ? 1 : 2} gap={spacings.sm}>
-                                <ClaimCard />
-                                <Flex direction={canClaim ? 'column' : 'row'} gap={spacings.sm}>
-                                    <ApyCard apy={apy} />
-                                    <PayoutCard
-                                        nextRewardPayout={SOLANA_EPOCH_DAYS}
-                                        daysToAddToPool={SOLANA_EPOCH_DAYS}
-                                        validatorWithdrawTime={0}
-                                    />
-                                </Flex>
-                            </Grid>
-                            <StakingCard
-                                isValidatorsQueueLoading={undefined}
-                                daysToAddToPool={SOLANA_EPOCH_DAYS}
-                                daysToUnstake={SOLANA_EPOCH_DAYS}
-                                apy={apy}
-                            />
-                        </Column>
-                    </DashboardSection>
+                    {isStakingActive ? (
+                        <DashboardSection
+                            heading={
+                                <Translation
+                                    id="TR_STAKE_NETWORK"
+                                    values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
+                                />
+                            }
+                        >
+                            <Column alignItems="normal" gap={spacings.sm}>
+                                <Grid
+                                    columns={isBelowLaptop || !canClaim ? 1 : 2}
+                                    gap={spacings.sm}
+                                >
+                                    <ClaimCard />
+                                    <Flex direction={canClaim ? 'column' : 'row'} gap={spacings.sm}>
+                                        <ApyCard apy={apy} />
+                                        <PayoutCard
+                                            nextRewardPayout={SOLANA_EPOCH_DAYS}
+                                            daysToAddToPool={SOLANA_EPOCH_DAYS}
+                                            validatorWithdrawTime={0}
+                                        />
+                                    </Flex>
+                                </Grid>
+                                <StakingCard
+                                    isValidatorsQueueLoading={undefined}
+                                    daysToAddToPool={SOLANA_EPOCH_DAYS}
+                                    daysToUnstake={SOLANA_EPOCH_DAYS}
+                                    apy={apy}
+                                />
+                            </Column>
+                        </DashboardSection>
+                    ) : (
+                        <EmptyStakingCard />
+                    )}
                     <RewardsList account={account} />
                 </Column>
             }

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/components/Rewards/RewardsList.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/components/Rewards/RewardsList.tsx
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 
 import { SOLANA_EPOCH_DAYS } from '@suite-common/wallet-constants';
+import { selectAccountIsStakingActive } from '@suite-common/wallet-core';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { Badge, Card, Column, Icon, Row, SkeletonStack, Text, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
@@ -14,6 +15,7 @@ import {
     Translation,
 } from 'src/components/suite';
 import { Pagination } from 'src/components/wallet';
+import { useSelector } from 'src/hooks/suite';
 import { useSolanaRewards } from 'src/hooks/wallet/useSolanaRewards';
 import { Account } from 'src/types/wallet';
 import SkeletonTransactionItem from 'src/views/wallet/transactions/TransactionList/SkeletonTransactionItem';
@@ -48,8 +50,14 @@ export const RewardsList = ({ account }: RewardsListProps) => {
         }
     };
 
+    const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
+
     if (!isSolanaMainnet || !totalItems) {
-        return <RewardsEmpty />;
+        if (isStakingActive) {
+            return <RewardsEmpty />;
+        }
+
+        return null;
     }
 
     return (

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/StakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/StakingDashboard.tsx
@@ -1,11 +1,8 @@
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
-import { selectEthAccountHasStaked, selectSolAccountHasStaked } from '@suite-common/wallet-core';
 import { SelectedAccountStatus } from '@suite-common/wallet-types';
 
 import { WalletLayout } from 'src/components/wallet';
-import { useSelector } from 'src/hooks/suite';
 
-import { EmptyStakingCard } from './components/EmptyStakingCard';
 import { EverstakeFooter } from './components/EverstakeFooter';
 
 interface StakingDashboardProps {
@@ -14,16 +11,7 @@ interface StakingDashboardProps {
 }
 
 export const StakingDashboard = ({ selectedAccount, dashboard }: StakingDashboardProps) => {
-    const hasEthStaked = useSelector(state =>
-        selectEthAccountHasStaked(state, selectedAccount.account?.key ?? ''),
-    );
-    const hasSolStaked = useSelector(state =>
-        selectSolAccountHasStaked(state, selectedAccount.account?.key),
-    );
-
     if (selectedAccount.status !== 'loaded') return null;
-
-    const shouldShowDashboard = hasEthStaked || hasSolStaked;
 
     return (
         <WalletLayout
@@ -31,7 +19,7 @@ export const StakingDashboard = ({ selectedAccount, dashboard }: StakingDashboar
             titleValues={{ symbol: getNetworkDisplaySymbol(selectedAccount.account.symbol) }}
             account={selectedAccount}
         >
-            {shouldShowDashboard ? dashboard : <EmptyStakingCard />}
+            {dashboard}
             <EverstakeFooter />
         </WalletLayout>
     );

--- a/suite-common/wallet-core/src/stake/stakeUtils.ts
+++ b/suite-common/wallet-core/src/stake/stakeUtils.ts
@@ -1,0 +1,33 @@
+import { Account, WalletAccountTransaction } from '@suite-common/wallet-types';
+import {
+    getStakingDataForNetwork,
+    isPending,
+    isSupportedStakingNetworkSymbol,
+} from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+export const isAccountStakingActive = (
+    account: Account | null,
+    claimTransactions: WalletAccountTransaction[],
+) => {
+    if (!account) return false;
+
+    if (!isSupportedStakingNetworkSymbol(account.symbol)) return false;
+
+    const {
+        totalPendingStakeBalance = '0',
+        withdrawTotalAmount = '0',
+        claimableAmount = '0',
+        canClaim = false,
+        depositedBalance = '0',
+    } = getStakingDataForNetwork(account) ?? {};
+
+    const pendingClaimTxs = claimTransactions.filter(tx => isPending(tx));
+
+    const isStakePending = new BigNumber(totalPendingStakeBalance).gt(0);
+    const isUnstakePending = new BigNumber(withdrawTotalAmount).gt(0);
+    const isClaimPending = new BigNumber(claimableAmount).gt(0) && pendingClaimTxs.length > 0;
+    const hasDepositedBalance = new BigNumber(depositedBalance).gt(0);
+
+    return hasDepositedBalance || isStakePending || isUnstakePending || isClaimPending || canClaim;
+};

--- a/suite-common/wallet-core/src/transactions/transactionsReducer.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsReducer.ts
@@ -37,6 +37,7 @@ import {
     BlockchainRootState,
     selectBlockchainHeightBySymbol,
 } from '../blockchain/blockchainReducer';
+import { isAccountStakingActive } from '../stake/stakeUtils';
 
 export type AccountTransactionsFetchStatusDetail =
     | {
@@ -380,6 +381,29 @@ export const selectAccountClaimTransactions = createMemoizedSelector(
         returnStableArrayIfEmpty(
             transactions.filter(tx => isClaimTx(tx?.ethereumSpecific?.parsedData?.methodId)),
         ),
+);
+
+export const selectAccountIsStakingActive = createMemoizedSelector(
+    [selectAccountClaimTransactions, selectAccountByKey],
+    (claimTransactions, account) => isAccountStakingActive(account, claimTransactions),
+);
+
+export const selectAnyAccountIsStakingActive = createMemoizedSelector(
+    [
+        (state: TransactionsRootState, accounts: Account[]) =>
+            accounts.map(account => ({
+                account,
+                transactions: state.wallet.transactions.transactions[account.key] ?? [],
+            })),
+    ],
+    items =>
+        items.some(({ account, transactions }) => {
+            const claimTransactions = transactions.filter(tx =>
+                isClaimTx(tx?.ethereumSpecific?.parsedData?.methodId),
+            );
+
+            return isAccountStakingActive(account, claimTransactions);
+        }),
 );
 
 export const selectEthAccountHasStaked = createMemoizedSelector(


### PR DESCRIPTION
## Description

Staking in sidebar/dashboard is shown only if non-zero balance is staked or there is stake/unstake/claim pending or the claim is ready.

If an account is not staking at the moment but there has been staking history, show `Start staking` banner but also show the past transactions. Same with Solana and its rewards.

## Related Issue

Resolve #16864 

## Screenshots:

`Ethereum #1` staking is shown in the sidebar because claim is ready.

<img width="1450" alt="Screenshot 2025-03-14 at 10 08 02" src="https://github.com/user-attachments/assets/4c5d038f-3343-443b-86e6-5566f1259765" />

Therefore, staking is shown in the dashboard view.

<img width="1140" alt="Screenshot 2025-03-14 at 10 08 20" src="https://github.com/user-attachments/assets/9e0af572-144a-45ef-a769-a37ca9034caa" />

`Ethereum #1` has zero balance staked and the check fails, so `Start staking` banner is shown.

<img width="1448" alt="Screenshot 2025-03-14 at 10 08 35" src="https://github.com/user-attachments/assets/0f3c0c62-2923-45ca-8f2d-840d7a26eddb" />

However, it has been used for staking in the past, so transactions are still visible.

<img width="1138" alt="Screenshot 2025-03-14 at 10 08 43" src="https://github.com/user-attachments/assets/626f4dc2-f867-4d42-aeb7-cd69d607fc69" />
