### PR TITLE
chore(suite-native): add node-gyp to main dev dependencies to satisfy sharp build

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
         "jest-expo": "^52.0.1",
         "metro-react-native-babel-preset": "0.77.0",
         "node-fetch": "^2.6.4",
+        "node-gyp": "10.2.0",
         "nx": "^18.0.3",
         "patch-package": "8.0.0",
         "prettier": "^3.3.2",

--- a/scripts/list-outdated-dependencies/common-dependencies.txt
+++ b/scripts/list-outdated-dependencies/common-dependencies.txt
@@ -56,6 +56,7 @@ jest-watch-typeahead
 jsdom
 minimatch
 node-fetch
+node-gyp
 nx
 octokit
 patch-package

--- a/yarn.lock
+++ b/yarn.lock
@@ -40257,6 +40257,7 @@ __metadata:
     jest-expo: "npm:^52.0.1"
     metro-react-native-babel-preset: "npm:0.77.0"
     node-fetch: "npm:^2.6.4"
+    node-gyp: "npm:10.2.0"
     nx: "npm:^18.0.3"
     patch-package: "npm:8.0.0"
     prettier: "npm:^3.3.2"


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

iOS builds started failing after dependencies update; this seems to satisfy the build process of sharp and shouldn’t cause any issues, as we already have this version of node-gyp specified in resolutions anyway.

Example of failing build on develop: https://expo.dev/accounts/trezorcompany/projects/trezor-suite-develop/builds/7c5cca20-8b58-42bc-8b24-8964a9d98b05

Adhoc build with this change applied: https://expo.dev/accounts/trezorcompany-develop/projects/trezor-suite-preview/builds/5b348c4d-e0b9-4713-85e4-dce9b39ee483 

