### PR TITLE
chore(message-system): temporarily disable other error on hash check

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2025-03-25T00:00:00+00:00",
-    "sequence": 86,
+    "timestamp": "2025-04-02T00:00:00+00:00",
+    "sequence": 87,
     "actions": [
         {
             "conditions": [
@@ -1523,6 +1523,45 @@
                 "feature": [
                     {
                         "domain": "security.firmware.hashCheck",
+                        "flag": false
+                    }
+                ]
+            }
+        },
+        {
+            "conditions": [
+                {
+                    "environment": {
+                        "desktop": ">=25.3.1 <25.4.0",
+                        "mobile": "!",
+                        "web": "*"
+                    }
+                }
+            ],
+            "message": {
+                "id": "2f93e955-0d41-4e3e-a778-1812bbd0fa72",
+                "priority": 1,
+                "dismissible": false,
+                "variant": "info",
+                "category": "feature",
+                "content": {
+                    "en-GB": "Placeholder",
+                    "en": "Placeholder",
+                    "es": "Placeholder",
+                    "cs": "Placeholder",
+                    "de": "Placeholder",
+                    "fr": "Placeholder",
+                    "it": "Placeholder",
+                    "pt": "Placeholder",
+                    "tr": "Placeholder",
+                    "ru": "Placeholder",
+                    "ja": "Placeholder",
+                    "uk": "Placeholder",
+                    "hu": "Placeholder"
+                },
+                "feature": [
+                    {
+                        "domain": "security.firmware.hashCheck.otherError",
                         "flag": false
                     }
                 ]


### PR DESCRIPTION
We need to tackle better the UI so users will not panic - cc @hynek-jina & @rabbitholiness 