### PR TITLE
Remove selectors returning whole state

### DIFF
--- a/packages/suite-desktop-ui/src/support/DesktopUpdater.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater.tsx
@@ -15,7 +15,7 @@ import {
     setUpdateModalVisibility,
 } from 'src/actions/suite/desktopUpdateActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { UpdateState } from 'src/reducers/suite/desktopUpdateReducer';
+import { UpdateState, selectDesktopUpdate } from 'src/reducers/suite/desktopUpdateReducer';
 import { ModalContextProvider } from 'src/support/suite/ModalContext';
 import { getAppUpdatePayload } from 'src/utils/suite/analytics';
 
@@ -32,7 +32,7 @@ interface DesktopUpdaterProps {
 
 export const DesktopUpdater = ({ children }: DesktopUpdaterProps) => {
     const dispatch = useDispatch();
-    const { desktopUpdate } = useSelector(state => state);
+    const desktopUpdate = useSelector(selectDesktopUpdate);
 
     const desktopUpdateState = desktopUpdate.state;
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/UpdateTooltip.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/UpdateTooltip.tsx
@@ -86,10 +86,9 @@ type SuiteRowProps = {
 const SuiteRow = ({ updateStatus, onClick }: SuiteRowProps) => {
     const theme = useTheme();
 
-    const { desktopUpdate } = useSelector(state => state);
+    const suiteNewVersion = useSelector(state => state.desktopUpdate.latest?.version);
 
     const suiteCurrentVersion = process.env.VERSION || '';
-    const suiteNewVersion = desktopUpdate.latest?.version;
 
     return (
         <TooltipRow

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApplicationLogModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApplicationLogModal.tsx
@@ -46,12 +46,11 @@ type ApplicationLogModalProps = { onCancel: () => void };
 export const ApplicationLogModal = ({ onCancel }: ApplicationLogModalProps) => {
     const [hideSensitiveInfo, setHideSensitiveInfo] = useState(false);
     const logs = useSelector(selectLogs);
-    const state = useSelector(state => state);
+    const applicationInfo = useSelector(state => getApplicationInfo(state, hideSensitiveInfo));
     const { ShadowTop, ShadowBottom, ShadowContainer, onScroll, scrollElementRef } =
         useScrollShadow();
 
     const actionLog = getApplicationLog(logs, hideSensitiveInfo);
-    const applicationInfo = getApplicationInfo(state, hideSensitiveInfo);
     const log = prettifyLog([applicationInfo, ...actionLog]);
 
     const download = () => {

--- a/packages/suite/src/hooks/suite/useOnboarding.ts
+++ b/packages/suite/src/hooks/suite/useOnboarding.ts
@@ -9,7 +9,7 @@ import { useActions, useDispatch, useSelector } from 'src/hooks/suite';
 export const useOnboarding = () => {
     const dispatch = useDispatch();
 
-    const { onboarding, modal } = useSelector(state => state);
+    const { onboarding, modal } = useSelector(({ onboarding, modal }) => ({ onboarding, modal }));
 
     const showPinMatrix =
         modal.context === '@modal/context-device' && modal.windowType === UI.REQUEST_PIN;

--- a/packages/suite/src/reducers/suite/desktopUpdateReducer.ts
+++ b/packages/suite/src/reducers/suite/desktopUpdateReducer.ts
@@ -36,6 +36,10 @@ export interface DesktopUpdateState {
     justUpdatedInteractedWith: boolean;
 }
 
+type DesktopUpdateRootState = {
+    desktopUpdate: DesktopUpdateState;
+};
+
 const initialState: DesktopUpdateState = {
     enabled: false,
     state: UpdateState.NotAvailable,
@@ -109,5 +113,7 @@ const desktopUpdateReducer = (
             // no default
         }
     });
+
+export const selectDesktopUpdate = (state: DesktopUpdateRootState) => state.desktopUpdate;
 
 export default desktopUpdateReducer;


### PR DESCRIPTION
## Description

According to redux docs, `useSelector call returning the entire root state is almost always a mistake`, so I fixed them.