### PR TITLE
chore(message-system): add update banner for t1b1

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2025-02-24T00:00:00+00:00",
-    "sequence": 82,
+    "timestamp": "2025-03-13T00:00:00+00:00",
+    "sequence": 83,
     "actions": [
         {
             "conditions": [
@@ -561,6 +561,127 @@
                         "pt": "Atualizar agora",
                         "uk": "Оновити зараз"
                     }
+                }
+            }
+        },
+        {
+            "conditions": [
+                {
+                    "environment": {
+                        "desktop": ">=25.2.1",
+                        "mobile": "!",
+                        "web": ">=25.2.1"
+                    },
+                    "devices": [
+                        {
+                            "model": "T1B1",
+                            "firmware": "1.12.1",
+                            "bootloader": "*",
+                            "variant": "*",
+                            "firmwareRevision": "*",
+                            "vendor": "*"
+                        },
+                        {
+                            "model": "1",
+                            "firmware": "1.12.1",
+                            "bootloader": "*",
+                            "variant": "*",
+                            "firmwareRevision": "*",
+                            "vendor": "*"
+                        }
+                    ]
+                }
+            ],
+            "message": {
+                "id": "8901bcbb-d9b2-4901-bfc3-3669175f04a8",
+                "priority": 94,
+                "dismissible": true,
+                "variant": "info",
+                "category": ["banner"],
+                "content": {
+                    "en-GB": "New Trezor firmware is available! Please update your device.",
+                    "en": "New Trezor firmware is available! Please update your device.",
+                    "es": "¡Hay disponible un nuevo firmware de Trezor! Por favor, actualiza tu dispositivo.",
+                    "cs": "Je k dispozici nový firmware pro Trezor! Aktualizujte prosím své zařízení.",
+                    "ru": "Доступна новая прошивка Trezor! Пожалуйста, обновите ваше устройство.",
+                    "ja": "新しいTrezorファームウェアが利用可能です！デバイスをアップデートしてください。",
+                    "hu": "Új Trezor firmware érhető el! Kérjük, frissítse a készülékét.",
+                    "it": "È disponibile un nuovo firmware Trezor! Si prega di aggiornare il dispositivo.",
+                    "fr": "Un nouveau firmware Trezor est disponible ! Veuillez mettre à jour votre appareil.",
+                    "de": "Neue Trezor-Firmware verfügbar! Bitte aktualisieren Sie Ihr Gerät.",
+                    "tr": "Yeni Trezor yazılımı mevcut! Lütfen cihazınızı güncelleyin.",
+                    "pt": "Está disponível um novo firmware Trezor! Por favor, atualize o seu dispositivo.",
+                    "uk": "Доступна нова прошивка Trezor! Будь ласка, оновіть ваш пристрій."
+                },
+                "cta": {
+                    "action": "internal-link",
+                    "link": "firmware-index",
+                    "label": {
+                        "en-GB": "Update now",
+                        "en": "Update now",
+                        "es": "Actualizar ahora",
+                        "cs": "Aktualizovat teď",
+                        "ru": "Обновить сейчас",
+                        "ja": "今すぐアップデート",
+                        "hu": "Frissítés most",
+                        "it": "Aggiorna ora",
+                        "fr": "Mettre à jour maintenant",
+                        "de": "Jetzt aktualisieren",
+                        "tr": "Şimdi Güncelle",
+                        "pt": "Atualizar agora",
+                        "uk": "Оновити зараз"
+                    }
+                }
+            }
+        },
+        {
+            "conditions": [
+                {
+                    "environment": {
+                        "desktop": "!",
+                        "mobile": "25.2.1",
+                        "web": "!"
+                    },
+                    "devices": [
+                        {
+                            "model": "T1B1",
+                            "firmware": "1.12.1",
+                            "bootloader": "*",
+                            "variant": "*",
+                            "firmwareRevision": "*",
+                            "vendor": "*"
+                        },
+                        {
+                            "model": "1",
+                            "firmware": "1.12.1",
+                            "bootloader": "*",
+                            "variant": "*",
+                            "firmwareRevision": "*",
+                            "vendor": "*"
+                        }
+                    ]
+                }
+            ],
+            "message": {
+                "id": "49e7400f-c457-4309-b0bb-a221f6b09b36",
+                "priority": 94,
+                "dismissible": true,
+                "variant": "info",
+                "category": ["banner"],
+                "content": {
+                    "en-GB": "New Trezor firmware is available! Please update your device.",
+                    "en": "New Trezor firmware is available! Please update your device.",
+                    "es": "¡Hay disponible un nuevo firmware de Trezor! Por favor, actualiza tu dispositivo.",
+                    "cs": "Je k dispozici nový firmware pro Trezor! Aktualizujte prosím své zařízení.",
+                    "ru": "Доступна новая прошивка Trezor! Пожалуйста, обновите ваше устройство.",
+                    "ja": "新しいTrezorファームウェアが利用可能です！デバイスをアップデートしてください。",
+                    "hu": "Új Trezor firmware érhető el! Kérjük, frissítse a készülékét.",
+                    "it": "È disponibile un nuovo firmware Trezor! Si prega di aggiornare il dispositivo.",
+                    "fr": "Un nouveau firmware Trezor est disponible ! Veuillez mettre à jour votre appareil.",
+                    "de": "Neue Trezor-Firmware verfügbar! Bitte aktualisieren Sie Ihr Gerät.",
+                    "tr": "Yeni Trezor yazılımı mevcut! Lütfen cihazınızı güncelleyin.",
+                    "pt": "Está disponível um novo firmware Trezor! Por favor, atualize o seu dispositivo.",
+                    "uk": "Доступна нова прошивка Trezor! Будь ласка, оновіть ваш пристрій."
                 }
             }
         },


### PR DESCRIPTION
Tracked in Notion [here](https://www.notion.so/satoshilabs/T1B1-update-banner-1b6dc526060680d6be4af9f0884b91f3?pvs=4)

This pull request includes updates to the `suite-common/message-system/config/config.v1.json` file to modify the timestamp and sequence number, and to add new message conditions and content for firmware updates.

Updates to configuration:

* Updated the `timestamp` to "2025-03-13T00:00:00+00:00" and the `sequence` to 83.

New message conditions and content:

* Added a new message condition for environments with desktop and web versions greater than 25.2.2 and mobile excluded, targeting specific device models and firmware versions. The message informs users about the availability of new Trezor firmware and prompts them to update their device.
* Added another message condition for environments with mobile version 25.2.1 and desktop and web excluded, targeting the same device models and firmware versions. The message content is similar, informing users about the new Trezor firmware and urging them to update their device.