### PR TITLE
feat(trading): support ethereum holesky testnet in trading

### DIFF
--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -498,8 +498,8 @@ export const networks = {
         features: ['rbf', 'sign-verify', 'tokens', 'staking', 'nfts', 'nft-definitions', 'eip1559'],
         backendTypes: ['blockbook'],
         accountTypes: {},
-        coingeckoId: undefined,
-        tradeCryptoId: undefined,
+        coingeckoId: 'holesky-test-ethereum', // fake, coingecko does not have testnets
+        tradeCryptoId: 'holesky-test-ethereum', // fake, coingecko does not have testnets
     },
     dsol: {
         symbol: 'dsol',


### PR DESCRIPTION
Support ethereum holesky testnet in trading.

## Related Issue

Resolve #18129

## Screenshots:
![image](https://github.com/user-attachments/assets/30e4165e-a742-4744-b2e0-de501952bcdb)
![image](https://github.com/user-attachments/assets/63c5d200-72e3-46da-be38-8df89c0a8c75)

