### PR TITLE
Fix selecting wrong token when sending from the tokens list

### DIFF
--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
@@ -184,10 +184,13 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
         if (sendFormPrefill) {
             setValue(tokenInputName, sendFormPrefill, { shouldValidate: true, shouldDirty: true });
             setDraftSaveRequest(true);
-            dispatch({
-                type: SUITE.SET_SEND_FORM_PREFILL,
-                payload: '',
-            });
+
+            return () => {
+                dispatch({
+                    type: SUITE.SET_SEND_FORM_PREFILL,
+                    payload: '',
+                });
+            };
         }
     }, [sendFormPrefill, setValue, tokenInputName, setDraftSaveRequest, dispatch]);
 


### PR DESCRIPTION
## Description

Fixes an issue where sending a Solana token from the tokens list would incorrectly select SOL instead of the intended token.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18213

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/send-token-prefill-selection&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/send-token-prefill-selection&lookback=7)