### PR TITLE
ci: exclude .md from triggering actions

### DIFF
--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -11,6 +11,7 @@ on:
       - "ci/**"
       - ".vscode/**"
       - ".maestro/**"
+      - "**.md"
   pull_request:
     types: [labeled]
   workflow_dispatch:

--- a/.github/workflows/build-suite-native-preview.yml
+++ b/.github/workflows/build-suite-native-preview.yml
@@ -13,6 +13,7 @@ on:
       - "packages/transport-native-usb/**"
       - "yarn.lock"
       - ".github/workflows/build-suite-native-preview.yml"
+      - '!**.md'
       # list of paths is not complete, but it's always possible to dispatch manually using 'build-mobile' label
   workflow_dispatch:
     # manual dispatch will not add any comment to PR, use label 'build-mobile' if PR exists

--- a/.github/workflows/build-suite-web.yml
+++ b/.github/workflows/build-suite-web.yml
@@ -20,6 +20,7 @@ on:
       - ".github/workflows/build-desktop*"
       - ".github/workflows/release*"
       - ".github/workflows/template*"
+      - "**.md"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "suite-native/**"
       - "suite-common/**"
+      - '!**.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-suite-desktop-e2e-pr.yml
+++ b/.github/workflows/test-suite-desktop-e2e-pr.yml
@@ -22,6 +22,7 @@ on:
       - ".github/workflows/build-desktop*"
       - ".github/workflows/release*"
       - ".github/workflows/template*"
+      - "**.md"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-suite-native-e2e-android.yml
+++ b/.github/workflows/test-suite-native-e2e-android.yml
@@ -12,6 +12,7 @@ on:
       - "suite-common/**"
       - "packages/connect/**"
       - ".github/workflows/test-suite-native-e2e-android.yml"
+      - '!**.md'
   push:
     branches:
       - release-native/*
@@ -182,9 +183,9 @@ jobs:
     needs: prepare_android_test_app
     strategy:
       fail-fast: false
-      matrix: 
-        TEST_GROUP: [0, 1, 2, 3]  
-      
+      matrix:
+        TEST_GROUP: [0, 1, 2, 3]
+
     steps:
       - name: Checkout project
         uses: actions/checkout@v4

--- a/.github/workflows/test-suite-web-e2e-pr.yml
+++ b/.github/workflows/test-suite-web-e2e-pr.yml
@@ -35,6 +35,7 @@ on:
       - ".github/workflows/release*"
       - ".github/workflows/template*"
       - ".github/actions/release*/**"
+      - "**.md"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Description

Exclude `**.md` files from triggering certain actions.

I carefully checked MDs that are used in runtime **and** are commited to repo
_(for example `suite-data/files/guide` isn't commited, but pulled at build time)_

- Suite: `packages/suite-desktop/releaseNotes/release-notes.md` 
- Suite Native: none
- Connect: a lot of them are used in Connect Explorer, so I didn't touch Connect tests

### Notes

:thought_balloon: I think it's fine to exclude `release-notes.md` even though it is used, as there is no E2E test that covers it. It renders after update is performed and that never happens during our tests. But if we really wanted, we can hack it by renaming to a different conventional extension, such as `release-notes.markdown` [like so](https://github.com/trezor/trezor-suite/compare/exclude-md-from-CI-runs..exclude-md-from-CI-runs-include-release-notes). I tested that and it works in Suite Desktop, and IDE and github do recognize the extension as md.

[FYI github action yaml docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths)

@coderabbitai ignore

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=exclude-md-from-CI-runs&lookback=7)