### PR TITLE
Fix/bch lowercase button

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5448,6 +5448,10 @@ export default defineMessages({
         defaultMessage: 'Convert to lowercase',
         id: 'TR_CONVERT_TO_LOWERCASE',
     },
+    TR_ADD_BITCOINCASH_PREFIX: {
+        defaultMessage: 'Add "bitcoincash:" prefix',
+        id: 'TR_ADD_BITCOINCASH_PREFIX',
+    },
     TR_CONVERT_TO_CHECKSUM_ADDRESS: {
         defaultMessage: 'Convert to checksum',
         id: 'TR_CONVERT_TO_CHECKSUM_ADDRESS',

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -10,10 +10,11 @@ import type { Output } from '@suite-common/wallet-types';
 import {
     checkIsAddressNotUsedNotChecksummed,
     getInputState,
+    hasBitcoinCashAddressPrefix,
     isAddressDeprecated,
     isAddressValid,
     isBech32AddressUppercase,
-    isCashAddressUppercase,
+    isBitcoinCashAddressUppercase,
     isTaprootAddress,
 } from '@suite-common/wallet-utils';
 import { Button, Icon, IconButton, Input, Link, Row } from '@trezor/components';
@@ -221,6 +222,16 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                         text: translationString('TR_CONVERT_TO_LOWERCASE'),
                     },
                 };
+            case 'bch_missing_prefix':
+                return {
+                    buttonProps: {
+                        onClick: () =>
+                            setValue(inputName, 'bitcoincash:' + address, {
+                                shouldValidate: true,
+                            }),
+                        text: translationString('TR_ADD_BITCOINCASH_PREFIX'),
+                    },
+                };
             default:
                 return {};
         }
@@ -245,7 +256,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
             uppercase: (value: string) => {
                 if (
                     (networkType === 'bitcoin' && isBech32AddressUppercase(value)) ||
-                    (symbol === 'bch' && isCashAddressUppercase(value))
+                    (symbol === 'bch' && isBitcoinCashAddressUppercase(value))
                 ) {
                     return translationString('RECIPIENT_IS_NOT_VALID');
                 }
@@ -263,6 +274,11 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                     device?.unavailableCapabilities?.taproot
                 ) {
                     return translationString('RECIPIENT_REQUIRES_UPDATE');
+                }
+            },
+            bch_missing_prefix: (value: string) => {
+                if (symbol === 'bch' && !hasBitcoinCashAddressPrefix(value)) {
+                    return translationString('RECIPIENT_IS_NOT_VALID');
                 }
             },
             evmchecks: async (address: string) => {

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -211,8 +211,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                 }
 
                 return {};
-            case 'cashaddr_uppercase':
-            case 'bech32_uppercase':
+            case 'uppercase':
                 return {
                     buttonProps: {
                         onClick: () =>
@@ -242,8 +241,12 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                     return translationString('TR_UNSUPPORTED_ADDRESS_FORMAT');
                 }
             },
-            cashaddr_uppercase: (value: string) => {
-                if (symbol === 'bch' && isCashAddressUppercase(value)) {
+            // bech32 and CashAddr addresses are valid as uppercase but are not accepted by Trezor
+            uppercase: (value: string) => {
+                if (
+                    (networkType === 'bitcoin' && isBech32AddressUppercase(value)) ||
+                    (symbol === 'bch' && isCashAddressUppercase(value))
+                ) {
                     return translationString('RECIPIENT_IS_NOT_VALID');
                 }
             },
@@ -260,12 +263,6 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                     device?.unavailableCapabilities?.taproot
                 ) {
                     return translationString('RECIPIENT_REQUIRES_UPDATE');
-                }
-            },
-            // bech32 addresses are valid as uppercase but are not accepted by Trezor
-            bech32_uppercase: (value: string) => {
-                if (networkType === 'bitcoin' && isBech32AddressUppercase(value)) {
-                    return translationString('RECIPIENT_IS_NOT_VALID');
                 }
             },
             evmchecks: async (address: string) => {

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -13,6 +13,7 @@ import {
     isAddressDeprecated,
     isAddressValid,
     isBech32AddressUppercase,
+    isCashAddressUppercase,
     isTaprootAddress,
 } from '@suite-common/wallet-utils';
 import { Button, Icon, IconButton, Input, Link, Row } from '@trezor/components';
@@ -210,7 +211,8 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                 }
 
                 return {};
-            case 'uppercase':
+            case 'cashaddr_uppercase':
+            case 'bech32_uppercase':
                 return {
                     buttonProps: {
                         onClick: () =>
@@ -240,6 +242,11 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                     return translationString('TR_UNSUPPORTED_ADDRESS_FORMAT');
                 }
             },
+            cashaddr_uppercase: (value: string) => {
+                if (symbol === 'bch' && isCashAddressUppercase(value)) {
+                    return translationString('RECIPIENT_IS_NOT_VALID');
+                }
+            },
             valid: (value: string) => {
                 if (!isAddressValid(value, symbol)) {
                     return translationString('RECIPIENT_IS_NOT_VALID');
@@ -256,7 +263,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                 }
             },
             // bech32 addresses are valid as uppercase but are not accepted by Trezor
-            uppercase: (value: string) => {
+            bech32_uppercase: (value: string) => {
                 if (networkType === 'bitcoin' && isBech32AddressUppercase(value)) {
                     return translationString('RECIPIENT_IS_NOT_VALID');
                 }

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -215,20 +215,24 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
             case 'uppercase':
                 return {
                     buttonProps: {
-                        onClick: () =>
+                        onClick: () => {
                             setValue(inputName, address.toLowerCase(), {
                                 shouldValidate: true,
-                            }),
+                            });
+                            composeTransaction();
+                        },
                         text: translationString('TR_CONVERT_TO_LOWERCASE'),
                     },
                 };
             case 'bch_missing_prefix':
                 return {
                     buttonProps: {
-                        onClick: () =>
+                        onClick: () => {
                             setValue(inputName, 'bitcoincash:' + address, {
                                 shouldValidate: true,
-                            }),
+                            });
+                            composeTransaction();
+                        },
                         text: translationString('TR_ADD_BITCOINCASH_PREFIX'),
                     },
                 };

--- a/suite-common/wallet-utils/src/__tests__/validation.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/validation.test.ts
@@ -173,18 +173,6 @@ describe('validation', () => {
         expect(
             isCashAddressUppercase('BITCOINCASH:QZ8GJEXL9X7GAG53XL08MT7QSKVJG8X2WUEEJJMTTC'),
         ).toBe(true);
-        expect(isCashAddressUppercase('bchtest:qqyr08lnsfc82ek7y6xys6j0ne2v5uv7a5pj9v0t07')).toBe(
-            false,
-        );
-        expect(isCashAddressUppercase('BCHTEST:QQYR08LNSFC82EK7Y6XYS6J0NE2V5UV7A5PJ9V0T07')).toBe(
-            true,
-        );
-        expect(isCashAddressUppercase('bchreg:qp3wjpa3tjlj042z7x7z0ur7t3g4a2t5p9z4wpgs4y')).toBe(
-            false,
-        );
-        expect(isCashAddressUppercase('BCHREG:QP3WJPA3TJLJ042Z7X7Z0UR7T3G4A2T5P9Z4WPGS4Y')).toBe(
-            true,
-        );
         expect(isCashAddressUppercase('1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu')).toBe(false);
         expect(isCashAddressUppercase('1BPEI6DFDAUFD7GTITTLSDBEYJVCOAVGGU')).toBe(false);
         expect(isCashAddressUppercase('NotValidAddressContainsBITCOINCASH:BCHTEST:1')).toBe(false);
@@ -198,10 +186,6 @@ describe('validation', () => {
         expect(isBech32AddressUppercase('TB1QKVWU9G3K2PDXEWFQR7SYZ89R3GJ557L3UUF9R9')).toBe(true);
         expect(isBech32AddressUppercase('ltc1qkzyarpkhdecu5rzeuj78pwpr5sfm798afny4n6')).toBe(false);
         expect(isBech32AddressUppercase('LTC1QKZYARPKHDECU5RZEUJ78PWPR5SFM798AFNY4N6')).toBe(true);
-        expect(isBech32AddressUppercase('tltc1qkvwu9g3k2pdxewfqr7syz89r3gj557l395tmnv')).toBe(
-            false,
-        );
-        expect(isBech32AddressUppercase('TLTC1QKVWU9G3K2PDXEWFQR7SYZ89R3GJ557L395TMNV')).toBe(true);
         expect(isBech32AddressUppercase('37VJHKeBA9DHKmTwYE7TWYjwDzo5JTb1sz')).toBe(false); // real btc address contains tb1 string
         expect(isBech32AddressUppercase('NotValidAddressContainsTb1bc1Ltc1Tltc1')).toBe(false);
     });

--- a/suite-common/wallet-utils/src/__tests__/validation.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/validation.test.ts
@@ -1,8 +1,9 @@
 import {
+    hasBitcoinCashAddressPrefix,
     isAddressDeprecated,
     isAddressValid,
     isBech32AddressUppercase,
-    isCashAddressUppercase,
+    isBitcoinCashAddressUppercase,
     isDecimalsValid,
     isHexValid,
     isInteger,
@@ -165,17 +166,26 @@ describe('validation', () => {
         ).toEqual(true);
     });
 
-    it('isCashAddressUppercase', () => {
-        expect(isCashAddressUppercase('')).toBe(false);
-        expect(
-            isCashAddressUppercase('bitcoincash:qz8gjexl9x7gag53xl08mt7qskvjg8x2wueejjmttc'),
-        ).toBe(false);
-        expect(
-            isCashAddressUppercase('BITCOINCASH:QZ8GJEXL9X7GAG53XL08MT7QSKVJG8X2WUEEJJMTTC'),
-        ).toBe(true);
-        expect(isCashAddressUppercase('1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu')).toBe(false);
-        expect(isCashAddressUppercase('1BPEI6DFDAUFD7GTITTLSDBEYJVCOAVGGU')).toBe(false);
-        expect(isCashAddressUppercase('NotValidAddressContainsBITCOINCASH:BCHTEST:1')).toBe(false);
+    it.each([
+        ['', false],
+        ['bitcoincash', false],
+        ['bitcoincash:', true],
+        ['bitcoincash:qz8gjexl9x7gag53xl08mt7qskvjg8x2wueejjmttc', true],
+        ['BITCOINCASH:QZ8GJEXL9X7GAG53XL08MT7QSKVJG8X2WUEEJJMTTC', true],
+        ['somethingbitcoincash:something', false],
+    ])('hasBitcoinCashAddressPrefix', (address, expected) => {
+        expect(hasBitcoinCashAddressPrefix(address)).toBe(expected);
+    });
+
+    it.each([
+        ['', false],
+        ['bitcoincash:qz8gjexl9x7gag53xl08mt7qskvjg8x2wueejjmttc', false],
+        ['BITCOINCASH:QZ8GJEXL9X7GAG53XL08MT7QSKVJG8X2WUEEJJMTTC', true],
+        ['1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu', false],
+        ['1BPEI6DFDAUFD7GTITTLSDBEYJVCOAVGGU', false],
+        ['NotValidAddressContainsBITCOINCASH:BCHTEST:1', false],
+    ])('isBitcoinCashAddressUppercase', (address, expected) => {
+        expect(isBitcoinCashAddressUppercase(address)).toBe(expected);
     });
 
     it('isBech32AddressUppercase', () => {

--- a/suite-common/wallet-utils/src/__tests__/validation.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/validation.test.ts
@@ -2,6 +2,7 @@ import {
     isAddressDeprecated,
     isAddressValid,
     isBech32AddressUppercase,
+    isCashAddressUppercase,
     isDecimalsValid,
     isHexValid,
     isInteger,
@@ -162,6 +163,31 @@ describe('validation', () => {
                 'test',
             ),
         ).toEqual(true);
+    });
+
+    it('isCashAddressUppercase', () => {
+        expect(isCashAddressUppercase('')).toBe(false);
+        expect(
+            isCashAddressUppercase('bitcoincash:qz8gjexl9x7gag53xl08mt7qskvjg8x2wueejjmttc'),
+        ).toBe(false);
+        expect(
+            isCashAddressUppercase('BITCOINCASH:QZ8GJEXL9X7GAG53XL08MT7QSKVJG8X2WUEEJJMTTC'),
+        ).toBe(true);
+        expect(isCashAddressUppercase('bchtest:qqyr08lnsfc82ek7y6xys6j0ne2v5uv7a5pj9v0t07')).toBe(
+            false,
+        );
+        expect(isCashAddressUppercase('BCHTEST:QQYR08LNSFC82EK7Y6XYS6J0NE2V5UV7A5PJ9V0T07')).toBe(
+            true,
+        );
+        expect(isCashAddressUppercase('bchreg:qp3wjpa3tjlj042z7x7z0ur7t3g4a2t5p9z4wpgs4y')).toBe(
+            false,
+        );
+        expect(isCashAddressUppercase('BCHREG:QP3WJPA3TJLJ042Z7X7Z0UR7T3G4A2T5P9Z4WPGS4Y')).toBe(
+            true,
+        );
+        expect(isCashAddressUppercase('1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu')).toBe(false);
+        expect(isCashAddressUppercase('1BPEI6DFDAUFD7GTITTLSDBEYJVCOAVGGU')).toBe(false);
+        expect(isCashAddressUppercase('NotValidAddressContainsBITCOINCASH:BCHTEST:1')).toBe(false);
     });
 
     it('isBech32AddressUppercase', () => {

--- a/suite-common/wallet-utils/src/validationUtils.ts
+++ b/suite-common/wallet-utils/src/validationUtils.ts
@@ -62,8 +62,11 @@ export const isTaprootAddress = (address: string, symbol: Account['symbol']) => 
     );
 };
 
-export const isCashAddressUppercase = (address: string) =>
-    /^bitcoincash:/.test(address.toLowerCase()) && /[A-Z]/.test(address);
+export const hasBitcoinCashAddressPrefix = (address: string) =>
+    /^bitcoincash:/.test(address.toLowerCase());
+
+export const isBitcoinCashAddressUppercase = (address: string) =>
+    hasBitcoinCashAddressPrefix(address) && /[A-Z]/.test(address);
 
 export const isBech32AddressUppercase = (address: string) =>
     /^(bc1|tb1|ltc1|vtc1)/.test(address.toLowerCase()) && /[A-Z]/.test(address);

--- a/suite-common/wallet-utils/src/validationUtils.ts
+++ b/suite-common/wallet-utils/src/validationUtils.ts
@@ -62,6 +62,9 @@ export const isTaprootAddress = (address: string, symbol: Account['symbol']) => 
     );
 };
 
+export const isCashAddressUppercase = (address: string) =>
+    /^(bitcoincash|bchtest|bchreg):/.test(address.toLowerCase()) && /[A-Z]/.test(address);
+
 export const isBech32AddressUppercase = (address: string) =>
     /^(bc1|tb1|ltc1|tltc1|vtc1|tvtc1)/.test(address.toLowerCase()) && /[A-Z]/.test(address);
 

--- a/suite-common/wallet-utils/src/validationUtils.ts
+++ b/suite-common/wallet-utils/src/validationUtils.ts
@@ -63,10 +63,10 @@ export const isTaprootAddress = (address: string, symbol: Account['symbol']) => 
 };
 
 export const isCashAddressUppercase = (address: string) =>
-    /^(bitcoincash|bchtest|bchreg):/.test(address.toLowerCase()) && /[A-Z]/.test(address);
+    /^bitcoincash:/.test(address.toLowerCase()) && /[A-Z]/.test(address);
 
 export const isBech32AddressUppercase = (address: string) =>
-    /^(bc1|tb1|ltc1|tltc1|vtc1|tvtc1)/.test(address.toLowerCase()) && /[A-Z]/.test(address);
+    /^(bc1|tb1|ltc1|vtc1)/.test(address.toLowerCase()) && /[A-Z]/.test(address);
 
 export const isDecimalsValid = (value: string, decimals: number) => {
     const DECIMALS_RE = new RegExp(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Add case-sensitive validation BCH addresses
2. Add validation for BCH address prefix
3. Recompose transaction when address field is manipulated by the button


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/5151

## Screenshots:
#### before:
Uppercase address creates compose error, no field validation message is shown:

https://github.com/user-attachments/assets/7976fd89-d908-4cdb-8c45-3e48b81e3209

Prefix-less address not detected by validation, fails when signing:

https://github.com/user-attachments/assets/38c24d03-fdb8-48d0-ad7b-d0b1c7703fce
#### after:

https://github.com/user-attachments/assets/f56e1fa6-52a4-46ab-98da-9563858cf827



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bch-lowercase-button&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bch-lowercase-button&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/bch-lowercase-button&lookback=7)