### PR TITLE
chore(suite): upgrade wallet-sdk to the latest

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -18,7 +18,7 @@
         "test-unit:watch": "yarn g:jest -o --watch"
     },
     "dependencies": {
-        "@everstake/wallet-sdk": "1.0.13",
+        "@everstake/wallet-sdk": "1.0.14",
         "@floating-ui/react": "^0.27.5",
         "@formatjs/intl": "3.1.6",
         "@hookform/resolvers": "^4.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3161,16 +3161,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@everstake/wallet-sdk@npm:1.0.13":
-  version: 1.0.13
-  resolution: "@everstake/wallet-sdk@npm:1.0.13"
+"@everstake/wallet-sdk@npm:1.0.14":
+  version: 1.0.14
+  resolution: "@everstake/wallet-sdk@npm:1.0.14"
   dependencies:
     "@solana/web3.js": "npm:1.95.8"
     bignumber.js: "npm:9.1.2"
     ethereum-multicall: "npm:^2.26.0"
     superstruct: "npm:2.0.2"
     web3: "npm:4.16.0"
-  checksum: 10/41ee77d1107df7e3c008928edd1a321605ff5ea01ad5ec10f90dd5a7a8ea49d7259af3baf88a604c3681a3079f0c22483912d75552ed2d5a368d1e8290a6fe72
+  checksum: 10/a45447e5d47fd43cc5d5a1387c080720322316936e3bf9a3ba9bbd0875f104f770ebd4762d667480408c5e8c9dd5a7e910f7ca4340e861a8272262432bc52882
   languageName: node
   linkType: hard
 
@@ -12114,7 +12114,7 @@ __metadata:
   resolution: "@trezor/suite@workspace:packages/suite"
   dependencies:
     "@crowdin/cli": "npm:4.7.0"
-    "@everstake/wallet-sdk": "npm:1.0.13"
+    "@everstake/wallet-sdk": "npm:1.0.14"
     "@floating-ui/react": "npm:^0.27.5"
     "@formatjs/cli": "npm:6.6.3"
     "@formatjs/intl": "npm:3.1.6"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated elliptic dependency in Everstake Wallet SDK to address security alerts.


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18334

## Screenshots:
