### PR TITLE
test(suite-desktop): split connect-ws.test file per connect method

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/getAddress.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/getAddress.test.ts
@@ -1,0 +1,65 @@
+import TrezorConnect from '@trezor/connect-web';
+
+import { expect, test } from '../../support/fixtures';
+
+test.describe('TrezorConnect.getAddress', { tag: ['@group=suite', '@desktopOnly'] }, () => {
+    test.use({ electronConf: { exposeConnectWs: true } });
+    test.beforeEach(async ({ onboardingPage }) => {
+        await onboardingPage.completeOnboarding();
+        await test.step('Initialize TrezorConnect', async () => {
+            await TrezorConnect.init({
+                manifest: {
+                    appUrl: 'http://localhost:8080',
+                    email: '',
+                    appName: 'Tester',
+                },
+                coreMode: 'suite-desktop',
+                debug: true,
+            });
+        });
+    });
+
+    test('TrezorConnect.getAddress', async ({
+        page,
+        connectPermissionsModal,
+        trezorUserEnvLink,
+    }) => {
+        const res = TrezorConnect.getAddress({
+            path: "m/44'/0'/0'/0/0",
+            coin: 'btc',
+        });
+
+        await connectPermissionsModal.confirmButton.click();
+
+        // export single address
+        await expect(connectPermissionsModal.loadingHeader).toHaveText('Export Bitcoin address');
+        await page.getByTestId('@connect-address-confirmation/verify-button').click();
+        expect(page.getByTestId('@connect-address-confirmation/verify-button')).toBeDisabled();
+        await trezorUserEnvLink.pressYes();
+        // todo: verified badge appears
+
+        expect(await res).toMatchObject({ success: true });
+
+        // export multiple addresses
+        const resMultiple = TrezorConnect.getAddress({
+            bundle: [
+                {
+                    path: "m/44'/0'/0'/0/0",
+                    coin: 'btc',
+                },
+                {
+                    path: "m/44'/0'/0'/0/0",
+                    coin: 'btc',
+                },
+            ],
+        });
+        await connectPermissionsModal.confirmButton.click();
+        await expect(connectPermissionsModal.loadingHeader).toHaveText(
+            'Export multiple Bitcoin addresses',
+        );
+
+        expect(await resMultiple).toMatchObject({ success: true });
+    });
+
+    // todo: use account not available in suite (weird derivation path)
+});

--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/signMessage.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/signMessage.test.ts
@@ -9,7 +9,7 @@ const passThroughPermissions = async (connectPermissionsModal: ConnectPermission
     await connectPermissionsModal.confirmButton.click();
 };
 
-test.describe('TrezorConnect', { tag: ['@group=suite', '@desktopOnly'] }, () => {
+test.describe('TrezorConnect.signMessage', { tag: ['@group=suite', '@desktopOnly'] }, () => {
     test.use({ electronConf: { exposeConnectWs: true } });
     test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
@@ -24,48 +24,6 @@ test.describe('TrezorConnect', { tag: ['@group=suite', '@desktopOnly'] }, () => 
                 debug: true,
             });
         });
-    });
-
-    test('TrezorConnect.getAddress', async ({
-        page,
-        connectPermissionsModal,
-        trezorUserEnvLink,
-    }) => {
-        const res = TrezorConnect.getAddress({
-            path: "m/44'/0'/0'/0/0",
-            coin: 'btc',
-        });
-
-        await passThroughPermissions(connectPermissionsModal);
-
-        // export single address
-        await expect(connectPermissionsModal.loadingHeader).toHaveText('Export Bitcoin address');
-        await page.getByTestId('@connect-address-confirmation/verify-button').click();
-        expect(page.getByTestId('@connect-address-confirmation/verify-button')).toBeDisabled();
-        await trezorUserEnvLink.pressYes();
-        // todo: verified badge appears
-
-        expect(await res).toMatchObject({ success: true });
-
-        // export multiple addresses
-        const resMultiple = TrezorConnect.getAddress({
-            bundle: [
-                {
-                    path: "m/44'/0'/0'/0/0",
-                    coin: 'btc',
-                },
-                {
-                    path: "m/44'/0'/0'/0/0",
-                    coin: 'btc',
-                },
-            ],
-        });
-        await connectPermissionsModal.confirmButton.click();
-        await expect(connectPermissionsModal.loadingHeader).toHaveText(
-            'Export multiple Bitcoin addresses',
-        );
-
-        expect(await resMultiple).toMatchObject({ success: true });
     });
 
     test('TrezorConnect.ethereumSignTransaction', async ({
@@ -121,13 +79,3 @@ test.describe('TrezorConnect', { tag: ['@group=suite', '@desktopOnly'] }, () => 
 
     // todo: use account not available in suite (weird derivation path)
 });
-
-// todo: write tests:
-// - connect request is accepted when all kind of weird stuff is happening
-//   - discovery is in progress
-//   - onboarding is in progress
-//   - recovery/backup is in progress
-//   - device is not connected
-//   - device is used by another application
-//   - device is not initialized, device is in bootloader
-// - permissions, grant, revoke, settings page


### PR DESCRIPTION
🧹 just splitting connect tests to separated files per methods

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-desktop-tests&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-desktop-tests&lookback=7)