### PR TITLE
fix(suite): handle cancel on device in connect confirm address modal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectAddressConfirmation.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectAddressConfirmation.tsx
@@ -40,7 +40,9 @@ export const ConnectAddressConfirmation = () => {
         const isLoading = popupCall?.addresses.some(address => address.loading);
         const addressToVerify = popupCall?.addresses.findIndex(
             address =>
-                address.validatePayload.showOnTrezor && !address.validated && !address.loading,
+                address.validatePayload.showOnTrezor &&
+                address.validated === 'not-started' &&
+                !address.loading,
         );
         if (!isLoading && addressToVerify >= 0) {
             dispatch(
@@ -86,9 +88,14 @@ export const ConnectAddressConfirmation = () => {
                             >
                                 <Row gap={spacings.sm} alignItems="center" flex="1">
                                     <Paragraph wordBreak="break-all">{address.address}</Paragraph>
-                                    {address.validated && (
+                                    {address.validated === 'valid' && (
                                         <Badge variant="primary" icon="check" size="small">
                                             <Translation id="TR_VERIFIED" />
+                                        </Badge>
+                                    )}
+                                    {address.validated === 'failed' && (
+                                        <Badge variant="warning" icon="warning" size="small">
+                                            <Translation id="TR_ERROR" />
                                         </Badge>
                                     )}
                                 </Row>

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -96,8 +96,7 @@ export const connectPopupCallThunkInner = createThunk<
 
             const txSigningPrecomposed: PrecomposedTransactionFinal | undefined =
                 methodInfo.payload.precomposed;
-            const originalPayload = { ...payload };
-            await preCallHooks({
+            const modifiedPayload = await preCallHooks({
                 method,
                 payload,
                 dispatch,
@@ -113,7 +112,7 @@ export const connectPopupCallThunkInner = createThunk<
                     state: device.state,
                 },
                 useEmptyPassphrase: device.useEmptyPassphrase,
-                ...payload,
+                ...modifiedPayload,
             });
             response.id = undefined;
 
@@ -122,8 +121,8 @@ export const connectPopupCallThunkInner = createThunk<
 
             const postCallOngoing = await postCallHooks({
                 method,
-                payload,
-                originalPayload,
+                payload: modifiedPayload,
+                originalPayload: payload,
                 response,
                 dispatch,
                 getState,
@@ -263,12 +262,13 @@ export const connectPopupVerifyAddressThunk = createThunk<void, { index: number 
                 showOnTrezor: true,
                 chunked: false,
             });
+            const validatedStatus = res.success ? 'valid' : 'failed';
             dispatch(
                 connectPopupActions.confirmAddresses({
                     addresses: call.addresses.map((address, i) => ({
                         ...address,
                         loading: false,
-                        validated: i === index ? res.success : address.validated,
+                        validated: i === index ? validatedStatus : address.validated,
                     })),
                 }),
             );
@@ -279,7 +279,7 @@ export const connectPopupVerifyAddressThunk = createThunk<void, { index: number 
                     addresses: call.addresses.map((address, i) => ({
                         ...address,
                         loading: false,
-                        validated: i === index ? false : address.validated,
+                        validated: i === index ? 'failed' : address.validated,
                     })),
                 }),
             );

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -64,7 +64,7 @@ export type ConnectPopupCallLoaded = {
           addresses: {
               address: string;
               loading: boolean;
-              validated: boolean;
+              validated: 'valid' | 'failed' | 'not-started';
               validatePayload: any;
           }[];
       }

--- a/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
+++ b/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
@@ -33,7 +33,7 @@ const preCallHook = <M extends keyof typeof TrezorConnect>({
 }: PreCallHookParams<M>) => {
     if (methods.includes(method)) {
         if ('bundle' in payload && Array.isArray(payload.bundle)) {
-            payload = {
+            return {
                 ...payload,
                 bundle: payload.bundle.map(item => ({
                     ...item,
@@ -41,12 +41,14 @@ const preCallHook = <M extends keyof typeof TrezorConnect>({
                 })),
             };
         } else {
-            payload = {
+            return {
                 ...payload,
                 showOnTrezor: false,
             };
         }
     }
+
+    return payload;
 };
 
 export function postCallHook<M extends keyof typeof TrezorConnect>({
@@ -77,7 +79,7 @@ export function postCallHook<M extends keyof typeof TrezorConnect>({
 
             return {
                 address: displayAddress(),
-                validated: false,
+                validated: 'not-started' as const,
                 loading: false,
                 validatePayload,
             };

--- a/suite-common/connect-popup/src/methodHooks/index.ts
+++ b/suite-common/connect-popup/src/methodHooks/index.ts
@@ -25,8 +25,9 @@ export type PostCallHookParams<M extends keyof TrezorConnect> = PreCallHookParam
 };
 
 export const preCallHooks = async <M extends keyof TrezorConnect>(params: PreCallHookParams<M>) => {
-    await addressConfirmationModalHooks.preCallHook(params);
     await ethereumSignTransaction.preCallHook(params);
+
+    return await addressConfirmationModalHooks.preCallHook(params);
 };
 
 export async function postCallHooks<M extends keyof TrezorConnect>(params: PostCallHookParams<M>) {


### PR DESCRIPTION
## Description

Previously if you cancelled the address confirmation on device, the modal would keep retrying. 
Now it will be handled with an error icon. 