### PR TITLE
fix(connect-web): dev server output path

### DIFF
--- a/packages/connect-web/webpack/dev.webpack.config.ts
+++ b/packages/connect-web/webpack/dev.webpack.config.ts
@@ -17,7 +17,7 @@ const dev = {
         'trezor-connect': path.resolve(__dirname, '../src/index.ts'),
     },
     output: {
-        filename: '[name].js',
+        filename: 'js/[name].js',
         path: path.resolve(__dirname, '../build'),
         publicPath: './',
         library: 'TrezorConnect',


### PR DESCRIPTION
## Description

Fix an issue with connect-web Webpack dev server, after changes in #17702 the output path needs to be changed to `js/` for consistency with prod.