### PR TITLE
fix(suite-native): disconnected device onboarding recovery

### DIFF
--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -198,16 +198,13 @@ export const useHandleDeviceConnection = () => {
                 return;
             }
 
-            if (isDeviceOnboardingStackFocused && !wasDeviceOnboardingCancelled) {
-                setWasDeviceOnboardingCancelled(false);
-
+            if (isDeviceOnboardingStackFocused) {
                 navigation.navigate(RootStackRoutes.DeviceOnboardingStack, {
                     screen: DeviceOnboardingStackRoutes.ConnectAndUnlockDevice,
                 });
 
                 return;
             }
-            setWasDeviceOnboardingCancelled(false);
 
             navigation.navigate(RootStackRoutes.AppTabs, {
                 screen: AppTabsRoutes.HomeStack,

--- a/suite-native/module-device-onboarding/src/screens/ConnectAndUnlockDeviceScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ConnectAndUnlockDeviceScreen.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { useNavigation } from '@react-navigation/core';
-import { useAtom, useSetAtom } from 'jotai';
+import { useSetAtom } from 'jotai';
 
 import { useAlert } from '@suite-native/alerts';
 import {
@@ -38,9 +38,7 @@ export const ConnectAndUnlockDeviceScreen = () => {
     const hideDeviceDisconnectedAlert = () =>
         setIsOnboardingDeviceDisconnectedAlertDisplayed(false);
 
-    const [wasDeviceOnboardingCancelled, setWasDeviceOnboardingCancelled] = useAtom(
-        wasDeviceOnboardingCancelledAtom,
-    );
+    const setWasDeviceOnboardingCancelled = useSetAtom(wasDeviceOnboardingCancelledAtom);
 
     const navigateToHome = () =>
         navigation.navigate(RootStackRoutes.AppTabs, {
@@ -53,30 +51,26 @@ export const ConnectAndUnlockDeviceScreen = () => {
     useEffect(() => {
         // This alert should be shown only if the device was physically disconnected from the phone.
         // In case that user "disconnects" device by cancelling the onboarding flow via the app UI, the alert is not shown!
-        if (!wasDeviceOnboardingCancelled) {
-            setIsOnboardingDeviceDisconnectedAlertDisplayed(true);
-            showAlert({
-                title: translate('moduleDeviceOnboarding.deviceDisconnectedAlert.title'),
-                description: translate(
-                    'moduleDeviceOnboarding.deviceDisconnectedAlert.description',
-                ),
-                primaryButtonTitle: translate(
-                    'moduleDeviceOnboarding.deviceDisconnectedAlert.reconnectButton',
-                ),
-                pictogramVariant: 'critical',
-                primaryButtonVariant: 'redBold',
-                secondaryButtonTitle: translate('generic.buttons.cancel'),
-                secondaryButtonVariant: 'redElevation0',
-                onPressPrimaryButton: hideDeviceDisconnectedAlert,
-                onPressSecondaryButton: () => {
-                    hideDeviceDisconnectedAlert();
-                    navigateToHome();
-                },
-            });
-
-            return;
-        }
+        setIsOnboardingDeviceDisconnectedAlertDisplayed(true);
         setWasDeviceOnboardingCancelled(false);
+
+        showAlert({
+            title: translate('moduleDeviceOnboarding.deviceDisconnectedAlert.title'),
+            description: translate('moduleDeviceOnboarding.deviceDisconnectedAlert.description'),
+            primaryButtonTitle: translate(
+                'moduleDeviceOnboarding.deviceDisconnectedAlert.reconnectButton',
+            ),
+            pictogramVariant: 'critical',
+            primaryButtonVariant: 'redBold',
+            secondaryButtonTitle: translate('generic.buttons.cancel'),
+            secondaryButtonVariant: 'redElevation0',
+            onPressPrimaryButton: hideDeviceDisconnectedAlert,
+            onPressSecondaryButton: () => {
+                setWasDeviceOnboardingCancelled(true);
+                hideDeviceDisconnectedAlert();
+                navigateToHome();
+            },
+        });
 
         // This effect should be called only once during the first render.
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/suite-native/module-device-onboarding/src/screens/FirmwareInstallationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/FirmwareInstallationScreen.tsx
@@ -1,3 +1,7 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { firmwareActions } from '@suite-common/firmware';
 import { FirmwareInstallationScreenContent } from '@suite-native/firmware';
 import {
     DeviceOnboardingStackParamList,
@@ -13,6 +17,14 @@ export const FirmwareInstallationScreen = ({
     DeviceOnboardingStackParamList,
     DeviceOnboardingStackRoutes.FirmwareInstallation
 >) => {
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        // On first render, set the firmware installation status to 'initial'. Some previous failed firmware updates might
+        // happened before and we want do avoid showing the "firmware update failed" UI when user returns to this screen.
+        dispatch(firmwareActions.setStatus('initial'));
+    }, [dispatch]);
+
     const handleFirmwareInstallationSuccess = () => {
         navigation.navigate(DeviceOnboardingStackRoutes.DeviceTutorial);
     };


### PR DESCRIPTION
Fixes problems that might happen if the user disconnects the device during the device onboarding flow.

## Description
- [fix(suite-native): device onboarding error handling loop](https://github.com/trezor/trezor-suite/commit/efaa3c72095433caf6a9ae439ff46da156c4648d): fixes problem that occurred if user first cancels the flow by app UI, returns to it and then disconnects device physically from the phone 
- [fix(suite-native): device onboarding firmware fail recovery](https://github.com/trezor/trezor-suite/commit/ed68a7112b373d313076153cec7b502dfc1da3a0): In case that user fails FW install/update and returns to the FW installation screen, the error state is not rendered on the first render anymore

## Related Issue

Resolve #16291 

## Screenshots:
the UI is unchanged, please test the behavior 