### PR TITLE
fix(suite-desktop): url decoding before sanitization

### DIFF
--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -296,6 +296,14 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
         }
     }
 
+    private getSafeDecodedURI(param: string) {
+        try {
+            return decodeURIComponent(param);
+        } catch (e) {
+            this.logger.error(`Failed to decode param: ${e.message}`);
+        }
+    }
+
     /**
      * pathname could be /a/b/c/d
      * return route with highest number of matching segments
@@ -348,8 +356,9 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
                     let isParamInvalid = false;
 
                     query[key] = allParamsOfSameKey.map(singleParam => {
-                        const sanitized = sanitizeUrl(singleParam);
-                        if (sanitized !== singleParam) isParamInvalid = true;
+                        const decoded = this.getSafeDecodedURI(singleParam);
+                        const sanitized = sanitizeUrl(decoded);
+                        if (sanitized !== decoded) isParamInvalid = true;
 
                         return sanitized;
                     });
@@ -405,9 +414,10 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
 
         requestWithParams.params = route.params.reduce<Record<string, string>>(
             (acc, param, index) => {
-                if (!paramsSegments[index]) return acc;
-                const sanitized = sanitizeUrl(paramsSegments[index]);
-                if (sanitized !== paramsSegments[index]) {
+                const paramsSegment = paramsSegments[index];
+                if (!paramsSegment) return acc;
+                const sanitized = sanitizeUrl(paramsSegment);
+                if (sanitized !== paramsSegment) {
                     isSegmentInvalid = true;
                 }
 

--- a/packages/node-utils/src/tests/http.test.ts
+++ b/packages/node-utils/src/tests/http.test.ts
@@ -373,6 +373,43 @@ describe('HttpServer', () => {
         expect(await res.text()).toEqual('?a=1&a=2&b=3');
     });
 
+    test('should get query string as url when using encoded parameters', async () => {
+        const handler = jest.fn((request, response) => {
+            const { search } = url.parse(request.url, true);
+            response.end(search);
+        });
+        server.post('/foo', [parseBodyText, handler]);
+        await server.start();
+        const address = server.getServerAddress();
+        expect(address).toBeDefined();
+        const res = await fetch(
+            `http://${address.address}:${address.port}/foo?c=%2Fredirect%2Fdetail`,
+            {
+                method: 'POST',
+                body: 'foo',
+            },
+        );
+        expect(res.status).toEqual(200);
+        expect(await res.text()).toEqual('?c=%2Fredirect%2Fdetail');
+    });
+
+    test('should not get query string as url when using invalid encoded parameters', async () => {
+        const handler = jest.fn((request, response) => {
+            const { search } = url.parse(request.url, true);
+            response.end(search);
+        });
+        server.post('/foo', [parseBodyText, handler]);
+        await server.start();
+        const address = server.getServerAddress();
+        expect(address).toBeDefined();
+        const res = await fetch(`http://${address.address}:${address.port}/foo?c=%E0%A4%A`, {
+            method: 'POST',
+            body: 'foo',
+        });
+        expect(res.status).toEqual(403);
+        expect(await res.text()).toEqual('');
+    });
+
     test('query string sanitization', async () => {
         const handler = jest.fn((request, response) => {
             const { search } = url.parse(request.url, true);


### PR DESCRIPTION
## Description
- fixed bug when decoded URL was rejected with `403` 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18549



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/url-decoding-in-http&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/url-decoding-in-http&lookback=7)