### PR TITLE
fix(trading): max balance

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -128,7 +128,7 @@
         "@testing-library/user-event": "14.5.2",
         "@trezor/eslint": "workspace:*",
         "@types/file-saver": "^2.0.6",
-        "@types/invity-api": "^1.1.5",
+        "@types/invity-api": "^1.1.6",
         "@types/jws": "^3.2.10",
         "@types/pako": "^2.0.3",
         "@types/pdfmake": "^0.2.11",

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -565,6 +565,8 @@ export const useTradingSellForm = ({
         // destinationAddress may be set by useTradingWatchTrade hook to the trade object
         const destinationAddress =
             selectedTrade?.destinationAddress || trade?.data?.destinationAddress;
+        const lockSendAmount =
+            !!sellInfo?.providerInfos[selectedTrade?.exchange ?? '']?.lockSendAmount;
 
         if (
             !selectedTrade ||
@@ -592,6 +594,8 @@ export const useTradingSellForm = ({
             address: destinationAddress,
             amount: cryptoStringAmount,
             destinationTag: destinationPaymentExtraId,
+            // when lockSendAmount is true, the amount should not be recomputed based on the maximum balance.
+            setMaxOutputId: lockSendAmount ? undefined : values.setMaxOutputId,
         });
 
         if (!result?.success) {

--- a/suite-common/trading/package.json
+++ b/suite-common/trading/package.json
@@ -27,6 +27,6 @@
     },
     "devDependencies": {
         "@suite-common/test-utils": "workspace:*",
-        "@types/invity-api": "^1.1.5"
+        "@types/invity-api": "^1.1.6"
     }
 }

--- a/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
@@ -92,6 +92,7 @@ export const sendTransactionThunk = createThunk<
                 amount: sendStringAmount,
                 destinationTag: sendPaymentExtraId,
                 signAndPushSendFormTransaction,
+                setMaxOutputId,
             }),
         );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9377,7 +9377,7 @@ __metadata:
     "@trezor/env-utils": "workspace:*"
     "@trezor/react-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.5"
+    "@types/invity-api": "npm:^1.1.6"
     react: "npm:18.2.0"
     react-redux: "npm:9.2.0"
     uuid: "npm:^11.1.0"
@@ -12366,7 +12366,7 @@ __metadata:
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/file-saver": "npm:^2.0.6"
-    "@types/invity-api": "npm:^1.1.5"
+    "@types/invity-api": "npm:^1.1.6"
     "@types/jws": "npm:^3.2.10"
     "@types/pako": "npm:^2.0.3"
     "@types/pdfmake": "npm:^0.2.11"
@@ -13232,10 +13232,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/invity-api@npm:^1.1.5":
-  version: 1.1.5
-  resolution: "@types/invity-api@npm:1.1.5"
-  checksum: 10/104a0e0ea4082ab5b7f45b6f36bce39551f9dc0fc5f4786d411bb2ef6bf08294b33e079299cfc0c0b0ad5c91eee6c4ffe371033c0c645c73351d6f6ab171c0fe
+"@types/invity-api@npm:^1.1.6":
+  version: 1.1.6
+  resolution: "@types/invity-api@npm:1.1.6"
+  checksum: 10/6a3ab75e626fb7c676cce84907a10c573ebef176207f97f38a8eceb6bed480f8f8dffc57565633cb3e78ca50de488a5f390cd5b375fb73aa261b3c56fe5670ba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
- For Swap, it should be possible to use the whole balance of the account (resolving the issue)
- For Sell, add partner-specific property `lockSendAmount`, which causes the transaction to not be recalculated before sending the transaction (related issue)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17640
Related https://github.com/trezor/trezor-suite/issues/16046


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-max-balance&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-max-balance&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading-max-balance&lookback=7)