### PR TITLE
fix(suite): display bridge-requested view only in suite-desktop

### DIFF
--- a/packages/suite/src/views/suite/bridge-requested/index.tsx
+++ b/packages/suite/src/views/suite/bridge-requested/index.tsx
@@ -11,7 +11,7 @@ import { useDispatch, useLayout } from 'src/hooks/suite';
 import { AutoStart } from 'src/views/settings/SettingsGeneral/AutoStart';
 
 /**
- * This component renders only in desktop version
+ * This component renders only in desktop version - as an explanation why suite-desktop app was opened using a deeplink from suite-web
  */
 export const BridgeRequested = () => {
     const [confirmGoToWallet, setConfirmGoToWallet] = useState(false);
@@ -27,6 +27,11 @@ export const BridgeRequested = () => {
     };
 
     useLayout('Bridge');
+
+    if (!isDesktop()) {
+        // this component doesn't make sense for web.
+        return null;
+    }
 
     if (confirmGoToWallet) {
         return (
@@ -90,18 +95,16 @@ export const BridgeRequested = () => {
                     <Translation id="TR_BRIDGE_REQUESTED_DESCRIPTION" />
                 </Paragraph>
             </Column>
-            {!isDesktop() && (
-                <Card
-                    label={
-                        <Text typographyStyle="label">
-                            <Translation id="TR_BRIDGE_TIP_AUTOSTART" />
-                        </Text>
-                    }
-                    margin={{ top: spacings.xxl }}
-                >
-                    <AutoStart />
-                </Card>
-            )}
+            <Card
+                label={
+                    <Text typographyStyle="label">
+                        <Translation id="TR_BRIDGE_TIP_AUTOSTART" />
+                    </Text>
+                }
+                margin={{ top: spacings.xxl }}
+            >
+                <AutoStart />
+            </Card>
         </NewModal>
     );
 };


### PR DESCRIPTION
before 

![image](https://github.com/user-attachments/assets/16a51f49-2f16-4119-81bc-a9026e9cbcaa)

after 

![image](https://github.com/user-attachments/assets/91bc06e3-4729-4597-a7a4-a3998147c119)

related #18146


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=bridge-requested-only-desktop&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=bridge-requested-only-desktop&lookback=7)