### PR TITLE
fix(suite-native): e2e detox path

### DIFF
--- a/.github/workflows/test-suite-native-e2e-android.yml
+++ b/.github/workflows/test-suite-native-e2e-android.yml
@@ -12,7 +12,7 @@ on:
       - "suite-common/**"
       - "packages/connect/**"
       - ".github/workflows/test-suite-native-e2e-android.yml"
-      - '!**.md'
+      - "!**.md"
   push:
     branches:
       - release-native/*
@@ -161,7 +161,7 @@ jobs:
       - name: Build a new Detox test .apk
         if: steps.s3_build_cache.outputs.hit == 'false'
         working-directory: ./suite-native/app
-        run: ../../node_modules/.bin/detox build -PreactNativeArchitectures=x86_64 --configuration android.emu.release
+        run: npx detox build -PreactNativeArchitectures=x86_64 --configuration android.emu.release
 
       - name: save .apk to the aws s3 bucket
         if: steps.s3_build_cache.outputs.hit == 'false'

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -16,8 +16,8 @@
         "eas-build-post-install": "yarn workspace @suite-common/message-system sign-config",
         "eas-build-on-success": "./eas-post-success.sh",
         "prebuild:clean": "expo prebuild --clean",
-        "build:e2e": "../../node_modules/.bin/detox build --configuration",
-        "test:e2e": "../../node_modules/.bin/detox test --configuration",
+        "build:e2e": "npx detox build --configuration",
+        "test:e2e": "npx detox test --configuration",
         "start:e2e": "NODE_ENV=test RN_SRC_EXT=e2e.tsx expo start --dev-client",
         "reverse-ports": "adb reverse tcp:8081 tcp:8081 && adb reverse tcp:21325 tcp:21325 && adb reverse tcp:19121 tcp:19121"
     },


### PR DESCRIPTION
Fixes the path pointing to the detox e2e binary. It used to be located in the global `node_modules` folder. Now it is directly in `suite-native/app/node_modules` where is the detox used.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/e2e-detox-path&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/e2e-detox-path&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/e2e-detox-path&lookback=7)