### PR TITLE
fix(suite-native): fix token send

### DIFF
--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -546,7 +546,7 @@ export const enhancePrecomposedTransactionThunk = createThunk<
             (!hasDecreasedOutput && nativeRbfAvailable) ||
             (hasDecreasedOutput && decreaseOutputAvailable);
 
-        const createGeneralPrecomposedTransactionFinal = (): GeneralPrecomposedTransactionFinal => {
+        const createRbfEnhancedTransaction = (): GeneralPrecomposedTransactionFinal => {
             if (!isCardanoTx(selectedAccount, precomposedTransaction) && formValues.rbfParams) {
                 const enhancedRbfPrecomposedTx: PrecomposedTransactionFinalBumpFeeRbf = {
                     ...precomposedTransaction,
@@ -569,15 +569,16 @@ export const enhancePrecomposedTransactionThunk = createThunk<
             return precomposedTransaction;
         };
 
-        const enhancedPrecomposedTransaction = createGeneralPrecomposedTransactionFinal();
+        const enhancedPrecomposedTransaction = createRbfEnhancedTransaction();
 
+        let isTokenKnown;
         if (
             !isCardanoTx(selectedAccount, enhancedPrecomposedTransaction) &&
             selectedAccount.networkType === 'ethereum' &&
             enhancedPrecomposedTransaction.token?.contract &&
             selectedAccountNetwork.chainId
         ) {
-            const isTokenKnown = await fetch(
+            isTokenKnown = await fetch(
                 `https://data.trezor.io/firmware/eth-definitions/chain-id/${
                     selectedAccountNetwork.chainId
                 }/token-${enhancedPrecomposedTransaction.token.contract.substring(2).toLowerCase()}.dat`,
@@ -585,17 +586,15 @@ export const enhancePrecomposedTransactionThunk = createThunk<
             )
                 .then(response => response.ok)
                 .catch(() => false);
-
-            enhancedPrecomposedTransaction.isTokenKnown = isTokenKnown;
         }
 
-        // store formValues and transactionInfo in send reducer to be used by TransactionReviewModal
         dispatch(
             sendFormActions.storePrecomposedTransaction({
                 formState: formValues,
                 precomposedTransaction: {
                     ...enhancedPrecomposedTransaction,
                     createdTimestamp: new Date().getTime(),
+                    isTokenKnown,
                 },
             }),
         );


### PR DESCRIPTION
## Description
Fixes send review of a token transactions. The bug was introduced by https://github.com/trezor/trezor-suite/pull/16905 where the `enhancePrecomposedTransactionThunk` was changed. Initially, the `enhancedPrecomposedTransaction` object was duplicated (by the spread operator) but this PR removed the spreading. For this reason `isTokenKnown` prop change failed on the unwritable object and even if token definitions knew the token, the app treated it as an unknown token, and the flow got stuck.

The bug was located in the `suite-common` parts so it is very likely that desktop suffered by this bug as well.