### PR TITLE
Add modal with transaction details

### DIFF
--- a/packages/components/src/components/typography/Text/Text.tsx
+++ b/packages/components/src/components/typography/Text/Text.tsx
@@ -25,6 +25,7 @@ export const allowedTextTextProps = [
     'align',
     'ellipsisLineCount',
     'case',
+    'wordBreak',
 ] as const satisfies TextPropsKeys[];
 type AllowedTextTextProps = Pick<TextPropsCommon, (typeof allowedTextTextProps)[number]>;
 

--- a/packages/components/src/components/typography/utils.tsx
+++ b/packages/components/src/components/typography/utils.tsx
@@ -11,12 +11,16 @@ export type TextWrap = (typeof textWraps)[number];
 export const textCase = ['uppercase', 'lowercase', 'titlecase', 'capitalize'] as const;
 export type TextCase = (typeof textCase)[number];
 
+export const wordBreaks = ['normal', 'break-all', 'keep-all', 'inherit', 'unset'] as const;
+export type WordBreak = (typeof wordBreaks)[number];
+
 export type TextProps = {
     typographyStyle?: TypographyStyle;
     textWrap?: TextWrap;
     align?: UIAlignment;
     ellipsisLineCount?: number;
     case?: TextCase;
+    wordBreak?: WordBreak;
 };
 
 export type TextPropsKeys = keyof TextProps;
@@ -37,10 +41,15 @@ export const withTextProps = ({
     $align,
     $ellipsisLineCount = 0,
     $case,
+    $wordBreak,
 }: TransientTextProps) => css`
     ${$textWrap &&
     css`
         text-wrap: ${$textWrap};
+    `}
+    ${$wordBreak &&
+    css`
+        word-break: ${$wordBreak};
     `}
     ${$typographyStyle
         ? css`
@@ -79,6 +88,13 @@ export const withTextProps = ({
 
 const getStorybookType = (key: TextPropsKeys) => {
     switch (key) {
+        case 'wordBreak':
+            return {
+                control: {
+                    type: 'select',
+                    options: wordBreaks,
+                },
+            };
         case 'textWrap':
             return {
                 options: [undefined, ...textWraps],
@@ -140,6 +156,7 @@ export const getTextPropsStory = (allowedTextProps: Array<TextPropsKeys>) => {
     return {
         args: {
             ...(allowedTextProps.includes('textWrap') ? { textWrap: undefined } : {}),
+            ...(allowedTextProps.includes('wordBreak') ? { wordBreak: undefined } : {}),
             ...(allowedTextProps.includes('typographyStyle') ? { typographyStyle: undefined } : {}),
             ...(allowedTextProps.includes('align') ? { align: undefined } : {}),
             ...(allowedTextProps.includes('ellipsisLineCount') ? { hasEllipsis: undefined } : {}),

--- a/packages/suite/src/components/suite/copy/IOAddress.tsx
+++ b/packages/suite/src/components/suite/copy/IOAddress.tsx
@@ -55,17 +55,6 @@ const TextOverflowContainer = styled.div<{ $shouldAllowCopy?: boolean }>`
         `}
 `;
 
-const SpanTextStart = styled.span`
-    display: inline-block;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-`;
-
-const SpanTextEnd = styled.span`
-    display: inline-block;
-`;
-
 interface IOAddressProps {
     explorerUrl?: string;
     txAddress?: string;
@@ -106,14 +95,9 @@ export const IOAddress = ({
                     id={txAddress}
                     $shouldAllowCopy={shouldAllowCopy}
                 >
-                    {txAddress.length <= 5 ? (
-                        <SpanTextEnd onClick={copy}>{txAddress}</SpanTextEnd>
-                    ) : (
-                        <>
-                            <SpanTextStart onClick={copy}>{txAddress.slice(0, -4)}</SpanTextStart>
-                            <SpanTextEnd onClick={copy}>{txAddress.slice(-4)}</SpanTextEnd>
-                        </>
-                    )}
+                    <Text wordBreak="break-all" onClick={copy}>
+                        {txAddress}
+                    </Text>
                     {shouldAllowCopy ? (
                         <IconWrapper onClick={copy}>
                             <Icon

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -4,6 +4,7 @@ import { fromWei } from 'web3-utils';
 import { Network } from '@suite-common/wallet-config';
 import { getFeeRate, getTxIcon, isPending } from '@suite-common/wallet-utils';
 import {
+    Box,
     Card,
     Divider,
     Grid,
@@ -48,10 +49,13 @@ const Item = ({ label, iconName, children }: Partial<InfoItemProps>) => (
         labelWidth={120}
         typographyStyle="label"
         direction="row"
+        verticalAlignment="start"
     >
-        <Text as="div" typographyStyle="label" ellipsisLineCount={1}>
-            {children}
-        </Text>
+        <Box padding={{ top: spacings.xxxs }}>
+            <Text as="div" typographyStyle="label">
+                {children}
+            </Text>
+        </Box>
     </InfoItem>
 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Lucka reached has that they'd need a way to display raw transaction data in the app. So we added this very simple modal that displays all in the purest form.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


![Screenshot 2025-03-26 at 9 39 58 AM](https://github.com/user-attachments/assets/4f56fc53-43ab-42a0-8059-9822cea1452f)

