### PR TITLE
Fix data analytics: Correct onboarding duration tracking

### DIFF
--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
@@ -2,7 +2,11 @@ import { MouseEvent } from 'react';
 
 import { Button } from '@trezor/components';
 
-import { enableOnboardingReducer, resetOnboarding } from 'src/actions/onboarding/onboardingActions';
+import {
+    enableOnboardingReducer,
+    resetOnboarding,
+    updateAnalytics,
+} from 'src/actions/onboarding/onboardingActions';
 import { goto } from 'src/actions/suite/routerActions';
 import { Translation, TroubleshootingTips } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
@@ -16,6 +20,8 @@ export const DeviceInitialize = () => {
         dispatch(resetOnboarding());
         // and resetting state disables onboarding reducer so we need to enable it again
         dispatch(enableOnboardingReducer(true));
+
+        dispatch(updateAnalytics({ startTime: Date.now() }));
 
         dispatch(goto('onboarding-index'));
     };

--- a/packages/suite/src/reducers/onboarding/onboardingReducer.ts
+++ b/packages/suite/src/reducers/onboarding/onboardingReducer.ts
@@ -62,7 +62,11 @@ const removePath = (paths: AnyPath[], state: OnboardingState) =>
 const onboarding = (state: OnboardingState = initialState, action: Action) => {
     if (
         !state.isActive &&
-        ![ONBOARDING.RESET_ONBOARDING, ONBOARDING.ENABLE_ONBOARDING_REDUCER].includes(action.type)
+        ![
+            ONBOARDING.RESET_ONBOARDING,
+            ONBOARDING.ENABLE_ONBOARDING_REDUCER,
+            ONBOARDING.ANALYTICS,
+        ].includes(action.type)
     ) {
         return state;
     }

--- a/packages/suite/src/views/onboarding/steps/Final.tsx
+++ b/packages/suite/src/views/onboarding/steps/Final.tsx
@@ -205,8 +205,6 @@ export const FinalStep = () => {
                         variant="primary"
                         data-testid="@onboarding/exit-app-button"
                         onClick={() => {
-                            goToSuite(true);
-
                             const payload = {
                                 ...onboardingAnalytics,
                                 duration: Date.now() - onboardingAnalytics.startTime!,
@@ -219,6 +217,8 @@ export const FinalStep = () => {
                                 type: EventType.DeviceSetupCompleted,
                                 payload,
                             });
+
+                            goToSuite(true);
                         }}
                         icon="arrowRightLong"
                         iconAlignment="end"


### PR DESCRIPTION
## Description

This fixes an issue where the `duration` parameter in the `device-setup-completed` event was often incorrectly reported as `NaN`.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13297
