### PR TITLE
Feat: TrezorConnect.bleUnpair method

### DIFF
--- a/packages/connect/src/api/bleUnpair.ts
+++ b/packages/connect/src/api/bleUnpair.ts
@@ -1,0 +1,29 @@
+import { Assert } from '@trezor/schema-utils';
+
+import { PROTO } from '../constants';
+import { AbstractMethod } from '../core/AbstractMethod';
+import { UI } from '../events';
+
+export default class BleUnpair extends AbstractMethod<'bleUnpair', PROTO.BleUnpair> {
+    init() {
+        this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
+        this.requiredPermissions = ['management'];
+        this.useDeviceState = false;
+        this.skipFinalReload = true;
+
+        const { payload } = this;
+        this.params = {
+            all: payload.all,
+        };
+
+        Assert(PROTO.BleUnpair, payload);
+    }
+
+    async run() {
+        const cmd = this.device.getCommands();
+        // unpair current bluetooth connection session or all known sessions
+        const response = await cmd.typedCall('BleUnpair', 'Success', this.params);
+
+        return response.message;
+    }
+}

--- a/packages/connect/src/api/index.ts
+++ b/packages/connect/src/api/index.ts
@@ -5,6 +5,7 @@ export { default as authorizeCoinjoin } from './authorizeCoinjoin';
 export { default as cancelCoinjoinAuthorization } from './cancelCoinjoinAuthorization';
 export { default as showDeviceTutorial } from './showDeviceTutorial';
 export { default as backupDevice } from './backupDevice';
+export { default as bleUnpair } from './bleUnpair';
 export { default as blockchainDisconnect } from './blockchainDisconnect';
 export { default as blockchainEstimateFee } from './blockchainEstimateFee';
 export { default as blockchainGetAccountBalanceHistory } from './blockchainGetAccountBalanceHistory';

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -58,6 +58,8 @@ export const factory = <
 
     // methods
 
+    bleUnpair: params => call({ ...params, method: 'bleUnpair' }),
+
     blockchainGetAccountBalanceHistory: params =>
         call({ ...params, method: 'blockchainGetAccountBalanceHistory' }),
 

--- a/packages/connect/src/types/api/bleUnpair.ts
+++ b/packages/connect/src/types/api/bleUnpair.ts
@@ -1,0 +1,4 @@
+import type { PROTO } from '../../constants';
+import type { Params, Response } from '../params';
+
+export declare function bleUnpair(params: Params<PROTO.BleUnpair>): Response<PROTO.Success>;

--- a/packages/connect/src/types/api/index.ts
+++ b/packages/connect/src/types/api/index.ts
@@ -6,6 +6,7 @@ import { backupDevice } from './backupDevice';
 import { binanceGetAddress } from './binanceGetAddress';
 import { binanceGetPublicKey } from './binanceGetPublicKey';
 import { binanceSignTransaction } from './binanceSignTransaction';
+import { bleUnpair } from './bleUnpair';
 import { blockchainDisconnect } from './blockchainDisconnect';
 import { blockchainEstimateFee } from './blockchainEstimateFee';
 import { blockchainEvmRpcCall } from './blockchainEvmRpcCall';
@@ -117,6 +118,9 @@ export interface TrezorConnect {
 
     // https://connect.trezor.io/9/methods/binance/binanceSignTransaction/
     binanceSignTransaction: typeof binanceSignTransaction;
+
+    // https://connect.trezor.io/9/methods/device/bleUnpair/
+    bleUnpair: typeof bleUnpair;
 
     // todo: link docs
     blockchainDisconnect: typeof blockchainDisconnect;

--- a/packages/protobuf/messages.json
+++ b/packages/protobuf/messages.json
@@ -1552,6 +1552,14 @@
                 }
             }
         },
+        "BleUnpair": {
+            "fields": {
+                "all": {
+                    "type": "bool",
+                    "id": 1
+                }
+            }
+        },
         "FirmwareErase": {
             "fields": {
                 "length": {
@@ -6797,6 +6805,7 @@
                 "FirmwareUpload": 7,
                 "FirmwareRequest": 8,
                 "ProdTestT1": 32,
+                "BleUnpair": 8001,
                 "GetPublicKey": 11,
                 "PublicKey": 12,
                 "SignTx": 15,

--- a/packages/protobuf/src/messages-schema.ts
+++ b/packages/protobuf/src/messages-schema.ts
@@ -803,6 +803,14 @@ export const AuthorizeCoinJoin = Type.Object(
     { $id: 'AuthorizeCoinJoin' },
 );
 
+export type BleUnpair = Static<typeof BleUnpair>;
+export const BleUnpair = Type.Object(
+    {
+        all: Type.Optional(Type.Boolean()),
+    },
+    { $id: 'BleUnpair' },
+);
+
 export type FirmwareErase = Static<typeof FirmwareErase>;
 export const FirmwareErase = Type.Object(
     {
@@ -1385,7 +1393,7 @@ export const EnumFailureType = Type.Enum(FailureType);
 export type Failure = Static<typeof Failure>;
 export const Failure = Type.Object(
     {
-        code: Type.Optional(EnumFailureType),
+        code: Type.Optional(Type.KeyOfEnum(FailureType)),
         message: Type.Optional(Type.String()),
     },
     { $id: 'Failure' },
@@ -3592,6 +3600,7 @@ export const MessageType = Type.Object(
         GetOwnershipProof,
         OwnershipProof,
         AuthorizeCoinJoin,
+        BleUnpair,
         FirmwareErase,
         FirmwareRequest,
         FirmwareUpload,

--- a/packages/protobuf/src/messages.ts
+++ b/packages/protobuf/src/messages.ts
@@ -552,6 +552,10 @@ export type AuthorizeCoinJoin = {
     amount_unit?: AmountUnit;
 };
 
+export type BleUnpair = {
+    all?: boolean;
+};
+
 export type FirmwareErase = {
     length?: number;
 };
@@ -2343,6 +2347,7 @@ export type MessageType = {
     GetOwnershipProof: GetOwnershipProof;
     OwnershipProof: OwnershipProof;
     AuthorizeCoinJoin: AuthorizeCoinJoin;
+    BleUnpair: BleUnpair;
     FirmwareErase: FirmwareErase;
     FirmwareRequest: FirmwareRequest;
     FirmwareUpload: FirmwareUpload;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

cherry picked (not quite) from the `feat/rust-bluetooth` branch

`BleUnpair` message is already in the firmware repo but bluetooth branch still uses the old one (EraseBonds + Unpair messages in `TrezorConnect.eraseBonds` method)

i will rebase on top of this once i have newest BT FW build containing this message