### PR TITLE
fix(suite-native): asset can be undefined in useQuotes

### DIFF
--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -189,7 +189,13 @@ export const selectTradingPaymentMethods = (state: TradingRootState) =>
 export const selectTradingTrades = (state: TradingRootState) =>
     returnStableArrayIfEmpty(state.wallet.tradingNew.trades);
 
-export const selectTradingCoinInfoByCryptoId = (state: TradingRootState, cryptoId: CryptoId) => {
+export const selectTradingCoinInfoByCryptoId = (
+    state: TradingRootState,
+    cryptoId: CryptoId | undefined,
+) => {
+    if (!cryptoId) {
+        return undefined;
+    }
     const { coins = {} } = state.wallet.tradingNew.info;
 
     return getTradingCoinInfoByCryptoId(coins, cryptoId);

--- a/suite-native/module-trading/src/hooks/useQuotes.ts
+++ b/suite-native/module-trading/src/hooks/useQuotes.ts
@@ -88,7 +88,7 @@ export const useQuotes = (form: TradingBuyForm) => {
         selectTradingCoinInfoByCryptoId(state, asset?.cryptoId),
     );
 
-    if (shouldFetchQuotes || shouldReload) {
+    if (asset && (shouldFetchQuotes || shouldReload)) {
         if (promiseRef.current?.abort) {
             promiseRef.current.abort('Request was replaced by another one.');
         }

--- a/suite-native/module-trading/src/types.ts
+++ b/suite-native/module-trading/src/types.ts
@@ -22,7 +22,7 @@ export type ReceiveAccount = {
 
 export type TradingBuyFormValues = {
     quoteId: string | undefined;
-    asset: TradeableAsset;
+    asset: TradeableAsset | undefined;
     receiveAccount: ReceiveAccount | undefined;
     fiatCurrency: FiatCurrencyCode;
     fiatValue: string | undefined;


### PR DESCRIPTION
asset can be undefined in buy form, but there was a bad type in Buy Form causing errors in useQuotes.

It should resolve [Sentry issue](https://satoshilabs.sentry.io/issues/6534940586/?project=4504214699245568)



## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/use-quotes&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/use-quotes&lookback=7)