### PR TITLE
fix(trading): show offers by redirect url params

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.tsx
@@ -36,6 +36,7 @@ import { useTradingHandleChange } from 'src/hooks/wallet/trading/form/common/use
 import { useTradingModalCrypto } from 'src/hooks/wallet/trading/form/common/useTradingModalCrypto';
 import { useTradingPreviousRoute } from 'src/hooks/wallet/trading/form/common/useTradingPreviousRoute';
 import { useTradingBuyFormDefaultValues } from 'src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues';
+import { useTradingBuyFormRedirectValues } from 'src/hooks/wallet/trading/form/useTradingBuyFormRedirectValues';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { useFormDraft } from 'src/hooks/wallet/useFormDraft';
 import { useTradingNavigation } from 'src/hooks/wallet/useTradingNavigation';
@@ -81,6 +82,7 @@ export const useTradingBuyForm = ({
         defaultPaymentMethod,
         suggestedFiatCurrency,
     } = useTradingBuyFormDefaultValues(account.symbol, buyInfo);
+    const redirectValues = useTradingBuyFormRedirectValues(isFromRedirect, quotesRequest);
     const buyDraftKey = account.key;
     const { saveDraft, getDraft, removeDraft } = useFormDraft<TradingBuyFormProps>('trading-buy');
     const draft = getDraft(buyDraftKey);
@@ -101,11 +103,13 @@ export const useTradingBuyForm = ({
     const isDraft = !!draftUpdated || !!isNotFormPage;
     const methods = useForm<TradingBuyFormProps>({
         mode: 'onChange',
-        defaultValues: isDraft && draftUpdated ? draftUpdated : defaultValues,
+        defaultValues: redirectValues || (isDraft && draftUpdated ? draftUpdated : defaultValues),
     });
     const { register, control, formState, reset, setValue, handleSubmit } = methods;
     const values = useWatch<TradingBuyFormProps>({ control });
-    const previousValues = useRef<typeof values | null>(isNotFormPage ? draftUpdated : null);
+    const previousValues = useRef<typeof values | null>(
+        !isFromRedirect && isNotFormPage ? draftUpdated : null,
+    );
 
     const isInitialDataLoading = !buyInfo || !buyInfo?.buyInfo;
     const noProviders = !isInitialDataLoading && buyInfo?.buyInfo?.providers.length === 0;
@@ -156,7 +160,10 @@ export const useTradingBuyForm = ({
 
         if (!quotesRequest || !provider) return;
 
-        const returnUrl = await createQuoteLink(quotesRequest, account);
+        const returnUrl = await createQuoteLink(
+            { ...quotesRequest, paymentMethod: quote.paymentMethod },
+            account,
+        );
 
         const userConsent = async (provider: string, cryptoCurrency: string) =>
             Boolean(

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormRedirectValues.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormRedirectValues.tsx
@@ -1,0 +1,26 @@
+import { BuyTradeQuoteRequest } from 'invity-api';
+
+import { TradingBuyFormProps, getDefaultCountry, useTradingInfo } from '@suite-common/trading';
+
+import { buildFiatOption } from 'src/utils/wallet/trading/tradingUtils';
+
+export const useTradingBuyFormRedirectValues = (
+    isFromRedirect: boolean,
+    quotesRequest: BuyTradeQuoteRequest | undefined,
+): TradingBuyFormProps | null => {
+    const { buildDefaultCryptoOption } = useTradingInfo();
+
+    return isFromRedirect && quotesRequest
+        ? {
+              amountInCrypto: quotesRequest.wantCrypto,
+              cryptoSelect: buildDefaultCryptoOption(quotesRequest.receiveCurrency),
+              currencySelect: buildFiatOption(quotesRequest.fiatCurrency),
+              countrySelect: getDefaultCountry(quotesRequest.country),
+              cryptoInput: quotesRequest.cryptoStringAmount,
+              paymentMethod: quotesRequest.paymentMethod && {
+                  value: quotesRequest.paymentMethod,
+                  label: quotesRequest.paymentMethod,
+              },
+          }
+        : null;
+};

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -41,6 +41,7 @@ import { useTradingCurrencySwitcher } from 'src/hooks/wallet/trading/form/common
 import { useTradingFormActions } from 'src/hooks/wallet/trading/form/common/useTradingFormActions';
 import { useTradingPreviousRoute } from 'src/hooks/wallet/trading/form/common/useTradingPreviousRoute';
 import { useTradingSellFormDefaultValues } from 'src/hooks/wallet/trading/form/useTradingSellFormDefaultValues';
+import { useTradingSellFormRedirectValues } from 'src/hooks/wallet/trading/form/useTradingSellFormRedirectValues';
 import { useTradingLoadData } from 'src/hooks/wallet/trading/useTradingLoadData';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { useFormDraft } from 'src/hooks/wallet/useFormDraft';
@@ -123,6 +124,7 @@ export const useTradingSellForm = ({
 
     const { defaultValues, defaultCountry, defaultCurrency, defaultPaymentMethod } =
         useTradingSellFormDefaultValues(account, sellInfo);
+    const redirectValues = useTradingSellFormRedirectValues(isFromRedirect, quotesRequest);
     const sellDraftKey = 'trading-sell';
     const { saveDraft, getDraft, removeDraft } = useFormDraft<TradingSellFormProps>(sellDraftKey);
     const draft = getDraft(sellDraftKey);
@@ -152,7 +154,7 @@ export const useTradingSellForm = ({
     const isDraft = !!draft;
     const methods = useForm<TradingSellFormProps>({
         mode: 'onChange',
-        defaultValues: draftUpdated ? draftUpdated : defaultValues,
+        defaultValues: redirectValues || (draftUpdated ? draftUpdated : defaultValues),
     });
     const { register, setValue, reset, control, formState } = methods;
     const values = useWatch<TradingSellFormProps>({ control });
@@ -356,7 +358,7 @@ export const useTradingSellForm = ({
         // without the orderId the return link will point to offers
         const orderId = provider.flow === 'PAYMENT_GATE' ? quote.orderId : undefined;
         const returnUrl = await createQuoteLink(
-            quotesRequest,
+            { ...quotesRequest, paymentMethod: quote.paymentMethod },
             account,
             { selectedFee: selectedFeeRecomposedAndSigned, composed },
             orderId,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellFormRedirectValues.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellFormRedirectValues.tsx
@@ -1,0 +1,65 @@
+import { useMemo } from 'react';
+
+import { SellFiatTradeQuoteRequest } from 'invity-api';
+
+import { getDefaultCountry } from '@suite-common/trading';
+import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants';
+
+import { useSelector } from 'src/hooks/suite';
+import { useTradingBuildAccountGroups } from 'src/hooks/wallet/trading/form/common/useTradingBuildAccountGroups';
+import { TradingSellFormProps } from 'src/types/trading/tradingForm';
+import {
+    buildFiatOption,
+    getAddressAndTokenFromAccountOptionsGroupProps,
+} from 'src/utils/wallet/trading/tradingUtils';
+
+export const useTradingSellFormRedirectValues = (
+    isFromRedirect: boolean,
+    quotesRequest: SellFiatTradeQuoteRequest | undefined,
+): TradingSellFormProps | null => {
+    const { composedTransactionInfo } = useSelector(state => state.wallet.trading);
+
+    const cryptoGroups = useTradingBuildAccountGroups('sell');
+    const cryptoOptions = useMemo(
+        () => cryptoGroups.flatMap(group => group.options),
+        [cryptoGroups],
+    );
+
+    const sendCryptoSelect = useMemo(
+        () =>
+            quotesRequest?.cryptoCurrency
+                ? cryptoOptions.find(option => option.value === quotesRequest.cryptoCurrency)
+                : undefined,
+        [cryptoOptions, quotesRequest?.cryptoCurrency],
+    );
+
+    const { address, token } = getAddressAndTokenFromAccountOptionsGroupProps(sendCryptoSelect);
+
+    return isFromRedirect && quotesRequest && sendCryptoSelect
+        ? {
+              ...DEFAULT_VALUES,
+              amountInCrypto: quotesRequest.amountInCrypto,
+              sendCryptoSelect,
+              countrySelect: getDefaultCountry(quotesRequest.country),
+              paymentMethod: quotesRequest.paymentMethod && {
+                  value: quotesRequest.paymentMethod,
+                  label: quotesRequest.paymentMethod,
+              },
+              feeLimit: composedTransactionInfo.composed?.feeLimit ?? '',
+              feePerUnit: composedTransactionInfo.composed?.feePerByte ?? '',
+              selectedFee: composedTransactionInfo.selectedFee,
+              selectedUtxos: [],
+              options: ['broadcast'],
+              outputs: [
+                  {
+                      ...DEFAULT_PAYMENT,
+                      fiat: quotesRequest.fiatStringAmount as string,
+                      currency: buildFiatOption(quotesRequest.fiatCurrency),
+                      amount: quotesRequest.cryptoStringAmount as string,
+                      address,
+                      token,
+                  },
+              ],
+          }
+        : null;
+};

--- a/packages/suite/src/hooks/wallet/useTradingRedirect.ts
+++ b/packages/suite/src/hooks/wallet/useTradingRedirect.ts
@@ -1,7 +1,9 @@
 import {
+    BuyCryptoPaymentMethod,
     BuyTradeQuoteRequest,
     CryptoId,
     ExchangeTradeQuoteRequest,
+    SellCryptoPaymentMethod,
     SellFiatTradeQuoteRequest,
 } from 'invity-api';
 
@@ -15,7 +17,7 @@ import * as tradingSellActions from 'src/actions/wallet/tradingSellActions';
 import { useDispatch } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
 
-interface OfferRedirectParams {
+interface BuyOfferRedirectParams {
     symbol: Account['symbol'];
     index: Account['index'];
     accountType: Account['accountType'];
@@ -24,6 +26,7 @@ interface OfferRedirectParams {
     receiveCurrency: CryptoId;
     amount: string;
     country: string;
+    paymentMethod: BuyCryptoPaymentMethod;
 }
 
 interface SellOfferRedirectParams {
@@ -35,6 +38,7 @@ interface SellOfferRedirectParams {
     cryptoCurrency: CryptoId;
     amount: string;
     country: string;
+    paymentMethod: SellCryptoPaymentMethod;
     orderId?: string;
     selectedFee?: FeeLevel['label'];
     feePerByte?: string;
@@ -68,7 +72,7 @@ interface DetailRedirectParams {
 export const useTradingRedirect = () => {
     const dispatch = useDispatch();
 
-    const redirectToOffers = (params: OfferRedirectParams) => {
+    const redirectToBuyOffers = (params: BuyOfferRedirectParams) => {
         const {
             symbol,
             index,
@@ -78,9 +82,10 @@ export const useTradingRedirect = () => {
             receiveCurrency,
             amount,
             country,
+            paymentMethod,
         } = params;
         let request: BuyTradeQuoteRequest;
-        const commonParams = { fiatCurrency, receiveCurrency, country };
+        const commonParams = { fiatCurrency, receiveCurrency, country, paymentMethod };
 
         if (wantCrypto) {
             request = {
@@ -98,7 +103,7 @@ export const useTradingRedirect = () => {
         dispatch(tradingBuyActions.saveQuoteRequest(request));
         dispatch(tradingBuyActions.setIsFromRedirect(true));
         dispatch(
-            goto('wallet-trading-buy-confirm', {
+            goto('wallet-trading-buy-offers', {
                 params: { symbol, accountIndex: index, accountType },
             }),
         );
@@ -114,6 +119,7 @@ export const useTradingRedirect = () => {
             cryptoCurrency,
             amount,
             country,
+            paymentMethod,
             orderId,
             feeLimit,
             feePerByte,
@@ -122,7 +128,7 @@ export const useTradingRedirect = () => {
             maxPriorityFeePerGas,
         } = params;
         let request: SellFiatTradeQuoteRequest;
-        const commonParams = { fiatCurrency, cryptoCurrency, country };
+        const commonParams = { fiatCurrency, cryptoCurrency, country, paymentMethod };
 
         if (amountInCrypto) {
             request = {
@@ -149,7 +155,7 @@ export const useTradingRedirect = () => {
         dispatch(saveComposedTransactionInfo({ selectedFee: selectedFee || 'normal', composed }));
         dispatch(tradingSellActions.saveTransactionId(orderId));
         dispatch(
-            goto('wallet-trading-sell-confirm', {
+            goto(orderId ? 'wallet-trading-sell-confirm' : 'wallet-trading-sell-offers', {
                 params: { symbol, accountIndex: index, accountType },
             }),
         );
@@ -194,7 +200,7 @@ export const useTradingRedirect = () => {
         );
     };
 
-    const redirectToDetail = (params: DetailRedirectParams) => {
+    const redirectToBuyDetail = (params: DetailRedirectParams) => {
         const { transactionId } = params;
 
         dispatch(tradingBuyActions.saveTransactionId(transactionId));
@@ -210,8 +216,8 @@ export const useTradingRedirect = () => {
     };
 
     return {
-        redirectToOffers,
-        redirectToDetail,
+        redirectToBuyOffers,
+        redirectToBuyDetail,
         redirectToSellOffers,
         redirectToExchangeOffers,
     };

--- a/packages/suite/src/utils/wallet/trading/__fixtures__/buyUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/__fixtures__/buyUtils.ts
@@ -8,6 +8,7 @@ export const QUOTE_REQUEST_FIAT: BuyTradeQuoteRequest = {
     fiatCurrency: 'EUR',
     receiveCurrency: bitcoin,
     fiatStringAmount: '10',
+    paymentMethod: 'creditCard',
 };
 
 export const QUOTE_REQUEST_CRYPTO: BuyTradeQuoteRequest = {
@@ -16,6 +17,7 @@ export const QUOTE_REQUEST_CRYPTO: BuyTradeQuoteRequest = {
     fiatCurrency: 'EUR',
     receiveCurrency: bitcoin,
     cryptoStringAmount: '0.001',
+    paymentMethod: 'creditCard',
 };
 
 export const MIN_MAX_QUOTES_OK: BuyTrade[] = [

--- a/packages/suite/src/utils/wallet/trading/__fixtures__/sellUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/__fixtures__/sellUtils.ts
@@ -8,6 +8,7 @@ export const QUOTE_REQUEST_FIAT: SellFiatTradeQuoteRequest = {
     fiatCurrency: 'EUR',
     cryptoCurrency: bitcoin,
     fiatStringAmount: '10',
+    paymentMethod: 'creditCard',
 };
 
 export const QUOTE_REQUEST_CRYPTO: SellFiatTradeQuoteRequest = {
@@ -16,6 +17,7 @@ export const QUOTE_REQUEST_CRYPTO: SellFiatTradeQuoteRequest = {
     fiatCurrency: 'EUR',
     cryptoCurrency: bitcoin,
     cryptoStringAmount: '0.001',
+    paymentMethod: 'creditCard',
 };
 
 export const MIN_MAX_QUOTES_OK: SellFiatTrade[] = [

--- a/packages/suite/src/utils/wallet/trading/__tests__/buyUtils.test.ts
+++ b/packages/suite/src/utils/wallet/trading/__tests__/buyUtils.test.ts
@@ -17,11 +17,11 @@ describe('trading/buy utils', () => {
         };
         // @ts-expect-error
         expect(await createQuoteLink(QUOTE_REQUEST_FIAT, accountMock)).toStrictEqual(
-            `${window.location.origin}/coinmarket-redirect#offers/btc/normal/1/qf/CZ/EUR/10/bitcoin`,
+            `${window.location.origin}/coinmarket-redirect#offers/btc/normal/1/qf/CZ/EUR/10/bitcoin/creditCard`,
         );
         // @ts-expect-error
         expect(await createQuoteLink(QUOTE_REQUEST_CRYPTO, accountMock)).toStrictEqual(
-            `${window.location.origin}/coinmarket-redirect#offers/btc/normal/1/qc/CZ/EUR/0.001/bitcoin`,
+            `${window.location.origin}/coinmarket-redirect#offers/btc/normal/1/qc/CZ/EUR/0.001/bitcoin/creditCard`,
         );
     });
 

--- a/packages/suite/src/utils/wallet/trading/__tests__/sellUtils.test.ts
+++ b/packages/suite/src/utils/wallet/trading/__tests__/sellUtils.test.ts
@@ -103,12 +103,12 @@ describe('trading/sell utils', () => {
         expect(
             await createQuoteLink(QUOTE_REQUEST_FIAT, accountMock, composedInfoMock),
         ).toStrictEqual(
-            `${window.location.origin}/coinmarket-redirect#sell-offers/btc/normal/1/qf/CZ/EUR/10/bitcoin/custom/1/2/3/4`,
+            `${window.location.origin}/coinmarket-redirect#sell-offers/btc/normal/1/qf/CZ/EUR/10/bitcoin/creditCard/custom/1/2/3/4`,
         );
         expect(
             await createQuoteLink(QUOTE_REQUEST_CRYPTO, accountMock, composedInfoMock),
         ).toStrictEqual(
-            `${window.location.origin}/coinmarket-redirect#sell-offers/btc/normal/1/qc/CZ/EUR/0.001/bitcoin/custom/1/2/3/4`,
+            `${window.location.origin}/coinmarket-redirect#sell-offers/btc/normal/1/qc/CZ/EUR/0.001/bitcoin/creditCard/custom/1/2/3/4`,
         );
         expect(
             await createQuoteLink(
@@ -118,7 +118,7 @@ describe('trading/sell utils', () => {
                 '42134432141234',
             ),
         ).toStrictEqual(
-            `${window.location.origin}/coinmarket-redirect#sell-offers/btc/normal/1/p-qc/CZ/EUR/0.001/bitcoin/42134432141234/custom/1/2/3/4`,
+            `${window.location.origin}/coinmarket-redirect#sell-offers/btc/normal/1/p-qc/CZ/EUR/0.001/bitcoin/creditCard/42134432141234/custom/1/2/3/4`,
         );
     });
 

--- a/packages/suite/src/utils/wallet/trading/buyUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/buyUtils.ts
@@ -11,9 +11,9 @@ export const createQuoteLink = async (request: BuyTradeQuoteRequest, account: Ac
     let hash: string;
 
     if (request.wantCrypto) {
-        hash = `qc/${request.country}/${request.fiatCurrency}/${request.cryptoStringAmount}/${request.receiveCurrency}`;
+        hash = `qc/${request.country}/${request.fiatCurrency}/${request.cryptoStringAmount}/${request.receiveCurrency}/${request.paymentMethod}`;
     } else {
-        hash = `qf/${request.country}/${request.fiatCurrency}/${request.fiatStringAmount}/${request.receiveCurrency}`;
+        hash = `qf/${request.country}/${request.fiatCurrency}/${request.fiatStringAmount}/${request.receiveCurrency}/${request.paymentMethod}`;
     }
 
     const params = `offers/${account.symbol}/${account.accountType}/${account.index}/${hash}`;

--- a/packages/suite/src/utils/wallet/trading/sellUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/sellUtils.ts
@@ -70,9 +70,9 @@ export const createQuoteLink = async (
     let hash: string;
 
     if (request.amountInCrypto) {
-        hash = `qc/${request.country}/${request.fiatCurrency}/${request.cryptoStringAmount}/${request.cryptoCurrency}`;
+        hash = `qc/${request.country}/${request.fiatCurrency}/${request.cryptoStringAmount}/${request.cryptoCurrency}/${request.paymentMethod}`;
     } else {
-        hash = `qf/${request.country}/${request.fiatCurrency}/${request.fiatStringAmount}/${request.cryptoCurrency}`;
+        hash = `qf/${request.country}/${request.fiatCurrency}/${request.fiatStringAmount}/${request.cryptoCurrency}/${request.paymentMethod}`;
     }
     if (orderId) {
         hash = `p-${hash}/${orderId}`;

--- a/packages/suite/src/views/wallet/trading/redirect/TradingRedirect.tsx
+++ b/packages/suite/src/views/wallet/trading/redirect/TradingRedirect.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { CryptoId } from 'invity-api';
+import { BuyCryptoPaymentMethod, CryptoId, SellCryptoPaymentMethod } from 'invity-api';
 import styled from 'styled-components';
 
 import { variables } from '@trezor/components';
@@ -22,8 +22,12 @@ const Wrapper = styled.div`
 `;
 
 export const TradingRedirect = () => {
-    const { redirectToOffers, redirectToDetail, redirectToSellOffers, redirectToExchangeOffers } =
-        useTradingRedirect();
+    const {
+        redirectToBuyOffers,
+        redirectToBuyDetail,
+        redirectToSellOffers,
+        redirectToExchangeOffers,
+    } = useTradingRedirect();
     const router = useSelector(state => state.router);
 
     useEffect(() => {
@@ -32,31 +36,41 @@ export const TradingRedirect = () => {
         if (!params) return;
 
         const redirectCommonParams = {
-            routeType: params[0] as 'detail' | 'offers' | 'sell-offers' | 'exchange-offers',
+            routeType: params[0] as
+                | 'detail'
+                | 'offers'
+                | 'sell-detail'
+                | 'sell-offers'
+                | 'exchange-offers',
             symbol: params[1] as Account['symbol'],
             accountType: params[2] as Account['accountType'],
             index: parseInt(params[3], 10),
         };
 
         if (redirectCommonParams.routeType === 'offers') {
-            redirectToOffers({
+            redirectToBuyOffers({
                 ...redirectCommonParams,
                 wantCrypto: params[4] === 'qc',
                 fiatCurrency: params[6],
                 amount: params[7],
                 receiveCurrency: params[8] as CryptoId,
                 country: params[5],
+                paymentMethod: params[9] as BuyCryptoPaymentMethod,
             });
         }
 
+        if (redirectCommonParams.routeType === 'detail') {
+            redirectToBuyDetail({ ...redirectCommonParams, transactionId: params[4] });
+        }
+
         if (redirectCommonParams.routeType === 'sell-offers') {
-            let feeIndex = 9;
+            let feeIndex = 10;
             let orderId: string | undefined;
             if (params[4].startsWith('p-')) {
-                feeIndex = 10;
+                feeIndex = 11;
                 params[4] = params[4].substring(2);
 
-                orderId = params[9];
+                orderId = params[10];
             }
             redirectToSellOffers({
                 ...redirectCommonParams,
@@ -65,6 +79,7 @@ export const TradingRedirect = () => {
                 amount: params[7],
                 cryptoCurrency: params[8] as CryptoId,
                 country: params[5],
+                paymentMethod: params[9] as SellCryptoPaymentMethod,
                 orderId,
                 selectedFee: params[feeIndex] as FeeLevel['label'],
                 feePerByte: params[feeIndex + 1],
@@ -89,13 +104,9 @@ export const TradingRedirect = () => {
                 feeLimit: params[feeIndex + 4],
             });
         }
-
-        if (redirectCommonParams.routeType === 'detail') {
-            redirectToDetail({ ...redirectCommonParams, transactionId: params[4] });
-        }
     }, [
-        redirectToOffers,
-        redirectToDetail,
+        redirectToBuyOffers,
+        redirectToBuyDetail,
         redirectToSellOffers,
         redirectToExchangeOffers,
         router,


### PR DESCRIPTION
## Description

These URLs should show offers page:
https://dev.suite.sldev.cz/suite-web/develop/web/coinmarket-redirect/#offers/btc/normal/0/qc/CZ/EUR/0.0006885/bitcoin/sepa
https://dev.suite.sldev.cz/suite-web/develop/web/coinmarket-redirect/#offers/btc/normal/0/qf/CZ/EUR/60/bitcoin/sepa
https://dev.suite.sldev.cz/suite-web/develop/web/coinmarket-redirect#sell-offers/btc/normal/0/qc/CZ/EUR/0.0006885/bitcoin/sepa
https://dev.suite.sldev.cz/suite-web/develop/web/coinmarket-redirect#sell-offers/btc/normal/0/qf/CZ/EUR/60/bitcoin/sepa

- added payment method to hash params which is selected in offers page

## Related Issue

Resolve #17563

## Screenshots:
### Before
![image](https://github.com/user-attachments/assets/ca2f0ca6-84cb-4659-9eef-79aec081ec44)

### After
![image](https://github.com/user-attachments/assets/4ca291ff-5945-4dce-8c88-8297d6fe4043)
