### PR TITLE
feat(suite): more process info in connect ws

### DIFF
--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -70,7 +70,8 @@ export class CoreInSuiteDesktop implements ConnectFactoryDependencies<ConnectSet
                     },
                 },
                 {
-                    timeout: 1000,
+                    // can take a while on slower machines due to loading process info
+                    timeout: 3000,
                 },
             );
 

--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -106,7 +106,7 @@ export class CoreInSuiteDesktop implements ConnectFactoryDependencies<ConnectSet
         this._settings = newSettings;
 
         try {
-            const ws = new WebsocketClient({ url: 'ws://localhost:21335/connect-ws' });
+            const ws = new WebsocketClient({ url: 'ws://127.0.0.1:21335/connect-ws' });
             await ws.connect();
             this.ws = ws;
         } catch (err) {

--- a/packages/node-utils/src/findProcessFromIncomingPort.ts
+++ b/packages/node-utils/src/findProcessFromIncomingPort.ts
@@ -24,23 +24,51 @@ function spawnAndCollectStdout(command: string): Promise<string> {
 export type ProcessInfo = {
     name: string;
     pid: string;
-    user: string;
+    fullPath: string;
+    warning?: boolean;
 };
 
-export async function findProcessFromIncomingPort(port: number) {
+export async function findProcessFromIncomingPort(
+    port: number,
+    filterSelf: boolean = false,
+): Promise<ProcessInfo | undefined> {
     switch (process.platform) {
         case 'darwin':
         case 'linux': {
             const command = `lsof -iTCP:${port} -n -P +c0`;
             const stdout = await spawnAndCollectStdout(command);
             const lines = stdout.split('\n');
-            const process = lines.find(line => line.includes(`:${port}`));
-            if (process) {
-                const name = process.split(/\s+/)[0].replace(/\\x\d{2}/g, ' ');
-                const pid = process.split(/\s+/)[1];
-                const user = process.split(/\s+/)[2];
+            const processLine = lines.find(
+                line =>
+                    line.includes(`:${port}`) && // Filter for the target port
+                    (!filterSelf || !line.includes(` ${process.pid} `)), // Filter out self
+            );
+            if (processLine) {
+                const name = processLine.split(/\s+/)[0].replace(/\\x\d{2}/g, ' ');
+                const pid = processLine.split(/\s+/)[1];
 
-                return { name, pid, user };
+                if (process.platform === 'darwin') {
+                    const fullPathCommand = `ps -p ${pid} -o comm=`;
+                    const fullPathRaw = await spawnAndCollectStdout(fullPathCommand);
+                    const fullPath = fullPathRaw.trim();
+                    const appPathRegex = /^(\/Users\/[^/]*)?\/Applications\/([^/]*)\.app\//;
+                    const appPathMatch = fullPath.match(appPathRegex);
+                    if (appPathMatch) {
+                        const appName = appPathMatch[2];
+
+                        return { name: appName, pid, fullPath: appPathMatch[0] };
+                    } else {
+                        // Binary in unusual location, show warning
+                        return { name, pid, fullPath, warning: true };
+                    }
+                } else {
+                    const fullPathCommand = `cat /proc/${pid}/cmdline`;
+                    const fullPathRaw = await spawnAndCollectStdout(fullPathCommand);
+                    const fullPath = fullPathRaw.split('\0')[0].trim();
+                    // Binaries can be all over the place on Linux, so we don't check the path
+
+                    return { name, pid, fullPath };
+                }
             }
 
             return undefined;
@@ -59,14 +87,21 @@ export async function findProcessFromIncomingPort(port: number) {
                 })
                 .find(({ local }) => local.endsWith(`:${port}`));
             if (record) {
-                const processInfo = await spawnAndCollectStdout(
-                    `tasklist /FI "PID eq ${record.pid}" | findstr ${record.pid}`,
-                );
-                const parts = processInfo.split(/\s+/);
-                const name = parts[0];
-                const user = parts[2];
-
-                return { name, pid: record.pid, user };
+                // Extract the app name from the full path on Windows
+                const appInfoCommand = `powershell -Command "(Get-Item (Get-Process -Id ${record.pid}).Path).VersionInfo | ConvertTo-Json"`;
+                const appInfoStdout = await spawnAndCollectStdout(appInfoCommand);
+                const appInfo = JSON.parse(appInfoStdout);
+                const fullPath = appInfo['FileName'];
+                const appName = appInfo['ProductName'];
+                const appPathRegex =
+                    /^(?:[A-Z]:\\(?:Program Files(?: \(x86\))?|Windows(?:\\(?:System32|SysWOW64))?|Users\\[^\\]+\\AppData\\(?:Local(?:\\Programs)?|Roaming))\\[^:*?"<>|\r\n]+\.exe)$/;
+                const appPathMatch = fullPath.match(appPathRegex);
+                if (appPathMatch) {
+                    return { name: appName, pid: record.pid, fullPath };
+                } else {
+                    // Binary in unusual location, show warning
+                    return { name: appName, pid: record.pid, fullPath, warning: true };
+                }
             }
 
             return undefined;

--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -132,7 +132,12 @@ export type ConnectPopupCall = {
     id: string;
     method: string;
     payload: any;
-    processName?: string;
+    process?: {
+        name: string;
+        warning: boolean;
+        fullPath: string;
+        icon?: string;
+    };
     origin: string;
     manifest: {
         appName: string;

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron';
+import { ipcMain, nativeImage } from 'electron';
 import { WebSocketServer } from 'ws';
 
 import {
@@ -10,12 +10,14 @@ import {
     PopupHandshake,
     parseConnectSettings,
 } from '@trezor/connect';
+import { isMacOs, isWindows } from '@trezor/env-utils';
 import { ProcessInfo, findProcessFromIncomingPort } from '@trezor/node-utils';
 import { ConnectPopupResponse } from '@trezor/suite-desktop-api/src/messages';
 import { Deferred, createDeferred, resolveAfter } from '@trezor/utils';
 
 import { createHttpReceiver } from './http-receiver';
 import { Dependencies } from '../modules';
+import { app } from '../typed-electron';
 
 const LOG_PREFIX = 'connect-ws';
 
@@ -56,6 +58,32 @@ const validateIncomingMessage = (message: any): message is IncomingMessage => {
     }
 
     return false;
+};
+
+export const getProcessIcon = async (path: string) => {
+    try {
+        const iconDim = { width: 48, height: 48 };
+        if (isWindows()) {
+            const icon = await app.getFileIcon(path, {
+                size: 'normal',
+            });
+
+            if (icon.isEmpty()) {
+                return undefined;
+            }
+
+            return icon.resize(iconDim).toDataURL();
+        } else if (isMacOs()) {
+            const icon = await nativeImage.createThumbnailFromPath(path, iconDim);
+            if (icon.isEmpty()) {
+                return undefined;
+            }
+
+            return icon.toDataURL();
+        }
+    } catch (error) {
+        logger.warn(LOG_PREFIX, 'Failed to get icon of process - ' + error);
+    }
 };
 
 export const exposeConnectWs = ({
@@ -123,7 +151,12 @@ export const exposeConnectWs = ({
                 return;
             }
             if (message.type === POPUP.HANDSHAKE) {
-                processOnPort = await findProcessFromIncomingPort(port);
+                const filterSelf = !process.env.PLAYWRIGHT_RUN; // ignore own process, unless testing
+                processOnPort = await findProcessFromIncomingPort(port, filterSelf).catch(() => {
+                    logger.error(LOG_PREFIX, 'findProcessFromIncomingPort failed');
+
+                    return undefined;
+                });
                 settings = parseConnectSettings(message.payload.settings);
                 ws.send(JSON.stringify({ id: message.id, type: POPUP.HANDSHAKE, payload: 'ok' }));
             } else if (message.type === POPUP.CLOSED) {
@@ -173,7 +206,12 @@ export const exposeConnectWs = ({
                     method,
                     payload: rest,
                     origin,
-                    processName: processOnPort?.name,
+                    process: {
+                        name: processOnPort.name,
+                        fullPath: processOnPort.fullPath,
+                        warning: !!processOnPort.warning,
+                        icon: await getProcessIcon(processOnPort.fullPath),
+                    },
                     manifest: {
                         appName: settings.manifest.appName,
                         appIcon: settings.manifest.appIcon,
@@ -191,6 +229,12 @@ export const exposeConnectWs = ({
                 );
             }
         });
+        ws.on('close', () => {
+            logger.info(LOG_PREFIX, 'Connection closed');
+        });
+    });
+    wss.on('close', () => {
+        logger.info(LOG_PREFIX, 'Websocket server closed');
     });
 
     httpReceiver.server.on('upgrade', (request, socket, head) => {

--- a/packages/suite/src/components/suite/ConnectProcessLabel.tsx
+++ b/packages/suite/src/components/suite/ConnectProcessLabel.tsx
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+
+import { ConnectProcessInfo } from '@suite-common/connect-popup/src/connectPopupTypes';
+import { Badge, Icon, Row, Text, Tooltip } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
+const AppIcon = styled.img`
+    width: 24px;
+    height: 24px;
+`;
+
+interface ConnectProcessLabelProps {
+    process: ConnectProcessInfo;
+    'data-testid'?: string;
+}
+
+export const ConnectProcessLabel = ({
+    process,
+    'data-testid': dataTest,
+}: ConnectProcessLabelProps) => {
+    if (process.warning) {
+        return (
+            <Tooltip content={process.fullPath}>
+                <Badge variant="warning" icon="warning">
+                    <Text data-testid={dataTest}>{process.name}</Text>
+                </Badge>
+            </Tooltip>
+        );
+    }
+
+    return (
+        <Badge variant="tertiary">
+            <Row gap={spacings.xs}>
+                {process.icon ? (
+                    <AppIcon src={process.icon} alt="Process icon" />
+                ) : (
+                    <Icon name="appWindow" variant="tertiary" />
+                )}
+                <Text data-testid={dataTest}>{process.name}</Text>
+            </Row>
+        </Badge>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import { connectPopupActions, selectConnectPopupCall } from '@suite-common/connect-popup';
 import { CALL_SOURCE_WALLETCONNECT } from '@suite-common/connect-popup/src/connectPopupTypes';
 import {
-    Badge,
     Card,
     Checkbox,
     Column,
@@ -18,6 +17,7 @@ import { ERRORS } from '@trezor/connect';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
+import { ConnectProcessLabel } from 'src/components/suite/ConnectProcessLabel';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { getPermissionText } from 'src/views/settings/SettingsConnectedApps/ConnectPermissions';
 
@@ -90,13 +90,12 @@ export const ConnectPermissionsModal = () => {
                                     <Text>{source.origin}</Text>
                                 )}
                             </Row>
-                            <Row gap={spacings.sm}>
-                                {source.processName && (
-                                    <Badge variant="tertiary" icon="appWindow">
-                                        <Text data-testid="@connect-popup-modal/paragraph-process">
-                                            {source.processName}
-                                        </Text>
-                                    </Badge>
+                            <Row>
+                                {source.process && (
+                                    <ConnectProcessLabel
+                                        process={source.process}
+                                        data-testid="@connect-popup-modal/paragraph-process"
+                                    />
                                 )}
                             </Row>
                         </Column>

--- a/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
@@ -1,10 +1,11 @@
 import styled from 'styled-components';
 
 import { connectPopupActions, selectConnectAppPermissions } from '@suite-common/connect-popup';
-import { Badge, Card, Column, Dropdown, H3, IconCircle, Row, Text } from '@trezor/components';
+import { Card, Column, Dropdown, H3, IconCircle, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
+import { ConnectProcessLabel } from 'src/components/suite/ConnectProcessLabel';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 const PermissionsList = styled.ul`
@@ -78,9 +79,8 @@ export const ConnectPermissions = () => {
                                 ) : (
                                     <Text>{app.origin}</Text>
                                 )}
-                                <Badge variant="tertiary" icon="appWindow">
-                                    {app.processName}
-                                </Badge>
+
+                                {app.process && <ConnectProcessLabel process={app.process} />}
                             </Row>
                             <Text variant="tertiary">
                                 <PermissionsList>

--- a/suite-common/connect-popup/src/connectPopupDesktopThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupDesktopThunks.ts
@@ -17,7 +17,11 @@ export const connectPopupDesktopInitThunk = createThunk(
                         payload: params.payload,
                         source: {
                             type: CALL_SOURCE_DESKTOP_WS,
-                            processName: params.processName ?? 'Unknown',
+                            process: params.process ?? {
+                                name: 'Unknown',
+                                fullPath: 'Unknown',
+                                warning: true,
+                            },
                             origin: params.origin,
                             manifest: params.manifest,
                         },

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -69,7 +69,7 @@ export const connectPopupCallThunkInner = createThunk<
             const isRemembered = rememberedApps.some(
                 app =>
                     app.origin === source.origin &&
-                    app.processName === source.processName &&
+                    app.process?.fullPath === source.process?.fullPath &&
                     methodInfo.payload.requiredPermissions.every((permission: MethodPermission) =>
                         app.types.includes(permission),
                     ),

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -12,22 +12,28 @@ export const CALL_SOURCE_WALLETCONNECT = 'walletconnect';
 export const CALL_SOURCE_DEEPLINK = 'deeplink';
 
 export type ConnectSerializedError = { error: string; code: ErrorCode };
+export type ConnectProcessInfo = {
+    name: string;
+    fullPath: string;
+    icon?: string;
+    warning: boolean;
+};
 export type ConnectCallSource = {
     origin: string;
 } & (
     | {
           type: typeof CALL_SOURCE_DESKTOP_WS;
-          processName: string;
+          process: ConnectProcessInfo;
           manifest: ManifestPartial;
       }
     | {
           type: typeof CALL_SOURCE_WALLETCONNECT;
-          processName?: undefined;
+          process?: undefined;
           manifest: ManifestPartial;
       }
     | {
           type: typeof CALL_SOURCE_DEEPLINK;
-          processName?: undefined;
+          process?: undefined;
           manifest?: undefined;
       }
 );


### PR DESCRIPTION
## Description

Adds support for resolving the full path of processes connecting to the WebSocket.

This is used to determine whether the process originates from a typical install location. If not, a warning is shown to the user. 
The full path is also used to retrieve and display the application's icon. 

Note: `findProcessFromIncomingPort` had an issue where sometimes it would resolve to the own process itself (since it was also on that port and in output of lsof). 
But tests rely on this, so I added a parameter to filter it out only in prod. 

Also I changed `localhost` to `127.0.0.1`, due to some issues with IPv6 in Playwright.

## Screenshots:

<img width="751" alt="Screenshot 2025-04-18 at 10 52 42" src="https://github.com/user-attachments/assets/1d684cb2-ffa7-433b-b2ce-d6bcb6b4aff9" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-connect-ws-process-info&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-connect-ws-process-info&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/suite-connect-ws-process-info&lookback=7)