### PR TITLE
chore(suite): don't remember selected fees in send form

### DIFF
--- a/packages/suite/src/actions/settings/constants/walletSettings.ts
+++ b/packages/suite/src/actions/settings/constants/walletSettings.ts
@@ -1,7 +1,6 @@
 export const SET_LOCAL_CURRENCY = '@wallet-settings/set-local-currency';
 export const SET_HIDE_BALANCE = '@wallet-settings/hide-balance';
 export const CHANGE_NETWORKS = '@wallet-settings/change-networks';
-export const SET_LAST_USED_FEE_LEVEL = '@wallet-settings/set-last-used-fee-level';
 export const FROM_STORAGE = '@wallet-settings/from-storage';
 export const SET_BITCOIN_AMOUNT_UNITS = '@suite/set-bitcoin-amount-units';
 export const TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS =

--- a/packages/suite/src/actions/settings/walletSettingsActions.ts
+++ b/packages/suite/src/actions/settings/walletSettingsActions.ts
@@ -3,7 +3,7 @@ import { createAction } from '@reduxjs/toolkit';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { UNIT_ABBREVIATIONS } from '@suite-common/suite-constants';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { FeeLevel, PROTO } from '@trezor/connect';
+import { PROTO } from '@trezor/connect';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
 import * as suiteActions from 'src/actions/suite/suiteActions';
@@ -32,11 +32,6 @@ export type WalletSettingsAction =
     | ReturnType<typeof setLocalCurrency>
     | { type: typeof WALLET_SETTINGS.TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS }
     | { type: typeof WALLET_SETTINGS.SET_HIDE_BALANCE; toggled: boolean }
-    | {
-          type: typeof WALLET_SETTINGS.SET_LAST_USED_FEE_LEVEL;
-          symbol: NetworkSymbol;
-          feeLevel?: FeeLevel;
-      }
     | {
           type: typeof WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS;
           payload: PROTO.AmountUnit;
@@ -79,24 +74,6 @@ export const changeCoinVisibility =
             },
         });
     };
-
-export const setLastUsedFeeLevel =
-    (feeLevel?: FeeLevel) => (dispatch: Dispatch, getState: GetState) => {
-        const { selectedAccount } = getState().wallet;
-        if (selectedAccount.status !== 'loaded') return;
-        dispatch({
-            type: WALLET_SETTINGS.SET_LAST_USED_FEE_LEVEL,
-            symbol: selectedAccount.account.symbol,
-            feeLevel,
-        });
-    };
-
-export const getLastUsedFeeLevel = () => (_: Dispatch, getState: GetState) => {
-    const { selectedAccount, settings } = getState().wallet;
-    if (selectedAccount.status !== 'loaded') return;
-
-    return settings.lastUsedFeeLevel[selectedAccount.account.symbol];
-};
 
 export const setBitcoinAmountUnits = (units: PROTO.AmountUnit): WalletSettingsAction => {
     analytics.report({

--- a/packages/suite/src/components/wallet/Fees/Fees.tsx
+++ b/packages/suite/src/components/wallet/Fees/Fees.tsx
@@ -139,10 +139,7 @@ export const Fees = <TFieldValues extends FormState>({
     const errors = props.errors as unknown as FieldErrors<FormState>;
 
     const error = errors.selectedFee;
-    // TODO: remove saving fee in draft or resolve this as it does not find level when eip-1559 and next time legacy
-    const selectedLevel =
-        feeInfo.levels.find(level => level.label === selectedOption) ||
-        feeInfo.levels.find(level => level.label === 'normal')!;
+    const selectedLevel = feeInfo.levels.find(level => level.label === selectedOption);
     const transactionInfo = composedLevels?.[selectedOption];
 
     const feeOptions = buildFeeOptions(feeInfo.levels, networkType, symbol, composedLevels);
@@ -194,7 +191,7 @@ export const Fees = <TFieldValues extends FormState>({
                 )}
             </Row>
 
-            {!isCustomFee && (
+            {!isCustomFee && selectedLevel && (
                 <StandardFee
                     networkType={networkType}
                     feeInfo={feeInfo}

--- a/packages/suite/src/hooks/wallet/form/useFees.ts
+++ b/packages/suite/src/hooks/wallet/form/useFees.ts
@@ -10,7 +10,6 @@ import {
 import { isEip1559 } from '@suite-common/wallet-utils';
 import { FeeLevel } from '@trezor/connect';
 
-import { setLastUsedFeeLevel } from 'src/actions/settings/walletSettingsActions';
 import { useDispatch } from 'src/hooks/suite';
 
 import { SendContextValues } from '../../../types/wallet/sendForm';
@@ -18,7 +17,6 @@ import { SendContextValues } from '../../../types/wallet/sendForm';
 interface Props<TFieldValues extends FormState> extends UseFormReturn<TFieldValues> {
     defaultValue?: FeeLevel['label'];
     feeInfo?: FeeInfo;
-    saveLastUsedFee?: boolean;
     onChange?: (prev?: FeeLevel['label'], current?: FeeLevel['label']) => void;
     composeRequest: SendContextValues['composeTransaction'];
     composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
@@ -29,7 +27,6 @@ interface Props<TFieldValues extends FormState> extends UseFormReturn<TFieldValu
 export const useFees = <TFieldValues extends FormState>({
     defaultValue,
     feeInfo,
-    saveLastUsedFee,
     onChange,
     composeRequest,
     composedLevels,
@@ -45,7 +42,6 @@ export const useFees = <TFieldValues extends FormState>({
     const maxPriorityFeePerGasRef = useRef<string | undefined>('');
     const maxFeePerGasRef = useRef<string | undefined>('');
     const estimatedFeeLimitRef = useRef<string | undefined>('');
-    const saveLastUsedFeeRef = useRef(saveLastUsedFee);
 
     // Type assertion allowing to make the component reusable, see https://stackoverflow.com/a/73624072.
     const { clearErrors, getValues, register, setValue, watch } =
@@ -101,28 +97,8 @@ export const useFees = <TFieldValues extends FormState>({
         }
 
         //compose
-        if (updateField) {
-            if (composeRequest) {
-                composeRequest(updateField);
-            }
-            // save last used fee
-            if (
-                saveLastUsedFeeRef.current &&
-                feePerUnit &&
-                !errors.feePerUnit &&
-                !errors.feeLimit
-            ) {
-                dispatch(
-                    setLastUsedFeeLevel({
-                        label: 'custom',
-                        feePerUnit,
-                        feeLimit,
-                        blocks: -1,
-                        maxPriorityFeePerGas,
-                        maxFeePerGas,
-                    }),
-                );
-            }
+        if (updateField && composeRequest) {
+            composeRequest(updateField);
         }
     }, [
         dispatch,
@@ -213,12 +189,6 @@ export const useFees = <TFieldValues extends FormState>({
 
         // on change callback
         if (onChange) onChange(selectedFeeRef.current, level);
-
-        // save last used fee
-        if (level !== 'custom' && saveLastUsedFeeRef.current) {
-            const nextLevel = feeInfo.levels.find(l => l.label === (level || 'normal'))!;
-            dispatch(setLastUsedFeeLevel(nextLevel));
-        }
 
         selectedFeeRef.current = selectedFee;
     };

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -13,10 +13,6 @@ import {
 } from '@suite-common/wallet-utils';
 import { useDidUpdate } from '@trezor/react-utils';
 
-import {
-    getLastUsedFeeLevel,
-    setLastUsedFeeLevel,
-} from 'src/actions/settings/walletSettingsActions';
 import { fillSendForm } from 'src/actions/suite/protocolActions';
 import { goto } from 'src/actions/suite/routerActions';
 import {
@@ -114,31 +110,13 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         name: 'outputs',
     });
 
-    // enhance DEFAULT_VALUES with last remembered FeeLevel and localCurrencyOption
     // used in "loadDraft" useEffect and "importTransaction" callback
     const getLoadedValues = useCallback(
-        (loadedState?: Partial<FormState>) => {
-            const feeEnhancement: Partial<FormState> = {};
-            if (!loadedState || !loadedState.selectedFee) {
-                const lastUsedFee = dispatch(getLastUsedFeeLevel());
-                if (lastUsedFee) {
-                    feeEnhancement.selectedFee = lastUsedFee.label;
-                    if (lastUsedFee.label === 'custom') {
-                        feeEnhancement.feePerUnit = lastUsedFee.feePerUnit;
-                        feeEnhancement.feeLimit = lastUsedFee.feeLimit;
-                        feeEnhancement.maxFeePerGas = lastUsedFee.maxFeePerGas;
-                        feeEnhancement.maxPriorityFeePerGas = lastUsedFee.maxPriorityFeePerGas;
-                    }
-                }
-            }
-
-            return {
-                ...getDefaultValues(localCurrencyOption),
-                ...loadedState,
-                ...feeEnhancement,
-            };
-        },
-        [dispatch, localCurrencyOption],
+        (loadedState?: Partial<FormState>) => ({
+            ...getDefaultValues(localCurrencyOption),
+            ...loadedState,
+        }),
+        [localCurrencyOption],
     );
 
     // update custom values
@@ -203,7 +181,6 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     const { changeFeeLevel } = useFees({
         defaultValue: undefined,
         feeInfo: state.feeInfo,
-        saveLastUsedFee: true,
         onChange: onFeeLevelChange,
         composedLevels,
         composeRequest,
@@ -224,7 +201,6 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     const resetContext = useCallback(() => {
         setComposedLevels(undefined);
         dispatch(removeSendFormDraftThunk()); // reset draft;
-        dispatch(setLastUsedFeeLevel()); // reset last known FeeLevel
         setState(getStateFromProps(props)); // resetting state will trigger "loadDraft" useEffect block, which will reset FormState to default
     }, [dispatch, props, setComposedLevels]);
 
@@ -364,7 +340,9 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     useEffect(() => {
         if (!draftSaveRequest) return;
         if (Object.keys(formState.errors).length === 0) {
-            dispatch(saveSendFormDraftThunk({ formState: getValues() }));
+            dispatch(
+                saveSendFormDraftThunk({ formState: { ...getValues(), selectedFee: undefined } }),
+            );
         }
         setDraftSaveRequest(false);
     }, [dispatch, draftSaveRequest, setDraftSaveRequest, getValues, formState.errors]);

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -220,7 +220,6 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case WALLET_SETTINGS.SET_HIDE_BALANCE:
                 case walletSettingsActions.setLocalCurrency.type:
                 case WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS:
-                case WALLET_SETTINGS.SET_LAST_USED_FEE_LEVEL:
                     api.dispatch(storageActions.saveWalletSettings());
                     break;
 

--- a/packages/suite/src/reducers/wallet/settingsReducer.ts
+++ b/packages/suite/src/reducers/wallet/settingsReducer.ts
@@ -17,7 +17,6 @@ export const initialState: State = {
     enabledNetworks: ['btc'],
     hideSuspiciousTransactions: false,
     bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN,
-    lastUsedFeeLevel: {},
 };
 
 const settingsReducer = (state: State = initialState, action: Action): State =>
@@ -46,13 +45,6 @@ const settingsReducer = (state: State = initialState, action: Action): State =>
                 break;
             }
 
-            case WALLET_SETTINGS.SET_LAST_USED_FEE_LEVEL:
-                if (action.feeLevel) {
-                    draft.lastUsedFeeLevel[action.symbol] = action.feeLevel;
-                } else {
-                    delete draft.lastUsedFeeLevel[action.symbol];
-                }
-                break;
             case WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS:
                 draft.bitcoinAmountUnit = action.payload;
                 break;

--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Storage changelog
 
+## 53
+
+-   remove `walletSettings.lastUsedFeeLevel` - we don't remember last selected fee in send form anymore
+
 ## 52
 
 -   Deprecated Vertcoin (VTC), Bitcoin Gold (BTG), Namecoin (NMC), DigiByte (DGB), and Dash (DASH) networks. Removed related transactions, accounts, and settings.

--- a/packages/suite/src/storage/index.ts
+++ b/packages/suite/src/storage/index.ts
@@ -5,7 +5,7 @@ import { reloadApp } from 'src/utils/suite/reload';
 import type { SuiteDBSchema } from './definitions';
 import { migrate } from './migrations';
 
-const VERSION = 52; // don't forget to add migration and CHANGELOG when changing versions!
+const VERSION = 53; // don't forget to add migration and CHANGELOG when changing versions!
 
 /**
  *  If the object stores don't already exist then creates them.

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -834,8 +834,11 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
         });
 
         await updateAll(transaction, 'walletSettings', walletSettings => {
+            // @ts-expect-error
             Object.keys(walletSettings.lastUsedFeeLevel).forEach(coin => {
+                // @ts-expect-error
                 if (walletSettings.lastUsedFeeLevel[coin].label === 'low') {
+                    // @ts-expect-error
                     delete walletSettings.lastUsedFeeLevel[coin];
                 }
             });
@@ -1006,12 +1009,17 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
         }
 
         await updateAll(transaction, 'walletSettings', walletSettings => {
+            // @ts-expect-error
             if (walletSettings.lastUsedFeeLevel['matic']) {
+                // @ts-expect-error
                 walletSettings.lastUsedFeeLevel = {
+                    // @ts-expect-error
                     ...walletSettings.lastUsedFeeLevel,
+                    // @ts-expect-error
                     pol: { ...walletSettings.lastUsedFeeLevel['matic'] },
                 };
 
+                // @ts-expect-error
                 delete walletSettings.lastUsedFeeLevel['matic'];
             }
 
@@ -1249,6 +1257,15 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
 
                 return account;
             }
+        });
+    }
+
+    if (oldVersion < 53) {
+        await updateAll(transaction, 'walletSettings', walletSettings => {
+            // @ts-expect-error
+            delete walletSettings.lastUsedFeeLevel;
+
+            return walletSettings;
         });
     }
 

--- a/packages/suite/src/storage/migrations/networks/bnb.ts
+++ b/packages/suite/src/storage/migrations/networks/bnb.ts
@@ -106,12 +106,17 @@ export const migrationOfBnbNetwork: OnUpgradeFunc<SuiteDBSchema> = async (
     }
 
     await updateAll(transaction, 'walletSettings', walletSettings => {
+        // @ts-expect-error
         if (walletSettings.lastUsedFeeLevel['bnb']) {
+            // @ts-expect-error
             walletSettings.lastUsedFeeLevel = {
+                // @ts-expect-error
                 ...walletSettings.lastUsedFeeLevel,
+                // @ts-expect-error
                 bsc: { ...walletSettings.lastUsedFeeLevel['bnb'] },
             };
 
+            // @ts-expect-error
             delete walletSettings.lastUsedFeeLevel['bnb'];
         }
 

--- a/suite-common/wallet-types/src/settings.ts
+++ b/suite-common/wallet-types/src/settings.ts
@@ -1,6 +1,6 @@
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { FeeLevel, PROTO } from '@trezor/connect';
+import { PROTO } from '@trezor/connect';
 
 export const AddressDisplayOptions = {
     ORIGINAL: 'original',
@@ -23,7 +23,4 @@ export interface WalletSettings {
     enabledNetworks: NetworkSymbol[];
     hideSuspiciousTransactions: boolean;
     bitcoinAmountUnit: PROTO.AmountUnit;
-    lastUsedFeeLevel: {
-        [key: string]: Omit<FeeLevel, 'blocks'>; // Key: Network['symbol']
-    };
 }


### PR DESCRIPTION
## Description

Send form should not remember selected fees by the user, both standard and advanced.

## Related Issue

Resolve #13533

## Screenshots:

https://github.com/user-attachments/assets/2ec9fe3e-d346-4644-9f74-b7b63aa1ee64
