### PR TITLE
feat(mobile): temporary remember device during fw update

### DIFF
--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -31,6 +31,7 @@ export interface ExtendedDevice {
     passphraseOnDevice?: boolean;
     remember?: boolean; // device should be remembered
     forceRemember?: true; // device was forced to be remembered
+    temporaryRemember?: boolean; // device should be remembered only for fw update or this session
     connected: boolean; // device is connected
     available: boolean; // device cannot be used because of features.passphrase_protection is different then expected
 

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -46,6 +46,11 @@ const rememberDevice = createAction(
     }),
 );
 
+const setTemporaryRememberedDevice = createAction(
+    `${DEVICE_MODULE_PREFIX}/setTemporaryRememberedDevice`,
+    (payload: { device: TrezorDevice; temporaryRemember: boolean }) => ({ payload }),
+);
+
 export type ForgetDeviceActionPayload = { device: TrezorDevice; settings: ConnectDeviceSettings };
 
 const forgetDevice = createAction(
@@ -101,6 +106,7 @@ export const deviceActions = {
     updatePassphraseMode,
     receiveAuthConfirm,
     rememberDevice,
+    setTemporaryRememberedDevice,
     forgetDevice,
     addButtonRequest,
     requestDeviceReconnect,

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -194,6 +194,7 @@ const connectDevice = (
         state: device._state,
         useEmptyPassphrase,
         remember: false,
+        temporaryRemember: false,
         connected: true,
         available: true,
         authConfirm: false,
@@ -488,6 +489,31 @@ const remember = (
 };
 
 /**
+ * This actions is used to temporary remember device for fw update
+ * @param {DeviceReducerState} draft
+ * @param {TrezorDevice} device
+ * @param {boolean} temporaryRemember
+ */
+const setTemporaryRememberedDevice = (
+    draft: DeviceReducerState,
+    device: TrezorDevice,
+    temporaryRemember: boolean,
+) => {
+    if (!device || !device.features) return;
+    const index = deviceUtils.findInstanceIndex(draft.devices, device);
+    const selectedInstance = draft.devices[index];
+    if (!selectedInstance) return;
+
+    if (temporaryRemember && !selectedInstance.remember) {
+        selectedInstance.temporaryRemember = true;
+        selectedInstance.remember = true;
+    } else if (!temporaryRemember && selectedInstance.temporaryRemember) {
+        selectedInstance.temporaryRemember = false;
+        selectedInstance.remember = false;
+    }
+};
+
+/**
  * Action handler: SUITE.FORGET_DEVICE
  * Remove all device instances
  * @param {DeviceReducerState} draft
@@ -607,6 +633,9 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
         })
         .addCase(deviceActions.rememberDevice, (state, { payload }) => {
             remember(state, payload.device, payload.remember, payload.forceRemember);
+        })
+        .addCase(deviceActions.setTemporaryRememberedDevice, (state, { payload }) => {
+            setTemporaryRememberedDevice(state, payload.device, payload.temporaryRemember);
         })
         .addCase(deviceActions.forgetDevice, (state, { payload }) => {
             forget(state, payload.device, payload.settings);

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -3,22 +3,21 @@ import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
 
 const NATIVE_DEVICE_MODULE_PREFIX = 'nativeDevice';
 
-export const setDeviceForceRememberedThunk = createThunk(
-    `${NATIVE_DEVICE_MODULE_PREFIX}/setDeviceForceRemembered`,
-    ({ forceRemember }: { forceRemember: boolean }, { getState, rejectWithValue, dispatch }) => {
+export const setTemporaryRememberedDeviceThunk = createThunk(
+    `${NATIVE_DEVICE_MODULE_PREFIX}/setTemporaryRememberedDevice`,
+    (
+        { temporaryRemember }: { temporaryRemember: boolean },
+        { getState, rejectWithValue, dispatch },
+    ) => {
         const device = selectSelectedDevice(getState());
         if (!device) {
             return rejectWithValue('Device not found');
         }
-        if (device.remember) {
-            return rejectWithValue('Device is already remembered');
-        }
 
         dispatch(
-            deviceActions.rememberDevice({
+            deviceActions.setTemporaryRememberedDevice({
                 device,
-                remember: false,
-                forceRemember: forceRemember ? true : undefined,
+                temporaryRemember,
             }),
         );
 

--- a/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
+++ b/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
@@ -13,7 +13,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { authorizeDeviceThunk } from '@suite-common/wallet-core';
 import { Box, Button, IconButton, Text, VStack } from '@suite-native/atoms';
-import { ConfirmOnTrezorImage, setDeviceForceRememberedThunk } from '@suite-native/device';
+import { ConfirmOnTrezorImage, setTemporaryRememberedDeviceThunk } from '@suite-native/device';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import { Translation } from '@suite-native/intl';
 import { SUITE_LITE_SUPPORT_URL, useOpenLink } from '@suite-native/link';
@@ -46,6 +46,7 @@ type FirmwareInstallationScreenContentProps = {
     onFirmwareInstallationFailure?: () => void;
     isCancellationAllowed?: boolean;
     isRetryAllowed?: boolean;
+    isTemporaryRememeberAllowed?: boolean;
 };
 
 // This component is shared between `module-onboarding` and `module-device-settings`.
@@ -55,6 +56,7 @@ export const FirmwareInstallationScreenContent = ({
     onFirmwareInstallationFailure,
     isCancellationAllowed = true,
     isRetryAllowed = true,
+    isTemporaryRememeberAllowed = true,
 }: FirmwareInstallationScreenContentProps) => {
     const dispatch = useDispatch();
     const { applyStyle } = useNativeStyles();
@@ -87,14 +89,16 @@ export const FirmwareInstallationScreenContent = ({
     const openLink = useOpenLink();
 
     useEffect(() => {
+        if (!isTemporaryRememeberAllowed) return;
+
         // This will prevent device from being forgotten after firmware update, so discovery will not run again
-        dispatch(setDeviceForceRememberedThunk({ forceRemember: true }));
+        dispatch(setTemporaryRememberedDeviceThunk({ temporaryRemember: true }));
 
         return () => {
-            dispatch(setDeviceForceRememberedThunk({ forceRemember: false }));
+            dispatch(setTemporaryRememberedDeviceThunk({ temporaryRemember: false }));
             resetReducer();
         };
-    }, [dispatch, resetReducer]);
+    }, [dispatch, resetReducer, isTemporaryRememeberAllowed]);
 
     const handleFirmwareUpdateFinished = useCallback(async () => {
         await requestPrioritizedDeviceAccess({

--- a/suite-native/module-device-onboarding/src/screens/FirmwareInstallationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/FirmwareInstallationScreen.tsx
@@ -18,6 +18,7 @@ export const FirmwareInstallationScreen = () => {
                 onFirmwareInstallationSuccess={handleFirmwareInstallationSuccess}
                 isCancellationAllowed={false}
                 isRetryAllowed={false}
+                isTemporaryRememeberAllowed={false}
             />
         </DeviceOnboardingScreenWithExitButton>
     );

--- a/suite-native/storage/src/transforms/deviceTransforms.ts
+++ b/suite-native/storage/src/transforms/deviceTransforms.ts
@@ -7,6 +7,7 @@ const serializeDevice = (device: TrezorDevice): Omit<TrezorDevice, 'path'> & { p
     ...device,
     path: '',
     remember: true,
+    temporaryRemember: false,
     connected: false,
     buttonRequests: [],
 });
@@ -18,7 +19,7 @@ export const devicePersistTransform = createTransform<
     inboundState =>
         pipe(
             inboundState,
-            A.filter(device => !!device.remember),
+            A.filter(device => !!device.remember && device.temporaryRemember !== true),
             A.map(serializeDevice),
         ),
     undefined,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If user doesn't have remembered device, discovery will run again after FW update/reinstall. This PR should prevent that by temporarily remembering device. I was thinking that desktop is doing something similar but after some investigation I found out that desktop is simply running discovery again after FW update.

QA:
1. Discovery doesn't run again after FW update for non-remembered devices
2. Non remembered device should correctly should dissappear from app by disconnecting after FW update
3. Normal remembered device should stay remembered after FW update and after disconnecting
4. (edge case) if you kill app during FW update it should forget temporary reremembered device and do not forget normally remembered device
5. FW installation during onboarding works as before
6. Would be nice to test at least few first points also when using passphrase wallet

## Related Issue

Resolve #16460 

## Screenshots:
