### PR TITLE
feat(suite-desktop): open bluetooth permissions settings

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -107,7 +107,7 @@ export interface InvokeChannels {
     'connect-popup/enabled': () => boolean;
     'connect-popup/ready': () => void;
     'connect-popup/response': (response: ConnectPopupResponse) => void;
-    'system/open-settings': (settings: 'bluetooth') => InvokeResult;
+    'system/open-settings': (settings: string) => InvokeResult;
 }
 
 type DesktopApiListener = ListenerMethod<RendererChannels>;

--- a/packages/suite-desktop-core/src/modules/system-settings.ts
+++ b/packages/suite-desktop-core/src/modules/system-settings.ts
@@ -45,10 +45,24 @@ const openBluetoothSettings = () => {
     return { success: false, error: 'Unsupported os' };
 };
 
+const openBluetoothPermissions = () => {
+    // Settings > Privacy and security > Bluetooth
+    if (isMacOs()) {
+        return openSettings(
+            'open "x-apple.systempreferences:com.apple.preference.security?Privacy_Bluetooth"',
+        );
+    }
+
+    return { success: false, error: 'Unsupported os' };
+};
+
 export const init: ModuleInit = () => {
     ipcMain.handle('system/open-settings', (_, settings) => {
         if (settings === 'bluetooth') {
             return openBluetoothSettings();
+        }
+        if (settings === 'bluetooth-permissions') {
+            return openBluetoothPermissions();
         }
 
         return { success: false, error: `Unknown settings: ${settings}` };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Continuation of https://github.com/trezor/trezor-suite/pull/17017 relevant only for macos, similar could be used to open declined camera

if bluetooth permissions is declined
Open `Settings > Privacy and security > Bluetooth` and grant permissions manually

im changing desktop-api type from literal to `string` so we dont have to type it one place to use it in other place,
string value validation is done in ipcMain.handle