### PR TITLE
feat(suite): further soften FW hash check other-error UI

### DIFF
--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
@@ -58,6 +58,8 @@ const useSecurityCheckFailProps = (): SecurityCheckFailProps => {
             checklistItems: softFailureChecklistItems,
             goBack: goToSuite,
             supportUrl: TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL,
+            // make Contact support button less prominent
+            promoteSecondaryCta: true,
         };
     }
     if (hashCheckError !== null) {

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
@@ -16,6 +16,7 @@ export type SecurityCheckFailProps = {
     text?: TranslationKey;
     supportUrl: Url;
     checklistItems?: SecurityChecklistItem[];
+    promoteSecondaryCta?: boolean;
 };
 
 export const SecurityCheckFail = ({
@@ -24,6 +25,7 @@ export const SecurityCheckFail = ({
     text = 'TR_DEVICE_COMPROMISED_TEXT',
     supportUrl,
     checklistItems = hardFailureChecklistItems,
+    promoteSecondaryCta = false,
 }: SecurityCheckFailProps) => {
     const chatUrl = `${supportUrl}#open-chat`;
 
@@ -45,12 +47,18 @@ export const SecurityCheckFail = ({
                         variant="tertiary"
                         onClick={goBack}
                         size="large"
+                        flex={promoteSecondaryCta ? '1' : undefined}
                         data-testid="@device-compromised/back-button"
                     >
                         <Translation id="TR_BACK" />
                     </Button>
                 )}
-                <Button textWrap={false} href={chatUrl} isFullWidth size="large" flex="1">
+                <Button
+                    textWrap={false}
+                    href={chatUrl}
+                    flex={promoteSecondaryCta ? undefined : '1'}
+                    size="large"
+                >
                     <Translation id="TR_CONTACT_TREZOR_SUPPORT" />
                 </Button>
             </Row>

--- a/packages/suite/src/components/suite/SecurityCheck/checklistItems.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/checklistItems.tsx
@@ -1,17 +1,8 @@
-import styled from 'styled-components';
-
 import { Icon } from '@trezor/components';
-import { borders, spacingsPx } from '@trezor/theme';
 
 import { SecurityChecklistItem } from 'src/views/onboarding/steps/SecurityCheck/types';
 
 import { Translation } from '../Translation';
-
-const IconBackground = styled.div`
-    border-radius: ${borders.radii.full};
-    background-color: ${({ theme }) => theme.backgroundTertiaryDefaultOnElevation0};
-    padding: ${spacingsPx.xs};
-`;
 
 export const hardFailureChecklistItems: SecurityChecklistItem[] = [
     {
@@ -26,20 +17,17 @@ export const hardFailureChecklistItems: SecurityChecklistItem[] = [
 
 export const softFailureChecklistItems: SecurityChecklistItem[] = [
     {
-        icon: (
-            <IconBackground>
-                <Icon size={20} variant="default" name="numberOne" />
-            </IconBackground>
-        ),
+        icon: <Icon size={24} variant="default" name="browsers" />,
+        content: <Translation id="TR_TROUBLESHOOTING_CLOSE_TABS" />,
+        subtitle: <Translation id="TR_TROUBLESHOOTING_CLOSE_TABS_DESCRIPTION" />,
+    },
+    {
+        icon: <Icon size={24} variant="default" name="plugs" />,
         content: <Translation id="TR_DISCONNECT_YOUR_TREZOR" />,
         subtitle: <Translation id="TR_DISCONNECT_YOUR_TREZOR_SUBTITLE" />,
     },
     {
-        icon: (
-            <IconBackground>
-                <Icon size={20} variant="default" name="numberTwo" />
-            </IconBackground>
-        ),
+        icon: <Icon size={24} variant="default" name="chat" />,
         content: <Translation id="TR_PROBLEM_PERSISTS" />,
         subtitle: <Translation id="TR_PROBLEM_PERSISTS_SUBTITLE" />,
     },

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7067,11 +7067,11 @@ export default defineMessages({
     },
     TR_FAILED_VERIFY_DEVICE_HEADING: {
         id: 'TR_FAILED_VERIFY_DEVICE_HEADING',
-        defaultMessage: 'Failed to verify device',
+        defaultMessage: "The verification process didn't finish",
     },
     TR_FAILED_VERIFY_DEVICE_TEXT: {
         id: 'TR_FAILED_VERIFY_DEVICE_TEXT',
-        defaultMessage: 'Avoid using this device or sending any funds to it.',
+        defaultMessage: "Your device firmware hash check couldn't be performed.",
     },
     TR_DEVICE_COMPROMISED_ENTROPY_CHECK_TEXT: {
         id: 'TR_DEVICE_COMPROMISED_ENTROPY_CHECK_TEXT',


### PR DESCRIPTION
## Description

- change modal heading, modal subtitle
- add a first step: close other apps 
- change 1,2,3 icons to semantic icons
- make the primary Contact Trezor support button less prominent

## Related Issue

Resolve #18605

## Screenshots:

**other error**
![ghost other-error](https://github.com/user-attachments/assets/f0166542-c412-4b75-b7ab-bec8450748fd)

**hash mismatch (unchanged)**
![ghost hash-mismatch](https://github.com/user-attachments/assets/3f2e39f3-ed8d-4dd0-9c74-dc12c5935038)

@coderabbitai ignore

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/fw-hash-check-other-error-ui-tweaks&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/fw-hash-check-other-error-ui-tweaks&lookback=7)