### PR TITLE
chore: cleanup & comment on Discovery interruption

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx
@@ -1,4 +1,3 @@
-import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { Button, ButtonProps, IconButton, TOOLTIP_DELAY_NORMAL, Tooltip } from '@trezor/components';
 
 import { openModal } from 'src/actions/suite/modalActions';
@@ -31,20 +30,18 @@ export const AddAccountButton = ({
     isFullWidth,
     ...rest
 }: AddAccountButtonProps) => {
-    const { discovery } = useDiscovery();
+    const { isDiscoveryRunning } = useDiscovery();
     const dispatch = useDispatch();
-
-    const discoveryIsRunning = discovery ? discovery.status <= DiscoveryStatus.STOPPING : false;
 
     // TODO: add more cases when adding account is not possible
     const addAccountDisabled =
-        discoveryIsRunning ||
+        isDiscoveryRunning ||
         !device ||
         !device.connected ||
         device.authConfirm ||
         device.authFailed;
 
-    const tooltipMessage = getExplanationMessage(device, discoveryIsRunning);
+    const tooltipMessage = getExplanationMessage(device, isDiscoveryRunning);
 
     const handleOnClick = () => {
         if (!device) {

--- a/packages/suite/src/hooks/suite/__fixtures__/useDiscovery.ts
+++ b/packages/suite/src/hooks/suite/__fixtures__/useDiscovery.ts
@@ -13,7 +13,7 @@ export const actions = [
         },
         renders: 1,
         result: {
-            running: undefined,
+            running: false,
             status: { type: 'waiting-for-device' },
         },
     },
@@ -24,7 +24,7 @@ export const actions = [
         },
         renders: 2,
         result: {
-            running: undefined,
+            running: false,
             status: { type: 'auth' },
         },
     },
@@ -35,7 +35,7 @@ export const actions = [
         },
         renders: 2, // update of exact same device shouldn't cause render
         result: {
-            running: undefined,
+            running: false,
             status: { type: 'auth' },
         },
     },
@@ -46,7 +46,7 @@ export const actions = [
         },
         renders: 3,
         result: {
-            running: undefined,
+            running: false,
             status: undefined, // normally discoveryActions.createDiscovery is called before deviceActions.updateSelectedDevice.type, this is here only for coverage
         },
     },
@@ -118,7 +118,7 @@ export const actions = [
         },
         renders: 8,
         result: {
-            running: undefined,
+            running: false,
             status: { type: 'auth-failed' },
         },
     },
@@ -129,7 +129,7 @@ export const actions = [
         },
         renders: 9,
         result: {
-            running: undefined,
+            running: false,
             status: { type: 'auth-confirm-failed' },
         },
     },

--- a/packages/suite/src/hooks/suite/__tests__/useDiscovery.test.tsx
+++ b/packages/suite/src/hooks/suite/__tests__/useDiscovery.test.tsx
@@ -40,7 +40,7 @@ const initStore = (state: State) => {
 };
 
 type Result = {
-    running?: boolean;
+    running: boolean;
     status?: { type: string };
     progress: number;
 };

--- a/packages/suite/src/hooks/suite/useDiscovery.ts
+++ b/packages/suite/src/hooks/suite/useDiscovery.ts
@@ -26,7 +26,7 @@ export const useDiscovery = () => {
     return {
         device,
         discovery,
-        isDiscoveryRunning: discovery && discovery.status < DiscoveryStatus.STOPPING,
+        isDiscoveryRunning: discovery ? discovery.status < DiscoveryStatus.STOPPING : false,
         getDiscoveryStatus: getStatus,
         calculateProgress,
     };

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -26,10 +26,10 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
     async (action, { dispatch, next, getState }) => {
         const prevState = getState();
         const prevDiscovery = selectDeviceDiscovery(prevState);
-        const discoveryIsRunning =
+        const discoveryIsRunningAndNotCanceled =
             prevDiscovery &&
-            prevDiscovery.status > DiscoveryStatus.IDLE &&
-            prevDiscovery.status < DiscoveryStatus.STOPPING;
+            // condition excludes STOPPING state, so that `stopDiscoveryThunk` isn't called more than once
+            prevDiscovery.status === DiscoveryStatus.RUNNING;
 
         if (
             deviceActions.forgetDevice.match(action) &&
@@ -39,7 +39,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         }
 
         // do not close user context modals during discovery
-        if (action.type === UI.CLOSE_UI_WINDOW && discoveryIsRunning) {
+        if (action.type === UI.CLOSE_UI_WINDOW && discoveryIsRunningAndNotCanceled) {
             const { modal } = prevState;
             if (modal.context === MODAL.CONTEXT_USER) {
                 return action;
@@ -63,13 +63,21 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
             interruptionIntent = true;
         }
 
-        // discovery interruption ends after DISCOVERY.STOP action
-        // action which triggers this interruption will be propagated AFTER stop
-        if (interruptionIntent && discoveryIsRunning) {
+        /*
+         Some of the redux actions passing through here can:
+         - interrupt discovery if RUNNING, and not already STOPPING
+         - start a new discovery - must be neither RUNNING nor STOPPING
+         Most difficult case is when an action does both (e.g. change device/passphrase):
+         We need to interrupt discovery and delay this action until Connect cofirms it is cleared.
+         Only then we may finish processing the action in redux and start a new discovery.
+         Note: TrezorConnect.cancel is not awaitable; see `stopDiscoveryThunk` how it is circumvented
+        */
+        if (interruptionIntent && discoveryIsRunningAndNotCanceled) {
             await dispatch(stopDiscoveryThunk());
         }
 
-        // pass action
+        // Pass action to next middleware, meaning that the code below runs *only after* the action has been completely processed in Redux.
+        // Note: TS says next(action) generally isn't async, but the action may return anything; sometimes it's a Promise → needs to be awaited
         await next(action);
 
         if (walletSettingsActions.changeNetworks.match(action)) {

--- a/suite-common/wallet-core/src/discovery/discoveryReducer.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryReducer.ts
@@ -47,12 +47,9 @@ export const prepareDiscoveryReducer = createReducerWithExtraDeps(
                 }
             })
             .addCase(discoveryActions.startDiscovery, (state, { payload }) => {
+                update(state, payload);
                 const index = state.findIndex(f => f.deviceState === payload.deviceState);
                 if (index >= 0) {
-                    state[index] = {
-                        ...state[index],
-                        ...payload,
-                    };
                     discoveryRunningStateLocks[state[index].deviceState] = createDeferred();
                 }
             })

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -234,14 +234,13 @@ const handleProgressThunk = createThunk(
 /**
  * Note that the code looks like a sync thunk, but it actually behaves as async thunk!
  * It does three things:
- * 1. send TrezorConnect.cancel, which is not awaitable
+ * 1. send TrezorConnect.cancel (not awaitable)
  * 2. dispatch action to update state in redux accordingly
- * 3. and get the deferred promise (DFD) from the singleton object that holds it, representing state of the discovery
+ * 3. and get the deferred promise (dfd) from the singleton object that holds it, representing state of the discovery
  *
- * Because TrezorConnect.cancel is not awaitable, instead a DFD is stored in the singleton object and
+ * Because TrezorConnect.cancel is not awaitable, instead a dfd is stored in the singleton object and
  * it gets resolved at a different part of code (see `stopDiscovery` action called from `startDiscoveryThunk`).
- * The DFD could be accessed from anywhere, it is not necessary to return it from here, but it
- * simulates async behavior of the thunk that would be desirable.
+ * FYI that may take even several seconds.
  */
 export const stopDiscoveryThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/stop`,
@@ -257,7 +256,8 @@ export const stopDiscoveryThunk = createThunk(
             );
             TrezorConnect.cancel('discovery_interrupted');
 
-            // this is not perfect
+            // return a Promise. The record with dfds could be accessed anywhere; it isn't necessary to return it from
+            // here, but it simulates async behavior of the thunk, as if the cancel was awaitable.
             return dfd;
         }
     },
@@ -692,6 +692,8 @@ export const startDiscoveryThunk = createThunk(
                 });
             }
 
+            // 'discovery_interrupted' means that Connect cleared the discovery following a TrezorConnect.cancel call.
+            // cancel is not awaitable; instead, this is when Suite confirms that Connect has "finished cancelling the discovery".
             const error =
                 result.payload.error !== 'discovery_interrupted' ? result.payload.error : undefined;
             dispatch(


### PR DESCRIPTION
## Description

Small code cleanup in discovery (keeps the same function) and add comment explaining the complex moving parts when interrupting a discovery, especially in case of switching wallet (i.e. select device or change passphrase).

ATM, the `await dfd` logic cannot be removed as I first intended, [see this comment](https://github.com/trezor/trezor-suite/pull/17868#issuecomment-2752208161).

## Related Issue

Followup to  https://github.com/trezor/trezor-suite/issues/17597