### PR TITLE
feat: allow defualt code for PinInput

### DIFF
--- a/packages/components/src/components/PinInput/PinInput.tsx
+++ b/packages/components/src/components/PinInput/PinInput.tsx
@@ -88,29 +88,50 @@ const SymbolInput = forwardRef<HTMLInputElement, SymbolInputProps>(
     },
 );
 
+const parseDefaultCode = (code: string, length: number): Symbol[] => {
+    const chars = code.split('').filter(isSymbolValid);
+
+    while (chars.length < length) {
+        chars.push('');
+    }
+
+    return chars.slice(0, length);
+};
+
 export type PinInputProps = {
     length: number;
     onComplete: (value: string) => void;
     onChange?: (value: string) => void;
     disabled?: boolean;
     autoFocus?: boolean;
+    defaultCode?: string;
 };
 
-export const PinInput = ({ length, onChange, onComplete, disabled, autoFocus }: PinInputProps) => {
-    const [symbols, setSymbols] = useState<Symbol[]>(new Array(length).fill(''));
+export const PinInput = ({
+    length,
+    onChange,
+    onComplete,
+    disabled,
+    autoFocus,
+    defaultCode = '',
+}: PinInputProps) => {
+    const [symbols, setSymbols] = useState<Symbol[]>(parseDefaultCode(defaultCode, length));
     const refs = useRef<HTMLInputElement[]>([]);
 
     useEffect(() => {
         onChange?.(symbols.join(''));
 
         if (symbols.filter(symbol => symbol !== EMPTY_SYMBOL).length === length) {
-            onComplete(symbols.join(''));
+            const newCode = symbols.join('');
+            if (newCode !== defaultCode?.slice(0, length)) {
+                onComplete(newCode);
+            }
         }
-    }, [length, onChange, onComplete, symbols]);
+    }, [length, onChange, onComplete, symbols, defaultCode]);
 
     useEffect(() => {
-        setSymbols(new Array(length).fill(''));
-    }, [length]);
+        setSymbols(parseDefaultCode(defaultCode, length));
+    }, [length, defaultCode]);
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>, index: number) => {
         if (e.key === 'Backspace') {


### PR DESCRIPTION
Needed for https://github.com/trezor/trezor-suite/issues/17962


Enabled preloading of the input with default state. It is useful to display disabled input in error state with previously filled code

![image](https://github.com/user-attachments/assets/7ad39df4-4127-4250-b45b-9ace6eca1f49)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=allow-defualt-for-pin-input&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=allow-defualt-for-pin-input&lookback=7)