### PR TITLE
fix: show Ghost Modal for failed device Auth in settings correctly (synchornously)

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceModal.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 
 import { checkDeviceAuthenticityThunk } from '@suite-common/device-authenticity';
 import { TranslationKey } from '@suite-common/intl-types';
-import { selectSelectedDeviceAuthenticity } from '@suite-common/wallet-core';
 import { Icon, IconName, List, NewModal, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -21,16 +20,17 @@ export const AuthenticateDeviceModal = () => {
     const [isLoading, setIsLoading] = useState(false);
     const dispatch = useDispatch();
     const isDebugModeActive = useSelector(selectIsDebugModeActive);
-    const selectedDeviceAuthenticity = useSelector(selectSelectedDeviceAuthenticity);
 
     const handleClick = async () => {
         setIsLoading(true);
 
-        await dispatch(checkDeviceAuthenticityThunk({ allowDebugKeys: isDebugModeActive }));
+        const result = await dispatch(
+            checkDeviceAuthenticityThunk({ allowDebugKeys: isDebugModeActive }),
+        ).unwrap();
 
         setIsLoading(false);
 
-        if (selectedDeviceAuthenticity?.valid === false) {
+        if (result?.valid === false) {
             dispatch(openModal({ type: 'authenticate-device-fail' }));
         }
     };

--- a/suite-common/device-authenticity/src/deviceAuthenticityThunks.ts
+++ b/suite-common/device-authenticity/src/deviceAuthenticityThunks.ts
@@ -4,17 +4,25 @@ import TrezorConnect, { AuthenticateDeviceResult } from '@trezor/connect';
 
 import { ACTION_PREFIX, deviceAuthenticityActions } from './deviceAuthenticityActions';
 
-export const checkDeviceAuthenticityThunk = createThunk(
+type CheckDeviceAuthenticityThunkParams = {
+    allowDebugKeys: boolean;
+    skipSuccessToast?: boolean;
+};
+
+type CheckDeviceAuthenticityThunkResult =
+    | AuthenticateDeviceResult
+    | { error: string; valid?: boolean }
+    | undefined;
+
+export const checkDeviceAuthenticityThunk = createThunk<
+    CheckDeviceAuthenticityThunkResult,
+    CheckDeviceAuthenticityThunkParams,
+    void
+>(
     `${ACTION_PREFIX}/checkDeviceAuthenticity`,
     async (
-        {
-            allowDebugKeys,
-            skipSuccessToast,
-        }: {
-            allowDebugKeys: boolean;
-            skipSuccessToast?: boolean;
-        },
-        { dispatch, getState, extra },
+        { allowDebugKeys, skipSuccessToast },
+        { dispatch, getState, extra, fulfillWithValue },
     ) => {
         const {
             selectors: { selectDevice },
@@ -31,10 +39,7 @@ export const checkDeviceAuthenticityThunk = createThunk(
             allowDebugKeys,
         });
 
-        let storedResult:
-            | AuthenticateDeviceResult
-            | { error: string; valid?: boolean }
-            | undefined = result.payload;
+        let storedResult: CheckDeviceAuthenticityThunkResult = result.payload;
         let toastPayload: ToastPayload | undefined;
 
         if (!result.success) {
@@ -70,5 +75,7 @@ export const checkDeviceAuthenticityThunk = createThunk(
         }
 
         dispatch(deviceAuthenticityActions.result({ device, result: storedResult }));
+
+        return fulfillWithValue(storedResult);
     },
 );


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/16891