### PR TITLE
fix(e2e): Stabilize few flaky tests

### DIFF
--- a/packages/suite-desktop-core/e2e/fixtures/invity/swap/list.json
+++ b/packages/suite-desktop-core/e2e/fixtures/invity/swap/list.json
@@ -5909,7 +5909,7 @@
         ],
         "supportUrl": "https://help.sideshift.ai/en/",
         "kycPolicyType": "KYC-yesrefund",
-        "statusUrl": "https://sideshift.ai/orders/{{orderId}}",
+        "statusUrl": "https://example.org/orders/{{orderId}}",
         "kycPolicy": "KYC requested in exceptional cases. KYC may be required for refunds. 🤝",
         "isRefundRequired": true
     },
@@ -6342,7 +6342,7 @@
         ],
         "supportUrl": "https://help.sideshift.ai/en/",
         "kycPolicyType": "KYC-yesrefund",
-        "statusUrl": "https://sideshift.ai/orders/{{orderId}}",
+        "statusUrl": "https://example.org/orders/{{orderId}}",
         "kycPolicy": "KYC requested in exceptional cases. KYC may be required for refunds. 🤝",
         "isRefundRequired": true
     },

--- a/packages/suite-desktop-core/e2e/fixtures/invity/swap/trade-solana-btc.json
+++ b/packages/suite-desktop-core/e2e/fixtures/invity/swap/trade-solana-btc.json
@@ -4,7 +4,7 @@
     "orderId": "1061e2d760262e1de932",
     "quoteId": "5d7e2530-cb13-4fd1-80d7-aec23fcb67d4",
     "status": "CONFIRM",
-    "statusUrl": "https://sideshift.ai/orders/1061e2d760262e1de932",
+    "statusUrl": "https://example.org/orders/1061e2d760262e1de932",
     "exchange": "sideshiftfr",
     "send": "solana",
     "receive": "bitcoin",

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
@@ -33,7 +33,7 @@ test.describe('Trading - Sell inputs', { tag: ['@group=other', '@webOnly'] }, ()
                 await tradingPage.youPayCryptoInput.fill('0.00000001');
                 await expect
                     .soft(tradingPage.cryptoInputBottomText)
-                    .toHaveText(/Minimum is 0\.\d+ BTC/, { timeout: 15_000 });
+                    .toHaveText(/Minimum is 0\.\d+( BTC)?/, { timeout: 15_000 });
             });
 
             await test.step('Too many decimal digits', async () => {

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
@@ -107,7 +107,8 @@ test.describe('Trading - Swap coins', { tag: ['@group=other', '@webOnly'] }, () 
                 const partnerPagePromise = page.context().waitForEvent('page', { timeout: 5_000 });
                 await page.getByRole('link', { name: 'Go to provider support' }).click();
                 const partnerTab = await partnerPagePromise;
-                await expect(partnerTab).toHaveURL(/https:\/\/sideshift\.ai\/orders\//);
+                // Mocked data have URL changed to https://example.org/orders/{{orderId}} for stability reasons
+                await expect(partnerTab).toHaveURL(/https:\/\/example\.org\/orders\//);
                 await partnerTab.close();
             }).toPass({ timeout: 20_000 });
         });

--- a/packages/suite-desktop-core/e2e/tests/wallet/coin-balance.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/coin-balance.test.ts
@@ -1,3 +1,5 @@
+import { localizeNumber } from '@suite-common/wallet-utils';
+
 import { expect, test } from '../../support/fixtures';
 
 test.describe('Coin balance', { tag: ['@group=wallet'] }, () => {
@@ -25,7 +27,8 @@ test.describe('Coin balance', { tag: ['@group=wallet'] }, () => {
 
         await test.step('Balance is increased after sending another BTC', async () => {
             const originalValue = await walletPage.balanceOfAccount('regtest').textContent();
-            const expectedIncreasedValue = (Number(originalValue) + 1).toString();
+            const rawIncreasedValue = (Number(originalValue) + 1).toString();
+            const expectedIncreasedValue = localizeNumber(rawIncreasedValue, 'en', 0, 7);
             await trezorUserEnvLink.sendToAddressAndMineBlock({ address, btc_amount: 1 });
             await expect(walletPage.balanceOfAccount('regtest')).toHaveText(expectedIncreasedValue);
         });


### PR DESCRIPTION
Based on currents report, I have improved flaky tests:
- sell-inputs.test.ts sometimes the Symbol currency is not part of the error message.
- swap-coins.test.ts the partner site was unstable
- coin-balance.test.ts the flow aritmetics added sometimes extra decimals

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-flaky-tests&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-flaky-tests&lookback=7)