### PR TITLE
feat(suite): hash check failure UI tweaks

### DIFF
--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
@@ -56,7 +56,6 @@ const useSecurityCheckFailProps = (): SecurityCheckFailProps => {
             heading: 'TR_FAILED_VERIFY_DEVICE_HEADING',
             text: 'TR_FAILED_VERIFY_DEVICE_TEXT',
             checklistItems: softFailureChecklistItems,
-            supportButtonVariant: 'warning',
             goBack: goToSuite,
             supportUrl: TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL,
         };

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
@@ -1,5 +1,3 @@
-import { ComponentProps } from 'react';
-
 import styled from 'styled-components';
 
 import { TranslationKey } from '@suite-common/intl-types';
@@ -30,7 +28,6 @@ export type SecurityCheckFailProps = {
     text?: TranslationKey;
     supportUrl: Url;
     checklistItems?: SecurityChecklistItem[];
-    supportButtonVariant?: ComponentProps<typeof Button>[`variant`];
 };
 
 export const SecurityCheckFail = ({
@@ -39,7 +36,6 @@ export const SecurityCheckFail = ({
     text = 'TR_DEVICE_COMPROMISED_TEXT',
     supportUrl,
     checklistItems = hardFailureChecklistItems,
-    supportButtonVariant = 'primary',
 }: SecurityCheckFailProps) => {
     const chatUrl = `${supportUrl}#open-chat`;
 
@@ -72,7 +68,7 @@ export const SecurityCheckFail = ({
                         href={chatUrl}
                         isFullWidth
                         size="large"
-                        variant={supportButtonVariant}
+                        variant="primary"
                     >
                         <Translation id="TR_CONTACT_TREZOR_SUPPORT" />
                     </Button>

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareAuthenticityCheckBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareAuthenticityCheckBanner.tsx
@@ -2,10 +2,7 @@ import { TranslationKey } from '@suite-common/intl-types';
 import { Banner, Row } from '@trezor/components';
 import { FirmwareHashCheckError, FirmwareRevisionCheckError } from '@trezor/connect';
 import { spacings } from '@trezor/theme';
-import {
-    HELP_CENTER_FIRMWARE_REVISION_CHECK,
-    TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL,
-} from '@trezor/urls';
+import { TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL } from '@trezor/urls';
 
 import { Translation, TrezorLink } from 'src/components/suite';
 import { SkippedHashCheckError } from 'src/constants/suite/firmware';
@@ -53,11 +50,6 @@ const BannerButtons = () => (
                 <Translation id="TR_CONTACT_TREZOR_SUPPORT" />
             </Banner.Button>
         </TrezorLink>
-        <TrezorLink variant="nostyle" href={HELP_CENTER_FIRMWARE_REVISION_CHECK}>
-            <Banner.Button isSubtle>
-                <Translation id="TR_LEARN_MORE" />
-            </Banner.Button>
-        </TrezorLink>
     </Row>
 );
 
@@ -67,6 +59,7 @@ export const FirmwareAuthenticityCheckBanner = () => {
     const wasOffline = firmwareRevisionError === 'cannot-perform-check-offline';
     const isHashCheckOtherError =
         firmwareRevisionError === null && firmwareHashError === 'other-error';
+    const hideBannerButtons = wasOffline || isHashCheckOtherError;
 
     const message = useAuthenticityCheckMessage();
     if (message === null) return null;
@@ -75,7 +68,7 @@ export const FirmwareAuthenticityCheckBanner = () => {
         <Banner
             icon
             variant={isHashCheckOtherError ? 'warning' : 'destructive'}
-            rightContent={wasOffline ? null : <BannerButtons />}
+            rightContent={hideBannerButtons ? null : <BannerButtons />}
         >
             <Translation id={message} />
         </Banner>

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7115,7 +7115,7 @@ export default defineMessages({
     },
     TR_FAILED_VERIFY_DEVICE_HEADING: {
         id: 'TR_FAILED_VERIFY_DEVICE_HEADING',
-        defaultMessage: 'Failed to verify device',
+        defaultMessage: "Couldn't verify device",
     },
     TR_FAILED_VERIFY_DEVICE_TEXT: {
         id: 'TR_FAILED_VERIFY_DEVICE_TEXT',
@@ -7340,7 +7340,7 @@ export default defineMessages({
     TR_DEVICE_FIRMWARE_HASH_CHECK_OTHER_ERROR: {
         id: 'TR_DEVICE_FIRMWARE_HASH_CHECK_OTHER_ERROR',
         defaultMessage:
-            "Failed to verify device. Reconnect your Trezor and try again. Don't send any funds until the issue is resolved. If the issue persists, contact Trezor Support.",
+            'Couldn’t verify device. Reconnect your Trezor to try resolving the issue. If the problem continues, contact Trezor Support.',
     },
     TR_ONBOARDING_COINS_STEP: {
         id: 'TR_ONBOARDING_COINS_STEP',


### PR DESCRIPTION
## Description

UI tweaks for FW hash check:
- other error less severe wording
- use consistent color for :ghost: modal CTA 
- remove Learn more button from all variants

[See discussion in figma](https://www.figma.com/design/eKie94qfryjTHEnR8jfmgk/Security-checks?node-id=4275-3387&t=yLbuu0aWJXMRlygv-4)

## Screenshots:

:ghost: modal for FW hash check `other-error`
![Screenshot from 2025-04-04 15-28-18](https://github.com/user-attachments/assets/57171993-6956-4e28-aec5-47776d221f6b)

banner for FW hash check `other-error`
![image](https://github.com/user-attachments/assets/fc2c8beb-4b40-42c6-9858-7a36936af4a2)

:ghost: modal for FW hash check `hash-mismatch` (no change)
![image](https://github.com/user-attachments/assets/0f63230e-2935-4e03-9bc5-eff84a70ed6d)


banner for FW hash check `hash-mismatch` (only Learn more CTA gone)
![image](https://github.com/user-attachments/assets/4e698801-d4aa-4ce5-b295-e216e9e7678a)
