### PR TITLE
feat(suite): CoinsFilter updates

### DIFF
--- a/packages/components/src/components/buttons/Button/Button.tsx
+++ b/packages/components/src/components/buttons/Button/Button.tsx
@@ -30,11 +30,11 @@ export const allowedButtonFrameProps = [
     'minWidth',
     'maxWidth',
 ] as const satisfies FramePropsKeys[];
-type AllowedFrameProps = Pick<FrameProps, (typeof allowedButtonFrameProps)[number]>;
+export type AllowedButtonFrameProps = Pick<FrameProps, (typeof allowedButtonFrameProps)[number]>;
 
 export type IconOrComponent = IconName | JSX.Element;
 
-type ButtonContainerProps = TransientProps<AllowedFrameProps> & {
+type ButtonContainerProps = TransientProps<AllowedButtonFrameProps> & {
     $elevation: Elevation;
     $variant: ButtonVariant;
     $size: ButtonSize;
@@ -113,7 +113,7 @@ type ExclusiveAProps =
       };
 
 export type ButtonProps = SelectedHTMLButtonProps &
-    AllowedFrameProps &
+    AllowedButtonFrameProps &
     ExclusiveAProps & {
         variant?: ButtonVariant;
         isSubtle?: boolean;
@@ -167,7 +167,7 @@ export const Button = ({
     textWrap = true,
     title,
     type = 'button',
-    variant = 'primary',
+    variant = 'tertiary',
     ...rest
 }: ButtonProps) => {
     const frameProps = pickAndPrepareFrameProps(rest, allowedButtonFrameProps);

--- a/packages/components/src/components/buttons/TextButton/TextButton.stories.tsx
+++ b/packages/components/src/components/buttons/TextButton/TextButton.stories.tsx
@@ -2,7 +2,9 @@ import { Meta, StoryObj } from '@storybook/react';
 
 import { TextButton as TextButtonComponent, TextButtonProps } from './TextButton';
 import { variables } from '../../../config';
-import { buttonSizes, iconAlignments } from '../buttonStyleUtils';
+import { getFramePropsStory } from '../../../utils/frameProps';
+import { allowedButtonFrameProps } from '../Button/Button';
+import { buttonSizes, buttonVariants, iconAlignments } from '../buttonStyleUtils';
 
 const meta: Meta = {
     title: 'Buttons',
@@ -13,10 +15,12 @@ export default meta;
 export const TextButton: StoryObj<TextButtonProps> = {
     args: {
         children: 'Button label',
+        variant: 'primary',
         iconAlignment: 'start',
         size: 'large',
         isDisabled: false,
         isLoading: false,
+        ...getFramePropsStory(allowedButtonFrameProps).args,
     },
     argTypes: {
         children: {
@@ -25,6 +29,12 @@ export const TextButton: StoryObj<TextButtonProps> = {
                     summary: 'ReactNode',
                 },
             },
+        },
+        variant: {
+            control: {
+                type: 'radio',
+            },
+            options: buttonVariants,
         },
         icon: {
             options: [null, ...variables.ICONS],
@@ -61,5 +71,6 @@ export const TextButton: StoryObj<TextButtonProps> = {
         title: {
             control: { type: 'text' },
         },
+        ...getFramePropsStory(allowedButtonFrameProps).argTypes,
     },
 };

--- a/packages/components/src/components/buttons/TextButton/TextButton.tsx
+++ b/packages/components/src/components/buttons/TextButton/TextButton.tsx
@@ -1,18 +1,50 @@
 import React from 'react';
 
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 
 import { borders, spacingsPx, typography } from '@trezor/theme';
 
+import { pickAndPrepareFrameProps, withFrameProps } from '../../../utils/frameProps';
+import { TransientProps } from '../../../utils/transientProps';
 import { focusStyleTransition, getFocusShadowStyle } from '../../../utils/utils';
 import { Spinner } from '../../loaders/Spinner/Spinner';
-import { ButtonProps, getIcon } from '../Button/Button';
-import { ButtonSize, IconAlignment, getIconSize } from '../buttonStyleUtils';
+import {
+    AllowedButtonFrameProps,
+    ButtonProps,
+    allowedButtonFrameProps,
+    getIcon,
+} from '../Button/Button';
+import {
+    ButtonSize,
+    ButtonVariant,
+    IconAlignment,
+    getIconColor,
+    getIconSize,
+} from '../buttonStyleUtils';
 
-const TextButtonContainer = styled.button<{
-    $size: ButtonSize;
-    $iconAlignment: IconAlignment;
-}>`
+const mapVariantToColor: Record<ButtonVariant, string> = {
+    primary: 'textPrimaryDefault',
+    tertiary: 'textSubdued',
+    info: 'textAlertBlue',
+    warning: 'textAlertYellow',
+    destructive: 'textAlertRed',
+};
+
+const mapVariantToHoverColor: Record<ButtonVariant, string> = {
+    primary: 'textPrimaryPressed',
+    tertiary: 'textPrimaryPressed',
+    info: 'textPrimaryPressed',
+    warning: 'textPrimaryPressed',
+    destructive: 'textPrimaryPressed',
+};
+
+const TextButtonContainer = styled.button<
+    TransientProps<AllowedButtonFrameProps> & {
+        $size: ButtonSize;
+        $iconAlignment: IconAlignment;
+        $variant: ButtonVariant;
+    }
+>`
     display: flex;
     align-items: center;
     flex-direction: ${({ $iconAlignment }) => $iconAlignment === 'end' && 'row-reverse'};
@@ -22,7 +54,8 @@ const TextButtonContainer = styled.button<{
     border: 1px solid transparent;
     border-radius: ${borders.radii.xxs};
     background: none;
-    color: ${({ theme }) => theme.textPrimaryDefault};
+    color: ${({ theme, $variant }) => theme[mapVariantToColor[$variant]]};
+
     ${({ $size }) => ($size === 'small' ? typography.hint : typography.body)};
     white-space: nowrap;
     transition:
@@ -32,17 +65,13 @@ const TextButtonContainer = styled.button<{
     cursor: pointer;
 
     ${getFocusShadowStyle()}
-
-    path {
-        fill: ${({ theme }) => theme.iconPrimaryDefault};
-        transition: fill 0.1s ease-out;
-    }
+    ${withFrameProps}
 
     &:hover {
-        color: ${({ theme }) => theme.textPrimaryPressed};
+        color: ${({ theme, $variant }) => theme[mapVariantToHoverColor[$variant]]};
 
         path {
-            fill: ${({ theme }) => theme.iconPrimaryPressed};
+            fill: ${({ theme, $variant }) => theme[mapVariantToHoverColor[$variant]]};
         }
     }
 
@@ -56,9 +85,9 @@ const TextButtonContainer = styled.button<{
     }
 `;
 
-export interface TextButtonProps extends Omit<ButtonProps, 'isFullWidth' | 'iconSize' | 'variant'> {
-    children: React.ReactNode;
-}
+export type TextButtonProps = Omit<ButtonProps, 'iconSize' | 'isSubtle' | 'children'> & {
+    children?: React.ReactNode;
+};
 
 export const TextButton = ({
     icon,
@@ -67,9 +96,17 @@ export const TextButton = ({
     isDisabled = false,
     isLoading = false,
     children,
+    variant = 'primary',
     ...rest
 }: TextButtonProps) => {
-    const IconComponent = getIcon({ icon, size: getIconSize(size) });
+    const frameProps = pickAndPrepareFrameProps(rest, allowedButtonFrameProps);
+    const theme = useTheme();
+    const IconComponent = getIcon({
+        icon,
+        size: getIconSize(size),
+        color: getIconColor({ variant, isDisabled, theme, isSubtle: true }),
+    });
+
     const Loader = <Spinner size={getIconSize(size)} />;
 
     return (
@@ -77,6 +114,8 @@ export const TextButton = ({
             $size={size}
             $iconAlignment={iconAlignment}
             disabled={isDisabled || isLoading}
+            $variant={variant}
+            {...frameProps}
             {...rest}
         >
             {!isLoading && icon && IconComponent}

--- a/packages/suite-desktop-core/e2e/tests/trading/navigation.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/navigation.test.ts
@@ -19,6 +19,7 @@ test.describe('Trading - Navigation', { tag: ['@group=other'] }, () => {
         await test.step('Buy from dashboard asset card', async () => {
             await page.getByTestId('@dashboard/asset/btc/buy-button').click();
             await tradingPage.verifyBuyFormOpened('BTC');
+            await page.getByTestId(`@account-menu/filter-accounts`).click();
             await walletPage.walletFilter('btc').click();
         });
 

--- a/packages/suite-desktop-core/e2e/tests/wallet/add-account-types.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/add-account-types.test.ts
@@ -125,6 +125,7 @@ test.describe('Account types suite', { tag: ['@group=wallet'] }, () => {
         await dashboardPage.discoveryShouldFinish();
 
         analytics.interceptAnalytics();
+        await page.getByTestId(`@account-menu/filter-accounts`).click();
         for (const coin of coins) {
             await test.step(`Add and verify ${coin.symbol} account`, async () => {
                 analytics.requests = [];

--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -36,3 +36,4 @@ export const LOCK_TYPE = {
 export const REQUEST_DEVICE_RECONNECT = '@suite/request-device-reconnect';
 export const SET_EXPERIMENTAL_FEATURES = '@suite/set-experimental-features';
 export const SET_SIDEBAR_WIDTH = '@suite/set-sidebar-width';
+export const SET_IS_COINS_FILTER_VISIBLE = '@suite/set-is-coins-filter-visible';

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -93,7 +93,10 @@ export type SuiteAction =
               enabledFeatures: ExperimentalFeature[] | undefined; // undefined means the experimental features are off as a whole
           };
       }
-    | { type: typeof SUITE.SET_SIDEBAR_WIDTH; payload: { width: number } };
+    | {
+          type: typeof SUITE.SET_IS_COINS_FILTER_VISIBLE;
+          payload: { isCoinsFilterVisible: boolean };
+      };
 
 export const appChanged = createAction(SUITE.APP_CHANGED, (payload: AppState['router']['app']) => ({
     payload,
@@ -147,6 +150,12 @@ export const initialRunCompleted = () => (dispatch: Dispatch, getState: GetState
 export const setSidebarWidth = (payload: { width: number }): SuiteAction => ({
     type: SUITE.SET_SIDEBAR_WIDTH,
     payload: { width: payload.width },
+});
+export const setIsCoinsFilterVisible = (payload: {
+    isCoinsFilterVisible: boolean;
+}): SuiteAction => ({
+    type: SUITE.SET_IS_COINS_FILTER_VISIBLE,
+    payload: { isCoinsFilterVisible: payload.isCoinsFilterVisible },
 });
 
 /**

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSearchBox.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSearchBox.tsx
@@ -1,3 +1,5 @@
+import { useRef } from 'react';
+
 import styled, { useTheme } from 'styled-components';
 
 import { Icon, Input } from '@trezor/components';
@@ -19,6 +21,7 @@ const StyledInput = styled(Input)`
 
 export const AccountSearchBox = () => {
     const theme = useTheme();
+    const inputRef = useRef<HTMLInputElement | null>(null);
     const { translationString } = useTranslation();
     const { setCoinFilter, searchString, setSearchString } = useAccountSearch();
 
@@ -33,13 +36,24 @@ export const AccountSearchBox = () => {
             onChange={e => {
                 setSearchString(e.target.value);
             }}
-            innerAddon={<Icon name="search" size={16} color={theme.iconDefault} />}
+            innerAddon={
+                <Icon
+                    name="search"
+                    size={16}
+                    color={theme.iconDefault}
+                    onClick={() => {
+                        inputRef?.current?.select();
+                    }}
+                    cursor="pointer"
+                />
+            }
             innerAddonAlign="start"
             size="small"
-            placeholder={translationString('TR_SEARCH')}
+            placeholder={translationString('TR_WALLET')}
             showClearButton="always"
             onClear={onClear}
             data-testid="@account-menu/search-input"
+            innerRef={inputRef}
         />
     );
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -175,7 +175,7 @@ export const AccountsList = ({ onItemClick }: AccountListProps) => {
         return (
             <Column gap={spacings.xs} margin={{ bottom: spacings.lg }}>
                 {buildGroup('coinjoin', coinjoinAccounts)}
-                {buildGroup('normal', normalAccounts, coinjoinAccounts.length === 0)}
+                {buildGroup('normal', normalAccounts, true)}
                 {buildGroup('taproot', taprootAccounts)}
                 {buildGroup('segwit', segwitAccounts)}
                 {buildGroup('legacy', legacyAccounts)}

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx
@@ -2,23 +2,17 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
-import { getFailedAccounts, sortByCoin } from '@suite-common/wallet-utils';
-import { Column, Row, SkeletonRectangle, useScrollShadow } from '@trezor/components';
-import { spacings, spacingsPx, zIndices } from '@trezor/theme';
+import { useScrollShadow } from '@trezor/components';
+import { spacingsPx, zIndices } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
 import { useDiscovery, useSelector } from 'src/hooks/suite';
 
-import { AccountSearchBox } from './AccountSearchBox';
 import { AccountsList } from './AccountsList';
+import { AccountsMenuHeader } from './AccountsMenuHeader';
 import { AccountsMenuNotice } from './AccountsMenuNotice';
-import { AddAccountButton } from './AddAccountButton';
-import { CoinsFilter } from './CoinsFilter';
 import { RefreshAfterDiscoveryNeeded } from './RefreshAfterDiscoveryNeeded';
-import { CollapsedSidebarOnly } from '../../../suite/layouts/SuiteLayout/Sidebar/CollapsedSidebarOnly';
-import { ExpandedSidebarOnly } from '../../../suite/layouts/SuiteLayout/Sidebar/ExpandedSidebarOnly';
 import { useIsSidebarCollapsed } from '../../../suite/layouts/SuiteLayout/Sidebar/utils';
 
 const Wrapper = styled.div`
@@ -30,12 +24,6 @@ const Wrapper = styled.div`
     gap: ${spacingsPx.sm};
 `;
 
-const Header = styled.div`
-    border-top: 1px solid ${({ theme }) => theme.borderElevation1};
-    padding: ${spacingsPx.sm} ${spacingsPx.xs};
-    padding-bottom: 0;
-`;
-
 const ScrollContainer = styled.div`
     height: auto;
     overflow: hidden auto;
@@ -43,12 +31,12 @@ const ScrollContainer = styled.div`
 
 export const AccountsMenu = () => {
     const device = useSelector(selectSelectedDevice);
-    const accounts = useSelector(state => state.wallet.accounts);
+
     const { discovery } = useDiscovery();
+
     const { scrollElementRef, onScroll, ShadowTop, ShadowBottom, ShadowContainer } =
         useScrollShadow();
     const isSidebarCollapsed = useIsSidebarCollapsed();
-    const isDiscoveryRunning = discovery?.status === DiscoveryStatus.RUNNING;
 
     if (!device || !discovery) {
         if (isSidebarCollapsed) return <Wrapper />;
@@ -62,42 +50,9 @@ export const AccountsMenu = () => {
         );
     }
 
-    const failed = getFailedAccounts(discovery);
-    const list = sortByCoin(
-        accounts.filter(a => a.deviceState === device.state?.staticSessionId).concat(failed),
-    );
-    const isEmpty = list.length === 0;
-
     return (
         <Wrapper>
-            <Header>
-                <ExpandedSidebarOnly>
-                    <Row justifyContent="space-between" gap={spacings.xs}>
-                        {isDiscoveryRunning ? (
-                            <SkeletonRectangle animate width="100%" height={38} />
-                        ) : (
-                            <>
-                                {!isEmpty && <AccountSearchBox />}
-                                <AddAccountButton
-                                    isFullWidth={isEmpty}
-                                    data-testid="@account-menu/add-account"
-                                    device={device}
-                                />
-                            </>
-                        )}
-                    </Row>
-                    <CoinsFilter />
-                </ExpandedSidebarOnly>
-                <CollapsedSidebarOnly>
-                    <Column alignItems="center" margin={{ bottom: spacings.sm }}>
-                        <AddAccountButton
-                            isFullWidth={false}
-                            data-testid="@account-menu/add-account"
-                            device={device}
-                        />
-                    </Column>
-                </CollapsedSidebarOnly>
-            </Header>
+            <AccountsMenuHeader discovery={discovery} />
             <ShadowContainer>
                 <ShadowTop backgroundColor="backgroundSurfaceElevationNegative" />
                 <ScrollContainer ref={scrollElementRef} onScroll={onScroll}>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
@@ -1,0 +1,103 @@
+import { DiscoveryStatus } from '@suite-common/wallet-constants';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { Discovery } from '@suite-common/wallet-types';
+import { getFailedAccounts, sortByCoin } from '@suite-common/wallet-utils';
+import {
+    Box,
+    Column,
+    Divider,
+    Row,
+    SkeletonRectangle,
+    TextButton,
+    Tooltip,
+} from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
+import { AccountSearchBox } from './AccountSearchBox';
+import { AddAccountButton } from './AddAccountButton';
+import { CoinsFilter } from './CoinsFilter';
+import { useAvailableNetworkSymbols } from './useAvailableNetworkSymbols';
+import { setIsCoinsFilterVisible } from '../../../../actions/suite/suiteActions';
+import { useDispatch, useSelector } from '../../../../hooks/suite';
+import { Translation } from '../../../suite';
+import { CollapsedSidebarOnly } from '../../../suite/layouts/SuiteLayout/Sidebar/CollapsedSidebarOnly';
+import { ExpandedSidebarOnly } from '../../../suite/layouts/SuiteLayout/Sidebar/ExpandedSidebarOnly';
+
+export const AccountsMenuHeader = ({ discovery }: { discovery: Discovery }) => {
+    const device = useSelector(selectSelectedDevice);
+    const accounts = useSelector(state => state.wallet.accounts);
+    const failed = getFailedAccounts(discovery);
+    const list = sortByCoin(
+        accounts.filter(a => a.deviceState === device?.state?.staticSessionId).concat(failed),
+    );
+    const isEmpty = list.length === 0;
+
+    const isDiscoveryRunning = discovery?.status === DiscoveryStatus.RUNNING;
+    const isCoinsFilterVisible = useSelector(state => state.suite.settings.isCoinsFilterVisible);
+    const dispatch = useDispatch();
+    const availableNetworksSymbols = useAvailableNetworkSymbols();
+
+    const toggleCoinsFilter = () =>
+        dispatch(
+            setIsCoinsFilterVisible({
+                isCoinsFilterVisible: !isCoinsFilterVisible,
+            }),
+        );
+    const showCoinFilter = availableNetworksSymbols.length > 1;
+
+    return (
+        <>
+            <Divider margin={{ top: 0, bottom: spacings.sm }} />
+            <Box margin={{ horizontal: spacings.xs }}>
+                <ExpandedSidebarOnly>
+                    <Row justifyContent="space-between" gap={spacings.xs}>
+                        {isDiscoveryRunning ? (
+                            <SkeletonRectangle animate width="100%" height={38} />
+                        ) : (
+                            <>
+                                {!isEmpty && <AccountSearchBox />}
+                                {!isEmpty && showCoinFilter && (
+                                    <Tooltip
+                                        content={
+                                            <Translation
+                                                id={
+                                                    isCoinsFilterVisible
+                                                        ? 'TR_HIDE_COINS_FILTER'
+                                                        : 'TR_SHOW_COINS_FILTER'
+                                                }
+                                            />
+                                        }
+                                    >
+                                        <TextButton
+                                            size="small"
+                                            variant={isCoinsFilterVisible ? 'primary' : 'tertiary'}
+                                            icon="funnelSimple"
+                                            onClick={toggleCoinsFilter}
+                                            data-testid="@account-menu/filter-accounts"
+                                        />
+                                    </Tooltip>
+                                )}
+
+                                <AddAccountButton
+                                    isFullWidth={isEmpty}
+                                    data-testid="@account-menu/add-account"
+                                    device={device}
+                                />
+                            </>
+                        )}
+                    </Row>
+                    {isCoinsFilterVisible && <CoinsFilter />}
+                </ExpandedSidebarOnly>
+                <CollapsedSidebarOnly>
+                    <Column alignItems="center" margin={{ bottom: spacings.sm }}>
+                        <AddAccountButton
+                            isFullWidth={false}
+                            data-testid="@account-menu/add-account"
+                            device={device}
+                        />
+                    </Column>
+                </CollapsedSidebarOnly>
+            </Box>
+        </>
+    );
+};

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx
@@ -1,9 +1,12 @@
-import { Button, ButtonProps, IconButton, TOOLTIP_DELAY_NORMAL, Tooltip } from '@trezor/components';
+import { Button, ButtonProps, TOOLTIP_DELAY_NORMAL, TextButton, Tooltip } from '@trezor/components';
+import { spacings } from '@trezor/theme';
 
 import { openModal } from 'src/actions/suite/modalActions';
 import { Translation } from 'src/components/suite';
 import { useDiscovery, useDispatch } from 'src/hooks/suite';
 import { TrezorDevice } from 'src/types/suite';
+
+import { useIsSidebarCollapsed } from '../../../suite/layouts/SuiteLayout/Sidebar/utils';
 
 const getExplanationMessage = (device: TrezorDevice | undefined, discoveryIsRunning: boolean) => {
     let message;
@@ -32,7 +35,7 @@ export const AddAccountButton = ({
 }: AddAccountButtonProps) => {
     const { isDiscoveryRunning } = useDiscovery();
     const dispatch = useDispatch();
-
+    const isSidebarCollapsed = useIsSidebarCollapsed();
     // TODO: add more cases when adding account is not possible
     const addAccountDisabled =
         isDiscoveryRunning ||
@@ -67,18 +70,20 @@ export const AddAccountButton = ({
             isFullWidth
             {...rest}
         >
-            <Translation id="TR_SIDEBAR_ADD_COIN" />
+            <Translation id="TR_ADD_ACCOUNT" />
         </Button>
     ) : (
-        <IconButton
-            onClick={device ? handleOnClick : undefined}
-            icon="plus"
-            isDisabled={addAccountDisabled || isDisabled}
-            size="small"
-            variant="tertiary"
-            {...rest}
-            label={!tooltipMessage && <Translation id="TR_ADD_ACCOUNT" />}
-        />
+        <Tooltip isActive={!tooltipMessage} content={<Translation id="TR_ADD_ACCOUNT" />}>
+            <TextButton
+                onClick={device ? handleOnClick : undefined}
+                icon="plus"
+                isDisabled={addAccountDisabled || isDisabled}
+                size="small"
+                variant="tertiary"
+                margin={{ right: isSidebarCollapsed ? 0 : spacings.xs }}
+                {...rest}
+            />
+        </Tooltip>
     );
 
     if (tooltipMessage) {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/CoinsFilter.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/CoinsFilter.tsx
@@ -6,23 +6,24 @@ import { TOOLTIP_DELAY_NORMAL, Tooltip, motionEasing } from '@trezor/components'
 import { CoinLogo } from '@trezor/product-components';
 import { borders, spacingsPx } from '@trezor/theme';
 
-import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
-import { useAccountSearch, useSelector } from 'src/hooks/suite';
-import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
+import { useAccountSearch } from 'src/hooks/suite';
+
+import { useAvailableNetworkSymbols } from './useAvailableNetworkSymbols';
 
 // eslint-disable-next-line local-rules/no-override-ds-component
-const StyledCoinLogo = styled(CoinLogo)<{ $isSelected?: boolean }>`
+const StyledCoinLogo = styled(CoinLogo)<{ $isSelected?: boolean; $coinFilter?: string }>`
     display: block;
     border-radius: ${borders.radii.xxs};
-    outline: 2px solid
-        ${({ $isSelected, theme }) =>
-            $isSelected ? theme.backgroundSecondaryPressed : 'transparent'};
+    opacity: ${({ $isSelected, $coinFilter }) =>
+        $coinFilter === undefined || $isSelected ? 1 : 0.5};
+
     transition: outline 0.2s;
     filter: ${({ $isSelected }) => !$isSelected && 'grayscale(100%)'};
     cursor: pointer;
 
     &:hover {
-        outline: 2px solid ${({ theme }) => theme.backgroundSecondaryDefault};
+        opacity: ${({ $isSelected, $coinFilter }) =>
+            $coinFilter !== undefined && !$isSelected ? 0.7 : 1};
     }
 `;
 
@@ -44,18 +45,7 @@ const Container = styled.div`
 
 export const CoinsFilter = () => {
     const { coinFilter, setCoinFilter } = useAccountSearch();
-    const enabledNetworks = useSelector(selectEnabledNetworks);
-    const { supportedMainnets, supportedTestnets } = useNetworkSupport();
-
-    const supportedNetworkSymbols = [...supportedMainnets, ...supportedTestnets].map(
-        network => network.symbol,
-    );
-
-    const availableNetworksSymbols = enabledNetworks.filter(networkSymbol =>
-        supportedNetworkSymbols.includes(networkSymbol),
-    );
-
-    const showCoinFilter = availableNetworksSymbols.length > 1;
+    const availableNetworksSymbols = useAvailableNetworkSymbols();
 
     const coinAnimcationConfig: MotionProps = {
         initial: {
@@ -74,10 +64,6 @@ export const CoinsFilter = () => {
             },
         },
     };
-
-    if (!showCoinFilter) {
-        return null;
-    }
 
     return (
         <Container
@@ -104,6 +90,7 @@ export const CoinsFilter = () => {
                                     size={16}
                                     data-test-activated={coinFilter === networkSymbol}
                                     $isSelected={isSelected}
+                                    $coinFilter={coinFilter}
                                     onClick={e => {
                                         e.stopPropagation();
                                         // select the coin or deactivate if it's already selected

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/useAvailableNetworkSymbols.ts
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/useAvailableNetworkSymbols.ts
@@ -1,0 +1,18 @@
+import { useNetworkSupport } from '../../../../hooks/settings/useNetworkSupport';
+import { useSelector } from '../../../../hooks/suite';
+import { selectEnabledNetworks } from '../../../../reducers/wallet/settingsReducer';
+
+export const useAvailableNetworkSymbols = () => {
+    const enabledNetworks = useSelector(selectEnabledNetworks);
+    const { supportedMainnets, supportedTestnets } = useNetworkSupport();
+
+    const supportedNetworkSymbols = [...supportedMainnets, ...supportedTestnets].map(
+        network => network.symbol,
+    );
+
+    const availableNetworksSymbols = enabledNetworks.filter(networkSymbol =>
+        supportedNetworkSymbols.includes(networkSymbol),
+    );
+
+    return availableNetworksSymbols;
+};

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -118,6 +118,7 @@ export interface SuiteSettings {
     defaultWalletLoading: WalletType;
     experimental?: ExperimentalFeature[];
     sidebarWidth: number;
+    isCoinsFilterVisible: boolean;
 }
 
 export interface TransportState extends InstallerInfo {
@@ -204,6 +205,7 @@ const initialState: SuiteState = {
         addressDisplayType: AddressDisplayOptions.CHUNKED,
         defaultWalletLoading: WalletType.STANDARD,
         sidebarWidth: SIDEBAR_WIDTH_NUMERIC,
+        isCoinsFilterVisible: false,
     },
 };
 
@@ -318,6 +320,10 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
 
             case SUITE.SET_SIDEBAR_WIDTH:
                 draft.settings.sidebarWidth = action.payload.width;
+                break;
+
+            case SUITE.SET_IS_COINS_FILTER_VISIBLE:
+                draft.settings.isCoinsFilterVisible = action.payload.isCoinsFilterVisible;
                 break;
 
             case TRANSPORT.START: {

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -145,6 +145,14 @@ export default defineMessages({
         defaultMessage: 'Add account',
         id: 'TR_ADD_ACCOUNT',
     },
+    TR_SHOW_COINS_FILTER: {
+        defaultMessage: 'Show filter',
+        id: 'TR_SHOW_COINS_FILTER',
+    },
+    TR_HIDE_COINS_FILTER: {
+        defaultMessage: 'Hide filter',
+        id: 'TR_HIDE_COINS_FILTER',
+    },
     TR_ADD_NETWORK_ACCOUNT: {
         defaultMessage: 'Add {network} account',
         id: 'TR_ADD_NETWORK_ACCOUNT',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

quite a lot small stuff were done:

- coins filter is hidden and toggled by small funnel icon next to adding new account
- opened/closed filter is stored in local storage so if you leave it open, it will remain open for next launch
- different highlighting of active and hovered coin logo
- `TextButton` accepts variant
- clicking on magnifier glass in search focuses on the input
- search text is replaced by accounts
- "default accounts" group is disabled for all occurences

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before

<img width="434" alt="image" src="https://github.com/user-attachments/assets/32e868eb-0aed-414b-8adb-392afcff32fc" />


after

https://github.com/user-attachments/assets/a4d20b60-780a-41bf-865d-8eff8198ed08

