### PR TITLE
feat(suite): connect popup sign message modal

### DIFF
--- a/packages/connect/src/api/ethereum/api/ethereumSignMessage.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignMessage.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../types';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';
 import { messageToHex } from '../../../utils/formatUtils';
-import { getSlip44ByPath, validatePath } from '../../../utils/pathUtils';
+import { getSerializedPath, getSlip44ByPath, validatePath } from '../../../utils/pathUtils';
 import { getFirmwareRange } from '../../common/paramsValidator';
 import { getEthereumDefinitions } from '../ethereumDefinitions';
 
@@ -56,6 +56,17 @@ export default class EthereumSignMessage extends AbstractMethod<'ethereumSignMes
 
     get info() {
         return getNetworkLabel('Sign #NETWORK message', getEthereumNetwork(this.params.address_n));
+    }
+
+    getButtonRequestData(code: string, name?: string) {
+        if (code === 'ButtonRequest_Other' && name === 'sign_message') {
+            return {
+                type: 'message' as const,
+                coin: this.params.network?.shortcut ?? 'ETH',
+                serializedPath: getSerializedPath(this.params.address_n),
+                message: this.payload.message,
+            };
+        }
     }
 
     async run() {

--- a/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../types/api/ethereum';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';
 import { messageToHex } from '../../../utils/formatUtils';
-import { getSlip44ByPath, validatePath } from '../../../utils/pathUtils';
+import { getSerializedPath, getSlip44ByPath, validatePath } from '../../../utils/pathUtils';
 import { getFirmwareRange } from '../../common/paramsValidator';
 import { getEthereumDefinitions } from '../ethereumDefinitions';
 import { encodeData, getFieldType, parseArrayType } from '../ethereumSignTypedData';
@@ -116,6 +116,17 @@ export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignT
             'Sign #NETWORK typed data',
             getEthereumNetwork(this.params.address_n),
         );
+    }
+
+    getButtonRequestData(code: string) {
+        if (code === 'ButtonRequest_Other') {
+            return {
+                type: 'message' as const,
+                coin: this.params.network?.shortcut ?? 'ETH',
+                serializedPath: getSerializedPath(this.params.address_n),
+                message: JSON.stringify(this.params.data, null, 2),
+            };
+        }
     }
 
     async run() {

--- a/packages/connect/src/api/signMessage.ts
+++ b/packages/connect/src/api/signMessage.ts
@@ -9,9 +9,11 @@ import { SignMessage as SignMessageSchema } from '../types';
 import { getFirmwareRange, validateCoinPath } from './common/paramsValidator';
 import { getBitcoinNetwork } from '../data/coinInfo';
 import { messageToHex } from '../utils/formatUtils';
-import { getLabel, getScriptType, validatePath } from '../utils/pathUtils';
+import { getLabel, getScriptType, getSerializedPath, validatePath } from '../utils/pathUtils';
 
 export default class SignMessage extends AbstractMethod<'signMessage', PROTO.SignMessage> {
+    coinInfo: BitcoinNetworkInfo | undefined;
+
     init() {
         this.requiredPermissions = ['read', 'write'];
 
@@ -21,19 +23,18 @@ export default class SignMessage extends AbstractMethod<'signMessage', PROTO.Sig
         Assert(SignMessageSchema, payload);
 
         const path = validatePath(payload.path);
-        let coinInfo: BitcoinNetworkInfo | undefined;
         if (payload.coin) {
-            coinInfo = getBitcoinNetwork(payload.coin);
-            validateCoinPath(path, coinInfo);
+            this.coinInfo = getBitcoinNetwork(payload.coin);
+            validateCoinPath(path, this.coinInfo);
         } else {
-            coinInfo = getBitcoinNetwork(path);
+            this.coinInfo = getBitcoinNetwork(path);
         }
 
         // firmware range depends on used no_script_type parameter
         // no_script_type is possible since 1.10.4 / 2.4.3
         this.firmwareRange = getFirmwareRange(
             payload.no_script_type ? 'signMessageNoScriptType' : this.name,
-            coinInfo,
+            this.coinInfo,
             this.firmwareRange,
         );
 
@@ -44,7 +45,7 @@ export default class SignMessage extends AbstractMethod<'signMessage', PROTO.Sig
         this.params = {
             address_n: path,
             message: messageHex,
-            coin_name: coinInfo ? coinInfo.name : undefined,
+            coin_name: this.coinInfo ? this.coinInfo.name : undefined,
             script_type: scriptType && scriptType !== 'SPENDMULTISIG' ? scriptType : 'SPENDADDRESS', // script_type 'SPENDMULTISIG' throws Failure_FirmwareError
             no_script_type: payload.no_script_type,
         };
@@ -54,6 +55,17 @@ export default class SignMessage extends AbstractMethod<'signMessage', PROTO.Sig
         const coinInfo = getBitcoinNetwork(this.payload.coin ?? this.params.address_n);
 
         return getLabel('Sign #NETWORK message', coinInfo);
+    }
+
+    getButtonRequestData(code: string, name?: string) {
+        if (code === 'ButtonRequest_Other' && name === 'sign_message') {
+            return {
+                type: 'message' as const,
+                serializedPath: getSerializedPath(this.params.address_n.slice(0, 4)),
+                coin: this.coinInfo?.shortcut ?? 'BTC',
+                message: this.payload.message,
+            };
+        }
     }
 
     async run() {

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -158,7 +158,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
 
     noBackupConfirmationMode: 'never' | 'always' | 'popup-only';
 
-    getButtonRequestData?(code: string): UiRequestButtonData | undefined;
+    getButtonRequestData?(code: string, name?: string): UiRequestButtonData | undefined;
 
     // callbacks
     // @ts-expect-error: strictPropertyInitialization

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -780,7 +780,7 @@ const onDeviceButtonHandler =
         }
         const data =
             typeof method?.getButtonRequestData === 'function' && request.code
-                ? method?.getButtonRequestData(request.code)
+                ? method?.getButtonRequestData(request.code, request.name)
                 : undefined;
         // interaction timeout
         startInteractionTimeout(context);

--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -131,11 +131,18 @@ export type UiRequestDeviceAction =
           };
       };
 
-export interface UiRequestButtonData {
-    type: 'address';
-    serializedPath: string;
-    address: string;
-}
+export type UiRequestButtonData =
+    | {
+          type: 'address';
+          serializedPath: string;
+          address: string;
+      }
+    | {
+          type: 'message';
+          serializedPath: string;
+          coin: string;
+          message: string;
+      };
 
 // ButtonRequest_FirmwareUpdate is a artificial button request thrown by "uploadFirmware" method
 // at the beginning of the uploading process

--- a/packages/connect/src/types/api/__tests__/events.ts
+++ b/packages/connect/src/types/api/__tests__/events.ts
@@ -94,7 +94,12 @@ export const events = (api: TrezorConnect) => {
             if (event.payload.code === 'foo') {
                 //
             }
-            event.payload.data?.address.toLowerCase();
+            if (event.payload.data?.type === 'address') {
+                event.payload.data.address.toLowerCase();
+            }
+            if (event.payload.data?.type === 'message') {
+                event.payload.data.message.toLowerCase();
+            }
             event.payload.device.label.toLowerCase();
         }
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
@@ -19,6 +19,7 @@ import { useSelector } from 'src/hooks/suite';
 import messages from 'src/support/messages';
 
 import type { ReduxModalProps } from '../ReduxModal';
+import { SignMessageModal } from './SignMessageModal';
 
 /** Modals requested by Device from `trezor-connect` */
 export const DeviceContextModal = ({
@@ -52,6 +53,8 @@ export const DeviceContextModal = ({
             return <TransactionReviewModal type="sign-transaction" />;
         }
         case 'ButtonRequest_Other': {
+            if (data?.type === 'message') return <SignMessageModal device={device} {...data} />;
+
             return <ConfirmActionModal device={device} />;
         }
         case 'ButtonRequest_FirmwareCheck':
@@ -72,7 +75,7 @@ export const DeviceContextModal = ({
         case 'ButtonRequest_PinEntry':
             return <ConfirmActionModal device={device} />;
         case 'ButtonRequest_Address':
-            return data ? (
+            return data?.type === 'address' ? (
                 <ConfirmAddressModal
                     value={data.address}
                     addressPath={data.serializedPath}

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/SignMessageModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/SignMessageModal.tsx
@@ -1,0 +1,113 @@
+import { selectConnectPopupCall } from '@suite-common/connect-popup';
+import { TrezorDevice } from '@suite-common/suite-types';
+import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { selectDeviceAccounts } from '@suite-common/wallet-core';
+import { Card, Column, DotIndicator, H4, NewModal, Row, Text } from '@trezor/components';
+import TrezorConnect from '@trezor/connect';
+import { CoinLogo, ConfirmOnDevice } from '@trezor/product-components';
+import { spacings } from '@trezor/theme';
+
+import { AccountLabel } from 'src/components/suite/AccountLabel';
+import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
+import { Translation } from 'src/components/suite/Translation';
+import { useSelector } from 'src/hooks/suite';
+import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
+
+import { ConfirmActionModal } from './ConfirmActionModal';
+
+interface SignMessageModalProps {
+    device: TrezorDevice;
+    message: string;
+    coin?: string;
+    serializedPath?: string;
+}
+
+export const SignMessageModal = ({
+    device,
+    message,
+    coin,
+    serializedPath,
+}: SignMessageModalProps) => {
+    const popupCall = useSelector(selectConnectPopupCall);
+    const accounts = useSelector(selectDeviceAccounts);
+    const accountLabels = useSelector(selectAccountLabels);
+    const deviceModelInternal = device.features?.internal_model;
+
+    if (!popupCall || popupCall?.state !== 'ongoing') return <ConfirmActionModal device={device} />;
+
+    const onCancel = () => {
+        TrezorConnect.cancel();
+    };
+
+    // Connect's coin shortcut (uppercase) <-> Suite's network symbol (lowercase)
+    const networkSymbol = coin?.toLowerCase() as NetworkSymbol;
+    const network = networkSymbol ? getNetwork(networkSymbol) : undefined;
+    const account = accounts.find(a => a.symbol === networkSymbol && a.path === serializedPath);
+
+    return (
+        <NewModal.Backdrop>
+            <ConfirmOnDevice
+                title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
+                deviceModelInternal={deviceModelInternal}
+                deviceUnitColor={device?.features?.unit_color}
+                successText={<Translation id="TR_CONFIRMED_TX" />}
+                onCancel={onCancel}
+            />
+            <NewModal.ModalBase
+                size="small"
+                heading={
+                    popupCall.method === 'ethereumSignTypedData' ? (
+                        <Translation id="TR_SIGN_EIP712_TYPED_DATA" />
+                    ) : (
+                        <Translation id="TR_SIGN_MESSAGE" />
+                    )
+                }
+                description={
+                    <Row
+                        columnGap={spacings.md}
+                        rowGap={spacings.xxs}
+                        flexWrap="wrap"
+                        margin={{ top: spacings.xs }}
+                    >
+                        {network && (
+                            <Row gap={spacings.xxs}>
+                                <CoinLogo size={14} symbol={network.symbol} />
+                                {account ? (
+                                    <AccountLabel
+                                        accountLabel={
+                                            accountLabels[account.key] || account.accountLabel
+                                        }
+                                        accountType={account.accountType}
+                                        symbol={account.symbol}
+                                        index={account.index}
+                                    />
+                                ) : (
+                                    network.name
+                                )}
+                            </Row>
+                        )}
+                        <ConnectCallSource />
+                    </Row>
+                }
+            >
+                <Column gap={spacings.xs}>
+                    <Card
+                        heading={
+                            <Row gap={spacings.sm}>
+                                <DotIndicator isActive={true} />
+                                <H4 margin={{ left: spacings.xxs }} typographyStyle="callout">
+                                    <Translation id="TR_MESSAGE" />
+                                </H4>
+                            </Row>
+                        }
+                        paddingType="small"
+                    >
+                        <Text isMonospaced as="pre" margin={{ left: spacings.xxl }}>
+                            {message}
+                        </Text>
+                    </Card>
+                </Column>
+            </NewModal.ModalBase>
+        </NewModal.Backdrop>
+    );
+};

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9887,4 +9887,8 @@ export default defineMessages({
         id: 'TR_NOT_ENOUGH_FUNDS',
         defaultMessage: 'Not enough funds, please select a different account.',
     },
+    TR_SIGN_EIP712_TYPED_DATA: {
+        id: 'TR_SIGN_EIP712_TYPED_DATA',
+        defaultMessage: 'Sign EIP-712 typed data',
+    },
 });


### PR DESCRIPTION
## Description

New modal for sign message confirmation for Connect Popup calls in Suite.
The implementation is done by extending button request data. 

This covers the following methods:
- signMessage
- ethereumSignMessage
- ethereumSignTypedData

## Screenshots:

<img width="666" alt="Screenshot 2025-04-11 at 15 52 13" src="https://github.com/user-attachments/assets/aad441a3-08a4-4b0a-97e2-7599644884c0" />
