### PR TITLE
fix(suite): Reverse order of revealed addresses too

### DIFF
--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -154,7 +154,7 @@ export const UsedAddresses = ({
     );
     // TODO: add skipped addresses?
     // add revealed addresses to `used` list
-    const list = revealed.concat(used.slice().reverse());
+    const list = used.concat(revealed).reverse();
 
     if (list.length < 1) {
         return null;


### PR DESCRIPTION
## Description

Now reversing all shown addresses and not only used ones.

## Related Issue

Resolve #7248

## Screenshots:

**after:**

https://github.com/user-attachments/assets/59bdc242-69f0-4a2b-9997-b6b2d1226cfc