### PR TITLE
fix(suite): disable closing connect address verification when verifying

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectAddressConfirmation.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectAddressConfirmation.tsx
@@ -64,6 +64,7 @@ export const ConnectAddressConfirmation = () => {
                             onClick={onFinish}
                             size="medium"
                             data-testid="@connect-address-confirmation/close-button"
+                            isDisabled={isLoading}
                         >
                             <Translation id="TR_DONE" />
                         </Modal.Button>


### PR DESCRIPTION
## Description

Disable the "Done" button in Connect address verification modal when still verifying. 
I thought we had it there but maybe it slipped out during some merging...

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-connect-confirmation-disable-closing&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-connect-confirmation-disable-closing&lookback=7)