### PR TITLE
feat(suite-native): polished UI of TradeableAssetButton

### DIFF
--- a/suite-native/module-trading/src/__fixtures__/tradeableAssets.ts
+++ b/suite-native/module-trading/src/__fixtures__/tradeableAssets.ts
@@ -21,7 +21,7 @@ export const ethAsset: TradeableAsset = {
 };
 
 export const usdcAsset: TradeableAsset = {
-    symbol: 'eth',
+    symbol: 'usdc',
     name: 'USDC',
     coingeckoId: 'usd-coin',
     cryptoId: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CryptoId,

--- a/suite-native/module-trading/src/components/general/FiatCurrencyButton.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencyButton.tsx
@@ -21,7 +21,7 @@ const GRADIENT_START = { x: 0, y: 0.5 } as const;
 const GRADIENT_END = { x: 1, y: 0.5 } as const;
 
 const buttonStyle = prepareNativeStyle(({ spacings }) => ({
-    padding: spacings.sp8,
+    padding: 6,
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',

--- a/suite-native/module-trading/src/components/general/FiatCurrencyIcon.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencyIcon.tsx
@@ -4,7 +4,8 @@ export const FiatCurrencyIcon = () => (
     <RoundedIcon
         name="coin"
         color="iconSubdued"
-        containerSize={34}
+        iconSize="small"
+        containerSize={24}
         backgroundColor="backgroundSurfaceElevation0"
     />
 );

--- a/suite-native/module-trading/src/components/general/TradeableAssetButton.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetButton.tsx
@@ -5,6 +5,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 import { invariant } from '@suite-common/suite-utils';
 import { cryptoIdToSymbol } from '@suite-common/trading';
+import { NetworkDisplaySymbol, getDisplaySymbol } from '@suite-common/wallet-config';
 import { CryptoIcon, Icon } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { hexToRgba } from '@trezor/utils';
@@ -24,7 +25,7 @@ const GRADIENT_START = { x: 0, y: 0.5 } as const;
 const GRADIENT_END = { x: 1, y: 0.5 } as const;
 
 const buttonStyle = prepareNativeStyle(({ spacings }) => ({
-    padding: spacings.sp8,
+    padding: 6,
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
@@ -54,6 +55,12 @@ export const TradeableAssetButton = ({
         [dominantAssetColor],
     );
 
+    // when there is no contract address, we want to use display symbol instead
+    // this way we can present ETH icon for EVMs instead of network icon
+    const adjustedSymbol = contractAddress
+        ? networkSymbol
+        : (getDisplaySymbol(networkSymbol) as NetworkDisplaySymbol);
+
     return (
         <LinearGradient
             colors={gradientColors}
@@ -68,7 +75,11 @@ export const TradeableAssetButton = ({
                 accessibilityRole="button"
                 accessibilityLabel={accessibilityLabel}
             >
-                <CryptoIcon symbol={networkSymbol} contractAddress={contractAddress} size="small" />
+                <CryptoIcon
+                    symbol={adjustedSymbol}
+                    contractAddress={contractAddress}
+                    size="extraSmall"
+                />
                 <NetworkSymbolExtendedFormatter symbol={symbol} variant="callout" />
                 {caret && <Icon name="caretDown" color="textSubdued" size="medium" />}
             </Pressable>

--- a/suite-native/module-trading/src/components/general/TradeableAssetsSheet/__tests__/TradeableAssetListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetsSheet/__tests__/TradeableAssetListItem.comp.test.tsx
@@ -14,7 +14,7 @@ describe('TradeableAssetListItem', () => {
         const { getByLabelText } = await renderComponent({ asset: usdcAsset });
 
         expect(getByLabelText('Coin name')).toHaveTextContent('USDC');
-        expect(getByLabelText('Coin symbol')).toHaveTextContent('ETH');
+        expect(getByLabelText('Coin symbol')).toHaveTextContent('USDC');
         expect(getByLabelText('Network name')).toHaveTextContent('Ethereum');
     });
 

--- a/suite-native/module-trading/src/components/general/__tests__/TradeableAssetButton.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradeableAssetButton.comp.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { btcAsset } from '../../../__fixtures__/tradeableAssets';
+import { btcAsset, ethOnBaseAsset, usdcAsset } from '../../../__fixtures__/tradeableAssets';
 import { TradeableAssetButton } from '../TradeableAssetButton';
 
 describe('TradeableAssetButton', () => {
@@ -14,6 +14,30 @@ describe('TradeableAssetButton', () => {
         );
 
         expect(getByText('BTC')).toBeDefined();
+    });
+
+    it('should render display ETH as display symbol for L2 EVMs', () => {
+        const { getByText } = renderWithBasicProvider(
+            <TradeableAssetButton
+                asset={ethOnBaseAsset}
+                onPress={jest.fn()}
+                accessibilityLabel="a11yLabel"
+            />,
+        );
+
+        expect(getByText('ETH')).toBeDefined();
+    });
+
+    it('should render display token name when token is present', () => {
+        const { getByText } = renderWithBasicProvider(
+            <TradeableAssetButton
+                asset={usdcAsset}
+                onPress={jest.fn()}
+                accessibilityLabel="a11yLabel"
+            />,
+        );
+
+        expect(getByText('USDC')).toBeDefined();
     });
 
     it('should call onPress callback', () => {


### PR DESCRIPTION
Visual tweaks for TrateableAssetButton


## Related Issue

Resolve #17930

## Screenshots:
<img width="285" alt="Screenshot 2025-03-27 at 14 08 11" src="https://github.com/user-attachments/assets/ece899b5-6eac-4bdf-b1a5-eeff350523dd" />
