### PR TITLE
Fix `FailureType` enum type

### DIFF
--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -1,7 +1,6 @@
 // original file https://github.com/trezor/connect/blob/develop/src/js/device/DeviceCommands.js
 
 import { MessagesSchema as Messages } from '@trezor/protobuf';
-import { FailureType } from '@trezor/protobuf/src/messages';
 import { TransportProtocol } from '@trezor/protocol';
 import { Assert } from '@trezor/schema-utils';
 import { Session, Transport } from '@trezor/transport';
@@ -175,14 +174,10 @@ export class DeviceCurrentSession implements TypedCallProvider {
                         message ||
                         // T1B1 does not send any message in firmware update
                         // https://github.com/trezor/trezor-firmware/issues/1334
-                        (code &&
-                            FailureType[code] === 'Failure_FirmwareError' &&
-                            'Firmware installation failed') ||
+                        (code === 'Failure_FirmwareError' && 'Firmware installation failed') ||
                         // Failure_ActionCancelled message could be also missing
                         // https://github.com/trezor/connect/issues/865
-                        (code &&
-                            FailureType[code] === 'Failure_ActionCancelled' &&
-                            'Action cancelled by user') ||
+                        (code === 'Failure_ActionCancelled' && 'Action cancelled by user') ||
                         'Failure_UnknownMessage';
 
                     // pass code and message from firmware error

--- a/packages/protobuf/scripts/protobuf-patches/index.ts
+++ b/packages/protobuf/scripts/protobuf-patches/index.ts
@@ -46,6 +46,7 @@ export const ENUM_KEYS = [
     'BackupAvailability',
     'RecoveryType',
     'DisplayRotation',
+    'FailureType',
 ];
 
 // type rule fixes, ideally it should not be here

--- a/packages/protobuf/src/messages-schema.ts
+++ b/packages/protobuf/src/messages-schema.ts
@@ -1369,7 +1369,7 @@ export const Success = Type.Object(
     { $id: 'Success' },
 );
 
-export enum FailureType {
+export enum Enum_FailureType {
     Failure_UnexpectedMessage = 1,
     Failure_ButtonExpected = 2,
     Failure_DataError = 3,
@@ -1387,13 +1387,16 @@ export enum FailureType {
     Failure_FirmwareError = 99,
 }
 
-export type EnumFailureType = Static<typeof EnumFailureType>;
-export const EnumFailureType = Type.Enum(FailureType);
+export type EnumEnum_FailureType = Static<typeof EnumEnum_FailureType>;
+export const EnumEnum_FailureType = Type.Enum(Enum_FailureType);
+
+export type FailureType = Static<typeof FailureType>;
+export const FailureType = Type.KeyOfEnum(Enum_FailureType, { $id: 'FailureType' });
 
 export type Failure = Static<typeof Failure>;
 export const Failure = Type.Object(
     {
-        code: Type.Optional(Type.KeyOfEnum(FailureType)),
+        code: Type.Optional(FailureType),
         message: Type.Optional(Type.String()),
     },
     { $id: 'Failure' },

--- a/packages/protobuf/src/messages.ts
+++ b/packages/protobuf/src/messages.ts
@@ -906,7 +906,7 @@ export type Success = {
     message: string;
 };
 
-export enum FailureType {
+export enum Enum_FailureType {
     Failure_UnexpectedMessage = 1,
     Failure_ButtonExpected = 2,
     Failure_DataError = 3,
@@ -923,6 +923,8 @@ export enum FailureType {
     Failure_InvalidSession = 14,
     Failure_FirmwareError = 99,
 }
+
+export type FailureType = keyof typeof Enum_FailureType;
 
 export type Failure = {
     code?: FailureType;


### PR DESCRIPTION
## Description

Added `FailureType` to the enums used by key when generating protobuf types and validation schema, and fixed comparing it in `DeviceCurrentSession`.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/failure-enum&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/failure-enum&lookback=7)