### PR TITLE
chore(connect): simplify legacy fee estimation logic

### DIFF
--- a/packages/connect/src/backend/fees/BitcoinFeeLevels.ts
+++ b/packages/connect/src/backend/fees/BitcoinFeeLevels.ts
@@ -4,13 +4,12 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import type { BitcoinNetworkInfo } from '../../types';
 import { Blockchain } from '../Blockchain';
-import { Blocks, MiscFeeLevels } from './MiscFeeLevels';
+import { MiscFeeLevels } from './MiscFeeLevels';
 import { DEFAULT_BITCOIN_LONGTERM_FEE_RATE } from '../../data/defaultFeeLevels';
 
 export class BitcoinFeeLevels extends MiscFeeLevels {
     coinInfo: BitcoinNetworkInfo;
     longTermFeeRate: string; // long term fee rate is used by @trezor/utxo-lib composeTx module
-    blocks: Blocks = [];
 
     // override only to narrow down the coinInfo type
     constructor(coinInfo: BitcoinNetworkInfo) {

--- a/packages/connect/src/backend/fees/BitcoinFeeLevels.ts
+++ b/packages/connect/src/backend/fees/BitcoinFeeLevels.ts
@@ -5,141 +5,57 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 import type { BitcoinNetworkInfo } from '../../types';
 import { Blockchain } from '../Blockchain';
 import { Blocks, MiscFeeLevels } from './MiscFeeLevels';
-
-const findBlocksForFee = (feePerUnit: string, blocks: Blocks) => {
-    const fee = new BigNumber(feePerUnit);
-    // find first occurrence of value lower or equal than requested
-    const lower = blocks.find(block => typeof block === 'string' && fee.gte(block));
-    if (!lower) return -1;
-
-    // if not found get latest know value
-    return blocks.indexOf(lower);
-};
-
-const convertFeeRate = (fee: string, minFee: number) => {
-    const feePerKB = new BigNumber(fee);
-    if (feePerKB.isNaN() || feePerKB.lte('0')) return;
-    const feePerB = feePerKB.div(1000);
-    if (feePerB.lt(minFee)) return minFee.toString();
-
-    return feePerB.isInteger() ? feePerB.toString() : feePerB.toFixed(2);
-};
-
-const fillGap = (from: number, step: number, size: number) => {
-    const fill: number[] = [];
-    for (let i = from + step; i <= from + size; i += step) {
-        fill.push(i);
-    }
-
-    return fill;
-};
-
-const findNearest = (requested: number, blocks: Blocks) => {
-    // found exact requested value
-    if (typeof blocks[requested] === 'string') return blocks[requested];
-
-    // exact value for requested block is unknown?
-    // walk forward through blocks and try to find first known value
-    const len = blocks.length;
-    let index = requested;
-    while (typeof blocks[index] !== 'string' && index < len) {
-        index++;
-    }
-    // found something useful
-    if (typeof blocks[index] === 'string') {
-        return blocks[index];
-    }
-    // didn't find anything while looking forward? then try to walk backward
-    index = requested;
-    while (typeof blocks[index] !== 'string' && index > 0) {
-        index--;
-    }
-
-    // return something or undefined
-    return blocks[index];
-};
-
-const findLowest = (blocks: Blocks) =>
-    blocks
-        .slice(0)
-        .reverse()
-        .find(item => typeof item === 'string');
+import { DEFAULT_BITCOIN_LONGTERM_FEE_RATE } from '../../data/defaultFeeLevels';
 
 export class BitcoinFeeLevels extends MiscFeeLevels {
     coinInfo: BitcoinNetworkInfo;
-
-    longTermFeeRate?: string; // long term fee rate is used by @trezor/utxo-lib composeTx module
-
+    longTermFeeRate: string; // long term fee rate is used by @trezor/utxo-lib composeTx module
     blocks: Blocks = [];
 
     // override only to narrow down the coinInfo type
     constructor(coinInfo: BitcoinNetworkInfo) {
         super(coinInfo);
         this.coinInfo = coinInfo;
+        // TODO https://github.com/trezor/trezor-suite/issues/18483 rewrite with response from a new planned blockbook API
+        this.longTermFeeRate = DEFAULT_BITCOIN_LONGTERM_FEE_RATE;
     }
 
     async load(blockchain: Blockchain) {
-        let blocks = fillGap(0, 1, 10);
-        if (this.levels.length > 1) {
-            // multiple levels
-            blocks = this.levels
-                .map(l => l.blocks)
-                .reduce((result: number[], bl: number) => {
-                    // return first value
-                    if (result.length === 0) return result.concat([bl]);
-                    // get previous block request
-                    const from = result[result.length - 1];
-                    // calculate gap between previous and current
-                    const gap = bl - from;
-                    // if gap is lower than 30 blocks (normal and economy)
-                    // fill every block in range
-                    // otherwise fill every 6th block (1h)
-                    const incr = gap <= 30 ? 1 : 6;
-                    const fill = fillGap(from, incr, gap);
-
-                    // add to result
-                    return result.concat(fill);
-                }, []);
-        }
-        // add more blocks to the request to find `longTermFee`
-        const oneDayBlocks = 6 * 24; // maximum value accepted by backends is usually 1008 - 7 days (6 * 24 * 7)
-        blocks.push(...fillGap(oneDayBlocks, oneDayBlocks / 2, oneDayBlocks * 6));
-
         try {
+            const { minFee, maxFee } = this.coinInfo;
+            // get numbers of blocks to be requested, filter out 'custom' if present (the last one)
+            const blocks = this.levels.map(level => level.blocks).filter(b => b > 0);
             const response = await blockchain.estimateFee({ blocks });
-            response.forEach(({ feePerUnit }, index) => {
-                this.blocks[blocks[index]] = convertFeeRate(
-                    feePerUnit || '0',
-                    this.coinInfo.minFee,
-                );
-            });
 
-            this.levels.forEach(level => {
-                const updatedValue = findNearest(level.blocks, this.blocks);
-                if (typeof updatedValue === 'string') {
-                    level.blocks = this.blocks.indexOf(updatedValue);
-                    level.feePerUnit = updatedValue;
-                }
-            });
+            response.forEach(({ feePerUnit: feePerKB }, index) => {
+                // for bitcoin-like coins, blockbook websocket API returns sat/kB by default
+                const feePerB = new BigNumber(feePerKB).div(1000).toNumber();
 
-            this.longTermFeeRate = findLowest(this.blocks);
+                // in case of invalid blockbook response, keep the previous or default data
+                if (isNaN(feePerB) || feePerB < 0) return;
+
+                const trimmedFeePerUnit = Math.min(maxFee, Math.max(minFee, feePerB));
+                this.levels[index].feePerUnit = trimmedFeePerUnit.toString();
+            });
             this.wasFetchedSuccessfully = true;
         } catch {
-            // do not throw
+            // do not throw, just keep current fee levels
         }
 
         return this.levels;
     }
 
     updateBitcoinCustomFee(feePerUnit: string) {
-        // remove "custom" level from list
         this.levels = this.levels.filter(l => l.label !== 'custom');
-        // recreate "custom" level
-        const blocks = findBlocksForFee(feePerUnit, this.blocks);
         this.levels.push({
             label: 'custom',
             feePerUnit,
-            blocks,
+            /*
+             We do not estimate confirmation time for custom fees. It could be interpolated if we had
+             an array of historical fee rates, but not with the mempool.space API that blockbook provides.
+             That data, although great for estimating low/normal/high fees, means something completely different.
+            */
+            blocks: -1,
         });
     }
 }

--- a/packages/connect/src/backend/fees/EthereumFeeLevels.ts
+++ b/packages/connect/src/backend/fees/EthereumFeeLevels.ts
@@ -2,11 +2,10 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import type { EthereumNetworkInfo, FeeLevel } from '../../types';
 import { Blockchain } from '../Blockchain';
-import { Blocks, MiscFeeLevels } from './MiscFeeLevels';
+import { MiscFeeLevels } from './MiscFeeLevels';
 
 export class EthereumFeeLevels extends MiscFeeLevels {
     coinInfo: EthereumNetworkInfo;
-    blocks: Blocks = [];
 
     // override only to narrow down the coinInfo type
     constructor(coinInfo: EthereumNetworkInfo) {

--- a/packages/connect/src/backend/fees/MiscFeeLevels.ts
+++ b/packages/connect/src/backend/fees/MiscFeeLevels.ts
@@ -6,12 +6,9 @@ import { cloneObject } from '@trezor/utils/src/cloneObject';
 import type { CoinInfo, FeeLevel } from '../../types';
 import { Blockchain } from '../Blockchain';
 
-export type Blocks = Array<string | undefined>;
-
 export class MiscFeeLevels {
     coinInfo: CoinInfo;
     levels: FeeLevel[];
-    blocks: Blocks = [];
     // indicates that this.levels are current rates from backend, otherwise they are only the default values from jsons
     wasFetchedSuccessfully: boolean = false;
 

--- a/packages/connect/src/backend/fees/MiscFeeLevels.ts
+++ b/packages/connect/src/backend/fees/MiscFeeLevels.ts
@@ -1,6 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/tx/Fees.js
 
 import { BigNumber } from '@trezor/utils/src/bigNumber';
+import { cloneObject } from '@trezor/utils/src/cloneObject';
 
 import type { CoinInfo, FeeLevel } from '../../types';
 import { Blockchain } from '../Blockchain';
@@ -16,7 +17,7 @@ export class MiscFeeLevels {
 
     constructor(coinInfo: CoinInfo) {
         this.coinInfo = coinInfo;
-        this.levels = coinInfo.defaultFees;
+        this.levels = cloneObject(coinInfo.defaultFees);
     }
 
     async load(blockchain: Blockchain, request: Parameters<typeof blockchain.estimateFee>[0]) {

--- a/packages/connect/src/backend/fees/__tests__/BitcoinFeeLevels.test.ts
+++ b/packages/connect/src/backend/fees/__tests__/BitcoinFeeLevels.test.ts
@@ -4,7 +4,7 @@ import coinsJSON from '@trezor/connect-common/files/coins.json';
 
 import { getBitcoinNetwork, parseCoinsJson } from '../../../data/coinInfo';
 import { FeeLevel } from '../../../types';
-import { initBlockchain } from '../../BlockchainLink';
+import { dispose, initBlockchain } from '../../BlockchainLink';
 import { BitcoinFeeLevels } from '../BitcoinFeeLevels';
 
 // simple linear mock for decreasing fees per requested block number
@@ -17,157 +17,113 @@ const defaultFeesMock: FeeLevel[] = [
     { label: 'economy', blocks: 80, feePerUnit: '22' },
 ];
 
+const estimateFeeMockOK: typeof BlockchainLink.prototype.estimateFee = params =>
+    Promise.resolve(
+        (params.blocks ?? []).map(block => ({
+            feePerUnit: mockFeeValuePerBlock(block).toString(),
+        })),
+    );
+
+const estimateFeeMockIncomplete: typeof BlockchainLink.prototype.estimateFee = params =>
+    Promise.resolve(
+        (params.blocks ?? []).map(block =>
+            // no data for the 'economy' fee level
+            block === 80
+                ? { feePerUnit: '-1' }
+                : { feePerUnit: mockFeeValuePerBlock(block).toString() },
+        ),
+    );
+
 describe('BitcoinFeeLevels', () => {
     // load coin definitions
     parseCoinsJson({ ...coinsJSON, ...coinsJSONEth });
 
-    it('should fetch Bitcoin smart FeeLevels with exact match', async () => {
+    afterAll(() => {
+        dispose();
+        jest.resetAllMocks();
+    });
+
+    it('fetches Bitcoin smart FeeLevels with exact match', async () => {
         const coinInfo = getBitcoinNetwork('Bitcoin');
         if (!coinInfo) throw new Error('coinInfo is missing');
         const coinInfoMock = { ...coinInfo, defaultFees: defaultFeesMock };
 
-        const spy = jest
-            .spyOn(BlockchainLink.prototype, 'estimateFee')
-            .mockImplementation(params => {
-                if (!params.blocks) return Promise.resolve([]);
-                const response = params.blocks.map(block => ({
-                    feePerUnit: mockFeeValuePerBlock(block).toString(),
-                }));
-
-                return Promise.resolve(response);
-            });
+        jest.spyOn(BlockchainLink.prototype, 'estimateFee').mockImplementation(estimateFeeMockOK);
 
         const backend = await initBlockchain(coinInfoMock, () => {});
-        const feeLevels = new BitcoinFeeLevels(coinInfoMock);
+        const feeLevelsInstance = new BitcoinFeeLevels(coinInfoMock);
 
-        expect(feeLevels.levels.length).toEqual(4);
+        expect(feeLevelsInstance.levels.length).toEqual(4);
         // returns preloaded values from coins.json
-        expect(feeLevels.levels.map(l => l.feePerUnit)).toEqual(['222', '111', '77', '22']);
+        expect(feeLevelsInstance.levels.map(l => l.feePerUnit)).toEqual(['222', '111', '77', '22']);
 
-        const smartFeeLevels = await feeLevels.load(backend);
+        const result = await feeLevelsInstance.load(backend);
         // linear mock of requested blocks
-        expect(smartFeeLevels.map(l => l.feePerUnit)).toEqual(['9.9', '9', '6', '2']);
-
-        backend.disconnect();
-        spy.mockReset();
+        expect(result.map(l => l.feePerUnit)).toEqual(['9.9', '9', '6', '2']);
     });
 
-    it('should fetch Bitcoin smart FeeLevels with some unknown results in response', async () => {
+    it('fetches Bitcoin smart FeeLevels with some unknown results in response', async () => {
         const coinInfo = getBitcoinNetwork('Bitcoin');
         if (!coinInfo) throw new Error('coinInfo is missing');
         const coinInfoMock = { ...coinInfo, defaultFees: defaultFeesMock };
 
-        const spy = jest
-            .spyOn(BlockchainLink.prototype, 'estimateFee')
-            .mockImplementation(params => {
-                if (!params.blocks) return Promise.resolve([]);
-                const response = params.blocks.map(block =>
-                    block === 80
-                        ? // no data for economy fee level
-                          { feePerUnit: '-1' }
-                        : { feePerUnit: mockFeeValuePerBlock(block).toString() },
-                );
-
-                return Promise.resolve(response);
-            });
+        jest.spyOn(BlockchainLink.prototype, 'estimateFee').mockImplementation(
+            estimateFeeMockIncomplete,
+        );
 
         const backend = await initBlockchain(coinInfoMock, () => {});
-        const feeLevels = new BitcoinFeeLevels(coinInfoMock);
+        const feeLevelsInstance = new BitcoinFeeLevels(coinInfoMock);
 
-        const smartFeeLevels = await feeLevels.load(backend);
+        const result = await feeLevelsInstance.load(backend);
         // linear mock of requested blocks, or preloaded values if not fetched successfully
-        expect(smartFeeLevels.map(l => l.feePerUnit)).toEqual(['9.9', '9', '6', '22']);
-
-        backend.disconnect();
-        spy.mockReset();
+        expect(result.map(l => l.feePerUnit)).toEqual(['9.9', '9', '6', '22']);
     });
 
-    it('should fetch Bitcoin smart FeeLevels with custom fee level', async () => {
+    it('fetches Bitcoin smart FeeLevels with custom fee level', async () => {
         const coinInfo = getBitcoinNetwork('Bitcoin');
         if (!coinInfo) throw new Error('coinInfo is missing');
         const coinInfoMock = { ...coinInfo, defaultFees: defaultFeesMock };
 
         const spy = jest
             .spyOn(BlockchainLink.prototype, 'estimateFee')
-            .mockImplementation(params => {
-                if (!params.blocks) return Promise.resolve([]);
-                const response = params.blocks.map(block => ({
-                    feePerUnit: mockFeeValuePerBlock(block).toString(),
-                }));
-
-                return Promise.resolve(response);
-            });
+            .mockImplementation(estimateFeeMockOK);
 
         const backend = await initBlockchain(coinInfoMock, () => {});
-        const feeLevels = new BitcoinFeeLevels(coinInfoMock);
+        const feeLevelsInstance = new BitcoinFeeLevels(coinInfoMock);
 
         // 'custom' level is appended at the end
-        feeLevels.updateBitcoinCustomFee('7.6');
-        expect(feeLevels.levels.at(-1)).toMatchObject({ label: 'custom', feePerUnit: '7.6' });
+        feeLevelsInstance.updateBitcoinCustomFee('7.6');
+        expect(feeLevelsInstance.levels.at(-1)).toMatchObject({
+            label: 'custom',
+            feePerUnit: '7.6',
+        });
 
-        const smartFeeLevels = await feeLevels.load(backend);
+        const result = await feeLevelsInstance.load(backend);
         // 'custom' level is excluded from the query
         expect(spy).toHaveBeenCalledWith({ blocks: [1, 10, 40, 80] });
 
         // but the 'custom' level is still present, unchanged
-        expect(smartFeeLevels.map(l => l.feePerUnit)).toEqual(['9.9', '9', '6', '2', '7.6']);
-
-        backend.disconnect();
-        spy.mockReset();
+        expect(result.map(l => l.feePerUnit)).toEqual(['9.9', '9', '6', '2', '7.6']);
     });
 
-    it('should fetch Testnet smart FeeLevels with some unknown results in response', async () => {
+    it('fetches Testnet smart FeeLevels with some unknown results in response', async () => {
         const coinInfo = getBitcoinNetwork('Testnet');
         if (!coinInfo) throw new Error('coinInfo is missing');
         // testnet has only one fee level 'normal'
         const coinInfoMock = { ...coinInfo, defaultFees: [defaultFeesMock[1]] };
 
-        const spy = jest
-            .spyOn(BlockchainLink.prototype, 'estimateFee')
-            .mockImplementation(params => {
-                if (!params.blocks) return Promise.resolve([]);
-                const response = params.blocks.map(block =>
-                    block < 10
-                        ? // no data for high fee level (but that one is not queried now)
-                          { feePerUnit: '-1' }
-                        : { feePerUnit: mockFeeValuePerBlock(block).toString() },
-                );
-
-                return Promise.resolve(response);
-            });
+        jest.spyOn(BlockchainLink.prototype, 'estimateFee').mockImplementation(
+            estimateFeeMockIncomplete,
+        );
 
         const backend = await initBlockchain(coinInfoMock, () => {});
-        const feeLevels = new BitcoinFeeLevels(coinInfoMock);
+        const feeLevelsInstance = new BitcoinFeeLevels(coinInfoMock);
 
-        expect(feeLevels.levels.length).toEqual(1);
+        expect(feeLevelsInstance.levels.length).toEqual(1);
         // returns preloaded values from coins.json
-        expect(feeLevels.levels.map(l => l.feePerUnit)).toEqual(['111']);
+        expect(feeLevelsInstance.levels.map(l => l.feePerUnit)).toEqual(['111']);
 
-        const smartFeeLevels = await feeLevels.load(backend);
-        expect(smartFeeLevels?.map(l => l.feePerUnit)).toEqual(['9']);
-
-        backend.disconnect();
-        spy.mockReset();
+        const result = await feeLevelsInstance.load(backend);
+        expect(result?.map(l => l.feePerUnit)).toEqual(['9']);
     });
-
-    // This block is useful to manually observe fee rates from real backends (supported in suite)
-    // How to: uncomment test below
-    // Note: currently broken! The "test" runs, but all you can see is the defaults from json.
-    // Because all API responses are -1. Maybe websocket issue in jest?
-
-    // const e2eNetworks = ['BTC', 'TEST', 'BCH', 'DASH', 'DOGE', 'LTC'];
-    // e2eNetworks.forEach(network => {
-    // eslint-disable-next-line jest/no-commented-out-tests
-    //     it.only(`${network} e2e smart FeeLevels`, async () => {
-    //         const coinInfo = getBitcoinNetwork(network)!;
-    //         if (!coinInfo) throw new Error('coinInfo is missing');
-    //
-    //         const backend = await initBlockchain(coinInfo, () => {});
-    //         const feeLevels = new BitcoinFeeLevels(coinInfo);
-    //         const smartFeeLevels = await feeLevels.load(backend);
-    //         console.info(`${network} FeeLevels`, smartFeeLevels);
-    //         console.info(`${network} longTermFeeRate`, feeLevels.longTermFeeRate);
-    //         backend.disconnect();
-    //     });
-    // });
 });

--- a/packages/connect/src/backend/fees/__tests__/BitcoinFeeLevels.test.ts
+++ b/packages/connect/src/backend/fees/__tests__/BitcoinFeeLevels.test.ts
@@ -3,124 +3,170 @@ import coinsJSONEth from '@trezor/connect-common/files/coins-eth.json';
 import coinsJSON from '@trezor/connect-common/files/coins.json';
 
 import { getBitcoinNetwork, parseCoinsJson } from '../../../data/coinInfo';
+import { FeeLevel } from '../../../types';
 import { initBlockchain } from '../../BlockchainLink';
 import { BitcoinFeeLevels } from '../BitcoinFeeLevels';
 
-describe('api/bitcoin/Fees', () => {
+// simple linear mock for decreasing fees per requested block number
+const mockFeeValuePerBlock = (block: number) => 10_000 - block * 100;
+
+const defaultFeesMock: FeeLevel[] = [
+    { label: 'high', blocks: 1, feePerUnit: '222' },
+    { label: 'normal', blocks: 10, feePerUnit: '111' },
+    { label: 'low', blocks: 40, feePerUnit: '77' },
+    { label: 'economy', blocks: 80, feePerUnit: '22' },
+];
+
+describe('BitcoinFeeLevels', () => {
     // load coin definitions
     parseCoinsJson({ ...coinsJSON, ...coinsJSONEth });
 
-    it('Bitcoin smart FeeLevels exact match', async () => {
+    it('should fetch Bitcoin smart FeeLevels with exact match', async () => {
         const coinInfo = getBitcoinNetwork('Bitcoin');
         if (!coinInfo) throw new Error('coinInfo is missing');
+        const coinInfoMock = { ...coinInfo, defaultFees: defaultFeesMock };
 
         const spy = jest
             .spyOn(BlockchainLink.prototype, 'estimateFee')
             .mockImplementation(params => {
                 if (!params.blocks) return Promise.resolve([]);
-                const response = params.blocks.map(block => {
-                    const reduce = Math.floor(block / 10) * 379; // every 10th result is lower
-                    const fee = 10000 - reduce;
-
-                    return { feePerUnit: fee.toString() };
-                });
+                const response = params.blocks.map(block => ({
+                    feePerUnit: mockFeeValuePerBlock(block).toString(),
+                }));
 
                 return Promise.resolve(response);
             });
 
-        const backend = await initBlockchain(coinInfo, () => {});
-        const feeLevels = new BitcoinFeeLevels(coinInfo);
+        const backend = await initBlockchain(coinInfoMock, () => {});
+        const feeLevels = new BitcoinFeeLevels(coinInfoMock);
 
-        expect(feeLevels.levels.length).toEqual(4); // Bitcoin has 4 defined levels in coins.json
-        expect(feeLevels.levels.map(l => l.feePerUnit)).toEqual(
-            coinInfo.defaultFees.map(l => l.feePerUnit),
-        ); // preloaded values from coins.json
+        expect(feeLevels.levels.length).toEqual(4);
+        // returns preloaded values from coins.json
+        expect(feeLevels.levels.map(l => l.feePerUnit)).toEqual(['222', '111', '77', '22']);
 
         const smartFeeLevels = await feeLevels.load(backend);
-        expect(smartFeeLevels?.map(l => l.feePerUnit)).toEqual(['10', '10', '9.62', '8.86']);
+        // linear mock of requested blocks
+        expect(smartFeeLevels.map(l => l.feePerUnit)).toEqual(['9.9', '9', '6', '2']);
 
         backend.disconnect();
-        spy.mockClear();
+        spy.mockReset();
     });
 
-    it('Bitcoin smart FeeLevels with unknown results in the response', async () => {
+    it('should fetch Bitcoin smart FeeLevels with some unknown results in response', async () => {
         const coinInfo = getBitcoinNetwork('Bitcoin');
         if (!coinInfo) throw new Error('coinInfo is missing');
+        const coinInfoMock = { ...coinInfo, defaultFees: defaultFeesMock };
 
         const spy = jest
             .spyOn(BlockchainLink.prototype, 'estimateFee')
             .mockImplementation(params => {
                 if (!params.blocks) return Promise.resolve([]);
-                const response = params.blocks.map(block => {
-                    if (block < 20 && block % 3 === 0) return { feePerUnit: '-1' }; // each third requested block returns unknown value
-                    const reduce = Math.floor(block / 2) * 379; // every second known result is lower
-                    const fee = 10000 - reduce;
-
-                    return { feePerUnit: fee.toString() };
-                });
+                const response = params.blocks.map(block =>
+                    block === 80
+                        ? // no data for economy fee level
+                          { feePerUnit: '-1' }
+                        : { feePerUnit: mockFeeValuePerBlock(block).toString() },
+                );
 
                 return Promise.resolve(response);
             });
 
-        const backend = await initBlockchain(coinInfo, () => {});
-        const feeLevels = new BitcoinFeeLevels(coinInfo);
+        const backend = await initBlockchain(coinInfoMock, () => {});
+        const feeLevels = new BitcoinFeeLevels(coinInfoMock);
 
         const smartFeeLevels = await feeLevels.load(backend);
-        expect(smartFeeLevels?.map(l => l.feePerUnit)).toEqual(['10', '9.24', '7.73', '3.18']);
+        // linear mock of requested blocks, or preloaded values if not fetched successfully
+        expect(smartFeeLevels.map(l => l.feePerUnit)).toEqual(['9.9', '9', '6', '22']);
 
         backend.disconnect();
-        spy.mockClear();
+        spy.mockReset();
     });
 
-    it('Testnet smart FeeLevels with unknown results in the response', async () => {
+    it('should fetch Bitcoin smart FeeLevels with custom fee level', async () => {
+        const coinInfo = getBitcoinNetwork('Bitcoin');
+        if (!coinInfo) throw new Error('coinInfo is missing');
+        const coinInfoMock = { ...coinInfo, defaultFees: defaultFeesMock };
+
+        const spy = jest
+            .spyOn(BlockchainLink.prototype, 'estimateFee')
+            .mockImplementation(params => {
+                if (!params.blocks) return Promise.resolve([]);
+                const response = params.blocks.map(block => ({
+                    feePerUnit: mockFeeValuePerBlock(block).toString(),
+                }));
+
+                return Promise.resolve(response);
+            });
+
+        const backend = await initBlockchain(coinInfoMock, () => {});
+        const feeLevels = new BitcoinFeeLevels(coinInfoMock);
+
+        // 'custom' level is appended at the end
+        feeLevels.updateBitcoinCustomFee('7.6');
+        expect(feeLevels.levels.at(-1)).toMatchObject({ label: 'custom', feePerUnit: '7.6' });
+
+        const smartFeeLevels = await feeLevels.load(backend);
+        // 'custom' level is excluded from the query
+        expect(spy).toHaveBeenCalledWith({ blocks: [1, 10, 40, 80] });
+
+        // but the 'custom' level is still present, unchanged
+        expect(smartFeeLevels.map(l => l.feePerUnit)).toEqual(['9.9', '9', '6', '2', '7.6']);
+
+        backend.disconnect();
+        spy.mockReset();
+    });
+
+    it('should fetch Testnet smart FeeLevels with some unknown results in response', async () => {
         const coinInfo = getBitcoinNetwork('Testnet');
         if (!coinInfo) throw new Error('coinInfo is missing');
+        // testnet has only one fee level 'normal'
+        const coinInfoMock = { ...coinInfo, defaultFees: [defaultFeesMock[1]] };
 
         const spy = jest
             .spyOn(BlockchainLink.prototype, 'estimateFee')
             .mockImplementation(params => {
                 if (!params.blocks) return Promise.resolve([]);
-                const response = params.blocks.map(block => {
-                    if (block < 5) return { feePerUnit: '-1' }; // first 5 requested blocks are unknown
-                    const reduce = Math.floor(block / 2) * 379; // every second known result is lower
-                    const fee = 10000 - reduce;
-
-                    return { feePerUnit: fee.toString() };
-                });
+                const response = params.blocks.map(block =>
+                    block < 10
+                        ? // no data for high fee level (but that one is not queried now)
+                          { feePerUnit: '-1' }
+                        : { feePerUnit: mockFeeValuePerBlock(block).toString() },
+                );
 
                 return Promise.resolve(response);
             });
 
-        const backend = await initBlockchain(coinInfo, () => {});
-        const feeLevels = new BitcoinFeeLevels(coinInfo);
+        const backend = await initBlockchain(coinInfoMock, () => {});
+        const feeLevels = new BitcoinFeeLevels(coinInfoMock);
 
-        expect(feeLevels.levels.length).toEqual(1); // Testnet has 1 defined levels in coins.json
-        expect(feeLevels.levels.map(l => l.feePerUnit)).toEqual(
-            coinInfo.defaultFees.map(l => l.feePerUnit),
-        ); // preloaded values from coins.json
+        expect(feeLevels.levels.length).toEqual(1);
+        // returns preloaded values from coins.json
+        expect(feeLevels.levels.map(l => l.feePerUnit)).toEqual(['111']);
 
         const smartFeeLevels = await feeLevels.load(backend);
-        expect(smartFeeLevels?.map(l => l.feePerUnit)).toEqual(['9.24']);
+        expect(smartFeeLevels?.map(l => l.feePerUnit)).toEqual(['9']);
 
         backend.disconnect();
-        spy.mockClear();
+        spy.mockReset();
     });
 
-    // This block is useful to perform e2e test locally using listed networks with real backends (supported in suite)
-    // How to: comment out jest.mock on top of the file and uncomment test below
+    // This block is useful to manually observe fee rates from real backends (supported in suite)
+    // How to: uncomment test below
+    // Note: currently broken! The "test" runs, but all you can see is the defaults from json.
+    // Because all API responses are -1. Maybe websocket issue in jest?
 
-    // const e2eNetworks = ['BTC', 'TEST', 'BCH', 'BTG', 'DASH', 'DGB', 'DOGE', 'LTC', 'NMC', 'VTC'];
+    // const e2eNetworks = ['BTC', 'TEST', 'BCH', 'DASH', 'DOGE', 'LTC'];
     // e2eNetworks.forEach(network => {
     // eslint-disable-next-line jest/no-commented-out-tests
     //     it.only(`${network} e2e smart FeeLevels`, async () => {
     //         const coinInfo = getBitcoinNetwork(network)!;
     //         if (!coinInfo) throw new Error('coinInfo is missing');
-
+    //
     //         const backend = await initBlockchain(coinInfo, () => {});
-    //         const feeLevels = new FeeLevels(coinInfo);
+    //         const feeLevels = new BitcoinFeeLevels(coinInfo);
     //         const smartFeeLevels = await feeLevels.load(backend);
-    //         console.warn(`${network} FeeLevels`, smartFeeLevels);
-    //         console.warn(`${network} longTermFeeRate`, feeLevels.longTermFeeRate);
+    //         console.info(`${network} FeeLevels`, smartFeeLevels);
+    //         console.info(`${network} longTermFeeRate`, feeLevels.longTermFeeRate);
     //         backend.disconnect();
     //     });
     // });

--- a/packages/connect/src/data/defaultFeeLevels.ts
+++ b/packages/connect/src/data/defaultFeeLevels.ts
@@ -15,11 +15,15 @@ const BLOCKS_FOR_FEE_LEVEL: Record<string, Record<string, number>> = {
         low: 36,
     },
 };
+// used for bitcoin-like coins that do not have multiple fee levels defined, like BTC does
+const DEFAULT_BLOCK_FOR_FEE_LEVEL = 1;
 
 const getDefaultBlocksForFeeLevel = (shortcut: string, label: string) =>
     BLOCKS_FOR_FEE_LEVEL[shortcut] && BLOCKS_FOR_FEE_LEVEL[shortcut][label]
         ? BLOCKS_FOR_FEE_LEVEL[shortcut][label]
-        : -1; // -1 for unknown
+        : DEFAULT_BLOCK_FOR_FEE_LEVEL;
+
+export const DEFAULT_BITCOIN_LONGTERM_FEE_RATE = '1'; // [sat/vB]
 
 const EVM_GAS_PRICE_PER_CHAIN_IN_GWEI: Record<
     string,


### PR DESCRIPTION
## Description

Simplify outdated estimateFee logic based on old blockbook behavior, which does not make sense anymore (unfortunately) and update tests accordingly. 

### Notes

See #18474 for the whole big-picture context.

Current logic is this for bitcoin-like networks: Generate a list of blocks to query, such as this:
```
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90, 96, 102, 108, 114, 120, 126, 132, 138, 144, 216, 288, 360, 432, 504, 576, 648, 720, 792, 864, 936, 1008 ]
```
And query all that from blockbook.estimateFee. All we really need to display in Suite is `[1, 6, 36]` so why do we query all these blocks? Two more usecases:
1. to interpolate estimated duration for custom fee rate when you set it very low. But feature was removed in Suite long time ago.
1. to calculate the `longtermFeeRate` as the minimum of all these fees, done in [#9109](https://github.com/trezor/trezor-suite/pull/9109) (which is misleading, and anyway it ends up 1 sat/vB.. [See comment](https://github.com/trezor/trezor-suite/pull/18416#discussion_r2058829558)) 
 
:arrow_right: The `longtermFeeRate` calculation, while valid, does not make sense _when based on the data we have_,

## Related Issue

Resolve #18475

## Screenshots

[Fee selection BTC](https://github.com/user-attachments/assets/1085f4f6-19ac-4818-95c9-1f5c02b30ded)
[Fee selection LTC](https://github.com/user-attachments/assets/2806599c-ac7a-456d-b3b8-be1f64385957)
[Fee selection TEST](https://github.com/user-attachments/assets/85851a13-daae-4f66-8b2a-6ba74ba646b2)

[blockbook API BTC query](https://github.com/user-attachments/assets/17cb3adc-e515-4322-b8bd-c52c15912b9e)
[blockbook API BTC response](https://github.com/user-attachments/assets/70c7e1fd-932b-4de0-addd-beedf8db683c)
[blockbook API LTC query](https://github.com/user-attachments/assets/b383c891-17a8-4a07-a0e3-a40542a73ac8)
[blockbook API LTC response](https://github.com/user-attachments/assets/cbafd61a-9e5c-4834-a5ce-7e031be195c6)
[blockbook API TEST query](https://github.com/user-attachments/assets/550e0e3b-0757-4911-b77f-88178dcb029c)
[blockbook API TEST response](https://github.com/user-attachments/assets/5d3c9bcc-bac0-4849-be89-74d6203d60b4)

[Dust coalescing into fee](https://github.com/user-attachments/assets/88e04730-247d-4e99-a3d3-e493a29f224c)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/cleanup-updating-btc-fees&lookback=7)