### PR TITLE
find process improvements and port collisions error handling

### DIFF
--- a/.github/workflows/test-misc.yml
+++ b/.github/workflows/test-misc.yml
@@ -73,6 +73,21 @@ jobs:
       - run: yarn message-system-sign-config
       - run: yarn test:unit
 
+  test-unit-windows:
+    runs-on: windows-latest
+    if: github.repository == 'trezor/trezor-suite'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - run: yarn install --immutable
+      - run: yarn workspace @trezor/node-utils test:unit
+
   utility-scripts:
     runs-on: ubuntu-latest
     if: github.repository == 'trezor/trezor-suite'

--- a/packages/node-utils/src/findProcessFromIncomingPort.ts
+++ b/packages/node-utils/src/findProcessFromIncomingPort.ts
@@ -31,10 +31,10 @@ export async function findProcessFromIncomingPort(port: number) {
     switch (process.platform) {
         case 'darwin':
         case 'linux': {
-            const command = `lsof -iTCP:${port} -sTCP:ESTABLISHED -n -P +c0`;
+            const command = `lsof -iTCP:${port} -n -P +c0`;
             const stdout = await spawnAndCollectStdout(command);
             const lines = stdout.split('\n');
-            const process = lines.find(line => line.includes(`:${port}->`));
+            const process = lines.find(line => line.includes(`:${port}`));
             if (process) {
                 const name = process.split(/\s+/)[0].replace(/\\x\d{2}/g, ' ');
                 const pid = process.split(/\s+/)[1];
@@ -46,7 +46,7 @@ export async function findProcessFromIncomingPort(port: number) {
             return undefined;
         }
         case 'win32': {
-            const command = `netstat -ano | findstr :${port} | findstr ESTABLISHED`;
+            const command = `netstat -ano | findstr :${port}`;
             const stdout = await spawnAndCollectStdout(command);
             const lines = stdout.split('\n');
             const record = lines

--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -6,6 +6,7 @@ import * as url from 'url';
 import type { RequiredKey } from '@trezor/type-utils';
 import { Log, TypedEmitter, arrayPartition } from '@trezor/utils';
 
+import { findProcessFromIncomingPort } from './findProcessFromIncomingPort';
 import { getFreePort } from './getFreePort';
 
 type Request = RequiredKey<http.IncomingMessage, 'url'>;
@@ -143,7 +144,19 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
     public async start() {
         const port = this.port || (this.port = await getFreePort());
 
-        return new Promise<net.AddressInfo>((resolve, reject) => {
+        return new Promise<
+            | { success: true; payload: net.AddressInfo }
+            | {
+                  success: false;
+                  error: 'port already in use';
+                  message: string;
+              }
+            | {
+                  success: false;
+                  error: 'other error';
+                  message: string;
+              }
+        >(resolve => {
             let nextSocketId = 0;
             this.server.on('connection', socket => {
                 // Add a newly connected socket
@@ -155,19 +168,34 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
                 });
             });
 
-            this.server.on('error', e => {
+            this.server.on('error', async e => {
                 this.server.close();
                 // @ts-expect-error - type is missing
                 const errorCode: string = e.code;
+                const portOccupied = errorCode === 'EADDRINUSE' || errorCode === 'EACCES';
 
-                const errorMessage =
-                    errorCode === 'EADDRINUSE' || errorCode === 'EACCES'
-                        ? `Port ${port} already in use!` // TODO: Try different port?
-                        : `Start error code: ${errorCode}`;
+                if (portOccupied) {
+                    const processInfo = await findProcessFromIncomingPort(port).catch(() => {});
+                    const errorMessage = processInfo
+                        ? `Port ${port} is occupied by process ${processInfo.name} (${processInfo.pid})`
+                        : 'process info not found';
+                    this.logger.error(errorMessage);
+
+                    return resolve({
+                        success: false,
+                        error: 'port already in use',
+                        message: errorMessage,
+                    });
+                }
+                const errorMessage = `Start error code: ${errorCode}`;
 
                 this.logger.error(errorMessage);
 
-                return reject(new Error(`http-receiver: ${errorMessage}`));
+                return {
+                    success: false,
+                    error: 'other error',
+                    message: `Start error code: ${errorCode}`,
+                };
             });
 
             this.server.listen(port, '127.0.0.1', undefined, () => {
@@ -177,7 +205,7 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
                     this.emitter.emit('server/listening', address);
                 }
 
-                return resolve(address);
+                return resolve({ success: true, payload: address });
             });
         });
     }

--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -110,6 +110,10 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
     }
 
     public getServerAddress() {
+        if (!this.server.listening) {
+            // this happens when port was already in use at the time of starting the server
+            throw new Error(`Server is not listening`);
+        }
         const address = this.server.address();
         if (!address || typeof address === 'string') {
             // this is only for typescript

--- a/packages/node-utils/src/tests/findProcessFromIncomingPort.test.ts
+++ b/packages/node-utils/src/tests/findProcessFromIncomingPort.test.ts
@@ -1,0 +1,38 @@
+import net from 'net';
+
+import { findProcessFromIncomingPort } from '../findProcessFromIncomingPort';
+import { getFreePort } from '../getFreePort';
+
+describe('findProcessFromIncomingPort', () => {
+    test('start a server on a random free port and try to detect it', async () => {
+        const port = await getFreePort();
+
+        const server = net.createServer().listen(port);
+        try {
+            // wait for listening
+            await new Promise(resolve => {
+                server.on('listening', () => {
+                    resolve(undefined);
+                });
+            });
+
+            const processInfo = await findProcessFromIncomingPort(port);
+            expect(processInfo).toBeDefined();
+
+            if (process.platform === 'win32') {
+                expect(processInfo?.name).toEqual('node.exe');
+            } else {
+                expect(processInfo?.name).toEqual('node');
+            }
+        } finally {
+            server.close();
+        }
+    });
+
+    test('if there is nothing running on the port, findProcessFromIncomingPort throws', async () => {
+        const port = await getFreePort();
+        await expect(findProcessFromIncomingPort(port)).rejects.toThrow(
+            'Command failed with code 1: ',
+        );
+    });
+});

--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -58,12 +58,16 @@ export const initBackground: ModuleInitBackground = ({ mainWindowProxy, mainThre
         // when httpReceiver was asked to provide current address for given pathname
         ipcMain.handle('server/request-address', (ipcEvent, pathname) => {
             validateIpcMessage(ipcEvent);
-            const address = receiver.getRouteAddress(pathname);
-            if (address) {
-                receiver.activateRoute(pathname);
-            }
+            try {
+                const address = receiver.getRouteAddress(pathname);
+                if (address) {
+                    receiver.activateRoute(pathname);
+                }
 
-            return address;
+                return address;
+            } catch (e) {
+                logger.error(SERVICE_NAME, `Failed to get address: ${e.message}`);
+            }
         });
 
         const connectPopupEnabled = hasSwitch('expose-connect-ws') || isDevEnv;

--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -82,16 +82,18 @@ export const initBackground: ModuleInitBackground = ({ mainWindowProxy, mainThre
 
         logger.info(SERVICE_NAME, 'Starting server');
 
-        try {
-            await receiver.start();
-
-            return receiver.getInfo();
-        } catch (error) {
+        const startResult = await receiver.start();
+        if (!startResult.success) {
             // Don't fail hard if the server can't start
-            logger.error(SERVICE_NAME, 'Failed to start server: ' + error);
+            logger.error(
+                SERVICE_NAME,
+                `Failed to start server:  ${startResult.error}, error details: ${startResult.message}`,
+            );
 
             return { url: null };
         }
+
+        return receiver.getInfo();
     };
 
     const onQuit = async () => {

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -480,12 +480,15 @@ export class TrezordNode {
 
             app.post('/configure', [this.handleInfo.bind(this)]);
 
-            app.start()
-                .then(() => {
+            app.start().then(result => {
+                if (result.success) {
                     this.server = app;
-                    resolve();
-                })
-                .catch(reject);
+
+                    return resolve();
+                } else {
+                    reject(result.error);
+                }
+            });
         });
     }
 


### PR DESCRIPTION
- process occupying port detection is now used to improve [electron logs](https://fs.currents.dev/655b6840ac3c8a71f6753b77/21d9450103a1155f/desktop/0g6pGwQgI4i93ZHv.txt?Expires=1744302957&Key-Pair-Id=K1ZNDCCIZ3P4FU&Signature=VDsVS7LfCfP-XgZETOzVU4caBvYGle2UkNnW1OcX7o9vDv5Maz8GDi7zeUF9odSXs4vvAlwlAtZ9lcGfbszgziTgaVUpe7Ia9cCaMYEaqSmvdQLWotDuD~DCDn10WX6dODY9wKDiOCBKuM3-aWz4lDAzKffgNbQ9PHZ28TOeHs~5ztBQyyc1ldohvZ0J5Sd-J-fKqC0kEQXoDHDjY7SNmQCT9M~sDmyR2UMyDBh5LEmhOIVfQRKQD-hviUwCGCTwROUJQISwRWb3C6uqa5ZIJO6JqgDfPYmaaaaEiNIS96X8Zr07poZf0Gsa3Y81YGzlBnZ1KECaYRPNplLYmZxRTw__) to print colliding process name if we fail to start a process in suite-desktop
- added [nightly tests ](https://github.com/trezor/trezor-suite/actions/runs/14399786534/job/40382808487?pr=18283)for @trezor/node-utils using a windows runner  
![image](https://github.com/user-attachments/assets/07bc6432-d7ca-4e6e-b8dc-80526ca3506f)
- error handling what happens when you start something on 127.0.0.1:21335 where suite wants to start its own HTTP server. to test it you can run `yarn npx http-server -a 127.0.0.1 -p 21335` and:
  - observe logs  
<img width="1138" alt="image" src="https://github.com/user-attachments/assets/e9c22f1a-5f9b-41d2-a6b2-cecad96b3fe4" />
  - try to authenticate dropbox in labeling
<img width="741" alt="image" src="https://github.com/user-attachments/assets/1f4d4a5c-1a7e-4bef-89c9-e7bafd311dde" />
<img width="838" alt="image" src="https://github.com/user-attachments/assets/b459723b-c833-4ed5-bad7-1522fc41d035" />
