### PR TITLE
fix(device-manager): fix DeviceItem key to prevent two children with the same key

### DIFF
--- a/suite-native/device-manager/src/components/DeviceList.tsx
+++ b/suite-native/device-manager/src/components/DeviceList.tsx
@@ -173,7 +173,7 @@ export const DeviceList = ({ isVisible, onSelectDevice }: DeviceListProps) => {
                         d =>
                             d.state && (
                                 <DeviceItem
-                                    key={d.path}
+                                    key={d.state.staticSessionId}
                                     deviceState={d.state}
                                     onPress={() => onSelectDevice(d)}
                                 />


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Prevent `two children with the same key, ""` on device switcher open (with multiple devices remembered).

## Screenshots:
<img width="1061" alt="image" src="https://github.com/user-attachments/assets/ac02ad10-4e1d-4924-b3e2-be961c185dfc" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-list-key&lookback=7)