### PR TITLE
feat(suite): set electron window background color

### DIFF
--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -38,6 +38,7 @@
         "@trezor/request-manager": "workspace:*",
         "@trezor/suite": "workspace:*",
         "@trezor/suite-desktop-api": "workspace:*",
+        "@trezor/theme": "workspace:*",
         "@trezor/transport": "workspace:*",
         "@trezor/transport-bluetooth": "workspace:*",
         "@trezor/transport-bridge": "workspace:*",

--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -1,10 +1,11 @@
-import { BrowserWindow, app } from 'electron';
+import { BrowserWindow, app, nativeTheme } from 'electron';
 import path from 'path';
 
 import { isDevEnv } from '@suite-common/suite-utils';
 import { isMacOs } from '@trezor/env-utils';
 import { validateIpcMessage } from '@trezor/ipc-proxy';
 import type { HandshakeClient } from '@trezor/suite-desktop-api';
+import { colorVariants } from '@trezor/theme';
 import { TimerId } from '@trezor/type-utils';
 import { createDeferred, resolveAfter } from '@trezor/utils';
 
@@ -42,7 +43,11 @@ const parseRemoveUserDataSwitch = () => {
 };
 parseRemoveUserDataSwitch();
 
-const createMainWindow = (winBounds: WinBounds) => {
+const createMainWindow = (winBounds: WinBounds, store: Store) => {
+    const darkTheme =
+        store.getThemeSettings() === 'dark' ||
+        (store.getThemeSettings() === 'system' && nativeTheme.shouldUseDarkColors);
+
     const mainWindow = new BrowserWindow({
         title: APP_NAME,
         width: winBounds.width,
@@ -61,6 +66,7 @@ const createMainWindow = (winBounds: WinBounds) => {
             preload: path.join(__dirname, 'preload.js'),
         },
         icon: path.join(global.resourcesPath, 'images', 'icons', '512x512.png'),
+        backgroundColor: colorVariants[darkTheme ? 'dark' : 'standard'].backgroundSurfaceElevation0,
     });
 
     let resizeDebounce: TimerId | null = null;
@@ -223,7 +229,7 @@ const init = async () => {
         let mainWindow = mainWindowProxy.getInstance();
         if (!mainWindow || mainWindow.isDestroyed()) {
             logger.info('main', 'Main window destroyed, recreating');
-            mainWindow = createMainWindow(winBounds);
+            mainWindow = createMainWindow(winBounds, store);
             mainWindowProxy.setInstance(mainWindow);
         }
 
@@ -363,7 +369,7 @@ const init = async () => {
     });
 
     // Create main window last, so all listeners are set up
-    mainWindowProxy.setInstance(createMainWindow(winBounds));
+    mainWindowProxy.setInstance(createMainWindow(winBounds, store));
 };
 
 init();

--- a/packages/suite-desktop-core/tsconfig.json
+++ b/packages/suite-desktop-core/tsconfig.json
@@ -39,6 +39,7 @@
         { "path": "../request-manager" },
         { "path": "../suite" },
         { "path": "../suite-desktop-api" },
+        { "path": "../theme" },
         { "path": "../transport" },
         { "path": "../transport-bluetooth" },
         { "path": "../transport-bridge" },

--- a/packages/suite/src/views/settings/SettingsGeneral/Theme.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Theme.tsx
@@ -1,5 +1,5 @@
 import { EventType, analytics } from '@trezor/suite-analytics';
-import { SuiteThemeVariant, desktopApi } from '@trezor/suite-desktop-api';
+import { desktopApi } from '@trezor/suite-desktop-api';
 import { ThemeColorVariant } from '@trezor/theme';
 
 import { setAutodetect, setTheme } from 'src/actions/suite/suiteActions';
@@ -59,7 +59,10 @@ export const Theme = () => {
     const themeVariant = autodetectTheme ? 'system' : theme.variant;
     const selectedValue = getOption(themeVariant === 'light' ? 'standard' : themeVariant);
 
-    const onChange = ({ value }: { value: SuiteThemeVariant }) => {
+    const onChange = ({ value }: { value: ThemeColorVariantWithSystem }) => {
+        // Inconsistency between types (standard = light)
+        const themeValue = value === 'standard' ? 'light' : value;
+
         const platformTheme = getOsTheme();
         analytics.report({
             type: EventType.SettingsGeneralChangeTheme,
@@ -67,21 +70,23 @@ export const Theme = () => {
                 platformTheme,
                 previousTheme: theme.variant,
                 previousAutodetectTheme: autodetectTheme,
-                theme: value === 'system' ? platformTheme : value,
-                autodetectTheme: value === 'system',
+                theme: themeValue === 'system' ? platformTheme : themeValue,
+                autodetectTheme: themeValue === 'system',
             },
         });
 
-        if ((value === 'system') !== autodetectTheme) {
+        if ((themeValue === 'system') !== autodetectTheme) {
             dispatch(setAutodetect({ theme: !autodetectTheme }));
         }
 
-        if (value !== 'system') {
-            dispatch(setTheme(value));
+        if (themeValue !== 'system') {
+            dispatch(setTheme(themeValue));
         }
 
         if (desktopApi.available) {
-            desktopApi.themeChange(value);
+            // Remove `debug` option
+            const nativeThemeValue = themeValue === 'debug' ? 'light' : themeValue;
+            desktopApi.themeChange(nativeThemeValue);
         }
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12285,6 +12285,7 @@ __metadata:
     "@trezor/request-manager": "workspace:*"
     "@trezor/suite": "workspace:*"
     "@trezor/suite-desktop-api": "workspace:*"
+    "@trezor/theme": "workspace:*"
     "@trezor/transport": "workspace:*"
     "@trezor/transport-bluetooth": "workspace:*"
     "@trezor/transport-bridge": "workspace:*"


### PR DESCRIPTION
## Description

Add a background color to Electron window that matches the actual background color of the app. 
This avoids the "flash of light" during start up and makes the loading look more smooth. 
It adapts to user light/dark mode settings. While looking into that I found that the types in Suite are inconsistent, using "standard" for "light" mode, which did not get saved in Electron.

## Screenshots:

Before - *epilepsy warning*

https://github.com/user-attachments/assets/79e09680-0614-4876-9513-bc96ee265537

After - smooth goodness

https://github.com/user-attachments/assets/59ef2565-e8a7-4a19-a03f-861374de8eef


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-window-background-color&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-window-background-color&lookback=7)