### PR TITLE
Chore/run depcheck in root

### DIFF
--- a/.depcheckrc.json
+++ b/.depcheckrc.json
@@ -12,8 +12,8 @@
         "tslib",
         "protobufjs-cli",
         "buffer",
-        "version-bump-prompt",
-        "node-gyp"
+        "node-gyp",
+        "version-bump-prompt"
     ],
     "skip-missing": true
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "check-workspace-resolutions": "yarn tsx ./scripts/check-workspace-resolutions.ts",
         "generate-package": "yarn workspace @trezor/scripts generate-package",
         "deps": "rimraf **/node_modules && yarn",
-        "depcheck": "yarn nx affected --target=depcheck",
+        "depcheck": "depcheck && yarn nx affected --target=depcheck",
         "list-outdated": "./scripts/list-outdated-dependencies/list-outdated-dependencies.sh",
         "message-system-sign-config": "yarn workspace @suite-common/message-system sign-config",
         "format": "yarn nx format:write",
@@ -147,8 +147,5 @@
             "built": true
         }
     },
-    "packageManager": "yarn@4.5.3",
-    "dependencies": {
-        "version-bump-prompt": "^6.1.0"
-    }
+    "packageManager": "yarn@4.5.3"
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -26,6 +26,7 @@
         "@types/semver": "^7.7.0",
         "@types/tar": "^6.1.11",
         "semver": "^7.7.1",
-        "tar": "^7.0.1"
+        "tar": "^7.0.1",
+        "version-bump-prompt": "^6.1.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12197,6 +12197,7 @@ __metadata:
     sort-package-json: "npm:^1.57.0"
     tar: "npm:^7.0.1"
     tsx: "npm:^4.19.3"
+    version-bump-prompt: "npm:^6.1.0"
     yargs: "npm:17.7.2"
   languageName: unknown
   linkType: soft
@@ -40110,7 +40111,6 @@ __metadata:
     tslib: "npm:^2.6.2"
     tsx: "npm:^4.19.3"
     typescript: "npm:5.8.2"
-    version-bump-prompt: "npm:^6.1.0"
   dependenciesMeta:
     core-js-pure:
       built: false


### PR DESCRIPTION
Follow-up to https://github.com/trezor/trezor-suite/pull/17954. We skipped `depcheck` for root until now. Enabling for root and adding some of the newly reported dependencies to ignore list.