### PR TITLE
feat(suite-native): Device Onboarding: Conneting missing screens

### DIFF
--- a/suite-native/app/src/hooks/useCoinEnablingInitialCheck.tsx
+++ b/suite-native/app/src/hooks/useCoinEnablingInitialCheck.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { A } from '@mobily/ts-belt';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useNavigationState } from '@react-navigation/native';
 
 import { selectHasBitcoinOnlyFirmware } from '@suite-common/wallet-core';
 import { selectShouldShowCoinEnablingInitFlow } from '@suite-native/coin-enabling';
@@ -26,6 +26,8 @@ export const useCoinEnablingInitialCheck = () => {
     const navigation =
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.CoinEnablingInit>>();
 
+    const lastRoute = useNavigationState(state => state?.routes.at(-1)?.name);
+    const isDeviceOnboardingStackFocused = lastRoute === RootStackRoutes.DeviceOnboardingStack;
     const hasBitcoinOnlyFirmware = useSelector(selectHasBitcoinOnlyFirmware);
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
     const shouldShowCoinEnablingInitFlow = useSelector(selectShouldShowCoinEnablingInitFlow);
@@ -35,7 +37,8 @@ export const useCoinEnablingInitialCheck = () => {
 
     const wasInitScreenShown = useRef(false);
 
-    const canShowCoinEnablingInitFlow = isOnboardingFinished && !wasInitScreenShown.current;
+    const canShowCoinEnablingInitFlow =
+        isOnboardingFinished && !wasInitScreenShown.current && !isDeviceOnboardingStackFocused;
 
     useEffect(() => {
         if (shouldShowCoinEnablingInitFlow && canShowCoinEnablingInitFlow) {

--- a/suite-native/atoms/src/Spinner/Spinner.tsx
+++ b/suite-native/atoms/src/Spinner/Spinner.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import LottieView from 'lottie-react-native';
 
@@ -10,11 +10,13 @@ export type SpinnerLoadingState = 'success' | 'error' | 'idle';
 type SpinnerProps = {
     loadingState: SpinnerLoadingState;
     onComplete?: () => void;
+    endFrame?: number;
+    size?: number;
 };
 
-const spinnerStyle = prepareNativeStyle(_ => ({
-    width: 50,
-    height: 50,
+const spinnerStyle = prepareNativeStyle<{ size: number }>((_, { size }) => ({
+    width: size,
+    height: size,
 }));
 
 const animationsMap = {
@@ -25,38 +27,43 @@ const animationsMap = {
 };
 type AnimationName = keyof typeof animationsMap;
 
-export const Spinner = ({ loadingState, onComplete }: SpinnerProps) => {
+const END_FRAME_WHITELIST: AnimationName[] = ['success', 'error'];
+
+export const Spinner = ({ loadingState, onComplete, endFrame, size = 50 }: SpinnerProps) => {
     const animationRef = useRef<LottieView>(null);
     const [currentAnimation, setCurrentAnimation] = useState<AnimationName>('start');
     const { applyStyle } = useNativeStyles();
+
+    useEffect(() => {
+        const shouldPlayPartial = END_FRAME_WHITELIST.includes(currentAnimation) && endFrame;
+        animationRef.current?.play(0, shouldPlayPartial ? endFrame : undefined);
+    }, [currentAnimation, endFrame]);
 
     const handleAnimationFinish = () => {
         if (currentAnimation === 'start') {
             setCurrentAnimation('idle');
         } else if (currentAnimation === 'idle') {
-            setCurrentAnimation(loadingState);
+            if (loadingState !== 'idle') {
+                setCurrentAnimation(loadingState);
+            } else {
+                animationRef.current?.play(); // repeat idle animation
+            }
         }
 
         if (currentAnimation === 'success' || currentAnimation === 'error') {
             onComplete?.();
-
-            return;
         }
-
-        // Play the next loop of the animation.
-        animationRef.current?.play();
     };
 
     return (
         <LottieView
-            autoPlay
             resizeMode="cover"
             loop={false}
             ref={animationRef}
             speed={ANIMATION_SPEED}
             source={animationsMap[currentAnimation]}
             onAnimationFinish={handleAnimationFinish}
-            style={applyStyle(spinnerStyle)}
+            style={applyStyle(spinnerStyle, { size })}
         />
     );
 };

--- a/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
+++ b/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
@@ -13,16 +13,23 @@ import {
 } from '@suite-native/discovery';
 import { Translation } from '@suite-native/intl';
 import {
+    AppTabsRoutes,
+    HomeStackRoutes,
+    RootStackParamList,
+    RootStackRoutes,
     Screen,
     ScreenFooterGradient,
+    StackNavigationProps,
     useHandleHardwareBackNavigation,
 } from '@suite-native/navigation';
 
 import { DiscoveryCoinsFilter } from '../components/DiscoveryCoinsFilter';
 
+type NavigationProps = StackNavigationProps<RootStackParamList, RootStackRoutes.CoinEnablingInit>;
+
 export const CoinEnablingInitScreen = () => {
     const dispatch = useDispatch();
-    const navigation = useNavigation();
+    const navigation = useNavigation<NavigationProps>();
     useHandleHardwareBackNavigation();
 
     const enabledNetworkSymbols = useSelector(selectDeviceEnabledDiscoveryNetworkSymbols);
@@ -36,7 +43,13 @@ export const CoinEnablingInitScreen = () => {
                 type: EventType.CoinEnablingInitState,
                 payload: { enabledNetworks: enabledNetworkSymbols },
             });
-            navigation.goBack();
+
+            navigation.navigate(RootStackRoutes.AppTabs, {
+                screen: AppTabsRoutes.HomeStack,
+                params: {
+                    screen: HomeStackRoutes.Home,
+                },
+            });
         }
     };
 

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -1059,7 +1059,9 @@ export const en = {
                     "After writing your wallet backup, you'll verify it's correct. Your Trezor will display a random selection of words along with their correct positions.\n\nCompare them to your wallet backup card and select the matching word for each position.",
             },
         },
-
+        walletCreatedSuccessScreen: {
+            successLabel: 'All good!',
+        },
         deviceDisconnectedAlert: {
             title: 'Your Trezor has been disconnected',
             description: 'Connect your Trezor to start again.',

--- a/suite-native/module-device-onboarding/src/components/WalletBackupRecap/WalletBackupRecapStep4.tsx
+++ b/suite-native/module-device-onboarding/src/components/WalletBackupRecap/WalletBackupRecapStep4.tsx
@@ -1,4 +1,12 @@
+import { useNavigation } from '@react-navigation/core';
+
 import { Translation } from '@suite-native/intl';
+import {
+    DeviceOnboardingStackParamList,
+    DeviceOnboardingStackRoutes,
+    RootStackParamList,
+    StackToStackCompositeNavigationProps,
+} from '@suite-native/navigation';
 
 import { WalletBackupTutorialNumberedStepProps } from './WalletBackupRecapStep1';
 import { WalletBackupRecapStepContent } from './WalletBackupRecapStepContent';
@@ -6,11 +14,20 @@ import { WALLET_BACKUP_RECAP_STEPS } from './presets';
 import { HoldToConfirmButton } from '../SwipeableWalkthrough/HoldToConfirmButton';
 import { SwipeableWalkthroughStep } from '../SwipeableWalkthrough/SwipeableWalkthroughStep';
 
+type NavigationProps = StackToStackCompositeNavigationProps<
+    DeviceOnboardingStackParamList,
+    DeviceOnboardingStackRoutes.WalletBackupRecap,
+    RootStackParamList
+>;
+
 export const WalletBackupRecapStep4 = ({
     currentStepIndex,
 }: WalletBackupTutorialNumberedStepProps) => {
-    // TODO: add action
-    const handleHoldToStartSuccess = () => {};
+    const navigation = useNavigation<NavigationProps>();
+
+    const handleHoldToStartSuccess = () => {
+        navigation.navigate(DeviceOnboardingStackRoutes.CreatePin);
+    };
 
     return (
         <SwipeableWalkthroughStep

--- a/suite-native/module-device-onboarding/src/navigation/DeviceOnboardingStackNavigator.tsx
+++ b/suite-native/module-device-onboarding/src/navigation/DeviceOnboardingStackNavigator.tsx
@@ -95,6 +95,9 @@ export const DeviceOnboardingStackNavigator = () => (
         <DeviceOnboardingStack.Screen
             name={DeviceOnboardingStackRoutes.WalletBackupRecap}
             component={WalletBackupRecapScreen}
+            options={{
+                animation: 'fade',
+            }}
         />
     </DeviceOnboardingStack.Navigator>
 );

--- a/suite-native/module-device-onboarding/src/screens/CreatePinScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/CreatePinScreen.tsx
@@ -8,9 +8,12 @@ import { usePinAction } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 import { deviceImageMap } from '@suite-native/module-authorize-device';
 import {
+    AppTabsRoutes,
     DeviceOnboardingStackParamList,
     DeviceOnboardingStackRoutes,
+    HomeStackRoutes,
     RootStackParamList,
+    RootStackRoutes,
     Screen,
     ScreenHeader,
     StackToStackCompositeNavigationProps,
@@ -49,8 +52,12 @@ export const CreatePinScreen = () => {
     usePinAction({
         type: 'enable',
         onSuccess: () => {
-            // TODO: temporary, not implemented yet
-            navigation.goBack();
+            navigation.navigate(RootStackRoutes.AppTabs, {
+                screen: AppTabsRoutes.HomeStack,
+                params: {
+                    screen: HomeStackRoutes.Home,
+                },
+            });
         },
     });
 

--- a/suite-native/module-device-onboarding/src/screens/CreatePinScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/CreatePinScreen.tsx
@@ -2,9 +2,10 @@ import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/core';
 
-import { selectDeviceModel } from '@suite-common/wallet-core';
+import { selectDeviceModel, selectHasBitcoinOnlyFirmware } from '@suite-common/wallet-core';
 import { Box, Image, TitleHeader } from '@suite-native/atoms';
 import { usePinAction } from '@suite-native/device';
+import { selectIsCoinEnablingInitFinished } from '@suite-native/discovery';
 import { Translation } from '@suite-native/intl';
 import { deviceImageMap } from '@suite-native/module-authorize-device';
 import {
@@ -48,17 +49,26 @@ type NavigationProps = StackToStackCompositeNavigationProps<
 export const CreatePinScreen = () => {
     const navigation = useNavigation<NavigationProps>();
     const deviceModel = useSelector(selectDeviceModel);
+    const hasBitcoinOnlyFirmware = useSelector(selectHasBitcoinOnlyFirmware);
+    const isCoinEnablingInitFinished = useSelector(selectIsCoinEnablingInitFinished);
     const { applyStyle } = useNativeStyles();
-    usePinAction({
-        type: 'enable',
-        onSuccess: () => {
+
+    const handlePinCreated = () => {
+        if (hasBitcoinOnlyFirmware || isCoinEnablingInitFinished) {
             navigation.navigate(RootStackRoutes.AppTabs, {
                 screen: AppTabsRoutes.HomeStack,
                 params: {
                     screen: HomeStackRoutes.Home,
                 },
             });
-        },
+        } else {
+            navigation.navigate(RootStackRoutes.CoinEnablingInit);
+        }
+    };
+
+    usePinAction({
+        type: 'enable',
+        onSuccess: handlePinCreated,
     });
 
     const onCancel = () => {

--- a/suite-native/module-device-onboarding/src/screens/WalletCreatedSuccessScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletCreatedSuccessScreen.tsx
@@ -1,12 +1,56 @@
-import { Box, Text } from '@suite-native/atoms';
-import { Screen } from '@suite-native/navigation';
+import { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
-export const WalletCreatedSuccessScreen = () => (
-    <Screen isScrollable={false}>
-        <Box justifyContent="center" alignItems="center" flex={1}>
-            <Text color="textAlertRed" variant="titleMedium" textAlign="center">
-                Wallet created successfully!{'\n'}TODO: implement next screen.
-            </Text>
-        </Box>
-    </Screen>
-);
+import { useNavigation } from '@react-navigation/core';
+
+import { AnimatedText, Box, Spinner, VStack } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import {
+    DeviceOnboardingStackParamList,
+    DeviceOnboardingStackRoutes,
+    RootStackParamList,
+    Screen,
+    StackToStackCompositeNavigationProps,
+} from '@suite-native/navigation';
+
+type NavigationProps = StackToStackCompositeNavigationProps<
+    DeviceOnboardingStackParamList,
+    DeviceOnboardingStackRoutes.WalletCreatedSuccess,
+    RootStackParamList
+>;
+
+const NAVIGATION_TIMEOUT = 3000;
+const ANIMATION_END_FRAME = 305;
+
+export const WalletCreatedSuccessScreen = () => {
+    const textOpacity = useSharedValue(0);
+    const navigation = useNavigation<NavigationProps>();
+
+    const handleAnimationEnd = () => {
+        textOpacity.value = withTiming(1);
+        setTimeout(() => {
+            navigation.navigate(DeviceOnboardingStackRoutes.WalletBackupRecap);
+        }, NAVIGATION_TIMEOUT);
+    };
+
+    const textStyle = useAnimatedStyle(() => ({
+        opacity: textOpacity.value,
+    }));
+
+    return (
+        <Screen isScrollable={false}>
+            <Box justifyContent="center" alignItems="center" flex={1}>
+                <VStack alignItems="center" spacing="sp20">
+                    <Spinner
+                        loadingState="success"
+                        onComplete={handleAnimationEnd}
+                        endFrame={ANIMATION_END_FRAME}
+                        size={80}
+                    />
+                    <AnimatedText style={textStyle} variant="titleSmall">
+                        <Translation id="moduleDeviceOnboarding.walletCreatedSuccessScreen.successLabel" />
+                    </AnimatedText>
+                </VStack>
+            </Box>
+        </Screen>
+    );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Created Success Screen
- Connected Wallet Backup Recap Screen
- Connected Create Pin Screen
- prevent coin enabling from being displayed during Device onboarding

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17469

## Screenshots:

https://github.com/user-attachments/assets/63bdb3ad-9b65-41bc-9fc6-256f1f4c0591


https://github.com/user-attachments/assets/4fdcb811-94e5-4476-8727-5582e86c39e0





🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/device-onboarding-create-pin-recap-connect&lookback=7)