### PR TITLE
Polish colors after palette update

### DIFF
--- a/suite-native/atoms/src/IconListItem.tsx
+++ b/suite-native/atoms/src/IconListItem.tsx
@@ -19,7 +19,7 @@ type IconColors = {
 const iconColorsMap = {
     default: {
         iconColor: 'iconDefault',
-        iconBorderColor: 'borderElevation1',
+        iconBorderColor: 'borderElevation0',
         iconBackgroundColor: 'backgroundTertiaryDefaultOnElevation1',
     },
     red: {

--- a/suite-native/atoms/src/OrderedListIcon.tsx
+++ b/suite-native/atoms/src/OrderedListIcon.tsx
@@ -40,7 +40,7 @@ export const OrderedListIcon = ({
     iconColor,
     iconSize = 'mediumLarge',
     iconBackgroundColor = 'backgroundTertiaryDefaultOnElevation1',
-    iconBorderColor = 'borderElevation1',
+    iconBorderColor = 'borderElevation0',
 }: OrderedListIconProps) => {
     const { applyStyle } = useNativeStyles();
 

--- a/suite-native/firmware/src/components/UpdateProgressIndicator.tsx
+++ b/suite-native/firmware/src/components/UpdateProgressIndicator.tsx
@@ -191,7 +191,7 @@ export const UpdateProgressIndicator = ({
             <Group>
                 <Path
                     path={progressCirclePath}
-                    color={utils.colors.backgroundPrimarySubtleOnElevationNegative}
+                    color={utils.colors.backgroundTertiaryDefaultOnElevationNegative}
                     strokeCap="round"
                     strokeJoin="round"
                     strokeWidth={PROGRESS_STROKE_WIDTH}

--- a/suite-native/module-send/src/components/AddressReviewStep.tsx
+++ b/suite-native/module-send/src/components/AddressReviewStep.tsx
@@ -23,7 +23,7 @@ const getIconProps = (stepNumber: AddressReviewStepProps['stepNumber']): Ordered
     stepNumber
         ? {
               iconNumber: stepNumber,
-              iconBackgroundColor: 'backgroundTertiaryDefaultOnElevation0',
+              iconBackgroundColor: 'backgroundTertiaryDefaultOnElevation1',
               iconBorderColor: 'borderElevation0',
           }
         : {
@@ -40,8 +40,8 @@ const cardStyle = prepareNativeStyle<{ isFinalStep: boolean }>((utils, { isFinal
     extend: {
         condition: isFinalStep,
         style: {
-            backgroundColor: utils.colors.backgroundPrimarySubtleOnElevation0,
-            borderColor: utils.colors.backgroundPrimarySubtleOnElevationNegative,
+            backgroundColor: utils.colors.backgroundPrimarySubtleOnElevation1,
+            borderColor: utils.colors.backgroundPrimarySubtleOnElevation0,
             ...utils.boxShadows.none,
         },
     },

--- a/suite-native/module-send/src/components/CorrectNetworkMessageCard.tsx
+++ b/suite-native/module-send/src/components/CorrectNetworkMessageCard.tsx
@@ -7,7 +7,7 @@ import { isCoinWithTokens } from '@suite-native/tokens';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 const cardStyle = prepareNativeStyle(utils => ({
-    backgroundColor: utils.colors.backgroundTertiaryDefaultOnElevation0,
+    backgroundColor: utils.colors.backgroundTertiaryDefaultOnElevation1,
     borderColor: utils.colors.borderElevation0,
     borderWidth: utils.borders.widths.small,
     paddingVertical: utils.spacings.sp12,

--- a/suite-native/module-send/src/components/RecipientsSummary.tsx
+++ b/suite-native/module-send/src/components/RecipientsSummary.tsx
@@ -27,7 +27,7 @@ type FeesRecipientsProps = {
 
 const cardStyle = prepareNativeStyle(utils => ({
     borderColor: utils.colors.borderElevation0,
-    backgroundColor: utils.colors.backgroundTertiaryDefaultOnElevation0,
+    backgroundColor: utils.colors.backgroundTertiaryDefaultOnElevation1,
     borderWidth: utils.borders.widths.small,
     paddingVertical: utils.spacings.sp12,
     ...utils.boxShadows.none,

--- a/suite-native/module-send/src/components/ReviewOutputCard.tsx
+++ b/suite-native/module-send/src/components/ReviewOutputCard.tsx
@@ -21,7 +21,7 @@ const cardStyle = prepareNativeStyle<{ isConfirmed: boolean }>((utils, { isConfi
     extend: {
         condition: isConfirmed,
         style: {
-            backgroundColor: utils.colors.backgroundSurfaceElevationNegative,
+            backgroundColor: utils.colors.backgroundTertiaryDefaultOnElevation1,
             borderColor: utils.colors.borderElevation0,
         },
     },

--- a/suite-native/module-send/src/components/SendOutputFields.tsx
+++ b/suite-native/module-send/src/components/SendOutputFields.tsx
@@ -17,7 +17,7 @@ type SendOutputFieldsProps = {
 };
 
 const cardStyle = prepareNativeStyle(utils => ({
-    borderColor: utils.colors.borderElevation1,
+    borderColor: utils.colors.borderElevation0,
     borderWidth: utils.borders.widths.small,
 }));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Only a few subtle fixes in light mode done together with @shenkys. We haven't checked dark mode yet.

- [fix elevations on border and background colors](https://github.com/trezor/trezor-suite/commit/2d3fea9018d71b2ed55a572e972e4cc82ef033fa)
- [fix background color of FW update progress circle](https://github.com/trezor/trezor-suite/commit/c2177f6f37fa4e98fd63a8ec0374f79aff7e41de)

## Screenshots:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/4b3ecbb6-6274-4eda-ad58-f7efa89b2aba" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/65c45ad7-3bab-4035-a400-9f0a8a86eadd" />

<img width="359" alt="image" src="https://github.com/user-attachments/assets/a17a507e-e166-46f1-9866-64b23383e9af" />

