### PR TITLE
fix(suite-native): Show FW update banner only if the Trezor is connected

### DIFF
--- a/suite-native/module-home/src/screens/HomeScreen/components/FirmwareUpdateAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/FirmwareUpdateAlert.tsx
@@ -12,7 +12,7 @@ import {
     selectDeviceReleaseInfo,
     selectDeviceState,
     selectDeviceUpdateFirmwareVersion,
-    selectIsDeviceConnectedAndAuthorized,
+    selectIsDeviceConnected,
     selectIsDiscoveryActiveByDeviceState,
     selectIsPortfolioTrackerDevice,
 } from '@suite-common/wallet-core';
@@ -56,7 +56,7 @@ export const FirmwareUpdateAlert = () => {
     const deviceReleaseInfo = useSelector(selectDeviceReleaseInfo);
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const deviceId = useSelector(selectDeviceId);
-    const isConnected = useSelector(selectIsDeviceConnectedAndAuthorized);
+    const isConnected = useSelector(selectIsDeviceConnected);
     const deviceState = useSelector(selectDeviceState);
     const isDiscoveryRunning = useSelector((state: DiscoveryRootState & DeviceRootState) =>
         selectIsDiscoveryActiveByDeviceState(state, deviceState),

--- a/suite-native/module-home/src/screens/HomeScreen/components/FirmwareUpdateAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/FirmwareUpdateAlert.tsx
@@ -12,6 +12,7 @@ import {
     selectDeviceReleaseInfo,
     selectDeviceState,
     selectDeviceUpdateFirmwareVersion,
+    selectIsDeviceBackedUp,
     selectIsDeviceConnected,
     selectIsDiscoveryActiveByDeviceState,
     selectIsPortfolioTrackerDevice,
@@ -57,6 +58,7 @@ export const FirmwareUpdateAlert = () => {
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const deviceId = useSelector(selectDeviceId);
     const isConnected = useSelector(selectIsDeviceConnected);
+    const isDeviceBackedUp = useSelector(selectIsDeviceBackedUp);
     const deviceState = useSelector(selectDeviceState);
     const isDiscoveryRunning = useSelector((state: DiscoveryRootState & DeviceRootState) =>
         selectIsDiscoveryActiveByDeviceState(state, deviceState),
@@ -101,6 +103,7 @@ export const FirmwareUpdateAlert = () => {
         isPortfolioTrackerDevice ||
         isDiscoveryRunning ||
         !isConnected ||
+        !isDeviceBackedUp ||
         isClosed
     ) {
         return null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Show FW update banner only if the Trezor is connected and has backup to unify the conditions with Device Settings screen.

Followup for https://github.com/trezor/trezor-suite/pull/17538#issuecomment-2713325842

## Related Issue

Fixes https://github.com/trezor/trezor-suite/issues/16476

## Screenshots:
BEFORE with disconnected view-only device:

https://github.com/user-attachments/assets/ca47fcf6-1e93-47e5-b8b7-062abf4425ac


