### PR TITLE
fix(suite): adjust gas limit also for approve txs to be sure

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -500,7 +500,7 @@ export const useTradingExchangeForm = ({
                 destinationTag: selectedQuote.partnerPaymentExtraId,
                 ethereumDataHex: selectedQuote.dexTx.data,
                 recalcCustomLimit: true,
-                ethereumAdjustGasLimit: selectedQuote.status === 'CONFIRM' ? '1.25' : undefined,
+                ethereumAdjustGasLimit: '1.25',
                 setMaxOutputId: values.setMaxOutputId,
             });
 

--- a/suite-common/wallet-constants/src/sendForm.ts
+++ b/suite-common/wallet-constants/src/sendForm.ts
@@ -12,8 +12,8 @@ export const BTC_LOCKTIME_SEQUENCE = 0xffffffff - 1;
 export const BTC_LOCKTIME_VALUE = 500000000; // if locktime is equal/greater than this then it's a timestamp
 export const XRP_FLAG = 0x80000000;
 export const U_INT_32 = 0xffffffff;
-export const ETH_BACKUP_GAS_LIMIT = '21000';
-export const ERC20_BACKUP_GAS_LIMIT = '200000';
+export const ETH_TRANSFER_BACKUP_GAS_LIMIT = '50000'; // sending ETH to contract needs more gas limit than 21000
+export const ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT = '250000';
 export const ERC20_TRANSFER = 'a9059cbb'; // 4 bytes function signature of solidity erc20 `transfer(address,uint256)`
 
 export const DEFAULT_PAYMENT = {

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -4,8 +4,8 @@ import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
-    ERC20_BACKUP_GAS_LIMIT,
-    ETH_BACKUP_GAS_LIMIT,
+    ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT,
+    ETH_TRANSFER_BACKUP_GAS_LIMIT,
     STAKE_GAS_LIMIT_RESERVE,
 } from '@suite-common/wallet-constants';
 import {
@@ -190,7 +190,9 @@ export const composeEthereumTransactionFeeLevelsThunk = createThunk<
             customFeeLimit = new BigNumber(estimatedFee.payload.levels[0].feeLimit || '');
         } else {
             customFeeLimit = new BigNumber(
-                tokenInfo ? ERC20_BACKUP_GAS_LIMIT : ETH_BACKUP_GAS_LIMIT,
+                tokenInfo || ethereumDataHex
+                    ? ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT
+                    : ETH_TRANSFER_BACKUP_GAS_LIMIT,
             );
             dispatch(
                 notificationsActions.addToast({


### PR DESCRIPTION
## Description

- adjust gas limit value also for approve tx (it is good to have buffer)
- improve fallback gas limit values
  - ETH transfer can consume more when transferring to address with contract https://github.com/trezor/trezor-suite/issues/17987
  - swap usually needs 150-300k, with adjuster, 250k is just fine
- use bigger gas limit also when ethereum hex data are available (approve tx, staking,..)

## Related Issue

Resolve [#17826](https://github.com/trezor/trezor-suite/issues/17826)
Resolve #17987
Should help with #17986 but does not solve it

## Screenshots:
