### PR TITLE
Resolved `_core not found`

### DIFF
--- a/packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts
+++ b/packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts
@@ -10,14 +10,18 @@ export const useOpenSuiteDesktop = () => {
     const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
     const windowFocused = useWindowFocus();
     const handleOpenSuite = () => {
-        if (isWebUsbTransport) {
-            (TrezorConnect as typeof TrezorConnectWeb).disableWebUSB();
-        }
+        const iframe = document.createElement('iframe');
+        iframe.style.display = 'none';
+        document.body.appendChild(iframe);
 
-        location.href = SUITE_BRIDGE_DEEPLINK;
+        iframe.src = SUITE_BRIDGE_DEEPLINK;
 
         // fallback in case deeplink does not work
         window.setTimeout(() => {
+            document.body.removeChild(iframe);
+            if (isWebUsbTransport) {
+                (TrezorConnect as typeof TrezorConnectWeb).disableWebUSB();
+            }
             if (!windowFocused.current) return;
 
             window.open(SUITE_URL);


### PR DESCRIPTION
## Description

When opening deeplink by `location.href`, connect considers it `beforeunload` and [disposes itself](https://github.com/trezor/trezor-suite/blob/ba461c3088ff080ceed13186bdcdaad4b794abfb/packages/connect-web/src/module/index.ts#L86). It can be bypassed by opening it from temporary iframe.

Also, when WebUSB is successfully disabled, it rerenders the page and therefore invalidates the focussness of window (detected by `useWindowFocus` hook) and opens fallback page as well as desktop app, which I tried to mitigate by disabling it from inside the timeout callback. Nevertheless, it's still not :100: successful for me. Sometimes both desktop app and fallback page open :man_shrugging:

Should be checked on every platform under various conditions.

## Related Issue

Could resolve Sentry issue https://satoshilabs.sentry.io/issues/6432455614/


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/disable-webusb-core-dispose&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/disable-webusb-core-dispose&lookback=7)