### PR TITLE
chore(suite-native): move trading state to tradingNew

### DIFF
--- a/suite-native/module-trading/src/__tests__/tradingSlice.test.ts
+++ b/suite-native/module-trading/src/__tests__/tradingSlice.test.ts
@@ -72,7 +72,7 @@ describe('tradingSlice', () => {
                 }),
             );
 
-            expect(selectBuySelectedReceiveAccount({ wallet: { trading: state } })).toBe(
+            expect(selectBuySelectedReceiveAccount({ wallet: { tradingNew: state } })).toBe(
                 receiveAccount,
             );
         });
@@ -88,7 +88,9 @@ describe('tradingSlice', () => {
             ];
             const state = actions.reduce(tradingReducer, undefined) as TradingState;
 
-            expect(selectBuySelectedReceiveAccount({ wallet: { trading: state } })).toBeUndefined();
+            expect(
+                selectBuySelectedReceiveAccount({ wallet: { tradingNew: state } }),
+            ).toBeUndefined();
         });
 
         describe('favouriteAssets', () => {
@@ -109,7 +111,7 @@ describe('tradingSlice', () => {
                 ];
                 const state = actions.reduce(tradingReducer, undefined) as TradingState;
 
-                expect(selectTradingFavouriteAssets({ wallet: { trading: state } })).toEqual({
+                expect(selectTradingFavouriteAssets({ wallet: { tradingNew: state } })).toEqual({
                     btc_abc: {
                         symbol: 'btc',
                         contractAddress: 'abc',
@@ -141,11 +143,13 @@ describe('tradingSlice', () => {
                         addTradeableAssetToFavourites({ symbol: 'btc' }),
                     );
 
-                    expect(selectTradingFavouriteAssets({ wallet: { trading: state } })).toEqual({
-                        btc: {
-                            symbol: 'btc',
+                    expect(selectTradingFavouriteAssets({ wallet: { tradingNew: state } })).toEqual(
+                        {
+                            btc: {
+                                symbol: 'btc',
+                            },
                         },
-                    });
+                    );
                 });
 
                 it('removeTradeableAssetFromFavourites should remove asset from favourites', () => {
@@ -154,7 +158,7 @@ describe('tradingSlice', () => {
                         removeTradeableAssetFromFavourites({ symbol: 'btc' }),
                     );
 
-                    expect(selectTradingFavouriteAssets({ wallet: { trading: state } })).toEqual(
+                    expect(selectTradingFavouriteAssets({ wallet: { tradingNew: state } })).toEqual(
                         {},
                     );
                 });
@@ -166,13 +170,13 @@ describe('tradingSlice', () => {
                     );
 
                     const favouritesArray = selectTradingFavouriteAssetsArray({
-                        wallet: { trading: state },
+                        wallet: { tradingNew: state },
                     });
 
                     expect(favouritesArray).toEqual([{ symbol: 'btc' }]);
-                    expect(selectTradingFavouriteAssetsArray({ wallet: { trading: state } })).toBe(
-                        favouritesArray,
-                    );
+                    expect(
+                        selectTradingFavouriteAssetsArray({ wallet: { tradingNew: state } }),
+                    ).toBe(favouritesArray);
                 });
 
                 it.each([
@@ -186,7 +190,7 @@ describe('tradingSlice', () => {
 
                         expect(
                             selectIsTradingFavouriteAsset(
-                                { wallet: { trading: prevState } },
+                                { wallet: { tradingNew: prevState } },
                                 asset,
                             ),
                         ).toBe(expectedValue);
@@ -200,7 +204,7 @@ describe('tradingSlice', () => {
         it('should have production as initial trading environment', () => {
             const state = tradingReducer(undefined, { type: 'undefined_action' });
 
-            expect(selectTradingEnvironment({ wallet: { trading: state } })).toBe('production');
+            expect(selectTradingEnvironment({ wallet: { tradingNew: state } })).toBe('production');
         });
 
         it('should correctly select trading environment', () => {
@@ -209,7 +213,7 @@ describe('tradingSlice', () => {
                 tradingEnvironment: 'staging' as InvityServerEnvironment,
             };
 
-            expect(selectTradingEnvironment({ wallet: { trading: state } })).toBe('staging');
+            expect(selectTradingEnvironment({ wallet: { tradingNew: state } })).toBe('staging');
         });
     });
 });

--- a/suite-native/module-trading/src/components/buy/__tests__/ReceiveAccountPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/ReceiveAccountPicker.comp.test.tsx
@@ -42,7 +42,7 @@ const btcAccount: Account = {
 
 const getBuyState = (selectedReceiveAccount: ReceiveAccount | undefined) => ({
     wallet: {
-        trading: {
+        tradingNew: {
             buy: {
                 selectedReceiveAccount,
             },

--- a/suite-native/module-trading/src/tradingSlice.ts
+++ b/suite-native/module-trading/src/tradingSlice.ts
@@ -23,7 +23,7 @@ export interface TradingState extends CommonTradingState {
 
 export type TradingRootState = {
     wallet: {
-        trading: TradingState;
+        tradingNew: TradingState;
     };
 };
 
@@ -76,10 +76,10 @@ export const {
 
 export const createMemoizedSelector = createWeakMapSelector.withTypes<TradingRootState>();
 
-export const selectTradingBuy = (state: TradingRootState) => state.wallet.trading.buy;
+export const selectTradingBuy = (state: TradingRootState) => state.wallet.tradingNew.buy;
 
 export const selectTradingFavouriteAssets = (state: TradingRootState) =>
-    state.wallet.trading.favouriteAssets;
+    state.wallet.tradingNew.favouriteAssets;
 
 export const selectTradingFavouriteAssetsArray = createMemoizedSelector(
     [selectTradingFavouriteAssets],
@@ -95,4 +95,4 @@ export const selectBuySelectedReceiveAccount = (state: TradingRootState) =>
     selectTradingBuy(state).selectedReceiveAccount;
 
 export const selectTradingEnvironment = (state: TradingRootState) =>
-    state.wallet.trading.tradingEnvironment;
+    state.wallet.tradingNew.tradingEnvironment;

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -91,7 +91,7 @@ export const prepareRootReducers = async () => {
         send: sendFormReducer,
         fees: feesReducer,
         stake: stakeReducer,
-        trading: tradingPersistedReducer,
+        tradingNew: tradingPersistedReducer,
     });
 
     const walletPersistedReducer = await preparePersistReducer({


### PR DESCRIPTION
Desktop has moved buy to `tradingNew` in the `wallet` reducer, so we are moving it here to work with the same data.


## Related Issue

Resolve #17587


