### PR TITLE
fix(suite): include migrations under correct db version

### DIFF
--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -1258,6 +1258,10 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
                 return account;
             }
         });
+
+        await migrationCoinmarketToTrading(db, oldVersion, newVersion, transaction);
+
+        db.createObjectStore('security');
     }
 
     if (oldVersion < 53) {
@@ -1272,8 +1276,4 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
     if (oldVersion < 54) {
         db.createObjectStore('connect');
     }
-
-    await migrationCoinmarketToTrading(db, oldVersion, newVersion, transaction);
-
-    db.createObjectStore('security');
 };


### PR DESCRIPTION
I accidentally included these migrations under a broader scope [here](https://github.com/trezor/trezor-suite/commit/b0039a01c66dd6b753123cd4a4e1e0c7a9feda5c).

Tested by switching branches from release/25.1 (db version 51; this migration was not included yet - it runs successfully) and release/25.3 (db version 52; the migration has already run - it is skipped). Db version 53 hasn't been released yet.