### PR TITLE
chore(suite, suite-data): add typecheck for messages

### DIFF
--- a/packages/suite-data/src/translations/backport-en.ts
+++ b/packages/suite-data/src/translations/backport-en.ts
@@ -38,7 +38,11 @@ fs.writeFileSync(
     `
 import { defineMessages } from 'react-intl';
 
-export default defineMessages(${JSON.stringify(messages, null, 2).replace(/"([^"]+)":/g, '$1:')})
+import { typeCheckMessages } from './typeCheckMessages';
+
+const messages = typeCheckMessages(${JSON.stringify(messages, null, 2).replace(/"([^"]+)":/g, '$1:')})
+
+export default defineMessages(messages);
 
 `,
 );

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -7,7 +7,7 @@
         "lint": "yarn lint:styles && yarn lint:js",
         "lint:styles": "npx stylelint './src/**/*{.ts,.tsx}' --cache --config ../../.stylelintrc",
         "translations:format": "yarn g:prettier --write \"../suite-data/files/translations/*\"",
-        "translations:extract": "formatjs extract src/support/messages.ts --format simple > ../suite-data/files/translations/master.json",
+        "translations:extract": "formatjs extract src/support/messages.ts --format simple --additional-function-names typeCheckMessages > ../suite-data/files/translations/master.json",
         "translations:upload": "crowdin upload",
         "translations:download": "crowdin download --all",
         "translations:backport-en": "yarn g:tsx ../suite-data/src/translations/backport-en.ts && yarn g:prettier --write \"./src/support/messages.ts\"",

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1,6 +1,8 @@
 import { defineMessages } from 'react-intl';
 
-export default defineMessages({
+import { typeCheckMessages } from './typeCheckMessages';
+
+const messages = typeCheckMessages({
     TR_404_DESCRIPTION: {
         defaultMessage: 'Looks like a wrong URL or broken link.',
         id: 'TR_404_DESCRIPTION',
@@ -8891,7 +8893,7 @@ export default defineMessages({
         id: 'TR_STAKE_WHAT_IS_STAKING',
         defaultMessage: 'What is staking?',
     },
-    TR_STAKE_NETWORK_STAKING_IS: {
+    TR_STAKE_STAKING_IS: {
         id: 'TR_STAKE_STAKING_IS',
         defaultMessage:
             "Staking involves temporarily locking your {symbol} to support the blockchain's operation. In return, you'll earn additional {symbol} as a reward.",
@@ -9828,3 +9830,5 @@ export default defineMessages({
         defaultMessage: 'Requested networks',
     },
 });
+
+export default defineMessages(messages);

--- a/packages/suite/src/support/typeCheckMessages.ts
+++ b/packages/suite/src/support/typeCheckMessages.ts
@@ -12,6 +12,6 @@ type MessageDescriptor<K extends string> = {
 /**
 Checks whether id corresponds to the property name. Otherwise, text is not translated. Returns the same value that was passed in.
  */
-export const defineMessagesWithTypeCheck = <Key extends string>(messages: {
+export const typeCheckMessages = <Key extends string>(messages: {
     [K in Key]: MessageDescriptor<K>;
 }) => messages;

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
@@ -105,7 +105,7 @@ export const EmptyStakingCard = () => {
                         </Text>
                         <Paragraph variant="tertiary">
                             <Translation
-                                id="TR_STAKE_NETWORK_STAKING_IS"
+                                id="TR_STAKE_STAKING_IS"
                                 values={{
                                     symbol: displaySymbol,
                                 }}


### PR DESCRIPTION
My next attempt at https://github.com/trezor/trezor-suite/pull/15347/files#diff-988baecac61429698981f7b86b979d1627f33f484918f65402c4b345b5c57cba. The original solution caused deletion of the Crowdin database because `formatjs` couldn't parse the file due to renaming of the function. Let's see if the additional parametr to the `formatjs` command solves this.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/react-intl-ts&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/react-intl-ts&lookback=7)