### PR TITLE
feat(message-system): introduce ff and context for trade

### DIFF
--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -17,7 +17,7 @@ export type MessageSystemRootState = {
     messageSystem: MessageSystemState;
 };
 
-// Note: do not rename the feature flag identifiers (otherwise, both old & new would have to be targetted by a message system release)
+// Note: do not rename the feature flag identifiers (otherwise, both old & new would have to be targeted by a message system release)
 export const Feature = {
     coinjoin: 'coinjoin',
     killswitch: 'killswitch',
@@ -41,6 +41,12 @@ export const Feature = {
     entropyCheck: 'security.entropyCheck',
     // FW update feature flag implemented only for mobile app
     firmwareUpdate: 'device.firmware.update',
+    // trading feature flags implemented for mobile app
+    trading: {
+        buy: 'trading.buy',
+        sell: 'trading.sell',
+        swap: 'trading.swap',
+    },
 } as const;
 
 type ExtractFeatureValues<T> =
@@ -56,6 +62,10 @@ export const Context = {
     coinjoin: 'accounts.coinjoin',
     ethStaking: 'accounts.eth.staking',
     solStaking: 'accounts.sol.staking',
+    // trading contexts are implemented for mobile app
+    tradingBuy: 'trading.buy',
+    tradingSell: 'trading.sell',
+    tradingSwap: 'trading.swap',
 } as const;
 
 export type ContextDomain = (typeof Context)[keyof typeof Context];

--- a/suite-native/app/src/navigation/AppTabNavigator.tsx
+++ b/suite-native/app/src/navigation/AppTabNavigator.tsx
@@ -3,11 +3,10 @@ import { useSelector } from 'react-redux';
 import { BottomTabBarProps, createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
 import { useHandleDeviceRequestsPassphrase } from '@suite-native/device-authorization';
-import { FeatureFlag, createSelectIsFeatureFlagEnabled } from '@suite-native/feature-flags';
 import { AccountsStackNavigator } from '@suite-native/module-accounts-management';
 import { HomeStackNavigator } from '@suite-native/module-home';
 import { SettingsScreen } from '@suite-native/module-settings';
-import { TradingStackNavigator } from '@suite-native/module-trading';
+import { TradingStackNavigator, selectIsTradingEnabled } from '@suite-native/module-trading';
 import { AppTabsParamList, AppTabsRoutes, TabBar } from '@suite-native/navigation';
 
 import { rootTabsOptions } from './routes';
@@ -17,9 +16,7 @@ const Tab = createBottomTabNavigator<AppTabsParamList>();
 export const AppTabNavigator = () => {
     useHandleDeviceRequestsPassphrase();
 
-    const isTradingEnabled = useSelector(
-        createSelectIsFeatureFlagEnabled(FeatureFlag.IsTradingEnabled),
-    );
+    const isTradingEnabled = useSelector(selectIsTradingEnabled);
 
     return (
         <Tab.Navigator

--- a/suite-native/app/src/navigation/__tests__/AppTabNavigator.comp.test.tsx
+++ b/suite-native/app/src/navigation/__tests__/AppTabNavigator.comp.test.tsx
@@ -27,22 +27,24 @@ describe('AppTabNavigator', () => {
         expect(getByText('Settings')).toBeDefined();
     });
 
-    it('should not render Trade tab when IsTradingEnabled is false', async () => {
+    it('should not render Trade tab when all trading flags are disabled', async () => {
         const { queryByText } = await renderTabs({
             featureFlags: {
                 ...featureFlagsInitialState,
-                [FeatureFlag.IsTradingEnabled]: false,
+                [FeatureFlag.IsTradingBuyEnabled]: false,
+                [FeatureFlag.IsTradingSwapEnabled]: false,
+                [FeatureFlag.IsTradingSellEnabled]: false,
             },
         });
 
         expect(queryByText('Trade')).toBe(null);
     });
 
-    it('should render Trade tab when IsTradingEnabled is true', async () => {
+    it('should render Trade tab when at least one trading flag is enabled', async () => {
         const { getByText, getAllByText } = await renderTabs({
             featureFlags: {
                 ...featureFlagsInitialState,
-                [FeatureFlag.IsTradingEnabled]: true,
+                [FeatureFlag.IsTradingBuyEnabled]: true,
             },
         });
 

--- a/suite-native/atoms/src/AlertBox.tsx
+++ b/suite-native/atoms/src/AlertBox.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { ActivityIndicator } from 'react-native';
+import { AccessibilityProps, ActivityIndicator } from 'react-native';
 
 import { Icon, IconName } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -78,7 +78,7 @@ const variantToIconName = {
     error: 'warningCircle',
 } as const satisfies Record<AlertBoxVariant, IconName>;
 
-export type AlertBoxProps = {
+export type AlertBoxProps = AccessibilityProps & {
     variant: AlertBoxVariant;
     title: ReactNode;
     borderRadius?: NativeRadius | number;
@@ -102,6 +102,7 @@ export const AlertBox = ({
     variant = 'info',
     borderRadius = 'r16',
     textVariant = 'label',
+    ...props
 }: AlertBoxProps) => {
     const { applyStyle } = useNativeStyles();
     const {
@@ -119,6 +120,7 @@ export const AlertBox = ({
                 borderColor,
                 backgroundColor,
             })}
+            {...props}
         >
             {variant === 'loading' ? (
                 <AlertSpinner color={color} />

--- a/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
+++ b/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
@@ -20,9 +20,11 @@ describe('featureFlagsSlice', () => {
                 isCardanoSendEnabled: false,
                 isRegtestEnabled: false,
                 isConnectPopupEnabled: false,
-                isTradingEnabled: false,
                 isDeviceOnboardingEnabled: false,
                 isWalletConnectEnabled: false,
+                isTradingBuyEnabled: false,
+                isTradingSwapEnabled: false,
+                isTradingSellEnabled: false,
             });
         });
 
@@ -41,9 +43,11 @@ describe('featureFlagsSlice', () => {
                 isCardanoSendEnabled: false,
                 isRegtestEnabled: false,
                 isConnectPopupEnabled: false,
-                isTradingEnabled: false,
                 isDeviceOnboardingEnabled: false,
                 isWalletConnectEnabled: false,
+                isTradingBuyEnabled: false,
+                isTradingSwapEnabled: false,
+                isTradingSellEnabled: false,
             });
         });
     });

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -8,8 +8,10 @@ export const FeatureFlag = {
     IsRegtestEnabled: 'isRegtestEnabled',
     IsConnectPopupEnabled: 'isConnectPopupEnabled',
     IsDeviceOnboardingEnabled: 'isDeviceOnboardingEnabled',
-    IsTradingEnabled: 'isTradingEnabled',
     IsWalletConnectEnabled: 'isWalletConnectEnabled',
+    IsTradingBuyEnabled: 'isTradingBuyEnabled',
+    IsTradingSwapEnabled: 'isTradingSwapEnabled',
+    IsTradingSellEnabled: 'isTradingSellEnabled',
 } as const;
 
 export type FeatureFlag = (typeof FeatureFlag)[keyof typeof FeatureFlag];
@@ -31,9 +33,13 @@ export const featureFlagsInitialState: FeatureFlagsState = {
         process.env.EXPO_PUBLIC_FF_IS_CONNECT_POPUP_ENABLED === 'true',
     [FeatureFlag.IsDeviceOnboardingEnabled]:
         process.env.EXPO_PUBLIC_FF_IS_DEVICE_ONBOARDING_ENABLED === 'true',
-    [FeatureFlag.IsTradingEnabled]: process.env.EXPO_PUBLIC_FF_IS_TRADING_ENABLED === 'true',
     [FeatureFlag.IsWalletConnectEnabled]:
         process.env.EXPO_PUBLIC_FF_IS_WALLET_CONNECT_ENABLED === 'true',
+    [FeatureFlag.IsTradingBuyEnabled]: process.env.EXPO_PUBLIC_FF_IS_TRADING_BUY_ENABLED === 'true',
+    [FeatureFlag.IsTradingSwapEnabled]:
+        process.env.EXPO_PUBLIC_FF_IS_TRADING_SWAP_ENABLED === 'true',
+    [FeatureFlag.IsTradingSellEnabled]:
+        process.env.EXPO_PUBLIC_FF_IS_TRADING_SELL_ENABLED === 'true',
 };
 
 export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
@@ -42,8 +48,10 @@ export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsRegtestEnabled,
     FeatureFlag.IsConnectPopupEnabled,
     FeatureFlag.IsDeviceOnboardingEnabled,
-    FeatureFlag.IsTradingEnabled,
     FeatureFlag.IsWalletConnectEnabled,
+    FeatureFlag.IsTradingBuyEnabled,
+    FeatureFlag.IsTradingSwapEnabled,
+    FeatureFlag.IsTradingSellEnabled,
 ];
 
 export const featureFlagsSlice = createSlice({

--- a/suite-native/message-system/jest.config.js
+++ b/suite-native/message-system/jest.config.js
@@ -1,0 +1,5 @@
+const { ...baseConfig } = require('../../jest.config.native');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-native/message-system/package.json
+++ b/suite-native/message-system/package.json
@@ -7,7 +7,8 @@
     "main": "src/index",
     "scripts": {
         "depcheck": "yarn g:depcheck",
-        "type-check": "yarn g:tsc --build"
+        "type-check": "yarn g:tsc --build",
+        "test:unit": "yarn g:jest"
     },
     "dependencies": {
         "@mobily/ts-belt": "^3.13.1",

--- a/suite-native/message-system/redux.d.ts
+++ b/suite-native/message-system/redux.d.ts
@@ -1,0 +1,11 @@
+import { AsyncThunkAction } from '@reduxjs/toolkit';
+
+declare module 'redux' {
+    export interface Dispatch<A extends Action = AnyAction> {
+        <TThunk extends AsyncThunkAction<any, any, any>>(thunk: TThunk): ReturnType<TThunk>;
+
+        <ReturnType = any, State = any, ExtraThunkArg = any>(
+            thunkAction: ThunkAction<ReturnType, State, ExtraThunkArg, A>,
+        ): ReturnType;
+    }
+}

--- a/suite-native/message-system/src/components/ContextMessage.tsx
+++ b/suite-native/message-system/src/components/ContextMessage.tsx
@@ -1,0 +1,49 @@
+import { AccessibilityProps } from 'react-native';
+import { useSelector } from 'react-redux';
+
+import {
+    Context,
+    MessageSystemRootState,
+    selectContextMessage,
+} from '@suite-common/message-system';
+import { Message } from '@suite-common/suite-types';
+import { AlertBox, AlertBoxVariant } from '@suite-native/atoms';
+
+import { MessageLink } from './MessageLink';
+
+type ContextMessageProps = AccessibilityProps & {
+    context: (typeof Context)[keyof typeof Context];
+};
+
+const getAlertBoxVariantForMessage = (message: Message): AlertBoxVariant => {
+    if (message.variant === 'critical') {
+        return 'error';
+    }
+
+    return message.variant;
+};
+
+export const ContextMessage = ({ context, ...rest }: ContextMessageProps) => {
+    // TODO: We use only English locale in suite-native so far. When the localization to other
+    // languages is implemented, the language selection logic has to be added here.
+    const language = 'en';
+    const message = useSelector((state: MessageSystemRootState) =>
+        selectContextMessage(state, context),
+    );
+
+    if (!message) return null;
+
+    return (
+        <AlertBox
+            variant={getAlertBoxVariantForMessage(message)}
+            textVariant="hint"
+            title={message.content[language]}
+            rightButton={
+                message.cta && (
+                    <MessageLink messageCTA={message.cta} language={language} textVariant="hint" />
+                )
+            }
+            {...rest}
+        />
+    );
+};

--- a/suite-native/message-system/src/components/KillswitchMessageScreen.tsx
+++ b/suite-native/message-system/src/components/KillswitchMessageScreen.tsx
@@ -55,9 +55,10 @@ export const KillswitchMessageScreen = () => {
 
     // TODO: We use only English locale in suite-native so far. When the localization to other
     // languages is implemented, the language selection logic has to be added here.
-    const messageTitle = headline?.en;
-    const messageContent = content.en;
-    const ctaLabel = cta?.label.en;
+    const language = 'en';
+    const messageTitle = headline?.[language];
+    const messageContent = content[language];
+    const ctaLabel = cta?.label[language];
     const ctaLink = cta?.link;
     const isExternalCta = cta?.action === 'external-link';
 

--- a/suite-native/message-system/src/components/MessageBanner.tsx
+++ b/suite-native/message-system/src/components/MessageBanner.tsx
@@ -3,12 +3,13 @@ import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import { useDispatch } from 'react-redux';
 
 import { messageSystemActions } from '@suite-common/message-system';
-import { CTA, Message, Variant } from '@suite-common/suite-types';
+import { Message, Variant } from '@suite-common/suite-types';
 import { Box, HStack, RoundedIcon, Text, VStack } from '@suite-native/atoms';
 import { Icon, IconName } from '@suite-native/icons';
-import { Link } from '@suite-native/link';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Color } from '@trezor/theme';
+
+import { MessageLink } from './MessageLink';
 
 type MessageBannerProps = {
     message: Message;
@@ -64,28 +65,6 @@ const messageTextContainerStyle = prepareNativeStyle(() => ({
     justifyContent: 'center',
 }));
 
-const MessageLink = ({ messageCTA }: { messageCTA?: CTA }) => {
-    // TODO: We use only English locale in suite-native so far. When the localization to other
-    // languages is implemented, the language selection logic has to be added here.
-    const messageLinkLabel = messageCTA?.label.en;
-    const messageLink = messageCTA?.link;
-    const isExternalLink = messageCTA?.action === 'external-link';
-
-    const isLinkDisplayable = isExternalLink && messageLinkLabel && messageLink;
-
-    if (!isLinkDisplayable) return null;
-
-    return (
-        <Link
-            href={messageLink}
-            label={messageLinkLabel}
-            isUnderlined
-            textColor="textDefault"
-            textPressedColor="textSubdued"
-        />
-    );
-};
-
 const MessageCloseButton = ({
     backgroundColor,
     onClose,
@@ -109,7 +88,8 @@ export const MessageBanner = ({ message }: MessageBannerProps) => {
 
     // TODO: We use only English locale in suite-native so far. When the localization to other
     // languages is implemented, the language selection logic has to be added here.
-    const messageContent = message.content.en;
+    const language = 'en';
+    const messageContent = message.content[language];
 
     const isMessageDismissible = message.dismissible;
 
@@ -145,7 +125,13 @@ export const MessageBanner = ({ message }: MessageBannerProps) => {
                         {messageContent}
                     </Text>
 
-                    {message.cta && <MessageLink messageCTA={message.cta} />}
+                    {message.cta && (
+                        <MessageLink
+                            messageCTA={message.cta}
+                            language={language}
+                            textVariant="body"
+                        />
+                    )}
                 </VStack>
                 {isMessageDismissible && (
                     <MessageCloseButton

--- a/suite-native/message-system/src/components/MessageLink.tsx
+++ b/suite-native/message-system/src/components/MessageLink.tsx
@@ -1,0 +1,29 @@
+import { CTA, Localization } from '@suite-common/suite-types';
+import { Link } from '@suite-native/link';
+import { TypographyStyle } from '@trezor/theme';
+
+type MessageLinkProps = {
+    messageCTA?: CTA;
+    language: keyof Localization;
+    textVariant?: TypographyStyle;
+};
+export const MessageLink = ({ messageCTA, language, textVariant = 'hint' }: MessageLinkProps) => {
+    const messageLinkLabel = messageCTA?.label[language];
+    const messageLink = messageCTA?.link;
+    const isExternalLink = messageCTA?.action === 'external-link';
+
+    const isLinkDisplayable = isExternalLink && messageLinkLabel && messageLink;
+
+    if (!isLinkDisplayable) return null;
+
+    return (
+        <Link
+            href={messageLink}
+            label={messageLinkLabel}
+            isUnderlined
+            textColor="textDefault"
+            textPressedColor="textSubdued"
+            textVariant={textVariant}
+        />
+    );
+};

--- a/suite-native/message-system/src/components/__tests__/ContextMessage.comp.test.tsx
+++ b/suite-native/message-system/src/components/__tests__/ContextMessage.comp.test.tsx
@@ -1,0 +1,94 @@
+import { Context, ContextDomain } from '@suite-common/message-system';
+import { Action, Message } from '@suite-common/suite-types';
+import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { ContextMessage } from '../ContextMessage';
+
+const contextActionId = 'ContextActionId_1';
+const contentText = 'Content Text';
+const tradingContextMsg = {
+    id: contextActionId,
+    priority: 1,
+    dismissible: true,
+    variant: 'info',
+    category: ['context'],
+    content: {
+        'en-GB': contentText,
+        en: contentText,
+        es: contentText,
+        cs: contentText,
+        ru: contentText,
+        ja: contentText,
+        hu: contentText,
+        it: contentText,
+        fr: contentText,
+        de: contentText,
+        tr: contentText,
+        pt: contentText,
+        uk: contentText,
+    },
+    context: {
+        domain: 'trading.buy',
+    },
+} as Message;
+
+const stateWithTradeContextMessage = {
+    messageSystem: {
+        config: {
+            version: 1,
+            timestamp: '2023-01-01',
+            sequence: 1,
+            actions: [{ message: tradingContextMsg } as Action],
+            experiments: [],
+        },
+        currentSequence: 1,
+        timestamp: 0,
+        validMessages: {
+            banner: [],
+            context: [tradingContextMsg.id],
+            modal: [],
+            feature: [],
+        },
+        dismissedMessages: {},
+        validExperiments: [],
+    },
+};
+
+describe('ContextMessage', () => {
+    const render = ({
+        context,
+        preloadedState,
+    }: {
+        context: ContextDomain;
+        preloadedState?: PreloadedState;
+    }) =>
+        renderWithStoreProviderAsync(
+            <ContextMessage context={context} accessibilityHint={contextActionId} />,
+            {
+                preloadedState,
+            },
+        );
+
+    it('should return null when there is no message fetched', async () => {
+        const { queryByHintText } = await render({
+            context: Context.tradingBuy,
+        });
+        expect(queryByHintText(contextActionId)).toBeNull();
+    });
+
+    it('should return null when there is message of different context', async () => {
+        const { queryByHintText } = await render({
+            context: Context.coinjoin,
+            preloadedState: stateWithTradeContextMessage,
+        });
+        expect(queryByHintText(contextActionId)).toBeNull();
+    });
+
+    it('should render content when there is message of given context', async () => {
+        const { queryByText } = await render({
+            context: Context.tradingBuy,
+            preloadedState: stateWithTradeContextMessage,
+        });
+        expect(queryByText(contentText)).toBeDefined();
+    });
+});

--- a/suite-native/message-system/src/index.ts
+++ b/suite-native/message-system/src/index.ts
@@ -1,4 +1,5 @@
 export * from './messageSystemMiddleware';
+export * from './components/ContextMessage';
 export * from './components/MessageSystemBannerRenderer';
 export * from './components/KillswitchMessageScreen';
 export * from './messageSystemSelectors';

--- a/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
@@ -12,8 +12,10 @@ const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsRegtestEnabled]: 'Regtest',
     [FeatureFlagEnum.IsConnectPopupEnabled]: 'Connect Popup',
     [FeatureFlagEnum.IsDeviceOnboardingEnabled]: 'Device onboarding',
-    [FeatureFlagEnum.IsTradingEnabled]: 'Trading',
     [FeatureFlagEnum.IsWalletConnectEnabled]: 'WalletConnect',
+    [FeatureFlagEnum.IsTradingBuyEnabled]: '💰 Trading Buy',
+    [FeatureFlagEnum.IsTradingSwapEnabled]: '💰 Trading Swap',
+    [FeatureFlagEnum.IsTradingSellEnabled]: '💰 Trading Sell',
 } as const satisfies Record<FeatureFlagEnum, string>;
 
 const FeatureFlag = ({ featureFlag }: { featureFlag: FeatureFlagEnum }) => {

--- a/suite-native/module-trading/src/navigation/__tests__/TradingStackNavigator.comp.test.tsx
+++ b/suite-native/module-trading/src/navigation/__tests__/TradingStackNavigator.comp.test.tsx
@@ -11,8 +11,8 @@ jest.mock('../../hooks/useTradingBuyData', () => ({
 
 describe('TradingStackNavigator', () => {
     it('should render', async () => {
-        const { getByText } = await renderWithStoreProviderAsync(<TradingStackNavigator />);
+        const { getByTestId } = await renderWithStoreProviderAsync(<TradingStackNavigator />);
 
-        expect(getByText('Buy')).toBeDefined();
+        expect(getByTestId('@screen/Trading')).toBeDefined();
     });
 });

--- a/suite-native/module-trading/src/screens/TradingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingScreen.tsx
@@ -1,24 +1,35 @@
+import { useSelector } from 'react-redux';
+
+import { Context } from '@suite-common/message-system';
 import { DeviceManagerScreenHeader } from '@suite-native/device-manager';
+import { ContextMessage } from '@suite-native/message-system';
 import { Screen } from '@suite-native/navigation';
 
 import { BuyForm } from '../components/buy/BuyForm';
 import { BuyFormContextProvider } from '../components/buy/BuyFormContextProvider';
 import { BuyFormSkeleton } from '../components/buy/BuyFormSkeleton';
 import { useTradingBuyData } from '../hooks/useTradingBuyData';
+import { selectIsTradingBuyEnabled } from '../selectors/commonSelectors';
 
 export const TradingScreen = () => {
+    const isTradingBuyEnabled = useSelector(selectIsTradingBuyEnabled);
     const { isLoading, lastLoadedTimestamp } = useTradingBuyData();
 
     const displaySkeleton = isLoading || lastLoadedTimestamp === 0;
 
     return (
         <Screen header={<DeviceManagerScreenHeader />}>
-            {displaySkeleton ? (
-                <BuyFormSkeleton />
-            ) : (
-                <BuyFormContextProvider>
-                    <BuyForm />
-                </BuyFormContextProvider>
+            {isTradingBuyEnabled && (
+                <>
+                    <ContextMessage context={Context.tradingBuy} />
+                    {displaySkeleton ? (
+                        <BuyFormSkeleton />
+                    ) : (
+                        <BuyFormContextProvider>
+                            <BuyForm />
+                        </BuyFormContextProvider>
+                    )}
+                </>
             )}
         </Screen>
     );

--- a/suite-native/module-trading/src/screens/__tests__/TradingScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingScreen.comp.test.tsx
@@ -1,4 +1,5 @@
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
+import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 
 import { TradingScreen } from '../TradingScreen';
 
@@ -13,34 +14,57 @@ jest.mock('../../hooks/useTradingBuyData', () => ({
     useTradingBuyData: () => mockUseTradingBuyDataValue,
 }));
 
+const stateWithEnabledBuy = {
+    featureFlags: {
+        ...featureFlagsInitialState,
+        [FeatureFlag.IsTradingBuyEnabled]: true,
+    },
+};
+
+const stateWithDisabledBuy = {
+    featureFlags: {
+        ...featureFlagsInitialState,
+        [FeatureFlag.IsTradingBuyEnabled]: false,
+    },
+};
+
 describe('TradingScreen', () => {
     beforeEach(() => {
         mockUseTradingBuyDataValue = { isLoading: false, lastLoadedTimestamp: 0 };
     });
 
-    const renderTradingScreen = () => renderWithStoreProviderAsync(<TradingScreen />);
+    const renderTradingScreen = (preloadedState?: PreloadedState) =>
+        renderWithStoreProviderAsync(<TradingScreen />, { preloadedState });
 
-    it('should render skeleton when isLoading is true', async () => {
+    it('should render Buy skeleton when isLoading is true', async () => {
         mockUseTradingBuyDataValue = { isLoading: true, lastLoadedTimestamp: 1 };
 
-        const { getAllByText } = await renderTradingScreen();
+        const { getAllByText } = await renderTradingScreen(stateWithEnabledBuy);
 
         expect(getAllByText('Buy').length).toBe(1);
     });
 
-    it('should render skeleton when lastLoadedTimestamp is 0', async () => {
+    it('should render Buy skeleton when lastLoadedTimestamp is 0', async () => {
         mockUseTradingBuyDataValue = { isLoading: false, lastLoadedTimestamp: 0 };
 
-        const { getAllByText } = await renderTradingScreen();
+        const { getAllByText } = await renderTradingScreen(stateWithEnabledBuy);
 
         expect(getAllByText('Buy').length).toBe(1);
     });
 
-    it('should render form when isLoading is false and lastLoadedTimestamp is greater than 0', async () => {
+    it('should render Buy form when isLoading is false and lastLoadedTimestamp is greater than 0', async () => {
         mockUseTradingBuyDataValue = { isLoading: false, lastLoadedTimestamp: 1 };
 
-        const { getAllByText } = await renderTradingScreen();
+        const { getAllByText } = await renderTradingScreen(stateWithEnabledBuy);
 
         expect(getAllByText('Buy').length).toBe(2);
+    });
+
+    it('should not render Buy form when feature flag is not enabled', async () => {
+        mockUseTradingBuyDataValue = { isLoading: false, lastLoadedTimestamp: 1 };
+
+        const { queryByText } = await renderTradingScreen(stateWithDisabledBuy);
+
+        expect(queryByText('Buy')).toBeNull();
     });
 });

--- a/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
@@ -1,7 +1,97 @@
+import { Action, Feature, Message } from '@suite-common/suite-types';
 import { InvityServerEnvironment } from '@suite-common/trading';
+import { featureFlagsInitialState } from '@suite-native/feature-flags';
 
 import { initialState } from '../../tradingSlice';
-import { selectTradingEnvironment } from '../commonSelectors';
+import {
+    selectIsTradingBuyEnabled,
+    selectIsTradingEnabled,
+    selectIsTradingSellEnabled,
+    selectIsTradingSwapEnabled,
+    selectTradingEnvironment,
+} from '../commonSelectors';
+
+const actionId = 'ActionId_1';
+const contentText = 'Content Text';
+
+const getPreloadedState = ({
+    buy = false,
+    sell = false,
+    swap = false,
+}: {
+    buy?: boolean;
+    sell?: boolean;
+    swap?: boolean;
+}) => {
+    const features: Feature[] = [];
+    if (buy) {
+        features.push({
+            domain: 'trading.buy',
+            flag: true,
+        });
+    }
+    if (sell) {
+        features.push({
+            domain: 'trading.sell',
+            flag: true,
+        });
+    }
+    if (swap) {
+        features.push({
+            domain: 'trading.swap',
+            flag: true,
+        });
+    }
+
+    return {
+        featureFlags: featureFlagsInitialState,
+        messageSystem: {
+            config: {
+                version: 1,
+                timestamp: '2023-01-01',
+                sequence: 1,
+                actions: [
+                    {
+                        message: {
+                            id: actionId,
+                            priority: 1,
+                            dismissible: true,
+                            variant: 'info',
+                            category: ['feature'],
+                            content: {
+                                'en-GB': contentText,
+                                en: contentText,
+                                es: contentText,
+                                cs: contentText,
+                                ru: contentText,
+                                ja: contentText,
+                                hu: contentText,
+                                it: contentText,
+                                fr: contentText,
+                                de: contentText,
+                                tr: contentText,
+                                pt: contentText,
+                                uk: contentText,
+                            },
+                            feature: features,
+                        } as Message,
+                    } as Action,
+                ],
+                experiments: [],
+            },
+            currentSequence: 1,
+            timestamp: 0,
+            validMessages: {
+                banner: [],
+                context: [],
+                modal: [],
+                feature: [actionId],
+            },
+            dismissedMessages: {},
+            validExperiments: [],
+        },
+    };
+};
 
 describe('commonSelectors', () => {
     describe('selectTradingEnvironment', () => {
@@ -12,6 +102,46 @@ describe('commonSelectors', () => {
             };
 
             expect(selectTradingEnvironment({ wallet: { tradingNew: state } })).toBe('staging');
+        });
+    });
+
+    describe('selectIsTradingBuyEnabled', () => {
+        it('should correctly select that buy is enabled if remote feature is enabled', () => {
+            expect(selectIsTradingBuyEnabled(getPreloadedState({ buy: true }))).toBe(true);
+        });
+
+        it('should correctly select that buy is not enabled if remote feature is not enabled', () => {
+            expect(selectIsTradingBuyEnabled(getPreloadedState({}))).toBe(false);
+        });
+    });
+
+    describe('selectIsTradingSwapEnabled', () => {
+        it('should correctly select that swap is enabled if remote feature is enabled', () => {
+            expect(selectIsTradingSwapEnabled(getPreloadedState({ swap: true }))).toBe(true);
+        });
+
+        it('should correctly select that swap is not enabled if remote feature is not enabled', () => {
+            expect(selectIsTradingSwapEnabled(getPreloadedState({}))).toBe(false);
+        });
+    });
+
+    describe('selectIsTradingSellEnabled', () => {
+        it('should correctly select that sell is enabled if remote feature is enabled', () => {
+            expect(selectIsTradingSellEnabled(getPreloadedState({ sell: true }))).toBe(true);
+        });
+
+        it('should correctly select that sell is not enabled if remote feature is not enabled', () => {
+            expect(selectIsTradingSellEnabled(getPreloadedState({}))).toBe(false);
+        });
+    });
+
+    describe('selectIsTradingEnabled', () => {
+        it('should correctly select that trading is enabled if one of remote features is enabled', () => {
+            expect(selectIsTradingEnabled(getPreloadedState({ sell: true }))).toBe(true);
+        });
+
+        it('should correctly select that trading is not enabled if no remote feature is enabled', () => {
+            expect(selectIsTradingEnabled(getPreloadedState({}))).toBe(false);
         });
     });
 });

--- a/suite-native/module-trading/src/selectors/commonSelectors.ts
+++ b/suite-native/module-trading/src/selectors/commonSelectors.ts
@@ -1,4 +1,32 @@
+import {
+    Feature,
+    MessageSystemRootState,
+    selectIsFeatureEnabled,
+} from '@suite-common/message-system';
+import {
+    FeatureFlag,
+    FeatureFlagsRootState,
+    selectIsFeatureFlagEnabled,
+} from '@suite-native/feature-flags';
+
 import { TradingRootState } from '../tradingSlice';
 
 export const selectTradingEnvironment = (state: TradingRootState) =>
     state.wallet.tradingNew.tradingEnvironment;
+
+export const selectIsTradingBuyEnabled = (state: MessageSystemRootState & FeatureFlagsRootState) =>
+    selectIsFeatureFlagEnabled(state, FeatureFlag.IsTradingBuyEnabled) ||
+    selectIsFeatureEnabled(state, Feature.trading.buy, false);
+
+export const selectIsTradingSwapEnabled = (state: MessageSystemRootState & FeatureFlagsRootState) =>
+    selectIsFeatureFlagEnabled(state, FeatureFlag.IsTradingSwapEnabled) ||
+    selectIsFeatureEnabled(state, Feature.trading.swap, false);
+
+export const selectIsTradingSellEnabled = (state: MessageSystemRootState & FeatureFlagsRootState) =>
+    selectIsFeatureFlagEnabled(state, FeatureFlag.IsTradingSellEnabled) ||
+    selectIsFeatureEnabled(state, Feature.trading.sell, false);
+
+export const selectIsTradingEnabled = (state: MessageSystemRootState & FeatureFlagsRootState) =>
+    selectIsTradingBuyEnabled(state) ||
+    selectIsTradingSwapEnabled(state) ||
+    selectIsTradingSellEnabled(state);


### PR DESCRIPTION
- Introduce remote and local feature flags for buy, sell and swap in Trading. Any of these FFs enables Trading tab in navigation.
- Introduce `ContextMessage` component and use it for trading context. `AlertBox` component is used for the visual style. Consulted UI with @rojcyk and agreed to keep it `AlertBox` for now

## Related Issue

Resolve #17615

## Screenshots:

Functionality showcase:

https://github.com/user-attachments/assets/267f3ace-25b3-4538-8d9d-10fb1deb76a9



Context message variants:
<img width=250 src="https://github.com/user-attachments/assets/ca79ff41-aa8d-485f-aa2e-054d5acfe7ec" /><img width=250 src="https://github.com/user-attachments/assets/dfb73b13-adc5-4a64-b8e3-d904f8437f09" /><img width=250 src="https://github.com/user-attachments/assets/8e0e0dc0-f458-43cf-ace6-11431fecece2" />

