### PR TITLE
Feat: suite desktop BluetoothProcess

### DIFF
--- a/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
@@ -1,0 +1,67 @@
+import { isDevEnv } from '@suite-common/suite-utils';
+
+import { BaseProcess, Status } from './BaseProcess';
+import { getSwitchValue } from '../process-switches';
+
+export class BluetoothProcess extends BaseProcess {
+    private readonly port;
+
+    constructor(port = 21327) {
+        super('bluetooth', 'trezor-bluetooth');
+        this.port = port;
+    }
+
+    getUrl() {
+        return `http://localhost:${this.port}/`;
+    }
+
+    getPort() {
+        return this.port;
+    }
+
+    async status(): Promise<Status> {
+        if (!this.process) {
+            return {
+                service: false,
+                process: false,
+            };
+        }
+
+        // service
+        try {
+            const resp = await fetch(this.getUrl(), {
+                method: 'GET',
+                headers: {
+                    Origin: 'https://electron.trezor.io',
+                },
+            });
+            this.logger.debug(this.logTopic, `Checking status (${resp.status})`);
+            if (resp.status === 200) {
+                const data = await resp.json();
+                if (data?.version) {
+                    return {
+                        service: true,
+                        process: true,
+                    };
+                }
+            }
+        } catch (err) {
+            this.logger.debug(this.logTopic, `Status error: ${err.message}`);
+        }
+
+        // process
+        return {
+            service: false,
+            process: Boolean(this.process),
+        };
+    }
+
+    start() {
+        if (isDevEnv || getSwitchValue('log-level') === 'debug') {
+            process.env.RUST_LOG = 'debug';
+            process.env.RUST_BACKTRACE = '1';
+        }
+
+        return super.start(['-p', this.port.toString()]);
+    }
+}

--- a/packages/suite-desktop-core/src/modules/bluetooth.ts
+++ b/packages/suite-desktop-core/src/modules/bluetooth.ts
@@ -1,7 +1,10 @@
 import { ipcMain } from 'electron';
 
 import { IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
+import { getFreePort } from '@trezor/node-utils';
 import { BluetoothIpc, BluetoothIpcApi } from '@trezor/transport-bluetooth';
+
+import { BluetoothProcess } from '../libs/processes/BluetoothProcess';
 
 import type { ModuleInit } from './index';
 
@@ -10,23 +13,64 @@ export const SERVICE_NAME = '@trezor/transport-bluetooth';
 export const init: ModuleInit = () => {
     const { logger } = global;
 
+    let bluetoothProcess: BluetoothProcess | undefined;
+
+    const getBluetoothProcess = async () => {
+        if (!bluetoothProcess) {
+            const port = await getFreePort();
+            bluetoothProcess = new BluetoothProcess(port);
+        }
+
+        return bluetoothProcess;
+    };
+
+    const killBluetoothProcess = () => {
+        if (bluetoothProcess) {
+            bluetoothProcess.stop();
+            bluetoothProcess = undefined;
+        }
+    };
+
+    const initBluetoothIpc = async () => {
+        const btProcess = await getBluetoothProcess();
+        await btProcess.start();
+
+        return new BluetoothIpc({
+            // @ts-expect-error TODO BluetoothIpc params will be added in upcoming PR
+            url: btProcess.getUrl(),
+            logger,
+        });
+    };
+
     const proxyOptions: IpcProxyHandlerOptions<BluetoothIpcApi> = {
         onCreateInstance() {
-            const api = new BluetoothIpc();
+            let api: BluetoothIpc | undefined;
+            const apiError = new Error('BluetoothIpc api not initialized');
 
             return {
-                onRequest: (method, params) => {
+                onRequest: async (method, params) => {
                     logger.debug(SERVICE_NAME, `call ${method}`);
+                    if (method === 'init') {
+                        api = await initBluetoothIpc();
+                    }
+
+                    if (!api) throw apiError;
+
+                    if (method === 'dispose') {
+                        killBluetoothProcess();
+                    }
 
                     return (api[method] as any)(...params);
                 },
                 onAddListener: (eventName, listener) => {
                     logger.debug(SERVICE_NAME, `add listener ${eventName}`);
+                    if (!api) throw apiError;
 
                     return api.on(eventName, listener);
                 },
                 onRemoveListener: (eventName: any) => {
                     logger.debug(SERVICE_NAME, `remove listener ${eventName}`);
+                    if (!api) throw apiError;
 
                     return api.removeAllListeners(eventName);
                 },
@@ -36,12 +80,13 @@ export const init: ModuleInit = () => {
 
     const unregisterProxy = createIpcProxyHandler(ipcMain, 'Bluetooth', proxyOptions);
     const onLoad = () => {
-        // TODO: start binary
+        // empty, binary starts after bluetoothIpc.init
     };
 
     const onQuit = () => {
         logger.info(SERVICE_NAME, 'Stopping (app quit)');
         unregisterProxy();
+        killBluetoothProcess();
     };
 
     return { onLoad, onQuit };

--- a/packages/suite-desktop-ui/src/MainDesktop.tsx
+++ b/packages/suite-desktop-ui/src/MainDesktop.tsx
@@ -31,6 +31,7 @@ import { useDebugLanguageShortcut, useFormattersConfig } from 'src/hooks/suite';
 import history from 'src/support/history';
 import { ModalContextProvider } from 'src/support/suite/ModalContext';
 import { desktopHandshake } from 'src/actions/suite/suiteActions';
+import { initBluetoothThunk } from 'src/actions/bluetooth/initBluetoothThunk';
 import * as STORAGE from 'src/actions/suite/constants/storageConstants';
 
 import { DesktopUpdater } from './support/DesktopUpdater';
@@ -138,6 +139,9 @@ export const init = async (container: HTMLElement) => {
         // @ts-expect-error key vs union of values endless problem
         TrezorConnect[method] = proxy[method];
     });
+
+    // init bluetooth module
+    await store.dispatch(initBluetoothThunk());
 
     // finally render whole app
     root.render(

--- a/packages/suite/src/actions/bluetooth/disposeBluetoothThunk.ts
+++ b/packages/suite/src/actions/bluetooth/disposeBluetoothThunk.ts
@@ -1,0 +1,23 @@
+import { BLUETOOTH_PREFIX } from '@suite-common/bluetooth';
+import { createThunk } from '@suite-common/redux-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import { bluetoothIpc } from '@trezor/transport-bluetooth';
+
+export const disposeBluetoothThunk = createThunk<void, void, void>(
+    `${BLUETOOTH_PREFIX}/bluetoothDisposeThunk`,
+    async (_, { dispatch }) => {
+        bluetoothIpc.removeAllListeners();
+        const result = await bluetoothIpc.dispose();
+
+        if (!result.success) {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'error',
+                    error: 'Unable to dispose Bluetooth Module.',
+                }),
+            );
+
+            return;
+        }
+    },
+);

--- a/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
+++ b/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
@@ -1,0 +1,48 @@
+import { BLUETOOTH_PREFIX, selectKnownDevices } from '@suite-common/bluetooth';
+import { createThunk } from '@suite-common/redux-utils/';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import { BluetoothDevice, bluetoothIpc } from '@trezor/transport-bluetooth';
+
+import { selectSuiteFlags } from '../../reducers/suite/suiteReducer';
+
+export const initBluetoothThunk = createThunk<void, void, void>(
+    `${BLUETOOTH_PREFIX}/initBluetoothThunk`,
+    async (_, { getState, dispatch }) => {
+        const { isBluetoothEnabled } = selectSuiteFlags(getState());
+
+        if (!isBluetoothEnabled) {
+            return;
+        }
+
+        const knownDevices = selectKnownDevices<BluetoothDevice>(getState());
+        const result = await bluetoothIpc.init({ knownDevices });
+        if (!result.success) {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'error',
+                    error: 'Unable to initialize Bluetooth Module.',
+                }),
+            );
+
+            return;
+        }
+
+        bluetoothIpc.on('adapter-event', status => {
+            console.warn('adapter-event', status);
+
+            // TO BE DONE
+        });
+
+        bluetoothIpc.on('device-list-update', nearbyDevices => {
+            console.warn('device-list-update', nearbyDevices);
+
+            // TO BE DONE
+        });
+
+        bluetoothIpc.on('device-update', (device: BluetoothDevice) => {
+            console.warn('device-update', device);
+
+            // TO BE DONE
+        });
+    },
+);

--- a/packages/suite/src/views/settings/SettingsDebug/Bluetooth.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Bluetooth.tsx
@@ -5,7 +5,8 @@ import { Checkbox } from '@trezor/components';
 import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
-// import { initBluetoothThunk } from '../../../actions/bluetooth/initBluetoothThunk';
+import { disposeBluetoothThunk } from '../../../actions/bluetooth/disposeBluetoothThunk';
+import { initBluetoothThunk } from '../../../actions/bluetooth/initBluetoothThunk';
 import { setFlag } from '../../../actions/suite/suiteActions';
 import { selectSuiteFlags } from '../../../reducers/suite/suiteReducer';
 
@@ -14,10 +15,17 @@ export const Bluetooth = () => {
     const dispatch = useDispatch();
     const [isLoading, setIsLoading] = useState(false);
 
-    const handleOnClick = () => {
+    const handleOnClick = async () => {
         setIsLoading(true);
+
         dispatch(setFlag('isBluetoothEnabled', !isBluetoothEnabled));
-        // await dispatch(initBluetoothThunk());
+
+        if (isBluetoothEnabled) {
+            await dispatch(disposeBluetoothThunk());
+        } else {
+            await dispatch(initBluetoothThunk());
+        }
+
         setIsLoading(false);
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Cherry picked from `feat/rust-bluetooth` branch

- added `BluetoothProcess` to suite-desktop. The process will start [websocket server](https://github.com/trezor/trezor-suite/pull/18126)
- picked some components and actions to call `bluetoothIpc.init` and `bluetoothIpc.dispose` - which should start or stop the process. cc @peter-sanderson


~~I've found a bug in the `BaseProcess` and i think its there since forever.
When BaseProcess fails to run the binary (this exact case - binary is not here yet) then stopping this process is not possible.
as a workaround i've used code below, but i'm not sure if this is the right solution since error event doesnt exactly mean that the process is not running (or does it? i could be wrong)~~
addressed: https://github.com/trezor/trezor-suite/pull/18234