### PR TITLE
feat(websocket-client): autospoof Origin header in node.js

### DIFF
--- a/packages/blockchain-link/src/workers/blockbook/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockbook/websocket.ts
@@ -50,7 +50,6 @@ export class BlockbookAPI extends BaseWebsocket<BlockbookEvents> {
             url,
             agent: this.options.agent,
             headers: {
-                Origin: 'https://node.trezor.io',
                 'User-Agent': `Trezor Suite ${getSuiteVersion()}`,
                 ...this.options.headers,
             },

--- a/packages/blockchain-link/src/workers/blockfrost/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockfrost/websocket.ts
@@ -25,7 +25,6 @@ export class BlockfrostAPI extends BaseWebsocket<BlockfrostEvents> {
             url,
             agent: this.options.agent,
             headers: {
-                Origin: 'https://node.trezor.io',
                 'User-Agent': `Trezor Suite ${getSuiteVersion()}`,
                 ...this.options.headers,
             },

--- a/packages/coinjoin/tests/tools/benchmark-test.ts
+++ b/packages/coinjoin/tests/tools/benchmark-test.ts
@@ -112,7 +112,6 @@ const getWebsocket = async () => {
         agent,
         perMessageDeflate: true,
         headers: {
-            Origin: 'https://node.trezor.io',
             'User-Agent': 'Trezor Suite',
         },
     });

--- a/packages/websocket-client/src/client.ts
+++ b/packages/websocket-client/src/client.ts
@@ -64,7 +64,15 @@ export class WebsocketClient<Events extends Record<string, any>> extends TypedEm
             url = url.replace('http', 'ws');
         }
 
-        return new WebSocket(url, { timeout, headers, agent });
+        return new WebSocket(url, {
+            timeout,
+            headers: {
+                // for convenience auto spoof Origin header in node.js
+                Origin: 'https://node.trezor.io',
+                ...headers,
+            },
+            agent,
+        });
     }
 
     private setPingTimeout() {


### PR DESCRIPTION
cherry-picked from #18077 where I need to communicate over websocket from node.js layer and where origin needs to be set since I made it required in this commit 4500c05acf3e6e867c4b9ebf9f5e34ead1f8d43b

