### PR TITLE
chore(connect-ui): implement new async getOsVersion in analytics

### DIFF
--- a/packages/connect-ui/src/utils/analytics.ts
+++ b/packages/connect-ui/src/utils/analytics.ts
@@ -3,8 +3,8 @@ import { storage } from '@trezor/connect-common';
 import {
     getBrowserName,
     getBrowserVersion,
-    getDeprecatedOsVersion,
     getOsName,
+    getOsVersion,
     getPlatformLanguages,
     getScreenHeight,
     getScreenWidth,
@@ -39,7 +39,7 @@ const onDisable = () => {
     );
 };
 
-export const initAnalytics = () => {
+export const initAnalytics = async () => {
     let trackingId = storage.load().tracking_id;
     if (!trackingId) {
         trackingId = getRandomId();
@@ -58,13 +58,15 @@ export const initAnalytics = () => {
         },
     });
 
+    const osVersion = await getOsVersion();
+
     analytics.report({
         type: EventType.AppInfo,
         payload: {
             browserName: getBrowserName(),
             browserVersion: getBrowserVersion(),
             osName: getOsName(),
-            osVersion: getDeprecatedOsVersion(),
+            osVersion,
             screenWidth: getScreenWidth(),
             screenHeight: getScreenHeight(),
             windowWidth: getWindowWidth(),


### PR DESCRIPTION
## Description

Followup to https://github.com/trezor/trezor-suite/pull/18023:
use the new async `getOsVersion` in connect-ui analytics, so that we can distinguish macOS > catalina (currently targetted as if it was catalina), and Windows 11 (currently targetted as if it was 10).

@coderabbitai ignore