### PR TITLE
chore(scripts): add T3W1 to authenticityPaths

### DIFF
--- a/scripts/ci/check-connect-data.ts
+++ b/scripts/ci/check-connect-data.ts
@@ -7,25 +7,22 @@ import { comment, commit } from './helpers';
 const { exec } = require('./helpers');
 
 const AUTHENTICITY_BASE_URL = 'https://data.trezor.io';
-const authenticityPaths = {
-    T2B1: {
-        authenticity: 'firmware/t2b1/authenticity.json',
-        authenticityDev: 'firmware/t2b1/authenticity-dev.json',
-    },
-    T3B1: {
-        authenticity: 'firmware/t3b1/authenticity.json',
-        authenticityDev: 'firmware/t3b1/authenticity-dev.json',
-    },
-    T3T1: {
-        authenticity: 'firmware/t3t1/authenticity.json',
-        authenticityDev: 'firmware/t3t1/authenticity-dev.json',
-    },
-};
-
 const ROOT = path.join(__dirname, '..', '..');
 const CONFIG_FILE_PATH = path.join(ROOT, 'packages/connect/src/data/deviceAuthenticityConfig.ts');
+const DEVICES_SUPPORTING_DEVICE_AUTHENTICITY_CHECK = ['T2B1', 'T3B1', 'T3T1', 'T3W1'] as const;
 
-type AuthenticityPathsKeys = keyof typeof authenticityPaths;
+type DeviceModel = (typeof DEVICES_SUPPORTING_DEVICE_AUTHENTICITY_CHECK)[number];
+
+const authenticityPaths = DEVICES_SUPPORTING_DEVICE_AUTHENTICITY_CHECK.reduce(
+    (acc, device) => {
+        acc[device] = {
+            authenticity: `firmware/${device.toLowerCase()}/authenticity.json`,
+            authenticityDev: `firmware/${device.toLowerCase()}/authenticity-dev.json`,
+        };
+        return acc;
+    },
+    {} as Record<DeviceModel, { authenticity: string; authenticityDev: string }>,
+);
 
 const fetchJSON = async (url: string) => {
     const response = await fetch(url);
@@ -47,7 +44,7 @@ const getLatestTimestamp = (timestamps: string[]): string | null => {
 
 const updateConfigFromJSON = async () => {
     try {
-        const devicesKeys = Object.keys(authenticityPaths) as AuthenticityPathsKeys[];
+        const devicesKeys = Object.keys(authenticityPaths) as DeviceModel[];
 
         // Import the current configuration object
         let { deviceAuthenticityConfig } = require(CONFIG_FILE_PATH);

--- a/suite-common/suite-constants/src/device.ts
+++ b/suite-common/suite-constants/src/device.ts
@@ -3,7 +3,7 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 export const DEFAULT_FLAGSHIP_MODEL = DeviceModelInternal.T3T1;
 
 export const SUPPORTS_DEVICE_AUTHENTICITY_CHECK: Record<DeviceModelInternal, boolean> = {
-    [DeviceModelInternal.UNKNOWN]: true, // We must require device authenticity check so it cannot be used as and exploit to bypass it
+    [DeviceModelInternal.UNKNOWN]: true, // We must require device authenticity check so it cannot be used as an exploit to bypass it
     [DeviceModelInternal.T1B1]: false,
     [DeviceModelInternal.T2T1]: false,
     [DeviceModelInternal.T2B1]: true,


### PR DESCRIPTION
Updating the script so that it works for T3W1 as well. Dev keys have been added in https://github.com/trezor/data/pull/133, this change allows them to be ported to Suite automatically over night.

QA: this should enable passing deviceAuthenticityCheck in debug mode on T3B1 and T3W1 emulators after the action is performed over night (i.e. one day after this PR is merged). T3B1 is not in tenv yet.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/add-t3w1-to-script&lookback=7)