### PR TITLE
chore: upgrade to TS 5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         "s": "yarn native:start"
     },
     "resolutions": {
-        "typescript": "5.7.3",
+        "typescript": "5.8.2",
         "react-native": "0.76.1",
         "prettier": "3.2.5",
         "type-fest": "4.24.0",
@@ -143,7 +143,7 @@
         "tsconfig-paths": "^4.2.0",
         "tslib": "^2.6.2",
         "tsx": "^4.19.3",
-        "typescript": "5.7.3",
+        "typescript": "5.8.2",
         "version-bump-prompt": "^6.1.0"
     },
     "dependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         "s": "yarn native:start"
     },
     "resolutions": {
-        "typescript": "5.5.4",
+        "typescript": "5.6.3",
         "react-native": "0.76.1",
         "prettier": "3.2.5",
         "type-fest": "4.24.0",
@@ -143,7 +143,7 @@
         "tsconfig-paths": "^4.2.0",
         "tslib": "^2.6.2",
         "tsx": "^4.19.3",
-        "typescript": "5.5.4",
+        "typescript": "5.6.3",
         "version-bump-prompt": "^6.1.0"
     },
     "dependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -89,14 +89,14 @@
         "s": "yarn native:start"
     },
     "resolutions": {
-        "typescript": "5.6.3",
+        "typescript": "5.7.3",
         "react-native": "0.76.1",
         "prettier": "3.2.5",
         "type-fest": "4.24.0",
         "bcrypto": "5.4.0",
         "react": "18.2.0",
         "electron": "35.0.1",
-        "@types/node": "22.10.1",
+        "@types/node": "22.13.10",
         "@types/react": "18.2.55",
         "bn.js": "5.2.1",
         "node-gyp": "10.2.0",
@@ -119,7 +119,7 @@
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/eslint": "workspace:*",
         "@types/jest": "29.5.12",
-        "@types/node": "22.10.1",
+        "@types/node": "22.13.10",
         "@types/prettier": "^3.0.0",
         "@types/semver": "^7.5.6",
         "@types/tar": "^6.1.11",
@@ -143,7 +143,7 @@
         "tsconfig-paths": "^4.2.0",
         "tslib": "^2.6.2",
         "tsx": "^4.19.3",
-        "typescript": "5.6.3",
+        "typescript": "5.7.3",
         "version-bump-prompt": "^6.1.0"
     },
     "dependenciesMeta": {

--- a/packages/connect-examples/mobile-expo/package.json
+++ b/packages/connect-examples/mobile-expo/package.json
@@ -19,7 +19,7 @@
     "devDependencies": {
         "@babel/core": "^7.20.0",
         "@types/react": "18.2.45",
-        "typescript": "^5.3.3"
+        "typescript": "5.7.3"
     },
     "private": true
 }

--- a/packages/connect-examples/mobile-expo/package.json
+++ b/packages/connect-examples/mobile-expo/package.json
@@ -19,7 +19,7 @@
     "devDependencies": {
         "@babel/core": "^7.20.0",
         "@types/react": "18.2.45",
-        "typescript": "5.7.3"
+        "typescript": "5.8.2"
     },
     "private": true
 }

--- a/packages/connect-plugin-ethereum/tsconfig.libESM.json
+++ b/packages/connect-plugin-ethereum/tsconfig.libESM.json
@@ -3,6 +3,6 @@
     "compilerOptions": {
         "outDir": "libESM",
         "module": "ESNext",
-        "target": "esnext"
+        "target": "ES2023"
     }
 }

--- a/packages/connect-plugin-stellar/tsconfig.libESM.json
+++ b/packages/connect-plugin-stellar/tsconfig.libESM.json
@@ -3,6 +3,6 @@
     "compilerOptions": {
         "outDir": "libESM",
         "module": "ESNext",
-        "target": "esnext"
+        "target": "ES2023"
     }
 }

--- a/packages/connect/src/api/cipherKeyValue.ts
+++ b/packages/connect/src/api/cipherKeyValue.ts
@@ -34,11 +34,14 @@ export default class CipherKeyValue extends AbstractMethod<
         this.params = payload.bundle.map(batch => ({
             address_n: validatePath(batch.path),
             key: batch.key,
-            value: batch.value instanceof Buffer ? batch.value.toString('hex') : batch.value,
+            value:
+                batch.value instanceof Buffer
+                    ? batch.value.toString('hex')
+                    : (batch.value as string),
             encrypt: batch.encrypt,
             ask_on_encrypt: batch.askOnEncrypt,
             ask_on_decrypt: batch.askOnDecrypt,
-            iv: batch.iv instanceof Buffer ? batch.iv.toString('hex') : batch.iv,
+            iv: batch.iv instanceof Buffer ? batch.iv.toString('hex') : (batch.iv as string),
         }));
     }
 

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -35,7 +35,7 @@
     },
     "dependencies": {
         "@trezor/schema-utils": "workspace:*",
-        "long": "5.2.0",
+        "long": "5.2.5",
         "protobufjs": "7.4.0"
     },
     "devDependencies": {

--- a/packages/protobuf/tsconfig.json
+++ b/packages/protobuf/tsconfig.json
@@ -1,9 +1,6 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "outDir": "libDev",
-        "allowSyntheticDefaultImports": true
-    },
+    "compilerOptions": { "outDir": "libDev" },
     "include": ["src"],
     "references": [{ "path": "../schema-utils" }]
 }

--- a/packages/protobuf/tsconfig.json
+++ b/packages/protobuf/tsconfig.json
@@ -1,6 +1,9 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": { "outDir": "libDev" },
+    "compilerOptions": {
+        "outDir": "libDev",
+        "allowSyntheticDefaultImports": true
+    },
     "include": ["src"],
     "references": [{ "path": "../schema-utils" }]
 }

--- a/packages/suite-desktop-core/src/tsconfig.json
+++ b/packages/suite-desktop-core/src/tsconfig.json
@@ -6,7 +6,7 @@
         "outDir": "../dist",
         "noEmit": false,
         "jsx": "preserve",
-        "target": "esnext",
+        "target": "ES2023",
         "sourceMap": true,
         "lib": [
             "dom",

--- a/packages/trezor-user-env-link/package.json
+++ b/packages/trezor-user-env-link/package.json
@@ -16,6 +16,6 @@
     },
     "devDependencies": {
         "ts-node": "^10.9.2",
-        "typescript": "5.5.4"
+        "typescript": "5.7.3"
     }
 }

--- a/packages/trezor-user-env-link/package.json
+++ b/packages/trezor-user-env-link/package.json
@@ -16,6 +16,6 @@
     },
     "devDependencies": {
         "ts-node": "^10.9.2",
-        "typescript": "5.7.3"
+        "typescript": "5.8.2"
     }
 }

--- a/packages/utils/tsconfig.libESM.json
+++ b/packages/utils/tsconfig.libESM.json
@@ -3,6 +3,6 @@
     "compilerOptions": {
         "outDir": "libESM",
         "module": "ESNext",
-        "target": "esnext"
+        "target": "ES2023"
     }
 }

--- a/packages/utxo-lib/src/transaction/zcash.ts
+++ b/packages/utxo-lib/src/transaction/zcash.ts
@@ -309,8 +309,10 @@ function getExtraData(tx: TransactionBase<ZcashSpecific>) {
     return tx.toBuffer().subarray(offset);
 }
 
-function getBlake2bDigestHash(buffer: Buffer, personalization: string | Buffer) {
-    const hash = blake2b(buffer, undefined, 32, undefined, Buffer.from(personalization));
+function getBlake2bDigestHash(buffer: Buffer, personalization: string | Buffer<ArrayBufferLike>) {
+    const personalizedBuffer =
+        typeof personalization === 'string' ? Buffer.from(personalization) : personalization;
+    const hash = blake2b(buffer, undefined, 32, undefined, personalizedBuffer);
 
     return Buffer.from(hash);
 }

--- a/suite-common/formatters/src/makeFormatter.tsx
+++ b/suite-common/formatters/src/makeFormatter.tsx
@@ -44,8 +44,9 @@ export const makeFormatter = <TInput, TOutput, TDataContext extends DataContext 
     format: FormatDefinition<TInput, TOutput, TDataContext>,
     displayName = 'Formatter',
 ): Formatter<TInput, TOutput, TDataContext> => {
-    const FormatterComponent: Formatter<TInput, TOutput, TDataContext> = props =>
-        <>{format(props.value, props, useShouldRedactNumbers())}</> ?? null;
+    const FormatterComponent: Formatter<TInput, TOutput, TDataContext> = props => (
+        <>{format(props.value, props, useShouldRedactNumbers())}</>
+    );
     FormatterComponent.displayName = displayName;
 
     FormatterComponent.format = (value, dataContext = {}) => format(value, dataContext);

--- a/suite-common/formatters/src/makeFormatter.tsx
+++ b/suite-common/formatters/src/makeFormatter.tsx
@@ -30,7 +30,7 @@ type FormatterProps<TInput, TDataContext extends DataContext> = {
 export interface Formatter<TInput, TOutput, TDataContext extends DataContext = DataContext> {
     /** Formats a value. */
     format: FormatMethod<TInput, TOutput, TDataContext>;
-    (props: FormatterProps<TInput, TDataContext>): JSX.Element | null;
+    (props: FormatterProps<TInput, TDataContext>): JSX.Element;
     /** Name of the formatter for easier debugging and profiling. */
     displayName?: string;
 }

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -136,7 +136,7 @@
         "@suite-common/test-utils": "workspace:^",
         "@trezor/connect-mobile": "workspace:^",
         "@types/jest": "^29.5.12",
-        "@types/node": "22.10.1",
+        "@types/node": "22.13.10",
         "babel-plugin-transform-inline-environment-variables": "^0.4.4",
         "babel-plugin-transform-remove-console": "^6.9.4",
         "detox": "^20.34.4",
@@ -145,7 +145,7 @@
         "jest-junit": "^16.0.0",
         "metro": "0.81.0",
         "ts-jest": "^29.1.2",
-        "typescript": "^5.3.3"
+        "typescript": "5.7.3"
     },
     "private": true
 }

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -145,7 +145,7 @@
         "jest-junit": "^16.0.0",
         "metro": "0.81.0",
         "ts-jest": "^29.1.2",
-        "typescript": "5.7.3"
+        "typescript": "5.8.2"
     },
     "private": true
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,7 @@
         "jsx": "preserve",
         "module": "ESNext",
         "moduleResolution": "Bundler",
-        "target": "esnext",
+        "target": "ES2023",
         "removeComments": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10015,7 +10015,7 @@ __metadata:
     react-redux: "npm:9.2.0"
     redux-persist: "npm:6.0.0"
     ts-jest: "npm:^29.1.2"
-    typescript: "npm:5.7.3"
+    typescript: "npm:5.8.2"
   languageName: unknown
   linkType: soft
 
@@ -12816,7 +12816,7 @@ __metadata:
     "@trezor/websocket-client": "workspace:*"
     cross-fetch: "npm:^4.0.0"
     ts-node: "npm:^10.9.2"
-    typescript: "npm:5.7.3"
+    typescript: "npm:5.8.2"
   languageName: unknown
   linkType: soft
 
@@ -18759,7 +18759,7 @@ __metadata:
     expo-status-bar: "npm:^2.0.0"
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"
-    typescript: "npm:5.7.3"
+    typescript: "npm:5.8.2"
   languageName: unknown
   linkType: soft
 
@@ -40679,7 +40679,7 @@ __metadata:
     tsconfig-paths: "npm:^4.2.0"
     tslib: "npm:^2.6.2"
     tsx: "npm:^4.19.3"
-    typescript: "npm:5.7.3"
+    typescript: "npm:5.8.2"
     version-bump-prompt: "npm:^6.1.0"
   dependenciesMeta:
     core-js-pure:
@@ -41148,23 +41148,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.7.3":
-  version: 5.7.3
-  resolution: "typescript@npm:5.7.3"
+"typescript@npm:5.8.2":
+  version: 5.8.2
+  resolution: "typescript@npm:5.8.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/6a7e556de91db3d34dc51cd2600e8e91f4c312acd8e52792f243c7818dfadb27bae677175fad6947f9c81efb6c57eb6b2d0c736f196a6ee2f1f7d57b74fc92fa
+  checksum: 10/dbc2168a55d56771f4d581997be52bab5cbc09734fec976cfbaabd787e61fb4c6cf9125fd48c6f98054ce549c77ecedefc7f64252a830dd8e9c3381f61fbeb78
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>":
-  version: 5.7.3
-  resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>":
+  version: 5.8.2
+  resolution: "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>::version=5.8.2&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/dc58d777eb4c01973f7fbf1fd808aad49a0efdf545528dab9b07d94fdcb65b8751742804c3057e9619a4627f2d9cc85547fdd49d9f4326992ad0181b49e61d81
+  checksum: 10/97920a082ffc57583b1cb6bc4faa502acc156358e03f54c7fc7fdf0b61c439a717f4c9070c449ee9ee683d4cfc3bb203127c2b9794b2950f66d9d307a4ff262c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12192,7 +12192,7 @@ __metadata:
   resolution: "@trezor/protobuf@workspace:packages/protobuf"
   dependencies:
     "@trezor/schema-utils": "workspace:*"
-    long: "npm:5.2.0"
+    long: "npm:5.2.5"
     protobufjs: "npm:7.4.0"
     protobufjs-cli: "npm:^1.1.3"
     tsx: "npm:^4.19.3"
@@ -29565,10 +29565,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"long@npm:5.2.0":
-  version: 5.2.0
-  resolution: "long@npm:5.2.0"
-  checksum: 10/9bb47091fea71634d9bf59f150ecc25180c44bead2e1408d78f3ff4ea68f16b38587be413b59acb46fb0bbe51e6823ec8547aa61aa8aef10cae4ff9a2538db3d
+"long@npm:5.2.5":
+  version: 5.2.5
+  resolution: "long@npm:5.2.5"
+  checksum: 10/972589d04a564ef4c066069d5ed06db14cd63de2a08d4f6c989512fa414bc2239479564e3a85de3efd42eb533ce142cdcaa28f12f4ecd051670015d36cbbb10b
   languageName: node
   linkType: hard
 
@@ -40679,7 +40679,7 @@ __metadata:
     tsconfig-paths: "npm:^4.2.0"
     tslib: "npm:^2.6.2"
     tsx: "npm:^4.19.3"
-    typescript: "npm:5.5.4"
+    typescript: "npm:5.6.3"
     version-bump-prompt: "npm:^6.1.0"
   dependenciesMeta:
     core-js-pure:
@@ -41148,23 +41148,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.5.4":
-  version: 5.5.4
-  resolution: "typescript@npm:5.5.4"
+"typescript@npm:5.6.3":
+  version: 5.6.3
+  resolution: "typescript@npm:5.6.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/1689ccafef894825481fc3d856b4834ba3cc185a9c2878f3c76a9a1ef81af04194849840f3c69e7961e2312771471bb3b460ca92561e1d87599b26c37d0ffb6f
+  checksum: 10/c328e418e124b500908781d9f7b9b93cf08b66bf5936d94332b463822eea2f4e62973bfb3b8a745fdc038785cb66cf59d1092bac3ec2ac6a3e5854687f7833f1
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>":
-  version: 5.5.4
-  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=379a07"
+"typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>":
+  version: 5.6.3
+  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/746fdd0865c5ce4f15e494c57ede03a9e12ede59cfdb40da3a281807853fe63b00ef1c912d7222143499aa82f18b8b472baa1830df8804746d09b55f6cf5b1cc
+  checksum: 10/00504c01ee42d470c23495426af07512e25e6546bce7e24572e72a9ca2e6b2e9bea63de4286c3cfea644874da1467dcfca23f4f98f7caf20f8b03c0213bb6837
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9967,7 +9967,7 @@ __metadata:
     "@trezor/theme": "workspace:*"
     "@trezor/trezor-user-env-link": "workspace:*"
     "@types/jest": "npm:^29.5.12"
-    "@types/node": "npm:22.10.1"
+    "@types/node": "npm:22.13.10"
     "@whatwg-node/events": "npm:0.1.2"
     abortcontroller-polyfill: "npm:1.7.6"
     babel-plugin-transform-inline-environment-variables: "npm:^0.4.4"
@@ -10015,7 +10015,7 @@ __metadata:
     react-redux: "npm:9.2.0"
     redux-persist: "npm:6.0.0"
     ts-jest: "npm:^29.1.2"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.7.3"
   languageName: unknown
   linkType: soft
 
@@ -12816,7 +12816,7 @@ __metadata:
     "@trezor/websocket-client": "workspace:*"
     cross-fetch: "npm:^4.0.0"
     ts-node: "npm:^10.9.2"
-    typescript: "npm:5.5.4"
+    typescript: "npm:5.7.3"
   languageName: unknown
   linkType: soft
 
@@ -13866,12 +13866,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:22.10.1":
-  version: 22.10.1
-  resolution: "@types/node@npm:22.10.1"
+"@types/node@npm:22.13.10":
+  version: 22.13.10
+  resolution: "@types/node@npm:22.13.10"
   dependencies:
     undici-types: "npm:~6.20.0"
-  checksum: 10/c802a526da2f3fa3ccefd00a71244e7cb825329951719e79e8fec62b1dbc2855388c830489770611584665ce10be23c05ed585982038b24924e1ba2c2cce03fd
+  checksum: 10/57dc6a5e0110ca9edea8d7047082e649fa7fa813f79e4a901653b9174141c622f4336435648baced5b38d9f39843f404fa2d8d7a10981610da26066bc8caab48
   languageName: node
   linkType: hard
 
@@ -18759,7 +18759,7 @@ __metadata:
     expo-status-bar: "npm:^2.0.0"
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.7.3"
   languageName: unknown
   linkType: soft
 
@@ -40655,7 +40655,7 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/eslint": "workspace:*"
     "@types/jest": "npm:29.5.12"
-    "@types/node": "npm:22.10.1"
+    "@types/node": "npm:22.13.10"
     "@types/prettier": "npm:^3.0.0"
     "@types/semver": "npm:^7.5.6"
     "@types/tar": "npm:^6.1.11"
@@ -40679,7 +40679,7 @@ __metadata:
     tsconfig-paths: "npm:^4.2.0"
     tslib: "npm:^2.6.2"
     tsx: "npm:^4.19.3"
-    typescript: "npm:5.6.3"
+    typescript: "npm:5.7.3"
     version-bump-prompt: "npm:^6.1.0"
   dependenciesMeta:
     core-js-pure:
@@ -41148,23 +41148,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.6.3":
-  version: 5.6.3
-  resolution: "typescript@npm:5.6.3"
+"typescript@npm:5.7.3":
+  version: 5.7.3
+  resolution: "typescript@npm:5.7.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/c328e418e124b500908781d9f7b9b93cf08b66bf5936d94332b463822eea2f4e62973bfb3b8a745fdc038785cb66cf59d1092bac3ec2ac6a3e5854687f7833f1
+  checksum: 10/6a7e556de91db3d34dc51cd2600e8e91f4c312acd8e52792f243c7818dfadb27bae677175fad6947f9c81efb6c57eb6b2d0c736f196a6ee2f1f7d57b74fc92fa
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>":
-  version: 5.6.3
-  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
+"typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>":
+  version: 5.7.3
+  resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/00504c01ee42d470c23495426af07512e25e6546bce7e24572e72a9ca2e6b2e9bea63de4286c3cfea644874da1467dcfca23f4f98f7caf20f8b03c0213bb6837
+  checksum: 10/dc58d777eb4c01973f7fbf1fd808aad49a0efdf545528dab9b07d94fdcb65b8751742804c3057e9619a4627f2d9cc85547fdd49d9f4326992ad0181b49e61d81
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -29565,17 +29565,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"long@npm:5.2.5":
+"long@npm:5.2.5, long@npm:^5.0.0":
   version: 5.2.5
   resolution: "long@npm:5.2.5"
   checksum: 10/972589d04a564ef4c066069d5ed06db14cd63de2a08d4f6c989512fa414bc2239479564e3a85de3efd42eb533ce142cdcaa28f12f4ecd051670015d36cbbb10b
-  languageName: node
-  linkType: hard
-
-"long@npm:^5.0.0":
-  version: 5.2.4
-  resolution: "long@npm:5.2.4"
-  checksum: 10/c27c060a683d4d76dc48da12ded0ae49c610aaf10d028ec938829d7bebe916979dcc8b67ed71f8bf6d845a90151b66a9b741a3ee51ec874908e496c2a576697a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I had to set target to ES2023 because 24 introduces some changes to Buffer typings which caused huge amount of error across mostly codebase. I don't see it as issue to have it set for ES2023.

There was few minor changes necessary but it should not break anything.

Also updated ESlint because it's kind of dependant on TS version.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
