### PR TITLE
feat(suite): hide walletconnect for BTC-only

### DIFF
--- a/packages/suite/src/views/settings/SettingsConnectedApps/SettingsConnectedApps.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/SettingsConnectedApps.tsx
@@ -1,29 +1,40 @@
 import { useState } from 'react';
 
+import { selectDevices } from '@suite-common/wallet-core';
+import { selectSessions } from '@suite-common/walletconnect';
 import { Column, Icon, Row, SubTabs } from '@trezor/components';
+import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
 
 import { ConnectPermissions } from './ConnectPermissions';
 import { WalletConnectButton } from './WalletConnectButton';
 import { WalletConnectList } from './WalletConnectList';
 
 export const SettingsConnectedApps = () => {
+    const hasSupportedDevice =
+        useSelector(selectDevices).find(device => !hasBitcoinOnlyFirmware(device)) !== undefined;
+    const hasExistingWalletConnectSessions = useSelector(selectSessions).length > 0;
+    const wcEnabled = hasSupportedDevice || hasExistingWalletConnectSessions;
+
     const tabs = [
         {
             id: 'trezor-connect',
             icon: 'trezorLogo' as const,
             title: <Translation id="TR_TREZOR_CONNECT" />,
             component: <ConnectPermissions />,
+            isEnabled: true,
         },
         {
             id: 'walletconnect',
             icon: 'walletConnect' as const,
             title: <Translation id="TR_WALLETCONNECT" />,
             component: <WalletConnectList />,
+            isEnabled: wcEnabled,
         },
-    ];
+    ].filter(tab => tab.isEnabled);
     const [activeItemdId, setActiveItemId] = useState(tabs[0].id);
 
     return (
@@ -43,7 +54,7 @@ export const SettingsConnectedApps = () => {
                         </SubTabs.Item>
                     ))}
                 </SubTabs>
-                <WalletConnectButton />
+                {wcEnabled && <WalletConnectButton />}
             </Row>
             {tabs.find(tab => tab.id === activeItemdId)?.component}
         </Column>


### PR DESCRIPTION
## Description

Hide WalletConnect tab in Connected Apps settings if only BTC devices are connected and there are no existing sessions.
This prevents confusion (or panic) for BTC-only users.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/hide-walletconnect-btconly&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/hide-walletconnect-btconly&lookback=7)