### PR TITLE
fix: add typecheck for translations, fix mismatch

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -8891,7 +8891,7 @@ export default defineMessages({
         id: 'TR_STAKE_WHAT_IS_STAKING',
         defaultMessage: 'What is staking?',
     },
-    TR_STAKE_NETWORK_STAKING_IS: {
+    TR_STAKE_STAKING_IS: {
         id: 'TR_STAKE_STAKING_IS',
         defaultMessage:
             "Staking involves temporarily locking your {symbol} to support the blockchain's operation. In return, you'll earn additional {symbol} as a reward.",
@@ -9827,4 +9827,4 @@ export default defineMessages({
         id: 'TR_REQUESTED_NETWORKS',
         defaultMessage: 'Requested networks',
     },
-});
+} as const);

--- a/packages/suite/src/support/messagesTypeCheck.ts
+++ b/packages/suite/src/support/messagesTypeCheck.ts
@@ -1,0 +1,15 @@
+import messages from './messages';
+
+/**
+ * This file is here just to be picked up by type-check to check that keys and ids match in `messages.ts`
+ */
+
+type Messages = typeof messages;
+type TranslationKey = keyof Messages;
+type TranslationId = Messages[keyof Messages]['id'];
+
+const functionJustForTypeCheck = (k: TranslationId): TranslationKey => k;
+
+// @ts-expect-error TS6133: Suppress unused variable error;
+// can't do this over the function so that it does not suppress the type check itself
+const _suppressUnusedVariableError = functionJustForTypeCheck;

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
@@ -105,7 +105,7 @@ export const EmptyStakingCard = () => {
                         </Text>
                         <Paragraph variant="tertiary">
                             <Translation
-                                id="TR_STAKE_NETWORK_STAKING_IS"
+                                id="TR_STAKE_STAKING_IS"
                                 values={{
                                     symbol: displaySymbol,
                                 }}


### PR DESCRIPTION
https://github.com/trezor/trezor-suite/pull/18439 doesn't work :(
https://github.com/trezor/trezor-suite/pull/18444 has an effect on performance :(
This is the best solution 🚀 @Lemonexe

Tested [here](https://github.com/trezor/trezor-suite/actions/runs/14593069167/job/40932516563).

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=messages-type-check&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=messages-type-check&lookback=7)