### PR TITLE
fix(suite-data): correctly detect mobile chrome

### DIFF
--- a/packages/suite-data/src/browser-detection/index.ts
+++ b/packages/suite-data/src/browser-detection/index.ts
@@ -155,6 +155,12 @@ window.addEventListener('load', () => {
             version: 92,
             mobile: true,
         },
+        // in UAParser v2, chrome is differently identified between desktop & mobile version
+        {
+            name: 'mobilechrome',
+            version: 92,
+            mobile: true,
+        },
         {
             name: 'firefox',
             version: 102,


### PR DESCRIPTION
## Description

Hotfix for bug caused by bumping UAParser, where Suite-Web fails to detect mobile chrome as a supported browser, and display the screen below.

**Note:** [UAParser breaking change described here](https://github.com/faisalman/ua-parser-js/blob/master/CHANGELOG.md#whats-breaking) but it's very misleading. Nowhere on the documentation in mentions that the actual return of [getBrowser().name](https://github.com/trezor/trezor-suite/blob/b3deeb546bbaf4bef500ea78bdfbaf4eb26cc755/packages/env-utils/src/envUtils.ts#L64-L68) is `'mobilechrome'`, instead [they write](https://docs.uaparser.dev/info/browser/name/mobile-chrome.html) `'Mobile Chrome'`

<img src="https://github.com/user-attachments/assets/77d5417e-c469-4edd-b59e-642b43a5fa2d" width="250" />

## QA instructions

- open Suite Web on Android: should work as usually (without the screen above)