### PR TITLE
feat(suite-native): skip device tutorial action

### DIFF
--- a/suite-native/atoms/src/Button/Button.tsx
+++ b/suite-native/atoms/src/Button/Button.tsx
@@ -209,7 +209,7 @@ export const buttonSizeToDimensionsMap = {
     },
     small: {
         minHeight: 40,
-        paddingVertical: 10,
+        paddingVertical: nativeSpacings.sp10,
         paddingHorizontal: nativeSpacings.sp12,
     },
     medium: {

--- a/suite-native/device/src/components/ContinueOnTrezorScreenContent.tsx
+++ b/suite-native/device/src/components/ContinueOnTrezorScreenContent.tsx
@@ -1,7 +1,9 @@
 import { useSelector } from 'react-redux';
 
+import { RequireAllOrNone } from 'type-fest';
+
 import { selectDeviceModel } from '@suite-common/wallet-core';
-import { Box, Text } from '@suite-native/atoms';
+import { Box, Button, Text, VStack } from '@suite-native/atoms';
 import { Translation, TxKeyPath } from '@suite-native/intl';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { getScreenHeight } from '@trezor/env-utils';
@@ -12,7 +14,13 @@ import { DeviceImage } from './DeviceImage';
 
 type ContinueOnTrezorScreenContentProps = {
     titleTxKey?: TxKeyPath;
-};
+} & RequireAllOrNone<
+    {
+        actionLabelTxKey: TxKeyPath;
+        onActionPress: () => void;
+    },
+    'actionLabelTxKey' | 'onActionPress'
+>;
 
 const SCREEN_HEIGHT = getScreenHeight();
 
@@ -21,8 +29,14 @@ const titleStyle = prepareNativeStyle(utils => ({
     textAlign: 'center',
 }));
 
+const actionButtonStyle = prepareNativeStyle(() => ({
+    alignSelf: 'center',
+}));
+
 export const ContinueOnTrezorScreenContent = ({
     titleTxKey = 'device.title.continueOnTrezor',
+    actionLabelTxKey,
+    onActionPress,
 }: ContinueOnTrezorScreenContentProps) => {
     const { applyStyle } = useNativeStyles();
 
@@ -30,9 +44,21 @@ export const ContinueOnTrezorScreenContent = ({
 
     return (
         <>
-            <Text variant="titleMedium" style={applyStyle(titleStyle)}>
-                <Translation id={titleTxKey} />
-            </Text>
+            <VStack spacing="sp24">
+                <Text variant="titleMedium" style={applyStyle(titleStyle)}>
+                    <Translation id={titleTxKey} />
+                </Text>
+                {onActionPress && (
+                    <Button
+                        size="small"
+                        colorScheme="tertiaryElevation0"
+                        style={applyStyle(actionButtonStyle)}
+                        onPress={onActionPress}
+                    >
+                        <Translation id={actionLabelTxKey} />
+                    </Button>
+                )}
+            </VStack>
             <Box flex={1} alignItems="center" justifyContent="flex-end">
                 <DeviceImage
                     deviceModel={deviceModel || DeviceModelInternal.T3T1}

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -921,6 +921,7 @@ export const en = {
         },
         deviceTutorialScreen: {
             title: 'Continue with short tutorial on Trezor',
+            actionLabel: 'Skip tutorial',
         },
         createOrRecoverCrossroadsScreen: {
             create: {

--- a/suite-native/module-device-onboarding/src/screens/DeviceTutorialScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/DeviceTutorialScreen.tsx
@@ -30,9 +30,18 @@ export const DeviceTutorialScreen = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    const handleSkipTutorial = () => {
+        TrezorConnect.cancel();
+        navigation.navigate(DeviceOnboardingStackRoutes.CreateOrRecoverCrossroads);
+    };
+
     return (
         <DeviceOnboardingScreenWithExitButton>
-            <ContinueOnTrezorScreenContent titleTxKey="moduleDeviceOnboarding.deviceTutorialScreen.title" />
+            <ContinueOnTrezorScreenContent
+                titleTxKey="moduleDeviceOnboarding.deviceTutorialScreen.title"
+                actionLabelTxKey="moduleDeviceOnboarding.deviceTutorialScreen.actionLabel"
+                onActionPress={handleSkipTutorial}
+            />
         </DeviceOnboardingScreenWithExitButton>
     );
 };


### PR DESCRIPTION

## Description
- option to skip on device tutorial added to the onboarding flow

## Related Issue

Resolve #18374 

## Screenshots:

https://github.com/user-attachments/assets/87c77e30-45cb-4eb1-96f9-5711f142fecb




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/device-onboarding/skip-device-tutorial&lookback=7)