### PR TITLE
WIP: suite(refactor): remove the need for observing of the selected device…

### DIFF
--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -1,18 +1,13 @@
-import { isAnyOf } from '@reduxjs/toolkit';
 import { MiddlewareAPI } from 'redux';
 
-import { AnyAction } from '@suite-common/redux-utils';
-import { isAnyDeviceEventAction } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     authConfirm,
-    authorizeDeviceThunk,
     createDeviceInstanceThunk,
     deviceActions,
     forgetDisconnectedDevices,
     handleDeviceConnect,
     handleDeviceDisconnect,
-    observeSelectedDevice,
     restartDiscoveryThunk,
     selectDeviceThunk,
     updateFeeInfoThunk,
@@ -20,35 +15,11 @@ import {
 import { DEVICE } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { METADATA, ROUTER, SUITE } from 'src/actions/suite/constants';
+import { ROUTER, SUITE } from 'src/actions/suite/constants';
 import { handleProtocolRequest } from 'src/actions/suite/protocolActions';
 import { appChanged, setFlag } from 'src/actions/suite/suiteActions';
 import { Action, AppState, Dispatch } from 'src/types/suite';
 
-const isActionDeviceRelated = (action: AnyAction): boolean => {
-    if (
-        isAnyOf(
-            authorizeDeviceThunk.fulfilled,
-            authorizeDeviceThunk.rejected,
-            deviceActions.selectDevice,
-            deviceActions.receiveAuthConfirm,
-            deviceActions.updatePassphraseMode,
-            deviceActions.addButtonRequest,
-            deviceActions.removeButtonRequests,
-            deviceActions.rememberDevice,
-            deviceActions.forgetDevice,
-        )(action)
-    ) {
-        return true;
-    }
-
-    if (action.type === METADATA.SET_DEVICE_METADATA) return true;
-    if (action.type === METADATA.SET_DEVICE_METADATA_PASSWORDS) return true;
-
-    if (isAnyDeviceEventAction(action)) return true;
-
-    return false;
-};
 const suite =
     (api: MiddlewareAPI<Dispatch, AppState>) =>
     (next: Dispatch) =>
@@ -128,11 +99,6 @@ const suite =
 
             default:
                 break;
-        }
-
-        if (isActionDeviceRelated(action)) {
-            // keep suite reducer synchronized with other reducers (selected device)
-            api.dispatch(observeSelectedDevice());
         }
 
         return action;

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -485,7 +485,7 @@ export const selectIsCopyAddressModalShown = (state: SuiteRootState) =>
 export const selectIsInitialRun = (state: SuiteRootState) => state.suite.flags.initialRun;
 
 export const selectIsLoggedOut = (state: SuiteRootState & DeviceRootState) =>
-    selectIsInitialRun(state) || state.device?.selectedDevice?.mode !== 'normal';
+    selectIsInitialRun(state) || selectSelectedDevice(state)?.mode !== 'normal';
 
 export const selectSuiteFlags = (state: SuiteRootState) => state.suite.flags;
 

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -16,6 +16,7 @@ import {
     deviceActions,
     selectDiscoveryByDeviceState,
     selectIsPendingTransportEvent,
+    selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { buildHistoricRatesFromStorage, getAccountKey } from '@suite-common/wallet-utils';
 import { PROTO, StaticSessionId } from '@trezor/connect';
@@ -83,11 +84,11 @@ export const extraDependencies: ExtraDependencies = {
         selectDebugSettings: (state: AppState) => state.suite.settings.debug,
         // FW binaries on desktop are stored in "*/static/connect/data/firmware/*/*.bin" (see "connect-common" package)
         selectDesktopBinDir: (state: AppState) => state.desktop?.paths?.binDir,
-        selectDevice: (state: AppState) => state.device.selectedDevice,
+        selectDevice: (state: AppState) => selectSelectedDevice(state),
         selectLanguage: (state: AppState) => state.suite.settings.language,
         selectMetadata: (state: AppState) => state.metadata,
         selectDeviceDiscovery: (state: DiscoveryRootState & DeviceRootState) =>
-            selectDiscoveryByDeviceState(state, state.device.selectedDevice?.state),
+            selectDiscoveryByDeviceState(state, selectSelectedDevice(state)?.state),
         selectRouterApp: (state: AppState) => state.router.app,
         selectRoute: (state: AppState) => state.router.route,
         selectAddressDisplayType: (state: AppState) => state.suite.settings.addressDisplayType,

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -259,11 +259,14 @@ export const findInstanceIndex = (draft: TrezorDevice[], device: AcquiredDevice)
  * @returns {TrezorDevice | undefined }
  */
 export const getSelectedDevice = (
-    device: TrezorDevice,
+    device: Pick<TrezorDevice, 'state' | 'path' | 'instance' | 'features' | 'id'> | null,
     devices: TrezorDevice[],
 ): TrezorDevice | undefined => {
+    if (device?.state?.staticSessionId) {
+        return devices.find(d => d.state?.staticSessionId === device.state?.staticSessionId);
+    }
     // selected device is not acquired
-    if (!device.features) return devices.find(d => d.path === device.path);
+    if (!device?.features) return devices.find(d => d.path === device?.path);
     const { path, instance } = device;
 
     return devices.find(d => {

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -35,7 +35,7 @@ const createMemoizedSelector = createWeakMapSelector.withTypes<DeviceRootState>(
 
 export type DeviceReducerState = {
     devices: TrezorDevice[];
-    selectedDevice?: TrezorDevice;
+    selectedDevice: Pick<TrezorDevice, 'state' | 'path' | 'instance'> | null; // Renamed from selectedDevice
     deviceAuthenticity?: Record<string, StoredAuthenticateDeviceResult>;
     devicesWithFailedEntropyCheck?: (string | null)[]; // protobuf allows null values and we want to store this even if a fake device has id set to null
     dismissedSecurityChecks?: {
@@ -43,7 +43,7 @@ export type DeviceReducerState = {
     };
 };
 
-const initialState: DeviceReducerState = { devices: [], selectedDevice: undefined };
+const initialState: DeviceReducerState = { devices: [], selectedDevice: null };
 
 export type DeviceRootState = {
     device: DeviceReducerState;
@@ -410,7 +410,7 @@ const authFailed = (draft: DeviceReducerState, device: TrezorDevice) => {
  * @returns
  */
 const resetAuthFailed = (draft: DeviceReducerState) => {
-    const device = draft.selectedDevice;
+    const device = deviceUtils.getSelectedDevice(draft.selectedDevice, draft.devices);
     // only acquired devices
     if (!device || !device.features) return;
     const index = deviceUtils.findInstanceIndex(draft.devices, device);
@@ -647,16 +647,28 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
             removeButtonRequests(state, payload.device, payload.buttonRequestCode);
         })
         .addCase(deviceActions.requestDeviceReconnect, state => {
-            if (state.selectedDevice) {
-                state.selectedDevice.reconnectRequested = true;
+            const selectedDevice = deviceUtils.getSelectedDevice(
+                state.selectedDevice,
+                state.devices,
+            );
+
+            if (selectedDevice) {
+                selectedDevice.reconnectRequested = true;
             }
         })
         .addCase(deviceActions.selectDevice, (state, { payload }) => {
             updateTimestamp(state, payload);
-            state.selectedDevice = payload;
-        })
-        .addCase(deviceActions.updateSelectedDevice, (state, { payload }) => {
-            state.selectedDevice = payload;
+            state.selectedDevice = payload
+                ? {
+                      state: payload.state?.staticSessionId
+                          ? {
+                                staticSessionId: payload.state?.staticSessionId,
+                            }
+                          : undefined,
+                      path: payload.path,
+                      instance: payload.instance,
+                  }
+                : null;
         })
         .addCase(deviceAuthenticityActions.result, (state, { payload }) => {
             setDeviceAuthenticity(state, payload.device, payload.result);
@@ -699,7 +711,16 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
 // Basic state selectors (no need to wrap in createMemoizedSelector)
 export const selectDevices = (state: DeviceRootState) => state.device?.devices;
 export const selectDevicesCount = (state: DeviceRootState) => state.device?.devices?.length;
-export const selectSelectedDevice = (state: DeviceRootState) => state.device.selectedDevice;
+export const selectselectedDevice = (state: DeviceRootState) => state.device.selectedDevice;
+// Get the actual device from the devices array based on the selector
+export const selectSelectedDevice = createMemoizedSelector(
+    [state => state.device.devices, state => state.device.selectedDevice],
+    (devices, selector) => {
+        if (!selector) return undefined;
+
+        return deviceUtils.getSelectedDevice(selector, devices);
+    },
+);
 
 // Derived selectors
 export const selectIsPendingTransportEvent = createMemoizedSelector(

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -29,7 +29,6 @@ import TrezorConnect, {
     UI,
 } from '@trezor/connect';
 import { getEnvironment } from '@trezor/env-utils';
-import { isChanged } from '@trezor/utils';
 
 import { DEVICE_MODULE_PREFIX, DeviceConnectActionPayload, deviceActions } from './deviceActions';
 import { PORTFOLIO_TRACKER_DEVICE_ID, portfolioTrackerDevice } from './deviceConstants';
@@ -164,11 +163,11 @@ export const handleDeviceDisconnect = createThunk(
             selectors: { selectRouterApp },
         } = extra;
 
-        const selectedDevice = selectSelectedDevice(getState());
+        const devicePresent = selectSelectedDevice(getState());
         const routerApp = selectRouterApp(getState());
         const devices = selectDevices(getState());
-        if (!selectedDevice) return;
-        if (selectedDevice.path !== device.path) return;
+        if (!devicePresent) return;
+        if (devicePresent.path !== device.path) return;
 
         /**
          * Under normal circumstances, after device is disconnected we want suite to select another existing device (either remembered or physically connected)
@@ -182,8 +181,7 @@ export const handleDeviceDisconnect = createThunk(
 
         // selected device is disconnected, decide what to do next
         // device is still present in reducer (remembered or candidate to remember)
-        const devicePresent = getSelectedDevice(selectedDevice, devices);
-        const deviceInstances = getDeviceInstances(selectedDevice, devices);
+        const deviceInstances = getDeviceInstances(devicePresent, devices);
         if (deviceInstances.length > 0) {
             // if selected device is gone from reducer, switch to first instance
             if (!devicePresent) {
@@ -218,28 +216,6 @@ export const forgetDisconnectedDevices = createThunk(
         });
     },
 );
-
-/**
- * Called from `suiteMiddleware`
- * Keep `suite` reducer synchronized with `devices` reducer
- * @param {Action} action
- */
-export const observeSelectedDevice = () => (dispatch: any, getState: any) => {
-    const devices = selectDevices(getState());
-    const selectedDevice = selectSelectedDevice(getState());
-
-    if (!selectedDevice) return false;
-
-    const deviceFromReducer = getSelectedDevice(selectedDevice, devices);
-    if (!deviceFromReducer) return true;
-
-    const changed = isChanged(selectedDevice, deviceFromReducer);
-    if (changed) {
-        dispatch(deviceActions.updateSelectedDevice(deviceFromReducer));
-    }
-
-    return changed;
-};
 
 /**
  * Called from <AcquireDevice /> component
@@ -336,7 +312,7 @@ export const authorizeDeviceThunk = createThunk<
                     d.instance !== device.instance,
             );
             // get fresh data from reducer, `useEmptyPassphrase` might be changed after TrezorConnect call
-            const freshDeviceData = getSelectedDevice(device, devices);
+            const freshDeviceData = selectSelectedDevice(getState());
 
             if (duplicate) {
                 const isStandardWallet = freshDeviceData!.useEmptyPassphrase;

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -1,16 +1,13 @@
-import { AnyAction, isAnyOf } from '@reduxjs/toolkit';
+import { isAnyOf } from '@reduxjs/toolkit';
 
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
-import { isAnyDeviceEventAction } from '@suite-common/suite-utils';
 import {
     accountsActions,
-    authorizeDeviceThunk,
     createDeviceInstanceThunk,
     createImportedDeviceThunk,
     deviceActions,
     forgetDisconnectedDevices,
     handleDeviceDisconnect,
-    observeSelectedDevice,
     selectAccountsByDeviceState,
     selectDeviceThunk,
     selectIsDeviceForceRemembered,
@@ -20,26 +17,6 @@ import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-f
 import { DEVICE } from '@trezor/connect';
 
 import { isDeviceEventAction } from '../utils';
-
-const isActionDeviceRelated = (action: AnyAction): boolean => {
-    if (
-        isAnyOf(
-            authorizeDeviceThunk.fulfilled,
-            authorizeDeviceThunk.rejected,
-            deviceActions.selectDevice,
-            deviceActions.receiveAuthConfirm,
-            deviceActions.updatePassphraseMode,
-            deviceActions.addButtonRequest,
-            deviceActions.removeButtonRequests,
-            deviceActions.rememberDevice,
-            deviceActions.forgetDevice,
-        )(action)
-    ) {
-        return true;
-    }
-
-    return isAnyDeviceEventAction(action);
-};
 
 export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
     (action, { dispatch, next, getState }) => {
@@ -92,10 +69,6 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
                 break;
             default:
                 break;
-        }
-
-        if (isActionDeviceRelated(action)) {
-            dispatch(observeSelectedDevice());
         }
 
         return action;


### PR DESCRIPTION
… thanks to the storing just a selector to the devices list

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR removes the need to sync the `device.selectedDevice` state with middlewares. The solution to it was to create selected device selector in state, that would only describe which of the `devices` in the list should be selected rather then copyingthe whole object all the time.

## The challenges faced:
- which of the properties use to select the device current order:
  -  `staticSessionId` = hash of device and passphrase
  - `path` = that's generated ID of the device selected
  - `instance` = the order in which the device wallet was created. eg. when you add a new passphrase wallet, the device is the same only "another wallet on the device" is made


## Possible issues
- miryad of problems regarding adding wallets, removing wallets, remembering devices, forgetting devices, switching devices, reconnecting etc.

## Related Issue

Reason to do it: I was working on the passphrase wallet and I couldn't find how things are influenced with and noticed this which was possible to change

## Screenshots:
