### PR TITLE
Refactor changing of enabled coins + discoveryShouldFinish uses

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/dashboardPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/dashboardPage.ts
@@ -8,7 +8,6 @@ export type graphRangeOptions = 'day' | 'week' | 'month' | 'year' | 'all';
 export class DashboardPage {
     readonly dashboardMenuButton: Locator;
     readonly dashboardHeader: Locator;
-    readonly discoveryBar: Locator;
     readonly graph: Locator;
     readonly graphRangeSelector = (range: graphRangeOptions) =>
         this.page.getByTestId(`@dashboard/graph/range-${range}`);
@@ -45,7 +44,6 @@ export class DashboardPage {
     ) {
         this.dashboardMenuButton = this.page.getByTestId('@suite/menu/suite-index');
         this.dashboardHeader = this.page.getByRole('heading', { name: 'Dashboard' });
-        this.discoveryBar = this.page.getByTestId('@wallet/discovery-progress-bar');
         this.graph = this.page.getByTestId('@dashboard/graph');
         this.deviceSwitchingOpenButton = this.page.getByTestId('@menu/switch-device');
         this.deviceSwitchingCloseButton = this.page.getByTestId('@switch-device/cancel-button');
@@ -83,14 +81,6 @@ export class DashboardPage {
     }
 
     @step()
-    async discoveryShouldFinish() {
-        await expect(this.discoveryBar, 'discovery bar should be visible').toBeVisible({
-            timeout: 10_000,
-        });
-        await this.discoveryBar.waitFor({ state: 'detached', timeout: 120_000 });
-    }
-
-    @step()
     async openDeviceSwitcher() {
         await this.deviceSwitchingOpenButton.click();
         await expect(this.modal).toBeVisible();
@@ -108,7 +98,7 @@ export class DashboardPage {
     async addStandardWallet() {
         await this.addStandardWalletButton.click();
         await this.modal.waitFor({ state: 'detached' });
-        await this.discoveryShouldFinish();
+        await this.page.discoveryShouldFinish();
     }
 
     @step()
@@ -132,7 +122,7 @@ export class DashboardPage {
         // Sometimes the pressYes action takes 5,5s and suite in meantime can finish discovery
         // This would cause failure of the test even tho the flow continued correctly
         // Solution is to fire both Promises asynchronously and wait for both to finish
-        await Promise.all([TrezorUserEnvLinkProxy.pressYes(), this.discoveryShouldFinish()]);
+        await Promise.all([TrezorUserEnvLinkProxy.pressYes(), this.page.discoveryShouldFinish()]);
     }
 
     @step()

--- a/packages/suite-desktop-core/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/settings/settingsPage.ts
@@ -1,5 +1,6 @@
 import { Locator, Page, test } from '@playwright/test';
 
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import { CoinsTab } from './coinsTab';
@@ -214,5 +215,23 @@ export class SettingsPage {
         await this.page.getByTestId('@safety-checks-apply').click();
         await expect(this.confirmOnDevicePrompt).toBeVisible();
         await TrezorUserEnvLinkProxy.pressYes();
+    }
+
+    @step()
+    async changeNetworks(options: {
+        enableNetworks: NetworkSymbol[];
+        disableNetworks?: NetworkSymbol[];
+    }) {
+        await this.navigateTo('coins');
+        for (const network of options.enableNetworks) {
+            this.coins.enableNetwork(network);
+        }
+
+        for (const network of options.disableNetworks ?? []) {
+            this.coins.disableNetwork(network);
+        }
+
+        await this.coins.activateCoinsButton.click();
+        await this.discoveryShouldFinish();
     }
 }

--- a/packages/suite-desktop-core/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/settings/settingsPage.ts
@@ -224,11 +224,11 @@ export class SettingsPage {
     }) {
         await this.navigateTo('coins');
         for (const network of options.enableNetworks) {
-            this.coins.enableNetwork(network);
+            await this.coins.enableNetwork(network);
         }
 
         for (const network of options.disableNetworks ?? []) {
-            this.coins.disableNetwork(network);
+            await this.coins.disableNetwork(network);
         }
 
         await this.coins.activateCoinsButton.click();

--- a/packages/suite-desktop-core/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/settings/settingsPage.ts
@@ -232,6 +232,6 @@ export class SettingsPage {
         }
 
         await this.coins.activateCoinsButton.click();
-        await this.discoveryShouldFinish();
+        await this.page.discoveryShouldFinish();
     }
 }

--- a/packages/suite-desktop-core/e2e/tests/analytics/toggle.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/analytics/toggle.test.ts
@@ -44,7 +44,7 @@ test.describe('Analytics Toggle - Enabling and Disabling', { tag: ['@group=other
 
         // reload app (important, app needs time to save initialRun flag into storage) to change session id
         await page.getByTestId('@suite/loading').waitFor({ state: 'hidden' });
-        await dashboardPage.discoveryShouldFinish();
+        await page.discoveryShouldFinish();
         await page.reload();
 
         // go to settings, analytics should not enabled and no additional analytics requests should be fired

--- a/packages/suite-desktop-core/e2e/tests/dashboard/assets.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/dashboard/assets.test.ts
@@ -24,6 +24,7 @@ test.describe('Assets', { tag: ['@group=suite'] }, () => {
     });
 
     test('New asset is shown in both grid and row', async ({
+        page,
         assetsSection,
         dashboardPage,
         settingsPage,
@@ -31,7 +32,7 @@ test.describe('Assets', { tag: ['@group=suite'] }, () => {
         await assetsSection.enableMoreCoins.click();
         await settingsPage.coins.enableNetwork('eth');
         await dashboardPage.navigateTo();
-        await dashboardPage.discoveryShouldFinish();
+        await page.discoveryShouldFinish();
         await assetsSection.verifyAssetContents();
         await assetsSection.tableIcon.click();
         await assetsSection.verifyAssetContents();

--- a/packages/suite-desktop-core/e2e/tests/metadata/metadata-lifecycle.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/metadata-lifecycle.test.ts
@@ -46,7 +46,7 @@ test.describe(
             await devicePrompt.confirmOnDevicePromptIsShown();
             await trezorUserEnvLink.pressNo();
 
-            await dashboardPage.discoveryShouldFinish();
+            await page.discoveryShouldFinish();
             await dashboardPage.deviceSwitchingOpenButton.click();
             await page.getByTestId('@viewOnlyStatus/disabled').click();
             await page.getByTestId('@viewOnly/radios/enabled').click();

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-cardano.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-cardano.test.ts
@@ -27,12 +27,7 @@ test.describe('Passphrase with cardano', { tag: ['@group=passphrase'] }, () => {
             await expect(page.getByTestId('@deviceStatus-connected')).toBeVisible();
         }
 
-        await settingsPage.navigateTo('coins');
-        await settingsPage.coins.enableNetwork('ada');
-
-        // starting discovery triggers passphrase dialogue
-        await dashboardPage.dashboardMenuButton.click();
-        await dashboardPage.discoveryShouldFinish();
+        await settingsPage.changeNetworks({ enableNetworks: ['ada'] });
         await dashboardPage.openDeviceSwitcher();
         await dashboardPage.addUnusedHiddenWallet(passphrase);
 

--- a/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
@@ -10,6 +10,7 @@ test.describe(
         });
 
         test('Electrum completes discovery successfully', async ({
+            page,
             dashboardPage,
             settingsPage,
             walletPage,
@@ -26,7 +27,7 @@ test.describe(
             await settingsPage.coins.changeBackend('electrum', electrumUrl);
 
             await dashboardPage.navigateTo();
-            await dashboardPage.discoveryShouldFinish();
+            await page.discoveryShouldFinish();
 
             await expect(walletPage.balanceOfAccount('regtest').first()).toBeVisible();
         });

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
@@ -18,23 +18,18 @@ const formattedFiatAmount = `CZK ${fiatAmount}`;
 const { receiveAddress, paymentMethodName } = buyTradeSolanaToken.trade;
 
 test.describe('Trading - Buy Solana', { tag: ['@group=other', '@webOnly'] }, () => {
-    test.beforeEach(
-        async ({ page, tradingMock, onboardingPage, settingsPage, walletPage, dashboardPage }) => {
-            await page.route(invityEndpoint.buyQuotes, async route => {
-                await route.fulfill({ json: buyQuotesSolanaToken });
-            });
-            await tradingMock.routeTrade(invityEndpoint.buyTrade, buyTradeSolanaToken);
-            await onboardingPage.completeOnboarding();
+    test.beforeEach(async ({ page, tradingMock, onboardingPage, settingsPage, walletPage }) => {
+        await page.route(invityEndpoint.buyQuotes, async route => {
+            await route.fulfill({ json: buyQuotesSolanaToken });
+        });
+        await tradingMock.routeTrade(invityEndpoint.buyTrade, buyTradeSolanaToken);
+        await onboardingPage.completeOnboarding();
 
-            await test.step('Enable Solana and open its trading', async () => {
-                await settingsPage.navigateTo('coins');
-                await settingsPage.coins.enableNetwork('sol');
-                await dashboardPage.navigateTo();
-                await dashboardPage.discoveryShouldFinish();
-                await walletPage.openTrading({ symbol: 'sol' });
-            });
-        },
-    );
+        await test.step('Enable Solana and open its trading', async () => {
+            await settingsPage.changeNetworks({ enableNetworks: ['sol'] });
+            await walletPage.openTrading({ symbol: 'sol' });
+        });
+    });
 
     test('Buy Solana Jupiter token - amount specified in crypto', async ({ page, tradingPage }) => {
         await test.step('Request a specific crypto amount of Jupiter token to buy', async () => {

--- a/packages/suite-desktop-core/e2e/tests/trading/navigation.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/navigation.test.ts
@@ -2,13 +2,13 @@ import { test } from '../../support/fixtures';
 
 test.describe('Trading - Navigation', { tag: ['@group=other'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
-    test.beforeEach(async ({ onboardingPage, dashboardPage, settingsPage }) => {
+    test.beforeEach(async ({ page, onboardingPage, dashboardPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
         await settingsPage.navigateTo('coins');
         await settingsPage.coins.enableNetwork('ltc');
         await settingsPage.coins.enableNetwork('eth');
         await settingsPage.coins.activateCoinsButton.click();
-        await dashboardPage.discoveryShouldFinish();
+        await page.discoveryShouldFinish();
         await dashboardPage.deviceSwitchingOpenButton.click();
         await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
     });

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum-token.test.ts
@@ -36,10 +36,7 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=other', '@webOnly'] }, 
             await onboardingPage.completeOnboarding();
 
             await test.step('Enable Ethereum and open its token sell trading', async () => {
-                await settingsPage.navigateTo('coins');
-                await settingsPage.coins.enableNetwork('eth');
-                await settingsPage.coins.activateCoinsButton.click();
-                await dashboardPage.discoveryShouldFinish();
+                await settingsPage.changeNetworks({ enableNetworks: ['eth'] });
                 await dashboardPage.deviceSwitchingOpenButton.click();
                 await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
                 await walletPage.openSellTradingOfToken('eth', 'USD Coin');

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
@@ -12,10 +12,7 @@ test.describe('Trading - Sell inputs', { tag: ['@group=other', '@webOnly'] }, ()
         await onboardingPage.completeOnboarding();
 
         await test.step('Enable Solana', async () => {
-            await settingsPage.navigateTo('coins');
-            await settingsPage.coins.enableNetwork('sol');
-            await settingsPage.coins.activateCoinsButton.click();
-            await dashboardPage.discoveryShouldFinish();
+            await settingsPage.changeNetworks({ enableNetworks: ['sol'] });
             await dashboardPage.deviceSwitchingOpenButton.click();
             await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
         });

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
@@ -51,10 +51,7 @@ test.describe('Trading - Sell Solana', { tag: ['@group=other', '@webOnly'] }, ()
             await onboardingPage.completeOnboarding();
 
             await test.step('Enable Solana and open its sell trading', async () => {
-                await settingsPage.navigateTo('coins');
-                await settingsPage.coins.enableNetwork('sol');
-                await settingsPage.coins.activateCoinsButton.click();
-                await dashboardPage.discoveryShouldFinish();
+                await settingsPage.changeNetworks({ enableNetworks: ['sol'] });
                 await dashboardPage.deviceSwitchingOpenButton.click();
                 await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
                 await walletPage.openTrading({ symbol: 'sol' });

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
@@ -30,12 +30,10 @@ test.describe('Trading - Swap coin to token', { tag: ['@group=other', '@webOnly'
                 await tradingMock.routeSolanaSendRequests();
             });
             await onboardingPage.completeOnboarding();
-            await settingsPage.navigateTo('coins');
-            await settingsPage.coins.enableNetwork('sol');
-            await settingsPage.coins.enableNetwork('eth');
-            await settingsPage.coins.disableNetwork('btc');
-            await settingsPage.coins.activateCoinsButton.click();
-            await dashboardPage.discoveryShouldFinish();
+            await settingsPage.changeNetworks({
+                enableNetworks: ['sol', 'eth'],
+                disableNetworks: ['btc'],
+            });
             await dashboardPage.deviceSwitchingOpenButton.click();
             await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
             await walletPage.openSwapTrading({ symbol: 'sol' });

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
@@ -40,10 +40,7 @@ test.describe('Trading - Swap coins', { tag: ['@group=other', '@webOnly'] }, () 
                 });
             });
             await onboardingPage.completeOnboarding();
-            await settingsPage.navigateTo('coins');
-            await settingsPage.coins.enableNetwork('sol');
-            await settingsPage.coins.activateCoinsButton.click();
-            await dashboardPage.discoveryShouldFinish();
+            await settingsPage.changeNetworks({ enableNetworks: ['sol'] });
             await dashboardPage.deviceSwitchingOpenButton.click();
             await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
             await walletPage.openSwapTrading({ symbol: 'sol' });

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
@@ -31,11 +31,7 @@ test.describe('Trading - Swap token to coin', { tag: ['@group=other', '@webOnly'
                 await tradingMock.routeSolanaSendRequests();
             });
             await onboardingPage.completeOnboarding();
-            await settingsPage.navigateTo('coins');
-            await settingsPage.coins.enableNetwork('sol');
-            await settingsPage.coins.activateCoinsButton.click();
-            await dashboardPage.discoveryShouldFinish();
-            await dashboardPage.deviceSwitchingOpenButton.click();
+            await settingsPage.changeNetworks({ enableNetworks: ['sol'] });
             await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
             await walletPage.openSwapTrading({ symbol: 'sol' });
         },

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
@@ -32,6 +32,7 @@ test.describe('Trading - Swap token to coin', { tag: ['@group=other', '@webOnly'
             });
             await onboardingPage.completeOnboarding();
             await settingsPage.changeNetworks({ enableNetworks: ['sol'] });
+            await dashboardPage.openDeviceSwitcher();
             await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
             await walletPage.openSwapTrading({ symbol: 'sol' });
         },

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
@@ -32,6 +32,7 @@ test.describe('Trading - Swap tokens', { tag: ['@group=other', '@webOnly'] }, ()
             });
             await onboardingPage.completeOnboarding();
             await settingsPage.changeNetworks({ enableNetworks: ['sol'] });
+            await dashboardPage.openDeviceSwitcher();
             await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
             await walletPage.openSwapTrading({ symbol: 'sol' });
         },

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
@@ -31,11 +31,7 @@ test.describe('Trading - Swap tokens', { tag: ['@group=other', '@webOnly'] }, ()
                 await tradingMock.routeSolanaSendRequests();
             });
             await onboardingPage.completeOnboarding();
-            await settingsPage.navigateTo('coins');
-            await settingsPage.coins.enableNetwork('sol');
-            await settingsPage.coins.activateCoinsButton.click();
-            await dashboardPage.discoveryShouldFinish();
-            await dashboardPage.deviceSwitchingOpenButton.click();
+            await settingsPage.changeNetworks({ enableNetworks: ['sol'] });
             await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
             await walletPage.openSwapTrading({ symbol: 'sol' });
         },

--- a/packages/suite-desktop-core/e2e/tests/wallet/account-search.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/account-search.test.ts
@@ -8,13 +8,10 @@ test.describe('Look up a BTC account', { tag: ['@group=wallet'] }, () => {
     });
     test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
-        await settingsPage.navigateTo('coins');
-        await settingsPage.coins.enableNetwork('ltc');
+        await settingsPage.changeNetworks({ enableNetworks: ['ltc'] });
     });
 
-    test('Search for bitcoin in accounts', async ({ dashboardPage, walletPage }) => {
-        await dashboardPage.navigateTo();
-        await dashboardPage.discoveryShouldFinish();
+    test('Search for bitcoin in accounts', async ({ walletPage }) => {
         await walletPage.accountSearch.fill('bitcoin');
         await expect(walletPage.accountButton({ symbol: 'ltc' })).not.toBeVisible();
         await expect(walletPage.accountButton({ symbol: 'btc' })).toBeVisible();

--- a/packages/suite-desktop-core/e2e/tests/wallet/add-account-types.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/add-account-types.test.ts
@@ -23,7 +23,12 @@ test.describe('Account types suite', { tag: ['@group=wallet'] }, () => {
      * 5. Get the number of accounts again
      * 6. Verify that the current number is equal to previous number + 1
      */
-    test('Add-account-types-btc-like', async ({ page, settingsPage, walletPage }) => {
+    test('Add-account-types-btc-like', async ({
+        page,
+        dashboardPage,
+        settingsPage,
+        walletPage,
+    }) => {
         const accountTypes = [
             {
                 coin: 'btc',
@@ -47,6 +52,7 @@ test.describe('Account types suite', { tag: ['@group=wallet'] }, () => {
         await settingsPage.changeNetworks({
             enableNetworks: coinsWithoutBTC as NetworkSymbol[],
         });
+        await dashboardPage.navigateTo();
 
         const chevrons = await walletPage.accountChevron.all();
         for (const chevron of chevrons) {

--- a/packages/suite-desktop-core/e2e/tests/wallet/add-account-types.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/add-account-types.test.ts
@@ -97,7 +97,6 @@ test.describe('Account types suite', { tag: ['@group=wallet'] }, () => {
      */
     test('Add-account-types-non-BTC-coins', async ({
         page,
-        dashboardPage,
         settingsPage,
         walletPage,
         analytics,
@@ -126,7 +125,7 @@ test.describe('Account types suite', { tag: ['@group=wallet'] }, () => {
                 await expect(page.getByTestId('@modal')).toBeVisible();
                 await page.getByTestId(`@settings/wallet/network/${coin.symbol}`).click();
                 await page.getByTestId('@add-account').click();
-                await dashboardPage.discoveryShouldFinish();
+                await page.discoveryShouldFinish();
 
                 const numberOfAccountsAfter = await page
                     .getByTestId('@account-menu/normal/group')

--- a/packages/suite-desktop-core/e2e/tests/wallet/add-account-types.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/add-account-types.test.ts
@@ -23,12 +23,7 @@ test.describe('Account types suite', { tag: ['@group=wallet'] }, () => {
      * 5. Get the number of accounts again
      * 6. Verify that the current number is equal to previous number + 1
      */
-    test('Add-account-types-btc-like', async ({
-        page,
-        settingsPage,
-        dashboardPage,
-        walletPage,
-    }) => {
+    test('Add-account-types-btc-like', async ({ page, settingsPage, walletPage }) => {
         const accountTypes = [
             {
                 coin: 'btc',
@@ -45,15 +40,13 @@ test.describe('Account types suite', { tag: ['@group=wallet'] }, () => {
             },
         ];
 
-        await settingsPage.navigateTo('coins');
-        for (const { coin } of accountTypes.filter(
-            ({ coin: coinSymbol }) => coinSymbol !== 'btc',
-        )) {
-            await settingsPage.coins.enableNetwork(coin as NetworkSymbol);
-        }
+        const coinsWithoutBTC = accountTypes
+            .map(account => account.coin)
+            .filter(coin => coin !== 'btc');
 
-        await dashboardPage.dashboardMenuButton.click();
-        await dashboardPage.discoveryShouldFinish();
+        await settingsPage.changeNetworks({
+            enableNetworks: coinsWithoutBTC as NetworkSymbol[],
+        });
 
         const chevrons = await walletPage.accountChevron.all();
         for (const chevron of chevrons) {
@@ -113,15 +106,10 @@ test.describe('Account types suite', { tag: ['@group=wallet'] }, () => {
             { symbol: 'ada', path: `m/1852'/1815'/1'` },
             { symbol: 'eth', path: `m/44'/60'/0'/0/1` },
         ];
-
-        await settingsPage.navigateTo('coins');
-        for (const coin of coins) {
-            await settingsPage.coins.enableNetwork(coin.symbol as NetworkSymbol);
-        }
-
-        await dashboardPage.dashboardMenuButton.click();
+        await settingsPage.changeNetworks({
+            enableNetworks: coins.map(coin => coin.symbol) as NetworkSymbol[],
+        });
         await walletPage.openAccount();
-        await dashboardPage.discoveryShouldFinish();
 
         analytics.interceptAnalytics();
         await page.getByTestId(`@account-menu/filter-accounts`).click();

--- a/packages/suite-desktop-core/e2e/tests/wallet/blockbook-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/blockbook-discovery.test.ts
@@ -16,7 +16,7 @@ test.describe('Custom-blockbook-discovery', { tag: ['@group=wallet'] }, () => {
         //TODO: Improve verification
     });
 
-    test('LTC blockbook discovery', async ({ settingsPage, dashboardPage }) => {
+    test('LTC blockbook discovery', async ({ page, settingsPage, dashboardPage }) => {
         const ltcBlockbook = 'https://ltc1.trezor.io';
         await settingsPage.navigateTo('coins');
         await settingsPage.coins.disableNetwork('btc');
@@ -24,7 +24,7 @@ test.describe('Custom-blockbook-discovery', { tag: ['@group=wallet'] }, () => {
         await settingsPage.coins.openNetworkAdvanceSettings('ltc');
         await settingsPage.coins.changeBackend('blockbook', ltcBlockbook);
         await dashboardPage.navigateTo();
-        await dashboardPage.discoveryShouldFinish();
+        await page.discoveryShouldFinish();
         await expect(dashboardPage.graph).toBeVisible();
         //TODO: Improve verification
     });

--- a/packages/suite-desktop-core/e2e/tests/wallet/coin-balance.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/coin-balance.test.ts
@@ -15,10 +15,8 @@ test.describe('Coin balance', { tag: ['@group=wallet'] }, () => {
     }) => {
         await trezorUserEnvLink.sendToAddressAndMineBlock({ address, btc_amount: 1 });
         await test.step('Regtest discovered with non zero value', async () => {
-            await settingsPage.navigateTo('coins');
-            await settingsPage.coins.enableNetwork('regtest');
+            await settingsPage.changeNetworks({ enableNetworks: ['regtest'] });
             await dashboardPage.navigateTo();
-            await dashboardPage.discoveryShouldFinish();
             await expect(walletPage.accountLabel({ symbol: 'regtest' })).toHaveText(
                 'Bitcoin Regtest #1',
             );

--- a/packages/suite-desktop-core/e2e/tests/wallet/export-transactions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/export-transactions.test.ts
@@ -26,19 +26,14 @@ test.describe('Export transactions', { tag: ['@group=wallet', '@webOnly'] }, () 
      */
     test('Go to account and try to export all possible variants (pdf, csv, json)', async ({
         page,
-        dashboardPage,
         settingsPage,
         walletPage,
         onboardingPage,
     }) => {
         const symbols: NetworkSymbol[] = ['btc', 'ltc', 'eth', 'ada'];
-        await settingsPage.navigateTo('coins');
-        for (const symbol of symbols.filter(s => s !== 'btc')) {
-            await settingsPage.coins.enableNetwork(symbol);
-        }
-
-        await dashboardPage.dashboardMenuButton.click();
-        await dashboardPage.discoveryShouldFinish();
+        await settingsPage.changeNetworks({
+            enableNetworks: symbols.filter(symbol => symbol !== 'btc'),
+        });
 
         for (const symbol of symbols) {
             await walletPage.openAccount({ symbol });

--- a/packages/suite-desktop-core/e2e/tests/wallet/pending-transactions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/pending-transactions.test.ts
@@ -22,14 +22,7 @@ test.describe.skip(
     () => {
         test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });
         test.beforeEach(
-            async ({
-                page,
-                onboardingPage,
-                dashboardPage,
-                settingsPage,
-                trezorUserEnvLink,
-                walletPage,
-            }) => {
+            async ({ page, onboardingPage, settingsPage, trezorUserEnvLink, walletPage }) => {
                 const payments = [
                     { address: accounts.account1.address, amount: 10 },
                     { address: accounts.account2.address, amount: 10 },
@@ -46,11 +39,10 @@ test.describe.skip(
                 await page.waitForTimeout(5_000);
 
                 await onboardingPage.completeOnboarding();
-                await settingsPage.navigateTo('coins');
-                await settingsPage.coins.disableNetwork('btc');
-                await settingsPage.coins.enableNetwork('regtest');
-                await dashboardPage.dashboardMenuButton.click();
-                await page.discoveryShouldFinish();
+                await settingsPage.changeNetworks({
+                    enableNetworks: ['regtest'],
+                    disableNetworks: ['btc'],
+                });
                 expect(
                     await walletPage.getAccountsCount('regtest'),
                     'expected 3 Regtest accounts to be discovered. They might not have been mined yet',

--- a/packages/suite-desktop-core/e2e/tests/wallet/send-doge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/send-doge.test.ts
@@ -16,17 +16,19 @@ test.describe('Doge Send', { tag: ['@group=wallet', '@snapshot'] }, () => {
     const feeAmount = '0.01450643';
     const totalAmount = '115,568,568,500.01450643';
 
-    test.beforeEach(async ({ onboardingPage, settingsPage, dashboardPage, blockbookMock }) => {
-        await blockbookMock.start('doge');
-        await onboardingPage.completeOnboarding();
-        await settingsPage.navigateTo('coins');
-        await settingsPage.coins.disableNetwork('btc');
-        await settingsPage.coins.enableNetwork('doge');
-        await settingsPage.coins.openNetworkAdvanceSettings('doge');
-        await settingsPage.coins.changeBackend('blockbook', blockbookMock.url);
-        await dashboardPage.navigateTo();
-        await dashboardPage.discoveryShouldFinish();
-    });
+    test.beforeEach(
+        async ({ page, onboardingPage, settingsPage, dashboardPage, blockbookMock }) => {
+            await blockbookMock.start('doge');
+            await onboardingPage.completeOnboarding();
+            await settingsPage.navigateTo('coins');
+            await settingsPage.coins.disableNetwork('btc');
+            await settingsPage.coins.enableNetwork('doge');
+            await settingsPage.coins.openNetworkAdvanceSettings('doge');
+            await settingsPage.coins.changeBackend('blockbook', blockbookMock.url);
+            await dashboardPage.navigateTo();
+            await page.discoveryShouldFinish();
+        },
+    );
 
     test('Cannot send amount exceeding MAX_SAFE_INTEGER', async ({
         page,

--- a/packages/suite-desktop-core/e2e/tests/wallet/send-form-ltc.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/send-form-ltc.test.ts
@@ -6,20 +6,22 @@ test.describe('LTC send form with mocked blockbook', { tag: ['@group=wallet'] },
             mnemonic: 'access juice claim special truth ugly swarm rabbit hair man error bar',
         },
     });
-    test.beforeEach(async ({ dashboardPage, onboardingPage, settingsPage, blockbookMock }) => {
-        await onboardingPage.completeOnboarding();
+    test.beforeEach(
+        async ({ page, dashboardPage, onboardingPage, settingsPage, blockbookMock }) => {
+            await onboardingPage.completeOnboarding();
 
-        await settingsPage.navigateTo('coins');
-        await blockbookMock.start('ltc');
+            await settingsPage.navigateTo('coins');
+            await blockbookMock.start('ltc');
 
-        await settingsPage.coins.disableNetwork('btc');
-        await settingsPage.coins.enableNetwork('ltc');
-        await settingsPage.coins.openNetworkAdvanceSettings('ltc');
-        await settingsPage.coins.changeBackend('blockbook', blockbookMock.url);
+            await settingsPage.coins.disableNetwork('btc');
+            await settingsPage.coins.enableNetwork('ltc');
+            await settingsPage.coins.openNetworkAdvanceSettings('ltc');
+            await settingsPage.coins.changeBackend('blockbook', blockbookMock.url);
 
-        await dashboardPage.dashboardMenuButton.click();
-        await dashboardPage.discoveryShouldFinish();
-    });
+            await dashboardPage.dashboardMenuButton.click();
+            await page.discoveryShouldFinish();
+        },
+    );
 
     test('spend output originating from mimble-wimble peg out tx', async ({
         page,

--- a/packages/suite-desktop-core/e2e/tests/wallet/send-form-regtest.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/send-form-regtest.test.ts
@@ -9,24 +9,19 @@ test.describe('Send form for bitcoin', { tag: ['@group=wallet'] }, () => {
             mnemonic: 'mnemonic_all',
         },
     });
-    test.beforeEach(
-        async ({ onboardingPage, dashboardPage, settingsPage, walletPage, trezorUserEnvLink }) => {
-            await onboardingPage.completeOnboarding();
+    test.beforeEach(async ({ onboardingPage, settingsPage, walletPage, trezorUserEnvLink }) => {
+        await onboardingPage.completeOnboarding();
+        await settingsPage.changeNetworks({ enableNetworks: ['regtest'] });
 
-            await settingsPage.navigateTo('coins');
-            await settingsPage.coins.enableNetwork('regtest');
+        await trezorUserEnvLink.sendToAddressAndMineBlock({
+            address: ADDRESS_INDEX_1,
+            btc_amount: 1,
+        });
+        await trezorUserEnvLink.mineBlocks({ block_amount: 1 });
 
-            await trezorUserEnvLink.sendToAddressAndMineBlock({
-                address: ADDRESS_INDEX_1,
-                btc_amount: 1,
-            });
-            await trezorUserEnvLink.mineBlocks({ block_amount: 1 });
-
-            await dashboardPage.dashboardMenuButton.click();
-            await walletPage.openAccount({ symbol: 'regtest' });
-            await walletPage.openSendFormButton.click();
-        },
-    );
+        await walletPage.openAccount({ symbol: 'regtest' });
+        await walletPage.openSendFormButton.click();
+    });
 
     test('add and remove output in send form, toggle form options, input data', async ({
         page,

--- a/packages/suite-desktop-core/e2e/tests/wallet/send-form-regtest.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/send-form-regtest.test.ts
@@ -9,19 +9,24 @@ test.describe('Send form for bitcoin', { tag: ['@group=wallet'] }, () => {
             mnemonic: 'mnemonic_all',
         },
     });
-    test.beforeEach(async ({ onboardingPage, settingsPage, walletPage, trezorUserEnvLink }) => {
-        await onboardingPage.completeOnboarding();
-        await settingsPage.changeNetworks({ enableNetworks: ['regtest'] });
+    test.beforeEach(
+        async ({ onboardingPage, dashboardPage, settingsPage, walletPage, trezorUserEnvLink }) => {
+            await onboardingPage.completeOnboarding();
 
-        await trezorUserEnvLink.sendToAddressAndMineBlock({
-            address: ADDRESS_INDEX_1,
-            btc_amount: 1,
-        });
-        await trezorUserEnvLink.mineBlocks({ block_amount: 1 });
+            await settingsPage.navigateTo('coins');
+            await settingsPage.coins.enableNetwork('regtest');
 
-        await walletPage.openAccount({ symbol: 'regtest' });
-        await walletPage.openSendFormButton.click();
-    });
+            await trezorUserEnvLink.sendToAddressAndMineBlock({
+                address: ADDRESS_INDEX_1,
+                btc_amount: 1,
+            });
+            await trezorUserEnvLink.mineBlocks({ block_amount: 1 });
+
+            await dashboardPage.dashboardMenuButton.click();
+            await walletPage.openAccount({ symbol: 'regtest' });
+            await walletPage.openSendFormButton.click();
+        },
+    );
 
     test('add and remove output in send form, toggle form options, input data', async ({
         page,

--- a/packages/suite-desktop-core/e2e/tests/wallet/sign-and-verify-eth.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/sign-and-verify-eth.test.ts
@@ -2,16 +2,9 @@ import { expect, test } from '../../support/fixtures';
 
 test.describe('Sign and verify ETH', { tag: ['@group=wallet'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });
-    test.beforeEach(async ({ dashboardPage, onboardingPage, settingsPage }) => {
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
-
-        await settingsPage.navigateTo('coins');
-
-        await settingsPage.coins.disableNetwork('btc');
-        await settingsPage.coins.enableNetwork('eth');
-
-        await dashboardPage.dashboardMenuButton.click();
-        await dashboardPage.discoveryShouldFinish();
+        await settingsPage.changeNetworks({ enableNetworks: ['eth'], disableNetworks: ['btc'] });
     });
 
     const MESSAGE_SIGN = 'hello world';

--- a/packages/suite-desktop-core/e2e/tests/wallet/staking.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/staking.test.ts
@@ -6,20 +6,22 @@ test.describe('ETH staking', { tag: ['@group=wallet'] }, () => {
             mnemonic: 'access juice claim special truth ugly swarm rabbit hair man error bar',
         },
     });
-    test.beforeEach(async ({ dashboardPage, onboardingPage, settingsPage, blockbookMock }) => {
-        await onboardingPage.completeOnboarding();
+    test.beforeEach(
+        async ({ page, dashboardPage, onboardingPage, settingsPage, blockbookMock }) => {
+            await onboardingPage.completeOnboarding();
 
-        await settingsPage.navigateTo('coins');
-        await blockbookMock.start('eth');
+            await settingsPage.navigateTo('coins');
+            await blockbookMock.start('eth');
 
-        await settingsPage.coins.disableNetwork('btc');
-        await settingsPage.coins.enableNetwork('eth');
-        await settingsPage.coins.openNetworkAdvanceSettings('eth');
-        await settingsPage.coins.changeBackend('blockbook', blockbookMock.url);
+            await settingsPage.coins.disableNetwork('btc');
+            await settingsPage.coins.enableNetwork('eth');
+            await settingsPage.coins.openNetworkAdvanceSettings('eth');
+            await settingsPage.coins.changeBackend('blockbook', blockbookMock.url);
 
-        await dashboardPage.dashboardMenuButton.click();
-        await dashboardPage.discoveryShouldFinish();
-    });
+            await dashboardPage.dashboardMenuButton.click();
+            await page.discoveryShouldFinish();
+        },
+    );
 
     test('checks that staking dashboard works', async ({ page, walletPage, tradingPage }) => {
         await walletPage.openAccount({ symbol: 'eth', type: 'normal', atIndex: 0 });


### PR DESCRIPTION
Follow up on my previous PR, this one utilizes the now available  discoveryShouldFinish on page object to DRY some of our setup.
Mainly change of what coins are enabled. Now it can be just one method on settings page object.
