### PR TITLE
Icon with percentage - visual tweak

### DIFF
--- a/suite-native/icons/src/CryptoIconWithPercentage.tsx
+++ b/suite-native/icons/src/CryptoIconWithPercentage.tsx
@@ -20,7 +20,7 @@ import { PizzaIcon, usePizzaAnimation } from './PizzaIcon';
 
 const CANVAS_SIZE = 48;
 const ICON_SIZE = 32;
-const RADIUS = 20;
+const RADIUS = 21;
 
 type CryptoIconProps = {
     iconName: CryptoIconName;
@@ -92,7 +92,7 @@ export const CryptoIconWithPercentage = ({
                                 cy={CANVAS_SIZE / 2}
                                 r={RADIUS}
                                 style="stroke"
-                                strokeWidth={4}
+                                strokeWidth={6}
                                 color={utils.colors.backgroundSurfaceElevation2}
                             />
                             <Path
@@ -100,7 +100,7 @@ export const CryptoIconWithPercentage = ({
                                 start={0}
                                 end={percentageFill}
                                 style="stroke"
-                                strokeWidth={4}
+                                strokeWidth={6}
                                 color={percentageColor}
                                 opacity={0.3}
                             />


### PR DESCRIPTION
Requested by @shenkys to align with [design system](https://www.figma.com/design/Y2E8dcdNYrSMGIVRjYFXKp/-Suite--Components-1.0?node-id=1-3979&t=F7Kin5UJdIZgavK0-0) after we updated icons while adding Ethereum L2s. Sheny has seen and approved visual


## Screenshots:
<img width="300" alt="Screenshot 2025-04-09 at 12 07 20" src="https://github.com/user-attachments/assets/960d02f6-77cf-47b4-9e1f-0344b8feb067" />

