### PR TITLE
feat(suite): ConfirmOnDevice component in connect address confirmation

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectAddressConfirmation.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectAddressConfirmation.tsx
@@ -7,7 +7,7 @@ import {
 } from '@suite-common/connect-popup';
 import { Badge, Button, Card, Column, H3, Icon, Modal, Paragraph, Row } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/device-utils';
-import { mapTrezorModelToIcon } from '@trezor/product-components';
+import { ConfirmOnDevice, mapTrezorModelToIcon } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite/Translation';
@@ -23,11 +23,13 @@ export const ConnectAddressConfirmation = () => {
     const onFinish = () => {
         dispatch(connectPopupActions.finishCall());
     };
+    const isLoading =
+        popupCall?.state === 'address-confirmation' &&
+        popupCall?.addresses.some(address => address.loading);
 
     useEffect(() => {
         // Automatically verify addresses that have showOnDevice enabled and are not already verified
         if (!popupCall || popupCall?.state !== 'address-confirmation') return;
-        const isLoading = popupCall?.addresses.some(address => address.loading);
         const addressToVerify = popupCall?.addresses.findIndex(
             address =>
                 address.validatePayload.showOnTrezor &&
@@ -41,83 +43,93 @@ export const ConnectAddressConfirmation = () => {
                 }),
             );
         }
-    }, [popupCall, dispatch]);
+    }, [popupCall, isLoading, dispatch]);
 
     if (!popupCall || popupCall?.state !== 'address-confirmation') return null;
 
     return (
-        <Modal
-            variant="primary"
-            bottomContent={
-                <>
-                    <Modal.Button
-                        variant="tertiary"
-                        onClick={onFinish}
-                        size="medium"
-                        data-testid="@connect-address-confirmation/close-button"
-                    >
-                        <Translation id="TR_DONE" />
-                    </Modal.Button>
-                </>
-            }
-        >
-            <Column gap={spacings.xs}>
-                <Row alignItems="center" gap={spacings.sm}>
-                    <Icon name="checkCircle" size={32} variant="primary" />
-                    <H3 variant="primary">
-                        <Translation id="TR_CONNECT_ADDRESS_CONFIRMATION_SUCCESS" />
-                    </H3>
-                </Row>
-                <Paragraph>
-                    <Translation id="TR_CONNECT_ADDRESS_CONFIRMATION_DESCRIPTION" />
-                </Paragraph>
+        <Modal.Backdrop>
+            <ConfirmOnDevice
+                title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
+                deviceModelInternal={device?.features?.internal_model}
+                deviceUnitColor={device?.features?.unit_color}
+                isConfirmed={!isLoading}
+            />
+            <Modal.ModalBase
+                variant="primary"
+                bottomContent={
+                    <>
+                        <Modal.Button
+                            variant="tertiary"
+                            onClick={onFinish}
+                            size="medium"
+                            data-testid="@connect-address-confirmation/close-button"
+                        >
+                            <Translation id="TR_DONE" />
+                        </Modal.Button>
+                    </>
+                }
+            >
+                <Column gap={spacings.xs}>
+                    <Row alignItems="center" gap={spacings.sm}>
+                        <Icon name="checkCircle" size={32} variant="primary" />
+                        <H3 variant="primary">
+                            <Translation id="TR_CONNECT_ADDRESS_CONFIRMATION_SUCCESS" />
+                        </H3>
+                    </Row>
+                    <Paragraph>
+                        <Translation id="TR_CONNECT_ADDRESS_CONFIRMATION_DESCRIPTION" />
+                    </Paragraph>
 
-                <Card heading={<Translation id="TR_ADDRESSES" />} margin={{ top: spacings.md }}>
-                    <Column gap={spacings.sm}>
-                        {popupCall?.addresses.map((address, index) => (
-                            <Row
-                                key={index}
-                                alignItems="center"
-                                justifyContent="space-between"
-                                gap={spacings.sm}
-                            >
-                                <Row gap={spacings.sm} alignItems="center" flex="1">
-                                    <Paragraph wordBreak="break-all">{address.address}</Paragraph>
-                                    {address.validated === 'valid' && (
-                                        <Badge variant="primary" icon="check" size="small">
-                                            <Translation id="TR_VERIFIED" />
-                                        </Badge>
-                                    )}
-                                    {address.validated === 'failed' && (
-                                        <Badge variant="warning" icon="warning" size="small">
-                                            <Translation id="TR_ERROR" />
-                                        </Badge>
-                                    )}
-                                </Row>
-                                <Button
-                                    data-testid="@connect-address-confirmation/verify-button"
-                                    variant="tertiary"
-                                    onClick={() => onVerify(index)}
-                                    icon={
-                                        mapTrezorModelToIcon[
-                                            device?.features?.internal_model ||
-                                                DeviceModelInternal.UNKNOWN
-                                        ]
-                                    }
-                                    size="small"
-                                    isLoading={address.loading}
+                    <Card heading={<Translation id="TR_ADDRESSES" />} margin={{ top: spacings.md }}>
+                        <Column gap={spacings.sm}>
+                            {popupCall?.addresses.map((address, index) => (
+                                <Row
+                                    key={index}
+                                    alignItems="center"
+                                    justifyContent="space-between"
+                                    gap={spacings.sm}
                                 >
-                                    {address.loading ? (
-                                        <Translation id="TR_VERIFYING" />
-                                    ) : (
-                                        <Translation id="TR_VERIFY" />
-                                    )}
-                                </Button>
-                            </Row>
-                        ))}
-                    </Column>
-                </Card>
-            </Column>
-        </Modal>
+                                    <Row gap={spacings.sm} alignItems="center" flex="1">
+                                        <Paragraph wordBreak="break-all">
+                                            {address.address}
+                                        </Paragraph>
+                                        {address.validated === 'valid' && (
+                                            <Badge variant="primary" icon="check" size="small">
+                                                <Translation id="TR_VERIFIED" />
+                                            </Badge>
+                                        )}
+                                        {address.validated === 'failed' && (
+                                            <Badge variant="warning" icon="warning" size="small">
+                                                <Translation id="TR_ERROR" />
+                                            </Badge>
+                                        )}
+                                    </Row>
+                                    <Button
+                                        data-testid="@connect-address-confirmation/verify-button"
+                                        variant="tertiary"
+                                        onClick={() => onVerify(index)}
+                                        icon={
+                                            mapTrezorModelToIcon[
+                                                device?.features?.internal_model ||
+                                                    DeviceModelInternal.UNKNOWN
+                                            ]
+                                        }
+                                        size="small"
+                                        isLoading={address.loading}
+                                    >
+                                        {address.loading ? (
+                                            <Translation id="TR_VERIFYING" />
+                                        ) : (
+                                            <Translation id="TR_VERIFY" />
+                                        )}
+                                    </Button>
+                                </Row>
+                            ))}
+                        </Column>
+                    </Card>
+                </Column>
+            </Modal.ModalBase>
+        </Modal.Backdrop>
     );
 };

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -70,6 +70,16 @@ const buttonRequest =
             }
         }
 
+        if (action.type === UI.REQUEST_BUTTON && action.payload.code === 'ButtonRequest_Address') {
+            const {
+                connectPopup: { activeCall },
+            } = api.getState();
+            // Skip if address confirmation modal open
+            if (activeCall?.state === 'address-confirmation') {
+                return action;
+            }
+        }
+
         // pass action
         next(action);
 


### PR DESCRIPTION
## Description

Add standard ConfirmOnDevice component in connect address confirmation flow. 
With this change I also bypass the device context modal in buttonRequestMiddleware, because the modal rerender causes a glitch in animation. 

## Screenshots:

![Screenshot 2025-04-22 at 13 49 24](https://github.com/user-attachments/assets/9c6baf1f-7cd2-4019-b398-82c86ee112cc)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/confirmondevice-connect-address-confirmation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/confirmondevice-connect-address-confirmation&lookback=7)