### PR TITLE
fix(suite): use unit_btconly flag directly for isBitcoinOnlyDevice

### DIFF
--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -18,7 +18,6 @@ import {
     getFirmwareRevision,
     getFirmwareVersion,
     hasBitcoinOnlyFirmware,
-    isBitcoinOnlyDevice,
     isDeviceInBootloaderMode,
     isOfficialFirmware,
 } from '@trezor/device-utils';
@@ -121,7 +120,7 @@ const analyticsMiddleware =
                             passphrase_protection: features.passphrase_protection,
                             totalInstances: selectDevicesCount(state),
                             isBitcoinOnly: hasBitcoinOnlyFirmware(action.payload.device),
-                            isBitcoinOnlyDevice: isBitcoinOnlyDevice(action.payload.device),
+                            isBitcoinOnlyDevice: !!features?.unit_btconly,
                             totalDevices: getPhysicalDeviceCount(selectDevices(state)),
                             language: features.language,
                             model: features.internal_model,


### PR DESCRIPTION
## Description

Data Analytics: _device-connect_ now sets `isBitcoinOnlyDevice` based on `unit_btconly` flag.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/9752

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/data-analytics-btcUnit&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/data-analytics-btcUnit&lookback=7)