### PR TITLE
feat(connect-web): use suite-desktop by default

### DIFF
--- a/packages/connect-examples/browser-inline-script/index.html
+++ b/packages/connect-examples/browser-inline-script/index.html
@@ -10,6 +10,7 @@
                 lazyLoad: true,
                 manifest: {
                     email: 'developer@xyz.com',
+                    appName: 'Trezor Connect Example',
                     appUrl: 'http://your.application.com',
                 },
             });

--- a/packages/connect-examples/electron-main-process/src/trezor-connect-ipc.js
+++ b/packages/connect-examples/electron-main-process/src/trezor-connect-ipc.js
@@ -98,6 +98,7 @@ exports.initTrezorConnect = sender => {
         // this is useful when you don't know if you are dealing with Trezor user
         manifest: {
             email: 'email@developer.com',
+            appName: 'Trezor Connect Example',
             appUrl: 'electron-app-boilerplate',
         },
         transports: ['BridgeTransport'],

--- a/packages/connect-examples/electron-renderer-with-popup/src/renderer.js
+++ b/packages/connect-examples/electron-renderer-with-popup/src/renderer.js
@@ -30,6 +30,7 @@ TrezorConnect.init({
     // this is useful when you don't know if you are dealing with Trezor user
     manifest: {
         email: 'email@developer.com',
+        appName: 'Trezor Connect Example',
         appUrl: 'electron-app-boilerplate',
     },
     transports: ['BridgeTransport'],

--- a/packages/connect-examples/mobile-expo/App.tsx
+++ b/packages/connect-examples/mobile-expo/App.tsx
@@ -28,6 +28,7 @@ export const App = () => {
         TrezorConnect.init({
             manifest: {
                 email: 'developer@xyz.com',
+                appName: 'Trezor Connect Example',
                 appUrl: 'http://your.application.com',
             },
             // for local development purposes. for production, leave it undefined to use the default value.

--- a/packages/connect-examples/node/src/index.ts
+++ b/packages/connect-examples/node/src/index.ts
@@ -9,6 +9,7 @@ const runExample = async () => {
     await TrezorConnect.init({
         manifest: {
             appUrl: 'my app',
+            appName: 'Trezor Connect Example',
             email: 'app@myapp.meow',
         },
     });

--- a/packages/connect-examples/webextension-mv2/src/background.js
+++ b/packages/connect-examples/webextension-mv2/src/background.js
@@ -10,6 +10,7 @@ function loadTrezorConnect() {
     return TrezorConnect.init({
         manifest: {
             email: 'email@developer.com',
+            appName: 'Trezor Connect Example',
             appUrl: 'webextension-app-boilerplate',
         },
         connectSrc: DEFAULT_SRC,

--- a/packages/connect-examples/webextension-mv3-sw-ts/src/service-worker.ts
+++ b/packages/connect-examples/webextension-mv3-sw-ts/src/service-worker.ts
@@ -14,6 +14,7 @@ chrome.runtime.onInstalled.addListener((details: chrome.runtime.InstalledDetails
     TrezorConnect.init({
         manifest: {
             email: 'meow@example.com',
+            appName: 'Trezor Connect Example',
             appUrl: 'https://yourAppUrl.com/',
         },
         transports: ['BridgeTransport', 'WebUsbTransport'], // Transport protocols to be used

--- a/packages/connect-examples/webextension-mv3-sw/src/serviceWorker.js
+++ b/packages/connect-examples/webextension-mv3-sw/src/serviceWorker.js
@@ -12,6 +12,7 @@ chrome.runtime.onInstalled.addListener(details => {
     TrezorConnect.init({
         manifest: {
             email: 'meow@example.com',
+            appName: 'Trezor Connect Example',
             appUrl: 'https://yourAppUrl.com/',
         },
         transports: ['BridgeTransport', 'WebUsbTransport'], // Transport protocols to be used

--- a/packages/connect-examples/webextension-mv3/src/connect-manager.js
+++ b/packages/connect-examples/webextension-mv3/src/connect-manager.js
@@ -4,6 +4,7 @@ window.TrezorConnect.init({
     lazyLoad: true,
     manifest: {
         email: 'developer@xyz.com',
+        appName: 'Trezor Connect Example',
         appUrl: 'http://your.application.com',
     },
     connectSrc: DEFAULT_SRC,

--- a/packages/connect-explorer/src/pages/guides/webextension-implementation-tutorial.mdx
+++ b/packages/connect-explorer/src/pages/guides/webextension-implementation-tutorial.mdx
@@ -110,6 +110,7 @@ export const SectionCard = styled(TrezorCard)`
         TrezorConnect.init({
             manifest: {
                 email: 'meow@example.com',
+                appName: 'Trezor Connect Example',
                 appUrl: 'https://yourAppUrl.com/',
             },
             transports: ['WebUsbTransport'], // Transport protocols to be used

--- a/packages/connect-explorer/src/pages/methods/other/init.mdx
+++ b/packages/connect-explorer/src/pages/methods/other/init.mdx
@@ -63,6 +63,7 @@ It is also possible to customize more advanced options for TrezorConnect.
 const result = await TrezorConnect.init({
     manifest: {
         appUrl: 'https://your.application.com',
+        appName: 'Trezor Connect Example',
         email: 'your@email.com',
     },
     // More advanced options

--- a/packages/connect-mobile/README.md
+++ b/packages/connect-mobile/README.md
@@ -20,6 +20,7 @@ import TrezorConnect from '@trezor/connect-mobile';
 TrezorConnect.init({
     manifest: {
         email: 'developer@xyz.com',
+        appName: 'Trezor Connect Example',
         appUrl: 'http://your.application.com',
     },
     deeplinkOpen: url => {

--- a/packages/connect-popup/e2e/tests/popup-pages.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-pages.test.ts
@@ -111,7 +111,12 @@ test('log page should contain logs from shared worker', async ({ page, context }
     const errorLogs: any[] = [];
     page.on('console', message => {
         if (message.type() === 'error') {
-            errorLogs.push(message.text());
+            const text = message.text();
+            // Ignore network errors logged from browser
+            if (text.includes('net::ERR_CONNECTION_REFUSED')) {
+                return;
+            }
+            errorLogs.push(text);
         }
     });
     await TrezorUserEnvLink.stopBridge();

--- a/packages/connect-web/e2e/tests/init.test.ts
+++ b/packages/connect-web/e2e/tests/init.test.ts
@@ -39,6 +39,7 @@ fixtures.forEach(f => {
                     lazyLoad: false,
                     manifest: {
                         email: 'developer@xyz.com',
+                        appName: 'Trezor Connect Example',
                         appUrl: 'http://your.application.com',
                     },
                     connectSrc: '${f.params.connectSrc}'

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -52,7 +52,9 @@ const impl = new TrezorConnectDynamic<
     handleBeforeCall: async () => {
         // Always try if desktop is available again
         const isCoreModeDesktop = impl.lastSettings?.coreMode === 'suite-desktop';
-        if (isCoreModeDesktop) {
+        const isCoreModeAuto =
+            impl.lastSettings?.coreMode === 'auto' || impl.lastSettings?.coreMode === undefined;
+        if (isCoreModeDesktop || isCoreModeAuto) {
             await impl.switchTarget('core-in-suite-desktop');
         }
     },
@@ -65,11 +67,10 @@ const impl = new TrezorConnectDynamic<
 
         // Handle desktop errors
         if (
-            !isCoreModeDisabled &&
             impl.getTargetType() === 'core-in-suite-desktop' &&
             errorCode === 'Desktop_ConnectionMissing'
         ) {
-            await impl.switchTarget('core-in-popup');
+            await impl.switchTarget('iframe');
 
             return true;
         }

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -41,7 +41,9 @@ const impl = new TrezorConnectDynamic<
     handleBeforeCall: async () => {
         // Always try if desktop is available again
         const isCoreModeDesktop = impl.lastSettings?.coreMode === 'suite-desktop';
-        if (isCoreModeDesktop) {
+        const isCoreModeAuto =
+            impl.lastSettings?.coreMode === 'auto' || impl.lastSettings?.coreMode === undefined;
+        if (isCoreModeDesktop || isCoreModeAuto) {
             await impl.switchTarget('core-in-suite-desktop');
         }
     },

--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -173,6 +173,7 @@ export const initTrezorConnect = async (
 
     await TrezorConnect.init({
         manifest: {
+            appName: 'Trezor Connect Tests',
             appUrl: 'tests.connect.trezor.io',
             email: 'tests@connect.trezor.io',
         },

--- a/packages/connect/e2e/tests/api/init.test.ts
+++ b/packages/connect/e2e/tests/api/init.test.ts
@@ -45,7 +45,7 @@ describe('TrezorConnect.init', () => {
         });
 
         try {
-            await TrezorConnect.init({ manifest: { appUrl: 'a', email: 'b' } });
+            await TrezorConnect.init({ manifest: { appName: 'a', appUrl: 'a', email: 'b' } });
             throw new Error('Should not be resolved');
         } catch (error) {
             expect(error).toMatchObject({ code: 'Init_AlreadyInitialized' });
@@ -54,6 +54,7 @@ describe('TrezorConnect.init', () => {
 
     it('calling multiple methods synchronously', async () => {
         TrezorConnect.manifest({
+            appName: 'a',
             appUrl: 'a',
             email: 'b',
         });
@@ -68,7 +69,7 @@ describe('TrezorConnect.init', () => {
     });
 
     it('init success', async () => {
-        await TrezorConnect.init({ manifest: { appUrl: 'a', email: 'b' } });
+        await TrezorConnect.init({ manifest: { appName: 'a', appUrl: 'a', email: 'b' } });
 
         const resp = await TrezorConnect.getCoinInfo({ coin: 'btc' });
         expect(resp).toMatchObject({
@@ -78,6 +79,7 @@ describe('TrezorConnect.init', () => {
 
     it('manifest success', async () => {
         TrezorConnect.manifest({
+            appName: 'a',
             appUrl: 'a',
             email: 'b',
         });

--- a/packages/connect/src/data/__tests__/DataManager.test.ts
+++ b/packages/connect/src/data/__tests__/DataManager.test.ts
@@ -9,6 +9,7 @@ const settings = {
     pendingTransportEvent: false,
     manifest: {
         email: 'info@trezor.io',
+        appName: 'Trezor Connect Tests',
         appUrl: 'https://connect.trezor.io/9/',
     },
     // internal part, not to be accepted from .init()

--- a/packages/connect/src/impl/dynamic.ts
+++ b/packages/connect/src/impl/dynamic.ts
@@ -1,7 +1,9 @@
 import EventEmitter from 'events';
 
+import { getSynchronize } from '@trezor/utils';
+
 import { ERRORS } from '../constants';
-import { CallMethodPayload } from '../events';
+import { CallMethodPayload, createErrorMessage } from '../events';
 import { ConnectFactoryDependencies } from '../factory';
 import { InitFullSettings } from '../types/api/init';
 import type { SetTransports } from '../types/api/setTransports';
@@ -57,6 +59,8 @@ export class TrezorConnectDynamic<
     >['handleErrorFallback'];
 
     public lastSettings?: InitFullSettings<SettingsType>;
+    private callPending = 0;
+    private beforeCallSynchronize = getSynchronize();
 
     public constructor({
         implementations,
@@ -88,7 +92,7 @@ export class TrezorConnectDynamic<
         }
 
         if (!this.lastSettings) {
-            throw ERRORS.TypedError('Init_NotInitialized');
+            throw ERRORS.TypedError('Init_ManifestMissing');
         }
 
         // Go back to the old target if the new target fails to initialize
@@ -117,6 +121,7 @@ export class TrezorConnectDynamic<
         this.lastSettings = settings;
 
         this.currentTarget = this.getInitTarget(settings);
+        this.callPending = 0;
 
         // Initialize the target
         try {
@@ -124,7 +129,7 @@ export class TrezorConnectDynamic<
         } catch (error) {
             // Handle error by switching to other implementation if available as defined in `handleErrorFallback`.
             if (await this.handleErrorFallback(error.code)) {
-                return await this.getTarget().init(settings);
+                return;
             }
 
             throw error;
@@ -137,15 +142,28 @@ export class TrezorConnectDynamic<
     }
 
     public async call(params: CallMethodPayload) {
-        await this.handleBeforeCall();
-        const response = await this.getTarget().call(params);
-        if (!response.success) {
-            if (await this.handleErrorFallback(response.payload.code)) {
-                return await this.getTarget().call(params);
+        try {
+            // Edge case - if there are simultaneous calls, we only want to call `handleBeforeCall` once
+            if (this.callPending === 0) {
+                await this.beforeCallSynchronize(async () => {
+                    this.callPending++;
+                    await this.handleBeforeCall();
+                });
             }
-        }
+            const response = await this.getTarget().call(params);
+            if (!response.success) {
+                if (await this.handleErrorFallback(response.payload.code)) {
+                    return await this.getTarget().call(params);
+                }
+            }
 
-        return response;
+            return response;
+        } catch (error) {
+            // Don't throw but return error payload
+            return createErrorMessage(error);
+        } finally {
+            this.callPending--;
+        }
     }
 
     public requestLogin(params: any) {
@@ -162,6 +180,7 @@ export class TrezorConnectDynamic<
 
     public dispose() {
         this.eventEmitter.removeAllListeners();
+        this.callPending = 0;
 
         return this.getTarget().dispose();
     }

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -4,7 +4,7 @@ import type { Transport } from '@trezor/transport';
 
 export type { SystemInfo } from '@trezor/connect-common';
 export interface Manifest {
-    appName?: string;
+    appName: string;
     appIcon?: string;
     appUrl: string;
     email: string;

--- a/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
@@ -133,6 +133,7 @@ describe('useRbfForm hook', () => {
             pendingTransportEvent: false,
             manifest: {
                 email: 'info@trezor.io',
+                appName: 'Trezor Connect Tests',
                 appUrl: '@trezor/suite',
             },
         });

--- a/suite-common/test-utils/src/extraDependenciesMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesMock.ts
@@ -146,6 +146,7 @@ export const extraDependenciesMock: ExtraDependencies = {
             debug: false,
             manifest: {
                 email: 'info@trezor.io',
+                appName: 'Trezor Suite',
                 appUrl: '@suite-native/app',
             },
         },

--- a/suite-native/app/e2e/tests/deeplinkPopup.test.ts
+++ b/suite-native/app/e2e/tests/deeplinkPopup.test.ts
@@ -73,6 +73,7 @@ describe.skip('Deeplink connect popup.', () => {
         await TrezorConnect.init({
             manifest: {
                 email: 'developer@xyz.com',
+                appName: 'Trezor Connect Tests',
                 appUrl: 'http://your.application.com',
             },
             deeplinkOpen: url => {

--- a/suite-native/module-connect-popup/src/components/ConnectPopupDebugOptions.tsx
+++ b/suite-native/module-connect-popup/src/components/ConnectPopupDebugOptions.tsx
@@ -19,6 +19,7 @@ export const ConnectPopupDebugOptions = ({
         TrezorConnectDeeplink.init({
             manifest: {
                 email: 'info@trezor.io',
+                appName: 'Trezor Connect Tests',
                 appUrl: '@suite-native/app',
             },
             deeplinkCallbackUrl: 'https://httpbin.org/get',


### PR DESCRIPTION
## Description

Set default implementation in Connect Web to `core-in-suite-desktop` - before every call, we will try to Connect to desktop initially. 
Handle edge cases with simultaneous calls and init errors. 
Require appName in TypeScript, add it to all examples.

In case the connection is not available, fall back to iframe. 
In case iframe has no transport available, fall back to popup. 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-default-coremode-suite-desktop&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connect-default-coremode-suite-desktop&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-default-coremode-suite-desktop&lookback=7)