### PR TITLE
chore(suite-desktop): Unify suite desktop flags

### DIFF
--- a/packages/suite-desktop-core/src/__tests__/process-switches.test.ts
+++ b/packages/suite-desktop-core/src/__tests__/process-switches.test.ts
@@ -1,0 +1,78 @@
+import { SuiteSwitch, getSwitchValue, hasSwitch } from '../libs/process-switches';
+
+type Fixture = {
+    it: string;
+    query: SuiteSwitch;
+    args?: string[];
+    hasSwitchResult: boolean;
+    getSwitchValueResult: string;
+};
+
+const BASE_ARGS = ['--open-devtools', '--tor', '--updater-url=https://example.com', '--log-file='];
+
+const FIXTURES: Fixture[] = [
+    {
+        it: 'no process args available',
+        query: 'tor',
+        args: [],
+        hasSwitchResult: false,
+        getSwitchValueResult: '',
+    },
+    {
+        it: 'queried switch not present',
+        query: 'pre-release',
+        args: [...BASE_ARGS, 'pre-rel'],
+        hasSwitchResult: false,
+        getSwitchValueResult: '',
+    },
+    {
+        it: 'queried switch present without value',
+        query: 'tor',
+        hasSwitchResult: true,
+        getSwitchValueResult: '',
+    },
+    {
+        it: 'queried switch present with value',
+        query: 'updater-url',
+        hasSwitchResult: true,
+        getSwitchValueResult: 'https://example.com',
+    },
+    {
+        it: 'queried switch present with empty value',
+        query: 'log-file',
+        hasSwitchResult: true,
+        getSwitchValueResult: '',
+    },
+    {
+        it: 'only first occurence of duplicated switch is valid',
+        query: 'log-file',
+        args: ['--log-file=foo', '--log-file=bar'],
+        hasSwitchResult: true,
+        getSwitchValueResult: 'foo',
+    },
+    {
+        it: 'queried switch is only a substring of present switches',
+        query: 'log-file',
+        args: ['--log-filee', '--log-fileee=', '--log-fileeee=foo'],
+        hasSwitchResult: false,
+        getSwitchValueResult: '',
+    },
+];
+
+describe(hasSwitch.name, () => {
+    FIXTURES.forEach(f => {
+        it(f.it, () => {
+            process.argv = f.args ?? BASE_ARGS;
+            expect(hasSwitch(f.query)).toBe(f.hasSwitchResult);
+        });
+    });
+});
+
+describe(getSwitchValue.name, () => {
+    FIXTURES.forEach(f => {
+        it(f.it, () => {
+            process.argv = f.args ?? BASE_ARGS;
+            expect(getSwitchValue(f.query)).toBe(f.getSwitchValueResult);
+        });
+    });
+});

--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -14,6 +14,7 @@ import { APP_NAME } from './libs/constants';
 import { getBuildInfo, getComputerInfo } from './libs/info';
 import { Logger } from './libs/logger';
 import { MainWindowProxy } from './libs/main-window-proxy';
+import { hasSwitch } from './libs/process-switches';
 import { createInterceptor } from './libs/request-interceptor';
 import { MIN_HEIGHT, MIN_WIDTH } from './libs/screen';
 import { initSentry } from './libs/sentry';
@@ -34,7 +35,7 @@ global.resourcesPath = isDevEnv
     : process.resourcesPath;
 
 const parseRemoveUserDataSwitch = () => {
-    if (process.argv.includes('--remove-user-data-on-start')) {
+    if (hasSwitch('remove-user-data-on-start')) {
         removeElectronAppData();
     }
 };
@@ -158,8 +159,8 @@ const init = async () => {
 
     // Daemon mode with no UI
     const { wasOpenedAtLogin } = app.getLoginItemSettings();
-    const daemon = app.commandLine.hasSwitch('bridge-daemon') || wasOpenedAtLogin;
-    const daemonShowUI = app.commandLine.hasSwitch('bridge-daemon-show-ui'); // show UI immediately even in daemon mode
+    const daemon = hasSwitch('bridge-daemon') || wasOpenedAtLogin;
+    const daemonShowUI = hasSwitch('bridge-daemon-show-ui'); // show UI immediately even in daemon mode
     if (daemon && !daemonShowUI) {
         logger.info('main', 'App is hidden, starting bridge only');
         app.dock?.hide(); // hide dock icon on macOS

--- a/packages/suite-desktop-core/src/libs/app-utils.ts
+++ b/packages/suite-desktop-core/src/libs/app-utils.ts
@@ -45,6 +45,7 @@ type ProcessStatePatchResult = Record<string, any> | undefined;
  * Get all state patches from process args and parse them to return an aggregated state object patch
  */
 export const processStatePatch = (): ProcessStatePatchResult =>
+    // not using getSwitchValue because this is a very customized way to parse process switches
     process.argv
         .map(arg => arg.match(STATE_ASSIGNMENT_REGEX))
         .filter(match => match !== null)

--- a/packages/suite-desktop-core/src/libs/logger.ts
+++ b/packages/suite-desktop-core/src/libs/logger.ts
@@ -9,6 +9,7 @@ import { ensureDirectoryExists } from '@trezor/node-utils';
 import { TimerId } from '@trezor/type-utils';
 
 import { getBuildInfo, getComputerInfo } from './info';
+import { getSwitchValue, hasSwitch } from './process-switches';
 
 const logLevels = ['mute', 'error', 'warn', 'info', 'debug'] as const;
 
@@ -28,7 +29,7 @@ export type Options = {
     memoryCap: number; // Maximum number of messages stored in memory
 };
 
-const logLevelSwitchValue = app?.commandLine.getSwitchValue('log-level');
+const logLevelSwitchValue = getSwitchValue('log-level');
 const logLevelByEnv = isDevEnv ? 'debug' : 'error';
 const logLevelDefault = isLogLevel(logLevelSwitchValue) ? logLevelSwitchValue : logLevelByEnv;
 
@@ -52,12 +53,11 @@ export class Logger implements ILogger {
 
         this.defaultOptions = {
             colors: true,
-            writeToConsole: !app?.commandLine.hasSwitch('log-no-print'),
-            writeToDisk: app?.commandLine.hasSwitch('log-write'),
-            outputFile: app?.commandLine.getSwitchValue('log-file') || 'trezor-suite-log-%tt.txt',
+            writeToConsole: !hasSwitch('log-no-print'),
+            writeToDisk: hasSwitch('log-write'),
+            outputFile: getSwitchValue('log-file') || 'trezor-suite-log-%tt.txt',
             outputPath:
-                app?.commandLine.getSwitchValue('log-path') ||
-                (userDataDir ? `${userDataDir}/logs` : process.cwd()),
+                getSwitchValue('log-path') || (userDataDir ? `${userDataDir}/logs` : process.cwd()),
             logFormat: '%dt - %lvl(%top): %rep%msg',
             dedupeTimeout: 500,
             writeToMemory: false,

--- a/packages/suite-desktop-core/src/libs/process-switches.ts
+++ b/packages/suite-desktop-core/src/libs/process-switches.ts
@@ -1,0 +1,44 @@
+export type SuiteSwitch =
+    | 'open-devtools'
+    | 'tor'
+    | 'pre-release'
+    | 'enable-updater'
+    | 'disable-updater'
+    | 'updater-url'
+    | 'bridge-legacy'
+    | 'bridge-test'
+    | 'bridge-dev'
+    | 'skip-new-bridge-rollout'
+    | 'bridge-daemon'
+    | 'bridge-daemon-show-ui'
+    | 'log-level'
+    | 'log-write'
+    | 'log-ui'
+    | 'log-file'
+    | 'log-path'
+    | 'log-no-print'
+    | 'log-connect'
+    | 'remove-user-data-on-start'
+    | 'expose-connect-ws'
+    | 'state'; // very special handling, see `./app-utils.ts`
+
+/**
+ * Check if a switch is present in process arguments.
+ */
+export const hasSwitch = (switchName: SuiteSwitch) => {
+    const isSwitch = new RegExp(`^--${switchName}(?:=[^=]+)?=?$`);
+
+    return process.argv.some(arg => isSwitch.test(arg));
+};
+
+/**
+ * Get value of a switch from process arguments, if present and if it has a value.
+ * Returns empty string otherwise, as Electron's `app.commandLine.getSwitchValue`.
+ */
+export const getSwitchValue = (switchName: SuiteSwitch): string => {
+    const switchValueMatch = new RegExp(`^--${switchName}=(.+)$`);
+    const valueMatch = process.argv.map(arg => arg.match(switchValueMatch)).find(Boolean);
+    if (!valueMatch) return '';
+
+    return valueMatch[1];
+};

--- a/packages/suite-desktop-core/src/modules/auto-updater.ts
+++ b/packages/suite-desktop-core/src/modules/auto-updater.ts
@@ -11,6 +11,7 @@ import { isDevEnv, isFeatureFlagEnabled } from '@suite-common/suite-utils';
 import { HandshakeElectron } from '@trezor/suite-desktop-api';
 import { bytesToHumanReadable } from '@trezor/utils';
 
+import { getSwitchValue, hasSwitch } from '../libs/process-switches';
 import { verifySignature } from '../libs/update-checker';
 import { b2t } from '../libs/utils';
 import { app, ipcMain } from '../typed-electron';
@@ -24,10 +25,10 @@ const defaultFeedURL = {
 };
 
 // Runtime flags
-const enableUpdater = app.commandLine.hasSwitch('enable-updater');
-const disableUpdater = app.commandLine.hasSwitch('disable-updater');
-const preReleaseFlag = app.commandLine.hasSwitch('pre-release');
-const updaterURL = app.commandLine.getSwitchValue('updater-url');
+const enableUpdater = hasSwitch('enable-updater');
+const disableUpdater = hasSwitch('disable-updater');
+const preReleaseFlag = hasSwitch('pre-release');
+const updaterURL = getSwitchValue('updater-url');
 
 export const SERVICE_NAME = 'auto-updater';
 

--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -8,19 +8,20 @@ import { InvokeResult } from '@trezor/suite-desktop-api';
 import { TrezordNode } from '@trezor/transport-bridge';
 import { scheduleAction } from '@trezor/utils';
 
+import { hasSwitch } from '../libs/process-switches';
 import { BridgeProcess } from '../libs/processes/BridgeProcess';
 import { ThreadProxy } from '../libs/thread-proxy';
 import { b2t } from '../libs/utils';
-import { app, ipcMain } from '../typed-electron';
+import { ipcMain } from '../typed-electron';
 
 import type { Dependencies } from './index';
 
-const bridgeLegacy = app.commandLine.hasSwitch('bridge-legacy');
+const bridgeLegacy = hasSwitch('bridge-legacy');
 // bridge node is intended for internal testing
-const bridgeTest = app.commandLine.hasSwitch('bridge-test');
-const bridgeDev = app.commandLine.hasSwitch('bridge-dev');
+const bridgeTest = hasSwitch('bridge-test');
+const bridgeDev = hasSwitch('bridge-dev');
 
-const skipNewBridgeRollout = app.commandLine.hasSwitch('skip-new-bridge-rollout');
+const skipNewBridgeRollout = hasSwitch('skip-new-bridge-rollout');
 
 export const SERVICE_NAME = 'bridge';
 

--- a/packages/suite-desktop-core/src/modules/dev-tools.ts
+++ b/packages/suite-desktop-core/src/modules/dev-tools.ts
@@ -1,13 +1,13 @@
 /**
  * Enable DevTools
  */
-import { app } from 'electron';
-
 import { isDevEnv } from '@suite-common/suite-utils';
+
+import { hasSwitch } from '../libs/process-switches';
 
 import type { ModuleInit } from './index';
 
-const openDevToolsFlag = app.commandLine.hasSwitch('open-devtools');
+const openDevToolsFlag = hasSwitch('open-devtools');
 
 export const SERVICE_NAME = 'dev-tools';
 

--- a/packages/suite-desktop-core/src/modules/event-logging/contents.ts
+++ b/packages/suite-desktop-core/src/modules/event-logging/contents.ts
@@ -1,8 +1,7 @@
-import { app } from 'electron';
-
+import { hasSwitch } from '../../libs/process-switches';
 import type { ModuleInit } from '../index';
 
-const logUI = app.commandLine.hasSwitch('log-ui');
+const logUI = hasSwitch('log-ui');
 
 export const SERVICE_NAME = 'content';
 

--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -6,6 +6,7 @@ import { validateIpcMessage } from '@trezor/ipc-proxy';
 
 import { exposeConnectWs } from '../libs/connect-ws';
 import { createHttpReceiver } from '../libs/http-receiver';
+import { hasSwitch } from '../libs/process-switches';
 import { app, ipcMain } from '../typed-electron';
 
 import type { ModuleInitBackground } from './index';
@@ -61,7 +62,7 @@ export const initBackground: ModuleInitBackground = ({ mainWindowProxy, mainThre
             return receiver.getRouteAddress(pathname);
         });
 
-        const connectPopupEnabled = app.commandLine.hasSwitch('expose-connect-ws') || isDevEnv;
+        const connectPopupEnabled = hasSwitch('expose-connect-ws') || isDevEnv;
         ipcMain.handle('connect-popup/enabled', ipcEvent => {
             validateIpcMessage(ipcEvent);
 

--- a/packages/suite-desktop-core/src/modules/tor.ts
+++ b/packages/suite-desktop-core/src/modules/tor.ts
@@ -11,6 +11,7 @@ import { getFreePort } from '@trezor/node-utils';
 import { BootstrapEvent } from '@trezor/request-manager';
 import { BootstrapTorEvent, HandshakeTorModule, TorStatus } from '@trezor/suite-desktop-api';
 
+import { hasSwitch } from '../libs/process-switches';
 import { TorExternalProcess } from '../libs/processes/TorExternalProcess';
 import { TorProcess, TorProcessStatus } from '../libs/processes/TorProcess';
 import { app, ipcMain } from '../typed-electron';
@@ -306,7 +307,7 @@ const load = async ({ mainWindowProxy, store, mainThreadEmitter }: Dependencies)
         handleTorProcessStatus(status);
     });
 
-    if (app.commandLine.hasSwitch('tor')) {
+    if (hasSwitch('tor')) {
         logger.info('tor', 'Tor enabled by command line option.');
         store.setTorSettings({ ...store.getTorSettings(), running: true });
     }

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -1,8 +1,10 @@
-import { app, ipcMain } from 'electron';
+import { ipcMain } from 'electron';
 
 import TrezorConnect, { DEVICE_EVENT } from '@trezor/connect';
 import { IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
 import { parseElectrumUrl } from '@trezor/utils';
+
+import { getSwitchValue } from '../libs/process-switches';
 
 import { MainThreadEmitter, ModuleInit, ModuleInitBackground } from './index';
 
@@ -60,7 +62,7 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
                         ...params[0],
                         // poor mans solution to enable debug logs in trezor-connect.
                         // todo: ideally connect should accept logger as a param
-                        debug: app?.commandLine.getSwitchValue('log-connect') === 'true',
+                        debug: getSwitchValue('log-connect') === 'true',
                     });
                     await setProxy();
 


### PR DESCRIPTION
## Description

- create helpers `hasSwitch` & `getSwitchValue` incl. unit tests
  - to mimic behavior of same-named `app.commandLine` methods, which are not to be used for this ([see issue](https://github.com/trezor/trezor-suite/issues/17686)) 
- refactor current usages of `app.commandLine` methods, or direct `process.argv` access
  - the only remaning usage of either of those two methods are width & height
  - those are actualy Chromium flags, so that's 

Note: only [width & height](https://github.com/trezor/trezor-suite/blob/1ba404577dc99c9918bb1d67b345de0dc5ec54e4/packages/suite-desktop-core/src/app.ts#L198-L199) remain, where the electron API is OK, because those are Chromium switches :heavy_check_mark: 

## Related Issue

Resolve #17686