### PR TITLE
chore(suite-desktop): revert "bump electron-builder"

### DIFF
--- a/packages/connect-examples/electron-main-process/package.json
+++ b/packages/connect-examples/electron-main-process/package.json
@@ -57,6 +57,6 @@
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
         "electron": "35.1.2",
-        "electron-builder": "26.0.12"
+        "electron-builder": "26.0.3"
     }
 }

--- a/packages/connect-examples/electron-renderer-with-popup/package.json
+++ b/packages/connect-examples/electron-renderer-with-popup/package.json
@@ -54,6 +54,6 @@
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
         "electron": "35.1.2",
-        "electron-builder": "26.0.12"
+        "electron-builder": "26.0.3"
     }
 }

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -33,7 +33,7 @@
         "@electron/fuses": "^1.8.0",
         "@electron/notarize": "2.5.0",
         "electron": "35.1.2",
-        "electron-builder": "26.0.12",
+        "electron-builder": "26.0.3",
         "glob": "^10.3.10"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11927,7 +11927,7 @@ __metadata:
     "@electron/notarize": "npm:2.5.0"
     blake-hash: "npm:^2.0.0"
     electron: "npm:35.1.2"
-    electron-builder: "npm:26.0.12"
+    electron-builder: "npm:26.0.3"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:8.2.0"
     electron-updater: "npm:6.6.2"
@@ -15078,9 +15078,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"app-builder-lib@npm:26.0.12":
-  version: 26.0.12
-  resolution: "app-builder-lib@npm:26.0.12"
+"app-builder-lib@npm:26.0.3":
+  version: 26.0.3
+  resolution: "app-builder-lib@npm:26.0.3"
   dependencies:
     "@develar/schema-utils": "npm:~2.6.5"
     "@electron/asar": "npm:3.2.18"
@@ -15092,7 +15092,7 @@ __metadata:
     "@malept/flatpak-bundler": "npm:^0.4.0"
     "@types/fs-extra": "npm:9.0.13"
     async-exit-hook: "npm:^2.0.1"
-    builder-util: "npm:26.0.11"
+    builder-util: "npm:26.0.1"
     builder-util-runtime: "npm:9.3.1"
     chromium-pickle-js: "npm:^0.2.0"
     config-file-ts: "npm:0.2.8-rc1"
@@ -15100,7 +15100,7 @@ __metadata:
     dotenv: "npm:^16.4.5"
     dotenv-expand: "npm:^11.0.6"
     ejs: "npm:^3.1.8"
-    electron-publish: "npm:26.0.11"
+    electron-publish: "npm:26.0.1"
     fs-extra: "npm:^10.1.0"
     hosted-git-info: "npm:^4.1.0"
     is-ci: "npm:^3.0.0"
@@ -15109,16 +15109,15 @@ __metadata:
     json5: "npm:^2.2.3"
     lazy-val: "npm:^1.0.5"
     minimatch: "npm:^10.0.0"
-    plist: "npm:3.1.0"
     resedit: "npm:^1.7.0"
     semver: "npm:^7.3.8"
     tar: "npm:^6.1.12"
     temp-file: "npm:^3.4.0"
     tiny-async-pool: "npm:1.3.0"
   peerDependencies:
-    dmg-builder: 26.0.12
-    electron-builder-squirrel-windows: 26.0.12
-  checksum: 10/b95a54bb2a4192b6ca7fdc29fccf97a86a68640b9b65b5d5e8a48b91f45221b9ffc35303e03c4a98f97da96d7d80a23f253319d39aebb0dd31b8cecf8ac8153f
+    dmg-builder: 26.0.3
+    electron-builder-squirrel-windows: 26.0.3
+  checksum: 10/6c46e655856747e6125f533407b0c0a3a6dad87a8fdb6865da721dc02fd9f80bd1bfba7f82429b1acf75192299c0578494fad13aa056db8b2814cb003c437f13
   languageName: node
   linkType: hard
 
@@ -16607,9 +16606,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"builder-util@npm:26.0.11":
-  version: 26.0.11
-  resolution: "builder-util@npm:26.0.11"
+"builder-util@npm:26.0.1":
+  version: 26.0.1
+  resolution: "builder-util@npm:26.0.1"
   dependencies:
     7zip-bin: "npm:~5.2.0"
     "@types/debug": "npm:^4.1.6"
@@ -16628,7 +16627,7 @@ __metadata:
     stat-mode: "npm:^1.0.0"
     temp-file: "npm:^3.4.0"
     tiny-async-pool: "npm:1.3.0"
-  checksum: 10/30b3174dd9f3000bc1237f09d49dd92022ebb76867ea2aa9a393de379aed8e1f0092f87bed96dc6df8826fb30827fd3af562b822694dfbd2def341d19d049565
+  checksum: 10/c967ecea34e35a41af5dce9fa3125ff25452f201d9a90ae9a7981212890dbd4b5e578b9d56269f9e4fcc12b7d49efea12551e66a82f583cf2a768295fb71c5d5
   languageName: node
   linkType: hard
 
@@ -17935,7 +17934,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/eslint": "workspace:*"
     electron: "npm:35.1.2"
-    electron-builder: "npm:26.0.12"
+    electron-builder: "npm:26.0.3"
   languageName: unknown
   linkType: soft
 
@@ -17945,7 +17944,7 @@ __metadata:
   dependencies:
     "@trezor/eslint": "workspace:*"
     electron: "npm:35.1.2"
-    electron-builder: "npm:26.0.12"
+    electron-builder: "npm:26.0.3"
   languageName: unknown
   linkType: soft
 
@@ -19903,12 +19902,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dmg-builder@npm:26.0.12":
-  version: 26.0.12
-  resolution: "dmg-builder@npm:26.0.12"
+"dmg-builder@npm:26.0.3":
+  version: 26.0.3
+  resolution: "dmg-builder@npm:26.0.3"
   dependencies:
-    app-builder-lib: "npm:26.0.12"
-    builder-util: "npm:26.0.11"
+    app-builder-lib: "npm:26.0.3"
+    builder-util: "npm:26.0.1"
     builder-util-runtime: "npm:9.3.1"
     dmg-license: "npm:^1.0.11"
     fs-extra: "npm:^10.1.0"
@@ -19917,7 +19916,7 @@ __metadata:
   dependenciesMeta:
     dmg-license:
       optional: true
-  checksum: 10/b03461a30c02b3340a67e8f749a5baade9a77c942fbdf15ea1a8ee5a0245a0b79c1dc2cd7d3b1fffafdc100639d3b04e2f62ef2b0437af134ceb25f07bfb566c
+  checksum: 10/4a1de6207bc8a20c9d540bb38e5cadcc94ff05b542c09a86a9eb652b815effc2deaa2159570ae7ecb7e3aac0d5c0cdca8aa39e53d7716affc340be3f9b172a4f
   languageName: node
   linkType: hard
 
@@ -20278,15 +20277,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-builder@npm:26.0.12":
-  version: 26.0.12
-  resolution: "electron-builder@npm:26.0.12"
+"electron-builder@npm:26.0.3":
+  version: 26.0.3
+  resolution: "electron-builder@npm:26.0.3"
   dependencies:
-    app-builder-lib: "npm:26.0.12"
-    builder-util: "npm:26.0.11"
+    app-builder-lib: "npm:26.0.3"
+    builder-util: "npm:26.0.1"
     builder-util-runtime: "npm:9.3.1"
     chalk: "npm:^4.1.2"
-    dmg-builder: "npm:26.0.12"
+    dmg-builder: "npm:26.0.3"
     fs-extra: "npm:^10.1.0"
     is-ci: "npm:^3.0.0"
     lazy-val: "npm:^1.0.5"
@@ -20295,7 +20294,7 @@ __metadata:
   bin:
     electron-builder: cli.js
     install-app-deps: install-app-deps.js
-  checksum: 10/c7f16d2a04b65b2507921fad61597023ff9eb0c6dbb25d5c49d54de4925e67d4b9e3ddec70a86966df9830f0051cbde4449ae0f32fea265807ffdeaca162d78c
+  checksum: 10/2a98fb70fcf8198fdf5cf3b6059696a473f34d6032c703cf02396a29e26df8c06f074d88d4219acd310855327eb00561e508a80f68f6f4212f3229cbad8ac4de
   languageName: node
   linkType: hard
 
@@ -20318,19 +20317,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-publish@npm:26.0.11":
-  version: 26.0.11
-  resolution: "electron-publish@npm:26.0.11"
+"electron-publish@npm:26.0.1":
+  version: 26.0.1
+  resolution: "electron-publish@npm:26.0.1"
   dependencies:
     "@types/fs-extra": "npm:^9.0.11"
-    builder-util: "npm:26.0.11"
+    builder-util: "npm:26.0.1"
     builder-util-runtime: "npm:9.3.1"
     chalk: "npm:^4.1.2"
     form-data: "npm:^4.0.0"
     fs-extra: "npm:^10.1.0"
     lazy-val: "npm:^1.0.5"
     mime: "npm:^2.5.2"
-  checksum: 10/8eb1dfdb8fca2bcef297ac9ffa77e273d0d8e6c59f253549444bf0105b9232cc4a25b633320212edbbe27e04585dccbb2d4675d98d2e8af9a44cb9b6b09b9419
+  checksum: 10/0310ee1af8807bb58dbd8d02312c7a8d82d22a2b771b978c67104ba8c79ae7acf7c7980a6ac9ebb9add470d2905e342a7f42f56660a6950bcd66d3a75e9ce7e6
   languageName: node
   linkType: hard
 
@@ -33246,7 +33245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"plist@npm:3.1.0, plist@npm:^3.0.4, plist@npm:^3.0.5, plist@npm:^3.1.0":
+"plist@npm:^3.0.4, plist@npm:^3.0.5, plist@npm:^3.1.0":
   version: 3.1.0
   resolution: "plist@npm:3.1.0"
   dependencies:


### PR DESCRIPTION
## Description

After the last Electron-builder update in #18087, Mac builds stopped working in CI/locally due to code-signing issues.

<img width="1135" alt="Screenshot 2025-04-07 at 13 12 31" src="https://github.com/user-attachments/assets/994c8d91-8238-4836-84a3-cea1e477bf0c" />
