### PR TITLE
Prevent false positive in entropy check

### DIFF
--- a/packages/connect/src/api/resetDevice.ts
+++ b/packages/connect/src/api/resetDevice.ts
@@ -106,13 +106,13 @@ export default class ResetDevice extends AbstractMethod<'resetDevice', PROTO.Res
             this.params.entropy_check = false;
         }
 
-        try {
-            // Entropy check workflow:
-            // https://github.com/trezor/trezor-firmware/blob/57868ad48f4c462bb1f4fa57572067e89a039a60/docs/common/message-workflows.md#entropy-check-workflow
-            // steps: 1 - 4
-            // ResetDevice > EntropyRequest > EntropyAck > EntropyCheckReady (new fw) || Success (old fw)
-            let entropyData = await this.getEntropyData('ResetDevice');
+        // Entropy check workflow:
+        // https://github.com/trezor/trezor-firmware/blob/57868ad48f4c462bb1f4fa57572067e89a039a60/docs/common/message-workflows.md#entropy-check-workflow
+        // steps: 1 - 4
+        // ResetDevice > EntropyRequest > EntropyAck > EntropyCheckReady (new fw) || Success (old fw)
+        let entropyData = await this.getEntropyData('ResetDevice'); // this call is intentionally excluded from the catch error handling below because it is not in the 'critical' phase yet
 
+        try {
             if (this.params.entropy_check) {
                 const tries = getRandomInt(1, 5);
                 for (let i = 0; i < tries; i++) {

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -186,7 +186,10 @@ export const resetDevice =
                     vendor: device?.features?.fw_vendor,
                     error: result.payload.error,
                 });
-                dispatch(deviceActions.setEntropyCheckFail(device.id));
+                // TODO: temporary exception to avoid false positives
+                if (result.payload.error !== 'device disconnected during action') {
+                    dispatch(deviceActions.setEntropyCheckFail(device.id));
+                }
             }
         }
 


### PR DESCRIPTION
Unfortunately, https://github.com/trezor/trezor-suite/pull/17282 yields some false positives that we didn't catch initially. Disconnecting device during wallet creation causes entropy check failure.

This PR temporarily ignores device disconnect events until a better solution is implemented. 
