### PR TITLE
fix(e2e): stabilizes pending-transaction test

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/wallet/pending-transactions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/pending-transactions.test.ts
@@ -15,157 +15,169 @@ const accounts = {
     },
 };
 
-test.describe('Use regtest to test pending transactions', { tag: ['@group=wallet'] }, () => {
-    test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });
-    test.beforeEach(
-        async ({
+test.describe(
+    'Use regtest to test pending transactions',
+    { tag: ['@group=wallet', '@desktopOnly'] },
+    () => {
+        test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });
+        test.beforeEach(
+            async ({
+                page,
+                onboardingPage,
+                dashboardPage,
+                settingsPage,
+                trezorUserEnvLink,
+                walletPage,
+            }) => {
+                const payments = [
+                    { address: accounts.account1.address, amount: 10 },
+                    { address: accounts.account2.address, amount: 10 },
+                ];
+
+                for (const payment of payments) {
+                    await trezorUserEnvLink.sendToAddressAndMineBlock({
+                        address: payment.address,
+                        btc_amount: payment.amount,
+                    });
+                }
+                // Mining needs to happen in time before discovery
+                await trezorUserEnvLink.mineBlocks({ block_amount: 1 });
+                await page.waitForTimeout(5_000);
+
+                await onboardingPage.completeOnboarding();
+                await dashboardPage.discoveryShouldFinish();
+                await settingsPage.navigateTo('coins');
+                await settingsPage.coins.disableNetwork('btc');
+                await settingsPage.coins.enableNetwork('regtest');
+                await dashboardPage.dashboardMenuButton.click();
+                await dashboardPage.discoveryShouldFinish();
+                expect(
+                    await walletPage.getAccountsCount('regtest'),
+                    'expected 3 Regtest accounts to be discovered. They might not have been mined yet',
+                ).toBe(3);
+            },
+        );
+
+        test('Send couple of pending txs and check that they are pending until mined', async ({
             page,
-            onboardingPage,
-            dashboardPage,
-            settingsPage,
-            trezorUserEnvLink,
             walletPage,
+            devicePrompt,
+            tradingPage,
+            trezorUserEnvLink,
         }) => {
-            const payments = [
-                { address: accounts.account1.address, amount: 10 },
-                { address: accounts.account2.address, amount: 10 },
-            ];
+            await walletPage
+                .accountLabel({ symbol: 'regtest', type: 'normal', atIndex: 0 })
+                .click();
 
-            for (const payment of payments) {
-                await trezorUserEnvLink.sendToAddressAndMineBlock({
-                    address: payment.address,
-                    btc_amount: payment.amount,
-                });
+            // create 2 transactions (one self, one fund another account of mine)
+            for (const [index, transaction] of [accounts.account1, accounts.account2].entries()) {
+                await walletPage.openSendFormButton.click();
+                await tradingPage.sendAmountInput.fill('0.3');
+                await tradingPage.sendAddressInput.fill(transaction.address);
+                await page.getByTestId('add-output').click();
+                await page.getByTestId('outputs.1.amount').fill('0.7');
+                await page.getByTestId('outputs.1.address').fill(transaction.address);
+                await tradingPage.sendButton.click();
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await trezorUserEnvLink.pressYes();
+                await trezorUserEnvLink.pressYes();
+                await trezorUserEnvLink.pressYes();
+                await trezorUserEnvLink.pressYes();
+                await trezorUserEnvLink.pressYes();
+                await devicePrompt.sendButton.click();
+
+                const pendingTransactionsList = page.getByTestId(
+                    '@wallet/accounts/transaction-list/pending/group/0',
+                );
+                await expect(
+                    pendingTransactionsList.getByTestId('@transaction-item/0/prepending/heading'),
+                ).toBeVisible();
+                await pendingTransactionsList.getByTestId('@transaction-item/0/heading').click();
+
+                await expect(page.getByTestId('@transaction-group/pending/count')).toContainText(
+                    (index + 1).toString(),
+                );
+                transaction.txid =
+                    (await page.getByTestId('@tx-detail/txid-value').getAttribute('id')) ?? '';
+
+                await page.getByTestId('@modal/close-button').click();
             }
-            // Mining needs to happen in time before discovery
-            await trezorUserEnvLink.mineBlocks({ block_amount: 1 });
-            await page.waitForTimeout(5_000);
 
-            await onboardingPage.completeOnboarding();
-            await dashboardPage.discoveryShouldFinish();
-            await settingsPage.navigateTo('coins');
-            await settingsPage.coins.disableNetwork('btc');
-            await settingsPage.coins.enableNetwork('regtest');
-            await dashboardPage.dashboardMenuButton.click();
-            await dashboardPage.discoveryShouldFinish();
-            expect(
-                await walletPage.getAccountsCount('regtest'),
-                'expected 3 Regtest accounts to be discovered. They might not have been mined yet',
-            ).toBe(3);
-        },
-    );
-
-    test('Send couple of pending txs and check that they are pending until mined', async ({
-        page,
-        walletPage,
-        devicePrompt,
-        tradingPage,
-        trezorUserEnvLink,
-    }) => {
-        await walletPage.accountLabel({ symbol: 'regtest', type: 'normal', atIndex: 0 }).click();
-
-        // create 2 transactions (one self, one fund another account of mine)
-        for (const [index, transaction] of [accounts.account1, accounts.account2].entries()) {
-            await walletPage.openSendFormButton.click();
-            await tradingPage.sendAmountInput.fill('0.3');
-            await tradingPage.sendAddressInput.fill(transaction.address);
-            await page.getByTestId('add-output').click();
-            await page.getByTestId('outputs.1.amount').fill('0.7');
-            await page.getByTestId('outputs.1.address').fill(transaction.address);
-            await tradingPage.sendButton.click();
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await trezorUserEnvLink.pressYes();
-            await trezorUserEnvLink.pressYes();
-            await trezorUserEnvLink.pressYes();
-            await trezorUserEnvLink.pressYes();
-            await trezorUserEnvLink.pressYes();
-            await devicePrompt.sendButton.click();
-
-            const pendingTransactionsList = page.getByTestId(
+            // account 1 has 2 pending transactions (self and sent)
+            const pendingTransactionsAccount1 = page.getByTestId(
                 '@wallet/accounts/transaction-list/pending/group/0',
             );
             await expect(
-                pendingTransactionsList.getByTestId('@transaction-item/0/prepending/heading'),
-            ).toBeVisible();
-            await pendingTransactionsList.getByTestId('@transaction-item/0/heading').click();
+                pendingTransactionsAccount1.getByTestId('@transaction-item/0/heading'),
+            ).toContainText('Sending REGTEST');
+            await expect(
+                pendingTransactionsAccount1.getByTestId('@transaction-item/1/heading'),
+            ).toContainText('Sending REGTEST to myself');
 
-            await expect(page.getByTestId('@transaction-group/pending/count')).toContainText(
-                (index + 1).toString(),
+            // account 2 has 1 pending transaction (receive)
+            await walletPage
+                .accountLabel({ symbol: 'regtest', type: 'normal', atIndex: 1 })
+                .click();
+            const pendingTransactionsAccount2 = page.getByTestId(
+                '@wallet/accounts/transaction-list/pending/group/0',
             );
-            transaction.txid =
-                (await page.getByTestId('@tx-detail/txid-value').getAttribute('id')) ?? '';
+            await expect(
+                pendingTransactionsAccount2.getByTestId('@transaction-item/0/heading'),
+            ).toContainText('Receiving REGTEST');
 
-            await page.getByTestId('@modal/close-button').click();
-        }
+            await trezorUserEnvLink.generateBlock({
+                address: accounts.miner_account.address,
+                txids: [],
+            });
+            await page.waitForTimeout(2000);
 
-        // account 1 has 2 pending transactions (self and sent)
-        const pendingTransactionsAccount1 = page.getByTestId(
-            '@wallet/accounts/transaction-list/pending/group/0',
-        );
-        await expect(
-            pendingTransactionsAccount1.getByTestId('@transaction-item/0/heading'),
-        ).toContainText('Sending REGTEST');
-        await expect(
-            pendingTransactionsAccount1.getByTestId('@transaction-item/1/heading'),
-        ).toContainText('Sending REGTEST to myself');
+            // nothing has changed
+            await walletPage
+                .accountLabel({ symbol: 'regtest', type: 'normal', atIndex: 0 })
+                .click();
+            const pendingTransactionsAccount1AfterMine = page.getByTestId(
+                '@wallet/accounts/transaction-list/pending/group/0',
+            );
+            await expect(
+                pendingTransactionsAccount1AfterMine.getByTestId('@transaction-item/0/heading'),
+            ).toContainText('Sending REGTEST');
+            await expect(
+                pendingTransactionsAccount1AfterMine.getByTestId('@transaction-item/1/heading'),
+            ).toContainText('Sending REGTEST to myself');
 
-        // account 2 has 1 pending transaction (receive)
-        await walletPage.accountLabel({ symbol: 'regtest', type: 'normal', atIndex: 1 }).click();
-        const pendingTransactionsAccount2 = page.getByTestId(
-            '@wallet/accounts/transaction-list/pending/group/0',
-        );
-        await expect(
-            pendingTransactionsAccount2.getByTestId('@transaction-item/0/heading'),
-        ).toContainText('Receiving REGTEST');
+            // mine the "not-self" transaction
+            await trezorUserEnvLink.generateBlock({
+                address: accounts.miner_account.address,
+                txids: [accounts.account2.txid],
+            });
 
-        await trezorUserEnvLink.generateBlock({
-            address: accounts.miner_account.address,
-            txids: [],
+            // which causes sent transaction to disappear, self transaction stays
+            const pendingTransactionsAccount1AfterMine2 = page.getByTestId(
+                '@wallet/accounts/transaction-list/pending/group/0',
+            );
+            await expect(
+                pendingTransactionsAccount1AfterMine2.getByTestId('@transaction-item/0/heading'),
+            ).toContainText('Sending REGTEST to myself');
+            await expect(page.getByTestId('@transaction-group/pending/count')).toContainText('1');
+
+            // and new group of transactions appears with the previously pending transaction now confirmed
+            const confirmedTransactionsAccount1 = page.getByTestId(
+                '@wallet/accounts/transaction-list/confirmed/group/0',
+            );
+            await expect(
+                confirmedTransactionsAccount1.getByTestId('@transaction-item/0/heading'),
+            ).toContainText('Sent REGTEST');
+
+            // receive pending transaction on account2 is now mined as well
+            await walletPage
+                .accountLabel({ symbol: 'regtest', type: 'normal', atIndex: 1 })
+                .click();
+            const confirmedTransactionsAccount2 = page.getByTestId(
+                '@wallet/accounts/transaction-list/confirmed/group/0',
+            );
+            await expect(
+                confirmedTransactionsAccount2.getByTestId('@transaction-item/0/heading'),
+            ).toContainText('Received REGTEST');
         });
-        await page.waitForTimeout(2000);
-
-        // nothing has changed
-        await walletPage.accountLabel({ symbol: 'regtest', type: 'normal', atIndex: 0 }).click();
-        const pendingTransactionsAccount1AfterMine = page.getByTestId(
-            '@wallet/accounts/transaction-list/pending/group/0',
-        );
-        await expect(
-            pendingTransactionsAccount1AfterMine.getByTestId('@transaction-item/0/heading'),
-        ).toContainText('Sending REGTEST');
-        await expect(
-            pendingTransactionsAccount1AfterMine.getByTestId('@transaction-item/1/heading'),
-        ).toContainText('Sending REGTEST to myself');
-
-        // mine the "not-self" transaction
-        await trezorUserEnvLink.generateBlock({
-            address: accounts.miner_account.address,
-            txids: [accounts.account2.txid],
-        });
-
-        // which causes sent transaction to disappear, self transaction stays
-        const pendingTransactionsAccount1AfterMine2 = page.getByTestId(
-            '@wallet/accounts/transaction-list/pending/group/0',
-        );
-        await expect(
-            pendingTransactionsAccount1AfterMine2.getByTestId('@transaction-item/0/heading'),
-        ).toContainText('Sending REGTEST to myself');
-        await expect(page.getByTestId('@transaction-group/pending/count')).toContainText('1');
-
-        // and new group of transactions appears with the previously pending transaction now confirmed
-        const confirmedTransactionsAccount1 = page.getByTestId(
-            '@wallet/accounts/transaction-list/confirmed/group/0',
-        );
-        await expect(
-            confirmedTransactionsAccount1.getByTestId('@transaction-item/0/heading'),
-        ).toContainText('Sent REGTEST');
-
-        // receive pending transaction on account2 is now mined as well
-        await walletPage.accountLabel({ symbol: 'regtest', type: 'normal', atIndex: 1 }).click();
-        const confirmedTransactionsAccount2 = page.getByTestId(
-            '@wallet/accounts/transaction-list/confirmed/group/0',
-        );
-        await expect(
-            confirmedTransactionsAccount2.getByTestId('@transaction-item/0/heading'),
-        ).toContainText('Received REGTEST');
-    });
-});
+    },
+);

--- a/packages/suite-desktop-core/e2e/tests/wallet/pending-transactions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/pending-transactions.test.ts
@@ -18,7 +18,14 @@ const accounts = {
 test.describe('Use regtest to test pending transactions', { tag: ['@group=wallet'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });
     test.beforeEach(
-        async ({ onboardingPage, dashboardPage, settingsPage, trezorUserEnvLink, walletPage }) => {
+        async ({
+            page,
+            onboardingPage,
+            dashboardPage,
+            settingsPage,
+            trezorUserEnvLink,
+            walletPage,
+        }) => {
             const payments = [
                 { address: accounts.account1.address, amount: 10 },
                 { address: accounts.account2.address, amount: 10 },
@@ -32,6 +39,7 @@ test.describe('Use regtest to test pending transactions', { tag: ['@group=wallet
             }
             // Mining needs to happen in time before discovery
             await trezorUserEnvLink.mineBlocks({ block_amount: 1 });
+            await page.waitForTimeout(5_000);
 
             await onboardingPage.completeOnboarding();
             await dashboardPage.discoveryShouldFinish();

--- a/packages/suite-desktop-core/e2e/tests/wallet/pending-transactions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/pending-transactions.test.ts
@@ -17,37 +17,43 @@ const accounts = {
 
 test.describe('Use regtest to test pending transactions', { tag: ['@group=wallet'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });
-    test.beforeEach(async ({ onboardingPage, dashboardPage, settingsPage, trezorUserEnvLink }) => {
-        await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
+    test.beforeEach(
+        async ({ onboardingPage, dashboardPage, settingsPage, trezorUserEnvLink, walletPage }) => {
+            const payments = [
+                { address: accounts.account1.address, amount: 10 },
+                { address: accounts.account2.address, amount: 10 },
+            ];
 
-        await settingsPage.navigateTo('coins');
-        await settingsPage.coins.disableNetwork('btc');
-        await settingsPage.coins.enableNetwork('regtest');
+            for (const payment of payments) {
+                await trezorUserEnvLink.sendToAddressAndMineBlock({
+                    address: payment.address,
+                    btc_amount: payment.amount,
+                });
+            }
+            // Mining needs to happen in time before discovery
+            await trezorUserEnvLink.mineBlocks({ block_amount: 1 });
 
-        const payments = [
-            { address: accounts.account1.address, amount: 10 },
-            { address: accounts.account2.address, amount: 10 },
-        ];
-
-        for (const payment of payments) {
-            await trezorUserEnvLink.sendToAddressAndMineBlock({
-                address: payment.address,
-                btc_amount: payment.amount,
-            });
-        }
-        await trezorUserEnvLink.mineBlocks({ block_amount: 1 });
-    });
+            await onboardingPage.completeOnboarding();
+            await dashboardPage.discoveryShouldFinish();
+            await settingsPage.navigateTo('coins');
+            await settingsPage.coins.disableNetwork('btc');
+            await settingsPage.coins.enableNetwork('regtest');
+            await dashboardPage.dashboardMenuButton.click();
+            await dashboardPage.discoveryShouldFinish();
+            expect(
+                await walletPage.getAccountsCount('regtest'),
+                'expected 3 Regtest accounts to be discovered. They might not have been mined yet',
+            ).toBe(3);
+        },
+    );
 
     test('Send couple of pending txs and check that they are pending until mined', async ({
         page,
         walletPage,
-        dashboardPage,
         devicePrompt,
         tradingPage,
         trezorUserEnvLink,
     }) => {
-        await dashboardPage.dashboardMenuButton.click();
         await walletPage.accountLabel({ symbol: 'regtest', type: 'normal', atIndex: 0 }).click();
 
         // create 2 transactions (one self, one fund another account of mine)


### PR DESCRIPTION
Stabilize test.

- adds wait for discovery
- moves mining earlier so it is done by the time the discovery starts
- assert to validate setup
