### PR TITLE
chore(blockchain-link): update xrpl.js to 4.2.5 due to security issues in previous compromised versions

### DIFF
--- a/packages/blockchain-link-utils/package.json
+++ b/packages/blockchain-link-utils/package.json
@@ -23,7 +23,7 @@
         "@mobily/ts-belt": "^3.13.1",
         "@trezor/env-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "xrpl": "^4.2.0"
+        "xrpl": "^4.2.5"
     },
     "devDependencies": {
         "@solana/addresses": "^2.1.0",

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -85,7 +85,7 @@
         "@types/web": "^0.0.197",
         "events": "^3.3.0",
         "socks-proxy-agent": "8.0.5",
-        "xrpl": "^4.2.0"
+        "xrpl": "^4.2.5"
     },
     "peerDependencies": {
         "tslib": "^2.6.2"

--- a/packages/blockchain-link/src/workers/ripple/index.ts
+++ b/packages/blockchain-link/src/workers/ripple/index.ts
@@ -270,14 +270,9 @@ const onTransaction = ({ state, post }: Context, event: TransactionStream) => {
     // ignore transactions other than Payment
     if (event.tx_json?.TransactionType !== 'Payment') return;
 
-    const { tx_json } = event;
+    const { tx_json, hash } = event;
 
     const notify = (descriptor: string) => {
-        // Every signed transaction has a unique "hash" that identifies it,
-        // but its type is missing in the event definition.
-        // https://github.com/XRPLF/xrpl.js/issues/2938
-        const { hash } = event as unknown as { hash?: string };
-
         if (!tx_json || !hash) return;
 
         post({

--- a/yarn.lock
+++ b/yarn.lock
@@ -11302,7 +11302,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     tsx: "npm:^4.19.3"
-    xrpl: "npm:^4.2.0"
+    xrpl: "npm:^4.2.5"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -11336,7 +11336,7 @@ __metadata:
     webpack-cli: "npm:^5.1.4"
     webpack-dev-server: "npm:^5.0.4"
     worker-loader: "npm:^3.0.8"
-    xrpl: "npm:^4.2.0"
+    xrpl: "npm:^4.2.5"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -42766,9 +42766,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xrpl@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "xrpl@npm:4.2.0"
+"xrpl@npm:^4.2.5":
+  version: 4.2.5
+  resolution: "xrpl@npm:4.2.5"
   dependencies:
     "@scure/bip32": "npm:^1.3.1"
     "@scure/bip39": "npm:^1.2.1"
@@ -42779,7 +42779,7 @@ __metadata:
     ripple-address-codec: "npm:^5.0.0"
     ripple-binary-codec: "npm:^2.3.0"
     ripple-keypairs: "npm:^2.0.0"
-  checksum: 10/40ed2a681500b076cd6b9b1222e18a3b27a8581c5546a0ecc6fbfa66427b4a704eaf7f846d2ddd3bdcd551aa44c07fa842ae933b72bacc6e1945da94f770514c
+  checksum: 10/34c4c39ebf96ec1237c2e756b4d8c39f4a8972c1dd3cbac2acb302c24b905ff4089c0a7342107e298a3dbbd2c3e71162fc1ee8064d27ea0fb1b3ca5ce90ad21d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This updates xrpl.js to version `^4.2.5`, following reports of a vulnerability in versions `4.2.1`–`4.2.4`. Although version `4.2.0` is not directly affected, it was also flagged as potentially unsafe. To keep things clean and safe, we're going with the latest stable version.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18502

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/update-xrpl-4.2.5&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/update-xrpl-4.2.5&lookback=7)