### PR TITLE
fix(suite): simplify discovery, remove Promise from redux

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -19,11 +19,7 @@ import type { PreloadStoreAction } from 'src/support/suite/preloadStore';
 import type { AppState, Dispatch, GetState, TrezorDevice } from 'src/types/suite';
 import type { Account } from 'src/types/wallet';
 import { GraphData } from 'src/types/wallet/graph';
-import {
-    serializeCoinjoinAccount,
-    serializeDevice,
-    serializeDiscovery,
-} from 'src/utils/suite/storage';
+import { serializeCoinjoinAccount, serializeDevice } from 'src/utils/suite/storage';
 import { deviceGraphDataFilterFn } from 'src/utils/wallet/graph';
 
 import { STORAGE } from './constants';
@@ -270,9 +266,9 @@ export const rememberDevice =
         const graphData = wallet.graph.data.filter(d =>
             deviceGraphDataFilterFn(d, device.state?.staticSessionId),
         );
-        const discovery = wallet.discovery
-            .filter(d => d.deviceState === device.state?.staticSessionId)
-            .map(serializeDiscovery);
+        const discovery = wallet.discovery.filter(
+            d => d.deviceState === device.state?.staticSessionId,
+        );
         const historicRates = wallet.fiat.historic;
 
         const accountPromises = accounts.reduce(

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -66,10 +66,11 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         // discovery interruption ends after DISCOVERY.STOP action
         // action which triggers this interruption will be propagated AFTER stop
         if (interruptionIntent && discoveryIsRunning) {
-            await dispatch(stopDiscoveryThunk());
+            dispatch(stopDiscoveryThunk());
         }
 
-        // pass action
+        // pass action to next middleware; code below will run only after the action has been fully processed in redux.
+        // Even though next(action) generally isn't async as per TS, the action may return anything. Sometimes it's a Promise → needs to be awaited
         await next(action);
 
         if (walletSettingsActions.changeNetworks.match(action)) {

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -35,7 +35,6 @@ import * as COINJOIN from 'src/actions/wallet/constants/coinjoinConstants';
 import { db } from 'src/storage';
 import type { AppState, Dispatch, Action as SuiteAction } from 'src/types/suite';
 import type { WalletAction } from 'src/types/wallet';
-import { serializeDiscovery } from 'src/utils/suite/storage';
 
 const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
     db.onBlocking = () => api.dispatch({ type: STORAGE.ERROR, payload: 'blocking' });
@@ -142,7 +141,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 if (isDeviceRemembered(device)) {
                     const discovery = selectDiscoveryByDeviceState(api.getState(), deviceState);
                     if (discovery) {
-                        storageActions.saveDiscovery([serializeDiscovery(discovery)]);
+                        storageActions.saveDiscovery([discovery]);
                     }
                 }
             }

--- a/packages/suite/src/utils/suite/storage.ts
+++ b/packages/suite/src/utils/suite/storage.ts
@@ -1,16 +1,8 @@
 import { connectInitThunk } from '@suite-common/connect-init';
 import { DeviceWithEmptyPath } from '@suite-common/suite-types';
-import { Discovery } from '@suite-common/wallet-types';
 
 import { AcquiredDevice } from 'src/types/suite';
 import { CoinjoinAccount } from 'src/types/wallet/coinjoin';
-
-/**
- * Strip unserializable fields from Discovery (eg. promises)
- *
- * @param {Discovery} discovery
- */
-export const serializeDiscovery = (discovery: Discovery) => ({ ...discovery, running: undefined });
 
 /**
  * Strip fields from Device

--- a/suite-common/wallet-core/src/discovery/discoveryReducer.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryReducer.ts
@@ -2,7 +2,6 @@ import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { Discovery, PartialDiscovery } from '@suite-common/wallet-types';
 import { DeviceState, StaticSessionId } from '@trezor/connect';
-import { createDeferred } from '@trezor/utils';
 
 import { discoveryActions } from './discoveryActions';
 import { DeviceRootState, selectSelectedDevice } from '../device/deviceReducer';
@@ -17,18 +16,13 @@ export type DiscoveryRootState = {
 
 const initialState: DiscoveryState = [];
 
-const update = (draft: DiscoveryState, payload: PartialDiscovery, resolve?: boolean) => {
+const update = (draft: DiscoveryState, payload: PartialDiscovery) => {
     const index = draft.findIndex(f => f.deviceState === payload.deviceState);
     if (index >= 0) {
-        const dfd = draft[index].running;
         draft[index] = {
             ...draft[index],
             ...payload,
         };
-        if (resolve && dfd) {
-            dfd.resolve();
-            delete draft[index].running;
-        }
         if (!payload.error) {
             delete draft[index].error;
         }
@@ -46,14 +40,7 @@ export const prepareDiscoveryReducer = createReducerWithExtraDeps(
                 }
             })
             .addCase(discoveryActions.startDiscovery, (state, { payload }) => {
-                const index = state.findIndex(f => f.deviceState === payload.deviceState);
-                if (index >= 0) {
-                    state[index] = {
-                        ...state[index],
-                        ...payload,
-                        running: createDeferred(),
-                    };
-                }
+                update(state, payload);
             })
             .addCase(discoveryActions.removeDiscovery, (state, { payload }) => {
                 const index = state.findIndex(f => f.deviceState === payload);
@@ -66,10 +53,10 @@ export const prepareDiscoveryReducer = createReducerWithExtraDeps(
                 update(state, payload);
             })
             .addCase(discoveryActions.completeDiscovery, (state, { payload }) => {
-                update(state, payload, true);
+                update(state, payload);
             })
             .addCase(discoveryActions.stopDiscovery, (state, { payload }) => {
-                update(state, payload, true);
+                update(state, payload);
             })
             .addMatcher(
                 action => action.type === extra.actionTypes.storageLoad,

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -234,7 +234,7 @@ export const stopDiscoveryThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/stop`,
     (_, { dispatch, getState }) => {
         const discovery = selectDeviceDiscovery(getState());
-        if (discovery && discovery.running) {
+        if (discovery) {
             dispatch(
                 interruptDiscovery({
                     deviceState: discovery.deviceState,
@@ -242,8 +242,6 @@ export const stopDiscoveryThunk = createThunk(
                 }),
             );
             TrezorConnect.cancel('discovery_interrupted');
-
-            return discovery.running.promise;
         }
     },
 );

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -2,7 +2,6 @@ import { AccountType, Bip43Path, NetworkSymbol } from '@suite-common/wallet-conf
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { StaticSessionId } from '@trezor/connect';
 import { ObjectValues } from '@trezor/type-utils';
-import { Deferred } from '@trezor/utils';
 
 import { Account, AccountBackendSpecific } from './account';
 
@@ -23,7 +22,6 @@ export interface Discovery {
         fwException?: string;
     }[];
     networks: NetworkSymbol[];
-    running?: Deferred<void>;
     error?: string;
     errorCode?: string | number;
     // Array of account types which should be discovered for given device.


### PR DESCRIPTION
## Description

Proper fix after #17894 hotfix.

After through research, the defered promise (DFD) code is deemed useless and completely removed :monocle_face: :broom: 

## Related Issue

Resolve #17597 _properly_

## Details
The diff for [discoveryMiddleware.ts](https://github.com/trezor/trezor-suite/pull/17868/files#diff-fb6c5ddd60e84c647364e6cdbfb9311881b5dcd275c3c8d9a0dab95e63f293bc) is the pivotal point of this PR; read the file above & below for more context.

Here's an explanation what's going on in current state and what I'm changing:

- all redux actions pass through this middleware...
- ...but only some actions are marked as `interruptionIntent`:
  A) change device or passphrase
  B) navigate to somewhere else than `dashboard | wallet | settings`
  C) opening a connect popup (???)
- in case of a discovery running & an `interruptionIntent` action, middleware does
`await dispatch(stopDiscoveryThunk())` which:
  - calls Connect cancel
  - and _delays_ execution of that action until Connect confirms the discovery was interrupted
- delaying the action in the middleware cannot be done by awaiting the cancel (it's not awaitable)
  - only when periodically querying discovery state [here](https://github.com/trezor/trezor-suite/blob/9744c5b589214ee64dcdd7744a699da44bd8d755/suite-common/wallet-core/src/discovery/discoveryThunks.ts#L681) we can resolve the promise
  - and _that_ is why we needed a DFD kept in redux – to make `stopDiscoveryThunk` awaitable (meaning that Connect has cleared the previous discovery), while really it's a sync thunk that fetches DFD stored in redux, which is resolved from elsewhere, to make it look like async thunk :see_no_evil:  
  - the DFD was not awaited anywhere but in this middleware, through `stopDiscoveryThunk`
- the code below the discoveryMiddleware diff does: device (re)acqusition, auth and finally: discovery (re)start
- that's relevant only to A:
  - when changing device or passphrase, we need to cancel running discovery, and only after Connect reports that it has cleared discovery (DFD resolved from another thunk), we may start another discovery
- **but:** A is not allowed by UI when discovery is running at all, so we don't need to handle this case at all
- meanwhile, B can be dispatched during discovery, but it won't trigger new discovery, so we don't need to await connect clearing the previous discovery, we can let the action bubble through redux right away
  - example: navigate to `notifications` page in mobile view
    - I don't see why `notifications` page stops discovery, I think it's an oversight, but it can be used for testing 

@coderabbitai ignore