### PR TITLE
fix(suite): consider staking balances and ignore fake tokens in AccountsNonZeroBalance and AccountsTokensStatus

### DIFF
--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -11,6 +11,7 @@ import {
     selectDevicesCount,
 } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
+import { getAccountTotalStakingBalance } from '@suite-common/wallet-utils';
 import { DEVICE, TRANSPORT } from '@trezor/connect';
 import {
     getBootloaderHash,
@@ -37,6 +38,7 @@ import {
     redactRouterUrl,
     redactTransactionIdFromAnchor,
 } from 'src/utils/suite/analytics';
+import { hasVisibleTokens } from 'src/utils/wallet/tokenUtils';
 
 /*
     In analytics middleware we may intercept actions we would like to log. For example:
@@ -166,17 +168,26 @@ const analyticsMiddleware =
                     .filter(
                         account =>
                             new BigNumber(account.balance).gt(0) ||
-                            new BigNumber(
-                                (account.tokens || []).filter(token =>
-                                    new BigNumber(token.balance || 0).gt(0),
-                                ).length,
-                            ).gt(0),
+                            new BigNumber(getAccountTotalStakingBalance(account) || 0).gt(0) ||
+                            hasVisibleTokens(
+                                account.symbol,
+                                account.tokens ?? [],
+                                state.tokenDefinitions,
+                            ),
                     )
                     .reduce(accumulateAccountCountBySymbolAndType, {});
 
                 const accountsWithTokens = state.wallet.accounts
                     .filter(account => new BigNumber((account.tokens || []).length).gt(0))
-                    .reduce((acc: { [key: string]: number }, { symbol }: Account) => {
+                    .reduce((acc: { [key: string]: number }, { symbol, tokens }) => {
+                        if (
+                            tokens &&
+                            tokens.length > 0 &&
+                            !hasVisibleTokens(symbol, tokens, state.tokenDefinitions)
+                        ) {
+                            return acc;
+                        }
+
                         acc[symbol] = (acc[symbol] || 0) + 1;
 
                         return acc;

--- a/packages/suite/src/utils/wallet/__fixtures__/tokenUtils.ts
+++ b/packages/suite/src/utils/wallet/__fixtures__/tokenUtils.ts
@@ -1,4 +1,10 @@
-import { EnhancedTokenInfo, TokenDefinition } from '@suite-common/token-definitions';
+import {
+    EnhancedTokenInfo,
+    TokenDefinition,
+    TokenDefinitionsState,
+} from '@suite-common/token-definitions';
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { TokenInfo } from '@trezor/connect';
 
 export const getTokensFixtures = [
     {
@@ -137,5 +143,46 @@ export const getTokensFixtures = [
             unverifiedWithBalance: [],
             unverifiedWithoutBalance: [],
         },
+    },
+];
+
+const TOKEN_DEFINITIONS = {
+    eth: {
+        coin: {
+            error: false,
+            isLoading: false,
+            data: ['0xa', '0xb'],
+            show: [],
+            hide: [],
+        },
+    },
+    sol: {
+        coin: {
+            error: false,
+            isLoading: false,
+            data: ['0xc', '0xd'],
+            show: [],
+            hide: [],
+        },
+    },
+} as TokenDefinitionsState;
+
+export const hasVisibleTokensFixtures = [
+    {
+        testName: 'no tokens',
+        symbol: 'eth' as NetworkSymbol,
+        tokens: [] as TokenInfo[],
+        tokenDefinitions: TOKEN_DEFINITIONS,
+        result: false,
+    },
+    {
+        testName: 'tokens with definitions and balance',
+        symbol: 'eth' as NetworkSymbol,
+        tokens: [
+            { contract: '0xa', balance: '100' },
+            { contract: '0xb', balance: '200' },
+        ] as TokenInfo[],
+        tokenDefinitions: TOKEN_DEFINITIONS,
+        result: true,
     },
 ];

--- a/packages/suite/src/utils/wallet/__tests__/tokenUtils.test.ts
+++ b/packages/suite/src/utils/wallet/__tests__/tokenUtils.test.ts
@@ -1,5 +1,5 @@
-import { getTokensFixtures } from '../__fixtures__/tokenUtils';
-import { getTokens } from '../tokenUtils';
+import { getTokensFixtures, hasVisibleTokensFixtures } from '../__fixtures__/tokenUtils';
+import { getTokens, hasVisibleTokens } from '../tokenUtils';
 
 describe('getTokens', () => {
     getTokensFixtures.forEach(
@@ -16,4 +16,12 @@ describe('getTokens', () => {
             });
         },
     );
+});
+
+describe('hasVisibleTokens', () => {
+    hasVisibleTokensFixtures.forEach(({ testName, tokens, symbol, tokenDefinitions, result }) => {
+        test(testName, () => {
+            expect(hasVisibleTokens(symbol, tokens, tokenDefinitions)).toStrictEqual(result);
+        });
+    });
 });

--- a/packages/suite/src/utils/wallet/tokenUtils.ts
+++ b/packages/suite/src/utils/wallet/tokenUtils.ts
@@ -2,6 +2,7 @@ import { FiatCurrencyCode } from '@suite-common/suite-config';
 import {
     EnhancedTokenInfo,
     TokenDefinition,
+    TokenDefinitionsState,
     isTokenDefinitionKnown,
 } from '@suite-common/token-definitions';
 import { NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
@@ -156,4 +157,28 @@ export const getTokens = ({
         unverifiedWithBalance,
         unverifiedWithoutBalance,
     };
+};
+
+export const hasVisibleTokens = (
+    symbol: NetworkSymbol,
+    tokens: TokenInfo[],
+    tokenDefinitions: Partial<TokenDefinitionsState>,
+    isNft: boolean = false,
+): boolean => {
+    if (!tokens || tokens.length === 0) return false;
+
+    const coinDefinitions = tokenDefinitions?.[symbol]?.coin;
+    if (!coinDefinitions) return false;
+
+    const currentTokens = getTokens({
+        tokens,
+        symbol,
+        tokenDefinitions: coinDefinitions,
+        isNft,
+    });
+
+    const visibleTokenCount =
+        currentTokens.shownWithBalance.length + currentTokens.shownWithoutBalance.length;
+
+    return visibleTokenCount > 0;
 };


### PR DESCRIPTION
## Description

- `AccountsNonZeroBalance` now considers staking balances.
- Both `AccountsNonZeroBalance` and `AccountsTokensStatus` ignore fake tokens.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18251
Resolve https://github.com/trezor/trezor-suite/issues/18252

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/analytics-AccountsTokensStatus-AccountsNonZeroBalance&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/analytics-AccountsTokensStatus-AccountsNonZeroBalance&lookback=7)