### PR TITLE
fix(transport): `UDP` read from buffer or promise

### DIFF
--- a/packages/transport/src/api/udp.ts
+++ b/packages/transport/src/api/udp.ts
@@ -10,6 +10,7 @@ import {
 } from './abstract';
 import * as ERRORS from '../errors';
 import { DescriptorApiLevel, PathInternal } from '../types';
+import { readMessageBuffer } from '../utils/readMessageBuffer';
 
 export class UdpApi extends AbstractApi {
     chunkSize = 64;
@@ -21,17 +22,20 @@ export class UdpApi extends AbstractApi {
         signal: this.listenAbortController.signal,
     });
     private debugLink?: boolean;
-    private receivedMessagesBuffer: Buffer[] = [];
+    private readBuffer: ReturnType<typeof readMessageBuffer>;
 
     constructor({ logger, debugLink }: AbstractApiConstructorParams & { debugLink?: boolean }) {
         super({ logger });
         this.debugLink = debugLink;
+        this.readBuffer = readMessageBuffer();
 
-        const onMessage = (message: Buffer, _info: UDP.RemoteInfo) => {
+        const onMessage = (message: Buffer, info: UDP.RemoteInfo) => {
             if (message.toString() === 'PONGPONG') {
                 return;
             }
-            this.receivedMessagesBuffer.push(message);
+
+            const id = `${info.address}:${info.port}`;
+            this.readBuffer.onMessage(id, message);
             this.logger?.debug('udp: globalOnMessage log:', message.toString('hex'));
         };
         this.interface.addListener('message', onMessage);
@@ -87,34 +91,8 @@ export class UdpApi extends AbstractApi {
         });
     }
 
-    public async read(_path: string, signal?: AbortSignal) {
-        let message = this.receivedMessagesBuffer.shift();
-
-        if (message) {
-            return Promise.resolve(this.success(message));
-        }
-
-        try {
-            // give emu 500ms to send something
-            this.logger?.debug('udp: read: empty buffer, waiting for messages');
-            await resolveAfter(500, signal);
-        } catch {
-            // signal checked just below
-        }
-        if (signal?.aborted) {
-            return this.error({ error: ERRORS.ABORTED_BY_SIGNAL });
-        }
-
-        message = this.receivedMessagesBuffer.shift();
-
-        if (!message) {
-            return this.error({
-                error: ERRORS.INTERFACE_DATA_TRANSFER,
-                message: 'no message received',
-            });
-        }
-
-        return Promise.resolve(this.success(message));
+    public read(path: string, signal?: AbortSignal) {
+        return this.readBuffer.read(path, signal);
     }
 
     private async ping(path: string, signal?: AbortSignal) {

--- a/packages/transport/src/utils/readMessageBuffer.ts
+++ b/packages/transport/src/utils/readMessageBuffer.ts
@@ -1,0 +1,55 @@
+import { Deferred, createDeferred } from '@trezor/utils';
+
+import { error, success } from './result';
+import { ABORTED_BY_SIGNAL } from '../errors';
+import { ResultWithTypedError } from '../types';
+
+type ReadResult = ResultWithTypedError<Buffer, typeof ABORTED_BY_SIGNAL>;
+
+export const readMessageBuffer = () => {
+    const readBuffer: Record<string, Buffer[]> = {};
+    const readRequests: Record<string, Deferred<ReadResult>> = {};
+
+    const onMessage = (path: string, data: Buffer) => {
+        if (readRequests[path]) {
+            // message received AFTER read request, resolve pending response
+            readRequests[path].resolve(success(data));
+            delete readRequests[path];
+        } else {
+            // message received BEFORE read request, put chunk into buffer and wait for read request
+            if (!readBuffer[path]) {
+                readBuffer[path] = [];
+            }
+            readBuffer[path].push(data);
+        }
+    };
+
+    const read = (path: string, signal?: AbortSignal) => {
+        const bufferMessage = readBuffer[path]?.shift();
+        if (bufferMessage) {
+            return Promise.resolve(success(bufferMessage));
+        }
+
+        if (readRequests[path]) {
+            return readRequests[path].promise;
+        }
+
+        const dfd = createDeferred<ReadResult>();
+        readRequests[path] = dfd;
+
+        const abortListener = () => {
+            dfd.resolve(error({ error: ABORTED_BY_SIGNAL }));
+        };
+        signal?.addEventListener('abort', abortListener);
+
+        return dfd.promise.finally(() => {
+            signal?.removeEventListener('abort', abortListener);
+            delete readRequests[path];
+        });
+    };
+
+    return {
+        onMessage,
+        read,
+    };
+};

--- a/packages/transport/tests/readMessageBuffer.test.ts
+++ b/packages/transport/tests/readMessageBuffer.test.ts
@@ -1,0 +1,62 @@
+import { ABORTED_BY_SIGNAL } from '../src/errors';
+import { readMessageBuffer } from '../src/utils/readMessageBuffer';
+
+describe('readMessageBuffer', () => {
+    it('read from readBuffer', async () => {
+        const r = readMessageBuffer();
+
+        r.onMessage('1', Buffer.alloc(2).fill(1));
+        r.onMessage('2-ignored', Buffer.alloc(2).fill(3));
+        r.onMessage('1', Buffer.alloc(2).fill(2));
+
+        let result = await r.read('1');
+        if (!result.success) throw new Error(result.error);
+        expect(result.payload.toString('hex')).toEqual('0101');
+
+        result = await r.read('1');
+        if (!result.success) throw new Error(result.error);
+        expect(result.payload.toString('hex')).toEqual('0202');
+    });
+
+    it('read from readRequest promise', async () => {
+        const r = readMessageBuffer();
+
+        const readPromise1 = r.read('1');
+        const readPromise2 = r.read('1');
+
+        r.onMessage('1', Buffer.alloc(2).fill(1));
+        r.onMessage('2-ignored', Buffer.alloc(2).fill(3));
+        r.onMessage('1', Buffer.alloc(2).fill(2));
+
+        let result = await readPromise1;
+        if (!result.success) throw new Error(result.error);
+        expect(result.payload.toString('hex')).toEqual('0101');
+
+        result = await readPromise2;
+        if (!result.success) throw new Error(result.error);
+        expect(result.payload.toString('hex')).toEqual('0101');
+
+        result = await r.read('1');
+        if (!result.success) throw new Error(result.error);
+        expect(result.payload.toString('hex')).toEqual('0202');
+    });
+
+    it('read from readRequest aborted', async () => {
+        const r = readMessageBuffer();
+
+        const abortController = new AbortController();
+
+        const readPromise = r.read('1', abortController.signal);
+
+        abortController.abort();
+
+        let result = await readPromise;
+        if (result.success) throw new Error('Unexpected success');
+        expect(result.error).toEqual(ABORTED_BY_SIGNAL);
+
+        r.onMessage('1', Buffer.alloc(2).fill(1));
+        result = await r.read('1');
+        if (!result.success) throw new Error(result.error);
+        expect(result.payload.toString('hex')).toEqual('0101');
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

create shared utility for `UDP` and `Bluetooth` transports

read from message buffer or message promise (dfd)

fixing problem with `UDP.read` timeout error rejected on ButtonRequest