### PR TITLE
fix(transport): readMessageBuffer.cancleRead

### DIFF
--- a/packages/transport/src/api/udp.ts
+++ b/packages/transport/src/api/udp.ts
@@ -163,6 +163,13 @@ export class UdpApi extends AbstractApi {
             device => !!this.devices.find(d => d.path === device.path),
         );
 
+        // find all disconnected devices and cancel reading (if any)
+        const [disconnected] = arrayPartition(
+            this.devices,
+            device => !devices.find(d => d.path === device.path),
+        );
+        disconnected.forEach(d => this.readBuffer.cancelRead(d.path));
+
         if (known.length !== this.devices.length || unknown.length > 0) {
             this.devices = devices;
             if (this.listening) {
@@ -176,7 +183,9 @@ export class UdpApi extends AbstractApi {
         return Promise.resolve(this.success(undefined));
     }
 
-    public closeDevice(_path: string) {
+    public closeDevice(path: string) {
+        this.readBuffer.cancelRead(path);
+
         return Promise.resolve(this.success(undefined));
     }
 

--- a/packages/transport/src/utils/readMessageBuffer.ts
+++ b/packages/transport/src/utils/readMessageBuffer.ts
@@ -1,10 +1,13 @@
 import { Deferred, createDeferred } from '@trezor/utils';
 
 import { error, success } from './result';
-import { ABORTED_BY_SIGNAL } from '../errors';
+import { ABORTED_BY_SIGNAL, INTERFACE_DATA_TRANSFER } from '../errors';
 import { ResultWithTypedError } from '../types';
 
-type ReadResult = ResultWithTypedError<Buffer, typeof ABORTED_BY_SIGNAL>;
+type ReadResult = ResultWithTypedError<
+    Buffer,
+    typeof ABORTED_BY_SIGNAL | typeof INTERFACE_DATA_TRANSFER
+>;
 
 export const readMessageBuffer = () => {
     const readBuffer: Record<string, Buffer[]> = {};
@@ -48,8 +51,17 @@ export const readMessageBuffer = () => {
         });
     };
 
+    const cancelRead = (path: string) => {
+        if (readRequests[path]) {
+            readRequests[path].resolve(error({ error: INTERFACE_DATA_TRANSFER }));
+        }
+        delete readRequests[path];
+        delete readBuffer[path];
+    };
+
     return {
         onMessage,
         read,
+        cancelRead,
     };
 };

--- a/packages/transport/tests/readMessageBuffer.test.ts
+++ b/packages/transport/tests/readMessageBuffer.test.ts
@@ -1,4 +1,4 @@
-import { ABORTED_BY_SIGNAL } from '../src/errors';
+import { ABORTED_BY_SIGNAL, INTERFACE_DATA_TRANSFER } from '../src/errors';
 import { readMessageBuffer } from '../src/utils/readMessageBuffer';
 
 describe('readMessageBuffer', () => {
@@ -58,5 +58,16 @@ describe('readMessageBuffer', () => {
         result = await r.read('1');
         if (!result.success) throw new Error(result.error);
         expect(result.payload.toString('hex')).toEqual('0101');
+    });
+
+    it('read from readRequest cancelRead', async () => {
+        const r = readMessageBuffer();
+
+        const readPromise = r.read('1');
+        r.cancelRead('1');
+        const result = await readPromise;
+
+        if (result.success) throw new Error('Unexpected success');
+        expect(result.error).toEqual(INTERFACE_DATA_TRANSFER);
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

pending transport.read will never be resolved if device is closed

e2e testing script with emulator:
- create ./packages/transport/test.ts
- run `tsx  ./packages/transport/test.ts`

```
import * as messages from '@trezor/protobuf/messages.json';

import { UdpTransport } from '../transport/src';

const run = async () => {
    const debugTransport = new UdpTransport({ id: 'udp', messages, logger: console });

    await debugTransport.init();
    debugTransport.listen();

    const enumerate = await debugTransport.enumerate();
    const device = enumerate.payload[0];

    let session = await debugTransport.acquire({ input: device }).then(p => p.payload);
    let readPromise = debugTransport.receive({ session });
    await debugTransport.release({ path: device.path, session });
    let result = await readPromise;
    console.warn('result1', result);

    session = await debugTransport.acquire({ input: device }).then(p => p.payload);
    readPromise = debugTransport.receive({ session });
    console.warn('waiting for disconnect');

    result = await readPromise;
    console.warn('result2', result);
};

run();
```