### PR TITLE
chore(suite): ignore non-serializable fields in serializableCheck

### DIFF
--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -36,6 +36,7 @@ import type { PreloadStoreAction } from 'src/support/suite/preloadStore';
 import { desktopReducer } from './desktop';
 import { extraDependencies } from '../support/extraDependencies';
 import { BluetoothDevice } from '@trezor/transport-bluetooth';
+import { OPEN_USER_CONTEXT } from 'src/actions/suite/constants/modalConstants';
 
 const firmwareReducer = prepareFirmwareReducer(extraDependencies);
 const tokenDefinitionsReducer = prepareTokenDefinitionsReducer(extraDependencies);
@@ -128,6 +129,14 @@ export const initStore = (
         preloadedState: patchedState,
         middleware: getDefaultMiddleware =>
             getDefaultMiddleware({
+                serializableCheck: {
+                    ignoredActions: [OPEN_USER_CONTEXT],
+                    ignoredPaths: [
+                        'modal.payload.decision.promise',
+                        'modal.payload.decision.resolve',
+                        'modal.payload.decision.reject',
+                    ],
+                },
                 thunk: { extraArgument: extraDependencies },
             }).concat(getCustomMiddleware()),
         devTools,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removes annoying warnings. Although some fix akin to https://github.com/trezor/trezor-suite/pull/17894 would be preferable. Any ideas?

## Screenshots:

https://github.com/user-attachments/assets/5c60c424-8dd0-41c3-8ad7-f3ea0120849d



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/ignore-serializable-check&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/ignore-serializable-check&lookback=7)