### PR TITLE
fix(suite): disable closing SOL send modal when sending transaction

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -401,7 +401,7 @@ export const TransactionReviewModalContent = ({
                     deviceModelInternal={deviceModelInternal}
                     deviceUnitColor={device?.features?.unit_color}
                     successText={<Translation id="TR_CONFIRMED_TX" />}
-                    onCancel={onCancel}
+                    onCancel={isSending ? undefined : onCancel}
                 />
             )}
             <NewModal.ModalBase


### PR DESCRIPTION
## Description

When a Solana transaction is in sending state, disable closing the modal.

## Related Issue

Resolve #14961 
Resolve [#17646](https://github.com/trezor/trezor-suite/issues/17646)

## Screenshots:

https://github.com/user-attachments/assets/eb5b3090-a28d-4fd5-ad42-a5d59bc23997
