### PR TITLE
Fix incorrect Solana selection when swapping tokens across accounts

### DIFF
--- a/packages/suite/src/components/wallet/Fees/CustomFee/CurrentFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CurrentFee.tsx
@@ -16,19 +16,19 @@ type CurrentFeeProps = {
 const getCurrentFeeRate = (feeInfo: FeeInfo) => {
     const { levels } = feeInfo;
 
-    if (isEip1559(levels[0])) {
-        return levels[0].baseFeePerGas;
+    if (isEip1559(levels.at(0))) {
+        return levels.at(0)?.baseFeePerGas;
     }
 
     const middleIndex = Math.floor((levels.length - 1) / 2);
 
-    return levels[middleIndex].feePerUnit;
+    return levels.at(middleIndex)?.feePerUnit;
 };
 
 const getCurrentFeeRateLabel = (feeInfo: FeeInfo) => {
     const { levels } = feeInfo;
 
-    if (levels[0].baseFeePerGas) {
+    if (levels.at(0)?.baseFeePerGas) {
         return 'TR_CURRENT_BASE_FEE';
     }
 

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.tsx
@@ -27,7 +27,10 @@ interface TradingBalanceReturnProps {
     symbol: NetworkSymbol;
     networkDecimals: number;
     tokenAddress: TokenAddress | undefined;
-    fiatRatesUpdater: (value: FiatCurrencyCode | undefined) => Promise<FiatRatesResult | null>;
+    fiatRatesUpdater: (
+        value: FiatCurrencyCode | undefined,
+        currentTokenAddress?: TokenAddress,
+    ) => Promise<FiatRatesResult | null>;
 }
 
 export const useTradingFiatValues = ({
@@ -56,7 +59,10 @@ export const useTradingFiatValues = ({
     const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
 
     const fiatRatesUpdater = useCallback(
-        async (value: FiatCurrencyCode | undefined): Promise<FiatRatesResult | null> => {
+        async (
+            value: FiatCurrencyCode | undefined,
+            currentTokenAddress?: TokenAddress,
+        ): Promise<FiatRatesResult | null> => {
             if (!value) return null;
 
             const updateFiatRatesResult = await dispatch(
@@ -64,7 +70,7 @@ export const useTradingFiatValues = ({
                     tickers: [
                         {
                             symbol,
-                            tokenAddress: tokenAddressTyped,
+                            tokenAddress: currentTokenAddress ?? tokenAddressTyped,
                         },
                     ],
                     localCurrency: value,

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -11,6 +11,7 @@ import {
     useTradingInfo,
 } from '@suite-common/trading';
 import { selectAccounts, selectSelectedDevice } from '@suite-common/wallet-core';
+import { TokenAddress } from '@suite-common/wallet-types';
 import {
     amountToSmallestUnit,
     formatAmount,
@@ -179,18 +180,18 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
         setValue(FORM_OUTPUT_MAX, undefined);
         setValue(FORM_OUTPUT_FIAT, '');
         setValue(FORM_OUTPUT_AMOUNT, '');
+        setValue(FORM_SEND_CRYPTO_CURRENCY_SELECT, selected);
         setAmountLimits(undefined);
         setComposedLevels(undefined);
 
-        await tradingFiatValues?.fiatRatesUpdater(
-            getValues(FORM_OUTPUT_CURRENCY)?.value as FiatCurrencyCode,
-        );
-
         setAccountOnChange(account);
         setExchangeReceiveCrypto(selected);
-        setValue(FORM_SEND_CRYPTO_CURRENCY_SELECT, selected);
-
         changeFeeLevel('normal'); // reset fee level
+
+        await tradingFiatValues?.fiatRatesUpdater(
+            getValues(FORM_OUTPUT_CURRENCY)?.value as FiatCurrencyCode,
+            selected.contractAddress as TokenAddress,
+        );
     };
 
     const setRatioAmount = (divisor: number) => {

--- a/packages/suite/src/views/wallet/trading/common/TradingBalance.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingBalance.tsx
@@ -46,6 +46,7 @@ export const TradingBalance = ({
     const { fiatAmount } = useFiatFromCryptoValue({
         amount: stringBalance || '',
         symbol,
+        tokenAddress,
     });
 
     if (showOnlyAmount) {


### PR DESCRIPTION
## Description

Fixes issue where selecting a token on a different account during a swap would incorrectly fall back to mainnet Solana.

The fiat rate fetching (`fiatRatesUpdater`) was called *before* the UI reflected the newly selected token and account. This caused UI freeze by async call, which is particularly problematic for Solana tokens.

- Delayed the `fiatRatesUpdater` call until after the UI has updated.
- Ensured the token’s `contractAddress` is explicitly passed where needed to correctly fetch its fiat rate immediately.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15563

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-token-rate-fetch-delay&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-token-rate-fetch-delay&lookback=7)