### PR TITLE
fix(suite): composed fee level not type safe

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AffectedTransactions/DecreasedOutputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AffectedTransactions/DecreasedOutputs.tsx
@@ -53,7 +53,7 @@ const ReducedAmount = ({ composedLevels, setMaxOutputId, account, selectedFee }:
 
     const precomposedTx = composedLevels[selectedFee || 'normal'];
 
-    if (precomposedTx.type !== 'final') {
+    if (precomposedTx?.type !== 'final') {
         return null;
     }
 

--- a/packages/suite/src/hooks/wallet/form/useCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useCompose.ts
@@ -23,7 +23,7 @@ import { signAndPushSendFormTransactionThunk } from 'src/actions/wallet/send/sen
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 
-import { SendContextValues, UseSendFormState } from '../../../types/wallet/sendForm';
+import { SendContextValues } from '../../../types/wallet/sendForm';
 
 const DEFAULT_FIELD = 'outputs.0.amount';
 
@@ -117,6 +117,8 @@ export const useCompose = <TFieldValues extends FormState>({
     // update fields AFTER composedLevels change or selectedFee change (below)
     const updateComposedValues = useCallback(
         (composed: PrecomposedTransaction | PrecomposedTransactionCardano) => {
+            if (!composed) return;
+
             const values = getValues();
             if (composed.type === 'error') {
                 const { error, errorMessage } = composed;
@@ -185,16 +187,19 @@ export const useCompose = <TFieldValues extends FormState>({
     );
 
     const switchToNearestFee = useCallback(
-        (composedLevels: NonNullable<UseSendFormState['composedLevels']>) => {
+        (composedLevels: PrecomposedLevels | PrecomposedLevelsCardano) => {
             const { selectedFee, setMaxOutputId } = getValues();
             let composed = composedLevels[selectedFee || 'normal'];
+
+            // composed transaction does not exists (should never happen)
+            if (!composed) return;
 
             // selectedFee was not set yet (no interaction with Fees) and default (normal) fee tx is not valid
             // OR setMax option was used
             // try to switch to nearest possible composed transaction
             const shouldSwitch =
                 !selectedFee || (typeof setMaxOutputId === 'number' && selectedFee !== 'custom');
-            if (shouldSwitch && composed?.type === 'error') {
+            if (shouldSwitch && composed.type === 'error') {
                 // find nearest possible tx
                 const nearest = Object.keys(composedLevels)
                     .reverse()
@@ -215,9 +220,6 @@ export const useCompose = <TFieldValues extends FormState>({
                 }
                 // or do nothing, use default composed tx
             }
-
-            // composed transaction does not exists (should never happen)
-            if (!composed) return;
 
             updateComposedValues(composed);
         },

--- a/packages/suite/src/hooks/wallet/form/useStakeCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useStakeCompose.ts
@@ -160,16 +160,21 @@ export const useStakeCompose = <TFieldValues extends StakeFormState>({
                 setComposedLevels(levels);
             } else {
                 const currentLevel = composedLevels[current || 'normal'];
-                updateComposedValues(currentLevel);
+                if (currentLevel) {
+                    updateComposedValues(currentLevel);
+                }
             }
         },
         [composedLevels, updateComposedValues],
     );
 
     const switchToNearestFee = useCallback(
-        (composedLevels: NonNullable<StakeContextValues['composedLevels']>) => {
+        (composedLevels: PrecomposedLevels) => {
             const { selectedFee, setMaxOutputId } = getValues();
             let composed = composedLevels[selectedFee || 'normal'];
+
+            // composed transaction does not exists (should never happen)
+            if (!composed) return;
 
             // selectedFee was not set yet (no interaction with Fees) and default (normal) fee tx is not valid
             // OR setMax option was used
@@ -180,9 +185,9 @@ export const useStakeCompose = <TFieldValues extends StakeFormState>({
                 // find nearest possible tx
                 const nearest = Object.keys(composedLevels)
                     .reverse()
-                    .find((key): key is FeeLevel['label'] => composedLevels[key].type !== 'error');
+                    .find((key): key is FeeLevel['label'] => composedLevels[key]?.type !== 'error');
                 // switch to it
-                if (nearest) {
+                if (nearest && composedLevels[nearest]) {
                     composed = composedLevels[nearest];
                     setValue('selectedFee', nearest);
                     if (nearest === 'custom') {
@@ -198,8 +203,6 @@ export const useStakeCompose = <TFieldValues extends StakeFormState>({
                 }
                 // or do nothing, use default composed tx
             }
-            // composed transaction does not exists (should never happen)
-            if (!composed) return;
 
             updateComposedValues(composed);
         },

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -172,6 +172,7 @@ export const useSendFormCompose = ({
     const updateComposedValues = useCallback(
         (composed: PrecomposedTransaction | PrecomposedTransactionCardano) => {
             const values = getValues();
+            if (!composed) return;
             if (composed.type === 'error') {
                 const { error, errorMessage } = composed;
                 if (!errorMessage) {
@@ -249,6 +250,9 @@ export const useSendFormCompose = ({
         const { selectedFee, setMaxOutputId } = values;
         let composed = composedLevels[selectedFee || 'normal'];
 
+        // composed transaction does not exists (not going to happen?)
+        if (!composed) return;
+
         // selectedFee was not set yet (no interaction with Fees) and default (normal) fee tx is not valid
         // OR setMax option was used
         // try to switch to nearest possible composed transaction
@@ -274,11 +278,6 @@ export const useSendFormCompose = ({
                 setDraftSaveRequest(true);
             }
             // or do nothing, use default composed tx
-        }
-
-        // composed transaction does not exists (not going to happen?)
-        if (!composed) {
-            return;
         }
 
         updateComposedValues(composed);

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -165,8 +165,8 @@ export type GeneralPrecomposedTransactionFinal = Extract<
     { type: 'final' }
 >;
 
-export type PrecomposedLevels = { [key: string]: PrecomposedTransaction };
-export type PrecomposedLevelsCardano = { [key: string]: PrecomposedTransactionCardano };
+export type PrecomposedLevels = Record<string, PrecomposedTransaction>;
+export type PrecomposedLevelsCardano = Record<string, PrecomposedTransactionCardano>;
 export type GeneralPrecomposedLevels = PrecomposedLevels | PrecomposedLevelsCardano;
 
 export interface RbfTransactionParamsBitcoin {


### PR DESCRIPTION
## Description

Accessing `composedLevels[selectedFee]` was not type safe, it could have been undefined