### PR TITLE
Remove deprecated `node-libs-browser`

### DIFF
--- a/.depcheckrc.json
+++ b/.depcheckrc.json
@@ -7,7 +7,7 @@
         "@playwright/*",
         "webpack*",
         "worker-loader",
-        "node-libs-browser",
+        "process",
         "rimraf",
         "tslib",
         "protobufjs-cli",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -121,7 +121,7 @@
         "karma-sourcemap-loader": "^0.4.0",
         "karma-webpack": "^5.0.1",
         "node-fetch": "^2.6.4",
-        "node-libs-browser": "^2.2.1",
+        "process": "^0.11.10",
         "stream-browserify": "^3.0.0",
         "ts-node": "^10.9.2",
         "tsx": "^4.20.3",

--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -59,6 +59,7 @@ const config: webpack.Configuration = {
             https: false,
             http: false,
             zlib: false,
+            url: false,
         },
     },
     optimization: {

--- a/scripts/list-outdated-dependencies/trade-dependencies.txt
+++ b/scripts/list-outdated-dependencies/trade-dependencies.txt
@@ -22,6 +22,7 @@
 @types/react
 @types/react-dom
 babel-preset-expo
+browserify-zlib
 expo
 expo-atlas
 expo-build-properties
@@ -47,10 +48,11 @@ expo-store-review
 expo-updates
 expo-video
 fs-extra
+https-browserify
 jest-expo
 jotai
 metro-config
-node-libs-browser
+process
 react
 react-dom
 react-error-boundary
@@ -61,6 +63,7 @@ react-native-performance
 react-native-permissions
 react-native-restart
 rimraf
+stream-http
 tslib
 tsx
 type-fest

--- a/suite-native/app/metro.config.js
+++ b/suite-native/app/metro.config.js
@@ -5,7 +5,6 @@ const { withRozeniteReduxDevTools } = require('@rozenite/redux-devtools-plugin/m
 const { getSentryExpoConfig } = require('@sentry/react-native/metro');
 const { withStorybook } = require('@storybook/react-native/metro/withStorybook');
 const { mergeConfig } = require('metro-config');
-const nodejs = require('node-libs-browser');
 
 const { metroSecureResolver } = require('@trezor/bundler-security/src/metroSecureResolver');
 
@@ -36,12 +35,12 @@ const config = {
         blockList: [/libDev/],
         extraNodeModules: {
             // modules needed for trezor-connect
-            crypto: nodejs.crypto,
-            stream: nodejs.stream,
-            https: nodejs.https,
-            http: nodejs.http,
-            zlib: nodejs.zlib,
-            vm: nodejs.vm,
+            crypto: require.resolve('crypto-browserify'),
+            stream: require.resolve('stream-browserify'),
+            https: require.resolve('https-browserify'),
+            http: require.resolve('stream-http'),
+            zlib: require.resolve('browserify-zlib'),
+            vm: require.resolve('vm-browserify'),
         },
         sourceExts,
         resolveRequest: (context, moduleName, platform) => {

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -98,6 +98,8 @@
         "@walletconnect/react-native-compat": "^2.20.3",
         "@whatwg-node/events": "0.1.2",
         "abortcontroller-polyfill": "1.7.8",
+        "browserify-zlib": "^0.2.0",
+        "crypto-browserify": "3.12.0",
         "event-target-shim": "6.0.2",
         "expo": "~54.0.30",
         "expo-build-properties": "~1.0.10",
@@ -117,10 +119,10 @@
         "expo-system-ui": "~6.0.9",
         "expo-updates": "~29.0.15",
         "expo-video": "~3.0.15",
+        "https-browserify": "^1.0.0",
         "jotai": "2.15.0",
         "lottie-react-native": "7.3.4",
         "metro-config": "^0.82.4",
-        "node-libs-browser": "^2.2.1",
         "react": "19.1.0",
         "react-freeze": "^1.0.4",
         "react-intl": "^8.0.6",
@@ -151,7 +153,10 @@
         "set.prototype.issupersetof": "^1.1.3",
         "set.prototype.symmetricdifference": "^1.1.3",
         "set.prototype.union": "^1.1.3",
-        "storybook": "^10.1.0"
+        "storybook": "^10.1.0",
+        "stream-browserify": "^3.0.0",
+        "stream-http": "^3.2.0",
+        "vm-browserify": "^1.1.2"
     },
     "devDependencies": {
         "@babel/core": "7.28.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11521,6 +11521,8 @@ __metadata:
     babel-jest: "npm:29.7.0"
     babel-plugin-transform-remove-console: "npm:^6.9.4"
     babel-preset-expo: "npm:~54.0.9"
+    browserify-zlib: "npm:^0.2.0"
+    crypto-browserify: "npm:3.12.0"
     detox: "npm:20.45.1"
     dotenv: "npm:^17.2.1"
     event-target-shim: "npm:6.0.2"
@@ -11543,12 +11545,12 @@ __metadata:
     expo-system-ui: "npm:~6.0.9"
     expo-updates: "npm:~29.0.15"
     expo-video: "npm:~3.0.15"
+    https-browserify: "npm:^1.0.0"
     jest: "npm:29.7.0"
     jest-junit: "npm:^16.0.0"
     jotai: "npm:2.15.0"
     lottie-react-native: "npm:7.3.4"
     metro-config: "npm:^0.82.4"
-    node-libs-browser: "npm:^2.2.1"
     react: "npm:19.1.0"
     react-freeze: "npm:^1.0.4"
     react-intl: "npm:^8.0.6"
@@ -11581,9 +11583,12 @@ __metadata:
     set.prototype.symmetricdifference: "npm:^1.1.3"
     set.prototype.union: "npm:^1.1.3"
     storybook: "npm:^10.1.0"
+    stream-browserify: "npm:^3.0.0"
+    stream-http: "npm:^3.2.0"
     ts-jest: "npm:29.4.1"
     ts-node: "npm:^10.9.2"
     typescript: "npm:5.8.3"
+    vm-browserify: "npm:^1.1.2"
   languageName: unknown
   linkType: soft
 
@@ -14373,7 +14378,7 @@ __metadata:
     karma-sourcemap-loader: "npm:^0.4.0"
     karma-webpack: "npm:^5.0.1"
     node-fetch: "npm:^2.6.4"
-    node-libs-browser: "npm:^2.2.1"
+    process: "npm:^0.11.10"
     stream-browserify: "npm:^3.0.0"
     ts-node: "npm:^10.9.2"
     tsx: "npm:^4.20.3"
@@ -18615,16 +18620,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"assert@npm:^1.1.1":
-  version: 1.5.0
-  resolution: "assert@npm:1.5.0"
-  dependencies:
-    object-assign: "npm:^4.1.1"
-    util: "npm:0.10.3"
-  checksum: 10/6266761663f40638b8eb685795e22d16df2e4885cc9006cbbeddc5fde3e853ddc489eb6d634df62d1a0c2b8ef9927e40f47f90bea49ace3776a2b758f5051ea3
-  languageName: node
-  linkType: hard
-
 "assert@npm:^2.0.0":
   version: 2.1.0
   resolution: "assert@npm:2.1.0"
@@ -19196,7 +19191,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.0.2, base64-js@npm:^1.1.2, base64-js@npm:^1.2.3, base64-js@npm:^1.3.0, base64-js@npm:^1.3.1, base64-js@npm:^1.5.1":
+"base64-js@npm:^1.1.2, base64-js@npm:^1.2.3, base64-js@npm:^1.3.0, base64-js@npm:^1.3.1, base64-js@npm:^1.5.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 10/669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
@@ -19718,17 +19713,6 @@ __metadata:
   version: 1.0.3
   resolution: "buffer-xor@npm:1.0.3"
   checksum: 10/4a63d48b5117c7eda896d81cd3582d9707329b07c97a14b0ece2edc6e64220ea7ea17c94b295e8c2cb7b9f8291e2b079f9096be8ac14be238420a43e06ec66e2
-  languageName: node
-  linkType: hard
-
-"buffer@npm:^4.3.0":
-  version: 4.9.2
-  resolution: "buffer@npm:4.9.2"
-  dependencies:
-    base64-js: "npm:^1.0.2"
-    ieee754: "npm:^1.1.4"
-    isarray: "npm:^1.0.0"
-  checksum: 10/4852a455e167bc8ca580c3c585176bbe0931c9929aeb68f3e0b49adadcb4e513fd0922a43efdf67ddb2e8785bbe8254ae17f4b69038dd06329ee9e3283c8508f
   languageName: node
   linkType: hard
 
@@ -21581,7 +21565,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"crypto-browserify@npm:^3.11.0, crypto-browserify@npm:^3.12.1":
+"crypto-browserify@npm:^3.12.1":
   version: 3.12.1
   resolution: "crypto-browserify@npm:3.12.1"
   dependencies:
@@ -23180,13 +23164,6 @@ __metadata:
   version: 4.22.0
   resolution: "domain-browser@npm:4.22.0"
   checksum: 10/3ffbaf0cae8da717698d472ca85ab52f96c538fe1fe85e5eb3351d4e7af52423ce096b8a0c51bb318e1c9ccf9c2e94b3b0f68e5923ad0aa0c623a32b641ed11c
-  languageName: node
-  linkType: hard
-
-"domain-browser@npm:^1.1.1":
-  version: 1.2.0
-  resolution: "domain-browser@npm:1.2.0"
-  checksum: 10/3f339b1be9a22135d66fe12398d788ff35ba936c924b1b201b27ef221c1381790454fffc028fe01b69a434c60fdae4082005a4d43b40c32c47d0b0e71874f944
   languageName: node
   linkType: hard
 
@@ -28679,7 +28656,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ieee754@npm:^1.1.13, ieee754@npm:^1.1.4, ieee754@npm:^1.2.1":
+"ieee754@npm:^1.1.13, ieee754@npm:^1.2.1":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 10/d9f2557a59036f16c282aaeb107832dc957a93d73397d89bbad4eb1130560560eb695060145e8e6b3b498b15ab95510226649a0b8f52ae06583575419fe10fc4
@@ -28828,17 +28805,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.1, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10/cd45e923bee15186c07fa4c89db0aace24824c482fb887b528304694b2aa6ff8a898da8657046a5dcf3e46cd6db6c61629551f9215f208d7c3f157cf9b290521
-  languageName: node
-  linkType: hard
-
-"inherits@npm:2.0.1":
-  version: 2.0.1
-  resolution: "inherits@npm:2.0.1"
-  checksum: 10/37165f42e53627edc18d815654a79e7407e356adf480aab77db3a12c978e597f3af632cf0459472dd5a088bc21ee911020f544c0d3c23b45bcfd1cd92fe9e404
   languageName: node
   linkType: hard
 
@@ -29616,17 +29586,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isarray@npm:^1.0.0, isarray@npm:~1.0.0":
-  version: 1.0.0
-  resolution: "isarray@npm:1.0.0"
-  checksum: 10/f032df8e02dce8ec565cf2eb605ea939bdccea528dbcf565cdf92bfa2da9110461159d86a537388ef1acef8815a330642d7885b29010e8f7eac967c9993b65ab
-  languageName: node
-  linkType: hard
-
 "isarray@npm:^2.0.5":
   version: 2.0.5
   resolution: "isarray@npm:2.0.5"
   checksum: 10/1d8bc7911e13bb9f105b1b3e0b396c787a9e63046af0b8fe0ab1414488ab06b2b099b87a2d8a9e31d21c9a6fad773c7fc8b257c4880f2d957274479d28ca3414
+  languageName: node
+  linkType: hard
+
+"isarray@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "isarray@npm:1.0.0"
+  checksum: 10/f032df8e02dce8ec565cf2eb605ea939bdccea528dbcf565cdf92bfa2da9110461159d86a537388ef1acef8815a330642d7885b29010e8f7eac967c9993b65ab
   languageName: node
   linkType: hard
 
@@ -35536,37 +35506,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-libs-browser@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "node-libs-browser@npm:2.2.1"
-  dependencies:
-    assert: "npm:^1.1.1"
-    browserify-zlib: "npm:^0.2.0"
-    buffer: "npm:^4.3.0"
-    console-browserify: "npm:^1.1.0"
-    constants-browserify: "npm:^1.0.0"
-    crypto-browserify: "npm:^3.11.0"
-    domain-browser: "npm:^1.1.1"
-    events: "npm:^3.0.0"
-    https-browserify: "npm:^1.0.0"
-    os-browserify: "npm:^0.3.0"
-    path-browserify: "npm:0.0.1"
-    process: "npm:^0.11.10"
-    punycode: "npm:^1.2.4"
-    querystring-es3: "npm:^0.2.0"
-    readable-stream: "npm:^2.3.3"
-    stream-browserify: "npm:^2.0.1"
-    stream-http: "npm:^2.7.2"
-    string_decoder: "npm:^1.0.0"
-    timers-browserify: "npm:^2.0.4"
-    tty-browserify: "npm:0.0.0"
-    url: "npm:^0.11.0"
-    util: "npm:^0.11.0"
-    vm-browserify: "npm:^1.0.1"
-  checksum: 10/41fa7927378edc0cb98a8cc784d3f4a47e43378d3b42ec57a23f81125baa7287c4b54d6d26d062072226160a3ce4d8b7a62e873d2fb637aceaddf71f5a26eca0
-  languageName: node
-  linkType: hard
-
 "node-loader@npm:^2.1.0":
   version: 2.1.0
   resolution: "node-loader@npm:2.1.0"
@@ -36681,13 +36620,6 @@ __metadata:
   bin:
     patch-package: index.js
   checksum: 10/920a9fb0001ea67a66d79ea696e6d74e3040b0f282e09addae913978b6d0e8cb5ef9a4030eb77df8a5497e8822fa8449c2dfdc668ecff7fb9ff8bfef0c897c6e
-  languageName: node
-  linkType: hard
-
-"path-browserify@npm:0.0.1":
-  version: 0.0.1
-  resolution: "path-browserify@npm:0.0.1"
-  checksum: 10/37ec7a0073eb8c5e96eb72f82dbdffd9b91e1c850cc618c9b5ebb5991fed5d4cd86ec730e7f4690ad68ee67a4cf9450baaf1ac84820c26624cfc2f20b3a75397
   languageName: node
   linkType: hard
 
@@ -38148,7 +38080,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^1.2.4, punycode@npm:^1.4.1":
+"punycode@npm:^1.4.1":
   version: 1.4.1
   resolution: "punycode@npm:1.4.1"
   checksum: 10/af2700dde1a116791ff8301348ff344c47d6c224e875057237d1b5112035655fb07a6175cfdb8bf0e3a8cdfd2dc82b3a622e0aefd605566c0e949a6d0d1256a4
@@ -38240,7 +38172,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"querystring-es3@npm:^0.2.0, querystring-es3@npm:^0.2.1":
+"querystring-es3@npm:^0.2.1":
   version: 0.2.1
   resolution: "querystring-es3@npm:0.2.1"
   checksum: 10/c99fccfe1a9c4c25ea6194fa7a559fdb83d2628f118f898af6f0ac02c4ffcd7e0576997bb80e7dfa892d193988b60e23d4968122426351819f87051862af991c
@@ -39381,7 +39313,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.0.2, readable-stream@npm:^2.0.5, readable-stream@npm:^2.3.3, readable-stream@npm:^2.3.5, readable-stream@npm:^2.3.6, readable-stream@npm:^2.3.8, readable-stream@npm:~2.3.6":
+"readable-stream@npm:^2.0.2, readable-stream@npm:^2.0.5, readable-stream@npm:^2.3.5, readable-stream@npm:^2.3.8, readable-stream@npm:~2.3.6":
   version: 2.3.8
   resolution: "readable-stream@npm:2.3.8"
   dependencies:
@@ -41993,16 +41925,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stream-browserify@npm:^2.0.1":
-  version: 2.0.2
-  resolution: "stream-browserify@npm:2.0.2"
-  dependencies:
-    inherits: "npm:~2.0.1"
-    readable-stream: "npm:^2.0.2"
-  checksum: 10/aeb28368310162210f011eb7c73fdf455c22f226de9f95d600bd0616afbeba7bca8e47524f404695765732a9431115585e16b61b3cfa9c8c5770d7baa2467be3
-  languageName: node
-  linkType: hard
-
 "stream-browserify@npm:^3.0.0":
   version: 3.0.0
   resolution: "stream-browserify@npm:3.0.0"
@@ -42034,19 +41956,6 @@ __metadata:
     consumable-stream: "npm:^3.0.0"
     writable-consumable-stream: "npm:^4.1.0"
   checksum: 10/279ac7cf42498d81b6cd8c05a45e8f3537b63a32116eb0c9c2d3358280a616d33d039b9ee96e2fdcb98d54a624f6606eaa06f2f53db6066f8af51648d6a83629
-  languageName: node
-  linkType: hard
-
-"stream-http@npm:^2.7.2":
-  version: 2.8.3
-  resolution: "stream-http@npm:2.8.3"
-  dependencies:
-    builtin-status-codes: "npm:^3.0.0"
-    inherits: "npm:^2.0.1"
-    readable-stream: "npm:^2.3.6"
-    to-arraybuffer: "npm:^1.0.0"
-    xtend: "npm:^4.0.0"
-  checksum: 10/b8ecb9c05f2fa7a6def0747ae5837d3290a5fa5c08c5f29def96cceda0b4a7e4d30faedbe287d272512fe6604268b571fdc883361dc01ad50fe31f58bb1770f4
   languageName: node
   linkType: hard
 
@@ -43361,13 +43270,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"to-arraybuffer@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "to-arraybuffer@npm:1.0.1"
-  checksum: 10/31433c10b388722729f5da04c6b2a06f40dc84f797bb802a5a171ced1e599454099c6c5bc5118f4b9105e7d049d3ad9d0f71182b77650e4fdb04539695489941
-  languageName: node
-  linkType: hard
-
 "to-buffer@npm:^1.2.0, to-buffer@npm:^1.2.2":
   version: 1.2.2
   resolution: "to-buffer@npm:1.2.2"
@@ -43788,13 +43690,6 @@ __metadata:
   bin:
     ttf2woff: ttf2woff.js
   checksum: 10/c8fca24616e1d4356c4141c7ec2e3d7f839185b7b6f3baf0bfb13f2eebba64e5ab3620f9f882161ac71e7c36980a70c6fc2548599ea2f66876e5947acaf65765
-  languageName: node
-  linkType: hard
-
-"tty-browserify@npm:0.0.0":
-  version: 0.0.0
-  resolution: "tty-browserify@npm:0.0.0"
-  checksum: 10/a06f746acc419cb2527ba19b6f3bd97b4a208c03823bfb37b2982629d2effe30ebd17eaed0d7e2fc741f3c4f2a0c43455bd5fb4194354b378e78cfb7ca687f59
   languageName: node
   linkType: hard
 
@@ -44723,7 +44618,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"url@npm:^0.11.0, url@npm:^0.11.4":
+"url@npm:^0.11.4":
   version: 0.11.4
   resolution: "url@npm:0.11.4"
   dependencies:
@@ -44817,24 +44712,6 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10/474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
-  languageName: node
-  linkType: hard
-
-"util@npm:0.10.3":
-  version: 0.10.3
-  resolution: "util@npm:0.10.3"
-  dependencies:
-    inherits: "npm:2.0.1"
-  checksum: 10/648120d93dbbd82e677cda9af564a8cc95b93f3b488355f67f02ba27c15cca17b89f2a465b576c38ce8b9f542d5041cae23277be7e30ee6fbf819610d645efb5
-  languageName: node
-  linkType: hard
-
-"util@npm:^0.11.0":
-  version: 0.11.1
-  resolution: "util@npm:0.11.1"
-  dependencies:
-    inherits: "npm:2.0.3"
-  checksum: 10/03c26d737705c6173ace351e9b429cb9a2839dee38016ffb49eac88fb629322e300c85ff381ff31034745f56c755b5f81b752f93738d54510484d0f72bfe7a57
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

When I tried to resolve `punycode` deprecation warnings, I've found out that we use six-years-unupdated lib `node-libs-browser` with many deprecated dependencies as well. Given that it seems [not doing anything important](https://github.com/webpack/node-libs-browser/blob/master/index.js), I've tried to replace it with its dependencies themselves, but only the used ones.

## What to discuss

- `process` was allegedly used as a polyfill (https://github.com/trezor/trezor-suite/pull/11523/files#r1519412045) so I've added it as a direct dependency
- even if `url` transitive dependency is not directly used by us, it's used in `micro-ftch` which is a dependency of `@ethereumjs/util` so it must be either a) added as an unused dependency of connect package and ignored in `.depcheckrc` (which is basically status quo), or b) added as an unresolved fallback into `base.webpack.config.ts` which I did, but it may break eth logic in some cases? Dunno.
- which team should be responsible for new dependencies (previously transitive dependencies of `node-libs-browser`)? For now I've just left them to trade as they were responsible for `node-libs-browser` anyway.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/node-libs-browser&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/node-libs-browser&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/node-libs-browser&lookback=7)