### PR TITLE
fix(suite-desktop-core): refactor desktop state patches to avoid breaking change

### DIFF
--- a/packages/suite-desktop-core/e2e/support/electron.ts
+++ b/packages/suite-desktop-core/e2e/support/electron.ts
@@ -9,8 +9,8 @@ import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 // specific version of legacy bridge is requested & expected
 export const LEGACY_BRIDGE_VERSION = '2.0.33';
 const disableHashCheckStatePatch =
-    '--state=suite.settings.enabledSecurityChecks.firmwareHash=false';
-const showDebugMenuStatePatch = `--state=suite.settings.debug.showDebugMenu=true`;
+    '--state.suite.settings.enabledSecurityChecks.firmwareHash=false';
+const showDebugMenuStatePatch = `--state.suite.settings.debug.showDebugMenu=true`;
 
 type LaunchSuiteParams = {
     rmUserData?: boolean;

--- a/packages/suite-desktop-core/src/__tests__/app-utils.test.ts
+++ b/packages/suite-desktop-core/src/__tests__/app-utils.test.ts
@@ -1,20 +1,20 @@
 import { processStatePatch } from '../libs/app-utils';
 
-const fullState = 'state={ "d": { "e": true, "f": null }, "a.c": "baz" }';
-const partialState1 = 'state=a={"b": [5] }';
-const partialState2 = 'state=a.b=[1, 3, 8]';
-const singleProperty = 'state=a.c=foobar';
-const notInState = 'a=nothing';
-const notAssignment = 'hasNoEqualitySign';
+const fullState = '--state={ "d": { "e": true, "f": null }, "a.c": "baz" }';
+const partialState1 = '--state.a={"b": [5] }';
+const partialState2 = '--state.a.b=[1, 3, 8]';
+const singleProperty = '--state.a.c=foo=bar';
+const notInState = '--a=nothing';
+const notAssignment = '--hasNoEqualitySign';
 
 const FIXTURES: [string, string[], any][] = [
     ['none', [], undefined],
-    ['simple', [partialState2, singleProperty], { a: { b: [1, 3, 8], c: 'foobar' } }],
+    ['simple', [partialState2, singleProperty], { a: { b: [1, 3, 8], c: 'foo=bar' } }],
     ['mixed', [notInState, partialState1, notInState, partialState2], { a: { b: [5, 1, 3, 8] } }],
     [
         'complex',
         [partialState2, notInState, fullState, notAssignment, partialState1, singleProperty],
-        { a: { b: [1, 3, 8, 5], c: 'foobar' }, d: { e: true, f: null } },
+        { a: { b: [1, 3, 8, 5], c: 'foo=bar' }, d: { e: true, f: null } },
     ],
     ['invalid', [notAssignment, notInState], undefined],
 ];
@@ -22,7 +22,7 @@ const FIXTURES: [string, string[], any][] = [
 describe('process state patch', () => {
     FIXTURES.map(([name, args, value]) => {
         it(name, () => {
-            process.argv = args.map(arg => `--${arg}`);
+            process.argv = args;
             expect(processStatePatch()).toStrictEqual(value);
         });
     });

--- a/packages/suite-desktop-core/src/libs/app-utils.ts
+++ b/packages/suite-desktop-core/src/libs/app-utils.ts
@@ -35,17 +35,7 @@ const tryParseJson = (value: string) => {
     }
 };
 
-/**
- * Parse each statePatch arg, which may be either a JSON, or a key value pair as [dot.notation.path: value]
- */
-const parseAssignment = (assignment: string) => {
-    const keyValuePair = assignment.split('=');
-    if (keyValuePair.length !== 2) return tryParseJson(keyValuePair[0]);
-    const [key, value] = keyValuePair;
-
-    return { [key]: tryParseJson(value) };
-};
-
+const STATE_ASSIGNMENT_REGEX = /^--(state[^=]*)=(.+)$/;
 type ProcessStatePatchResult = Record<string, any> | undefined;
 
 /**
@@ -53,10 +43,14 @@ type ProcessStatePatchResult = Record<string, any> | undefined;
  */
 export const processStatePatch = (): ProcessStatePatchResult =>
     process.argv
-        .map(arg => arg.match(/^--state=(.+)/))
-        .filter(arg => arg !== null)
-        .map(match => parseAssignment(match[1]))
+        .map(arg => arg.match(STATE_ASSIGNMENT_REGEX))
+        .filter(match => match !== null)
+        .map((assignment: RegExpMatchArray) => {
+            const [_, key, value] = assignment;
+
+            return { [key]: tryParseJson(value) };
+        })
         .reduce<ProcessStatePatchResult>(
             (prev, cur) => mergeDeepObject.withOptions({ dotNotation: true }, prev ?? {}, cur),
             undefined,
-        );
+        )?.state;


### PR DESCRIPTION
## Description

Partial revert of 5a84a1f5 (#17526)
- There, desktop state patch process args were refactored, as they stopped working in Electron 35
  - that was a breaking change for Trezor Suite process args :disappointed: 
- I believed at the time that Electron checks args at startup and throws if there are dots on the left-hand side of assignment in a switch.
- It is not so; only the [app.commandLine.getSwitchValue](https://github.com/trezor/trezor-suite/blob/098a0b3889b4c0ce8263c8592e926657502274cf/packages/suite-desktop-core/src/libs/app-utils.ts#L42) throws. And it's actually not related to dots but uppercase letters!
- But that function call was not needed at all, even in the original implementation.
- In 5a84a1f5, the `processStatePatch` + tests were _also_ refactored for better clarity, so this PR keeps that...
- ...but reverts to the original API :arrow_right: **no breaking change** :slightly_smiling_face: 

### Notes

:point_right: I will still did file a bug with Electron https://github.com/electron/electron/issues/45991, because the function started throwing without mention in changelog. But they said the function is not supposed to be used for custom application parameters, it's an API to set Chromium flags. We are supposed to use `process.argv` for custom params, as it currently is 🙂 
