### PR TITLE
Data Analytics: add events for new address generation

### DIFF
--- a/packages/suite-analytics/src/constants.ts
+++ b/packages/suite-analytics/src/constants.ts
@@ -28,6 +28,10 @@ export enum EventType {
 
     CreateBackup = 'create-backup',
 
+    CreateReceiveAddressShowAddress = 'create-receive-address/show-address',
+    CreateReceiveAddressCopyAddress = 'create-receive-address/copy-address',
+    CreateReceiveAddressConfirmOnTrezor = 'create-receive-address/confirm-on-trezor',
+
     AccountsStatus = 'accounts/status',
     AccountsTokensStatus = 'accounts/tokens-status',
     AccountsNonZeroBalance = 'accounts/non-zero-balance',

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -1,3 +1,5 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
+
 import { EventType } from '../constants';
 import type { AppUpdateEvent, OnboardingAnalytics } from './definitions';
 
@@ -130,6 +132,25 @@ export type SuiteAnalyticsEvent =
           payload: {
               status: 'finished' | 'error';
               error: string;
+          };
+      }
+    | {
+          type: EventType.CreateReceiveAddressShowAddress;
+          payload: {
+              assetSymbol: NetworkSymbol;
+              type: 'verified' | 'unverified';
+          };
+      }
+    | {
+          type: EventType.CreateReceiveAddressCopyAddress;
+          payload: {
+              assetSymbol: NetworkSymbol;
+          };
+      }
+    | {
+          type: EventType.CreateReceiveAddressConfirmOnTrezor;
+          payload: {
+              assetSymbol: NetworkSymbol;
           };
       }
     | {

--- a/packages/suite/src/actions/wallet/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/receiveActions.ts
@@ -2,6 +2,7 @@ import { UserContextPayload } from '@suite-common/suite-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { confirmAddressOnDeviceThunk, selectSelectedDevice } from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
+import { EventType, analytics } from '@trezor/suite-analytics';
 
 import * as modalActions from 'src/actions/suite/modalActions';
 import { RECEIVE } from 'src/actions/wallet/constants';
@@ -62,10 +63,26 @@ export const showAddress =
                 }),
             );
 
+            analytics.report({
+                type: EventType.CreateReceiveAddressShowAddress,
+                payload: {
+                    assetSymbol: account.symbol,
+                    type: 'unverified',
+                },
+            });
+
             return;
         }
 
         dispatch(modalActions.preserve());
+
+        analytics.report({
+            type: EventType.CreateReceiveAddressShowAddress,
+            payload: {
+                assetSymbol: account.symbol,
+                type: 'verified',
+            },
+        });
 
         const response = await dispatch(
             confirmAddressOnDeviceThunk({ accountKey: account.key, addressPath: path, chunkify }),
@@ -74,6 +91,11 @@ export const showAddress =
         if (response.success) {
             // show second part of the "confirm address" modal
             dispatch(openAddressModal({ ...modalPayload, isConfirmed: true }));
+
+            analytics.report({
+                type: EventType.CreateReceiveAddressConfirmOnTrezor,
+                payload: { assetSymbol: account.symbol },
+            });
         } else {
             dispatch(modalActions.onCancel());
             // special case: device no-backup permissions not granted

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -21,6 +21,7 @@ import {
 } from '@trezor/components';
 import { copyToClipboard } from '@trezor/dom-utils';
 import { CoinLogo, ConfirmOnDevice } from '@trezor/product-components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { MODAL } from 'src/actions/suite/constants';
@@ -72,6 +73,13 @@ export const ConfirmValueModal = ({
 
     const copy = () => {
         const result = copyToClipboard(value);
+
+        if (account) {
+            analytics.report({
+                type: EventType.CreateReceiveAddressCopyAddress,
+                payload: { assetSymbol: account.symbol },
+            });
+        }
 
         if (typeof result !== 'string') {
             setIsCopied(true);


### PR DESCRIPTION
## Description

Three events have been added to improve tracking of new receive address generation: `create-receive-address/copy-address`, `create-receive-address/show-address`, and `create-receive-address/confirm-on-trezor`. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15716