### PR TITLE
fix(suite): move Promise from redux to a local object

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -19,11 +19,7 @@ import type { PreloadStoreAction } from 'src/support/suite/preloadStore';
 import type { AppState, Dispatch, GetState, TrezorDevice } from 'src/types/suite';
 import type { Account } from 'src/types/wallet';
 import { GraphData } from 'src/types/wallet/graph';
-import {
-    serializeCoinjoinAccount,
-    serializeDevice,
-    serializeDiscovery,
-} from 'src/utils/suite/storage';
+import { serializeCoinjoinAccount, serializeDevice } from 'src/utils/suite/storage';
 import { deviceGraphDataFilterFn } from 'src/utils/wallet/graph';
 
 import { STORAGE } from './constants';
@@ -270,9 +266,9 @@ export const rememberDevice =
         const graphData = wallet.graph.data.filter(d =>
             deviceGraphDataFilterFn(d, device.state?.staticSessionId),
         );
-        const discovery = wallet.discovery
-            .filter(d => d.deviceState === device.state?.staticSessionId)
-            .map(serializeDiscovery);
+        const discovery = wallet.discovery.filter(
+            d => d.deviceState === device.state?.staticSessionId,
+        );
         const historicRates = wallet.fiat.historic;
 
         const accountPromises = accounts.reduce(

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -35,7 +35,6 @@ import * as COINJOIN from 'src/actions/wallet/constants/coinjoinConstants';
 import { db } from 'src/storage';
 import type { AppState, Dispatch, Action as SuiteAction } from 'src/types/suite';
 import type { WalletAction } from 'src/types/wallet';
-import { serializeDiscovery } from 'src/utils/suite/storage';
 
 const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
     db.onBlocking = () => api.dispatch({ type: STORAGE.ERROR, payload: 'blocking' });
@@ -142,7 +141,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 if (isDeviceRemembered(device)) {
                     const discovery = selectDiscoveryByDeviceState(api.getState(), deviceState);
                     if (discovery) {
-                        storageActions.saveDiscovery([serializeDiscovery(discovery)]);
+                        storageActions.saveDiscovery([discovery]);
                     }
                 }
             }

--- a/packages/suite/src/utils/suite/storage.ts
+++ b/packages/suite/src/utils/suite/storage.ts
@@ -1,16 +1,8 @@
 import { connectInitThunk } from '@suite-common/connect-init';
 import { DeviceWithEmptyPath } from '@suite-common/suite-types';
-import { Discovery } from '@suite-common/wallet-types';
 
 import { AcquiredDevice } from 'src/types/suite';
 import { CoinjoinAccount } from 'src/types/wallet/coinjoin';
-
-/**
- * Strip unserializable fields from Discovery (eg. promises)
- *
- * @param {Discovery} discovery
- */
-export const serializeDiscovery = (discovery: Discovery) => ({ ...discovery, running: undefined });
 
 /**
  * Strip fields from Device

--- a/suite-common/wallet-core/src/discovery/discoveryReducer.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryReducer.ts
@@ -5,6 +5,7 @@ import { DeviceState, StaticSessionId } from '@trezor/connect';
 import { createDeferred } from '@trezor/utils';
 
 import { discoveryActions } from './discoveryActions';
+import { discoveryRunningStateLocks } from './discoveryRunningStateLocks';
 import { DeviceRootState, selectSelectedDevice } from '../device/deviceReducer';
 
 export type DiscoveryState = Discovery[];
@@ -20,14 +21,14 @@ const initialState: DiscoveryState = [];
 const update = (draft: DiscoveryState, payload: PartialDiscovery, resolve?: boolean) => {
     const index = draft.findIndex(f => f.deviceState === payload.deviceState);
     if (index >= 0) {
-        const dfd = draft[index].running;
+        const dfd = discoveryRunningStateLocks[draft[index].deviceState];
         draft[index] = {
             ...draft[index],
             ...payload,
         };
         if (resolve && dfd) {
             dfd.resolve();
-            delete draft[index].running;
+            delete discoveryRunningStateLocks[draft[index].deviceState];
         }
         if (!payload.error) {
             delete draft[index].error;
@@ -51,8 +52,8 @@ export const prepareDiscoveryReducer = createReducerWithExtraDeps(
                     state[index] = {
                         ...state[index],
                         ...payload,
-                        running: createDeferred(),
                     };
+                    discoveryRunningStateLocks[state[index].deviceState] = createDeferred();
                 }
             })
             .addCase(discoveryActions.removeDiscovery, (state, { payload }) => {

--- a/suite-common/wallet-core/src/discovery/discoveryRunningStateLocks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryRunningStateLocks.ts
@@ -1,0 +1,6 @@
+import { StaticSessionId } from '@trezor/connect';
+import { Deferred } from '@trezor/utils';
+
+// this object will hold a Promises for each currently running discovery, so that different parts of code can await it independently
+// this was moved here from Redux because it mustn't hold a non-serializable value
+export const discoveryRunningStateLocks: Record<StaticSessionId, Deferred<void>> = {};

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -36,6 +36,7 @@ import {
     selectDiscovery,
     selectDiscoveryByDeviceState,
 } from './discoveryReducer';
+import { discoveryRunningStateLocks } from './discoveryRunningStateLocks';
 import { accountsActions } from '../accounts/accountsActions';
 import { selectAccounts } from '../accounts/accountsReducer';
 import { selectDeviceByStaticSessionId } from '../device/deviceReducer';
@@ -230,11 +231,24 @@ const handleProgressThunk = createThunk(
     },
 );
 
+/**
+ * Note that the code looks like a sync thunk, but it actually behaves as async thunk!
+ * It does three things:
+ * 1. send TrezorConnect.cancel, which is not awaitable
+ * 2. dispatch action to update state in redux accordingly
+ * 3. and get the deferred promise (DFD) from the singleton object that holds it, representing state of the discovery
+ *
+ * Because TrezorConnect.cancel is not awaitable, instead a DFD is stored in the singleton object and
+ * it gets resolved at a different part of code (see `stopDiscovery` action called from `startDiscoveryThunk`).
+ * The DFD could be accessed from anywhere, it is not necessary to return it from here, but it
+ * simulates async behavior of the thunk that would be desirable.
+ */
 export const stopDiscoveryThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/stop`,
     (_, { dispatch, getState }) => {
         const discovery = selectDeviceDiscovery(getState());
-        if (discovery && discovery.running) {
+        const dfd = discovery && discoveryRunningStateLocks[discovery.deviceState];
+        if (discovery && dfd) {
             dispatch(
                 interruptDiscovery({
                     deviceState: discovery.deviceState,
@@ -243,7 +257,8 @@ export const stopDiscoveryThunk = createThunk(
             );
             TrezorConnect.cancel('discovery_interrupted');
 
-            return discovery.running.promise;
+            // this is not perfect
+            return dfd;
         }
     },
 );

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -15,6 +15,7 @@ export * from './device/deviceThunks';
 export * from './discovery/discoveryActions';
 export * from './discovery/discoveryReducer';
 export * from './discovery/discoveryThunks';
+export * from './discovery/discoveryRunningStateLocks';
 export * from './fees/feesReducer';
 export * from './fiat-rates/fiatRatesMiddleware';
 export * from './fiat-rates/fiatRatesReducer';

--- a/suite-common/wallet-types/package.json
+++ b/suite-common/wallet-types/package.json
@@ -18,7 +18,6 @@
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/type-utils": "workspace:*",
-        "@trezor/utils": "workspace:*",
         "react": "18.2.0"
     }
 }

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -2,7 +2,6 @@ import { AccountType, Bip43Path, NetworkSymbol } from '@suite-common/wallet-conf
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { StaticSessionId } from '@trezor/connect';
 import { ObjectValues } from '@trezor/type-utils';
-import { Deferred } from '@trezor/utils';
 
 import { Account, AccountBackendSpecific } from './account';
 
@@ -23,7 +22,6 @@ export interface Discovery {
         fwException?: string;
     }[];
     networks: NetworkSymbol[];
-    running?: Deferred<void>;
     error?: string;
     errorCode?: string | number;
     // Array of account types which should be discovered for given device.

--- a/suite-common/wallet-types/tsconfig.json
+++ b/suite-common/wallet-types/tsconfig.json
@@ -11,7 +11,6 @@
             "path": "../../packages/blockchain-link-types"
         },
         { "path": "../../packages/connect" },
-        { "path": "../../packages/type-utils" },
-        { "path": "../../packages/utils" }
+        { "path": "../../packages/type-utils" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9727,7 +9727,6 @@ __metadata:
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/type-utils": "workspace:*"
-    "@trezor/utils": "workspace:*"
     react: "npm:18.2.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

A temporary solution that solves error, that surfaced when bumping Redux, because we have been storing non-serializable values in Redux (previous version did not mind, but it was a code smell for years).
It's a defered promise (DFD) in `state.wallet.discovery[i].running`.

The whole logic should ideally be removed, as it does not seem to be necessary. I'm working on that in #17868 but there are still some obstacles, hence this "quick fix" :disappointed: 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17597

@coderabbitai ignore