### PR TITLE
 Desktop ci build flag

### DIFF
--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -14,6 +14,11 @@ on:
   pull_request:
     types: [labeled]
   workflow_dispatch:
+    bluetooth:
+      description: "include bluetooth rust websocket server build"
+      required: false
+      type: boolean
+      default: false
 
 env:
   DESKTOP_APP_NAME: "Trezor-Suite"
@@ -59,7 +64,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          yarn workspace @trezor/suite-desktop build:${{ matrix.platform }}
+          BLUETOOTH=${{ github.event.inputs.bluetooth }} yarn workspace @trezor/suite-desktop build:${{ matrix.platform }}
           bash packages/suite-desktop-core/scripts/gnupg-sign.sh
           mv packages/suite-desktop/build-electron/* .
 


### PR DESCRIPTION
adding possibilty to set optional bluetooth flag which controls whether bluetooth server should be baked into suite-desktop build (#18126)


why it doesn't show here? https://github.com/trezor/trezor-suite/actions/workflows/build-desktop-apps.yml?query=event%3Aschedule+branch%3Adesktop-ci-build-flag 
does it need to be merged first into develop? 🤔 

<img width="1145" alt="image" src="https://github.com/user-attachments/assets/f65771bc-0f6c-4686-b205-329e2a768c55" />

cc @szymonlesisz 