### PR TITLE
fix(suite-native): Testing: replace toBeDefined with toBeTruthy in component tests

### DIFF
--- a/suite-native/accounts/src/components/__tests__/AccountLabelFieldHint.comp.test.tsx
+++ b/suite-native/accounts/src/components/__tests__/AccountLabelFieldHint.comp.test.tsx
@@ -12,6 +12,6 @@ describe('AccountLabelFieldHint', () => {
 
         const { getByText } = renderComponent({ formControl: result.current.control });
 
-        expect(getByText('13 / 30 letters')).toBeDefined();
+        expect(getByText('13 / 30 letters')).toBeTruthy();
     });
 });

--- a/suite-native/app/src/navigation/__tests__/AppTabNavigator.comp.test.tsx
+++ b/suite-native/app/src/navigation/__tests__/AppTabNavigator.comp.test.tsx
@@ -22,9 +22,9 @@ describe('AppTabNavigator', () => {
     it('should render 3 buttons', async () => {
         const { getByText } = await renderTabs();
 
-        expect(getByText('Home')).toBeDefined();
-        expect(getByText('My assets')).toBeDefined();
-        expect(getByText('Settings')).toBeDefined();
+        expect(getByText('Home')).toBeTruthy();
+        expect(getByText('My assets')).toBeTruthy();
+        expect(getByText('Settings')).toBeTruthy();
     });
 
     it('should not render Trade tab when all trading flags are disabled', async () => {

--- a/suite-native/atoms/src/Card/__tests__/Card.comp.test.tsx
+++ b/suite-native/atoms/src/Card/__tests__/Card.comp.test.tsx
@@ -17,13 +17,13 @@ describe('Card', () => {
     it('should render children prop', () => {
         const { getByText } = renderComponent({});
 
-        expect(getByText('hello')).toBeDefined();
+        expect(getByText('hello')).toBeTruthy();
     });
 
     it('should render children and alert, when alert props are specified', () => {
         const { getByText } = renderComponent({ alertProps: { title: 'alert', variant: 'info' } });
 
-        expect(getByText('hello')).toBeDefined();
-        expect(getByText('alert')).toBeDefined();
+        expect(getByText('hello')).toBeTruthy();
+        expect(getByText('alert')).toBeTruthy();
     });
 });

--- a/suite-native/atoms/src/__tests__/PriceChangeBadge.comp.test.tsx
+++ b/suite-native/atoms/src/__tests__/PriceChangeBadge.comp.test.tsx
@@ -49,7 +49,7 @@ describe('PriceChangeBadge', () => {
             <PriceChangeBadge valuePercentageChange={null} />,
         );
 
-        expect(getByTestId('skeleton-box')).toBeDefined();
+        expect(getByTestId('skeleton-box')).toBeTruthy();
     });
 
     it('should render 3 significant digits', () => {
@@ -57,6 +57,6 @@ describe('PriceChangeBadge', () => {
             <PriceChangeBadge valuePercentageChange={0.1234} />,
         );
 
-        expect(getByText('12.3%')).toBeDefined();
+        expect(getByText('12.3%')).toBeTruthy();
     });
 });

--- a/suite-native/icons/src/tests/CryptoIconWithNetwork.comp.test.tsx
+++ b/suite-native/icons/src/tests/CryptoIconWithNetwork.comp.test.tsx
@@ -10,33 +10,33 @@ const networkIconHint = 'Network Icon';
 
 describe('CryptoIconWithNetwork', () => {
     it('should render without network icon for networks that are not l2 networks = op, arb, base', () => {
-        const { queryByHintText, queryByA11yHint } = renderWithBasicProvider(
+        const { getByHintText, getByLabelText, queryByHintText } = renderWithBasicProvider(
             <CryptoIconWithNetwork symbol="btc" />,
         );
 
-        expect(queryByHintText(cryptoIconHint)).toBeDefined();
-        expect(queryByA11yHint('btc')).toBeDefined();
+        expect(getByHintText(cryptoIconHint)).toBeTruthy();
+        expect(getByLabelText('BTC')).toBeTruthy();
         expect(queryByHintText(networkIconHint)).toBeNull();
     });
 
     it('should render network with network icon for l2 networks = op, arb, base and ETH as icon', () => {
-        const { queryByHintText, queryByA11yHint } = renderWithBasicProvider(
+        const { getByHintText, getByLabelText, queryByHintText } = renderWithBasicProvider(
             <CryptoIconWithNetwork symbol="op" />,
         );
 
-        expect(queryByHintText(cryptoIconHint)).toBeDefined();
-        expect(queryByA11yHint('ETH')).toBeDefined();
-        expect(queryByHintText(networkIconHint)).toBeDefined();
+        expect(getByHintText(cryptoIconHint)).toBeTruthy();
+        expect(getByLabelText('ETH')).toBeTruthy();
+        expect(queryByHintText(networkIconHint)).toBeTruthy();
     });
 
     it('should render with network icon for contracts', () => {
         const contract = '2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo' as TokenAddress;
-        const { queryByHintText, queryByA11yHint } = renderWithBasicProvider(
+        const { getByHintText, getByLabelText } = renderWithBasicProvider(
             <CryptoIconWithNetwork symbol="op" contractAddress={contract} />,
         );
 
-        expect(queryByHintText(cryptoIconHint)).toBeDefined();
-        expect(queryByA11yHint('ETH' + contract)).toBeDefined();
-        expect(queryByHintText(networkIconHint)).toBeDefined();
+        expect(getByHintText(cryptoIconHint)).toBeTruthy();
+        expect(getByLabelText('op' + contract)).toBeTruthy();
+        expect(getByHintText(networkIconHint)).toBeTruthy();
     });
 });

--- a/suite-native/message-system/src/components/__tests__/ContextMessage.comp.test.tsx
+++ b/suite-native/message-system/src/components/__tests__/ContextMessage.comp.test.tsx
@@ -89,6 +89,6 @@ describe('ContextMessage', () => {
             context: Context.tradingBuy,
             preloadedState: stateWithTradeContextMessage,
         });
-        expect(queryByText(contentText)).toBeDefined();
+        expect(queryByText(contentText)).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyForm.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyForm.comp.test.tsx
@@ -32,37 +32,38 @@ describe('BuyForm', () => {
 
         expect(queryAllByText('Buy').length).toBe(2);
         expect(getByLabelText('Select coin')).toHaveTextContent(/Select coin/);
-        expect(queryByText('Receive account')).toBeDefined();
-        expect(queryByText('Payment method')).toBeDefined();
-        expect(queryByText('Country of residence')).toBeDefined();
-        expect(queryByText('Provider')).toBeDefined();
-        expect(queryByText('Continue')).toBeDefined();
+        expect(queryByText('Receive account')).toBeTruthy();
+        expect(queryByText('Payment method')).toBeNull();
+        expect(queryByText('Country of residence')).toBeTruthy();
+        expect(queryByText('Provider')).toBeNull();
+        expect(queryByText('Continue')).toBeNull();
         // country
-        expect(queryByText('Not selected')).toBeDefined();
+        expect(queryByText('Not selected')).toBeTruthy();
         // receive account needs coin to be selected
-        expect(queryByText('Select coin first')).toBeDefined();
+        expect(queryByText('Select coin first')).toBeTruthy();
     });
 
     it('should render with default values', async () => {
         const preloadedState = { wallet: { tradingNew: getInitializedTradingState() } };
         const { result } = await renderFormHook(preloadedState);
-        const { queryByText, queryAllByText, getByLabelText } = await renderBuyForm(
+        const { queryByText, queryAllByText, getByLabelText, getByText } = await renderBuyForm(
             preloadedState,
             result.current,
         );
+
         expect(queryAllByText('Buy').length).toBe(2);
 
         expect(getByLabelText('Select fiat currency')).toHaveTextContent(/CZK/);
         expect(getByLabelText('Select coin')).toHaveTextContent(/Select coin/);
 
-        expect(queryByText('Receive account')).toBeDefined();
-        expect(queryByText('Not selected')).toBeDefined();
+        expect(getByText('Receive account')).toBeTruthy();
+        expect(getByText('Select coin first')).toBeTruthy();
 
-        expect(queryByText('Country of residence')).toBeDefined();
-        expect(queryByText('🇨🇿 Czech Republic')).toBeDefined();
+        expect(getByText('Country of residence')).toBeTruthy();
+        expect(getByText('🇨🇿 Czech Republic')).toBeTruthy();
 
-        expect(queryByText('Provider')).toBeDefined();
-        expect(queryByText('Continue')).toBeDefined();
+        expect(queryByText('Provider')).toBeNull();
+        expect(queryByText('Continue')).toBeNull();
     });
 
     it('should render only BuyCard and Done when amount input is active', async () => {
@@ -73,9 +74,9 @@ describe('BuyForm', () => {
         });
         const { queryByText } = await renderBuyForm(preloadedState, result.current);
 
-        expect(queryByText('Buy')).toBeDefined();
-        expect(queryByText('Fund')).toBeDefined();
-        expect(queryByText('Receive account')).toBeDefined();
+        expect(queryByText('Buy')).toBeTruthy();
+        expect(queryByText('Fund')).toBeTruthy();
+        expect(queryByText('Receive account')).toBeTruthy();
 
         expect(queryByText('Country of residence')).toBeNull();
         expect(queryByText('Payment method')).toBeNull();

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFormFieldErrorBadge.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFormFieldErrorBadge.comp.test.tsx
@@ -50,6 +50,6 @@ describe('BuyFormFieldErrorBadge', () => {
         });
         const { getByText } = renderBuyFormFieldErrorBadge({ fieldName: 'fiatValue' }, tradingForm);
 
-        expect(getByText('Error message')).toBeDefined();
+        expect(getByText('Error message')).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/buy/__tests__/Confirmation.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/Confirmation.comp.test.tsx
@@ -31,7 +31,7 @@ describe('Confirmation', () => {
         });
 
         const { getByText } = await renderConfirmation();
-        expect(getByText('Continue')).toBeDefined();
+        expect(getByText('Continue')).toBeTruthy();
     });
 
     it('should not render continue button when canProceed is false', async () => {

--- a/suite-native/module-trading/src/components/buy/__tests__/CountryOfResidencePicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/CountryOfResidencePicker.comp.test.tsx
@@ -60,7 +60,7 @@ describe('CountryOfResidencePicker', () => {
         const { getByText } = await renderCountryOfResidencePicker();
         fireEvent.press(getByText('Country of residence'));
 
-        expect(getByText('No country found')).toBeDefined();
-        expect(getByText(/a country matching your search/)).toBeDefined();
+        expect(getByText('No country found')).toBeTruthy();
+        expect(getByText(/a country matching your search/)).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/buy/__tests__/CryptoAmountInput.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/CryptoAmountInput.comp.test.tsx
@@ -111,7 +111,7 @@ describe('CryptoAmountInput', () => {
 
         const { getByLabelText } = await renderCryptoAmountInput({}, form, preloadedState);
 
-        expect(getByLabelText('Fetching offers...')).toBeDefined();
+        expect(getByLabelText('Fetching offers...')).toBeTruthy();
     });
 
     it('should not display loading skeleton while amountInCrypto is true and buyInfo is loading', async () => {

--- a/suite-native/module-trading/src/components/buy/__tests__/FiatAmountInput.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/FiatAmountInput.comp.test.tsx
@@ -57,7 +57,7 @@ describe('FiatAmountInput', () => {
 
         const { getByLabelText } = await renderFiatAmountInput(form, preloadedState);
 
-        expect(getByLabelText('Fetching offers...')).toBeDefined();
+        expect(getByLabelText('Fetching offers...')).toBeTruthy();
     });
 
     it('should not display loading skeleton while amountInCrypto is false and buyInfo is loading', async () => {

--- a/suite-native/module-trading/src/components/buy/__tests__/FiatCurrencyPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/FiatCurrencyPicker.comp.test.tsx
@@ -68,7 +68,7 @@ describe('FiatCurrencyPicker', () => {
 
         const { getByText } = await renderFiatCurrencyPicker();
 
-        expect(getByText('No currency found')).toBeDefined();
-        expect(getByText(/ a currency matching your search/)).toBeDefined();
+        expect(getByText('No currency found')).toBeTruthy();
+        expect(getByText(/ a currency matching your search/)).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/buy/__tests__/LegalSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/LegalSheet.comp.test.tsx
@@ -28,12 +28,12 @@ describe('LegalSheet', () => {
     it('should render text info with given tradeProviderName', async () => {
         const { getByText } = await renderLegalSheet();
 
-        expect(getByText('Buy with Invity Finance')).toBeDefined();
+        expect(getByText('Buy with Invity Finance')).toBeTruthy();
         expect(
             getByText(
                 "I understand that Invity doesn't provide this service. It's governed by Invity Finance’s Terms and Conditions.",
             ),
-        ).toBeDefined();
+        ).toBeTruthy();
     });
 
     it('should call onConsent callback on Continue button press and onClose not to be called', async () => {

--- a/suite-native/module-trading/src/components/buy/__tests__/PaymentMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/PaymentMethodPicker.test.tsx
@@ -52,7 +52,7 @@ describe('PaymentMethodPicker', () => {
             preloadedState!.wallet!.tradingNew!.buy!.isLoading = true;
             const { getByLabelText } = await renderPaymentMethodPicker(preloadedState);
 
-            expect(getByLabelText('Fetching offers...')).toBeDefined();
+            expect(getByLabelText('Fetching offers...')).toBeTruthy();
         });
     });
 });

--- a/suite-native/module-trading/src/components/buy/__tests__/ReceiveAccountPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/ReceiveAccountPicker.comp.test.tsx
@@ -66,7 +66,7 @@ describe('ReceiveAccountPicker', () => {
 
     it('should display "Select coin first" when selectedSymbol is not specified', async () => {
         const { getByText } = await renderPicker();
-        expect(getByText('Select coin first')).toBeDefined();
+        expect(getByText('Select coin first')).toBeTruthy();
     });
 
     it('should not call navigate on press when selectedSymbol is not specified', async () => {
@@ -81,7 +81,7 @@ describe('ReceiveAccountPicker', () => {
         setSelectedCryptoId('bitcoin');
         const { getByText } = await renderPicker();
 
-        expect(getByText('Not selected')).toBeDefined();
+        expect(getByText('Not selected')).toBeTruthy();
     });
 
     it('should call navigate to account picker when selectedSymbol is specified and picker pressed', async () => {
@@ -102,7 +102,7 @@ describe('ReceiveAccountPicker', () => {
             preloadedState: getBuyState({ account: getBtcAccount() }),
         });
 
-        expect(getByText(btcAccountName1)).toBeDefined();
+        expect(getByText(btcAccountName1)).toBeTruthy();
     });
 
     it('should display selected account name and address', async () => {
@@ -115,7 +115,7 @@ describe('ReceiveAccountPicker', () => {
             }),
         });
 
-        expect(getByText(btcAccountName1)).toBeDefined();
-        expect(getByText(btcAddressAddress)).toBeDefined();
+        expect(getByText(btcAccountName1)).toBeTruthy();
+        expect(getByText(btcAddressAddress)).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/buy/__tests__/TradingProviderPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/TradingProviderPicker.comp.test.tsx
@@ -64,6 +64,6 @@ describe('TradingProviderPicker', () => {
             preloadedState,
         );
 
-        expect(getByLabelText('Fetching offers...')).toBeDefined();
+        expect(getByLabelText('Fetching offers...')).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/general/AccountSheet/__tests__/AccountListAddressItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountSheet/__tests__/AccountListAddressItem.test.tsx
@@ -62,7 +62,7 @@ describe('AccountListAddressItem', () => {
         const { getByText, queryByAccessibilityHint } =
             await renderAccountListAddressItem(receiveAccount);
 
-        expect(getByText('BTC_address')).toBeDefined();
+        expect(getByText('BTC_address')).toBeTruthy();
         expect(queryByAccessibilityHint('Select to display account addresses')).toBeNull();
     });
 
@@ -82,7 +82,7 @@ describe('AccountListAddressItem', () => {
         const { getByText, queryByText, queryByAccessibilityHint, getByLabelText } =
             await renderAccountListAddressItem(receiveAccount);
 
-        expect(getByText('BTC_address')).toBeDefined();
+        expect(getByText('BTC_address')).toBeTruthy();
         expect(queryByText('My BTC account')).toBeNull();
         expect(queryByAccessibilityHint('Select to display account addresses')).toBeNull();
         expect(getByLabelText('Balance in fiat')).toHaveTextContent('$5,000,000.00');

--- a/suite-native/module-trading/src/components/general/AccountSheet/__tests__/AccountListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountSheet/__tests__/AccountListItem.comp.test.tsx
@@ -53,7 +53,7 @@ describe('AccountListItem', () => {
         const { getByText, queryByAccessibilityHint, getByLabelText } =
             await renderAccountListItem(receiveAccount);
 
-        expect(getByText('My BTC account')).toBeDefined();
+        expect(getByText('My BTC account')).toBeTruthy();
         expect(queryByAccessibilityHint('Select to display account addresses')).toBeNull();
         expect(getByLabelText('Balance in fiat')).toHaveTextContent('$10,000,000.00');
         expect(getByLabelText('Balance in crypto')).toHaveTextContent('0.1 BTC');
@@ -75,7 +75,7 @@ describe('AccountListItem', () => {
         };
         const { getByText, getByAccessibilityHint } = await renderAccountListItem(receiveAccount);
 
-        expect(getByText('My BTC account')).toBeDefined();
-        expect(getByAccessibilityHint('Select to display account addresses')).toBeDefined();
+        expect(getByText('My BTC account')).toBeTruthy();
+        expect(getByAccessibilityHint('Select to display account addresses')).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/general/AccountSheet/__tests__/AccountsListFooter.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountSheet/__tests__/AccountsListFooter.comp.test.tsx
@@ -17,7 +17,7 @@ describe('AccountsListFooter', () => {
     it('should render "OR" when hasTextualDivider props is true', () => {
         const { getByText } = renderAccountsListFooter({ hasTextualDivider: true });
 
-        expect(getByText('OR')).toBeDefined();
+        expect(getByText('OR')).toBeTruthy();
     });
 
     it('should call onAddAccountTap callback on "Add new" button press', () => {

--- a/suite-native/module-trading/src/components/general/AccountSheet/__tests__/NoAccountsComponent.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountSheet/__tests__/NoAccountsComponent.comp.test.tsx
@@ -18,7 +18,7 @@ describe('NoAccountsComponent', () => {
     it('should render for not connected device', async () => {
         const { queryByText } = await renderNoAccountsComponent({ isConnected: false });
 
-        expect(queryByText('You need to connect your device to add new account.')).toBeDefined();
+        expect(queryByText('You need to connect your device to add new account.')).toBeTruthy();
     });
 
     it('should render for no account but connected device', async () => {
@@ -26,6 +26,6 @@ describe('NoAccountsComponent', () => {
 
         expect(
             queryByText("It seems that you don't have any account matching selected asset."),
-        ).toBeDefined();
+        ).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/general/CountrySheet/__tests__/CountryListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/CountrySheet/__tests__/CountryListItem.comp.test.tsx
@@ -16,7 +16,7 @@ describe('CountryListItem', () => {
     it('should render given name', () => {
         const { getByText } = renderCountryListItem({ label: '🇺🇸 United States of America' });
 
-        expect(getByText('🇺🇸 United States of America')).toBeDefined();
+        expect(getByText('🇺🇸 United States of America')).toBeTruthy();
     });
 
     it('should call onPress callback on item press', () => {

--- a/suite-native/module-trading/src/components/general/FiatCurrencySheet/__tests__/FiatCurrencyListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencySheet/__tests__/FiatCurrencyListItem.comp.test.tsx
@@ -16,8 +16,8 @@ describe('FiatCurrencyListItem', () => {
     it('should render label and display value', () => {
         const { getByText } = renderFiatCurrencyListItem({});
 
-        expect(getByText('LABEL')).toBeDefined();
-        expect(getByText('DISPLAY_VALUE')).toBeDefined();
+        expect(getByText('LABEL')).toBeTruthy();
+        expect(getByText('DISPLAY_VALUE')).toBeTruthy();
     });
 
     it('should call onPress callback when pressed', () => {

--- a/suite-native/module-trading/src/components/general/PaymentMethodsSheet/__tests__/PaymentMethodListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodsSheet/__tests__/PaymentMethodListItem.comp.test.tsx
@@ -19,7 +19,7 @@ describe('PaymentMethodListItem', () => {
             paymentMethodName: 'Debit card',
         });
 
-        expect(getByText('Debit card')).toBeDefined();
+        expect(getByText('Debit card')).toBeTruthy();
     });
 
     it('should call onPress callback on item press', () => {

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.comp.test.tsx
@@ -30,6 +30,6 @@ describe('ProviderListItem', () => {
             companyName: 'tstName',
         });
 
-        expect(queryByText('tstName')).toBeDefined();
+        expect(queryByText('tstName')).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/general/TradeableAssetsSheet/__tests__/FavouriteIcon.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetsSheet/__tests__/FavouriteIcon.comp.test.tsx
@@ -7,14 +7,14 @@ describe('FavouriteIcon', () => {
         const { getByA11yHint } = renderWithBasicProvider(
             <FavouriteIcon isFavourite={true} onPress={jest.fn()} />,
         );
-        expect(getByA11yHint('Remove from favourites')).toBeDefined();
+        expect(getByA11yHint('Remove from favourites')).toBeTruthy();
     });
 
     it('should have correct hint when not marked as favourite', () => {
         const { getByA11yHint } = renderWithBasicProvider(
             <FavouriteIcon isFavourite={false} onPress={jest.fn()} />,
         );
-        expect(getByA11yHint('Add to favourites')).toBeDefined();
+        expect(getByA11yHint('Add to favourites')).toBeTruthy();
     });
 
     it('should call onPress callback', () => {

--- a/suite-native/module-trading/src/components/general/TradeableAssetsSheet/__tests__/TradeableAssetListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetsSheet/__tests__/TradeableAssetListItem.comp.test.tsx
@@ -32,7 +32,7 @@ describe('TradeableAssetListItem', () => {
 
         fireEvent.press(getByAccessibilityHint('Add to favourites'));
 
-        expect(getByAccessibilityHint('Remove from favourites')).toBeDefined();
+        expect(getByAccessibilityHint('Remove from favourites')).toBeTruthy();
     });
 
     it('should remove asset from favourites on star click', async () => {
@@ -41,6 +41,6 @@ describe('TradeableAssetListItem', () => {
         fireEvent.press(getByAccessibilityHint('Add to favourites'));
         fireEvent.press(getByAccessibilityHint('Remove from favourites'));
 
-        expect(getByAccessibilityHint('Add to favourites')).toBeDefined();
+        expect(getByAccessibilityHint('Add to favourites')).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/general/TradeableAssetsSheet/__tests__/TradeableAssetsFilterTabs.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetsSheet/__tests__/TradeableAssetsFilterTabs.comp.test.tsx
@@ -34,9 +34,9 @@ describe('TradeableAssetsFilterTabs', () => {
     it('should render all filter tabs including "All" option', async () => {
         const { getByText } = await renderComponent();
 
-        expect(getByText('All')).toBeDefined();
-        expect(getByText('Bitcoin')).toBeDefined();
-        expect(getByText('Ethereum')).toBeDefined();
+        expect(getByText('All')).toBeTruthy();
+        expect(getByText('Bitcoin')).toBeTruthy();
+        expect(getByText('Ethereum')).toBeTruthy();
     });
 
     it('should not render anything when visible is false', async () => {

--- a/suite-native/module-trading/src/components/general/TradeableAssetsSheet/__tests__/TradeableAssetsSheetHeader.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetsSheet/__tests__/TradeableAssetsSheetHeader.comp.test.tsx
@@ -25,7 +25,7 @@ describe('TradeableAssetsSheetHeader', () => {
     it('should display "Coins" and do not display tabs by default', async () => {
         const { getByText, queryByText } = await renderComponent();
 
-        expect(getByText('Coins')).toBeDefined();
+        expect(getByText('Coins')).toBeTruthy();
         expect(queryByText('All')).toBeNull();
     });
 
@@ -34,7 +34,7 @@ describe('TradeableAssetsSheetHeader', () => {
 
         fireEvent(getByPlaceholderText('Search'), 'focus');
 
-        expect(getByText('All')).toBeDefined();
+        expect(getByText('All')).toBeTruthy();
         expect(queryByText('Coins')).toBeNull();
     });
 
@@ -49,7 +49,7 @@ describe('TradeableAssetsSheetHeader', () => {
 
         fireEvent(getByPlaceholderText('Search'), 'focus');
 
-        expect(getByText('Cancel')).toBeDefined();
+        expect(getByText('Cancel')).toBeTruthy();
     });
 
     it('should call onClose when close button is pressed ', async () => {

--- a/suite-native/module-trading/src/components/general/__tests__/AccountAddress.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/AccountAddress.comp.test.tsx
@@ -9,7 +9,7 @@ describe('AccountAddress', () => {
                 <AccountAddress address="0x1234567890abcdef" />,
             );
 
-            expect(getByText('0x1234567890abcdef')).toBeDefined();
+            expect(getByText('0x1234567890abcdef')).toBeTruthy();
         });
     });
 
@@ -19,13 +19,13 @@ describe('AccountAddress', () => {
                 <AccountAddress address="0x1234567890abcdef" form="short" />,
             );
 
-            expect(getByText('0x123456...')).toBeDefined();
+            expect(getByText('0x123456...')).toBeTruthy();
         });
 
         it('should render full address when it is shorter than 9 characters', () => {
             const { getByText } = renderWithBasicProvider(<AccountAddress address="0x123456" />);
 
-            expect(getByText('0x123456')).toBeDefined();
+            expect(getByText('0x123456')).toBeTruthy();
         });
     });
 });

--- a/suite-native/module-trading/src/components/general/__tests__/NetworkSymbolExtendedFormatter.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/NetworkSymbolExtendedFormatter.comp.test.tsx
@@ -8,6 +8,6 @@ describe('NetworkSymbolExtendedFormatter', () => {
             <NetworkSymbolExtendedFormatter symbol="btc" />,
         );
 
-        expect(getByText('BTC')).toBeDefined();
+        expect(getByText('BTC')).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/general/__tests__/SearchInputWithCancel.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/SearchInputWithCancel.comp.test.tsx
@@ -43,7 +43,7 @@ describe('SearchInputWithCancel', () => {
 
         fireEvent(getByPlaceholderText('Search'), 'focus');
 
-        expect(getByText('Cancel')).toBeDefined();
+        expect(getByText('Cancel')).toBeTruthy();
         expect(focusMock).toHaveBeenCalledTimes(1);
     });
 

--- a/suite-native/module-trading/src/components/general/__tests__/SimpleSheetHeader.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/SimpleSheetHeader.comp.test.tsx
@@ -12,7 +12,7 @@ describe('SimpleSheetHeader', () => {
             onClose: jest.fn(),
         });
 
-        expect(getByText('Test title')).toBeDefined();
+        expect(getByText('Test title')).toBeTruthy();
     });
     it('should call onClose when X button is pressed', () => {
         const onCloseMock = jest.fn();

--- a/suite-native/module-trading/src/components/general/__tests__/TradeableAssetButton.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradeableAssetButton.comp.test.tsx
@@ -13,7 +13,7 @@ describe('TradeableAssetButton', () => {
             />,
         );
 
-        expect(getByText('BTC')).toBeDefined();
+        expect(getByText('BTC')).toBeTruthy();
     });
 
     it('should render display ETH as display symbol for L2 EVMs', () => {
@@ -25,7 +25,7 @@ describe('TradeableAssetButton', () => {
             />,
         );
 
-        expect(getByText('ETH')).toBeDefined();
+        expect(getByText('ETH')).toBeTruthy();
     });
 
     it('should render display token name when token is present', () => {
@@ -37,7 +37,7 @@ describe('TradeableAssetButton', () => {
             />,
         );
 
-        expect(getByText('USDC')).toBeDefined();
+        expect(getByText('USDC')).toBeTruthy();
         expect(getByLabelText('eth0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')).toBeTruthy();
     });
 

--- a/suite-native/module-trading/src/components/general/__tests__/TradingAlert.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingAlert.comp.test.tsx
@@ -33,7 +33,7 @@ describe('TradingAlert', () => {
 
         const { getByText } = renderTradingAlert();
 
-        expect(getByText('TEST')).toBeDefined();
+        expect(getByText('TEST')).toBeTruthy();
     });
 
     it.each([undefined, ''])('should render nothing when generalAlert is %s', generalAlertValue => {

--- a/suite-native/module-trading/src/components/general/__tests__/TradingEmptyComponent.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingEmptyComponent.comp.test.tsx
@@ -8,7 +8,7 @@ describe('TradingEmptyComponent', () => {
             <TradingEmptyComponent title="TITLE" description="DESCRIPTION" />,
         );
 
-        expect(getByText('TITLE')).toBeDefined();
-        expect(getByText('DESCRIPTION')).toBeDefined();
+        expect(getByText('TITLE')).toBeTruthy();
+        expect(getByText('DESCRIPTION')).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/general/__tests__/TradingOverviewRow.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingOverviewRow.comp.test.tsx
@@ -11,8 +11,8 @@ describe('TradingOverviewRow', () => {
             </TradingOverviewRow>,
         );
 
-        expect(getByText('Title')).toBeDefined();
-        expect(getByLabelText('Title')).toBeDefined();
+        expect(getByText('Title')).toBeTruthy();
+        expect(getByLabelText('Title')).toBeTruthy();
     });
 
     it('should call onPress callback when clicked', () => {

--- a/suite-native/module-trading/src/hooks/__tests__/useTradeableAssetsFilteredData.test.ts
+++ b/suite-native/module-trading/src/hooks/__tests__/useTradeableAssetsFilteredData.test.ts
@@ -71,7 +71,7 @@ describe('useTradeableAssetsFilteredData', () => {
             result.current.setFilterValue('0xa0b');
         });
         expect(result.current.filteredData).toHaveLength(1);
-        expect(result.current.filteredData[0].contractAddress).toBeDefined();
+        expect(result.current.filteredData[0].contractAddress).toBeTruthy();
     });
 
     it('should filter assets by filter symbol', () => {

--- a/suite-native/module-trading/src/navigation/__tests__/TradingStackNavigator.comp.test.tsx
+++ b/suite-native/module-trading/src/navigation/__tests__/TradingStackNavigator.comp.test.tsx
@@ -13,6 +13,6 @@ describe('TradingStackNavigator', () => {
     it('should render', async () => {
         const { getByTestId } = await renderWithStoreProviderAsync(<TradingStackNavigator />);
 
-        expect(getByTestId('@screen/Trading')).toBeDefined();
+        expect(getByTestId('@screen/Trading')).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/screens/__tests__/TradeWebviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradeWebviewScreen.comp.test.tsx
@@ -20,7 +20,7 @@ describe('TradingWebViewScreen', () => {
         };
         const { getByTestId } = await renderWithStoreProviderAsync(<TradingWebViewScreen />);
 
-        expect(getByTestId('@screen/sub-header/icon-left')).toBeDefined();
+        expect(getByTestId('@screen/sub-header/icon-left')).toBeTruthy();
     });
 
     it('should render error when no source is set', async () => {
@@ -29,7 +29,7 @@ describe('TradingWebViewScreen', () => {
         };
         const { getByText } = await renderWithStoreProviderAsync(<TradingWebViewScreen />);
 
-        expect(getByText('Something went wrong')).toBeDefined();
+        expect(getByText('Something went wrong')).toBeTruthy();
     });
 
     it('should render error when sources are undefined', async () => {
@@ -39,6 +39,6 @@ describe('TradingWebViewScreen', () => {
         };
         const { getByText } = await renderWithStoreProviderAsync(<TradingWebViewScreen />);
 
-        expect(getByText('Something went wrong')).toBeDefined();
+        expect(getByText('Something went wrong')).toBeTruthy();
     });
 });


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix component tests to use correct assertions.
<!--- Describe your changes in detail -->




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-tests-tobedefined&lookback=7)