### PR TITLE
feat(github): move staging percentage logic outside main production r…

### DIFF
--- a/.github/workflows/release-suite-desktop-web-production-rollout.yml
+++ b/.github/workflows/release-suite-desktop-web-production-rollout.yml
@@ -1,0 +1,43 @@
+name: "[Release] amend suite-desktop staging percentage"
+
+permissions:
+  id-token: write # for fetching the OIDC token
+  contents: read # for actions/checkout
+
+on:
+  workflow_dispatch:
+    inputs:
+      setStagingPercentage:
+        description: "Number between 0 and 100."
+        required: true
+        type: string
+
+jobs:
+  update-prod-staging-percentage:
+    if: ${{ github.repository == 'trezor/trezor-suite-release' }}
+    name: "Update staging percentage"
+    environment: suite-production
+    runs-on: trezor-suite-release-runners
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::538326561891:role/gh_actions_suite_production
+          aws-region: eu-central-1
+
+      - name: Update staging percentage
+        run: |
+          aws s3 cp s3://data.trezor.io/suite/releases/desktop/latest/latest.yml .
+          aws s3 cp s3://data.trezor.io/suite/releases/desktop/latest/latest-mac.yml .
+          aws s3 cp s3://data.trezor.io/suite/releases/desktop/latest/latest-linux.yml .
+          aws s3 cp s3://data.trezor.io/suite/releases/desktop/latest/latest-linux-arm64.yml .
+          ./scripts/ci/set-staging-percentage.sh ${{ github.event.inputs.setStagingPercentage }}
+          aws s3 cp latest.yml s3://data.trezor.io/suite/releases/desktop/latest/latest.yml
+          aws s3 cp latest-mac.yml s3://data.trezor.io/suite/releases/desktop/latest/latest-mac.yml
+          aws s3 cp latest-linux.yml s3://data.trezor.io/suite/releases/desktop/latest/latest-linux.yml
+          aws s3 cp latest-linux-arm64.yml s3://data.trezor.io/suite/releases/desktop/latest/latest-linux-arm64.yml
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation --distribution-id E1ERY5K2OTKKI1 --paths "/suite/releases/desktop/latest/*"

--- a/.github/workflows/release-suite-desktop-web-production.yml
+++ b/.github/workflows/release-suite-desktop-web-production.yml
@@ -24,15 +24,6 @@ on:
         options:
           - canary
           - latest
-      updateStagingPercentage:
-        description: "Suite desktop auto-update percentage"
-        required: false
-        type: boolean
-        default: false
-      setStagingPercentage:
-        description: "Number between 0 and 100."
-        required: false
-        type: string
 
 jobs:
   sync-canary-suite-desktop:
@@ -87,32 +78,3 @@ jobs:
         run: |
           aws s3 sync s3://staging-suite.trezor.io s3://suite.trezor.io
           aws cloudfront create-invalidation --distribution-id E4TDVEWU4P4CY --paths "/*"
-
-  update-prod-staging-percentage:
-    if: ${{ github.event.inputs.updateStagingPercentage == 'true' && github.repository == 'trezor/trezor-suite-release' }}
-    name: "Update staging percentage"
-    environment: suite-production
-    runs-on: trezor-suite-release-runners
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::538326561891:role/gh_actions_suite_production
-          aws-region: eu-central-1
-
-      - name: Update staging percentage
-        run: |
-          aws s3 cp s3://data.trezor.io/suite/releases/desktop/latest/latest.yml .
-          aws s3 cp s3://data.trezor.io/suite/releases/desktop/latest/latest-mac.yml .
-          aws s3 cp s3://data.trezor.io/suite/releases/desktop/latest/latest-linux.yml .
-          aws s3 cp s3://data.trezor.io/suite/releases/desktop/latest/latest-linux-arm64.yml .
-          ./scripts/ci/set-staging-percentage.sh ${{ github.event.inputs.setStagingPercentage }}
-          aws s3 cp latest.yml s3://data.trezor.io/suite/releases/desktop/latest/latest.yml
-          aws s3 cp latest-mac.yml s3://data.trezor.io/suite/releases/desktop/latest/latest-mac.yml
-          aws s3 cp latest-linux.yml s3://data.trezor.io/suite/releases/desktop/latest/latest-linux.yml
-          aws s3 cp latest-linux-arm64.yml s3://data.trezor.io/suite/releases/desktop/latest/latest-linux-arm64.yml
-      - name: Invalidate CloudFront cache
-        run: |
-          aws cloudfront create-invalidation --distribution-id E1ERY5K2OTKKI1 --paths "/suite/releases/desktop/latest/*"


### PR DESCRIPTION
This pull request introduces a new workflow for managing the suite-desktop staging percentage and removes the corresponding functionality from the existing workflow. The most important changes include adding a new workflow file and removing the related job and inputs from the existing workflow file.

New workflow for managing staging percentage:

* Added a new workflow file `.github/workflows/release-suite-desktop-web-production-rollout.yml` to handle the staging percentage updates for the suite-desktop. This workflow includes permissions, inputs, and jobs for checking out the repository, configuring AWS credentials, updating the staging percentage, and invalidating the CloudFront cache.

Modifications to existing workflow:

* Removed the `updateStagingPercentage` and `setStagingPercentage` inputs from the existing workflow file `.github/workflows/release-suite-desktop-web-production.yml`.
* Removed the `update-prod-staging-percentage` job from the existing workflow file `.github/workflows/release-suite-desktop-web-production.yml`. This job included steps for checking out the repository, configuring AWS credentials, updating the staging percentage, and invalidating the CloudFront cache.