### PR TITLE
fix(suite): wrong origin in connect popup

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPopupModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPopupModal.tsx
@@ -19,7 +19,7 @@ export const ConnectPopupModal = () => {
     const { methodTitle, confirmLabel, permissionTypes } = methodInfo;
 
     const rememberPayload = {
-        origin,
+        origin: source.origin,
         types: permissionTypes,
         ...(source.isWalletConnect
             ? {
@@ -68,7 +68,8 @@ export const ConnectPopupModal = () => {
                         <strong>{source.processName}</strong>
                     </Paragraph>
                     <Paragraph data-testid="@connect-popup-modal/paragraph-origin">
-                        <Translation id="TR_CONNECT_MODAL_WEB_ORIGIN" /> <strong>{origin}</strong>
+                        <Translation id="TR_CONNECT_MODAL_WEB_ORIGIN" />{' '}
+                        <strong>{source.origin}</strong>
                     </Paragraph>
                     {!source.isWalletConnect && (
                         <Paragraph>


### PR DESCRIPTION
## Description

Unnoticed bug in #18169 where origin refers to `window.origin` not `source.origin`