### PR TITLE
connect in desktop - tests and improvements

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/connect-ws.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/connect-ws.test.ts
@@ -1,6 +1,13 @@
 import TrezorConnect from '@trezor/connect-web';
 
 import { expect, test } from '../../support/fixtures';
+import { ConnectPopupModal } from '../../support/pageObjects/connectPopupModal';
+
+const passThroughPermissions = async (connectModal: ConnectPopupModal) => {
+    await expect(connectModal.processParagraph).toHaveText('Process: node');
+    await expect(connectModal.rememberCheckbox).toHaveText('Always allow for this app');
+    await connectModal.confirmButton.click();
+};
 
 test.describe('TrezorConnect', { tag: ['@group=suite', '@desktopOnly'] }, () => {
     test.use({ electronConf: { exposeConnectWs: true } });
@@ -26,13 +33,12 @@ test.describe('TrezorConnect', { tag: ['@group=suite', '@desktopOnly'] }, () => 
             coin: 'btc',
         });
 
-        // export single address
         await expect(connectModal.header).toHaveText('Export Bitcoin address');
-        await expect(connectModal.processParagraph).toHaveText('Process: node');
-        await expect(connectModal.rememberCheckbox).toHaveText('Always allow for this app');
-        await connectModal.confirmButton.click();
+        await passThroughPermissions(connectModal);
+
+        // export single address
         await trezorUserEnvLink.pressYes();
-        expect((await res).success).toBe(true);
+        expect(await res).toMatchObject({ success: true });
 
         // export multiple addresses
         const resMultiple = TrezorConnect.getAddress({
@@ -51,7 +57,34 @@ test.describe('TrezorConnect', { tag: ['@group=suite', '@desktopOnly'] }, () => 
         await connectModal.confirmButton.click();
         await trezorUserEnvLink.pressYes();
         await trezorUserEnvLink.pressYes();
-        expect((await resMultiple).success).toBe(true);
+
+        expect(await resMultiple).toMatchObject({ success: true });
+    });
+
+    test('TrezorConnect.ethereumSignTransaction', async ({ connectModal, trezorUserEnvLink }) => {
+        const res = TrezorConnect.ethereumSignTransaction({
+            path: "m/44'/60'/0'/0/0",
+            transaction: {
+                nonce: '0x0',
+                gasPrice: '0x14',
+                gasLimit: '0x14',
+                to: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+                chainId: 1,
+                value: '0x0',
+                data: '0xa9059cbb000000000000000000000000D6971aabeDC7f2A8113679199FE374aE1B1Aea96000000000000000000000000000000000000000000000000000000000097f6b2',
+            },
+        });
+
+        await expect(connectModal.header).toHaveText('Sign Ethereum transaction');
+        await passThroughPermissions(connectModal);
+
+        // todo: add UI asserts for step 1
+        await trezorUserEnvLink.swipeEmu('up');
+
+        // todo: add UI asserts for step 2
+        await trezorUserEnvLink.pressYes();
+
+        expect(await res).toMatchObject({ success: true });
     });
 });
 

--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/error.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/error.test.ts
@@ -1,0 +1,29 @@
+import TrezorConnect from '@trezor/connect-web';
+
+import { expect, test } from '../../support/fixtures';
+
+test.describe('TrezorConnect', { tag: ['@group=suite', '@desktopOnly'] }, () => {
+    test.use({ electronConf: { exposeConnectWs: true } });
+    test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
+        await onboardingPage.completeOnboarding();
+        await dashboardPage.discoveryShouldFinish();
+        await test.step('Initialize TrezorConnect', async () => {
+            await TrezorConnect.init({
+                manifest: {
+                    appUrl: 'http://localhost:8080',
+                    email: '',
+                    appName: 'Tester',
+                },
+                coreMode: 'suite-desktop',
+                debug: true,
+            });
+        });
+    });
+
+    test('Error screen', async ({ page }) => {
+        TrezorConnect.ethereumGetAddress({ path: 'foo bar' });
+        // todo: error should be handled in a modal
+        const toast = page.getByTestId('@toast/error');
+        await expect(toast).toHaveText('Error: Not a valid path');
+    });
+});

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -1,6 +1,7 @@
 import { AsyncThunkAction } from '@reduxjs/toolkit';
 
 import { CustomThunkAPI, createThunk } from '@suite-common/redux-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
 import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
 import { PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import TrezorConnect, { CallMethodParams, CallMethodResponse } from '@trezor/connect';
@@ -41,7 +42,7 @@ export const connectPopupCallThunkInner = createThunk<
             });
             if (!methodInfo.success) {
                 dispatch(connectPopupActions.setError(TypedError(methodInfo.payload.code)));
-                throw methodInfo;
+                throw methodInfo.payload;
             }
             if (
                 methodInfo.payload.requiredPermissions.includes('management') ||
@@ -134,6 +135,13 @@ export const connectPopupCallThunkInner = createThunk<
             return response;
         } catch (error) {
             console.error('connectPopupCallThunk', error);
+            // todo: there should be a modal with richer error message
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'error',
+                    error: `connect error: ${serializeError(error).error || 'unhandled error'}`,
+                }),
+            );
 
             return {
                 success: false,

--- a/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
+++ b/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
@@ -33,13 +33,18 @@ const preCallHook = <M extends keyof typeof TrezorConnect>({
 }: PreCallHookParams<M>) => {
     if (methods.includes(method)) {
         if ('bundle' in payload && Array.isArray(payload.bundle)) {
-            payload.bundle = payload.bundle.map(item => ({
-                ...item,
-                showOnTrezor: false,
-            }));
+            payload = {
+                ...payload,
+                bundle: payload.bundle.map(item => ({
+                    ...item,
+                    showOnTrezor: false,
+                })),
+            };
         } else {
-            // @ts-expect-error
-            payload.showOnTrezor = false;
+            payload = {
+                ...payload,
+                showOnTrezor: false,
+            };
         }
     }
 };


### PR DESCRIPTION
- test(suite-desktop): add ethereumSignTransaction test
- fix(suite-common): in connect-popup fix 'Cannot add property showOnTrezor, object is not extensible' error
- feat(suite): connect-popup: add minimal error feedback using toast (temporary) - to have at least something for now