### PR TITLE
fix(connect): update typescript in install test

### DIFF
--- a/packages/connect/e2e/test-yarn-install.sh
+++ b/packages/connect/e2e/test-yarn-install.sh
@@ -21,6 +21,5 @@ yarn add @trezor/connect@"$1"
 echo import TrezorConnect from \"@trezor/connect\" >index.ts
 
 # compile with typescript
-yarn add typescript@5.5.4
-yarn tsc ./index.ts --types node,w3c-web-usb --esModuleInterop --target ES2022 --module commonjs 
-
+yarn add typescript@5.8.2
+yarn tsc ./index.ts --types node,w3c-web-usb --esModuleInterop --target ES2022 --module commonjs


### PR DESCRIPTION
## Description

The repo uses TS 5.8.2, while the Connect install test used 5.5. 
This was causing some issues such as
```
error TS2315: Type 'Uint8Array' is not generic.
```

Failed run: https://github.com/trezor/trezor-suite/actions/runs/13824249043/job/38692338903