### PR TITLE
chore(suite): implement new async getOsVersion in ApplicationLogModal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApplicationLogModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApplicationLogModal.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 
 import styled from 'styled-components';
 
-import { selectLogs } from '@suite-common/logger';
 import {
     Card,
     Column,
@@ -18,8 +17,7 @@ import {
 import { spacings, spacingsPx } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
-import { useSelector } from 'src/hooks/suite';
-import { getApplicationInfo, getApplicationLog, prettifyLog } from 'src/utils/suite/logsUtils';
+import { usePrintableLog } from 'src/utils/suite/logsUtils';
 
 const ScrollContainer = styled.div`
     overflow: auto;
@@ -45,15 +43,13 @@ type ApplicationLogModalProps = { onCancel: () => void };
 
 export const ApplicationLogModal = ({ onCancel }: ApplicationLogModalProps) => {
     const [hideSensitiveInfo, setHideSensitiveInfo] = useState(false);
-    const logs = useSelector(selectLogs);
-    const applicationInfo = useSelector(state => getApplicationInfo(state, hideSensitiveInfo));
+    const log = usePrintableLog(hideSensitiveInfo);
+
     const { ShadowTop, ShadowBottom, ShadowContainer, onScroll, scrollElementRef } =
         useScrollShadow();
 
-    const actionLog = getApplicationLog(logs, hideSensitiveInfo);
-    const log = prettifyLog([applicationInfo, ...actionLog]);
-
     const download = () => {
+        if (log === null) return;
         const element = document.createElement('a');
         element.setAttribute('href', `data:text/plain;charset=utf-8,${encodeURIComponent(log)}`);
         element.setAttribute('download', 'trezor-suite-log.txt');
@@ -65,6 +61,9 @@ export const ApplicationLogModal = ({ onCancel }: ApplicationLogModalProps) => {
 
         document.body.removeChild(element);
     };
+
+    // usually takes less than 100 ms, so it's ok to delay display without a loader component
+    if (log === null) return null;
 
     return (
         <NewModal

--- a/packages/suite/src/utils/suite/logsUtils.ts
+++ b/packages/suite/src/utils/suite/logsUtils.ts
@@ -1,4 +1,6 @@
-import { LogEntry } from '@suite-common/logger';
+import { useEffect, useState } from 'react';
+
+import { LogEntry, selectLogs } from '@suite-common/logger';
 import { getPhysicalDeviceUniqueIds } from '@suite-common/suite-utils';
 import {
     accountsActions,
@@ -20,9 +22,9 @@ import {
     getBrowserName,
     getBrowserVersion,
     getCommitHash,
-    getDeprecatedOsVersion,
     getEnvironment,
     getOsName,
+    getOsVersion,
     getPlatformLanguages,
     getScreenHeight,
     getScreenWidth,
@@ -34,6 +36,7 @@ import {
 import { DeepPartial } from '@trezor/type-utils';
 
 import { METADATA_LABELING } from 'src/actions/suite/constants';
+import { useSelector } from 'src/hooks/suite';
 import { selectLabelingDataForWallet } from 'src/reducers/suite/metadataReducer';
 import { AppState, TrezorDevice } from 'src/types/suite';
 import { Account } from 'src/types/wallet';
@@ -178,22 +181,26 @@ export const getApplicationLog = (log: LogEntry[], redactSensitiveData = false) 
         };
     });
 
-export const getApplicationInfo = (state: AppState, hideSensitiveInfo: boolean) => ({
+const getEnvironmentInfo = async () => ({
     environment: getEnvironment(),
     suiteVersion: getSuiteVersion(),
     commitHash: getCommitHash(),
-    startTime,
     isDev: !isCodesignBuild(),
-    debugMenu: state.suite.settings.debug.showDebugMenu,
-    online: state.suite.online,
     browserName: getBrowserName(),
     browserVersion: getBrowserVersion(),
     osName: getOsName(),
-    osVersion: getDeprecatedOsVersion(),
+    osVersion: await getOsVersion(),
     windowWidth: getWindowWidth(),
     windowHeight: getWindowHeight(),
     screenWidth: getScreenWidth(),
     screenHeight: getScreenHeight(),
+});
+type EnvInfo = Awaited<ReturnType<typeof getEnvironmentInfo>>;
+
+const getApplicationInfo = (state: AppState, hideSensitiveInfo: boolean) => ({
+    startTime,
+    debugMenu: state.suite.settings.debug.showDebugMenu,
+    online: state.suite.online,
     earlyAccessProgram: state.desktopUpdate.allowPrerelease,
     language: state.suite.settings.language,
     autodetectLanguage: state.suite.settings.autodetect.language,
@@ -256,3 +263,21 @@ export const getApplicationInfo = (state: AppState, hideSensitiveInfo: boolean) 
         useEmptyPassphrase: hideSensitiveInfo ? REDACTED_REPLACEMENT : device.useEmptyPassphrase,
     })),
 });
+
+export const usePrintableLog = (hideSensitiveInfo: boolean) => {
+    const rawLogs = useSelector(selectLogs);
+    const actionLog = getApplicationLog(rawLogs, hideSensitiveInfo);
+
+    // redux warns that Selector is referentially unstable → should be memoized. We could use createMemoizedSelector,
+    // but it'd have state => state as input fn, so it'd rerender with every state change (we'd optimize nothing).
+    const appInfo = useSelector(state => getApplicationInfo(state, hideSensitiveInfo));
+
+    const [envInfo, setEnvInfo] = useState<EnvInfo | null>(null);
+    useEffect(() => {
+        (async () => setEnvInfo(await getEnvironmentInfo()))();
+    }, []);
+
+    if (envInfo === null) return null;
+
+    return prettifyLog([{ ...envInfo, ...appInfo }, actionLog]);
+};


### PR DESCRIPTION
## Description

Followup to https://github.com/trezor/trezor-suite/pull/18023:
use the new async `getOsVersion` in ApplicationLogModal.tsx

## Related Issue

Resolve #6877

## Screenshots:

![image](https://github.com/user-attachments/assets/29343003-54c1-4f80-935b-b03ec8764083)
