### PR TITLE
fix: replace SettingsSectionItem with SectionItem in debug settings

### DIFF
--- a/packages/suite/src/components/settings/SettingsSectionItem.tsx
+++ b/packages/suite/src/components/settings/SettingsSectionItem.tsx
@@ -4,10 +4,10 @@ import { SectionItem } from 'src/components/suite';
 import { SettingsAnchorValue } from 'src/constants/suite/anchors';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 
-interface SettingsSectionItemProps {
-    anchorId?: SettingsAnchorValue;
+type SettingsSectionItemProps = {
+    anchorId: SettingsAnchorValue;
     children: ReactNode;
-}
+};
 
 export const SettingsSectionItem = ({ anchorId, children }: SettingsSectionItemProps) => {
     const { anchorRef, shouldHighlight } = useAnchor(anchorId);

--- a/packages/suite/src/hooks/suite/useAnchor.ts
+++ b/packages/suite/src/hooks/suite/useAnchor.ts
@@ -6,7 +6,7 @@ import { useSelector } from 'src/hooks/suite';
 
 const OFFSET = 30;
 
-export const useAnchor = (anchorId: string | undefined) => {
+export const useAnchor = (anchorId: string) => {
     const anchorRef = useRef<HTMLDivElement>(null);
     const anchor = useSelector(state => state.router.anchor);
 

--- a/packages/suite/src/views/settings/SettingsDebug/GithubIssue.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/GithubIssue.tsx
@@ -1,5 +1,4 @@
-import { SettingsSectionItem } from 'src/components/settings';
-import { ActionButton, ActionColumn, TextColumn } from 'src/components/suite';
+import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { useDevice, useSelector } from 'src/hooks/suite';
 import { selectActiveTransports } from 'src/reducers/suite/suiteReducer';
 import { openGithubIssue } from 'src/services/github';
@@ -11,7 +10,7 @@ export const GithubIssue = () => {
     const handleClick = () => openGithubIssue({ device, transports });
 
     return (
-        <SettingsSectionItem>
+        <SectionItem>
             <TextColumn
                 title="Open issue on Github"
                 description="Open issue on Github with pre-filled details. Do not use with sensitive data!"
@@ -21,6 +20,6 @@ export const GithubIssue = () => {
                     Open issue
                 </ActionButton>
             </ActionColumn>
-        </SettingsSectionItem>
+        </SectionItem>
     );
 };

--- a/packages/suite/src/views/settings/SettingsDebug/InvityApi.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/InvityApi.tsx
@@ -3,8 +3,7 @@ import styled from 'styled-components';
 import { type InvityServerEnvironment, invityAPI } from '@suite-common/trading';
 
 import { setDebugMode } from 'src/actions/suite/suiteActions';
-import { SettingsSectionItem } from 'src/components/settings';
-import { ActionColumn, ActionSelect, TextColumn } from 'src/components/suite';
+import { ActionColumn, ActionSelect, SectionItem, TextColumn } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { reloadApp } from 'src/utils/suite/reload';
 
@@ -34,7 +33,7 @@ export const InvityApi = () => {
     };
 
     return (
-        <SettingsSectionItem>
+        <SectionItem>
             <TextColumn
                 title="API server"
                 description="Set the server url for buy and exchange features"
@@ -46,6 +45,6 @@ export const InvityApi = () => {
                     options={invityApiServerOptions}
                 />
             </ActionColumn>
-        </SettingsSectionItem>
+        </SectionItem>
     );
 };

--- a/packages/suite/src/views/settings/SettingsDebug/OAuthApi.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/OAuthApi.tsx
@@ -1,8 +1,7 @@
 import styled from 'styled-components';
 
 import { setDebugMode } from 'src/actions/suite/suiteActions';
-import { SettingsSectionItem } from 'src/components/settings';
-import { ActionColumn, ActionSelect, TextColumn } from 'src/components/suite';
+import { ActionColumn, ActionSelect, SectionItem, TextColumn } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import GoogleClient from 'src/services/google';
 import type { OAuthServerEnvironment } from 'src/types/suite/metadata';
@@ -28,7 +27,7 @@ export const OAuthApi = () => {
     };
 
     return (
-        <SettingsSectionItem>
+        <SectionItem>
             <TextColumn
                 title="Google auth server"
                 description="Set the authorisation server url for labeling in Google Drive"
@@ -40,6 +39,6 @@ export const OAuthApi = () => {
                     options={options}
                 />
             </ActionColumn>
-        </SettingsSectionItem>
+        </SectionItem>
     );
 };

--- a/packages/suite/src/views/settings/SettingsDebug/TranslationMode.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TranslationMode.tsx
@@ -1,11 +1,10 @@
 import { Switch } from '@trezor/components';
 
-import { SettingsSectionItem } from 'src/components/settings';
-import { ActionColumn, TextColumn } from 'src/components/suite';
+import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { isTranslationMode, setTranslationMode } from 'src/utils/suite/l10n';
 
 export const TranslationMode = () => (
-    <SettingsSectionItem>
+    <SectionItem>
         <TextColumn
             title="Translation mode"
             description="Translation mode enables distinctive visual styling for currently used intl messages. Helpful tooltip with an ID of the message will show up when you mouse over the message."
@@ -16,5 +15,5 @@ export const TranslationMode = () => (
                 onChange={() => setTranslationMode(!isTranslationMode())}
             />
         </ActionColumn>
-    </SettingsSectionItem>
+    </SectionItem>
 );

--- a/packages/suite/src/views/settings/SettingsDebug/WipeData.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/WipeData.tsx
@@ -3,8 +3,7 @@ import styled from 'styled-components';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
-import { SettingsSectionItem } from 'src/components/settings';
-import { ActionButton, ActionColumn, TextColumn } from 'src/components/suite';
+import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 const UserDataLink = styled.span`
@@ -20,7 +19,7 @@ export const WipeData = () => {
     const dispatch = useDispatch();
 
     return (
-        <SettingsSectionItem>
+        <SectionItem>
             <TextColumn
                 title="Wipe app data"
                 description={
@@ -57,6 +56,6 @@ export const WipeData = () => {
                     Wipe data
                 </ActionButton>
             </ActionColumn>
-        </SettingsSectionItem>
+        </SectionItem>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`SettingsSectionItem` is just a wrapper around `SectionItem` adding an anchor. We can use `SectionItem` directly in debug settings as no anchors are used there after they have been removed in https://github.com/trezor/trezor-suite/pull/18290.
## Related Issue

Resolve https://satoshilabs.slack.com/archives/C05R69DBKSN/p1744367829954769

## Screenshots:
before:
![image](https://github.com/user-attachments/assets/d9567128-fafa-4411-ac1f-f1b140ddcbe5)
