### PR TITLE
Simplify usage of analytics selectors

### DIFF
--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -44,11 +44,11 @@ export const init = () => (dispatch: Dispatch, getState: GetState) => {
     const sessionId = getTrackingRandomId();
     // if instanceId does not exist yet (was not loaded from storage), create a new one
     const instanceId = selectAnalyticsInstanceId(getState()) ?? getTrackingRandomId();
-    const userAllowedTracking = selectHasUserAllowedTracking(getState());
+    const hasUserAllowedTracking = selectHasUserAllowedTracking(getState());
     const isAnalyticsEnabled = selectIsAnalyticsEnabled(getState());
     const isAnalyticsConfirmed = selectIsAnalyticsConfirmed(getState());
 
-    analytics.init(userAllowedTracking, {
+    analytics.init(hasUserAllowedTracking, {
         instanceId,
         sessionId,
         environment: getEnvironment(),
@@ -60,7 +60,7 @@ export const init = () => (dispatch: Dispatch, getState: GetState) => {
         },
     });
 
-    allowSentryReport(!!userAllowedTracking);
+    allowSentryReport(isAnalyticsEnabled);
     setSentryUser(instanceId);
 
     dispatch(

--- a/packages/suite/src/views/settings/SettingsGeneral/Analytics.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Analytics.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import styled from 'styled-components';
 
-import { selectHasUserAllowedTracking } from '@suite-common/analytics';
+import { selectIsAnalyticsEnabled } from '@suite-common/analytics';
 import { Switch } from '@trezor/components';
 import { analytics } from '@trezor/suite-analytics';
 
@@ -15,7 +15,7 @@ const PositionedSwitch = styled.div`
 `;
 
 export const Analytics = () => {
-    const userAllowedTracking = useSelector(selectHasUserAllowedTracking);
+    const isAnalyticsEnabled = useSelector(selectIsAnalyticsEnabled);
 
     return (
         <SettingsSectionItem anchorId={SettingsAnchor.Analytics}>
@@ -27,9 +27,9 @@ export const Analytics = () => {
                 <PositionedSwitch>
                     <Switch
                         data-testid="@analytics/toggle-switch"
-                        isChecked={!!userAllowedTracking}
+                        isChecked={isAnalyticsEnabled}
                         onChange={() => {
-                            if (userAllowedTracking) {
+                            if (isAnalyticsEnabled) {
                                 analytics.disable();
                             } else {
                                 analytics.enable();

--- a/suite-common/analytics/package.json
+++ b/suite-common/analytics/package.json
@@ -7,7 +7,8 @@
     "main": "src/index",
     "scripts": {
         "depcheck": "yarn g:depcheck",
-        "type-check": "yarn g:tsc --build"
+        "type-check": "yarn g:tsc --build",
+        "test:unit": "yarn g:jest -c ../../jest.config.base.js"
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.6.0",

--- a/suite-common/analytics/src/analyticsReducer.ts
+++ b/suite-common/analytics/src/analyticsReducer.ts
@@ -61,11 +61,8 @@ export const selectIsAnalyticsEnabled = (state: AnalyticsRootState): boolean => 
 };
 
 export const selectHasUserAllowedTracking = (state: AnalyticsRootState): boolean | undefined => {
-    // If the user has not yet confirmed analytics, return undefined.
-    // Otherwise, return true or false based on the 'confirmed' and 'enabled' flags.
-    if (!state.analytics.confirmed) {
-        return undefined;
-    }
+    const isAnalyticsConfirmed = selectIsAnalyticsConfirmed(state);
 
-    return !!state.analytics.confirmed && !!state.analytics.enabled;
+    // If the user has not yet confirmed analytics, return undefined.
+    return isAnalyticsConfirmed ? !!state.analytics.enabled : undefined;
 };

--- a/suite-common/analytics/src/analyticsReducer.ts
+++ b/suite-common/analytics/src/analyticsReducer.ts
@@ -54,15 +54,13 @@ export const selectAnalyticsInstanceId = (state: AnalyticsRootState) => state.an
 export const selectIsAnalyticsConfirmed = (state: AnalyticsRootState) =>
     !!state.analytics.confirmed;
 
-export const selectIsAnalyticsEnabled = (state: AnalyticsRootState): boolean => {
-    const isAnalyticsConfirmed = selectIsAnalyticsConfirmed(state);
-
-    return isAnalyticsConfirmed ? !!state.analytics.enabled : false;
-};
-
+// Use this directly only if you need to handle unconfirmed state differently from the disabled state.
 export const selectHasUserAllowedTracking = (state: AnalyticsRootState): boolean | undefined => {
     const isAnalyticsConfirmed = selectIsAnalyticsConfirmed(state);
 
     // If the user has not yet confirmed analytics, return undefined.
     return isAnalyticsConfirmed ? !!state.analytics.enabled : undefined;
 };
+
+export const selectIsAnalyticsEnabled = (state: AnalyticsRootState): boolean =>
+    !!selectHasUserAllowedTracking(state);

--- a/suite-common/analytics/src/tests/analyticsReducer.test.ts
+++ b/suite-common/analytics/src/tests/analyticsReducer.test.ts
@@ -1,0 +1,92 @@
+import { selectHasUserAllowedTracking, selectIsAnalyticsEnabled } from '../analyticsReducer';
+import type { AnalyticsState } from '../analyticsReducer';
+
+type RootState = {
+    analytics: AnalyticsState;
+};
+
+describe('analyticsSelectors', () => {
+    describe('selectHasUserAllowedTracking', () => {
+        it('should return undefined when analytics is not confirmed', () => {
+            const state: RootState = {
+                analytics: {
+                    confirmed: false,
+                    enabled: true,
+                },
+            };
+            expect(selectHasUserAllowedTracking(state)).toBeUndefined();
+        });
+
+        it('should return true when analytics is confirmed and enabled', () => {
+            const state: RootState = {
+                analytics: {
+                    confirmed: true,
+                    enabled: true,
+                },
+            };
+            expect(selectHasUserAllowedTracking(state)).toBe(true);
+        });
+
+        it('should return false when analytics is confirmed but disabled', () => {
+            const state: RootState = {
+                analytics: {
+                    confirmed: true,
+                    enabled: false,
+                },
+            };
+            expect(selectHasUserAllowedTracking(state)).toBe(false);
+        });
+
+        it('should return false when analytics is confirmed but enabled is undefined', () => {
+            const state: RootState = {
+                analytics: {
+                    confirmed: true,
+                    enabled: undefined,
+                },
+            };
+            expect(selectHasUserAllowedTracking(state)).toBe(false);
+        });
+    });
+
+    describe('selectIsAnalyticsEnabled', () => {
+        it('should return false when analytics is not confirmed', () => {
+            const state: RootState = {
+                analytics: {
+                    confirmed: false,
+                    enabled: true,
+                },
+            };
+            expect(selectIsAnalyticsEnabled(state)).toBe(false);
+        });
+
+        it('should return true when analytics is confirmed and enabled', () => {
+            const state: RootState = {
+                analytics: {
+                    confirmed: true,
+                    enabled: true,
+                },
+            };
+            expect(selectIsAnalyticsEnabled(state)).toBe(true);
+        });
+
+        it('should return false when analytics is confirmed but disabled', () => {
+            const state: RootState = {
+                analytics: {
+                    confirmed: true,
+                    enabled: false,
+                },
+            };
+            expect(selectIsAnalyticsEnabled(state)).toBe(false);
+        });
+
+        it('should return false when analytics is confirmed but enabled is undefined', () => {
+            const state: RootState = {
+                analytics: {
+                    confirmed: true,
+                    enabled: undefined,
+                },
+            };
+            expect(selectIsAnalyticsEnabled(state)).toBe(false);
+        });
+    });
+});

--- a/suite-native/analytics/src/analyticsThunks.ts
+++ b/suite-native/analytics/src/analyticsThunks.ts
@@ -45,12 +45,12 @@ export const initAnalyticsThunk = createThunk(
     (_, { dispatch, getState }) => {
         const sessionId = getTrackingRandomId();
         const instanceId = selectAnalyticsInstanceId(getState()) ?? getTrackingRandomId();
-        const userAllowedTracking = selectHasUserAllowedTracking(getState());
+        const hasUserAllowedTracking = selectHasUserAllowedTracking(getState());
 
         const isAnalyticsEnabled = selectIsAnalyticsEnabled(getState());
         const isAnalyticsConfirmed = selectIsAnalyticsConfirmed(getState());
 
-        analytics.init(userAllowedTracking, {
+        analytics.init(hasUserAllowedTracking, {
             instanceId,
             sessionId,
             environment: 'mobile',
@@ -62,7 +62,7 @@ export const initAnalyticsThunk = createThunk(
             },
         });
 
-        allowSentryReport(!!userAllowedTracking);
+        allowSentryReport(isAnalyticsEnabled);
         setSentryUser(instanceId);
 
         dispatch(


### PR DESCRIPTION
## Description

Pure refactoring, no changes in logic. The usage of selectHasUserAllowedTracking was confusing. It’s only needed during analytics initialization to decide whether to flush the queue and if events should be queued.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/analytics-selectors-simplification&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/analytics-selectors-simplification&lookback=7)