### PR TITLE
feat(ci): Add smoke checks to PR e2e

### DIFF
--- a/.github/actions/build-desktop/action.yml
+++ b/.github/actions/build-desktop/action.yml
@@ -23,3 +23,14 @@ runs:
       run: |
         yarn workspace @trezor/suite-desktop build:app
         yarn workspace @trezor/suite-desktop build:ui
+
+    - name: Compress build artifacts
+      shell: bash
+      run: tar -czf app-build.tar.gz -C ${{ github.workspace }}/packages/suite-desktop build dist
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: desktop-app-build-e2e
+        path: app-build.tar.gz
+        retention-days: 7

--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -11,6 +11,10 @@ inputs:
   containers:
     description: "Docker containers to pull"
     required: true
+  workspace-dependencies:
+    description: "Additional workspaces to install"
+    required: false
+    default: ""
   test-group:
     description: "Test group to run"
     required: true
@@ -55,15 +59,16 @@ runs:
         cache: yarn
 
     - name: Install PW Dependencies
-      if: ${{ inputs.project == 'web' }}
       shell: bash
       run: |
         echo "::group::Install PW Dependencies"
         echo "Silently installing Playwright dependencies"
         echo -e "\nenableScripts: false" >> .yarnrc.yml
         echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-        yarn workspaces focus @trezor/suite-desktop-core > /dev/null
-        npx playwright install --with-deps > /dev/null
+        yarn workspaces focus @trezor/suite-desktop-core ${{ inputs.workspace-dependencies }} > /dev/null
+        if [[ "${{ inputs.project }}" == "web" ]]; then
+          npx playwright install --with-deps > /dev/null
+        fi
         echo "::endgroup::"
 
     - name: Pull Docker Images

--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -63,8 +63,6 @@ runs:
       run: |
         echo "::group::Install PW Dependencies"
         echo "Silently installing Playwright dependencies"
-        echo -e "\nenableScripts: false" >> .yarnrc.yml
-        echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
         yarn workspaces focus @trezor/suite-desktop-core ${{ inputs.workspace-dependencies }} > /dev/null
         if [[ "${{ inputs.project }}" == "web" ]]; then
           npx playwright install --with-deps > /dev/null

--- a/.github/workflows/test-suite-desktop-e2e-fw-canary.yml
+++ b/.github/workflows/test-suite-desktop-e2e-fw-canary.yml
@@ -14,6 +14,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-app:
+    if: github.repository == 'trezor/trezor-suite'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build and Upload Suite Desktop
+        uses: ./.github/actions/build-desktop
+
   load-e2e-matrix:
     if: github.repository == 'trezor/trezor-suite'
     runs-on: ubuntu-latest
@@ -49,8 +58,13 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
-      - name: Build desktop app
-        uses: ./.github/actions/build-desktop
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: desktop-app-build-e2e
+
+      - name: Extract build artifact
+        run: tar -xzf app-build.tar.gz -C ${{ github.workspace }}/packages/suite-desktop
 
       - name: Run Playwright E2E Tests
         uses: ./.github/actions/run-e2e-tests
@@ -59,6 +73,7 @@ jobs:
         with:
           project: "desktop"
           containers: ${{ matrix.CONTAINERS }}
+          workspace-dependencies: "@trezor/suite-desktop"
           test-group: ${{ matrix.TEST_GROUP }}
           additional-grep: "(?!.*@specificFirmware)"
           currents-project-id: "4ytF0E"

--- a/.github/workflows/test-suite-desktop-e2e-fw-canary.yml
+++ b/.github/workflows/test-suite-desktop-e2e-fw-canary.yml
@@ -42,6 +42,7 @@ jobs:
     if: github.repository == 'trezor/trezor-suite'
     runs-on: ubuntu-24.04
     needs:
+      - build-app
       - load-e2e-matrix
     strategy:
       fail-fast: false

--- a/.github/workflows/test-suite-desktop-e2e-nightly.yml
+++ b/.github/workflows/test-suite-desktop-e2e-nightly.yml
@@ -41,6 +41,7 @@ jobs:
     if: github.repository == 'trezor/trezor-suite'
     runs-on: ubuntu-24.04
     needs:
+      - build-app
       - load-e2e-matrix
     strategy:
       fail-fast: false

--- a/.github/workflows/test-suite-desktop-e2e-nightly.yml
+++ b/.github/workflows/test-suite-desktop-e2e-nightly.yml
@@ -13,6 +13,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-app:
+    if: github.repository == 'trezor/trezor-suite'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build and Upload Suite Desktop
+        uses: ./.github/actions/build-desktop
+        
   load-e2e-matrix:
     if: github.repository == 'trezor/trezor-suite'
     runs-on: ubuntu-latest
@@ -48,14 +57,20 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
-      - name: Build desktop app
-        uses: ./.github/actions/build-desktop
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: desktop-app-build-e2e
+
+      - name: Extract build artifact
+        run: tar -xzf app-build.tar.gz -C ${{ github.workspace }}/packages/suite-desktop
 
       - name: Run Playwright E2E Tests
         uses: ./.github/actions/run-e2e-tests
         with:
           project: "desktop"
           containers: ${{ matrix.CONTAINERS }}
+          workspace-dependencies: "@trezor/suite-desktop"
           test-group: ${{ matrix.TEST_GROUP }}
           currents-project-id: "4ytF0E"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}

--- a/.github/workflows/test-suite-desktop-e2e-pr.yml
+++ b/.github/workflows/test-suite-desktop-e2e-pr.yml
@@ -54,8 +54,9 @@ jobs:
     needs:
       - build-app
       - load-e2e-matrix
+    continue-on-error: ${{ !matrix.smoke }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix: ${{ fromJson(needs.load-e2e-matrix.outputs.matrix) }}
     steps:
       - name: Checkout
@@ -96,7 +97,7 @@ jobs:
         with:
           project: "desktop"
           containers: ${{ matrix.CONTAINERS }}
-          additional-workspaces: "@trezor/suite-desktop"
+          workspace-dependencies: "@trezor/suite-desktop"
           test-group: ${{ matrix.TEST_GROUP }}
           currents-project-id: "4ytF0E"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}

--- a/.github/workflows/test-suite-desktop-e2e-pr.yml
+++ b/.github/workflows/test-suite-desktop-e2e-pr.yml
@@ -24,6 +24,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-app:
+    if: github.repository == 'trezor/trezor-suite'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build and Upload Suite Desktop
+        uses: ./.github/actions/build-desktop
+
   load-e2e-matrix:
     if: github.repository == 'trezor/trezor-suite'
     runs-on: ubuntu-latest
@@ -43,6 +52,7 @@ jobs:
     if: github.repository == 'trezor/trezor-suite'
     runs-on: ubuntu-24.04
     needs:
+      - build-app
       - load-e2e-matrix
     strategy:
       fail-fast: false
@@ -72,9 +82,13 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
-      - name: Build desktop app
-        if: steps.check-previous-runs.outputs.skip_tests != 'true'
-        uses: ./.github/actions/build-desktop
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: desktop-app-build-e2e
+
+      - name: Extract build artifact
+        run: tar -xzf app-build.tar.gz -C ${{ github.workspace }}/packages/suite-desktop
 
       - name: Run Playwright E2E Tests
         if: steps.check-previous-runs.outputs.skip_tests != 'true'
@@ -82,6 +96,7 @@ jobs:
         with:
           project: "desktop"
           containers: ${{ matrix.CONTAINERS }}
+          additional-workspaces: "@trezor/suite-desktop"
           test-group: ${{ matrix.TEST_GROUP }}
           currents-project-id: "4ytF0E"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}

--- a/.github/workflows/test-suite-desktop-e2e-pr.yml
+++ b/.github/workflows/test-suite-desktop-e2e-pr.yml
@@ -84,11 +84,13 @@ jobs:
           cache: yarn
 
       - name: Download build artifact
+        if: steps.check-previous-runs.outputs.skip_tests != 'true'
         uses: actions/download-artifact@v4
         with:
           name: desktop-app-build-e2e
 
       - name: Extract build artifact
+        if: steps.check-previous-runs.outputs.skip_tests != 'true'
         run: tar -xzf app-build.tar.gz -C ${{ github.workspace }}/packages/suite-desktop
 
       - name: Run Playwright E2E Tests

--- a/.github/workflows/test-suite-desktop-e2e-release.yml
+++ b/.github/workflows/test-suite-desktop-e2e-release.yml
@@ -42,6 +42,7 @@ jobs:
     if: github.repository == 'trezor/trezor-suite'
     runs-on: ubuntu-24.04
     needs:
+      - build-app
       - load-e2e-matrix
     strategy:
       fail-fast: false

--- a/.github/workflows/test-suite-desktop-e2e-release.yml
+++ b/.github/workflows/test-suite-desktop-e2e-release.yml
@@ -14,6 +14,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-app:
+    if: github.repository == 'trezor/trezor-suite'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build and Upload Suite Desktop
+        uses: ./.github/actions/build-desktop
+
   load-e2e-matrix:
     if: github.repository == 'trezor/trezor-suite'
     runs-on: ubuntu-latest
@@ -49,14 +58,20 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
-      - name: Build desktop app
-        uses: ./.github/actions/build-desktop
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: desktop-app-build-e2e
+
+      - name: Extract build artifact
+        run: tar -xzf app-build.tar.gz -C ${{ github.workspace }}/packages/suite-desktop
 
       - name: Run Playwright E2E Tests
         uses: ./.github/actions/run-e2e-tests
         with:
           project: "desktop"
           containers: ${{ matrix.CONTAINERS }}
+          workspace-dependencies: "@trezor/suite-desktop"
           test-group: ${{ matrix.TEST_GROUP }}
           currents-project-id: "4ytF0E"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}

--- a/.github/workflows/test-suite-web-e2e-fw-canary.yml
+++ b/.github/workflows/test-suite-web-e2e-fw-canary.yml
@@ -39,8 +39,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.load-matrix.outputs.matrix }}
-    needs:
-      - build-web
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-suite-web-e2e-nightly.yml
+++ b/.github/workflows/test-suite-web-e2e-nightly.yml
@@ -37,8 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.load-matrix.outputs.matrix }}
-    needs:
-      - build-web
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-suite-web-e2e-pr.yml
+++ b/.github/workflows/test-suite-web-e2e-pr.yml
@@ -60,8 +60,6 @@ jobs:
     outputs:
       matrix: ${{ steps.load-matrix.outputs.matrix }}
     runs-on: ubuntu-latest
-    needs:
-      - build-web
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -108,7 +106,7 @@ jobs:
           project: "web"
           containers: ${{ matrix.CONTAINERS }}
           test-group: ${{ matrix.TEST_GROUP }}
-          additional-grep: ${{ matrix.SMOKE == true && "" || "(?=.*@webOnly)" }}
+          additional-grep: ${{ matrix.SMOKE && '(?=.*)' || '(?=.*@webOnly)' }}
           currents-project-id: "Og0NOQ"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}

--- a/.github/workflows/test-suite-web-e2e-pr.yml
+++ b/.github/workflows/test-suite-web-e2e-pr.yml
@@ -78,8 +78,9 @@ jobs:
     needs:
       - build-web
       - load-e2e-matrix
+    continue-on-error: ${{ !matrix.smoke }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix: ${{ fromJson(needs.load-e2e-matrix.outputs.matrix) }}
     steps:
       - name: Checkout
@@ -107,7 +108,7 @@ jobs:
           project: "web"
           containers: ${{ matrix.CONTAINERS }}
           test-group: ${{ matrix.TEST_GROUP }}
-          additional-grep: "(?=.*@webOnly)"
+          additional-grep: ${{ matrix.SMOKE == true && "" || "(?=.*@webOnly)" }}
           currents-project-id: "Og0NOQ"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}

--- a/.github/workflows/test-suite-web-e2e-pr.yml
+++ b/.github/workflows/test-suite-web-e2e-pr.yml
@@ -106,7 +106,7 @@ jobs:
           project: "web"
           containers: ${{ matrix.CONTAINERS }}
           test-group: ${{ matrix.TEST_GROUP }}
-          additional-grep: ${{ matrix.SMOKE && '(?=.*)' || '(?=.*@webOnly)' }}
+          additional-grep: ${{ !matrix.SMOKE && '(?=.*@webOnly)' }}
           currents-project-id: "Og0NOQ"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}

--- a/.github/workflows/test-suite-web-e2e-release.yml
+++ b/.github/workflows/test-suite-web-e2e-release.yml
@@ -37,8 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.load-matrix.outputs.matrix }}
-    needs:
-      - build-web
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/packages/suite-desktop-core/e2e/ci/matrix-base-desktop.yml
+++ b/packages/suite-desktop-core/e2e/ci/matrix-base-desktop.yml
@@ -1,3 +1,6 @@
+- TEST_GROUP: "@group=smoke"
+  CONTAINERS: "trezor-user-env-unix"
+  SMOKE: true
 - TEST_GROUP: "@group=suite"
   CONTAINERS: "trezor-user-env-unix"
 - TEST_GROUP: "@group=device-management"

--- a/packages/suite-desktop-core/e2e/ci/matrix-base-web.yml
+++ b/packages/suite-desktop-core/e2e/ci/matrix-base-web.yml
@@ -1,3 +1,6 @@
+- TEST_GROUP: "@group=smoke"
+  CONTAINERS: "trezor-user-env-unix"
+  SMOKE: true
 - TEST_GROUP: "@group=suite"
   CONTAINERS: "trezor-user-env-unix"
 - TEST_GROUP: "@group=device-management"

--- a/packages/suite-desktop-core/e2e/tests/smoke/wallet-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/smoke/wallet-discovery.test.ts
@@ -5,7 +5,7 @@ test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
     await onboardingPage.completeOnboarding();
     await dashboardPage.discoveryShouldFinish();
 });
-test.describe('Wallet discover tests', { tag: ['@group=wallet'] }, () => {
+test.describe('Wallet discover tests', { tag: ['@group=smoke'] }, () => {
     /**
      * Test case:
      * 1. Discover a standard wallet


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In this PR:
Extract desktop app build and do it only once. 
Share to e2e tests via artifacts.
Added Smoke check group which has the ability to cancel all other test groups if it fails. This is a fail fast strategy, that shortens feedback loop and saves currents reports in case of catastrophically breaking change in Suite.
Profit.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
