### PR TITLE
Do not log known blocked domains

### DIFF
--- a/packages/suite-desktop-core/src/config.ts
+++ b/packages/suite-desktop-core/src/config.ts
@@ -33,6 +33,10 @@ export const allowedDomains = [
     'verify.walletconnect.org', // WalletConnect
 ];
 
+export const silentlyBlockedDomains = [
+    'pulse.walletconnect.org', // WalletConnect analytics
+];
+
 export const cspRules = [
     // Default to only own resources
     "default-src 'self'",

--- a/packages/suite-desktop-core/src/modules/request-filter.ts
+++ b/packages/suite-desktop-core/src/modules/request-filter.ts
@@ -5,7 +5,7 @@ import { captureMessage } from '@sentry/electron/main';
 
 import { isWhitelistedHost } from '@trezor/utils';
 
-import { allowedDomains } from '../config';
+import { allowedDomains, silentlyBlockedDomains } from '../config';
 
 import type { ModuleInit } from './index';
 
@@ -31,11 +31,13 @@ export const init: ModuleInit = ({ interceptor }) => {
             return;
         }
 
-        logger.warn(
-            SERVICE_NAME,
-            `${details.url} was blocked because ${hostname} is not in the exception list`,
-        );
-        captureMessage(`request-filter: ${hostname}`, 'warning');
+        if (!isWhitelistedHost(hostname, silentlyBlockedDomains)) {
+            logger.warn(
+                SERVICE_NAME,
+                `${details.url} was blocked because ${hostname} is not in the exception list`,
+            );
+            captureMessage(`request-filter: ${hostname}`, 'warning');
+        }
 
         return { cancel: true };
     });


### PR DESCRIPTION
## Description

We know that some libs are requesting disallowed domains (`pulse.walletconnect.org` in this case) and we block these requests, so we don't need to log it anymore.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/silently-blocked-domains&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/silently-blocked-domains&lookback=7)