### PR TITLE
chore(suite, suite-common) remove hacky button request fix for old fi…

### DIFF
--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -3,6 +3,8 @@ import { MiddlewareAPI } from 'redux';
 import { checkDeviceAuthenticityThunk } from '@suite-common/device-authenticity';
 import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
 import TrezorConnect, { UI } from '@trezor/connect';
+import { getFirmwareVersion } from '@trezor/device-utils';
+import { isNewerOrEqual } from '@trezor/utils/src/versionUtils';
 
 import { ONBOARDING } from 'src/actions/onboarding/constants';
 import { SUITE } from 'src/actions/suite/constants';
@@ -41,6 +43,13 @@ const buttonRequest =
         // ugly hack to make Ethereum staking and bump fee review modal on specific devices work
         // root cause of this bug is wrong button request ButtonRequest_Other from CardanoSignTx - should be ButtonRequest_SignTx
         if (action.type === UI.REQUEST_BUTTON && action.payload.code === 'ButtonRequest_Other') {
+            // Fixed in https://github.com/trezor/trezor-firmware/commit/b8e2709ca8f141a5ded1ffdd5d20d4b388fe49d6
+            // The whole workaround can be removed when 2.8.8 is no longer supported by Suite.
+            const device = selectSelectedDevice(api.getState());
+            if (isNewerOrEqual(getFirmwareVersion(device), '2.8.9')) {
+                return action;
+            }
+
             const {
                 wallet: {
                     selectedAccount: { account },

--- a/suite-common/wallet-core/src/send/sendFormReducer.ts
+++ b/suite-common/wallet-core/src/send/sendFormReducer.ts
@@ -12,8 +12,9 @@ import {
 } from '@suite-common/wallet-types';
 import { getSendFormDraftKey } from '@suite-common/wallet-utils';
 import { BlockbookTransaction } from '@trezor/blockchain-link-types';
-import { DeviceModelInternal } from '@trezor/device-utils';
+import { DeviceModelInternal, getFirmwareVersion } from '@trezor/device-utils';
 import { cloneObject } from '@trezor/utils';
+import { isNewerOrEqual } from '@trezor/utils/src/versionUtils';
 
 import { sendFormActions } from './sendFormActions';
 import { SerializedTx } from './sendFormTypes';
@@ -22,6 +23,7 @@ import {
     DeviceRootState,
     selectDeviceButtonRequestsCodes,
     selectDeviceModel,
+    selectSelectedDevice,
 } from '../device/deviceReducer';
 
 export type SendState = {
@@ -143,20 +145,23 @@ export const selectSendFormReviewButtonRequestsCount = (
 ) => {
     const buttonRequestCodes = selectDeviceButtonRequestsCodes(state);
     const deviceModel = selectDeviceModel(state);
+    const device = selectSelectedDevice(state);
 
     if (G.isNullable(symbol)) return 0;
 
     const networkType = getNetworkType(symbol);
 
     const isCardano = networkType === 'cardano';
-    const isEthereum = networkType === 'ethereum';
 
     const sendFormReviewRequest = buttonRequestCodes.filter(
         code =>
             code === 'ButtonRequest_ConfirmOutput' ||
             code === 'ButtonRequest_SignTx' ||
-            isCardano ||
-            (isEthereum && code === 'ButtonRequest_Other'),
+            // Firmware 2.x.x below 2.8.9 returns 'ButtonRequest_Other' instead of 'ButtonRequest_SignTx' in some flows.
+            // This condition should be removed when 2.8.8 is no longer supported by Suite.
+            (!isNewerOrEqual(getFirmwareVersion(device), '2.8.9') &&
+                ['cardano', 'ethereum'].includes(networkType) &&
+                code === 'ButtonRequest_Other'),
     );
 
     // NOTE: T1B1 edge-case


### PR DESCRIPTION
Doesn't work properly yet, Cardano still sends `ButtonRequest_Other` for confirmation of address and amount.

![Screenshot 2025-04-22 at 19 49 32](https://github.com/user-attachments/assets/3d65494a-3be7-452b-926a-ddd5f92f6c28)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-button-request-hack&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-button-request-hack&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/remove-button-request-hack&lookback=7)