### PR TITLE
e2:e video web & electron logs

### DIFF
--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -68,7 +68,7 @@ export async function skipFixture({}, use: (r: void) => Promise<void>) {
 
 export const getVideoPath = (videoFolder: string) => {
     const videoFilenames = readdirSync(videoFolder).filter(file => file.endsWith('.webm'));
-    if (videoFilenames.length > 1) {
+    if (videoFilenames.length !== 1) {
         console.error(
             `Warning: More than one test video file found in the output directory: ${videoFolder}\nAttaching only the first one: ${videoFilenames[0]}`,
         );

--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -1,5 +1,7 @@
 import test, { TestInfo } from '@playwright/test';
 import { isEqual, omit } from 'lodash';
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
 
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 import { splitStringEveryNCharacters } from '@trezor/utils';
@@ -63,3 +65,14 @@ export async function skipFixture({}, use: (r: void) => Promise<void>) {
     await use();
 }
 /* eslint-enable no-empty-pattern, react-hooks/rules-of-hooks */
+
+export const getVideoPath = (videoFolder: string) => {
+    const videoFilenames = readdirSync(videoFolder).filter(file => file.endsWith('.webm'));
+    if (videoFilenames.length > 1) {
+        console.error(
+            `Warning: More than one test video file found in the output directory: ${videoFolder}\nAttaching only the first one: ${videoFilenames[0]}`,
+        );
+    }
+
+    return path.join(videoFolder, videoFilenames[0]);
+};

--- a/packages/suite-desktop-core/e2e/support/electron.ts
+++ b/packages/suite-desktop-core/e2e/support/electron.ts
@@ -1,7 +1,5 @@
-/* eslint-disable no-console */
-
 import { ElectronApplication, Page, _electron as electron } from '@playwright/test';
-import { readdirSync, removeSync } from 'fs-extra';
+import { createWriteStream, ensureDirSync, readdirSync, removeSync } from 'fs-extra';
 import path from 'path';
 
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
@@ -18,7 +16,7 @@ type LaunchSuiteParams = {
     bridgeDaemon?: boolean;
     locale?: string;
     colorScheme?: 'light' | 'dark' | 'no-preference' | null | undefined;
-    videoFolder: string;
+    artefactFolder: string;
     viewport: { width: number; height: number };
 };
 
@@ -43,7 +41,8 @@ export const launchSuiteElectronApp = async (params: LaunchSuiteParams) => {
     const options = Object.assign(defaultParams, params);
 
     const appDir = path.join(__dirname, '../../../suite-desktop');
-    const logLevelArgument = `--log-level=${process.env.LOGLEVEL ?? 'error'}`;
+    // #15670 Bug in desktop app that loglevel is ignored
+    const logLevelArgument = `--log-level=${process.env.LOGLEVEL ?? 'debug'}`;
     const viewportArgument = `--width=${options.viewport.width} --height=${options.viewport.height}`;
     const disableHWAccelerationArgument = '--disable-gpu'; // to fix chromium error GetVSyncParametersIfAvailable()
     if (!options.bridgeDaemon) {
@@ -64,7 +63,7 @@ export const launchSuiteElectronApp = async (params: LaunchSuiteParams) => {
         ],
         colorScheme: params.colorScheme,
         locale: params.locale,
-        recordVideo: { dir: options.videoFolder, size: options.viewport },
+        recordVideo: { dir: options.artefactFolder, size: options.viewport },
     });
 
     const localDataDir = await electronApp.evaluate(({ app }) => app.getPath('userData'));
@@ -83,15 +82,14 @@ export const launchSuiteElectronApp = async (params: LaunchSuiteParams) => {
         });
     }
 
-    // Electron logs so far didn't bring any value to the test logs.
-    // That is why we are logging only if LOGLEVEL is set.
-    if (process.env.LOGLEVEL) {
-        // #15670 Bug in desktop app that loglevel is ignored
-        electronApp.process().stdout?.on('data', data => console.log(data.toString()));
-        electronApp
-            .process()
-            .stderr?.on('data', data => console.error(formatErrorLogMessage(data.toString())));
-    }
+    const logFilePath = path.join(options.artefactFolder, 'electron-app.log');
+    ensureDirSync(options.artefactFolder);
+    const logStream = createWriteStream(logFilePath, { flags: 'a' });
+
+    electronApp.process().stdout?.on('data', data => logStream.write(data.toString()));
+    electronApp
+        .process()
+        .stderr?.on('data', data => logStream.write(formatErrorLogMessage(data.toString())));
 
     await electronApp.evaluate(
         (_, [resourcesPath]) => {

--- a/packages/suite-desktop-core/e2e/support/electron.ts
+++ b/packages/suite-desktop-core/e2e/support/electron.ts
@@ -93,6 +93,9 @@ export const launchSuiteElectronApp = async (params: LaunchSuiteParams) => {
     electronApp
         .process()
         .stderr?.on('data', data => logStream.write(formatErrorLogMessage(data.toString())));
+    electronApp.process().on('close', () => {
+        logStream.end();
+    });
 
     await electronApp.evaluate(
         (_, [resourcesPath]) => {

--- a/packages/suite-desktop-core/e2e/support/electron.ts
+++ b/packages/suite-desktop-core/e2e/support/electron.ts
@@ -83,13 +83,15 @@ export const launchSuiteElectronApp = async (params: LaunchSuiteParams) => {
         });
     }
 
-    // #15670 Bug in desktop app that loglevel is ignored so we conditionally don't log to stdout
+    // Electron logs so far didn't bring any value to the test logs.
+    // That is why we are logging only if LOGLEVEL is set.
     if (process.env.LOGLEVEL) {
+        // #15670 Bug in desktop app that loglevel is ignored
         electronApp.process().stdout?.on('data', data => console.log(data.toString()));
+        electronApp
+            .process()
+            .stderr?.on('data', data => console.error(formatErrorLogMessage(data.toString())));
     }
-    electronApp
-        .process()
-        .stderr?.on('data', data => console.error(formatErrorLogMessage(data.toString())));
 
     await electronApp.evaluate(
         (_, [resourcesPath]) => {
@@ -110,17 +112,4 @@ export const launchSuite = async (params: LaunchSuiteParams): Promise<Suite> => 
     const window = await electronApp.firstWindow();
 
     return { electronApp, window };
-};
-
-export const getElectronVideoPath = (videoFolder: string) => {
-    const videoFilenames = readdirSync(videoFolder).filter(file => file.endsWith('.webm'));
-    if (videoFilenames.length > 1) {
-        console.error(
-            formatErrorLogMessage(
-                `Warning: More than one electron video file found in the output directory: ${videoFolder}\nAttaching only the first one: ${videoFilenames[0]}`,
-            ),
-        );
-    }
-
-    return path.join(videoFolder, videoFilenames[0]);
 };

--- a/packages/suite-desktop-core/e2e/support/electron.ts
+++ b/packages/suite-desktop-core/e2e/support/electron.ts
@@ -28,8 +28,11 @@ export type Suite = {
 const formatErrorLogMessage = (data: string) => {
     const red = '\x1b[31m';
     const reset = '\x1b[0m';
+    const bold = '\x1b[1m';
+    const unbold = '\x1b[22m';
+    const timestamp = new Date().toISOString();
 
-    return `${red}${data}${reset}`;
+    return `${timestamp} - ${bold}${red}ERROR${unbold}: ${data}${reset}`;
 };
 
 export const launchSuiteElectronApp = async (params: LaunchSuiteParams) => {
@@ -82,7 +85,7 @@ export const launchSuiteElectronApp = async (params: LaunchSuiteParams) => {
         });
     }
 
-    const logFilePath = path.join(options.artefactFolder, 'electron-app.log');
+    const logFilePath = path.join(options.artefactFolder, 'electron-logs.txt');
     ensureDirSync(options.artefactFolder);
     const logStream = createWriteStream(logFilePath, { flags: 'a' });
 

--- a/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts
@@ -38,8 +38,8 @@ const electronTeardown = async (suite: Suite, testInfo: TestInfo) => {
     const tracePath = `${testInfo.outputDir}/trace.electron.zip`;
     await suite.window.context().tracing.stop({ path: tracePath });
     testInfo.attachments.push({
-        name: 'electron-logs',
-        path: `${testInfo.outputDir}/electron-app.log`,
+        name: 'electron-logs.txt',
+        path: `${testInfo.outputDir}/electron-logs.txt`,
         contentType: 'text/plain',
     });
     testInfo.attachments.push({

--- a/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts
@@ -23,7 +23,7 @@ const electronSetup = async (testInfo: TestInfo, locale: string | undefined, col
     const suite = await launchSuite({
         locale,
         colorScheme,
-        videoFolder: testInfo.outputDir,
+        artefactFolder: testInfo.outputDir,
         viewport: testInfo.project.use.viewport!,
     });
 
@@ -37,6 +37,11 @@ const electronSetup = async (testInfo: TestInfo, locale: string | undefined, col
 const electronTeardown = async (suite: Suite, testInfo: TestInfo) => {
     const tracePath = `${testInfo.outputDir}/trace.electron.zip`;
     await suite.window.context().tracing.stop({ path: tracePath });
+    testInfo.attachments.push({
+        name: 'electron-logs',
+        path: `${testInfo.outputDir}/electron-app.log`,
+        contentType: 'text/plain',
+    });
     testInfo.attachments.push({
         name: 'trace',
         path: tracePath,

--- a/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts
@@ -3,8 +3,8 @@ import { BrowserContext, Page, TestInfo, test as base } from '@playwright/test';
 
 import { Model, SetupEmu, StartEmu, TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
 
-import { TrezorUserEnvLinkProxy, getUrl, isDesktopProject } from '../common';
-import { Suite, getElectronVideoPath, launchSuite } from '../electron';
+import { TrezorUserEnvLinkProxy, getUrl, getVideoPath, isDesktopProject } from '../common';
+import { Suite, launchSuite } from '../electron';
 
 type StartEmuModelRequired = StartEmu & { model: Model };
 
@@ -27,7 +27,9 @@ const electronSetup = async (testInfo: TestInfo, locale: string | undefined, col
         viewport: testInfo.project.use.viewport!,
     });
 
-    await suite.window.context().tracing.start({ screenshots: true, snapshots: true });
+    await suite.window
+        .context()
+        .tracing.start({ screenshots: true, snapshots: true, sources: true });
 
     return suite;
 };
@@ -42,7 +44,7 @@ const electronTeardown = async (suite: Suite, testInfo: TestInfo) => {
     });
     testInfo.attachments.push({
         name: 'video',
-        path: getElectronVideoPath(testInfo.outputDir),
+        path: getVideoPath(testInfo.outputDir),
         contentType: 'video/webm',
     });
     await suite.electronApp.close();
@@ -59,6 +61,16 @@ const webSetup = async (browserContext: BrowserContext) => {
     await page.goto('./');
 
     return page;
+};
+
+const webTeardown = async (page: Page, browserContext: BrowserContext, testInfo: TestInfo) => {
+    await page.close();
+    await browserContext.close();
+    testInfo.attachments.push({
+        name: 'video',
+        path: getVideoPath(testInfo.outputDir),
+        contentType: 'video/webm',
+    });
 };
 
 const trezorEnvSetup = async (
@@ -126,11 +138,14 @@ const suiteBaseTest = base.extend<suiteBaseFixture>({
             await use(suite.window);
             await electronTeardown(suite, testInfo);
         } else {
-            const browserContext = await browser.newContext();
+            const browserContext = await browser.newContext({
+                recordVideo: {
+                    dir: testInfo.outputPath(),
+                },
+            });
             const page = await webSetup(browserContext);
             await use(page);
-            await page.close();
-            await browserContext.close();
+            await webTeardown(page, browserContext, testInfo);
         }
 
         await TrezorUserEnvLinkProxy.logTestDetails(

--- a/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
@@ -19,7 +19,7 @@ test.describe.serial('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => 
         const daemonApp = await launchSuiteElectronApp({
             bridgeDaemon: true,
             bridgeLegacyTest: false,
-            videoFolder: testInfo.outputDir,
+            artefactFolder: testInfo.outputDir,
             viewport: testInfo.project.use.viewport!,
         });
 
@@ -29,7 +29,7 @@ test.describe.serial('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => 
 
         // launch UI
         const suite = await launchSuite({
-            videoFolder: testInfo.outputDir,
+            artefactFolder: testInfo.outputDir,
             viewport: testInfo.project.use.viewport!,
         });
         const title = await suite.window.title();

--- a/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge.test.ts
@@ -24,7 +24,7 @@ test.describe.serial('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => 
         request,
     }, testInfo) => {
         const suite = await launchSuite({
-            videoFolder: testInfo.outputDir,
+            artefactFolder: testInfo.outputDir,
             viewport: testInfo.project.use.viewport!,
         });
         const title = await suite.window.title();
@@ -59,7 +59,7 @@ test.describe.serial('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => 
         await trezorUserEnvLink.startBridge(LEGACY_BRIDGE_VERSION);
 
         const suite = await launchSuite({
-            videoFolder: testInfo.outputDir,
+            artefactFolder: testInfo.outputDir,
             viewport: testInfo.project.use.viewport!,
         });
         await suite.window.title();

--- a/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-tor.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-tor.test.ts
@@ -39,7 +39,7 @@ test.describe.skip('Tor loading screen', { tag: ['@group=suite', '@desktopOnly']
     /* eslint-disable-next-line no-empty-pattern */
     test('Tor loading screen: happy path', async ({}, testInfo) => {
         const suiteArgs = {
-            videoFolder: testInfo.outputDir,
+            artefactFolder: testInfo.outputDir,
             viewport: testInfo.project.use.viewport!,
         };
         test.setTimeout(timeout);
@@ -64,7 +64,7 @@ test.describe.skip('Tor loading screen', { tag: ['@group=suite', '@desktopOnly']
     /* eslint-disable-next-line no-empty-pattern */
     test('Tor loading screen: making sure that all the request go throw Tor', async ({}, testInfo) => {
         const suiteArgs = {
-            videoFolder: testInfo.outputDir,
+            artefactFolder: testInfo.outputDir,
             viewport: testInfo.project.use.viewport!,
         };
 
@@ -97,7 +97,7 @@ test.describe.skip('Tor loading screen', { tag: ['@group=suite', '@desktopOnly']
     /* eslint-disable-next-line no-empty-pattern */
     test('Tor loading screen: disable tor while loading', async ({}, testInfo) => {
         const suiteArgs = {
-            videoFolder: testInfo.outputDir,
+            artefactFolder: testInfo.outputDir,
             viewport: testInfo.project.use.viewport!,
         };
         test.setTimeout(timeout);


### PR DESCRIPTION
Fixes attaching of video in our Web tests. Last refactoring that untangled our base Fixture `page` started creating new context for our Web tests. And this new context didn't instruction to create and attach the video recording

I also reworked how we deal with electron logs. Instead of sending them to console log where they just flood our CI runs, they are stored as file attachment in each trace.

## Screenshots:
![image](https://github.com/user-attachments/assets/9edc0353-f40c-4459-812a-7762405f3ba6)
