### PR TITLE
Chore/optimize regex

### DIFF
--- a/packages/styles/src/utils.ts
+++ b/packages/styles/src/utils.ts
@@ -4,7 +4,7 @@ import { CSSColor } from '@trezor/theme';
 
 export const getValueAndUnit = (valueAndUnit: string): [value: number, unit: string] => {
     const value = parseFloat(valueAndUnit);
-    const [unit] = valueAndUnit.match(/([a-zA-Z]*|%)$/) ?? [''];
+    const [unit] = valueAndUnit.match(/([a-zA-Z]{1,4}|%)$/) ?? ['']; // CSS units shouldn't have more than 4 characters.
 
     return [value, unit];
 };


### PR DESCRIPTION
An attempt to optimize regex. Suite is not really vulnerable to ReDoS attacks, but I want to silence the alerts.

Capped the capture group at 4 characters length so that it is not so greedy, CSS doesn't have any longer unit. [source](https://www.w3schools.com/cssref/css_units.php)

Resolves:
https://github.com/trezor/trezor-suite/security/code-scanning/157