### PR TITLE
fix(suite): show device disconnect info in staking modal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeEthForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeEthForm.tsx
@@ -68,7 +68,6 @@ export const UnstakeEthForm = () => {
                             />
                         </Banner>
                     )}
-
                     <SolanaStakingLimitBanner
                         account={account}
                         composedLevels={composedLevels}
@@ -122,7 +121,7 @@ export const UnstakeEthForm = () => {
                                 <Translation
                                     id="TR_STAKE_UNSTAKING_APPROXIMATE"
                                     values={{
-                                        symbol: symbol.toUpperCase(),
+                                        symbol: getDisplaySymbol(symbol),
                                     }}
                                 />
                             </Tooltip>

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/EthStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/EthStakingDashboard.tsx
@@ -17,8 +17,9 @@ import { spacings } from '@trezor/theme';
 
 import { DashboardSection } from 'src/components/dashboard';
 import { Translation } from 'src/components/suite';
-import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { getDaysToAddToPool, getDaysToUnstake } from 'src/utils/suite/ethereumStaking';
+import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
 
 import { InstantStakeBanner } from './InstantStakeBanner';
 import { StakingDashboard } from '../../StakingDashboard/StakingDashboard';
@@ -35,8 +36,11 @@ interface EthStakingDashboardProps {
 
 export const EthStakingDashboard = ({ selectedAccount }: EthStakingDashboardProps) => {
     const { account } = selectedAccount;
+    const { device } = useDevice();
+
     const accountKey = account?.key ?? '';
     const isBelowLaptop = useMediaQuery(`(max-width: ${variables.SCREEN_SIZE.LG})`);
+    const isDeviceConnected = device?.connected && device?.available;
 
     const { data, isLoading } =
         useSelector(state => selectValidatorsQueue(state, account?.symbol)) || {};
@@ -86,6 +90,8 @@ export const EthStakingDashboard = ({ selectedAccount }: EthStakingDashboardProp
                             }
                         >
                             <Column gap={spacings.sm}>
+                                {!isDeviceConnected && <ConnectDeviceGenericPromo />}
+
                                 <InstantStakeBanner
                                     txs={txs}
                                     daysToAddToPool={daysToAddToPool}

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
@@ -12,7 +12,8 @@ import { spacings } from '@trezor/theme';
 
 import { DashboardSection } from 'src/components/dashboard';
 import { Translation } from 'src/components/suite';
-import { useSelector } from 'src/hooks/suite';
+import { useDevice, useSelector } from 'src/hooks/suite';
+import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
 
 import { StakingDashboard } from '../StakingDashboard/StakingDashboard';
 import { ApyCard } from '../StakingDashboard/components/ApyCard';
@@ -28,8 +29,10 @@ interface SolStakingDashboardProps {
 
 export const SolStakingDashboard = ({ selectedAccount }: SolStakingDashboardProps) => {
     const { account } = selectedAccount;
+    const { device } = useDevice();
 
     const isBelowLaptop = useMediaQuery(`(max-width: ${variables.SCREEN_SIZE.LG})`);
+    const isDeviceConnected = device?.connected && device?.available;
 
     const { canClaim = false } = getStakingDataForNetwork(account) ?? {};
 
@@ -54,6 +57,8 @@ export const SolStakingDashboard = ({ selectedAccount }: SolStakingDashboardProp
                             }
                         >
                             <Column alignItems="normal" gap={spacings.sm}>
+                                {!isDeviceConnected && <ConnectDeviceGenericPromo />}
+
                                 <Grid
                                     columns={isBelowLaptop || !canClaim ? 1 : 2}
                                     gap={spacings.sm}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes missing device disconnect info in staking dashboard.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16594

## Screenshots:

![image](https://github.com/user-attachments/assets/6316fcd2-5c5c-44f6-aae8-8875b2d373f9)
![image](https://github.com/user-attachments/assets/99ee4e95-20da-400e-a482-e82584007834)


