### PR TITLE
fix(scripts): version-bump-prompt should be in root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,8 @@
         "ts-node": "^10.9.2",
         "tslib": "^2.6.2",
         "tsx": "^4.19.3",
-        "typescript": "5.8.3"
+        "typescript": "5.8.3",
+        "version-bump-prompt": "^6.1.0"
     },
     "dependenciesMeta": {
         "core-js-pure": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -23,7 +23,6 @@
         "@types/semver": "^7.7.0",
         "@types/tar": "^6.1.11",
         "semver": "^7.7.1",
-        "tar": "^7.0.1",
-        "version-bump-prompt": "^6.1.0"
+        "tar": "^7.0.1"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12014,7 +12014,6 @@ __metadata:
     sort-package-json: "npm:^1.57.0"
     tar: "npm:^7.0.1"
     tsx: "npm:^4.19.3"
-    version-bump-prompt: "npm:^6.1.0"
     yargs: "npm:17.7.2"
   languageName: unknown
   linkType: soft
@@ -39731,6 +39730,7 @@ __metadata:
     tslib: "npm:^2.6.2"
     tsx: "npm:^4.19.3"
     typescript: "npm:5.8.3"
+    version-bump-prompt: "npm:^6.1.0"
   dependenciesMeta:
     core-js-pure:
       built: false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The connect release script was broken by PR https://github.com/trezor/trezor-suite/pull/18096 since it did move the dependency to scripts package but it needs to be used as root package.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/version-bump-prompt-should-be-in-root-package.json&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/version-bump-prompt-should-be-in-root-package.json&lookback=7)