### PR TITLE
fix(suite-native): welcome flow device disconnected alert

### DIFF
--- a/suite-native/module-onboarding/src/screens/BiometricsScreen.tsx
+++ b/suite-native/module-onboarding/src/screens/BiometricsScreen.tsx
@@ -46,8 +46,6 @@ export const BiometricsScreen = ({
     };
 
     const exitOnboardingFlow = () => {
-        dispatch(setIsOnboardingFinished());
-
         navigation.dispatch(
             CommonActions.reset({
                 index: 0,
@@ -61,6 +59,14 @@ export const BiometricsScreen = ({
                 ],
             }),
         );
+
+        // FIXME: Hotfix temporary solution.
+        // Timeout is needed to ensure that navigation event already finishes before changing the redux state.
+        // Situation when the onboarding screen was still focused but the state was already changed made `useHandleDeviceConnection`
+        // to display the device disconnected alert even if it should not be displayed.
+        setTimeout(() => {
+            dispatch(setIsOnboardingFinished());
+        }, 500);
     };
 
     const handleEnableButtonPress = async () => {


### PR DESCRIPTION
## Description
- fixes an issue when device disconnected alert was displayed after finishing the welcome flow
- this is only a hotfix, proper solution will come up as a followup to make things simple for the upcoming freeze

