### PR TITLE
refactor(e2e): better error description of addUnusedHiddenWallet assert

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/dashboardPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/dashboardPage.ts
@@ -153,7 +153,10 @@ export class DashboardPage {
         await this.devicePrompt.confirmOnDevicePromptIsShown();
         await TrezorUserEnvLinkProxy.pressYes();
 
-        await this.modal.waitFor({ state: 'detached' });
+        await expect(
+            this.modal,
+            'expected Device Prompt to be hidden. pressYes may failed.',
+        ).toBeHidden();
     }
 
     @step()


### PR DESCRIPTION
better verbose error when pressYess fails and prompt is not hidden. Now we are just getting generic error `TimeoutError: locator.waitFor: Timeout 15000ms exceeded.`

instead we will get :
`expected Device Prompt to be hidden. pressYes may failed.`

## Screenshots:
![image](https://github.com/user-attachments/assets/946e3fb4-30a6-4150-a5d2-763187bf61af)
