### PR TITLE
feat(suite-desktop): force app update through stagingPercentage on manual action

### DIFF
--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -44,7 +44,7 @@
         "chalk": "^4.1.2",
         "electron-localshortcut": "^3.2.1",
         "electron-store": "8.2.0",
-        "electron-updater": "6.6.2",
+        "electron-updater": "6.6.3",
         "openpgp": "^6.1.0",
         "systeminformation": "^5.25.11",
         "ws": "^8.18.0"

--- a/packages/suite-desktop-core/src/modules/auto-updater.ts
+++ b/packages/suite-desktop-core/src/modules/auto-updater.ts
@@ -66,6 +66,15 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
     // You may turn this on for dev purposes, see docs/releases/desktop_updates.md
     autoUpdater.forceDevUpdateConfig = false;
 
+    // electron-updater always checks if user is within stagingPercentage rollout, but it offers
+    // possibility to override the default behavior. This wraps the original function, bypassing it if `isManualCheck`
+    const isUserWithinRolloutDefaultMethod = autoUpdater.isUserWithinRollout;
+    autoUpdater.isUserWithinRollout = async updateInfo =>
+        isManualCheck === true
+            ? // do not force if it is set to exactly 0, so we can completely stop distributing a release in case of trouble
+              updateInfo.stagingPercentage !== 0
+            : await isUserWithinRolloutDefaultMethod(updateInfo);
+
     const updateSettings = store.getUpdateSettings();
     let allowPrerelease = preReleaseFlag || updateSettings.allowPrerelease;
     let { isAutomaticUpdateEnabled } = updateSettings;

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -25,7 +25,7 @@
         "blake-hash": "^2.0.0",
         "electron-localshortcut": "^3.2.1",
         "electron-store": "8.2.0",
-        "electron-updater": "6.6.2",
+        "electron-updater": "6.6.3",
         "openpgp": "^6.1.0",
         "usb": "^2.15.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11983,7 +11983,7 @@ __metadata:
     electron: "npm:35.1.2"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:8.2.0"
-    electron-updater: "npm:6.6.2"
+    electron-updater: "npm:6.6.3"
     fs-extra: "npm:^11.2.0"
     glob: "npm:^10.3.10"
     jest-diff: "npm:^29.7.0"
@@ -12039,7 +12039,7 @@ __metadata:
     electron-builder: "npm:26.0.3"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:8.2.0"
-    electron-updater: "npm:6.6.2"
+    electron-updater: "npm:6.6.3"
     glob: "npm:^10.3.10"
     openpgp: "npm:^6.1.0"
     usb: "npm:^2.15.0"
@@ -16706,6 +16706,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"builder-util-runtime@npm:9.3.2":
+  version: 9.3.2
+  resolution: "builder-util-runtime@npm:9.3.2"
+  dependencies:
+    debug: "npm:^4.3.4"
+    sax: "npm:^1.2.4"
+  checksum: 10/79a2dc9848d0ade00a1f2350d4b338e46e1f1a2002d92a9978205bf66f0fc3a0822d550c4ea59f79bc5ea9de5a3299f124d8c322ecd503045a5385691e038055
+  languageName: node
+  linkType: hard
+
 "builder-util@npm:26.0.1":
   version: 26.0.1
   resolution: "builder-util@npm:26.0.1"
@@ -20423,11 +20433,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-updater@npm:6.6.2":
-  version: 6.6.2
-  resolution: "electron-updater@npm:6.6.2"
+"electron-updater@npm:6.6.3":
+  version: 6.6.3
+  resolution: "electron-updater@npm:6.6.3"
   dependencies:
-    builder-util-runtime: "npm:9.3.1"
+    builder-util-runtime: "npm:9.3.2"
     fs-extra: "npm:^10.1.0"
     js-yaml: "npm:^4.1.0"
     lazy-val: "npm:^1.0.5"
@@ -20435,7 +20445,7 @@ __metadata:
     lodash.isequal: "npm:^4.5.0"
     semver: "npm:^7.6.3"
     tiny-typed-emitter: "npm:^2.1.0"
-  checksum: 10/9524a9ee873a582310f23dc406863dbb1525895631b8c8bad708ad2f90e7c5ac11ff8f55b741c342188f7811a20a7c1c43411351c4ed3abe7379efdebc479c0b
+  checksum: 10/45dc13b1cc5d6ccd650b465117c49bf9d8beb6aa489d5ab422bdd8576149fae1aa94eb74c0f6c10caf24db7c095115f5c5bc8f4ac671eb9e7e0ac8094e5473ea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

After https://github.com/electron-userland/electron-builder/pull/9016 , bump `electron-updater` and use the new interface:
- force app update through staging percentage rollout logic when it is checked manually
- unless the `stagingPercentage` is exactly 0 ([required here](https://github.com/trezor/trezor-suite/issues/11676#issuecomment-2573167929))


## Related Issue

Resolve #11676

## Screenshots:

With locally mocked `latest,yml` on [a testing branch](https://github.com/trezor/trezor-suite/commit/d144dcdcb8e58c311233ab536f128174f6a5f49c), using [these instructions](https://github.com/trezor/trezor-suite/blob/4554a03a3c5093a9006b7ebf44781eb4238016bf/docs/releases/desktop_updates.md#development), this is how it behaves with different `stagingPercentage`:

stagingPercentage = 100, the download is offerred automatically (same as currently):
[fully released with 100.webm](https://github.com/user-attachments/assets/9f6bfd51-0638-4985-9c24-b1cfc2a20ed3)

stagingPercentage = 1, so I am not within the rollout, but I can force the update by checking manually:
[force update through 1.webm](https://github.com/user-attachments/assets/616dc319-bcbe-4ee0-bb06-2285e5501fb0)

stagingPercentage = 0, so the update is blocked (same as currently):
[cant force update through 0.webm](https://github.com/user-attachments/assets/987114c8-43d1-4b3e-81ed-f22278f2e260)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/force-desktop-update&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/force-desktop-update&lookback=7)