### PR TITLE
fix(suite): AccountsMenu: Open category with hidden label by default

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -159,7 +159,7 @@ export const AccountsList = ({ onItemClick }: AccountListProps) => {
                         type={type}
                         hideLabel={hideLabel}
                         hasBalance={groupHasBalance}
-                        keepOpen={keepOpen(type)}
+                        keepOpen={hideLabel || keepOpen(type)}
                     >
                         <Accounts {...accountProps} />
                     </AccountGroup>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before

<img width="455" alt="Screenshot 2025-03-18 at 16 21 00" src="https://github.com/user-attachments/assets/40583f07-1ff4-4fce-bc95-9410707cd500" />

after

<img width="438" alt="Screenshot 2025-03-18 at 16 20 02" src="https://github.com/user-attachments/assets/cff7c146-a03a-4866-9dfb-1a19424d0034" />
