### PR TITLE
fix(scripts): t3w1 empty config to avoid error

### DIFF
--- a/scripts/ci/check-connect-data.ts
+++ b/scripts/ci/check-connect-data.ts
@@ -42,6 +42,12 @@ const getLatestTimestamp = (timestamps: string[]): string | null => {
     return new Date(latestTime).toISOString();
 };
 
+const emptyAuthenticityConfig = {
+    root_pubkeys: [],
+    ca_pubkeys: [],
+    timestamp: 0,
+};
+
 const updateConfigFromJSON = async () => {
     try {
         const devicesKeys = Object.keys(authenticityPaths) as DeviceModel[];
@@ -54,7 +60,9 @@ const updateConfigFromJSON = async () => {
         for (const deviceKey of devicesKeys) {
             const { authenticity, authenticityDev } = authenticityPaths[deviceKey];
             const authenticityUrl = `${AUTHENTICITY_BASE_URL}/${authenticity}`;
-            const authenticityData = await fetchJSON(authenticityUrl);
+            // TODO: for now we do not have production keys for `T3W1` so we include it empty.
+            const authenticityData =
+                deviceKey === 'T3W1' ? emptyAuthenticityConfig : await fetchJSON(authenticityUrl);
             timestamps.push(authenticityData.timestamp);
             const authenticityDevUrl = `${AUTHENTICITY_BASE_URL}/${authenticityDev}`;
             const authenticityDevData = await fetchJSON(authenticityDevUrl);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The script was broken by PR https://github.com/trezor/trezor-suite/pull/18412 since it was requesting production data for T3W1 that was not available.
I am adding mock empty data for that device until there is not production data for it.

The script will be run next schedule.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/check-connect-data-script-for-t3w1&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/check-connect-data-script-for-t3w1&lookback=7)