### PR TITLE
chore(suite-native): specify EXPO env to fix EAS calls in androidAPK job

### DIFF
--- a/.github/workflows/release-suite-native-production.yml
+++ b/.github/workflows/release-suite-native-production.yml
@@ -89,6 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      EXPO_PUBLIC_ENVIRONMENT: production
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Expo environment has to be defined, otherive EAS calls results in "EAS project not configured.
Must configure EAS project by running 'eas init' before this command can be run in non-interactive mode." 
