### PR TITLE
fix(suite): on desktop, fix that the top title link in the guide was …

### DIFF
--- a/packages/suite/src/components/guide/GuideViewWrapper.tsx
+++ b/packages/suite/src/components/guide/GuideViewWrapper.tsx
@@ -9,6 +9,7 @@ const Wrapper = styled.div`
     display: flex;
     flex-direction: column;
     overflow: hidden scroll;
+    -webkit-app-region: no-drag;
     min-width: ${variables.LAYOUT_SIZE.GUIDE_PANEL_CONTENT_WIDTH};
 `;
 


### PR DESCRIPTION
…not clickable

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18051#event-17076846833

## Screenshots:
