### PR TITLE
feat(transport-bluetooth): add TrezorBluetooth client

### DIFF
--- a/packages/transport-bluetooth/package.json
+++ b/packages/transport-bluetooth/package.json
@@ -22,6 +22,7 @@
     },
     "dependencies": {
         "@trezor/ipc-proxy": "workspace:*",
-        "@trezor/utils": "workspace:*"
+        "@trezor/utils": "workspace:*",
+        "@trezor/websocket-client": "workspace:*"
     }
 }

--- a/packages/transport-bluetooth/src/client/trezor-bluetooth.ts
+++ b/packages/transport-bluetooth/src/client/trezor-bluetooth.ts
@@ -1,0 +1,69 @@
+import { WebsocketClient } from '@trezor/websocket-client';
+
+import {
+    BluetoothDevice,
+    BluetoothInfo,
+    Logger,
+    NotificationEvent,
+    TrezorBluetoothSettings,
+} from './types';
+
+// Client for trezor-bluetooth rust websocket server
+export class TrezorBluetooth extends WebsocketClient<NotificationEvent> {
+    readonly settings: TrezorBluetoothSettings;
+    readonly logger: Logger;
+
+    constructor(settings: TrezorBluetoothSettings) {
+        super({
+            url: settings.url,
+        });
+        this.settings = Object.freeze(settings);
+        this.logger = settings.logger || {
+            info: () => {},
+            debug: () => {},
+            log: () => {},
+            warn: () => {},
+            error: () => {},
+        };
+    }
+
+    createWebsocket() {
+        return this.initWebsocket({
+            url: this.settings.url,
+        });
+    }
+
+    ping() {
+        return Promise.resolve(this.sendRawMessage('PING'));
+    }
+
+    send(method: 'get_info', adapter?: boolean): Promise<BluetoothInfo>;
+    send(method: 'enumerate'): Promise<BluetoothDevice[]>;
+    send(method: 'start_scan'): Promise<BluetoothDevice[]>;
+    send(method: 'stop_scan'): Promise<boolean>;
+    send(method: 'connect_device', id: string): Promise<boolean>; // TODO: timeout
+    send(method: 'disconnect_device', id: string): Promise<boolean>;
+    send(method: 'forget_device', id: string): Promise<boolean>;
+    send(method: 'open_device', id: string): Promise<boolean>;
+    send(method: 'close_device', id: string): Promise<boolean>;
+    send(method: 'read', id: string): Promise<boolean>;
+    send(method: 'write', args: [string, number[]]): Promise<boolean>;
+    public send(method: string, args?: any) {
+        return this.sendMessage({ method, params: args || [] });
+    }
+
+    protected onMessage(message: string | Buffer) {
+        super.onMessage(message, data => {
+            if (data.event) {
+                this.emit(data.event, data.payload);
+
+                return;
+            }
+            if (data.error) {
+                throw new Error(data.error);
+            }
+
+            return data.payload;
+        });
+    }
+}

--- a/packages/transport-bluetooth/src/client/types.ts
+++ b/packages/transport-bluetooth/src/client/types.ts
@@ -1,9 +1,43 @@
 import type { TypedEmitter } from '@trezor/utils';
 
+export interface Logger {
+    info(...args: any[]): void;
+    debug(...args: any[]): void;
+    log(...args: any[]): void;
+    warn(...args: any[]): void;
+    error(...args: any[]): void;
+}
+
+export interface TrezorBluetoothSettings {
+    url: string;
+    logger?: Logger;
+    timeout?: number;
+}
+
+export type BluetoothInfo = {
+    state: BluetoothAdapterState;
+    api_version: string;
+    adapter_info: string;
+    adapter_version: number;
+};
+
+// see: ./src/server/device.rs
 export interface BluetoothDevice {
     id: string;
     name: string;
     macAddress: string; // changes after pairing (linux), unknown on macos
+
+    /**
+     * Manufacturer Specific Data:
+     *
+     * Bytes:
+     *      [0]: fist byte is advertising type.
+     *             0 - advertising with whitelist,
+     *             1 - without whitelist (pairing mode),
+     *             2 - also pairing mode but bond memory is full, cannot bond another dive
+     *      [1]: second is device color (interpreted same way as from Device Fetures)
+     *      [2-6]: four remaining bytes represent internal device name, i.e. T3W1
+     */
     data: number[]; // advertisement data bytes
     connected: boolean;
     connectionStatus: DeviceConnectionStatus;
@@ -12,7 +46,22 @@ export interface BluetoothDevice {
     rssi?: number; // signal strength
 }
 
+export type BluetoothAdapterState = 'enabled' | 'disabled' | 'permission-denied';
+
+export interface NotificationEvent {
+    adapter_state_changed: { state: BluetoothAdapterState };
+    device_discovered: { id: string; devices: BluetoothDevice[] };
+    device_updated: { id: string; devices: BluetoothDevice[] };
+    device_connected: { id: string; devices: BluetoothDevice[] };
+    device_connection_status: BluetoothDevice;
+    device_disconnected: { id: string; devices: BluetoothDevice[] };
+    device_read: { id: string; data: number[] };
+    device_settings_ui: undefined; // dispatched by linux pairing process
+    device_removed: { id: string };
+}
+
 // IpcApi related types
+// see: ./src/server/device.rs
 export type DeviceConnectionStatus =
     | { type: 'disconnected' }
     | { type: 'pairing'; pin?: string }
@@ -33,7 +82,7 @@ type Failure = { success: false; error: string };
 type IpcResponse<P = unknown> = Success<P> | Failure;
 
 export interface BluetoothIpcEvents {
-    'adapter-event': boolean;
+    'adapter-event': BluetoothAdapterState;
     'device-list-update': BluetoothDevice[];
     'device-update': BluetoothDevice;
 }

--- a/packages/transport-bluetooth/src/index.ts
+++ b/packages/transport-bluetooth/src/index.ts
@@ -1,3 +1,4 @@
+export { TrezorBluetooth } from './client/trezor-bluetooth';
 export { BluetoothIpc } from './client/bluetooth-ipc-main';
 export { bluetoothIpc } from './client/bluetooth-ipc-renderer';
 export * from './client/types';

--- a/packages/transport-bluetooth/tsconfig.json
+++ b/packages/transport-bluetooth/tsconfig.json
@@ -6,6 +6,7 @@
     },
     "references": [
         { "path": "../ipc-proxy" },
-        { "path": "../utils" }
+        { "path": "../utils" },
+        { "path": "../websocket-client" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12285,6 +12285,7 @@ __metadata:
   dependencies:
     "@trezor/ipc-proxy": "workspace:*"
     "@trezor/utils": "workspace:*"
+    "@trezor/websocket-client": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
cherry-picked from `feat/rust-bluetooth`

WebsocketClient for [trezor-bluetooth server](https://github.com/trezor/trezor-suite/pull/18126)

will be used by `BluetoothIpc` and `BluetoothApi` transport