### PR TITLE
chore(tenv): update trezor-user-env to latest version

### DIFF
--- a/.github/workflows/test-trezor-user-env-link-e2e.yml
+++ b/.github/workflows/test-trezor-user-env-link-e2e.yml
@@ -39,5 +39,5 @@ jobs:
 
       - name: Run e2e tests
         run: |
-          docker run -d --network=host ghcr.io/trezor/trezor-user-env:b3473dd9dff4064c3e08db4b78a9dd4467a77eab
+          docker run -d --network=host ghcr.io/trezor/trezor-user-env:5dab098a775ad4942ebdd0cda0281e19561e7802
           yarn workspace @trezor/trezor-user-env-link test:e2e

--- a/docker/docker-compose.connect-popup-ci.yml
+++ b/docker/docker-compose.connect-popup-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b3473dd9dff4064c3e08db4b78a9dd4467a77eab
+    image: ghcr.io/trezor/trezor-user-env:5dab098a775ad4942ebdd0cda0281e19561e7802
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-popup-test.yml
+++ b/docker/docker-compose.connect-popup-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b3473dd9dff4064c3e08db4b78a9dd4467a77eab
+    image: ghcr.io/trezor/trezor-user-env:5dab098a775ad4942ebdd0cda0281e19561e7802
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.connect-test.yml
+++ b/docker/docker-compose.connect-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b3473dd9dff4064c3e08db4b78a9dd4467a77eab
+    image: ghcr.io/trezor/trezor-user-env:5dab098a775ad4942ebdd0cda0281e19561e7802
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-webextension-test.yml
+++ b/docker/docker-compose.connect-webextension-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b3473dd9dff4064c3e08db4b78a9dd4467a77eab
+    image: ghcr.io/trezor/trezor-user-env:5dab098a775ad4942ebdd0cda0281e19561e7802
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-ci-e2e.yml
+++ b/docker/docker-compose.suite-ci-e2e.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b3473dd9dff4064c3e08db4b78a9dd4467a77eab
+    image: ghcr.io/trezor/trezor-user-env:5dab098a775ad4942ebdd0cda0281e19561e7802
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-desktop-ci.yml
+++ b/docker/docker-compose.suite-desktop-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b3473dd9dff4064c3e08db4b78a9dd4467a77eab
+    image: ghcr.io/trezor/trezor-user-env:5dab098a775ad4942ebdd0cda0281e19561e7802
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-dev.yml
+++ b/docker/docker-compose.suite-dev.yml
@@ -4,7 +4,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b3473dd9dff4064c3e08db4b78a9dd4467a77eab
+    image: ghcr.io/trezor/trezor-user-env:5dab098a775ad4942ebdd0cda0281e19561e7802
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.suite-native-ci.yml
+++ b/docker/docker-compose.suite-native-ci.yml
@@ -3,7 +3,7 @@ services:
   trezor-user-env-unix:
     network_mode: "host"
     container_name: trezor-user-env.unix
-    image: ghcr.io/trezor/trezor-user-env:b3473dd9dff4064c3e08db4b78a9dd4467a77eab
+    image: ghcr.io/trezor/trezor-user-env:5dab098a775ad4942ebdd0cda0281e19561e7802
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-test.yml
+++ b/docker/docker-compose.suite-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b3473dd9dff4064c3e08db4b78a9dd4467a77eab
+    image: ghcr.io/trezor/trezor-user-env:5dab098a775ad4942ebdd0cda0281e19561e7802
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.transport-test-ci.yml
+++ b/docker/docker-compose.transport-test-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b3473dd9dff4064c3e08db4b78a9dd4467a77eab
+    image: ghcr.io/trezor/trezor-user-env:5dab098a775ad4942ebdd0cda0281e19561e7802
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp


### PR DESCRIPTION
We have updated the base image of the `tenv` container with the latest `debian:trixie`, which comes with `glibc 2.38` installed, which is needed by recent builds of `main` firmware emulators.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=tenv-update&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=tenv-update&lookback=7)