### PR TITLE
chore(blockchain-link): move solana types

### DIFF
--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -19,7 +19,6 @@
         "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
-        "@solana/kit": "^2.0.0",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utxo-lib": "workspace:*"
     },

--- a/packages/blockchain-link-types/src/solana.ts
+++ b/packages/blockchain-link-types/src/solana.ts
@@ -1,74 +1,8 @@
-import type {
-    AccountInfoBase,
-    AccountInfoWithBase58EncodedData,
-    AccountInfoWithBase64EncodedData,
-    AccountInfoWithBase64EncodedZStdCompressedData,
-    AccountInfoWithJsonData,
-    GetTransactionApi,
-    Signature,
-} from '@solana/kit';
-
-import type {
-    GetObjectWithKey,
-    GetObjectWithoutKey,
-    ObjectsOnly,
-    Overloads,
-} from '@trezor/type-utils';
-
-type GetTransactionApiOverloads = Overloads<GetTransactionApi['getTransaction']>;
-type GetJsonParsedTransactionApiOverloads = {
-    [P in keyof GetTransactionApiOverloads]: GetTransactionApiOverloads[P] extends (
-        ...args: [
-            signature: Signature,
-            config: Readonly<{
-                encoding: 'jsonParsed';
-            }>,
-        ]
-    ) => infer R
-        ? R
-        : never;
-};
-
-export type ParsedTransactionWithMeta = Pick<
-    SolanaValidParsedTxWithMeta,
-    'slot' | 'transaction' | 'meta'
-> &
-    Readonly<{
-        blockTime?: SolanaValidParsedTxWithMeta['blockTime'];
-        version?: SolanaValidParsedTxWithMeta['version'];
-    }>;
-
-export type PartiallyDecodedInstruction = GetObjectWithoutKey<
-    SolanaValidParsedTxWithMeta['transaction']['message']['instructions'][number],
-    'parsed'
->;
-
-export type ParsedAccountData = ObjectsOnly<AccountInfoWithJsonData['data']>;
-
-export type ParsedInstruction = GetObjectWithKey<
-    SolanaValidParsedTxWithMeta['transaction']['message']['instructions'][number],
-    'parsed'
->;
-
-export type SolanaValidParsedTxWithMeta = NonNullable<
-    ObjectsOnly<GetJsonParsedTransactionApiOverloads[keyof GetTransactionApiOverloads]>
->;
-
 export type SolanaTokenAccountInfo = {
     address: string;
     mint: string | undefined;
     decimals: number | undefined;
 };
-
-export type AccountInfo<
-    TData extends
-        | AccountInfoWithBase58EncodedData['data']
-        | AccountInfoWithBase64EncodedData['data']
-        | AccountInfoWithBase64EncodedZStdCompressedData['data']
-        | AccountInfoWithJsonData['data'],
-> = AccountInfoBase & Readonly<{ data: TData }>;
-
-export type { Address } from '@solana/kit';
 
 export type SolanaStakingAccount = {
     status: string;

--- a/packages/blockchain-link-utils/package.json
+++ b/packages/blockchain-link-utils/package.json
@@ -25,6 +25,10 @@
         "@trezor/utils": "workspace:*"
     },
     "devDependencies": {
+        "@solana/addresses": "^2.1.0",
+        "@solana/keys": "^2.1.0",
+        "@solana/rpc-api": "^2.1.0",
+        "@solana/rpc-types": "^2.1.0",
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/eslint": "workspace:*",
         "@trezor/type-utils": "workspace:*",

--- a/packages/blockchain-link-utils/src/solana-types.ts
+++ b/packages/blockchain-link-utils/src/solana-types.ts
@@ -1,0 +1,64 @@
+import type { Signature } from '@solana/keys';
+import type { GetTransactionApi } from '@solana/rpc-api';
+import type {
+    AccountInfoBase,
+    AccountInfoWithBase58EncodedData,
+    AccountInfoWithBase64EncodedData,
+    AccountInfoWithBase64EncodedZStdCompressedData,
+    AccountInfoWithJsonData,
+} from '@solana/rpc-types';
+
+import type {
+    GetObjectWithKey,
+    GetObjectWithoutKey,
+    ObjectsOnly,
+    Overloads,
+} from '@trezor/type-utils';
+
+type GetTransactionApiOverloads = Overloads<GetTransactionApi['getTransaction']>;
+type GetJsonParsedTransactionApiOverloads = {
+    [P in keyof GetTransactionApiOverloads]: GetTransactionApiOverloads[P] extends (
+        ...args: [
+            signature: Signature,
+            config: Readonly<{
+                encoding: 'jsonParsed';
+            }>,
+        ]
+    ) => infer R
+        ? R
+        : never;
+};
+
+export type ParsedTransactionWithMeta = Pick<
+    SolanaValidParsedTxWithMeta,
+    'slot' | 'transaction' | 'meta'
+> &
+    Readonly<{
+        blockTime?: SolanaValidParsedTxWithMeta['blockTime'];
+        version?: SolanaValidParsedTxWithMeta['version'];
+    }>;
+
+export type PartiallyDecodedInstruction = GetObjectWithoutKey<
+    SolanaValidParsedTxWithMeta['transaction']['message']['instructions'][number],
+    'parsed'
+>;
+
+export type ParsedAccountData = ObjectsOnly<AccountInfoWithJsonData['data']>;
+
+export type ParsedInstruction = GetObjectWithKey<
+    SolanaValidParsedTxWithMeta['transaction']['message']['instructions'][number],
+    'parsed'
+>;
+
+export type SolanaValidParsedTxWithMeta = NonNullable<
+    ObjectsOnly<GetJsonParsedTransactionApiOverloads[keyof GetTransactionApiOverloads]>
+>;
+export type AccountInfo<
+    TData extends
+        | AccountInfoWithBase58EncodedData['data']
+        | AccountInfoWithBase64EncodedData['data']
+        | AccountInfoWithBase64EncodedZStdCompressedData['data']
+        | AccountInfoWithJsonData['data'],
+> = AccountInfoBase & Readonly<{ data: TData }>;
+
+export type { Address } from '@solana/addresses';

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -2,6 +2,14 @@ import { A, D, F, pipe } from '@mobily/ts-belt';
 
 import { Target, TokenTransfer, Transaction } from '@trezor/blockchain-link-types/src';
 import type { StakeType, TokenInfo, TokenStandard } from '@trezor/blockchain-link-types/src';
+import {
+    SolanaTokenAccountInfo,
+    TokenDetailByMint,
+} from '@trezor/blockchain-link-types/src/solana';
+import { isCodesignBuild } from '@trezor/env-utils';
+import { arrayPartition } from '@trezor/utils';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
+
 import type {
     AccountInfo,
     Address,
@@ -9,14 +17,8 @@ import type {
     ParsedInstruction,
     ParsedTransactionWithMeta,
     PartiallyDecodedInstruction,
-    SolanaTokenAccountInfo,
     SolanaValidParsedTxWithMeta,
-    TokenDetailByMint,
-} from '@trezor/blockchain-link-types/src/solana';
-import { isCodesignBuild } from '@trezor/env-utils';
-import { arrayPartition } from '@trezor/utils';
-import { BigNumber } from '@trezor/utils/src/bigNumber';
-
+} from './solana-types';
 import { formatTokenSymbol } from './utils';
 
 export type ApiTokenAccount = {

--- a/packages/blockchain-link-utils/src/tests/solana.test.ts
+++ b/packages/blockchain-link-utils/src/tests/solana.test.ts
@@ -1,8 +1,4 @@
 import { TokenTransfer, Transaction } from '@trezor/blockchain-link-types/src';
-import {
-    ParsedTransactionWithMeta,
-    SolanaValidParsedTxWithMeta,
-} from '@trezor/blockchain-link-types/src/solana';
 
 import {
     ApiTokenAccount,
@@ -17,6 +13,7 @@ import {
     transformTokenInfo,
     transformTransaction,
 } from '../solana';
+import { ParsedTransactionWithMeta, SolanaValidParsedTxWithMeta } from '../solana-types';
 import { fixtures } from './fixtures/solana';
 
 describe('solana/utils', () => {

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -47,9 +47,7 @@ import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/src/constants
 import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
 import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
 import type {
-    ParsedTransactionWithMeta,
     SolanaTokenAccountInfo,
-    SolanaValidParsedTxWithMeta,
     TokenDetailByMint,
 } from '@trezor/blockchain-link-types/src/solana';
 import { solanaUtils } from '@trezor/blockchain-link-utils';
@@ -58,6 +56,10 @@ import {
     tokenProgramsInfo,
     transformTokenInfo,
 } from '@trezor/blockchain-link-utils/src/solana';
+import type {
+    ParsedTransactionWithMeta,
+    SolanaValidParsedTxWithMeta,
+} from '@trezor/blockchain-link-utils/src/solana-types';
 import { getSuiteVersion } from '@trezor/env-utils';
 import { IntervalId } from '@trezor/type-utils';
 import { BigNumber, createDeferred, createLazy } from '@trezor/utils';

--- a/scripts/list-outdated-dependencies/trends-dependencies.txt
+++ b/scripts/list-outdated-dependencies/trends-dependencies.txt
@@ -9,6 +9,10 @@
 @solana-program/system
 @solana-program/token
 @solana-program/token-2022
+@solana/addresses
+@solana/keys
+@solana/rpc-api
+@solana/rpc-types
 web3-utils
 jws
 @metamask/eth-sig-util

--- a/yarn.lock
+++ b/yarn.lock
@@ -8121,7 +8121,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@solana/addresses@npm:2.1.0":
+"@solana/addresses@npm:2.1.0, @solana/addresses@npm:^2.1.0":
   version: 2.1.0
   resolution: "@solana/addresses@npm:2.1.0"
   dependencies:
@@ -8264,7 +8264,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@solana/keys@npm:2.1.0":
+"@solana/keys@npm:2.1.0, @solana/keys@npm:^2.1.0":
   version: 2.1.0
   resolution: "@solana/keys@npm:2.1.0"
   dependencies:
@@ -8342,7 +8342,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@solana/rpc-api@npm:2.1.0":
+"@solana/rpc-api@npm:2.1.0, @solana/rpc-api@npm:^2.1.0":
   version: 2.1.0
   resolution: "@solana/rpc-api@npm:2.1.0"
   dependencies:
@@ -8488,7 +8488,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@solana/rpc-types@npm:2.1.0":
+"@solana/rpc-types@npm:2.1.0, @solana/rpc-types@npm:^2.1.0":
   version: 2.1.0
   resolution: "@solana/rpc-types@npm:2.1.0"
   dependencies:
@@ -11470,7 +11470,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/blockchain-link-types@workspace:packages/blockchain-link-types"
   dependencies:
-    "@solana/kit": "npm:^2.0.0"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
     tsx: "npm:^4.19.3"
@@ -11484,6 +11483,10 @@ __metadata:
   resolution: "@trezor/blockchain-link-utils@workspace:packages/blockchain-link-utils"
   dependencies:
     "@mobily/ts-belt": "npm:^3.13.1"
+    "@solana/addresses": "npm:^2.1.0"
+    "@solana/keys": "npm:^2.1.0"
+    "@solana/rpc-api": "npm:^2.1.0"
+    "@solana/rpc-types": "npm:^2.1.0"
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/eslint": "workspace:*"


### PR DESCRIPTION
## Description

Move Solana dependencies away from `blockchain-link-types` into `blockchain-link-utils` and splitting them into individual packages