### PR TITLE
feat(e2e): add mobile browser to sanity tests

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/manual/browser/mobile-browser.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/browser/mobile-browser.test.ts
@@ -1,0 +1,30 @@
+import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+test.describe.skip('Mobile browser', { tag: ['@group=manual'] }, () => {
+    test(
+        'Suite web version mobile browser support',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Verifies that a user can connect and use a device via supported mobile browser on Android phone.',
+                prerequisites: [
+                    'Seeded Trezor device',
+                    'Supported mobile browser on Android phone',
+                    'Access to Staging version of Trezor Suite',
+                ],
+                steps: [
+                    'Start Google Chrome browser',
+                    'Navigate to https://staging-suite.trezor.io/web/ and connect and unlock device',
+                    'Connect device via webUSB dialogue',
+                    'Perform discovery and generate receive address',
+                    'Send a transaction',
+                ],
+                category: TestCategory.Wallets,
+                priority: TestPriority.Critical,
+            }),
+        },
+        async () => {},
+    );
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

adding test case: Verifies that a user can connect and use a device via supported mobile browser on Android phone
## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/add_mobile&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/add_mobile&lookback=7)