### PR TITLE
refactor(e2e): folder change for annotations.ts

### DIFF
--- a/packages/suite-desktop-core/e2e/support/reporters/annotations.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/annotations.ts
@@ -13,7 +13,7 @@ import {
     annotationsAddedToTest,
     annotationsForBodyDescription,
     annotationsForProjectFields,
-} from './enums/testAnnotations';
+} from '../enums/testAnnotations';
 
 type TestMetadataInput = {
     testCase?: string;

--- a/packages/suite-desktop-core/e2e/support/reporters/gitHubReporter.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/gitHubReporter.ts
@@ -3,7 +3,7 @@ import { Reporter, TestCase } from '@playwright/test/reporter';
 
 import { scheduleAction } from '@trezor/utils';
 
-import { TestReportProvider } from '../annotations';
+import { TestReportProvider } from './annotations';
 import { GitHubProject } from './gitHubProject';
 import { IssueRequests } from './issueRequests';
 import { LoggingFunctions, ProjectField } from './types';

--- a/packages/suite-desktop-core/e2e/tests/backup/t3t1-create-additional-share.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/backup/t3t1-create-additional-share.test.ts
@@ -1,8 +1,8 @@
 import { MNEMONICS } from '@trezor/trezor-user-env-link';
 
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../support/enums/testAnnotations';
 import { test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('Create additional share', { tag: ['@group=device-management'] }, () => {
     test.use({

--- a/packages/suite-desktop-core/e2e/tests/dashboard/discreet-mode.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/dashboard/discreet-mode.test.ts
@@ -2,9 +2,9 @@ import { Locator } from '@playwright/test';
 
 import { EventType } from '@trezor/suite-analytics';
 
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 import { ExtractByEventType } from '../../support/types';
 
 const verifyHiddenAndRevealedValue = async ({

--- a/packages/suite-desktop-core/e2e/tests/general/eap-modal.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/eap-modal.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.use({ startEmulator: false });
 

--- a/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });
 test.beforeEach(async ({ onboardingPage }) => {

--- a/packages/suite-desktop-core/e2e/tests/manual/accounts/pagination.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/accounts/pagination.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Pagination', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/browser/btc-link.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/browser/btc-link.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Bitcoin link', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/browser/old-browser.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/browser/old-browser.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Old browsers', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/browser/webusb-transport.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/browser/webusb-transport.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Web usb transport', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/btc/btc-transactions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/btc/btc-transactions.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Btc transactions', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/btc/receive.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/btc/receive.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Receive transaction', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/cardano/cardano-staking.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/cardano/cardano-staking.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Cardano staking', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/cardano/cardano-transactions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/cardano/cardano-transactions.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Cardano transactions', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/coinjoin/coinjoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/coinjoin/coinjoin.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Coinjoin', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/dashboard/portfolio.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/dashboard/portfolio.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Portfolio', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/eth/eth-transactions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/eth/eth-transactions.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 // Transaction types
 // Send ETH

--- a/packages/suite-desktop-core/e2e/tests/manual/eth/staking-testnet.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/eth/staking-testnet.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Ethereum staking on testnet', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/firmware/autolock.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/firmware/autolock.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Autolock', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/firmware/bootloader.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/firmware/bootloader.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Bootloader', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/firmware/btc-only-fw-update.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/firmware/btc-only-fw-update.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('BTC only firmware', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/firmware/custom-firmware.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/firmware/custom-firmware.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Custom firmware', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/firmware/factory-reset.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/firmware/factory-reset.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Factory reset', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/firmware/firmware-switch.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/firmware/firmware-switch.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Firmware switch', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/firmware/firmware-update.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/firmware/firmware-update.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Firmware update', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/settings/application-log.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/settings/application-log.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Application log', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/settings/check-update.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/settings/check-update.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Check for update', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/settings/device-language.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/settings/device-language.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Device language', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/settings/wallet-loading.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/settings/wallet-loading.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Wallet loading', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/solana/solana-staking.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/solana/solana-staking.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Solana staking', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/tor-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/tor-discovery.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../support/enums/testAnnotations';
 import { test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe.skip('Tor discovery', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/wallet/address-scan.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/wallet/address-scan.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Address scan', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/wallet/device-switch.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/wallet/device-switch.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Device switch', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/manual/wallet/remember-wallet.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/wallet/remember-wallet.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe.skip('Wallet remembering', { tag: ['@group=manual'] }, () => {
     test(

--- a/packages/suite-desktop-core/e2e/tests/metadata/output-labeling.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/output-labeling.test.ts
@@ -1,10 +1,10 @@
 import fs from 'fs';
 
-import { createTestAnnotation } from '../../support/annotations';
 import { OutputLabelId } from '../../support/enums/outputLabelId';
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
 import { MetadataProvider } from '../../support/mocks/metadataMock';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('Metadata - Output labeling', { tag: ['@group=metadata', '@webOnly'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
 import { expect, test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe('Onboarding - create wallet', { tag: ['@group=device-management'] }, () => {
     test.use({

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
 import { expect, test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 const mnemonic =
     'nasty answer gentle inform unaware abandon regret supreme dragon gravity behind lava dose pilot garden into dynamic outer hard speed luxury run truly armed';

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts
@@ -1,5 +1,5 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe('Onboarding - recover wallet T2T1', { tag: ['@group=device-management'] }, () => {
     test.use({

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
 import { expect, test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe('Onboarding - recover wallet T2T1', { tag: ['@group=device-management'] }, () => {
     test.use({

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
@@ -1,7 +1,7 @@
-import { createTestAnnotation } from '../../../support/annotations';
 import { SeedType } from '../../../support/enums/seedType';
 import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
 
 test.describe('Onboarding - create wallet', { tag: ['@group=device-management'] }, () => {
     test.use({

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase.test.ts
@@ -1,9 +1,9 @@
 import { EventType } from '@trezor/suite-analytics';
 
-import { createTestAnnotation } from '../../support/annotations';
 import { formatAddress } from '../../support/common';
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 import { ExtractByEventType } from '../../support/types';
 
 const abcAddr = 'bc1qpyfvfvm52zx7gek86ajj5pkkne3h385ada8r2y';

--- a/packages/suite-desktop-core/e2e/tests/recovery/t1b1-dry-run.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/recovery/t1b1-dry-run.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 const mnemonic =
     'nasty answer gentle inform unaware abandon regret supreme dragon gravity behind lava dose pilot garden into dynamic outer hard speed luxury run truly armed';

--- a/packages/suite-desktop-core/e2e/tests/recovery/t2t1-dry-run.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/recovery/t2t1-dry-run.test.ts
@@ -1,8 +1,8 @@
 import { MNEMONICS } from '@trezor/trezor-user-env-link';
 
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 const pin = '1';
 

--- a/packages/suite-desktop-core/e2e/tests/settings/coins.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/coins.test.ts
@@ -1,8 +1,8 @@
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('Coin Settings', { tag: ['@group=settings'] }, () => {
     test.beforeEach(async ({ analytics, onboardingPage, settingsPage }) => {

--- a/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });
 test.describe(

--- a/packages/suite-desktop-core/e2e/tests/settings/general.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/general.test.ts
@@ -1,9 +1,9 @@
 import { EventType } from '@trezor/suite-analytics';
 
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
 import { Language, Theme } from '../../support/pageObjects/settings/settingsPage';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 import { ExtractByEventType } from '../../support/types';
 
 export enum Currency {

--- a/packages/suite-desktop-core/e2e/tests/settings/t1b1-device-settings.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/t1b1-device-settings.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('T1B1 - Device settings', { tag: ['@group=settings'] }, () => {
     test.use({ emulatorStartConf: { model: 'T1B1', wipe: true } });

--- a/packages/suite-desktop-core/e2e/tests/settings/t2b1-device-settings.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/t2b1-device-settings.test.ts
@@ -3,9 +3,9 @@
 // - implement these differences in suite in the first place. both suite and T2B1 will happily accept
 //   request to change display rotation but it has no effect. It should be at least hidden on client.
 // https://github.com/trezor/trezor-suite/issues/6567
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe.serial('T2B1 - Device settings', { tag: ['@group=settings'] }, () => {
     test.use({

--- a/packages/suite-desktop-core/e2e/tests/settings/t2t1-device-settings.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/t2t1-device-settings.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('T2T1 - Device settings', { tag: ['@group=settings'] }, () => {
     test.use({ emulatorStartConf: { wipe: true, model: 'T2T1' } });

--- a/packages/suite-desktop-core/e2e/tests/suite/bug-report-form.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/bug-report-form.test.ts
@@ -1,8 +1,8 @@
 import { FeedbackCategory } from '@suite-common/suite-types';
 
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('Bug report forms', { tag: ['@group=suite'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });

--- a/packages/suite-desktop-core/e2e/tests/suite/db-migration.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/db-migration.test.ts
@@ -1,9 +1,9 @@
 import { colorVariants } from '@trezor/theme';
 import { hexToRgba } from '@trezor/utils';
 
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 const migrateFromVersion = 'release/22.5/web';
 const migrateToVersion = 'develop/web';

--- a/packages/suite-desktop-core/e2e/tests/suite/guide.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/guide.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('Guide without device', { tag: ['@group=suite', '@webOnly'] }, () => {
     test.use({ startEmulator: false });

--- a/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
@@ -1,13 +1,13 @@
 import * as messages from '@trezor/protobuf/src/messages';
 import { BridgeTransport } from '@trezor/transport';
 
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
 import { AnalyticsSection } from '../../support/pageObjects/analyticsSection';
 import { DashboardPage } from '../../support/pageObjects/dashboardPage';
 import { DevicePrompt } from '../../support/pageObjects/devicePrompt';
 import { OnboardingPage } from '../../support/pageObjects/onboarding/onboardingPage';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 import { enhancePage } from '../../support/testExtends/enhancePage';
 
 const stealBridgeSession = async () => {

--- a/packages/suite-desktop-core/e2e/tests/wallet/account-search.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/account-search.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('Look up a BTC account', { tag: ['@group=wallet'] }, () => {
     test.use({

--- a/packages/suite-desktop-core/e2e/tests/wallet/add-account-types.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/add-account-types.test.ts
@@ -1,9 +1,9 @@
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { EventType } from '@trezor/suite-analytics';
 
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 import { ExtractByEventType } from '../../support/types';
 
 test.describe('Account types suite', { tag: ['@group=wallet'] }, () => {

--- a/packages/suite-desktop-core/e2e/tests/wallet/blockbook-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/blockbook-discovery.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('Custom-blockbook-discovery', { tag: ['@group=wallet'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });

--- a/packages/suite-desktop-core/e2e/tests/wallet/cardano.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/cardano.test.ts
@@ -1,8 +1,8 @@
 import { cardanoAccountDetails } from '../../snapshots/web/wallet/cardano.test.ts/cardano-aria';
-import { createTestAnnotation } from '../../support/annotations';
 import { formatAddress } from '../../support/common';
 import { TestCategory, TestPriority, TestStream } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 const receiveAddress =
     'addr_test1qphsv6vspp4l3nvmqzw529teq2ha08s0fgjvzghzh628uccfey0wtrgp5rmxvld7khc745x9mk7gts5ctuzerlf4edrq5at0x5';

--- a/packages/suite-desktop-core/e2e/tests/wallet/export-transactions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/export-transactions.test.ts
@@ -2,10 +2,10 @@ import fs from 'fs';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
 import { ExportType } from '../../support/pageObjects/walletPage';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('Export transactions', { tag: ['@group=wallet', '@webOnly'] }, () => {
     test.use({

--- a/packages/suite-desktop-core/e2e/tests/wallet/import-btc-csv.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/import-btc-csv.test.ts
@@ -1,12 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 
-import { createTestAnnotation } from '../../support/annotations';
 import { csvToJson } from '../../support/csvToJson';
 import { AccountLabelId } from '../../support/enums/accountLabelId';
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
 import { MetadataProvider } from '../../support/mocks/metadataMock';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('Import a BTC csv file', { tag: ['@group=wallet', '@webOnly'] }, () => {
     test.beforeEach(async ({ metadataMock, onboardingPage }) => {

--- a/packages/suite-desktop-core/e2e/tests/wallet/staking.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/staking.test.ts
@@ -1,6 +1,6 @@
-import { createTestAnnotation } from '../../support/annotations';
 import { TestCategory, TestPriority, TestStream } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('ETH staking', { tag: ['@group=wallet'] }, () => {
     test.use({


### PR DESCRIPTION
Just moving file to keep all Reporter related files in one folder.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-pw-github-reporter-folder-move&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-pw-github-reporter-folder-move&lookback=7)