### PR TITLE
feat(suite-desktop): add AssetsFilterPlugin webpack plugin

### DIFF
--- a/packages/suite-build/configs/desktop.webpack.config.ts
+++ b/packages/suite-build/configs/desktop.webpack.config.ts
@@ -5,6 +5,7 @@ import webpack from 'webpack';
 
 import { FLAGS } from '@suite-common/suite-config';
 
+import { AssetsFilterPlugin } from '../plugins/assets-filter-plugin';
 import { NixosInterpreterPlugin } from '../plugins/nixos-interpreter-plugin';
 import ShellSpawnPlugin from '../plugins/shell-spawn-plugin';
 import { assetPrefix, isCodesignBuild, isDev, launchElectron } from '../utils/env';
@@ -15,6 +16,10 @@ const electronArgs = process.argv.slice(electronArgsIndex);
 
 const baseDirUI = getPathForProject('desktop-ui');
 const baseDir = getPathForProject('desktop');
+
+// conditionally remove bluetooth binaries from the build, see https://github.com/trezor/trezor-suite/pull/18196
+// to be removed when BT is ready
+const BLUETOOTH_BIN_FILTER = !isDev && !process.env.BLUETOOTH ? [/bin\/bluetooth\//] : [];
 
 const config: webpack.Configuration = {
     // Electron 35 runs on Chromium 134 https://www.electronjs.org/blog/electron-35-0#stack-changes
@@ -78,6 +83,9 @@ const config: webpack.Configuration = {
             options: {
                 concurrency: 100,
             },
+        }),
+        new AssetsFilterPlugin({
+            test: BLUETOOTH_BIN_FILTER,
         }),
         new HtmlWebpackPlugin({
             minify: !isDev,

--- a/packages/suite-build/plugins/assets-filter-plugin.ts
+++ b/packages/suite-build/plugins/assets-filter-plugin.ts
@@ -1,0 +1,43 @@
+import webpack from 'webpack';
+
+// manage included Assets
+export class AssetsFilterPlugin {
+    name = 'AssetsFilterPlugin';
+    initialRun = false;
+    patterns: RegExp[];
+
+    constructor(options: { test: RegExp[] }) {
+        this.patterns = options.test || [];
+    }
+
+    apply(compiler: webpack.Compiler) {
+        compiler.hooks.thisCompilation.tap(this.name, compilation => {
+            compilation.hooks.processAssets.tap(
+                {
+                    name: this.name,
+                    stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE,
+                },
+                () => {
+                    if (!this.initialRun) {
+                        this.initialRun = true;
+
+                        const assets = compilation.getAssets().map(a => a.name);
+                        const removed: string[] = [];
+                        for (const filename of assets) {
+                            if (this.patterns.some(pattern => pattern.test(filename))) {
+                                removed.push(filename);
+                                compilation.deleteAsset(filename);
+                            }
+                        }
+
+                        if (removed.length > 0) {
+                            console.log(` files removed from compilation: ${removed.join(', ')}`);
+                        } else {
+                            console.log(` no files removed from compilation`);
+                        }
+                    }
+                },
+            );
+        });
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I want to exclude [bluetooth assets/binaries](https://github.com/trezor/trezor-suite/pull/18126) from the compilation and [include them conditionally ](https://github.com/trezor/trezor-suite/pull/18196)

`suite-data/files/bin` directory is copied as a whole so i need to filter out files using regex

once binary is in develop branch you should see:
```
yarn workspace @trezor/suite-desktop dev
3% setup watch run webpack-plugin-serve⬡ wps: Server Listening on: http://localhost:8000

92% sealing asset processing AssetsFilterPlugin files removed from compilation: static/bin/bluetooth/mac-x64/trezor-bluetooth, static/bin/bluetooth/mac-arm64/trezor-bluetooth, static/bin/bluetooth/linux-arm64/trezor-bluetooth, static/bin/bluetooth/linux-x64/trezor-bluetooth, static/bin/bluetooth/win-x64/trezor-bluetooth.exe, static/bin/bluetooth/win-arm64/trezor-bluetooth.exe
98% emitting after emit NixosInterpreterPluginNixosInterpreterPlugin not used
98% emitting after emit ShellSpawnPluginassets by chunk 14.5 MiB (id hint: vendors) 20 assets
```

until then it should be:
```
92% sealing asset processing AssetsFilterPlugin no files removed
```

while doing so i've noticed that there is 4500+ assets in the compilation where more than 80% are svg and png files.
`AssetsFilterPlugin` could be good place to manage them and optimize the build