### PR TITLE
Used elsewhere better targeted

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -1223,7 +1223,9 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 type: 'unacquired',
                 label: 'Unacquired device',
                 name: this.name,
-                transportSessionOwner: this.transportSessionOwner,
+                transportSessionOwner: this.lastAcquiredHere
+                    ? undefined
+                    : this.transportSessionOwner,
                 bluetoothProps: this.bluetoothProps,
             };
         }

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -52,7 +52,7 @@ const connectInitSettings = {
     popup: false,
     manifest: {
         email: 'info@trezor.io',
-        appUrl: isDesktop() ? '@trezor/suite' : window.origin,
+        appUrl: isDesktop() ? 'Trezor Suite desktop' : window.origin,
     },
     sharedLogger: false,
     enableFirmwareHashCheck: true,


### PR DESCRIPTION
show this 
![image](https://github.com/user-attachments/assets/8fb5945c-929c-4e2c-9008-0b30eff6c629)

instead of the 'use elsehwere'  screen in case we can safely tell that it is not used elsewhere and we just failed to read the device


and change `@trezor/suite` to Trezor Suite desktop in the "used elsewhere screen"