### PR TITLE
feat(suite): select account modal

### DIFF
--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -40,6 +40,18 @@ export const onReceiveConfirmation = (confirmation: boolean) => (dispatch: Dispa
 
     dispatch(onCancel());
 };
+export const onReceiveAccount = (accountIndex: number | null) => (dispatch: Dispatch) => {
+    if (accountIndex === null) {
+        TrezorConnect.cancel();
+    } else {
+        TrezorConnect.uiResponse({
+            type: UI.RECEIVE_ACCOUNT,
+            payload: accountIndex,
+        });
+    }
+
+    dispatch(onCancel());
+};
 
 export const openModal = createAction(MODAL.OPEN_USER_CONTEXT, (payload: UserContextPayload) => ({
     payload,

--- a/packages/suite/src/components/suite/ConnectCallSource.tsx
+++ b/packages/suite/src/components/suite/ConnectCallSource.tsx
@@ -1,0 +1,21 @@
+import { selectConnectPopupCall } from '@suite-common/connect-popup';
+import { Note, Text } from '@trezor/components';
+
+import { useSelector } from 'src/hooks/suite';
+
+import { Translation } from './Translation';
+
+export const ConnectCallSource = () => {
+    const connectPopupCall = useSelector(selectConnectPopupCall);
+    if (connectPopupCall?.state !== 'ongoing') return null;
+
+    return (
+        <Note iconName="plug">
+            <Translation id="TR_CONNECTED_TO" />
+            {': '}
+            <Text variant="primary">
+                {connectPopupCall.source?.manifest?.appName || connectPopupCall.source?.origin}
+            </Text>
+        </Note>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/DeviceConfirmationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/DeviceConfirmationModal.tsx
@@ -1,13 +1,19 @@
+import { UI } from '@trezor/connect';
+
 import { MODAL } from 'src/actions/suite/constants';
 import { NoBackupModal } from 'src/components/suite/modals';
 
+import { SelectAccountModal } from './SelectAccountModal';
 import type { ReduxModalProps } from '../ReduxModal';
 
 /** Modals requested from `trezor-connect` */
 export const DeviceConfirmationModal = ({
     windowType,
+    data,
 }: ReduxModalProps<typeof MODAL.CONTEXT_DEVICE_CONFIRMATION>) => {
     switch (windowType) {
+        case UI.SELECT_ACCOUNT:
+            return data ? <SelectAccountModal data={data} /> : null;
         case 'no-backup':
             return <NoBackupModal />;
         default:

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectAccountModal.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState } from 'react';
+
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { selectAccounts } from '@suite-common/wallet-core';
+import {
+    Card,
+    Column,
+    Icon,
+    NewModal,
+    Row,
+    SkeletonCircle,
+    SkeletonRectangle,
+    SubTabs,
+    Table,
+} from '@trezor/components';
+import { UiRequestSelectAccount } from '@trezor/connect';
+import { CoinLogo } from '@trezor/product-components';
+import { NETWORK_ICONS } from '@trezor/product-components/src/components/CoinLogo/networks';
+import { spacings } from '@trezor/theme';
+
+import { onReceiveAccount } from 'src/actions/suite/modalActions';
+import { AccountLabel } from 'src/components/suite/AccountLabel';
+import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
+import { Translation } from 'src/components/suite/Translation';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
+
+interface SelectAccountModalProps {
+    data: UiRequestSelectAccount['payload'];
+}
+
+export const SelectAccountModal = ({ data }: SelectAccountModalProps) => {
+    const dispatch = useDispatch();
+    const suiteAccounts = useSelector(selectAccounts);
+    const suiteAccountLabels = useSelector(selectAccountLabels);
+
+    const [accounts, setAccounts] = useState(data.accounts);
+    const [accountTypes, setAccountTypes] = useState(data.accountTypes);
+    const [selectedAccountType, setSelectedAccountType] = useState(data.defaultAccountType);
+
+    const confirm = (accountIndex: number) => dispatch(onReceiveAccount(accountIndex));
+    const close = () => dispatch(onReceiveAccount(null));
+
+    useEffect(() => {
+        if (data.accountTypes) {
+            setAccountTypes(data.accountTypes);
+            if (data.defaultAccountType) {
+                setSelectedAccountType(data.defaultAccountType);
+            } else {
+                setSelectedAccountType(data.accountTypes[0]);
+            }
+        }
+        if (data.accounts) {
+            setAccounts(data.accounts);
+        }
+    }, [data.accountTypes, data.defaultAccountType, data.accounts]);
+    const typeLabels = {
+        p2wpkh: <Translation id="TR_NORMAL_ACCOUNTS" />,
+        p2tr: <Translation id="TR_TAPROOT_ACCOUNTS" />,
+        p2sh: <Translation id="TR_LEGACY_SEGWIT_ACCOUNTS" />,
+        p2pkh: <Translation id="TR_LEGACY_ACCOUNTS" />,
+    };
+    const filteredAccounts = accounts?.filter(account => account.type === selectedAccountType);
+
+    return (
+        <NewModal
+            onCancel={close}
+            variant="primary"
+            heading={
+                <Translation id="TR_SELECT_ACCOUNT" values={{ networkName: data.coinInfo.label }} />
+            }
+            description={
+                <>
+                    <ConnectCallSource />
+                </>
+            }
+        >
+            <Column gap={spacings.sm}>
+                <SubTabs activeItemId={selectedAccountType}>
+                    {accountTypes?.map((type, index) => (
+                        <SubTabs.Item
+                            key={index}
+                            id={type}
+                            onClick={() => {
+                                setSelectedAccountType(type);
+                            }}
+                        >
+                            {typeLabels[type]}
+                        </SubTabs.Item>
+                    ))}
+                </SubTabs>
+
+                <Card paddingType="none">
+                    <Table
+                        isRowHighlightedOnHover
+                        colWidths={[{ width: 'auto' }, { width: '200px' }, { width: '80px' }]}
+                    >
+                        <Table.Header>
+                            <Table.Row>
+                                <Table.Cell>
+                                    <Translation id="TR_ACCOUNT" />
+                                </Table.Cell>
+                                <Table.Cell>
+                                    <Translation id="TR_BALANCE" />
+                                </Table.Cell>
+                                <Table.Cell></Table.Cell>
+                            </Table.Row>
+                        </Table.Header>
+                        <Table.Body>
+                            {filteredAccounts?.map((account, index) => {
+                                const symbol = data.coinInfo.shortcut.toLowerCase();
+                                const suiteAccount = suiteAccounts.find(
+                                    a => a.descriptor === account.descriptor && a.symbol === symbol,
+                                );
+
+                                return (
+                                    <Table.Row
+                                        key={account.descriptor}
+                                        onClick={() => confirm(index)}
+                                    >
+                                        <Table.Cell>
+                                            <Row gap={spacings.sm}>
+                                                {symbol in NETWORK_ICONS && (
+                                                    <CoinLogo
+                                                        type="network"
+                                                        symbol={symbol as NetworkSymbol}
+                                                        size={24}
+                                                    />
+                                                )}
+                                                {suiteAccount ? (
+                                                    <AccountLabel
+                                                        accountLabel={
+                                                            suiteAccountLabels[suiteAccount.key]
+                                                        }
+                                                        accountType={suiteAccount.accountType}
+                                                        symbol={suiteAccount.symbol}
+                                                        index={suiteAccount.index}
+                                                    />
+                                                ) : (
+                                                    account.label
+                                                )}
+                                            </Row>
+                                        </Table.Cell>
+                                        <Table.Cell>
+                                            {account.empty ? (
+                                                <Translation id="TR_ACCOUNT_IS_EMPTY_TITLE" />
+                                            ) : (
+                                                account.balance
+                                            )}
+                                        </Table.Cell>
+                                        <Table.Cell align="end">
+                                            <Icon size="large" name="chevronRight" />
+                                        </Table.Cell>
+                                    </Table.Row>
+                                );
+                            })}
+                            {data.type !== 'end' && (
+                                <Table.Row>
+                                    <Table.Cell>
+                                        <SkeletonRectangle width="100px" animate />
+                                    </Table.Cell>
+                                    <Table.Cell>
+                                        <SkeletonRectangle width="80px" animate />
+                                    </Table.Cell>
+                                    <Table.Cell align="end">
+                                        <SkeletonCircle size="24px" />
+                                    </Table.Cell>
+                                </Table.Row>
+                            )}
+                        </Table.Body>
+                    </Table>
+                </Card>
+            </Column>
+        </NewModal>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -8,6 +8,7 @@ import { CoinLogo, FeeRate } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
 import { AccountLabel, Translation } from 'src/components/suite';
+import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
 import { useLocales } from 'src/hooks/suite';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
@@ -120,16 +121,7 @@ export const TransactionReviewSummary = ({
                 </Note>
             )}
 
-            {connectPopupCall?.state === 'ongoing' && (
-                <Note iconName="plug">
-                    <Translation id="TR_CONNECTED_TO" />
-                    {': '}
-                    <Text variant="primary">
-                        {connectPopupCall.source?.manifest?.appName ||
-                            connectPopupCall.source?.origin}
-                    </Text>
-                </Note>
-            )}
+            {connectPopupCall?.state === 'ongoing' && <ConnectCallSource />}
 
             {tx.inputs.length > 0 && (
                 // TODO: IconButton doesn't take margin even though it should

--- a/packages/suite/src/reducers/suite/modalReducer.ts
+++ b/packages/suite/src/reducers/suite/modalReducer.ts
@@ -1,5 +1,5 @@
 import { UserContextPayload } from '@suite-common/suite-types';
-import { DEVICE, Device, UI, UiRequestButtonData } from '@trezor/connect';
+import { DEVICE, Device, UI, UiRequestButtonData, UiRequestSelectAccount } from '@trezor/connect';
 
 import { MODAL } from 'src/actions/suite/constants';
 import type { Action, TrezorDevice } from 'src/types/suite';
@@ -17,6 +17,7 @@ type ModalState =
     | {
           context: typeof MODAL.CONTEXT_DEVICE_CONFIRMATION;
           windowType: string;
+          data?: UiRequestSelectAccount['payload'];
       }
     | {
           context: typeof MODAL.CONTEXT_USER;
@@ -77,6 +78,13 @@ const modalReducer = (state: State = initialState, action: Action): State => {
                 context: MODAL.CONTEXT_DEVICE,
                 device: action.payload.device,
                 windowType: action.payload.type,
+                preserve: state.preserve,
+            };
+        case UI.SELECT_ACCOUNT:
+            return {
+                context: MODAL.CONTEXT_DEVICE_CONFIRMATION,
+                windowType: UI.SELECT_ACCOUNT,
+                data: action.payload,
                 preserve: state.preserve,
             };
 

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9876,4 +9876,12 @@ export default defineMessages({
         id: 'TR_CONNECTED_TO',
         defaultMessage: 'Connected to',
     },
+    TR_SELECT_ACCOUNT: {
+        id: 'TR_SELECT_ACCOUNT',
+        defaultMessage: 'Select {networkName} account',
+    },
+    TR_ACCOUNT: {
+        id: 'TR_ACCOUNT',
+        defaultMessage: 'Account',
+    },
 });


### PR DESCRIPTION
## Description

Suite modal for Connect's `UI.SELECT_ACCOUNT`. The current flow is unchanged, this is basicailly a 1:1 compatible replacement. One bonus is that account labeling should work.

## Screenshots:

<img width="747" alt="Screenshot 2025-04-09 at 09 35 03" src="https://github.com/user-attachments/assets/7085cc2f-fb2e-49b8-b9dd-262bef4143d0" />
