### PR TITLE
fix(suite-native): initialized device connection

### DIFF
--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -128,13 +128,13 @@ export const useHandleDeviceConnection = () => {
         if (isFirmwareInstallationRunning || isSuspiciousDeviceScreenFocused) return;
 
         if (
+            isDeviceInitialized &&
             isDeviceConnected &&
             isOnboardingFinished &&
             !isPortfolioTrackerDevice &&
             !isDeviceConnectedAndAuthorized &&
             !isBiometricsOverlayVisible &&
-            !shouldNavigateToDeviceCompromisedModal &&
-            !isDeviceSetupSupported
+            !shouldNavigateToDeviceCompromisedModal
         ) {
             requestPrioritizedDeviceAccess({
                 deviceCallback: () => dispatch(authorizeDeviceThunk()),
@@ -156,7 +156,6 @@ export const useHandleDeviceConnection = () => {
         isDeviceConnected,
         isOnboardingFinished,
         isPortfolioTrackerDevice,
-        isNoPhysicalDeviceConnected,
         isDeviceConnectedAndAuthorized,
         isBiometricsOverlayVisible,
         navigation,
@@ -165,7 +164,6 @@ export const useHandleDeviceConnection = () => {
         isFirmwareInstallationRunning,
         isDeviceInitialized,
         shouldNavigateToDeviceCompromisedModal,
-        isDeviceSetupSupported,
         isSuspiciousDeviceScreenFocused,
     ]);
 


### PR DESCRIPTION
## Description
- connection of initialized TS3/TS5 device with enabled device onboarding feature flag works as expected

## Related Issue

Resolve #17626
