### PR TITLE
feat(suite): suite debug mode controls connect debug mode

### DIFF
--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -113,7 +113,6 @@ Available flags:
 | `--log-file=FILENAME`         | Name of the output file (defaults to `trezor-suite-log-%tt.txt`)                                                                                                                       |
 | `--log-path=PATHNAME`         | Path for the output file (defaults to `/logs` subfolder of Suite data directory or current working directory)                                                                          |
 | `--log-no-print`              | Suppress console logs                                                                                                                                                                  |
-| `--log-connect`               | Enable logs also from Connect                                                                                                                                                          |
 | `--remove-user-data-on-start` | Removes user data directory on start (used for E2E testing)                                                                                                                            |
 | `--expose-connect-ws`         | Expose Connect websocket even on production build                                                                                                                                      |
 

--- a/packages/suite-desktop-core/src/libs/process-switches.ts
+++ b/packages/suite-desktop-core/src/libs/process-switches.ts
@@ -17,7 +17,6 @@ export type SuiteSwitch =
     | 'log-file'
     | 'log-path'
     | 'log-no-print'
-    | 'log-connect'
     | 'remove-user-data-on-start'
     | 'expose-connect-ws'
     | 'state'; // very special handling, see `./app-utils.ts`

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -4,8 +4,6 @@ import TrezorConnect, { DEVICE_EVENT } from '@trezor/connect';
 import { IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
 import { parseElectrumUrl } from '@trezor/utils';
 
-import { getSwitchValue } from '../libs/process-switches';
-
 import { MainThreadEmitter, ModuleInit, ModuleInitBackground } from './index';
 
 export const SERVICE_NAME = '@trezor/connect';
@@ -60,9 +58,6 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
                 if (method === 'init') {
                     const response = await TrezorConnect.init({
                         ...params[0],
-                        // poor mans solution to enable debug logs in trezor-connect.
-                        // todo: ideally connect should accept logger as a param
-                        debug: getSwitchValue('log-connect') === 'true',
                     });
                     await setProxy();
 

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -43,6 +43,7 @@ export interface DebugModeOptions {
     showDebugMenu: boolean;
     transports: Extract<NonNullable<ConnectSettings['transports']>[number], string>[];
     isUnlockedBootloaderAllowed: boolean;
+    showConnectLogs: boolean;
 }
 
 export interface AutodetectSettings {
@@ -194,6 +195,7 @@ const initialState: SuiteState = {
             showDebugMenu: false,
             transports: [],
             isUnlockedBootloaderAllowed: false,
+            showConnectLogs: false,
         },
         autodetect: {
             language: true,

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -22,6 +22,7 @@ import { Tor } from './Tor';
 import { TranslationMode } from './TranslationMode';
 import { Transport } from './Transport';
 import { TransportBackends } from './TransportBackends';
+import { TrezorConnect } from './TrezorConnect';
 import { TriggerHighlight } from './TriggerHighlight';
 import { ViewOnlySettings } from './ViewOnlySettings';
 import { WipeData } from './WipeData';
@@ -91,6 +92,9 @@ export const SettingsDebug = () => {
                     <Bluetooth />
                 </SettingsSection>
             )}
+            <SettingsSection title="TrezorConnect">
+                <TrezorConnect />
+            </SettingsSection>
         </SettingsLayout>
     );
 };

--- a/packages/suite/src/views/settings/SettingsDebug/TrezorConnect.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TrezorConnect.tsx
@@ -1,0 +1,29 @@
+import { Switch } from '@trezor/components';
+
+import { setDebugMode } from 'src/actions/suite/suiteActions';
+import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+export const TrezorConnect = () => {
+    const showConnectLogs = useSelector(state => state.suite.settings.debug.showConnectLogs);
+    const dispatch = useDispatch();
+
+    return (
+        <>
+            <SectionItem>
+                <TextColumn
+                    title="TrezorConnect logs"
+                    description="Toggle to enable/disable TrezorConnect logs in console. You need to restart the application to apply changes."
+                />
+                <ActionColumn>
+                    <Switch
+                        isChecked={showConnectLogs}
+                        onChange={() => {
+                            dispatch(setDebugMode({ showConnectLogs: !showConnectLogs }));
+                        }}
+                    />
+                </ActionColumn>
+            </SectionItem>
+        </>
+    );
+};

--- a/packages/suite/src/views/settings/SettingsDebug/TrezorConnect.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TrezorConnect.tsx
@@ -1,4 +1,5 @@
 import { Switch } from '@trezor/components';
+import { isDesktop } from '@trezor/env-utils';
 
 import { setDebugMode } from 'src/actions/suite/suiteActions';
 import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
@@ -8,22 +9,15 @@ export const TrezorConnect = () => {
     const showConnectLogs = useSelector(state => state.suite.settings.debug.showConnectLogs);
     const dispatch = useDispatch();
 
+    const logsDescription = `Show TrezorConnect logs in ${isDesktop() ? 'terminal' : 'console'}. ${isDesktop() ? 'Restart' : 'Refresh'} the application to apply changes.`;
+    const toggleLogs = () => dispatch(setDebugMode({ showConnectLogs: !showConnectLogs }));
+
     return (
-        <>
-            <SectionItem>
-                <TextColumn
-                    title="TrezorConnect logs"
-                    description="Toggle to enable/disable TrezorConnect logs in console. You need to restart the application to apply changes."
-                />
-                <ActionColumn>
-                    <Switch
-                        isChecked={showConnectLogs}
-                        onChange={() => {
-                            dispatch(setDebugMode({ showConnectLogs: !showConnectLogs }));
-                        }}
-                    />
-                </ActionColumn>
-            </SectionItem>
-        </>
+        <SectionItem>
+            <TextColumn title="TrezorConnect logs" description={logsDescription} />
+            <ActionColumn>
+                <Switch isChecked={showConnectLogs} onChange={toggleLogs} />
+            </ActionColumn>
+        </SectionItem>
     );
 };

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -151,14 +151,15 @@ export const connectInitThunk = createThunk(
             ? extra.selectors.selectDesktopBinDir(getState())
             : DATA_URL;
 
+        const { transports, showConnectLogs } = selectDebugSettings(getState());
         try {
             await TrezorConnect.init({
                 ...connectInitSettings,
                 binFilesBaseUrl,
                 pendingTransportEvent: selectIsPendingTransportEvent(getState()),
-                transports: selectDebugSettings(getState()).transports,
+                transports,
                 _sessionsBackgroundUrl,
-                // debug: true, // Enable debug logs in TrezorConnect
+                debug: showConnectLogs,
             });
         } catch (error) {
             let formattedError: string;


### PR DESCRIPTION
Right now there is no way to access connect logs from suite-web in production. This change would enable it by setting TrezorConnect.init debug param to suite debug mode state. 

The question is if it won't be too spammy. If yes, we would need to introduce a special "connect debug mode switch" under debug settings. What is the preferred solution? 


<img width="723" alt="image" src="https://github.com/user-attachments/assets/ce89366b-f057-4132-98ff-db66d0281c79" />

<img width="767" alt="image" src="https://github.com/user-attachments/assets/18a597eb-2e3a-4073-ad10-8614393dc8d5" />
