### PR TITLE
PW GitHub reporter on release workflows

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -2,7 +2,7 @@ name: "Run Playwright E2E Tests"
 description: "Runs Playwright E2E tests with Docker and uploads logs"
 inputs:
   project:
-    description: "Playwright project name. (web|desktop)"
+    description: "Playwright project name. (web|web:release|desktop|desktop:release)"
     required: true
   base-url:
     description: "Base URL for E2E tests. Default: https://dev.suite.sldev.cz/suite-web/BRANCH_NAME/web/"
@@ -52,7 +52,7 @@ runs:
     # without requiring elevated privileges, which is essential for running the application.
     # This is workaround until electron builder solves this issue in future release.
     - name: Disable security rule 'Restricted unprivileged user namespaces'
-      if: ${{ inputs.project == 'desktop' }}
+      if: ${{ inputs.project == 'desktop' || inputs.project == 'desktop:release' }}
       shell: bash
       run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
@@ -68,7 +68,7 @@ runs:
         echo "::group::Install PW Dependencies"
         echo "Silently installing Playwright dependencies"
         yarn workspaces focus @trezor/suite-desktop-core ${{ inputs.workspace-dependencies }} > /dev/null
-        if [[ "${{ inputs.project }}" == "web" ]]; then
+        if [[ "${{ inputs.project }}" == "web" || "${{ inputs.project }}" == "web:release" ]]; then
           npx playwright install --with-deps > /dev/null
         fi
         echo "::endgroup::"
@@ -81,12 +81,13 @@ runs:
         echo "::group::Pull Docker Images"
         docker compose pull --quiet ${{ inputs.containers }}
         echo "::endgroup::"
-        
+
     - name: Run Playwright E2E Tests
       shell: bash
       env:
         COMPOSE_FILE: ./docker/docker-compose.suite-ci-e2e.yml
         GITHUB_ACTION: true
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CURRENTS_PROJECT_ID: ${{ inputs.currents-project-id }}
         CURRENTS_RECORD_KEY: ${{ inputs.currents-record-key }}
         CURRENTS_CI_BUILD_ID: pr-run-${{ github.run_id }}-${{ github.run_attempt }}
@@ -104,7 +105,7 @@ runs:
 
         docker compose up -d ${{ inputs.containers }}
         echo "Starting Playwright project ${{ inputs.project }} for test group ${{ inputs.test-group }}"
-        yarn workspace @trezor/suite-desktop-core test:orchestrated:e2e:${{ inputs.project }} --pwc-cancel-after-failures ${{ inputs.fail-fast }} --forbid-only --grep="${{ inputs.additional-grep }}" 
+        yarn workspace @trezor/suite-desktop-core test:orchestrated:e2e:${{ inputs.project }} --pwc-cancel-after-failures ${{ inputs.fail-fast }} --forbid-only --grep="${{ inputs.additional-grep }}"
 
     - name: Extract and Upload Logs
       if: ${{ !cancelled() }}

--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -38,6 +38,13 @@ inputs:
   e2e-passphrase:
     description: "Passphrase for E2E tests"
     required: true
+  github_token:
+    description: "GitHub token for GitHub Reporter, only on Release workflows"
+    required: false
+  release-build:
+    description: "Information for GitHub Reporter, only on Release workflows"
+    required: false
+
 runs:
   using: "composite"
   steps:
@@ -87,13 +94,14 @@ runs:
       env:
         COMPOSE_FILE: ./docker/docker-compose.suite-ci-e2e.yml
         GITHUB_ACTION: true
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CURRENTS_PROJECT_ID: ${{ inputs.currents-project-id }}
         CURRENTS_RECORD_KEY: ${{ inputs.currents-record-key }}
         CURRENTS_CI_BUILD_ID: pr-run-${{ github.run_id }}-${{ github.run_attempt }}
         CURRENTS_TAG: ${{ inputs.currents-tags }}
         GH_BRANCH: ${{ env.branch }} # Used by Currents reporter
         PASSPHRASE: ${{ inputs.e2e-passphrase }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        RELEASE_BUILD: ${{ inputs.release-build }}
       run: |
         if [[ -z "${{ inputs.base-url }}" ]]; then
           BASE_URL="https://dev.suite.sldev.cz/suite-web/${{ env.branch }}/web/"

--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -113,7 +113,7 @@ runs:
 
         docker compose up -d ${{ inputs.containers }}
         echo "Starting Playwright project ${{ inputs.project }} for test group ${{ inputs.test-group }}"
-        yarn workspace @trezor/suite-desktop-core test:orchestrated:e2e:${{ inputs.project }} --pwc-cancel-after-failures ${{ inputs.fail-fast }} --forbid-only --grep="${{ inputs.additional-grep }}" ings/general.test.ts
+        yarn workspace @trezor/suite-desktop-core test:orchestrated:e2e:${{ inputs.project }} --pwc-cancel-after-failures ${{ inputs.fail-fast }} --forbid-only --grep="${{ inputs.additional-grep }}"
 
     - name: Extract and Upload Logs
       if: ${{ !cancelled() }}

--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -38,7 +38,7 @@ inputs:
   e2e-passphrase:
     description: "Passphrase for E2E tests"
     required: true
-  github_token:
+  github-token:
     description: "GitHub token for GitHub Reporter, only on Release workflows"
     required: false
   release-build:
@@ -113,7 +113,7 @@ runs:
 
         docker compose up -d ${{ inputs.containers }}
         echo "Starting Playwright project ${{ inputs.project }} for test group ${{ inputs.test-group }}"
-        yarn workspace @trezor/suite-desktop-core test:orchestrated:e2e:${{ inputs.project }} --pwc-cancel-after-failures ${{ inputs.fail-fast }} --forbid-only --grep="${{ inputs.additional-grep }}"
+        yarn workspace @trezor/suite-desktop-core test:orchestrated:e2e:${{ inputs.project }} --pwc-cancel-after-failures ${{ inputs.fail-fast }} --forbid-only --grep="${{ inputs.additional-grep }}" ings/general.test.ts
 
     - name: Extract and Upload Logs
       if: ${{ !cancelled() }}

--- a/.github/workflows/test-suite-desktop-e2e-release.yml
+++ b/.github/workflows/test-suite-desktop-e2e-release.yml
@@ -11,7 +11,6 @@ on:
   push:
     branches:
       - release/2*
-      - feat-pw-github-reporter-workflow
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-suite-desktop-e2e-release.yml
+++ b/.github/workflows/test-suite-desktop-e2e-release.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - release/2*
+      - feat-pw-github-reporter-workflow
   workflow_dispatch:
 
 concurrency:
@@ -34,7 +35,7 @@ jobs:
       - build-app
     strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         TEST_GROUP: [1, 2, 3, 4, 5, 6, 7]
     steps:
       - name: Checkout
@@ -57,6 +58,12 @@ jobs:
       - name: Extract build artifact
         run: tar -xzf app-build.tar.gz -C ${{ github.workspace }}/packages/suite-desktop
 
+      - name: Extract Release Build
+        id: extract_branch
+        shell: bash
+        run: |
+          echo "release_build=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}-${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
+
       - name: Run Playwright E2E Tests
         uses: ./.github/actions/run-e2e-tests
         with:
@@ -68,3 +75,5 @@ jobs:
           currents-project-id: "4ytF0E"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}
+          github-token: ${{ secrets.TREZOR_BOT_TOKEN }}
+          release-build: ${{ env.release_build }}

--- a/.github/workflows/test-suite-desktop-e2e-release.yml
+++ b/.github/workflows/test-suite-desktop-e2e-release.yml
@@ -62,7 +62,7 @@ jobs:
         id: extract_branch
         shell: bash
         run: |
-          echo "release_build=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}-${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
+          echo "release_build=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}-${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
       - name: Run Playwright E2E Tests
         uses: ./.github/actions/run-e2e-tests

--- a/.github/workflows/test-suite-desktop-e2e-release.yml
+++ b/.github/workflows/test-suite-desktop-e2e-release.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        TEST_GROUP: [1]
+        TEST_GROUP: [1, 2, 3, 4, 5, 6, 7]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-suite-desktop-e2e-release.yml
+++ b/.github/workflows/test-suite-desktop-e2e-release.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Run Playwright E2E Tests
         uses: ./.github/actions/run-e2e-tests
         with:
-          project: "desktop"
+          project: "desktop:release"
           containers: "trezor-user-env-unix bitcoin-regtest"
           workspace-dependencies: "@trezor/suite-desktop"
           test-group: ${{ matrix.TEST_GROUP }}

--- a/.github/workflows/test-suite-desktop-e2e-release.yml
+++ b/.github/workflows/test-suite-desktop-e2e-release.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        TEST_GROUP: [1, 2, 3, 4, 5, 6, 7]
+        TEST_GROUP: [1]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -35,6 +35,12 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
+      - name: Extract Release Build
+        id: extract_branch
+        shell: bash
+        run: |
+          echo "release_build=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}-${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
+
       - name: Install PW Dependencies
         shell: bash
         run: |
@@ -47,6 +53,7 @@ jobs:
           GITHUB_ACTION: true
           GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}
           GITHUB_REPORTER_VERBOSE: true
+          RELEASE_BUILD: ${{ env.release_build }}
         run: |
           echo "Starting Playwright Reporter for manual regression suite"
           yarn workspace @trezor/suite-desktop-core test:e2e:manual

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -1,0 +1,53 @@
+name: "[Test] Release Suite manual e2e tests"
+description: "Runs Playwright reporter, creating manual regressions release suite in GitHub"
+# Triggered by push to release branch
+# Creates a manual regression suite in GitHub
+
+permissions:
+  id-token: write # for fetching the OIDC token
+  contents: read # for actions/checkout
+
+on:
+  push:
+    branches:
+      - release/2*
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+
+  run-e2e-suite-web-tests:
+    if: github.repository == 'trezor/trezor-suite'
+    runs-on: ubuntu-latest
+  
+    steps:
+    - name: Extract Branch Name
+      id: extract_branch
+      shell: bash
+      run: |
+        echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: ".nvmrc"
+        cache: yarn
+
+    - name: Install PW Dependencies
+      shell: bash
+      run: |
+        echo "Silently installing Playwright dependencies"
+        yarn workspaces focus @trezor/suite-desktop-core > /dev/null
+
+    - name: Run Playwright Reporter
+      shell: bash
+      env:
+        GITHUB_ACTION: true
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        echo "Starting Playwright Reporter for manual regression suite"
+        yarn workspace @trezor/suite-desktop-core test:e2e:manual
+

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -39,7 +39,7 @@ jobs:
         id: extract_branch
         shell: bash
         run: |
-          echo "release_build=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}-${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
+          echo "release_build=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}-${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
       - name: Install PW Dependencies
         shell: bash

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run-e2e-suite-web-tests:
+  run-e2e-suite-manual-tests:
     if: github.repository == 'trezor/trezor-suite'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -46,6 +46,7 @@ jobs:
         env:
           GITHUB_ACTION: true
           GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}
+          GITHUB_REPORTER_VERBOSE: true
         run: |
           echo "Starting Playwright Reporter for manual regression suite"
           yarn workspace @trezor/suite-desktop-core test:e2e:manual

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -5,6 +5,7 @@ name: "[Test] Release Suite manual e2e tests"
 permissions:
   issues: write # for creating issues which represent the manual regression tests
   repository-projects: write # for creating projects in QA team which contain the suite
+  discussions: write
 
 on:
   push:
@@ -38,8 +39,8 @@ jobs:
       - name: Install PW Dependencies
         shell: bash
         run: |
-          echo "Silently installing Playwright dependencies"
-          yarn workspaces focus @trezor/suite-desktop-core > /dev/null
+          echo "Installing Playwright dependencies"
+          yarn workspaces focus @trezor/suite-desktop-core
 
       - name: Run Playwright Reporter
         shell: bash

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -5,7 +5,6 @@ name: "[Test] Release Suite manual e2e tests"
 permissions:
   issues: write # for creating issues which represent the manual regression tests
   repository-projects: write # for creating projects in QA team which contain the suite
-  discussions: write
 
 on:
   push:
@@ -46,7 +45,7 @@ jobs:
         shell: bash
         env:
           GITHUB_ACTION: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}
         run: |
           echo "Starting Playwright Reporter for manual regression suite"
           yarn workspace @trezor/suite-desktop-core test:e2e:manual

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: true
+          ref: ${{ github.sha }}
+          fetch-depth: 2
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -1,7 +1,6 @@
 name: "[Test] Release Suite manual e2e tests"
-description: "Runs Playwright reporter, creating manual regressions release suite in GitHub"
 # Triggered by push to release branch
-# Creates a manual regression suite in GitHub
+# Runs Playwright reporter, creating manual regressions release suite in GitHub"
 
 permissions:
   issues: write # for creating issues which represent the manual regression tests

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -2,10 +2,6 @@ name: "[Test] Release Suite manual e2e tests"
 # Triggered by push to release branch
 # Runs Playwright reporter, creating manual regressions release suite in GitHub"
 
-permissions:
-  issues: write # for creating issues which represent the manual regression tests
-  repository-projects: write # for creating projects in QA team which contain the suite
-
 on:
   push:
     branches:

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -5,8 +5,6 @@ name: "[Test] Release Suite Regression test publisher"
 on:
   push:
     branches:
-      - release/2*
-      - feat-pw-github-reporter-workflow
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - release/2*
+      - feat-pw-github-reporter-workflow
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -4,8 +4,8 @@ description: "Runs Playwright reporter, creating manual regressions release suit
 # Creates a manual regression suite in GitHub
 
 permissions:
-  id-token: write # for fetching the OIDC token
-  contents: read # for actions/checkout
+  issues: write # for creating issues which represent the manual regression tests
+  repository-projects: write # for creating projects in QA team which contain the suite
 
 on:
   push:
@@ -18,36 +18,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   run-e2e-suite-web-tests:
     if: github.repository == 'trezor/trezor-suite'
     runs-on: ubuntu-latest
-  
+
     steps:
-    - name: Extract Branch Name
-      id: extract_branch
-      shell: bash
-      run: |
-        echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          ref: ${{ github.sha }}
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version-file: ".nvmrc"
-        cache: yarn
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: yarn
 
-    - name: Install PW Dependencies
-      shell: bash
-      run: |
-        echo "Silently installing Playwright dependencies"
-        yarn workspaces focus @trezor/suite-desktop-core > /dev/null
+      - name: Install PW Dependencies
+        shell: bash
+        run: |
+          echo "Silently installing Playwright dependencies"
+          yarn workspaces focus @trezor/suite-desktop-core > /dev/null
 
-    - name: Run Playwright Reporter
-      shell: bash
-      env:
-        GITHUB_ACTION: true
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        echo "Starting Playwright Reporter for manual regression suite"
-        yarn workspace @trezor/suite-desktop-core test:e2e:manual
-
+      - name: Run Playwright Reporter
+        shell: bash
+        env:
+          GITHUB_ACTION: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Starting Playwright Reporter for manual regression suite"
+          yarn workspace @trezor/suite-desktop-core test:e2e:manual

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -10,7 +10,6 @@ on:
   push:
     branches:
       - release/2*
-      - feat-pw-github-reporter-workflow
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -1,4 +1,4 @@
-name: "[Test] Release Suite manual e2e tests"
+name: "[Test] Release Suite Regression test publisher"
 # Triggered by push to release branch
 # Runs Playwright reporter, creating manual regressions release suite in GitHub"
 
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - release/2*
+      - feat-pw-github-reporter-workflow
   workflow_dispatch:
 
 concurrency:
@@ -20,9 +21,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: true
-          ref: ${{ github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test-suite-web-e2e-release.yml
+++ b/.github/workflows/test-suite-web-e2e-release.yml
@@ -11,7 +11,6 @@ on:
   push:
     branches:
       - release/2*
-      - feat-pw-github-reporter-workflow
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-suite-web-e2e-release.yml
+++ b/.github/workflows/test-suite-web-e2e-release.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        TEST_GROUP: [1]
+        TEST_GROUP: [1, 2, 3, 4, 5, 6, 7]
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-suite-web-e2e-release.yml
+++ b/.github/workflows/test-suite-web-e2e-release.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        TEST_GROUP: [1, 2, 3, 4, 5, 6, 7]
+        TEST_GROUP: [1]
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-suite-web-e2e-release.yml
+++ b/.github/workflows/test-suite-web-e2e-release.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - release/2*
+      - feat-pw-github-reporter-workflow
   workflow_dispatch:
 
 concurrency:
@@ -50,6 +51,12 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 2
 
+      - name: Extract Release Build
+        id: extract_branch
+        shell: bash
+        run: |
+          echo "release_build=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}-${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
+
       - name: Run Playwright E2E Tests
         uses: ./.github/actions/run-e2e-tests
         with:
@@ -60,3 +67,5 @@ jobs:
           currents-project-id: "Og0NOQ"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}
+          github-token: ${{ secrets.TREZOR_BOT_TOKEN }}
+          release-build: ${{ env.release_build }}

--- a/.github/workflows/test-suite-web-e2e-release.yml
+++ b/.github/workflows/test-suite-web-e2e-release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run Playwright E2E Tests
         uses: ./.github/actions/run-e2e-tests
         with:
-          project: "web"
+          project: "web:release"
           containers: "trezor-user-env-unix bitcoin-regtest"
           test-group: ${{ matrix.TEST_GROUP }}
           fail-fast: false

--- a/.github/workflows/test-suite-web-e2e-release.yml
+++ b/.github/workflows/test-suite-web-e2e-release.yml
@@ -55,7 +55,7 @@ jobs:
         id: extract_branch
         shell: bash
         run: |
-          echo "release_build=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}-${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
+          echo "release_build=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}-${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
       - name: Run Playwright E2E Tests
         uses: ./.github/actions/run-e2e-tests

--- a/docs/tests/e2e-playwright-github-reporter.md
+++ b/docs/tests/e2e-playwright-github-reporter.md
@@ -1,15 +1,15 @@
 # GitHub Test Reporter
 
-The GitHub Test Reporter is a unified test documentation and reporting framework designed to create a single source of truth for both automated and manual tests in our repository. This framework uses structured test annotations to document tests directly in the codebase and automatically generates GitHub projects during release builds for efficient QA workflows.
+The GitHub Test Reporter is a unified test documentation and reporting framework designed to create a single source of truth for both automated and manual tests in our repository. This framework uses structured test annotations to document tests directly in the codebase and automatically generates GitHub project items during release builds for efficient QA workflows.
 
 ## Purpose
 
 The primary goals of this reporter are to:
 
 1. **Unify Test Documentation** - Keep all test cases (both automated and manual) in one place within the repository
-2. **Streamline QA Regression** - Generate release-specific project boards with all tests as draft issues
+2. **Streamline QA Regression** - Populate a GitHub project with all tests as draft issues for release regression testing
 
-When executed during release builds, the reporter creates a new GitHub project populated with draft issues representing each test. These issues contain all relevant test metadata and results, providing QA teams with a comprehensive dashboard for regression testing and quality assurance.
+When executed during release builds, the reporter adds new draft issues to a GitHub project. These issues contain all relevant test metadata and results, providing QA teams with a comprehensive dashboard for regression testing and quality assurance.
 
 ## Overview
 
@@ -17,7 +17,7 @@ The framework consists of three main components:
 
 1. **Test Annotations** - Define metadata about tests
 2. **TestReportProvider** - Extracts and formats test metadata
-3. **GitHub Reporter** - Creates release build project and populates it with GitHub issues with test results
+3. **GitHub Reporter** - Populates GitHub project with test results as draft issues
 
 The reporter automatically creates draft issues in a GitHub project board when tests run, complete with test metadata, status, and other customizable fields.
 
@@ -45,6 +45,7 @@ The GitHub project is configured with fields that correspond to test metadata:
 -   **Priority** - Test importance
 -   **Device Model** - Target device for testing
 -   **Comment** - Additional notes
+-   **Release Build** - The release build identifier (branch-commit format)
 
 ## How to Use
 
@@ -80,22 +81,28 @@ test.describe('Test suite name', { tag: ['@group=manual'] }, () => {
 The reporter is configured with environment variables:
 
 -   `GITHUB_TOKEN` - Required for API access
--   `PROJECT_NAME` - Optional name for the GitHub project (defaults to "Test Results 35")
+-   `RELEASE_BUILD` - Used to identify the specific release build (format: branch-commit)
 -   `VERBOSE` - Set to control logging detail
+
+### Project Creation
+
+The GitHub project used for testing reports must be created manually using the provided script:
+
+```bash
+yarn workspace @trezor/suite-desktop-core node e2e/support/reporters/scriptCreateProject.ts
+```
+
+This script creates a central "Trezor Suite release testing" project that will contain all test results. The project is reused across releases, with the `Release Build` field differentiating between builds.
 
 ### Local run
 
-The reporter can be run even from local environment for troubleshooting and development purposes.
+The reporter can be run from a local environment for troubleshooting and development purposes:
 
--   `yarn test:e2e:web:report`
--   `yarn test:e2e:desktop:report`
+-   `yarn test:e2e:web --reporter=./e2e/support/reporters/gitHubReporter.ts"
+-   `yarn test:e2e:desktop --reporter=./e2e/support/reporters/gitHubReporter.ts"
+-   `yarn test:e2e:manual`
 
 ## Implementation Notes
-
-### Retry Strategy
-
-The GitHub Test Reporter implements a retry mechanism to handle network issues or temporary API failures. It uses the `scheduleAction` utility. Each API operation will be attempted up to 3 times with a 500ms delay between attempts.
-The current implementation does not have built-in deduplication logic for test issues.
 
 ### Extending the Framework
 
@@ -113,3 +120,26 @@ To add new annotation types:
     - update constant validGetterKeys in getterByKey
 
 To add or change value of annotation, simply change or add new enum value in corresponding object in `testAnnotations.ts`
+
+### Retry Strategy
+
+The GitHub Test Reporter implements a retry mechanism to handle network issues or temporary API failures. It uses the `scheduleAction` utility. Each API operation will be attempted up to 3 times with a 500ms delay between attempts.
+The current implementation does not have built-in deduplication logic for duplicate test issues created by retry.
+
+### Test Retry Deduplication
+
+The reporter handles test retries by tracking previously created issues for each test. When a test is retried, the reporter updates the existing issue's status field rather than creating a duplicate issue. This ensures that each test case appears only once in the project board regardless of how many retry attempts occur.
+
+### Release Build Differentiation
+
+Tests from different release builds are added to the same GitHub project but are differentiated by the `Release Build` field. This allows filtering and organization of tests by specific releases while maintaining a centralized project structure.
+
+### CI Integration
+
+The reporter is integrated into release branch CI workflows:
+
+-   `test-suite-web-e2e-release.yml` for Suite Web tests
+-   `test-suite-desktop-e2e-release.yml` for Suite Desktop tests
+-   `test-suite-manual-release.yml` for manual tests
+
+Each workflow passes the `RELEASE_BUILD` and `GITHUB_TOKEN` environment variables to enable test reporting.

--- a/docs/tests/e2e-playwright-github-reporter.md
+++ b/docs/tests/e2e-playwright-github-reporter.md
@@ -124,7 +124,7 @@ To add or change value of annotation, simply change or add new enum value in cor
 ### Retry Strategy
 
 The GitHub Test Reporter implements a retry mechanism to handle network issues or temporary API failures. It uses the `scheduleAction` utility. Each API operation will be attempted up to 3 times with a 500ms delay between attempts.
-The current implementation does not have built-in deduplication logic for duplicate test issues created by retry.
+The current implementation does not have built-in deduplication logic for duplicate test issues created by `scheduleAction` retries.
 
 ### Test Retry Deduplication
 

--- a/docs/tests/e2e-playwright-github-reporter.md
+++ b/docs/tests/e2e-playwright-github-reporter.md
@@ -98,8 +98,8 @@ This script creates a central "Trezor Suite release testing" project that will c
 
 The reporter can be run from a local environment for troubleshooting and development purposes:
 
--   `yarn test:e2e:web --reporter=./e2e/support/reporters/gitHubReporter.ts"
--   `yarn test:e2e:desktop --reporter=./e2e/support/reporters/gitHubReporter.ts"
+-   `yarn test:e2e:web --reporter=./e2e/support/reporters/gitHubReporter.ts`
+-   `yarn test:e2e:desktop --reporter=./e2e/support/reporters/gitHubReporter.ts`
 -   `yarn test:e2e:manual`
 
 ## Implementation Notes

--- a/packages/suite-desktop-core/.example.env
+++ b/packages/suite-desktop-core/.example.env
@@ -5,5 +5,7 @@ PASSPHRASE=
 # Custom Test timeout override, for convenient test development (optional)
 TEST_TIMEOUT_OVERRIDE=
 
+# GitHub Reporter
 # Token for GitHub Reporter local runs, used only for testing of reporter itself (optional)
-# GITHUB_TOKEN=
+GITHUB_TOKEN=
+GITHUB_REPORTER_VERBOSE=false

--- a/packages/suite-desktop-core/.example.env
+++ b/packages/suite-desktop-core/.example.env
@@ -9,3 +9,4 @@ TEST_TIMEOUT_OVERRIDE=
 # Token for GitHub Reporter local runs, used only for testing of reporter itself (optional)
 GITHUB_TOKEN=
 GITHUB_REPORTER_VERBOSE=false
+RELEASE_BUILD=

--- a/packages/suite-desktop-core/e2e/playwright.config.ts
+++ b/packages/suite-desktop-core/e2e/playwright.config.ts
@@ -9,6 +9,7 @@ dotenv.config({ path: path.resolve(__dirname, '../.env') });
 export enum PlaywrightProjects {
     Web = 'web',
     Desktop = 'desktop',
+    Manual = 'manual',
 }
 
 const CI_TIMEOUT = 1000 * 180;
@@ -37,6 +38,11 @@ const config: PlaywrightTestConfig = defineConfig<CurrentsFixtures, CurrentsWork
             name: PlaywrightProjects.Desktop,
             use: {},
             grepInvert: [/@webOnly/, /@group=manual/],
+        },
+        {
+            name: PlaywrightProjects.Manual,
+            use: {},
+            grep: /@group=manual/,
         },
     ],
     testDir: 'tests',

--- a/packages/suite-desktop-core/e2e/support/enums/testAnnotations.ts
+++ b/packages/suite-desktop-core/e2e/support/enums/testAnnotations.ts
@@ -112,6 +112,12 @@ export const testCaseAnnotation: BaseAnnotation = {
     valueType: 'TEXT',
 };
 
+export const releaseBuildAnnotation: BaseAnnotation = {
+    name: 'Release Build',
+    key: 'releaseBuild',
+    valueType: 'TEXT',
+};
+
 export const prerequisitesAnnotation: BaseAnnotation = {
     name: 'Prerequisites',
     key: 'prerequisites',
@@ -186,6 +192,7 @@ export const annotationsForBodyDescription = [prerequisitesAnnotation, stepsAnno
 
 // Defines which annotations are used in the project fields in GitHub Issue
 export const annotationsForProjectFields = [
+    releaseBuildAnnotation,
     statusAnnotation,
     streamAnnotation,
     testRunAnnotation,

--- a/packages/suite-desktop-core/e2e/support/reporters/annotations.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/annotations.ts
@@ -126,14 +126,21 @@ export class TestReportProvider {
         return this.getAnnotation(TestAnnotationType.Stream, this.defaults.stream);
     }
 
+    get testProject(): string {
+        const project = this.test.parent.project();
+        if (!project) {
+            throw new Error('Test project is not defined');
+        }
+
+        return project.name;
+    }
+
     get testRun(): string {
         if (this.isManual) {
             return 'Manual';
         } else {
             // Web or Desktop
-            const projectType = this.test.parent.project()?.name;
-
-            return capitalizeFirstLetter(projectType ?? 'Automated');
+            return capitalizeFirstLetter(this.testProject);
         }
     }
 
@@ -153,6 +160,10 @@ export class TestReportProvider {
         return this.test.tags.some(tag => tag.startsWith('@group=manual'));
     }
 
+    get isRetryAttempt(): boolean {
+        return this.test.results.length > 1;
+    }
+
     get bodyDescription(): string {
         const sections = [];
 
@@ -162,7 +173,7 @@ export class TestReportProvider {
                 sections.push(`## ${annotation.name}\n${value}`);
             }
         } else {
-            sections.push('## Automated Test');
+            sections.push(`## Automated Test\nID: ${this.test.id}`);
         }
 
         return sections.join('\n---\n');

--- a/packages/suite-desktop-core/e2e/support/reporters/annotations.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/annotations.ts
@@ -80,6 +80,15 @@ export class TestReportProvider {
     get testCase(): string {
         return this.getAnnotation(TestAnnotationType.TestCase, this.test.title);
     }
+
+    get releaseBuild(): string {
+        if (!process.env.RELEASE_BUILD) {
+            throw new Error('RELEASE_BUILD is not set');
+        }
+
+        return process.env.RELEASE_BUILD;
+    }
+
     get status(): string {
         // This condition covers manual and automated tests that are skipped
         if (this.test.outcome() === 'skipped') {
@@ -173,6 +182,7 @@ export class TestReportProvider {
         // This is the downside, we need to record of all our annotation getters here
         const getters: Record<string, () => string> = {
             testCase: () => this.testCase,
+            releaseBuild: () => this.releaseBuild,
             prerequisites: () => this.prerequisites,
             steps: () => this.steps,
             category: () => this.category,

--- a/packages/suite-desktop-core/e2e/support/reporters/gitHubProject.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/gitHubProject.ts
@@ -4,7 +4,7 @@ import { scheduleAction } from '@trezor/utils';
 
 import { ProjectRequests } from './projectRequests';
 import { LoggingFunctions } from './types';
-import { BaseAnnotation, annotationsForProjectFields } from '../enums/testAnnotations';
+import { BaseAnnotation } from '../enums/testAnnotations';
 
 const ORGANIZATION = 'trezor';
 const ORG_ID = 'MDEyOk9yZ2FuaXphdGlvbjQxNDY0NDc=';
@@ -34,6 +34,7 @@ export class GitHubProject {
         return this._projectId;
     }
 
+    // GraphQL requests require token with permissions `project, read:org`
     async init(): Promise<void> {
         try {
             const existingProject = await this.findExistingProject();
@@ -45,24 +46,28 @@ export class GitHubProject {
                 );
 
                 return;
-            }
-
-            await this.createProject(annotationsForProjectFields);
-
-            // Instead of taking projectId from 'createProject()' we run another 'findExistingProject()' query again
-            // Goal is to avoid conflicts by searching for the project again, by its name and choosing the oldest
-            // Source of conflict: Parallel workflows on CI (Web x Desktop), parallel groups in one workflow
-            const createdProject = await this.findExistingProject();
-            if (createdProject) {
-                this._projectId = createdProject.id;
-                this.logger.log(
-                    `Using created project: ${createdProject.title} (${createdProject.id})`,
-                );
-
-                return;
             } else {
-                throw new Error('Failed to find the created project');
+                this.logger.logError(`No existing project found.`);
+                throw new Error('No existing project found.');
             }
+
+            // We cannot get atm right token to be able to create project from Github Actions
+            // await this.createProject(annotationsForProjectFields);
+
+            // // Instead of taking projectId from 'createProject()' we run another 'findExistingProject()' query again
+            // // Goal is to avoid conflicts by searching for the project again, by its name and choosing the oldest
+            // // Source of conflict: Parallel workflows on CI (Web x Desktop), parallel groups in one workflow
+            // const createdProject = await this.findExistingProject();
+            // if (createdProject) {
+            //     this._projectId = createdProject.id;
+            //     this.logger.log(
+            //         `Using created project: ${createdProject.title} (${createdProject.id})`,
+            //     );
+
+            //     return;
+            // } else {
+            //     throw new Error('Failed to find the created project');
+            // }
         } catch (error) {
             this.logger.logError('Project initialization failed.');
             throw error;

--- a/packages/suite-desktop-core/e2e/support/reporters/gitHubProject.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/gitHubProject.ts
@@ -9,7 +9,7 @@ import { BaseAnnotation, annotationsForProjectFields } from '../enums/testAnnota
 const ORGANIZATION = 'trezor';
 const ORG_ID = 'MDEyOk9yZ2FuaXphdGlvbjQxNDY0NDc=';
 const QA_TEAM_ID = 'T_kwDOAD9FD84AMZXd';
-const PROJECT_NAME = 'Test Results 43'; // TODO: Get this from CI, probably build name
+const PROJECT_NAME = 'Test Results 35'; // 43 TODO: Get this from CI, probably build name
 const RETRY_CONF = {
     attempts: 3,
     gap: 500,

--- a/packages/suite-desktop-core/e2e/support/reporters/gitHubProject.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/gitHubProject.ts
@@ -9,7 +9,7 @@ import { BaseAnnotation, annotationsForProjectFields } from '../enums/testAnnota
 const ORGANIZATION = 'trezor';
 const ORG_ID = 'MDEyOk9yZ2FuaXphdGlvbjQxNDY0NDc=';
 const QA_TEAM_ID = 'T_kwDOAD9FD84AMZXd';
-const PROJECT_NAME = 'Test Results 38'; // TODO: Get this from CI, probably build name
+const PROJECT_NAME = 'Test Results 43'; // TODO: Get this from CI, probably build name
 const RETRY_CONF = {
     attempts: 3,
     gap: 500,

--- a/packages/suite-desktop-core/e2e/support/reporters/gitHubProject.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/gitHubProject.ts
@@ -9,7 +9,7 @@ import { BaseAnnotation, annotationsForProjectFields } from '../enums/testAnnota
 const ORGANIZATION = 'trezor';
 const ORG_ID = 'MDEyOk9yZ2FuaXphdGlvbjQxNDY0NDc=';
 const QA_TEAM_ID = 'T_kwDOAD9FD84AMZXd';
-const PROJECT_NAME = 'Test Results 44'; // TODO: Get this from CI, probably build name
+const PROJECT_NAME = 'Test Results 46'; // TODO: Get this from CI, probably build name
 const RETRY_CONF = {
     attempts: 3,
     gap: 500,

--- a/packages/suite-desktop-core/e2e/support/reporters/gitHubProject.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/gitHubProject.ts
@@ -4,12 +4,12 @@ import { scheduleAction } from '@trezor/utils';
 
 import { ProjectRequests } from './projectRequests';
 import { LoggingFunctions } from './types';
-import { BaseAnnotation } from '../enums/testAnnotations';
+import { BaseAnnotation, annotationsForProjectFields } from '../enums/testAnnotations';
 
 const ORGANIZATION = 'trezor';
 const ORG_ID = 'MDEyOk9yZ2FuaXphdGlvbjQxNDY0NDc=';
 const QA_TEAM_ID = 'T_kwDOAD9FD84AMZXd';
-const PROJECT_NAME = 'Test Results 35'; // 43 TODO: Get this from CI, probably build name
+const PROJECT_NAME = 'Test Results 44'; // TODO: Get this from CI, probably build name
 const RETRY_CONF = {
     attempts: 3,
     gap: 500,
@@ -102,7 +102,7 @@ export class GitHubProject {
         }
     }
 
-    async createProject(desiredFields: Array<BaseAnnotation>): Promise<void> {
+    async createProject(): Promise<void> {
         const projectId = await scheduleAction(
             () => this.graphQLClient.createProject(ORG_ID, QA_TEAM_ID, PROJECT_NAME),
             RETRY_CONF,
@@ -115,7 +115,7 @@ export class GitHubProject {
         );
         const existingStatusField = existingFields.find(f => f.name === 'Status');
 
-        for (const desiredField of desiredFields) {
+        for (const desiredField of annotationsForProjectFields) {
             // Update STATUS field with new options
             if (desiredField.name === 'Status' && existingStatusField) {
                 this.logger.log('Status field already exists, updating options...');

--- a/packages/suite-desktop-core/e2e/support/reporters/gitHubProject.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/gitHubProject.ts
@@ -98,7 +98,10 @@ export class GitHubProject {
     }
 
     async createProject(desiredFields: Array<BaseAnnotation>): Promise<void> {
-        const projectId = await this.graphQLClient.createProject(ORG_ID, QA_TEAM_ID, PROJECT_NAME);
+        const projectId = await scheduleAction(
+            () => this.graphQLClient.createProject(ORG_ID, QA_TEAM_ID, PROJECT_NAME),
+            RETRY_CONF,
+        );
 
         // Get default STATUS field that was automatically created.
         const existingFields = await scheduleAction(

--- a/packages/suite-desktop-core/e2e/support/reporters/gitHubProject.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/gitHubProject.ts
@@ -9,7 +9,10 @@ import { BaseAnnotation, annotationsForProjectFields } from '../enums/testAnnota
 const ORGANIZATION = 'trezor';
 const ORG_ID = 'MDEyOk9yZ2FuaXphdGlvbjQxNDY0NDc=';
 const QA_TEAM_ID = 'T_kwDOAD9FD84AMZXd';
-const PROJECT_NAME = 'Test Results 46'; // TODO: Get this from CI, probably build name
+// DevOps is working on tokens in our GitHub atm. Once that is settled we can rework this
+// and try to create project separately for each build. Until then we will use one project
+// for all builds and have name hardcoded here.
+const PROJECT_NAME = 'Trezor Suite release testing';
 const RETRY_CONF = {
     attempts: 3,
     gap: 500,

--- a/packages/suite-desktop-core/e2e/support/reporters/gitHubProject.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/gitHubProject.ts
@@ -9,7 +9,7 @@ import { BaseAnnotation, annotationsForProjectFields } from '../enums/testAnnota
 const ORGANIZATION = 'trezor';
 const ORG_ID = 'MDEyOk9yZ2FuaXphdGlvbjQxNDY0NDc=';
 const QA_TEAM_ID = 'T_kwDOAD9FD84AMZXd';
-const PROJECT_NAME = 'Test Results 37'; // TODO: Get this from CI, probably build name
+const PROJECT_NAME = 'Test Results 38'; // TODO: Get this from CI, probably build name
 const RETRY_CONF = {
     attempts: 3,
     gap: 500,

--- a/packages/suite-desktop-core/e2e/support/reporters/gitHubProject.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/gitHubProject.ts
@@ -10,8 +10,10 @@ const ORGANIZATION = 'trezor';
 const ORG_ID = 'MDEyOk9yZ2FuaXphdGlvbjQxNDY0NDc=';
 const QA_TEAM_ID = 'T_kwDOAD9FD84AMZXd';
 // DevOps is working on tokens in our GitHub atm. Once that is settled we can rework this
-// and try to create project separately for each build. Until then we will use one project
-// for all builds and have name hardcoded here.
+// and try to create project separately for each build. Needs to be discussed with DevOps.
+// And we would need to some kind of cleanup after each build of projects not longer used.
+// Until then we will use one project for all builds and have name hardcoded here.
+// We should first try this approach and get feedback from QA after one release.
 const PROJECT_NAME = 'Trezor Suite release testing';
 const RETRY_CONF = {
     attempts: 3,

--- a/packages/suite-desktop-core/e2e/support/reporters/gitHubReporter.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/gitHubReporter.ts
@@ -7,6 +7,7 @@ import { TestReportProvider } from './annotations';
 import { GitHubProject } from './gitHubProject';
 import { IssueRequests } from './issueRequests';
 import { LoggingFunctions, ProjectField } from './types';
+import { statusAnnotation } from '../enums/testAnnotations';
 
 const RETRY_CONF = {
     attempts: 3,
@@ -27,6 +28,7 @@ class GitHubReporter implements Reporter, LoggingFunctions {
     private pendingOperations: Promise<any>[] = [];
     private cachedFields: ProjectField[] | null = null;
     private initState: InitializationState = InitializationState.NOT_STARTED;
+    private createdIssuesMap: Map<string, string> = new Map();
 
     private initializationPromise: Promise<void> | null = null;
 
@@ -129,41 +131,11 @@ class GitHubReporter implements Reporter, LoggingFunctions {
                 const report = new TestReportProvider(test);
 
                 try {
-                    const issueNodeId = await scheduleAction(() => {
-                        this.log(`Creating GitHub draft issue for test "${test.title}"...`);
-
-                        return this.issueRequests.createDraftIssueInProject(
-                            this.gitHubProject.id,
-                            report.testCase,
-                            report.bodyDescription,
-                        );
-                    }, RETRY_CONF);
-                    this.log(`[${issueNodeId}] Successfully created issue "${test.title}"`);
-
-                    const fields = await scheduleAction(() => this.getProjectFields(), RETRY_CONF);
-
-                    for (const { name, value } of report.projectValues) {
-                        const { fieldId, valueOrOptionId } = this.resolveFieldAndValue(
-                            fields,
-                            name,
-                            value,
-                        );
-                        await scheduleAction(() => {
-                            this.log(`[${issueNodeId}] Updating field ${name}:"${value}"...`);
-
-                            return this.issueRequests.setItemValue(
-                                this.gitHubProject.id,
-                                issueNodeId,
-                                fieldId,
-                                valueOrOptionId,
-                            );
-                        }, RETRY_CONF);
-                        this.log(`[${issueNodeId}] Successfully updated field ${name}:"${value}"`);
+                    if (report.isRetryAttempt && this.createdIssuesMap.has(test.id)) {
+                        this.updateIssue(test, report);
+                    } else {
+                        this.createIssue(test, report);
                     }
-
-                    this.log(
-                        `[${issueNodeId}] Successfully recorded test result for "${test.title}"`,
-                    );
                 } catch (error) {
                     this.logError(`Failed to process test end for "${test.title}":`, error);
                     // Non-Critical error, no need to rethrow
@@ -199,10 +171,66 @@ class GitHubReporter implements Reporter, LoggingFunctions {
         }
     }
 
+    private async createIssue(test: TestCase, report: TestReportProvider): Promise<void> {
+        const issueNodeId = await scheduleAction(() => {
+            this.log(`Creating GitHub draft issue for test "${test.title}"...`);
+
+            return this.issueRequests.createDraftIssueInProject(
+                this.gitHubProject.id,
+                report.testCase,
+                report.bodyDescription,
+            );
+        }, RETRY_CONF);
+
+        this.createdIssuesMap.set(test.id, issueNodeId);
+        this.log(`[${issueNodeId}] Successfully created issue "${test.title}"`);
+
+        const fields = await scheduleAction(() => this.getProjectFields(), RETRY_CONF);
+
+        for (const { name, value } of report.projectValues) {
+            const { fieldId, valueOrOptionId } = this.resolveFieldAndValue(fields, name, value);
+            await scheduleAction(() => {
+                this.log(`[${issueNodeId}] Updating field ${name}:"${value}"...`);
+
+                return this.issueRequests.setItemValue(
+                    this.gitHubProject.id,
+                    issueNodeId,
+                    fieldId,
+                    valueOrOptionId,
+                );
+            }, RETRY_CONF);
+            this.log(`[${issueNodeId}] Successfully updated field ${name}:"${value}"`);
+        }
+
+        this.log(`[${issueNodeId}] Successfully recorded test result for "${test.title}"`);
+    }
+
+    private async updateIssue(test: TestCase, report: TestReportProvider): Promise<void> {
+        const issueNodeId = this.createdIssuesMap.get(test.id);
+        if (!issueNodeId) {
+            throw new Error(`Issue ID not found for test retried test "${test.title}"`);
+        }
+        this.log(
+            `[${issueNodeId}] Updating GitHub draft issue with a retry of test "${test.title}"...`,
+        );
+
+        const fields = await scheduleAction(() => this.getProjectFields(), RETRY_CONF);
+
+        this.log(`[${issueNodeId}] Updating field Status:"${report.status}"...`);
+        const { fieldId: statusFieldId, valueOrOptionId: statusOptionId } =
+            this.resolveFieldAndValue(fields, statusAnnotation.name, report.status);
+        await scheduleAction(() => this.issueRequests.setItemValue(
+                this.gitHubProject.id,
+                issueNodeId,
+                statusFieldId,
+                statusOptionId,
+            ), RETRY_CONF);
+        this.log(`[${issueNodeId}] Successfully updated field Status:"${report.status}"`);
+        this.log(`[${issueNodeId}] Successfully updated test result for "${test.title}"`);
+    }
+
     private async getProjectFields(): Promise<ProjectField[]> {
         if (this.cachedFields) {
-            this.log('Using cached project fields');
-
             return this.cachedFields;
         }
 

--- a/packages/suite-desktop-core/e2e/support/reporters/gitHubReporter.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/gitHubReporter.ts
@@ -8,7 +8,6 @@ import { GitHubProject } from './gitHubProject';
 import { IssueRequests } from './issueRequests';
 import { LoggingFunctions, ProjectField } from './types';
 
-const VERBOSE = true;
 const RETRY_CONF = {
     attempts: 3,
     gap: 500,
@@ -32,7 +31,7 @@ class GitHubReporter implements Reporter, LoggingFunctions {
     private initializationPromise: Promise<void> | null = null;
 
     log(...args: any[]): void {
-        if (VERBOSE) {
+        if (process.env.GITHUB_REPORTER_VERBOSE) {
             console.warn('[GitHub Reporter]', ...args);
         }
     }
@@ -42,7 +41,7 @@ class GitHubReporter implements Reporter, LoggingFunctions {
     }
 
     logResponse(label: string, response: any): void {
-        if (VERBOSE) {
+        if (process.env.GITHUB_REPORTER_VERBOSE) {
             console.warn(`[GitHub Reporter] ${label}:`);
             console.warn(JSON.stringify(response, null, 2));
         }
@@ -105,8 +104,14 @@ class GitHubReporter implements Reporter, LoggingFunctions {
                 throw error; // Critical error, rethrow to stop execution
             }
 
-            await this.gitHubProject.init();
-            this.initState = InitializationState.COMPLETED;
+            try {
+                await this.gitHubProject.init();
+                this.initState = InitializationState.COMPLETED;
+            } catch (error) {
+                this.initState = InitializationState.FAILED;
+                this.logError('Failed to initialize GitHub Project.');
+                throw error; // Critical error, rethrow to stop execution
+            }
         })();
         this.initializationPromise = initPromise;
 

--- a/packages/suite-desktop-core/e2e/support/reporters/gitHubReporter.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/gitHubReporter.ts
@@ -132,9 +132,9 @@ class GitHubReporter implements Reporter, LoggingFunctions {
 
                 try {
                     if (report.isRetryAttempt && this.createdIssuesMap.has(test.id)) {
-                        this.updateIssue(test, report);
+                        await this.updateIssue(test, report);
                     } else {
-                        this.createIssue(test, report);
+                        await this.createIssue(test, report);
                     }
                 } catch (error) {
                     this.logError(`Failed to process test end for "${test.title}":`, error);
@@ -219,12 +219,16 @@ class GitHubReporter implements Reporter, LoggingFunctions {
         this.log(`[${issueNodeId}] Updating field Status:"${report.status}"...`);
         const { fieldId: statusFieldId, valueOrOptionId: statusOptionId } =
             this.resolveFieldAndValue(fields, statusAnnotation.name, report.status);
-        await scheduleAction(() => this.issueRequests.setItemValue(
-                this.gitHubProject.id,
-                issueNodeId,
-                statusFieldId,
-                statusOptionId,
-            ), RETRY_CONF);
+        await scheduleAction(
+            () =>
+                this.issueRequests.setItemValue(
+                    this.gitHubProject.id,
+                    issueNodeId,
+                    statusFieldId,
+                    statusOptionId,
+                ),
+            RETRY_CONF,
+        );
         this.log(`[${issueNodeId}] Successfully updated field Status:"${report.status}"`);
         this.log(`[${issueNodeId}] Successfully updated test result for "${test.title}"`);
     }

--- a/packages/suite-desktop-core/e2e/support/reporters/projectRequests.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/projectRequests.ts
@@ -53,35 +53,6 @@ export class ProjectRequests {
     ) {}
 
     async createProject(ownerId: string, teamId: string, projectName: string): Promise<string> {
-        //   const query = `
-        //     query {
-        //         organization(login: "trezor") {
-        //             team(slug: "qa") {
-        //                 id
-        //                 name
-        //             }
-        //         }
-        //     }
-        // `;
-
-        //   interface TeamQueryResponse {
-        //       organization: {
-        //           team: {
-        //               id: string;
-        //               name: string;
-        //           };
-        //       };
-        //   }
-
-        //   const responseTeam = await this.octokit.graphql<TeamQueryResponse>(query);
-        //   const teamId2 = responseTeam.organization.team;
-
-        //   this.logger.logResponse('TeamQueryResponse', responseTeam);
-        //   this.logger.log(`Creating project "${projectName}" with owner ID: ${ownerId}`);
-        //   this.logger.log(
-        //       `Creating project for ${teamId2.id} : ${teamId2.name} instead of hardcoded ${teamId}`,
-        //   );
-
         const mutation = `
             mutation {
                 createProjectV2(
@@ -158,7 +129,7 @@ export class ProjectRequests {
         const query = `
             query {
               organization(login: "${organization}") {
-                projectsV2(first: 30, query: "${projectName}", orderBy: {field: NUMBER, direction: ASC}) {
+                projectsV2(query: "${projectName}", first: 30, orderBy: {field: NUMBER, direction: ASC}) {
                   nodes {
                     id
                     title

--- a/packages/suite-desktop-core/e2e/support/reporters/projectRequests.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/projectRequests.ts
@@ -109,6 +109,9 @@ export class ProjectRequests {
               ... on ProjectV2SingleSelectField {
                 id
               }
+              ... on ProjectV2FieldCommon {
+                id
+              }
             }
         } 
       }`;

--- a/packages/suite-desktop-core/e2e/support/reporters/projectRequests.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/projectRequests.ts
@@ -53,7 +53,33 @@ export class ProjectRequests {
     ) {}
 
     async createProject(ownerId: string, teamId: string, projectName: string): Promise<string> {
+        const query = `
+          query {
+              organization(login: "trezor") {
+                  team(slug: "qa") {
+                      id
+                      name
+                  }
+              }
+          }
+      `;
+
+        interface TeamQueryResponse {
+            organization: {
+                team: {
+                    id: string;
+                    name: string;
+                };
+            };
+        }
+
+        const responseTeam = await this.octokit.graphql<TeamQueryResponse>(query);
+        const teamId2 = responseTeam.organization.team;
+
         this.logger.log(`Creating project "${projectName}" with owner ID: ${ownerId}`);
+        this.logger.log(
+            `Creating project for ${teamId2.id} : ${teamId2.name} instead of hardcoded ${teamId}`,
+        );
 
         const mutation = `
             mutation {
@@ -61,7 +87,7 @@ export class ProjectRequests {
                 input: {
                     ownerId: "${ownerId}"
                     title: "${projectName}"
-                    teamId: "${teamId}"
+                    teamId: "${teamId2.id}"
                 }) {
                     projectV2 {
                         id

--- a/packages/suite-desktop-core/e2e/support/reporters/projectRequests.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/projectRequests.ts
@@ -76,6 +76,7 @@ export class ProjectRequests {
         const responseTeam = await this.octokit.graphql<TeamQueryResponse>(query);
         const teamId2 = responseTeam.organization.team;
 
+        this.logger.logResponse('TeamQueryResponse', responseTeam);
         this.logger.log(`Creating project "${projectName}" with owner ID: ${ownerId}`);
         this.logger.log(
             `Creating project for ${teamId2.id} : ${teamId2.name} instead of hardcoded ${teamId}`,

--- a/packages/suite-desktop-core/e2e/support/reporters/projectRequests.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/projectRequests.ts
@@ -53,34 +53,34 @@ export class ProjectRequests {
     ) {}
 
     async createProject(ownerId: string, teamId: string, projectName: string): Promise<string> {
-        const query = `
-          query {
-              organization(login: "trezor") {
-                  team(slug: "qa") {
-                      id
-                      name
-                  }
-              }
-          }
-      `;
+        //   const query = `
+        //     query {
+        //         organization(login: "trezor") {
+        //             team(slug: "qa") {
+        //                 id
+        //                 name
+        //             }
+        //         }
+        //     }
+        // `;
 
-        interface TeamQueryResponse {
-            organization: {
-                team: {
-                    id: string;
-                    name: string;
-                };
-            };
-        }
+        //   interface TeamQueryResponse {
+        //       organization: {
+        //           team: {
+        //               id: string;
+        //               name: string;
+        //           };
+        //       };
+        //   }
 
-        const responseTeam = await this.octokit.graphql<TeamQueryResponse>(query);
-        const teamId2 = responseTeam.organization.team;
+        //   const responseTeam = await this.octokit.graphql<TeamQueryResponse>(query);
+        //   const teamId2 = responseTeam.organization.team;
 
-        this.logger.logResponse('TeamQueryResponse', responseTeam);
-        this.logger.log(`Creating project "${projectName}" with owner ID: ${ownerId}`);
-        this.logger.log(
-            `Creating project for ${teamId2.id} : ${teamId2.name} instead of hardcoded ${teamId}`,
-        );
+        //   this.logger.logResponse('TeamQueryResponse', responseTeam);
+        //   this.logger.log(`Creating project "${projectName}" with owner ID: ${ownerId}`);
+        //   this.logger.log(
+        //       `Creating project for ${teamId2.id} : ${teamId2.name} instead of hardcoded ${teamId}`,
+        //   );
 
         const mutation = `
             mutation {
@@ -88,7 +88,7 @@ export class ProjectRequests {
                 input: {
                     ownerId: "${ownerId}"
                     title: "${projectName}"
-                    teamId: "${teamId2.id}"
+                    teamId: "${teamId}"
                 }) {
                     projectV2 {
                         id

--- a/packages/suite-desktop-core/e2e/support/reporters/scriptCreateProject.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/scriptCreateProject.ts
@@ -1,0 +1,50 @@
+import { Octokit } from '@octokit/rest';
+import dotenv from 'dotenv';
+import path from 'path';
+
+import { GitHubProject } from './gitHubProject';
+
+dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
+
+class ScriptLogger {
+    log(...args: any[]): void {
+        console.warn('[GitHub Project Creator]', ...args);
+    }
+
+    logError(...args: any[]): void {
+        console.error('[GitHub Project Creator ERROR]', ...args);
+    }
+
+    logResponse(label: string, response: any): void {
+        console.warn(`[GitHub Project Creator] ${label}:`);
+        console.warn(JSON.stringify(response, null, 2));
+    }
+}
+
+async function main() {
+    // Check for GitHub token with permissions `project, read:org`
+    if (!process.env.GITHUB_TOKEN) {
+        console.error('Error: GITHUB_TOKEN environment variable is required');
+        process.exit(1);
+    }
+
+    const logger = new ScriptLogger();
+    logger.log('Initializing...');
+
+    try {
+        const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+        const gitHubProject = new GitHubProject(octokit, logger);
+
+        logger.log('Creating GitHub project...');
+        await gitHubProject.createProject();
+        logger.log('GitHub project created successfully!');
+    } catch (error) {
+        logger.logError('Failed to create GitHub project:', error);
+        process.exit(1);
+    }
+}
+
+main().catch(error => {
+    console.error('Unhandled error:', error);
+    process.exit(1);
+});

--- a/packages/suite-desktop-core/e2e/support/reporters/types.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/types.ts
@@ -71,14 +71,16 @@ export interface CreateFieldResponse {
     };
 }
 
+interface Issue {
+    id: string;
+    title: string;
+}
+
 export interface AddDraftIssueResponse {
     addProjectV2DraftIssue: {
         projectItem: {
             id: string;
-            content: {
-                id: string;
-                title: string;
-            };
+            content: Issue;
         };
     };
 }

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -18,7 +18,8 @@
         "test:orchestrated:e2e:desktop": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=desktop",
         "test:orchestrated:e2e:desktop:release": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=desktop --reporter=@currents/playwright,./e2e/support/reporters/gitHubReporter.ts",
         "test:orchestrated:e2e:web": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=web",
-        "test:orchestrated:e2e:web:release": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=web --reporter=@currents/playwright,./e2e/support/reporters/gitHubReporter.ts"
+        "test:orchestrated:e2e:web:release": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=web --reporter=@currents/playwright,./e2e/support/reporters/gitHubReporter.ts",
+        "github:create-project": "tsx ./e2e/support/reporters/scriptCreateProject.ts"
     },
     "dependencies": {
         "@sentry/electron": "^5.12.0",
@@ -75,6 +76,7 @@
         "jest-diff": "^29.7.0",
         "lodash": "^4.17.21",
         "terser-webpack-plugin": "^5.3.14",
+        "tsx": "^4.19.3",
         "webpack": "^5.97.1",
         "xvfb-maybe": "^0.2.1"
     }

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -11,13 +11,14 @@
         "build:core": "yarn g:rimraf dist && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/core.webpack.config.ts",
         "type-check": "yarn g:tsc --build tsconfig.json",
         "test:unit": "yarn g:jest",
-        "test:orchestrated:e2e:web": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=web",
-        "test:orchestrated:e2e:desktop": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=desktop",
-        "test:e2e:web": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --project=web",
         "test:e2e:desktop": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --project=desktop",
-        "test:e2e:web:report": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --project=web --reporter=./e2e/support/reporters/gitHubReporter.ts",
-        "test:e2e:desktop:report": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --project=desktop --reporter=./e2e/support/reporters/gitHubReporter.ts",
-        "test:e2e:update-snapshots": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --grep @snapshot --update-snapshots"
+        "test:e2e:web": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --project=web",
+        "test:e2e:manual": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --project=manual --reporter=./e2e/support/reporters/gitHubReporter.ts",
+        "test:e2e:update-snapshots": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --grep @snapshot --update-snapshots",
+        "test:orchestrated:e2e:desktop": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=desktop",
+        "test:orchestrated:e2e:desktop:release": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=desktop --reporter=@currents/playwright,./e2e/support/reporters/gitHubReporter.ts",
+        "test:orchestrated:e2e:web": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=web",
+        "test:orchestrated:e2e:web:release": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=web --reporter=@currents/playwright,./e2e/support/reporters/gitHubReporter.ts"
     },
     "dependencies": {
         "@sentry/electron": "^5.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12305,6 +12305,7 @@ __metadata:
     openpgp: "npm:^6.1.0"
     systeminformation: "npm:^5.25.11"
     terser-webpack-plugin: "npm:^5.3.14"
+    tsx: "npm:^4.19.3"
     webpack: "npm:^5.97.1"
     ws: "npm:^8.18.0"
     xvfb-maybe: "npm:^0.2.1"


### PR DESCRIPTION
Update reporter to work only with one Project and allow filtering by release build
The project creation is done by a script run from a local machine. Project name is hardcoded. Project already exists.
Logic preventing retry duplicit introduced.

https://github.com/orgs/trezor/projects/107


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-pw-github-reporter-workflow&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-pw-github-reporter-workflow&lookback=7)