### PR TITLE
chore(ci): run e2e tests and basic validations on release branches

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -1,6 +1,11 @@
 name: "[Check] Validation"
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - release/2*
+      - release-native/*
 
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_GHACTIONS_TOKEN }}

--- a/.github/workflows/test-suite-native-e2e-android.yml
+++ b/.github/workflows/test-suite-native-e2e-android.yml
@@ -12,6 +12,9 @@ on:
       - "suite-common/**"
       - "packages/connect/**"
       - ".github/workflows/test-suite-native-e2e-android.yml"
+  push:
+    branches:
+      - release-native/*
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -3,6 +3,9 @@ name: "[Test] suite-native iOS E2E"
 on:
   schedule:
     - cron: "0 0 * * *"
+  push:
+    branches:
+      - release-native/*
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -3,9 +3,10 @@ name: "[Test] suite-native iOS E2E"
 on:
   schedule:
     - cron: "0 0 * * *"
-  push:
-    branches:
-      - release-native/*
+  # FIXME:Disabled for now, iOS tests are failing
+  # push:
+  #   branches:
+  #     - release-native/*
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

It's important to run the tests on release branch because we can introduce some errors by integrating more PRs together on the develop so it's not covered by CI in PRs. And it's also important to check cherry picks (they might have some conflicts).

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/ci-for-release-branches&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/ci-for-release-branches&lookback=7)