### PR TITLE
fix(e2e): stabilize trading navigation and swap tokens

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/tradingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/tradingPage.ts
@@ -371,6 +371,7 @@ export class TradingPage {
     @step()
     async initiateSendConfirmation(options?: { confirmAlsoToken: boolean }) {
         await this.confirmOnTrezorAndSend.click();
+        await expect(this.modal).toBeVisible({ timeout: 30_000 });
         await expect(this.devicePrompt.sendButton).toBeDisabled();
         await this.devicePrompt.confirmOnDevicePromptIsShown();
         await TrezorUserEnvLinkProxy.pressYes();

--- a/packages/suite-desktop-core/e2e/tests/trading/navigation.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/navigation.test.ts
@@ -17,6 +17,7 @@ test.describe('Trading - Navigation', { tag: ['@group=other'] }, () => {
     test('Navigate to', async ({ page, dashboardPage, tradingPage, walletPage }) => {
         // BUY
         await test.step('Buy from dashboard asset card', async () => {
+            await dashboardPage.navigateTo();
             await page.getByTestId('@dashboard/asset/btc/buy-button').click();
             await tradingPage.verifyBuyFormOpened('BTC');
             await page.getByTestId(`@account-menu/filter-accounts`).click();


### PR DESCRIPTION
In trading there are two failing tests
- desktop swap navigation - discovery in some cases ended up in BTC account page instead of Dashboard. I will investigate why
- Swap tokens Send modal appears after 9s. We will investigate the performance problem and in meantime increase the timeout and improve verification.



