### PR TITLE
fix: staking epoch update

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -259,8 +259,26 @@ const getAccountInfo = async (
         return allTxIds;
     };
 
+    const getEpoch = async (): Promise<number> => {
+        const cachedEpoch = await request.state.cache.get('epoch');
+
+        if (cachedEpoch) {
+            return cachedEpoch;
+        }
+
+        // for parallel requests we store the promise in the cache immediately
+        const deferred = createDeferred<number>();
+        request.state.cache.set('epoch', deferred.promise, 3_600_000);
+
+        const { epoch } = await api.rpc.getEpochInfo().send();
+        deferred.resolve(Number(epoch));
+
+        return deferred.promise;
+    };
+
     if (details === 'txids') {
         const txids = await getAllTxIds(request.payload.tokenAccountsPubKeys || []);
+        const solEpoch = await getEpoch();
 
         const account: AccountInfo = {
             descriptor: payload.descriptor,
@@ -272,6 +290,7 @@ const getAccountInfo = async (
                 unconfirmed: 0,
                 txids,
             },
+            misc: { solEpoch },
         };
 
         return {
@@ -314,23 +333,6 @@ const getAccountInfo = async (
                 },
             )
             .send();
-
-    const getEpoch = async (): Promise<number> => {
-        const cachedEpoch = await request.state.cache.get('epoch');
-
-        if (cachedEpoch) {
-            return cachedEpoch;
-        }
-
-        // for parallel requests we store the promise in the cache immediately
-        const deferred = createDeferred<number>();
-        request.state.cache.set('epoch', deferred.promise, 3_600_000);
-
-        const { epoch } = await api.rpc.getEpochInfo().send();
-        deferred.resolve(Number(epoch));
-
-        return deferred.promise;
-    };
 
     const tokenAccounts = (
         await Promise.all(

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -761,8 +761,12 @@ export const isAccountOutdated = (account: Account, freshInfo: AccountInfo) => {
                 freshInfo.misc!.staking?.poolId !== account.misc.staking.poolId
             );
         case 'solana':
-            // compare last transaction signature since the total number of txs may not be fetched fully
-            return freshInfo.history.txids?.[0] !== account.history.txids?.[0];
+            return (
+                // compare last transaction signature since the total number of txs may not be fetched fully
+                freshInfo.history.txids?.[0] !== account.history.txids?.[0] ||
+                // compare last epoch
+                freshInfo.misc?.solEpoch !== account.misc?.solEpoch
+            );
         default:
             return false;
     }


### PR DESCRIPTION
## Description

- update Solana account when epoch changes
- should fix remembered wallets do not update staking info
- in case user stakes something in different instance of app, accounts should be updated by change of txids

## Related Issue

Resolve #17913
