### PR TITLE
chore(suite): move connect reducers to root

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -462,9 +462,9 @@ export const saveEntropyCheckFail = () => async (_dispatch: Dispatch, getState: 
 
 export const saveConnectSettings = () => async (_dispatch: Dispatch, getState: GetState) => {
     if (!(await db.isAccessible())) return;
-    const { wallet } = getState();
+    const { connectPopup } = getState();
 
-    db.addItem('connect', { permissions: wallet.connectPopup.permissions }, 'connect', true);
+    db.addItem('connect', { permissions: connectPopup.permissions }, 'connect', true);
 };
 
 export const removeDatabase = () => async (dispatch: Dispatch, getState: GetState) => {

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -44,8 +44,8 @@ const buttonRequest =
             const {
                 wallet: {
                     selectedAccount: { account },
-                    connectPopup: { activeCall },
                 },
+                connectPopup: { activeCall },
                 router: { route },
             } = api.getState();
             const isInSuite =

--- a/packages/suite/src/reducers/suite/index.ts
+++ b/packages/suite/src/reducers/suite/index.ts
@@ -1,8 +1,10 @@
 import { prepareAnalyticsReducer } from '@suite-common/analytics';
+import { prepareConnectPopupReducer } from '@suite-common/connect-popup';
 import { logsSlice } from '@suite-common/logger';
 import { prepareMessageSystemReducer } from '@suite-common/message-system';
 import { notificationsReducer } from '@suite-common/toast-notifications';
 import { prepareDeviceReducer } from '@suite-common/wallet-core';
+import { prepareWalletConnectReducer } from '@suite-common/walletconnect';
 
 import { extraDependencies } from 'src/support/extraDependencies';
 
@@ -19,6 +21,8 @@ const analytics = prepareAnalyticsReducer(extraDependencies);
 // Type annotation as workaround for type-check error "The inferred type of 'default' cannot be named..."
 const messageSystem = prepareMessageSystemReducer(extraDependencies);
 const device = prepareDeviceReducer(extraDependencies);
+const connectPopupReducer = prepareConnectPopupReducer(extraDependencies);
+const walletConnectReducer = prepareWalletConnectReducer(extraDependencies);
 
 export default {
     suite,
@@ -34,4 +38,6 @@ export default {
     messageSystem,
     guide,
     protocol,
+    connectPopup: connectPopupReducer,
+    walletConnect: walletConnectReducer,
 };

--- a/packages/suite/src/reducers/wallet/index.ts
+++ b/packages/suite/src/reducers/wallet/index.ts
@@ -1,6 +1,5 @@
 import { combineReducers } from 'redux';
 
-import { prepareConnectPopupReducer } from '@suite-common/connect-popup';
 import { prepareTradingReducer } from '@suite-common/trading';
 import {
     feesReducer,
@@ -12,7 +11,6 @@ import {
     prepareStakeReducer,
     prepareTransactionsReducer,
 } from '@suite-common/wallet-core';
-import { prepareWalletConnectReducer } from '@suite-common/walletconnect';
 
 import { extraDependencies } from 'src/support/extraDependencies';
 
@@ -33,8 +31,6 @@ export const fiatRatesReducer = prepareFiatRatesReducer(extraDependencies);
 export const discoveryReducer = prepareDiscoveryReducer(extraDependencies);
 export const stakeReducer = prepareStakeReducer(extraDependencies);
 export const sendFormReducer = prepareSendFormReducer(extraDependencies);
-export const connectPopupReducer = prepareConnectPopupReducer(extraDependencies);
-export const walletConnectReducer = prepareWalletConnectReducer(extraDependencies);
 export const tradingNewReducer = prepareTradingReducer(extraDependencies);
 
 const WalletReducers = combineReducers({
@@ -56,8 +52,6 @@ const WalletReducers = combineReducers({
     cardanoStaking: cardanoStakingReducer,
     coinjoin: coinjoinReducer,
     stake: stakeReducer,
-    connectPopup: connectPopupReducer,
-    walletConnect: walletConnectReducer,
 });
 
 export default WalletReducers;

--- a/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
+++ b/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
@@ -18,8 +18,8 @@ export type SelectedAccountRootStateWithTrading = SelectedAccountRootState & {
     wallet: {
         trading: TradingState;
         tradingNew: TradingNewState;
-        connectPopup: ConnectPopupState;
     };
+    connectPopup: ConnectPopupState;
 };
 
 export const initialState: State = {
@@ -70,7 +70,7 @@ export const selectAccountIncludingChosenInTrading = (
         return selectAccountByKey(state, modalAccountKeyNew) ?? undefined;
     }
 
-    const { activeCall } = state.wallet.connectPopup;
+    const { activeCall } = state.connectPopup;
     if (activeCall?.state === 'ongoing') {
         return selectAccountByKey(state, activeCall.selectedAccountKey) ?? undefined;
     }

--- a/suite-common/connect-popup/src/connectPopupReducer.ts
+++ b/suite-common/connect-popup/src/connectPopupReducer.ts
@@ -15,7 +15,7 @@ export type ConnectPopupState = {
 };
 
 type ConnectPopupStateRootState = {
-    wallet: { connectPopup: ConnectPopupState };
+    connectPopup: ConnectPopupState;
 };
 
 type StorageActionPayload = {
@@ -121,10 +121,10 @@ export const prepareConnectPopupReducer = createReducerWithExtraDeps(
 );
 
 export const selectConnectPopupCall = (state: ConnectPopupStateRootState) =>
-    state.wallet.connectPopup.activeCall;
+    state.connectPopup.activeCall;
 
 export const selectConnectAppPermissions = (state: ConnectPopupStateRootState) =>
-    state.wallet.connectPopup.permissions.filter(p => p.type !== CALL_SOURCE_WALLETCONNECT);
+    state.connectPopup.permissions.filter(p => p.type !== CALL_SOURCE_WALLETCONNECT);
 
 export const selectWalletConnectAppPermissions = (state: ConnectPopupStateRootState) =>
-    state.wallet.connectPopup.permissions.filter(p => p.type === CALL_SOURCE_WALLETCONNECT);
+    state.connectPopup.permissions.filter(p => p.type === CALL_SOURCE_WALLETCONNECT);

--- a/suite-common/walletconnect/src/walletConnectReducer.ts
+++ b/suite-common/walletconnect/src/walletConnectReducer.ts
@@ -9,7 +9,7 @@ export type WalletConnectState = {
 };
 
 type WalletConnectStateRootState = {
-    wallet: { walletConnect: WalletConnectState };
+    walletConnect: WalletConnectState;
 };
 
 const walletConnectInitialState: WalletConnectState = {
@@ -48,11 +48,10 @@ export const prepareWalletConnectReducer = createReducerWithExtraDeps(
     },
 );
 
-export const selectSessions = (state: WalletConnectStateRootState) =>
-    state.wallet.walletConnect.sessions;
+export const selectSessions = (state: WalletConnectStateRootState) => state.walletConnect.sessions;
 
 export const selectSessionByTopic = (state: WalletConnectStateRootState, topic: string) =>
-    state.wallet.walletConnect.sessions.find(session => session.topic === topic);
+    state.walletConnect.sessions.find(session => session.topic === topic);
 
 export const selectPendingProposal = (state: WalletConnectStateRootState) =>
-    state.wallet.walletConnect.pendingProposal;
+    state.walletConnect.pendingProposal;

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -98,8 +98,6 @@ export const prepareRootReducers = async () => {
         fees: feesReducer,
         stake: stakeReducer,
         tradingNew: tradingPersistedReducer,
-        connectPopup: connectPopupReducer,
-        walletConnect: walletConnectReducer,
     });
 
     const walletPersistedReducer = await preparePersistReducer({
@@ -229,6 +227,8 @@ export const prepareRootReducers = async () => {
             discoveryConfig: discoveryConfigPersistedReducer,
             messageSystem: messageSystemPersistedReducer,
             tokenDefinitions: tokenDefinitionsReducer,
+            connectPopup: connectPopupReducer,
+            walletConnect: walletConnectReducer,
         } as const),
         // 'wallet' and 'graph' need to be persisted at the top level to ensure device state
         // is accessible for transformation.


### PR DESCRIPTION
## Description

Move connect reducers to root after discussion with @mroz22

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/suite-move-connect-reducers&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/suite-move-connect-reducers&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/suite-move-connect-reducers&lookback=7)