### PR TITLE
fix(suite-common): Fix unstable selectAccounts selector

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -161,8 +161,10 @@ const createMemoizedSelector = createWeakMapSelector.withTypes<
 
 const EMPTY_STABLE_ACCOUNTS_ARRAY: Account[] = [];
 
-export const selectAccounts = (state: AccountsRootState) =>
-    state.wallet.accounts.filter(a => a.accountType !== 'placeholder');
+export const selectAccounts = createMemoizedSelector(
+    [(state: AccountsRootState) => state.wallet.accounts],
+    accounts => accounts.filter(a => a.accountType !== 'placeholder'),
+);
 
 export const getAccountsByDeviceState = (
     accounts: Account[],

--- a/suite-common/wallet-core/src/accounts/tests/accountsReducer.test.ts
+++ b/suite-common/wallet-core/src/accounts/tests/accountsReducer.test.ts
@@ -6,7 +6,7 @@ import { Bip43Path } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 
 import { accountsActions } from '../accountsActions';
-import { AccountsRootState, prepareAccountsReducer } from '../accountsReducer';
+import { AccountsRootState, prepareAccountsReducer, selectAccounts } from '../accountsReducer';
 
 const accountsReducer = prepareAccountsReducer(extraDependenciesMock);
 
@@ -112,5 +112,53 @@ describe('Account Reducer', () => {
         spyWarn.mockRestore();
 
         expect(store.getState().wallet.accounts.length).toEqual(0);
+    });
+});
+
+describe('Account selectors', () => {
+    describe('selectAccounts', () => {
+        it('should return all accounts', () => {
+            const state = {
+                wallet: {
+                    accounts: [
+                        getAccount({
+                            symbol: 'ltc',
+                            path: testBip43Path,
+                            visible: false,
+                        }) as Account,
+                        getAccount({
+                            symbol: 'btc',
+                            path: testBip43Path,
+                            visible: false,
+                        }) as Account,
+                    ],
+                },
+            };
+
+            const accounts = selectAccounts(state);
+
+            expect(accounts.length).toEqual(2);
+        });
+
+        it('should be stable', () => {
+            const state = {
+                wallet: {
+                    accounts: [
+                        getAccount({
+                            symbol: 'ltc',
+                            path: testBip43Path,
+                            visible: false,
+                        }) as Account,
+                        getAccount({
+                            symbol: 'btc',
+                            path: testBip43Path,
+                            visible: false,
+                        }) as Account,
+                    ],
+                },
+            };
+
+            expect(selectAccounts(state)).toBe(selectAccounts(state));
+        });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes multiple warnings given in console about unstable input selector.

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-unstable-selectAccounts&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-unstable-selectAccounts&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-unstable-selectAccounts&lookback=7)