### PR TITLE
Standalone bridge deprecation. Phase 3

### DIFF
--- a/packages/connect-ui/src/components/Notification.tsx
+++ b/packages/connect-ui/src/components/Notification.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { Button, Icon } from '@trezor/components';
-import { SUITE_BACKUP_URL, SUITE_FIRMWARE_URL, SUITE_BRIDGE_DEEPLINK } from '@trezor/urls';
+import { SUITE_BRIDGE_DEEPLINK } from '@trezor/urls';
 
 const NotificationBox = styled.div`
     background-color: ${({ color }) => color};
@@ -109,28 +109,6 @@ const Notification = ({ header, body, cta, variant }: NotificationProps) => {
         </NotificationBox>
     );
 };
-
-export const FirmwareUpdateNotification = () => (
-    <Notification
-        variant="warning"
-        header="New firmware update available"
-        body="A new firmware update is available for your Trezor device. Update now
-for the latest features."
-        cta={{ desc: 'Update my firmware', url: SUITE_FIRMWARE_URL }}
-    />
-);
-
-export const BackupNotification = () => (
-    <Notification
-        variant="warning"
-        header="Your Trezor is not backed up"
-        body=""
-        cta={{
-            desc: 'Create a backup in 3 minutes',
-            url: SUITE_BACKUP_URL,
-        }}
-    />
-);
 
 export const UseSuiteDesktopNotification = () => (
     <Notification

--- a/packages/connect-ui/src/components/Notification.tsx
+++ b/packages/connect-ui/src/components/Notification.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { Button, Icon } from '@trezor/components';
-import { SUITE_BACKUP_URL, SUITE_FIRMWARE_URL, SUITE_URL } from '@trezor/urls';
+import { SUITE_BACKUP_URL, SUITE_FIRMWARE_URL, SUITE_BRIDGE_DEEPLINK } from '@trezor/urls';
 
 const NotificationBox = styled.div`
     background-color: ${({ color }) => color};
@@ -132,12 +132,12 @@ export const BackupNotification = () => (
     />
 );
 
-export const BridgeUpdateNotification = () => (
+export const UseSuiteDesktopNotification = () => (
     <Notification
         variant="warning"
-        header="Current bridge is outdated"
-        body="Trezor Bridge is no longer supported. Switch to Trezor Suite desktop for the best experience."
-        cta={{ desc: 'Install Trezor Suite', url: SUITE_URL }}
+        header="Try something new"
+        body="Switch to Trezor Suite desktop for the best experience."
+        cta={{ desc: 'Try Trezor Suite', url: SUITE_BRIDGE_DEEPLINK }}
     />
 );
 

--- a/packages/connect-ui/src/index.tsx
+++ b/packages/connect-ui/src/index.tsx
@@ -2,7 +2,7 @@ import { JSX, ReactNode, useCallback, useEffect, useMemo, useState } from 'react
 
 import styled from 'styled-components';
 
-import { CoreRequestMessage, POPUP, UI, UI_REQUEST } from '@trezor/connect';
+import { CoreRequestMessage, POPUP, UI } from '@trezor/connect';
 import { isConnectOutdated } from '@trezor/connect/src/utils/versionCheck';
 import { OriginBoundState, storage } from '@trezor/connect-common';
 import { isNewerOrEqual } from '@trezor/utils/src/versionUtils';
@@ -13,9 +13,6 @@ import { BottomRightFloatingBar } from './components/BottomRightFloatingBar';
 import { InfoPanel } from './components/InfoPanel';
 import { Loader } from './components/Loader';
 import {
-    BackupNotification,
-    UseSuiteDesktopNotification,
-    FirmwareUpdateNotification,
     SuspiciousOriginNotification,
     UseSuiteDesktopNotification,
 } from './components/Notification';
@@ -138,11 +135,7 @@ export const ConnectUI = ({ postMessage, clearLegacyView }: ConnectUIProps) => {
             );
         }
         messages.forEach(message => {
-            if (message?.type === UI_REQUEST.FIRMWARE_OUTDATED) {
-                notifications[message.type] = <FirmwareUpdateNotification key={message.type} />;
-            } else if (message?.type === UI_REQUEST.DEVICE_NEEDS_BACKUP) {
-                notifications[message.type] = <BackupNotification key={message.type} />;
-            } else if (message?.type === 'phishing-domain') {
+            if (message?.type === 'phishing-domain') {
                 notifications[message.type] = <SuspiciousOriginNotification key={message.type} />;
             }
 

--- a/packages/connect-ui/src/index.tsx
+++ b/packages/connect-ui/src/index.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { CoreRequestMessage, POPUP, UI, UI_REQUEST } from '@trezor/connect';
 import { isConnectOutdated } from '@trezor/connect/src/utils/versionCheck';
 import { OriginBoundState, storage } from '@trezor/connect-common';
+import { isNewerOrEqual } from '@trezor/utils/src/versionUtils';
 
 // views
 
@@ -13,9 +14,10 @@ import { InfoPanel } from './components/InfoPanel';
 import { Loader } from './components/Loader';
 import {
     BackupNotification,
-    BridgeUpdateNotification,
+    UseSuiteDesktopNotification,
     FirmwareUpdateNotification,
     SuspiciousOriginNotification,
+    UseSuiteDesktopNotification,
 } from './components/Notification';
 import { ErrorBoundary } from './support/ErrorBoundary';
 import { GlobalStyle } from './support/GlobalStyle';
@@ -99,7 +101,8 @@ export const ConnectUI = ({ postMessage, clearLegacyView }: ConnectUIProps) => {
         };
     }, [state?.settings?.origin]);
 
-    const outdated = state?.transports?.find(t => t.type === 'BridgeTransport')?.outdated;
+    const suiteDesktopIsSupported =
+        !!state.settings?.npmVersion && isNewerOrEqual(state.settings?.npmVersion, '9.6.0');
 
     const [Component, Notifications] = useMemo(() => {
         let component: ReactNode | null;
@@ -129,8 +132,10 @@ export const ConnectUI = ({ postMessage, clearLegacyView }: ConnectUIProps) => {
 
         // notifications
         const notifications: { [key: string]: JSX.Element } = {};
-        if (outdated) {
-            notifications['bridge-outdated'] = <BridgeUpdateNotification key="bridge-outdated" />;
+        if (suiteDesktopIsSupported) {
+            notifications['use-suite-desktop'] = (
+                <UseSuiteDesktopNotification key="use-suite-desktop" />
+            );
         }
         messages.forEach(message => {
             if (message?.type === UI_REQUEST.FIRMWARE_OUTDATED) {
@@ -145,7 +150,7 @@ export const ConnectUI = ({ postMessage, clearLegacyView }: ConnectUIProps) => {
         });
 
         return [component, notifications];
-    }, [messages, postMessage, outdated]);
+    }, [messages, postMessage, suiteDesktopIsSupported]);
 
     useEffect(() => {
         if (Component) {

--- a/packages/connect/src/utils/versionCheck.ts
+++ b/packages/connect/src/utils/versionCheck.ts
@@ -2,7 +2,7 @@ import { isNewerOrEqual } from '@trezor/utils/src/versionUtils';
 
 import { ConnectSettings } from '../types/settings';
 
-export const isConnectOutdated = (settings?: ConnectSettings) => {
+export const isConnectOutdated = (settings?: ConnectSettings): false | 'error' | 'warning' => {
     // web only for now
     if (settings?.env !== 'web') return false;
 

--- a/packages/suite/src/components/suite/banners/SuiteBanners/BridgeDeprecatedBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/BridgeDeprecatedBanner.tsx
@@ -20,7 +20,7 @@ export const BridgeDeprecated = () => {
                 </Banner.Button>
             }
         >
-            <Translation id="TR_YOUR_BRIDGE_VERSION_WILL_SOON_BE_DEPRECATED" />
+            <Translation id="TR_STANDALONE_BRIDGE_DEPRECATED" />
         </Banner>
     );
 };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -10454,6 +10454,15 @@ export default defineMessages({
         defaultMessage:
             'To connect to the app, activate at least one supported asset in Trezor Suite.',
     },
+    TR_STANDALONE_BRIDGE_DEPRECATED: {
+        id: 'TR_STANDALONE_BRIDGE_DEPRECATED',
+        defaultMessage: 'Standalone Trezor Bridge is deprecated',
+    },
+    TR_STANDALONE_BRIDGE_DEPRECATED_DESCRIPTION: {
+        id: 'TR_STANDALONE_BRIDGE_DEPRECATED_DESCRIPTION',
+        defaultMessage:
+            'We recommend <a>uninstalling</a> standalone Trezor Bridge as explained in this article. Having standalone Trezor Bridge installed on your computer may interfere with using your Trezor device in future releases.',
+    },
     TR_REQUESTED_NETWORKS: {
         id: 'TR_REQUESTED_NETWORKS',
         defaultMessage: 'Requested networks',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -10086,7 +10086,7 @@ export default defineMessages({
     TR_BRIDGE_TIP_AUTOSTART: {
         id: 'TR_BRIDGE_TIP_AUTOSTART',
         defaultMessage:
-            'Tip: Enable the auto-start feature and have Trezor Bridge always running in the background.',
+            'Tip: Enable the auto-start and allow Trezor Suite to runing the background to enable smooth interaction with 3rd party apps.',
     },
     TR_BRIDGE_NEEDED_DESCRIPTION: {
         id: 'TR_BRIDGE_NEEDED_DESCRIPTION',

--- a/packages/suite/src/views/suite/bridge-deprecated/index.tsx
+++ b/packages/suite/src/views/suite/bridge-deprecated/index.tsx
@@ -39,11 +39,11 @@ export const BridgeDeprecated = () => {
             <Metadata title="Bridge | Trezor Suite" />
             <Column gap={spacings.xxs}>
                 <H3>
-                    <Translation id="TR_BRIDGE" />
+                    <Translation id="TR_STANDALONE_BRIDGE_DEPRECATED" />
                 </H3>
                 <Paragraph variant="tertiary">
                     <Translation
-                        id="TR_BRIDGE_UNINSTALL_INSTRUCTIONS"
+                        id="TR_STANDALONE_BRIDGE_DEPRECATED_DESCRIPTION"
                         values={{
                             a: chunks => (
                                 <Box margin={{ top: spacings.xs }}>

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -98,14 +98,9 @@ export class BridgeTransport extends AbstractTransport {
 
                 this.version = response.payload.version;
 
-                if (this.version.startsWith('3')) {
-                    this.isOutdated = false;
-                } else {
-                    this.isOutdated =
-                        // as for trezord-go only 2.0.33 (suite-desktop bundled) is supported
-                        !['2.0.33'].includes(this.version);
+                if (!this.version.startsWith('3')) {
+                    this.isOutdated = true;
                 }
-
                 this.useProtocolMessages = !!response.payload.protocolMessages;
 
                 this.stopped = false;

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -102,8 +102,8 @@ export class BridgeTransport extends AbstractTransport {
                     this.isOutdated = false;
                 } else {
                     this.isOutdated =
-                        // as for trezord-go only 2.0.27 (standalone) and 2.0.33 (suite-desktop bundled) are supported
-                        !['2.0.27', '2.0.33'].includes(this.version);
+                        // as for trezord-go only 2.0.33 (suite-desktop bundled) is supported
+                        !['2.0.33'].includes(this.version);
                 }
 
                 this.useProtocolMessages = !!response.payload.protocolMessages;

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -7,8 +7,6 @@ import { Url } from './types';
 
 export const SUITE_WEB_URL = 'https://suite.trezor.io/web/';
 export const SUITE_URL: Url = 'https://trezor.io/trezor-suite';
-
-export const SUITE_BACKUP_URL: Url = 'https://suite.trezor.io/web/backup/';
 export const SUITE_FIRMWARE_URL: Url = 'https://suite.trezor.io/web/firmware/';
 export const SUITE_UDEV_URL: Url = 'https://suite.trezor.io/web/udev/';
 export const SUITE_WEB_DEVICE_SETTINGS_URL = (SUITE_WEB_URL + 'settings/device/') as Url;


### PR DESCRIPTION
### Phase 1 [already in production]

- suite: show banner with copy to uninstall non-canonicall standalone bridges
- stop offering standalone bridge installation as CTA

### Phase 2 [already in production]

- #18754 stop offering standalone bridge installation (escape hatch)
-  update copy 
- auto-starting built in variant in suite-desktop #17746 after the standalone one is gone.
- make suite-desktop background mode available in production ✅ 
- set node-bridge as default in CI for connect tests #19214
- give user an option to switch between implementation in troubleshooting tips. just in case #19863

### Phase 3 - oblivion [now]
- in old connect popup - present a deeplink to open suite-desktop instead so that users start running suite in the background more frequently

<img width="1233" height="859" alt="image" src="https://github.com/user-attachments/assets/f45d0b47-b5a3-4748-ac80-2870108a2951" />
<img width="938" height="392" alt="image" src="https://github.com/user-attachments/assets/560b8f7b-5242-43fd-9337-cea59702782e" />

- get node-bridge rollout to 100%. #19209
- start using new port for bridge  #20245 
 -  mark all non non-built in bridges as outdated and show copy (banner, modal) with instructions to uninstall. 

<img width="949" height="664" alt="image" src="https://github.com/user-attachments/assets/c964672f-6174-4eb2-b128-9f6ec4d61ed1" />

<img width="764" height="572" alt="image" src="https://github.com/user-attachments/assets/42839002-397e-419b-b730-67bf7f0aab44" />

### Phase 4 - death 
- kill public bridge (and Bluetooth) endpoint, start using a single trezor-connect websocket endpoint

Related issues
- All issues [labeled as trezord-2.0.27 ](https://github.com/trezor/trezor-suite/issues?q=is%3Aissue%20state%3Aopen%20label%3Atrezord-2.0.27) should go away


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=bridge-deprecated&lookback=7)