### PR TITLE
fix(blockchain-link): do not fetch sol staking for tokens detail

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -371,8 +371,9 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
     const { value: balance } = await api.rpc.getBalance(publicKey).send();
 
     let misc: AccountInfo['misc'] | undefined;
-    // Not necessary for basic details
-    if (details !== 'basic') {
+
+    // Not necessary for basic and tokens details
+    if (!['basic', 'tokens'].includes(details)) {
         // https://solana.stackexchange.com/a/13102
         const { value: accountInfo } = await api.rpc
             .getAccountInfo(publicKey, { encoding: 'base64' })

--- a/packages/suite-desktop-core/e2e/support/pageObjects/tradingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/tradingPage.ts
@@ -371,7 +371,7 @@ export class TradingPage {
     @step()
     async initiateSendConfirmation(options?: { confirmAlsoToken: boolean }) {
         await this.confirmOnTrezorAndSend.click();
-        await expect(this.modal).toBeVisible({ timeout: 30_000 });
+        await expect(this.modal).toBeVisible();
         await expect(this.devicePrompt.sendButton).toBeDisabled();
         await this.devicePrompt.confirmOnDevicePromptIsShown();
         await TrezorUserEnvLinkProxy.pressYes();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- `fetchAccountOwnerAndTokenInfoForAddress` method fetches `tokens` detail when signing token tx. In send form, it fetches it once, in trading, it fetches it twice (no idea why, no time to fix). 
- this `tokens` detail now takes min 3s, because to get staking solana data, fetch takes 3s
