### PR TITLE
Data Analytics: add value closed to the provider parameter of the event settings/general/labeling-provider

### DIFF
--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -454,6 +454,7 @@ export type SuiteAnalyticsEvent =
                   | 'fileSystem'
                   | 'missing-provider'
                   | 'inMemoryTest'
+                  | 'closed'
                   | ''; // Todo: 'sdCard' not implemented yet
           };
       }

--- a/packages/suite/src/actions/suite/metadataLabelingActions.ts
+++ b/packages/suite/src/actions/suite/metadataLabelingActions.ts
@@ -4,6 +4,7 @@ import {
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import TrezorConnect, { StaticSessionId } from '@trezor/connect';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { cloneObject } from '@trezor/utils';
 
 import { METADATA, METADATA_LABELING } from 'src/actions/suite/constants';
@@ -626,6 +627,13 @@ export const init =
         if (!selectSelectedProviderForLabels(getState())) {
             const providerResult = await dispatch(metadataProviderActions.initProvider());
             if (!providerResult) {
+                analytics.report({
+                    type: EventType.SettingsGeneralLabelingProvider,
+                    payload: {
+                        provider: 'closed',
+                    },
+                });
+
                 dispatch({ type: METADATA.SET_INITIATING, payload: false });
                 dispatch({ type: METADATA.SET_EDITING, payload: undefined });
                 // NOTE: when the provider is not initialized


### PR DESCRIPTION
## Description

The settings/general/labeling-provider event now includes a new provider value: "closed". This value is triggered when the modal is closed without selecting a provider, improving tracking of user interactions.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15717
