### PR TITLE
feat(suite-native): add payment method picker stub

### DIFF
--- a/suite-native/module-trading/src/components/buy/PaymentCard.tsx
+++ b/suite-native/module-trading/src/components/buy/PaymentCard.tsx
@@ -2,6 +2,7 @@ import { Card, Text } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 
 import { CountryOfResidencePicker } from './CountryOfResidencePicker';
+import { PaymentMethodPicker } from './PaymentMethodPicker';
 import { TradingOverviewRow } from '../general/TradingOverviewRow';
 
 const notImplementedCallback = () => {
@@ -14,14 +15,7 @@ export const PaymentCard = () => {
 
     return (
         <Card noPadding>
-            <TradingOverviewRow
-                title={translate('moduleTrading.tradingScreen.paymentMethod')}
-                onPress={notImplementedCallback}
-            >
-                <Text color="textSubdued" variant="body">
-                    Credit card
-                </Text>
-            </TradingOverviewRow>
+            <PaymentMethodPicker />
             <CountryOfResidencePicker />
             <TradingOverviewRow
                 title={translate('moduleTrading.tradingScreen.provider')}

--- a/suite-native/module-trading/src/components/buy/PaymentMethodPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/PaymentMethodPicker.tsx
@@ -1,0 +1,99 @@
+import { useMemo } from 'react';
+
+import { BuyTrade, CryptoId } from 'invity-api';
+
+import { TradingPaymentMethodListProps, getTradingPaymentMethods } from '@suite-common/trading';
+import { HStack, Text } from '@suite-native/atoms';
+import { useTranslate } from '@suite-native/intl';
+
+import { useTradeSheetControls } from '../../hooks/useTradeSheetControls';
+import { PaymentMethodsSheet } from '../general/PaymentMethodsSheet/PaymentMethodsSheet';
+import { TradingOverviewRow } from '../general/TradingOverviewRow';
+
+const bitcoin = 'bitcoin' as CryptoId;
+
+const mockedQuotes: BuyTrade[] = [
+    {
+        fiatStringAmount: '10',
+        fiatCurrency: 'EUR',
+        receiveCurrency: bitcoin,
+        receiveStringAmount: '0.0005',
+        rate: 20000,
+        quoteId: 'fc12d4c4-9078-4175-becd-90fc58a3145c',
+        error: 'Amount too low, minimum is EUR 25 or BTC 0.002.',
+        exchange: 'cexdirect',
+        minFiat: 25,
+        maxFiat: 1000,
+        minCrypto: 0.002,
+        maxCrypto: 0.10532,
+        paymentMethod: 'creditCard',
+        paymentMethodName: 'Credit Card',
+        paymentId: 'e709df77-ee9e-4d12-98c2-84004a19c546',
+    },
+    {
+        fiatStringAmount: '10',
+        fiatCurrency: 'EUR',
+        receiveCurrency: bitcoin,
+        receiveStringAmount: '0.0010001683607972866',
+        rate: 9998.316675433,
+        quoteId: 'ff259797-6cbe-4fea-8330-5181353f64a0',
+        exchange: 'mercuryo',
+        minFiat: 20,
+        maxFiat: 1999.96,
+        minCrypto: 0.002,
+        maxCrypto: 0.20003,
+        paymentMethod: 'applePay',
+        paymentMethodName: 'Apple Pay',
+        paymentId: 'e709df77-ee9e-4d12-98c2-84004a19c521',
+    },
+    {
+        fiatStringAmount: '10',
+        fiatCurrency: 'EUR',
+        receiveCurrency: bitcoin,
+        receiveStringAmount: '0',
+        rate: 0,
+        error: 'Transaction amount too low. Please enter a value of 43 EUR or more.',
+        exchange: 'simplex',
+        minFiat: 43,
+        maxFiat: 17044,
+        minCrypto: 0.00415525,
+        maxCrypto: 1.66210137,
+    },
+];
+
+export const PaymentMethodPicker = () => {
+    const { translate } = useTranslate();
+
+    const { isSheetVisible, hideSheet, showSheet, setSelectedValue, selectedValue } =
+        useTradeSheetControls<TradingPaymentMethodListProps>();
+
+    const methods = useMemo(() => getTradingPaymentMethods(mockedQuotes), []);
+
+    return (
+        <>
+            <TradingOverviewRow
+                title={translate('moduleTrading.tradingScreen.paymentMethod')}
+                onPress={showSheet}
+            >
+                {selectedValue ? (
+                    <HStack>
+                        <Text color="textSubdued" variant="body">
+                            {selectedValue.label}
+                        </Text>
+                    </HStack>
+                ) : (
+                    <Text color="textDisabled" variant="body">
+                        {translate('moduleTrading.notSelected')}
+                    </Text>
+                )}
+            </TradingOverviewRow>
+            <PaymentMethodsSheet
+                methods={methods}
+                isVisible={isSheetVisible}
+                onClose={hideSheet}
+                onMethodSelect={setSelectedValue}
+                selectedMethod={selectedValue}
+            />
+        </>
+    );
+};

--- a/suite-native/module-trading/src/components/buy/__tests__/PaymentMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/PaymentMethodPicker.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@suite-native/test-utils';
+
+import { PaymentMethodPicker } from '../PaymentMethodPicker';
+
+describe('PaymentMethodPicker', () => {
+    it('should display "Not selected" when in default state', () => {
+        const { getByText } = render(<PaymentMethodPicker />);
+        expect(getByText('Not selected')).toBeDefined();
+    });
+});

--- a/suite-native/module-trading/src/components/general/PaymentMethodsSheet/PaymentMethodListItem.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodsSheet/PaymentMethodListItem.tsx
@@ -1,0 +1,38 @@
+import { Pressable } from 'react-native';
+
+import { TradingPaymentMethodListProps } from '@suite-common/trading';
+import { Card, HStack, Radio, Text } from '@suite-native/atoms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+export type PaymentMethodListItemProps = {
+    method: TradingPaymentMethodListProps;
+    isSelected: boolean;
+    onPress: () => void;
+};
+
+export const PAYMENT_METHOD_LIST_ITEM_HEIGHT = 64 as const;
+
+const wrapperStyle = prepareNativeStyle(({ spacings }) => ({
+    marginVertical: spacings.sp4,
+}));
+
+export const PaymentMethodListItem = ({
+    onPress,
+    method,
+    isSelected,
+}: PaymentMethodListItemProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <Pressable onPress={onPress} style={applyStyle(wrapperStyle)}>
+            <Card>
+                <HStack alignItems="center" justifyContent="space-between">
+                    <Text variant="body" color="textDefault">
+                        {method.label}
+                    </Text>
+                    <Radio value={method.value} onPress={onPress} isChecked={isSelected} />
+                </HStack>
+            </Card>
+        </Pressable>
+    );
+};

--- a/suite-native/module-trading/src/components/general/PaymentMethodsSheet/PaymentMethodsSheet.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodsSheet/PaymentMethodsSheet.tsx
@@ -1,0 +1,46 @@
+import { TradingPaymentMethodListProps } from '@suite-common/trading';
+import { BottomSheetFlashList } from '@suite-native/atoms';
+
+import { PAYMENT_METHOD_LIST_ITEM_HEIGHT, PaymentMethodListItem } from './PaymentMethodListItem';
+
+export type PaymentMethodsSheetProps = {
+    methods: TradingPaymentMethodListProps[];
+    isVisible: boolean;
+    onClose: () => void;
+    onMethodSelect: (method: TradingPaymentMethodListProps) => void;
+    selectedMethod?: TradingPaymentMethodListProps;
+};
+
+const keyExtractor = (item: TradingPaymentMethodListProps) => item.value;
+const getEstimatedListHeight = (itemsCount: number) => itemsCount * PAYMENT_METHOD_LIST_ITEM_HEIGHT;
+
+export const PaymentMethodsSheet = ({
+    methods,
+    isVisible,
+    onClose,
+    onMethodSelect,
+    selectedMethod,
+}: PaymentMethodsSheetProps) => {
+    const onMethodSelectCallback = (method: TradingPaymentMethodListProps) => {
+        onMethodSelect(method);
+        onClose();
+    };
+
+    return (
+        <BottomSheetFlashList<TradingPaymentMethodListProps>
+            isVisible={isVisible}
+            onClose={onClose}
+            renderItem={({ item }) => (
+                <PaymentMethodListItem
+                    method={item}
+                    onPress={() => onMethodSelectCallback(item)}
+                    isSelected={item.value === selectedMethod?.value}
+                />
+            )}
+            data={methods}
+            estimatedListHeight={getEstimatedListHeight(methods.length)}
+            estimatedItemSize={PAYMENT_METHOD_LIST_ITEM_HEIGHT}
+            keyExtractor={keyExtractor}
+        />
+    );
+};

--- a/suite-native/module-trading/src/components/general/PaymentMethodsSheet/__tests__/PaymentMethodListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodsSheet/__tests__/PaymentMethodListItem.comp.test.tsx
@@ -1,0 +1,37 @@
+import { act, fireEvent, render } from '@suite-native/test-utils';
+
+import { PaymentMethodListItem, PaymentMethodListItemProps } from '../PaymentMethodListItem';
+
+describe('PaymentMethodListItem', () => {
+    const renderPaymentMethodListItem = (props: Partial<PaymentMethodListItemProps>) =>
+        render(
+            <PaymentMethodListItem
+                method={{ label: 'Credit card', value: 'creditCard' }}
+                isSelected={false}
+                onPress={jest.fn()}
+                {...props}
+            />,
+        );
+
+    it('should render given name', () => {
+        const { getByText } = renderPaymentMethodListItem({
+            method: {
+                label: 'Debit card',
+                value: 'debitCard',
+            },
+        });
+
+        expect(getByText('Debit card')).toBeDefined();
+    });
+
+    it('should call onPress callback on item press', () => {
+        const onPress = jest.fn();
+        const { getByText } = renderPaymentMethodListItem({ onPress });
+
+        act(() => {
+            fireEvent.press(getByText('Credit card'));
+        });
+
+        expect(onPress).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
Prepare UI for payment method picker. Quotes for preparing methods is mocked until it is wired to 

## Related Issue

Resolve #17582


<img width=300 src="https://github.com/user-attachments/assets/4c175218-fc1e-46fd-8515-3b80573764f6" />

