### PR TITLE
fix(connect-ui): improve no transport error message on supported browsers

### DIFF
--- a/packages/connect-ui/src/views/Transport.tsx
+++ b/packages/connect-ui/src/views/Transport.tsx
@@ -26,20 +26,36 @@ export const Transport = () => {
             window.open(SUITE_URL);
         }, 500);
     };
+    // @ts-expect-error usb is not included in types here
+    const wouldSupportWebUSB = window.navigator.usb?.getDevices !== undefined;
 
     return (
         <View
             title={
-                <FormattedMessage
-                    id="TR_NO_TRANSPORT"
-                    defaultMessage="Browser can't communicate with device"
-                />
+                wouldSupportWebUSB ? (
+                    <FormattedMessage
+                        id="TR_NO_TRANSPORT_SUPPORTED_BROWSER"
+                        defaultMessage="Open Trezor Suite to enable communication"
+                    />
+                ) : (
+                    <FormattedMessage
+                        id="TR_NO_TRANSPORT"
+                        defaultMessage="Browser can't communicate with device"
+                    />
+                )
             }
             description={
-                <FormattedMessage
-                    id="TR_BRIDGE_NEEDED_DESCRIPTION"
-                    defaultMessage="Your browser is not supported. For the best experience, download and run the Trezor Suite desktop app in the background, or use a supported Chromium-based browser that is compatible with WebUSB."
-                />
+                wouldSupportWebUSB ? (
+                    <FormattedMessage
+                        id="TR_BRIDGE_NEEDED_DESCRIPTION_SUPPORTED_BROWSER"
+                        defaultMessage="This version of Connect requires Trezor Suite to be installed and running on your computer. Suite will facilitate communication between your device and the browser."
+                    />
+                ) : (
+                    <FormattedMessage
+                        id="TR_BRIDGE_NEEDED_DESCRIPTION"
+                        defaultMessage="Your browser is not supported. For the best experience, download and run the Trezor Suite desktop app in the background, or use a supported Chromium-based browser that is compatible with WebUSB."
+                    />
+                )
             }
             image={<Image imageSrc={imageSrc} />}
             buttons={


### PR DESCRIPTION
## Description

The no transport error message in popup was specifically mentioning browser support. 
However this error can occur in iframe mode even when the browser actually does support WebUSB. 
With this PR we display a different message for this situation. 

## Screenshots:
Before
<img width="787" alt="Screenshot 2025-03-18 at 17 01 10" src="https://github.com/user-attachments/assets/3f873fb3-2352-49e6-8904-7e613da55646" />

After
<img width="787" alt="Screenshot 2025-03-18 at 17 16 25" src="https://github.com/user-attachments/assets/088fe77e-ea78-4f6e-94c1-750ee0a40036" />
