### PR TITLE
Feat: `transport-bluetooth` rust websocket server

### DIFF
--- a/packages/transport-bluetooth/.gitignore
+++ b/packages/transport-bluetooth/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target

--- a/packages/transport-bluetooth/CHANGELOG.md
+++ b/packages/transport-bluetooth/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+### 0.3.0
+
+- add websocket server

--- a/packages/transport-bluetooth/Cargo.toml
+++ b/packages/transport-bluetooth/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "trezor-bluetooth"
+version = "0.3.0"
+edition = "2021"
+
+[dependencies]
+futures = "^0.3.31"
+hyper = {version="^1.6.0",features = ["server", "http1"]}
+hyper-tungstenite = "^0.17.0"
+hyper-util = "0.1.11"
+http-body-util = "0.1.3"
+log = "0.4.27"
+pretty_env_logger = "0.5.0"
+serde = {version = "1.0.219", features = ["derive"] }
+serde_json = "^1.0.140"
+structopt = "0.3.26"
+tokio = { version = "^1.44.0", features = ["sync", "rt", "macros", "rt-multi-thread", "io-util"] }
+thiserror = "^2.0.12"

--- a/packages/transport-bluetooth/README.md
+++ b/packages/transport-bluetooth/README.md
@@ -6,7 +6,7 @@
 
 use `bluetoothIpc` proxy
 
-```
+```typescript
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
 await bluetoothIpc.init();
@@ -16,7 +16,7 @@ await bluetoothIpc.init();
 
 implement proxy handler and `BluetoothIpc`
 
-```
+```typescript
 import { BluetoothIpc } from '@trezor/transport-bluetooth';
 
 createIpcProxyHandler(ipcMain, 'Bluetooth', {
@@ -30,10 +30,48 @@ createIpcProxyHandler(ipcMain, 'Bluetooth', {
             onAddListener: (eventName, listener) => {
                 api.on(eventName, listener);
             },
-            onRemoveListener: (eventName) => {
-                api.removeAllListeners(eventName)
+            onRemoveListener: eventName => {
+                api.removeAllListeners(eventName);
             },
         };
     },
 });
+```
+
+### Server development
+
+Prerequisites: [RUST](https://www.rust-lang.org/tools/install)
+
+### Vscode:
+
+Vscode rust-analyzer extensions:
+
+- install `rust-analyzer` plugin
+- (NixOS only) install `nix-env-selector` plugin and [follow readme](https://marketplace.visualstudio.com/items?itemName=arrterian.nix-env-selector) to setup
+
+Vscode `.vscode/settings`:
+
+```json
+
+"rust-analyzer.cargo.sysroot": "discover",
+"rust-analyzer.diagnostics.disabled": ["unresolved-proc-macro"],
+"rust-analyzer.linkedProjects": ["./packages/transport-bluetooth/Cargo.toml"],
+"nixEnvSelector.nixFile": "${workspaceFolder}/packages/transport-bluetooth/shell.nix" // NixOS only
+
+```
+
+### NixOS:
+
+```
+
+nix-shell ./packages/transport-bluetooth/shell.nix
+
+```
+
+### Run server:
+
+```
+
+yarn workspace @trezor/transport-bluetooth dev:server
+
 ```

--- a/packages/transport-bluetooth/README.md
+++ b/packages/transport-bluetooth/README.md
@@ -38,6 +38,10 @@ createIpcProxyHandler(ipcMain, 'Bluetooth', {
 });
 ```
 
+### Server build:
+
+`yarn workspace @trezor/transport-bluetooth build:server`
+
 ### Server development
 
 Prerequisites: [RUST](https://www.rust-lang.org/tools/install)

--- a/packages/transport-bluetooth/package.json
+++ b/packages/transport-bluetooth/package.json
@@ -18,7 +18,9 @@
     "browser": "./src/browser.ts",
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "type-check": "yarn g:tsc --build"
+        "type-check": "yarn g:tsc --build",
+        "lint:rs": "cargo fmt --all -- --check",
+        "dev:server": "RUST_BACKTRACE=1 RUST_LOG=debug cargo run"
     },
     "dependencies": {
         "@trezor/ipc-proxy": "workspace:*",

--- a/packages/transport-bluetooth/package.json
+++ b/packages/transport-bluetooth/package.json
@@ -20,7 +20,8 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "type-check": "yarn g:tsc --build",
         "lint:rs": "cargo fmt --all -- --check",
-        "dev:server": "RUST_BACKTRACE=1 RUST_LOG=debug cargo run"
+        "dev:server": "RUST_BACKTRACE=1 RUST_LOG=debug cargo run",
+        "build:server": "./scripts/build.sh"
     },
     "dependencies": {
         "@trezor/ipc-proxy": "workspace:*",

--- a/packages/transport-bluetooth/scripts/Dockerfile
+++ b/packages/transport-bluetooth/scripts/Dockerfile
@@ -1,0 +1,40 @@
+# https://github.com/joseluisq/rust-linux-darwin-builder/blob/master/README.md
+
+FROM joseluisq/rust-linux-darwin-builder:1.75.0
+
+RUN apt-get update && apt-get install -y mingw-w64
+
+WORKDIR /app
+
+COPY ./src ./src
+COPY ./Cargo.toml ./Cargo.toml
+
+RUN rustup target add x86_64-pc-windows-gnu && \
+  cargo build --target x86_64-pc-windows-gnu --release && \
+  mkdir -p /output/win-x64 && \
+  cp ./target/x86_64-pc-windows-gnu/release/trezor-bluetooth.exe /output/win-x64/trezor-bluetooth.exe && \
+  x86_64-w64-mingw32-strip /output/win-x64/trezor-bluetooth.exe
+
+# RUN cargo build --target aarch64-apple-darwin --release && \
+#   mkdir -p /output/mac-arm64 && \
+#   cp ./target/aarch64-apple-darwin/release/trezor-bluetooth /output/mac-arm64/trezor-bluetooth && \
+#   aarch64-apple-darwin22.4-strip /output/mac-arm64/trezor-bluetooth
+
+RUN cargo build --target x86_64-apple-darwin --release && \
+  mkdir -p /output/mac-x64 && \
+  cp ./target/x86_64-apple-darwin/release/trezor-bluetooth /output/mac-x64/trezor-bluetooth && \
+  x86_64-apple-darwin22.4-strip /output/mac-x64/trezor-bluetooth && \
+  # mac arm build doesn't work on mac M1 but x64 works well. investigate more
+  mkdir -p /output/mac-arm64 && \
+  cp ./target/x86_64-apple-darwin/release/trezor-bluetooth /output/mac-arm64/trezor-bluetooth && \
+  x86_64-apple-darwin22.4-strip /output/mac-arm64/trezor-bluetooth
+
+RUN cargo build --target aarch64-unknown-linux-gnu --release && \
+  mkdir -p /output/linux-arm64 && \
+  cp ./target/aarch64-unknown-linux-gnu/release/trezor-bluetooth /output/linux-arm64/trezor-bluetooth && \
+  aarch64-linux-gnu-strip /output/linux-arm64/trezor-bluetooth
+
+RUN cargo build --target x86_64-unknown-linux-gnu --release && \
+  mkdir -p /output/linux-x64 && \
+  cp ./target/x86_64-unknown-linux-gnu/release/trezor-bluetooth /output/linux-x64/trezor-bluetooth && \
+  strip /output/linux-x64/trezor-bluetooth

--- a/packages/transport-bluetooth/scripts/build.sh
+++ b/packages/transport-bluetooth/scripts/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+docker build . -f ./scripts/Dockerfile -t trezor-bluetooth-image
+docker create --name trezor-bluetooth-container trezor-bluetooth-image
+docker cp trezor-bluetooth-container:/output/. ../suite-data/files/bin/bluetooth
+docker rm trezor-bluetooth-container

--- a/packages/transport-bluetooth/shell.nix
+++ b/packages/transport-bluetooth/shell.nix
@@ -1,0 +1,26 @@
+# pinned to nixos-24.05 on commit https://github.com/NixOS/nixpkgs/commit/c6ce5bd4ab657df958ebd6f38723f81c5546a661
+with import
+  (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/c6ce5bd4ab657df958ebd6f38723f81c5546a661.tar.gz";
+    sha256 = "0i5z7b087kr2hnkgs17d36c54arjbgwlwyxw1ibh03d1k1xfcyf2";
+  })
+{ };
+
+stdenv.mkDerivation {
+  name = "trezor-bluetooth-dev";
+  nativeBuildInputs = [
+    rustc
+    rustfmt
+    cargo
+    cargo-cross
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    dbus
+  ];
+
+  RUST_BACKTRACE = 1;
+  RUST_LOG = "debug";
+}

--- a/packages/transport-bluetooth/src/main.rs
+++ b/packages/transport-bluetooth/src/main.rs
@@ -1,0 +1,26 @@
+use pretty_env_logger;
+use structopt::StructOpt;
+
+mod server;
+
+#[derive(StructOpt, Debug)]
+#[structopt(name = "trezor-bluetooth")]
+struct Opts {
+    #[structopt(short, long, default_value = "21327")]
+    port: u16,
+}
+
+#[tokio::main]
+async fn main() {
+    pretty_env_logger::init();
+
+    let opt = Opts::from_args();
+    let addr = format!("127.0.0.1:{}", opt.port);
+
+    match server::start_server(&addr).await {
+        // Ok should not happen as start_server runs indefinitely unless there's an error
+        Ok(_) => Err("Server unexpectedly stopped".to_string()),
+        Err(err) => Err(format!("Server start error {:?}", err)),
+    }
+    .expect("Server unexpectedly stopped")
+}

--- a/packages/transport-bluetooth/src/server/connection_handler.rs
+++ b/packages/transport-bluetooth/src/server/connection_handler.rs
@@ -1,0 +1,168 @@
+use futures::{SinkExt, StreamExt};
+use http_body_util::Full;
+use hyper::{
+    body::{Bytes, Incoming},
+    Response as HyperResponse,
+};
+use hyper_tungstenite::{tungstenite::Message, HyperWebsocket};
+use hyper_util::rt::TokioIo;
+use log::info;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+use tokio::sync::Mutex;
+
+use crate::server::handle_message;
+use crate::server::types::{AbortProcess, ChannelMessage};
+use crate::server::utils;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ServerError {
+    #[error("WebSocket error: {0}")]
+    WebSocketError(#[from] hyper_tungstenite::tungstenite::Error),
+
+    #[error("HTTP error: {0}")]
+    HttpError(#[from] hyper::Error),
+
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+}
+
+async fn handle_ws_connection(peer: String, websocket: HyperWebsocket) -> Result<(), ServerError> {
+    info!("WebSocket connection: {peer}");
+
+    let websocket = websocket.await?;
+    let (ws_write, mut ws_read) = websocket.split();
+    let (sender, mut receiver) = broadcast::channel::<ChannelMessage>(32);
+
+    // create websocket stream mutex to be shared between two threads
+    let ws_write = Arc::new(Mutex::new(ws_write));
+
+    // start thread and listen for ChannelMessages emitted by current connection processes
+    let ws_write_event = ws_write.clone();
+    let channel_message_listener = tokio::spawn(async move {
+        while let Ok(event) = receiver.recv().await {
+            match event {
+                ChannelMessage::Notification(event) => {
+                    info!("Sending notification to peer {peer}");
+                    let response = match serde_json::to_string(&event) {
+                        Ok(json) => json,
+                        Err(err) => {
+                            info!("Error serialize notification {err:?}");
+                            return;
+                        }
+                    };
+
+                    let mut ws = ws_write_event.lock().await;
+                    if let Err(err) = ws.send(response.into()).await {
+                        info!("Error sending notification {err:?}");
+                    };
+                }
+                _ => {
+                    info!("ChannelMessage listener {event:?}");
+                }
+            }
+        }
+    });
+
+    // in current thread keep listening for incoming websocket messages
+    let ws_write_method = ws_write.clone();
+    while let Some(msg) = ws_read.next().await {
+        // TODO: panic thrown here when computer suspended (macos?)
+        // fallback to empty json. it should fail in handle_message serialization
+        let request = msg.unwrap_or(Message::text("{}"));
+        let ws_write_method = Arc::clone(&ws_write_method);
+        let sender = sender.clone();
+        // spawn new thread and process request
+        tokio::spawn(async move {
+            let response = handle_message(request.clone(), sender).await;
+            match response {
+                Some(response) => {
+                    let mut ws = ws_write_method.lock().await;
+                    if let Err(err) = ws.send(response).await {
+                        info!("Error response to ws {err:?}");
+                    };
+                }
+                None => {
+                    info!("No response request {request:?}");
+                }
+            }
+        });
+    }
+
+    // peer disconnected
+    channel_message_listener.abort();
+
+    if let Err(err) = sender.send(ChannelMessage::Abort(AbortProcess::ClientDisconnected)) {
+        info!("AbortProcess not sent {err}");
+    }
+
+    info!("Closing websocket connection");
+
+    Ok(())
+}
+
+async fn handle_http_request(
+    peer: String,
+    req: hyper::Request<Incoming>,
+) -> Result<HyperResponse<Full<Bytes>>, ServerError> {
+    // TODO: cors check like trezord-go and node-bridge
+    // let = req.headers().get("origin");
+
+    if hyper_tungstenite::is_upgrade_request(&req) {
+        let (response, websocket) = match hyper_tungstenite::upgrade(req, None) {
+            Ok(r) => r,
+            Err(e) => {
+                info!("Failed to upgrade WebSocket: {e:?}");
+                return Ok(HyperResponse::new(Full::<Bytes>::from("Upgrade failed")));
+            }
+        };
+        tokio::spawn(async move {
+            if let Err(err) = handle_ws_connection(peer.clone(), websocket).await {
+                log::error!("WebSocket connection error for peer {}: {:?}", peer, err);
+
+                match err {
+                    ServerError::WebSocketError(ws_err) => {
+                        log::debug!("WebSocket protocol error: {}", ws_err);
+                    }
+                    ServerError::IoError(io_err) => {
+                        log::warn!("IO error in WebSocket connection: {}", io_err);
+                    }
+                    ServerError::HttpError(http_err) => {
+                        log::warn!("HTTP error in WebSocket connection: {}", http_err);
+                    }
+                }
+            }
+        });
+        Ok(response)
+    } else {
+        // TODO: serve index.html file
+        Ok(HyperResponse::new(Full::<Bytes>::from("OK")))
+    }
+}
+
+pub async fn start_server(address: &str) -> Result<(), ServerError> {
+    let tcp_listener = TcpListener::bind(&address).await.expect("Failed to bind");
+    info!("Version: {} Listening on: {}", utils::APP_VERSION, address);
+
+    let mut http = hyper::server::conn::http1::Builder::new();
+    http.keep_alive(true);
+
+    loop {
+        let (stream, _) = tcp_listener.accept().await?;
+        let peer = stream.peer_addr().expect("Missing peer address");
+
+        let service =
+            hyper::service::service_fn(move |req| handle_http_request(peer.to_string(), req));
+
+        let connection = http
+            .serve_connection(TokioIo::new(stream), service)
+            .with_upgrades();
+
+        tokio::spawn(async move {
+            if let Err(err) = connection.await {
+                info!("HTTP connection error {err:?}");
+            }
+        });
+    }
+}

--- a/packages/transport-bluetooth/src/server/message_handler.rs
+++ b/packages/transport-bluetooth/src/server/message_handler.rs
@@ -1,0 +1,93 @@
+use hyper_tungstenite::tungstenite::Message;
+use log::info;
+use tokio::sync::broadcast::Sender;
+
+use crate::server::methods;
+use crate::server::types::{ChannelMessage, WsError, WsRequest, WsRequestMethod, WsResponse};
+
+pub async fn handle_message(message: Message, sender: Sender<ChannelMessage>) -> Option<Message> {
+    let msg: String = match message {
+        Message::Text(msg) => Some(msg.to_string()),
+        Message::Binary(msg) => {
+            let msg_str = msg.escape_ascii().to_string();
+            if msg_str == "PING" {
+                Some(msg_str.to_string())
+            } else {
+                None
+            }
+        }
+        Message::Close(msg) => {
+            if let Some(msg) = &msg {
+                info!("Message::Close code {}, {}", msg.code, msg.reason);
+            } else {
+                info!("Message::Close without message");
+            }
+            None
+        }
+        msg => {
+            info!("unknown Message {msg:?}");
+            None
+        }
+    }?;
+
+    if msg.to_string() == "PING" {
+        return Some(Message::text("PONG"));
+    }
+
+    info!("WsRequest: {:?}", msg);
+    let request = match serde_json::from_str::<WsRequest>(&msg) {
+        Ok(req) => req,
+        Err(err) => {
+            let json_error = serde_json::json!({
+                "id": "-1", // TODO: try to read "id" from malformed json? this could not be exact WsRequest but it can have "id"
+                "error": format!("WsRequest serialization error: {err:?}"),
+            });
+            return Some(Message::text(json_error.to_string()));
+        }
+    };
+    info!("Method: {request:?}");
+
+    let payload = match request.method.clone() {
+        WsRequestMethod::GetInfo => methods::get_info().await,
+        _ => methods::noop().await, // TODO: implement methods
+    };
+
+    match payload {
+        Ok(payload) => {
+            info!("WsResponse {payload:?}");
+
+            let response = WsResponse {
+                id: request.id.to_string(),
+                payload,
+            };
+
+            match serde_json::to_string(&response) {
+                Ok(json) => Some(Message::text(json)),
+                Err(err) => {
+                    let err_json = serde_json::json!({
+                        "id": request.id,
+                        "error": format!("WsResponse serialization error: {err:?}"),
+                    });
+                    Some(Message::text(err_json.to_string()))
+                }
+            }
+        }
+        Err(error) => {
+            info!("WsError {error:?}");
+
+            let ws_error = WsError {
+                id: request.id.to_string(),
+                error: error.to_string(),
+            };
+            // This unwrap is relatively safe as WsError is a simple structure
+            let json = serde_json::to_string(&ws_error).unwrap_or_else(|_| {
+                format!(
+                    "{{\"id\":\"{}\",\"error\":\"Failed to serialize error\"}}",
+                    request.id
+                )
+            });
+
+            Some(Message::text(json))
+        }
+    }
+}

--- a/packages/transport-bluetooth/src/server/methods/get_info.rs
+++ b/packages/transport-bluetooth/src/server/methods/get_info.rs
@@ -1,0 +1,49 @@
+use crate::server::types::{MethodResult, WsResponsePayload};
+use crate::server::utils;
+
+#[cfg(target_os = "linux")]
+pub async fn get_adapter_info() -> Result<String, Box<dyn std::error::Error>> {
+    // TODO: look for LMP version 10+
+    // TODO: https://askubuntu.com/a/591813, hciconfig deprecated
+    let result = std::process::Command::new("hciconfig").arg("-a").output();
+
+    match result {
+        Ok(info) => Ok(String::from_utf8_lossy(&info.stdout).to_string()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub async fn get_adapter_info() -> Result<String, Box<dyn std::error::Error>> {
+    // system_profiler -detailLevel full SPBluetoothDataType
+    let result = std::process::Command::new("system_profiler")
+        .arg("-detailLevel")
+        .arg("full")
+        .arg("SPBluetoothDataType")
+        .output();
+
+    match result {
+        Ok(info) => Ok(String::from_utf8_lossy(&info.stdout).to_string()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub async fn get_adapter_info() -> Result<String, Box<dyn std::error::Error>> {
+    Ok("TODO: get_adapter_info windows.".to_string())
+}
+
+pub async fn get_info() -> MethodResult {
+    let api_version = utils::APP_VERSION.to_string();
+
+    let info = match get_adapter_info().await {
+        Ok(info) => info,
+        Err(error) => error.to_string(),
+    };
+
+    return Ok(WsResponsePayload::Info {
+        api_version,
+        adapter_info: info,
+        adapter_version: 0,
+    });
+}

--- a/packages/transport-bluetooth/src/server/methods/mod.rs
+++ b/packages/transport-bluetooth/src/server/methods/mod.rs
@@ -1,0 +1,5 @@
+pub mod get_info;
+pub mod noop;
+
+pub use self::get_info::get_info;
+pub use self::noop::noop;

--- a/packages/transport-bluetooth/src/server/methods/noop.rs
+++ b/packages/transport-bluetooth/src/server/methods/noop.rs
@@ -1,0 +1,5 @@
+use crate::server::types::MethodResult;
+
+pub async fn noop() -> MethodResult {
+    Err("NOOP".into())
+}

--- a/packages/transport-bluetooth/src/server/mod.rs
+++ b/packages/transport-bluetooth/src/server/mod.rs
@@ -1,0 +1,8 @@
+pub mod connection_handler;
+pub mod message_handler;
+pub mod methods;
+pub mod types;
+pub mod utils;
+
+pub use self::connection_handler::start_server;
+pub use self::message_handler::handle_message;

--- a/packages/transport-bluetooth/src/server/types.rs
+++ b/packages/transport-bluetooth/src/server/types.rs
@@ -1,0 +1,53 @@
+#[derive(serde::Serialize, Clone, Debug)]
+pub enum AbortProcess {
+    ClientDisconnected, // websocket client disconnected
+}
+
+#[derive(serde::Serialize, Clone, Debug)]
+pub enum ChannelMessage {
+    Abort(AbortProcess),
+    Notification(NotificationEvent),
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[serde(tag = "method", content = "params", rename_all = "snake_case")]
+pub enum WsRequestMethod {
+    GetInfo,
+    StartScan,
+    StopScan,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub struct WsRequest {
+    pub id: String,
+    #[serde(flatten)]
+    pub method: WsRequestMethod,
+}
+
+#[derive(serde::Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum WsResponsePayload {
+    Info {
+        api_version: String,
+        adapter_info: String,
+        adapter_version: u8,
+    },
+}
+
+#[derive(serde::Serialize, Clone, Debug)]
+pub struct WsResponse {
+    pub id: String,
+    pub payload: WsResponsePayload,
+}
+
+#[derive(serde::Serialize, Clone, Debug)]
+pub struct WsError {
+    pub id: String,
+    pub error: String,
+}
+
+#[derive(serde::Serialize, Clone, Debug)]
+#[serde(tag = "event", content = "payload", rename_all = "snake_case")]
+pub enum NotificationEvent {}
+
+pub type MethodResult = Result<WsResponsePayload, Box<dyn std::error::Error>>;

--- a/packages/transport-bluetooth/src/server/utils.rs
+++ b/packages/transport-bluetooth/src/server/utils.rs
@@ -1,0 +1,1 @@
+pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

cherry-picking initial part of `trezor-bluetooth` websocket server aka. bridge for bluetooth

the server will be used in `suite-desktop` as a bluetooth transport.
server has no method implementation yet, returns `{"error":"NOOP"}` for the requests, bluetooth logic will follow in upcoming pull requests.

im picking this part to get the early review of the architecture, naming and binary builds
