### PR TITLE
fix(message-system): remove unsued gitlab key

### DIFF
--- a/suite-common/message-system/scripts/sign-config.ts
+++ b/suite-common/message-system/scripts/sign-config.ts
@@ -27,10 +27,7 @@ const getPrivateKey = () => {
 
     console.log('Signing config using production private key!');
 
-    const keyEnv = process.env.JWS_PRIVATE_KEY_ENV; // available on GitHub
-    const keyFile = process.env.JWS_PRIVATE_KEY_FILE; // available on GitLab
-
-    const privateKey = keyEnv || (keyFile && fs.readFileSync(keyFile, 'utf-8'));
+    const privateKey = process.env.JWS_PRIVATE_KEY_ENV; // available on GitHub
 
     if (!privateKey) {
         throw Error('Missing private key!');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We do not use GitLab anymore so it seams that `JWS_PRIVATE_KEY_FILE` is not necessary anymore. @matejkriz  ???