### PR TITLE
feat(connect): decrease block values for fee estimation

### DIFF
--- a/packages/connect/src/api/bitcoin/__tests__/BitcoinFees.test.ts
+++ b/packages/connect/src/api/bitcoin/__tests__/BitcoinFees.test.ts
@@ -37,7 +37,7 @@ describe('api/bitcoin/Fees', () => {
         ); // preloaded values from coins.json
 
         const smartFeeLevels = await feeLevels.load(backend);
-        expect(smartFeeLevels?.map(l => l.feePerUnit)).toEqual(['10', '10', '8.86', '4.69']);
+        expect(smartFeeLevels?.map(l => l.feePerUnit)).toEqual(['10', '10', '9.62', '8.86']);
 
         backend.disconnect();
         spy.mockClear();
@@ -66,7 +66,7 @@ describe('api/bitcoin/Fees', () => {
         const feeLevels = new BitcoinFeeLevels(coinInfo);
 
         const smartFeeLevels = await feeLevels.load(backend);
-        expect(smartFeeLevels?.map(l => l.feePerUnit)).toEqual(['10', '8.86', '3.18', '1']);
+        expect(smartFeeLevels?.map(l => l.feePerUnit)).toEqual(['10', '9.24', '7.73', '3.18']);
 
         backend.disconnect();
         spy.mockClear();

--- a/packages/connect/src/data/defaultFeeLevels.ts
+++ b/packages/connect/src/data/defaultFeeLevels.ts
@@ -9,9 +9,10 @@ const BLOCKS_FOR_FEE_LEVEL: Record<string, Record<string, number>> = {
     btc: {
         // blocktime ~ 600sec.
         high: 1,
-        normal: 6,
-        economy: 36,
-        low: 144,
+        normal: 3,
+        economy: 12,
+        // low fee is offerred by Connect, though Suite only uses the first three levels (see feesThunks.ts)
+        low: 36,
     },
 };
 


### PR DESCRIPTION
## Description

Change default fee levels for BTC (block values to be queried from blockbook estimateFee API) 

## Related Issue

Resolve #18381

## Screenshots:
[Fee selection BTC](https://github.com/user-attachments/assets/1085f4f6-19ac-4818-95c9-1f5c02b30ded)
[Fee selection LTC](https://github.com/user-attachments/assets/2806599c-ac7a-456d-b3b8-be1f64385957)
[Fee selection TEST](https://github.com/user-attachments/assets/85851a13-daae-4f66-8b2a-6ba74ba646b2)

[blockbook API BTC query](https://github.com/user-attachments/assets/17cb3adc-e515-4322-b8bd-c52c15912b9e)
[blockbook API BTC response](https://github.com/user-attachments/assets/70c7e1fd-932b-4de0-addd-beedf8db683c)
[blockbook API LTC query](https://github.com/user-attachments/assets/b383c891-17a8-4a07-a0e3-a40542a73ac8)
[blockbook API LTC response](https://github.com/user-attachments/assets/cbafd61a-9e5c-4834-a5ce-7e031be195c6)
[blockbook API TEST query](https://github.com/user-attachments/assets/550e0e3b-0757-4911-b77f-88178dcb029c)
[blockbook API TEST response](https://github.com/user-attachments/assets/5d3c9bcc-bac0-4849-be89-74d6203d60b4)



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/change-default-fee-blocks&lookback=7)