### PR TITLE
fix(components): badge icon sizing

### DIFF
--- a/packages/components/src/components/Badge/Badge.tsx
+++ b/packages/components/src/components/Badge/Badge.tsx
@@ -82,7 +82,7 @@ const mapVariantToIconColor = ({ $variant, theme }: MapArgs): CSSColor => {
     return theme[colorMap[$variant]];
 };
 
-const mapVariantToPadding = ({ $size }: { $size: BadgeSize }): string => {
+const mapSizeToPadding = ({ $size }: { $size: BadgeSize }): string => {
     const colorMap: Record<BadgeSize, string> = {
         tiny: `0 ${spacings.xs - spacings.xxxs}px`,
         small: `0 ${spacingsPx.xs}`,
@@ -92,11 +92,21 @@ const mapVariantToPadding = ({ $size }: { $size: BadgeSize }): string => {
     return colorMap[$size];
 };
 
+const mapSizeToIconSize = ({ $size }: { $size: BadgeSize }): number => {
+    const sizes: Record<BadgeSize, number> = {
+        tiny: 12,
+        small: 16,
+        medium: 20,
+    };
+
+    return sizes[$size];
+};
+
 const Container = styled.div<BadgeContainerProps>`
     display: ${({ $inline }) => ($inline ? 'inline-flex' : 'flex')};
     align-items: center;
     gap: ${spacingsPx.xxs};
-    padding: ${mapVariantToPadding};
+    padding: ${mapSizeToPadding};
     border-radius: ${borders.radii.full};
     border: 1px solid transparent;
     background: ${mapVariantToBackgroundColor};
@@ -159,6 +169,7 @@ export const Badge = ({
                             ? theme.iconDisabled
                             : mapVariantToIconColor({ $variant: variant, theme })
                     }
+                    size={mapSizeToIconSize({ $size: size })}
                 />
             )}
 


### PR DESCRIPTION
## Description

Badge icon size should adapt to the size of the badge. 

## Screenshots:

Before

![Screenshot 2025-04-03 at 13 11 13](https://github.com/user-attachments/assets/0045805c-0a7e-45ac-ae84-510f556afb0d)![Screenshot 2025-04-03 at 13 11 27](https://github.com/user-attachments/assets/22b8d4cc-e323-4c1c-9e13-10ddbf1f7594)![Screenshot 2025-04-03 at 13 11 21](https://github.com/user-attachments/assets/643c3dea-492c-4f3a-b019-586498cea542)

After

![Screenshot 2025-04-03 at 13 11 46](https://github.com/user-attachments/assets/cafd22ee-4f14-458e-b645-0be0bd1ddb34)![Screenshot 2025-04-03 at 13 11 39](https://github.com/user-attachments/assets/e2ab49d9-12ba-4119-8c80-1f2dd9c51a7d)![Screenshot 2025-04-03 at 13 11 43](https://github.com/user-attachments/assets/aa7317bc-17ea-4b83-b967-770630591319)