### PR TITLE
fix(suite): DeviceUsedElsewhere with BT off

### DIFF
--- a/packages/suite-data/files/translations/en.json
+++ b/packages/suite-data/files/translations/en.json
@@ -2094,7 +2094,7 @@
   "TR_TROUBLESHOOTING_TIP_USB_PORT_DESCRIPTION": "Connect your device directly to your computer, without using a USB hub.",
   "TR_TROUBLESHOOTING_TIP_USB_PORT_TITLE": "Use a different USB port",
   "TR_TROUBLESHOOTING_UNREADABLE_UNKNOWN": "Unexpected state: {error}",
-  "TR_TROUBLE_SHOOTING_TIPS": "Troubleshooting Bluetooth",
+  "TR_TROUBLE_SHOOTING_TIPS": "Troubleshooting tips",
   "TR_TRY_AGAIN": "Try again",
   "TR_TXID": "TX ID",
   "TR_TXID_RBF": "Original TX ID to be replaced",

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUsedElsewhere.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUsedElsewhere.tsx
@@ -1,20 +1,26 @@
 import { MouseEventHandler } from 'react';
 
+import { isDesktop } from '@trezor/env-utils';
+
 import { Translation, TroubleshootingTips } from 'src/components/suite';
 import {
     TROUBLESHOOTING_TIP_CLOSE_ALL_TABS,
     TROUBLESHOOTING_TIP_RECONNECT,
 } from 'src/components/suite/troubleshooting/tips';
-import { useDevice } from 'src/hooks/suite';
+import { useDevice, useSelector } from 'src/hooks/suite';
 
+import { selectSuiteFlags } from '../../../reducers/suite/suiteReducer';
 import { AcquireDeviceButton } from '../AcquireDeviceButton';
 
 export const DeviceUsedElsewhere = () => {
     const { device } = useDevice();
+    const { isBluetoothEnabled } = useSelector(selectSuiteFlags);
 
     const handleClick: MouseEventHandler = e => {
         e.stopPropagation();
     };
+
+    const isBluetoothExpected = isBluetoothEnabled && isDesktop();
 
     const tips = [
         {
@@ -38,6 +44,9 @@ export const DeviceUsedElsewhere = () => {
             label={<Translation id="TR_ACQUIRE_DEVICE_TITLE" />}
             cta={<AcquireDeviceButton onClick={handleClick} />}
             items={tips}
+            toggleText={
+                isBluetoothExpected ? <Translation id="TR_TROUBLE_SHOOTING_BLUETOOTH" /> : undefined
+            }
         />
     );
 };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7367,6 +7367,10 @@ export default defineMessages({
     },
     TR_TROUBLE_SHOOTING_TIPS: {
         id: 'TR_TROUBLE_SHOOTING_TIPS',
+        defaultMessage: 'Troubleshooting tips',
+    },
+    TR_TROUBLE_SHOOTING_BLUETOOTH: {
+        id: 'TR_TROUBLE_SHOOTING_BLUETOOTH',
         defaultMessage: 'Troubleshooting Bluetooth',
     },
     TR_ONBOARDING_ADVANCED: {


### PR DESCRIPTION
Fix issue where "Troubleshooting Bluetooth" is shown even with Bluetooth off.

:information_source: This is fix only for `release/25.4`

@coderabbitai ignore