### PR TITLE
chore(suite-native): do not upload @trezor/transport-bluetooth to EAS…

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -12,6 +12,7 @@ packages/suite-desktop-core/
 packages/suite-desktop-ui/
 packages/suite-storage/
 packages/suite-web/
+packages/transport-bluetooth/
 
 ### content of all .gitignore files is not applied if .easignore is present
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Do not upload newly created @trezor/transport-bluetooth to EAS to prevent build failure on missing   @trezor/ipc-proxy workspace


see the failing build https://expo.dev/accounts/trezorcompany/projects/trezor-suite-develop/builds/940babf8-5632-4bdb-98ad-87bbbb3fe6de
