### PR TITLE
feat(suite-native): Mobile Trade: improve list item animations

### DIFF
--- a/suite-native/module-trading/src/components/general/CountrySheet/CountryListItem.tsx
+++ b/suite-native/module-trading/src/components/general/CountrySheet/CountryListItem.tsx
@@ -1,7 +1,8 @@
 import { ReactNode } from 'react';
 import { Pressable } from 'react-native';
+import { FadeInLeft, FadeOutRight } from 'react-native-reanimated';
 
-import { Card, HStack, Radio, Text } from '@suite-native/atoms';
+import { AnimatedBox, Card, HStack, Radio, Text } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 export type CountryListItemProps = {
@@ -21,17 +22,19 @@ export const CountryListItem = ({ label, onPress, value, isSelected }: CountryLi
     const { applyStyle } = useNativeStyles();
 
     return (
-        <Pressable onPress={onPress} style={applyStyle(wrapperStyle)}>
-            <Card>
-                <HStack alignItems="center" justifyContent="space-between">
-                    <HStack>
-                        <Text variant="body" color="textDefault">
-                            {label}
-                        </Text>
+        <AnimatedBox entering={FadeInLeft} exiting={FadeOutRight}>
+            <Pressable onPress={onPress} style={applyStyle(wrapperStyle)}>
+                <Card>
+                    <HStack alignItems="center" justifyContent="space-between">
+                        <HStack>
+                            <Text variant="body" color="textDefault">
+                                {label}
+                            </Text>
+                        </HStack>
+                        <Radio value={value} onPress={onPress} isChecked={isSelected} />
                     </HStack>
-                    <Radio value={value} onPress={onPress} isChecked={isSelected} />
-                </HStack>
-            </Card>
-        </Pressable>
+                </Card>
+            </Pressable>
+        </AnimatedBox>
     );
 };

--- a/suite-native/module-trading/src/hooks/useSectionList.tsx
+++ b/suite-native/module-trading/src/hooks/useSectionList.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, ReactNode, useMemo } from 'react';
-import { FadeInUp, FadeOutUp } from 'react-native-reanimated';
+import { FadeInLeft, FadeInUp, FadeOutRight, FadeOutUp } from 'react-native-reanimated';
 
 import { UnreachableCaseError } from '@suite-common/suite-utils';
 import { AnimatedBox, Text } from '@suite-native/atoms';
@@ -119,8 +119,8 @@ const renderInternalItem = <T, U>(
         case 'item':
             return (
                 <AnimatedBox
-                    entering={FadeInUp}
-                    exiting={FadeOutUp}
+                    entering={FadeInLeft}
+                    exiting={FadeOutRight}
                     style={applyStyle(itemStyle, item[2])}
                 >
                     {renderItem(item[1], item[2])}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes animations in mobile trade section lists. Adds entering and leaving animations to country picker, where animations were missing.
<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
