### PR TITLE
WIP: Enable wallet switcher while loading

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
@@ -1,17 +1,15 @@
 import styled, { css } from 'styled-components';
 
-import { selectSelectedDevice } from '@suite-common/wallet-core';
-import { Icon, Tooltip } from '@trezor/components';
+import { Icon } from '@trezor/components';
 import { focusStyleTransition, getFocusShadowStyle } from '@trezor/components/src/utils/utils';
 import { borders, spacingsPx } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { ViewOnlyTooltip } from 'src/views/view-only/ViewOnlyTooltip';
 
 import { SidebarDeviceStatus } from './SidebarDeviceStatus';
 import { useResponsiveContext } from '../../../../../support/suite/ResponsiveContext';
-import { Translation } from '../../../Translation';
 import { ExpandedSidebarOnly } from '../Sidebar/ExpandedSidebarOnly';
 
 const CaretContainer = styled.div`
@@ -57,22 +55,16 @@ const InnerContainer = styled.div<{ $isDisabled?: boolean }>`
 `;
 
 export const DeviceSelector = () => {
-    const selectedDevice = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();
-    const { getDiscoveryStatus } = useDiscovery();
-    const discoveryStatus = getDiscoveryStatus();
-    const discoveryInProgress = Boolean(discoveryStatus && discoveryStatus.status === 'loading');
 
     const handleSwitchDeviceClick = () => {
-        if (!discoveryInProgress) {
-            dispatch(
-                goto('suite-switch-device', {
-                    params: {
-                        cancelable: true,
-                    },
-                }),
-            );
-        }
+        dispatch(
+            goto('suite-switch-device', {
+                params: {
+                    cancelable: true,
+                },
+            }),
+        );
     };
 
     const { isSidebarCollapsed } = useResponsiveContext();
@@ -80,30 +72,19 @@ export const DeviceSelector = () => {
     return (
         <Wrapper $isSidebarCollapsed={isSidebarCollapsed}>
             <ViewOnlyTooltip>
-                <Tooltip
-                    isActive={discoveryInProgress}
-                    isFullWidth
-                    placement="bottom"
-                    cursor={discoveryInProgress ? 'not-allowed' : undefined}
-                    content={<Translation id="TR_UNAVAILABLE_WHILE_LOADING" />}
+                <InnerContainer
+                    onClick={handleSwitchDeviceClick}
+                    tabIndex={0}
+                    data-testid="@menu/switch-device"
                 >
-                    <InnerContainer
-                        onClick={handleSwitchDeviceClick}
-                        $isDisabled={discoveryInProgress}
-                        tabIndex={0}
-                        data-testid="@menu/switch-device"
-                    >
-                        <SidebarDeviceStatus />
+                    <SidebarDeviceStatus />
 
-                        <ExpandedSidebarOnly>
-                            {selectedDevice && selectedDevice.state && (
-                                <CaretContainer>
-                                    <Icon size={20} name="caretCircleDown" />
-                                </CaretContainer>
-                            )}
-                        </ExpandedSidebarOnly>
-                    </InnerContainer>
-                </Tooltip>
+                    <ExpandedSidebarOnly>
+                        <CaretContainer>
+                            <Icon size={20} name="caretCircleDown" />
+                        </CaretContainer>
+                    </ExpandedSidebarOnly>
+                </InnerContainer>
             </ViewOnlyTooltip>
         </Wrapper>
     );

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { AnimatePresence, MotionProps, motion } from 'framer-motion';
 import styled from 'styled-components';
 
-import { selectSelectedDevice, startDiscoveryThunk } from '@suite-common/wallet-core';
+import { selectSelectedDevice, startSelectedDeviceDiscovery } from '@suite-common/wallet-core';
 import { Button, IconButton, Row, Tooltip, motionEasing } from '@trezor/components';
 import { spacings, spacingsPx, typography } from '@trezor/theme';
 
@@ -49,7 +49,7 @@ export const RefreshAfterDiscoveryNeeded = () => {
     }
 
     const startDiscovery = () => {
-        dispatch(startDiscoveryThunk());
+        dispatch(startSelectedDeviceDiscovery());
     };
 
     return (

--- a/packages/suite/src/hooks/suite/useDiscovery.ts
+++ b/packages/suite/src/hooks/suite/useDiscovery.ts
@@ -1,14 +1,18 @@
 import { useCallback } from 'react';
 
+import { TrezorDevice } from '@suite-common/suite-types';
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { selectDiscoveryByDeviceState, selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { useSelector } from './useSelector';
 import { getDiscoveryStatus } from '../../utils/wallet/getDiscoveryStatus';
 
-export const useDiscovery = () => {
-    const device = useSelector(selectSelectedDevice);
-    const discovery = useSelector(state => selectDiscoveryByDeviceState(state, device?.state));
+export const useDiscovery = ({ device }: { device?: TrezorDevice } = {}) => {
+    const selectedDevice = useSelector(selectSelectedDevice);
+    const discoveryDevice = device ?? selectedDevice;
+    const discovery = useSelector(state =>
+        selectDiscoveryByDeviceState(state, discoveryDevice?.state),
+    );
 
     const calculateProgress = useCallback(() => {
         if (discovery && discovery.loaded && discovery.total) {
@@ -19,12 +23,12 @@ export const useDiscovery = () => {
     }, [discovery]);
 
     const getStatus = useCallback(
-        () => getDiscoveryStatus({ device, discovery }),
-        [device, discovery],
+        () => getDiscoveryStatus({ device: discoveryDevice, discovery }),
+        [discoveryDevice, discovery],
     );
 
     return {
-        device,
+        device: discoveryDevice,
         discovery,
         isDiscoveryRunning: discovery ? discovery.status < DiscoveryStatus.STOPPING : false,
         getDiscoveryStatus: getStatus,

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -11,7 +11,7 @@ import {
     removeFeeInfoThunk,
     selectDeviceDiscovery,
     selectSelectedDevice,
-    startDiscoveryThunk,
+    startSelectedDeviceDiscovery,
     stopDiscoveryThunk,
     updateNetworkSettingsThunk,
 } from '@suite-common/wallet-core';
@@ -56,7 +56,8 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
             action.type === ROUTER.LOCATION_CHANGE &&
             getApp(action.payload.url) !== 'wallet' &&
             getApp(action.payload.url) !== 'dashboard' &&
-            getApp(action.payload.url) !== 'settings'
+            getApp(action.payload.url) !== 'settings' &&
+            getApp(action.payload.url) !== 'switch-device'
         ) {
             interruptionIntent = true;
         }
@@ -180,7 +181,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
                 (discovery.status === DiscoveryStatus.IDLE ||
                     discovery.status >= DiscoveryStatus.STOPPED)
             ) {
-                dispatch(startDiscoveryThunk());
+                dispatch(startSelectedDeviceDiscovery());
             }
         }
 

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -1,7 +1,10 @@
 import { AnimatePresence, MotionProps, motion } from 'framer-motion';
 import styled from 'styled-components';
 
-import { selectDeviceSupportedNetworks, startDiscoveryThunk } from '@suite-common/wallet-core';
+import {
+    selectDeviceSupportedNetworks,
+    startSelectedDeviceDiscovery,
+} from '@suite-common/wallet-core';
 import { Button, Tooltip, motionEasing } from '@trezor/components';
 import { hasBitcoinOnlyFirmware, isBitcoinOnlyDevice } from '@trezor/device-utils';
 import { spacingsPx } from '@trezor/theme';
@@ -104,7 +107,7 @@ export const SettingsCoins = () => {
         (bitcoinOnlyFirmware || (!bitcoinOnlyFirmware && onlyBitcoinNetworksEnabled));
 
     const startDiscovery = () => {
-        dispatch(startDiscoveryThunk());
+        dispatch(startSelectedDeviceDiscovery());
     };
 
     const animation = getDiscoveryButtonAnimationConfig(!!isDiscoveryRunning);

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
@@ -10,11 +10,17 @@ import { AcquiredDevice, ForegroundAppProps, TrezorDevice } from 'src/types/suit
 
 interface AddWalletButtonProps {
     device: TrezorDevice;
+    disabled?: boolean;
     instances: AcquiredDevice[];
     onCancel: ForegroundAppProps['onCancel'];
 }
 
-export const AddWalletButton = ({ device, instances, onCancel }: AddWalletButtonProps) => {
+export const AddWalletButton = ({
+    device,
+    disabled,
+    instances,
+    onCancel,
+}: AddWalletButtonProps) => {
     const dispatch = useDispatch();
     // Find a "standard wallet" among user's wallet instances. If no such wallet is found, the variable is undefined.
     const emptyPassphraseWalletExists = instances.find(d => d.useEmptyPassphrase && d.state);
@@ -44,7 +50,7 @@ export const AddWalletButton = ({ device, instances, onCancel }: AddWalletButton
                         variant="tertiary"
                         isFullWidth
                         icon="plus"
-                        isDisabled={isLocked}
+                        isDisabled={disabled || isLocked}
                         onClick={() => onAddWallet({ walletType: WalletType.STANDARD })}
                     >
                         <Translation id="TR_ADD_WALLET" />
@@ -57,7 +63,7 @@ export const AddWalletButton = ({ device, instances, onCancel }: AddWalletButton
                         variant="tertiary"
                         isFullWidth
                         icon="plus"
-                        isDisabled={isLocked}
+                        isDisabled={disabled || isLocked}
                         onClick={() => onAddWallet({ walletType: WalletType.PASSPHRASE })}
                     >
                         <Row gap={spacings.xs}>

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
@@ -5,7 +5,7 @@ import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Column, variables } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { useSelector } from 'src/hooks/suite';
+import { useDiscovery, useSelector } from 'src/hooks/suite';
 import type { AcquiredDevice, ForegroundAppProps, TrezorDevice } from 'src/types/suite';
 
 import { AddWalletButton } from './AddWalletButton';
@@ -36,6 +36,13 @@ export const DeviceItem = ({
     isFullHeaderVisible,
 }: DeviceItemProps) => {
     const selectedDevice = useSelector(selectSelectedDevice);
+    const { getDiscoveryStatus } = useDiscovery({
+        device,
+    });
+    const discoveryStatus = getDiscoveryStatus();
+    const discoveryInProgress = Boolean(
+        discoveryStatus && discoveryStatus.status === 'loading' && device.state,
+    );
 
     const instancesWithState = instances.filter(i => i.state);
 
@@ -65,7 +72,12 @@ export const DeviceItem = ({
                             ))}
                         </Column>
                     )}
-                    <AddWalletButton device={device} instances={instances} onCancel={onCancel} />
+                    <AddWalletButton
+                        device={device}
+                        disabled={discoveryInProgress}
+                        instances={instances}
+                        onCancel={onCancel}
+                    />
                 </Column>
             </WalletsWrapper>
         </CardWithDevice>

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -84,10 +84,8 @@ export const filterUnavailableAccountTypes = (
     );
 
 const calculateProgress =
-    (discovery: Discovery) =>
+    (discovery: Discovery, device: TrezorDevice) =>
     (_dispatch: any, getState: any, extra: ExtraDependencies): PartialDiscovery => {
-        const { selectDevice } = extra.selectors;
-        const device = selectDevice(getState());
         // reconstruct networks from discovery symbols, because we need to iterate through accounts
         const networksToCount = filterUnavailableNetworks(discovery.networks, device);
 
@@ -162,11 +160,13 @@ const handleProgressThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/handleProgress`,
     (
         {
+            device,
             event,
             deviceState,
             item,
             metadataEnabled,
         }: {
+            device: TrezorDevice;
             event: ProgressEvent;
             deviceState: StaticSessionId;
             item: DiscoveryItem;
@@ -206,10 +206,13 @@ const handleProgressThunk = createThunk(
         }
         // calculate progress
         const progress = dispatch(
-            calculateProgress({
-                ...discovery,
-                failed,
-            }),
+            calculateProgress(
+                {
+                    ...discovery,
+                    failed,
+                },
+                device,
+            ),
         );
 
         // change auth confirm field only if metadata are not enabled
@@ -430,13 +433,12 @@ export const getAvailableCardanoDerivationsThunk = createThunk(
 
 export const startDiscoveryThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/start`,
-    async (_, { dispatch, getState, extra }): Promise<void> => {
+    async (device: TrezorDevice, { dispatch, getState, extra }): Promise<void> => {
         const {
-            selectors: { selectMetadata, selectDevice },
+            selectors: { selectMetadata },
             thunks: { initMetadata, fetchAndSaveMetadata },
             actions: { requestAuthConfirm },
         } = extra;
-        const device = selectDevice(getState());
         const metadata = selectMetadata(getState());
         const discovery = selectDeviceDiscovery(getState());
 
@@ -572,6 +574,7 @@ export const startDiscoveryThunk = createThunk(
             // pass more parameters to handler
             dispatch(
                 handleProgressThunk({
+                    device,
                     event,
                     deviceState,
                     item: bundle[progress],
@@ -616,7 +619,7 @@ export const startDiscoveryThunk = createThunk(
                 await dispatch(initMetadata(false));
             }
             if (currentDiscovery.status === DiscoveryStatus.RUNNING) {
-                await dispatch(startDiscoveryThunk()); // try next index
+                await dispatch(startDiscoveryThunk(device)); // try next index
             } else if (currentDiscovery.status === DiscoveryStatus.STOPPING) {
                 dispatch(stopDiscovery({ deviceState, status: DiscoveryStatus.STOPPED }));
             } else {
@@ -654,10 +657,13 @@ export const startDiscoveryThunk = createThunk(
                     }));
 
                     const progress = dispatch(
-                        calculateProgress({
-                            ...discovery,
-                            failed,
-                        }),
+                        calculateProgress(
+                            {
+                                ...discovery,
+                                failed,
+                            },
+                            device,
+                        ),
                     );
 
                     dispatch(
@@ -668,7 +674,7 @@ export const startDiscoveryThunk = createThunk(
                         }),
                     );
 
-                    await dispatch(startDiscoveryThunk()); // restart process, exclude failed coins
+                    await dispatch(startDiscoveryThunk(device)); // restart process, exclude failed coins
 
                     return;
                 } catch {
@@ -709,6 +715,22 @@ export const startDiscoveryThunk = createThunk(
                 dispatch(notificationsActions.addToast({ type: 'discovery-error', error }));
             }
         }
+    },
+);
+
+export const startSelectedDeviceDiscovery = createThunk(
+    `${DISCOVERY_MODULE_PREFIX}/startSelectedDeviceDiscovery`,
+    (_, { dispatch, getState, extra }) => {
+        const selectedDevice = extra.selectors.selectDevice(getState());
+        if (!selectedDevice) {
+            console.warn(
+                'DiscoveryThunks#startSelectedDeviceDiscovery -> started discovery without any selected device, skipping',
+            );
+
+            return;
+        }
+
+        return dispatch(startDiscoveryThunk(selectedDevice));
     },
 );
 
@@ -763,12 +785,20 @@ export const updateNetworkSettingsThunk = createThunk(
                 n => n.symbol,
             );
 
+            if (!device) {
+                return;
+            }
+
             const progress = dispatch(
-                calculateProgress({
-                    ...d,
-                    networks: networksSymbols,
-                    failed: [],
-                }),
+                calculateProgress(
+                    {
+                        ...d,
+
+                        networks: networksSymbols,
+                        failed: [],
+                    },
+                    device,
+                ),
             );
             dispatch(
                 updateDiscovery({
@@ -783,14 +813,18 @@ export const updateNetworkSettingsThunk = createThunk(
 
 export const restartDiscoveryThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/restart`,
-    async (_, { dispatch, getState }) => {
+    async (_, { dispatch, getState, extra }) => {
         const discovery = selectDeviceDiscovery(getState());
-        if (!discovery) return;
+        const device = extra.selectors.selectDevice(getState());
+        if (!discovery || !device) return;
         const progress = dispatch(
-            calculateProgress({
-                ...discovery,
-                failed: [],
-            }),
+            calculateProgress(
+                {
+                    ...discovery,
+                    failed: [],
+                },
+                device,
+            ),
         );
         dispatch(
             updateDiscovery({
@@ -798,6 +832,6 @@ export const restartDiscoveryThunk = createThunk(
                 failed: [],
             }),
         );
-        await dispatch(startDiscoveryThunk());
+        await dispatch(startDiscoveryThunk(device));
     },
 );


### PR DESCRIPTION
This is a POC if it is possible to enable the device selector while discovery is running

## Description

<!--- Describe your changes in detail -->

## Problems:
- clicking at the add wallet / passphrase wallet adds another wallet

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=enable-device-switch-discovery&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=enable-device-switch-discovery&lookback=7)