### PR TITLE
Better device run interruption

### DIFF
--- a/packages/connect/src/api/getFeatures.ts
+++ b/packages/connect/src/api/getFeatures.ts
@@ -10,6 +10,7 @@ export default class GetFeatures extends AbstractMethod<'getFeatures'> {
         this.allowDeviceMode = [...this.allowDeviceMode, UI.INITIALIZE, UI.BOOTLOADER];
         this.useDeviceState = false;
         this.skipFirmwareCheck = true;
+        this.skipFinalReload = true;
     }
 
     run() {

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -258,7 +258,6 @@ const inner = async (context: CoreContext, method: AbstractMethod<any>, device: 
         method.requireDeviceMode,
     );
     if (unexpectedMode) {
-        device.releaseTransportSession();
         if (isUsingPopup) {
             // wait for popup handshake
             await waitForPopup(context);
@@ -542,8 +541,7 @@ const onCallDevice = async (
     message: IFrameCallMessage,
     method: AbstractMethod<any>,
 ): Promise<void> => {
-    const { deviceList, callMethods, getOverridePromise, setOverridePromise, sendCoreMessage } =
-        context;
+    const { deviceList, callMethods, sendCoreMessage } = context;
     const responseID = message.id;
     const { origin, env, useCoreInPopup, transports } = DataManager.getSettings();
 
@@ -602,8 +600,8 @@ const onCallDevice = async (
         // interrupt potential communication with device. this should throw error in try/catch block below
         // this error will apply to the last item of pending methods
         const overrideError = ERRORS.TypedError('Method_Override');
-        setOverridePromise(device.override(overrideError));
-        await getOverridePromise();
+        await device.interrupt(overrideError); // TODO not necessary to release session here
+
         // if current method was overridden while waiting for device.override result
         // return response with status false
         if (method.overridden) {
@@ -648,10 +646,6 @@ const onCallDevice = async (
     let messageResponse: CoreEventMessage;
 
     try {
-        // run inner function
-        if (getOverridePromise()) {
-            await getOverridePromise();
-        }
         const innerAction = () =>
             inner(context, method, device).then(response => {
                 messageResponse = response;
@@ -688,10 +682,6 @@ const onCallDevice = async (
             messageResponse = createResponseMessage(method.responseID, false, { error });
         }
     } finally {
-        // TODO This condition has to be there; awaiting undefined breaks e2e tests, which is a complete mystery
-        if (getOverridePromise()) {
-            await getOverridePromise();
-        }
         // Work done
 
         if (
@@ -926,7 +916,6 @@ const onPopupClosed = (context: CoreContext, customErrorMessage?: string) => {
         deviceList,
         callMethods,
         resetWaitForFirstMethod,
-        setOverridePromise,
         sendCoreMessage,
     } = context;
     const error = customErrorMessage
@@ -935,9 +924,8 @@ const onPopupClosed = (context: CoreContext, customErrorMessage?: string) => {
     // Device was already acquired. Try to interrupt running action which will throw error from onCall try/catch block
     if (deviceList.isConnected() && deviceList.getDeviceCount() > 0) {
         deviceList.getAllDevices().forEach(d => {
-            d.releaseTransportSession(); // clear transportSession on release
             if (d.isUsedHere()) {
-                setOverridePromise(d.interruptionFromUser(error));
+                d.interrupt(error);
             } else {
                 const success = uiPromises.resolve({ type: DEVICE.DISCONNECT, payload: undefined });
                 if (!success) {
@@ -1049,7 +1037,6 @@ export class Core extends EventEmitter {
         startInteractionTimeout(this.getCoreContext()),
     );
 
-    private overridePromise: Promise<void> | undefined;
     private waitForFirstMethod = createDeferred();
 
     private _interactionTimeout?: InteractionTimeout;
@@ -1091,10 +1078,6 @@ export class Core extends EventEmitter {
             },
             resolveWaitForFirstMethod: () => {
                 this.waitForFirstMethod.resolve();
-            },
-            getOverridePromise: () => this.overridePromise,
-            setOverridePromise: (promise: Promise<void>) => {
-                this.overridePromise = promise;
             },
         };
     }

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -610,12 +610,12 @@ const onCallDevice = async (
             );
             throw overrideError;
         }
-    } else if (device.isRunning()) {
-        if (!device.isLoaded()) {
+    } else if (device.currentRun) {
+        if (device.isUnacquired()) {
             // corner case
             // device didn't finish loading for the first time. @see DeviceList._createAndSaveDevice
             // wait for self-release and then carry on
-            await device.waitForFirstRun();
+            await device.currentRun;
         } else {
             // cancel popup request
             // sendCoreMessage(UiMessage(POPUP.CANCEL_POPUP_REQUEST));

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -139,7 +139,7 @@ const waitForReconnectedDevice = async (
     }
 
     registerEvents(reconnectedDevice);
-    await reconnectedDevice.waitForFirstRun();
+    await reconnectedDevice.currentRun;
 
     if (!reconnectedDevice.isUsedHere()) {
         await reconnectedDevice.acquire();

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -160,6 +160,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     private releasePromise?: ReturnType<Transport['release']>;
 
     private runAbort?: AbortController;
+    private runPromise?: Promise<void>;
 
     private keepTransportSession = false;
     private currentSession?: DeviceCurrentSession;
@@ -319,10 +320,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
         return this.releasePromise;
     }
 
-    releaseTransportSession() {
-        this.keepTransportSession = false;
-    }
-
     // call only once, right after device creation
     async handshake(delay?: number) {
         if (delay) {
@@ -396,7 +393,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         if (!descriptor.session) {
             const methodStillRunning = !this.currentSession?.isDisposed();
             if (methodStillRunning) {
-                this.releaseTransportSession();
+                this.keepTransportSession = false;
             }
         }
 
@@ -407,7 +404,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     // TODO empty fn variant can be split/removed
     run(fn?: () => Promise<void>, options: RunOptions = {}) {
-        if (this.runAbort) {
+        if (this.runPromise) {
             _log.warn('Previous call is still running');
             throw ERRORS.TypedError('Device_CallInProgress');
         }
@@ -417,49 +414,40 @@ export class Device extends TypedEmitter<DeviceEvents> {
         this.runAbort = new AbortController();
         const { signal } = this.runAbort;
 
-        return Promise.race([
+        this.runPromise = Promise.race([
             this._runInner(fn, options),
             new Promise<never>((_, reject) => {
                 signal.addEventListener('abort', () => reject(signal.reason));
             }),
         ])
+            .catch(async err => {
+                this.keepTransportSession = false;
+                await this.acquirePromise;
+                await this.release();
+
+                throw err;
+            })
+            .finally(() => {
+                this.runAbort = undefined;
+                this.runPromise = undefined;
+            })
             .then(() => {
                 if (wasUnacquired && !this.isUnacquired()) {
                     this.emitLifecycle(DEVICE.CONNECT);
                 }
-                this.runAbort = undefined;
-            })
-            .catch(async err => {
-                if (!signal.aborted) {
-                    await this.release();
-                }
-                this.runAbort = undefined;
-                throw err;
             });
+
+        return this.runPromise;
     }
 
-    async override(error: Error) {
-        if (this.acquirePromise) {
-            await this.acquirePromise;
-        }
-
-        if (this.runAbort) {
-            await this.interruptionFromUser(error);
-        }
-        if (this.releasePromise) {
-            await this.releasePromise;
-        }
-    }
-
-    async interruptionFromUser(error: Error) {
-        _log.debug('interruptionFromUser');
-
-        await this.currentSession?.abort(error);
+    async interrupt(reason: Error) {
+        await this.currentSession?.abort(reason);
         await this.currentSession?.dispose();
 
         // reject inner defer
-        this.runAbort?.abort(error);
-        this.runAbort = undefined;
+        this.runAbort?.abort(reason);
+
+        await this.runPromise?.catch(() => {});
     }
 
     public usedElsewhere() {
@@ -1072,7 +1060,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
         this.emitLifecycle(DEVICE.DISCONNECT);
 
-        return this.interruptionFromUser(ERRORS.TypedError('Device_Disconnected'));
+        return this.interrupt(ERRORS.TypedError('Device_Disconnected'));
     }
 
     isBootloader() {
@@ -1123,7 +1111,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     isRunning() {
-        return !!this.runAbort;
+        return !!this.runPromise;
     }
 
     isLoaded() {

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -604,11 +604,11 @@ export class Device extends TypedEmitter<DeviceEvents> {
         // call inner function
         if (fn) {
             await fn();
-        }
 
-        // reload features
-        if (this.features && !options.skipFinalReload) {
-            await this.getFeatures();
+            // reload features
+            if (!options.skipFinalReload) {
+                await this.getFeatures();
+            }
         }
 
         if (

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -165,11 +165,8 @@ export class Device extends TypedEmitter<DeviceEvents> {
     private keepTransportSession = false;
     private currentSession?: DeviceCurrentSession;
 
-    private loaded = false;
-
     private inconsistent = false;
 
-    private firstRunPromise: Deferred<boolean>;
     private instance = 0;
 
     // DeviceState list [this.instance]: DeviceState | undefined
@@ -222,9 +219,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
         this.session = descriptor.session;
         this.lastAcquiredHere = false;
-
-        // this will be released after first run
-        this.firstRunPromise = createDeferred();
     }
 
     private getSessionChangePromise() {
@@ -447,7 +441,11 @@ export class Device extends TypedEmitter<DeviceEvents> {
         // reject inner defer
         this.runAbort?.abort(reason);
 
-        await this.runPromise?.catch(() => {});
+        await this.currentRun;
+    }
+
+    get currentRun() {
+        return this.runPromise?.catch(() => {});
     }
 
     public usedElsewhere() {
@@ -609,7 +607,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         }
 
         // reload features
-        if (this.loaded && this.features && !options.skipFinalReload) {
+        if (this.features && !options.skipFinalReload) {
             await this.getFeatures();
         }
 
@@ -619,11 +617,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
         ) {
             this.keepTransportSession = false;
             await this.release();
-        }
-
-        if (!this.loaded) {
-            this.loaded = true;
-            this.firstRunPromise.resolve(true);
         }
     }
 
@@ -1108,18 +1101,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     isUsedElsewhere() {
         return this.isUsed() && !this.lastAcquiredHere;
-    }
-
-    isRunning() {
-        return !!this.runPromise;
-    }
-
-    isLoaded() {
-        return this.loaded;
-    }
-
-    waitForFirstRun() {
-        return this.firstRunPromise.promise;
     }
 
     getUniquePath() {


### PR DESCRIPTION
## Description

1) Improved device run overriding - instead of `getOverridePromise`/`setOverridePromise` and awaiting device override promise, `device.interrupt` method was implemented which aborts current run **and** awaits its end, including final cleaning.

2) First run improved - device's `firstRunPromise` and `loaded` replaced by regular run promise and its `'acquiredness'` state.

3) Final reload - final reload was explicitly omitted from `GetFeatures` method and from initial device run (the one without `fn` as it's been done just before that).

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/method-overriding&lookback=7)