### PR TITLE
Feat(suite): FW hash check other-error 2step modal

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -93,7 +93,7 @@ export class OnboardingPage {
         await this.verifySuiteIsLoaded();
         // dismisses the error modal only if it appears (handle it async in parallel, not necessary to block the rest of the flow)
         this.page
-            .$('[data-testid="@device-compromised/back-button"]')
+            .$('[data-testid="@device-compromised/dismiss-button"]')
             .then(dismissFwHashCheckButton => dismissFwHashCheckButton?.click());
     }
 

--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
@@ -1,87 +1,92 @@
-import { deviceActions } from '@suite-common/wallet-core';
+import { selectWasFwHashCheckOtherErrorLastTime } from '@suite-common/wallet-core';
 import { Card } from '@trezor/components';
-import {
-    HELP_CENTER_ENTROPY_CHECK_URL,
-    TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL,
-} from '@trezor/urls';
 
-import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
+import { useSelector } from 'src/hooks/suite';
 import {
     selectFirmwareHashCheckErrorIfEnabled,
     selectFirmwareRevisionCheckErrorIfEnabled,
     selectIsEntropyCheckEnabledAndFailed,
 } from 'src/reducers/suite/suiteReducer';
 
-import { SecurityCheckFail, SecurityCheckFailProps } from './SecurityCheckFail';
+import { SecurityCheckFail } from './SecurityCheckFail';
 import { hardFailureChecklistItems, softFailureChecklistItems } from './checklistItems';
+import {
+    DismissFwAuthenticityCheckButton,
+    EntropyCheckSupportButton,
+    FwAuthencityChecksCtas,
+} from './deviceCompromisedCtas';
 import { WelcomeLayout } from '../layouts/WelcomeLayout/WelcomeLayout';
 
-const useSecurityCheckFailProps = (): SecurityCheckFailProps => {
-    const { device } = useDevice();
+const DeviceCompromisedContent = () => {
     const revisionCheckError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
     const hashCheckError = useSelector(selectFirmwareHashCheckErrorIfEnabled);
     const isEntropyCheckFailed = useSelector(selectIsEntropyCheckEnabledAndFailed);
-    const dispatch = useDispatch();
-
-    // Let user access the wallet if it may have been initiated before so that they can access the funds and send them to safety.
-    const goToSuite = () => {
-        // Condition to satisfy TypeScript, device.id is always defined at this point.
-        if (device?.id) {
-            dispatch(deviceActions.dismissFirmwareAuthenticityCheck(device.id));
-        }
-    };
+    const wasHashCheckOtherErrorLastTime = useSelector(selectWasFwHashCheckOtherErrorLastTime);
 
     if (isEntropyCheckFailed) {
-        return {
-            heading: 'TR_DEVICE_COMPROMISED_HEADING',
-            text: 'TR_DEVICE_COMPROMISED_ENTROPY_CHECK_TEXT',
-            checklistItems: hardFailureChecklistItems,
-            goBack: undefined,
-            supportUrl: HELP_CENTER_ENTROPY_CHECK_URL,
-        };
+        return (
+            <SecurityCheckFail
+                ctaSection={<EntropyCheckSupportButton />}
+                heading="TR_DEVICE_COMPROMISED_HEADING"
+                text="TR_DEVICE_COMPROMISED_ENTROPY_CHECK_TEXT"
+                checklistItems={hardFailureChecklistItems}
+            />
+        );
     }
     // revision check has precedence over hash check, because it does not have the ambiguous other-error state
     if (revisionCheckError !== null) {
-        return {
-            heading: 'TR_DEVICE_COMPROMISED_HEADING',
-            text: 'TR_DEVICE_COMPROMISED_FW_REVISION_CHECK_TEXT',
-            checklistItems: hardFailureChecklistItems,
-            goBack: goToSuite,
-            supportUrl: TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL,
-        };
+        return (
+            <SecurityCheckFail
+                ctaSection={<FwAuthencityChecksCtas />}
+                heading="TR_DEVICE_COMPROMISED_HEADING"
+                text="TR_DEVICE_COMPROMISED_FW_REVISION_CHECK_TEXT"
+                checklistItems={hardFailureChecklistItems}
+            />
+        );
     }
-    // hash check other-error shall display softer wording than standard hash check errors
     if (hashCheckError === 'other-error') {
-        return {
-            heading: 'TR_FAILED_VERIFY_DEVICE_HEADING',
-            text: 'TR_FAILED_VERIFY_DEVICE_TEXT',
-            checklistItems: softFailureChecklistItems,
-            goBack: goToSuite,
-            supportUrl: TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL,
-        };
+        // display harsh modal only if there was an other-error for the second time
+        if (wasHashCheckOtherErrorLastTime) {
+            return (
+                <SecurityCheckFail
+                    ctaSection={<FwAuthencityChecksCtas />}
+                    heading="TR_FAILED_VERIFY_DEVICE_HEADING"
+                    text="TR_FAILED_VERIFY_DEVICE_AGAIN_TEXT"
+                    checklistItems={hardFailureChecklistItems}
+                />
+            );
+        }
+
+        // for the first time, display a softer version without a CTA to contact support
+        return (
+            <SecurityCheckFail
+                ctaSection={<DismissFwAuthenticityCheckButton />}
+                heading="TR_FAILED_VERIFY_DEVICE_HEADING"
+                text="TR_FAILED_VERIFY_DEVICE_TEXT"
+                checklistItems={softFailureChecklistItems}
+                useCompromisedImage={false}
+            />
+        );
     }
     if (hashCheckError !== null) {
-        return {
-            heading: 'TR_DEVICE_COMPROMISED_HEADING',
-            text: 'TR_DEVICE_COMPROMISED_FW_HASH_CHECK_TEXT',
-            checklistItems: hardFailureChecklistItems,
-            goBack: goToSuite,
-            supportUrl: TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL,
-        };
+        return (
+            <SecurityCheckFail
+                ctaSection={<FwAuthencityChecksCtas />}
+                heading="TR_DEVICE_COMPROMISED_HEADING"
+                text="TR_DEVICE_COMPROMISED_FW_HASH_CHECK_TEXT"
+                checklistItems={hardFailureChecklistItems}
+            />
+        );
     }
 
     // should not happen, but default props will be used with no problem
-    return { supportUrl: TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL };
+    return <SecurityCheckFail ctaSection={<FwAuthencityChecksCtas />} />;
 };
 
-export const DeviceCompromised = () => {
-    const securityCheckFailProps = useSecurityCheckFailProps();
-
-    return (
-        <WelcomeLayout>
-            <Card data-testid="@device-compromised">
-                <SecurityCheckFail {...securityCheckFailProps} />
-            </Card>
-        </WelcomeLayout>
-    );
-};
+export const DeviceCompromised = () => (
+    <WelcomeLayout>
+        <Card data-testid="@device-compromised">
+            <DeviceCompromisedContent />
+        </Card>
+    </WelcomeLayout>
+);

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
@@ -1,7 +1,8 @@
+import { ReactNode } from 'react';
+
 import { TranslationKey } from '@suite-common/intl-types';
-import { Button, Column, Divider, H2, Paragraph, Row } from '@trezor/components';
+import { Column, Divider, H2, Paragraph, Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
-import { Url } from '@trezor/urls';
 
 import { Translation } from 'src/components/suite';
 import { SecurityChecklist } from 'src/views/onboarding/steps/SecurityCheck/SecurityChecklist';
@@ -10,50 +11,34 @@ import { SecurityChecklistItem } from 'src/views/onboarding/steps/SecurityCheck/
 import { SecurityCheckLayout } from './SecurityCheckLayout';
 import { hardFailureChecklistItems } from './checklistItems';
 
-export type SecurityCheckFailProps = {
-    goBack?: () => void;
+type SecurityCheckFailProps = {
+    ctaSection: ReactNode;
     heading?: TranslationKey;
     text?: TranslationKey;
-    supportUrl: Url;
     checklistItems?: SecurityChecklistItem[];
+    useCompromisedImage?: boolean;
 };
 
 export const SecurityCheckFail = ({
-    goBack,
     heading = 'TR_DEVICE_COMPROMISED_HEADING',
     text = 'TR_DEVICE_COMPROMISED_TEXT',
-    supportUrl,
+    ctaSection,
     checklistItems = hardFailureChecklistItems,
-}: SecurityCheckFailProps) => {
-    const chatUrl = `${supportUrl}#open-chat`;
-
-    return (
-        <SecurityCheckLayout isFailed>
-            <Column gap={spacings.sm} padding={{ top: spacings.xs }}>
-                <H2>
-                    <Translation id={heading} />
-                </H2>
-                <Paragraph variant="tertiary">
-                    <Translation id={text} />
-                </Paragraph>
-            </Column>
-            <Divider margin={{ vertical: spacings.xl }} />
-            <SecurityChecklist items={checklistItems} />
-            <Row flexWrap="wrap" gap={spacings.xl} width="100%" margin={{ top: spacings.xxxxl }}>
-                {goBack && (
-                    <Button
-                        variant="tertiary"
-                        onClick={goBack}
-                        size="large"
-                        data-testid="@device-compromised/back-button"
-                    >
-                        <Translation id="TR_BACK" />
-                    </Button>
-                )}
-                <Button textWrap={false} href={chatUrl} isFullWidth size="large" flex="1">
-                    <Translation id="TR_CONTACT_TREZOR_SUPPORT" />
-                </Button>
-            </Row>
-        </SecurityCheckLayout>
-    );
-};
+    useCompromisedImage = true,
+}: SecurityCheckFailProps) => (
+    <SecurityCheckLayout isFailed={useCompromisedImage}>
+        <Column gap={spacings.sm} padding={{ top: spacings.xs }}>
+            <H2>
+                <Translation id={heading} />
+            </H2>
+            <Paragraph variant="tertiary">
+                <Translation id={text} />
+            </Paragraph>
+        </Column>
+        <Divider margin={{ vertical: spacings.xl }} />
+        <SecurityChecklist items={checklistItems} />
+        <Row flexWrap="wrap" gap={spacings.xl} width="100%" margin={{ top: spacings.xxxxl }}>
+            {ctaSection}
+        </Row>
+    </SecurityCheckLayout>
+);

--- a/packages/suite/src/components/suite/SecurityCheck/checklistItems.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/checklistItems.tsx
@@ -1,17 +1,8 @@
-import styled from 'styled-components';
-
 import { Icon } from '@trezor/components';
-import { borders, spacingsPx } from '@trezor/theme';
 
 import { SecurityChecklistItem } from 'src/views/onboarding/steps/SecurityCheck/types';
 
 import { Translation } from '../Translation';
-
-const IconBackground = styled.div`
-    border-radius: ${borders.radii.full};
-    background-color: ${({ theme }) => theme.backgroundTertiaryDefaultOnElevation0};
-    padding: ${spacingsPx.xs};
-`;
 
 export const hardFailureChecklistItems: SecurityChecklistItem[] = [
     {
@@ -26,21 +17,11 @@ export const hardFailureChecklistItems: SecurityChecklistItem[] = [
 
 export const softFailureChecklistItems: SecurityChecklistItem[] = [
     {
-        icon: (
-            <IconBackground>
-                <Icon size={20} variant="default" name="numberOne" />
-            </IconBackground>
-        ),
-        content: <Translation id="TR_DISCONNECT_YOUR_TREZOR" />,
-        subtitle: <Translation id="TR_DISCONNECT_YOUR_TREZOR_SUBTITLE" />,
+        icon: <Icon size={24} variant="default" name="browsers" />,
+        content: <Translation id="TR_TROUBLESHOOTING_CLOSE_TABS" />,
     },
     {
-        icon: (
-            <IconBackground>
-                <Icon size={20} variant="default" name="numberTwo" />
-            </IconBackground>
-        ),
-        content: <Translation id="TR_PROBLEM_PERSISTS" />,
-        subtitle: <Translation id="TR_PROBLEM_PERSISTS_SUBTITLE" />,
+        icon: <Icon size={24} variant="default" name="plugs" />,
+        content: <Translation id="TR_DISCONNECT_YOUR_TREZOR" />,
     },
 ];

--- a/packages/suite/src/components/suite/SecurityCheck/deviceCompromisedCtas.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/deviceCompromisedCtas.tsx
@@ -1,0 +1,70 @@
+import { deviceActions } from '@suite-common/wallet-core';
+import { Button } from '@trezor/components';
+import {
+    HELP_CENTER_ENTROPY_CHECK_URL,
+    TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL,
+    TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL,
+    Url,
+} from '@trezor/urls';
+
+import { Translation } from 'src/components/suite';
+
+import { useDevice, useDispatch } from '../../../hooks/suite';
+
+type ContactSupportProps = {
+    supportUrl: Url;
+};
+export const ContactSupport = ({ supportUrl }: ContactSupportProps) => {
+    const chatUrl = `${supportUrl}#open-chat`;
+
+    return (
+        <Button textWrap={false} href={chatUrl} flex="1" size="large">
+            <Translation id="TR_CONTACT_TREZOR_SUPPORT" />
+        </Button>
+    );
+};
+
+export const EntropyCheckSupportButton = () => (
+    <ContactSupport supportUrl={HELP_CENTER_ENTROPY_CHECK_URL} />
+);
+
+export const AuthenticateDeviceSupportButton = () => (
+    <ContactSupport supportUrl={TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL} />
+);
+
+const FwAuthenticityCheckSupportButton = () => (
+    <ContactSupport supportUrl={TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL} />
+);
+
+type DismissButtonProps = {
+    onClick: () => void;
+};
+const DismissButton = ({ onClick }: DismissButtonProps) => (
+    <Button
+        variant="tertiary"
+        onClick={onClick}
+        size="large"
+        data-testid="@device-compromised/dismiss-button"
+    >
+        <Translation id="TR_DISMISS" />
+    </Button>
+);
+
+export const DismissFwAuthenticityCheckButton = () => {
+    const { device } = useDevice();
+    const dispatch = useDispatch();
+
+    const goToSuite = () => {
+        if (!device?.id) return; // device.id is always defined at this point
+        dispatch(deviceActions.dismissFirmwareAuthenticityCheck(device.id));
+    };
+
+    return <DismissButton onClick={goToSuite} />;
+};
+
+export const FwAuthencityChecksCtas = () => (
+    <>
+        <DismissFwAuthenticityCheckButton />
+        <FwAuthenticityCheckSupportButton />
+    </>
+);

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareAuthenticityCheckBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareAuthenticityCheckBanner.tsx
@@ -1,4 +1,5 @@
 import { TranslationKey } from '@suite-common/intl-types';
+import { selectWasFwHashCheckOtherErrorLastTime } from '@suite-common/wallet-core';
 import { Banner, Row } from '@trezor/components';
 import { FirmwareHashCheckError, FirmwareRevisionCheckError } from '@trezor/connect';
 import { spacings } from '@trezor/theme';
@@ -30,11 +31,16 @@ const hashCheckMessages: Record<
 const useAuthenticityCheckMessage = (): TranslationKey | null => {
     const firmwareRevisionError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
     const firmwareHashError = useSelector(selectFirmwareHashCheckErrorIfEnabled);
+    const wasHashCheckOtherErrorLastTime = useSelector(selectWasFwHashCheckOtherErrorLastTime);
 
     if (firmwareRevisionError) {
         return revisionCheckMessages[firmwareRevisionError];
     }
     if (firmwareHashError) {
+        if (firmwareHashError === 'other-error' && wasHashCheckOtherErrorLastTime) {
+            return 'TR_DEVICE_FIRMWARE_HASH_CHECK_OTHER_ERROR_AGAIN';
+        }
+
         return hashCheckMessages[firmwareHashError];
     }
 
@@ -59,7 +65,11 @@ export const FirmwareAuthenticityCheckBanner = () => {
     const wasOffline = firmwareRevisionError === 'cannot-perform-check-offline';
     const isHashCheckOtherError =
         firmwareRevisionError === null && firmwareHashError === 'other-error';
-    const hideBannerButtons = wasOffline || isHashCheckOtherError;
+    const wasHashCheckOtherErrorLastTime = useSelector(selectWasFwHashCheckOtherErrorLastTime);
+    const isFirstHashCheckOtherError = isHashCheckOtherError && !wasHashCheckOtherErrorLastTime;
+
+    const useWarningVariant = isFirstHashCheckOtherError;
+    const hideBannerButtons = wasOffline || isFirstHashCheckOtherError;
 
     const message = useAuthenticityCheckMessage();
     if (message === null) return null;
@@ -67,7 +77,7 @@ export const FirmwareAuthenticityCheckBanner = () => {
     return (
         <Banner
             icon
-            variant={isHashCheckOtherError ? 'warning' : 'destructive'}
+            variant={useWarningVariant ? 'warning' : 'destructive'}
             rightContent={hideBannerButtons ? null : <BannerButtons />}
         >
             <Translation id={message} />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceFailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceFailModal.tsx
@@ -1,13 +1,13 @@
 import { Card, Modal } from '@trezor/components';
-import { TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL } from '@trezor/urls';
 
 import { SecurityCheckFail } from 'src/components/suite/SecurityCheck/SecurityCheckFail';
+import { AuthenticateDeviceSupportButton } from 'src/components/suite/SecurityCheck/deviceCompromisedCtas';
 
 export const AuthenticateDeviceFailModal = () => (
     <Modal>
         <Card>
             <SecurityCheckFail
-                supportUrl={TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL}
+                ctaSection={<AuthenticateDeviceSupportButton />}
                 text="TR_DEVICE_COMPROMISED_DEVICE_AUTHENTICITY_TEXT"
             />
         </Card>

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7068,6 +7068,10 @@ export default defineMessages({
         id: 'TR_FAILED_VERIFY_DEVICE_TEXT',
         defaultMessage: "Your device firmware hash check couldn't be performed.",
     },
+    TR_FAILED_VERIFY_DEVICE_AGAIN_TEXT: {
+        id: 'TR_FAILED_VERIFY_DEVICE_AGAIN_TEXT',
+        defaultMessage: "Your device firmware hash check couldn't be performed repeatedly.",
+    },
     TR_DEVICE_COMPROMISED_ENTROPY_CHECK_TEXT: {
         id: 'TR_DEVICE_COMPROMISED_ENTROPY_CHECK_TEXT',
         defaultMessage: 'Security check (entropy verification) failed.',
@@ -7104,18 +7108,6 @@ export default defineMessages({
     TR_DISCONNECT_YOUR_TREZOR: {
         id: 'TR_DISCONNECT_YOUR_TREZOR',
         defaultMessage: 'Reconnect your device',
-    },
-    TR_DISCONNECT_YOUR_TREZOR_SUBTITLE: {
-        id: 'TR_DISCONNECT_YOUR_TREZOR_SUBTITLE',
-        defaultMessage: 'This usually solves the issue.',
-    },
-    TR_PROBLEM_PERSISTS: {
-        id: 'TR_PROBLEM_PERSISTS',
-        defaultMessage: 'If the issue persists, contact Trezor Support',
-    },
-    TR_PROBLEM_PERSISTS_SUBTITLE: {
-        id: 'TR_PROBLEM_PERSISTS_SUBTITLE',
-        defaultMessage: 'Figure out what’s going on with your device and what to do next.',
     },
     TR_CONTACT_TREZOR_SUPPORT: {
         id: 'TR_CONTACT_TREZOR_SUPPORT',
@@ -7287,7 +7279,12 @@ export default defineMessages({
     TR_DEVICE_FIRMWARE_HASH_CHECK_OTHER_ERROR: {
         id: 'TR_DEVICE_FIRMWARE_HASH_CHECK_OTHER_ERROR',
         defaultMessage:
-            "Failed to verify device. Reconnect your Trezor and try again. Don't send any funds until the issue is resolved. If the issue persists, contact Trezor Support.",
+            "The verification process didn't finish. Close other tabs and windows that might be using your Trezor. Then reconnect your Trezor to try again.",
+    },
+    TR_DEVICE_FIRMWARE_HASH_CHECK_OTHER_ERROR_AGAIN: {
+        id: 'TR_DEVICE_FIRMWARE_HASH_CHECK_OTHER_ERROR_AGAIN',
+        defaultMessage:
+            "The verification process couldn't be performed repeatedly. Your Trezor may be counterfeit.",
     },
     TR_ONBOARDING_COINS_STEP: {
         id: 'TR_ONBOARDING_COINS_STEP',

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
@@ -6,12 +6,12 @@ import { checkDeviceAuthenticityThunk } from '@suite-common/device-authenticity'
 import { selectSelectedDevice, selectSelectedDeviceAuthenticity } from '@suite-common/wallet-core';
 import { variables } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
-import { TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL } from '@trezor/urls';
 
 import { OnboardingButtonCta, OnboardingStepBox } from 'src/components/onboarding';
 import { CollapsibleOnboardingCard } from 'src/components/onboarding/CollapsibleOnboardingCard';
 import { DeviceAuthenticationExplainer, Translation } from 'src/components/suite';
 import { SecurityCheckFail } from 'src/components/suite/SecurityCheck/SecurityCheckFail';
+import { AuthenticateDeviceSupportButton } from 'src/components/suite/SecurityCheck/deviceCompromisedCtas';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 
@@ -114,7 +114,7 @@ export const DeviceAuthenticity = ({ goToNext }: DeviceAuthenticityProps) => {
         return (
             <StyledCard>
                 <SecurityCheckFail
-                    supportUrl={TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL}
+                    ctaSection={<AuthenticateDeviceSupportButton />}
                     text="TR_DEVICE_COMPROMISED_DEVICE_AUTHENTICITY_TEXT"
                 />
             </StyledCard>

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
@@ -30,6 +30,7 @@ import { Hologram, OnboardingButtonSkip } from 'src/components/onboarding';
 import { Translation, TrezorLink } from 'src/components/suite';
 import { SecurityCheckFail } from 'src/components/suite/SecurityCheck/SecurityCheckFail';
 import { SecurityCheckLayout } from 'src/components/suite/SecurityCheck/SecurityCheckLayout';
+import { ContactSupport } from 'src/components/suite/SecurityCheck/deviceCompromisedCtas';
 import { useDispatch, useLayoutSize, useOnboarding, useSelector } from 'src/hooks/suite';
 import { selectIsOnboardingActive } from 'src/reducers/onboarding/onboardingReducer';
 import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
@@ -167,10 +168,16 @@ const SecurityCheckContent = ({
 
     return isFailed ? (
         <SecurityCheckFail
-            goBack={toggleView}
+            ctaSection={
+                <>
+                    <Button variant="tertiary" onClick={toggleView} size="large">
+                        <Translation id="TR_BACK" />
+                    </Button>
+                    <ContactSupport supportUrl={supportUrl} />
+                </>
+            }
             heading="TR_PLAY_IT_SAFE"
             text="TR_DEVICE_COMPROMISED_TEXT_SOFT"
-            supportUrl={supportUrl}
         />
     ) : (
         <SecurityCheckLayout imageMode="ROTATE">

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -12,9 +12,14 @@ import {
 } from '@suite-common/redux-utils';
 import { AcquiredDevice, ButtonRequest, TrezorDevice } from '@suite-common/suite-types';
 import * as deviceUtils from '@suite-common/suite-utils';
-import { getDeviceInstances, getFwUpdateVersion, getStatus } from '@suite-common/suite-utils';
+import {
+    getDeviceInstances,
+    getFwUpdateVersion,
+    getStatus,
+    isDeviceAcquired,
+} from '@suite-common/suite-utils';
 import { networkSymbolCollection } from '@suite-common/wallet-config';
-import { Device, DeviceState, Features, StaticSessionId, UI } from '@trezor/connect';
+import { Device, DeviceState, Features, KnownDevice, StaticSessionId, UI } from '@trezor/connect';
 import {
     getFirmwareVersion,
     getFirmwareVersionArray,
@@ -41,6 +46,7 @@ export type DeviceReducerState = {
     dismissedSecurityChecks?: {
         firmwareAuthenticity?: string[];
     };
+    lastConnectedAuthenticityChecks?: KnownDevice['authenticityChecks'];
 };
 
 const initialState: DeviceReducerState = { devices: [], selectedDevice: undefined };
@@ -332,6 +338,10 @@ const disconnectDevice = (draft: DeviceReducerState, device: TrezorDevice) => {
             draft.devices.splice(draft.devices.indexOf(d), 1);
         }
     });
+
+    if (isDeviceAcquired(device)) {
+        draft.lastConnectedAuthenticityChecks = device.authenticityChecks;
+    }
 };
 
 /**
@@ -913,6 +923,15 @@ export const selectIsEntropyCheckFailed = createMemoizedSelector(
     [selectSelectedDevice, state => state.device.devicesWithFailedEntropyCheck],
     (device, devicesWithFailedEntropyCheck) =>
         !!(device?.id && devicesWithFailedEntropyCheck?.includes(device.id)),
+);
+
+export const selectWasFwHashCheckOtherErrorLastTime = createMemoizedSelector(
+    [state => state.device.lastConnectedAuthenticityChecks],
+    lastConnectedAuthenticityChecks => {
+        const lastHashCheck = lastConnectedAuthenticityChecks?.firmwareHash;
+
+        return lastHashCheck && !lastHashCheck.success && lastHashCheck.error === 'other-error';
+    },
 );
 
 export const selectIsPortfolioTrackerDevice = createMemoizedSelector(


### PR DESCRIPTION
## Description

- include changes from closed [#18606](https://github.com/trezor/trezor-suite/pull/18606)
- on disconnecting device, persist the "last connected state of `authenticityChecks`"
  - if `other-error` now but not in last connected record, display the 1st modal
  - if `other-error` now and also in last connected record, display the 2nd modal
- refactor DeviceCompromised and SecurityCheck component structure to keep the ifs at bay

## Related Issue

Resolve #18615

## Screenshots:

Videos of the new flows: (**not latest** UI, but shows the flow. See screenshots for latest UI)
- [other error 1st and 2nd.webm](https://github.com/user-attachments/assets/40a57f05-6412-473d-b35c-b2f5574ef23f)
- [dismissing & reloading.webm](https://github.com/user-attachments/assets/306f9936-6cf9-4e1e-bc27-f214b8b86a0c)
  - when you dismiss the 1st modal, the device gets remembered as "dismissed fw authenticity check" and won't display the 2nd one; reloading Suite resets this to the 1st modal

**1st modal**
![other-error 1st](https://github.com/user-attachments/assets/2af1a5d3-28f2-420a-b4f0-084c176187a1)

**2nd modal**
![other-error 2nd](https://github.com/user-attachments/assets/4b3c6112-f59d-4cab-b886-f82d84cd9abb)


**1st banner**
![banner other-error 1st](https://github.com/user-attachments/assets/211c3279-2b40-499f-a99b-df6011c0c0e2)
**2nd banner**
![banner other-error 2nd](https://github.com/user-attachments/assets/058946b5-7201-45ef-936d-6347882c021d)



---

**Revision check** – only Dismiss button changed
![revision-mismatch](https://github.com/user-attachments/assets/65e37ed8-ad1f-4b5c-a4b5-abbb0580f4a9)

**Hash check mismatch** – only Dismiss button changed
![hash-mismatch](https://github.com/user-attachments/assets/2fe88ee8-d17e-458c-9b66-a6c3e518abd4)

---

**Device manual check** – unchanged
![DMC](https://github.com/user-attachments/assets/4b1c8f19-1596-4520-ac61-a536c5596e34)

**Entropy check** – unchanged
![entropy](https://github.com/user-attachments/assets/e9b5321d-08bf-4e16-93a3-13b8f2b5a96b)

**Device authenticity check** (onboarding/settings) – unchanged
![DAC](https://github.com/user-attachments/assets/c803ceae-6b77-4bab-b098-ac8a505b77ab)
![DAC from settings](https://github.com/user-attachments/assets/dcd3a695-d467-41c1-857e-16fdf5975fe7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/fw-hash-check-other-error-2step-modal&lookback=7)