### PR TITLE
feat(suite): show account limit banner in Solana staking modals

### DIFF
--- a/packages/suite-desktop-core/src/config.ts
+++ b/packages/suite-desktop-core/src/config.ts
@@ -28,8 +28,8 @@ export const allowedDomains = [
     'blockfrost.dev',
     'eth-api-b2c-stage.everstake.one', // staking endpoint for Holesky testnet, works only with VPN
     'eth-api-b2c.everstake.one', // staking endpoint for Ethereum mainnet
-    'dashboard-api.everstake.one', // staking enpoint for Solana
-    'stake-sync-api.everstake.one', // staking rewards enpoint for Solana
+    'dashboard-api.everstake.one', // staking endpoint for Solana
+    'stake-sync-api.everstake.one', // staking rewards endpoint for Solana
     'verify.walletconnect.org', // WalletConnect
 ];
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
@@ -14,6 +14,8 @@ import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking
 import { useClaimEthForm } from 'src/hooks/wallet/useClaimEthForm';
 import { CRYPTO_INPUT } from 'src/types/wallet/stakeForms';
 
+import { SolanaStakingLimitBanner } from '../SolanaStakingLimitBanner';
+
 interface ClaimModalModalProps {
     onCancel?: () => void;
     selectedAccount: SelectedAccountLoaded;
@@ -112,6 +114,12 @@ const ClaimModalLoaded = ({ onCancel, selectedAccount }: ClaimModalModalProps) =
         >
             <form onSubmit={onClaimClick}>
                 <Column gap={spacings.lg}>
+                    <SolanaStakingLimitBanner
+                        account={account}
+                        composedLevels={composedLevels}
+                        type="claim"
+                    />
+
                     <InfoItem direction="column" label={<Translation id="AMOUNT" />}>
                         <Paragraph typographyStyle="titleSmall">
                             <FormattedCryptoAmount

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SolanaStakingLimitBanner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SolanaStakingLimitBanner.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT, claim, unstake } from '@suite-common/staking-solana';
+import { getDisplaySymbol } from '@suite-common/wallet-config';
+import { WALLET_SDK_SOURCE } from '@suite-common/wallet-constants';
+import { selectBlockchainState } from '@suite-common/wallet-core';
+import { Account, PrecomposedLevels } from '@suite-common/wallet-types';
+import {
+    formatNetworkAmount,
+    getOutputTxAmount,
+    getSolanaStakingAccountsByStatus,
+} from '@suite-common/wallet-utils';
+import { StakeState } from '@trezor/blockchain-link-types/src/solana';
+import { Banner } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { Translation } from 'src/components/suite';
+
+interface SolanaStakingLimitBannerProps {
+    account: Account;
+    composedLevels?: PrecomposedLevels;
+    type: 'claim' | 'unstake';
+}
+
+export const SolanaStakingLimitBanner = ({
+    account,
+    composedLevels,
+    type,
+}: SolanaStakingLimitBannerProps) => {
+    const blockchain = useSelector(selectBlockchainState);
+
+    const [estimatedAmount, setEstimatedAmount] = useState<string>('0');
+    const [isAccountLimitExeeded, setIsAccountLimitExeeded] = useState<boolean>(false);
+
+    const selectedBlockchain = blockchain[account.symbol];
+
+    useEffect(() => {
+        const outputTxAmount = getOutputTxAmount(composedLevels);
+        if (!outputTxAmount || !selectedBlockchain?.url) return;
+
+        const estimateTx = async () => {
+            if (type === 'unstake') {
+                const { unstakeAmount } = await unstake({
+                    network: account.symbol,
+                    sender: account.descriptor,
+                    lamports: BigInt(outputTxAmount),
+                    source: WALLET_SDK_SOURCE,
+                    url: selectedBlockchain.url,
+                });
+                const estimatedAmount = unstakeAmount.toString();
+                setEstimatedAmount(estimatedAmount);
+
+                // If the estimated transaction amount is less than the output,
+                // we assume the account limit has been exceeded
+                const isLimitExeeded = new BigNumber(estimatedAmount).lt(outputTxAmount);
+                setIsAccountLimitExeeded(isLimitExeeded);
+            }
+
+            if (type === 'claim') {
+                const { totalClaimAmount } = await claim({
+                    network: account.symbol,
+                    sender: account.descriptor,
+                    url: selectedBlockchain.url,
+                });
+
+                const estimatedAmount = totalClaimAmount.toString();
+                setEstimatedAmount(estimatedAmount);
+
+                const stakingAccounts = getSolanaStakingAccountsByStatus(
+                    account,
+                    StakeState.Deactivated,
+                );
+                // estimatedAmount for claims includes rent-exempt reserves.
+                // We subtract rent from each account to get the real claimable amount.
+                const claimableAmount = stakingAccounts.reduce(
+                    (acc, { rentExemptReserve }) => acc.minus(rentExemptReserve),
+                    new BigNumber(estimatedAmount),
+                );
+
+                const isLimitExeeded = claimableAmount.lt(outputTxAmount);
+                setIsAccountLimitExeeded(isLimitExeeded);
+            }
+        };
+
+        estimateTx();
+    }, [account, composedLevels, selectedBlockchain?.url, type]);
+
+    if (!isAccountLimitExeeded) return null;
+
+    return (
+        <Banner variant="info">
+            <Translation
+                id={
+                    type === 'claim'
+                        ? 'TR_STAKE_CAN_CLAIM_FROM_ACCOUNTS'
+                        : 'TR_STAKE_CAN_UNSTAKE_FROM_ACCOUNTS'
+                }
+                values={{
+                    limit: MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT,
+                    amount: formatNetworkAmount(estimatedAmount, account.symbol),
+                    symbol: getDisplaySymbol(account.symbol),
+                }}
+            />
+        </Banner>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeEthForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeEthForm.tsx
@@ -1,3 +1,4 @@
+import { getDisplaySymbol } from '@suite-common/wallet-config';
 import { selectValidatorsQueueData } from '@suite-common/wallet-core';
 import { getStakingDataForNetwork, getUnstakingPeriodInDays } from '@suite-common/wallet-utils';
 import { Banner, Column, InfoItem, Tooltip } from '@trezor/components';
@@ -13,6 +14,7 @@ import { CRYPTO_INPUT, FIAT_INPUT } from 'src/types/wallet/stakeForms';
 import { ApproximateInstantEthAmount } from 'src/views/wallet/staking/components/EthStakingDashboard/components/ApproximateInstantEthAmount';
 
 import { Inputs } from './Inputs';
+import { SolanaStakingLimitBanner } from '../../SolanaStakingLimitBanner';
 import { AvailableBalance } from '../../StakeModal/StakeEthForm/AvailableBalance';
 
 export const UnstakeEthForm = () => {
@@ -53,18 +55,26 @@ export const UnstakeEthForm = () => {
     return (
         <form onSubmit={handleSubmit(signTx)}>
             <Column gap={spacings.xxl} margin={{ bottom: spacings.lg }}>
-                {canClaim && (
-                    <Banner variant="info">
-                        <Translation
-                            id="TR_STAKE_CAN_CLAIM_WARNING"
-                            values={{
-                                amount: claimableAmount,
-                                symbol: symbol.toUpperCase(),
-                                br: <br />,
-                            }}
-                        />
-                    </Banner>
-                )}
+                <Column gap={spacings.md}>
+                    {canClaim && (
+                        <Banner variant="info">
+                            <Translation
+                                id="TR_STAKE_CAN_CLAIM_WARNING"
+                                values={{
+                                    amount: claimableAmount,
+                                    symbol: getDisplaySymbol(symbol),
+                                    br: <br />,
+                                }}
+                            />
+                        </Banner>
+                    )}
+
+                    <SolanaStakingLimitBanner
+                        account={account}
+                        composedLevels={composedLevels}
+                        type="unstake"
+                    />
+                </Column>
 
                 <AvailableBalance formattedBalance={autocompoundBalance} symbol={symbol} />
 

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9340,6 +9340,16 @@ export default defineMessages({
         defaultMessage:
             'You can already claim {amount} {symbol}. {br}Claim now or wait until your new unstake is processed.',
     },
+    TR_STAKE_CAN_UNSTAKE_FROM_ACCOUNTS: {
+        id: 'TR_STAKE_CAN_UNSTAKE_FROM_ACCOUNTS',
+        defaultMessage:
+            'Due to Solana transaction size restrictions, you can unstake from {limit} accounts at once. In the next transaction you can unstake up to {amount} {symbol}. To unstake more, please repeat the process.',
+    },
+    TR_STAKE_CAN_CLAIM_FROM_ACCOUNTS: {
+        id: 'TR_STAKE_CAN_CLAIM_FROM_ACCOUNTS',
+        defaultMessage:
+            'Due to Solana transaction size restrictions, you can claim from {limit} accounts at once. In the next transaction you can claim up to {amount} {symbol}. To claim more, please repeat the process.',
+    },
     TR_STAKE_CLAIM_IN_NEXT_BLOCK: {
         id: 'TR_STAKE_CLAIM_IN_NEXT_BLOCK',
         defaultMessage: 'in the next block',

--- a/suite-common/wallet-utils/src/stakingUtils.ts
+++ b/suite-common/wallet-utils/src/stakingUtils.ts
@@ -11,7 +11,7 @@ import {
     SOLANA_EPOCH_DAYS,
     UNSTAKING_ETH_PERIOD,
 } from '@suite-common/wallet-constants';
-import { Account, StakingPoolExtended } from '@suite-common/wallet-types';
+import { Account, PrecomposedLevels, StakingPoolExtended } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils';
 
 import {
@@ -122,4 +122,13 @@ export const getUnstakingPeriodInDays = ({
         .toNumber();
 
     return secondsToDays(unstakingPeriodInSeconds);
+};
+
+export const getOutputTxAmount = (composedLevels?: PrecomposedLevels) => {
+    if (!composedLevels) return null;
+
+    const precomposedTx = composedLevels['normal'];
+    if (precomposedTx?.type !== 'final') return null;
+
+    return precomposedTx.outputs[0].amount;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds an info banner to Solana staking modals. 

## Related Issue

Resolve #18336

## Screenshots:

![image](https://github.com/user-attachments/assets/2df80291-ad4a-4f5d-8a5d-5b3d695f998f)

