### PR TITLE
fix(suite-data): fix string formating in zh

### DIFF
--- a/packages/suite-data/files/translations/zh.json
+++ b/packages/suite-data/files/translations/zh.json
@@ -1390,7 +1390,7 @@
   "TR_PAYMENT_METHOD_TEN31SEPA": "TEN31 SEPA",
   "TR_PAYMENT_METHOD_UNKNOWN": "未知",
   "TR_PAYMENT_METHOD_WORLDPAYCREDIT": "Worldpay Credit",
-  "TR_PENDING_TX_HEADING": "待办中 {count, plural, one {transaction} other {transactions}}",
+  "TR_PENDING_TX_HEADING": "有 {count} 笔交易正等待处理",
   "TR_PERSONALIZATION": "自定义",
   "TR_PIN": "PIN码",
   "TR_PIN_HEADING_FIRST": "设置新的PIN码",


### PR DESCRIPTION
Fixing string format and formatting in Simplified Chinese.

This pull request includes a small change to the `packages/suite-data/files/translations/zh.json` file. The change updates the translation for the pending transactions heading to improve clarity.

Translation update:

* [`packages/suite-data/files/translations/zh.json`](diffhunk://#diff-afd5e2492483340b35dd3ba85fbdaa5d46dc1228ad13b018b4f1e7d6fdb2a64dL1393-R1393): Changed the translation for "TR_PENDING_TX_HEADING" from "待办中 {count, plural, one {transaction} other {transactions}}" to "有 {count} 笔交易正等待处理" to make it more clear and accurate.