### PR TITLE
Trading - start on selected account in from input

### DIFF
--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -1,5 +1,10 @@
-import { ReactNode, useCallback, useMemo, useRef } from 'react';
-import ReactSelect, { Props as ReactSelectProps, SelectInstance, StylesConfig } from 'react-select';
+import { ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
+import ReactSelect, {
+    Props as ReactSelectProps,
+    SelectInstance,
+    StylesConfig,
+    components as reactSelectComponents,
+} from 'react-select';
 
 import styled, { CSSObject, DefaultTheme, css, useTheme } from 'styled-components';
 
@@ -280,8 +285,29 @@ export type SelectProps = KeyPressScrollProps &
         isMenuOpen?: boolean;
         isLoading?: boolean;
         onChange?: (value: Option, ref?: SelectInstance<Option, boolean> | null) => void;
+        /**
+         * @deprecated This prop will be replaced by internal logic - https://github.com/trezor/trezor-suite/issues/18749
+         */
+        scrollIndex?: number;
         'data-testid'?: string;
     };
+
+type MenuProps = any & {
+    selectRef: React.RefObject<SelectInstance<any, boolean>>;
+    scrollIndex?: number;
+};
+
+const Menu = ({ selectRef, scrollIndex, ...rest }: MenuProps) => {
+    useEffect(() => {
+        if (scrollIndex) {
+            const menuList = selectRef.current?.menuListRef;
+            const option = menuList?.children[scrollIndex];
+            option?.scrollIntoView({ behavior: 'instant' });
+        }
+    }, [selectRef, scrollIndex]);
+
+    return <reactSelectComponents.Menu {...rest} />;
+};
 
 export const Select = ({
     isClean = false,
@@ -322,6 +348,11 @@ export const Select = ({
         [onChange, isMenuOpen],
     );
 
+    const MenuWithProps = useCallback(
+        (props: any) => <Menu {...props} selectRef={selectRef} scrollIndex={rest.scrollIndex} />,
+        [selectRef, rest.scrollIndex],
+    );
+
     /**
      * This memoization is necessary to prevent jumping of the Select
      * to the corder. This may happen when parent component re-renders
@@ -336,9 +367,10 @@ export const Select = ({
                 <Option {...optionProps} data-testid={dataTest} />
             ),
             GroupHeading,
+            Menu: MenuWithProps,
             ...components,
         }),
-        [components, dataTest],
+        [components, dataTest, MenuWithProps],
     );
 
     return (

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAccount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAccount.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { Controller } from 'react-hook-form';
 import { createFilter } from 'react-select';
 
@@ -46,6 +47,22 @@ export const TradingFormInputAccount = <
         fiatCurrency: getValues().outputs?.[0]?.currency?.value as FiatCurrencyCode,
     });
 
+    const selectedAccountIndex = useMemo(() => {
+        if (!selectedOption) {
+            return 0;
+        }
+
+        const index = optionGroups.findIndex(group =>
+            group.options.some(
+                option =>
+                    option.descriptor === selectedOption.descriptor &&
+                    option.value === selectedOption.value,
+            ),
+        );
+
+        return index >= 0 ? index : 0;
+    }, [optionGroups, selectedOption]);
+
     return (
         <Controller
             name={accountSelectName}
@@ -53,6 +70,7 @@ export const TradingFormInputAccount = <
             render={({ field: { value } }) => (
                 <Select
                     value={value}
+                    scrollIndex={selectedAccountIndex}
                     labelLeft={label && <Translation id={label} />}
                     options={optionGroups}
                     onChange={async (selected: TradingAccountOptionsGroupOptionProps) => {


### PR DESCRIPTION
## Description

Upon selecting a coin in select dropdown and reopening it, start from the account which has the selected coin.

## Related Issue

Resolve #18237 

## Screenshots:

https://github.com/user-attachments/assets/6f74dbb6-f326-4369-b27d-e6d159457c1c



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-input-select&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-input-select&lookback=7)