### PR TITLE
fix(suite-native): correct trade assets filter deselect

### DIFF
--- a/suite-native/module-trading/src/components/general/TradeableAssetsSheet/TradeableAssetsFilterTabs.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetsSheet/TradeableAssetsFilterTabs.tsx
@@ -81,6 +81,7 @@ export const TradeableAssetsFilterTabs = ({
                     {item.label}
                 </FilterTab>
             )}
+            keyboardShouldPersistTaps="always"
         />
     );
 };


### PR DESCRIPTION
Clear network filter on unmounting whole header not only the filter (which was unmounted when selected). It wrongly worked in ios emulator but not elsewhere.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve #16992

## Screenshots:

https://github.com/user-attachments/assets/d58fd636-d3e8-4aef-a30f-ac9ba6a5fa44

