### PR TITLE
Analytics - Staking

### DIFF
--- a/packages/product-components/src/components/InputWithOptions/InputWithOptions.tsx
+++ b/packages/product-components/src/components/InputWithOptions/InputWithOptions.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { FieldValues } from 'react-hook-form';
 
 import styled from 'styled-components';
@@ -21,6 +21,7 @@ export type InputWithOptionsProps<TFieldValues extends FieldValues> = {
         fiat: React.ReactNode;
         crypto: React.ReactNode;
     };
+    onCurrencyChange?: (currency: 'crypto' | 'fiat') => void;
 };
 
 export const InputWithOptions = <TFieldValues extends FieldValues>({
@@ -29,8 +30,14 @@ export const InputWithOptions = <TFieldValues extends FieldValues>({
     fiatValue,
     options,
     switchTranslation,
+    onCurrencyChange,
 }: InputWithOptionsProps<TFieldValues>) => {
     const [amountInCrypto, setAmountInCrypto] = React.useState(true);
+
+    useEffect(() => {
+        const currency = amountInCrypto ? 'crypto' : 'fiat';
+        onCurrencyChange?.(currency);
+    }, [amountInCrypto, onCurrencyChange]);
 
     const canSwitchInputs = fiatInputProps != null;
 

--- a/packages/suite-analytics/src/constants.ts
+++ b/packages/suite-analytics/src/constants.ts
@@ -39,12 +39,21 @@ export enum EventType {
     AccountsTransactionsExport = 'accounts/transactions-export',
     AccountsDashboardBuy = 'accounts/dashboard/buy',
     AccountsTradeboxButton = 'accounts/tradebox/button',
+
     TransactionCreated = 'transaction-created',
+    TransactionRetry = 'transaction/timeout-retry',
+    TransactionCancel = 'transaction/cancel',
     SendRawTransaction = 'send-raw-transaction',
 
     CoinjoinAnonymityGain = 'coinjoin/anonymity-gain',
 
     TradingConfirmTrade = 'trade/confirm-trade',
+
+    StakingNavigate = 'staking/navigate',
+    StakingStake = 'staking/stake',
+    StakingUnstake = 'staking/unstake',
+    StakingClaim = 'staking/claim',
+    StakingConfirm = 'staking/confirm',
 
     MenuGuide = 'menu/guide',
     MenuNotificationsToggle = 'menu/notifications/toggle',

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -51,6 +51,7 @@ export type TransactionCreatedEvent = {
         selectedFee: string;
         isCoinControlEnabled: boolean;
         hasCoinControlBeenOpened: boolean;
+        txType?: 'trade' | 'stake';
     };
 };
 
@@ -194,6 +195,70 @@ export type SuiteAnalyticsEvent =
           type: EventType.TradingConfirmTrade;
           payload: {
               type: 'buy' | 'sell' | 'exchange';
+          };
+      }
+    | {
+          type: EventType.StakingNavigate;
+          payload: {
+              action: 'navigate' | 'cancel';
+              from:
+                  | 'sidebar'
+                  | 'account/navigation'
+                  | 'account/banner'
+                  | 'dashboard/banner'
+                  | 'dashboard/assets';
+              networkSymbol?: string;
+          };
+      }
+    | {
+          type: EventType.StakingStake;
+          payload: {
+              action: 'continue' | 'cancel';
+              step:
+                  | 'staking-dashboard'
+                  | 'stake-in-a-nutshell-modal'
+                  | 'funds-maintained-modal'
+                  | 'stake-form-modal'
+                  | 'entry-period-stake-modal';
+              networkSymbol?: string;
+              currency?: 'crypto' | 'fiat';
+          };
+      }
+    | {
+          type: EventType.StakingUnstake;
+          payload: {
+              action: 'continue' | 'cancel';
+              step: 'staking-dashboard' | 'unstake-form-modal';
+              networkSymbol?: string;
+              currency?: 'crypto' | 'fiat';
+          };
+      }
+    | {
+          type: EventType.StakingClaim;
+          payload: {
+              action: 'continue' | 'cancel';
+              step: 'staking-dashboard' | 'claim-form-modal';
+              networkSymbol?: string;
+          };
+      }
+    | {
+          type: EventType.StakingConfirm;
+          payload: {
+              action: 'stake' | 'unstake' | 'claim';
+              networkSymbol?: string;
+          };
+      }
+    | {
+          type: EventType.TransactionRetry;
+          payload: {
+              url: string;
+          };
+      }
+    | {
+          type: EventType.TransactionCancel;
+          payload: {
+              txType?: 'trade' | 'stake';
+              networkSymbol: string;
           };
       }
     | {

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics.ts
@@ -1,18 +1,20 @@
+import { Account } from '@suite-common/wallet-types';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { goto } from '../../../../../actions/suite/routerActions';
 import { useDispatch, useSelector } from '../../../../../hooks/suite';
 import { selectSelectedAccount } from '../../../../../reducers/wallet/selectedAccountReducer';
 
-export const useGoToWithAnalytics = () => {
-    const account = useSelector(selectSelectedAccount);
+export const useGoToWithAnalytics = (account?: Account) => {
+    const selectedAccount = useSelector(selectSelectedAccount);
+    const accountToUse = account ?? selectedAccount;
     const dispatch = useDispatch();
 
     return (...[routeName, options]: Parameters<typeof goto>) => {
-        if (account?.symbol) {
+        if (accountToUse?.symbol) {
             analytics.report({
                 type: EventType.AccountsActions,
-                payload: { symbol: account.symbol, action: routeName },
+                payload: { symbol: accountToUse.symbol, action: routeName },
             });
         }
         dispatch(goto(routeName, options));

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -42,6 +42,7 @@ import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
 import { selectAccountIncludingChosenInTrading } from 'src/reducers/wallet/selectedAccountReducer';
+import { redactRouterUrl } from 'src/utils/suite/analytics';
 import { getTransactionReviewModalActionText } from 'src/utils/suite/transactionReview';
 
 import { TransactionReviewDetails } from './TransactionReviewDetails';
@@ -93,6 +94,13 @@ const isStakeState = (state: SendState | StakeState): state is StakeState => 'da
 const isStakeForm = (form: FormState | StakeFormState): form is StakeFormState =>
     'stakeType' in form;
 
+const getTxType = (txInfoState: SendState | StakeState, precomposedForm: FormState) => {
+    const stakeType = isStakeState(txInfoState) ? 'stake' : undefined;
+    const tradeType = precomposedForm.isTrading ? 'trade' : undefined;
+
+    return stakeType ?? tradeType;
+};
+
 const mapRbfTypeToReporting: Record<
     RbfTransactionType,
     TransactionCreatedEvent['payload']['action']
@@ -125,6 +133,8 @@ export const TransactionReviewModalContent = ({
     const [areDetailsVisible, setAreDetailsVisible] = useState(false);
     const deviceModelInternal = device?.features?.internal_model;
     const { precomposedTx, serializedTx } = txInfoState;
+
+    const router = useSelector(state => state.router);
 
     const precomposedForm = useSelector(state =>
         isStakeState(txInfoState)
@@ -181,6 +191,8 @@ export const TransactionReviewModalContent = ({
     const { symbol, networkType } = account;
     const { options, selectedFee } = precomposedForm;
 
+    const txType = getTxType(txInfoState, precomposedForm);
+
     const outputs = constructTransactionReviewOutputs({
         account,
         decreaseOutputId,
@@ -206,6 +218,14 @@ export const TransactionReviewModalContent = ({
             cancelSignTx();
             decision?.resolve(false);
         }
+
+        analytics.report({
+            type: EventType.TransactionCancel,
+            payload: {
+                txType,
+                networkSymbol: symbol,
+            },
+        });
     };
 
     const isCancelRbfAction = isRbfCancelTransaction(precomposedTx);
@@ -246,11 +266,12 @@ export const TransactionReviewModalContent = ({
                 broadcast: isBroadcastEnabled,
                 bitcoinLockTime: !!options.includes('bitcoinLockTime'),
                 ethereumData: !!options.includes('ethereumData'),
-                rippleDestinationTag: !!options.includes('rippleDestinationTag'),
                 ethereumNonce: !!options.includes('ethereumNonce'),
+                rippleDestinationTag: !!options.includes('rippleDestinationTag'),
                 selectedFee: selectedFee || 'normal',
                 isCoinControlEnabled: precomposedForm.isCoinControlEnabled,
                 hasCoinControlBeenOpened: precomposedForm.hasCoinControlBeenOpened,
+                txType,
             },
         });
 
@@ -258,6 +279,7 @@ export const TransactionReviewModalContent = ({
         if (networkType === 'solana') {
             setIsSending(true);
         }
+
         if (decision) {
             decision.resolve(true);
             reportTransactionCreatedEvent(
@@ -265,6 +287,16 @@ export const TransactionReviewModalContent = ({
                     ? mapRbfTypeToReporting[precomposedTx.rbfType]
                     : 'sent',
             );
+
+            if (stakeType) {
+                return analytics.report({
+                    type: EventType.StakingConfirm,
+                    payload: {
+                        action: stakeType,
+                        networkSymbol: symbol,
+                    },
+                });
+            }
         }
     };
 
@@ -293,6 +325,11 @@ export const TransactionReviewModalContent = ({
         }
 
         tryAgainSignTx();
+
+        analytics.report({
+            type: EventType.TransactionRetry,
+            payload: { url: redactRouterUrl(router.url) },
+        });
     };
 
     const BottomContent = () => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
@@ -4,6 +4,7 @@ import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { getStakingDataForNetwork } from '@suite-common/wallet-utils';
 import { Banner, Column, InfoItem, NewModal, Paragraph, Tooltip } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
@@ -55,6 +56,32 @@ export const ClaimModal = ({ onCancel }: ClaimModalModalProps) => {
         onClaimChange(claimableAmount);
     }, [onClaimChange, claimableAmount]);
 
+    const onClaimClick = () => {
+        handleSubmit(signTx)();
+
+        analytics.report({
+            type: EventType.StakingClaim,
+            payload: {
+                action: 'continue',
+                step: 'claim-form-modal',
+                networkSymbol: selectedAccount.account.symbol,
+            },
+        });
+    };
+
+    const onCancelClick = () => {
+        onCancel?.();
+
+        analytics.report({
+            type: EventType.StakingClaim,
+            payload: {
+                action: 'cancel',
+                step: 'claim-form-modal',
+                networkSymbol: selectedAccount.account.symbol,
+            },
+        });
+    };
+
     // it shouldn't be possible to open this modal without having selected account
     if (!selectedAccount?.account || selectedAccount?.status !== 'loaded') return null;
 
@@ -68,7 +95,7 @@ export const ClaimModal = ({ onCancel }: ClaimModalModalProps) => {
                 />
             }
             size="small"
-            onCancel={onCancel}
+            onCancel={onCancelClick}
             bottomContent={
                 <>
                     <Tooltip content={claimingMessageContent}>
@@ -76,19 +103,19 @@ export const ClaimModal = ({ onCancel }: ClaimModalModalProps) => {
                             type="submit"
                             isDisabled={isDisabled || isClaimingDisabled}
                             isLoading={isComposing || isSubmitting}
-                            onClick={handleSubmit(signTx)}
+                            onClick={onClaimClick}
                             icon={isClaimingDisabled ? 'info' : undefined}
                         >
                             <Translation id="TR_STAKE_CLAIM" />
                         </NewModal.Button>
                     </Tooltip>
-                    <NewModal.Button variant="tertiary" onClick={onCancel}>
+                    <NewModal.Button variant="tertiary" onClick={onCancelClick}>
                         <Translation id="TR_CANCEL" />
                     </NewModal.Button>
                 </>
             }
         >
-            <form onSubmit={handleSubmit(signTx)}>
+            <form onSubmit={onClaimClick}>
                 <Column gap={spacings.lg}>
                     <InfoItem direction="column" label={<Translation id="AMOUNT" />}>
                         <Paragraph typographyStyle="titleSmall">

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeInANutshellModal/StakeInANutshellModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeInANutshellModal/StakeInANutshellModal.tsx
@@ -17,6 +17,7 @@ import {
     Row,
     Text,
 } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { openModal } from 'src/actions/suite/modalActions';
@@ -73,6 +74,28 @@ export const StakeInANutshellModal = ({ onCancel }: StakeInANutshellModalProps) 
     const proceedToEverstakeModal = () => {
         onCancel();
         dispatch(openModal({ type: 'everstake' }));
+
+        analytics.report({
+            type: EventType.StakingStake,
+            payload: {
+                action: 'continue',
+                step: 'stake-in-a-nutshell-modal',
+                networkSymbol: account?.symbol,
+            },
+        });
+    };
+
+    const onCancelClick = () => {
+        onCancel();
+
+        analytics.report({
+            type: EventType.StakingStake,
+            payload: {
+                action: 'cancel',
+                step: 'stake-in-a-nutshell-modal',
+                networkSymbol: account?.symbol,
+            },
+        });
     };
 
     const processes = [
@@ -99,7 +122,7 @@ export const StakeInANutshellModal = ({ onCancel }: StakeInANutshellModalProps) 
         <NewModal
             heading={<Translation id="TR_STAKE_STAKING_IN_A_NUTSHELL" />}
             size="tiny"
-            onCancel={onCancel}
+            onCancel={onCancelClick}
             bottomContent={
                 <NewModal.Button onClick={proceedToEverstakeModal}>
                     <Translation id="TR_CONTINUE" />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/ConfirmStakeEthModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/ConfirmStakeEthModal.tsx
@@ -4,6 +4,7 @@ import { type NetworkType, getNetworkDisplaySymbol } from '@suite-common/wallet-
 import { SOLANA_EPOCH_DAYS } from '@suite-common/wallet-constants';
 import { selectValidatorsQueueData } from '@suite-common/wallet-core';
 import { Banner, Card, Checkbox, Column, NewModal } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 import { HELP_CENTER_ETH_STAKING, HELP_CENTER_SOL_STAKING } from '@trezor/urls';
 
@@ -43,10 +44,28 @@ export const ConfirmStakeEthModal = ({
     const handleOnCancel = () => {
         onCancel();
         dispatch(openModal({ type: 'stake' }));
+
+        analytics.report({
+            type: EventType.StakingStake,
+            payload: {
+                action: 'cancel',
+                step: 'entry-period-stake-modal',
+                networkSymbol: account?.symbol,
+            },
+        });
     };
 
     const onClick = () => {
         onConfirm();
+
+        analytics.report({
+            type: EventType.StakingStake,
+            payload: {
+                action: 'continue',
+                step: 'entry-period-stake-modal',
+                networkSymbol: account?.symbol,
+            },
+        });
     };
 
     const learnMoreLink = useMemo(() => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/Inputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/Inputs.tsx
@@ -43,6 +43,7 @@ export const Inputs = () => {
         currentRate,
         setRatioAmount,
         setMax,
+        setCurrency,
     } = useStakeEthFormContext();
 
     const { MIN_FOR_WITHDRAWALS, MAX_AMOUNT_FOR_STAKING, MIN_AMOUNT_FOR_STAKING } =
@@ -115,6 +116,7 @@ export const Inputs = () => {
     return (
         <Column gap={spacings.sm} alignItems="center">
             <InputWithOptions<StakeFormState>
+                onCurrencyChange={setCurrency}
                 cryptoInputProps={{
                     name: CRYPTO_INPUT,
                     locale,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/StakeButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/StakeButton.tsx
@@ -1,5 +1,6 @@
 import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { NewModal, Tooltip } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { Translation } from 'src/components/suite';
 import { useDevice, useSelector } from 'src/hooks/suite';
@@ -18,6 +19,7 @@ export const StakeButton = () => {
         formState: { errors, isSubmitting },
         isComposing,
         watch,
+        currency,
     } = useStakeEthFormContext();
     const { isStakingDisabled, stakingMessageContent } = useMessageSystemStaking(
         selectedAccount.network.symbol,
@@ -29,12 +31,26 @@ export const StakeButton = () => {
     const isDisabled =
         !(formIsValid && hasValues) || isSubmitting || isLocked() || !device?.available;
 
+    const onStakeClick = () => {
+        handleSubmit(onSubmit)();
+
+        analytics.report({
+            type: EventType.StakingStake,
+            payload: {
+                action: 'continue',
+                step: 'stake-form-modal',
+                currency,
+                networkSymbol: selectedAccount.account.symbol,
+            },
+        });
+    };
+
     return (
         <Tooltip content={stakingMessageContent}>
             <NewModal.Button
                 isDisabled={isDisabled || isStakingDisabled}
                 isLoading={isComposing || isSubmitting}
-                onClick={handleSubmit(onSubmit)}
+                onClick={onStakeClick}
                 icon={isStakingDisabled ? 'info' : undefined}
             >
                 <Translation id="TR_CONTINUE" />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeModal.tsx
@@ -1,5 +1,6 @@
 import { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { Grid, NewModal, useMediaQuery, variables } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
@@ -25,6 +26,19 @@ export const StakeModal = ({ onCancel }: StakeModalModalProps) => {
     // it shouldn't be possible to open this modal without having selected account
     if (!account || status !== 'loaded') return null;
 
+    const onCancelClick = () => {
+        onCancel?.();
+
+        analytics.report({
+            type: EventType.StakingStake,
+            payload: {
+                action: 'cancel',
+                step: 'stake-form-modal',
+                networkSymbol: selectedAccount.account.symbol,
+            },
+        });
+    };
+
     return (
         <StakeEthFormContext.Provider value={stakeEthContextValues}>
             <NewModal
@@ -35,7 +49,7 @@ export const StakeModal = ({ onCancel }: StakeModalModalProps) => {
                         values={{ symbol: account.symbol.toUpperCase() }}
                     />
                 }
-                onCancel={onCancel}
+                onCancel={onCancelClick}
                 bottomContent={<StakeButton />}
             >
                 <Grid columns={isBelowTablet ? 1 : 2} gap={spacings.xxl}>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/EverstakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/EverstakeModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { Banner, Card, Checkbox, Column, IconName, NewModal } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { openModal } from 'src/actions/suite/modalActions';
@@ -21,6 +22,28 @@ export const EverstakeModal = ({ onCancel }: EverstakeModalProps) => {
     const proceedToStaking = () => {
         onCancel();
         dispatch(openModal({ type: 'stake' }));
+
+        analytics.report({
+            type: EventType.StakingStake,
+            payload: {
+                action: 'continue',
+                step: 'funds-maintained-modal',
+                networkSymbol: account?.symbol,
+            },
+        });
+    };
+
+    const onCancelClick = () => {
+        onCancel();
+
+        analytics.report({
+            type: EventType.StakingStake,
+            payload: {
+                action: 'cancel',
+                step: 'funds-maintained-modal',
+                networkSymbol: account?.symbol,
+            },
+        });
     };
 
     if (!account) return null;
@@ -68,14 +91,14 @@ export const EverstakeModal = ({ onCancel }: EverstakeModalProps) => {
         <NewModal
             heading={<Translation id="TR_STAKE_NETWORK" values={{ symbol: displaySymbol }} />}
             description={<Translation id="TR_STAKE_YOUR_FUNDS_MAINTAINED" />}
-            onCancel={onCancel}
+            onCancel={onCancelClick}
             size="small"
             bottomContent={
                 <>
                     <NewModal.Button isDisabled={!hasAgreed} onClick={proceedToStaking}>
                         <Translation id="TR_CONFIRM" />
                     </NewModal.Button>
-                    <NewModal.Button variant="tertiary" onClick={onCancel}>
+                    <NewModal.Button variant="tertiary" onClick={onCancelClick}>
                         <Translation id="TR_CANCEL" />
                     </NewModal.Button>
                 </>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Inputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Inputs.tsx
@@ -37,6 +37,7 @@ export const Inputs = () => {
         localCurrency,
         currentRate,
         setRatioAmount,
+        setCurrency,
     } = useUnstakeEthFormContext();
 
     const {
@@ -88,6 +89,7 @@ export const Inputs = () => {
     return (
         <Column gap={spacings.sm} alignItems="center">
             <InputWithOptions<UnstakeFormState>
+                onCurrencyChange={setCurrency}
                 cryptoInputProps={{
                     name: OUTPUT_AMOUNT,
                     locale,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeButton.tsx
@@ -1,5 +1,6 @@
 import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { Button, Tooltip } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { Translation } from 'src/components/suite';
 import { useDevice, useSelector } from 'src/hooks/suite';
@@ -22,6 +23,7 @@ export const UnstakeButton = () => {
         handleSubmit,
         watch,
         signTx,
+        currency,
     } = useUnstakeEthFormContext();
 
     const hasValues = Boolean(watch(FIAT_INPUT) || watch(CRYPTO_INPUT));
@@ -31,13 +33,27 @@ export const UnstakeButton = () => {
     const isDisabled =
         !(formIsValid && hasValues) || isSubmitting || isLocked() || !device?.available;
 
+    const onUnstakeClick = () => {
+        handleSubmit(signTx)();
+
+        analytics.report({
+            type: EventType.StakingUnstake,
+            payload: {
+                action: 'continue',
+                step: 'unstake-form-modal',
+                currency,
+                networkSymbol: selectedAccount.account.symbol,
+            },
+        });
+    };
+
     return (
         <Tooltip content={unstakingMessageContent}>
             <Button
                 type="submit"
                 isDisabled={isDisabled || isUnstakingDisabled}
                 isLoading={isComposing || isSubmitting}
-                onClick={handleSubmit(signTx)}
+                onClick={onUnstakeClick}
                 icon={isUnstakingDisabled ? 'info' : undefined}
             >
                 <Translation id="TR_STAKE_UNSTAKE" />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeModal.tsx
@@ -8,6 +8,7 @@ import {
     useMediaQuery,
     variables,
 } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
@@ -33,13 +34,26 @@ export const UnstakeModal = ({ onCancel }: UnstakeModalModalProps) => {
     // it shouldn't be possible to open this modal without having selected account
     if (!account || status !== 'loaded') return null;
 
+    const onCancelClick = () => {
+        onCancel?.();
+
+        analytics.report({
+            type: EventType.StakingUnstake,
+            payload: {
+                action: 'cancel',
+                step: 'unstake-form-modal',
+                networkSymbol: selectedAccount.account.symbol,
+            },
+        });
+    };
+
     return (
         <UnstakeEthFormContext.Provider value={unstakeEthContextValues}>
             <NewModal
                 size="huge"
                 heading={<Translation id="TR_STAKE_UNSTAKE" />}
                 description={<Translation id="TR_STAKE_CLAIM_AFTER_UNSTAKING" />}
-                onCancel={onCancel}
+                onCancel={onCancelClick}
                 bottomContent={<UnstakeButton />}
             >
                 <Grid columns={isBelowTablet ? 1 : 2} gap={spacings.xxl}>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -12,6 +12,7 @@ import {
     isSupportedSolStakingNetworkSymbol,
 } from '@suite-common/wallet-utils';
 import { Banner, Button, Column, IconButton, Row, Text } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
@@ -40,10 +41,28 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
                 dispatch(setFlag('stakeSolBannerClosed', true));
                 break;
         }
+
+        analytics.report({
+            type: EventType.StakingNavigate,
+            payload: {
+                action: 'cancel',
+                from: 'account/banner',
+                networkSymbol: account.symbol,
+            },
+        });
     };
 
     const goToStakingTab = () => {
         dispatch(goto('wallet-staking', { preserveParams: true }));
+
+        analytics.report({
+            type: EventType.StakingNavigate,
+            payload: {
+                action: 'navigate',
+                from: 'account/banner',
+                networkSymbol: account.symbol,
+            },
+        });
     };
 
     const getNetworkDetails = (networkType: NetworkType) => {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
@@ -2,10 +2,10 @@ import { getNetworkOptional } from '@suite-common/wallet-config';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
-import { goto } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite/Translation';
 import { NavigationItem, SubpageNavigation } from 'src/components/suite/layouts/SuiteLayout';
-import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useGoToWithAnalytics } from 'src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics';
+import { useSelector } from 'src/hooks/suite';
 import { selectHasExperimentalFeature } from 'src/reducers/suite/suiteReducer';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { WalletParams } from 'src/types/wallet';
@@ -13,20 +13,10 @@ import { WalletParams } from 'src/types/wallet';
 export const AccountNavigation = () => {
     const account = useSelector(selectSelectedAccount);
     const routerParams = useSelector(state => state.router.params) as WalletParams;
-    const dispatch = useDispatch();
     const enabledNftSection = useSelector(selectHasExperimentalFeature('nft-section'));
     const network = getNetworkOptional(routerParams?.symbol);
     const networkType = account?.networkType || network?.networkType || '';
-
-    const goToWithAnalytics = (...[routeName, options]: Parameters<typeof goto>) => {
-        if (account?.symbol) {
-            analytics.report({
-                type: EventType.AccountsActions,
-                payload: { symbol: account.symbol, action: routeName },
-            });
-        }
-        dispatch(goto(routeName, options));
-    };
+    const goToWithAnalytics = useGoToWithAnalytics(account);
 
     const accountTabs: NavigationItem[] = [
         {
@@ -61,6 +51,15 @@ export const AccountNavigation = () => {
             id: 'wallet-staking',
             callback: () => {
                 goToWithAnalytics('wallet-staking', { preserveParams: true });
+
+                analytics.report({
+                    type: EventType.StakingNavigate,
+                    payload: {
+                        action: 'navigate',
+                        from: 'account/navigation',
+                        networkSymbol: network?.symbol,
+                    },
+                });
             },
             title: <Translation id="TR_NAV_STAKING" />,
             isHidden: !hasNetworkFeatures(account, 'staking'),

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx
@@ -3,10 +3,10 @@ import { Ref, forwardRef } from 'react';
 import styled from 'styled-components';
 
 import { Column, TOOLTIP_DELAY_NORMAL, Tooltip } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 
-import { goto } from 'src/actions/suite/routerActions';
+import { useGoToWithAnalytics } from 'src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics';
 import { NavigationItemBase } from 'src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem';
-import { useDispatch } from 'src/hooks/suite';
 import { Account, AccountItemType } from 'src/types/wallet';
 
 import { AccountItemLeft } from './AccountItemLeft';
@@ -64,9 +64,9 @@ export const AccountItem = forwardRef(
         }: AccountItemProps,
         ref: Ref<HTMLDivElement>,
     ) => {
-        const dispatch = useDispatch();
-
         const { accountType, index, symbol } = account;
+
+        const goToWithAnalytics = useGoToWithAnalytics(account);
 
         const accountRouteParams = {
             symbol,
@@ -87,7 +87,18 @@ export const AccountItem = forwardRef(
 
         const handleHeaderClick = () => {
             onClick?.();
-            dispatch(goto(getRoute(), { params: accountRouteParams }));
+            goToWithAnalytics(getRoute(), { params: accountRouteParams });
+
+            if (type === 'staking') {
+                analytics.report({
+                    type: EventType.StakingNavigate,
+                    payload: {
+                        action: 'navigate',
+                        from: 'sidebar',
+                        networkSymbol: symbol,
+                    },
+                });
+            }
         };
 
         const content = (

--- a/packages/suite/src/hooks/wallet/useStakeEthForm.ts
+++ b/packages/suite/src/hooks/wallet/useStakeEthForm.ts
@@ -49,6 +49,8 @@ export const useStakeEthForm = ({ selectedAccount }: UseStakeFormsProps): StakeC
     const localCurrency = useSelector(selectLocalCurrency);
     const symbolFees = useSelector(state => state.wallet.fees[symbol]);
 
+    const [currency, setCurrency] = useState<'crypto' | 'fiat' | undefined>(undefined);
+
     const currentRate = useSelector(state =>
         selectFiatRatesByFiatRateKey(state, getFiatRateKey(symbol, localCurrency), 'current'),
     );
@@ -410,6 +412,8 @@ export const useStakeEthForm = ({ selectedAccount }: UseStakeFormsProps): StakeC
         signTx,
         currentRate,
         isLoading,
+        currency,
+        setCurrency,
     };
 };
 

--- a/packages/suite/src/hooks/wallet/useUnstakeEthForm.ts
+++ b/packages/suite/src/hooks/wallet/useUnstakeEthForm.ts
@@ -42,6 +42,8 @@ type UnstakeContextValues = UnstakeContextValuesBase & {
     amountLimits: AmountLimitProps;
     approximatedInstantEthAmount?: string | null;
     setRatioAmount: (divisor: number) => void;
+    currency?: 'crypto' | 'fiat';
+    setCurrency: (currency: 'crypto' | 'fiat') => void;
 };
 
 export const UnstakeEthFormContext = createContext<UnstakeContextValues | null>(null);
@@ -60,6 +62,8 @@ export const useUnstakeEthForm = ({
 
     const localCurrency = useSelector(selectLocalCurrency);
     const symbolFees = useSelector(state => state.wallet.fees[symbol]);
+
+    const [currency, setCurrency] = useState<'crypto' | 'fiat' | undefined>(undefined);
 
     const currentRate = useSelector(state =>
         selectFiatRatesByFiatRateKey(state, getFiatRateKey(symbol, localCurrency), 'current'),
@@ -295,6 +299,8 @@ export const useUnstakeEthForm = ({
         feeInfo,
         changeFeeLevel,
         approximatedInstantEthAmount,
+        currency,
+        setCurrency,
     };
 };
 

--- a/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
@@ -142,6 +142,17 @@ export const AssetCard = ({
             currentFiatRates,
         );
 
+    const onStakeButtonClick = () => {
+        analytics.report({
+            type: EventType.StakingNavigate,
+            payload: {
+                action: 'navigate',
+                from: 'dashboard/assets',
+                networkSymbol: symbol,
+            },
+        });
+    };
+
     return (
         <Card
             paddingType="small"
@@ -215,7 +226,11 @@ export const AssetCard = ({
 
                             <Row gap={spacings.xs}>
                                 {isStakeNetwork && (
-                                    <TradingButton symbol={symbol} routeName="wallet-staking">
+                                    <TradingButton
+                                        symbol={symbol}
+                                        onClick={onStakeButtonClick}
+                                        routeName="wallet-staking"
+                                    >
                                         <Translation id="TR_STAKE_STAKE" />
                                     </TradingButton>
                                 )}

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
@@ -103,6 +103,17 @@ export const AssetRow = memo(
             currentFiatRates,
         );
 
+        const onStakeButtonClick = () => {
+            analytics.report({
+                type: EventType.StakingNavigate,
+                payload: {
+                    action: 'navigate',
+                    from: 'dashboard/assets',
+                    networkSymbol: symbol,
+                },
+            });
+        };
+
         return (
             <>
                 <Table.Row onClick={handleRowClick} data-testid={`@dashboard/asset-item/${symbol}`}>
@@ -165,7 +176,11 @@ export const AssetRow = memo(
                     <Table.Cell align="end" colSpan={2}>
                         <Row gap={spacings.md}>
                             {isStakeNetwork && (
-                                <TradingButton symbol={symbol} routeName="wallet-staking">
+                                <TradingButton
+                                    symbol={symbol}
+                                    onClick={onStakeButtonClick}
+                                    routeName="wallet-staking"
+                                >
                                     <Translation id="TR_STAKE_STAKE" />
                                 </TradingButton>
                             )}

--- a/packages/suite/src/views/dashboard/StakeEthCard/StakeEthCardFooter/StakeEthCardFooter.tsx
+++ b/packages/suite/src/views/dashboard/StakeEthCard/StakeEthCardFooter/StakeEthCardFooter.tsx
@@ -1,5 +1,6 @@
-import { getNetwork } from '@suite-common/wallet-config';
+import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { Button, Paragraph, Row } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
@@ -13,22 +14,47 @@ type StakeEthCardFooterProps = {
     hideSection: () => void;
 };
 
+const symbol: NetworkSymbol = 'eth';
+
 export const StakeEthCardFooter = ({ accountIndex = 0, hideSection }: StakeEthCardFooterProps) => {
     const dispatch = useDispatch();
     const { setCoinFilter, setSearchString } = useAccountSearch();
+
     const goToEthStakingTab = () => {
         dispatch(
             goto('wallet-staking', {
                 params: {
-                    symbol: 'eth',
+                    symbol,
                     accountIndex,
                     accountType: 'normal',
                 },
             }),
         );
         // activate coin filter and reset account search string
-        setCoinFilter('eth');
+        setCoinFilter(symbol);
         setSearchString(undefined);
+
+        analytics.report({
+            type: EventType.StakingNavigate,
+            payload: {
+                action: 'navigate',
+                from: 'dashboard/banner',
+                networkSymbol: symbol,
+            },
+        });
+    };
+
+    const onMaybeLaterClick = () => {
+        hideSection();
+
+        analytics.report({
+            type: EventType.StakingNavigate,
+            payload: {
+                action: 'cancel',
+                from: 'dashboard/banner',
+                networkSymbol: symbol,
+            },
+        });
     };
 
     return (
@@ -37,14 +63,14 @@ export const StakeEthCardFooter = ({ accountIndex = 0, hideSection }: StakeEthCa
                 <Paragraph variant="tertiary" typographyStyle="label">
                     <Translation id="TR_AVAILABLE_NOW_FOR" />
                 </Paragraph>
-                <NetworkBadge symbol="eth" name={getNetwork('eth').name} />
+                <NetworkBadge symbol={symbol} name={getNetwork(symbol).name} />
             </div>
 
             <Row gap={spacings.xs}>
                 <Button onClick={goToEthStakingTab}>
                     <Translation id="TR_STAKE_START_STAKING" />
                 </Button>
-                <Button variant="tertiary" onClick={hideSection}>
+                <Button variant="tertiary" onClick={onMaybeLaterClick}>
                     <Translation id="TR_MAYBE_LATER" />
                 </Button>
             </Row>

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ClaimCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ClaimCard.tsx
@@ -4,6 +4,7 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import { selectAccountClaimTransactions } from '@suite-common/wallet-core';
 import { getStakingDataForNetwork, isPending } from '@suite-common/wallet-utils';
 import { Button, Card, Column, InfoItem, Paragraph, Tooltip } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { openModal } from 'src/actions/suite/modalActions';
@@ -52,6 +53,15 @@ export const ClaimCard = () => {
     const openClaimModal = () => {
         if (!isClaimingDisabled) {
             dispatch(openModal({ type: 'claim' }));
+
+            analytics.report({
+                type: EventType.StakingClaim,
+                payload: {
+                    action: 'continue',
+                    step: 'staking-dashboard',
+                    networkSymbol: selectedAccount?.symbol,
+                },
+            });
         }
     };
 

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
@@ -15,6 +15,7 @@ import {
     useMediaQuery,
     variables,
 } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { openModal } from 'src/actions/suite/modalActions';
@@ -33,9 +34,19 @@ export const EmptyStakingCard = () => {
     const apy = useSelector(state => selectPoolStatsApyData(state, account?.symbol));
 
     const dispatch = useDispatch();
+
     const openStakeInANutshellModal = () => {
         if (!isStakingDisabled) {
             dispatch(openModal({ type: 'stake-in-a-nutshell' }));
+
+            analytics.report({
+                type: EventType.StakingStake,
+                payload: {
+                    action: 'continue',
+                    step: 'staking-dashboard',
+                    networkSymbol: account?.symbol,
+                },
+            });
         }
     };
 

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
@@ -22,6 +22,7 @@ import {
     useMediaQuery,
     variables,
 } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
@@ -129,14 +130,34 @@ export const StakingCard = ({
     });
 
     const dispatch = useDispatch();
+
     const openStakeModal = () => {
         if (!isStakingDisabled) {
             dispatch(openModal({ type: 'stake' }));
+
+            analytics.report({
+                type: EventType.StakingStake,
+                payload: {
+                    action: 'continue',
+                    step: 'staking-dashboard',
+                    networkSymbol: selectedAccount?.symbol,
+                },
+            });
         }
     };
+
     const openUnstakeModal = () => {
         if (!isUnstakingDisabled) {
             dispatch(openModal({ type: 'unstake' }));
+
+            analytics.report({
+                type: EventType.StakingUnstake,
+                payload: {
+                    action: 'continue',
+                    step: 'staking-dashboard',
+                    networkSymbol: selectedAccount?.symbol,
+                },
+            });
         }
     };
 

--- a/suite-common/wallet-core/src/stake/stakeTypes.ts
+++ b/suite-common/wallet-core/src/stake/stakeTypes.ts
@@ -82,6 +82,8 @@ export type StakeContextValues = UseFormReturn<StakeFormState> &
         onSubmit: () => void;
         currentRate: Rate | undefined;
         isLoading: boolean;
+        currency?: 'crypto' | 'fiat';
+        setCurrency: (currency: 'crypto' | 'fiat') => void;
     };
 
 export type UnstakeFormState = Omit<StakeFormState, 'setMaxOutputId'>;


### PR DESCRIPTION
## Description

Added analytics for staking.

Event types:
- `StakingNavigate` - fires on navigating from staking buttons to the staking dashboard
- `StakingStake` - fires on every step during the stake process
- `StakingUnstake` - fires on every step during the unstake process
- `StakingClaim` - fires on every step during the claim process
- `StakingConfirm` - fires on confirming a stake/unstake/claim transaction

Other event types:
- `TransactionRetry` - fires on clicking on the `Retry` button when transaction has timed out
- `TransactionCancel` - fires on canceling transaction review & sign modal

## Related Issue

Resolve #13755 

## Screenshots

<img width="1174" alt="s1" src="https://github.com/user-attachments/assets/760673af-7943-4630-a46f-7acfbfb87001" />

<img width="1176" alt="s2" src="https://github.com/user-attachments/assets/1c51f747-5122-489b-bdc9-6861554b3198" />

<img width="1176" alt="s3" src="https://github.com/user-attachments/assets/008da67f-1111-48f2-8421-23ff7ce30adb" />

<img width="512" alt="s4" src="https://github.com/user-attachments/assets/25d328ef-6f39-47c4-ad76-6d947673fce8" />

<img width="1175" alt="s5" src="https://github.com/user-attachments/assets/57b60c71-b003-4792-9d43-50a5032b1626" />

<img width="1176" alt="s6" src="https://github.com/user-attachments/assets/06238356-0416-49f6-a519-7367331fdc3d" />

<img width="1175" alt="s7" src="https://github.com/user-attachments/assets/641075dd-7cf1-426c-89ab-31625af6f5a9" />

<img width="519" alt="s8" src="https://github.com/user-attachments/assets/848af0f6-bf7b-4ae5-bf95-450c42ebf2d9" />

<img width="685" alt="s9" src="https://github.com/user-attachments/assets/be50fdd4-40ca-470e-9fa8-80f1f5ba13c0" />

<img width="1029" alt="s10" src="https://github.com/user-attachments/assets/1106718c-c02f-406d-baaf-ffca8ba8ff2e" />

<img width="698" alt="s11" src="https://github.com/user-attachments/assets/573cf6af-e1c0-4b1f-8833-81ab3832ed00" />

<img width="724" alt="s12" src="https://github.com/user-attachments/assets/30c5fe42-fb10-4995-8143-fabcda684472" />

<img width="793" alt="Screenshot 2025-03-26 at 16 32 08" src="https://github.com/user-attachments/assets/e85c9d9a-8796-4c1c-83c3-147079d8675b" />

<img width="709" alt="Screenshot 2025-03-26 at 16 32 17" src="https://github.com/user-attachments/assets/ac45dadc-2039-46f8-8c6b-c1b040a754cd" />

<img width="1026" alt="Screenshot 2025-03-26 at 16 32 31" src="https://github.com/user-attachments/assets/13fd7ce2-7aa9-4bab-bae9-0e35357df56b" />

<img width="1173" alt="Screenshot 2025-03-28 at 12 00 35" src="https://github.com/user-attachments/assets/9a259cc1-d7fe-4359-bf8d-20f5b8df6447" />
