### PR TITLE
[testing] connect in desktop testing branch

### DIFF
--- a/packages/connect-explorer/src/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/actions/trezorConnectActions.ts
@@ -139,8 +139,8 @@ export const init =
         }
 
         // Get default coreMode from URL params (?core-mode=auto)
-        const urlParams = new URLSearchParams(window.location.search);
-        const coreMode = (urlParams.get('core-mode') as ConnectOptions['coreMode']) || 'auto';
+        // const urlParams = new URLSearchParams(window.location.search);
+        // const coreMode = (urlParams.get('core-mode') as ConnectOptions['coreMode']) || 'auto';
 
         // localhost + dev server
         let _sessionsBackgroundUrl = process.env.CONNECT_EXPLORER_FULL_URL
@@ -153,8 +153,8 @@ export const init =
                 'https://connect.trezor.io/9/workers/sessions-background-sharedworker.js';
         }
 
-        const connectOptions = {
-            coreMode,
+        const connectOptions: ConnectOptions = {
+            coreMode: 'suite-desktop',
             transportReconnect: true,
             popup: true,
             debug: true,


### PR DESCRIPTION
This branch sets connect-explorer to use connect-in-desktop by default for testing purposes only. [Build available here](https://dev.suite.sldev.cz/connect/connect-desktop/)

To make it work with Suite-desktop run it with `--expose-connect-ws` flag

Lets please test it, not focusing suite-side UI but rather websocket connection stability, reconnections, edgecases...

<img width="1500" alt="image" src="https://github.com/user-attachments/assets/2d8098db-e6ca-4c4d-9f69-bb72bee1892d" />

list of tasks https://www.notion.so/satoshilabs/1c9dc526060680d4af55eeff75cee8bf?v=1c9dc5260606806593be000cfffe7aaa
