### PR TITLE
ci: run e2e-test-trezor-user-env-link tests nightly

### DIFF
--- a/.github/workflows/test-trezor-user-env-link-e2e.yml
+++ b/.github/workflows/test-trezor-user-env-link-e2e.yml
@@ -1,6 +1,9 @@
 name: "[Test] trezor-user-env-link e2e"
 
 on:
+  schedule:
+    # Runs at midnight UTC every day at 01:00 AM CET
+    - cron: "0 0 * * *"
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
run nightly to detect failing emulator based on the main branch. 