### PR TITLE
Catch requestDevice error

### DIFF
--- a/packages/connect-web/src/module/index.ts
+++ b/packages/connect-web/src/module/index.ts
@@ -55,9 +55,12 @@ const disableWebUSB = () => {
 };
 
 const requestWebUSBDevice = async () => {
-    await window.navigator.usb.requestDevice({ filters: config.webusb });
-
-    impl.getTarget().handleCoreMessage({ type: TRANSPORT.REQUEST_DEVICE });
+    try {
+        await window.navigator.usb.requestDevice({ filters: config.webusb });
+        impl.getTarget().handleCoreMessage({ type: TRANSPORT.REQUEST_DEVICE });
+    } catch {
+        // empty
+    }
 };
 
 const TrezorConnect = factory(


### PR DESCRIPTION
## Description

Catching semi-expected `Failed to execute 'requestDevice' on 'USB': No device selected.` error so it doesn't pollute Sentry anymore.