### PR TITLE
fix(suite): change isOfficialFw to firmwareSource

### DIFF
--- a/packages/device-utils/src/firmwareUtils.ts
+++ b/packages/device-utils/src/firmwareUtils.ts
@@ -1,15 +1,24 @@
 import { isDeviceInBootloaderMode } from './modeUtils';
-import { FirmwareType, FirmwareVersionString, PartialDevice, VersionArray } from './types';
+import {
+    FirmwareSource,
+    FirmwareType,
+    FirmwareVersionString,
+    PartialDevice,
+    VersionArray,
+} from './types';
 
-export const isOfficialFirmware = (device?: PartialDevice): boolean => {
+export const getFirmwareSource = (device?: PartialDevice): FirmwareSource => {
+    if (device?.mode === 'bootloader') {
+        return 'NA - bootloader';
+    }
     if (
         device?.authenticityChecks?.firmwareRevision?.success &&
         device?.authenticityChecks?.firmwareHash?.success
     ) {
-        return true;
+        return 'official';
     }
 
-    return false;
+    return 'unknown';
 };
 
 export const getFirmwareRevision = (device?: PartialDevice) => device?.features?.revision || '';

--- a/packages/device-utils/src/types.ts
+++ b/packages/device-utils/src/types.ts
@@ -66,6 +66,7 @@ export type PartialDevice = {
         firmwareRevision: { success: boolean } | null;
         firmwareHash: { success: boolean } | null;
     };
+    mode?: 'normal' | 'bootloader' | 'initialize' | 'seedless';
 
     features?: {
         major_version: number;
@@ -82,3 +83,5 @@ export type PartialDevice = {
         unit_btconly?: boolean;
     };
 };
+
+export type FirmwareSource = 'official' | 'unknown' | 'NA - bootloader';

--- a/packages/suite-analytics/src/types/definitions.ts
+++ b/packages/suite-analytics/src/types/definitions.ts
@@ -19,3 +19,5 @@ export type AppUpdateEvent = {
     isPrerelease?: boolean;
     isAutoUpdated?: boolean;
 };
+
+export type FirmwareSource = 'official' | 'unknown' | 'NA - bootloader';

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -1,7 +1,7 @@
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { EventType } from '../constants';
-import type { AppUpdateEvent, OnboardingAnalytics } from './definitions';
+import type { AppUpdateEvent, FirmwareSource, OnboardingAnalytics } from './definitions';
 
 export type SuiteAnalyticsEventSuiteReady = {
     type: EventType.SuiteReady;
@@ -91,7 +91,7 @@ export type SuiteAnalyticsEvent =
           payload: {
               mode: 'normal' | 'bootloader' | 'initialize' | 'seedless';
               firmware: string;
-              isOfficialFw: boolean;
+              firmwareSource: FirmwareSource;
               bootloader?: string;
               pin_protection?: boolean | null;
               passphrase_protection?: boolean | null;
@@ -118,7 +118,7 @@ export type SuiteAnalyticsEvent =
               fromFwVersion: string;
               toFwVersion?: string;
               toBtcOnly?: boolean;
-              isOfficialFw: boolean;
+              firmwareSource: FirmwareSource;
               error: string;
           };
       }

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -16,10 +16,10 @@ import {
     getBootloaderHash,
     getBootloaderVersion,
     getFirmwareRevision,
+    getFirmwareSource,
     getFirmwareVersion,
     hasBitcoinOnlyFirmware,
     isDeviceInBootloaderMode,
-    isOfficialFirmware,
 } from '@trezor/device-utils';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
@@ -74,7 +74,7 @@ const analyticsMiddleware =
                         error,
                         toBtcOnly,
                         toFwVersion,
-                        isOfficialFw: isOfficialFirmware(device),
+                        firmwareSource: getFirmwareSource(device),
                     },
                 });
             }
@@ -125,7 +125,7 @@ const analyticsMiddleware =
                             language: features.language,
                             model: features.internal_model,
                             optiga_sec: features.optiga_sec,
-                            isOfficialFw: isOfficialFirmware(action.payload.device),
+                            firmwareSource: getFirmwareSource(action.payload.device),
                         },
                     });
                 } else {
@@ -135,7 +135,7 @@ const analyticsMiddleware =
                             mode: 'bootloader',
                             firmware: getFirmwareVersion(action.payload.device),
                             bootloader: getBootloaderVersion(action.payload.device),
-                            isOfficialFw: isOfficialFirmware(action.payload.device),
+                            firmwareSource: getFirmwareSource(action.payload.device),
                         },
                     });
                 }


### PR DESCRIPTION
## Description

`isOfficialFw` property in device-update-firmware events now accepts a string value `NA - bootloader` to represent devices in bootloader mode, where official firmware verification is not possible.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/14893


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/data-analytics-customFw&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/data-analytics-customFw&lookback=7)