### PR TITLE
feat(suite): setting to toggle connect websocket server

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -107,6 +107,7 @@ export interface InvokeChannels {
     'tray/change-settings': (payload: TraySettings) => InvokeResult;
     'tray/get-settings': () => InvokeResult<TraySettings>;
     'connect-popup/enabled': () => boolean;
+    'connect-popup/set-enabled': (enabled: boolean) => void;
     'connect-popup/ready': () => void;
     'connect-popup/response': (response: ConnectPopupResponse) => void;
     'system/open-settings': (settings: string) => InvokeResult;
@@ -172,6 +173,7 @@ export interface DesktopApi {
     getTraySettings: DesktopApiInvoke<'tray/get-settings'>;
     // Connect popup
     connectPopupEnabled: DesktopApiInvoke<'connect-popup/enabled'>;
+    connectPopupSetEnabled: DesktopApiInvoke<'connect-popup/set-enabled'>;
     connectPopupReady: DesktopApiInvoke<'connect-popup/ready'>;
     connectPopupResponse: DesktopApiInvoke<'connect-popup/response'>;
     //system

--- a/packages/suite-desktop-api/src/factory.ts
+++ b/packages/suite-desktop-api/src/factory.ts
@@ -179,6 +179,13 @@ export const factory = <R extends StrictIpcRenderer<any, IpcRendererEvent>>(
 
         // Connect popup
         connectPopupEnabled: () => ipcRenderer.invoke('connect-popup/enabled'),
+        connectPopupSetEnabled: (enabled: boolean) => {
+            if (validation.isPrimitive('boolean', enabled)) {
+                ipcRenderer.invoke('connect-popup/set-enabled', enabled);
+            }
+
+            return Promise.resolve();
+        },
         connectPopupReady: () => ipcRenderer.invoke('connect-popup/ready'),
         connectPopupResponse: response => ipcRenderer.invoke('connect-popup/response', response),
 

--- a/packages/suite-desktop-core/src/index.d.ts
+++ b/packages/suite-desktop-core/src/index.d.ts
@@ -134,3 +134,7 @@ declare type BridgeSettings = {
 declare type TraySettings = {
     showOnTray: boolean;
 };
+
+declare type ConnectSettings = {
+    enableWs: boolean;
+};

--- a/packages/suite-desktop-core/src/libs/store.ts
+++ b/packages/suite-desktop-core/src/libs/store.ts
@@ -15,6 +15,7 @@ export class Store {
         torSettings: TorSettings;
         bridgeSettings: BridgeSettings;
         traySettings: TraySettings;
+        connectSettings: ConnectSettings;
     }>;
 
     private constructor() {
@@ -98,6 +99,16 @@ export class Store {
 
     public setTraySettings(traySettings: TraySettings) {
         this.store.set('traySettings', traySettings);
+    }
+
+    public getConnectSettings() {
+        return this.store.get('connectSettings', {
+            enableWs: false,
+        });
+    }
+
+    public setConnectSettings(connectSettings: ConnectSettings) {
+        this.store.set('connectSettings', connectSettings);
     }
 
     /** Deletes all items from the store. */

--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -1,9 +1,9 @@
 /**
  * Local web server for handling requests to app
  */
-import { isDevEnv } from '@suite-common/suite-utils';
 import { validateIpcMessage } from '@trezor/ipc-proxy';
 
+import { restartApp } from '../libs/app-utils';
 import { exposeConnectWs } from '../libs/connect-ws';
 import { createHttpReceiver } from '../libs/http-receiver';
 import { hasSwitch } from '../libs/process-switches';
@@ -13,7 +13,11 @@ import type { ModuleInitBackground } from './index';
 
 export const SERVICE_NAME = 'http-receiver';
 
-export const initBackground: ModuleInitBackground = ({ mainWindowProxy, mainThreadEmitter }) => {
+export const initBackground: ModuleInitBackground = ({
+    mainWindowProxy,
+    mainThreadEmitter,
+    store,
+}) => {
     const { logger } = global;
     let httpReceiver: ReturnType<typeof createHttpReceiver> | null = null;
 
@@ -70,13 +74,20 @@ export const initBackground: ModuleInitBackground = ({ mainWindowProxy, mainThre
             }
         });
 
-        const connectPopupEnabled = hasSwitch('expose-connect-ws') || isDevEnv;
+        const connectPopupEnabled = () =>
+            hasSwitch('expose-connect-ws') || store.getConnectSettings().enableWs;
         ipcMain.handle('connect-popup/enabled', ipcEvent => {
             validateIpcMessage(ipcEvent);
 
-            return connectPopupEnabled;
+            return connectPopupEnabled();
         });
-        if (connectPopupEnabled) {
+        ipcMain.handle('connect-popup/set-enabled', (ipcEvent, enabled: boolean) => {
+            validateIpcMessage(ipcEvent);
+
+            store.setConnectSettings({ enableWs: enabled });
+            restartApp();
+        });
+        if (connectPopupEnabled()) {
             exposeConnectWs({ mainThreadEmitter, httpReceiver: receiver, mainWindowProxy });
         }
 

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -22,7 +22,8 @@ import { Tor } from './Tor';
 import { TranslationMode } from './TranslationMode';
 import { Transport } from './Transport';
 import { TransportBackends } from './TransportBackends';
-import { TrezorConnect } from './TrezorConnect';
+import { TrezorConnectLogs } from './TrezorConnectLogs';
+import { TrezorConnectWS } from './TrezorConnectWS';
 import { TriggerHighlight } from './TriggerHighlight';
 import { ViewOnlySettings } from './ViewOnlySettings';
 import { WipeData } from './WipeData';
@@ -93,7 +94,8 @@ export const SettingsDebug = () => {
                 </SettingsSection>
             )}
             <SettingsSection title="TrezorConnect">
-                <TrezorConnect />
+                <TrezorConnectLogs />
+                {isDesktop() && <TrezorConnectWS />}
             </SettingsSection>
         </SettingsLayout>
     );

--- a/packages/suite/src/views/settings/SettingsDebug/TrezorConnectLogs.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TrezorConnectLogs.tsx
@@ -5,7 +5,7 @@ import { setDebugMode } from 'src/actions/suite/suiteActions';
 import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
-export const TrezorConnect = () => {
+export const TrezorConnectLogs = () => {
     const showConnectLogs = useSelector(state => state.suite.settings.debug.showConnectLogs);
     const dispatch = useDispatch();
 

--- a/packages/suite/src/views/settings/SettingsDebug/TrezorConnectWS.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TrezorConnectWS.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+import { Switch } from '@trezor/components';
+import { desktopApi } from '@trezor/suite-desktop-api';
+
+import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
+
+export const TrezorConnectWS = () => {
+    const [websocketEnabled, setWebsocketEnabled] = useState(false);
+    const updateWebsocketStatus = () => {
+        desktopApi.connectPopupEnabled().then(result => {
+            setWebsocketEnabled(result);
+        });
+    };
+    useEffect(() => {
+        updateWebsocketStatus();
+    }, []);
+    const toggleWebsocket = () => {
+        desktopApi.connectPopupSetEnabled(!websocketEnabled).then(() => {
+            updateWebsocketStatus();
+        });
+    };
+
+    return (
+        <SectionItem>
+            <TextColumn
+                title="TrezorConnect WebSocket server"
+                description="Enables new Connect-in-Suite workflow"
+            />
+            <ActionColumn>
+                <Switch isChecked={websocketEnabled} onChange={toggleWebsocket} />
+            </ActionColumn>
+        </SectionItem>
+    );
+};


### PR DESCRIPTION
## Description

Adds an option to debug settings to enable/disable Trezor Connect websocket server in Suite.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-ws-settings&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connect-ws-settings&lookback=7)