### PR TITLE
fix(suite): Show convert to lowercase button for bch CashAddress

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5497,6 +5497,10 @@ export default defineMessages({
         defaultMessage: 'Convert to lowercase',
         id: 'TR_CONVERT_TO_LOWERCASE',
     },
+    TR_ADD_BITCOINCASH_PREFIX: {
+        defaultMessage: 'Add bitcoincash: prefix',
+        id: 'TR_ADD_BITCOINCASH_PREFIX',
+    },
     TR_CONVERT_TO_CHECKSUM_ADDRESS: {
         defaultMessage: 'Convert to checksum',
         id: 'TR_CONVERT_TO_CHECKSUM_ADDRESS',

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -13,6 +13,7 @@ import {
     isAddressDeprecated,
     isAddressValid,
     isBech32AddressUppercase,
+    isCashAddressUppercase,
     isTaprootAddress,
 } from '@suite-common/wallet-utils';
 import { Button, Icon, IconButton, Input, Link, Row } from '@trezor/components';
@@ -210,7 +211,8 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                 }
 
                 return {};
-            case 'uppercase':
+            case 'cashaddr_uppercase':
+            case 'bech32_uppercase':
                 return {
                     buttonProps: {
                         onClick: () =>
@@ -240,6 +242,11 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                     return translationString('TR_UNSUPPORTED_ADDRESS_FORMAT');
                 }
             },
+            cashaddr_uppercase: (value: string) => {
+                if (symbol === 'bch' && isCashAddressUppercase(value)) {
+                    return translationString('RECIPIENT_IS_NOT_VALID');
+                }
+            },
             valid: (value: string) => {
                 if (!isAddressValid(value, symbol)) {
                     return translationString('RECIPIENT_IS_NOT_VALID');
@@ -256,7 +263,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                 }
             },
             // bech32 addresses are valid as uppercase but are not accepted by Trezor
-            uppercase: (value: string) => {
+            bech32_uppercase: (value: string) => {
                 if (networkType === 'bitcoin' && isBech32AddressUppercase(value)) {
                     return translationString('RECIPIENT_IS_NOT_VALID');
                 }

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -10,6 +10,7 @@ import type { Output } from '@suite-common/wallet-types';
 import {
     checkIsAddressNotUsedNotChecksummed,
     getInputState,
+    hasCashAddressPrefix,
     isAddressDeprecated,
     isAddressValid,
     isBech32AddressUppercase,
@@ -221,6 +222,16 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                         text: translationString('TR_CONVERT_TO_LOWERCASE'),
                     },
                 };
+            case 'bch_missing_prefix':
+                return {
+                    buttonProps: {
+                        onClick: () =>
+                            setValue(inputName, 'bitcoincash:' + address, {
+                                shouldValidate: true,
+                            }),
+                        text: translationString('TR_ADD_BITCOINCASH_PREFIX'),
+                    },
+                };
             default:
                 return {};
         }
@@ -262,6 +273,11 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                     device?.unavailableCapabilities?.taproot
                 ) {
                     return translationString('RECIPIENT_REQUIRES_UPDATE');
+                }
+            },
+            bch_missing_prefix: (value: string) => {
+                if (symbol == 'bch' && !hasCashAddressPrefix(value)) {
+                    return translationString('RECIPIENT_IS_NOT_VALID');
                 }
             },
             evmchecks: async (address: string) => {

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -211,8 +211,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                 }
 
                 return {};
-            case 'cashaddr_uppercase':
-            case 'bech32_uppercase':
+            case 'uppercase':
                 return {
                     buttonProps: {
                         onClick: () =>
@@ -242,8 +241,11 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                     return translationString('TR_UNSUPPORTED_ADDRESS_FORMAT');
                 }
             },
-            cashaddr_uppercase: (value: string) => {
-                if (symbol === 'bch' && isCashAddressUppercase(value)) {
+            uppercase: (value: string) => {
+                if (
+                    (symbol === 'bch' && isCashAddressUppercase(value)) ||
+                    (networkType === 'bitcoin' && isBech32AddressUppercase(value))
+                ) {
                     return translationString('RECIPIENT_IS_NOT_VALID');
                 }
             },
@@ -260,12 +262,6 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                     device?.unavailableCapabilities?.taproot
                 ) {
                     return translationString('RECIPIENT_REQUIRES_UPDATE');
-                }
-            },
-            // bech32 addresses are valid as uppercase but are not accepted by Trezor
-            bech32_uppercase: (value: string) => {
-                if (networkType === 'bitcoin' && isBech32AddressUppercase(value)) {
-                    return translationString('RECIPIENT_IS_NOT_VALID');
                 }
             },
             evmchecks: async (address: string) => {

--- a/suite-common/wallet-utils/src/__tests__/validation.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/validation.test.ts
@@ -173,18 +173,6 @@ describe('validation', () => {
         expect(
             isCashAddressUppercase('BITCOINCASH:QZ8GJEXL9X7GAG53XL08MT7QSKVJG8X2WUEEJJMTTC'),
         ).toBe(true);
-        expect(isCashAddressUppercase('bchtest:qqyr08lnsfc82ek7y6xys6j0ne2v5uv7a5pj9v0t07')).toBe(
-            false,
-        );
-        expect(isCashAddressUppercase('BCHTEST:QQYR08LNSFC82EK7Y6XYS6J0NE2V5UV7A5PJ9V0T07')).toBe(
-            true,
-        );
-        expect(isCashAddressUppercase('bchreg:qp3wjpa3tjlj042z7x7z0ur7t3g4a2t5p9z4wpgs4y')).toBe(
-            false,
-        );
-        expect(isCashAddressUppercase('BCHREG:QP3WJPA3TJLJ042Z7X7Z0UR7T3G4A2T5P9Z4WPGS4Y')).toBe(
-            true,
-        );
         expect(isCashAddressUppercase('1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu')).toBe(false);
         expect(isCashAddressUppercase('1BPEI6DFDAUFD7GTITTLSDBEYJVCOAVGGU')).toBe(false);
         expect(isCashAddressUppercase('NotValidAddressContainsBITCOINCASH:BCHTEST:1')).toBe(false);
@@ -198,10 +186,6 @@ describe('validation', () => {
         expect(isBech32AddressUppercase('TB1QKVWU9G3K2PDXEWFQR7SYZ89R3GJ557L3UUF9R9')).toBe(true);
         expect(isBech32AddressUppercase('ltc1qkzyarpkhdecu5rzeuj78pwpr5sfm798afny4n6')).toBe(false);
         expect(isBech32AddressUppercase('LTC1QKZYARPKHDECU5RZEUJ78PWPR5SFM798AFNY4N6')).toBe(true);
-        expect(isBech32AddressUppercase('tltc1qkvwu9g3k2pdxewfqr7syz89r3gj557l395tmnv')).toBe(
-            false,
-        );
-        expect(isBech32AddressUppercase('TLTC1QKVWU9G3K2PDXEWFQR7SYZ89R3GJ557L395TMNV')).toBe(true);
         expect(isBech32AddressUppercase('37VJHKeBA9DHKmTwYE7TWYjwDzo5JTb1sz')).toBe(false); // real btc address contains tb1 string
         expect(isBech32AddressUppercase('NotValidAddressContainsTb1bc1Ltc1Tltc1')).toBe(false);
     });

--- a/suite-common/wallet-utils/src/__tests__/validation.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/validation.test.ts
@@ -2,6 +2,7 @@ import {
     isAddressDeprecated,
     isAddressValid,
     isBech32AddressUppercase,
+    isCashAddressUppercase,
     isDecimalsValid,
     isHexValid,
     isInteger,
@@ -162,6 +163,31 @@ describe('validation', () => {
                 'test',
             ),
         ).toEqual(true);
+    });
+
+    it('isCashAddressUppercase', () => {
+        expect(isCashAddressUppercase('')).toBe(false);
+        expect(
+            isCashAddressUppercase('bitcoincash:qz8gjexl9x7gag53xl08mt7qskvjg8x2wueejjmttc'),
+        ).toBe(false);
+        expect(
+            isCashAddressUppercase('BITCOINCASH:QZ8GJEXL9X7GAG53XL08MT7QSKVJG8X2WUEEJJMTTC'),
+        ).toBe(true);
+        expect(isCashAddressUppercase('bchtest:qqyr08lnsfc82ek7y6xys6j0ne2v5uv7a5pj9v0t07')).toBe(
+            false,
+        );
+        expect(isCashAddressUppercase('BCHTEST:QQYR08LNSFC82EK7Y6XYS6J0NE2V5UV7A5PJ9V0T07')).toBe(
+            true,
+        );
+        expect(isCashAddressUppercase('bchreg:qp3wjpa3tjlj042z7x7z0ur7t3g4a2t5p9z4wpgs4y')).toBe(
+            false,
+        );
+        expect(isCashAddressUppercase('BCHREG:QP3WJPA3TJLJ042Z7X7Z0UR7T3G4A2T5P9Z4WPGS4Y')).toBe(
+            true,
+        );
+        expect(isCashAddressUppercase('1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu')).toBe(false);
+        expect(isCashAddressUppercase('1BPEI6DFDAUFD7GTITTLSDBEYJVCOAVGGU')).toBe(false);
+        expect(isCashAddressUppercase('NotValidAddressContainsBITCOINCASH:BCHTEST:1')).toBe(false);
     });
 
     it('isBech32AddressUppercase', () => {

--- a/suite-common/wallet-utils/src/__tests__/validation.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/validation.test.ts
@@ -1,4 +1,5 @@
 import {
+    hasCashAddressPrefix,
     isAddressDeprecated,
     isAddressValid,
     isBech32AddressUppercase,
@@ -163,6 +164,19 @@ describe('validation', () => {
                 'test',
             ),
         ).toEqual(true);
+    });
+
+    it('hasCashAddressPrefix', () => {
+        expect(hasCashAddressPrefix('')).toBe(false);
+        expect(hasCashAddressPrefix('bitcoincash')).toBe(false);
+        expect(hasCashAddressPrefix('bitcoincash:')).toBe(true);
+        expect(hasCashAddressPrefix('bitcoincash:qz8gjexl9x7gag53xl08mt7qskvjg8x2wueejjmttc')).toBe(
+            true,
+        );
+        expect(hasCashAddressPrefix('BITCOINCASH:QZ8GJEXL9X7GAG53XL08MT7QSKVJG8X2WUEEJJMTTC')).toBe(
+            true,
+        );
+        expect(hasCashAddressPrefix('somethingbitcoincash:something')).toBe(false);
     });
 
     it('isCashAddressUppercase', () => {

--- a/suite-common/wallet-utils/src/validationUtils.ts
+++ b/suite-common/wallet-utils/src/validationUtils.ts
@@ -62,6 +62,9 @@ export const isTaprootAddress = (address: string, symbol: Account['symbol']) => 
     );
 };
 
+export const isCashAddressUppercase = (address: string) =>
+    /^(bitcoincash|bchtest|bchreg):/.test(address.toLowerCase()) && /[A-Z]/.test(address);
+
 export const isBech32AddressUppercase = (address: string) =>
     /^(bc1|tb1|ltc1|tltc1|vtc1|tvtc1)/.test(address.toLowerCase()) && /[A-Z]/.test(address);
 

--- a/suite-common/wallet-utils/src/validationUtils.ts
+++ b/suite-common/wallet-utils/src/validationUtils.ts
@@ -63,10 +63,10 @@ export const isTaprootAddress = (address: string, symbol: Account['symbol']) => 
 };
 
 export const isCashAddressUppercase = (address: string) =>
-    /^(bitcoincash|bchtest|bchreg):/.test(address.toLowerCase()) && /[A-Z]/.test(address);
+    /^bitcoincash:/.test(address.toLowerCase()) && /[A-Z]/.test(address);
 
 export const isBech32AddressUppercase = (address: string) =>
-    /^(bc1|tb1|ltc1|tltc1|vtc1|tvtc1)/.test(address.toLowerCase()) && /[A-Z]/.test(address);
+    /^(bc1|tb1|ltc1|vtc1)/.test(address.toLowerCase()) && /[A-Z]/.test(address);
 
 export const isDecimalsValid = (value: string, decimals: number) => {
     const DECIMALS_RE = new RegExp(

--- a/suite-common/wallet-utils/src/validationUtils.ts
+++ b/suite-common/wallet-utils/src/validationUtils.ts
@@ -62,8 +62,11 @@ export const isTaprootAddress = (address: string, symbol: Account['symbol']) => 
     );
 };
 
+export const hasCashAddressPrefix = (address: string) =>
+    /^bitcoincash:/.test(address.toLowerCase());
+
 export const isCashAddressUppercase = (address: string) =>
-    /^bitcoincash:/.test(address.toLowerCase()) && /[A-Z]/.test(address);
+    hasCashAddressPrefix(address) && /[A-Z]/.test(address);
 
 export const isBech32AddressUppercase = (address: string) =>
     /^(bc1|tb1|ltc1|vtc1)/.test(address.toLowerCase()) && /[A-Z]/.test(address);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/5151

## Screenshots:
