### PR TITLE
chore(suite-native): Introduce EmptyHomeRenderer tests

### DIFF
--- a/suite-native/module-home/jest.config.js
+++ b/suite-native/module-home/jest.config.js
@@ -1,0 +1,5 @@
+const { ...baseConfig } = require('../../jest.config.native');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-native/module-home/package.json
+++ b/suite-native/module-home/package.json
@@ -4,11 +4,11 @@
     "private": true,
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
-    "type": "module",
     "main": "src/index",
     "scripts": {
         "depcheck": "yarn g:depcheck",
-        "type-check": "yarn g:tsc --build"
+        "type-check": "yarn g:tsc --build",
+        "test:unit": "yarn g:jest --coverage"
     },
     "dependencies": {
         "@react-navigation/native": "6.1.18",

--- a/suite-native/module-home/src/screens/HomeScreen/components/__tests__/EmptyHomeRenderer.comp.test.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/__tests__/EmptyHomeRenderer.comp.test.tsx
@@ -1,0 +1,141 @@
+import { PORTFOLIO_TRACKER_DEVICE_ID } from '@suite-common/wallet-core';
+import { PreloadedState, renderWithStoreProviderAsync, screen } from '@suite-native/test-utils';
+import { DeviceModelInternal } from '@trezor/device-utils';
+
+import { EmptyHomeRenderer } from '../EmptyHomeRenderer';
+
+describe('EmptyHomeRenderer', () => {
+    const renderEmptyHomeRenderer = (preloadedState: PreloadedState) =>
+        renderWithStoreProviderAsync(<EmptyHomeRenderer />, { preloadedState });
+
+    const expectPortfolioTrackerState = () => {
+        const { getByText } = screen;
+
+        expect(getByText('Get started')).toBeTruthy();
+    };
+
+    const expectUninitializedConnectedDeviceState = () => {
+        const { getByText } = screen;
+
+        expect(getByText('Your Trezor is ready for setup')).toBeTruthy();
+    };
+
+    const expectEmptyPortfolioCrossroadsState = () => {
+        const { getByText } = screen;
+
+        expect(getByText('Connect & unlock my Trezor')).toBeTruthy();
+    };
+
+    const expectEmptyConnectedDeviceState = () => {
+        const { getByText } = screen;
+
+        expect(getByText('Your wallet is empty')).toBeTruthy();
+    };
+
+    it('should display EmptyPortfolioTrackerState when IsDeviceConnectEnabled FF is disabled', async () => {
+        await renderEmptyHomeRenderer({
+            featureFlags: { isDeviceConnectEnabled: false, isDeviceOnboardingEnabled: true },
+            device: {
+                selectedDevice: { type: 'acquired' },
+                devices: [{ id: 'device_id' }],
+            },
+        });
+
+        expectPortfolioTrackerState();
+    });
+
+    describe('when IsDeviceConnectEnabled FF is enabled', () => {
+        it('should display UninitializedConnectedDeviceState when device is connected but not initialized', async () => {
+            await renderEmptyHomeRenderer({
+                featureFlags: { isDeviceConnectEnabled: true, isDeviceOnboardingEnabled: true },
+                device: {
+                    selectedDevice: {
+                        connected: true,
+                        features: { initialized: false, internal_model: DeviceModelInternal.T2B1 },
+                    },
+                    devices: [{ id: 'device_id' }],
+                },
+            });
+
+            expectUninitializedConnectedDeviceState();
+        });
+
+        it('should not display UninitializedConnectedDeviceState when device is connected, not initialized, but isDeviceOnboardingEnabled FF is disabled', async () => {
+            await renderEmptyHomeRenderer({
+                featureFlags: { isDeviceConnectEnabled: true, isDeviceOnboardingEnabled: false },
+                device: {
+                    selectedDevice: {
+                        connected: true,
+                        features: { initialized: false, internal_model: DeviceModelInternal.T2B1 },
+                    },
+                    devices: [{ id: 'device_id' }],
+                },
+            });
+
+            expectEmptyPortfolioCrossroadsState();
+        });
+
+        it('should not display UninitializedConnectedDeviceState when device is connected, not initialized, but model does not support setup', async () => {
+            await renderEmptyHomeRenderer({
+                featureFlags: { isDeviceConnectEnabled: true, isDeviceOnboardingEnabled: false },
+                device: {
+                    selectedDevice: {
+                        connected: true,
+                        features: { initialized: false, internal_model: DeviceModelInternal.T1B1 },
+                    },
+                    devices: [{ id: 'device_id' }],
+                },
+            });
+
+            expectEmptyPortfolioCrossroadsState();
+        });
+
+        it('should display EmptyPortfolioCrossroadsState when only portfolio tracker is allowed', async () => {
+            await renderEmptyHomeRenderer({
+                featureFlags: { isDeviceConnectEnabled: true },
+                device: {
+                    selectedDevice: {
+                        connected: false,
+                        features: { initialized: true },
+                        state: {},
+                    },
+                    devices: [{ id: PORTFOLIO_TRACKER_DEVICE_ID }],
+                },
+            });
+
+            expectEmptyPortfolioCrossroadsState();
+        });
+
+        it('should display EmptyPortfolioCrossroadsState when device is not authorized', async () => {
+            await renderEmptyHomeRenderer({
+                featureFlags: { isDeviceConnectEnabled: true },
+                device: {
+                    selectedDevice: {
+                        connected: false,
+                        features: { initialized: true },
+                        state: undefined,
+                    },
+                    devices: [{ id: 'device_id' }],
+                },
+            });
+
+            expectEmptyPortfolioCrossroadsState();
+        });
+    });
+
+    it('should display EmptyConnectedDeviceState when device is connected and authorized', async () => {
+        await renderEmptyHomeRenderer({
+            featureFlags: { isDeviceConnectEnabled: true },
+            device: {
+                selectedDevice: {
+                    connected: true,
+                    features: { initialized: true },
+                    state: {},
+                },
+                devices: [{ id: 'device_id' }],
+            },
+        });
+
+        expectEmptyConnectedDeviceState();
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds test for EmptyHomeRenderer component, including recent regression.

@coderabbitai review

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore-onboarding-tests&lookback=7)