### PR TITLE
Closing Keyboard on showSheet

### DIFF
--- a/suite-native/module-trading/src/hooks/__tests__/useBottomSheetControls.test.ts
+++ b/suite-native/module-trading/src/hooks/__tests__/useBottomSheetControls.test.ts
@@ -1,8 +1,14 @@
+import { Keyboard } from 'react-native';
+
 import { act, renderHook } from '@suite-native/test-utils';
 
 import { useBottomSheetControls } from '../useBottomSheetControls';
 
 describe('useBottomSheetControls', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     describe('isSheetVisible', () => {
         it('should be false by default', () => {
             const { result } = renderHook(() => useBottomSheetControls());
@@ -10,24 +16,28 @@ describe('useBottomSheetControls', () => {
             expect(result.current.isSheetVisible).toBe(false);
         });
 
-        it('should be true after showTradeableAssetsSheet call', () => {
+        it('should be true after showTradeableAssetsSheet call and Keyboard.dismiss should be called one time', () => {
             const { result } = renderHook(() => useBottomSheetControls());
+            const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
             act(() => {
                 result.current.showSheet();
             });
 
+            expect(keyboardDismissSpy).toHaveBeenCalledTimes(1);
             expect(result.current.isSheetVisible).toBe(true);
         });
 
-        it('should be false after hideTradeableAssetsSheet call', () => {
+        it('should be false after hideTradeableAssetsSheet call and Keyboard.dismiss should be called one time', () => {
             const { result } = renderHook(() => useBottomSheetControls());
+            const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
             act(() => {
                 result.current.showSheet();
                 result.current.hideSheet();
             });
 
+            expect(keyboardDismissSpy).toHaveBeenCalledTimes(1);
             expect(result.current.isSheetVisible).toBe(false);
         });
     });

--- a/suite-native/module-trading/src/hooks/useBottomSheetControls.ts
+++ b/suite-native/module-trading/src/hooks/useBottomSheetControls.ts
@@ -1,9 +1,11 @@
 import { useCallback, useState } from 'react';
+import { Keyboard } from 'react-native';
 
 export const useBottomSheetControls = () => {
     const [isSheetVisible, setIsSheetVisible] = useState(false);
 
     const showSheet = useCallback(() => {
+        Keyboard.dismiss();
         setIsSheetVisible(true);
     }, []);
 


### PR DESCRIPTION
Hello, this is a fix for https://github.com/trezor/trezor-suite/issues/18352. The bug is also reproducible for the component above, so I put Keyboard.dismiss(); into showSheet function. Also, during reproducing the bug, I had an error:

`
 ERROR  Warning: Cannot update a component (`BuyFormFieldErrorBadge`) while rendering a different component (`BuyFormContextProvider`). To locate the bad setState() call inside `BuyFormContextProvider`, follow the stack trace as described in https://react.dev/link/setstate-in-render
`

Resolve #18352
