### PR TITLE
fix(websocket-client): sendMessage timeout handler

### DIFF
--- a/packages/websocket-client/src/client.ts
+++ b/packages/websocket-client/src/client.ts
@@ -51,7 +51,7 @@ export class WebsocketClient<Events extends Record<string, any>> extends TypedEm
         this.options = options;
         this.messages = createDeferredManager({
             timeout: this.options.timeout || DEFAULT_TIMEOUT,
-            onTimeout: this.onTimeout.bind(this),
+            onTimeout: () => this.onMessageTimeout(),
         });
     }
 
@@ -93,11 +93,11 @@ export class WebsocketClient<Events extends Record<string, any>> extends TypedEm
         return this.ping();
     }
 
-    private onTimeout() {
+    private onMessageTimeout() {
         const { ws } = this;
         if (!ws) return;
-        this.messages.rejectAll(new WebsocketError('websocket_timeout'));
-        ws.close();
+        this.messages.rejectAll(new WebsocketError('websocket_timeout')); // <- this rejects all(!) pending messages, but only one is failed
+        // ws.close(); // <- this is wrong, if sendMessage throws timeout it disconnect whole client
     }
 
     private onError() {

--- a/packages/websocket-client/tests/client.test.ts
+++ b/packages/websocket-client/tests/client.test.ts
@@ -21,7 +21,7 @@ class Server extends WebSocket.Server {
         return this._url;
     }
 
-    private sendResponse(client: WebSocket, data: any) {
+    sendResponse(client: WebSocket, data: any) {
         const request = JSON.parse(data);
         const { id, method } = request;
         let response;
@@ -151,5 +151,25 @@ describe('WebsocketClient', () => {
         const cli = new Client({ url: 'invalid-url' });
 
         await expect(() => cli.connect()).rejects.toThrow('invalid-url');
+    });
+
+    it('throws timeout error on sendMessage', async () => {
+        const cli = new WebsocketClient({ url: server.getUrl() });
+        await cli.connect();
+
+        // do not respond, client will timeout
+        const sendSpy = jest.spyOn(server, 'sendResponse').mockImplementation(() => {});
+        await expect(() => cli.sendMessage({ method: 'init' }, { timeout: 300 })).rejects.toThrow(
+            'websocket_timeout',
+        );
+
+        // client is still connected
+        const disconnectedSpy = jest.fn();
+        expect(cli.isConnected()).toEqual(true);
+        cli.on('disconnected', disconnectedSpy);
+        expect(disconnectedSpy).toHaveBeenCalledTimes(0);
+
+        sendSpy.mockRestore();
+        cli.dispose();
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
detective is needed :) @marekrjpolak and @mroz22 

i think there is a little mess in what timeout does what, as [discussed here](https://github.com/trezor/trezor-suite/pull/18214#discussion_r2034789257)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/websocket-client-sendmessage-timeout&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/websocket-client-sendmessage-timeout&lookback=7)