### PR TITLE
chore(connect): cleanup constants for FW hash check

### DIFF
--- a/packages/connect/src/constants/firmware.ts
+++ b/packages/connect/src/constants/firmware.ts
@@ -1,9 +1,5 @@
 import { FirmwareHashCheckError, FirmwareRevisionCheckError } from '../types';
 
-// given that firmware hash is a security feature, we prefer to hardcode the version rather than to query the device capabilities
-// (a counterfeit device could simply declare it's incapable of hash check)
-export const FW_HASH_SUPPORTED_VERSIONS = ['1.11.1', '2.5.1'];
-
 export const HASH_CHECK_MAX_ATTEMPTS = 3;
 
 export const HASH_CHECK_RETRIABLE_ERRORS = ['other-error'] satisfies FirmwareHashCheckError[];

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -230,6 +230,7 @@ export const config = {
             },
         },
         {
+            capabilities: ['getFirmwareHash'],
             methods: ['getFirmwareHash'],
             min: { T1B1: '1.11.1', T2T1: '2.5.1' },
         },

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -824,7 +824,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
             return null;
         }
 
-        const checkSupported = this.atLeast(FIRMWARE.FW_HASH_SUPPORTED_VERSIONS);
+        const checkSupported = !this.unavailableCapabilities.getFirmwareHash;
         if (!checkSupported) return createFailResult('check-unsupported');
 
         const release = getReleases(this.features.internal_model).find(r =>

--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -166,6 +166,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 signMessageNoScriptType: 'update-required',
                 chunkify: 'no-support',
                 entropyCheck: 'no-support',
+                getFirmwareHash: 'update-required',
             });
         });
 
@@ -196,6 +197,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 dsol: 'no-capability',
                 chunkify: 'update-required',
                 entropyCheck: 'update-required',
+                getFirmwareHash: 'update-required',
             });
         });
 
@@ -312,6 +314,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 signMessageNoScriptType: 'update-required',
                 taproot: 'update-required',
                 entropyCheck: 'update-required',
+                getFirmwareHash: 'update-required',
             });
         });
 
@@ -344,6 +347,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 signMessageNoScriptType: 'update-required',
                 taproot: 'update-required',
                 entropyCheck: 'no-support',
+                getFirmwareHash: 'update-required',
             });
         });
 
@@ -377,6 +381,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 signMessageNoScriptType: 'update-required',
                 taproot: 'update-required',
                 entropyCheck: 'no-support',
+                getFirmwareHash: 'update-required',
             });
         });
     });


### PR DESCRIPTION
## Description

:broom: cleanup: remove `FW_HASH_SUPPORTED_VERSIONS` constant, which duplicated the info already present in `data/config.ts` → use the `unvailableCapabilities` to determine if FW version is capable of FW hash check.

@coderabbitai ignore