### PR TITLE
feat(suite-native): device onboarding analytics

### DIFF
--- a/suite-native/analytics/src/constants.ts
+++ b/suite-native/analytics/src/constants.ts
@@ -59,4 +59,8 @@ export enum EventType {
     TradingQuoteReceived = 'trading/quote_received',
     TradingSuccess = 'trading/success',
     TradingCompareOffers = 'trading/compare_offers',
+    DeviceSetupStarted = 'device_setup/started',
+    DeviceSetupCompleted = 'device_setup/completed',
+    DeviceSetupSecurityCheck = 'device_setup/security_check',
+    DeviceSetupInfo = 'device_setup/info',
 }

--- a/suite-native/analytics/src/events.ts
+++ b/suite-native/analytics/src/events.ts
@@ -353,4 +353,44 @@ export type SuiteNativeAnalyticsEvent =
           payload: {
               type: 'buy' | 'sell' | 'exchange';
           };
+      }
+    | {
+          type: EventType.DeviceSetupStarted;
+          payload: {
+              osName: string;
+              deviceModel: DeviceModelInternal | null;
+          };
+      }
+    | {
+          type: EventType.DeviceSetupCompleted;
+          payload: Partial<{
+              osName: string;
+              deviceModel: DeviceModelInternal | null;
+              duration: number;
+              seed: 'create' | 'recovery';
+              firmware: 'install' | 'update' | 'skip' | 'up-to-date';
+              seedType: 'shamir-single' | 'shamir-advanced' | '12-words' | '24-words';
+
+              // TODO: https://github.com/trezor/trezor-suite/issues/18570
+              // not supported yet:
+              //   recoveryType: 'standard' | 'advanced';
+              //   recoveryStepBack: boolean;
+          }>;
+      }
+    | {
+          type: EventType.DeviceSetupSecurityCheck;
+          payload: {
+              location:
+                  | 'deviceLooksDifferent'
+                  | 'firmwareAlreadyInstalled'
+                  | 'untrustedReseller'
+                  | 'securitySeal'
+                  | 'packaging';
+          };
+      }
+    | {
+          type: EventType.DeviceSetupInfo;
+          payload: {
+              location: 'untrustedReseller' | 'securitySeal';
+          };
       };

--- a/suite-native/analytics/src/types.ts
+++ b/suite-native/analytics/src/types.ts
@@ -22,6 +22,7 @@ export type FirmwareUpdatePayload = {
     toFwVersion: string;
     fromFwType: FirmwareType | 'none';
     toFwType: FirmwareType;
+    location: 'settings' | 'onboarding' | null;
 };
 
 export type FirmwareUpdateStuckedState = 'modalPart1' | 'modalPart2' | 'buttonVisible';

--- a/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
+++ b/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
@@ -47,6 +47,7 @@ type FirmwareInstallationScreenContentProps = {
     isCancellationAllowed?: boolean;
     isRetryAllowed?: boolean;
     isTemporaryRememeberAllowed?: boolean;
+    navigationLocation: 'settings' | 'onboarding';
 };
 
 // This component is shared between `module-onboarding` and `module-device-settings`.
@@ -57,6 +58,7 @@ export const FirmwareInstallationScreenContent = ({
     isCancellationAllowed = true,
     isRetryAllowed = true,
     isTemporaryRememeberAllowed = true,
+    navigationLocation,
 }: FirmwareInstallationScreenContentProps) => {
     const dispatch = useDispatch();
     const { applyStyle } = useNativeStyles();
@@ -76,7 +78,7 @@ export const FirmwareInstallationScreenContent = ({
         mayBeStucked,
         originalDevice,
         targetFirmwareType,
-    } = useFirmware({});
+    } = useFirmware({ navigationLocation });
     const {
         handleAnalyticsReportFinished,
         handleAnalyticsReportStucked,
@@ -85,6 +87,7 @@ export const FirmwareInstallationScreenContent = ({
     } = useFirmwareAnalytics({
         device: originalDevice,
         targetFirmwareType,
+        navigationLocation,
     });
     const openLink = useOpenLink();
 

--- a/suite-native/firmware/src/hooks/useFirmware.tsx
+++ b/suite-native/firmware/src/hooks/useFirmware.tsx
@@ -16,7 +16,11 @@ import { useFirmwareAnalytics } from './useFirmwareAnalytics';
 // If progress doesn't change for 1 minute
 const MAYBE_STUCKED_TIMEOUT = 1 * 60 * 1000; // 1 minute
 
-export const useFirmware = (params?: UseFirmwareInstallationParams) => {
+export const useFirmware = (
+    params?: UseFirmwareInstallationParams & {
+        navigationLocation: 'settings' | 'onboarding';
+    },
+) => {
     const dispatch = useDispatch();
     const {
         firmwareUpdate: firmwareUpdateCommon,
@@ -33,6 +37,7 @@ export const useFirmware = (params?: UseFirmwareInstallationParams) => {
     const { handleAnalyticsReportStucked } = useFirmwareAnalytics({
         device: firmwareInstallation.originalDevice,
         targetFirmwareType: firmwareInstallation.targetFirmwareType,
+        navigationLocation: params?.navigationLocation,
     });
 
     const setIsFirmwareInstallationRunning = useCallback(

--- a/suite-native/firmware/src/hooks/useFirmwareAnalytics.ts
+++ b/suite-native/firmware/src/hooks/useFirmwareAnalytics.ts
@@ -19,9 +19,11 @@ import {
 export const useFirmwareAnalytics = ({
     device,
     targetFirmwareType,
+    navigationLocation,
 }: {
     device?: TrezorDevice;
     targetFirmwareType: FirmwareType;
+    navigationLocation?: 'settings' | 'onboarding';
 }) => {
     const toFwVersion = useSelector(selectDeviceUpdateFirmwareVersion);
 
@@ -33,8 +35,9 @@ export const useFirmwareAnalytics = ({
             toFwVersion: toFwVersion ?? '?.?.?',
             fromFwType: (device?.firmwareType || 'none') as FirmwareType | 'none',
             toFwType: targetFirmwareType,
+            location: navigationLocation ?? null,
         }),
-        [device, targetFirmwareType, toFwVersion],
+        [device, targetFirmwareType, toFwVersion, navigationLocation],
     );
 
     // Use refs to avoid any re-renders because of analytics and to make useCallback dependencies stable

--- a/suite-native/link/src/components/Link.tsx
+++ b/suite-native/link/src/components/Link.tsx
@@ -6,14 +6,14 @@ import Animated, {
     withTiming,
 } from 'react-native-reanimated';
 
-import { RequireExactlyOne } from 'type-fest';
+import { RequireAtLeastOne } from 'type-fest';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Color, TypographyStyle } from '@trezor/theme';
 
 import { useOpenLink } from '../useOpenLink';
 
-type LinkProps = RequireExactlyOne<
+type LinkProps = RequireAtLeastOne<
     {
         label: React.ReactNode;
         href?: string;
@@ -70,11 +70,9 @@ export const Link = ({
 
     const handlePressOut = (e: GestureResponderEvent) => {
         isPressed.value = withTiming(IS_NOT_PRESSED_VALUE, { duration: ANIMATION_DURATION });
-        if (href) {
-            openLink(href);
-        } else if (onPress) {
-            onPress();
-        }
+        if (href) openLink(href);
+
+        onPress?.();
         e.stopPropagation();
     };
 

--- a/suite-native/module-device-onboarding/atoms.ts
+++ b/suite-native/module-device-onboarding/atoms.ts
@@ -1,0 +1,26 @@
+import { atom } from 'jotai';
+
+// TODO: more properties will be added for wallet recovery
+// https://github.com/trezor/trezor-suite/issues/18570
+type OnboardingAnalytics = {
+    startTimestamp: number;
+    seed: 'create' | 'recovery';
+    firmware: 'install' | 'update' | 'skip' | 'up-to-date';
+    seedType: 'shamir-single' | 'shamir-advanced' | '12-words' | '24-words';
+};
+
+export const onboardingAnalyticsAtom = atom<Partial<OnboardingAnalytics>>({});
+
+export const updateOnboardingAnalyticsAtom = atom(
+    null,
+    (get, set, update: Partial<OnboardingAnalytics>) => {
+        set(onboardingAnalyticsAtom, {
+            ...get(onboardingAnalyticsAtom),
+            ...update,
+        });
+    },
+);
+
+export const resetOnboardingAnalyticsAtom = atom(null, (_get, set) => {
+    set(onboardingAnalyticsAtom, { startTimestamp: Date.now() });
+});

--- a/suite-native/module-device-onboarding/src/components/SecurityCheckStepCard.tsx
+++ b/suite-native/module-device-onboarding/src/components/SecurityCheckStepCard.tsx
@@ -3,6 +3,7 @@ import { FadeOutUp, useAnimatedStyle, withDelay, withTiming } from 'react-native
 
 import { useNavigation } from '@react-navigation/core';
 
+import { EventType, analytics } from '@suite-native/analytics';
 import {
     AnimatedCard,
     AnimatedVStack,
@@ -81,6 +82,12 @@ export const SecurityCheckStepCard = ({
     const navigateToSuspiciousDeviceScreen = () => {
         navigation.navigate(DeviceOnboardingStackRoutes.SuspiciousDevice, {
             suspicionCause,
+        });
+        analytics.report({
+            type: EventType.DeviceSetupSecurityCheck,
+            payload: {
+                location: suspicionCause,
+            },
         });
     };
     const animatedCardStyle = useAnimatedStyle(

--- a/suite-native/module-device-onboarding/src/components/SecuritySealDescription.tsx
+++ b/suite-native/module-device-onboarding/src/components/SecuritySealDescription.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { selectDeviceModel } from '@suite-common/wallet-core';
+import { EventType, analytics } from '@suite-native/analytics';
 import { BottomSheet, Box, Button, Text, VStack } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
@@ -15,7 +16,15 @@ export const SecuritySealDescription = () => {
     const openLink = useOpenLink();
     const [isBottomSheetVisible, setIsBottomSheetVisible] = useState(false);
 
-    const openBottomSheet = () => setIsBottomSheetVisible(true);
+    const handleLinkPress = () => {
+        setIsBottomSheetVisible(true);
+        analytics.report({
+            type: EventType.DeviceSetupInfo,
+            payload: {
+                location: 'securitySeal',
+            },
+        });
+    };
     const closeBottomSheet = () => setIsBottomSheetVisible(false);
 
     const deviceModel = useSelector(selectDeviceModel);
@@ -37,7 +46,7 @@ export const SecuritySealDescription = () => {
                     values={{
                         link: linkChunk => (
                             <Link
-                                onPress={openBottomSheet}
+                                onPress={handleLinkPress}
                                 label={linkChunk}
                                 isUnderlined
                                 textVariant="highlight"

--- a/suite-native/module-device-onboarding/src/components/WalletBackupTutorial/WalletBackupTutorialStep6.tsx
+++ b/suite-native/module-device-onboarding/src/components/WalletBackupTutorial/WalletBackupTutorialStep6.tsx
@@ -1,6 +1,7 @@
 import { useDerivedValue } from 'react-native-reanimated';
 
 import { useNavigation } from '@react-navigation/core';
+import { useSetAtom } from 'jotai';
 
 import { WalletBackupType } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
@@ -14,6 +15,7 @@ import {
 import { WalletBackupInstructionCards } from './WalletBackupInstructionCards';
 import { WalletBackupTutorialStep } from './WalletBackupTutorialStep';
 import { WalletBackupTutorialNumberedStepProps } from './WalletBackupTutorialStep1';
+import { updateOnboardingAnalyticsAtom } from '../../../atoms';
 import { HoldToConfirmButton } from '../SwipeableWalkthrough/HoldToConfirmButton';
 
 type WalletBackupTutorialStep6Props = WalletBackupTutorialNumberedStepProps & {
@@ -31,12 +33,16 @@ export const WalletBackupTutorialStep6 = ({
     selectedType,
 }: WalletBackupTutorialStep6Props) => {
     const navigation = useNavigation<NavigationProps>();
+    const updateOnboardingAnalytics = useSetAtom(updateOnboardingAnalyticsAtom);
 
     const isStepFocused = useDerivedValue(() => currentStepIndex.value === 5);
 
     const isMultishareSelected = selectedType === 'shamir-advanced';
 
     const handleHoldToStartSuccess = () => {
+        updateOnboardingAnalytics({
+            seedType: selectedType,
+        });
         navigation.navigate(DeviceOnboardingStackRoutes.WalletCreation, {
             walletBackupType: selectedType,
         });

--- a/suite-native/module-device-onboarding/src/screens/ConfirmFirmwareUpdateScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ConfirmFirmwareUpdateScreen.tsx
@@ -1,5 +1,8 @@
 import { useSelector } from 'react-redux';
 
+import { useSetAtom } from 'jotai';
+
+import { selectHasDeviceFirmwareInstalled } from '@suite-common/wallet-core';
 import { selectIsDeviceFirmwareSupported } from '@suite-native/device';
 import {
     ConfirmFirmwareUpdateScreenContent,
@@ -11,6 +14,7 @@ import {
     StackProps,
 } from '@suite-native/navigation';
 
+import { updateOnboardingAnalyticsAtom } from '../../atoms';
 import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboardingScreenWithExitButton';
 
 export const ConfirmFirmwareUpdateScreen = ({
@@ -19,13 +23,21 @@ export const ConfirmFirmwareUpdateScreen = ({
     DeviceOnboardingStackParamList,
     DeviceOnboardingStackRoutes.ConfirmFirmwareUpdate
 >) => {
+    const hasDeviceFirmwareInstalled = useSelector(selectHasDeviceFirmwareInstalled);
     const isDeviceFirmwareSupported = useSelector(selectIsDeviceFirmwareSupported);
+    const updateOnboardingAnalytics = useSetAtom(updateOnboardingAnalyticsAtom);
 
     const handleUpdateConfirmation = () => {
+        updateOnboardingAnalytics({
+            firmware: hasDeviceFirmwareInstalled ? 'update' : 'install',
+        });
         navigation.navigate(DeviceOnboardingStackRoutes.FirmwareInstallation);
     };
 
     const handleSkipUpdate = () => {
+        updateOnboardingAnalytics({
+            firmware: 'skip',
+        });
         navigation.navigate(DeviceOnboardingStackRoutes.DeviceTutorial);
     };
 

--- a/suite-native/module-device-onboarding/src/screens/CreateOrRecoverCrossroadsScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/CreateOrRecoverCrossroadsScreen.tsx
@@ -1,3 +1,5 @@
+import { useSetAtom } from 'jotai';
+
 import { Box, Button, Card, CenteredTitleHeader, TextDivider, VStack } from '@suite-native/atoms';
 import { EmptyWalletSvg } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
@@ -8,6 +10,7 @@ import {
 } from '@suite-native/navigation';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
+import { updateOnboardingAnalyticsAtom } from '../../atoms';
 import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboardingScreenWithExitButton';
 
 const cardStyle = prepareNativeStyle(_ => ({
@@ -21,11 +24,19 @@ export const CreateOrRecoverCrossroadsScreen = ({
     DeviceOnboardingStackRoutes.CreateOrRecoverCrossroads
 >) => {
     const { applyStyle } = useNativeStyles();
+    const updateOnboardingAnalytics = useSetAtom(updateOnboardingAnalyticsAtom);
+
     const handleCreateButtonPress = () => {
+        updateOnboardingAnalytics({
+            seed: 'create',
+        });
         navigation.navigate(DeviceOnboardingStackRoutes.CreateWalletLoading);
     };
 
     const handleRecoverButtonPress = () => {
+        updateOnboardingAnalytics({
+            seed: 'recovery',
+        });
         navigation.navigate(DeviceOnboardingStackRoutes.Recovery);
     };
 

--- a/suite-native/module-device-onboarding/src/screens/CreatePinScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/CreatePinScreen.tsx
@@ -1,8 +1,11 @@
+import { Platform } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/core';
+import { useAtomValue } from 'jotai';
 
 import { selectDeviceModel, selectHasBitcoinOnlyFirmware } from '@suite-common/wallet-core';
+import { EventType, analytics } from '@suite-native/analytics';
 import { Box, Image, TitleHeader } from '@suite-native/atoms';
 import { usePinAction } from '@suite-native/device';
 import { selectIsCoinEnablingInitFinished } from '@suite-native/discovery';
@@ -23,6 +26,8 @@ import TrezorConnect from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { getScreenHeight } from '@trezor/env-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+import { onboardingAnalyticsAtom } from '../../atoms';
 
 const SCREEN_HEIGHT = getScreenHeight();
 
@@ -52,6 +57,7 @@ export const CreatePinScreen = () => {
     const hasBitcoinOnlyFirmware = useSelector(selectHasBitcoinOnlyFirmware);
     const isCoinEnablingInitFinished = useSelector(selectIsCoinEnablingInitFinished);
     const { applyStyle } = useNativeStyles();
+    const onboardingAnalytics = useAtomValue(onboardingAnalyticsAtom);
 
     const handlePinCreated = () => {
         if (hasBitcoinOnlyFirmware || isCoinEnablingInitFinished) {
@@ -64,6 +70,19 @@ export const CreatePinScreen = () => {
         } else {
             navigation.navigate(RootStackRoutes.CoinEnablingInit);
         }
+
+        analytics.report({
+            type: EventType.DeviceSetupCompleted,
+            payload: {
+                deviceModel,
+                osName: Platform.OS,
+                seed: 'create',
+                duration: onboardingAnalytics.startTimestamp
+                    ? Date.now() - onboardingAnalytics.startTimestamp
+                    : undefined,
+                ...onboardingAnalytics,
+            },
+        });
     };
 
     usePinAction({

--- a/suite-native/module-device-onboarding/src/screens/FirmwareInstallationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/FirmwareInstallationScreen.tsx
@@ -36,6 +36,7 @@ export const FirmwareInstallationScreen = ({
                 isCancellationAllowed={false}
                 isRetryAllowed={false}
                 isTemporaryRememeberAllowed={false}
+                navigationLocation="onboarding"
             />
         </DeviceOnboardingScreenWithExitButton>
     );

--- a/suite-native/module-device-onboarding/src/screens/SecurityCheckScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/SecurityCheckScreen.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useState } from 'react';
 
+import { EventType, analytics } from '@suite-native/analytics';
 import { TitleHeader, VStack } from '@suite-native/atoms';
 import { IconName } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
@@ -27,6 +28,14 @@ const stepToContentMap = {
                     link: linkChunk => (
                         <Link
                             href={TREZOR_RESELLERS_URL}
+                            onPress={() => {
+                                analytics.report({
+                                    type: EventType.DeviceSetupInfo,
+                                    payload: {
+                                        location: 'untrustedReseller',
+                                    },
+                                });
+                            }}
                             label={linkChunk}
                             isUnderlined
                             textVariant="highlight"

--- a/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
@@ -1,10 +1,15 @@
+import { useEffect } from 'react';
+import { Platform } from 'react-native';
 import { useSelector } from 'react-redux';
+
+import { useSetAtom } from 'jotai';
 
 import {
     selectDeviceModel,
     selectHasDeviceFirmwareInstalled,
     selectIsLatestFirmwareInstalled,
 } from '@suite-common/wallet-core';
+import { EventType, analytics } from '@suite-native/analytics';
 import { Box, Button, Image, Text, TextButton, TitleHeader, VStack } from '@suite-native/atoms';
 import { SetupSupportingDeviceModel } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
@@ -17,6 +22,7 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 import { getScreenHeight } from '@trezor/env-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
+import { resetOnboardingAnalyticsAtom, updateOnboardingAnalyticsAtom } from '../../atoms';
 import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboardingScreenWithExitButton';
 import { HeaderUnderlineSvg } from '../components/HeaderUnderlineSvg';
 
@@ -83,12 +89,18 @@ export const UninitializedDeviceLandingScreen = ({
 >) => {
     const hasDeviceFirmwareInstalled = useSelector(selectHasDeviceFirmwareInstalled);
     const isLatestFirmwareInstalled = useSelector(selectIsLatestFirmwareInstalled);
+    const deviceModel = useSelector(selectDeviceModel);
+    const resetOnboardingAnalytics = useSetAtom(resetOnboardingAnalyticsAtom);
+    const updateOnboardingAnalytics = useSetAtom(updateOnboardingAnalyticsAtom);
 
     const handleConfirmButtonPress = () => {
         if (hasDeviceFirmwareInstalled) {
             if (isLatestFirmwareInstalled) {
                 // If user already has the latest firmware installed, skip this update screen and navigate to device auth-check directly.
                 navigation.navigate(DeviceOnboardingStackRoutes.DeviceTutorial);
+                updateOnboardingAnalytics({
+                    firmware: 'up-to-date',
+                });
             } else {
                 navigation.navigate(DeviceOnboardingStackRoutes.ConfirmFirmwareUpdate);
             }
@@ -99,16 +111,45 @@ export const UninitializedDeviceLandingScreen = ({
     };
 
     const handleNeverUsedThisDeviceButtonPress = () => {
+        const suspicionCause = 'firmwareAlreadyInstalled';
         navigation.navigate(DeviceOnboardingStackRoutes.SuspiciousDevice, {
             suspicionCause: 'firmwareAlreadyInstalled',
+        });
+
+        analytics.report({
+            type: EventType.DeviceSetupSecurityCheck,
+            payload: {
+                location: suspicionCause,
+            },
         });
     };
 
     const handleDeviceLooksDifferentButtonPress = () => {
+        const suspicionCause = 'deviceLooksDifferent';
         navigation.navigate(DeviceOnboardingStackRoutes.SuspiciousDevice, {
-            suspicionCause: 'deviceLooksDifferent',
+            suspicionCause,
+        });
+
+        analytics.report({
+            type: EventType.DeviceSetupSecurityCheck,
+            payload: {
+                location: suspicionCause,
+            },
         });
     };
+
+    useEffect(() => {
+        resetOnboardingAnalytics();
+        analytics.report({
+            type: EventType.DeviceSetupStarted,
+            payload: {
+                osName: Platform.OS,
+                deviceModel,
+            },
+        });
+        // report device-setup event only on first render of this screen
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     return (
         <DeviceOnboardingScreenWithExitButton>

--- a/suite-native/module-device-settings/src/screens/FirmwareInstallationScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/FirmwareInstallationScreen.tsx
@@ -37,6 +37,7 @@ export const FirmwareInstallationScreen = () => {
             <FirmwareInstallationScreenContent
                 onFirmwareInstallationSuccess={handleFirmwareInstallationSuccess}
                 onFirmwareInstallationFailure={handleFirmwareInstallationFailure}
+                navigationLocation="settings"
             />
         </Screen>
     );


### PR DESCRIPTION
## Description
- adds analytics for device onboarding flow (so far only for wallet creation, recovery will be added later when implemented)

## Related Issue

Resolve #17532


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/device-onboarding/analytics&lookback=7)