### PR TITLE
feat(transport): add `getMessages` method

### DIFF
--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -342,6 +342,10 @@ export abstract class AbstractTransport extends TransportEmitter {
         return !!this.messages.get(message);
     }
 
+    public getMessages() {
+        return this.messages;
+    }
+
     public updateMessages(messages: Record<string, any>) {
         this.messages = parseConfigure(messages);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
cherry-pick from `feat/thp`

i need to get current, already parsed protobuf.Root to decode some protubuf message outside of `send/receive/call` flow (in connect, not in transport)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/transport-get-messages&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/transport-get-messages&lookback=7)