### PR TITLE
fix(suite-native): prevent layout shift on coin price card

### DIFF
--- a/suite-native/formatters/package.json
+++ b/suite-native/formatters/package.json
@@ -21,6 +21,7 @@
         "@suite-native/atoms": "workspace:*",
         "@suite-native/settings": "workspace:*",
         "@suite-native/tokens": "workspace:*",
+        "@trezor/env-utils": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/utils": "workspace:*",
         "react": "18.2.0",

--- a/suite-native/formatters/src/components/CryptoAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/CryptoAmountFormatter.tsx
@@ -10,7 +10,6 @@ import { FormatterProps } from '../types';
 import { AmountText } from './AmountText';
 import { formatNumberWithThousandCommas } from '../utils';
 import { EmptyAmountSkeleton } from './EmptyAmountSkeleton';
-import { EmptyAmountText } from './EmptyAmountText';
 
 type CryptoToFiatAmountFormatterProps = FormatterProps<string | null | number> &
     TextProps & {
@@ -37,10 +36,8 @@ export const CryptoAmountFormatter = React.memo(
         const { CryptoAmountFormatter: formatter } = useFormatters();
 
         if (value === null || isLoading) {
-            return <EmptyAmountSkeleton />;
+            return <EmptyAmountSkeleton variant={variant} />;
         }
-
-        if (G.isNullable(value)) return <EmptyAmountText />;
 
         const maxDisplayedDecimals = decimals ?? getNetwork(symbol).decimals;
 

--- a/suite-native/formatters/src/components/EmptyAmountSkeleton.tsx
+++ b/suite-native/formatters/src/components/EmptyAmountSkeleton.tsx
@@ -1,15 +1,28 @@
-import { Dimensions } from 'react-native';
-
 import { BoxSkeleton, HStack } from '@suite-native/atoms';
+import { getWindowWidth } from '@trezor/env-utils';
+import { useNativeStyles } from '@trezor/styles';
+import { TypographyStyle } from '@trezor/theme';
 
 import { EmptyAmountText } from './EmptyAmountText';
 
-const SKELETON_WIDTH = 0.2 * Dimensions.get('window').width;
+type EmptyAmountSkeletonProps = {
+    variant?: TypographyStyle;
+};
 
-export const EmptyAmountSkeleton = () => (
-    // Usage of EmptyAmountText ensures the correct line height.
-    <HStack alignItems="center">
-        <EmptyAmountText />
-        <BoxSkeleton width={SKELETON_WIDTH} height={20} borderRadius="r4" />
-    </HStack>
-);
+const SKELETON_WIDTH = 0.2 * getWindowWidth();
+
+export const EmptyAmountSkeleton = ({ variant = 'body' }: EmptyAmountSkeletonProps) => {
+    const { utils } = useNativeStyles();
+
+    // Only font size is too small, only line height is too big.
+    const { fontSize, lineHeight } = utils.typography[variant];
+    const skeletonHeight = (fontSize + lineHeight) / 2;
+
+    return (
+        // Usage of EmptyAmountText ensures the correct line height.
+        <HStack alignItems="center" spacing={0}>
+            <EmptyAmountText variant={variant} />
+            <BoxSkeleton width={SKELETON_WIDTH} height={skeletonHeight} borderRadius="r4" />
+        </HStack>
+    );
+};

--- a/suite-native/formatters/src/components/EmptyAmountText.tsx
+++ b/suite-native/formatters/src/components/EmptyAmountText.tsx
@@ -1,4 +1,12 @@
 import { Text } from '@suite-native/atoms';
+import { TypographyStyle } from '@trezor/theme';
 
-// The text has to contain a whitespace to keep desired line height.
-export const EmptyAmountText = () => <Text> </Text>;
+type EmptyAmountTextProps = {
+    variant?: TypographyStyle;
+};
+
+// The text has to contain a zero width space to have zero width and keep the desired line height.
+export const EmptyAmountText = ({ variant }: EmptyAmountTextProps) => (
+    // eslint-disable-next-line no-irregular-whitespace
+    <Text variant={variant}>​</Text>
+);

--- a/suite-native/formatters/src/components/FiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/FiatAmountFormatter.tsx
@@ -22,6 +22,7 @@ export const FiatAmountFormatter = React.memo(
     ({
         symbol,
         value,
+        variant,
         isDiscreetText = true,
         isLoading = false,
         ...otherProps
@@ -29,16 +30,21 @@ export const FiatAmountFormatter = React.memo(
         const { FiatAmountFormatter: formatter } = useFormatters();
 
         if (!!symbol && isTestnet(symbol)) {
-            return <EmptyAmountText />;
+            return <EmptyAmountText variant={variant} />;
         }
         if (isLoading || value === null) {
-            return <EmptyAmountSkeleton />;
+            return <EmptyAmountSkeleton variant={variant} />;
         }
 
         const formattedValue = formatter.format(value);
 
         return (
-            <AmountText value={formattedValue} isDiscreetText={isDiscreetText} {...otherProps} />
+            <AmountText
+                value={formattedValue}
+                variant={variant}
+                isDiscreetText={isDiscreetText}
+                {...otherProps}
+            />
         );
     },
 );

--- a/suite-native/formatters/tsconfig.json
+++ b/suite-native/formatters/tsconfig.json
@@ -23,6 +23,7 @@
         { "path": "../atoms" },
         { "path": "../settings" },
         { "path": "../tokens" },
+        { "path": "../../packages/env-utils" },
         { "path": "../../packages/styles" },
         { "path": "../../packages/utils" }
     ]

--- a/suite-native/module-accounts-management/src/components/CoinPriceCard.tsx
+++ b/suite-native/module-accounts-management/src/components/CoinPriceCard.tsx
@@ -39,7 +39,7 @@ const indicatorContainer = prepareNativeStyle(utils => ({
     maxWidth: '40%',
     alignItems: 'center',
     justifyContent: 'flex-start',
-    marginTop: utils.spacings.sp2,
+    gap: utils.spacings.sp4,
 }));
 
 const PriceChangeIndicator = ({ valuePercentageChange }: PriceChangeIndicatorProps) => {
@@ -80,19 +80,16 @@ export const CoinPriceCard = ({ accountKey }: CoinPriceCardProps) => {
                             values={{ coinName }}
                         />
                     </Text>
-                    {currentValue && (
-                        <FiatAmountFormatter
-                            symbol={symbol}
-                            value={`${currentValue}`}
-                            variant="titleSmall"
-                            isDiscreetText={false}
-                            numberOfLines={1}
-                            adjustsFontSizeToFit
-                        />
-                    )}
+                    <FiatAmountFormatter
+                        symbol={symbol}
+                        value={currentValue ? `${currentValue}` : null}
+                        variant="titleSmall"
+                        isDiscreetText={false}
+                        numberOfLines={1}
+                        adjustsFontSizeToFit
+                    />
                 </Box>
             </Box>
-
             <PriceChangeIndicator valuePercentageChange={valuePercentageChange} />
         </Card>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -10240,6 +10240,7 @@ __metadata:
     "@suite-native/atoms": "workspace:*"
     "@suite-native/settings": "workspace:*"
     "@suite-native/tokens": "workspace:*"
+    "@trezor/env-utils": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/utils": "workspace:*"
     react: "npm:18.2.0"


### PR DESCRIPTION
- coin price card layout shift fixed
- alignment of price change indicator fixed

### Before fix

https://github.com/user-attachments/assets/e6a4c994-620c-4480-ac25-d286bae0c3a7
