### PR TITLE
fix(suite): hide receive address before selecting account

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/trading/buy-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-ethereum.test.ts
@@ -43,7 +43,7 @@ test.describe('Trading - Buy Ethereum', { tag: ['@group=other', '@webOnly'] }, (
             await expect(tradingPage.confirmationAccountDropdown).toHaveText(
                 'Select ETHEREUM receive account',
             );
-            await expect(tradingPage.confirmationAddress).toHaveText('');
+            await expect(tradingPage.confirmationAddress).not.toBeVisible();
             await tradingPage.confirmationAccountDropdown.click();
             await page.getByRole('option', { name: 'Create a new Ethereum account' }).click();
             await expect(settingsPage.coins.networkButton('eth')).toBeEnabledCoin();

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerify.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerify.tsx
@@ -166,71 +166,77 @@ export const TradingVerify = ({ tradingVerifyAccount, cryptoId }: TradingVerifyP
                 }
             />
 
-            <Column gap={spacings.sm}>
-                {selectedAccountOption?.type === 'SUITE' &&
-                    selectedAccountOption?.account?.networkType === 'bitcoin' && (
-                        <TradingAddressOptions
-                            account={selectedAccountOption?.account}
-                            address={address}
-                            control={form.control}
-                            receiveSymbol={cryptoId}
-                            setValue={form.setValue}
-                            label={
+            {selectedAccountOption && (
+                <Column gap={spacings.sm}>
+                    {selectedAccountOption?.type === 'SUITE' &&
+                        selectedAccountOption?.account?.networkType === 'bitcoin' && (
+                            <TradingAddressOptions
+                                account={selectedAccountOption?.account}
+                                address={address}
+                                control={form.control}
+                                receiveSymbol={cryptoId}
+                                setValue={form.setValue}
+                                label={
+                                    <Tooltip
+                                        hasIcon
+                                        content={<Translation id={addressTooltipTranslationId} />}
+                                    >
+                                        <Translation id="TR_BUY_RECEIVING_ADDRESS" />
+                                    </Tooltip>
+                                }
+                            />
+                        )}
+                    {selectedAccountOption?.account?.networkType !== 'bitcoin' && (
+                        <Input
+                            data-testid="@trading/form/verify/address"
+                            readOnly={selectedAccountOption?.type !== 'NON_SUITE'}
+                            inputState={form.formState.errors.address ? 'error' : undefined}
+                            labelLeft={
                                 <Tooltip
                                     hasIcon
                                     content={<Translation id={addressTooltipTranslationId} />}
                                 >
-                                    <Translation id="TR_BUY_RECEIVING_ADDRESS" />
+                                    <Translation id="TR_EXCHANGE_RECEIVING_ADDRESS" />
                                 </Tooltip>
                             }
+                            bottomText={form.formState.errors.address?.message || null}
+                            innerRef={networkRef}
+                            {...networkField}
                         />
                     )}
-                {selectedAccountOption?.account?.networkType !== 'bitcoin' && (
-                    <Input
-                        data-testid="@trading/form/verify/address"
-                        readOnly={selectedAccountOption?.type !== 'NON_SUITE'}
-                        inputState={form.formState.errors.address ? 'error' : undefined}
-                        labelLeft={
-                            <Tooltip
-                                hasIcon
-                                content={<Translation id={addressTooltipTranslationId} />}
-                            >
-                                <Translation id="TR_EXCHANGE_RECEIVING_ADDRESS" />
-                            </Tooltip>
-                        }
-                        bottomText={form.formState.errors.address?.message || null}
-                        innerRef={networkRef}
-                        {...networkField}
-                    />
-                )}
 
-                {exchangeQuote?.extraFieldDescription && (
-                    <TradingVerifyDestinationTag
-                        inputComponent={
-                            <Input
-                                label={
-                                    <Translation
-                                        id="TR_EXCHANGE_EXTRA_FIELD"
-                                        values={extraFieldDescription}
-                                    />
-                                }
-                                inputState={form.formState.errors.extraField ? 'error' : undefined}
-                                bottomText={form.formState.errors.extraField?.message || null}
-                                innerRef={descriptionRef}
-                                {...descriptionField}
-                            />
-                        }
-                        onToggle={() => form.setValue('extraField', '', { shouldValidate: true })}
-                        required={exchangeQuote.extraFieldDescription.required}
-                        extraFieldDescription={exchangeQuote.extraFieldDescription}
-                    />
-                )}
+                    {exchangeQuote?.extraFieldDescription && (
+                        <TradingVerifyDestinationTag
+                            inputComponent={
+                                <Input
+                                    label={
+                                        <Translation
+                                            id="TR_EXCHANGE_EXTRA_FIELD"
+                                            values={extraFieldDescription}
+                                        />
+                                    }
+                                    inputState={
+                                        form.formState.errors.extraField ? 'error' : undefined
+                                    }
+                                    bottomText={form.formState.errors.extraField?.message || null}
+                                    innerRef={descriptionRef}
+                                    {...descriptionField}
+                                />
+                            }
+                            onToggle={() =>
+                                form.setValue('extraField', '', { shouldValidate: true })
+                            }
+                            required={exchangeQuote.extraFieldDescription.required}
+                            extraFieldDescription={exchangeQuote.extraFieldDescription}
+                        />
+                    )}
 
-                {device?.connected &&
-                    device.available &&
-                    addressVerified &&
-                    addressVerified === address && <ConfirmedOnTrezor device={device} />}
-            </Column>
+                    {device?.connected &&
+                        device.available &&
+                        addressVerified &&
+                        addressVerified === address && <ConfirmedOnTrezor device={device} />}
+                </Column>
+            )}
             {selectedAccountOption && (
                 <Column>
                     <Divider margin={{ top: spacings.xs, bottom: spacings.lg }} />


### PR DESCRIPTION
## Description

In trading, hide receive address when no account is selected.

## Related Issue

Resolve #14846 

## Screenshots:

<img width="1134" alt="Screenshot 2025-04-25 at 11 42 40" src="https://github.com/user-attachments/assets/2e404e2f-20a9-440a-8e43-400f16305205" />

<img width="1136" alt="Screenshot 2025-04-25 at 11 42 49" src="https://github.com/user-attachments/assets/9011c933-3fc7-4c3a-960d-8c479fd670d9" />

<img width="1133" alt="Screenshot 2025-04-25 at 11 43 05" src="https://github.com/user-attachments/assets/5c7dbf2e-7e57-4a86-a3e1-84078e6223c8" />

<img width="1133" alt="Screenshot 2025-04-25 at 11 43 11" src="https://github.com/user-attachments/assets/efffa5de-b7d5-443f-9710-c683a461a729" />

<img width="1133" alt="Screenshot 2025-04-25 at 11 43 32" src="https://github.com/user-attachments/assets/c705cd76-3447-4295-9002-e085c4ef7705" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/receive-address&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/receive-address&lookback=7)