### PR TITLE
feat(transport-bridge): start logging libusb errors

### DIFF
--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -1,4 +1,4 @@
-import { WebUSB } from 'usb';
+import { WebUSB, usb } from 'usb';
 
 import { TransportProtocol, bridge as protocolBridge, v1 as protocolV1 } from '@trezor/protocol';
 import { AbstractApi } from '@trezor/transport/src/api/abstract';
@@ -19,6 +19,11 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
 
     const sessionsBackground = new SessionsBackground();
     const sessionsClient = new SessionsClient(sessionsBackground);
+
+    if (apiArg === 'usb' && logger?.enabled) {
+        // https://libusb.sourceforge.io/api-1.0/group__libusb__lib.html#ga2d6144203f0fc6d373677f6e2e89d2d2
+        usb.setDebugLevel(1); // Level 3 would probably be ok as well (doesn't seem too spammy). For full debugging use 4.
+    }
 
     if (typeof apiArg === 'string') {
         api =


### PR DESCRIPTION
useful when debugging with standalone node bridge. can't be used for the build-in version at the moment since it runs in a utility process