### PR TITLE
Data Analytics: device-update-firmware and device-connect - add isOfficialFw to the event

### DIFF
--- a/packages/device-utils/src/firmwareUtils.ts
+++ b/packages/device-utils/src/firmwareUtils.ts
@@ -1,6 +1,17 @@
 import { isDeviceInBootloaderMode } from './modeUtils';
 import { FirmwareType, FirmwareVersionString, PartialDevice, VersionArray } from './types';
 
+export const isOfficialFirmware = (device?: PartialDevice): boolean => {
+    if (
+        device?.authenticityChecks?.firmwareRevision?.success &&
+        device?.authenticityChecks?.firmwareHash?.success
+    ) {
+        return true;
+    }
+
+    return false;
+};
+
 export const getFirmwareRevision = (device?: PartialDevice) => device?.features?.revision || '';
 
 export const getFirmwareVersionArray = (device?: PartialDevice): VersionArray | null => {

--- a/packages/device-utils/src/types.ts
+++ b/packages/device-utils/src/types.ts
@@ -62,6 +62,10 @@ export type FeaturesNarrowing =
 // todo: this is copy-pasted from packages/protobuf/src/messages
 export type PartialDevice = {
     firmwareType?: FirmwareType;
+    authenticityChecks?: {
+        firmwareRevision: { success: boolean } | null;
+        firmwareHash: { success: boolean } | null;
+    };
 
     features?: {
         major_version: number;

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -91,6 +91,7 @@ export type SuiteAnalyticsEvent =
           payload: {
               mode: 'normal' | 'bootloader' | 'initialize' | 'seedless';
               firmware: string;
+              isOfficialFw: boolean;
               bootloader?: string;
               pin_protection?: boolean | null;
               passphrase_protection?: boolean | null;
@@ -116,6 +117,7 @@ export type SuiteAnalyticsEvent =
               fromFwVersion: string;
               toFwVersion?: string;
               toBtcOnly?: boolean;
+              isOfficialFw: boolean;
               error: string;
           };
       }

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -19,6 +19,7 @@ import {
     getFirmwareVersion,
     hasBitcoinOnlyFirmware,
     isDeviceInBootloaderMode,
+    isOfficialFirmware,
 } from '@trezor/device-utils';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
@@ -73,6 +74,7 @@ const analyticsMiddleware =
                         error,
                         toBtcOnly,
                         toFwVersion,
+                        isOfficialFw: isOfficialFirmware(device),
                     },
                 });
             }
@@ -122,6 +124,7 @@ const analyticsMiddleware =
                             language: features.language,
                             model: features.internal_model,
                             optiga_sec: features.optiga_sec,
+                            isOfficialFw: isOfficialFirmware(action.payload.device),
                         },
                     });
                 } else {
@@ -131,6 +134,7 @@ const analyticsMiddleware =
                             mode: 'bootloader',
                             firmware: getFirmwareVersion(action.payload.device),
                             bootloader: getBootloaderVersion(action.payload.device),
+                            isOfficialFw: isOfficialFirmware(action.payload.device),
                         },
                     });
                 }


### PR DESCRIPTION
## Description

Data Analytics: _device-update-firmware_ and _device-connect_ now has new parameter `isOfficialFw`

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/14893