### PR TITLE
chore(suite): add kb article links to release notes for 25.3

### DIFF
--- a/packages/suite-desktop/releaseNotes/release-notes.md
+++ b/packages/suite-desktop/releaseNotes/release-notes.md
@@ -1,7 +1,7 @@
 ### 🚀 New features
 
--   Users can now cancel outgoing Bitcoin transactions using Replace-By-Fee (RBF), providing more flexibility and control over their transactions.
--   Stake Solana (SOL) directly from Trezor Suite. Easily receive rewards by delegating your SOL through the new “Stake” feature in the assets and trade table.
+-   Users can now [cancel outgoing Bitcoin transactions](https://trezor.io/support/a/can-i-cancel-or-reverse-a-transaction) using Replace-By-Fee (RBF), providing more flexibility and control over their transactions.
+-   [Stake Solana (SOL)](https://trezor.io/learn/a/staking-solana-in-trezor-suite) directly from Trezor Suite. Easily receive rewards by delegating your SOL through the new “Stake” feature in the assets and trade table.
 -   A new Over-the-Counter (OTC) trade flow is now available for high-value Buy and Sell transactions that cannot be fulfilled through standard trading options.
 
 ### 🎨 Improvements


### PR DESCRIPTION
This pull request includes updates to the release notes in the `packages/suite-desktop/releaseNotes/release-notes.md` file. The changes primarily focus on adding links to provide users with more detailed information about new features.

New features:

* Added a link to the support page for canceling outgoing Bitcoin transactions using Replace-By-Fee (RBF).
* Added a link to the learning page for staking Solana (SOL) directly from Trezor Suite.