### PR TITLE
chore(connect-popup): remove time estimation for custom fee

### DIFF
--- a/packages/connect-popup/src/view/selectFee.ts
+++ b/packages/connect-popup/src/view/selectFee.ts
@@ -42,12 +42,7 @@ export const updateCustomFee = (payload: UpdateCustomFee['payload']) => {
             feeAmount.className = 'fee-amount';
             feeAmount.textContent = formatAmount(customFee.fee, payload.coinInfo);
 
-            const feeTime = document.createElement('span');
-            feeTime.className = 'fee-time';
-            // @ts-expect-error unrecognized union member.
-            feeTime.textContent = formatTime(customFee.minutes);
-
-            customFeeLabel.replaceChildren(feeAmount, feeTime);
+            customFeeLabel.replaceChildren(feeAmount);
         }
     }
 


### PR DESCRIPTION
## Description

Remove custom fee time estimate, as the calculation is based on unsuitable data, and so it returns unreliable numbers.

This feature used to be in Suite, but was removed and only remains in Connect Popup. Fixing is not planned – it is currently tightly couple to low/normal/high recommended fees, and we do want to continue using mempool.space for those. Fixing the calculation would require creating whole new logic that uses different API. See #18474 for more details 

Note that after #18475, the connect popup would show [No time estimate](https://github.com/trezor/trezor-suite/blob/1edbbc07f2dfc488ed05b1d262350f3dd4d3d389/packages/connect/src/utils/formatUtils.ts#L11) so I'm removing it.

## Related Issue

Resolve #18476

## Screenshots:

**Before:**
![Screenshot from 2025-04-23 22-17-59](https://github.com/user-attachments/assets/2a09fc2c-7253-4b08-8eb8-7f8deba6bccf)

**After:**
![Screenshot from 2025-04-23 22-09-08](https://github.com/user-attachments/assets/a3e7e3bb-0233-4ced-918d-d8d62c1e583d)
