### PR TITLE
feat: local firmwares in connect from suite desktop

### DIFF
--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -12,6 +12,7 @@ import { onCallFirmwareUpdate } from './onCallFirmwareUpdate';
 import { dispose as disposeBackend } from '../backend/BlockchainLink';
 import { DataManager } from '../data/DataManager';
 import { enhanceMessageWithAnalytics } from '../data/analyticsInfo';
+import { parseLocalFirmwares } from '../data/connectSettings';
 import type { Device, DeviceEvents } from '../device/Device';
 import { DeviceList, IDeviceList, assertDeviceListConnected } from '../device/DeviceList';
 import { WebextensionStateStorage } from '../device/StateStorage';
@@ -1143,6 +1144,13 @@ export class Core extends EventEmitter {
             case UI.LOGIN_CHALLENGE_RESPONSE:
                 this.uiPromises.resolve(message);
                 break;
+            case UI.RECEIVE_FIRMWARE: {
+                const localFirmwares = message.payload && parseLocalFirmwares(message.payload);
+                if (localFirmwares) {
+                    DataManager.setLocalFirmwares(localFirmwares);
+                }
+                break;
+            }
 
             // message from index
             case IFRAME.CALL:
@@ -1225,6 +1233,11 @@ export class Core extends EventEmitter {
 
         try {
             await DataManager.load(settings);
+            const localFirmwares =
+                settings.localFirmwares && parseLocalFirmwares(settings.localFirmwares);
+            if (localFirmwares) {
+                DataManager.setLocalFirmwares(localFirmwares);
+            }
             const { debug, priority, _sessionsBackgroundUrl, manifest } = DataManager.getSettings();
             const messages = DataManager.getProtobufMessages();
 

--- a/packages/connect/src/data/DataManager.ts
+++ b/packages/connect/src/data/DataManager.ts
@@ -7,7 +7,7 @@ import messages from '@trezor/protobuf/messages.json';
 
 import { parseCoinsJson } from './coinInfo';
 import { parseFirmwareReleases } from './firmwareInfo';
-import { ConnectSettings } from '../types';
+import type { ConnectSettings, LocalFirmwares } from '../types/settings';
 import { firmwareAssets } from '../utils/assetUtils'; // Adjust the path as necessary
 
 type AssetCollection = { [key: string]: Record<string, any> };
@@ -17,6 +17,7 @@ export class DataManager {
 
     private static settings: ConnectSettings;
     private static messages: Record<string, any> = messages;
+    private static localFirmwares: LocalFirmwares = { firmwareDir: '', firmwareList: [] };
 
     static load(settings: ConnectSettings, withAssets = true) {
         this.settings = settings;
@@ -65,5 +66,12 @@ export class DataManager {
         }
 
         return this.settings;
+    }
+
+    static setLocalFirmwares(firmwares: LocalFirmwares): void {
+        this.localFirmwares = firmwares;
+    }
+    static getLocalFirmwares(): LocalFirmwares {
+        return this.localFirmwares;
     }
 }

--- a/packages/connect/src/data/connectSettings.ts
+++ b/packages/connect/src/data/connectSettings.ts
@@ -1,8 +1,8 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/data/ConnectSettings.js
 
-import type { ConnectSettings, Manifest } from '../types';
 import { parseThpSettings } from './thpSettings';
 import { DEEPLINK_VERSION, DEFAULT_DOMAIN, VERSION } from './version';
+import type { ConnectSettings, LocalFirmwares, Manifest } from '../types/settings';
 
 /*
  * Initial settings for connect.
@@ -46,6 +46,17 @@ const parseManifest = (manifest?: Manifest) => {
         appUrl: manifest.appUrl,
         appName: manifest.appName,
         appIcon: manifest.appIcon,
+    };
+};
+
+export const parseLocalFirmwares = (localFirmwares: LocalFirmwares) => {
+    if (!localFirmwares) return;
+    if (typeof localFirmwares.firmwareDir !== 'string') return;
+    if (!Array.isArray(localFirmwares.firmwareList)) return;
+
+    return {
+        firmwareDir: localFirmwares.firmwareDir,
+        firmwareList: localFirmwares.firmwareList,
     };
 };
 
@@ -95,6 +106,10 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
 
     if (typeof input.transportReconnect === 'boolean') {
         settings.transportReconnect = input.transportReconnect;
+    }
+
+    if (typeof input.localFirmwares === 'object') {
+        settings.localFirmwares = parseLocalFirmwares(input.localFirmwares);
     }
 
     if (Array.isArray(input.transports)) {

--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -2,9 +2,17 @@
  * messages to UI emitted as UI_EVENT
  */
 import type { EventTypeDeviceSelected } from '@trezor/connect-analytics';
+import { DeviceModelInternal } from '@trezor/device-utils';
 
 import type { PROTO } from '../constants';
-import type { BitcoinNetworkInfo, CoinInfo, Device, SelectFeeLevel } from '../types';
+import type {
+    BinaryInfo,
+    BitcoinNetworkInfo,
+    CoinInfo,
+    Device,
+    FirmwareType,
+    SelectFeeLevel,
+} from '../types';
 import type { DeviceButtonRequest } from './device';
 import { MethodPermission } from '../core/AbstractMethod';
 import type { DiscoveryAccount, DiscoveryAccountType } from '../types/account';
@@ -27,6 +35,8 @@ export const UI_REQUEST = {
 
     /** connect is waiting for device to be automatically reconnected */
     FIRMWARE_RECONNECT: 'ui-firmware_reconnect',
+
+    FIRMWARE_DOWNLOADED: 'ui-firmware_downloaded',
 
     DEVICE_NEEDS_BACKUP: 'ui-device_needs_backup',
 
@@ -202,6 +212,16 @@ export interface UiRequestSelectDevice {
     };
 }
 
+export interface UiRequestFirmwareDownloaded {
+    type: typeof UI_REQUEST.FIRMWARE_DOWNLOADED;
+    payload:
+        | BinaryInfo
+        | {
+              internalModel?: DeviceModelInternal;
+              firmwareType?: FirmwareType;
+          };
+}
+
 export interface UiRequestUnexpectedDeviceMode {
     type:
         | typeof UI_REQUEST.BOOTLOADER
@@ -300,7 +320,8 @@ export type UiEvent =
     | FirmwareException
     | FirmwareReconnect
     | UiRequestAddressValidation
-    | UiRequestSetOperation;
+    | UiRequestSetOperation
+    | UiRequestFirmwareDownloaded;
 
 export type UiEventMessage = UiEvent & { event: typeof UI_EVENT };
 

--- a/packages/connect/src/events/ui-response.ts
+++ b/packages/connect/src/events/ui-response.ts
@@ -1,6 +1,7 @@
 import { POPUP } from './popup';
 import { UI_EVENT } from './ui-request';
 import type { Device } from '../types/device';
+import type { LocalFirmwares } from '../types/settings';
 import type { MessageFactoryFn } from '../types/utils';
 
 /*
@@ -10,6 +11,7 @@ import type { MessageFactoryFn } from '../types/utils';
 export const UI_RESPONSE = {
     RECEIVE_PERMISSION: 'ui-receive_permission',
     RECEIVE_CONFIRMATION: 'ui-receive_confirmation',
+    RECEIVE_FIRMWARE: 'ui-receive_firmware',
     RECEIVE_PIN: 'ui-receive_pin',
     RECEIVE_PASSPHRASE: 'ui-receive_passphrase',
     RECEIVE_DEVICE: 'ui-receive_device',
@@ -37,6 +39,11 @@ export interface UiResponsePermission {
 export interface UiResponseConfirmation {
     type: typeof UI_RESPONSE.RECEIVE_CONFIRMATION;
     payload: boolean;
+}
+
+export interface UiResponseFirmwares {
+    type: typeof UI_RESPONSE.RECEIVE_FIRMWARE;
+    payload: LocalFirmwares;
 }
 
 export interface UiResponseDevice {
@@ -111,7 +118,8 @@ export type UiResponseEvent =
     | UiResponsePassphraseAction
     | UiResponseAccount
     | UiResponseFee
-    | UiResponseLoginChallenge;
+    | UiResponseLoginChallenge
+    | UiResponseFirmwares;
 
 export type UiResponseMessage = UiResponseEvent & { event: typeof UI_EVENT };
 

--- a/packages/connect/src/types/firmware.ts
+++ b/packages/connect/src/types/firmware.ts
@@ -42,3 +42,9 @@ export type ReleaseInfo = {
     intermediaryVersion?: IntermediaryVersion;
     translations?: string[];
 };
+
+export type BinaryInfo = {
+    binary: ArrayBuffer;
+    binaryVersion: VersionArray;
+    releaseVersion: undefined;
+};

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -12,6 +12,8 @@ export interface Manifest {
 
 export type Proxy = BlockchainSettings['proxy'];
 
+export type LocalFirmwares = { firmwareDir: string; firmwareList: string[] };
+
 // omit transports which are not implemented in @trezor/connect
 type KnownTransport = Exclude<Transport['name'], 'NativeUsbTransport' | 'BluetoothTransport'>;
 export type ThpSettings = {
@@ -65,6 +67,7 @@ export interface ConnectSettingsInternal {
     proxy?: Proxy;
     sharedLogger?: boolean;
     useCoreInPopup?: boolean;
+    localFirmwares?: LocalFirmwares;
 }
 
 export interface ConnectSettingsWeb {

--- a/packages/connect/src/utils/firmwareUtils.ts
+++ b/packages/connect/src/utils/firmwareUtils.ts
@@ -1,6 +1,7 @@
+import { DeviceModelInternal } from '@trezor/device-utils';
 import { versionUtils } from '@trezor/utils';
 
-import type { Features, FirmwareRelease, StrictFeatures, VersionArray } from '../types';
+import { Features, FirmwareRelease, FirmwareType, StrictFeatures, VersionArray } from '../types';
 
 export const isStrictFeatures = (extFeatures: Features): extFeatures is StrictFeatures =>
     [1, 2].includes(extFeatures.major_version) &&
@@ -56,3 +57,13 @@ export const filterSafeListByFirmware = (
     releasesList.filter(item =>
         versionUtils.isNewerOrEqual(firmwareVersion, item.min_firmware_version),
     );
+
+export const buildFirmwareFileName = (
+    firmwareType: FirmwareType,
+    internalModel: DeviceModelInternal,
+    version: VersionArray,
+) => {
+    const firmwareTypeFileString = firmwareType === FirmwareType.BitcoinOnly ? '-bitcoinonly' : '';
+
+    return `trezor-${internalModel.toLocaleLowerCase()}-${version.join('.')}${firmwareTypeFileString}.bin`;
+};

--- a/packages/suite-desktop-core/src/libs/user-data.ts
+++ b/packages/suite-desktop-core/src/libs/user-data.ts
@@ -31,13 +31,24 @@ export const initUserData = () => {
     }
 };
 
-export const save = async (
-    directory: string,
-    name: string,
-    content: string,
-): Promise<InvokeResult> => {
+export const save: {
+    (directory: string, name: string, content: string, encoding: 'utf-8'): Promise<InvokeResult>;
+    (
+        directory: string,
+        name: string,
+        content: ArrayBuffer,
+        encoding: 'binary',
+    ): Promise<InvokeResult>;
+} = async (directory, name, content, encoding) => {
     const dir = path.join(app.getPath('userData'), directory);
     const file = path.join(dir, name);
+
+    let data: string | Buffer;
+    if (encoding === 'binary') {
+        data = Buffer.from(content as ArrayBuffer);
+    } else {
+        data = content as string;
+    }
 
     try {
         try {
@@ -46,7 +57,7 @@ export const save = async (
             await fs.promises.mkdir(dir);
         }
 
-        await fs.promises.writeFile(file, content, 'utf-8');
+        await fs.promises.writeFile(file, data, encoding);
 
         return { success: true };
     } catch (error) {

--- a/packages/suite-desktop-core/src/modules/firmware.ts
+++ b/packages/suite-desktop-core/src/modules/firmware.ts
@@ -1,0 +1,91 @@
+import { FirmwareType } from '@trezor/connect';
+import { buildFirmwareFileName } from '@trezor/connect/src/utils/firmwareUtils';
+import { DeviceModelInternal, VersionArray } from '@trezor/device-utils';
+
+import { readDir, save } from '../libs/user-data';
+import { app } from '../typed-electron';
+
+import type { ModuleInit } from './index';
+
+export const SERVICE_NAME = '@trezor/firmware';
+
+const FIRMWARE_DIR = '/firmware';
+
+export const getStoredFirmwares = async () => {
+    const userDataDir = app?.getPath('userData');
+    const resp = await readDir(FIRMWARE_DIR);
+    if (!resp.success) {
+        return { success: false, error: resp.error };
+    }
+    const { payload } = resp;
+
+    return {
+        success: true,
+        payload: {
+            firmwareDir: `${userDataDir}${FIRMWARE_DIR}/`,
+            firmwareList: payload,
+        },
+    };
+};
+
+export const init: ModuleInit = ({ mainThreadEmitter }) => {
+    const { logger } = global;
+
+    mainThreadEmitter.on(
+        'module/trezor-connect/firmware-store',
+        async (event: {
+            binary: ArrayBuffer;
+            binaryVersion: VersionArray;
+            releaseVersion: number[];
+            internalModel: DeviceModelInternal;
+            firmwareType: FirmwareType;
+        }) => {
+            const {
+                binary,
+                binaryVersion,
+                internalModel,
+                firmwareType = FirmwareType.Regular,
+            } = event;
+
+            const firmwareBinName = buildFirmwareFileName(
+                firmwareType,
+                internalModel,
+                binaryVersion,
+            );
+
+            const { success, error, payload } = await getStoredFirmwares();
+            if (!success || !payload) {
+                logger.error(SERVICE_NAME, `Failed to read firmware directory: ${error}`);
+
+                return;
+            }
+
+            const { firmwareList } = payload;
+
+            if (!firmwareList.includes(firmwareBinName)) {
+                logger.info(
+                    SERVICE_NAME,
+                    `Saving new downloaded firmware: ${firmwareBinName} to ${FIRMWARE_DIR}`,
+                );
+
+                const saveFwResponse = await save(FIRMWARE_DIR, firmwareBinName, binary, 'binary');
+                if (!saveFwResponse.success) {
+                    logger.error(SERVICE_NAME, `Failed to save firmware: ${saveFwResponse.error}`);
+
+                    return;
+                }
+
+                // Emit updated firmware list only if the firmware was saved successfully.
+                const updatedFirmwares = await getStoredFirmwares();
+                if (updatedFirmwares.payload) {
+                    mainThreadEmitter.emit('module/firmware/list', updatedFirmwares.payload);
+                }
+            } else {
+                logger.info(
+                    SERVICE_NAME,
+                    `Firmware ${firmwareBinName} already exists, skipping save.`,
+                );
+            }
+        },
+    );
+};

--- a/packages/suite-desktop-core/src/modules/index.ts
+++ b/packages/suite-desktop-core/src/modules/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { isDevEnv } from '@suite-common/suite-utils';
-import type { DeviceEvent } from '@trezor/connect';
+import type { DeviceEvent, LocalFirmwares } from '@trezor/connect';
 import { InterceptedEvent } from '@trezor/request-manager';
 import type { HandshakeClient, TorStatus } from '@trezor/suite-desktop-api';
 import { TypedEmitter, isNotUndefined } from '@trezor/utils';
@@ -82,6 +82,8 @@ interface MainThreadMessages {
         service: boolean;
         process: boolean;
     };
+    'module/trezor-connect/firmware-store': any;
+    'module/firmware/list': LocalFirmwares;
     'app/fully-quit': void;
     'app/show': void;
 }

--- a/packages/suite-desktop-core/src/modules/metadata.ts
+++ b/packages/suite-desktop-core/src/modules/metadata.ts
@@ -19,7 +19,7 @@ export const init: ModuleInit = () => {
         validateIpcMessage(ipcEvent);
 
         logger.info(SERVICE_NAME, `Writing metadata to ${DATA_DIR}/${message.file}`);
-        const resp = await save(DATA_DIR, message.file, message.content);
+        const resp = await save(DATA_DIR, message.file, message.content, 'utf-8');
 
         return resp;
     });

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -1,8 +1,10 @@
 import { ipcMain } from 'electron';
 
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { LocalFirmwares, UI, UI_EVENT } from '@trezor/connect';
 import { IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
 import { parseElectrumUrl } from '@trezor/utils';
+
+import { getStoredFirmwares } from './firmware';
 
 import { MainThreadEmitter, ModuleInit, ModuleInitBackground } from './index';
 
@@ -56,9 +58,13 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
             onRequest: async (method, params) => {
                 logger.debug(SERVICE_NAME, `call ${method}`);
                 if (method === 'init') {
-                    const response = await TrezorConnect.init({
+                    logger.info(SERVICE_NAME, `Retrieving stored firmwares`);
+                    const localFirmwares = await getStoredFirmwares();
+                    const settings = {
                         ...params[0],
-                    });
+                        localFirmwares: localFirmwares.success ? localFirmwares.payload : undefined,
+                    };
+                    const response = await TrezorConnect.init(settings);
                     await setProxy();
 
                     return response;
@@ -94,10 +100,17 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
         TrezorConnect.dispose();
     };
 
-    return { onLoad, onQuit };
+    return { onQuit, onLoad };
 };
 
-export const init: ModuleInit = () => {
+export const init: ModuleInit = ({ mainThreadEmitter }) => {
+    mainThreadEmitter.on('module/firmware/list', (event: LocalFirmwares) => {
+        TrezorConnect.uiResponse({
+            type: UI.RECEIVE_FIRMWARE,
+            payload: event,
+        });
+    });
+
     const onLoad = () => {
         // reset previous instance, possible left over after renderer refresh (F5)
         TrezorConnect.dispose();
@@ -108,6 +121,13 @@ export const init: ModuleInit = () => {
         // TrezorConnect.on(DEVICE_EVENT, event => {
         //     mainThreadEmitter.emit('module/trezor-connect/device-event', event);
         // });
+
+        TrezorConnect.on(UI_EVENT, event => {
+            const { type } = event;
+            if (type === UI.FIRMWARE_DOWNLOADED) {
+                mainThreadEmitter.emit('module/trezor-connect/firmware-store', event.payload);
+            }
+        });
     };
 
     return { onLoad };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR creates a new Connect setting called `localFirmwares` that is taken when connect initializes so Connect knows the available firmware that can be used from disk. This will be only used by Trezor Suite desktop and ignored by web.

It also creates the event 'ui-firmware_downloaded' that will be emitted by connect when new FW is downloaded (this part will come in next PR). Suite web will ignore the event but Suite Desktop will listen to it and store that fresh downloaded FW in the Suite config directory to be used in future.

There is the event that connect will listen to `ui-receive_firmware` that will be sent by Suite Desktop when the new downloaded FW is successfully store so Connect knows for sure it can be used during same session.

Related https://github.com/trezor/trezor-suite/issues/19763