### PR TITLE
fix(suite): make sure that once any fiat token rate is known its refr…

### DIFF
--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -589,7 +589,12 @@ export const areTokenFiatRatesLoading = (
             token.contract as TokenAddress,
         );
 
-        return rates?.[tokenFiatRateKey]?.isLoading;
+        // NOTE: designed the rate as loading only if it is loading and NO rate is currently available
+        return (
+            rates?.[tokenFiatRateKey]?.isLoading &&
+            !rates?.[tokenFiatRateKey]?.rate &&
+            rates?.[tokenFiatRateKey]?.rate !== 0
+        );
     });
 
 export const getAccountTokensFiatBalance = (


### PR DESCRIPTION
…esh won't cause UI loading

<!--- Provide a general summary of your changes in the Title above -->

## Description

When you added large QA seed with that passphrase, you could see how the Sol2 tokens values are loading - the skeleton was there correctly.

However, after it succesffully loaded the rates and displayed the value, it become skeleton again, coz one of the fiat rate started refetching.

Obvious fix was to check if even older fiat rate is there, so loading state was only when there is no fiat rate available and the there was no fiat rate.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
