### PR TITLE
feat(suite): display walletconnect validation status

### DIFF
--- a/packages/components/src/components/Badge/Badge.stories.tsx
+++ b/packages/components/src/components/Badge/Badge.stories.tsx
@@ -28,6 +28,7 @@ export const Badge: StoryObj<BadgeProps> = {
                 'tertiary',
                 'destructive',
                 'warning',
+                'info',
                 undefined,
             ] satisfies BadgeProps['variant'][],
         },

--- a/packages/components/src/components/Badge/Badge.tsx
+++ b/packages/components/src/components/Badge/Badge.tsx
@@ -21,7 +21,10 @@ export type BadgeSize = Extract<UISize, (typeof badgeSizes)[number]>;
 export const allowedBadgeFrameProps = ['margin'] as const satisfies FramePropsKeys[];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedBadgeFrameProps)[number]>;
 
-export type BadgeVariant = Extract<UIVariant, 'primary' | 'tertiary' | 'destructive' | 'warning'>;
+export type BadgeVariant = Extract<
+    UIVariant,
+    'primary' | 'tertiary' | 'destructive' | 'warning' | 'info'
+>;
 
 export type BadgeProps = AllowedFrameProps & {
     size?: BadgeSize;
@@ -55,6 +58,7 @@ const mapVariantToBackgroundColor = ({ $variant, $onElevation, theme }: MapArgs)
         tertiary: `backgroundNeutralSubtleOnElevation${$onElevation ? 1 : 0}`,
         destructive: 'backgroundAlertRedSubtleOnElevation0',
         warning: 'backgroundAlertYellowSubtleOnElevation0',
+        info: 'backgroundAlertBlueSubtleOnElevation0',
     };
 
     return theme[colorMap[$variant]];
@@ -66,6 +70,7 @@ const mapVariantToTextColor = ({ $variant, theme }: MapArgs): CSSColor => {
         tertiary: 'textSubdued',
         destructive: 'textAlertRed',
         warning: 'textAlertYellow',
+        info: 'textAlertBlue',
     };
 
     return theme[colorMap[$variant]];
@@ -77,6 +82,7 @@ const mapVariantToIconColor = ({ $variant, theme }: MapArgs): CSSColor => {
         tertiary: 'iconSubdued',
         destructive: 'iconAlertRed',
         warning: 'iconAlertYellow',
+        info: 'iconAlertBlue',
     };
 
     return theme[colorMap[$variant]];

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -462,9 +462,17 @@ export const saveEntropyCheckFail = () => async (_dispatch: Dispatch, getState: 
 
 export const saveConnectSettings = () => async (_dispatch: Dispatch, getState: GetState) => {
     if (!(await db.isAccessible())) return;
-    const { connectPopup } = getState();
+    const { connectPopup, walletConnect } = getState();
 
-    db.addItem('connect', { permissions: connectPopup.permissions }, 'connect', true);
+    db.addItem(
+        'connect',
+        {
+            permissions: connectPopup.permissions,
+            walletConnectSessions: walletConnect.sessions,
+        },
+        'connect',
+        true,
+    );
 };
 
 export const removeDatabase = () => async (dispatch: Dispatch, getState: GetState) => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
@@ -7,12 +7,12 @@ import {
 } from '@suite-common/walletconnect';
 import { PendingConnectionProposalNetwork } from '@suite-common/walletconnect/src/walletConnectTypes';
 import {
+    Badge,
     Banner,
     Card,
     Column,
     IconCircle,
     NewModal,
-    Note,
     Row,
     Text,
     Tooltip,
@@ -110,21 +110,21 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                             <Row gap={spacings.sm}>
                                 {!pendingProposal.isScam &&
                                     pendingProposal.validation === 'VALID' && (
-                                        <Note variant="info" iconName="shieldCheckFilled">
+                                        <Badge variant="info" icon="shieldCheckFilled">
                                             <Translation id="TR_WALLETCONNECT_SERVICE_VERIFIED" />
-                                        </Note>
+                                        </Badge>
                                     )}
                                 {!pendingProposal.isScam &&
                                     pendingProposal.validation === 'UNKNOWN' && (
-                                        <Note variant="warning" iconName="shieldWarningFilled">
+                                        <Badge variant="warning" icon="shieldWarningFilled">
                                             <Translation id="TR_WALLETCONNECT_SERVICE_UNKNOWN" />
-                                        </Note>
+                                        </Badge>
                                     )}
                                 {(pendingProposal.isScam ||
                                     pendingProposal.validation === 'INVALID') && (
-                                    <Note variant="destructive" iconName="shieldWarningFilled">
+                                    <Badge variant="destructive" icon="shieldWarningFilled">
                                         <Translation id="TR_WALLETCONNECT_SERVICE_DANGEROUS" />
-                                    </Note>
+                                    </Badge>
                                 )}
                             </Row>
                         </Column>

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -24,6 +24,7 @@ import {
     updateTxsFiatRatesThunk,
 } from '@suite-common/wallet-core';
 import { findAccountDevice } from '@suite-common/wallet-utils';
+import { walletConnectActions } from '@suite-common/walletconnect';
 
 import { WALLET_SETTINGS } from 'src/actions/settings/constants';
 import * as walletSettingsActions from 'src/actions/settings/walletSettingsActions';
@@ -220,6 +221,8 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 isAnyOf(
                     connectPopupActions.rememberAppPermissions,
                     connectPopupActions.forgetAppPermissions,
+                    walletConnectActions.saveSession,
+                    walletConnectActions.removeSession,
                 )(action)
             ) {
                 api.dispatch(storageActions.saveConnectSettings());

--- a/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectList.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectList.tsx
@@ -8,7 +8,7 @@ import {
     PendingConnectionProposalNetwork,
     WalletConnectSession,
 } from '@suite-common/walletconnect/src/walletConnectTypes';
-import { Card, Column, Dropdown, H3, IconCircle, Row, Text } from '@trezor/components';
+import { Badge, Card, Column, Dropdown, H3, IconCircle, Row, Text } from '@trezor/components';
 import { spacings, spacingsPx } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
@@ -78,6 +78,21 @@ export const WalletConnectList = () => {
                             <Row gap={spacings.sm}>
                                 <Text>{session.peer.metadata.name}</Text>
                                 <Text variant="tertiary">{session.peer.metadata.url}</Text>
+                                {session.validation === 'VALID' && (
+                                    <Badge variant="info" icon="shieldCheckFilled">
+                                        <Translation id="TR_WALLETCONNECT_SERVICE_VERIFIED" />
+                                    </Badge>
+                                )}
+                                {session.validation === 'UNKNOWN' && (
+                                    <Badge variant="warning" icon="shieldWarningFilled">
+                                        <Translation id="TR_WALLETCONNECT_SERVICE_UNKNOWN" />
+                                    </Badge>
+                                )}
+                                {session.validation === 'INVALID' && (
+                                    <Badge variant="destructive" icon="shieldWarningFilled">
+                                        <Translation id="TR_WALLETCONNECT_SERVICE_DANGEROUS" />
+                                    </Badge>
+                                )}
                             </Row>
 
                             <Text variant="tertiary">

--- a/suite-common/walletconnect/src/walletConnectReducer.ts
+++ b/suite-common/walletconnect/src/walletConnectReducer.ts
@@ -1,3 +1,5 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 
 import { walletConnectActions } from './walletConnectActions';
@@ -12,6 +14,12 @@ type WalletConnectStateRootState = {
     walletConnect: WalletConnectState;
 };
 
+type StorageActionPayload = {
+    connect: {
+        walletConnectSessions: WalletConnectSession[];
+    };
+};
+
 const walletConnectInitialState: WalletConnectState = {
     sessions: [],
     pendingProposal: undefined,
@@ -19,8 +27,15 @@ const walletConnectInitialState: WalletConnectState = {
 
 export const prepareWalletConnectReducer = createReducerWithExtraDeps(
     walletConnectInitialState,
-    (builder, _extra) => {
+    (builder, extra) => {
         builder
+            .addCase(
+                extra.actionTypes.storageLoad,
+                (state, { payload }: PayloadAction<StorageActionPayload>) => {
+                    if (payload.connect?.walletConnectSessions)
+                        state.sessions = payload.connect.walletConnectSessions;
+                },
+            )
             .addCase(walletConnectActions.saveSession, (state, { payload }) => {
                 const { topic, ...rest } = payload;
                 const exists = state.sessions.find(session => session.topic === topic);


### PR DESCRIPTION
## Description

Display WalletConnect validation status in Suite settings. 
To do that we need to start persisting sessions in storage, because the validation status is lost when loading them again from WalletConnect. 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/walletconnect-persist-metadata&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/walletconnect-persist-metadata&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/walletconnect-persist-metadata&lookback=7)