### PR TITLE
fix(suite-desktop-core): purge userData by using a flag instead of in playwright

### DIFF
--- a/packages/suite-desktop-core/e2e/support/electron.ts
+++ b/packages/suite-desktop-core/e2e/support/electron.ts
@@ -1,5 +1,5 @@
 import { ElectronApplication, Page, _electron as electron } from '@playwright/test';
-import { createWriteStream, ensureDirSync, readdirSync, removeSync } from 'fs-extra';
+import { createWriteStream, ensureDirSync } from 'fs-extra';
 import path from 'path';
 
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
@@ -61,6 +61,7 @@ export const launchSuiteElectronApp = async (params: LaunchSuiteParams) => {
             disableHWAccelerationArgument,
             ...(options.bridgeLegacyTest ? ['--bridge-legacy', '--bridge-test'] : []),
             ...(options.bridgeDaemon ? ['--bridge-daemon', '--skip-new-bridge-rollout'] : []),
+            ...(options.rmUserData ? ['--remove-user-data-on-start'] : []),
             disableHashCheckStatePatch,
             showDebugMenuStatePatch,
         ],
@@ -68,22 +69,6 @@ export const launchSuiteElectronApp = async (params: LaunchSuiteParams) => {
         locale: params.locale,
         recordVideo: { dir: options.artefactFolder, size: options.viewport },
     });
-
-    const localDataDir = await electronApp.evaluate(({ app }) => app.getPath('userData'));
-
-    if (options.rmUserData) {
-        const filesToDelete = readdirSync(localDataDir);
-        filesToDelete.forEach(file => {
-            // omitting Cache folder it sometimes prevents the deletion and is not necessary to delete for test idempotency
-            if (file !== 'Cache') {
-                try {
-                    removeSync(`${localDataDir}/${file}`);
-                } catch {
-                    // If files does not exist do nothing.
-                }
-            }
-        });
-    }
 
     const logFilePath = path.join(options.artefactFolder, 'electron-logs.txt');
     ensureDirSync(options.artefactFolder);
@@ -96,17 +81,6 @@ export const launchSuiteElectronApp = async (params: LaunchSuiteParams) => {
     electronApp.process().on('close', () => {
         logStream.end();
     });
-
-    await electronApp.evaluate(
-        (_, [resourcesPath]) => {
-            // This runs in the main Electron process.
-            // override global variable defined in app.ts
-            global.resourcesPath = resourcesPath;
-
-            return global.resourcesPath;
-        },
-        [path.join(appDir, 'build/static')],
-    );
 
     return electronApp;
 };

--- a/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
@@ -15,7 +15,7 @@ test.describe.serial('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => 
         await trezorUserEnvLink.stopBridge();
     });
 
-    test('App in daemon mode spawns bridge', async ({ request }, testInfo) => {
+    test('App in daemon mode spawns node-bridge', async ({ request }, testInfo) => {
         const daemonApp = await launchSuiteElectronApp({
             bridgeDaemon: true,
             bridgeLegacyTest: false,
@@ -27,7 +27,7 @@ test.describe.serial('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => 
             await expectBridgeToBeRunning(request);
         }).toPass({ timeout: 3_000 });
 
-        // launch UI
+        // launch UI, with node-bridge already running in background
         const suite = await launchSuite({
             artefactFolder: testInfo.outputDir,
             viewport: testInfo.project.use.viewport!,

--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -9,7 +9,7 @@ import { TimerId } from '@trezor/type-utils';
 import { createDeferred, resolveAfter } from '@trezor/utils';
 
 import { hangDetect } from './hang-detect';
-import { processStatePatch, restartApp } from './libs/app-utils';
+import { processStatePatch, removeElectronAppData, restartApp } from './libs/app-utils';
 import { APP_NAME } from './libs/constants';
 import { getBuildInfo, getComputerInfo } from './libs/info';
 import { Logger } from './libs/logger';
@@ -32,6 +32,13 @@ if (isDevEnv) app.setVersion(process.env.VERSION);
 global.resourcesPath = isDevEnv
     ? path.join(__dirname, '..', 'build', 'static')
     : process.resourcesPath;
+
+const parseRemoveUserDataSwitch = () => {
+    if (process.argv.includes('--remove-user-data-on-start')) {
+        removeElectronAppData();
+    }
+};
+parseRemoveUserDataSwitch();
 
 const createMainWindow = (winBounds: WinBounds) => {
     const mainWindow = new BrowserWindow({

--- a/packages/suite-desktop-core/src/libs/app-utils.ts
+++ b/packages/suite-desktop-core/src/libs/app-utils.ts
@@ -1,3 +1,6 @@
+import fs from 'fs';
+import path from 'path';
+
 import { mergeDeepObject } from '@trezor/utils';
 
 import { app } from '../typed-electron';
@@ -54,3 +57,18 @@ export const processStatePatch = (): ProcessStatePatchResult =>
             (prev, cur) => mergeDeepObject.withOptions({ dotNotation: true }, prev ?? {}, cur),
             undefined,
         )?.state;
+
+export const removeElectronAppData = () => {
+    const localDataDir = app.getPath('userData');
+    const filesToDelete = fs.readdirSync(localDataDir);
+    filesToDelete.forEach(file => {
+        // omitting Cache folder it sometimes prevents the deletion and is not necessary to delete for test idempotency
+        if (file !== 'Cache') {
+            try {
+                fs.rmSync(path.join(localDataDir, file), { recursive: true });
+            } catch {
+                // If files does not exist do nothing.
+            }
+        }
+    });
+};


### PR DESCRIPTION
## Description

Attempt to fix desktop E2E instability because of errors like this that popup when calling `electronApp.evaluate`:
```
Error: electronApplication.evaluate: Execution context was destroyed, most likely because of a navigation.
Error: electronApplication.firstWindow: Target page, context or browser has been closed
```
The `evaluate` fn serves to inject code from Playwright process to Electron main, we use it to purge app data on startup. But that can be achieved in a more straightforward way:
- introduce `--remove-user-data-on-start` flag for Suite Desktop, which purges app data on startup
- use the flag in Playwright