### PR TITLE
fix(suite-common): fix selectAnyAccountIsStakingActive memoization

### DIFF
--- a/suite-common/wallet-core/src/transactions/transactionsReducer.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsReducer.ts
@@ -389,16 +389,11 @@ export const selectAccountIsStakingActive = createMemoizedSelector(
 );
 
 export const selectAnyAccountIsStakingActive = createMemoizedSelector(
-    [
-        (state: TransactionsRootState, accounts: Account[]) =>
-            accounts.map(account => ({
-                account,
-                transactions: state.wallet.transactions.transactions[account.key] ?? [],
-            })),
-    ],
-    items =>
-        items.some(({ account, transactions }) => {
-            const claimTransactions = transactions.filter(tx =>
+    [selectTransactions, (_: TransactionsRootState, accounts: Account[]) => accounts],
+    (transactions, accounts) =>
+        accounts.some(account => {
+            const accountTransactions = transactions[account.key] ?? [];
+            const claimTransactions = accountTransactions.filter(tx =>
                 isClaimTx(tx?.ethereumSpecific?.parsedData?.methodId),
             );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The input selector was not memoized and was breaking the memoization.

QA: Just refactoring of a selector added in https://github.com/trezor/trezor-suite/pull/17525

## Screenshots:
This can be seen in console whenever you go to Dashboard:
![Screenshot 2025-04-24 at 11 26 36](https://github.com/user-attachments/assets/7e0eddfe-d024-46c9-8c9e-1119f666a734)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/optimiza-staking-selector&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/optimiza-staking-selector&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/optimiza-staking-selector&lookback=7)