### PR TITLE
@trezor/websocket-client tuning

### DIFF
--- a/packages/blockchain-link/src/workers/baseWebsocket.ts
+++ b/packages/blockchain-link/src/workers/baseWebsocket.ts
@@ -37,7 +37,7 @@ export abstract class BaseWebsocket<T extends Record<string, any>> extends Webso
         });
     }
 
-    protected sendMessage(message: WebsocketRequest) {
+    sendMessage(message: WebsocketRequest) {
         return super.sendMessage(message).catch(error => {
             throw new CustomError(error.message);
         });

--- a/packages/trezor-user-env-link/src/websocket-client.ts
+++ b/packages/trezor-user-env-link/src/websocket-client.ts
@@ -38,10 +38,6 @@ interface WebsocketResponse {
 }
 
 export class WebsocketClient extends WebsocketClientBase<WebsocketClientEvents> {
-    protected createWebsocket() {
-        return this.initWebsocket(this.options);
-    }
-
     protected ping() {
         return this.send({ type: 'ping' });
     }

--- a/packages/trezor-user-env-link/src/websocket-client.ts
+++ b/packages/trezor-user-env-link/src/websocket-client.ts
@@ -38,10 +38,6 @@ interface WebsocketResponse {
 }
 
 export class WebsocketClient extends WebsocketClientBase<WebsocketClientEvents> {
-    protected ping() {
-        return this.send({ type: 'ping' });
-    }
-
     constructor(options: any = {}) {
         super({
             ...options,

--- a/packages/websocket-client/src/client.ts
+++ b/packages/websocket-client/src/client.ts
@@ -39,7 +39,7 @@ export abstract class WebsocketClient<Events extends Record<string, any>> extend
     private pingTimeout?: ReturnType<typeof setTimeout>;
     private connectPromise?: Promise<void>;
 
-    protected abstract createWebsocket(): WebSocket;
+    protected createWebsocket?(): WebSocket;
     protected abstract ping(): Promise<unknown>;
 
     constructor(options: Options) {
@@ -161,7 +161,7 @@ export abstract class WebsocketClient<Events extends Record<string, any>> extend
         const dfd = createDeferred();
         this.connectPromise = dfd.promise;
 
-        const ws = this.createWebsocket();
+        const ws = this.createWebsocket ? this.createWebsocket() : this.initWebsocket(this.options);
 
         // set connection timeout before WebSocket initialization
         const connectionTimeout = setTimeout(

--- a/packages/websocket-client/src/client.ts
+++ b/packages/websocket-client/src/client.ts
@@ -27,7 +27,7 @@ type WebsocketClientEvents = {
 export type WebsocketRequest = Record<string, any>;
 export type WebsocketResponse = WebSocket.Data;
 
-export abstract class WebsocketClient<Events extends Record<string, any>> extends TypedEmitter<
+export class WebsocketClient<Events extends Record<string, any>> extends TypedEmitter<
     Events & WebsocketClientEvents
 > {
     readonly options: Options;
@@ -40,7 +40,9 @@ export abstract class WebsocketClient<Events extends Record<string, any>> extend
     private connectPromise?: Promise<void>;
 
     protected createWebsocket?(): WebSocket;
-    protected abstract ping(): Promise<unknown>;
+    protected ping() {
+        return this.sendMessage({ type: 'ping' });
+    }
 
     constructor(options: Options) {
         super();

--- a/packages/websocket-client/src/client.ts
+++ b/packages/websocket-client/src/client.ts
@@ -94,10 +94,10 @@ export class WebsocketClient<Events extends Record<string, any>> extends TypedEm
         this.onClose();
     }
 
-    protected sendMessage(message: WebsocketRequest) {
+    sendMessage(message: WebsocketRequest, { timeout }: { timeout?: number } = {}) {
         const { ws } = this;
         if (!ws || !this.isConnected()) throw new Error('websocket_not_initialized');
-        const { promiseId, promise } = this.messages.create();
+        const { promiseId, promise } = this.messages.create(timeout);
 
         const req = { id: promiseId.toString(), ...message };
 

--- a/packages/websocket-client/tests/client.test.ts
+++ b/packages/websocket-client/tests/client.test.ts
@@ -3,9 +3,6 @@ import { ServerOptions, WebSocket } from 'ws';
 import { WebsocketClient } from '../src/client';
 
 class Client extends WebsocketClient<{ 'foo-event': 'bar-event' }> {
-    createWebsocket() {
-        return this.initWebsocket(this.options);
-    }
     ping() {
         return this.sendMessage({ method: 'ping' });
     }


### PR DESCRIPTION
couple of minor changes needed for #17786  - this makes it possible to use the @trezor/websocket-client package directly without creating an intermediary subclass