### PR TITLE
feat(connect-webextension): enable switching between multiple implementations

### DIFF
--- a/packages/connect-explorer/src/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/actions/trezorConnectActions.ts
@@ -173,6 +173,7 @@ export const init =
             if (connectOptions.coreMode === 'deeplink') {
                 await TrezorConnectMobile.init({
                     ...connectOptions,
+                    coreMode: 'deeplink',
                     deeplinkOpen(url) {
                         window.open(url, '_blank');
                     },

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -34,20 +34,17 @@
         "build:content-script": "TS_NODE_PROJECT=\"tsconfig.lib.json\" webpack --config ./webpack/content-script.webpack.config.ts",
         "build:inline": "TS_NODE_PROJECT=\"tsconfig.lib.json\" webpack --config ./webpack/inline.webpack.config.ts",
         "build": "yarn g:rimraf build && yarn build:content-script && yarn build:inline && node ./webpack/inline-content-script.js",
-        "prepublish": "yarn build"
+        "prepublish": "yarn build",
+        "depcheck": "yarn g:depcheck",
+        "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
         "@trezor/connect": "workspace:*",
-        "@trezor/connect-common": "workspace:*",
-        "@trezor/connect-web": "workspace:*",
-        "@trezor/utils": "workspace:*",
-        "events": "^3.3.0"
+        "@trezor/connect-web": "workspace:*"
     },
     "devDependencies": {
         "@babel/preset-typescript": "^7.24.7",
         "@trezor/eslint": "workspace:*",
-        "@trezor/node-utils": "workspace:*",
-        "@trezor/trezor-user-env-link": "workspace:*",
         "@types/chrome": "^0.0.299",
         "babel-loader": "^9.1.3",
         "copy-webpack-plugin": "^12.0.2",
@@ -57,8 +54,7 @@
         "webpack-cli": "^5.1.4",
         "webpack-merge": "^6.0.1",
         "webpack-plugin-serve": "^1.6.0",
-        "worker-loader": "^3.0.8",
-        "xvfb-maybe": "^0.2.1"
+        "worker-loader": "^3.0.8"
     },
     "peerDependencies": {
         "tslib": "^2.6.2"

--- a/packages/connect-webextension/src/impl.ts
+++ b/packages/connect-webextension/src/impl.ts
@@ -1,0 +1,50 @@
+import { InitFullSettings } from '@trezor/connect/src/types/api/init';
+import { initLog } from '@trezor/connect/src/utils/debug';
+import { CoreInPopup } from '@trezor/connect-web/src/impl/core-in-popup';
+import { CoreInSuiteDesktop } from '@trezor/connect-web/src/impl/core-in-suite-desktop';
+
+import { parseConnectSettings } from './connectSettings';
+import { ConnectSettingsWebextension } from './proxy';
+
+const extendLifetime = () => {
+    // Subscribing to runtime makes the Service Worker stay alive for 5 minutes instead of the default 30 seconds.
+    // We could make it to be continuously alive but it is probably overkilling.
+    // https://developer.chrome.com/blog/longer-esw-lifetimes
+    // https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers#keep-sw-alive
+    // https://stackoverflow.com/questions/66618136/persistent-service-worker-in-chrome-extension
+    chrome.runtime.onMessage.addListener(() => false);
+};
+
+export class CoreInPopupWebextension extends CoreInPopup {
+    public constructor() {
+        super();
+        this._settings = parseConnectSettings();
+
+        /**
+         * setup logger.
+         * service worker cant communicate directly with sharedworker logger so the communication is as follows:
+         * - service worker -> content script -> popup -> sharedworker
+         * todo: this could be simplified by injecting additional content script into log.html
+         */
+        this.logger = initLog('@trezor/connect-webextension');
+        this.popupManagerLogger = initLog('@trezor/connect-webextension/popupManager');
+    }
+
+    public init(settings: InitFullSettings<ConnectSettingsWebextension>): Promise<void> {
+        if (settings._extendWebextensionLifetime) {
+            extendLifetime();
+        }
+
+        return super.init(settings);
+    }
+}
+
+export class CoreInSuiteDesktopWebextension extends CoreInSuiteDesktop {
+    public init(settings: InitFullSettings<ConnectSettingsWebextension>): Promise<void> {
+        if (settings._extendWebextensionLifetime) {
+            extendLifetime();
+        }
+
+        return super.init(settings);
+    }
+}

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -1,66 +1,76 @@
 // NOTE: @trezor/connect part is intentionally not imported from the index so we do include the whole library.
 import {
     ConnectSettings,
+    ConnectSettingsPublic,
     ConnectSettingsWebextension,
     Manifest,
     POPUP,
 } from '@trezor/connect/src/exports';
-import { factory } from '@trezor/connect/src/factory';
-import { InitFullSettings } from '@trezor/connect/src/types/api/init';
-import { initLog } from '@trezor/connect/src/utils/debug';
+import { ConnectFactoryDependencies, factory } from '@trezor/connect/src/factory';
+import { TrezorConnectDynamic } from '@trezor/connect/src/impl/dynamic';
 // Import as src not lib due to webpack issues with inlining content script later
 import { ServiceWorkerWindowChannel } from '@trezor/connect-web/src/channels/serviceworker-window';
-import { CoreInPopup } from '@trezor/connect-web/src/impl/core-in-popup';
 
 import { parseConnectSettings } from './connectSettings';
+import { CoreInPopupWebextension, CoreInSuiteDesktopWebextension } from './impl';
 
 const _settings = parseConnectSettings();
 
-const extendLifetime = () => {
-    // Subscribing to runtime makes the Service Worker stay alive for 5 minutes instead of the default 30 seconds.
-    // We could make it to be continuously alive but it is probably overkilling.
-    // https://developer.chrome.com/blog/longer-esw-lifetimes
-    // https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers#keep-sw-alive
-    // https://stackoverflow.com/questions/66618136/persistent-service-worker-in-chrome-extension
-    chrome.runtime.onMessage.addListener(() => false);
-};
+const impl = new TrezorConnectDynamic<
+    'core-in-popup' | 'core-in-suite-desktop',
+    ConnectSettingsWebextension,
+    ConnectFactoryDependencies<ConnectSettingsWebextension>
+>({
+    implementations: [
+        {
+            type: 'core-in-popup',
+            impl: new CoreInPopupWebextension(),
+        },
+        {
+            type: 'core-in-suite-desktop',
+            impl: new CoreInSuiteDesktopWebextension(),
+        },
+    ],
+    getInitTarget: (settings: Partial<ConnectSettingsPublic & ConnectSettingsWebextension>) => {
+        if (settings.coreMode === 'suite-desktop') {
+            return 'core-in-suite-desktop';
+        } else {
+            return 'core-in-popup';
+        }
+    },
+    handleBeforeCall: async () => {
+        // Always try if desktop is available again
+        const isCoreModeDesktop = impl.lastSettings?.coreMode === 'suite-desktop';
+        if (isCoreModeDesktop) {
+            await impl.switchTarget('core-in-suite-desktop');
+        }
+    },
+    handleErrorFallback: async errorCode => {
+        // Handle desktop errors
+        if (
+            impl.getTargetType() === 'core-in-suite-desktop' &&
+            errorCode === 'Desktop_ConnectionMissing'
+        ) {
+            await impl.switchTarget('core-in-popup');
 
-class CoreInPopupWebextension extends CoreInPopup {
-    public constructor() {
-        super();
-        this._settings = parseConnectSettings();
-
-        /**
-         * setup logger.
-         * service worker cant communicate directly with sharedworker logger so the communication is as follows:
-         * - service worker -> content script -> popup -> sharedworker
-         * todo: this could be simplified by injecting additional content script into log.html
-         */
-        this.logger = initLog('@trezor/connect-webextension');
-        this.popupManagerLogger = initLog('@trezor/connect-webextension/popupManager');
-    }
-
-    public init(settings: InitFullSettings<ConnectSettingsWebextension>): Promise<void> {
-        if (settings._extendWebextensionLifetime) {
-            extendLifetime();
+            return true;
         }
 
-        return super.init(settings);
-    }
-}
+        return false;
+    },
+});
 
-const methods = new CoreInPopupWebextension();
 // Bind all methods due to shadowing `this`
 const TrezorConnect = factory({
-    eventEmitter: methods.eventEmitter,
-    init: methods.init.bind(methods),
-    call: methods.call.bind(methods),
-    setTransports: methods.setTransports.bind(methods),
-    manifest: methods.manifest.bind(methods),
-    requestLogin: methods.requestLogin.bind(methods),
-    uiResponse: methods.uiResponse.bind(methods),
-    cancel: methods.cancel.bind(methods),
-    dispose: methods.dispose.bind(methods),
+    eventEmitter: impl.eventEmitter,
+    init: impl.init.bind(impl),
+    call: impl.call.bind(impl),
+    setTransports: impl.setTransports.bind(impl),
+    manifest: impl.manifest.bind(impl),
+    requestLogin: impl.requestLogin.bind(impl),
+    uiResponse: impl.uiResponse.bind(impl),
+    cancel: impl.cancel.bind(impl),
+    dispose: impl.dispose.bind(impl),
 });
 
 const initProxyChannel = () => {
@@ -93,16 +103,18 @@ const initProxyChannel = () => {
         }
 
         // Core is loaded in popup and initialized every time, so we send the settings from here.
-        TrezorConnect.init(proxySettings as { manifest: Manifest } & Partial<ConnectSettings>).then(
-            () => {
-                (TrezorConnect as any)[method](payload).then((response: any) => {
-                    channel.postMessage({
-                        ...response,
-                        id,
-                    });
+        TrezorConnect.init(
+            proxySettings as { manifest: Manifest } & Partial<
+                ConnectSettingsPublic & ConnectSettingsWebextension
+            >,
+        ).then(() => {
+            (TrezorConnect as any)[method](payload).then((response: any) => {
+                channel.postMessage({
+                    ...response,
+                    id,
                 });
-            },
-        );
+            });
+        });
     });
 };
 

--- a/packages/connect-webextension/tsconfig.json
+++ b/packages/connect-webextension/tsconfig.json
@@ -8,11 +8,7 @@
     "include": ["**/*.ts", "**/*.js"],
     "references": [
         { "path": "../connect" },
-        { "path": "../connect-common" },
         { "path": "../connect-web" },
-        { "path": "../utils" },
-        { "path": "../eslint" },
-        { "path": "../node-utils" },
-        { "path": "../trezor-user-env-link" }
+        { "path": "../eslint" }
     ]
 }

--- a/packages/connect-webextension/tsconfig.lib.json
+++ b/packages/connect-webextension/tsconfig.lib.json
@@ -10,22 +10,10 @@
             "path": "../connect"
         },
         {
-            "path": "../connect-common"
-        },
-        {
             "path": "../connect-web"
         },
         {
-            "path": "../utils"
-        },
-        {
             "path": "../eslint"
-        },
-        {
-            "path": "../node-utils"
-        },
-        {
-            "path": "../trezor-user-env-link"
         }
     ]
 }

--- a/packages/connect/src/data/connectSettings.ts
+++ b/packages/connect/src/data/connectSettings.ts
@@ -133,7 +133,7 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
 
     if (
         typeof input.coreMode === 'string' &&
-        ['auto', 'popup', 'iframe'].includes(input.coreMode)
+        ['auto', 'popup', 'iframe', 'suite-desktop'].includes(input.coreMode)
     ) {
         settings.coreMode = input.coreMode;
     }

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -65,15 +65,21 @@ export interface ConnectSettingsWeb {
 export interface ConnectSettingsWebextension {
     /** _extendWebextensionLifetime features makes the service worker in @trezor/connect-webextension stay alive longer */
     _extendWebextensionLifetime?: boolean;
+    coreMode?: 'auto' | 'popup' | 'suite-desktop';
 }
 export interface ConnectSettingsMobile {
     deeplinkUrl: string;
     deeplinkOpen?: (url: string) => void;
     deeplinkCallbackUrl?: string;
+    coreMode?: 'deeplink';
 }
 
 export type ConnectSettings = ConnectSettingsPublic &
     ConnectSettingsInternal &
-    ConnectSettingsWeb &
-    ConnectSettingsWebextension &
-    ConnectSettingsMobile;
+    // coreMode is a common parameter between these, so it is explicitly handled here for correct handling
+    Omit<ConnectSettingsWeb & ConnectSettingsWebextension & ConnectSettingsMobile, 'coreMode'> & {
+        coreMode?:
+            | ConnectSettingsWeb['coreMode']
+            | ConnectSettingsWebextension['coreMode']
+            | ConnectSettingsMobile['coreMode'];
+    };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11971,16 +11971,11 @@ __metadata:
   dependencies:
     "@babel/preset-typescript": "npm:^7.24.7"
     "@trezor/connect": "workspace:*"
-    "@trezor/connect-common": "workspace:*"
     "@trezor/connect-web": "workspace:*"
     "@trezor/eslint": "workspace:*"
-    "@trezor/node-utils": "workspace:*"
-    "@trezor/trezor-user-env-link": "workspace:*"
-    "@trezor/utils": "workspace:*"
     "@types/chrome": "npm:^0.0.299"
     babel-loader: "npm:^9.1.3"
     copy-webpack-plugin: "npm:^12.0.2"
-    events: "npm:^3.3.0"
     rimraf: "npm:^6.0.1"
     terser-webpack-plugin: "npm:^5.3.14"
     webpack: "npm:^5.97.1"
@@ -11988,7 +11983,6 @@ __metadata:
     webpack-merge: "npm:^6.0.1"
     webpack-plugin-serve: "npm:^1.6.0"
     worker-loader: "npm:^3.0.8"
-    xvfb-maybe: "npm:^0.2.1"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown


### PR DESCRIPTION
## Description

Enable switching between different implementations in `connect-webextension`

This brings support for `coreMode: 'suite-desktop'`