### PR TITLE
fix: add ModalSwitcher into WelcomeLayout

### DIFF
--- a/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx
@@ -1,109 +1,12 @@
-import { ReactNode } from 'react';
-
-import styled from 'styled-components';
-
-import { selectBannerMessage } from '@suite-common/message-system';
 import {
-    Column,
-    ElevationDown,
-    ElevationUp,
-    NewModal,
-    Row,
-    useElevation,
-    variables,
-} from '@trezor/components';
-import { Elevation, spacings, spacingsPx } from '@trezor/theme';
+    WelcomeLayoutWithoutModalSwitcher,
+    WelcomeLayoutWithoutModalSwitcherProps,
+} from './WelcomeLayoutWithoutModalSwitcher';
+import { ModalSwitcher } from '../../modals/ModalSwitcher/ModalSwitcher';
 
-import { GuideButton, GuideRouter } from 'src/components/guide';
-// importing directly, otherwise unit tests fail, seems to be a styled-components issue
-import { MessageSystemBanner } from 'src/components/suite/banners';
-import { MAX_ONBOARDING_WIDTH } from 'src/constants/suite/layout';
-import { useSelector } from 'src/hooks/suite';
-
-import { LoggedOutSidebar } from '../LoggedOutSidebar';
-import { DebugLegend } from '../SuiteLayout/DebugLegend';
-
-const Content = styled.div<{ $elevation: Elevation }>`
-    display: flex;
-    flex-direction: column;
-    flex: 3;
-    padding: ${spacingsPx.lg};
-    align-items: center;
-    overflow-y: auto;
-    height: 100%;
-
-    @media (max-width: ${variables.SCREEN_SIZE.SM}) {
-        padding: ${spacingsPx.sm};
-    }
-`;
-
-const ChildrenWrapper = styled.div`
-    display: flex;
-    flex: 1;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    max-width: ${MAX_ONBOARDING_WIDTH}px;
-`;
-
-interface WelcomeLayoutProps {
-    children: ReactNode;
-}
-
-const Right = ({ bannerSlot, children }: { bannerSlot?: ReactNode; children: ReactNode }) => {
-    const { elevation } = useElevation();
-
-    return (
-        <Content $elevation={elevation}>
-            {bannerSlot ?? null}
-            <ChildrenWrapper>
-                <ElevationUp>{children}</ElevationUp>
-            </ChildrenWrapper>
-        </Content>
-    );
-};
-
-// WelcomeLayout is a top-level wrapper similar to @suite-components/SuiteLayout
-// used in Preloader and Onboarding
-export const WelcomeLayout = ({ children }: WelcomeLayoutProps) => {
-    const bannerMessage = useSelector(selectBannerMessage);
-    const theme = useSelector(state => state.suite.settings.theme);
-
-    return (
-        <ElevationDown>
-            <Column height="100%" width="100%">
-                <Row
-                    height="100%"
-                    width="100%"
-                    data-testid="@welcome-layout/body"
-                    alignItems="normal"
-                >
-                    <NewModal.Provider>
-                        <ElevationDown>
-                            <LoggedOutSidebar />
-                        </ElevationDown>
-
-                        <Right
-                            bannerSlot={
-                                bannerMessage && (
-                                    <MessageSystemBanner
-                                        message={bannerMessage}
-                                        margin={spacings.xs}
-                                        width="100%"
-                                    />
-                                )
-                            }
-                        >
-                            {children}
-                        </Right>
-
-                        <GuideButton />
-                        <GuideRouter />
-                    </NewModal.Provider>
-                </Row>
-            </Column>
-            {theme.variant === 'debug' && <DebugLegend />}
-        </ElevationDown>
-    );
-};
+export const WelcomeLayout = ({ children, ...rest }: WelcomeLayoutWithoutModalSwitcherProps) => (
+    <WelcomeLayoutWithoutModalSwitcher {...rest}>
+        <ModalSwitcher />
+        {children}
+    </WelcomeLayoutWithoutModalSwitcher>
+);

--- a/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayoutWithoutModalSwitcher.tsx
+++ b/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayoutWithoutModalSwitcher.tsx
@@ -1,0 +1,111 @@
+import { ReactNode } from 'react';
+
+import styled from 'styled-components';
+
+import { selectBannerMessage } from '@suite-common/message-system';
+import {
+    Column,
+    ElevationDown,
+    ElevationUp,
+    NewModal,
+    Row,
+    useElevation,
+    variables,
+} from '@trezor/components';
+import { Elevation, spacings, spacingsPx } from '@trezor/theme';
+
+import { GuideButton, GuideRouter } from 'src/components/guide';
+// importing directly, otherwise unit tests fail, seems to be a styled-components issue
+import { MessageSystemBanner } from 'src/components/suite/banners';
+import { MAX_ONBOARDING_WIDTH } from 'src/constants/suite/layout';
+import { useSelector } from 'src/hooks/suite';
+
+import { LoggedOutSidebar } from '../LoggedOutSidebar';
+import { DebugLegend } from '../SuiteLayout/DebugLegend';
+
+const Content = styled.div<{ $elevation: Elevation }>`
+    display: flex;
+    flex-direction: column;
+    flex: 3;
+    padding: ${spacingsPx.lg};
+    align-items: center;
+    overflow-y: auto;
+    height: 100%;
+
+    @media (max-width: ${variables.SCREEN_SIZE.SM}) {
+        padding: ${spacingsPx.sm};
+    }
+`;
+
+const ChildrenWrapper = styled.div`
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    max-width: ${MAX_ONBOARDING_WIDTH}px;
+`;
+
+export type WelcomeLayoutWithoutModalSwitcherProps = {
+    children: ReactNode;
+};
+
+const Right = ({ bannerSlot, children }: { bannerSlot?: ReactNode; children: ReactNode }) => {
+    const { elevation } = useElevation();
+
+    return (
+        <Content $elevation={elevation}>
+            {bannerSlot ?? null}
+            <ChildrenWrapper>
+                <ElevationUp>{children}</ElevationUp>
+            </ChildrenWrapper>
+        </Content>
+    );
+};
+
+// WelcomeLayout is a top-level wrapper similar to @suite-components/SuiteLayout
+// used in Preloader and Onboarding
+export const WelcomeLayoutWithoutModalSwitcher = ({
+    children,
+}: WelcomeLayoutWithoutModalSwitcherProps) => {
+    const bannerMessage = useSelector(selectBannerMessage);
+    const theme = useSelector(state => state.suite.settings.theme);
+
+    return (
+        <ElevationDown>
+            <Column height="100%" width="100%">
+                <Row
+                    height="100%"
+                    width="100%"
+                    data-testid="@welcome-layout/body"
+                    alignItems="normal"
+                >
+                    <NewModal.Provider>
+                        <ElevationDown>
+                            <LoggedOutSidebar />
+                        </ElevationDown>
+
+                        <Right
+                            bannerSlot={
+                                bannerMessage && (
+                                    <MessageSystemBanner
+                                        message={bannerMessage}
+                                        margin={spacings.xs}
+                                        width="100%"
+                                    />
+                                )
+                            }
+                        >
+                            {children}
+                        </Right>
+
+                        <GuideButton />
+                        <GuideRouter />
+                    </NewModal.Provider>
+                </Row>
+            </Column>
+            {theme.variant === 'debug' && <DebugLegend />}
+        </ElevationDown>
+    );
+};

--- a/packages/suite/src/views/start/SuiteStart.tsx
+++ b/packages/suite/src/views/start/SuiteStart.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { StartContent } from './StartContent';
-import { WelcomeLayout } from '../../components/suite/layouts/WelcomeLayout/WelcomeLayout';
+import { WelcomeLayoutWithoutModalSwitcher } from '../../components/suite/layouts/WelcomeLayout/WelcomeLayoutWithoutModalSwitcher';
 
 const Content = styled.div`
     display: flex;
@@ -11,9 +11,16 @@ const Content = styled.div`
 `;
 
 export const SuiteStart = () => (
-    <WelcomeLayout>
+    /**
+     * In onboarding we have custom confirm dialogs that rely on the fact,
+     * that we do not have the ModalProvider in layout, and therefore it is
+     * handled in a custom way in the onboarding.
+     *
+     * Go to `OnboardingStepBox` search for `ConfirmOnDevice`.
+     */
+    <WelcomeLayoutWithoutModalSwitcher>
         <Content data-testid="@onboarding/welcome">
             <StartContent />
         </Content>
-    </WelcomeLayout>
+    </WelcomeLayoutWithoutModalSwitcher>
 );


### PR DESCRIPTION
This is needed to display (UserContext/DeviceContext) modals on the Welcome screen