### PR TITLE
fix(discovery): recover discovery when connection is re-established

### DIFF
--- a/packages/blockchain-link/src/workers/baseWorker.ts
+++ b/packages/blockchain-link/src/workers/baseWorker.ts
@@ -96,13 +96,16 @@ export abstract class BaseWorker<API> {
             }
 
             const endpoints = prioritizeEndpoints(urls);
-            this.connectPromise = this.connectRecursive(endpoints).then(api => {
-                this.debug('Connected');
-                this.api = api;
-                this.connectPromise = undefined;
+            this.connectPromise = this.connectRecursive(endpoints)
+                .then(api => {
+                    this.debug('Connected');
+                    this.api = api;
 
-                return api;
-            });
+                    return api;
+                })
+                .finally(() => {
+                    this.connectPromise = undefined;
+                });
         }
 
         return this.connectPromise;

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -289,10 +289,10 @@ const discoverAccountsByDescriptorThunk = createThunk(
         },
         { dispatch, getState },
     ) => {
-        let isFinalRound = false;
+        let isFinished = false;
 
         if (A.isEmpty(descriptorsBundle)) {
-            isFinalRound = true;
+            isFinished = true;
         }
 
         const device = selectSelectedDevice(getState());
@@ -315,7 +315,7 @@ const discoverAccountsByDescriptorThunk = createThunk(
 
             if (success && !isAccountAlreadyDiscovered) {
                 if (accountInfo.empty) {
-                    isFinalRound = true;
+                    isFinished = true;
                 }
 
                 const isVisible =
@@ -333,9 +333,11 @@ const discoverAccountsByDescriptorThunk = createThunk(
                     }),
                 );
             }
+
+            if ('error' in accountInfo) return { isFinished: false, error: accountInfo.error };
         }
 
-        return isFinalRound;
+        return { isFinished };
     },
 );
 
@@ -511,7 +513,7 @@ const discoverNetworkBatchThunk = createThunk(
             networkType: network.networkType,
         });
 
-        const isFinished = await dispatch(
+        const { isFinished, error } = await dispatch(
             discoverAccountsByDescriptorThunk({
                 descriptorsBundle: deviceAccessResponse.payload,
                 deviceState,
@@ -525,9 +527,11 @@ const discoverNetworkBatchThunk = createThunk(
                     deviceState,
                     network,
                     accountType,
-                    round: round + 1,
+                    // Retry current round if discoverAccountsByDescriptorThunk fails
+                    round: error ? round : round + 1,
                 }),
             );
+            console.warn(error);
         } else {
             dispatch(finishNetworkTypeDiscoveryThunk());
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Resuming Discovery when the internet connection is re-established

note: The fix is build upon https://github.com/trezor/trezor-suite/pull/17903 by @marekrjpolak 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17524

## Screenshots:

### Before
https://github.com/user-attachments/assets/e84355d3-fc28-4f1b-bfd7-32ba78d38135




### After
https://github.com/user-attachments/assets/046a15b2-b58b-437e-9aeb-a700239b1f49


