### PR TITLE
e2e: New base page with discovery method

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -98,7 +98,7 @@ export class OnboardingPage {
     }
 
     @step()
-    async completeOnboarding({ enableViewOnly = false } = {}) {
+    async completeOnboarding(options?: { enableViewOnly?: boolean }) {
         await this.disableNecessaryFirmwareChecks();
         await this.optionallyDismissFwHashCheckError();
         await this.analyticsSection.continueButton.click();
@@ -106,12 +106,13 @@ export class OnboardingPage {
         if (this.isModelWithSecureElement()) {
             await this.passThroughAuthenticityCheck();
         }
-        if (enableViewOnly) {
+        if (options?.enableViewOnly) {
             await this.onboardingViewOnlyEnableButton.click();
         } else {
             await this.onboardingViewOnlySkipButton.click();
         }
         await this.viewOnlyTooltipGotItButton.click();
+        await this.page.discoveryShouldFinish();
     }
 
     @step()

--- a/packages/suite-desktop-core/e2e/support/testExtends/enhancePage.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/enhancePage.ts
@@ -1,0 +1,29 @@
+import { Locator, Page, expect, test } from '@playwright/test';
+
+// Add type declaration
+declare module '@playwright/test' {
+    interface Page {
+        // Locators
+        discoveryBar: Locator;
+        // Methods
+        discoveryShouldFinish(): Promise<void>;
+    }
+}
+
+// This function enhances the Page object with additional properties and methods
+// These properties and methods have general use across the whole test suite.
+// It is not specific to any particular test or feature.
+export const enhancePage = (page: Page): Page => {
+    // Locators
+    page.discoveryBar = page.locator('[data-test="@wallet/discovery-progress-bar"]');
+
+    // Methods
+    page.discoveryShouldFinish = async function () {
+        await test.step('Wait for discovery to finish', async () => {
+            await expect(this.discoveryBar, 'discovery bar should be visible').toBeVisible();
+            await this.discoveryBar.waitFor({ state: 'detached', timeout: 120_000 });
+        });
+    };
+
+    return page;
+};

--- a/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts
@@ -5,6 +5,7 @@ import { Model, SetupEmu, StartEmu, TrezorUserEnvLinkClass } from '@trezor/trezo
 
 import { TrezorUserEnvLinkProxy, getUrl, getVideoPath, isDesktopProject } from '../common';
 import { LaunchSuiteParams, Suite, launchSuite } from '../electron';
+import { enhancePage } from './enhancePage';
 
 type StartEmuModelRequired = StartEmu & { model: Model };
 
@@ -151,6 +152,7 @@ const suiteBaseTest = base.extend<suiteBaseFixture>({
 
         if (isDesktopProject(testInfo)) {
             const suite = await electronSetup(testInfo, locale, colorScheme, electronConf);
+            enhancePage(suite.window);
             await use(suite.window);
             await electronTeardown(suite, testInfo);
         } else {
@@ -160,6 +162,7 @@ const suiteBaseTest = base.extend<suiteBaseFixture>({
                 },
             });
             const page = await webSetup(browserContext);
+            enhancePage(page);
             await use(page);
             await webTeardown(page, browserContext, testInfo);
         }

--- a/packages/suite-desktop-core/e2e/tests/backup/t2t1-misc.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/backup/t2t1-misc.test.ts
@@ -6,9 +6,8 @@ test.describe('Backup misc', { tag: ['@group=device-management'] }, () => {
         emulatorSetupConf: { needs_backup: true },
     });
 
-    test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
+    test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
     });
 
     test('Backup should reset if modal is closed', async ({ onboardingPage, dashboardPage }) => {

--- a/packages/suite-desktop-core/e2e/tests/dashboard/assets.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/dashboard/assets.test.ts
@@ -28,7 +28,6 @@ test.describe('Assets', { tag: ['@group=suite'] }, () => {
         dashboardPage,
         settingsPage,
     }) => {
-        await dashboardPage.discoveryShouldFinish();
         await assetsSection.enableMoreCoins.click();
         await settingsPage.coins.enableNetwork('eth');
         await dashboardPage.navigateTo();

--- a/packages/suite-desktop-core/e2e/tests/dashboard/discreet-mode.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/dashboard/discreet-mode.test.ts
@@ -22,10 +22,9 @@ const verifyHiddenAndRevealedValue = async ({
 };
 
 test.describe('Discreet Mode', { tag: ['@group=suite'] }, () => {
-    test.beforeEach(async ({ analytics, dashboardPage, onboardingPage }) => {
+    test.beforeEach(async ({ analytics, onboardingPage }) => {
         await analytics.interceptAnalytics();
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
     });
 
     test('Balances are hidden when user enables discreet mode', async ({

--- a/packages/suite-desktop-core/e2e/tests/firmware/update-firmware.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/firmware/update-firmware.test.ts
@@ -6,9 +6,8 @@ test.describe.skip(
     { tag: ['@group=device-management', '@specificFirmware'] },
     () => {
         test.use({ emulatorStartConf: { wipe: true, model: 'T2T1', version: '2.5.2' } });
-        test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
+        test.beforeEach(async ({ onboardingPage }) => {
             await onboardingPage.completeOnboarding();
-            await dashboardPage.discoveryShouldFinish();
         });
 
         test('User triggers firmware update from a notification banner', async ({ page }) => {

--- a/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
@@ -1,9 +1,8 @@
 import { expect, test } from '../../support/fixtures';
 
 test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });
-test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
+test.beforeEach(async ({ onboardingPage }) => {
     await onboardingPage.completeOnboarding();
-    await dashboardPage.discoveryShouldFinish();
 });
 test.describe('Wallet discover tests', { tag: ['@group=wallet'] }, () => {
     /**

--- a/packages/suite-desktop-core/e2e/tests/metadata/account-metadata.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/account-metadata.test.ts
@@ -20,10 +20,6 @@ test.describe('Account metadata', { tag: ['@group=metadata', '@webOnly'] }, () =
     }) => {
         await onboardingPage.completeOnboarding();
 
-        // Finish discovery process
-        // Discovery process completed
-        await dashboardPage.discoveryShouldFinish();
-
         // Interact with accounts and metadata
         // Clicking "Bitcoin" label in account menu is not possible, click triggers metadata flow
         await page.getByTestId('@account-menu/btc/normal/0/label').click();

--- a/packages/suite-desktop-core/e2e/tests/metadata/address-metadata.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/address-metadata.test.ts
@@ -9,19 +9,8 @@ test.describe('Metadata - address labeling', { tag: ['@group=metadata', '@webOnl
         await metadataMock.start(MetadataProvider.GOOGLE);
     });
 
-    test('google provider', async ({
-        page,
-        onboardingPage,
-        metadataPage,
-        dashboardPage,
-        walletPage,
-    }) => {
-        // Pass through onboarding and device authentication
+    test('google provider', async ({ page, onboardingPage, metadataPage, walletPage }) => {
         await onboardingPage.completeOnboarding();
-
-        // Finish discovery process
-        // Discovery process completed
-        await dashboardPage.discoveryShouldFinish();
 
         // Interact with accounts and metadata
         await walletPage.openAccount();

--- a/packages/suite-desktop-core/e2e/tests/metadata/dropbox-api-errors.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/dropbox-api-errors.test.ts
@@ -13,7 +13,6 @@ test.describe('Dropbox API errors', { tag: ['@group=metadata', '@webOnly'] }, ()
     test('Malformed token', async ({
         page,
         onboardingPage,
-        dashboardPage,
         settingsPage,
         metadataPage,
         walletPage,
@@ -26,7 +25,6 @@ test.describe('Dropbox API errors', { tag: ['@group=metadata', '@webOnly'] }, ()
         );
 
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
 
         await settingsPage.navigateTo('application');
         await settingsPage.metadataSwitch.click();
@@ -65,7 +63,6 @@ test.describe('Dropbox API errors', { tag: ['@group=metadata', '@webOnly'] }, ()
     //TODO: #17855 Fix unstable test
     test.skip('Success after retrying GET request', async ({
         onboardingPage,
-        dashboardPage,
         settingsPage,
         metadataPage,
         walletPage,
@@ -78,7 +75,6 @@ test.describe('Dropbox API errors', { tag: ['@group=metadata', '@webOnly'] }, ()
         );
 
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
 
         await settingsPage.navigateTo('application');
         await settingsPage.metadataSwitch.click();
@@ -123,7 +119,6 @@ test.describe('Dropbox API errors', { tag: ['@group=metadata', '@webOnly'] }, ()
 
     test('Incomplete data returned from provider', async ({
         onboardingPage,
-        dashboardPage,
         settingsPage,
         metadataPage,
         walletPage,
@@ -142,7 +137,6 @@ test.describe('Dropbox API errors', { tag: ['@group=metadata', '@webOnly'] }, ()
         );
 
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
 
         await settingsPage.navigateTo('application');
         await settingsPage.metadataSwitch.click();

--- a/packages/suite-desktop-core/e2e/tests/metadata/google-api-errors.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/google-api-errors.test.ts
@@ -13,7 +13,6 @@ test.describe('Google API errors', { tag: ['@group=metadata', '@webOnly'] }, () 
     test('Malformed token', async ({
         page,
         onboardingPage,
-        dashboardPage,
         metadataPage,
         walletPage,
         metadataMock,
@@ -44,7 +43,6 @@ test.describe('Google API errors', { tag: ['@group=metadata', '@webOnly'] }, () 
         }
 
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
 
         await walletPage.openAccount();
         await metadataPage.account.clickAddLabelButton(AccountLabelId.BitcoinDefault1);

--- a/packages/suite-desktop-core/e2e/tests/metadata/interval-fetching.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/interval-fetching.test.ts
@@ -22,7 +22,6 @@ test.describe('Account metadata', { tag: ['@group=metadata', '@webOnly'] }, () =
         test(`${p.provider} - watches files over time`, async ({
             page,
             onboardingPage,
-            dashboardPage,
             metadataPage,
             metadataMock,
         }) => {
@@ -35,8 +34,6 @@ test.describe('Account metadata', { tag: ['@group=metadata', '@webOnly'] }, () =
             );
 
             await onboardingPage.completeOnboarding({ enableViewOnly: true });
-
-            await dashboardPage.discoveryShouldFinish();
 
             await page.getByTestId('@account-menu/btc/normal/0/label').click();
             await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(

--- a/packages/suite-desktop-core/e2e/tests/metadata/metadata-lifecycle.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/metadata-lifecycle.test.ts
@@ -28,7 +28,6 @@ test.describe(
             trezorUserEnvLink,
         }) => {
             await onboardingPage.completeOnboarding({ enableViewOnly: false });
-            await dashboardPage.discoveryShouldFinish();
 
             await settingsPage.navigateTo('application');
             await expect(

--- a/packages/suite-desktop-core/e2e/tests/metadata/output-labeling.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/output-labeling.test.ts
@@ -10,15 +10,8 @@ test.describe('Metadata - Output labeling', { tag: ['@group=metadata', '@webOnly
         await metadataMock.start(MetadataProvider.DROPBOX);
     });
 
-    test('dropbox provider', async ({
-        page,
-        onboardingPage,
-        dashboardPage,
-        metadataPage,
-        walletPage,
-    }) => {
+    test('dropbox provider', async ({ page, onboardingPage, metadataPage, walletPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
 
         await walletPage.openAccount();
 

--- a/packages/suite-desktop-core/e2e/tests/metadata/remembered-device.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/remembered-device.test.ts
@@ -22,7 +22,6 @@ test.describe('Remembered device', { tag: ['@group=metadata', '@webOnly'] }, () 
     test('google provider', async ({
         page,
         onboardingPage,
-        dashboardPage,
         settingsPage,
         metadataPage,
         walletPage,
@@ -30,7 +29,6 @@ test.describe('Remembered device', { tag: ['@group=metadata', '@webOnly'] }, () 
         trezorUserEnvLink,
     }) => {
         await onboardingPage.completeOnboarding({ enableViewOnly: true });
-        await dashboardPage.discoveryShouldFinish();
 
         await page.getByTestId('@account-menu/btc/normal/0/label').click();
 

--- a/packages/suite-desktop-core/e2e/tests/metadata/switching-providers.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/switching-providers.test.ts
@@ -13,14 +13,12 @@ test.describe(
         test('Start with one and switch to another', async ({
             page,
             onboardingPage,
-            dashboardPage,
             metadataPage,
             settingsPage,
             metadataMock,
             walletPage,
         }) => {
             await onboardingPage.completeOnboarding();
-            await dashboardPage.discoveryShouldFinish();
 
             // Navigate to account and verify initial state
             await walletPage.openAccount();

--- a/packages/suite-desktop-core/e2e/tests/metadata/wallet-metadata.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/wallet-metadata.test.ts
@@ -5,10 +5,9 @@ const standardWalletIndex = 0;
 const hiddenWalletIndex = 1;
 
 test.describe('Metadata - wallet labeling', { tag: ['@group=metadata', '@webOnly'] }, () => {
-    test.beforeEach(async ({ onboardingPage, dashboardPage, metadataMock }) => {
+    test.beforeEach(async ({ onboardingPage, metadataMock }) => {
         await metadataMock.start(MetadataProvider.DROPBOX);
         await onboardingPage.completeOnboarding({ enableViewOnly: true });
-        await dashboardPage.discoveryShouldFinish();
     });
 
     test.use({

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-cancel.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-cancel.test.ts
@@ -2,9 +2,8 @@ import { expect, test } from '../../support/fixtures';
 
 test.describe('Passphrase cancel', { tag: ['@group=passphrase'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all', passphrase_protection: true } });
-    test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
+    test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
     });
 
     test('possible to cancel passphrase', async ({ page, devicePrompt, dashboardPage }) => {

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-cardano.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-cardano.test.ts
@@ -7,9 +7,8 @@ const passphrase = 'secret passphrase A';
 
 test.describe('Passphrase with cardano', { tag: ['@group=passphrase'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all', passphrase_protection: true } });
-    test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
+    test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
     });
 
     test('verify cardano address behind passphrase', async ({

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-duplicate.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-duplicate.test.ts
@@ -2,10 +2,9 @@ import { expect, test } from '../../support/fixtures';
 
 test.describe('Passphrase duplicate', { tag: ['@group=passphrase'] }, () => {
     test.use({ emulatorSetupConf: { passphrase_protection: true } });
-    test.beforeEach(async ({ onboardingPage, dashboardPage, trezorUserEnvLink }) => {
+    test.beforeEach(async ({ onboardingPage, trezorUserEnvLink }) => {
         await trezorUserEnvLink.applySettings({ passphrase_always_on_device: false });
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
     });
 
     //TODO: #17161 Fix instable test

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-input.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-input.test.ts
@@ -2,9 +2,8 @@ import { expect, test } from '../../support/fixtures';
 
 test.describe('Passphrase input', { tag: ['@group=passphrase'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all', passphrase_protection: true } });
-    test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
+    test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
     });
 
     test('just test passphrase input', async ({ dashboardPage }) => {

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-numbering.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-numbering.test.ts
@@ -2,9 +2,8 @@ import { expect, test } from '../../support/fixtures';
 
 test.describe('Passphrase numbering', { tag: ['@group=passphrase'] }, () => {
     test.use({ emulatorSetupConf: { passphrase_protection: true } });
-    test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
+    test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
     });
 
     test('hidden wallet numbering', async ({ dashboardPage }) => {

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-reconnection.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-reconnection.test.ts
@@ -5,9 +5,8 @@ const abcAddr = 'bc1qpyfvfvm52zx7gek86ajj5pkkne3h385ada8r2y';
 
 test.describe('Passphrase reconnection', { tag: ['@group=passphrase'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all', passphrase_protection: true } });
-    test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
+    test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
     });
 
     // add 1st hidden wallet (abc)

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase.test.ts
@@ -9,9 +9,8 @@ const defAddr = 'bc1qek0hazgrelpuce8anp72ur4kpgel74ype3pw52';
 
 test.describe('Passphrase', { tag: ['@group=passphrase'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all', passphrase_protection: true } });
-    test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
+    test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
     });
 
     // add hidden wallet (abc)

--- a/packages/suite-desktop-core/e2e/tests/settings/application-log.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/application-log.test.ts
@@ -3,9 +3,8 @@ import { readFileSync } from 'fs-extra';
 import { expect, test } from '../../support/fixtures';
 
 test.describe('Application Logs', { tag: ['@group=settings'] }, () => {
-    test.beforeEach(async ({ onboardingPage, dashboardPage, settingsPage }) => {
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
         await settingsPage.navigateTo('application');
     });
 

--- a/packages/suite-desktop-core/e2e/tests/settings/coins.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/coins.test.ts
@@ -3,9 +3,8 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 import { expect, test } from '../../support/fixtures';
 
 test.describe('Coin Settings', { tag: ['@group=settings'] }, () => {
-    test.beforeEach(async ({ analytics, onboardingPage, dashboardPage, settingsPage }) => {
+    test.beforeEach(async ({ analytics, onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
         await settingsPage.navigateTo('coins');
         await analytics.interceptAnalytics();
     });

--- a/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
@@ -5,9 +5,8 @@ test.describe(
     'Suite works with Electrum server',
     { tag: ['@group=settings', '@desktopOnly'] },
     () => {
-        test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
+        test.beforeEach(async ({ onboardingPage }) => {
             await onboardingPage.completeOnboarding();
-            await dashboardPage.discoveryShouldFinish();
         });
 
         test('Electrum completes discovery successfully', async ({

--- a/packages/suite-desktop-core/e2e/tests/settings/passphrase.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/passphrase.test.ts
@@ -1,9 +1,8 @@
 import { expect, test } from '../../support/fixtures';
 
 test.describe('Passphrase', { tag: ['@group=settings'] }, () => {
-    test.beforeEach(async ({ onboardingPage, dashboardPage, settingsPage }) => {
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
         await settingsPage.navigateTo('device');
     });
 

--- a/packages/suite-desktop-core/e2e/tests/settings/t1b1-device-settings.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/t1b1-device-settings.test.ts
@@ -2,10 +2,8 @@ import { expect, test } from '../../support/fixtures';
 
 test.describe('T1B1 - Device settings', { tag: ['@group=settings'] }, () => {
     test.use({ emulatorStartConf: { model: 'T1B1', wipe: true } });
-    test.beforeEach(async ({ onboardingPage, settingsPage, dashboardPage }) => {
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
-        // Initiating pin change is not stable when discovery is not yet finished
-        await dashboardPage.discoveryShouldFinish();
         await settingsPage.navigateTo('device');
     });
 

--- a/packages/suite-desktop-core/e2e/tests/settings/t2b1-device-settings.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/t2b1-device-settings.test.ts
@@ -10,9 +10,8 @@ test.describe.serial('T2B1 - Device settings', { tag: ['@group=settings'] }, () 
         emulatorStartConf: { model: 'T2B1', wipe: true },
     });
 
-    test.beforeEach(async ({ onboardingPage, dashboardPage, settingsPage }) => {
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
         await settingsPage.navigateTo('device');
     });
 

--- a/packages/suite-desktop-core/e2e/tests/settings/t2t1-device-settings.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/t2t1-device-settings.test.ts
@@ -2,9 +2,8 @@ import { expect, test } from '../../support/fixtures';
 
 test.describe('T2T1 - Device settings', { tag: ['@group=settings'] }, () => {
     test.use({ emulatorStartConf: { wipe: true, model: 'T2T1' } });
-    test.beforeEach(async ({ onboardingPage, dashboardPage, settingsPage }) => {
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
         await settingsPage.navigateTo('device');
     });
 

--- a/packages/suite-desktop-core/e2e/tests/settings/without-device.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/without-device.test.ts
@@ -4,9 +4,8 @@ test.describe(
     'Settings changes persist when device disconnected',
     { tag: ['@group=settings'] },
     () => {
-        test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
+        test.beforeEach(async ({ onboardingPage }) => {
             await onboardingPage.completeOnboarding({ enableViewOnly: true });
-            await dashboardPage.discoveryShouldFinish();
         });
 
         test('Settings navigation', async ({ page, walletPage, trezorUserEnvLink }) => {

--- a/packages/suite-desktop-core/e2e/tests/suite/initial-run.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/initial-run.test.ts
@@ -26,7 +26,6 @@ test.describe('Suite initial run', { tag: ['@group=suite'] }, () => {
         onboardingPage,
     }) => {
         await onboardingPage.completeOnboarding({ enableViewOnly: true });
-        await dashboardPage.discoveryShouldFinish();
         await page.reload();
         await expect(dashboardPage.deviceSwitchingOpenButton).toContainText('Connected');
     });

--- a/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
@@ -36,7 +36,6 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
     for (const { testName, enableViewOnly } of testCases) {
         test(testName, async ({ page, onboardingPage, dashboardPage, devicePrompt }) => {
             await onboardingPage.completeOnboarding({ enableViewOnly });
-            await dashboardPage.discoveryShouldFinish();
             await test.step('Bridge session taken by another suite session', async () => {
                 await stealBridgeSession();
                 await expect(dashboardPage.deviceStatus).toHaveText('Refresh');
@@ -89,7 +88,6 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
         { tag: ['@webOnly'] },
         async ({ context, onboardingPage, dashboardPage }, testInfo) => {
             await onboardingPage.completeOnboarding();
-            await dashboardPage.discoveryShouldFinish();
 
             const pageTwo = await context.newPage();
             await pageTwo.context().addInitScript(() => {
@@ -107,7 +105,6 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
             );
             await onboardingPageTwo.completeOnboarding();
             const dashboardPageTwo = new DashboardPage(pageTwo, devicePromptTwo);
-            await dashboardPageTwo.discoveryShouldFinish();
             await expect(dashboardPageTwo.deviceStatus).toHaveText('Connected');
             await expect(dashboardPage.deviceStatus).toHaveText('Refresh');
 

--- a/packages/suite-desktop-core/e2e/tests/suite/safety-checks-warning.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/safety-checks-warning.test.ts
@@ -1,9 +1,8 @@
 import { expect, test } from '../../support/fixtures';
 
 test.describe('safety_checks Warnings', { tag: ['@group=suite'] }, () => {
-    test.beforeEach(async ({ onboardingPage, dashboardPage, settingsPage }) => {
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
         await settingsPage.changeSafetyChecksLevel('prompt');
     });
 

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-bitcoin.test.ts
@@ -49,13 +49,12 @@ const secondOfferCryptoAmount = `${buyQuotesBTCUpdate[5].receiveStringAmount} BT
 const formattedUpdateFiatAmount = `CZK ${localizeNumber(updateFiatAmount, 'en', 2)}`;
 
 test.describe('Trading - Buy BTC', { tag: ['@group=other', '@webOnly'] }, () => {
-    test.beforeEach(async ({ page, tradingMock, onboardingPage, dashboardPage, walletPage }) => {
+    test.beforeEach(async ({ page, tradingMock, onboardingPage, walletPage }) => {
         await page.route(invityEndpoint.buyQuotes, async route => {
             await route.fulfill({ json: buyQuotesBTC });
         });
         await tradingMock.routeTrade(invityEndpoint.buyTrade, buyTradeBTC);
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
         await walletPage.openTrading();
     });
 

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-ethereum.test.ts
@@ -13,18 +13,16 @@ const formattedFiatAmount = `CZK ${localizeNumber(fiatAmount, 'en', 2)}`;
 const { receiveAddress, paymentMethodName } = buyTradeEthereum.trade;
 
 test.describe('Trading - Buy Ethereum', { tag: ['@group=other', '@webOnly'] }, () => {
-    test.beforeEach(async ({ page, tradingMock, onboardingPage, dashboardPage }) => {
+    test.beforeEach(async ({ page, tradingMock, onboardingPage }) => {
         await page.route(invityEndpoint.buyQuotes, async route => {
             await route.fulfill({ json: buyQuotesEthereum });
         });
         await tradingMock.routeTrade(invityEndpoint.buyTrade, buyTradeEthereum);
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
     });
 
     test('Enable Ethereum on account by buying it', async ({
         page,
-        dashboardPage,
         settingsPage,
         devicePrompt,
         walletPage,
@@ -50,7 +48,7 @@ test.describe('Trading - Buy Ethereum', { tag: ['@group=other', '@webOnly'] }, (
             await page.getByRole('option', { name: 'Create a new Ethereum account' }).click();
             await expect(settingsPage.coins.networkButton('eth')).toBeEnabledCoin();
             await page.getByRole('button', { name: 'Find my Ethereum accounts' }).click();
-            await dashboardPage.discoveryShouldFinish();
+            await page.discoveryShouldFinish();
             await expect(tradingPage.confirmationAccountDropdown).toHaveText(
                 'Ethereum #1Balance: 0 ETH',
             );

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
@@ -25,7 +25,6 @@ test.describe('Trading - Buy Solana', { tag: ['@group=other', '@webOnly'] }, () 
             });
             await tradingMock.routeTrade(invityEndpoint.buyTrade, buyTradeSolanaToken);
             await onboardingPage.completeOnboarding();
-            await dashboardPage.discoveryShouldFinish();
 
             await test.step('Enable Solana and open its trading', async () => {
                 await settingsPage.navigateTo('coins');

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
@@ -36,7 +36,6 @@ test.describe('Trading - Sell BTC', { tag: ['@group=other', '@webOnly'] }, () =>
                 });
             });
             await onboardingPage.completeOnboarding();
-            await dashboardPage.discoveryShouldFinish();
             await dashboardPage.deviceSwitchingOpenButton.click();
             await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
             await walletPage.openTrading();

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum-token.test.ts
@@ -34,7 +34,6 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=other', '@webOnly'] }, 
                 });
             });
             await onboardingPage.completeOnboarding();
-            await dashboardPage.discoveryShouldFinish();
 
             await test.step('Enable Ethereum and open its token sell trading', async () => {
                 await settingsPage.navigateTo('coins');

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
@@ -49,7 +49,6 @@ test.describe('Trading - Sell Solana', { tag: ['@group=other', '@webOnly'] }, ()
                 });
             });
             await onboardingPage.completeOnboarding();
-            await dashboardPage.discoveryShouldFinish();
 
             await test.step('Enable Solana and open its sell trading', async () => {
                 await settingsPage.navigateTo('coins');

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
@@ -30,7 +30,6 @@ test.describe('Trading - Swap coin to token', { tag: ['@group=other', '@webOnly'
                 await tradingMock.routeSolanaSendRequests();
             });
             await onboardingPage.completeOnboarding();
-            await dashboardPage.discoveryShouldFinish();
             await settingsPage.navigateTo('coins');
             await settingsPage.coins.enableNetwork('sol');
             await settingsPage.coins.enableNetwork('eth');

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
@@ -40,7 +40,6 @@ test.describe('Trading - Swap coins', { tag: ['@group=other', '@webOnly'] }, () 
                 });
             });
             await onboardingPage.completeOnboarding();
-            await dashboardPage.discoveryShouldFinish();
             await settingsPage.navigateTo('coins');
             await settingsPage.coins.enableNetwork('sol');
             await settingsPage.coins.activateCoinsButton.click();

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
@@ -31,7 +31,6 @@ test.describe('Trading - Swap token to coin', { tag: ['@group=other', '@webOnly'
                 await tradingMock.routeSolanaSendRequests();
             });
             await onboardingPage.completeOnboarding();
-            await dashboardPage.discoveryShouldFinish();
             await settingsPage.navigateTo('coins');
             await settingsPage.coins.enableNetwork('sol');
             await settingsPage.coins.activateCoinsButton.click();

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
@@ -31,7 +31,6 @@ test.describe('Trading - Swap tokens', { tag: ['@group=other', '@webOnly'] }, ()
                 await tradingMock.routeSolanaSendRequests();
             });
             await onboardingPage.completeOnboarding();
-            await dashboardPage.discoveryShouldFinish();
             await settingsPage.navigateTo('coins');
             await settingsPage.coins.enableNetwork('sol');
             await settingsPage.coins.activateCoinsButton.click();

--- a/packages/suite-desktop-core/e2e/tests/wallet/account-search.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/account-search.test.ts
@@ -6,9 +6,8 @@ test.describe('Look up a BTC account', { tag: ['@group=wallet'] }, () => {
             mnemonic: 'cancel solid bulb sample fury scrap whale ranch raven razor sight skin',
         },
     });
-    test.beforeEach(async ({ onboardingPage, dashboardPage, settingsPage }) => {
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
         await settingsPage.navigateTo('coins');
         await settingsPage.coins.enableNetwork('ltc');
     });

--- a/packages/suite-desktop-core/e2e/tests/wallet/add-account-types.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/add-account-types.test.ts
@@ -10,9 +10,8 @@ test.describe('Account types suite', { tag: ['@group=wallet'] }, () => {
             mnemonic: 'town grace cat forest dress dust trick practice hair survey pupil regular',
         },
     });
-    test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
+    test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
     });
 
     /**

--- a/packages/suite-desktop-core/e2e/tests/wallet/blockbook-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/blockbook-discovery.test.ts
@@ -2,9 +2,8 @@ import { expect, test } from '../../support/fixtures';
 
 test.describe('Custom-blockbook-discovery', { tag: ['@group=wallet'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });
-    test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
+    test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
     });
 
     test('BTC blockbook discovery', async ({ settingsPage, dashboardPage }) => {

--- a/packages/suite-desktop-core/e2e/tests/wallet/cardano.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/cardano.test.ts
@@ -9,9 +9,8 @@ const receiveAddress =
 //mnemonic: 'clot trim improve bag pigeon party wave mechanic beyond clean cake maze protect left assist carry guitar bridge nest faith critic excuse tooth dutch',
 
 test.describe('Cardano', { tag: ['@group=wallet', '@snapshot'] }, () => {
-    test.beforeEach(async ({ onboardingPage, dashboardPage, settingsPage }) => {
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
         await settingsPage.navigateTo('coins');
     });
 

--- a/packages/suite-desktop-core/e2e/tests/wallet/coin-balance.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/coin-balance.test.ts
@@ -3,9 +3,8 @@ import { expect, test } from '../../support/fixtures';
 test.describe('Coin balance', { tag: ['@group=wallet'] }, () => {
     const address = 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v';
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });
-    test.beforeEach(async ({ dashboardPage, onboardingPage }) => {
+    test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
     });
 
     test('Account balance is increased', async ({

--- a/packages/suite-desktop-core/e2e/tests/wallet/discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/discovery.test.ts
@@ -17,9 +17,8 @@ const coinsToActivate = [
     'zec',
 ] as NetworkSymbol[];
 test.describe('Discovery', { tag: ['@group=wallet'] }, () => {
-    test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
+    test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
     });
 
     test('go to wallet settings page, activate all coins and see that there is equal number of records on dashboard', async ({

--- a/packages/suite-desktop-core/e2e/tests/wallet/export-transactions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/export-transactions.test.ts
@@ -11,9 +11,8 @@ test.describe('Export transactions', { tag: ['@group=wallet', '@webOnly'] }, () 
             mnemonic: 'town grace cat forest dress dust trick practice hair survey pupil regular',
         },
     });
-    test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
+    test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
     });
 
     /* Test case

--- a/packages/suite-desktop-core/e2e/tests/wallet/import-btc-csv.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/import-btc-csv.test.ts
@@ -7,10 +7,9 @@ import { expect, test } from '../../support/fixtures';
 import { MetadataProvider } from '../../support/mocks/metadataMock';
 
 test.describe('Import a BTC csv file', { tag: ['@group=wallet', '@webOnly'] }, () => {
-    test.beforeEach(async ({ metadataMock, onboardingPage, dashboardPage }) => {
+    test.beforeEach(async ({ metadataMock, onboardingPage }) => {
         await metadataMock.start(MetadataProvider.DROPBOX);
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
     });
 
     test('Go to BTC send form and import a csv', async ({

--- a/packages/suite-desktop-core/e2e/tests/wallet/pending-transactions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/pending-transactions.test.ts
@@ -46,12 +46,11 @@ test.describe.skip(
                 await page.waitForTimeout(5_000);
 
                 await onboardingPage.completeOnboarding();
-                await dashboardPage.discoveryShouldFinish();
                 await settingsPage.navigateTo('coins');
                 await settingsPage.coins.disableNetwork('btc');
                 await settingsPage.coins.enableNetwork('regtest');
                 await dashboardPage.dashboardMenuButton.click();
-                await dashboardPage.discoveryShouldFinish();
+                await page.discoveryShouldFinish();
                 expect(
                     await walletPage.getAccountsCount('regtest'),
                     'expected 3 Regtest accounts to be discovered. They might not have been mined yet',

--- a/packages/suite-desktop-core/e2e/tests/wallet/public-keys.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/public-keys.test.ts
@@ -24,9 +24,8 @@ test.describe('Public Keys', { tag: ['@group=wallet'] }, () => {
         },
     });
 
-    test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
+    test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
     });
 
     testCases.forEach(({ symbol, xpub }) => {

--- a/packages/suite-desktop-core/e2e/tests/wallet/send-doge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/send-doge.test.ts
@@ -19,7 +19,6 @@ test.describe('Doge Send', { tag: ['@group=wallet', '@snapshot'] }, () => {
     test.beforeEach(async ({ onboardingPage, settingsPage, dashboardPage, blockbookMock }) => {
         await blockbookMock.start('doge');
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
         await settingsPage.navigateTo('coins');
         await settingsPage.coins.disableNetwork('btc');
         await settingsPage.coins.enableNetwork('doge');

--- a/packages/suite-desktop-core/e2e/tests/wallet/send-form-ltc.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/send-form-ltc.test.ts
@@ -8,7 +8,6 @@ test.describe('LTC send form with mocked blockbook', { tag: ['@group=wallet'] },
     });
     test.beforeEach(async ({ dashboardPage, onboardingPage, settingsPage, blockbookMock }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
 
         await settingsPage.navigateTo('coins');
         await blockbookMock.start('ltc');

--- a/packages/suite-desktop-core/e2e/tests/wallet/send-form-regtest.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/send-form-regtest.test.ts
@@ -12,7 +12,6 @@ test.describe('Send form for bitcoin', { tag: ['@group=wallet'] }, () => {
     test.beforeEach(
         async ({ onboardingPage, dashboardPage, settingsPage, walletPage, trezorUserEnvLink }) => {
             await onboardingPage.completeOnboarding();
-            await dashboardPage.discoveryShouldFinish();
 
             await settingsPage.navigateTo('coins');
             await settingsPage.coins.enableNetwork('regtest');

--- a/packages/suite-desktop-core/e2e/tests/wallet/sign-and-verify-eth.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/sign-and-verify-eth.test.ts
@@ -4,7 +4,6 @@ test.describe('Sign and verify ETH', { tag: ['@group=wallet'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });
     test.beforeEach(async ({ dashboardPage, onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
 
         await settingsPage.navigateTo('coins');
 

--- a/packages/suite-desktop-core/e2e/tests/wallet/sign-and-verify.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/sign-and-verify.test.ts
@@ -9,9 +9,8 @@ const ELECTRUM_SIGNATURE =
     'HxpInbBQH8LYgBBnRt4/QCV+HBW3hL1o1Yg85biWX1DdBTbfN96pyLL7tLQdYn+VtjvuZWJhEYbUCasjZLmih6w=';
 test.describe('Sign and verify', { tag: ['@group=wallet'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });
-    test.beforeEach(async ({ page, walletPage, onboardingPage, dashboardPage }) => {
+    test.beforeEach(async ({ page, walletPage, onboardingPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
         await walletPage.openAccount();
         await page.waitForTimeout(500); // wait until is the dropdown loaded
         await walletPage.walletExtraDropDown.click();

--- a/packages/suite-desktop-core/e2e/tests/wallet/staking.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/staking.test.ts
@@ -8,7 +8,6 @@ test.describe('ETH staking', { tag: ['@group=wallet'] }, () => {
     });
     test.beforeEach(async ({ dashboardPage, onboardingPage, settingsPage, blockbookMock }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
 
         await settingsPage.navigateTo('coins');
         await blockbookMock.start('eth');

--- a/packages/suite-desktop-core/e2e/tests/wallet/transactions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/transactions.test.ts
@@ -11,9 +11,8 @@ const rangeData: { range: graphRangeOptions; label: string }[] = [
 
 test.describe('Account transactions overview', { tag: ['@group=wallet'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });
-    test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
+    test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
     });
 
     test('Check graph span and search a transaction by BTC address', async ({


### PR DESCRIPTION
Introduces a new base base page from which other pages classes extend. Not every page object. So far only ***Page classes. I have not extended classes like ***Modal, ***Section which do not consist of whole page.

The goal is to have some methods and locators more easily available. The first application of that is discoveryShouldFinish()

Thanks to that I have incorporated `discoveryShouldFinish()` into `completeOnboarding`. I have noticed around 15 tests that before didn't wait for the discovery. This might add few seconds of test runtime but potencionally can prevent unstable behaviour
## Screenshots:
