### PR TITLE
feat(suite): allow push_tx permission in connect popup

### DIFF
--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -44,7 +44,8 @@ export const connectPopupCallThunkInner = createThunk<
             }
             if (
                 methodInfo.payload.requiredPermissions.includes('management') ||
-                methodInfo.payload.requiredPermissions.includes('push_tx')
+                (methodInfo.payload.requiredPermissions.includes('push_tx') &&
+                    source.type === 'deeplink')
             ) {
                 throw TypedError('Method_NotAllowed');
             }


### PR DESCRIPTION
## Description

Allow `push_tx` permission in Connect Popup in Suite, but keep it blocked for mobile deeplinks. 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-connect-allow-pushtx&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-connect-allow-pushtx&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/suite-connect-allow-pushtx&lookback=7)