### PR TITLE
fix(protobuf): order of EthereumDefinitions

### DIFF
--- a/packages/protobuf/scripts/protobuf-patches/index.ts
+++ b/packages/protobuf/scripts/protobuf-patches/index.ts
@@ -29,6 +29,7 @@ export const ORDER = {
     RecoveryDevice: 'Features',
     RecoveryType: 'RecoveryDevice',
     RecoveryDeviceInputMethod: 'RecoveryType',
+    EthereumDefinitions: 'EthereumSignTypedData',
 };
 
 // enums used as keys (string), used as values (number) by default


### PR DESCRIPTION
## Description

In response to [protobuf test](https://github.com/trezor/trezor-suite/actions/runs/14744056002/job/41387955017) failing with `'EthereumDefinitions' was used before it was defined`

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/protobuf-order-ethereumdefinitions&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/protobuf-order-ethereumdefinitions&lookback=7)