### PR TITLE
feat(transport-bluetooth): add BluetoothApi and BluetoothTransport

### DIFF
--- a/packages/transport-bluetooth/package.json
+++ b/packages/transport-bluetooth/package.json
@@ -25,6 +25,8 @@
     },
     "dependencies": {
         "@trezor/ipc-proxy": "workspace:*",
+        "@trezor/protocol": "workspace:*",
+        "@trezor/transport": "workspace:*",
         "@trezor/utils": "workspace:*",
         "@trezor/websocket-client": "workspace:*"
     }

--- a/packages/transport-bluetooth/src/client/bluetooth-api.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-api.ts
@@ -1,0 +1,118 @@
+import {
+    AbstractApi,
+    AbstractApiConstructorParams,
+    DEVICE_TYPE,
+} from '@trezor/transport/src/api/abstract';
+import * as ERRORS from '@trezor/transport/src/errors';
+import { PathInternal } from '@trezor/transport/src/types';
+import { readMessageBuffer } from '@trezor/transport/src/utils/readMessageBuffer';
+
+import { TrezorBluetooth } from './trezor-bluetooth';
+import { BluetoothDevice } from './types';
+
+// implementation of @trezor/transport/src/api/abstract
+
+type BluetoothApiParams = AbstractApiConstructorParams & {
+    url: string;
+};
+
+export class BluetoothApi extends AbstractApi {
+    chunkSize = 244;
+    api: TrezorBluetooth;
+    private readBuffer = readMessageBuffer();
+
+    constructor(options: BluetoothApiParams) {
+        super(options);
+
+        this.api = new TrezorBluetooth({ url: options.url, logger: options.logger });
+    }
+
+    private devicesToDescriptors(devices: BluetoothDevice[]) {
+        return devices
+            .filter(device => device.connected && device.paired)
+            .map(device => ({
+                path: device.id as PathInternal,
+                type: DEVICE_TYPE.TypeBluetooth,
+                id: device.id,
+            }));
+    }
+
+    async init() {
+        const { api } = this;
+        try {
+            await api.connect();
+        } catch (error) {
+            return this.error({ error: ERRORS.UNEXPECTED_ERROR, message: error.message });
+        }
+
+        return this.success(true);
+    }
+
+    enumerate() {
+        return this.api
+            .send('enumerate')
+            .then(devices => this.success(this.devicesToDescriptors(devices)))
+            .catch(() => this.success([]));
+    }
+
+    listen() {
+        const { api } = this;
+
+        const transportApiEvent = ({ devices }: { devices: BluetoothDevice[] }) => {
+            this.emit('transport-interface-change', this.devicesToDescriptors(devices));
+        };
+        api.on('device_connected', transportApiEvent);
+        api.on('device_disconnected', event => {
+            this.readBuffer.cancelRead(event.id);
+            transportApiEvent(event);
+        });
+        api.on('device_read', ({ id, data }) => {
+            this.readBuffer.onMessage(id, Buffer.from(data));
+        });
+        api.on('adapter_state_changed', ({ state }) => {
+            if (state !== 'enabled') {
+                transportApiEvent({ devices: [] });
+            }
+        });
+        api.on('disconnected', () => {
+            this.emit('transport-interface-error', { error: ERRORS.API_DISCONNECTED });
+        });
+    }
+
+    dispose() {
+        this.api.removeAllListeners();
+
+        return this.api.disconnect();
+    }
+
+    read(path: string, signal?: AbortSignal) {
+        return this.readBuffer.read(path, signal);
+    }
+
+    write(path: string, buffer: Buffer) {
+        return this.api
+            .send('write', [path, Array.from(buffer)])
+            .then(() => this.success(undefined))
+            .catch(e => this.error({ error: ERRORS.INTERFACE_DATA_TRANSFER, message: e.message }));
+    }
+
+    openDevice(path: string) {
+        return this.api
+            .send('open_device', path)
+            .then(() => this.success(undefined))
+            .catch(e =>
+                this.error({ error: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE, message: e.message }),
+            );
+    }
+
+    closeDevice(path: string) {
+        this.readBuffer.cancelRead(path);
+
+        return this.api
+            .send('close_device', path)
+            .then(() => this.success(undefined))
+            .catch(e =>
+                this.error({ error: ERRORS.INTERFACE_UNABLE_TO_CLOSE_DEVICE, message: e.message }),
+            );
+    }
+}

--- a/packages/transport-bluetooth/src/client/transport.ts
+++ b/packages/transport-bluetooth/src/client/transport.ts
@@ -1,0 +1,41 @@
+import { AbstractTransportParams } from '@trezor/transport/src/transports/abstract';
+import { AbstractApiTransport } from '@trezor/transport/src/transports/abstractApi';
+
+import { BluetoothApi } from './bluetooth-api';
+
+// implementation of @trezor/transport/src/transports/abstractApi
+
+type BluetoothTransportParams = Omit<AbstractTransportParams, 'api'> & {
+    url: string;
+};
+
+export class BluetoothTransport extends AbstractApiTransport {
+    public name = 'BluetoothTransport' as const;
+    public apiType = 'bluetooth' as const;
+    private wsApi: BluetoothApi;
+
+    constructor(params: BluetoothTransportParams) {
+        const { url, logger, ...rest } = params;
+
+        const api = new BluetoothApi({ url, logger });
+        api.on('transport-interface-error', ({ error }) => {
+            this.emit('transport-error', error);
+        });
+
+        super({
+            api,
+            logger,
+            ...rest,
+        });
+
+        this.wsApi = api;
+    }
+
+    public init({ signal }: { signal?: AbortSignal } = {}) {
+        return this.scheduleAction(async () => {
+            await this.wsApi.init();
+
+            return super.init({ signal });
+        });
+    }
+}

--- a/packages/transport-bluetooth/src/client/trezor-bluetooth.ts
+++ b/packages/transport-bluetooth/src/client/trezor-bluetooth.ts
@@ -16,6 +16,7 @@ export class TrezorBluetooth extends WebsocketClient<NotificationEvent> {
     constructor(settings: TrezorBluetoothSettings) {
         super({
             url: settings.url,
+            keepAlive: true,
         });
         this.settings = Object.freeze(settings);
         this.logger = settings.logger || {
@@ -41,15 +42,23 @@ export class TrezorBluetooth extends WebsocketClient<NotificationEvent> {
     send(method: 'enumerate'): Promise<BluetoothDevice[]>;
     send(method: 'start_scan'): Promise<BluetoothDevice[]>;
     send(method: 'stop_scan'): Promise<boolean>;
-    send(method: 'connect_device', id: string): Promise<boolean>; // TODO: timeout
+    send(method: 'connect_device', args: [string, number]): Promise<boolean>; // args: id, timeout
     send(method: 'disconnect_device', id: string): Promise<boolean>;
     send(method: 'forget_device', id: string): Promise<boolean>;
     send(method: 'open_device', id: string): Promise<boolean>;
     send(method: 'close_device', id: string): Promise<boolean>;
     send(method: 'read', id: string): Promise<boolean>;
-    send(method: 'write', args: [string, number[]]): Promise<boolean>;
+    send(method: 'write', args: [string, number[]]): Promise<boolean>; // args: id, data
     public send(method: string, args?: any) {
-        return this.sendMessage({ method, params: args || [] });
+        const params = args || [];
+        // connect_device timeout is dynamically set,
+        // adjust websocket client and allow the server to respond with timeout error (timeout on the server)
+        const timeout =
+            method === 'connect_device' && typeof params[1] === 'number'
+                ? params[1] + 3000
+                : undefined;
+
+        return this.sendMessage({ method, params }, { timeout });
     }
 
     protected onMessage(message: string | Buffer) {

--- a/packages/transport-bluetooth/src/client/types.ts
+++ b/packages/transport-bluetooth/src/client/types.ts
@@ -1,12 +1,7 @@
+import type { Logger } from '@trezor/transport/src/types';
 import type { TypedEmitter } from '@trezor/utils';
 
-export interface Logger {
-    info(...args: any[]): void;
-    debug(...args: any[]): void;
-    log(...args: any[]): void;
-    warn(...args: any[]): void;
-    error(...args: any[]): void;
-}
+export type { Logger } from '@trezor/transport/src/types';
 
 export interface TrezorBluetoothSettings {
     url: string;

--- a/packages/transport-bluetooth/src/index.ts
+++ b/packages/transport-bluetooth/src/index.ts
@@ -1,4 +1,5 @@
 export { TrezorBluetooth } from './client/trezor-bluetooth';
+export { BluetoothTransport } from './client/transport';
 export { BluetoothIpc } from './client/bluetooth-ipc-main';
 export { bluetoothIpc } from './client/bluetooth-ipc-renderer';
 export * from './client/types';

--- a/packages/transport-bluetooth/tsconfig.json
+++ b/packages/transport-bluetooth/tsconfig.json
@@ -6,6 +6,8 @@
     },
     "references": [
         { "path": "../ipc-proxy" },
+        { "path": "../protocol" },
+        { "path": "../transport" },
         { "path": "../utils" },
         { "path": "../websocket-client" }
     ]

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -39,6 +39,7 @@ type AccessLock = {
 
 export abstract class AbstractApi extends TypedEmitter<{
     'transport-interface-change': DescriptorApiLevel[];
+    'transport-interface-error': { error: typeof ERRORS.API_DISCONNECTED };
 }> {
     protected logger?: Logger;
     protected listening: boolean = false;

--- a/packages/transport/src/errors.ts
+++ b/packages/transport/src/errors.ts
@@ -76,6 +76,8 @@ export const DEVICE_DISCONNECTED_DURING_ACTION = 'device disconnected during act
 export const OTHER_CALL_IN_PROGRESS = 'other call in progress' as const;
 // bridge
 export const HTTP_ERROR = 'Network request failed' as const;
+// bluetooth
+export const API_DISCONNECTED = 'Api disconnected' as const;
 /**
  * COMMON ERRORS
  */

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -77,6 +77,7 @@ class TransportEmitter extends TypedEmitter<{
     [TRANSPORT.DEVICE_REQUEST_RELEASE]: Descriptor;
     [TRANSPORT.ERROR]:
         | typeof ERRORS.HTTP_ERROR // most common error - bridge was killed
+        | typeof ERRORS.API_DISCONNECTED // BluetoothApi disconnected
         // probably never happens, wrong shape of data came from bridge
         | typeof ERRORS.WRONG_RESULT_TYPE
         | typeof ERRORS.UNEXPECTED_ERROR;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12575,6 +12575,8 @@ __metadata:
   resolution: "@trezor/transport-bluetooth@workspace:packages/transport-bluetooth"
   dependencies:
     "@trezor/ipc-proxy": "workspace:*"
+    "@trezor/protocol": "workspace:*"
+    "@trezor/transport": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@trezor/websocket-client": "workspace:*"
   languageName: unknown


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- [TrezorBluetooth](https://github.com/trezor/trezor-suite/pull/18214) client implementation in `BluetoothApi`
  👉 `@trezor/transport/src/api/AbstractApi`
- BluetoothApi implementation in `BluetoothTransport`
  👉 `@trezor/transport/src/transports/AbstractApiTransport`
  
waiting for https://github.com/trezor/trezor-suite/pull/18227