### PR TITLE
Feat(suite-native): mobile entropy check

### DIFF
--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -186,7 +186,7 @@ export const resetDevice =
                     vendor: device?.features?.fw_vendor,
                     error: result.payload.error,
                 });
-                // TODO: temporary exception to avoid false positives
+                // TODO: temporary exception to avoid false positives, see https://github.com/trezor/trezor-suite-private/issues/135
                 if (result.payload.error !== 'device disconnected during action') {
                     dispatch(deviceActions.setEntropyCheckFail(device.id));
                 }

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -39,6 +39,7 @@ export const Feature = {
     // subset of `firmwareHashCheck`: can turn off specifically UI for other-error result
     firmwareHashCheckOtherError: 'security.firmware.hashCheck.otherError',
     entropyCheck: 'security.entropyCheck',
+    entropyCheckMobile: 'security.entropyCheck.mobile',
     // FW update feature flag implemented only for mobile app
     firmwareUpdate: 'device.firmware.update',
     // trading feature flags implemented for mobile app

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -1,8 +1,9 @@
 import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
 import { createThunk } from '@suite-common/redux-utils';
 import { deviceActions, selectDevicePath, selectSelectedDevice } from '@suite-common/wallet-core';
-import { WalletBackupType } from '@suite-native/device';
+import { WalletBackupType, reportCheckFail } from '@suite-native/device';
 import TrezorConnect, { PROTO } from '@trezor/connect';
+import { getFirmwareVersion } from '@trezor/device-utils';
 
 const NATIVE_DEVICE_MODULE_PREFIX = 'nativeDevice';
 
@@ -53,7 +54,11 @@ const getResetDeviceConfig = (walletBackupType: WalletBackupType): PROTO.ResetDe
 
 export const createAndBackupWalletThunk = createThunk(
     `${NATIVE_DEVICE_MODULE_PREFIX}/resetDevice`,
-    async ({ walletBackupType }: { walletBackupType: WalletBackupType }, { getState }) => {
+    async (
+        { walletBackupType }: { walletBackupType: WalletBackupType },
+        { getState, dispatch },
+    ) => {
+        const device = selectSelectedDevice(getState());
         const devicePath = selectDevicePath(getState());
         const isEntropyCheckEnabled = selectIsFeatureEnabled(
             getState(),
@@ -61,16 +66,32 @@ export const createAndBackupWalletThunk = createThunk(
             true,
         );
 
-        if (!devicePath) {
+        if (!device || !device.features || !devicePath) {
             throw new Error('Device not found');
         }
 
-        return await TrezorConnect.resetDevice({
+        const result = await TrezorConnect.resetDevice({
             device: { path: devicePath },
             skip_backup: false,
             ...getResetDeviceConfig(walletBackupType),
             //Entropy check can be toggled via message system config so it should be always last to avoid unintentional disabling.
             entropy_check: isEntropyCheckEnabled,
         });
+
+        if (!result.success && result.payload.code === 'Failure_EntropyCheck') {
+            const contextData = {
+                model: device?.features?.internal_model,
+                revision: device?.features?.revision,
+                version: getFirmwareVersion(device),
+                vendor: device?.features?.fw_vendor,
+            };
+            reportCheckFail('Entropy', contextData, result.payload.error);
+            // TODO: temporary exception to avoid false positives, see https://github.com/trezor/trezor-suite-private/issues/135
+            if (result.payload.error !== 'device disconnected during action') {
+                dispatch(deviceActions.setEntropyCheckFail(device.id));
+            }
+        }
+
+        return result;
     },
 );

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -1,3 +1,4 @@
+import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
 import { createThunk } from '@suite-common/redux-utils';
 import { deviceActions, selectDevicePath, selectSelectedDevice } from '@suite-common/wallet-core';
 import { WalletBackupType } from '@suite-native/device';
@@ -54,14 +55,15 @@ export const createAndBackupWalletThunk = createThunk(
     `${NATIVE_DEVICE_MODULE_PREFIX}/resetDevice`,
     async ({ walletBackupType }: { walletBackupType: WalletBackupType }, { getState }) => {
         const devicePath = selectDevicePath(getState());
+        const isEntropyCheckEnabled = selectIsFeatureEnabled(
+            getState(),
+            Feature.entropyCheckMobile,
+            true,
+        );
 
         if (!devicePath) {
             throw new Error('Device not found');
         }
-
-        // TODO: implement entropy check for mobile
-        // https://github.com/trezor/trezor-suite/issues/18355
-        const isEntropyCheckEnabled = false;
 
         return await TrezorConnect.resetDevice({
             device: { path: devicePath },

--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -39,6 +39,7 @@ import {
 import {
     selectHasFirmwareAuthenticityCheckHardFailed,
     selectIsDeviceSetupSupported,
+    selectIsEntropyCheckEnabledAndFailed,
 } from '../selectors';
 
 type NavigationProp = StackToStackCompositeNavigationProps<
@@ -70,6 +71,7 @@ export const useHandleDeviceConnection = () => {
     const isFirmwareAuthenticityCheckDismissed = useSelector(
         selectIsFirmwareAuthenticityCheckDismissed,
     );
+    const shouldDisplayEntropyCheckError = useSelector(selectIsEntropyCheckEnabledAndFailed);
 
     const { isBiometricsOverlayVisible } = useIsBiometricsOverlayVisible();
     const isOnboardingDeviceDisconnectedAlertDisplayed = useAtomValue(
@@ -103,10 +105,16 @@ export const useHandleDeviceConnection = () => {
     const isOnPinMatrixBlacklistedRoute = pinMatrixBlacklistedScreens.includes(
         lastRoute as RootStackRoutes,
     );
+
+    const shouldDisplayFirmwareAuthenticityError =
+        hasFirmwareAuthenticityCheckHardFailed && !isFirmwareAuthenticityCheckDismissed;
+
+    // any failing check should navigate to the DeviceCompromisedModal
     const shouldNavigateToDeviceCompromisedModal =
-        hasFirmwareAuthenticityCheckHardFailed &&
-        !isFirmwareAuthenticityCheckDismissed &&
-        isOnboardingFinished;
+        shouldDisplayEntropyCheckError || shouldDisplayFirmwareAuthenticityError;
+    // but the DeviceCompromisedModal shall not be persistent for Entropy check, because you cannot exit the modal via normal means
+    const shouldKeepDeviceCompromisedModal =
+        isDeviceCompromisedModalFocused && !shouldDisplayEntropyCheckError;
 
     // When is an uninitialized device model that supports device setup, navigate to device onboarding.
     useEffect(() => {
@@ -120,7 +128,8 @@ export const useHandleDeviceConnection = () => {
             !isOnboardingDeviceDisconnectedAlertDisplayed &&
             !isFirmwareInstallationRunning &&
             (!isDeviceOnboardingStackFocused || isDeviceOnboardingConnectAndUnlockScreenFocused) &&
-            !wasDeviceOnboardingCancelled
+            !wasDeviceOnboardingCancelled &&
+            !shouldNavigateToDeviceCompromisedModal
         ) {
             navigation.navigate(RootStackRoutes.DeviceOnboardingStack, {
                 screen: DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
@@ -140,6 +149,7 @@ export const useHandleDeviceConnection = () => {
         isOnboardingDeviceDisconnectedAlertDisplayed,
         isDeviceOnboardingConnectAndUnlockScreenFocused,
         wasDeviceOnboardingCancelled,
+        shouldNavigateToDeviceCompromisedModal,
     ]);
 
     // At the moment when unauthorized physical device is selected,
@@ -200,7 +210,7 @@ export const useHandleDeviceConnection = () => {
             // TODO: this hook is getting very complex, and it's hard to understand the logic when it navigates there and back again.
             //  Ideally there'd be a single source of truth, a function returning "where we should be as per current state"
             //  rather than multiple useEffects with imperative instructions "go there when X changes"
-            if (isDeviceCompromisedModalFocused || isSuspiciousDeviceScreenFocused) {
+            if (shouldKeepDeviceCompromisedModal || isSuspiciousDeviceScreenFocused) {
                 return;
             }
 
@@ -225,7 +235,7 @@ export const useHandleDeviceConnection = () => {
         navigation,
         shouldBlockSendReviewRedirect,
         isFirmwareInstallationRunning,
-        isDeviceCompromisedModalFocused,
+        shouldKeepDeviceCompromisedModal,
         isSuspiciousDeviceScreenFocused,
         isOnboardingStackFocused,
         isDeviceOnboardingStackFocused,

--- a/suite-native/device/src/hooks/useReportDeviceCompromised.ts
+++ b/suite-native/device/src/hooks/useReportDeviceCompromised.ts
@@ -8,9 +8,9 @@ import { getFirmwareVersion } from '@trezor/device-utils';
 
 import { revisionCheckErrorScenarios } from '../config/firmware';
 
-const reportCheckFail = (
-    checkType: 'Firmware revision',
-    contextData: any,
+export const reportCheckFail = (
+    checkType: 'Entropy' | 'Firmware revision',
+    contextData: Record<string, any>,
     errorPayload?: unknown,
 ) => {
     const payloadLabel = `${checkType} check failed!`;

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -26,6 +26,7 @@ import {
     selectIsConnectedDeviceUninitialized,
     selectIsDeviceConnectedAndAuthorized,
     selectIsDiscoveredDeviceAccountless,
+    selectIsEntropyCheckFailed,
     selectIsUnacquiredDevice,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
@@ -198,6 +199,10 @@ export const selectHasFirmwareAuthenticityCheckHardFailed = (state: FwAuthentici
 
     return isRevisionHardError;
 };
+
+export const selectIsEntropyCheckEnabledAndFailed = (state: FwAuthenticityCheckState) =>
+    selectIsFeatureEnabled(state, Feature.entropyCheckMobile, true) &&
+    selectIsEntropyCheckFailed(state);
 
 export const selectIsDeviceSetupSupported = createMemoizedSelector(
     [

--- a/suite-native/module-authenticity-checks/package.json
+++ b/suite-native/module-authenticity-checks/package.json
@@ -11,6 +11,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
+        "@react-navigation/core": "^6.4.10",
         "@react-navigation/native": "6.1.18",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-native/atoms": "workspace:*",

--- a/suite-native/module-authenticity-checks/src/components/DeviceCompromisedModalContent.tsx
+++ b/suite-native/module-authenticity-checks/src/components/DeviceCompromisedModalContent.tsx
@@ -1,0 +1,60 @@
+import { ReactNode } from 'react';
+
+import { Button, IconListTextItem, TitleHeader, VStack } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import { useOpenLink } from '@suite-native/link';
+import { Screen } from '@suite-native/navigation';
+
+const InformativeList = () => (
+    <VStack spacing="sp24">
+        <IconListTextItem icon="plugs" variant="red">
+            <Translation id="moduleAuthenticityChecks.deviceCompromised.steps.disconnectDevice" />
+        </IconListTextItem>
+
+        <IconListTextItem icon="handPalm" variant="red">
+            <Translation id="moduleAuthenticityChecks.deviceCompromised.steps.avoidUsingDevice" />
+        </IconListTextItem>
+
+        <IconListTextItem icon="chatCircle" variant="red">
+            <Translation id="moduleAuthenticityChecks.deviceCompromised.steps.contactSupport" />
+        </IconListTextItem>
+    </VStack>
+);
+
+type DeviceCompromisedModalContentProps = {
+    contactSupportUrl: string;
+    screenHeaderContent: ReactNode;
+    closeButtonContent?: ReactNode;
+};
+
+export const DeviceCompromisedModalContent = ({
+    contactSupportUrl,
+    screenHeaderContent,
+    closeButtonContent,
+}: DeviceCompromisedModalContentProps) => {
+    const openLink = useOpenLink();
+
+    const handleContactSupportClick = () => openLink(contactSupportUrl);
+
+    return (
+        <Screen header={screenHeaderContent}>
+            <VStack spacing="sp32" flex={1}>
+                <TitleHeader
+                    titleVariant="titleMedium"
+                    titleSpacing="sp12"
+                    title={<Translation id="moduleAuthenticityChecks.deviceCompromised.title" />}
+                    subtitle={
+                        <Translation id="moduleAuthenticityChecks.deviceCompromised.subtitle" />
+                    }
+                />
+                <InformativeList />
+            </VStack>
+            <VStack spacing="sp12">
+                <Button colorScheme="redBold" onPress={handleContactSupportClick}>
+                    <Translation id="moduleAuthenticityChecks.deviceCompromised.buttonContactSupport" />
+                </Button>
+                {closeButtonContent}
+            </VStack>
+        </Screen>
+    );
+};

--- a/suite-native/module-authenticity-checks/src/components/EntropyCheckFailModalContent.tsx
+++ b/suite-native/module-authenticity-checks/src/components/EntropyCheckFailModalContent.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+
+import { useNavigation } from '@react-navigation/core';
+
+import { ScreenHeader } from '@suite-native/navigation';
+import { HELP_CENTER_ENTROPY_CHECK_URL } from '@trezor/urls';
+
+import { DeviceCompromisedModalContent } from './DeviceCompromisedModalContent';
+
+const supportUrlWithChat = `${HELP_CENTER_ENTROPY_CHECK_URL}#open-chat`;
+
+export const EntropyCheckFailModalContent = () => {
+    const navigation = useNavigation();
+
+    useEffect(() => {
+        // Prevent navigation GO_BACK action; this modal will be shown as long as the device is connected
+        const unsubscribe = navigation.addListener('beforeRemove', e => {
+            if (e.data.action.type === 'GO_BACK') {
+                e.preventDefault();
+            }
+        });
+
+        return unsubscribe;
+    }, [navigation]);
+
+    return (
+        <DeviceCompromisedModalContent
+            contactSupportUrl={supportUrlWithChat}
+            screenHeaderContent={<ScreenHeader leftIcon={null} />}
+        />
+    );
+};

--- a/suite-native/module-authenticity-checks/src/components/FirmwareAuthenticityCheckFailModalContent.tsx
+++ b/suite-native/module-authenticity-checks/src/components/FirmwareAuthenticityCheckFailModalContent.tsx
@@ -1,0 +1,70 @@
+import { useDispatch, useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
+import { Button } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import {
+    AppTabsRoutes,
+    HomeStackRoutes,
+    RootStackParamList,
+    RootStackRoutes,
+    ScreenHeader,
+    StackToStackCompositeNavigationProps,
+} from '@suite-native/navigation';
+import { TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_MOBILE_URL } from '@trezor/urls';
+
+import { DeviceCompromisedModalContent } from './DeviceCompromisedModalContent';
+
+const supportUrlWithChat = `${TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_MOBILE_URL}#open-chat`;
+
+type NavigationProp = StackToStackCompositeNavigationProps<
+    RootStackParamList,
+    RootStackRoutes.AppTabs,
+    RootStackParamList
+>;
+
+export const FirmwareAuthenticityCheckFailModalContent = () => {
+    const device = useSelector(selectSelectedDevice);
+    const dispatch = useDispatch();
+    const navigation = useNavigation<NavigationProp>();
+
+    const dismissCheck = () => {
+        if (device?.id) {
+            dispatch(deviceActions.dismissFirmwareAuthenticityCheck(device.id));
+        }
+    };
+
+    // After dismissCheck, an effect could fire in useHandleDeviceConnection to navigate away, but it's not guaranteed!
+    // To be sure we don't lock user on on this screen, we navigate home.
+    const handleClose = () => {
+        // the modal is most likely entered from OnboardingStack, ConnectingDevice or Home, so let's send user back
+        if (navigation.canGoBack()) {
+            navigation.goBack();
+        }
+        // Home screen set only as fallback if can't go back
+        else {
+            navigation.navigate(RootStackRoutes.AppTabs, {
+                screen: AppTabsRoutes.HomeStack,
+                params: { screen: HomeStackRoutes.Home },
+            });
+        }
+        dismissCheck();
+    };
+
+    const screenHeaderContent = <ScreenHeader closeActionType="close" closeAction={handleClose} />;
+    const closeButtonContent = (
+        <Button colorScheme="redElevation0" onPress={handleClose}>
+            <Translation id="generic.buttons.close" />
+        </Button>
+    );
+
+    return (
+        <DeviceCompromisedModalContent
+            contactSupportUrl={supportUrlWithChat}
+            screenHeaderContent={screenHeaderContent}
+            closeButtonContent={closeButtonContent}
+        />
+    );
+};

--- a/suite-native/module-authenticity-checks/src/screens/DeviceCompromisedModalScreen.tsx
+++ b/suite-native/module-authenticity-checks/src/screens/DeviceCompromisedModalScreen.tsx
@@ -1,108 +1,19 @@
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/native';
-
-import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
-import { Button, IconListTextItem, TitleHeader, VStack } from '@suite-native/atoms';
 import { selectIsEntropyCheckEnabledAndFailed } from '@suite-native/device';
-import { Translation } from '@suite-native/intl';
-import { useOpenLink } from '@suite-native/link';
-import {
-    AppTabsRoutes,
-    HomeStackRoutes,
-    RootStackParamList,
-    RootStackRoutes,
-    Screen,
-    ScreenHeader,
-    StackToStackCompositeNavigationProps,
-} from '@suite-native/navigation';
-import { TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_MOBILE_URL } from '@trezor/urls';
 
-const chatUrl = `${TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_MOBILE_URL}#open-chat`;
+import { EntropyCheckFailModalContent } from '../components/EntropyCheckFailModalContent';
+import { FirmwareAuthenticityCheckFailModalContent } from '../components/FirmwareAuthenticityCheckFailModalContent';
 
-const InformativeList = () => (
-    <VStack spacing="sp24">
-        <IconListTextItem icon="plugs" variant="red">
-            <Translation id="moduleAuthenticityChecks.deviceCompromised.steps.disconnectDevice" />
-        </IconListTextItem>
-
-        <IconListTextItem icon="handPalm" variant="red">
-            <Translation id="moduleAuthenticityChecks.deviceCompromised.steps.avoidUsingDevice" />
-        </IconListTextItem>
-
-        <IconListTextItem icon="chatCircle" variant="red">
-            <Translation id="moduleAuthenticityChecks.deviceCompromised.steps.contactSupport" />
-        </IconListTextItem>
-    </VStack>
-);
-
-type NavigationProp = StackToStackCompositeNavigationProps<
-    RootStackParamList,
-    RootStackRoutes.AppTabs,
-    RootStackParamList
->;
-
+/**
+ * The very similar modal can be displayed for entropy check failure or FW authenticity check failure
+ */
 export const DeviceCompromisedModalScreen = () => {
-    const device = useSelector(selectSelectedDevice);
-    const dispatch = useDispatch();
-    const openLink = useOpenLink();
-    const navigation = useNavigation<NavigationProp>();
-
-    const dismissCheck = () => {
-        if (device?.id) {
-            dispatch(deviceActions.dismissFirmwareAuthenticityCheck(device.id));
-        }
-    };
-
-    // After dismissCheck, an effect could fire in useHandleDeviceConnection to navigate away, but it's not guaranteed!
-    // To be sure we don't lock user on on this screen, we navigate home.
-    const handleClose = () => {
-        // the modal is most likely entered from OnboardingStack, ConnectingDevice or Home, so let's send user back
-        if (navigation.canGoBack()) {
-            navigation.goBack();
-        }
-        // Home screen set only as fallback if can't go back
-        else {
-            navigation.navigate(RootStackRoutes.AppTabs, {
-                screen: AppTabsRoutes.HomeStack,
-                params: { screen: HomeStackRoutes.Home },
-            });
-        }
-        dismissCheck();
-    };
-
-    const handleContactSupportClick = () => openLink(chatUrl);
-
     const isEntropyCheckEnabledAndFailed = useSelector(selectIsEntropyCheckEnabledAndFailed);
-    const isDismissible = !isEntropyCheckEnabledAndFailed;
-    const screenHeaderContent = isDismissible ? (
-        <ScreenHeader closeActionType="close" closeAction={handleClose} />
-    ) : null;
-    const closeButtonContent = isDismissible ? (
-        <Button colorScheme="redElevation0" onPress={handleClose}>
-            <Translation id="generic.buttons.close" />
-        </Button>
-    ) : null;
 
-    return (
-        <Screen header={screenHeaderContent}>
-            <VStack spacing="sp32" flex={1}>
-                <TitleHeader
-                    titleVariant="titleMedium"
-                    titleSpacing="sp12"
-                    title={<Translation id="moduleAuthenticityChecks.deviceCompromised.title" />}
-                    subtitle={
-                        <Translation id="moduleAuthenticityChecks.deviceCompromised.subtitle" />
-                    }
-                />
-                <InformativeList />
-            </VStack>
-            <VStack spacing="sp12">
-                <Button colorScheme="redBold" onPress={handleContactSupportClick}>
-                    <Translation id="moduleAuthenticityChecks.deviceCompromised.buttonContactSupport" />
-                </Button>
-                {closeButtonContent}
-            </VStack>
-        </Screen>
+    return isEntropyCheckEnabledAndFailed ? (
+        <EntropyCheckFailModalContent />
+    ) : (
+        <FirmwareAuthenticityCheckFailModalContent />
     );
 };

--- a/suite-native/module-authenticity-checks/src/screens/DeviceCompromisedModalScreen.tsx
+++ b/suite-native/module-authenticity-checks/src/screens/DeviceCompromisedModalScreen.tsx
@@ -4,6 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
 import { Button, IconListTextItem, TitleHeader, VStack } from '@suite-native/atoms';
+import { selectIsEntropyCheckEnabledAndFailed } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
 import {
@@ -72,8 +73,19 @@ export const DeviceCompromisedModalScreen = () => {
 
     const handleContactSupportClick = () => openLink(chatUrl);
 
+    const isEntropyCheckEnabledAndFailed = useSelector(selectIsEntropyCheckEnabledAndFailed);
+    const isDismissible = !isEntropyCheckEnabledAndFailed;
+    const screenHeaderContent = isDismissible ? (
+        <ScreenHeader closeActionType="close" closeAction={handleClose} />
+    ) : null;
+    const closeButtonContent = isDismissible ? (
+        <Button colorScheme="redElevation0" onPress={handleClose}>
+            <Translation id="generic.buttons.close" />
+        </Button>
+    ) : null;
+
     return (
-        <Screen header={<ScreenHeader closeActionType="close" closeAction={handleClose} />}>
+        <Screen header={screenHeaderContent}>
             <VStack spacing="sp32" flex={1}>
                 <TitleHeader
                     titleVariant="titleMedium"
@@ -89,9 +101,7 @@ export const DeviceCompromisedModalScreen = () => {
                 <Button colorScheme="redBold" onPress={handleContactSupportClick}>
                     <Translation id="moduleAuthenticityChecks.deviceCompromised.buttonContactSupport" />
                 </Button>
-                <Button colorScheme="redElevation0" onPress={handleClose}>
-                    <Translation id="generic.buttons.close" />
-                </Button>
+                {closeButtonContent}
             </VStack>
         </Screen>
     );

--- a/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
@@ -11,10 +11,14 @@ import {
     DeviceOnboardingStackRoutes,
     StackProps,
 } from '@suite-native/navigation';
+import { ERRORS } from '@trezor/connect';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboardingScreenWithExitButton';
 import { WalletCreationHint } from '../components/WalletCreationHint';
+
+// Do not retry if user cancelled the flow via the app UI, or the Entropy check has failed
+const DEFINITIVE_ERRORS: ERRORS.ErrorCode[] = ['Method_Interrupted', 'Failure_EntropyCheck'];
 
 const SHOW_HINT_DELAY = 5000;
 
@@ -42,11 +46,11 @@ export const WalletCreationScreen = ({
         const response = await dispatch(createAndBackupWalletThunk({ walletBackupType })).unwrap();
 
         if (response.success) {
-            navigation.navigate(DeviceOnboardingStackRoutes.WalletCreatedSuccess);
-        } else if (response.payload.code !== 'Method_Interrupted') {
-            // Do not retry if user cancelled the flow via the app UI.
-            handleCreateAndBackupWallet();
+            return navigation.navigate(DeviceOnboardingStackRoutes.WalletCreatedSuccess);
         }
+        if (response.payload.code && DEFINITIVE_ERRORS.includes(response.payload.code)) return;
+
+        handleCreateAndBackupWallet();
     }, [dispatch, walletBackupType, navigation]);
 
     useEffect(() => {

--- a/suite-native/module-settings/src/components/TurnOffFirmwareAuthenticityCheckCard.tsx
+++ b/suite-native/module-settings/src/components/TurnOffFirmwareAuthenticityCheckCard.tsx
@@ -7,7 +7,7 @@ import { SettingsStackRoutes } from '@suite-native/navigation';
 import {
     SettingsCardWithIconLayout,
     selectIsFirmwareAuthenticityCheckEnabled,
-    setCheckFirmwareAuthenticity,
+    setCheckFirmwareAuthenticityEnabled,
 } from '@suite-native/settings';
 import { useToast } from '@suite-native/toasts';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -43,7 +43,7 @@ const TurnOnButton = () => {
     const dispatch = useDispatch();
     const { showToast } = useToast();
     const handleButtonPress = () => {
-        dispatch(setCheckFirmwareAuthenticity(true));
+        dispatch(setCheckFirmwareAuthenticityEnabled(true));
         showToast({
             variant: 'default',
             message: 'Authenticity check turned on',

--- a/suite-native/module-settings/src/screens/TurnOffFirmwareAuthenticityCheckModalScreen.tsx
+++ b/suite-native/module-settings/src/screens/TurnOffFirmwareAuthenticityCheckModalScreen.tsx
@@ -23,7 +23,7 @@ import {
     SettingsStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
-import { setCheckFirmwareAuthenticity } from '@suite-native/settings';
+import { setCheckFirmwareAuthenticityEnabled } from '@suite-native/settings';
 import { useToast } from '@suite-native/toasts';
 
 const CHECKBOX_ANIMATION_DURATION = 200; // same as in useAccordionAnimation
@@ -67,7 +67,7 @@ export const TurnOffFirmwareAuthenticityCheckModalScreen = () => {
     const handleCheckboxPress = () => setIsChecked(prev => !prev);
 
     const handleButtonPress = () => {
-        dispatch(setCheckFirmwareAuthenticity(false));
+        dispatch(setCheckFirmwareAuthenticityEnabled(false));
         if (navigation.canGoBack()) {
             navigation.goBack();
         } else {

--- a/suite-native/navigation/src/components/ScreenHeader.tsx
+++ b/suite-native/navigation/src/components/ScreenHeader.tsx
@@ -49,7 +49,9 @@ export const ScreenHeader = ({
     return (
         <Box style={applyStyle(headerStyle)}>
             <Box style={applyStyle(iconWrapperStyle)} testID="@screen/sub-header/icon-left">
-                {leftIcon || (
+                {leftIcon !== undefined ? (
+                    leftIcon
+                ) : (
                     <GoBackIcon closeActionType={closeActionType} closeAction={closeAction} />
                 )}
             </Box>

--- a/suite-native/settings/src/settingsSlice.ts
+++ b/suite-native/settings/src/settingsSlice.ts
@@ -54,7 +54,7 @@ export const appSettingsSlice = createSlice({
         setViewOnlyCancelationTimestamp: (state, { payload }: PayloadAction<number>) => {
             state.viewOnlyCancelationTimestamp = payload;
         },
-        setCheckFirmwareAuthenticity: (state, { payload }: PayloadAction<boolean>) => {
+        setCheckFirmwareAuthenticityEnabled: (state, { payload }: PayloadAction<boolean>) => {
             state.isFirmwareRevisionCheckEnabled = payload;
             state.isFirmwareHashCheckEnabled = payload;
         },
@@ -73,7 +73,7 @@ export const selectViewOnlyCancelationTimestamp = (state: SettingsSliceRootState
 
 /**
  * Determine if either FW revision or FW hash check is disabled
- * (both are controlled by the same setting, see setCheckFirmwareAuthenticity reducer)
+ * (both are controlled by the same setting, see setCheckFirmwareAuthenticityEnabled reducer)
  */
 export const selectIsFirmwareAuthenticityCheckEnabled = (state: SettingsSliceRootState) =>
     state.appSettings.isFirmwareRevisionCheckEnabled &&
@@ -98,6 +98,6 @@ export const {
     setFiatCurrency,
     setBitcoinUnits,
     setViewOnlyCancelationTimestamp,
-    setCheckFirmwareAuthenticity,
+    setCheckFirmwareAuthenticityEnabled,
 } = appSettingsSlice.actions;
 export const appSettingsReducer = appSettingsSlice.reducer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10300,6 +10300,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/module-authenticity-checks@workspace:suite-native/module-authenticity-checks"
   dependencies:
+    "@react-navigation/core": "npm:^6.4.10"
     "@react-navigation/native": "npm:6.1.18"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-native/atoms": "workspace:*"


### PR DESCRIPTION
## Description

Implement entropy check on mobile:
- implement turning it off via message system 
- execute it in `createAndBackupWalletThunk`
- if failure:
  - report to Sentry
  - display :ghost: modal that is not dismissible, but disappears when disconnecting the device
- cleanup in react components for :ghost: modals

## Related Issue

Resolve #18070 (no design yet, so I repurposed FW revision check UI)

## Screenshots:

1. [Simualted failure with T2B1](https://github.com/user-attachments/assets/833d8f20-16a5-41bd-81e2-2886eeee5690)
_Btw in the testing code I also skipped tutorial screen to last page to save time..
Also, don't mind the tenv graphical glitch at the end xD_
2. [Wallet creation success with T3T1](https://github.com/user-attachments/assets/6fe687dd-6e2d-424d-89de-2a9497a5fa09)
_Similarly it passes with simulated failure && local message system that turns off_ `security.entropyCheck.mobile`
3. [Revision check modal flow is unchanged](https://github.com/user-attachments/assets/54a4aced-e6ee-4328-87a4-6c5d30117d0b)

Just the Entropy :ghost: modal itself:
![entropy ghost](https://github.com/user-attachments/assets/bb38f615-a90b-4346-a69b-9c9cb36b6519)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/mobile-entropy-check&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/mobile-entropy-check&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/mobile-entropy-check&lookback=7)