### PR TITLE
feat(suite-desktop): watch if bridge is running and spin up internal …

### DIFF
--- a/packages/suite-desktop-core/src/libs/processes/BridgeProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/BridgeProcess.ts
@@ -22,7 +22,7 @@ export class BridgeProcess extends BaseProcess {
                 if (data?.version) {
                     return {
                         service: true,
-                        process: true,
+                        process: Boolean(this.process),
                     };
                 }
             }

--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -138,9 +138,31 @@ const loadBridge = async (store: Dependencies['store']) => {
 export const initBackground = ({ store }: Pick<Dependencies, 'store'>) => {
     let loaded = false;
 
+    let watchInterval: NodeJS.Timeout | undefined;
+
     const onLoad = () => {
         if (loaded) return;
         loaded = true;
+
+        // if user uninstalled external bridge, start internal one if applicable
+        let isStartingLocalBridge = false;
+        watchInterval = setInterval(async () => {
+            const isBridgeRunning = await bridge.status();
+            if (isBridgeRunning.process) {
+                clearInterval(watchInterval);
+
+                return;
+            }
+            if (!isBridgeRunning.service && !isStartingLocalBridge) {
+                isStartingLocalBridge = true;
+                logger.info(SERVICE_NAME, 'Detected that no bridge is running, starting it');
+                await loadBridge(store)
+                    .catch(() => {})
+                    .finally(() => {
+                        isStartingLocalBridge = false;
+                    });
+            }
+        }, 30_000);
 
         return scheduleAction(() => loadBridge(store), { timeout: 3000 }).catch(err => {
             // Error ignored, user will see transport error afterwards
@@ -149,6 +171,7 @@ export const initBackground = ({ store }: Pick<Dependencies, 'store'>) => {
     };
 
     const onQuit = async () => {
+        clearInterval(watchInterval);
         await bridge?.stop();
     };
 

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -498,7 +498,10 @@ export class TrezordNode {
         this.throttler.dispose();
         this.core.dispose();
 
-        return this.server?.stop();
+        return this.server?.stop().finally(() => {
+            this.server = undefined;
+            this.logger.info('Trezor Bridge HTTP server stopped');
+        });
     }
 
     public async status() {
@@ -508,7 +511,7 @@ export class TrezordNode {
 
         return {
             service: running,
-            process: running,
+            process: Boolean(this.server),
         };
     }
 


### PR DESCRIPTION
…one if not

Consider the following scenario:
- user has a standalone bridge installed
- we finally deploy the 'auto-start' and 'run in background' feature, so we can expect that suite-dekstop is always running
- we start the long anticipated campaign aimed at removing standalone bridges. user unsintalls his standalone bridge. 
- suite-desktop, which is running, does not have transport and the only way to fix this is restarting it.

This PR: 
- fixes process status detection for bridge module - IMHO we should set process: true only if the process is controlled by Suite
- if we find that the bridge process is an external one, it sets a watcher for bridge service and starts the internal bridge if it detects that this service is not running

resolves #13180