### PR TITLE
feat(suite): autostart prompt before quitting

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -79,6 +79,8 @@ export interface RendererChannels {
     // connect
     'connect-popup/call': ConnectPopupCall;
     'connect-popup/cancel': ConnectPopupCancel;
+
+    'app/auto-start/popup-request': void;
 }
 
 // Invocation from renderer process
@@ -104,6 +106,9 @@ export interface InvokeChannels {
     'user-data/open': (directory?: string) => InvokeResult;
     'udev/install': () => InvokeResult;
     'app/auto-start/is-enabled': () => InvokeResult<boolean>;
+    'app/auto-start/popup-response': (
+        response: 'background-always' | 'background-now' | 'quit-always' | 'quit-now',
+    ) => void;
     'app/is-visible': () => boolean;
     'tray/change-settings': (payload: TraySettings) => InvokeResult;
     'tray/get-settings': () => InvokeResult<TraySettings>;
@@ -131,6 +136,7 @@ export interface DesktopApi {
     appHide: DesktopApiSend<'app/hide'>;
     appAutoStart: DesktopApiSend<'app/auto-start'>;
     getAppAutoStartIsEnabled: DesktopApiInvoke<'app/auto-start/is-enabled'>;
+    appAutoStartPopupResponse: DesktopApiInvoke<'app/auto-start/popup-response'>;
     appIsVisible: DesktopApiInvoke<'app/is-visible'>;
     // Auto-updater
     checkForUpdates: DesktopApiSend<'update/check'>;

--- a/packages/suite-desktop-api/src/factory.ts
+++ b/packages/suite-desktop-api/src/factory.ts
@@ -49,6 +49,8 @@ export const factory = <R extends StrictIpcRenderer<any, IpcRendererEvent>>(
         appHide: () => ipcRenderer.send('app/hide'),
         appAutoStart: (enabled: boolean) => ipcRenderer.send('app/auto-start', enabled),
         getAppAutoStartIsEnabled: () => ipcRenderer.invoke('app/auto-start/is-enabled'),
+        appAutoStartPopupResponse: response =>
+            ipcRenderer.invoke('app/auto-start/popup-response', response),
         appIsVisible: () => ipcRenderer.invoke('app/is-visible'),
 
         // Auto-updater

--- a/packages/suite-desktop-api/src/validation.ts
+++ b/packages/suite-desktop-api/src/validation.ts
@@ -46,5 +46,6 @@ const validChannels: Array<keyof RendererChannels> = [
     'tray/settings',
     'connect-popup/call',
     'connect-popup/cancel',
+    'app/auto-start/popup-request',
 ];
 export const isValidChannel = (channel: any) => validChannels.includes(channel);

--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -22,7 +22,7 @@ import { initSentry } from './libs/sentry';
 import { Store } from './libs/store';
 import { clearAppCache, initUserData } from './libs/user-data';
 import { initBackgroundModules, initModules, mainThreadEmitter } from './modules';
-import { isAutoStartEnabled } from './modules/auto-start';
+import { isAutoStartEnabled, promptForAutoStartBeforeQuit } from './modules/auto-start';
 import { init as initTorModule } from './modules/tor';
 import { ipcMain } from './typed-electron';
 
@@ -291,6 +291,7 @@ const init = async () => {
     });
     app.on('before-quit', async event => {
         if (readyToQuit) return;
+        event.preventDefault();
 
         const mainWindow = mainWindowProxy.getInstance();
         const windowExists =
@@ -298,15 +299,18 @@ const init = async () => {
             !mainWindow.isDestroyed() &&
             mainWindow.isClosable() &&
             (!isMacOs() || !app.isHidden());
-        const autoStartCurrentlyEnabled = isAutoStartEnabled();
         logger.info('main', `Before quit, window exists: ${windowExists}`);
+
         if (windowExists) {
+            const continued = await promptForAutoStartBeforeQuit(mainWindow, store);
             logger.info('main', 'Hiding main window');
             // NOTE: immediatly hide the main window for the better closing UX
             // for daemon mode, it doesn't matter
             mainWindow?.hide();
+            if (!continued) return;
         }
 
+        const autoStartCurrentlyEnabled = isAutoStartEnabled();
         if (
             !stoppingDaemon &&
             autoStartCurrentlyEnabled &&
@@ -314,16 +318,13 @@ const init = async () => {
         ) {
             // Prevent quitting app when in daemon mode, unless the UI is already closed
             logger.info('main', 'Preventing app quit in daemon mode');
-            event.preventDefault();
             app.dock?.hide();
             mainWindow?.close();
 
             return;
         }
 
-        event.preventDefault();
         logger.info('modules', 'Quitting all modules');
-
         await Promise.race([
             // await quitting all registered modules
             Promise.allSettled([quitModules(), quitTorModule(), quitBackgroundModules()]),

--- a/packages/suite-desktop-core/src/index.d.ts
+++ b/packages/suite-desktop-core/src/index.d.ts
@@ -137,4 +137,6 @@ declare type TraySettings = {
 
 declare type ConnectSettings = {
     enableWs: boolean;
+    autoStartDontAskAgain: boolean;
+    hasUsedConnectWs: boolean;
 };

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -90,10 +90,12 @@ export const exposeConnectWs = ({
     mainThreadEmitter,
     mainWindowProxy,
     httpReceiver,
+    store,
 }: {
     mainThreadEmitter: Dependencies['mainThreadEmitter'];
     mainWindowProxy: Dependencies['mainWindowProxy'];
     httpReceiver: ReturnType<typeof createHttpReceiver>;
+    store: Dependencies['store'];
 }) => {
     const { logger } = global;
     const messages: Record<string, Deferred<any, number>> = {};
@@ -182,6 +184,10 @@ export const exposeConnectWs = ({
 
                     return;
                 }
+
+                store.setConnectSettings({
+                    hasUsedConnectWs: true,
+                });
 
                 const { method, ...rest } = message.payload;
 

--- a/packages/suite-desktop-core/src/libs/store.ts
+++ b/packages/suite-desktop-core/src/libs/store.ts
@@ -104,11 +104,16 @@ export class Store {
     public getConnectSettings() {
         return this.store.get('connectSettings', {
             enableWs: false,
+            autoStartDontAskAgain: false,
+            hasUsedConnectWs: false,
         });
     }
 
-    public setConnectSettings(connectSettings: ConnectSettings) {
-        this.store.set('connectSettings', connectSettings);
+    public setConnectSettings(connectSettings: Partial<ConnectSettings>) {
+        this.store.set('connectSettings', {
+            ...this.store.get('connectSettings'),
+            ...connectSettings,
+        });
     }
 
     /** Deletes all items from the store. */

--- a/packages/suite-desktop-core/src/modules/auto-start.ts
+++ b/packages/suite-desktop-core/src/modules/auto-start.ts
@@ -1,12 +1,15 @@
 /**
  * Auto start handler
  */
+import { BrowserWindow } from 'electron';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
 import { validateIpcMessage } from '@trezor/ipc-proxy';
+import { createDeferred } from '@trezor/utils';
 
+import { Store } from '../libs/store';
 import { app, ipcMain } from '../typed-electron';
 
 import type { ModuleInit } from './index';
@@ -65,22 +68,72 @@ const linuxAutoStart = (enabled: boolean) => {
     }
 };
 
+export const setAutoStartEnabled = (enabled: boolean) => {
+    if (process.platform === 'linux') {
+        // For Linux, we use a custom implementation
+        linuxAutoStart(enabled);
+    } else {
+        // For Windows and macOS, we use native Electron API
+        app.setLoginItemSettings({
+            openAtLogin: enabled,
+            openAsHidden: true,
+            args: ['--bridge-daemon'],
+        });
+    }
+};
+
+/**
+ * Prompt user to enable auto start before quitting the app
+ * @param mainWindow - Main window to show the dialog
+ * @returns continue - if true continue the flow of closing the app, if false, stop and only hide the window
+ */
+export const promptForAutoStartBeforeQuit = async (mainWindow: BrowserWindow, store: Store) => {
+    if (
+        isAutoStartEnabled() ||
+        store.getConnectSettings().autoStartDontAskAgain ||
+        !store.getConnectSettings().hasUsedConnectWs
+    ) {
+        return true;
+    }
+
+    // Display popup in renderer and wait for response
+    const deferred = createDeferred<
+        'background-always' | 'background-now' | 'quit-always' | 'quit-now'
+    >();
+    ipcMain.handleOnce('app/auto-start/popup-response', (ipcEvent, response) => {
+        validateIpcMessage(ipcEvent);
+        deferred.resolve(response);
+    });
+    mainWindow.webContents.send('app/auto-start/popup-request');
+    const response = await deferred.promise;
+
+    switch (response) {
+        case 'background-always': {
+            setAutoStartEnabled(true);
+
+            return true;
+        }
+        case 'background-now': {
+            return false;
+        }
+        case 'quit-always': {
+            store.setConnectSettings({ autoStartDontAskAgain: true });
+
+            return true;
+        }
+        default:
+        case 'quit-now': {
+            return true;
+        }
+    }
+};
+
 export const init: ModuleInit = () => {
     const { logger } = global;
 
     ipcMain.on('app/auto-start', (_, enabled: boolean) => {
         logger.debug(SERVICE_NAME, 'Auto start ' + (enabled ? 'enabled' : 'disabled'));
-        if (process.platform === 'linux') {
-            // For Linux, we use a custom implementation
-            linuxAutoStart(enabled);
-        } else {
-            // For Windows and macOS, we use native Electron API
-            app.setLoginItemSettings({
-                openAtLogin: enabled,
-                openAsHidden: true,
-                args: ['--bridge-daemon'],
-            });
-        }
+        setAutoStartEnabled(enabled);
     });
 
     ipcMain.handle('app/auto-start/is-enabled', ipcEvent => {

--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -88,7 +88,7 @@ export const initBackground: ModuleInitBackground = ({
             restartApp();
         });
         if (connectPopupEnabled()) {
-            exposeConnectWs({ mainThreadEmitter, httpReceiver: receiver, mainWindowProxy });
+            exposeConnectWs({ mainThreadEmitter, httpReceiver: receiver, mainWindowProxy, store });
         }
 
         logger.info(SERVICE_NAME, 'Starting server');

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AutoStartBeforeQuitModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AutoStartBeforeQuitModal.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+
+import { Card, Checkbox, Column, Modal, Paragraph } from '@trezor/components';
+import { desktopApi } from '@trezor/suite-desktop-api';
+import { spacings } from '@trezor/theme';
+
+import * as modalActions from 'src/actions/suite/modalActions';
+import { Translation } from 'src/components/suite/Translation';
+import { useDispatch } from 'src/hooks/suite';
+
+export const AutoStartBeforeQuitModal = () => {
+    const dispatch = useDispatch();
+    const [dontAskAgain, setDontAskAgain] = useState(false);
+    if (!desktopApi.available) return null;
+
+    const handleBackground = () => {
+        desktopApi.appAutoStartPopupResponse(dontAskAgain ? 'background-always' : 'background-now');
+        dispatch(modalActions.onCancel());
+    };
+    const handleQuit = () => {
+        desktopApi.appAutoStartPopupResponse(dontAskAgain ? 'quit-always' : 'quit-now');
+        dispatch(modalActions.onCancel());
+    };
+
+    return (
+        <Modal
+            data-testid="@auto-start-before-quit"
+            variant="primary"
+            onCancel={() => handleQuit()}
+            heading={<Translation id="TR_RUN_IN_BACKGROUND_TITLE" />}
+            bottomContent={
+                <>
+                    <Modal.Button
+                        onClick={() => handleBackground()}
+                        data-test="@auto-start-before-quit/button-background"
+                    >
+                        <Translation id="TR_RUN_IN_BACKGROUND" />
+                    </Modal.Button>
+                    <Modal.Button
+                        onClick={() => handleQuit()}
+                        data-test="@auto-start-before-quit/button-quit"
+                        variant="tertiary"
+                    >
+                        <Translation id="TR_QUIT_NOW" />
+                    </Modal.Button>
+                </>
+            }
+        >
+            <Column gap={spacings.md}>
+                <Paragraph>
+                    <Translation id="TR_RUN_IN_BACKGROUND_DESCRIPTION" />
+                </Paragraph>
+                <Card>
+                    <Checkbox
+                        data-testid="auto-start-before-quit/dont-ask-again-checkbox"
+                        isChecked={dontAskAgain}
+                        onClick={() => setDontAskAgain(!dontAskAgain)}
+                    >
+                        <Translation id="TR_DONT_ASK_AGAIN" />
+                    </Checkbox>
+                </Card>
+            </Column>
+        </Modal>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -47,6 +47,7 @@ import { useDispatch } from 'src/hooks/suite';
 import type { AcquiredDevice } from 'src/types/suite';
 
 import type { ReduxModalProps } from '../ReduxModal';
+import { AutoStartBeforeQuitModal } from './AutoStartBeforeQuitModal';
 import { FirmwareRevisionOptOutModal } from './FirmwareRevisionOptOutModal';
 import { PassphraseMismatchModal } from './PassphraseMismatchModal';
 import { CardanoWithdrawModal } from '../CardanoWithdrawModal';
@@ -226,6 +227,8 @@ export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL.CONTE
             return <ConnectErrorModal />;
         case 'connect-loading':
             return <ConnectLoadingModal />;
+        case 'auto-start-before-quit':
+            return <AutoStartBeforeQuitModal />;
         default:
             return null;
     }

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9833,4 +9833,25 @@ export default defineMessages({
         id: 'TR_VERIFICATION_CANCELED',
         defaultMessage: 'Verification canceled',
     },
+    TR_DONT_ASK_AGAIN: {
+        id: 'TR_DONT_ASK_AGAIN',
+        defaultMessage: "Don't ask again",
+    },
+    TR_RUN_IN_BACKGROUND_TITLE: {
+        id: 'TR_RUN_IN_BACKGROUND_TITLE',
+        defaultMessage: 'Run Trezor Suite in the background',
+    },
+    TR_RUN_IN_BACKGROUND_DESCRIPTION: {
+        id: 'TR_RUN_IN_BACKGROUND_DESCRIPTION',
+        defaultMessage:
+            'Keep Trezor Suite running in the background for a better experience—this enables auto-launch when your Trezor is connected and seamless connection with third-party wallets.',
+    },
+    TR_RUN_IN_BACKGROUND: {
+        id: 'TR_RUN_IN_BACKGROUND',
+        defaultMessage: 'Run in background',
+    },
+    TR_QUIT_NOW: {
+        id: 'TR_QUIT_NOW',
+        defaultMessage: 'Quit now',
+    },
 } as const);

--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -9,6 +9,7 @@ import { CALL_SOURCE_DESKTOP_WS } from '@suite-common/connect-popup/src/connectP
 import TrezorConnect from '@trezor/connect';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
+import { openModal } from 'src/actions/suite/modalActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const useConnectPopupDesktop = () => {
@@ -39,6 +40,9 @@ export const useConnectPopupDesktop = () => {
                 });
                 desktopApi.on('connect-popup/cancel', params => {
                     dispatch(connectPopupCancelThunk(params));
+                });
+                desktopApi.on('app/auto-start/popup-request', () => {
+                    dispatch(openModal({ type: 'auto-start-before-quit' }));
                 });
                 desktopApi.connectPopupReady();
             }

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -212,4 +212,7 @@ export type UserContextPayload =
       }
     | {
           type: 'connect-loading';
+      }
+    | {
+          type: 'auto-start-before-quit';
       };


### PR DESCRIPTION
## Description

Add a prompt that asks the user to enable auto-start before quitting Suite, if the user has used Connect WS. 

The following outcomes are possible:
- Run in background, don't ask again - will enable autostart/background mode
- Run in background - only hides app for once
- Quit now, don't ask again - will quit, will disable this prompt
- Quit now - will quit, only for once

## Screenshots

<img width="782" alt="Screenshot 2025-04-29 at 13 26 04" src="https://github.com/user-attachments/assets/f9e30574-4221-4d4d-80c5-5266b1bb0630" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-autostart-prompt&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-autostart-prompt&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/suite-autostart-prompt&lookback=7)