### PR TITLE
feat(suite): tx review modal for ethereumSignTransaction

### DIFF
--- a/packages/connect/src/api/ethereum/api/ethereumSignTransaction.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTransaction.ts
@@ -2,12 +2,14 @@
 
 import { MessagesSchema } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
+import { BigNumber } from '@trezor/utils';
 
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getEthereumNetwork } from '../../../data/coinInfo';
 import {
     EthereumNetworkInfoDefinitionValues,
     EthereumSignTransaction as EthereumSignTransactionSchema,
+    TokenInfo,
 } from '../../../types';
 import type { EthereumTransaction, EthereumTransactionEIP1559 } from '../../../types/api/ethereum';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';
@@ -116,6 +118,72 @@ export default class EthereumSignTransaction extends AbstractMethod<
 
     get info() {
         return getNetworkLabel('Sign #NETWORK transaction', this.params.network);
+    }
+
+    async payloadToPrecomposed() {
+        const feePerByte = new BigNumber(
+            this.payload.transaction.gasPrice || this.payload.transaction.maxFeePerGas!,
+        );
+        const fee = feePerByte.multipliedBy(this.payload.transaction.gasLimit);
+        const data = this.payload.transaction.data?.replace(/^0x/, '');
+        let recipient = this.payload.transaction.to!;
+        let amount = new BigNumber(this.payload.transaction.value);
+        let totalSpent = amount.plus(fee);
+        let token: TokenInfo | undefined;
+
+        // ERC-20 transfer
+        // TODO: consider refactoring to shared util package together with `suite-common/wallet-constants/src/sendForm.ts`
+        if (this.payload.transaction.to && data?.startsWith('a9059cbb') && amount.eq(0)) {
+            const definitions = await getEthereumDefinitions({
+                chainId: this.payload.transaction.chainId,
+                contractAddress: this.payload.transaction.to.replace(/^0x/, ''),
+            });
+            const decoded = decodeEthereumDefinition(definitions);
+            if (decoded.token) {
+                recipient = '0x' + data.slice(32, 72);
+                amount = new BigNumber(data.slice(72, 136), 16);
+                totalSpent = amount;
+                token = {
+                    ...decoded.token,
+                    type: 'ERC20',
+                    standard: 'ERC20',
+                    contract: decoded.token.address,
+                };
+            }
+        }
+
+        return {
+            type: 'final' as const,
+            inputs: [],
+            outputsPermutation: [0],
+            outputs: [
+                {
+                    address: recipient,
+                    amount: amount.toString(),
+                    script_type: 'PAYTOADDRESS' as const,
+                },
+            ],
+            totalSpent: totalSpent.toString(),
+            fee: fee.toString(),
+            feePerByte: feePerByte
+                .dividedBy(1e9) // wei to Gwei
+                .toString(),
+            maxFeePerGas: this.payload.transaction.maxFeePerGas
+                ? new BigNumber(this.payload.transaction.maxFeePerGas)
+                      .dividedBy(1e9) // wei to Gwei
+                      .toString()
+                : undefined,
+            maxPriorityFeePerGas: this.payload.transaction.maxPriorityFeePerGas
+                ? new BigNumber(this.payload.transaction.maxPriorityFeePerGas)
+                      .dividedBy(1e9) // wei to Gwei
+                      .toString()
+                : undefined,
+            feeLimit: new BigNumber(this.payload.transaction.gasLimit).toString(),
+            bytes: 0,
+            max: undefined,
+            isTokenKnown: !!token,
+            token,
+        };
     }
 
     async run() {

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -16,7 +16,13 @@ import {
     UiRequestConfirmation,
     createDeviceMessage,
 } from '../events';
-import type { ConnectSettings, DeviceState, FirmwareRange, StaticSessionId } from '../types';
+import type {
+    ConnectSettings,
+    DeviceState,
+    FirmwareRange,
+    PrecomposeResultFinal,
+    StaticSessionId,
+} from '../types';
 import { getHost } from '../utils/urlUtils';
 
 export type Payload<M> = Extract<CallMethodPayload, { method: M }> & { override?: boolean };
@@ -334,7 +340,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
 
     abstract init(): void;
 
-    getMethodInfo() {
+    async getMethodInfo() {
         return {
             useDevice: this.useDevice,
             useDeviceState: this.useDeviceState,
@@ -342,8 +348,14 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
             requiredPermissions: this.requiredPermissions,
             info: this.info,
             confirmation: this.confirmation,
+            precomposed: await this.payloadToPrecomposed(),
             // this could be used for more. it could tell clients what are min firmware versions (firmwareRange) and much more
         };
+    }
+
+    payloadToPrecomposed(): Promise<PrecomposeResultFinal | undefined> {
+        // Suite uses precomposed result for transaction review modals
+        return Promise.resolve(undefined);
     }
 
     checkDeviceCapability() {

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -497,7 +497,7 @@ const onCall = async (context: CoreContext, message: IFrameCallMessage) => {
     }
 
     if (method.payload.__info) {
-        const response = method.getMethodInfo();
+        const response = await method.getMethodInfo();
         sendCoreMessage(createResponseMessage(method.responseID, true, response));
 
         return Promise.resolve();

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+import { selectConnectPopupCall } from '@suite-common/connect-popup';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { NetworkSymbol, NetworkType } from '@suite-common/wallet-config';
 import {
@@ -129,6 +130,7 @@ export const TransactionReviewModalContent = ({
     const accounts = useSelector(selectAccounts);
     const device = useSelector(selectSelectedDevice);
     const isActionAbortable = useSelector(selectIsActionAbortable);
+    const connectPopupCall = useSelector(selectConnectPopupCall);
     const [isSending, setIsSending] = useState(false);
     const [areDetailsVisible, setAreDetailsVisible] = useState(false);
     const deviceModelInternal = device?.features?.internal_model;
@@ -345,6 +347,10 @@ export const TransactionReviewModalContent = ({
         }
 
         if (areDetailsVisible) {
+            return null;
+        }
+
+        if (connectPopupCall?.state === 'ongoing') {
             return null;
         }
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -1,3 +1,4 @@
+import { selectConnectPopupCall } from '@suite-common/connect-popup';
 import { formatDurationStrict } from '@suite-common/suite-utils';
 import { NetworkType, networks } from '@suite-common/wallet-config';
 import { FeeInfo, GeneralPrecomposedTransactionFinal, StakeType } from '@suite-common/wallet-types';
@@ -53,6 +54,7 @@ export const TransactionReviewSummary = ({
     const network = networks[symbol];
     const fee = getFee(account.networkType, tx);
     const estimateTime = getEstimatedTime(networkType, fees[account.symbol], tx);
+    const connectPopupCall = useSelector(selectConnectPopupCall);
 
     const formFeeRate = drafts[currentAccountKey]?.feePerUnit;
     const isFeeCustom = drafts[currentAccountKey]?.selectedFee === 'custom';
@@ -65,7 +67,7 @@ export const TransactionReviewSummary = ({
             <Row gap={spacings.xxs}>
                 <CoinLogo size={14} symbol={symbol} />
                 <AccountLabel
-                    accountLabel={accountLabel}
+                    accountLabel={accountLabel || account.accountLabel}
                     accountType={accountType}
                     symbol={symbol}
                     index={index}
@@ -108,12 +110,23 @@ export const TransactionReviewSummary = ({
                 <Translation id="TR_FEE_RATE_CHANGED" />
             )}
 
-            {!stakeType && !broadcast && (
+            {!stakeType && !broadcast && connectPopupCall?.state !== 'ongoing' && (
                 <Note iconName="broadcast">
                     <Translation id="BROADCAST" />
                     {': '}
                     <Text variant="destructive">
                         <Translation id="TR_OFF" />
+                    </Text>
+                </Note>
+            )}
+
+            {connectPopupCall?.state === 'ongoing' && (
+                <Note iconName="plug">
+                    <Translation id="TR_CONNECTED_TO" />
+                    {': '}
+                    <Text variant="primary">
+                        {connectPopupCall.source?.manifest?.appName ||
+                            connectPopupCall.source?.origin}
                     </Text>
                 </Note>
             )}

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -44,10 +44,11 @@ const buttonRequest =
             const {
                 wallet: {
                     selectedAccount: { account },
+                    connectPopup: { activeCall },
                 },
                 router: { route },
             } = api.getState();
-            if (
+            const isInSuite =
                 ['cardano', 'ethereum'].includes(account?.networkType || '') &&
                 [
                     'wallet-send',
@@ -55,8 +56,11 @@ const buttonRequest =
                     'wallet-index',
                     'wallet-trading-exchange-confirm',
                     'wallet-trading-sell-confirm',
-                ].includes(route?.name || '')
-            ) {
+                ].includes(route?.name || '');
+            const isInConnectCall =
+                activeCall?.state === 'ongoing' &&
+                ['cardanoSignTransaction', 'ethereumSignTransaction'].includes(activeCall.method);
+            if (isInSuite || isInConnectCall) {
                 api.dispatch({
                     ...action,
                     payload: { ...action.payload, code: 'ButtonRequest_SignTx' },

--- a/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
+++ b/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
@@ -1,3 +1,4 @@
+import { ConnectPopupState } from '@suite-common/connect-popup';
 import { TradingState as TradingNewState } from '@suite-common/trading';
 import { AccountsRootState, accountsActions, selectAccountByKey } from '@suite-common/wallet-core';
 import type { SelectedAccountStatus } from '@suite-common/wallet-types';
@@ -17,6 +18,7 @@ export type SelectedAccountRootStateWithTrading = SelectedAccountRootState & {
     wallet: {
         trading: TradingState;
         tradingNew: TradingNewState;
+        connectPopup: ConnectPopupState;
     };
 };
 
@@ -66,6 +68,11 @@ export const selectAccountIncludingChosenInTrading = (
 
     if (modalAccountKeyNew) {
         return selectAccountByKey(state, modalAccountKeyNew) ?? undefined;
+    }
+
+    const { activeCall } = state.wallet.connectPopup;
+    if (activeCall?.state === 'ongoing') {
+        return selectAccountByKey(state, activeCall.selectedAccountKey) ?? undefined;
     }
 
     const selectedAccount = selectSelectedAccount(state);

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9872,4 +9872,8 @@ export default defineMessages({
         id: 'TR_VERIFYING',
         defaultMessage: 'Verifying',
     },
+    TR_CONNECTED_TO: {
+        id: 'TR_CONNECTED_TO',
+        defaultMessage: 'Connected to',
+    },
 });

--- a/suite-common/connect-popup/src/connectPopupActions.ts
+++ b/suite-common/connect-popup/src/connectPopupActions.ts
@@ -37,6 +37,13 @@ const confirmAddresses = createAction(
     }),
 );
 
+const setSelectedAccountKey = createAction(
+    `${ACTION_PREFIX}/setSelectedAccountKey`,
+    (payload: Pick<ConnectPopupCall & { state: 'ongoing' }, 'selectedAccountKey'>) => ({
+        payload,
+    }),
+);
+
 const deeplinkCallback = createAction(
     `${ACTION_PREFIX}/deeplinkCallback`,
     (payload: Pick<ConnectPopupCall & { state: 'deeplink-callback' }, 'callbackUrl'>) => ({
@@ -69,6 +76,7 @@ export const connectPopupActions = {
     rejectPermissions,
     finishCall,
     confirmAddresses,
+    setSelectedAccountKey,
     deeplinkCallback,
     setError,
     rememberAppPermissions,

--- a/suite-common/connect-popup/src/connectPopupReducer.ts
+++ b/suite-common/connect-popup/src/connectPopupReducer.ts
@@ -58,6 +58,7 @@ export const prepareConnectPopupReducer = createReducerWithExtraDeps(
                     state.activeCall.permissionDecision?.resolve();
                     state.activeCall = {
                         ...state.activeCall,
+                        permissionDecision: undefined,
                         state: 'ongoing',
                     };
                 }
@@ -67,6 +68,7 @@ export const prepareConnectPopupReducer = createReducerWithExtraDeps(
                     state.activeCall.permissionDecision?.reject(payload);
                     state.activeCall = {
                         ...state.activeCall,
+                        permissionDecision: undefined,
                         state: 'finished',
                     };
                 }
@@ -80,6 +82,14 @@ export const prepareConnectPopupReducer = createReducerWithExtraDeps(
                         ...state.activeCall,
                         state: 'address-confirmation',
                         addresses: payload.addresses,
+                    };
+                }
+            })
+            .addCase(connectPopupActions.setSelectedAccountKey, (state, { payload }) => {
+                if (state.activeCall?.state === 'ongoing') {
+                    state.activeCall = {
+                        ...state.activeCall,
+                        ...payload,
                     };
                 }
             })

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -2,6 +2,7 @@ import { AsyncThunkAction } from '@reduxjs/toolkit';
 
 import { CustomThunkAPI, createThunk } from '@suite-common/redux-utils';
 import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
+import { PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import TrezorConnect, { CallMethodParams, CallMethodResponse } from '@trezor/connect';
 import { TypedError, serializeError } from '@trezor/connect/src/constants/errors';
 import { MethodPermission } from '@trezor/connect/src/core/AbstractMethod';
@@ -91,8 +92,16 @@ export const connectPopupCallThunkInner = createThunk<
                 throw TypedError('Device_NotFound');
             }
 
+            const txSigningPrecomposed: PrecomposedTransactionFinal | undefined =
+                methodInfo.payload.precomposed;
             const originalPayload = { ...payload };
-            await preCallHooks({ method, payload, dispatch, getState });
+            await preCallHooks({
+                method,
+                payload,
+                dispatch,
+                getState,
+                txSigningPrecomposed,
+            });
 
             // @ts-expect-error: method is dynamic
             const response = await TrezorConnect[method]({

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -43,9 +43,12 @@ export type ConnectPopupCallLoaded = {
 } & (
     | {
           state: 'ongoing';
+          permissionDecision?: undefined;
+          selectedAccountKey?: string;
       }
     | {
           state: 'finished';
+          permissionDecision?: undefined;
       }
     | {
           state: 'permission-request';

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -1,0 +1,118 @@
+import { Bip43Path, getNetworkByEvmChainId } from '@suite-common/wallet-config';
+import {
+    accountsActions,
+    selectAccountForNetworkSymbolAndPath,
+    sendFormActions,
+} from '@suite-common/wallet-core';
+import { Account } from '@suite-common/wallet-types';
+import TrezorConnect from '@trezor/connect';
+import type { EthereumSignTransaction } from '@trezor/connect';
+import { getSerializedPath, validatePath } from '@trezor/connect/src/utils/pathUtils';
+
+import { connectPopupActions } from '../connectPopupActions';
+
+import { PostCallHookParams, PreCallHookParams } from './index';
+
+const temporaryAccounts: Account[] = [];
+
+const preCallHook = async <M extends keyof typeof TrezorConnect>({
+    method,
+    payload,
+    getState,
+    dispatch,
+    txSigningPrecomposed,
+}: PreCallHookParams<M>) => {
+    try {
+        if (method === 'ethereumSignTransaction' && txSigningPrecomposed) {
+            const typedPayload = payload as any as EthereumSignTransaction;
+            const path = getSerializedPath(validatePath(typedPayload.path)) as Bip43Path;
+            const network = getNetworkByEvmChainId(typedPayload.transaction.chainId || 1) || {
+                // Placeholder for chains not supported in Suite
+                networkType: 'ethereum',
+                symbol: 'eth',
+                name: 'Chain ID: ' + typedPayload.transaction.chainId,
+                isHidden: true,
+            };
+            // Try to find matching account
+            let selectedAccount = !network.isHidden
+                ? selectAccountForNetworkSymbolAndPath(getState(), network.symbol, path)
+                : null;
+            if (!selectedAccount) {
+                // Create a new placeholder account
+                const createdAccount = await dispatch(
+                    accountsActions.createAccount({
+                        // Real device state not needed, this is also better to differentiate from real accounts
+                        deviceState: 'placeholder@connect:0',
+                        discoveryItem: {
+                            index: 0,
+                            path,
+                            accountType: 'imported',
+                            networkType: network.networkType,
+                            coin: network.symbol,
+                        },
+                        accountInfo: {
+                            path,
+                            descriptor: '',
+                            balance: '',
+                            availableBalance: '',
+                            empty: false,
+                            history: { total: 0, unconfirmed: 0 },
+                        },
+                        imported: true,
+                        visible: false,
+                        accountLabel: network.name,
+                    }),
+                );
+                temporaryAccounts.push(createdAccount.payload);
+                selectedAccount = createdAccount.payload;
+            }
+            if (!selectedAccount) {
+                throw new Error('Selected account is missing'); // Should not happen
+            }
+            dispatch(
+                connectPopupActions.setSelectedAccountKey({
+                    selectedAccountKey: selectedAccount.key,
+                }),
+            );
+            dispatch(
+                sendFormActions.storePrecomposedTransaction({
+                    formState: {
+                        // Can be left empty, not used in tx review modal
+                        outputs: [],
+                        feeLimit: '',
+                        feePerUnit: '',
+                        selectedUtxos: [],
+                        isCoinControlEnabled: false,
+                        hasCoinControlBeenOpened: false,
+                        options: ['ethereumNonce', 'ethereumData'],
+                        selectedFee: 'custom',
+                        ethereumDataAscii: '',
+                        ethereumDataHex: typedPayload.transaction.data?.replace(/^0x/, ''),
+                        ethereumNonce: typedPayload.transaction.nonce,
+                    },
+                    precomposedTransaction: txSigningPrecomposed,
+                }),
+            );
+        }
+    } catch (error) {
+        // If an error occurs it's not a problem, we just fall back to generic UI
+        console.error(`Error in Connect Popup ${method} hook:`, error);
+    }
+};
+
+export function postCallHook<M extends keyof typeof TrezorConnect>({
+    dispatch,
+}: PostCallHookParams<M>) {
+    if (temporaryAccounts.length) {
+        // Remove temporary accounts
+        dispatch(accountsActions.removeAccount(temporaryAccounts));
+        temporaryAccounts.length = 0;
+    }
+
+    return false;
+}
+
+export const ethereumSignTransaction = {
+    preCallHook,
+    postCallHook,
+};

--- a/suite-common/connect-popup/src/methodHooks/index.ts
+++ b/suite-common/connect-popup/src/methodHooks/index.ts
@@ -1,5 +1,6 @@
 import { Dispatch } from '@reduxjs/toolkit/react';
 
+import { PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import {
     CallMethodParams,
     CallMethodResponse,
@@ -9,12 +10,14 @@ import {
 } from '@trezor/connect';
 
 import { addressConfirmationModalHooks } from './addressConfirmation';
+import { ethereumSignTransaction } from './ethereumSignTransaction';
 
 export type PreCallHookParams<M extends keyof TrezorConnect> = {
     method: M;
     payload: Omit<CallMethodParams<M>, 'method'>;
     dispatch: Dispatch;
     getState: () => any;
+    txSigningPrecomposed?: PrecomposedTransactionFinal;
 };
 export type PostCallHookParams<M extends keyof TrezorConnect> = PreCallHookParams<M> & {
     originalPayload: Omit<CallMethodParams<M>, 'method'>;
@@ -23,8 +26,14 @@ export type PostCallHookParams<M extends keyof TrezorConnect> = PreCallHookParam
 
 export const preCallHooks = async <M extends keyof TrezorConnect>(params: PreCallHookParams<M>) => {
     await addressConfirmationModalHooks.preCallHook(params);
+    await ethereumSignTransaction.preCallHook(params);
 };
 
 export async function postCallHooks<M extends keyof TrezorConnect>(params: PostCallHookParams<M>) {
-    return await addressConfirmationModalHooks.postCallHook(params);
+    const hooks = [
+        await ethereumSignTransaction.postCallHook(params),
+        await addressConfirmationModalHooks.postCallHook(params),
+    ];
+
+    return hooks.some(Boolean);
 }

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -104,6 +104,9 @@ export const getNetworkByCoingeckoId = (coingeckoId: string) =>
 export const getNetworkByTradeCryptoId = (coingeckoId: string) =>
     networksCollection.find(n => n.tradeCryptoId === coingeckoId);
 
+export const getNetworkByEvmChainId = (chainId: number) =>
+    networksCollection.find(n => n.chainId === chainId);
+
 export const getNetworkDisplaySymbol = (symbol: NetworkSymbol) => getNetwork(symbol).displaySymbol;
 
 export const getDisplaySymbol = (coinSymbol: string, contractAddress?: string | null) => {

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -6,7 +6,12 @@ import {
     createWeakMapSelector,
     returnStableArrayIfEmpty,
 } from '@suite-common/redux-utils';
-import { type AccountType, type NetworkSymbol, networks } from '@suite-common/wallet-config';
+import {
+    type AccountType,
+    type Bip43Path,
+    type NetworkSymbol,
+    networks,
+} from '@suite-common/wallet-config';
 import { Account, AccountKey } from '@suite-common/wallet-types';
 import { enhanceHistory, isTestnet, isUtxoBased } from '@suite-common/wallet-utils';
 import { DeviceState, StaticSessionId } from '@trezor/connect';
@@ -366,6 +371,16 @@ export const selectFirstNormalAccountForNetworkSymbol = createMemoizedSelector(
             selectDeviceAccountsForNetworkSymbolAndAccountType(state, symbol, 'normal'),
     ],
     accounts => accounts.find(account => account.index === 0) ?? null,
+);
+
+export const selectAccountForNetworkSymbolAndPath = createMemoizedSelector(
+    [
+        selectAccounts,
+        (_state: AccountsRootState, networkSymbol: NetworkSymbol) => networkSymbol,
+        (_state: AccountsRootState, _networkSymbol: NetworkSymbol, path: Bip43Path) => path,
+    ],
+    (accounts, networkSymbol, path) =>
+        accounts.find(account => path === account.path && networkSymbol === account.symbol) ?? null,
 );
 
 export const selectAccountLabel = createMemoizedSelector(


### PR DESCRIPTION
## Description

Initializes TransactionReviewModal when calling ethereumSignTransaction through desktop Connect.
This is done by adapting the payload to send form precompose state.

## Screenshots:

<img width="674" alt="Screenshot 2025-04-04 at 16 10 55" src="https://github.com/user-attachments/assets/5fcce054-32d0-4941-9e19-8d0d5d92e489" />
