### PR TITLE
packages/websocket-client nitpicks

### DIFF
--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -40,7 +40,7 @@
     ],
     "scripts": {
         "depcheck": "yarn g:depcheck",
-        "test:unit": "jest -c ../../jest.config.base.js",
+        "test:unit": "yarn g:jest -c ../../jest.config.base.js",
         "type-check": "yarn g:tsc --build",
         "build:lib": "yarn g:rimraf lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/replace-imports.sh ./lib",
         "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",

--- a/packages/websocket-client/src/client.ts
+++ b/packages/websocket-client/src/client.ts
@@ -32,7 +32,7 @@ export class WebsocketClient<Events extends Record<string, any>> extends TypedEm
 > {
     readonly options: Options;
 
-    public readonly messages;
+    protected readonly messages;
     private readonly emitter: TypedEmitter<WebsocketClientEvents> = this;
 
     private ws?: WebSocket;

--- a/packages/websocket-client/tests/client.test.ts
+++ b/packages/websocket-client/tests/client.test.ts
@@ -2,14 +2,7 @@ import { ServerOptions, WebSocket } from 'ws';
 
 import { WebsocketClient } from '../src/client';
 
-class Client extends WebsocketClient<{ 'foo-event': 'bar-event' }> {
-    ping() {
-        return this.sendMessage({ method: 'ping' });
-    }
-    sendMessage(message: Record<string, any>) {
-        return super.sendMessage(message);
-    }
-}
+class Client extends WebsocketClient<{ 'foo-event': 'bar-event' }> {}
 
 class Server extends WebSocket.Server {
     private _url: string;
@@ -95,6 +88,7 @@ describe('WebsocketClient', () => {
         jest.useFakeTimers();
 
         const cli = new Client({ url: server.getUrl(), pingTimeout: 5000 });
+        // @ts-expect-error ping is protected
         const pingSpy = jest.spyOn(cli, 'ping');
         await cli.connect();
 
@@ -112,7 +106,7 @@ describe('WebsocketClient', () => {
     });
 
     it('reconnect with sync disconnect()', async () => {
-        const cli = new Client({ url: server.getUrl() });
+        const cli = new WebsocketClient({ url: server.getUrl() });
         await cli.connect();
         cli.disconnect(); // NOTE: intentionally not awaited
         await cli.connect();


### PR DESCRIPTION
- field privatization
- unify script command in packages.json to allow `yarn workspace @trezor/websocket-client test:unit` 
- remove unneeded intermediary class in tests