### PR TITLE
fix(suite): fixed Suite crash on cancelling stake transaction

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -210,9 +210,7 @@ export const TransactionReviewModalContent = ({
               .find(type => type) || null;
 
     const onCancel = () => {
-        if (isRbfConfirmedError || shouldCheckTxTimeValidity) {
-            dispatch(modalActions.onCancel());
-        }
+        dispatch(modalActions.onCancel());
 
         if (isActionAbortable || serializedTx) {
             cancelSignTx();

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
@@ -16,13 +16,11 @@ import { CRYPTO_INPUT } from 'src/types/wallet/stakeForms';
 
 interface ClaimModalModalProps {
     onCancel?: () => void;
+    selectedAccount: SelectedAccountLoaded;
 }
 
-export const ClaimModal = ({ onCancel }: ClaimModalModalProps) => {
+const ClaimModalLoaded = ({ onCancel, selectedAccount }: ClaimModalModalProps) => {
     const { device, isLocked } = useDevice();
-    const selectedAccount = useSelector(
-        state => state.wallet.selectedAccount,
-    ) as SelectedAccountLoaded;
     const { isClaimingDisabled, claimingMessageContent } = useMessageSystemStaking(
         selectedAccount.network.symbol,
     );
@@ -81,9 +79,6 @@ export const ClaimModal = ({ onCancel }: ClaimModalModalProps) => {
             },
         });
     };
-
-    // it shouldn't be possible to open this modal without having selected account
-    if (!selectedAccount?.account || selectedAccount?.status !== 'loaded') return null;
 
     return (
         <NewModal
@@ -159,5 +154,22 @@ export const ClaimModal = ({ onCancel }: ClaimModalModalProps) => {
                 </Column>
             </form>
         </NewModal>
+    );
+};
+
+export const ClaimModal = ({ onCancel }: Omit<ClaimModalModalProps, 'selectedAccount'>) => {
+    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+
+    if (selectedAccount.status !== 'loaded' || !selectedAccount.account) {
+        onCancel?.();
+
+        return null;
+    }
+
+    return (
+        <ClaimModalLoaded
+            onCancel={onCancel}
+            selectedAccount={selectedAccount as SelectedAccountLoaded}
+        />
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeModal.tsx
@@ -13,18 +13,14 @@ import { StakingInfoCards } from './StakingInfoCards/StakingInfoCards';
 
 interface StakeModalModalProps {
     onCancel?: () => void;
+    selectedAccount: SelectedAccountLoaded;
 }
 
-export const StakeModal = ({ onCancel }: StakeModalModalProps) => {
-    const selectedAccount = useSelector(
-        state => state.wallet.selectedAccount,
-    ) as SelectedAccountLoaded;
+export const StakeModalLoaded = ({ onCancel, selectedAccount }: StakeModalModalProps) => {
+    const { account } = selectedAccount;
+
     const stakeEthContextValues = useStakeEthForm({ selectedAccount });
     const isBelowTablet = useMediaQuery(`(max-width: ${variables.SCREEN_SIZE.MD})`);
-
-    const { account, status } = selectedAccount;
-    // it shouldn't be possible to open this modal without having selected account
-    if (!account || status !== 'loaded') return null;
 
     const onCancelClick = () => {
         onCancel?.();
@@ -34,7 +30,7 @@ export const StakeModal = ({ onCancel }: StakeModalModalProps) => {
             payload: {
                 action: 'cancel',
                 step: 'stake-form-modal',
-                networkSymbol: selectedAccount.account.symbol,
+                networkSymbol: account.symbol,
             },
         });
     };
@@ -58,5 +54,22 @@ export const StakeModal = ({ onCancel }: StakeModalModalProps) => {
                 </Grid>
             </NewModal>
         </StakeEthFormContext.Provider>
+    );
+};
+
+export const StakeModal = ({ onCancel }: Omit<StakeModalModalProps, 'selectedAccount'>) => {
+    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+
+    if (selectedAccount.status !== 'loaded' || !selectedAccount.account) {
+        onCancel?.();
+
+        return null;
+    }
+
+    return (
+        <StakeModalLoaded
+            onCancel={onCancel}
+            selectedAccount={selectedAccount as SelectedAccountLoaded}
+        />
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeModal.tsx
@@ -21,18 +21,14 @@ import { UnstakeEthForm } from './UnstakeEthForm/UnstakeEthForm';
 
 interface UnstakeModalModalProps {
     onCancel?: () => void;
+    selectedAccount: SelectedAccountLoaded;
 }
 
-export const UnstakeModal = ({ onCancel }: UnstakeModalModalProps) => {
-    const selectedAccount = useSelector(
-        state => state.wallet.selectedAccount,
-    ) as SelectedAccountLoaded;
+export const UnstakeModalLoaded = ({ onCancel, selectedAccount }: UnstakeModalModalProps) => {
+    const { account } = selectedAccount;
+
     const unstakeEthContextValues = useUnstakeEthForm({ selectedAccount });
     const isBelowTablet = useMediaQuery(`(max-width: ${variables.SCREEN_SIZE.MD})`);
-
-    const { account, status } = selectedAccount;
-    // it shouldn't be possible to open this modal without having selected account
-    if (!account || status !== 'loaded') return null;
 
     const onCancelClick = () => {
         onCancel?.();
@@ -42,7 +38,7 @@ export const UnstakeModal = ({ onCancel }: UnstakeModalModalProps) => {
             payload: {
                 action: 'cancel',
                 step: 'unstake-form-modal',
-                networkSymbol: selectedAccount.account.symbol,
+                networkSymbol: account.symbol,
             },
         });
     };
@@ -74,5 +70,22 @@ export const UnstakeModal = ({ onCancel }: UnstakeModalModalProps) => {
                 </Grid>
             </NewModal>
         </UnstakeEthFormContext.Provider>
+    );
+};
+
+export const UnstakeModal = ({ onCancel }: Omit<UnstakeModalModalProps, 'selectedAccount'>) => {
+    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+
+    if (selectedAccount.status !== 'loaded' || !selectedAccount.account) {
+        onCancel?.();
+
+        return null;
+    }
+
+    return (
+        <UnstakeModalLoaded
+            onCancel={onCancel}
+            selectedAccount={selectedAccount as SelectedAccountLoaded}
+        />
     );
 };


### PR DESCRIPTION
## Description

Fixed Suite crashing when the user cancels a transaction in the stake/unstake/claim modal and then cancels the transaction on the device.

Happens when using `BridgeTransport` version `2.0.27`.

## Related Issue

Resolve #17646 

## Screenshots:

https://github.com/user-attachments/assets/2a3a41b6-fd1e-4c57-ad99-be3bf6a7820f


