### PR TITLE
Don't expect BIP-380 from older fw

### DIFF
--- a/packages/connect/e2e/__fixtures__/getPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/getPublicKey.ts
@@ -35,6 +35,11 @@ export default {
                 descriptor:
                     'wpkh([95d8f670/84h/0h/0h]xpub6Bmuozp73G1Ng4FtB1dzVJ9WGg6BcMn5xgUd7rQ8NybSHytQjkyfqMZfJ635zoHMYZoMuS4uCEz86SPLpvfFQxQe1acY5U7FzX9yL5DyRAe/<0;1>/*)#78czyhf0',
             },
+            get legacyResults() {
+                const { descriptor, ...payload } = this.result;
+
+                return [{ rules: ['<2.7.0'], payload }];
+            },
         },
         {
             description: 'Bitcoin p2sh first account',
@@ -48,6 +53,11 @@ export default {
                     'ypub6Y5EDdQK9nQzpNeMtgXxhBB3SoLk2SyR2MFLQYsBkAusAHpaQNxTTwefgnL9G3oFGrRS9VkVvyY1SaApFAzQPZ99wto5etdReeE3XFkkMZt',
                 descriptor:
                     'sh(wpkh([95d8f670/49h/0h/0h]xpub6DExuxjQ16sWy5TF4KkLV65YGqCJ5pyv7Ej7d9yJNAXz7C1M9intqszXfaNZG99KsDJdQ29wUKBTZHZFXUaPbKTZ5Z6f4yowNvAQ8fEJw2G/<0;1>/*))#euxgwkh5',
+            },
+            get legacyResults() {
+                const { descriptor, ...payload } = this.result;
+
+                return [{ rules: ['<2.7.0'], payload }];
             },
         },
         {
@@ -63,6 +73,11 @@ export default {
                 descriptor:
                     'sh(wpkh([95d8f670/49h/0h/0h]xpub6DExuxjQ16sWy5TF4KkLV65YGqCJ5pyv7Ej7d9yJNAXz7C1M9intqszXfaNZG99KsDJdQ29wUKBTZHZFXUaPbKTZ5Z6f4yowNvAQ8fEJw2G/<0;1>/*))#euxgwkh5',
             },
+            get legacyResults() {
+                const { descriptor, ...payload } = this.result;
+
+                return [{ rules: ['<2.7.0'], payload }];
+            },
         },
         {
             description: 'Bitcoin p2pkh first account',
@@ -74,6 +89,11 @@ export default {
                 xpub: 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH',
                 descriptor:
                     'pkh([95d8f670/44h/0h/0h]xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH/<0;1>/*)#k60fe5pm',
+            },
+            get legacyResults() {
+                const { descriptor, ...payload } = this.result;
+
+                return [{ rules: ['<2.7.0'], payload }];
             },
         },
         {


### PR DESCRIPTION
## Description

Recently we started to return BIP-380 descriptors from `GetPublicKey`, which was [added in 2.7.0 fw](https://github.com/trezor/trezor-firmware/blob/main/core/CHANGELOG.md#added-6), so we have to conditionally omit it from fixtures when testing older fw.

I'm not sure whether T1 supports it, but we're not testing it anyway. :smirk: 

