### PR TITLE
fix(nix): add vips build dependency of sharp@npm

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -29,6 +29,7 @@ in
       docker         # for e2e tests running on localhost
       docker-compose # for e2e tests running on localhost
       nodejs
+      vips
       (yarn.override {
         nodejs = null; # use input nodejs
       })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Latest version of sharp@npm requires vips (Image processing system for large images) dependency in the system.
Adding it to `shell.nix` so we can run `yarn install`.