### PR TITLE
fix(suite): detect feeInfo changes based on blockHeight to fix outdated fee calculation

### DIFF
--- a/packages/suite/src/hooks/wallet/form/useCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useCompose.ts
@@ -44,6 +44,7 @@ export const useCompose = <TFieldValues extends FormState>({
 }: Props<TFieldValues>) => {
     const [isLoading, setLoading] = useState(false);
     const composeRequestIDRef = useRef(0);
+    const prevFeeInfoRef = useRef(state?.feeInfo);
     const defaultFieldRef = useRef(defaultField || DEFAULT_FIELD);
     const [composedLevels, setComposedLevels] =
         useState<SendContextValues['composedLevels']>(undefined);
@@ -229,6 +230,16 @@ export const useCompose = <TFieldValues extends FormState>({
             composeRequest();
         }
     }, [state, composeRequest]);
+
+    useEffect(() => {
+        const hasFeeInfoChanged =
+            state && state?.feeInfo.blockHeight !== prevFeeInfoRef.current?.blockHeight;
+
+        if (hasFeeInfoChanged) {
+            prevFeeInfoRef.current = state.feeInfo;
+            composeRequest();
+        }
+    }, [state, state?.feeInfo, composeRequest]);
 
     // handle composedLevels change
     useEffect(() => {

--- a/packages/suite/src/hooks/wallet/form/useStakeCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useStakeCompose.ts
@@ -32,6 +32,7 @@ export const useStakeCompose = <TFieldValues extends StakeFormState>({
 }: Props<TFieldValues>) => {
     const [isLoading, setLoading] = useState(false);
     const composeRequestIDRef = useRef(0);
+    const prevFeeInfoRef = useRef(state?.feeInfo);
     const defaultFieldRef = useRef(defaultField || DEFAULT_FIELD);
     const [composedLevels, setComposedLevels] =
         useState<StakeContextValues['composedLevels']>(undefined);
@@ -99,6 +100,8 @@ export const useStakeCompose = <TFieldValues extends StakeFormState>({
     const updateComposedValues = useCallback(
         (composed: PrecomposedTransaction) => {
             const values = getValues();
+            if (!composed) return;
+
             if (composed.type === 'error') {
                 const { error, errorMessage } = composed;
                 if (!errorMessage) {
@@ -209,6 +212,16 @@ export const useStakeCompose = <TFieldValues extends StakeFormState>({
             composeRequest();
         }
     }, [state, composeRequest]);
+
+    useEffect(() => {
+        const hasFeeInfoChanged =
+            state && state?.feeInfo.blockHeight !== prevFeeInfoRef.current?.blockHeight;
+
+        if (hasFeeInfoChanged) {
+            prevFeeInfoRef.current = state.feeInfo;
+            composeRequest();
+        }
+    }, [state, state?.feeInfo, composeRequest]);
 
     // handle composedLevels change
     useEffect(() => {

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
@@ -94,7 +94,15 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
             state.account.symbol === initState.account.symbol
         );
 
-        if (hasAccountChanged || (!outputAddress && account.symbol !== 'ada')) {
+        // update fee info only if the block height has increased.
+        // note: This approach may not be ideal for Bitcoin, as fees can change within the same block
+        const hasFeeInfoChanged = feeInfo.blockHeight - state.feeInfo.blockHeight > 0;
+
+        if (
+            hasAccountChanged ||
+            (!outputAddress && account.symbol !== 'ada') ||
+            hasFeeInfoChanged
+        ) {
             setStateAsync();
         }
         // call effect only when listed dependencies will change
@@ -109,6 +117,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
         state.account.symbol,
         initState.account.descriptor,
         initState.account.symbol,
+        initState.feeInfo,
         outputAddress,
     ]);
 

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -1,4 +1,12 @@
-import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import {
+    createContext,
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 
 import { FiatCurrencyCode } from '@suite-common/suite-config';
@@ -57,11 +65,6 @@ export interface UseSendFormProps extends SendFormProps {
 // convert UseSendFormProps to UseSendFormState
 const getStateFromProps = (props: UseSendFormProps) => {
     const { account, network } = props.selectedAccount;
-    const { symbol, networkType } = account;
-    const feeInfo = getFeeInfo({
-        networkType,
-        feeInfo: props.fees[symbol],
-    });
     const currencyCode = props.localCurrency;
     const localCurrencyOption = {
         value: currencyCode,
@@ -71,7 +74,7 @@ const getStateFromProps = (props: UseSendFormProps) => {
     return {
         account,
         network,
-        feeInfo,
+
         localCurrencyOption,
         online: props.online,
         metadataEnabled: props.metadataEnabled,
@@ -94,6 +97,16 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     const dispatch = useDispatch();
 
     const { localCurrencyOption } = state;
+
+    const { symbol, networkType } = state.account;
+    const feeInfo = useMemo(
+        () =>
+            getFeeInfo({
+                networkType,
+                feeInfo: props.fees[symbol],
+            }),
+        [networkType, props.fees, symbol],
+    );
 
     // register `react-hook-form`, defaultValues are set later in "loadDraft" useEffect block
     const useFormMethods = useForm<FormState>({
@@ -132,7 +145,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
 
     const excludedUtxos = useExcludedUtxos({
         account: state.account,
-        dustLimit: state.feeInfo.dustLimit,
+        dustLimit: feeInfo.dustLimit,
         targetAnonymity: props.targetAnonymity,
     });
 
@@ -154,6 +167,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     } = useSendFormCompose({
         ...useFormMethods,
         state,
+        feeInfo,
         account: props.selectedAccount.account,
         prison: props.prison,
         excludedUtxos,
@@ -180,7 +194,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     // sub-hook
     const { changeFeeLevel } = useFees({
         defaultValue: undefined,
-        feeInfo: state.feeInfo,
+        feeInfo,
         onChange: onFeeLevelChange,
         composedLevels,
         composeRequest,
@@ -257,21 +271,6 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
             }
         }
     }, [getValues, composedLevels, dispatch, resetContext, props.selectedAccount.account]);
-
-    // replace default feeInfo with data loaded from the server
-    useEffect(() => {
-        const feeInfo = getFeeInfo({
-            networkType: state.account.networkType,
-            feeInfo: props.fees[state.account.symbol],
-        });
-
-        // update fee info only if the block height has increased.
-        // note: This approach may not be ideal for Bitcoin, as fees can change within the same block
-        if (feeInfo.blockHeight - state.feeInfo.blockHeight > 0) {
-            setState(prev => ({ ...prev, feeInfo }));
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [props.fees]);
 
     // reset on account change
     useEffect(() => {
@@ -381,6 +380,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     return {
         ...state,
         ...useFormMethods,
+        feeInfo,
         isLoading,
         register,
         outputs: outputsFieldArray.fields,

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -8,6 +8,7 @@ import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 import { composeSendFormTransactionFeeLevelsThunk } from '@suite-common/wallet-core';
 import {
     ExcludedUtxos,
+    FeeInfo,
     FormState,
     PrecomposedLevels,
     PrecomposedLevelsCardano,
@@ -27,6 +28,7 @@ import { useSolanaSubscribeBlocks } from './form/useSolanaSubscribeBlocks';
 
 type Props = UseFormReturn<FormState> & {
     state: UseSendFormState;
+    feeInfo: FeeInfo;
     excludedUtxos: ExcludedUtxos;
     account: UseSendFormState['account']; // account from the component props !== state.account
     updateContext: SendContextValues['updateContext'];
@@ -44,6 +46,7 @@ export const useSendFormCompose = ({
     formState: { errors, isDirty },
     clearErrors,
     state,
+    feeInfo,
     account,
     excludedUtxos,
     updateContext,
@@ -76,7 +79,7 @@ export const useSendFormCompose = ({
                     composeContext: {
                         account,
                         network: state.network,
-                        feeInfo: state.feeInfo,
+                        feeInfo,
                         excludedUtxos,
                         prison,
                     },
@@ -90,7 +93,7 @@ export const useSendFormCompose = ({
                 setLoading(false);
             }
         },
-        [account, dispatch, prison, excludedUtxos, setLoading, state.network, state.feeInfo],
+        [account, dispatch, prison, excludedUtxos, setLoading, state.network, feeInfo],
     );
 
     // Create a compose request
@@ -127,7 +130,7 @@ export const useSendFormCompose = ({
                         composeContext: {
                             account,
                             network: state.network,
-                            feeInfo: state.feeInfo,
+                            feeInfo,
                             excludedUtxos,
                             prison,
                         },
@@ -159,7 +162,7 @@ export const useSendFormCompose = ({
             getValues,
             account,
             state.network,
-            state.feeInfo,
+            feeInfo,
             excludedUtxos,
             prison,
         ],
@@ -338,7 +341,7 @@ export const useSendFormCompose = ({
         updateContext({ account });
     }, [
         state.account,
-        state.feeInfo.dustLimit,
+        feeInfo.dustLimit,
         isDirty,
         account,
         clearErrors,

--- a/packages/suite/src/hooks/wallet/useUnstakeEthForm.ts
+++ b/packages/suite/src/hooks/wallet/useUnstakeEthForm.ts
@@ -61,7 +61,11 @@ export const useUnstakeEthForm = ({
     const { symbol } = account;
 
     const localCurrency = useSelector(selectLocalCurrency);
-    const symbolFees = useSelector(state => state.wallet.fees[symbol]);
+    const fees = useSelector(state => state.wallet.fees);
+    const feeInfo = getFeeInfo({
+        networkType: account.networkType,
+        feeInfo: fees[account.symbol],
+    });
 
     const [currency, setCurrency] = useState<'crypto' | 'fiat' | undefined>(undefined);
 
@@ -92,19 +96,15 @@ export const useUnstakeEthForm = ({
     const draft = getDraft(account.key);
     const isDraft = !!draft;
 
-    const state = useMemo(() => {
-        const feeInfo = getFeeInfo({
-            networkType: account.networkType,
-            feeInfo: symbolFees,
-        });
-
-        return {
+    const state = useMemo(
+        () => ({
             account,
             network,
             feeInfo,
             formValues: defaultValues,
-        };
-    }, [account, defaultValues, symbolFees, network]);
+        }),
+        [account, network, feeInfo, defaultValues],
+    );
 
     const methods = useForm<UnstakeFormState>({
         mode: 'onChange',
@@ -168,12 +168,6 @@ export const useUnstakeEthForm = ({
         state,
     });
 
-    // sub-hook, FeeLevels handler
-    const fees = useSelector(state => state.wallet.fees);
-    const feeInfo = getFeeInfo({
-        networkType: account.networkType,
-        feeInfo: fees[account.symbol],
-    });
     const { changeFeeLevel, selectedFee: _selectedFee } = useFees({
         defaultValue: 'normal',
         feeInfo,

--- a/packages/suite/src/types/wallet/sendForm.ts
+++ b/packages/suite/src/types/wallet/sendForm.ts
@@ -32,7 +32,6 @@ export type UseSendFormState = {
     account: Account;
     network: Network;
     localCurrencyOption: { value: FiatCurrencyCode; label: Uppercase<FiatCurrencyCode> };
-    feeInfo: FeeInfo;
     composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
     online: boolean;
     metadataEnabled: boolean;
@@ -71,6 +70,7 @@ export type SendContextValues<TFormValues extends FormState = FormState> =
     UseFormReturn<TFormValues> &
         UseSendFormState & {
             isLoading: boolean;
+            feeInfo: FeeInfo;
             // additional fields
             outputs: Partial<Output & { id: string }>[]; // useFieldArray fields
             updateContext: (value: Partial<UseSendFormState>) => void;


### PR DESCRIPTION
## Description

This PR fixes a global issue where `feeInfo` was not updating correctly, causing incorrect fee calculations across the app, including in the Sell form and Bump Fee form.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18062
