### PR TITLE
Mobile Trade: Amount selector improvements

### DIFF
--- a/suite-native/module-trading/src/components/buy/CryptoAmountInput.tsx
+++ b/suite-native/module-trading/src/components/buy/CryptoAmountInput.tsx
@@ -9,7 +9,11 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { useTradingBuyFormContext } from '../../hooks/useTradingBuyFormContext';
 import { getSelectedSymbolFromBuyForm } from '../../utils/tradeableAssetUtils';
-import { INPUT_HEIGHT, INPUT_MIN_WIDTH, TradingAmountInput } from '../general/TradingAmountInput';
+import {
+    MAX_INPUT_HEIGHT,
+    MIN_INPUT_WIDTH,
+    TradingAmountInput,
+} from '../general/TradingAmountInput';
 
 export type CryptoAmountInputProps = {
     showAssetsSheet: () => void;
@@ -33,8 +37,8 @@ export const CryptoAmountInput = ({ showAssetsSheet }: CryptoAmountInputProps) =
     if (isLoading && !amountInCrypto) {
         return (
             <BoxSkeleton
-                height={INPUT_HEIGHT}
-                width={INPUT_MIN_WIDTH}
+                height={MAX_INPUT_HEIGHT}
+                width={MIN_INPUT_WIDTH}
                 accessibilityLabel={translate('moduleTrading.tradingScreen.quotesLoadingLabel')}
             />
         );

--- a/suite-native/module-trading/src/components/buy/CryptoAmountInput.tsx
+++ b/suite-native/module-trading/src/components/buy/CryptoAmountInput.tsx
@@ -19,6 +19,8 @@ export type CryptoAmountInputProps = {
     showAssetsSheet: () => void;
 };
 
+const MAX_CRYPTO_DECIMALS = 9;
+
 const pressableStyle = prepareNativeStyle(() => ({
     flex: 1,
 }));
@@ -54,6 +56,7 @@ export const CryptoAmountInput = ({ showAssetsSheet }: CryptoAmountInputProps) =
                     accessibilityLabel={translate('moduleTrading.selectCoin.amountLabel')}
                     editable={false}
                     inputTransformer={cryptoAmountTransformer}
+                    maxDecimals={MAX_CRYPTO_DECIMALS}
                     onPress={showAssetsSheet}
                 />
             </Pressable>
@@ -66,6 +69,7 @@ export const CryptoAmountInput = ({ showAssetsSheet }: CryptoAmountInputProps) =
             accessibilityLabel={translate('moduleTrading.selectCoin.amountLabel')}
             editable={isAssetSelected}
             inputTransformer={cryptoAmountTransformer}
+            maxDecimals={MAX_CRYPTO_DECIMALS}
         />
     );
 };

--- a/suite-native/module-trading/src/components/buy/FiatAmountInput.tsx
+++ b/suite-native/module-trading/src/components/buy/FiatAmountInput.tsx
@@ -12,6 +12,8 @@ import {
     TradingAmountInput,
 } from '../general/TradingAmountInput';
 
+const MAX_FIAT_DECIMALS = 3;
+
 export const FiatAmountInput = () => {
     const { translate } = useTranslate();
     const form = useTradingBuyFormContext();
@@ -35,6 +37,7 @@ export const FiatAmountInput = () => {
             name="fiatValue"
             accessibilityLabel={translate('moduleTrading.selectFiat.amountLabel')}
             inputTransformer={fiatAmountTransformer}
+            maxDecimals={MAX_FIAT_DECIMALS}
         />
     );
 };

--- a/suite-native/module-trading/src/components/buy/FiatAmountInput.tsx
+++ b/suite-native/module-trading/src/components/buy/FiatAmountInput.tsx
@@ -6,7 +6,11 @@ import { useAmountInputTransformers } from '@suite-native/helpers';
 import { useTranslate } from '@suite-native/intl';
 
 import { useTradingBuyFormContext } from '../../hooks/useTradingBuyFormContext';
-import { INPUT_HEIGHT, INPUT_MIN_WIDTH, TradingAmountInput } from '../general/TradingAmountInput';
+import {
+    MAX_INPUT_HEIGHT,
+    MIN_INPUT_WIDTH,
+    TradingAmountInput,
+} from '../general/TradingAmountInput';
 
 export const FiatAmountInput = () => {
     const { translate } = useTranslate();
@@ -19,8 +23,8 @@ export const FiatAmountInput = () => {
     if (isLoading && amountInCrypto) {
         return (
             <BoxSkeleton
-                height={INPUT_HEIGHT}
-                width={INPUT_MIN_WIDTH}
+                height={MAX_INPUT_HEIGHT}
+                width={MIN_INPUT_WIDTH}
                 accessibilityLabel={translate('moduleTrading.tradingScreen.quotesLoadingLabel')}
             />
         );

--- a/suite-native/module-trading/src/components/buy/__tests__/CryptoAmountInput.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/CryptoAmountInput.comp.test.tsx
@@ -87,6 +87,7 @@ describe('CryptoAmountInput', () => {
         await userEvent.type(getByLabelText('You get'), 'asd1.123');
 
         expect(form.getValues('cryptoValue')).toEqual('1.123');
+        expect(getByLabelText('You get')).toHaveDisplayValue('1.123');
     });
 
     it('should format input value to be integer when BTC asset is selected and value should be displayed in sats', async () => {
@@ -102,6 +103,23 @@ describe('CryptoAmountInput', () => {
         await userEvent.type(getByLabelText('You get'), 'asd1.123');
 
         expect(form.getValues('cryptoValue')).toEqual('1123');
+        expect(getByLabelText('You get')).toHaveDisplayValue('1123');
+    });
+
+    it('should always escape non-numeric characters', async () => {
+        const preloadedState = {
+            appSettings: { bitcoinUnits: PROTO.AmountUnit.SATOSHI },
+        };
+        const form = await renderUseTradingBuyForm();
+        act(() => {
+            form.setValue('asset', btcAsset);
+        });
+        const { getByLabelText } = await renderCryptoAmountInput({}, form, preloadedState);
+
+        await userEvent.type(getByLabelText('You get'), 'asd');
+
+        expect(form.getValues('cryptoValue')).toBeUndefined();
+        expect(getByLabelText('You get')).toHaveDisplayValue('');
     });
 
     it('should display loading skeleton while amountInCrypto is false and buyInfo is loading', async () => {

--- a/suite-native/module-trading/src/components/buy/__tests__/CryptoAmountInput.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/CryptoAmountInput.comp.test.tsx
@@ -126,4 +126,16 @@ describe('CryptoAmountInput', () => {
 
         expect(queryByLabelText('Fetching offers...')).toBeNull();
     });
+
+    it('should limit value to 9 decimals', async () => {
+        const form = await renderUseTradingBuyForm();
+        act(() => {
+            form.setValue('asset', btcAsset);
+        });
+        const { getByLabelText } = await renderCryptoAmountInput({}, form);
+
+        await userEvent.type(getByLabelText('You get'), '1.0123456789');
+
+        expect(form.getValues('cryptoValue')).toEqual('1.012345678');
+    });
 });

--- a/suite-native/module-trading/src/components/buy/__tests__/FiatAmountInput.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/FiatAmountInput.comp.test.tsx
@@ -69,4 +69,13 @@ describe('FiatAmountInput', () => {
 
         expect(queryByLabelText('Fetching offers...')).toBeNull();
     });
+
+    it('should limit value to 3 decimals', async () => {
+        const form = await renderUseTradingBuyForm();
+        const { getByLabelText } = await renderFiatAmountInput(form);
+
+        await userEvent.type(getByLabelText('You pay'), '1.0123456789');
+
+        expect(form.getValues('fiatValue')).toEqual('1.012');
+    });
 });

--- a/suite-native/module-trading/src/components/buy/__tests__/FiatAmountInput.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/FiatAmountInput.comp.test.tsx
@@ -45,6 +45,17 @@ describe('FiatAmountInput', () => {
         await userEvent.type(getByLabelText('You pay'), 'asd1.123');
 
         expect(form.getValues('fiatValue')).toEqual('1.123');
+        expect(getByLabelText('You pay')).toHaveDisplayValue('1.123');
+    });
+
+    it('should always escape non-numeric characters', async () => {
+        const form = await renderUseTradingBuyForm();
+        const { getByLabelText } = await renderFiatAmountInput(form);
+
+        await userEvent.type(getByLabelText('You pay'), 'asd');
+
+        expect(form.getValues('fiatValue')).toBeUndefined();
+        expect(getByLabelText('You pay')).toHaveDisplayValue('');
     });
 
     it('should display loading skeleton while amountInCrypto is true and buyInfo is loading', async () => {

--- a/suite-native/module-trading/src/components/general/TradingAmountInput.tsx
+++ b/suite-native/module-trading/src/components/general/TradingAmountInput.tsx
@@ -1,5 +1,7 @@
-import { TextInput, TextInputProps } from 'react-native';
+import { useCallback, useState } from 'react';
+import { LayoutChangeEvent, TextInput, TextInputProps } from 'react-native';
 
+import { Box } from '@suite-native/atoms';
 import { useField } from '@suite-native/forms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
@@ -8,22 +10,125 @@ import { useTradingBuyFormContext } from '../../hooks/useTradingBuyFormContext';
 export type TradingAmountInputProps = {
     name: 'fiatValue' | 'cryptoValue';
     inputTransformer: (value: string) => string;
-} & Omit<TextInputProps, 'value' | 'onChangeText' | 'placeholder' | 'style' | 'onBlur'>;
+} & Omit<
+    TextInputProps,
+    'value' | 'style' | 'onBlur' | 'onFocus' | 'onChangeText' | 'onLayout' | 'onContentSizeChange'
+>;
 
-export const INPUT_MIN_WIDTH = 60;
-export const INPUT_HEIGHT = 42;
+const MAX_FONT_SIZE = 34;
+const MIN_FONT_SIZE = Math.ceil(MAX_FONT_SIZE / 2);
+const FONT_TO_LINE_HEIGHT_RATIO = 1.235;
+const FONT_SIZE_SHRINK_THRESHOLD = 20;
+const FONT_SIZE_GROW_HYSTERESIS = 20;
 
-const inputStyle = prepareNativeStyle<{ hasError: boolean }>(
-    ({ colors, typography }, { hasError }) => ({
+export const MIN_INPUT_WIDTH = 70;
+export const MAX_INPUT_HEIGHT = Math.floor(MAX_FONT_SIZE * FONT_TO_LINE_HEIGHT_RATIO);
+
+const boxStyle = prepareNativeStyle(() => ({
+    flex: 1,
+    alignItems: 'flex-end',
+    paddingLeft: 0,
+    marginLeft: 0,
+    overflow: 'visible',
+}));
+
+const inputStyle = prepareNativeStyle<{ hasError: boolean; fontSize: number }>(
+    ({ colors, typography }, { hasError, fontSize }) => ({
         ...typography.body,
         color: hasError ? colors.textAlertRed : colors.textDefault,
         textAlign: 'right',
-        fontSize: 34,
-        lineHeight: INPUT_HEIGHT,
-        minWidth: INPUT_MIN_WIDTH,
-        flex: 1,
+        fontSize,
+        lineHeight: Math.floor(fontSize * FONT_TO_LINE_HEIGHT_RATIO),
+        minWidth: MIN_INPUT_WIDTH,
     }),
 );
+
+const useInputLayoutControls = () => {
+    const [availableWidth, setAvailableWidth] = useState(
+        MIN_INPUT_WIDTH + FONT_SIZE_SHRINK_THRESHOLD,
+    );
+    const [fontSize, setFontSize] = useState(MAX_FONT_SIZE);
+
+    const handleAvailableWith = useCallback(({ nativeEvent }: LayoutChangeEvent) => {
+        const { width } = nativeEvent.layout;
+        setAvailableWidth(width);
+    }, []);
+
+    const handleFontSizeOnContentChange = useCallback(
+        ({ nativeEvent }: LayoutChangeEvent) => {
+            const contentWidth = nativeEvent.layout.width;
+
+            if (contentWidth === 0 || availableWidth === 0) {
+                setFontSize(MAX_FONT_SIZE);
+
+                return;
+            }
+
+            const shrinkThreshold = availableWidth - FONT_SIZE_SHRINK_THRESHOLD;
+            if (contentWidth > shrinkThreshold) {
+                const newFontSize = Math.max(
+                    Math.floor((shrinkThreshold / contentWidth) * fontSize),
+                    MIN_FONT_SIZE,
+                );
+                setFontSize(newFontSize);
+            }
+
+            const growThreshold = shrinkThreshold - FONT_SIZE_GROW_HYSTERESIS;
+            if (contentWidth < growThreshold) {
+                const newFontSize = Math.min(
+                    Math.floor((shrinkThreshold / contentWidth) * fontSize),
+                    MAX_FONT_SIZE,
+                );
+                setFontSize(newFontSize);
+            }
+        },
+        [availableWidth, fontSize],
+    );
+
+    return {
+        fontSize,
+        onBoxLayout: handleAvailableWith,
+        onInputLayout: handleFontSizeOnContentChange,
+    };
+};
+
+const useInputFormControls = (
+    name: 'fiatValue' | 'cryptoValue',
+    inputTransformer: (value: string) => string,
+    maxLength: number | undefined,
+) => {
+    const { getValues, setValue } = useTradingBuyFormContext();
+    // do not use `value` from `useField` here, because it does not work properly with `undefined`
+    const value = getValues(name);
+    const { onChange, onBlur, hasError } = useField({ name });
+
+    const setFocusedValue = useCallback(() => {
+        setValue('focusedValue', name);
+    }, [name, setValue]);
+
+    const handleTextChange = useCallback(
+        (text: string) => {
+            const transformedText = inputTransformer(text);
+            const truncatedText = transformedText.slice(0, maxLength);
+
+            return onChange(truncatedText === '' ? undefined : truncatedText);
+        },
+        [maxLength, inputTransformer, onChange],
+    );
+
+    const clearFocusedValueAndBlur = useCallback(() => {
+        onBlur();
+        setValue('focusedValue', undefined);
+    }, [onBlur, setValue]);
+
+    return {
+        value,
+        hasError,
+        onFocus: setFocusedValue,
+        onChangeText: handleTextChange,
+        onBlur: clearFocusedValueAndBlur,
+    };
+};
 
 export const TradingAmountInput = ({
     name,
@@ -32,42 +137,34 @@ export const TradingAmountInput = ({
     ...inputProps
 }: TradingAmountInputProps) => {
     const { applyStyle, utils } = useNativeStyles();
-    const { getValues, setValue } = useTradingBuyFormContext();
-    // do not use `value` from `useField` here, because it does not work properly with `undefined`
-    const value = getValues(name);
-    const { onChange, onBlur, hasError } = useField({ name });
+    const { fontSize, onBoxLayout, onInputLayout } = useInputLayoutControls();
+    const { value, hasError, onFocus, onChangeText, onBlur } = useInputFormControls(
+        name,
+        inputTransformer,
+        maxLength,
+    );
 
-    const setFocusedValue = () => {
-        setValue('focusedValue', name);
-    };
-
-    const clearFocusedValue = () => {
-        setValue('focusedValue', undefined);
-    };
-
-    const handleTextChange = (text: string) => {
-        const transformedText = inputTransformer(text);
-        const truncatedText = transformedText.slice(0, maxLength);
-
-        return onChange(truncatedText === '' ? undefined : truncatedText);
-    };
-
+    // Note: it would be nice to use `onContentSizeChange` instead of `<Box />` once this bug is fixed https://github.com/facebook/react-native/issues/29702
     return (
-        <TextInput
-            style={applyStyle(inputStyle, { hasError })}
-            placeholder="0.0"
-            keyboardType="decimal-pad"
-            inputMode="decimal"
-            value={value}
-            onChangeText={handleTextChange}
-            onFocus={setFocusedValue}
-            onBlur={() => {
-                onBlur();
-                clearFocusedValue();
-            }}
-            maxLength={maxLength}
-            placeholderTextColor={utils.colors.textDisabled}
-            {...inputProps}
-        />
+        <Box
+            style={applyStyle(boxStyle)}
+            onLayout={onBoxLayout}
+            testID="@trading/amountInput/wrapper"
+        >
+            <TextInput
+                style={applyStyle(inputStyle, { hasError, fontSize })}
+                keyboardType="decimal-pad"
+                inputMode="decimal"
+                placeholder="0.0"
+                placeholderTextColor={utils.colors.textDisabled}
+                value={value ?? ''}
+                maxLength={maxLength}
+                onChangeText={onChangeText}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                onLayout={onInputLayout}
+                {...inputProps}
+            />
+        </Box>
     );
 };

--- a/suite-native/module-trading/src/components/general/TradingAmountInput.tsx
+++ b/suite-native/module-trading/src/components/general/TradingAmountInput.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { LayoutChangeEvent, TextInput, TextInputProps } from 'react-native';
 
 import { Box } from '@suite-native/atoms';
@@ -10,6 +10,7 @@ import { useTradingBuyFormContext } from '../../hooks/useTradingBuyFormContext';
 export type TradingAmountInputProps = {
     name: 'fiatValue' | 'cryptoValue';
     inputTransformer: (value: string) => string;
+    maxDecimals?: number;
 } & Omit<
     TextInputProps,
     'value' | 'style' | 'onBlur' | 'onFocus' | 'onChangeText' | 'onLayout' | 'onContentSizeChange'
@@ -96,6 +97,7 @@ const useInputFormControls = (
     name: 'fiatValue' | 'cryptoValue',
     inputTransformer: (value: string) => string,
     maxLength: number | undefined,
+    maxDecimals: number | undefined,
 ) => {
     const { getValues, setValue } = useTradingBuyFormContext();
     // do not use `value` from `useField` here, because it does not work properly with `undefined`
@@ -106,14 +108,23 @@ const useInputFormControls = (
         setValue('focusedValue', name);
     }, [name, setValue]);
 
+    const maxDecimalRegex = useMemo(
+        () =>
+            maxDecimals !== undefined ? new RegExp(`[.](\\d{${maxDecimals}})(\\d+)$`) : undefined,
+        [maxDecimals],
+    );
+
     const handleTextChange = useCallback(
         (text: string) => {
-            const transformedText = inputTransformer(text);
-            const truncatedText = transformedText.slice(0, maxLength);
+            let transformedText = inputTransformer(text);
+            if (maxDecimalRegex) {
+                transformedText = transformedText.replace(maxDecimalRegex, '.$1');
+            }
+            transformedText = transformedText.slice(0, maxLength);
 
-            return onChange(truncatedText === '' ? undefined : truncatedText);
+            return onChange(transformedText === '' ? undefined : transformedText);
         },
-        [maxLength, inputTransformer, onChange],
+        [maxLength, maxDecimalRegex, inputTransformer, onChange],
     );
 
     const clearFocusedValueAndBlur = useCallback(() => {
@@ -134,6 +145,7 @@ export const TradingAmountInput = ({
     name,
     inputTransformer,
     maxLength,
+    maxDecimals,
     ...inputProps
 }: TradingAmountInputProps) => {
     const { applyStyle, utils } = useNativeStyles();
@@ -142,6 +154,7 @@ export const TradingAmountInput = ({
         name,
         inputTransformer,
         maxLength,
+        maxDecimals,
     );
 
     // Note: it would be nice to use `onContentSizeChange` instead of `<Box />` once this bug is fixed https://github.com/facebook/react-native/issues/29702

--- a/suite-native/module-trading/src/components/general/__tests__/TradingAmountInput.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingAmountInput.comp.test.tsx
@@ -243,4 +243,44 @@ describe('TradingAmountInput', () => {
             });
         });
     });
+
+    describe('maxDecimals property', () => {
+        it('should not limit input value when property is not set', async () => {
+            const { result } = await renderBuyFormHook();
+            const { getByLabelText } = renderTradingAmountInput({}, result.current);
+
+            await userEvent.type(getByLabelText('INPUT'), '1234567890.123456789');
+            expect(getByLabelText('INPUT')).toHaveDisplayValue('1234567890.123456789');
+        });
+
+        it('should truncate decimals exceeding specified limit', async () => {
+            const { result } = await renderBuyFormHook();
+            const { getByLabelText } = renderTradingAmountInput({ maxDecimals: 3 }, result.current);
+
+            await userEvent.type(getByLabelText('INPUT'), '1234567890.123456789');
+            expect(getByLabelText('INPUT')).toHaveDisplayValue('1234567890.123');
+        });
+
+        it('should truncate zero decimals exceeding specified limit', async () => {
+            const { result } = await renderBuyFormHook();
+            const { getByLabelText } = renderTradingAmountInput({ maxDecimals: 3 }, result.current);
+
+            await userEvent.type(getByLabelText('INPUT'), '1234567890.100000000');
+            expect(getByLabelText('INPUT')).toHaveDisplayValue('1234567890.100');
+        });
+
+        it.each(['0', '123456', '0.1', '12345.789'])(
+            'should do nothing when number of decimals is not exceeding limit, case [%s]',
+            async value => {
+                const { result } = await renderBuyFormHook();
+                const { getByLabelText } = renderTradingAmountInput(
+                    { maxDecimals: 3 },
+                    result.current,
+                );
+
+                await userEvent.type(getByLabelText('INPUT'), value);
+                expect(getByLabelText('INPUT')).toHaveDisplayValue(value);
+            },
+        );
+    });
 });

--- a/suite-native/module-trading/src/components/general/__tests__/TradingAmountInput.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingAmountInput.comp.test.tsx
@@ -1,6 +1,7 @@
 import { Form } from '@suite-native/forms';
 import {
     act,
+    fireEvent,
     renderHookWithStoreProviderAsync,
     renderWithBasicProvider,
     userEvent,
@@ -86,5 +87,160 @@ describe('TradingAmountInput', () => {
         });
 
         expect(getByLabelText('INPUT')).toHaveStyle({ color: paletteV1.lightAccentRed700 });
+    });
+
+    it('should have font size of 34 before layout events', async () => {
+        const { result } = await renderBuyFormHook();
+        const { getByLabelText } = renderTradingAmountInput({}, result.current);
+
+        expect(getByLabelText('INPUT')).toHaveStyle({ fontSize: 34, lineHeight: 41 });
+    });
+
+    describe('font size scaling on content change', () => {
+        let input: ReturnType<ReturnType<typeof renderTradingAmountInput>['getByLabelText']>;
+        let box: ReturnType<ReturnType<typeof renderTradingAmountInput>['getByTestId']>;
+
+        beforeEach(async () => {
+            const { result } = await renderBuyFormHook();
+            const { getByLabelText, getByTestId } = renderTradingAmountInput({}, result.current);
+
+            input = getByLabelText('INPUT');
+            box = getByTestId('@trading/amountInput/wrapper');
+
+            act(() => {
+                fireEvent(box, 'layout', {
+                    nativeEvent: {
+                        layout: {
+                            width: 120,
+                        },
+                    },
+                });
+            });
+        });
+
+        it('should have font size of 34 after initial layout events', () => {
+            expect(input).toHaveStyle({ fontSize: 34, lineHeight: 41 });
+        });
+
+        it.each([
+            [120, 28, 34],
+            [150, 22, 27],
+            [200, 17, 20],
+            [250, 17, 20],
+        ])(
+            'should downscale font when not enough space is available for content with width %i',
+            (contentWidth, expectedFontSize, expectedLineHeight) => {
+                act(() => {
+                    fireEvent(input, 'layout', {
+                        nativeEvent: {
+                            layout: {
+                                width: contentWidth,
+                            },
+                        },
+                    });
+                });
+
+                expect(input).toHaveStyle({
+                    fontSize: expectedFontSize,
+                    lineHeight: expectedLineHeight,
+                });
+            },
+        );
+
+        it.each([
+            [79, 21, 25],
+            [50, 34, 41],
+            [10, 34, 41],
+        ])(
+            'should upscale font when enough space is available for content with width %i',
+            (contentWidth, expectedFontSize, expectedLineHeight) => {
+                act(() => {
+                    fireEvent(input, 'layout', {
+                        nativeEvent: {
+                            layout: {
+                                width: 200,
+                            },
+                        },
+                    });
+                });
+                act(() => {
+                    fireEvent(input, 'layout', {
+                        nativeEvent: {
+                            layout: {
+                                width: contentWidth,
+                            },
+                        },
+                    });
+                });
+
+                expect(input).toHaveStyle({
+                    fontSize: expectedFontSize,
+                    lineHeight: expectedLineHeight,
+                });
+            },
+        );
+
+        it.each([100, 80])(
+            'should not upscale until hysteresis is reached for content with width %i',
+            contentWidth => {
+                act(() => {
+                    fireEvent(input, 'layout', {
+                        nativeEvent: {
+                            layout: {
+                                width: 200,
+                            },
+                        },
+                    });
+                });
+                act(() => {
+                    fireEvent(input, 'layout', {
+                        nativeEvent: {
+                            layout: {
+                                width: contentWidth,
+                            },
+                        },
+                    });
+                });
+
+                expect(input).toHaveStyle({
+                    fontSize: 17,
+                    lineHeight: 20,
+                });
+            },
+        );
+
+        it('should not divide by zero', () => {
+            act(() => {
+                fireEvent(input, 'layout', {
+                    nativeEvent: {
+                        layout: {
+                            width: 0,
+                        },
+                    },
+                });
+            });
+
+            expect(input).toHaveStyle({
+                fontSize: 34,
+                lineHeight: 41,
+            });
+        });
+
+        it('should use full sized font when available space is equal zero', () => {
+            act(() => {
+                fireEvent(box, 'layout', {
+                    nativeEvent: {
+                        layout: {
+                            width: 0,
+                        },
+                    },
+                });
+            });
+
+            expect(input).toHaveStyle({
+                fontSize: 34,
+                lineHeight: 41,
+            });
+        });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- scales input font to fit
- limit visible fiat amount to 3 decimals and crypto amount to 9 decimals

<!--- Describe your changes in detail -->

## Related Issue

Resolve [#16994](https://github.com/trezor/trezor-suite/issues/16994)

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=16994-mobile-trade-amount-input&lookback=7)