### PR TITLE
Add basic cooldown for retry button in TransactionReviewOutputTimer

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputTimer.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputTimer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 
 import styled from 'styled-components';
 
@@ -6,6 +6,8 @@ import { Badge, Banner, Button, Text } from '@trezor/components';
 
 import { CountdownTimer } from 'src/components/suite/CountdownTimer';
 import { Translation } from 'src/components/suite/Translation';
+
+const RETRY_THROTTLE_TIMEOUT_MS = 3000;
 
 const TimerBox = styled.div`
     font-variant-numeric: tabular-nums;
@@ -24,6 +26,19 @@ export const TransactionReviewOutputTimer = ({
     onTryAgain,
     isSending,
 }: TransactionReviewOutputTimerProps) => {
+    const lastRetryRef = useRef<number>(0);
+
+    const handleTryAgain = () => {
+        const now = Date.now();
+
+        if (now - lastRetryRef.current < RETRY_THROTTLE_TIMEOUT_MS) {
+            return;
+        }
+
+        lastRetryRef.current = now;
+        onTryAgain(true);
+    };
+
     if (isMinimal) {
         return (
             <>
@@ -33,7 +48,7 @@ export const TransactionReviewOutputTimer = ({
                     type="button"
                     size="tiny"
                     isDisabled={isSending}
-                    onClick={() => onTryAgain(true)}
+                    onClick={handleTryAgain}
                 >
                     <Translation id="TR_RETRY" />
                 </Button>


### PR DESCRIPTION
## Description

Added a throttle mechanism to limit the use of the repeat button within the TransactionReviewOutputTimer to once every 3 seconds.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17950

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/timer-retry-throttle&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/timer-retry-throttle&lookback=7)