### PR TITLE
Feat: use UAParser2 for message system

### DIFF
--- a/packages/env-utils/src/index.ts
+++ b/packages/env-utils/src/index.ts
@@ -1,6 +1,6 @@
 import { envUtils } from './envUtils';
 
-export type { Environment } from './types';
+export type { Environment, EnvUtils } from './types';
 
 export const {
     isWeb,

--- a/packages/suite/src/middlewares/suite/__tests__/messageSystemMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/messageSystemMiddleware.test.ts
@@ -70,7 +70,7 @@ const initStore = (preloadedState: State) => {
 };
 
 describe('Message system middleware', () => {
-    it('prepares valid messages for being displayed', () => {
+    it('prepares valid messages for being displayed', async () => {
         const message1 = {
             id: '22e6444d-a586-4593-bc8d-5d013f193eba',
             category: 'banner',
@@ -89,16 +89,15 @@ describe('Message system middleware', () => {
         };
 
         // @ts-expect-error: all properties except category and id are not required for testing
-        jest.spyOn(messageSystemUtils, 'getValidMessages').mockImplementation(() => [
-            message1,
-            message2,
-            message3,
-            message4,
-        ]);
-        jest.spyOn(messageSystemUtils, 'getValidExperimentIds').mockImplementation(() => []);
+        jest.spyOn(messageSystemUtils, 'getValidMessages').mockImplementation(() =>
+            Promise.resolve([message1, message2, message3, message4]),
+        );
+        jest.spyOn(messageSystemUtils, 'getValidExperimentIds').mockImplementation(() =>
+            Promise.resolve([]),
+        );
 
         const store = initStore(getInitialState(undefined, undefined));
-        store.dispatch({
+        await store.dispatch({
             type: messageSystemActions.fetchSuccessUpdate.type,
             payload: { config: { sequence: 1 }, timestamp: 0 },
         });
@@ -125,12 +124,16 @@ describe('Message system middleware', () => {
         ]);
     });
 
-    it('saves messages even if there are no valid messages', () => {
-        jest.spyOn(messageSystemUtils, 'getValidMessages').mockImplementation(() => []);
-        jest.spyOn(messageSystemUtils, 'getValidExperimentIds').mockImplementation(() => []);
+    it('saves messages even if there are no valid messages', async () => {
+        jest.spyOn(messageSystemUtils, 'getValidMessages').mockImplementation(() =>
+            Promise.resolve([]),
+        );
+        jest.spyOn(messageSystemUtils, 'getValidExperimentIds').mockImplementation(() =>
+            Promise.resolve([]),
+        );
 
         const store = initStore(getInitialState(undefined, undefined));
-        store.dispatch({
+        await store.dispatch({
             type: messageSystemActions.fetchSuccessUpdate.type,
             payload: { config: { sequence: 1 }, timestamp: 0 },
         });
@@ -152,7 +155,7 @@ describe('Message system middleware', () => {
         ]);
     });
 
-    it('test of experiment action', () => {
+    it('test of experiment action', async () => {
         const experiment1 = {
             id: '3bed56a4-ecd8-4e0f-9e5f-014b484c2afa',
             groups: [
@@ -167,12 +170,12 @@ describe('Message system middleware', () => {
             ],
         };
 
-        jest.spyOn(messageSystemUtils, 'getValidExperimentIds').mockImplementation(() => [
-            experiment1.id,
-        ]);
+        jest.spyOn(messageSystemUtils, 'getValidExperimentIds').mockImplementation(() =>
+            Promise.resolve([experiment1.id]),
+        );
 
         const store = initStore(getInitialState(undefined, undefined));
-        store.dispatch({
+        await store.dispatch({
             type: messageSystemActions.fetchSuccessUpdate.type,
             payload: { config: { sequence: 1 }, timestamp: 0 },
         });

--- a/packages/suite/src/middlewares/suite/messageSystemMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/messageSystemMiddleware.ts
@@ -1,18 +1,16 @@
-import { MiddlewareAPI } from 'redux';
-
 import {
     categorizeMessages,
     getValidExperimentIds,
     getValidMessages,
     messageSystemActions,
 } from '@suite-common/message-system';
+import { createMiddleware } from '@suite-common/redux-utils';
 import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
 import { DEVICE, TRANSPORT } from '@trezor/connect';
 
 import * as walletSettingsActions from 'src/actions/settings/walletSettingsActions';
 import { SUITE } from 'src/actions/suite/constants';
 import { selectActiveTransports } from 'src/reducers/suite/suiteReducer';
-import type { Action, AppState, Dispatch } from 'src/types/suite';
 import { getIsTorEnabled } from 'src/utils/suite/tor';
 
 // actions which can affect message system messages
@@ -25,38 +23,36 @@ const actions = [
     DEVICE.CONNECT,
 ];
 
-const messageSystemMiddleware =
-    (api: MiddlewareAPI<Dispatch, AppState>) =>
-    (next: Dispatch) =>
-    (action: Action): Action => {
-        next(action);
+const messageSystemMiddleware = createMiddleware(async (action, { next, dispatch, getState }) => {
+    next(action);
 
-        if (actions.includes(action.type)) {
-            const { config } = api.getState().messageSystem;
-            const { torStatus } = api.getState().suite;
-            const transports = selectActiveTransports(api.getState());
-            const device = selectSelectedDevice(api.getState());
-            const { enabledNetworks } = api.getState().wallet.settings;
+    if (actions.includes(action.type)) {
+        const { config } = getState().messageSystem;
+        const { torStatus } = getState().suite;
+        const transports = selectActiveTransports(getState());
+        const device = selectSelectedDevice(getState());
+        const { enabledNetworks } = getState().wallet.settings;
 
-            const validationParams = {
-                device,
-                transports,
-                settings: {
-                    tor: getIsTorEnabled(torStatus),
-                    enabledNetworks,
-                },
-            };
+        const validationParams = {
+            device,
+            transports,
+            settings: {
+                tor: getIsTorEnabled(torStatus),
+                enabledNetworks,
+            },
+        };
 
-            const validMessages = getValidMessages(config, validationParams);
-            const categorizedValidMessages = categorizeMessages(validMessages);
+        const [validMessages, validExperimentIds] = await Promise.all([
+            getValidMessages(config, validationParams),
+            getValidExperimentIds(config, validationParams),
+        ]);
+        const categorizedValidMessages = categorizeMessages(validMessages);
 
-            const validExperimentIds = getValidExperimentIds(config, validationParams);
+        dispatch(messageSystemActions.updateValidMessages(categorizedValidMessages));
+        dispatch(messageSystemActions.updateValidExperiments(validExperimentIds));
+    }
 
-            api.dispatch(messageSystemActions.updateValidMessages(categorizedValidMessages));
-            api.dispatch(messageSystemActions.updateValidExperiments(validExperimentIds));
-        }
-
-        return action;
-    };
+    return action;
+});
 
 export default messageSystemMiddleware;

--- a/suite-common/message-system/src/__fixtures__/messageSystemUtils.ts
+++ b/suite-common/message-system/src/__fixtures__/messageSystemUtils.ts
@@ -1,8 +1,22 @@
+import { AcquiredDevice, ExperimentsItem, Message, MessageSystem } from '@suite-common/suite-types';
 import { testMocks } from '@suite-common/test-utils';
-import { FirmwareType } from '@trezor/connect';
+import { FirmwareType, TransportInfo } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
+import { EnvUtils } from '@trezor/env-utils';
+
+import { Options } from '../messageSystemUtils';
 
 const { getDeviceFeatures, getConnectDevice, getMessageSystemConfig } = testMocks;
+
+const defaultOptions: Options = { settings: { tor: false, enabledNetworks: ['btc'] } };
+const defaultTransportsOption: TransportInfo = {
+    type: 'BridgeTransport',
+    apiType: 'usb',
+    version: '2.0.33',
+    outdated: false,
+};
+type GetConnectAcquiredDevice = (...args: Parameters<typeof getConnectDevice>) => AcquiredDevice;
+const getConnectAcquiredDevice = getConnectDevice as GetConnectAcquiredDevice;
 
 export const createVersionRange = [
     {
@@ -473,7 +487,7 @@ export const validateTransportCompatibility = [
             bridge: ['2.0.27', '2.0.28'],
             webusbplugin: '*',
         },
-        transports: [{ type: 'bridge', version: '2.0.27' }],
+        transports: [{ ...defaultTransportsOption, version: '2.0.27' }],
         result: true,
     },
     {
@@ -491,7 +505,7 @@ export const validateTransportCompatibility = [
             bridge: '*',
             webusbplugin: '*',
         },
-        transports: [{ type: 'bridge', version: '2.0.27' }],
+        transports: [{ ...defaultTransportsOption, version: '2.0.27' }],
         result: true,
     },
     {
@@ -509,7 +523,7 @@ export const validateTransportCompatibility = [
             bridge: '2',
             webusbplugin: '*',
         },
-        transports: [{ type: 'BridgeTransport', version: '2.0.25' }],
+        transports: [{ ...defaultTransportsOption, version: '2.0.25' }],
         result: true,
     },
     {
@@ -518,7 +532,7 @@ export const validateTransportCompatibility = [
             bridge: '2',
             webusbplugin: '*',
         },
-        transports: [{ type: 'bridge' }],
+        transports: [{ ...defaultTransportsOption, version: undefined }],
         result: false,
     },
     {
@@ -556,7 +570,7 @@ export const validateTransportCompatibility = [
         },
         transports: [
             { type: 'UdpTransport', version: '1.9.3' },
-            { type: 'BridgeTransport', version: '2.0.31' },
+            { ...defaultTransportsOption, version: '2.0.31' },
         ],
         result: true,
     },
@@ -1307,16 +1321,28 @@ export const validateDeviceCompatibility = [
     },
 ];
 
-export const getValidMessages = [
+type GetValidMessagesFixture = {
+    description: string;
+    currentDate: string;
+    userAgent: string;
+    osName: ReturnType<EnvUtils['getOsName']>;
+    environment: ReturnType<EnvUtils['getEnvironment']>;
+    suiteVersion: string;
+    config: MessageSystem | null;
+    options: Options;
+    result: Message[];
+};
+
+export const getValidMessages: GetValidMessagesFixture[] = [
     {
         description: 'getValidMessages case 1',
         currentDate: '',
         userAgent: '',
         osName: '',
-        environment: '',
+        environment: 'desktop',
         suiteVersion: '',
         config: null,
-        options: {},
+        options: defaultOptions,
         result: [],
     },
     {
@@ -1325,10 +1351,10 @@ export const getValidMessages = [
         userAgent:
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',
         osName: 'macos',
-        environment: '',
+        environment: 'desktop',
         suiteVersion: '',
         config: getMessageSystemConfig(),
-        options: {},
+        options: defaultOptions,
         result: [getMessageSystemConfig().actions[1].message],
     },
     {
@@ -1337,14 +1363,14 @@ export const getValidMessages = [
         userAgent:
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',
         osName: 'macos',
-        environment: '',
+        environment: 'desktop',
         suiteVersion: '',
         config: getMessageSystemConfig(undefined, undefined, {
             conditions: [
                 { duration: { from: '2021-03-01T12:10:00.000Z', to: '2021-03-05T12:10:00.000Z' } },
             ],
         }),
-        options: {},
+        options: defaultOptions,
         result: [],
     },
     {
@@ -1353,14 +1379,14 @@ export const getValidMessages = [
         userAgent:
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',
         osName: 'macos',
-        environment: '',
+        environment: 'desktop',
         suiteVersion: '',
         config: getMessageSystemConfig(undefined, undefined, {
             conditions: [
                 { duration: { from: '2021-03-01T12:10:00.000Z', to: '2021-05-01T12:10:00.000Z' } },
             ],
         }),
-        options: {},
+        options: defaultOptions,
         result: [getMessageSystemConfig().actions[1].message],
     },
     {
@@ -1369,14 +1395,14 @@ export const getValidMessages = [
         userAgent:
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',
         osName: 'macos',
-        environment: '',
+        environment: 'desktop',
         suiteVersion: '',
         config: getMessageSystemConfig(undefined, undefined, {
             conditions: [
                 { duration: { from: '2021-03-01T12:10:00.000Z', to: '2021-05-01T12:10:00.000Z' } },
             ],
         }),
-        options: {},
+        options: defaultOptions,
         result: [getMessageSystemConfig().actions[1].message],
     },
     {
@@ -1431,7 +1457,7 @@ export const getValidMessages = [
         userAgent:
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',
         osName: 'macos',
-        environment: '',
+        environment: 'desktop',
         suiteVersion: '',
         config: getMessageSystemConfig(undefined, undefined, {
             conditions: [
@@ -1447,7 +1473,7 @@ export const getValidMessages = [
                 },
             ],
         }),
-        options: {},
+        options: defaultOptions,
         result: [getMessageSystemConfig().actions[1].message],
     },
     {
@@ -1456,7 +1482,7 @@ export const getValidMessages = [
         userAgent:
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',
         osName: 'macos',
-        environment: '',
+        environment: 'desktop',
         suiteVersion: '',
         config: getMessageSystemConfig(undefined, undefined, {
             conditions: [
@@ -1472,7 +1498,7 @@ export const getValidMessages = [
                 },
             ],
         }),
-        options: {},
+        options: defaultOptions,
         result: [],
     },
     {
@@ -1494,7 +1520,7 @@ export const getValidMessages = [
                 },
             ],
         }),
-        options: {},
+        options: defaultOptions,
         result: [getMessageSystemConfig().actions[1].message],
     },
     {
@@ -1516,7 +1542,7 @@ export const getValidMessages = [
                 },
             ],
         }),
-        options: {},
+        options: defaultOptions,
         result: [getMessageSystemConfig().actions[1].message],
     },
     {
@@ -1538,7 +1564,7 @@ export const getValidMessages = [
                 },
             ],
         }),
-        options: {},
+        options: defaultOptions,
         result: [],
     },
     {
@@ -1547,7 +1573,7 @@ export const getValidMessages = [
         userAgent:
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',
         osName: 'macos',
-        environment: '',
+        environment: 'desktop',
         suiteVersion: '',
         config: getMessageSystemConfig(undefined, undefined, {
             conditions: [
@@ -1565,7 +1591,7 @@ export const getValidMessages = [
         userAgent:
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',
         osName: 'macos',
-        environment: '',
+        environment: 'desktop',
         suiteVersion: '',
         config: getMessageSystemConfig(undefined, undefined, {
             conditions: [
@@ -1583,7 +1609,7 @@ export const getValidMessages = [
         userAgent:
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',
         osName: 'macos',
-        environment: '',
+        environment: 'desktop',
         suiteVersion: '',
         config: getMessageSystemConfig(undefined, undefined, {
             conditions: [
@@ -1597,7 +1623,7 @@ export const getValidMessages = [
         }),
         options: {
             settings: { tor: false, enabledNetworks: [] },
-            transports: [{ type: 'bridge', version: '2.3.4' }],
+            transports: [{ ...defaultTransportsOption, version: '2.3.4' }],
         },
         result: [getMessageSystemConfig().actions[1].message],
     },
@@ -1607,7 +1633,7 @@ export const getValidMessages = [
         userAgent:
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',
         osName: 'macos',
-        environment: '',
+        environment: 'desktop',
         suiteVersion: '',
         config: getMessageSystemConfig(undefined, undefined, {
             conditions: [
@@ -1621,7 +1647,7 @@ export const getValidMessages = [
         }),
         options: {
             settings: { tor: false, enabledNetworks: [] },
-            transports: [{ type: 'bridge', version: '2.3.4' }],
+            transports: [{ ...defaultTransportsOption, version: '2.3.4' }],
         },
         result: [],
     },
@@ -1631,7 +1657,7 @@ export const getValidMessages = [
         userAgent:
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',
         osName: 'macos',
-        environment: '',
+        environment: 'desktop',
         suiteVersion: '',
         config: getMessageSystemConfig(undefined, undefined, {
             conditions: [
@@ -1659,7 +1685,7 @@ export const getValidMessages = [
         }),
         options: {
             settings: { tor: false, enabledNetworks: [] },
-            device: getConnectDevice(),
+            device: getConnectAcquiredDevice(),
         },
         result: [getMessageSystemConfig().actions[1].message],
     },
@@ -1669,7 +1695,7 @@ export const getValidMessages = [
         userAgent:
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',
         osName: 'macos',
-        environment: '',
+        environment: 'desktop',
         suiteVersion: '',
         config: getMessageSystemConfig(undefined, undefined, {
             conditions: [
@@ -1689,7 +1715,7 @@ export const getValidMessages = [
         }),
         options: {
             settings: { tor: false, enabledNetworks: [] },
-            device: getConnectDevice(),
+            device: getConnectAcquiredDevice(),
         },
         result: [],
     },
@@ -1699,7 +1725,7 @@ export const getValidMessages = [
         userAgent:
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',
         osName: 'macos',
-        environment: '',
+        environment: 'desktop',
         suiteVersion: '',
         config: getMessageSystemConfig(undefined, undefined, {
             conditions: [
@@ -1720,7 +1746,7 @@ export const getValidMessages = [
         options: {
             settings: { tor: false, enabledNetworks: [] },
             device: {
-                ...getConnectDevice(undefined, {
+                ...getConnectAcquiredDevice(undefined, {
                     capabilities: ['Capability_Bitcoin'],
                 }),
             },
@@ -1733,7 +1759,7 @@ export const getValidMessages = [
         userAgent:
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',
         osName: 'macos',
-        environment: '',
+        environment: 'desktop',
         suiteVersion: '',
         config: getMessageSystemConfig(undefined, undefined, {
             conditions: [
@@ -1754,7 +1780,7 @@ export const getValidMessages = [
         options: {
             settings: { tor: false, enabledNetworks: [] },
             device: {
-                ...getConnectDevice(undefined, {
+                ...getConnectAcquiredDevice(undefined, {
                     capabilities: ['Capability_Bitcoin_like'],
                 }),
             },
@@ -1772,8 +1798,8 @@ export const getValidMessages = [
         config: getMessageSystemConfig(),
         options: {
             settings: { tor: true, enabledNetworks: ['btc'] },
-            transports: [{ type: 'bridge', version: '2.0.30' }],
-            device: getConnectDevice(),
+            transports: [{ ...defaultTransportsOption, version: '2.0.30' }],
+            device: getConnectAcquiredDevice(),
         },
         result: getMessageSystemConfig().actions.map(action => action.message),
     },
@@ -1783,7 +1809,7 @@ export const getValidMessages = [
         userAgent:
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',
         osName: 'macos',
-        environment: '',
+        environment: 'desktop',
         suiteVersion: '',
         config: getMessageSystemConfig(undefined, undefined, {
             conditions: [
@@ -1804,7 +1830,7 @@ export const getValidMessages = [
         options: {
             settings: { tor: false, enabledNetworks: [] },
             device: {
-                ...getConnectDevice(undefined, {
+                ...getConnectAcquiredDevice(undefined, {
                     capabilities: ['Capability_Bitcoin'],
                     revision: 'fae8ac',
                     bootloader_mode: true,
@@ -1946,16 +1972,29 @@ export const validateExperiments = [
     },
 ];
 
-export const getValidExperimentIds = [
+type GetValidExperimentIdsFixture = {
+    description: string;
+    currentDate: string;
+    userAgent: string;
+    osName: ReturnType<EnvUtils['getOsName']>;
+    environment: ReturnType<EnvUtils['getEnvironment']>;
+    suiteVersion: string;
+    config: MessageSystem;
+    options: Options;
+    result: ExperimentsItem['id'][];
+};
+
+export const getValidExperimentIds: GetValidExperimentIdsFixture[] = [
     {
         description: 'getValidExperimentIds - case 1',
         currentDate: '2021-04-01T12:10:00.000Z',
         userAgent:
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',
         osName: 'macos',
-        environment: '',
+        environment: 'desktop',
         suiteVersion: '',
         config: getMessageSystemConfig(),
+        options: defaultOptions,
         result: [
             ...(getMessageSystemConfig().experiments ?? []).map(
                 experiment => experiment.experiment.id,

--- a/suite-common/message-system/src/__fixtures__/messageSystemUtils.ts
+++ b/suite-common/message-system/src/__fixtures__/messageSystemUtils.ts
@@ -1325,6 +1325,9 @@ type GetValidMessagesFixture = {
     description: string;
     currentDate: string;
     userAgent: string;
+    // For some systems, userAgent may not be sufficient to determine osVersion (see envUtils.ts).
+    // To simulate those cases, instead of mocking userAgent, getOsVersion will be mocked directly
+    osVersion?: string;
     osName: ReturnType<EnvUtils['getOsName']>;
     environment: ReturnType<EnvUtils['getEnvironment']>;
     suiteVersion: string;
@@ -1840,6 +1843,40 @@ export const getValidMessages: GetValidMessagesFixture[] = [
                     patch_version: 4,
                 }),
             },
+        },
+        result: [getMessageSystemConfig().actions[1].message],
+    },
+    {
+        description: 'getValidMessages case 23',
+        currentDate: '2021-04-01T12:10:00.000Z',
+        userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',
+        osVersion: '10.14',
+        osName: 'macos',
+        environment: 'web',
+        suiteVersion: '2.0.0',
+        config: getMessageSystemConfig(),
+        options: {
+            settings: { tor: true, enabledNetworks: ['btc'] },
+            transports: [{ ...defaultTransportsOption, version: '2.0.30' }],
+            device: getConnectAcquiredDevice(),
+        },
+        result: getMessageSystemConfig().actions.map(action => action.message),
+    },
+    {
+        description: 'getValidMessages case 24',
+        currentDate: '2021-04-01T12:10:00.000Z',
+        userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',
+        osVersion: '15.3.2',
+        osName: 'macos',
+        environment: 'web',
+        suiteVersion: '2.0.0',
+        config: getMessageSystemConfig(),
+        options: {
+            settings: { tor: true, enabledNetworks: ['btc'] },
+            transports: [{ ...defaultTransportsOption, version: '2.0.30' }],
+            device: getConnectAcquiredDevice(),
         },
         result: [getMessageSystemConfig().actions[1].message],
     },

--- a/suite-common/message-system/src/__tests__/messageSystemUtils.test.ts
+++ b/suite-common/message-system/src/__tests__/messageSystemUtils.test.ts
@@ -114,14 +114,11 @@ describe('Message system utils', () => {
         fixtures.getValidMessages.forEach(f => {
             it(f.description, async () => {
                 jest.spyOn(Date, 'now').mockImplementation(() => new Date(f.currentDate).getTime());
-                // @ts-expect-error (getOsName returns union of string literals)
                 jest.spyOn(envUtils, 'getOsName').mockImplementation(() => f.osName);
                 userAgentGetter.mockReturnValue(f.userAgent);
-                // @ts-expect-error
                 jest.spyOn(envUtils, 'getEnvironment').mockImplementation(() => f.environment);
                 process.env.VERSION = f.suiteVersion;
 
-                // @ts-expect-error
                 expect(await messageSystem.getValidMessages(f.config, f.options)).toEqual(f.result);
             });
         });
@@ -143,14 +140,11 @@ describe('Message system utils', () => {
         fixtures.getValidExperimentIds.forEach(f => {
             it(f.description, async () => {
                 jest.spyOn(Date, 'now').mockImplementation(() => new Date(f.currentDate).getTime());
-                // @ts-expect-error (getOsName returns union of string literals)
                 jest.spyOn(envUtils, 'getOsName').mockImplementation(() => f.osName);
                 userAgentGetter.mockReturnValue(f.userAgent);
-                // @ts-expect-error
                 jest.spyOn(envUtils, 'getEnvironment').mockImplementation(() => f.environment);
                 process.env.VERSION = f.suiteVersion;
 
-                // @ts-expect-error
                 expect(await messageSystem.getValidExperimentIds(f.config, f.options)).toEqual(
                     f.result,
                 );

--- a/suite-common/message-system/src/__tests__/messageSystemUtils.test.ts
+++ b/suite-common/message-system/src/__tests__/messageSystemUtils.test.ts
@@ -112,7 +112,7 @@ describe('Message system utils', () => {
         });
 
         fixtures.getValidMessages.forEach(f => {
-            it(f.description, () => {
+            it(f.description, async () => {
                 jest.spyOn(Date, 'now').mockImplementation(() => new Date(f.currentDate).getTime());
                 // @ts-expect-error (getOsName returns union of string literals)
                 jest.spyOn(envUtils, 'getOsName').mockImplementation(() => f.osName);
@@ -122,7 +122,7 @@ describe('Message system utils', () => {
                 process.env.VERSION = f.suiteVersion;
 
                 // @ts-expect-error
-                expect(messageSystem.getValidMessages(f.config, f.options)).toEqual(f.result);
+                expect(await messageSystem.getValidMessages(f.config, f.options)).toEqual(f.result);
             });
         });
     });
@@ -141,7 +141,7 @@ describe('Message system utils', () => {
         });
 
         fixtures.getValidExperimentIds.forEach(f => {
-            it(f.description, () => {
+            it(f.description, async () => {
                 jest.spyOn(Date, 'now').mockImplementation(() => new Date(f.currentDate).getTime());
                 // @ts-expect-error (getOsName returns union of string literals)
                 jest.spyOn(envUtils, 'getOsName').mockImplementation(() => f.osName);
@@ -151,7 +151,9 @@ describe('Message system utils', () => {
                 process.env.VERSION = f.suiteVersion;
 
                 // @ts-expect-error
-                expect(messageSystem.getValidExperimentIds(f.config, f.options)).toEqual(f.result);
+                expect(await messageSystem.getValidExperimentIds(f.config, f.options)).toEqual(
+                    f.result,
+                );
             });
         });
     });

--- a/suite-common/message-system/src/__tests__/messageSystemUtils.test.ts
+++ b/suite-common/message-system/src/__tests__/messageSystemUtils.test.ts
@@ -119,6 +119,13 @@ describe('Message system utils', () => {
                 jest.spyOn(envUtils, 'getEnvironment').mockImplementation(() => f.environment);
                 process.env.VERSION = f.suiteVersion;
 
+                const { osVersion } = f;
+                if (osVersion) {
+                    jest.spyOn(envUtils, 'getOsVersion').mockImplementation(() =>
+                        Promise.resolve(osVersion),
+                    );
+                }
+
                 expect(await messageSystem.getValidMessages(f.config, f.options)).toEqual(f.result);
             });
         });

--- a/suite-common/message-system/src/messageSystemUtils.ts
+++ b/suite-common/message-system/src/messageSystemUtils.ts
@@ -60,7 +60,7 @@ type CurrentSettings = {
     enabledNetworks: NetworkSymbol[];
 };
 
-type Options = {
+export type Options = {
     settings: CurrentSettings;
     transports?: TransportInfo[];
     device?: TrezorDevice;

--- a/suite-common/message-system/src/messageSystemUtils.ts
+++ b/suite-common/message-system/src/messageSystemUtils.ts
@@ -24,9 +24,9 @@ import {
     getBrowserName,
     getBrowserVersion,
     getCommitHash,
-    getDeprecatedOsVersion,
     getEnvironment,
     getOsName,
+    getOsVersion,
     getSuiteVersion,
 } from '@trezor/env-utils';
 
@@ -205,18 +205,30 @@ export const validateEnvironmentCompatibility = (
     );
 };
 
-export const validateConditions = (condition: Condition, options: Options) => {
+type EnvData = {
+    osName: ReturnType<typeof getOsName>;
+    osVersion: ReturnType<typeof transformVersionToSemverFormat>;
+    browserName: ReturnType<typeof getBrowserName>;
+    browserVersion: ReturnType<typeof transformVersionToSemverFormat>;
+    environment: ReturnType<typeof getEnvironment>;
+    suiteVersion: ReturnType<typeof transformVersionToSemverFormat>;
+    commitHash: ReturnType<typeof getCommitHash>;
+};
+
+export const getEnvData = async (): Promise<EnvData> => ({
+    osName: getOsName(),
+    osVersion: transformVersionToSemverFormat(await getOsVersion()),
+
+    browserName: getBrowserName(),
+    browserVersion: transformVersionToSemverFormat(getBrowserVersion()),
+
+    environment: getEnvironment(),
+    suiteVersion: transformVersionToSemverFormat(getSuiteVersion()),
+    commitHash: getCommitHash(),
+});
+
+export const validateConditions = (condition: Condition, options: Options, envData: EnvData) => {
     const { device, transports = [], settings } = options;
-
-    const currentOsName = getOsName();
-    const currentOsVersion = transformVersionToSemverFormat(getDeprecatedOsVersion());
-
-    const currentBrowserName = getBrowserName();
-    const currentBrowserVersion = transformVersionToSemverFormat(getBrowserVersion());
-
-    const environment = getEnvironment();
-    const suiteVersion = transformVersionToSemverFormat(getSuiteVersion());
-    const commitHash = getCommitHash();
 
     const {
         duration: durationCondition,
@@ -236,9 +248,9 @@ export const validateConditions = (condition: Condition, options: Options) => {
         environmentCondition &&
         !validateEnvironmentCompatibility(
             environmentCondition,
-            environment,
-            suiteVersion,
-            commitHash,
+            envData.environment,
+            envData.suiteVersion,
+            envData.commitHash,
         )
     ) {
         return false;
@@ -246,15 +258,15 @@ export const validateConditions = (condition: Condition, options: Options) => {
 
     if (
         osCondition &&
-        !validateVersionCompatibility(osCondition, currentOsName, currentOsVersion)
+        !validateVersionCompatibility(osCondition, envData.osName, envData.osVersion)
     ) {
         return false;
     }
 
     if (
-        environment === 'web' &&
+        envData.environment === 'web' &&
         browserCondition &&
-        !validateVersionCompatibility(browserCondition, currentBrowserName, currentBrowserVersion)
+        !validateVersionCompatibility(browserCondition, envData.browserName, envData.browserVersion)
     ) {
         return false;
     }
@@ -274,30 +286,42 @@ export const validateConditions = (condition: Condition, options: Options) => {
     return true;
 };
 
-export const getValidMessages = (config: MessageSystem | null, options: Options): Message[] => {
+export const getValidMessages = async (
+    config: MessageSystem | null,
+    options: Options,
+): Promise<Message[]> => {
     if (!config) {
         return [];
     }
+    const envData = await getEnvData();
 
     return config.actions
         .filter(
             action =>
                 !action.conditions.length ||
-                action.conditions.some(condition => validateConditions(condition, options)),
+                action.conditions.some(condition =>
+                    validateConditions(condition, options, envData),
+                ),
         )
         .map(action => action.message);
 };
 
-export const getValidExperimentIds = (config: MessageSystem | null, options: Options): string[] => {
+export const getValidExperimentIds = async (
+    config: MessageSystem | null,
+    options: Options,
+): Promise<string[]> => {
     if (!config?.experiments) {
         return [];
     }
+    const envData = await getEnvData();
 
     return config.experiments
         .filter(
             experiment =>
                 !experiment.conditions.length ||
-                experiment.conditions.some(condition => validateConditions(condition, options)),
+                experiment.conditions.some(condition =>
+                    validateConditions(condition, options, envData),
+                ),
         )
         .map(experiment => experiment?.experiment?.id);
 };

--- a/suite-native/message-system/src/messageSystemMiddleware.ts
+++ b/suite-native/message-system/src/messageSystemMiddleware.ts
@@ -21,32 +21,35 @@ const isAnyOfMessageSystemAffectingActions = isAnyOf(
     toggleEnabledDiscoveryNetworkSymbol,
 );
 
-export const messageSystemMiddleware = createMiddleware((action, { next, dispatch, getState }) => {
-    // The action has to be handled by the reducer first to apply its
-    // changes first, because this middleware expects already updated state.
-    next(action);
+export const messageSystemMiddleware = createMiddleware(
+    async (action, { next, dispatch, getState }) => {
+        // The action has to be handled by the reducer first to apply its
+        // changes first, because this middleware expects already updated state.
+        next(action);
 
-    if (isAnyOfMessageSystemAffectingActions(action)) {
-        const config = selectMessageSystemConfig(getState());
-        const device = selectSelectedDevice(getState());
-        const enabledNetworks = selectDeviceEnabledDiscoveryNetworkSymbols(getState());
+        if (isAnyOfMessageSystemAffectingActions(action)) {
+            const config = selectMessageSystemConfig(getState());
+            const device = selectSelectedDevice(getState());
+            const enabledNetworks = selectDeviceEnabledDiscoveryNetworkSymbols(getState());
 
-        const validationParams = {
-            device,
-            settings: {
-                tor: false, // not supported in suite-native
-                enabledNetworks,
-            },
-        };
+            const validationParams = {
+                device,
+                settings: {
+                    tor: false, // not supported in suite-native
+                    enabledNetworks,
+                },
+            };
+            const [validMessages, validExperimentIds] = await Promise.all([
+                getValidMessages(config, validationParams),
+                getValidExperimentIds(config, validationParams),
+            ]);
 
-        const validMessages = getValidMessages(config, validationParams);
-        const categorizedValidMessages = categorizeMessages(validMessages);
+            const categorizedValidMessages = categorizeMessages(validMessages);
 
-        const validExperimentIds = getValidExperimentIds(config, validationParams);
+            dispatch(messageSystemActions.updateValidMessages(categorizedValidMessages));
+            dispatch(messageSystemActions.updateValidExperiments(validExperimentIds));
+        }
 
-        dispatch(messageSystemActions.updateValidMessages(categorizedValidMessages));
-        dispatch(messageSystemActions.updateValidExperiments(validExperimentIds));
-    }
-
-    return action;
-});
+        return action;
+    },
+);


### PR DESCRIPTION
## Description

:eyes: CR commit by commit recommended.

Followup to https://github.com/trezor/trezor-suite/pull/18023:
use the new async `getOsVersion` in message system, so that we can distinguish macOS > catalina (currently targetted as if it was catalina), and Windows 11 (currently targetted as if it was 10).

Also, cleanup message system test fixtures :broom: 

## Related Issue

Resolve #8674

## Screenshots:

You can test it [on this branch.](https://github.com/trezor/trezor-suite/compare/feat/use-uaparser2-for-message-system..feat/use-uaparser2-for-message-system-TESTING).

![image](https://github.com/user-attachments/assets/a257245d-0544-4687-8b7d-5e7fbea2df58)

For a very quick simulation, paste this on page load in console and play around:
```
OS_NAME = 'windows';
OS_VERSION = '11';
```

```
OS_NAME = 'macos'
OS_VERSION = "15.3.2"
UA='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36';
```