### PR TITLE
Default fees used fix - #18159 alternative

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
@@ -44,9 +44,7 @@ test.describe('Trading - Sell BTC', { tag: ['@group=other', '@webOnly'] }, () =>
         },
     );
 
-    //TODO: Enable once #18062 is fixed
-    // Bug: Incorrect fee calculation in Sell form and Bump fee form
-    test.skip('Sell Bitcoin for best offer', async ({ page, tradingPage, devicePrompt }) => {
+    test('Sell Bitcoin for best offer', async ({ page, tradingPage, devicePrompt }) => {
         await test.step('Fill in a sell request', async () => {
             await tradingPage.fillSellForm(cryptoAmount);
             await expect(tradingPage.bestOfferAmount).toHaveText(fiatAmount);

--- a/packages/suite/src/hooks/wallet/form/useCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useCompose.ts
@@ -64,7 +64,9 @@ export const useCompose = <TFieldValues extends FormState>({
     // update composeRequestID
     const composeRequest = useCallback(
         async (field = defaultFieldRef.current) => {
-            if (!state) return;
+            // skip compose for cached older fee (edge case for trading)
+            if (!state || prevFeeInfoRef.current.blockHeight > state.feeInfo.blockHeight) return;
+
             // reset precomposed transactions
             setComposedLevels(undefined);
             // set ref for later use in useEffect


### PR DESCRIPTION
Alternative of https://github.com/trezor/trezor-suite/issues/18159

- for some reason, default older fees appear in compose state, skip compose in case it tries to compose tx with old fees
- this can cause some troubles in case suite reconnects to different backend which is stuck on older block. However, it is total edge case which would fix by entering form again and it should not happen as we do not refetch fees for now

resolve #18143
