### PR TITLE
fix(connect-explorer): allow passing false value to optional fields

### DIFF
--- a/packages/connect-explorer/src/reducers/methodCommon.ts
+++ b/packages/connect-explorer/src/reducers/methodCommon.ts
@@ -35,7 +35,10 @@ export const getParam = (field: FieldBasic<any>, $params: Record<string, any> = 
     if (field.omit) {
         return params;
     }
-    if (field.optional && ((!field.value && field.value !== 0) || field.value === '')) {
+    if (
+        field.optional &&
+        ((!field.value && field.value !== 0 && field.value !== false) || field.value === '')
+    ) {
         return params;
     }
 


### PR DESCRIPTION
## Description

Small fix for setting an optional booelan field to false in Connect Explorer method tester

## Related Issue

Resolve #16522
