### PR TITLE
fix(suite): don't lock router if not loaded

### DIFF
--- a/packages/suite/src/actions/suite/__tests__/routerActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/routerActions.test.ts
@@ -107,6 +107,7 @@ describe('Suite Actions', () => {
     it(`onLocationChange with lock`, () => {
         const state = getInitialState({
             suite: { locks: { router: 1 } },
+            router: { loaded: true },
         } as InitialState);
         const store = initStore(state);
         store.dispatch(routerActions.onLocationChange('/'));

--- a/packages/suite/src/actions/suite/routerActions.ts
+++ b/packages/suite/src/actions/suite/routerActions.ts
@@ -55,8 +55,8 @@ export const onBeforePopState = () => (_dispatch: Dispatch, getState: GetState) 
 export const onLocationChange =
     (url: string, anchor?: AnchorType) => (dispatch: Dispatch, getState: GetState) => {
         const unlocked = dispatch(onBeforePopState());
-        if (!unlocked) return;
         const { router } = getState();
+        if (!unlocked && router.loaded) return;
         if (router.url === url && router.app !== 'unknown') return null;
         // TODO: check if the view is not locked by the device request
 


### PR DESCRIPTION
## Description

This issue happened to me when testing Connect modal opening from background. 
The modal locks the router, but the router is not loaded yet, so Suite is stuck.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-router-lock-loading&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-router-lock-loading&lookback=7)