### PR TITLE
test(suite): add unit test for isStepCategoryUsed

### DIFF
--- a/packages/suite/src/utils/onboarding/__tests__/steps.test.ts
+++ b/packages/suite/src/utils/onboarding/__tests__/steps.test.ts
@@ -2,9 +2,15 @@ import { AcquiredDevice } from '@suite-common/suite-types';
 import { DeviceModelInternal, FirmwareType } from '@trezor/device-utils';
 
 import * as STEP from 'src/constants/onboarding/steps';
-import { Step } from 'src/types/onboarding';
+import { Step, StepCategory } from 'src/types/onboarding';
 
-import { IsStepUsedProps, findNextStep, findPrevStep, isStepUsed } from '../steps';
+import {
+    IsStepUsedProps,
+    findNextStep,
+    findPrevStep,
+    isStepCategoryUsed,
+    isStepUsed,
+} from '../steps';
 
 const firmwareStep: Step = {
     id: STEP.ID_FIRMWARE_STEP,
@@ -25,6 +31,12 @@ const coinsStep: Step = {
     supportedFirmwareTypes: [FirmwareType.Regular],
 };
 
+const stepCategory: StepCategory = {
+    id: 'device',
+    labelTranslationId: 'TR_DEVICE',
+    steps: [firmwareStep],
+};
+
 const defaultDevice = {
     features: { internal_model: DeviceModelInternal.T1B1 },
     firmwareType: FirmwareType.Regular,
@@ -40,7 +52,7 @@ const propsMock: IsStepUsedProps = {
 const stepsMock = [firmwareStep, backupStep];
 
 describe('steps', () => {
-    describe('findNextStep', () => {
+    describe(findNextStep.name, () => {
         it('should find next step', () => {
             expect(findNextStep(firmwareStep.id, stepsMock)).toEqual(backupStep);
         });
@@ -50,7 +62,7 @@ describe('steps', () => {
         });
     });
 
-    describe('findPrevStep', () => {
+    describe(findPrevStep.name, () => {
         it('should find previous step', () => {
             expect(findPrevStep(backupStep.id, stepsMock)).toEqual(firmwareStep);
         });
@@ -60,33 +72,35 @@ describe('steps', () => {
         });
     });
 
-    describe('isStepUsed', () => {
+    describe(isStepUsed.name, () => {
         it('empty path means no restriction', () => {
             expect(isStepUsed(firmwareStep, propsMock)).toEqual(true);
         });
 
         it('should return false for no overlap', () => {
-            const step = { ...firmwareStep };
-            firmwareStep.path = ['create'];
-            expect(isStepUsed(step, { ...propsMock, onboardingPath: ['recovery'] })).toEqual(false);
+            const stepWithPath: Step = { ...firmwareStep, path: ['create'] };
+            const propsWithPath: IsStepUsedProps = { ...propsMock, onboardingPath: ['recovery'] };
+            expect(isStepUsed(stepWithPath, propsWithPath)).toEqual(false);
         });
 
         it('should return true for full overlap', () => {
-            const step = { ...firmwareStep };
-            firmwareStep.path = ['create'];
-            expect(isStepUsed(step, { ...propsMock, onboardingPath: ['create'] })).toEqual(true);
+            const stepWithPath: Step = { ...firmwareStep, path: ['create'] };
+            const propsWithPath: IsStepUsedProps = { ...propsMock, onboardingPath: ['create'] };
+            expect(isStepUsed(stepWithPath, propsWithPath)).toEqual(true);
         });
 
         it('should exclude steps not supported by device', () => {
             const deviceT2B1 = {
                 features: { internal_model: DeviceModelInternal.T2B1 },
             } as AcquiredDevice;
-            expect(isStepUsed(backupStep, { ...propsMock, device: deviceT2B1 })).toEqual(true);
+            const propsWithT2B1 = { ...propsMock, device: deviceT2B1 };
+            expect(isStepUsed(backupStep, propsWithT2B1)).toEqual(true);
 
             const deviceT1B1 = {
                 features: { internal_model: DeviceModelInternal.T1B1 },
             } as AcquiredDevice;
-            expect(isStepUsed(backupStep, { ...propsMock, device: deviceT1B1 })).toEqual(false);
+            const propsWithT1B1 = { ...propsMock, device: deviceT1B1 };
+            expect(isStepUsed(backupStep, propsWithT1B1)).toEqual(false);
         });
 
         it('should exclude steps not supported by firmware', () => {
@@ -98,7 +112,8 @@ describe('steps', () => {
                     patch_version: 0,
                 },
             } as AcquiredDevice;
-            expect(isStepUsed(backupStep, { ...propsMock, device: deviceT3T1newer })).toEqual(true);
+            const propsNewerT3T1 = { ...propsMock, device: deviceT3T1newer };
+            expect(isStepUsed(backupStep, propsNewerT3T1)).toEqual(true);
 
             const deviceT3T1older = {
                 features: {
@@ -108,9 +123,8 @@ describe('steps', () => {
                     patch_version: 2,
                 },
             } as AcquiredDevice;
-            expect(isStepUsed(backupStep, { ...propsMock, device: deviceT3T1older })).toEqual(
-                false,
-            );
+            const propsOlderT3T1 = { ...propsMock, device: deviceT3T1older };
+            expect(isStepUsed(backupStep, propsOlderT3T1)).toEqual(false);
         });
 
         it('should exclude steps as per firmware type', () => {
@@ -119,11 +133,42 @@ describe('steps', () => {
                 ...coinsStep,
                 supportedFirmwareTypes: [FirmwareType.BitcoinOnly],
             };
+            const propsBtcOnly = { ...propsMock, device: btcOnlyDevice };
 
             expect(isStepUsed(coinsStep, propsMock)).toEqual(true);
             expect(isStepUsed(btcOnlyStep, propsMock)).toEqual(false);
-            expect(isStepUsed(coinsStep, { ...propsMock, device: btcOnlyDevice })).toEqual(false);
-            expect(isStepUsed(btcOnlyStep, { ...propsMock, device: btcOnlyDevice })).toEqual(true);
+            expect(isStepUsed(coinsStep, propsBtcOnly)).toEqual(false);
+            expect(isStepUsed(btcOnlyStep, propsBtcOnly)).toEqual(true);
+        });
+    });
+
+    describe(isStepCategoryUsed.name, () => {
+        it('should return true for category with at least one valid step', () => {
+            expect(isStepCategoryUsed(stepCategory, propsMock)).toEqual(true);
+        });
+
+        it('should return false for category with no steps', () => {
+            const modifiedStepCategory: StepCategory = { ...stepCategory, steps: [] };
+            expect(isStepCategoryUsed(modifiedStepCategory, propsMock)).toEqual(false);
+        });
+
+        it('should return false for category with only irrelevant steps', () => {
+            const deviceBtcOnlyT1B1 = {
+                firmwareType: FirmwareType.BitcoinOnly,
+                features: {
+                    internal_model: DeviceModelInternal.T3T1,
+                    major_version: 1,
+                    minor_version: 12,
+                    patch_version: 1,
+                },
+            } as AcquiredDevice;
+            const propsWithBtcOnlyT1B1 = { ...propsMock, device: deviceBtcOnlyT1B1 };
+
+            const modifiedStepCategory: StepCategory = {
+                ...stepCategory,
+                steps: [backupStep, coinsStep],
+            };
+            expect(isStepCategoryUsed(modifiedStepCategory, propsWithBtcOnlyT1B1)).toEqual(false);
         });
     });
 });

--- a/packages/suite/src/utils/onboarding/steps.ts
+++ b/packages/suite/src/utils/onboarding/steps.ts
@@ -85,7 +85,7 @@ export const isStepUsed = (step: Step, props: IsStepUsedProps): boolean => {
 };
 
 export const isStepCategoryUsed = (stepCategory: StepCategory, props: IsStepUsedProps): boolean =>
-    stepCategory.steps.filter(step => isStepUsed(step, props)).length > 0;
+    stepCategory.steps.some(step => isStepUsed(step, props));
 
 export const findNextStep = (currentStepId: AnyStepId, steps: Step[]) => {
     const currentIndex = steps.findIndex((step: Step) => step.id === currentStepId);


### PR DESCRIPTION
## Description

Add a unit test for `isStepCategoryUsed`, which was forgotten to do in #18220.

Plus slight cosmetic changes in that file :lipstick: :nail_care: 

@coderabbitai ignore

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/test-isStepCategoryUsed&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/test-isStepCategoryUsed&lookback=7)