### PR TITLE
Mobile trade timer quotes fix

### DIFF
--- a/packages/react-utils/src/hooks/useTimer.ts
+++ b/packages/react-utils/src/hooks/useTimer.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export interface Timer {
     timeSpent: {
@@ -40,22 +40,22 @@ export const useTimer = (): Timer => {
         };
     }, [isLoading, isStopped]);
 
-    const reset = () => {
+    const reset = useCallback(() => {
         setIsLoading(false);
         setResetCount(prev => prev + 1);
         setTimeSpent(0);
         setIsStopped(false);
-    };
+    }, []);
 
-    const stop = () => {
+    const stop = useCallback(() => {
         setIsStopped(true);
-    };
+    }, []);
 
-    const loading = () => {
+    const loading = useCallback(() => {
         setTimeSpent(0);
         setIsLoading(true);
         setIsStopped(false);
-    };
+    }, []);
 
     return {
         timeSpent: { seconds: timeSpent },

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -189,7 +189,14 @@ export const selectTradingPaymentMethods = (state: TradingRootState) =>
 export const selectTradingTrades = (state: TradingRootState) =>
     returnStableArrayIfEmpty(state.wallet.tradingNew.trades);
 
-export const selectTradingCoinInfoByCryptoId = (state: TradingRootState, cryptoId: CryptoId) => {
+export const selectTradingCoinInfoByCryptoId = (
+    state: TradingRootState,
+    cryptoId: CryptoId | undefined,
+) => {
+    if (!cryptoId) {
+        return undefined;
+    }
+
     const { coins = {} } = state.wallet.tradingNew.info;
 
     return getTradingCoinInfoByCryptoId(coins, cryptoId);

--- a/suite-native/module-trading/src/hooks/__tests__/useQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/__tests__/useQuotes.test.ts
@@ -156,7 +156,7 @@ describe('useQuotes', () => {
         },
     );
 
-    it('should not re-fetch quotes when refetch time elapsed', async () => {
+    it('should re-fetch quotes when re-fetch time elapsed', async () => {
         const store = await getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
         const { result, rerender } = await renderUseQuotes(store);
@@ -181,5 +181,19 @@ describe('useQuotes', () => {
                 type: 'handleRequestThunkMock',
             }),
         );
+    });
+
+    it('should not re-fetch quotes when re-fetch time elapsed but not all required data are available', async () => {
+        const store = await getInitializedStore();
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+        const { result, rerender } = await renderUseQuotes(store);
+        act(() => {
+            result.current.setValue('fiatCurrency', 'usd');
+        });
+
+        mockTimeSpent = INVITY_API_RELOAD_QUOTES_AFTER_SECONDS;
+        rerender({});
+
+        expect(dispatchSpy).toHaveBeenCalledTimes(0);
     });
 });

--- a/suite-native/module-trading/src/hooks/__tests__/useReloadTimer.test.ts
+++ b/suite-native/module-trading/src/hooks/__tests__/useReloadTimer.test.ts
@@ -12,7 +12,10 @@ jest.mock('@trezor/react-utils', () => ({
 }));
 
 describe('useReloadTimer', () => {
-    const renderUseReloadTimer = () => renderHook(() => useReloadTimer());
+    const renderUseReloadTimer = (initialEnabled: boolean = true) =>
+        renderHook(({ isEnabled }) => useReloadTimer(isEnabled), {
+            initialProps: { isEnabled: initialEnabled },
+        });
 
     beforeEach(() => {
         mockTimerReturn = {
@@ -83,5 +86,43 @@ describe('useReloadTimer', () => {
 
         expect(result.current.shouldReload).toBe(false);
         expect(result.current.timer.stop).not.toHaveBeenCalled();
+    });
+
+    it('should stop timer when isEnabled is false', () => {
+        const { result } = renderUseReloadTimer(false);
+
+        expect(result.current.timer.stop).toHaveBeenCalled();
+        expect(result.current.shouldReload).toBe(false);
+    });
+
+    it('should return shouldReload when timer is not enabled even when reload time is reached', () => {
+        mockTimerReturn.timeSpent.seconds = INVITY_API_RELOAD_QUOTES_AFTER_SECONDS + 1;
+        const { result } = renderUseReloadTimer(false);
+
+        expect(result.current.timer.stop).toHaveBeenCalled();
+        expect(result.current.shouldReload).toBe(false);
+    });
+
+    it('should reset timer when enabled but stopped', () => {
+        mockTimerReturn.isStopped = true;
+        const { result } = renderUseReloadTimer();
+
+        expect(result.current.timer.reset).toHaveBeenCalled();
+    });
+
+    it('should not reset timer when isStopped and isLoading', () => {
+        mockTimerReturn.isStopped = true;
+        mockTimerReturn.isLoading = true;
+        const { result } = renderUseReloadTimer();
+
+        expect(result.current.timer.reset).not.toHaveBeenCalled();
+    });
+
+    it('should not reset timer when stopped and MAX_RESET_COUNT is reached', () => {
+        mockTimerReturn.isStopped = true;
+        mockTimerReturn.resetCount = MAX_RESET_COUNT + 1;
+        const { result } = renderUseReloadTimer();
+
+        expect(result.current.timer.reset).not.toHaveBeenCalled();
     });
 });

--- a/suite-native/module-trading/src/hooks/useQuotes.ts
+++ b/suite-native/module-trading/src/hooks/useQuotes.ts
@@ -22,7 +22,27 @@ type PromiseType = {
     abort: (message?: string) => void;
 };
 
-const useShouldFetchQuotes = (form: TradingBuyForm) => {
+type ShouldFetchQuotesState = {
+    cryptoId: string | undefined;
+    fiatCurrency: string | undefined;
+    amount: string | undefined;
+    amountInCrypto: boolean | undefined;
+    country: string | undefined;
+};
+
+type ShouldFetchQuotes = {
+    isFetchAllowed: boolean;
+    shouldFetchQuotes: boolean;
+};
+
+const useShouldFetchQuotes = (form: TradingBuyForm): ShouldFetchQuotes => {
+    const [prevState, setPrevState] = useState<ShouldFetchQuotesState>({
+        cryptoId: undefined,
+        fiatCurrency: undefined,
+        amount: undefined,
+        amountInCrypto: false,
+        country: undefined,
+    });
     const [asset, fiatCurrency, fiatValue, cryptoValue, amountInCrypto, country] = form.watch([
         'asset',
         'fiatCurrency',
@@ -31,25 +51,9 @@ const useShouldFetchQuotes = (form: TradingBuyForm) => {
         'amountInCrypto',
         'country',
     ]);
-    const [prevState, setPrevState] = useState<{
-        cryptoId: string | undefined;
-        fiatCurrency: string | undefined;
-        amount: string | undefined;
-        amountInCrypto: boolean | undefined;
-        country: string | undefined;
-    }>({
-        cryptoId: undefined,
-        fiatCurrency: undefined,
-        amount: undefined,
-        amountInCrypto: false,
-        country: undefined,
-    });
 
     const amount = amountInCrypto ? cryptoValue : fiatValue;
-
-    if (!asset || !fiatCurrency || !amount) {
-        return false;
-    }
+    const isFetchAllowed = !!(asset && fiatCurrency && amount);
 
     if (
         asset?.cryptoId === prevState.cryptoId &&
@@ -58,7 +62,10 @@ const useShouldFetchQuotes = (form: TradingBuyForm) => {
         amountInCrypto === prevState.amountInCrypto &&
         country?.value === prevState.country
     ) {
-        return false;
+        return {
+            isFetchAllowed,
+            shouldFetchQuotes: false,
+        };
     }
 
     setPrevState({
@@ -69,16 +76,18 @@ const useShouldFetchQuotes = (form: TradingBuyForm) => {
         country: country?.value,
     });
 
-    return true;
+    return {
+        isFetchAllowed,
+        shouldFetchQuotes: true,
+    };
 };
 
 export const useQuotes = (form: TradingBuyForm) => {
     const dispatch = useDispatch();
     const debounce = useDebounce();
-    const { timer, shouldReload } = useReloadTimer();
     const promiseRef = useRef<PromiseType | undefined>(undefined);
-    const shouldFetchQuotes = useShouldFetchQuotes(form);
-
+    const { isFetchAllowed, shouldFetchQuotes } = useShouldFetchQuotes(form);
+    const { timer, shouldReload } = useReloadTimer(isFetchAllowed);
     const asset = form.watch('asset');
     const symbol = getSelectedSymbolFromBuyForm(form);
     const shouldSendInSats = useSelector((state: SettingsSliceRootState) =>
@@ -88,11 +97,13 @@ export const useQuotes = (form: TradingBuyForm) => {
         selectTradingCoinInfoByCryptoId(state, asset?.cryptoId),
     );
 
-    if (shouldFetchQuotes || shouldReload) {
+    if (isFetchAllowed && (shouldFetchQuotes || shouldReload)) {
         if (promiseRef.current?.abort) {
             promiseRef.current.abort('Request was replaced by another one.');
         }
+
         debounce(() => {
+            invariant(asset, 'Asset is not defined');
             const network = getNetworkByCoingeckoId(asset.networkId);
             invariant(network, `Network not found for ${asset.networkId}`);
 

--- a/suite-native/module-trading/src/hooks/useReloadTimer.ts
+++ b/suite-native/module-trading/src/hooks/useReloadTimer.ts
@@ -3,21 +3,38 @@ import { useTimer } from '@trezor/react-utils';
 
 export const MAX_RESET_COUNT = 40;
 
-export const useReloadTimer = () => {
+export const useReloadTimer = (isEnabled: boolean) => {
     const timer = useTimer();
+    const {
+        timeSpent: { seconds },
+        resetCount,
+        isStopped,
+        isLoading,
+        stop,
+        reset,
+    } = timer;
 
-    if (timer.isStopped || timer.isLoading) {
+    if (isEnabled && isStopped && !isLoading && resetCount < MAX_RESET_COUNT) {
+        reset();
+    }
+
+    if ((!isEnabled && !isStopped) || resetCount >= MAX_RESET_COUNT) {
+        stop();
+
         return {
             timer,
             shouldReload: false,
         };
     }
 
-    if (timer.resetCount >= MAX_RESET_COUNT) {
-        timer.stop();
+    if (isStopped || isLoading) {
+        return {
+            timer,
+            shouldReload: false,
+        };
     }
 
-    const shouldReload = timer.timeSpent.seconds >= INVITY_API_RELOAD_QUOTES_AFTER_SECONDS;
+    const shouldReload = seconds >= INVITY_API_RELOAD_QUOTES_AFTER_SECONDS;
 
     return {
         timer,

--- a/suite-native/module-trading/src/types.ts
+++ b/suite-native/module-trading/src/types.ts
@@ -22,7 +22,7 @@ export type ReceiveAccount = {
 
 export type TradingBuyFormValues = {
     quoteId: string | undefined;
-    asset: TradeableAsset;
+    asset: TradeableAsset | undefined;
     receiveAccount: ReceiveAccount | undefined;
     fiatCurrency: FiatCurrencyCode;
     fiatValue: string | undefined;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Asset can be undefined in buy form, but there was a bad type in Buy Form causing errors in useQuotes.
- Timer now ticks only when valid form data are provided
- Quotes should be fetched only when all required values are available
- useTimer now returns stable reference to callbacks (`reset`, `stop` and `loading`)

It should resolve [Sentry issue](https://satoshilabs.sentry.io/issues/6534940586/?project=4504214699245568).



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mobile-trade-timer-quotes-fix&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mobile-trade-timer-quotes-fix&lookback=7)