### PR TITLE
feat(suite): hide maximum fee when data is missing

### DIFF
--- a/packages/suite/src/components/wallet/Fees/CustomFee/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CustomFee.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import {
     Control,
     FieldErrors,
@@ -64,6 +65,13 @@ export const CustomFee = <TFieldValues extends FormState>({
     ...props
 }: CustomFeeProps<TFieldValues>) => {
     const { translationString } = useTranslation();
+    const [cachedNetworkAmount, setCachedNetworkAmount] = useState<string | undefined>(undefined);
+
+    useEffect(() => {
+        if (transactionInfo && transactionInfo.type !== 'error' && transactionInfo.fee) {
+            setCachedNetworkAmount(formatNetworkAmount(transactionInfo.fee, symbol));
+        }
+    }, [symbol, transactionInfo]);
 
     const sharedRules = {
         required: translationString('CUSTOM_FEE_IS_NOT_SET'),
@@ -74,11 +82,6 @@ export const CustomFee = <TFieldValues extends FormState>({
             }
         },
     };
-
-    const networkAmount =
-        transactionInfo && transactionInfo.type !== 'error'
-            ? formatNetworkAmount(transactionInfo.fee, symbol)
-            : null;
 
     const feeUnits = getFeeUnits(networkType);
 
@@ -113,32 +116,33 @@ export const CustomFee = <TFieldValues extends FormState>({
                     />
                 )}
             </CustomFeeWrapper>
-            <Column>
-                <Row gap={spacings.sm} alignItems="baseline" justifyContent="space-between">
-                    <Text variant="tertiary" typographyStyle="hint">
-                        <Translation id={networkType === 'ethereum' ? 'MAX_FEE' : 'FEE'} />:
-                    </Text>
-                    {networkAmount && (
+            {cachedNetworkAmount && (
+                <Column>
+                    <Row gap={spacings.sm} alignItems="baseline" justifyContent="space-between">
+                        <Text variant="tertiary" typographyStyle="hint">
+                            <Translation id={networkType === 'ethereum' ? 'MAX_FEE' : 'FEE'} />:
+                        </Text>
+
                         <Row gap={spacings.xxs}>
                             <Text variant="default" typographyStyle="hint">
                                 <FormattedCryptoAmount
                                     disableHiddenPlaceholder
-                                    value={networkAmount}
+                                    value={cachedNetworkAmount}
                                     symbol={symbol}
                                 />
                             </Text>
                             <Text variant="tertiary" typographyStyle="hint">
                                 <FiatValue
                                     disableHiddenPlaceholder
-                                    amount={networkAmount}
+                                    amount={cachedNetworkAmount}
                                     symbol={symbol}
                                     showApproximationIndicator
                                 />
                             </Text>
                         </Row>
-                    )}
-                </Row>
-            </Column>
+                    </Row>
+                </Column>
+            )}
         </>
     );
 };


### PR DESCRIPTION
## Description

Show the "maximum fee" line in the advance fee section only if the amount exists.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17997

## Screenshots:

<img width="785" alt="image" src="https://github.com/user-attachments/assets/735b030c-01de-4af4-b965-0b31b8cab103" />

<img width="785" alt="image" src="https://github.com/user-attachments/assets/3dc907fd-10ce-4771-9cc5-6fb9a5bf9e65" />
