### PR TITLE
fix(suite): do not show selected account in global buy trade

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -46,27 +46,38 @@ const Accounts = ({
     const { params } = selectedAccount;
     const isSkeletonShown = discoveryInProgress || (type === 'coinjoin' && coinjoinIsPreloading);
 
+    const router = useSelector(state => state.router);
+
+    const isAccountSelected = (account: Account) => {
+        const isSelected = (account: Account) =>
+            params &&
+            account.symbol === params.symbol &&
+            account.accountType === params.accountType &&
+            account.index === params.accountIndex;
+
+        const isHashSelected = (account: Account) =>
+            router.app === 'wallet' &&
+            router.params &&
+            account.symbol === router.params.symbol &&
+            account.accountType === router.params.accountType &&
+            account.index === router.params.accountIndex;
+
+        const isTradingBuyRoute = router.route?.name.startsWith('wallet-trading-buy');
+
+        return isTradingBuyRoute ? !!isHashSelected(account) : !!isSelected(account);
+    };
+
     return (
         <>
-            {accounts.map(account => {
-                const isSelected = (account: Account) =>
-                    params &&
-                    account.symbol === params.symbol &&
-                    account.accountType === params.accountType &&
-                    account.index === params.accountIndex;
-
-                const selected = !!isSelected(account);
-
-                return (
-                    <AccountSection
-                        key={account.key}
-                        account={account}
-                        selected={selected}
-                        accountLabel={accountLabels[account.key]}
-                        onItemClick={onItemClick}
-                    />
-                );
-            })}
+            {accounts.map(account => (
+                <AccountSection
+                    key={account.key}
+                    account={account}
+                    selected={isAccountSelected(account)}
+                    accountLabel={accountLabels[account.key]}
+                    onItemClick={onItemClick}
+                />
+            ))}
             {isSkeletonShown && <AccountItemSkeleton />}
         </>
     );


### PR DESCRIPTION
## Description

When clicking on `Buy` from dashboard with no account selected, do not automatically select the first account and do not highlight it in sidebar.

The issue goes deeper, for instance:
- on doing a global trade, for instance buying bitcoin from dashboard, on the second trading step `/eth/0/normal` is added to router params because it is the first account (it gets automatically selected)

## Related Issue

Resolve #15430 

## Screenshots:

https://github.com/user-attachments/assets/b5e5ceeb-0d3a-4d04-b81f-1ea467c68955


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/selected-account-sidebar&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/selected-account-sidebar&lookback=7)