### PR TITLE
Enable development on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,11 @@ Welcome to the Trezor Suite repository! This repository contains the source code
 
 # Development
 
-Development is not possible on Windows. This can be circumvented by tools such as [WSL](https://learn.microsoft.com/en-us/windows/wsl/install), see our [guide](https://docs.trezor.io/trezor-suite/misc/development-on-windows.html).
-
 ### Prerequisities
 
--   [NVM](https://github.com/nvm-sh/nvm)
--   [Yarn](https://yarnpkg.com/lang/en/docs/install/)
--   [Git LFS](https://git-lfs.github.com/) (For Linux/Ubuntu, [after adding the repository](https://packagecloud.io/github/git-lfs/install) do `sudo apt-get install git-lfs`, more info [here](https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md))
+-   Install [NVM](https://github.com/nvm-sh/nvm)
+-   Enable [Yarn](https://yarnpkg.com/getting-started/install) through npm
+-   Install [Git LFS](https://git-lfs.github.com/) (For Linux/Ubuntu, [after adding the repository](https://packagecloud.io/github/git-lfs/install) do `sudo apt-get install git-lfs`, more info [here](https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md))
 
 ### Getting started
 
@@ -40,6 +38,9 @@ This repository is used for development of version 9 of @trezor/connect. For det
 Historically, Trezor Connect had its [own repository](https://github.com/trezor/connect). This repository is now archived.
 
 ## **Trezor Suite** @trezor/suite
+
+Dev environment is primarily supported on **macOS or Linux**,
+though development on Windows is possible by following [this guide](https://docs.trezor.io/trezor-suite/misc/development-on-windows.html).
 
 Run a dev build:
 

--- a/docs/misc/development-on-windows.md
+++ b/docs/misc/development-on-windows.md
@@ -1,8 +1,40 @@
 # Development on Windows
 
-Thanks to Windows Subsystem for Linux (WSL), you can run Trezor Suite dev environment on a Windows machine.
+This guide will describe two ways how to run Trezor Suite dev environment & build pipeline on a Windows system:<br>
+[natively on Windows](#native-windows) or [through WSL](#windows-subsystem-for-linux).
 
-## Prerequisites
+## Native Windows
+
+Running the dev environment natively on Windows is not most straightforward, but it should offer best compatibility.
+
+### Prerequisites
+
+-   Install Python either via the [Python for Windows installer](https://www.python.org/downloads/windows/), or from Microsoft Store
+-   Install [latest Visual Studio Community](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community) with C++ build tools
+    -   **Make sure** to install the "Desktop development with C++" workload
+    -   _FYI: it's necessary so that yarn packages with native code can be built, `node-gyp` depends on it: [details](https://github.com/nodejs/node-gyp?tab=readme-ov-file#on-windows)_
+-   Install [git](https://git-scm.com/downloads/win) using the installer and make sure to include git bash for Windows
+-   Install nodeJS version as per [.nvmrc](https://github.com/trezor/trezor-suite/blob/develop/.nvmrc)
+    -   You may use nvm, but it's not officially supported on Windows; manual nodeJS installation will work
+-   Enable [Yarn](https://yarnpkg.com/getting-started/install) through npm
+-   Install [Git LFS](https://git-lfs.com/)
+-   It is **imperative** that all further commands are run in bash for Windows, **not** in cmd or powershell!
+    -   Especially, do not run any `yarn` command in a shell other than bash for Windows. If you have done so, delete `node_modules` and start over.
+
+### Setup
+
+-   Proceed with the [Getting Started instructions in README](https://github.com/trezor/trezor-suite/blob/develop/README.md#getting-started).
+    -   _(except possibly the `nvm` step, depending on your choice)_
+
+### Tips
+
+-   Exclude the `trezor-suite` folder from Windows Defender, as it may slow down the build process considerably
+
+## Windows Subsystem for Linux
+
+⚠ Using WSL is a more sandboxed way to run the dev env, but note that it is **not** actively maintained, and not all features may work.
+
+### Setup
 
 On Windows:
 
@@ -15,11 +47,9 @@ In WSL:
 -   Install these [Electron dependencies](https://www.electronjs.org/docs/latest/development/build-instructions-linux) for Linux
 -   Install udev rules [as per the Trezor docs](https://trezor.io/learn/a/udev-rules)
 
-## Setup
+Then proceed with the [Getting Started instructions in README](https://github.com/trezor/trezor-suite/blob/develop/README.md#getting-started).
 
-Proceed with the [general readme instructions](../../README.md#trezor-suite-trezorsuite).
-
-## Connecting USB device
+#### Connecting USB device
 
 On Windows, run `usbipd list`, find the bus id of the Trezor device, e.g. `2-1`.
 

--- a/packages/env-utils/src/envUtils.ts
+++ b/packages/env-utils/src/envUtils.ts
@@ -71,14 +71,14 @@ const getProcessPlatform = () => (typeof process !== 'undefined' ? process.platf
 
 const isMacOs = () => {
     if (getProcessPlatform() === 'darwin') return true;
-    if (typeof window === 'undefined') return;
+    if (typeof window === 'undefined') return false;
 
     return getPlatform().toLowerCase().startsWith('mac');
 };
 
 const isWindows = () => {
     if (getProcessPlatform() === 'win32') return true;
-    if (typeof window === 'undefined') return;
+    if (typeof window === 'undefined') return false;
 
     return getPlatform().toLowerCase().startsWith('win');
 };
@@ -87,7 +87,7 @@ const isIOs = () => ['iPhone', 'iPad', 'iPod'].includes(getPlatform());
 
 const isLinux = () => {
     if (getProcessPlatform() === 'linux') return true;
-    if (typeof window === 'undefined') return;
+    if (typeof window === 'undefined') return false;
 
     // exclude Android and Chrome OS as window.navigator.platform of those OS is Linux
     if (isAndroid() || isChromeOs()) return false;

--- a/packages/env-utils/src/types.ts
+++ b/packages/env-utils/src/types.ts
@@ -24,10 +24,10 @@ export interface EnvUtils {
     getLocationOrigin: () => string;
     getLocationHostname: () => string;
     getProcessPlatform: () => string;
-    isMacOs: () => boolean | undefined;
-    isWindows: () => boolean | undefined;
+    isMacOs: () => boolean;
+    isWindows: () => boolean;
     isIOs: () => boolean;
-    isLinux: () => boolean | undefined;
+    isLinux: () => boolean;
     isCodesignBuild: () => boolean;
     getOsName: () => '' | 'android' | 'linux' | 'windows' | 'macos' | 'chromeos' | 'ios';
     getOsNameWeb: () => string | undefined;

--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -135,7 +135,8 @@ const config: webpack.Configuration = {
             },
             // This worker loader is used for suite-desktop
             {
-                test: /\/workers\/[^/]+\/index\.ts$/,
+                // during compilation, it matches the worker file name both with Unix and Windows paths
+                test: /[/\\]workers[/\\][^/\\]+[/\\]index\.ts$/,
                 use: [
                     {
                         loader: 'worker-loader',

--- a/packages/suite-build/package.json
+++ b/packages/suite-build/package.json
@@ -25,6 +25,7 @@
     "dependencies": {
         "@suite-common/suite-config": "workspace:*",
         "@trezor/bundler-security": "workspace:*",
+        "@trezor/env-utils": "workspace:*",
         "@trezor/suite": "workspace:*",
         "babel-loader": "^9.1.3",
         "babel-plugin-styled-components": "^2.1.4",

--- a/packages/suite-build/plugins/shell-spawn-plugin.ts
+++ b/packages/suite-build/plugins/shell-spawn-plugin.ts
@@ -1,6 +1,8 @@
 import { spawn, spawnSync } from 'child_process';
 import webpack from 'webpack';
 
+import { isWindows } from '@trezor/env-utils';
+
 interface Command {
     command: string;
     args: string[];
@@ -31,10 +33,20 @@ class ShellSpawnPlugin {
         compiler.hooks.afterEmit.tap('ShellSpawnPlugin', (_: webpack.Compilation) => {
             const execute = ({ command, args, isSync }: Command) => {
                 if (isSync) {
-                    return spawnSync(command, args, { stdio: 'inherit', cwd: this.options.cwd });
+                    return spawnSync(command, args, {
+                        stdio: 'inherit',
+                        cwd: this.options.cwd,
+                        // on Unix systems, the compile process doesn't need direct shell access, as it recognizes `yarn` executable in PATH and can call it directly
+                        // but it's a common issue on Windows that nodeJS can't access `yarn` and needs to use shell at CWD to run commands through it
+                        shell: isWindows(),
+                    });
                 }
 
-                return spawn(command, args, { stdio: 'inherit', cwd: this.options.cwd });
+                return spawn(command, args, {
+                    stdio: 'inherit',
+                    cwd: this.options.cwd,
+                    shell: isWindows(), // see spawnSync above
+                });
             };
 
             if (!this.initialRun) {

--- a/packages/suite-build/tsconfig.json
+++ b/packages/suite-build/tsconfig.json
@@ -7,6 +7,7 @@
             "path": "../../suite-common/suite-config"
         },
         { "path": "../bundler-security" },
+        { "path": "../env-utils" },
         { "path": "../suite" },
         { "path": "../eslint" }
     ]

--- a/packages/suite-desktop-core/webpack/core.webpack.config.ts
+++ b/packages/suite-desktop-core/webpack/core.webpack.config.ts
@@ -43,9 +43,14 @@ const source = path.join(__dirname, '..', 'src');
 const dist = path.join(__dirname, '../../suite-desktop/dist');
 
 const threadPath = path.join(source, 'threads');
-const threads = sync(`${threadPath}/**/*.ts`).map(
-    u => `threads${u.replace(threadPath, '').replace('.ts', '')}`,
-);
+const threads = sync(`${threadPath}/**/*.ts`).map(globMatch => {
+    // glob sync has non-standard output on Windows,
+    // so we need to process the glob matches with node.path to normalize them both for Unix & Windows
+    const absPath = path.resolve(globMatch);
+    const relPath = path.relative(threadPath, absPath);
+
+    return path.join(`threads`, relPath.replace('.ts', ''));
+});
 
 /* **** EXTERNALS **** */
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12208,6 +12208,7 @@ __metadata:
     "@sentry/webpack-plugin": "npm:^2.22.7"
     "@suite-common/suite-config": "workspace:*"
     "@trezor/bundler-security": "workspace:*"
+    "@trezor/env-utils": "workspace:*"
     "@trezor/eslint": "workspace:*"
     "@trezor/suite": "workspace:*"
     "@types/copy-webpack-plugin": "npm:^10.1.0"


### PR DESCRIPTION
## Description

Fix three issues that were blocking development on Windows and update the docs :books: 
Solved together with @peter-sanderson :muscle:

I have tested the following both on Linux & Windows:
- `yarn suite:dev`
- `yarn suite:dev:desktop`, especially testing:
  - Dashboard graph
  - tor + that feature which shall not be named
  - labeling (local)
  - FW update on physical Trezor
- local build

## Related Issue

Resolve #17784