### PR TITLE
Data Analytics: device-connect - add isBitcoinOnlyDevice to the event

### DIFF
--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -98,6 +98,7 @@ export type SuiteAnalyticsEvent =
               totalInstances?: number | null;
               backup_type?: string;
               isBitcoinOnly?: boolean;
+              isBitcoinOnlyDevice?: boolean;
               totalDevices?: number;
               language?: string | null;
               model?: string;

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -18,6 +18,7 @@ import {
     getFirmwareRevision,
     getFirmwareVersion,
     hasBitcoinOnlyFirmware,
+    isBitcoinOnlyDevice,
     isDeviceInBootloaderMode,
     isOfficialFirmware,
 } from '@trezor/device-utils';
@@ -120,6 +121,7 @@ const analyticsMiddleware =
                             passphrase_protection: features.passphrase_protection,
                             totalInstances: selectDevicesCount(state),
                             isBitcoinOnly: hasBitcoinOnlyFirmware(action.payload.device),
+                            isBitcoinOnlyDevice: isBitcoinOnlyDevice(action.payload.device),
                             totalDevices: getPhysicalDeviceCount(selectDevices(state)),
                             language: features.language,
                             model: features.internal_model,


### PR DESCRIPTION
## Description

Data Analytics: `device-connect` now has new parameter `isBitcoinOnlyDevice`

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/9752