### PR TITLE
feat: add DeviceItem into the Onboarding (reuse from ViewOnlyPromo)

### DIFF
--- a/packages/suite/src/components/onboarding/OnboardingLayout.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingLayout.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 
 import { selectBannerMessage } from '@suite-common/message-system';
 import { Button, variables } from '@trezor/components';
-import { TrezorLogo } from '@trezor/product-components';
 import { spacings, spacingsPx, zIndices } from '@trezor/theme';
 import { TREZOR_SUPPORT_URL } from '@trezor/urls';
 
@@ -16,6 +15,7 @@ import { MAX_ONBOARDING_WIDTH } from 'src/constants/suite/layout';
 import { useSelector } from 'src/hooks/suite';
 import { ModalContextProvider } from 'src/support/suite/ModalContext';
 
+import { SmallDeviceItem } from '../../views/suite/SwitchDevice/DeviceItem/SmallDeviceItem';
 import { TrafficLightOffset } from '../suite/TrafficLightOffset';
 import { DebugLegend } from '../suite/layouts/SuiteLayout/DebugLegend';
 
@@ -132,7 +132,7 @@ export const OnboardingLayout = ({ children }: OnboardingLayoutProps) => {
                             <ContentWrapper id="layout-scroll">
                                 <Header>
                                     <LogoHeaderRow>
-                                        <TrezorLogo type="suite" width="128px" />
+                                        <SmallDeviceItem />
 
                                         <Button
                                             variant="tertiary"

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/SmallDeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/SmallDeviceItem.tsx
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+
+import { DEFAULT_FLAGSHIP_MODEL } from '@suite-common/suite-constants';
+import { selectDeviceLabelOrNameById, selectSelectedDevice } from '@suite-common/wallet-core';
+import { Image, Row } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
+import { DeviceConnectionText } from './DeviceConnectionText';
+import { DeviceDetail } from './DeviceDetail';
+import { Translation } from '../../../../components/suite';
+import { useSelector } from '../../../../hooks/suite';
+
+// eslint-disable-next-line local-rules/no-override-ds-component
+const DeviceImage = styled(Image)`
+    object-fit: contain;
+`;
+
+const SmallDeviceImage = styled(DeviceImage)`
+    width: 18px;
+`;
+
+type SmallDeviceItemProps = {
+    forceAlternativeDeviceLabel?: string;
+};
+
+export const SmallDeviceItem = ({ forceAlternativeDeviceLabel }: SmallDeviceItemProps) => {
+    const selectedDevice = useSelector(selectSelectedDevice);
+    const selectedDeviceModelInternal =
+        selectedDevice?.features?.internal_model || DEFAULT_FLAGSHIP_MODEL;
+    const deviceLabel = useSelector(state =>
+        selectDeviceLabelOrNameById(state, selectedDevice?.id),
+    );
+
+    return (
+        <Row
+            gap={spacings.xs}
+            padding={{ vertical: spacings.xs, horizontal: spacings.xs }}
+            alignItems="center"
+        >
+            <SmallDeviceImage alt="Trezor" image={`TREZOR_${selectedDeviceModelInternal}`} />
+
+            <DeviceDetail label={forceAlternativeDeviceLabel ?? deviceLabel}>
+                <DeviceConnectionText icon="link" variant="primary">
+                    <Translation id="TR_CONNECTED" />
+                </DeviceConnectionText>
+            </DeviceDetail>
+        </Row>
+    );
+};

--- a/packages/suite/src/views/view-only/ViewOnlyPromoContent.tsx
+++ b/packages/suite/src/views/view-only/ViewOnlyPromoContent.tsx
@@ -27,8 +27,7 @@ import { PriceChartLine } from './images/PriceChartLine';
 import { setFlag } from '../../actions/suite/suiteActions';
 import { FormattedCryptoAmount, Translation } from '../../components/suite';
 import { useDispatch, useSelector } from '../../hooks/suite';
-import { DeviceConnectionText } from '../suite/SwitchDevice/DeviceItem/DeviceConnectionText';
-import { DeviceDetail } from '../suite/SwitchDevice/DeviceItem/DeviceDetail';
+import { SmallDeviceItem } from '../suite/SwitchDevice/DeviceItem/SmallDeviceItem';
 
 const Callout = styled.div`
     display: flex;
@@ -58,10 +57,6 @@ const DeviceImage = styled(Image)`
     object-fit: contain;
 `;
 
-const SmallDeviceImage = styled(DeviceImage)`
-    width: 18px;
-`;
-
 const LargeDeviceImage = styled(DeviceImage)`
     width: 93px;
 `;
@@ -78,14 +73,6 @@ const LargeDeviceImageContainer = styled.div`
     @media (max-width: ${variables.SCREEN_SIZE.SM}) {
         padding: ${spacingsPx.zero} ${spacingsPx.lg} ${spacingsPx.sm};
     }
-`;
-
-const DeviceItem = styled.div`
-    display: flex;
-    flex-direction: row;
-    gap: ${spacingsPx.xs};
-    padding: ${spacingsPx.xs};
-    align-items: center;
 `;
 
 const StyledGrayTop = styled.div<{ $elevation: Elevation }>`
@@ -162,18 +149,8 @@ const Top = () => {
             <ElevationContext baseElevation={elevation}>
                 <MacWindow>
                     <WindowGrayTop>
-                        <DeviceItem>
-                            <SmallDeviceImage
-                                alt="Trezor"
-                                image={`TREZOR_${selectedDeviceModelInternal}`}
-                            />
-
-                            <DeviceDetail label="My Trezor">
-                                <DeviceConnectionText icon="link" variant="primary">
-                                    <Translation id="TR_CONNECTED" />
-                                </DeviceConnectionText>
-                            </DeviceDetail>
-                        </DeviceItem>
+                        {/* Use forceAlternativeDeviceLabel to indicate to the user, that this is just an example, and not theirs actual Trezor */}
+                        <SmallDeviceItem forceAlternativeDeviceLabel="My Trezor" />
                     </WindowGrayTop>
                     <WindowChart>
                         <ChartText>


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/18377

![image](https://github.com/user-attachments/assets/f28c53a1-148d-4527-8078-921085a3154d)
![image](https://github.com/user-attachments/assets/1203359e-8dc2-48ff-a3cf-35a5dd56abb6)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=add-device-component-to-onboarding&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=add-device-component-to-onboarding&lookback=7)