### PR TITLE
Fix: device onboarding design QA part 2

### DIFF
--- a/suite-native/atoms/src/Badge.tsx
+++ b/suite-native/atoms/src/Badge.tsx
@@ -12,7 +12,7 @@ import { HStack } from './Stack';
 import { Text } from './Text';
 import { SurfaceElevation } from './types';
 
-export type BadgeVariant = 'neutral' | 'green' | 'greenSubtle' | 'yellow' | 'red' | 'bold';
+export type BadgeVariant = 'neutral' | 'green' | 'greenSubtle' | 'yellow' | 'red' | 'blue' | 'bold';
 export type BadgeSize = 'small' | 'medium';
 type IconType = IconName | NetworkSymbol;
 type BadgeProps = {
@@ -100,6 +100,13 @@ const badgeVariantToStylePropsMap = {
         backgroundColorElevation1: 'backgroundAlertRedSubtleOnElevation1',
         activeTextColor: 'textAlertRed',
         activeIconColor: 'iconAlertRed',
+        borderColor: undefined,
+    },
+    blue: {
+        backgroundColorElevation0: 'backgroundAlertBlueSubtleOnElevation0',
+        backgroundColorElevation1: 'backgroundAlertBlueSubtleOnElevation1',
+        activeTextColor: 'textAlertBlue',
+        activeIconColor: 'iconAlertBlue',
         borderColor: undefined,
     },
     bold: {

--- a/suite-native/firmware/src/components/ConfirmFirmwareUpdateScreenContent.tsx
+++ b/suite-native/firmware/src/components/ConfirmFirmwareUpdateScreenContent.tsx
@@ -6,7 +6,7 @@ import { FirmwareUpdateVersionCard } from '../components/FirmwareVersionCard';
 
 export const ConfirmFirmwareUpdateScreenContent = () => (
     <>
-        <Box paddingTop="sp16">
+        <Box>
             <Text variant="titleMedium">
                 <Translation id="firmware.firmwareUpdateScreen.title" />
             </Text>

--- a/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
+++ b/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
@@ -12,7 +12,7 @@ import { useDispatch } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
 import { authorizeDeviceThunk } from '@suite-common/wallet-core';
-import { Box, Button, IconButton, Text, VStack } from '@suite-native/atoms';
+import { Badge, Box, Button, IconButton, Text, VStack } from '@suite-native/atoms';
 import { ConfirmOnTrezorImage, setTemporaryRememberedDeviceThunk } from '@suite-native/device';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import { Translation } from '@suite-native/intl';
@@ -225,6 +225,16 @@ export const FirmwareInstallationScreenContent = ({
                             {translatedText.subtitle ?? ' '}
                         </Text>
                     </Box>
+                    {!isError && !isDone && (
+                        <Box paddingTop="sp24" alignItems="center" justifyContent="center">
+                            <Badge
+                                variant="blue"
+                                label={
+                                    <Translation id="firmware.firmwareUpdateProgress.dontCloseAppMessage" />
+                                }
+                            />
+                        </Box>
+                    )}
                 </Animated.View>
             </VStack>
             {isError && (

--- a/suite-native/firmware/src/hooks/useFirmware.tsx
+++ b/suite-native/firmware/src/hooks/useFirmware.tsx
@@ -7,6 +7,7 @@ import {
     useFirmwareInstallation,
 } from '@suite-common/firmware';
 import { TxKeyPath, useTranslate } from '@suite-native/intl';
+import { getFirmwareVersion } from '@trezor/device-utils';
 import { setPriorityMode } from '@trezor/react-native-usb';
 
 import { nativeFirmwareActions } from '../nativeFirmwareSlice';
@@ -92,6 +93,8 @@ export const useFirmware = (params?: UseFirmwareInstallationParams) => {
         // @ts-expect-error types are not correct here, IDK why
         firmwareInstallation.uiEvent?.payload?.code === 'ButtonRequest_Other';
 
+    const originalFirmwareVersion = getFirmwareVersion(firmwareInstallation.originalDevice);
+
     const translatedText = useMemo(() => {
         let text: { title: TxKeyPath; subtitle?: TxKeyPath } = {
             title: 'firmware.firmwareUpdateProgress.initializing.title',
@@ -106,22 +109,22 @@ export const useFirmware = (params?: UseFirmwareInstallationParams) => {
         } else if (isInitialState && !confirmOnDevice) {
             text = {
                 title: 'firmware.firmwareUpdateProgress.initializing.title',
-                subtitle: 'firmware.firmwareUpdateProgress.dontCloseAppMessage',
+                subtitle: 'firmware.firmwareUpdateProgress.generalSubtitle',
             };
         } else if (isInitialState) {
             text = {
                 title: 'firmware.firmwareUpdateProgress.confirming.title',
-                subtitle: 'firmware.firmwareUpdateProgress.confirmOnDeviceMessage',
+                subtitle: 'firmware.firmwareUpdateProgress.generalSubtitle',
             };
         } else if (operation === 'validating') {
             text = {
                 title: 'firmware.firmwareUpdateProgress.validating.title',
-                subtitle: 'firmware.firmwareUpdateProgress.dontCloseAppMessage',
+                subtitle: 'firmware.firmwareUpdateProgress.generalSubtitle',
             };
         } else if (operation === 'restarting') {
             text = {
                 title: 'firmware.firmwareUpdateProgress.restarting.title',
-                subtitle: 'firmware.firmwareUpdateProgress.dontCloseAppMessage',
+                subtitle: 'firmware.firmwareUpdateProgress.generalSubtitle',
             };
         } else if (operation === 'completed' || status === 'done') {
             text = {
@@ -130,8 +133,10 @@ export const useFirmware = (params?: UseFirmwareInstallationParams) => {
             };
         } else if (operation === 'installing') {
             text = {
-                title: 'firmware.firmwareUpdateProgress.installing.title',
-                subtitle: 'firmware.firmwareUpdateProgress.dontCloseAppMessage',
+                title: originalFirmwareVersion
+                    ? 'firmware.firmwareUpdateProgress.installing.title'
+                    : 'firmware.firmwareUpdateProgress.installing.title',
+                subtitle: 'firmware.firmwareUpdateProgress.generalSubtitle',
             };
         }
 
@@ -139,7 +144,7 @@ export const useFirmware = (params?: UseFirmwareInstallationParams) => {
             title: translate(text.title),
             subtitle: text.subtitle ? translate(text.subtitle) : error,
         };
-    }, [operation, status, error, confirmOnDevice, translate]);
+    }, [operation, status, error, confirmOnDevice, translate, originalFirmwareVersion]);
 
     return {
         ...firmwareInstallation,

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -1021,8 +1021,9 @@ export const en = {
             reconnectButton: 'Connect Trezor',
         },
         cancelOnboardingAlert: {
-            title: 'Are you sure you’d like to cancel your Trezor’s setup?',
+            title: 'Cancel Trezor setup?',
             description: 'Start again at anytime.',
+            cancelButton: 'Yes, cancel',
             continueButton: 'Continue setup',
         },
     },
@@ -1598,10 +1599,14 @@ export const en = {
             },
         },
         firmwareUpdateProgress: {
+            generalSubtitle: 'Firmware is your Trezor’s operating system.',
             initializing: { title: 'Preparing your Trezor' },
             confirming: { title: 'Confirm firmware update on your Trezor.' },
-            installing: {
+            updating: {
                 title: 'Updating your firmware',
+            },
+            installing: {
+                title: 'Installing firmware',
             },
             restarting: { title: 'Restarting Trezor.' },
             validating: { title: 'Validating firmware.' },

--- a/suite-native/link/src/components/Link.tsx
+++ b/suite-native/link/src/components/Link.tsx
@@ -63,11 +63,13 @@ export const Link = ({
         ),
     }));
 
-    const handlePressIn = () => {
+    const handlePressIn = (e: GestureResponderEvent) => {
         isPressed.value = withTiming(IS_PRESSED_VALUE, { duration: ANIMATION_DURATION });
+        e.stopPropagation();
     };
 
-    const handlePress = (e: GestureResponderEvent) => {
+    const handlePressOut = (e: GestureResponderEvent) => {
+        isPressed.value = withTiming(IS_NOT_PRESSED_VALUE, { duration: ANIMATION_DURATION });
         if (href) {
             openLink(href);
         } else if (onPress) {
@@ -76,14 +78,10 @@ export const Link = ({
         e.stopPropagation();
     };
 
-    const handlePressOut = () => {
-        isPressed.value = withTiming(IS_NOT_PRESSED_VALUE, { duration: ANIMATION_DURATION });
-    };
-
     return (
         <Animated.Text
             onPressIn={handlePressIn}
-            onPress={handlePress}
+            onPress={() => {}} // If the handling is defined in onPress, the very short taps are sometimes ignored
             onPressOut={handlePressOut}
             style={[applyStyle(textStyle, { isUnderlined, textVariant }), animatedTextColorStyle]}
             suppressHighlighting

--- a/suite-native/module-device-onboarding/src/components/DeviceOnboardingScreenWithExitButton.tsx
+++ b/suite-native/module-device-onboarding/src/components/DeviceOnboardingScreenWithExitButton.tsx
@@ -89,7 +89,7 @@ const DeviceOnboardingExitButtonScreenHeader = () => {
 
 export const DeviceOnboardingScreenWithExitButton = ({ children, ...screenProps }: ScreenProps) => (
     <Screen header={<DeviceOnboardingExitButtonScreenHeader />} {...screenProps}>
-        <Box flex={1} marginVertical="sp16">
+        <Box flex={1} marginTop="sp16">
             {children}
         </Box>
     </Screen>

--- a/suite-native/module-device-onboarding/src/components/DeviceOnboardingScreenWithExitButton.tsx
+++ b/suite-native/module-device-onboarding/src/components/DeviceOnboardingScreenWithExitButton.tsx
@@ -41,7 +41,9 @@ const DeviceOnboardingExitButtonScreenHeader = () => {
         showAlert({
             title: translate('moduleDeviceOnboarding.cancelOnboardingAlert.title'),
             description: translate('moduleDeviceOnboarding.cancelOnboardingAlert.description'),
-            primaryButtonTitle: translate('generic.buttons.cancel'),
+            primaryButtonTitle: translate(
+                'moduleDeviceOnboarding.cancelOnboardingAlert.cancelButton',
+            ),
             primaryButtonVariant: 'redBold',
             secondaryButtonTitle: translate(
                 'moduleDeviceOnboarding.cancelOnboardingAlert.continueButton',

--- a/suite-native/module-device-onboarding/src/components/SecurityCheckStepCard.tsx
+++ b/suite-native/module-device-onboarding/src/components/SecurityCheckStepCard.tsx
@@ -1,11 +1,5 @@
 import { ReactNode } from 'react';
-import {
-    FadeIn,
-    FadeOutUp,
-    useAnimatedStyle,
-    withDelay,
-    withTiming,
-} from 'react-native-reanimated';
+import { FadeOutUp, useAnimatedStyle, withDelay, withTiming } from 'react-native-reanimated';
 
 import { useNavigation } from '@react-navigation/core';
 
@@ -46,10 +40,24 @@ type NavigationProps = StackNavigationProps<
 
 const ANIMATION_DURATION = 300;
 
-const cardStyle = prepareNativeStyle<{ wasOpened: boolean }>((utils, { wasOpened }) => ({
-    backgroundColor: wasOpened
-        ? utils.colors.backgroundSurfaceElevationNegative
-        : utils.colors.backgroundSurfaceElevation1,
+const cardStyle = prepareNativeStyle<{ isDisabled: boolean }>((utils, { isDisabled }) => ({
+    backgroundColor: utils.colors.backgroundSurfaceElevation1,
+    borderColor: utils.colors.borderOnElevation1,
+    borderWidth: 1,
+    paddingVertical: utils.spacings.sp12,
+
+    extend: {
+        condition: isDisabled,
+        style: {
+            backgroundColor: utils.colors.backgroundSurfaceElevationNegative,
+            borderColor: utils.colors.borderOnElevation0,
+            ...utils.boxShadows.none,
+        },
+    },
+}));
+
+const dividerStyle = prepareNativeStyle(utils => ({
+    marginHorizontal: -utils.spacings.sp16,
 }));
 
 const buttonStyle = prepareNativeStyle(() => ({
@@ -75,9 +83,6 @@ export const SecurityCheckStepCard = ({
             suspicionCause,
         });
     };
-
-    const isFirstStepCard = suspicionCause === 'untrustedReseller';
-
     const animatedCardStyle = useAnimatedStyle(
         () => ({
             minHeight: withDelay(
@@ -90,11 +95,23 @@ export const SecurityCheckStepCard = ({
         [isOpened],
     );
 
+    const contentAnimatedStyle = useAnimatedStyle(() => ({
+        height: withTiming(isOpened ? 110 : 0, {
+            duration: ANIMATION_DURATION,
+        }),
+        opacity: withDelay(
+            ANIMATION_DURATION,
+            withTiming(isOpened ? 1 : 0, {
+                duration: ANIMATION_DURATION,
+            }),
+        ),
+    }));
+
     return (
         <AnimatedCard
             style={[
                 animatedCardStyle,
-                applyStyle(cardStyle, { wasOpened: !isOpened && !isChecked }),
+                applyStyle(cardStyle, { isDisabled: !isOpened && !isChecked }),
             ]}
         >
             <VStack spacing="sp16">
@@ -105,23 +122,17 @@ export const SecurityCheckStepCard = ({
                             {header}
                         </Text>
                     </HStack>
-                    {isOpened && <Divider />}
+                    {isOpened && <Divider style={applyStyle(dividerStyle)} />}
                 </VStack>
                 {isOpened && (
-                    <AnimatedVStack
-                        spacing="sp16"
-                        entering={isFirstStepCard ? undefined : FadeIn.delay(ANIMATION_DURATION)}
-                        exiting={FadeOutUp}
-                    >
+                    <AnimatedVStack spacing="sp16" style={contentAnimatedStyle} exiting={FadeOutUp}>
                         <Text variant="highlight">{description}</Text>
-                        <HStack flex={1} spacing="sp12" justifyContent="space-between">
-                            <Button
-                                size="small"
-                                style={applyStyle(buttonStyle)}
-                                onPress={onPressConfirmButton}
-                            >
-                                <Translation id="generic.buttons.yes" />
-                            </Button>
+                        <HStack
+                            flex={1}
+                            spacing="sp12"
+                            justifyContent="space-between"
+                            paddingBottom="sp4"
+                        >
                             <Button
                                 size="small"
                                 style={applyStyle(buttonStyle)}
@@ -129,6 +140,13 @@ export const SecurityCheckStepCard = ({
                                 onPress={navigateToSuspiciousDeviceScreen}
                             >
                                 <Translation id="moduleDeviceOnboarding.securityCheckScreen.declineButton" />
+                            </Button>
+                            <Button
+                                size="small"
+                                style={applyStyle(buttonStyle)}
+                                onPress={onPressConfirmButton}
+                            >
+                                <Translation id="generic.buttons.yes" />
                             </Button>
                         </HStack>
                     </AnimatedVStack>

--- a/suite-native/module-device-onboarding/src/components/SwipeableWalkthrough/SwipeableWalkthroughScreenHeader.tsx
+++ b/suite-native/module-device-onboarding/src/components/SwipeableWalkthrough/SwipeableWalkthroughScreenHeader.tsx
@@ -50,7 +50,7 @@ const SwipeableWalkthroughBackButton = ({
     return (
         <Animated.View style={animatedButtonStyle}>
             <IconButton
-                iconName="arrowLeft"
+                iconName="caretLeft"
                 size="medium"
                 colorScheme="tertiaryElevation0"
                 onPress={onPressBack}

--- a/suite-native/module-device-onboarding/src/components/SwipeableWalkthrough/SwipeableWalkthroughStep.tsx
+++ b/suite-native/module-device-onboarding/src/components/SwipeableWalkthrough/SwipeableWalkthroughStep.tsx
@@ -94,7 +94,7 @@ export const SwipeableWalkthroughStep = ({
                     {children}
                     {continueButton ?? (
                         <IconButton
-                            iconName="arrowDown"
+                            iconName="caretDown"
                             colorScheme="tertiaryElevation0"
                             size="large"
                             onPress={onNextButtonPress}

--- a/suite-native/module-device-onboarding/src/screens/ConfirmFirmwareUpdateScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ConfirmFirmwareUpdateScreen.tsx
@@ -1,9 +1,5 @@
-import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
-import { useFocusEffect } from '@react-navigation/native';
-
-import { selectIsLatestFirmwareInstalled } from '@suite-common/wallet-core';
 import { selectIsDeviceFirmwareSupported } from '@suite-native/device';
 import {
     ConfirmFirmwareUpdateScreenContent,
@@ -24,15 +20,6 @@ export const ConfirmFirmwareUpdateScreen = ({
     DeviceOnboardingStackRoutes.ConfirmFirmwareUpdate
 >) => {
     const isDeviceFirmwareSupported = useSelector(selectIsDeviceFirmwareSupported);
-    const isLatestFirmwareInstalled = useSelector(selectIsLatestFirmwareInstalled);
-
-    // If user already has the latest firmware installed, skip this screen and navigate to device auth-check directly.
-    useFocusEffect(
-        useCallback(() => {
-            if (isLatestFirmwareInstalled)
-                navigation.navigate(DeviceOnboardingStackRoutes.DeviceTutorial);
-        }, [isLatestFirmwareInstalled, navigation]),
-    );
 
     const handleUpdateConfirmation = () => {
         navigation.navigate(DeviceOnboardingStackRoutes.FirmwareInstallation);

--- a/suite-native/module-device-onboarding/src/screens/CreateOrRecoverCrossroadsScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/CreateOrRecoverCrossroadsScreen.tsx
@@ -31,7 +31,7 @@ export const CreateOrRecoverCrossroadsScreen = ({
 
     return (
         <DeviceOnboardingScreenWithExitButton>
-            <VStack spacing="sp24" flex={1} justifyContent="space-between">
+            <VStack spacing="sp24" flex={1} justifyContent="space-between" marginBottom="sp16">
                 <Card style={applyStyle(cardStyle)}>
                     <Box flex={1} justifyContent="space-between" alignItems="center">
                         <Box flex={1} justifyContent="center" paddingVertical="sp12">

--- a/suite-native/module-device-onboarding/src/screens/SecurityCheckScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/SecurityCheckScreen.tsx
@@ -80,7 +80,7 @@ export const SecurityCheckScreen = ({
 
     return (
         <DeviceOnboardingScreenWithExitButton>
-            <VStack justifyContent="flex-start" flex={1} marginTop="sp16">
+            <VStack justifyContent="flex-start" flex={1}>
                 <VStack spacing="sp24">
                     <TitleHeader
                         titleVariant="titleMedium"

--- a/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
@@ -112,7 +112,7 @@ export const UninitializedDeviceLandingScreen = ({
 
     return (
         <DeviceOnboardingScreenWithExitButton>
-            <VStack justifyContent="space-between" flex={1} paddingTop="sp16">
+            <VStack justifyContent="space-between" flex={1}>
                 <VStack spacing="sp32">
                     <UninitializedDeviceLandingScreenContent />
                     <TextButton

--- a/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
@@ -1,6 +1,10 @@
 import { useSelector } from 'react-redux';
 
-import { selectDeviceModel, selectHasDeviceFirmwareInstalled } from '@suite-common/wallet-core';
+import {
+    selectDeviceModel,
+    selectHasDeviceFirmwareInstalled,
+    selectIsLatestFirmwareInstalled,
+} from '@suite-common/wallet-core';
 import { Box, Button, Image, Text, TextButton, TitleHeader, VStack } from '@suite-native/atoms';
 import { SetupSupportingDeviceModel } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
@@ -78,11 +82,18 @@ export const UninitializedDeviceLandingScreen = ({
     DeviceOnboardingStackRoutes.UninitializedDeviceLanding
 >) => {
     const hasDeviceFirmwareInstalled = useSelector(selectHasDeviceFirmwareInstalled);
+    const isLatestFirmwareInstalled = useSelector(selectIsLatestFirmwareInstalled);
 
     const handleConfirmButtonPress = () => {
         if (hasDeviceFirmwareInstalled) {
-            navigation.navigate(DeviceOnboardingStackRoutes.ConfirmFirmwareUpdate);
+            if (isLatestFirmwareInstalled) {
+                // If user already has the latest firmware installed, skip this update screen and navigate to device auth-check directly.
+                navigation.navigate(DeviceOnboardingStackRoutes.DeviceTutorial);
+            } else {
+                navigation.navigate(DeviceOnboardingStackRoutes.ConfirmFirmwareUpdate);
+            }
         } else {
+            // Security check is relevant for brand new devices only.
             navigation.navigate(DeviceOnboardingStackRoutes.SecurityCheck);
         }
     };

--- a/suite-native/module-device-onboarding/src/screens/WalletBackupTutorialScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletBackupTutorialScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useSharedValue } from 'react-native-reanimated';
 
 import { useNavigation } from '@react-navigation/core';
@@ -41,6 +41,18 @@ export const WalletBackupTutorialScreen = () => {
             currentStepIndex.value -= 1;
         }
     }, [navigation, currentStepIndex]);
+
+    useEffect(() => {
+        // Override default navigation GO_BACK action to align it with the UI back button behavior.
+        const unsubscribe = navigation.addListener('beforeRemove', e => {
+            if (e.data.action.type === 'GO_BACK') {
+                e.preventDefault();
+                handlePressBackButton();
+            }
+        });
+
+        return unsubscribe;
+    }, [handlePressBackButton, navigation]);
 
     return (
         <Screen

--- a/suite-native/module-device-settings/src/screens/ConfirmFirmwareUpdateScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/ConfirmFirmwareUpdateScreen.tsx
@@ -1,5 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 
+import { Box } from '@suite-native/atoms';
 import {
     ConfirmFirmwareUpdateScreenContent,
     ConfirmFirmwareUpdateScreenFooter,
@@ -36,7 +37,9 @@ export const ConfirmFirmwareUpdateScreen = () => {
                 />
             }
         >
-            <ConfirmFirmwareUpdateScreenContent />
+            <Box flex={1} marginTop="sp16">
+                <ConfirmFirmwareUpdateScreenContent />
+            </Box>
         </Screen>
     );
 };


### PR DESCRIPTION
This PR fixes multiple minor UI discrepancies discovered during the design QA of device onboarding part 2.

## Description
- [fix(suite-native): skip firmware update screen for latest firmware](https://github.com/trezor/trezor-suite/commit/305e41ed1da491737ff2043a97df29b61b694544): FW update screen skipped for latest FW installed
- [fix(suite-native): cancel device onboarding alert copy](https://github.com/trezor/trezor-suite/commit/f368b603e4bb458f023487cd5f01a5902cec57dd) cancel onboarding flow alert copy adjusted
- [fix(suite-native): firmware installation copy](https://github.com/trezor/trezor-suite/commit/cf2d2aa97b1cad3c33afccfc77af056f90d14ed9): firmware installation copy fixed
- [fix(suite-native): wallet tutorial back buttons](https://github.com/trezor/trezor-suite/commit/7ce552ba4d3c4af9b0cb7be430e983a0acc083bb)
  - arrow substituted by caret. 
  - handling of Android system back button press 
- [fix(suite-native): security check step cards polished](https://github.com/trezor/trezor-suite/commit/a19cf3270fa6ea2b3255ccef86125343f70c1496)
  - animation improved
  - styling adjusted to the design
  - clickable links working now

## Related Issue

Resolve #18373
Resolve #17938 

## Screenshots
- please test it on your device to see the changes


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-onboarding/ui-review-part-2&lookback=7)