### PR TITLE
chore(suite): interface cleanup for TroubleshootingTips

### DIFF
--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceBootloader.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceBootloader.tsx
@@ -41,7 +41,7 @@ export const DeviceBootloader = ({ device }: DeviceBootloaderProps) => {
         <TroubleshootingTips
             label={<Translation id="TR_DEVICE_IN_BOOTLOADER" />}
             items={tips}
-            opened
+            initiallyIsOpen
         />
     );
 };

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceConnect.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceConnect.tsx
@@ -81,7 +81,8 @@ export const DeviceConnect = ({ setIsBluetoothConnectOpen }: DeviceConnectProps)
 
         return (
             <TroubleshootingTipsWithSections
-                label={<Translation id="TR_TREZOR_SAFE_7" />}
+                label={<Translation id="TR_CONNECTION_TYPE" />}
+                ctaLabel={<Translation id="TR_TREZOR_SAFE_7" />}
                 items={{
                     cable: { items: cableItem, label: <Translation id="TR_CABLE" /> },
                     bluetooth: { items: bluetoothItems, label: <Translation id="TR_BLUETOOTH" /> },
@@ -89,7 +90,6 @@ export const DeviceConnect = ({ setIsBluetoothConnectOpen }: DeviceConnectProps)
                 defaultSection="cable"
                 cta={getCallToActionButton({ setIsBluetoothConnectOpen })}
                 data-testid="@connect-device-prompt/no-device-detected"
-                sectionLabel={<Translation id="TR_CONNECTION_TYPE" />}
                 toggleText={<Translation id="TR_STILL_DONT_SEE_YOUR_TREZOR" />}
             />
         );

--- a/packages/suite/src/components/suite/troubleshooting/TroubleshootingTips.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/TroubleshootingTips.tsx
@@ -32,11 +32,11 @@ type SectionDefinition = { label: ReactNode; items: TroubleshootingTipsItem[] };
 type TroubleshootingTipsWithSectionsProps<K extends string, T extends K> = {
     label: ReactNode;
     cta?: ReactNode;
-    opened?: boolean;
+    ctaLabel?: ReactNode;
+    initiallyIsOpen?: boolean;
     'data-testid'?: string;
     items: Record<K, SectionDefinition>;
-    sectionLabel?: ReactNode;
-    defaultSection: T;
+    defaultSection?: T;
     toggleText?: ReactNode;
 };
 
@@ -44,14 +44,15 @@ export const TroubleshootingTipsWithSections = <K extends string, T extends K>({
     label,
     items,
     cta,
-    opened,
-    sectionLabel,
+    ctaLabel,
+    initiallyIsOpen,
     defaultSection,
     toggleText,
     'data-testid': dataTest,
 }: TroubleshootingTipsWithSectionsProps<K, T>) => {
-    const [isOpened, setIsOpened] = useState(opened === true);
-    const [selectedSection, setSelectedSection] = useState<K>(defaultSection);
+    const [isOpened, setIsOpened] = useState(initiallyIsOpen === true);
+    const firstSectionKey = Object.keys(items)[0] as K;
+    const [selectedSection, setSelectedSection] = useState<K>(defaultSection ?? firstSectionKey);
 
     const hasMultipleSections = Object.keys(items).length > 1;
 
@@ -61,7 +62,7 @@ export const TroubleshootingTipsWithSections = <K extends string, T extends K>({
             alignItems="center"
             margin={{ horizontal: spacings.sm }}
         >
-            <Text typographyStyle="body">{hasMultipleSections ? sectionLabel : label}</Text>
+            <Text typographyStyle="body">{label}</Text>
 
             {hasMultipleSections ? (
                 <Row>
@@ -84,7 +85,7 @@ export const TroubleshootingTipsWithSections = <K extends string, T extends K>({
             {cta && (
                 <Card width="auto">
                     <Row gap={spacings.md}>
-                        {label}
+                        {ctaLabel ?? label}
                         {cta}
                     </Row>
                 </Card>
@@ -97,7 +98,7 @@ export const TroubleshootingTipsWithSections = <K extends string, T extends K>({
                 <Column gap={spacings.md}>
                     <Collapsible.Toggle onClick={() => setIsOpened(!isOpened)}>
                         <Row justifyContent="center" flex="1" margin={{ bottom: spacings.xs }}>
-                            <TroubleshootingTipsToggle isOpen={isOpened === true}>
+                            <TroubleshootingTipsToggle isOpen={isOpened}>
                                 {toggleText}
                             </TroubleshootingTipsToggle>
                         </Row>
@@ -129,7 +130,7 @@ export const TroubleshootingTipsWithSections = <K extends string, T extends K>({
 type TroubleshootingTipsProps = {
     label: ReactNode;
     cta?: ReactNode;
-    opened?: boolean;
+    initiallyIsOpen?: boolean;
     'data-testid'?: string;
     items: TroubleshootingTipsItem[];
     toggleText?: ReactNode;
@@ -138,7 +139,7 @@ type TroubleshootingTipsProps = {
 export const TroubleshootingTips = ({ items, ...props }: TroubleshootingTipsProps) => (
     <TroubleshootingTipsWithSections
         {...props}
-        items={{ '': { items, label: '' } }}
-        defaultSection=""
+        // key is arbitrary, label won't be displayed with only one section
+        items={{ default: { items, label: '' } }}
     />
 );


### PR DESCRIPTION
## Description

Ex post CR suggestions for #17925

Mainly refactor props, IMO more intuitive now and without too many diffs.

And small nits

## Screenshots:
Proof that I did not mess up the order of the props:
**BT on**
![bt](https://github.com/user-attachments/assets/b745ac74-7b8f-435b-ad07-6b98dfc8cbc6)
**BT off**
![without bt](https://github.com/user-attachments/assets/ef754e2a-d272-4c8b-aa89-b10d9fbd4819)
**What we've got here is failure to communicate**
![failed comm](https://github.com/user-attachments/assets/29cf65e9-098f-4f34-af9d-f6d0598541f9)

@coderabbitai ignore