### PR TITLE
feat(suite): connect popup address confirmation modal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
@@ -11,8 +11,6 @@ import {
 import { useSelector } from 'src/hooks/suite';
 import { selectAccountIncludingChosenInTrading } from 'src/reducers/wallet/selectedAccountReducer';
 
-import { ConfirmActionModal } from './DeviceContextModal/ConfirmActionModal';
-
 interface ConfirmAddressModalProps
     extends Pick<ConfirmValueModalProps, 'isConfirmed' | 'onCancel' | 'value'> {
     addressPath: string;
@@ -32,8 +30,6 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
     );
 
     if (!device) return null;
-    // TODO: special case for Connect Popup
-    if (!account) return <ConfirmActionModal device={device} />;
 
     return (
         <ConfirmValueModal

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 
+import { selectConnectPopupCall } from '@suite-common/connect-popup';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { showAddress } from 'src/actions/wallet/receiveActions';
@@ -10,6 +11,8 @@ import {
 } from 'src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal';
 import { useSelector } from 'src/hooks/suite';
 import { selectAccountIncludingChosenInTrading } from 'src/reducers/wallet/selectedAccountReducer';
+
+import { ConnectAddressConfirmation } from './UserContextModal/ConnectAddressConfirmation';
 
 interface ConfirmAddressModalProps
     extends Pick<ConfirmValueModalProps, 'isConfirmed' | 'onCancel' | 'value'> {
@@ -23,12 +26,16 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
         state =>
             !!state.wallet.trading.modalAccountKey || !!state.wallet.tradingNew.modalAccountKey,
     );
+    const isConnectPopup = useSelector(
+        state => selectConnectPopupCall(state)?.state === 'address-confirmation',
+    );
 
     const validateAddress = useCallback(
         () => showAddress(addressPath, value),
         [addressPath, value],
     );
 
+    if (isConnectPopup) return <ConnectAddressConfirmation />;
     if (!device) return null;
 
     return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -34,7 +34,7 @@ import { ThunkAction } from 'src/types/suite';
 import { DESTINATION_TAG_GUIDE_PATH } from 'src/views/wallet/send/Options/RippleOptions/DestinationTag';
 
 export type ConfirmValueModalProps = Pick<NewModalProps, 'onCancel' | 'heading'> & {
-    account: Account;
+    account?: Account;
     'data-testid'?: string;
     isConfirmed?: boolean;
     areStepsVisible?: boolean;
@@ -64,7 +64,6 @@ export const ConfirmValueModal = ({
     const { accountLabel } = useSelector(selectLabelingDataForSelectedAccount);
     const dispatch = useDispatch();
     const { openNodeById } = useGuideOpenNode();
-    const { symbol, accountType, index } = account;
 
     const canConfirmOnDevice = !!(device?.connected && device?.available);
     const isCancelable = isActionAbortable || isConfirmed;
@@ -105,15 +104,17 @@ export const ConfirmValueModal = ({
             <NewModal.ModalBase
                 heading={heading}
                 description={
-                    <Row gap={spacings.xxs}>
-                        <CoinLogo size={14} symbol={symbol} />
-                        <AccountLabel
-                            accountLabel={accountLabel}
-                            accountType={accountType}
-                            symbol={symbol}
-                            index={index}
-                        />
-                    </Row>
+                    account && (
+                        <Row gap={spacings.xxs}>
+                            <CoinLogo size={14} symbol={account.symbol} />
+                            <AccountLabel
+                                accountLabel={accountLabel}
+                                accountType={account.accountType}
+                                symbol={account.symbol}
+                                index={account.index}
+                            />
+                        </Row>
+                    )
                 }
                 onCancel={isCancelable ? onCancel : undefined}
                 size="small"
@@ -132,7 +133,7 @@ export const ConfirmValueModal = ({
                             </Paragraph>
                         </Banner>
                     )}
-                    {account.networkType === 'ripple' && (
+                    {account?.networkType === 'ripple' && (
                         <Banner variant="info" icon="info">
                             <Translation
                                 id="DESTINATION_TAG_BANNER_RECEIVE"

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
@@ -1,3 +1,4 @@
+import { selectConnectPopupCall } from '@suite-common/connect-popup';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { convertTaprootXpub } from '@trezor/utils';
 
@@ -8,13 +9,21 @@ import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReduce
 
 import { ConfirmValueModal, ConfirmValueModalProps } from './ConfirmValueModal/ConfirmValueModal';
 import { ConfirmActionModal } from './DeviceContextModal/ConfirmActionModal';
+import { ConnectAddressConfirmation } from './UserContextModal/ConnectAddressConfirmation';
 
 export const ConfirmXpubModal = (
-    props: Pick<ConfirmValueModalProps, 'isConfirmed' | 'onCancel'>,
+    props: Pick<ConfirmValueModalProps, 'isConfirmed' | 'onCancel'> & {
+        descriptor?: string;
+        descriptorChecksum?: string;
+    },
 ) => {
     const device = useSelector(selectSelectedDevice);
     const account = useSelector(selectSelectedAccount);
+    const isConnectPopup = useSelector(
+        state => selectConnectPopupCall(state)?.state === 'address-confirmation',
+    );
 
+    if (isConnectPopup) return <ConnectAddressConfirmation />;
     if (!device) return null;
     // TODO: special case for Connect Popup
     if (!account) return <ConfirmActionModal device={device} />;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectAddressConfirmation.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectAddressConfirmation.tsx
@@ -1,0 +1,120 @@
+import { useEffect } from 'react';
+
+import {
+    connectPopupActions,
+    connectPopupVerifyAddressThunk,
+    selectConnectPopupCall,
+} from '@suite-common/connect-popup';
+import {
+    Badge,
+    Button,
+    Card,
+    Column,
+    H3,
+    Icon,
+    NewModal,
+    Paragraph,
+    Row,
+} from '@trezor/components';
+import { DeviceModelInternal } from '@trezor/device-utils';
+import { mapTrezorModelToIcon } from '@trezor/product-components';
+import { spacings } from '@trezor/theme';
+
+import { Translation } from 'src/components/suite/Translation';
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
+
+export const ConnectAddressConfirmation = () => {
+    const { device } = useDevice();
+    const dispatch = useDispatch();
+    const popupCall = useSelector(selectConnectPopupCall);
+    const onVerify = (index: number) => {
+        dispatch(connectPopupVerifyAddressThunk({ index }));
+    };
+    const onFinish = () => {
+        dispatch(connectPopupActions.finishCall());
+    };
+
+    useEffect(() => {
+        // Automatically verify addresses that have showOnDevice enabled and are not already verified
+        if (!popupCall || popupCall?.state !== 'address-confirmation') return;
+        const isLoading = popupCall?.addresses.some(address => address.loading);
+        const addressToVerify = popupCall?.addresses.findIndex(
+            address =>
+                address.validatePayload.showOnTrezor && !address.validated && !address.loading,
+        );
+        if (!isLoading && addressToVerify >= 0) {
+            dispatch(
+                connectPopupVerifyAddressThunk({
+                    index: addressToVerify,
+                }),
+            );
+        }
+    }, [popupCall, dispatch]);
+
+    if (!popupCall || popupCall?.state !== 'address-confirmation') return null;
+
+    return (
+        <NewModal
+            variant="primary"
+            bottomContent={
+                <>
+                    <NewModal.Button variant="tertiary" onClick={onFinish} size="medium">
+                        <Translation id="TR_DONE" />
+                    </NewModal.Button>
+                </>
+            }
+        >
+            <Column gap={spacings.xs}>
+                <Row alignItems="center" gap={spacings.sm}>
+                    <Icon name="checkCircle" size={32} variant="primary" />
+                    <H3 variant="primary">
+                        <Translation id="TR_CONNECT_ADDRESS_CONFIRMATION_SUCCESS" />
+                    </H3>
+                </Row>
+                <Paragraph>
+                    <Translation id="TR_CONNECT_ADDRESS_CONFIRMATION_DESCRIPTION" />
+                </Paragraph>
+
+                <Card heading={<Translation id="TR_ADDRESSES" />} margin={{ top: spacings.md }}>
+                    <Column gap={spacings.sm}>
+                        {popupCall?.addresses.map((address, index) => (
+                            <Row
+                                key={index}
+                                alignItems="center"
+                                justifyContent="space-between"
+                                gap={spacings.sm}
+                            >
+                                <Row gap={spacings.sm} alignItems="center" flex="1">
+                                    <Paragraph wordBreak="break-all">{address.address}</Paragraph>
+                                    {address.validated && (
+                                        <Badge variant="primary" icon="check" size="small">
+                                            <Translation id="TR_VERIFIED" />
+                                        </Badge>
+                                    )}
+                                </Row>
+                                <Button
+                                    variant="tertiary"
+                                    onClick={() => onVerify(index)}
+                                    icon={
+                                        mapTrezorModelToIcon[
+                                            device?.features?.internal_model ||
+                                                DeviceModelInternal.UNKNOWN
+                                        ]
+                                    }
+                                    size="small"
+                                    isLoading={address.loading}
+                                >
+                                    {address.loading ? (
+                                        <Translation id="TR_VERIFYING" />
+                                    ) : (
+                                        <Translation id="TR_VERIFY" />
+                                    )}
+                                </Button>
+                            </Row>
+                        ))}
+                    </Column>
+                </Card>
+            </Column>
+        </NewModal>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -50,6 +50,7 @@ import type { ReduxModalProps } from '../ReduxModal';
 import { FirmwareRevisionOptOutModal } from './FirmwareRevisionOptOutModal';
 import { PassphraseMismatchModal } from './PassphraseMismatchModal';
 import { CardanoWithdrawModal } from '../CardanoWithdrawModal';
+import { ConnectAddressConfirmation } from './ConnectAddressConfirmation';
 import { TradingDCAModal } from './TradingDCAModal';
 import { EverstakeModal } from './UnstakeModal/EverstakeModal';
 import { WalletConnectProposalModal } from './WalletConnectProposalModal';
@@ -217,6 +218,8 @@ export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL.CONTE
             return <WalletConnectProposalModal eventId={payload.eventId} />;
         case 'trading-dca':
             return <TradingDCAModal device={payload.device} onCancel={onCancel} />;
+        case 'connect-address-confirmation':
+            return <ConnectAddressConfirmation />;
         default:
             return null;
     }

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9831,4 +9831,25 @@ export default defineMessages({
         id: 'TR_FORGET',
         defaultMessage: 'Forget',
     },
+    TR_CONNECT_ADDRESS_CONFIRMATION_SUCCESS: {
+        id: 'TR_CONNECT_ADDRESS_CONFIRMATION_SUCCESS',
+        defaultMessage: 'Success',
+    },
+    TR_CONNECT_ADDRESS_CONFIRMATION_DESCRIPTION: {
+        id: 'TR_CONNECT_ADDRESS_CONFIRMATION_DESCRIPTION',
+        defaultMessage:
+            'Please check addresses on your device against the addresses shown in the app.',
+    },
+    TR_DONE: {
+        id: 'TR_DONE',
+        defaultMessage: 'Done',
+    },
+    TR_ADDRESSES: {
+        id: 'TR_ADDRESSES',
+        defaultMessage: 'Addresses',
+    },
+    TR_VERIFYING: {
+        id: 'TR_VERIFYING',
+        defaultMessage: 'Verifying',
+    },
 });

--- a/suite-common/connect-popup/src/connectPopupMiddleware.ts
+++ b/suite-common/connect-popup/src/connectPopupMiddleware.ts
@@ -6,10 +6,14 @@ export const prepareConnectPopupMiddleware = createMiddlewareWithExtraDeps(
     async (action, { dispatch, next, extra }) => {
         await next(action);
 
-        if (connectPopupActions.initiateCall.match(action) && action.payload.state === 'request') {
-            dispatch(extra.actions.openModal({ type: 'connect-popup' }));
+        if (connectPopupActions.initiateCall.match(action)) {
+            if (action.payload.state === 'request')
+                dispatch(extra.actions.openModal({ type: 'connect-popup' }));
+            if (action.payload.state === 'address-confirmation')
+                dispatch(extra.actions.openModal({ type: 'connect-address-confirmation' }));
         }
         if (
+            connectPopupActions.finishCall.match(action) ||
             connectPopupActions.approveCall.match(action) ||
             connectPopupActions.rejectCall.match(action)
         ) {

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -9,7 +9,8 @@ import { DEEPLINK_VERSION } from '@trezor/connect/src/data/version';
 import { createDeferred } from '@trezor/utils';
 
 import { connectPopupActions } from './connectPopupActions';
-import { selectConnectAppPermissions } from './connectPopupReducer';
+import { selectConnectAppPermissions, selectConnectPopupCall } from './connectPopupReducer';
+import { postCallHooks, preCallHooks } from './methodHooks';
 
 const CONNECT_POPUP_MODULE = '@common/connect-popup';
 
@@ -100,6 +101,9 @@ export const connectPopupCallThunkInner = createThunk<
                 throw ERRORS.TypedError('Device_NotFound');
             }
 
+            const originalPayload = { ...payload };
+            await preCallHooks({ method, payload, dispatch, getState });
+
             // @ts-expect-error: method is dynamic
             const response = await TrezorConnect[method]({
                 device: {
@@ -116,6 +120,8 @@ export const connectPopupCallThunkInner = createThunk<
             dispatch(deviceActions.removeButtonRequests({ device }));
 
             dispatch(connectPopupActions.finishCall());
+
+            await postCallHooks({ method, payload, originalPayload, response, dispatch, getState });
 
             return response;
         } catch (error) {
@@ -220,5 +226,65 @@ export const connectPopupDeeplinkThunk = createThunk<void, { url: string }>(
                 callbackUrl: callbackUrl.toString(),
             }),
         );
+    },
+);
+
+export const connectPopupVerifyAddressThunk = createThunk<void, { index: number }>(
+    `${CONNECT_POPUP_MODULE}/verifyAddressThunk`,
+    async ({ index }, { dispatch, getState, extra }) => {
+        // Unlock device access from previous call
+        dispatch(extra.actions.lockDevice(false));
+
+        const device = selectSelectedDevice(getState());
+        const call = selectConnectPopupCall(getState());
+        if (!device || !call || call.state !== 'address-confirmation') return;
+
+        // Update loading state of addresses
+        dispatch(
+            connectPopupActions.initiateCall({
+                ...call,
+                addresses: call.addresses.map((address, i) => ({
+                    ...address,
+                    loading: i === index,
+                })),
+            }),
+        );
+
+        try {
+            // @ts-expect-error: method is dynamic
+            const res = await TrezorConnect[call.method]({
+                device: {
+                    path: device.path,
+                    instance: device.instance,
+                    state: device.state,
+                },
+                useEmptyPassphrase: device.useEmptyPassphrase,
+                ...call.addresses[index].validatePayload,
+                showOnTrezor: true,
+                chunked: false,
+            });
+            dispatch(
+                connectPopupActions.initiateCall({
+                    ...call,
+                    addresses: call.addresses.map((address, i) => ({
+                        ...address,
+                        loading: false,
+                        validated: i === index ? res.success : address.validated,
+                    })),
+                }),
+            );
+        } catch (error) {
+            console.error('connectPopupVerifyAddressThunk', error);
+            dispatch(
+                connectPopupActions.initiateCall({
+                    ...call,
+                    addresses: call.addresses.map((address, i) => ({
+                        ...address,
+                        loading: false,
+                        validated: i === index ? false : address.validated,
+                    })),
+                }),
+            );
+        }
     },
 );

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -27,6 +27,16 @@ export type ConnectPopupCall =
       }
     | {
           state: 'finished';
+      }
+    | {
+          state: 'address-confirmation';
+          method: string;
+          addresses: {
+              address: string;
+              loading: boolean;
+              validated: boolean;
+              validatePayload: any;
+          }[];
       };
 
 export type AppRememberedPermission = {

--- a/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
+++ b/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
@@ -1,0 +1,93 @@
+import TrezorConnect, { Address } from '@trezor/connect';
+import { HDNodeResponse } from '@trezor/connect/src/types/api/getPublicKey';
+
+import { connectPopupActions } from '../connectPopupActions';
+
+import { PostCallHookParams, PreCallHookParams } from './index';
+
+const methodsAddress = [
+    'getAddress',
+    'ethereumGetAddress',
+    'binanceGetAddress',
+    'cardanoGetAddress',
+    'rippleGetAddress',
+    'solanaGetAddress',
+    'tezosGetAddress',
+    'eosGetAddress',
+    'stellarGetAddress',
+];
+const methodsPublicKey = [
+    'getPublicKey',
+    'ethereumGetPublicKey',
+    'binanceGetPublicKey',
+    'cardanoGetPublicKey',
+    'solanaGetPublicKey',
+    'tezosGetPublicKey',
+    'eosGetPublicKey',
+];
+const methods = [...methodsAddress, ...methodsPublicKey];
+
+const preCallHook = <M extends keyof typeof TrezorConnect>({
+    method,
+    payload,
+}: PreCallHookParams<M>) => {
+    if (methods.includes(method)) {
+        if ('bundle' in payload && Array.isArray(payload.bundle)) {
+            payload.bundle = payload.bundle.map(item => ({
+                ...item,
+                showOnTrezor: false,
+            }));
+        } else {
+            // @ts-expect-error
+            payload.showOnTrezor = false;
+        }
+    }
+};
+
+export function postCallHook<M extends keyof typeof TrezorConnect>({
+    method,
+    originalPayload,
+    response,
+    dispatch,
+}: PostCallHookParams<M>) {
+    if (methods.includes(method) && response.success) {
+        const bundledResponse = (
+            Array.isArray(response.payload) ? response.payload : [response.payload]
+        ) as Address[] | HDNodeResponse[];
+        const addresses = bundledResponse.map((item, index) => {
+            const validatePayload =
+                'bundle' in originalPayload && Array.isArray(originalPayload.bundle)
+                    ? originalPayload.bundle[index]
+                    : originalPayload;
+            const displayAddress = () => {
+                if ('address' in item) return item.address;
+
+                // NOTE: it's possible in some cases there will be a mismatch between the public key format on the device and the one in the app
+                // For BTC
+                if (method === 'getPublicKey') return item.xpubSegwit || item.xpub;
+
+                // For other altcoins
+                return item.publicKey;
+            };
+
+            return {
+                address: displayAddress(),
+                validated: false,
+                loading: false,
+                validatePayload,
+            };
+        });
+        dispatch(
+            connectPopupActions.initiateCall({
+                state: 'address-confirmation',
+                method,
+                addresses,
+            }),
+        );
+    }
+}
+
+export const addressConfirmationModalHooks = {
+    preCallHook,
+    postCallHook,
+};

--- a/suite-common/connect-popup/src/methodHooks/index.ts
+++ b/suite-common/connect-popup/src/methodHooks/index.ts
@@ -1,0 +1,30 @@
+import { Dispatch } from '@reduxjs/toolkit/react';
+
+import {
+    CallMethodParams,
+    CallMethodResponse,
+    Success,
+    TrezorConnect,
+    Unsuccessful,
+} from '@trezor/connect';
+
+import { addressConfirmationModalHooks } from './addressConfirmation';
+
+export type PreCallHookParams<M extends keyof TrezorConnect> = {
+    method: M;
+    payload: Omit<CallMethodParams<M>, 'method'>;
+    dispatch: Dispatch;
+    getState: () => any;
+};
+export type PostCallHookParams<M extends keyof TrezorConnect> = PreCallHookParams<M> & {
+    originalPayload: Omit<CallMethodParams<M>, 'method'>;
+    response: Success<CallMethodResponse<M>> | Unsuccessful;
+};
+
+export const preCallHooks = async <M extends keyof TrezorConnect>(params: PreCallHookParams<M>) => {
+    await addressConfirmationModalHooks.preCallHook(params);
+};
+
+export async function postCallHooks<M extends keyof TrezorConnect>(params: PostCallHookParams<M>) {
+    await addressConfirmationModalHooks.postCallHook(params);
+}

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -203,4 +203,7 @@ export type UserContextPayload =
     | {
           type: 'trading-dca';
           device: TrezorDevice;
+      }
+    | {
+          type: 'connect-address-confirmation';
       };


### PR DESCRIPTION
## Description

New address confirmation modal for getAddress/getPublicKey methods called via Connect Popup in Suite.

This modal appears after returning the response to the 3rd party app, so the user can check addresses between the Trezor, Suite and the app.

## Screenshots:

<img width="709" alt="Screenshot 2025-04-03 at 13 08 14" src="https://github.com/user-attachments/assets/8294e356-a70a-487d-b0ee-26f6b6a8d625" />
