### PR TITLE
chore(suite-native): Mobile Trade: refactor BuyForm to use quote directly

### DIFF
--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -19,7 +19,7 @@ import {
     selectTradingBuyInfo,
     selectTradingBuyIsLoading,
     selectTradingBuyProviders,
-    selectTradingBuyQuoteByQuoteId,
+    selectTradingBuyQuoteByOrderId,
     selectTradingBuyQuotes,
     selectTradingBuyQuotesRequest,
     selectTradingBuySelectedQuote,
@@ -524,19 +524,19 @@ describe('tradingSelectors', () => {
         });
     });
 
-    describe('selectTradingBuyQuoteByQuoteId', () => {
-        it('should return undefined when quoteId1 is not provided', () => {
-            const result = selectTradingBuyQuoteByQuoteId(state, undefined);
+    describe('selectTradingBuyQuoteByOrderId', () => {
+        it('should return undefined when orderId is not provided', () => {
+            const result = selectTradingBuyQuoteByOrderId(state, undefined);
             expect(result).toBeUndefined();
         });
 
-        it('should return undefined when quote with quoteId is not found', () => {
-            const result = selectTradingBuyQuoteByQuoteId(state, 'non_existent_id');
+        it('should return undefined when quote with orderId is not found', () => {
+            const result = selectTradingBuyQuoteByOrderId(state, 'non_existent_id');
             expect(result).toBeUndefined();
         });
 
         it('should return correct quote', () => {
-            const result = selectTradingBuyQuoteByQuoteId(state, 'quoteId1');
+            const result = selectTradingBuyQuoteByOrderId(state, 'orderId1');
             expect(result?.orderId).toBe('orderId1');
         });
     });

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -278,10 +278,10 @@ export const selectTradingBuyIsLoading = (state: TradingRootState) =>
 export const selectTradingBuyQuotes = (state: TradingRootState) =>
     state.wallet.tradingNew.buy.quotes;
 
-export const selectTradingBuyQuoteByQuoteId = (
+export const selectTradingBuyQuoteByOrderId = (
     state: TradingRootState,
-    quoteId: string | undefined,
-) => (quoteId ? state.wallet.tradingNew.buy.quotes.find(q => q.quoteId === quoteId) : undefined);
+    orderId: string | undefined,
+) => (orderId ? state.wallet.tradingNew.buy.quotes.find(q => q.orderId === orderId) : undefined);
 
 export const selectBuyQuotesByPaymentMethod = createMemoizedSelector(
     [

--- a/suite-native/module-trading/src/__fixtures__/quotes.json
+++ b/suite-native/module-trading/src/__fixtures__/quotes.json
@@ -13,6 +13,7 @@
         "maxCrypto": 0.20003,
         "paymentMethod": "applePay",
         "paymentMethodName": "Apple Pay",
+        "orderId": "order_id_0",
         "paymentId": "e709df77-ee9e-4d12-98c2-84004a19c521"
     },
     {
@@ -29,6 +30,7 @@
         "maxCrypto": 0.10532,
         "paymentMethod": "creditCard",
         "paymentMethodName": "Credit Card",
+        "orderId": "order_id_1",
         "paymentId": "e709df77-ee9e-4d12-98c2-84004a19c546"
     },
     {
@@ -45,13 +47,14 @@
         "maxCrypto": 1.66210137,
         "paymentMethod": "creditCard",
         "paymentMethodName": "Credit Card",
+        "orderId": "order_id_2",
         "paymentId": "e709df77-ee9e-4d12-98c2-84004a19c524"
     },
     {
         "fiatStringAmount": "10",
         "fiatCurrency": "EUR",
         "receiveCurrency": "bitcoin",
-        "receiveStringAmount": "0.00051",
+        "receiveStringAmount": "0.000499",
         "rate": 20001,
         "quoteId": "ab12d4c3-1001-4175-becd-90fc58a3145c",
         "exchange": "mercuryo",
@@ -61,6 +64,7 @@
         "maxCrypto": 0.105321,
         "paymentMethod": "creditCard",
         "paymentMethodName": "Credit Card",
+        "orderId": "order_id_3",
         "paymentId": "e709df77-ee9e-4d12-98c2-84004a19c546"
     }
 ]

--- a/suite-native/module-trading/src/components/buy/Confirmation.tsx
+++ b/suite-native/module-trading/src/components/buy/Confirmation.tsx
@@ -13,7 +13,7 @@ export const Confirmation = () => {
     const { canProceed, selectQuote, isConsentRequested, giveConsent, cancelConsent } =
         useTradingBuyFlow(form);
 
-    const provider = form.watch('provider');
+    const quote = form.watch('quote');
 
     return (
         <AnimatedBox entering={FadeInDown} exiting={FadeOutDown}>
@@ -26,7 +26,7 @@ export const Confirmation = () => {
                 onClose={cancelConsent}
                 isVisible={isConsentRequested}
                 onConsent={giveConsent}
-                tradeProvider={provider ?? ''}
+                tradeProvider={quote?.exchange ?? ''}
             />
         </AnimatedBox>
     );

--- a/suite-native/module-trading/src/components/buy/PaymentMethodPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/PaymentMethodPicker.tsx
@@ -1,11 +1,12 @@
 import { useSelector } from 'react-redux';
 
-import { selectTradingBuyIsLoading, selectTradingPaymentMethods } from '@suite-common/trading';
+import { selectTradingBuyIsLoading } from '@suite-common/trading';
 import { Text } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 
 import { useTradeSheetControls } from '../../hooks/useTradeSheetControls';
 import { useTradingBuyFormContext } from '../../hooks/useTradingBuyFormContext';
+import { selectBuyBestQuotesForAvailablePaymentMethods } from '../../selectors/buySelectors';
 import { PaymentMethodsSheet } from '../general/PaymentMethodsSheet/PaymentMethodsSheet';
 import { TradingOverviewRow } from '../general/TradingOverviewRow';
 import { TradingOverviewValueSkeleton } from '../general/TradingOverviewValueSkeleton';
@@ -13,10 +14,10 @@ import { TradingOverviewValueSkeleton } from '../general/TradingOverviewValueSke
 export const PaymentMethodPicker = () => {
     const { translate } = useTranslate();
     const form = useTradingBuyFormContext();
-    const methods = useSelector(selectTradingPaymentMethods);
+    const quotes = useSelector(selectBuyBestQuotesForAvailablePaymentMethods);
     const isLoading = useSelector(selectTradingBuyIsLoading);
     const { isSheetVisible, hideSheet, showSheet, setSelectedValue, selectedValue } =
-        useTradeSheetControls(form, 'paymentMethod');
+        useTradeSheetControls(form, 'quote');
 
     if (isLoading) {
         return (
@@ -29,7 +30,7 @@ export const PaymentMethodPicker = () => {
         );
     }
 
-    if (methods.length === 0) {
+    if (quotes.length === 0) {
         return null;
     }
 
@@ -47,7 +48,7 @@ export const PaymentMethodPicker = () => {
                             'moduleTrading.tradingScreen.selectedPaymentMethod',
                         )}
                     >
-                        {selectedValue.label}
+                        {selectedValue.paymentMethodName}
                     </Text>
                 ) : (
                     <Text
@@ -62,11 +63,11 @@ export const PaymentMethodPicker = () => {
                 )}
             </TradingOverviewRow>
             <PaymentMethodsSheet
-                methods={methods}
+                quotes={quotes}
                 isVisible={isSheetVisible}
                 onClose={hideSheet}
-                onMethodSelect={setSelectedValue}
-                selectedMethod={selectedValue}
+                onQuoteSelect={setSelectedValue}
+                selectedQuote={selectedValue}
             />
         </>
     );

--- a/suite-native/module-trading/src/components/buy/TradingProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/TradingProviderPicker.tsx
@@ -24,15 +24,12 @@ export const TradingProviderPicker = () => {
     const isLoading = useSelector(selectTradingBuyIsLoading);
 
     const { isSheetVisible, hideSheet, showSheet, setSelectedValue, selectedValue } =
-        useTradeSheetControls(form, 'quoteId');
-    const providerKey = form.watch('provider');
-    const paymentMethod = form.watch('paymentMethod');
+        useTradeSheetControls(form, 'quote');
+    const { paymentMethod, exchange: providerKey } = selectedValue ?? {};
     const quotes =
         useSelector((state: TradingRootState) =>
-            selectBuyQuotesByPaymentMethod(state, paymentMethod?.value),
+            selectBuyQuotesByPaymentMethod(state, paymentMethod),
         ) ?? [];
-
-    const selectedQuote = selectedValue ? quotes.find(q => q.quoteId === selectedValue) : undefined;
 
     if (isLoading) {
         return (
@@ -51,8 +48,6 @@ export const TradingProviderPicker = () => {
     }
 
     const { companyName, logo } = providers[providerKey];
-
-    const handleQuoteSelect = (quote: TradingTradeType) => setSelectedValue(quote.quoteId);
 
     return (
         <>
@@ -80,8 +75,8 @@ export const TradingProviderPicker = () => {
                 providerInfos={providers}
                 isVisible={isSheetVisible}
                 onClose={hideSheet}
-                onQuoteSelect={handleQuoteSelect}
-                selectedQuote={selectedQuote}
+                onQuoteSelect={setSelectedValue as (quote: TradingTradeType) => void}
+                selectedQuote={selectedValue}
             />
         </>
     );

--- a/suite-native/module-trading/src/components/buy/__tests__/TradingProviderPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/TradingProviderPicker.comp.test.tsx
@@ -1,3 +1,5 @@
+import { BuyTrade } from 'invity-api';
+
 import { Form } from '@suite-native/forms';
 import {
     PreloadedState,
@@ -6,6 +8,7 @@ import {
     renderWithStoreProviderAsync,
 } from '@suite-native/test-utils';
 
+import quotes from '../../../__fixtures__/quotes.json';
 import { getInitializedTradingStateWithQuotes } from '../../../__fixtures__/tradingState';
 import { useTradingBuyForm } from '../../../hooks/useTradingBuyForm';
 import { TradingBuyForm } from '../../../types';
@@ -38,7 +41,7 @@ describe('TradingProviderPicker', () => {
         const preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
         const { result } = await renderUseTradingBuyForm(preloadedState);
         act(() => {
-            result.current.setValue('provider', 'invity');
+            result.current.setValue('quote', quotes[2] as BuyTrade);
         });
 
         const { getByLabelText } = await renderTradingProviderPicker(
@@ -54,7 +57,7 @@ describe('TradingProviderPicker', () => {
         preloadedState!.wallet!.tradingNew!.buy!.isLoading = true;
         const { result } = await renderUseTradingBuyForm(preloadedState);
         act(() => {
-            result.current.setValue('provider', 'invity');
+            result.current.setValue('quote', quotes[2] as BuyTrade);
         });
         const { getByLabelText } = await renderTradingProviderPicker(
             result.current,

--- a/suite-native/module-trading/src/components/general/PaymentMethodsSheet/PaymentMethodListItem.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodsSheet/PaymentMethodListItem.tsx
@@ -1,11 +1,11 @@
 import { Pressable } from 'react-native';
 
-import { TradingPaymentMethodListProps } from '@suite-common/trading';
 import { Card, HStack, Radio, Text } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 export type PaymentMethodListItemProps = {
-    method: TradingPaymentMethodListProps;
+    orderId: string;
+    paymentMethodName: string;
     isSelected: boolean;
     onPress: () => void;
 };
@@ -18,7 +18,8 @@ const wrapperStyle = prepareNativeStyle(({ spacings }) => ({
 
 export const PaymentMethodListItem = ({
     onPress,
-    method,
+    orderId,
+    paymentMethodName,
     isSelected,
 }: PaymentMethodListItemProps) => {
     const { applyStyle } = useNativeStyles();
@@ -28,9 +29,9 @@ export const PaymentMethodListItem = ({
             <Card>
                 <HStack alignItems="center" justifyContent="space-between">
                     <Text variant="body" color="textDefault">
-                        {method.label}
+                        {paymentMethodName}
                     </Text>
-                    <Radio value={method.value} onPress={onPress} isChecked={isSelected} />
+                    <Radio value={orderId} onPress={onPress} isChecked={isSelected} />
                 </HStack>
             </Card>
         </Pressable>

--- a/suite-native/module-trading/src/components/general/PaymentMethodsSheet/PaymentMethodsSheet.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodsSheet/PaymentMethodsSheet.tsx
@@ -1,4 +1,5 @@
-import { TradingPaymentMethodListProps } from '@suite-common/trading';
+import type { BuyTrade } from 'invity-api';
+
 import { BottomSheetFlashList } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 
@@ -6,41 +7,42 @@ import { ESTIMATED_HEADER_HEIGHT, SimpleSheetHeader } from '../SimpleSheetHeader
 import { PAYMENT_METHOD_LIST_ITEM_HEIGHT, PaymentMethodListItem } from './PaymentMethodListItem';
 
 export type PaymentMethodsSheetProps = {
-    methods: TradingPaymentMethodListProps[];
+    quotes: BuyTrade[];
     isVisible: boolean;
     onClose: () => void;
-    onMethodSelect: (method: TradingPaymentMethodListProps) => void;
-    selectedMethod?: TradingPaymentMethodListProps;
+    onQuoteSelect: (quote: BuyTrade) => void;
+    selectedQuote?: BuyTrade;
 };
 
 const EXTRA_LIST_PADDING = 20;
 
-const keyExtractor = (item: TradingPaymentMethodListProps) => item.value;
+const keyExtractor = (item: BuyTrade) => item.orderId ?? '';
 const getEstimatedListHeight = (itemsCount: number) =>
     itemsCount * PAYMENT_METHOD_LIST_ITEM_HEIGHT + ESTIMATED_HEADER_HEIGHT + EXTRA_LIST_PADDING;
 
 export const PaymentMethodsSheet = ({
-    methods,
+    quotes,
     isVisible,
     onClose,
-    onMethodSelect,
-    selectedMethod,
+    onQuoteSelect,
+    selectedQuote,
 }: PaymentMethodsSheetProps) => {
     const { translate } = useTranslate();
-    const onMethodSelectCallback = (method: TradingPaymentMethodListProps) => {
-        onMethodSelect(method);
+    const onQuoteSelectCallback = (quote: BuyTrade) => {
+        onQuoteSelect(quote);
         onClose();
     };
 
     return (
-        <BottomSheetFlashList<TradingPaymentMethodListProps>
+        <BottomSheetFlashList<BuyTrade>
             isVisible={isVisible}
             onClose={onClose}
             renderItem={({ item }) => (
                 <PaymentMethodListItem
-                    method={item}
-                    onPress={() => onMethodSelectCallback(item)}
-                    isSelected={item.value === selectedMethod?.value}
+                    orderId={item.orderId ?? ''}
+                    paymentMethodName={item.paymentMethodName ?? ''}
+                    onPress={() => onQuoteSelectCallback(item)}
+                    isSelected={item.paymentMethod === selectedQuote?.paymentMethod}
                 />
             )}
             handleComponent={() => (
@@ -49,8 +51,8 @@ export const PaymentMethodsSheet = ({
                     title={translate('moduleTrading.tradingScreen.paymentMethod')}
                 />
             )}
-            data={methods}
-            estimatedListHeight={getEstimatedListHeight(methods.length)}
+            data={quotes}
+            estimatedListHeight={getEstimatedListHeight(quotes.length)}
             estimatedItemSize={PAYMENT_METHOD_LIST_ITEM_HEIGHT}
             keyExtractor={keyExtractor}
         />

--- a/suite-native/module-trading/src/components/general/PaymentMethodsSheet/__tests__/PaymentMethodListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodsSheet/__tests__/PaymentMethodListItem.comp.test.tsx
@@ -6,7 +6,8 @@ describe('PaymentMethodListItem', () => {
     const renderPaymentMethodListItem = (props: Partial<PaymentMethodListItemProps>) =>
         renderWithBasicProvider(
             <PaymentMethodListItem
-                method={{ label: 'Credit card', value: 'creditCard' }}
+                paymentMethodName="Credit card"
+                orderId="orderId"
                 isSelected={false}
                 onPress={jest.fn()}
                 {...props}
@@ -15,10 +16,7 @@ describe('PaymentMethodListItem', () => {
 
     it('should render given name', () => {
         const { getByText } = renderPaymentMethodListItem({
-            method: {
-                label: 'Debit card',
-                value: 'debitCard',
-            },
+            paymentMethodName: 'Debit card',
         });
 
         expect(getByText('Debit card')).toBeDefined();

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.tsx
@@ -6,7 +6,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { TradingProviderLogo } from '../TradingProviderLogo';
 
 export type ProviderListItemProps = {
-    quoteId: string;
+    orderId: string;
     companyName: string;
     logo: string;
     isSelected: boolean;
@@ -20,7 +20,7 @@ const wrapperStyle = prepareNativeStyle(({ spacings }) => ({
 }));
 
 export const ProviderListItem = ({
-    quoteId,
+    orderId,
     companyName,
     logo,
     isSelected,
@@ -38,7 +38,7 @@ export const ProviderListItem = ({
                             {companyName}
                         </Text>
                     </HStack>
-                    <Radio value={`${quoteId}`} onPress={onPress} isChecked={isSelected} />
+                    <Radio value={orderId} onPress={onPress} isChecked={isSelected} />
                 </HStack>
             </Card>
         </Pressable>

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProvidersSheet.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProvidersSheet.tsx
@@ -9,14 +9,14 @@ export type ProvidersSheetProps = {
     quotes: TradingTradeType[];
     isVisible: boolean;
     onClose: () => void;
-    onQuoteSelect: (method: TradingTradeType) => void;
+    onQuoteSelect: (quote: TradingTradeType) => void;
     selectedQuote?: TradingTradeType;
     providerInfos: { [name: string]: TradingProviderInfo };
 };
 
 const EXTRA_LIST_PADDING = 20;
 
-const keyExtractor = (item: TradingTradeType) => item.quoteId ?? '';
+const keyExtractor = (item: TradingTradeType) => item.orderId ?? '';
 const getEstimatedListHeight = (itemsCount: number) =>
     itemsCount * PROVIDER_LIST_ITEM_HEIGHT + ESTIMATED_HEADER_HEIGHT + EXTRA_LIST_PADDING;
 
@@ -52,17 +52,17 @@ export const ProvidersSheet = ({
 
                 const { companyName, logo } = provider;
 
-                if (!companyName || !item.quoteId) {
+                if (!companyName || !item.orderId) {
                     return null;
                 }
 
                 return (
                     <ProviderListItem
-                        quoteId={item.quoteId}
+                        orderId={item.orderId}
                         companyName={companyName ?? ''}
                         logo={logo ?? ''}
                         onPress={() => onQuoteSelectCallback(item)}
-                        isSelected={item.exchange === selectedQuote?.exchange}
+                        isSelected={item.orderId === selectedQuote?.orderId}
                     />
                 );
             }}

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.comp.test.tsx
@@ -12,7 +12,7 @@ describe('ProviderListItem', () => {
     ) =>
         renderWithStoreProviderAsync(
             <ProviderListItem
-                quoteId={quote.quoteId ?? ''}
+                orderId={quote.orderId ?? ''}
                 isSelected={false}
                 onPress={jest.fn()}
                 companyName=""

--- a/suite-native/module-trading/src/hooks/__tests__/useTradingBuyFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/__tests__/useTradingBuyFlow.test.ts
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
 
+import { BuyTrade } from 'invity-api';
+
 import {
     PreloadedState,
     TestStore,
@@ -9,6 +11,7 @@ import {
 } from '@suite-native/test-utils';
 
 import { getBtcAccount } from '../../__fixtures__/account';
+import quotes from '../../__fixtures__/quotes.json';
 import { getInitializedTradingStateWithQuotes } from '../../__fixtures__/tradingState';
 import { TradingBuyFormValues } from '../../types';
 import { useTradingBuyFlow } from '../useTradingBuyFlow';
@@ -69,12 +72,12 @@ describe('useTradingBuyFlow', () => {
         expect(result.current.canProceed).toBe(false);
     });
 
-    it('should canProceed be true when not loading and quoteId filters one in quotes', async () => {
+    it('should canProceed be true when not loading and orderId filters one in quotes', async () => {
         const store = await getInitializedStore({ isLoading: false });
 
         const { result } = await renderUseTradingBuyFlow({
             store,
-            quoteId: 'fc12d4c4-9078-4175-becd-90fc58a3145c',
+            quote: quotes[1] as BuyTrade,
         });
 
         expect(result.current.canProceed).toBe(true);
@@ -87,7 +90,7 @@ describe('useTradingBuyFlow', () => {
 
         const { result } = await renderUseTradingBuyFlow({
             store,
-            quoteId: 'e709df77-ee9e-4d12-98c2-84004a19c524',
+            quote: quotes[2] as BuyTrade,
             receiveAccount: { account: btcAccount, address: btcAccount.addresses?.used?.[0] },
         });
 
@@ -119,7 +122,7 @@ describe('useTradingBuyFlow', () => {
 
         const { result } = await renderUseTradingBuyFlow({
             store,
-            quoteId: 'e709df77-ee9e-4d12-98c2-84004a19c524',
+            quote: quotes[2] as BuyTrade,
             receiveAccount: { account: btcAccount, address: btcAccount.addresses?.used?.[0] },
         });
 

--- a/suite-native/module-trading/src/hooks/__tests__/useTradingBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/__tests__/useTradingBuyForm.test.tsx
@@ -188,122 +188,181 @@ describe('useTradingBuyForm', () => {
         expect(result.current.getValues('amountInCrypto')).toBe(false);
     });
 
-    it('should set payment method and provider after quotes are fetched', async () => {
-        const store = await getInitializedStore();
-        const { result } = await renderUseTradingBuyForm(store);
+    describe('on quotes change', () => {
+        it('if no quote is selected should select 1st quote with creditCard payment method', async () => {
+            const store = await getInitializedStore();
+            const { result } = await renderUseTradingBuyForm(store);
 
-        initFormAndQuotes(result.current, store);
+            initFormAndQuotes(result.current, store);
 
-        expect(result.current.getValues('provider')).toEqual('cexdirect');
-        expect(result.current.getValues('paymentMethod')).toEqual(
-            expect.objectContaining({ value: 'creditCard' }),
-        );
-    });
-
-    it('should set another payment method when card is not available', async () => {
-        const store = await getInitializedStore();
-        const { result } = await renderUseTradingBuyForm(store);
-
-        act(() => {
-            result.current.setValue('fiatValue', '10');
-            result.current.setValue('asset', btcAsset);
+            expect(result.current.getValues('quote')).toEqual(
+                expect.objectContaining({
+                    paymentMethod: 'creditCard',
+                    exchange: 'cexdirect',
+                }),
+            );
         });
 
-        act(() => {
-            store.dispatch(tradingBuyActions.saveQuotes([quotes[0]] as BuyTrade[]));
+        it('if no quote is selected and creditCard method is not available should select 1st quote', async () => {
+            const store = await getInitializedStore();
+            const { result } = await renderUseTradingBuyForm(store);
+
+            act(() => {
+                result.current.setValue('fiatValue', '10');
+                result.current.setValue('asset', btcAsset);
+                store.dispatch(tradingBuyActions.saveQuotes([quotes[0]] as BuyTrade[]));
+            });
+
+            expect(result.current.getValues('quote')).toEqual(
+                expect.objectContaining({
+                    paymentMethod: 'applePay',
+                    exchange: 'mercuryo',
+                }),
+            );
         });
 
-        expect(result.current.getValues('provider')).toEqual('mercuryo');
-        expect(result.current.getValues('paymentMethod')).toEqual(
-            expect.objectContaining({ value: 'applePay' }),
-        );
-    });
+        it('should set quote to undefined when no quotes are available', async () => {
+            const store = await getInitializedStore();
+            const { result } = await renderUseTradingBuyForm(store);
 
-    it('should clear payment method, provider and cryptoValue when quotes are empty and user inserted fiat', async () => {
-        const store = await getInitializedStore();
-        const { result } = await renderUseTradingBuyForm(store);
+            // this will load quotes and selects one
+            initFormAndQuotes(result.current, store);
 
-        initFormAndQuotes(result.current, store);
+            act(() => {
+                store.dispatch(tradingBuyActions.saveQuotes([]));
+            });
 
-        act(() => {
-            store.dispatch(tradingBuyActions.saveQuotes([]));
+            expect(result.current.getValues('quote')).toBeUndefined();
         });
 
-        expect(result.current.getValues('provider')).toBeUndefined();
-        expect(result.current.getValues('paymentMethod')).toBeUndefined();
-        expect(result.current.getValues('cryptoValue')).toBeUndefined();
-        expect(result.current.getValues('fiatValue')).toBe('10');
-    });
+        it('should clear cryptoValue when no quotes are available', async () => {
+            const store = await getInitializedStore();
+            const { result } = await renderUseTradingBuyForm(store);
 
-    it('should clear payment method, provider and fiatValue when quotes are empty and user inserted crypto', async () => {
-        const store = await getInitializedStore();
-        const { result } = await renderUseTradingBuyForm(store);
+            // this will load quotes and selects one
+            initFormAndQuotes(result.current, store);
 
-        act(() => {
-            result.current.setValue('amountInCrypto', true);
-            result.current.setValue('asset', btcAsset);
+            act(() => {
+                store.dispatch(tradingBuyActions.saveQuotes([]));
+            });
+
+            expect(result.current.getValues('cryptoValue')).toBeUndefined();
+            expect(result.current.getValues('fiatValue')).toBe('10');
         });
 
-        act(() => {
-            result.current.setValue('cryptoValue', '1');
-            store.dispatch(tradingBuyActions.saveQuotes(quotes as BuyTrade[]));
+        it('should clear fiatValue when no quotes are available and user inserted cryptoValue', async () => {
+            const store = await getInitializedStore();
+            const { result } = await renderUseTradingBuyForm(store);
+
+            // this will load quotes and selects one
+            act(() => {
+                result.current.setValue('amountInCrypto', true);
+                result.current.setValue('asset', btcAsset);
+                result.current.setValue('cryptoValue', '1');
+                store.dispatch(tradingBuyActions.saveQuotes(quotes as BuyTrade[]));
+            });
+
+            act(() => {
+                store.dispatch(tradingBuyActions.saveQuotes([]));
+            });
+
+            expect(result.current.getValues('fiatValue')).toBeUndefined();
+            expect(result.current.getValues('cryptoValue')).toBe('1');
         });
 
-        act(() => {
-            store.dispatch(tradingBuyActions.saveQuotes([]));
+        it('should update cryptoValue when selected quote is changed', async () => {
+            const store = await getInitializedStore();
+            const { result } = await renderUseTradingBuyForm(store);
+
+            initFormAndQuotes(result.current, store);
+
+            act(() => {
+                result.current.setValue('quote', quotes[0] as BuyTrade);
+            });
+
+            expect(result.current.getValues('cryptoValue')).toEqual('0.0010001683607972866');
+            expect(result.current.getValues('fiatValue')).toEqual('10');
         });
 
-        expect(result.current.getValues('provider')).toBeUndefined();
-        expect(result.current.getValues('paymentMethod')).toBeUndefined();
-        expect(result.current.getValues('fiatValue')).toBeUndefined();
-        expect(result.current.getValues('cryptoValue')).toBe('1');
-    });
+        it('should update fiatAmount when selected quote is changed and user inserted cryptoAmount', async () => {
+            const store = await getInitializedStore();
+            const { result } = await renderUseTradingBuyForm(store);
 
-    it('should update provider and cryptoValue when payment method is changed', async () => {
-        const store = await getInitializedStore();
-        const { result } = await renderUseTradingBuyForm(store);
+            act(() => {
+                result.current.setValue('asset', btcAsset);
+                result.current.setValue('amountInCrypto', true);
+                result.current.setValue('cryptoValue', '100');
+                store.dispatch(tradingBuyActions.saveQuotes(quotes as BuyTrade[]));
+            });
 
-        initFormAndQuotes(result.current, store);
+            act(() => {
+                result.current.setValue('quote', quotes[0] as BuyTrade);
+            });
 
-        act(() => {
-            result.current.setValue('paymentMethod', {
-                value: 'applePay',
-                label: 'Apple Pay',
+            expect(result.current.getValues('cryptoValue')).toEqual('100');
+            expect(result.current.getValues('fiatValue')).toEqual('10');
+        });
+
+        describe('when quote is selected and new quotes are fetched', () => {
+            let store: EnhancedStore;
+            let form: TradingBuyForm;
+
+            beforeEach(async () => {
+                store = await getInitializedStore();
+                const { result } = await renderUseTradingBuyForm(store);
+                form = result.current;
+
+                act(() => {
+                    result.current.setValue('asset', btcAsset);
+                    result.current.setValue('amountInCrypto', true);
+                    result.current.setValue('cryptoValue', '100');
+                });
+            });
+
+            it('should select quote with same payment method and provider', () => {
+                act(() => {
+                    form.setValue('quote', { ...quotes[3], orderId: 'test1' } as BuyTrade);
+                });
+
+                act(() => {
+                    store.dispatch(tradingBuyActions.saveQuotes(quotes as BuyTrade[]));
+                });
+
+                expect(form.getValues('quote')).toEqual(quotes[3]);
+            });
+
+            it('should select 1st quote with same payment method if same provider is not available', () => {
+                act(() => {
+                    form.setValue('quote', {
+                        ...quotes[3],
+                        orderId: 'test1',
+                        exchange: 'unavailable',
+                    } as BuyTrade);
+                });
+
+                act(() => {
+                    store.dispatch(tradingBuyActions.saveQuotes(quotes as BuyTrade[]));
+                });
+
+                expect(form.getValues('quote')).toEqual(quotes[1]);
+            });
+
+            it('should select 1st quote on new quotes when payment method is not available even with different payment method', () => {
+                act(() => {
+                    store.dispatch(tradingBuyActions.saveQuotes(quotes as BuyTrade[]));
+                });
+
+                act(() => {
+                    store.dispatch(tradingBuyActions.saveQuotes([quotes[0]] as BuyTrade[]));
+                });
+
+                expect(form.getValues('quote')).toEqual(
+                    expect.objectContaining({
+                        paymentMethod: 'applePay',
+                    }),
+                );
             });
         });
-
-        expect(result.current.getValues('provider')).toEqual('mercuryo');
-        expect(result.current.getValues('cryptoValue')).toEqual('0.0010001683607972866');
-        expect(result.current.getValues('fiatValue')).toEqual('10');
-    });
-
-    it('should update provider and fiatAmount when payment method is changed', async () => {
-        const store = await getInitializedStore();
-        const { result } = await renderUseTradingBuyForm(store);
-
-        act(() => {
-            result.current.setValue('asset', btcAsset);
-        });
-
-        act(() => {
-            result.current.setValue('amountInCrypto', true);
-            result.current.setValue('cryptoValue', '100');
-        });
-
-        act(() => {
-            store.dispatch(tradingBuyActions.saveQuotes(quotes as BuyTrade[]));
-        });
-
-        act(() => {
-            result.current.setValue('paymentMethod', {
-                value: 'applePay',
-                label: 'Apple Pay',
-            });
-        });
-
-        expect(result.current.getValues('provider')).toEqual('mercuryo');
-        expect(result.current.getValues('cryptoValue')).toEqual('100');
-        expect(result.current.getValues('fiatValue')).toEqual('10');
     });
 
     it('should set correct cryptoValue when using BTC and amount in sats', async () => {
@@ -313,56 +372,6 @@ describe('useTradingBuyForm', () => {
         initFormAndQuotes(result.current, store);
 
         expect(result.current.getValues('cryptoValue')).toEqual('50000');
-    });
-
-    it('should not change payment method on new quotes', async () => {
-        const store = await getInitializedStore(true);
-        const { result } = await renderUseTradingBuyForm(store);
-
-        initFormAndQuotes(result.current, store);
-        act(() => {
-            result.current.setValue('paymentMethod', {
-                value: 'applePay',
-                label: 'Apple Pay',
-            });
-        });
-
-        act(() => {
-            store.dispatch(tradingBuyActions.saveQuotes([...quotes] as BuyTrade[]));
-        });
-
-        expect(result.current.getValues('paymentMethod')).toEqual({
-            value: 'applePay',
-            label: 'Apple Pay',
-        });
-    });
-
-    it('should change payment method on new quotes when payment method is not available', async () => {
-        const store = await getInitializedStore(true);
-        const { result } = await renderUseTradingBuyForm(store);
-
-        initFormAndQuotes(result.current, store);
-
-        act(() => {
-            store.dispatch(tradingBuyActions.saveQuotes([quotes[0]] as BuyTrade[]));
-        });
-
-        expect(result.current.getValues('paymentMethod')).toEqual({
-            value: 'applePay',
-            label: 'Apple Pay',
-        });
-    });
-
-    it('should change data when quoteId is changed', async () => {
-        const store = await getInitializedStore(true);
-        const { result } = await renderUseTradingBuyForm(store);
-
-        initFormAndQuotes(result.current, store);
-        act(() => {
-            result.current.setValue('quoteId', 'ab12d4c3-1001-4175-becd-90fc58a3145c');
-        });
-
-        expect(result.current.getValues('provider')).toEqual('mercuryo');
     });
 
     describe('validations', () => {

--- a/suite-native/module-trading/src/hooks/useTradingBuyFlow.ts
+++ b/suite-native/module-trading/src/hooks/useTradingBuyFlow.ts
@@ -1,15 +1,10 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 import { BuyTrade, BuyTradeResponse, FormResponse } from 'invity-api';
 
-import {
-    buyThunks,
-    selectTradingBuyIsLoading,
-    selectTradingBuyQuotes,
-    tradingBuyActions,
-} from '@suite-common/trading';
+import { buyThunks, selectTradingBuyIsLoading, tradingBuyActions } from '@suite-common/trading';
 import { EventType, analytics } from '@suite-native/analytics';
 import {
     RootStackParamList,
@@ -55,7 +50,6 @@ const reportTradeConfirmation = () => {
 
 export const useTradingBuyFlow = (form: TradingBuyForm) => {
     const dispatch = useDispatch();
-    const quotes = useSelector(selectTradingBuyQuotes);
     const isLoading = useSelector(selectTradingBuyIsLoading);
 
     const timer = useTimer();
@@ -64,12 +58,7 @@ export const useTradingBuyFlow = (form: TradingBuyForm) => {
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes>>();
     const [isConsentRequested, setIsConsentRequested] = useState(false);
 
-    const [quoteId, receiveAccount] = form.watch(['quoteId', 'receiveAccount']);
-
-    const candidateQuote = useMemo(
-        () => (quotes.length > 0 ? quotes.filter(q => q.quoteId === quoteId)[0] : null),
-        [quotes, quoteId],
-    );
+    const [candidateQuote, receiveAccount] = form.watch(['quote', 'receiveAccount']);
 
     const canProceed = !isLoading && !!candidateQuote;
 

--- a/suite-native/module-trading/src/hooks/useTradingBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/useTradingBuyForm.ts
@@ -1,13 +1,14 @@
 import { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { BuyTrade } from 'invity-api';
+
 import { useFormatters } from '@suite-common/formatters';
 import {
     TradingAmountLimitProps,
-    TradingPaymentMethodListProps,
     TradingRootState,
-    selectBestBuyQuoteByPaymentMethod,
-    selectTradingBuyQuoteByQuoteId,
+    getBestRatedQuote,
+    selectTradingBuyQuoteByOrderId,
     selectTradingBuyQuotesRequest,
     selectValidTradingBuyQuotes,
 } from '@suite-common/trading';
@@ -66,6 +67,7 @@ const useAmountAndCurrencyFieldsChangeEffect = (form: TradingBuyForm) => {
 
                 case 'asset': {
                     form.setValue('cryptoValue', undefined);
+
                     form.trigger('cryptoValue');
 
                     if (asset?.networkId !== prevNetworkId.current) {
@@ -91,39 +93,42 @@ const useQuotesChangeEffect = (form: TradingBuyForm) => {
     const quotes = useSelector(selectValidTradingBuyQuotes);
 
     useEffect(() => {
-        const currentPaymentMethodValue = form.getValues('paymentMethod')?.value;
+        const currentQuote = form.getValues('quote');
+        let quoteCandidates: BuyTrade[] = [];
 
-        let selectedQuote = quotes.find(
-            ({ paymentMethod }) => paymentMethod === currentPaymentMethodValue,
-        );
+        if (currentQuote) {
+            quoteCandidates = quotes.filter(
+                ({ paymentMethod, exchange }) =>
+                    paymentMethod === currentQuote.paymentMethod &&
+                    exchange === currentQuote.exchange,
+            );
 
-        if (!selectedQuote) {
-            selectedQuote = quotes.find(({ paymentMethod }) => paymentMethod === 'creditCard');
+            if (quoteCandidates.length === 0) {
+                quoteCandidates = quotes.filter(
+                    ({ paymentMethod }) => paymentMethod === currentQuote.paymentMethod,
+                );
+            }
         }
 
-        if (!selectedQuote) {
-            selectedQuote = quotes[0];
+        if (quoteCandidates.length === 0) {
+            quoteCandidates = quotes.filter(({ paymentMethod }) => paymentMethod === 'creditCard');
         }
 
-        if (!selectedQuote) {
-            form.setValue('paymentMethod', undefined);
-
-            return;
+        if (quoteCandidates.length === 0) {
+            quoteCandidates = quotes;
         }
 
-        form.setValue('quoteId', selectedQuote?.quoteId);
-        form.setValue('paymentMethod', {
-            value: selectedQuote.paymentMethod,
-            label: selectedQuote.paymentMethodName,
-        } as TradingPaymentMethodListProps);
+        const selectedQuote = getBestRatedQuote(quoteCandidates, 'buy');
+        form.setValue('quote', selectedQuote);
     }, [quotes, form]);
 };
 
-const usePaymentMethodChangeEffect = (form: TradingBuyForm) => {
-    const paymentMethod = form.watch('paymentMethod');
+const useQuoteQuoteChangeEffect = (form: TradingBuyForm) => {
+    const quote = form.watch('quote');
+
     const symbol = getSelectedSymbolFromBuyForm(form);
     const selectedQuote = useSelector((state: TradingRootState) =>
-        selectBestBuyQuoteByPaymentMethod(state, paymentMethod?.value),
+        selectTradingBuyQuoteByOrderId(state, quote?.orderId),
     );
 
     const isAmountInSats = useSelector((state: SettingsSliceRootState) =>
@@ -131,57 +136,10 @@ const usePaymentMethodChangeEffect = (form: TradingBuyForm) => {
     );
 
     useEffect(() => {
-        const [provider, amountInCrypto, fiatValue, cryptoValue, quoteId] = form.getValues([
-            'provider',
+        const [amountInCrypto, fiatValue, cryptoValue] = form.getValues([
             'amountInCrypto',
             'fiatValue',
             'cryptoValue',
-            'quoteId',
-        ]);
-
-        if (selectedQuote?.exchange !== provider) {
-            form.setValue('provider', selectedQuote?.exchange);
-        }
-
-        if (amountInCrypto && fiatValue !== selectedQuote?.fiatStringAmount) {
-            form.setValue('fiatValue', selectedQuote?.fiatStringAmount);
-        }
-
-        if (!amountInCrypto && cryptoValue !== selectedQuote?.receiveStringAmount) {
-            const value =
-                isAmountInSats && selectedQuote?.receiveStringAmount && symbol
-                    ? amountToSmallestUnit(
-                          selectedQuote.receiveStringAmount,
-                          getNetwork(symbol).decimals,
-                      )
-                    : selectedQuote?.receiveStringAmount;
-            form.setValue('cryptoValue', value);
-        }
-
-        if (selectedQuote?.quoteId !== quoteId) {
-            form.setValue('quoteId', selectedQuote?.quoteId);
-        }
-    }, [selectedQuote, isAmountInSats, symbol, form]);
-};
-
-const useQuoteQuoteIdChangeEffect = (form: TradingBuyForm) => {
-    const quoteId = form.watch('quoteId');
-
-    const symbol = getSelectedSymbolFromBuyForm(form);
-    const selectedQuote = useSelector((state: TradingRootState) =>
-        selectTradingBuyQuoteByQuoteId(state, quoteId),
-    );
-
-    const isAmountInSats = useSelector((state: SettingsSliceRootState) =>
-        selectIsAmountInSats(state, symbol),
-    );
-
-    useEffect(() => {
-        const [amountInCrypto, fiatValue, cryptoValue, provider] = form.getValues([
-            'amountInCrypto',
-            'fiatValue',
-            'cryptoValue',
-            'provider',
         ]);
 
         if (amountInCrypto && fiatValue !== selectedQuote?.fiatStringAmount) {
@@ -197,10 +155,6 @@ const useQuoteQuoteIdChangeEffect = (form: TradingBuyForm) => {
                       )
                     : selectedQuote?.receiveStringAmount;
             form.setValue('cryptoValue', value);
-        }
-
-        if (selectedQuote?.exchange !== provider) {
-            form.setValue('provider', selectedQuote?.exchange);
         }
     }, [selectedQuote, isAmountInSats, symbol, form]);
 };
@@ -241,19 +195,16 @@ export const useTradingBuyForm = (): TradingBuyForm => {
     useAmountAndCurrencyFieldsChangeEffect(form);
     useReceiveAccountChangeEffect(form);
     useQuotesChangeEffect(form);
-    usePaymentMethodChangeEffect(form);
-    useQuoteQuoteIdChangeEffect(form);
+    useQuoteQuoteChangeEffect(form);
     useValidations(form, limits);
 
     return form;
 };
 
 export const clearTradingBuyFormQuoteData = (form: TradingBuyForm) => {
-    form.setValue('provider', undefined);
-    form.setValue('quoteId', undefined);
+    form.setValue('quote', undefined);
     form.setValue('fiatValue', undefined);
     form.setValue('cryptoValue', undefined);
-    form.setValue('paymentMethod', undefined);
     form.setValue('generalAlert', undefined);
     form.trigger(['fiatValue', 'cryptoValue']);
 };

--- a/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
@@ -1,12 +1,14 @@
-import { CryptoId } from 'invity-api';
+import { BuyTrade, CryptoId } from 'invity-api';
 
 import { extraDependenciesMock } from '@suite-common/test-utils';
 
 import { getBtcAccount } from '../../__fixtures__/account';
+import quotes from '../../__fixtures__/quotes.json';
 import { getInitializedTradingState } from '../../__fixtures__/tradingState';
 import { TradingState, tradingSlice } from '../../tradingSlice';
 import {
     selectBuyAmountLimits,
+    selectBuyBestQuotesForAvailablePaymentMethods,
     selectBuyFormDefaultValues,
     selectBuySelectedReceiveAccount,
     selectBuySupportedFiatCurrencies,
@@ -211,6 +213,41 @@ describe('buySelectors', () => {
                 maxCrypto: '50',
                 minCrypto: '0.0001',
             });
+        });
+    });
+
+    describe('selectBuyBestQuotesForAvailablePaymentMethods', () => {
+        beforeEach(() => {
+            prevState.buy.quotes = quotes as BuyTrade[];
+        });
+
+        it('should return only best quote for each payment method', () => {
+            expect(
+                selectBuyBestQuotesForAvailablePaymentMethods({
+                    wallet: { tradingNew: prevState },
+                }),
+            ).toEqual([
+                expect.objectContaining({
+                    paymentMethod: 'applePay',
+                    rate: 9998.316675433,
+                }),
+                expect.objectContaining({
+                    paymentMethod: 'creditCard',
+                    rate: 20000,
+                }),
+            ]);
+        });
+
+        it('should be stable', () => {
+            expect(
+                selectBuyBestQuotesForAvailablePaymentMethods({
+                    wallet: { tradingNew: prevState },
+                }),
+            ).toBe(
+                selectBuyBestQuotesForAvailablePaymentMethods({
+                    wallet: { tradingNew: prevState },
+                }),
+            );
         });
     });
 });

--- a/suite-native/module-trading/src/selectors/buySelectors.ts
+++ b/suite-native/module-trading/src/selectors/buySelectors.ts
@@ -1,9 +1,11 @@
-import { FiatCurrencyCode } from 'invity-api';
+import { BuyCryptoPaymentMethod, BuyTrade, FiatCurrencyCode } from 'invity-api';
 
 import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import {
+    getBestRatedQuote,
     regional,
     selectTradingBuyInfo,
+    selectTradingBuyQuotes,
     selectTradingBuySupportedCryptoIds,
 } from '@suite-common/trading';
 
@@ -96,3 +98,37 @@ export const selectBuySupportedFiatCurrenciesList = createMemoizedSelector(
 
 export const selectBuyAmountLimits = (state: TradingRootState) =>
     selectTradingBuy(state).amountLimits;
+
+export const selectBuyBestQuotesForAvailablePaymentMethods = createMemoizedSelector(
+    [
+        selectTradingBuyQuotes as unknown as (
+            state: TradingRootState,
+        ) => ReturnType<typeof selectTradingBuyQuotes>,
+    ],
+    quotes => {
+        if (!quotes) {
+            return [];
+        }
+
+        const allQuotesByPaymentMethodMap = quotes.reduce((quotesByPaymentMethodMap, quote) => {
+            const { paymentMethod } = quote;
+            if (!paymentMethod) {
+                return quotesByPaymentMethodMap;
+            }
+
+            const existingQuotes = quotesByPaymentMethodMap.get(paymentMethod);
+
+            if (!existingQuotes) {
+                quotesByPaymentMethodMap.set(paymentMethod, [quote]);
+            } else {
+                existingQuotes.push(quote);
+            }
+
+            return quotesByPaymentMethodMap;
+        }, new Map<BuyCryptoPaymentMethod, BuyTrade[]>());
+
+        return [...allQuotesByPaymentMethodMap.values()].map(quotesForPaymentMethod =>
+            getBestRatedQuote(quotesForPaymentMethod, 'buy'),
+        ) as BuyTrade[];
+    },
+);

--- a/suite-native/module-trading/src/types.ts
+++ b/suite-native/module-trading/src/types.ts
@@ -1,7 +1,7 @@
-import { CoinInfo, CryptoId, FiatCurrencyCode } from 'invity-api';
+import { BuyTrade, CoinInfo, CryptoId, FiatCurrencyCode } from 'invity-api';
 
 import { Formatters } from '@suite-common/formatters';
-import { TradingAmountLimitProps, TradingPaymentMethodListProps } from '@suite-common/trading';
+import { TradingAmountLimitProps } from '@suite-common/trading';
 import { NetworkSymbolExtended } from '@suite-common/wallet-config';
 import { Account, TokenAddress } from '@suite-common/wallet-types';
 import type { UseFormReturn } from '@suite-native/forms';
@@ -23,7 +23,7 @@ export type ReceiveAccount = {
 };
 
 export type TradingBuyFormValues = {
-    quoteId: string | undefined;
+    quote: BuyTrade | undefined;
     asset: TradeableAsset | undefined;
     receiveAccount: ReceiveAccount | undefined;
     fiatCurrency: FiatCurrencyCode;
@@ -31,9 +31,7 @@ export type TradingBuyFormValues = {
     cryptoValue: string | undefined;
     amountInCrypto: boolean;
     focusedValue: 'fiatValue' | 'cryptoValue' | undefined;
-    paymentMethod: TradingPaymentMethodListProps | undefined;
     country: Country;
-    provider: string | undefined;
     generalAlert: string | undefined;
 };
 

--- a/suite-native/module-trading/src/utils/__tests__/quotesUtils.test.ts
+++ b/suite-native/module-trading/src/utils/__tests__/quotesUtils.test.ts
@@ -1,11 +1,14 @@
+import { BuyTrade } from 'invity-api';
+
 import { act, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
 
 import coins from '../../__fixtures__/coins.json';
+import quotes from '../../__fixtures__/quotes.json';
 import { btcAsset } from '../../__fixtures__/tradeableAssets';
 import { getInitializedTradingState } from '../../__fixtures__/tradingState';
 import { useTradingBuyForm } from '../../hooks/useTradingBuyForm';
 import { TradingBuyForm } from '../../types';
-import { tradingBuyFormToTradingBuyFormProps } from '../quotesUtils';
+import { getPaymentMethodFromBuyForm, tradingBuyFormToTradingBuyFormProps } from '../quotesUtils';
 
 describe('quotesUtils', () => {
     let form: TradingBuyForm;
@@ -20,61 +23,77 @@ describe('quotesUtils', () => {
         form = result.current;
     });
 
-    it('should throw when crypto value is not selected', () => {
-        expect(() => tradingBuyFormToTradingBuyFormProps(form, coins.bitcoin)).toThrow(
-            'Asset is required',
-        );
-    });
-
-    describe('with buy form populated', () => {
-        beforeEach(() => {
-            act(() => {
-                form.setValue('fiatValue', '100');
-                form.setValue('asset', btcAsset);
-                form.setValue('country', {
-                    value: 'US',
-                    label: 'United States of America',
-                });
-                form.setValue('paymentMethod', {
-                    value: 'creditCard',
-                    label: 'Credit Card',
-                });
-            });
+    describe('getPaymentMethodFromBuyForm', () => {
+        it('should return undefined when quote is not set', () => {
+            expect(getPaymentMethodFromBuyForm(form)).toBeUndefined();
         });
 
-        it('should throw when info is not defined', () => {
-            expect(() => tradingBuyFormToTradingBuyFormProps(form, undefined)).toThrow(
-                'CoinInfo is required',
+        it('should return TradingPaymentMethodListProps object when quote is set', () => {
+            act(() => {
+                form.setValue('quote', quotes[0] as BuyTrade);
+            });
+
+            expect(getPaymentMethodFromBuyForm(form)).toEqual({
+                value: 'applePay',
+                label: 'Apple Pay',
+            });
+        });
+    });
+
+    describe('tradingBuyFormToTradingBuyFormProps', () => {
+        it('should throw when crypto value is not selected', () => {
+            expect(() => tradingBuyFormToTradingBuyFormProps(form, coins.bitcoin)).toThrow(
+                'Asset is required',
             );
         });
 
-        it('should return correct props', () => {
-            const props = tradingBuyFormToTradingBuyFormProps(form, coins.bitcoin);
-            expect(props).toEqual({
-                fiatInput: '100',
-                cryptoInput: undefined,
-                currencySelect: {
-                    value: 'czk',
-                    label: 'Czech Koruna',
-                },
-                cryptoSelect: {
-                    coingeckoId: 'bitcoin',
-                    contractAddress: null,
-                    cryptoName: 'Bitcoin',
-                    label: 'BTC',
-                    symbol: 'btc',
-                    type: 'currency',
-                    value: 'bitcoin',
-                },
-                countrySelect: {
-                    value: 'US',
-                    label: 'United States of America',
-                },
-                paymentMethod: {
-                    value: 'creditCard',
-                    label: 'Credit Card',
-                },
-                amountInCrypto: false,
+        describe('with buy form populated', () => {
+            beforeEach(() => {
+                act(() => {
+                    form.setValue('fiatValue', '100');
+                    form.setValue('asset', btcAsset);
+                    form.setValue('country', {
+                        value: 'US',
+                        label: 'United States of America',
+                    });
+                    form.setValue('quote', quotes[0] as BuyTrade);
+                });
+            });
+
+            it('should throw when info is not defined', () => {
+                expect(() => tradingBuyFormToTradingBuyFormProps(form, undefined)).toThrow(
+                    'CoinInfo is required',
+                );
+            });
+
+            it('should return correct props', () => {
+                const props = tradingBuyFormToTradingBuyFormProps(form, coins.bitcoin);
+                expect(props).toEqual({
+                    fiatInput: '100',
+                    cryptoInput: undefined,
+                    currencySelect: {
+                        value: 'czk',
+                        label: 'Czech Koruna',
+                    },
+                    cryptoSelect: {
+                        coingeckoId: 'bitcoin',
+                        contractAddress: null,
+                        cryptoName: 'Bitcoin',
+                        label: 'BTC',
+                        symbol: 'btc',
+                        type: 'currency',
+                        value: 'bitcoin',
+                    },
+                    countrySelect: {
+                        value: 'US',
+                        label: 'United States of America',
+                    },
+                    paymentMethod: {
+                        value: 'applePay',
+                        label: 'Apple Pay',
+                    },
+                    amountInCrypto: false,
+                });
             });
         });
     });

--- a/suite-native/module-trading/src/utils/quotesUtils.ts
+++ b/suite-native/module-trading/src/utils/quotesUtils.ts
@@ -1,26 +1,39 @@
 import { CoinInfo } from 'invity-api';
 
 import { invariant } from '@suite-common/suite-utils';
-import type { TradingBuyFormProps } from '@suite-common/trading';
+import type { TradingBuyFormProps, TradingPaymentMethodListProps } from '@suite-common/trading';
 import { toCryptoOption } from '@suite-common/trading';
 
 import { TradingBuyForm } from '../types';
 import { supportedFiatCurrenciesMap } from './supportedFiatCurrencies';
 
+export const getPaymentMethodFromBuyForm = (
+    form: TradingBuyForm,
+): TradingPaymentMethodListProps | undefined => {
+    const quote = form.getValues('quote');
+
+    if (quote) {
+        const { paymentMethodName: label, paymentMethod: value } = quote;
+        if (label && value) {
+            return { label, value };
+        }
+    }
+
+    return undefined;
+};
+
 export const tradingBuyFormToTradingBuyFormProps = (
     form: TradingBuyForm,
     coinInfo: CoinInfo | undefined,
 ): TradingBuyFormProps => {
-    const [asset, fiatCurrency, fiatValue, cryptoValue, amountInCrypto, country, paymentMethod] =
-        form.getValues([
-            'asset',
-            'fiatCurrency',
-            'fiatValue',
-            'cryptoValue',
-            'amountInCrypto',
-            'country',
-            'paymentMethod',
-        ]);
+    const [asset, fiatCurrency, fiatValue, cryptoValue, amountInCrypto, country] = form.getValues([
+        'asset',
+        'fiatCurrency',
+        'fiatValue',
+        'cryptoValue',
+        'amountInCrypto',
+        'country',
+    ]);
     const currencyName = supportedFiatCurrenciesMap.get(fiatCurrency)?.label;
 
     invariant(currencyName, 'Currency is required');
@@ -36,7 +49,7 @@ export const tradingBuyFormToTradingBuyFormProps = (
         },
         cryptoSelect: toCryptoOption(asset.cryptoId, coinInfo),
         countrySelect: country,
-        paymentMethod,
+        paymentMethod: getPaymentMethodFromBuyForm(form),
         amountInCrypto,
     };
 };


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Mobile trade buy form now uses single value of `quote` instead of `paumentMethod` and `provider`.

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mobile-trade-refactor-form&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mobile-trade-refactor-form&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mobile-trade-refactor-form&lookback=7)