### PR TITLE
Pre-pending txs for EVM chains without mempool

### DIFF
--- a/packages/suite/src/components/suite/copy/TxAddress.tsx
+++ b/packages/suite/src/components/suite/copy/TxAddress.tsx
@@ -2,14 +2,18 @@ import { useState } from 'react';
 
 import styled, { css, useTheme } from 'styled-components';
 
+import { Account } from '@suite-common/wallet-types';
 import { Icon, Text, TextVariant } from '@trezor/components';
 import { copyToClipboard } from '@trezor/dom-utils';
 import { TypographyStyle } from '@trezor/theme';
 
+import { openModal } from 'src/actions/suite/modalActions';
 import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
 import { TrezorLink } from 'src/components/suite/TrezorLink';
-import { useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
+
+type DisplayMode = 'copy' | 'modal' | 'static';
 
 const IconWrapper = styled.div`
     display: none;
@@ -35,17 +39,17 @@ const onHoverTextOverflowContainerHover = css`
     }
 `;
 
-const TextOverflowContainer = styled.div<{ $shouldAllowCopy?: boolean }>`
+const TextOverflowContainer = styled.div<{ $displayMode: DisplayMode }>`
     position: relative;
     display: inline-flex;
     align-items: center;
     max-width: 100%;
     overflow: hidden;
-    cursor: ${({ $shouldAllowCopy }) => ($shouldAllowCopy ? 'pointer' : 'cursor')};
+    cursor: ${({ $displayMode }) => ($displayMode === 'static' ? 'default' : 'pointer')};
     user-select: none;
 
-    ${({ $shouldAllowCopy }) =>
-        $shouldAllowCopy &&
+    ${({ $displayMode }) =>
+        $displayMode !== 'static' &&
         css`
             @media (hover: none) {
                 ${onHoverTextOverflowContainerHover}
@@ -58,7 +62,18 @@ const TextOverflowContainer = styled.div<{ $shouldAllowCopy?: boolean }>`
         `}
 `;
 
-interface IOAddressProps {
+const getDisplayMode = (
+    shouldAllowCopy: boolean,
+    account?: Account,
+    txAddress?: string,
+): DisplayMode => {
+    if (shouldAllowCopy) return 'copy';
+    if (account && txAddress) return 'modal';
+
+    return 'static';
+};
+
+interface TxAddressProps {
     explorerUrl?: string;
     txAddress?: string;
     explorerUrlQueryString?: string;
@@ -66,6 +81,7 @@ interface IOAddressProps {
     shouldChunk?: boolean;
     variant?: TextVariant;
     typographyStyle?: TypographyStyle;
+    account?: Account;
 }
 
 export const TxAddress = ({
@@ -76,31 +92,40 @@ export const TxAddress = ({
     shouldChunk = false,
     variant = 'default',
     typographyStyle = 'label',
-}: IOAddressProps) => {
+    account,
+}: TxAddressProps) => {
     const isChunkedSettings = useSelector(selectAddressDisplayType);
     const [isClicked, setIsClicked] = useState(false);
     const theme = useTheme();
+    const dispatch = useDispatch();
 
-    const copy = () => {
-        if (!shouldAllowCopy) {
-            return;
-        }
+    if (!txAddress) return null;
 
-        copyToClipboard(txAddress || '');
-
-        setIsClicked(true);
-    };
-
-    const addSpacing = (value: string) => value.match(/.{1,4}/g)?.join(' ') || value;
-
-    if (!txAddress) {
-        return null;
-    }
+    const displayMode = getDisplayMode(shouldAllowCopy, account, txAddress);
 
     const formattedTxAddress =
-        shouldChunk && isChunkedSettings === 'chunked' ? addSpacing(txAddress) : txAddress;
+        shouldChunk && isChunkedSettings === 'chunked'
+            ? txAddress.match(/.{1,4}/g)?.join(' ') || txAddress
+            : txAddress;
 
-    // HiddenPlaceholder disableKeepingWidth: it isn't needed (no numbers to redact), but inline-block disrupts overflow behavior
+    const handleClick = () => {
+        if (displayMode === 'copy') {
+            copyToClipboard(txAddress);
+            setIsClicked(true);
+        } else if (displayMode === 'modal') {
+            dispatch(
+                openModal({
+                    type: 'transaction-detail',
+                    txid: txAddress,
+                    descriptor: account!.descriptor,
+                    symbol: account!.symbol,
+                    deviceState: account!.deviceState,
+                    flow: 'detail',
+                }),
+            );
+        }
+    };
+
     return (
         <Text typographyStyle={typographyStyle} variant={variant}>
             <HiddenPlaceholder disableKeepingWidth>
@@ -108,21 +133,23 @@ export const TxAddress = ({
                     onMouseLeave={() => setIsClicked(false)}
                     data-testid="@tx-detail/txid-value"
                     id={txAddress}
-                    $shouldAllowCopy={shouldAllowCopy}
+                    $displayMode={displayMode}
                 >
-                    <Text wordBreak="break-all" onClick={copy}>
+                    <Text wordBreak="break-all" onClick={handleClick}>
                         {formattedTxAddress}
                     </Text>
-                    {shouldAllowCopy ? (
-                        <IconWrapper onClick={copy}>
+
+                    {displayMode === 'copy' && (
+                        <IconWrapper onClick={handleClick}>
                             <Icon
                                 name={isClicked ? 'check' : 'copy'}
                                 size={12}
                                 color={theme.iconOnPrimary}
                             />
                         </IconWrapper>
-                    ) : null}
-                    {explorerUrl ? (
+                    )}
+
+                    {explorerUrl && (
                         <IconWrapper>
                             <TrezorLink
                                 typographyStyle="label"
@@ -132,7 +159,7 @@ export const TxAddress = ({
                                 <Icon name="arrowUpRight" size={12} color={theme.iconOnPrimary} />
                             </TrezorLink>
                         </IconWrapper>
-                    ) : null}
+                    )}
                 </TextOverflowContainer>
             </HiddenPlaceholder>
         </Text>

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
@@ -16,6 +16,7 @@ import {
     isStakeTypeTx,
 } from '@suite-common/wallet-utils';
 
+import { openModal } from 'src/actions/suite/modalActions';
 import { goto } from 'src/actions/suite/routerActions';
 import {
     AccountLabeling,
@@ -24,6 +25,7 @@ import {
     NotificationViewProps,
 } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectRouteName } from 'src/reducers/suite/routerReducer';
 import { getTxAnchor } from 'src/utils/suite/anchor';
 
 type TransactionRendererProps = NotificationViewProps &
@@ -32,17 +34,17 @@ type TransactionRendererProps = NotificationViewProps &
     >;
 
 export const TransactionRenderer = ({ render: View, ...props }: TransactionRendererProps) => {
+    const { symbol, descriptor, txid, formattedAmount, device } = props.notification;
     const accounts = useSelector(selectAccounts);
     const transactions = useSelector(selectTransactions);
     const blockchain = useSelector(selectBlockchainState);
     const devices = useSelector(selectDevices);
     const currentDevice = useSelector(selectDeviceSelector);
+    const routeName = useSelector(selectRouteName);
     const dispatch = useDispatch();
-
-    const { symbol, descriptor, txid, formattedAmount, device } = props.notification;
-
     const networkAccounts = findAccountsByNetwork(symbol, accounts);
     const found = findAccountsByDescriptor(descriptor, networkAccounts);
+
     // fallback: account not found, it should never happen tho
     if (!found.length) return <View {...props} />;
 
@@ -71,21 +73,39 @@ export const TransactionRenderer = ({ render: View, ...props }: TransactionRende
             }}
             action={{
                 onClick: () => {
-                    const deviceToSelect = accountDevice || device;
-                    if (deviceToSelect?.id !== currentDevice?.id) {
-                        dispatch(selectDeviceThunk({ device: deviceToSelect }));
+                    const isTradingRoute = !!routeName?.includes('wallet-trading');
+
+                    // in trading, we do not want to take user to tx history
+                    if (!isTradingRoute) {
+                        const deviceToSelect = accountDevice || device;
+                        if (deviceToSelect?.id !== currentDevice?.id) {
+                            dispatch(selectDeviceThunk({ device: deviceToSelect }));
+                        }
+                        const txAnchor = getTxAnchor(tx?.txid);
+                        dispatch(
+                            goto(destinationRoute, {
+                                params: {
+                                    accountIndex: account.index,
+                                    accountType: account.accountType,
+                                    symbol: account.symbol,
+                                },
+                                anchor: txAnchor,
+                            }),
+                        );
                     }
-                    const txAnchor = getTxAnchor(tx?.txid);
-                    dispatch(
-                        goto(destinationRoute, {
-                            params: {
-                                accountIndex: account.index,
-                                accountType: account.accountType,
+
+                    if (tx?.txid) {
+                        dispatch(
+                            openModal({
+                                type: 'transaction-detail',
+                                txid: tx.txid,
+                                descriptor: account.descriptor,
                                 symbol: account.symbol,
-                            },
-                            anchor: txAnchor,
-                        }),
-                    );
+                                deviceState: account.deviceState,
+                                flow: 'detail',
+                            }),
+                        );
+                    }
                 },
                 label: 'TOAST_TX_BUTTON',
             }}

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
@@ -42,6 +42,7 @@ export const TransactionRenderer = ({ render: View, ...props }: TransactionRende
     const currentDevice = useSelector(selectDeviceSelector);
     const routeName = useSelector(selectRouteName);
     const dispatch = useDispatch();
+
     const networkAccounts = findAccountsByNetwork(symbol, accounts);
     const found = findAccountsByDescriptor(descriptor, networkAccounts);
 
@@ -57,6 +58,42 @@ export const TransactionRenderer = ({ render: View, ...props }: TransactionRende
         ? 'wallet-staking'
         : 'wallet-index';
 
+    const handleTransactionClick = () => {
+        const isTradingRoute = !!routeName?.includes('wallet-trading');
+
+        if (!isTradingRoute) {
+            const deviceToSelect = accountDevice || device;
+            if (deviceToSelect?.id !== currentDevice?.id) {
+                dispatch(selectDeviceThunk({ device: deviceToSelect }));
+            }
+
+            const txAnchor = getTxAnchor(tx?.txid);
+            dispatch(
+                goto(destinationRoute, {
+                    params: {
+                        accountIndex: account.index,
+                        accountType: account.accountType,
+                        symbol: account.symbol,
+                    },
+                    anchor: txAnchor,
+                }),
+            );
+        }
+
+        if (tx?.txid) {
+            dispatch(
+                openModal({
+                    type: 'transaction-detail',
+                    txid: tx.txid,
+                    descriptor: account.descriptor,
+                    symbol: account.symbol,
+                    deviceState: account.deviceState,
+                    flow: 'detail',
+                }),
+            );
+        }
+    };
+
     return (
         <View
             {...props}
@@ -71,44 +108,14 @@ export const TransactionRenderer = ({ render: View, ...props }: TransactionRende
                 ),
                 confirmations,
             }}
-            action={{
-                onClick: () => {
-                    const isTradingRoute = !!routeName?.includes('wallet-trading');
-
-                    // in trading, we do not want to take user to tx history
-                    if (!isTradingRoute) {
-                        const deviceToSelect = accountDevice || device;
-                        if (deviceToSelect?.id !== currentDevice?.id) {
-                            dispatch(selectDeviceThunk({ device: deviceToSelect }));
-                        }
-                        const txAnchor = getTxAnchor(tx?.txid);
-                        dispatch(
-                            goto(destinationRoute, {
-                                params: {
-                                    accountIndex: account.index,
-                                    accountType: account.accountType,
-                                    symbol: account.symbol,
-                                },
-                                anchor: txAnchor,
-                            }),
-                        );
-                    }
-
-                    if (tx?.txid) {
-                        dispatch(
-                            openModal({
-                                type: 'transaction-detail',
-                                txid: tx.txid,
-                                descriptor: account.descriptor,
-                                symbol: account.symbol,
-                                deviceState: account.deviceState,
-                                flow: 'detail',
-                            }),
-                        );
-                    }
-                },
-                label: 'TOAST_TX_BUTTON',
-            }}
+            action={
+                tx
+                    ? {
+                          onClick: handleTransactionClick,
+                          label: 'TOAST_TX_BUTTON',
+                      }
+                    : undefined
+            }
         />
     );
 };

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
@@ -9,6 +9,7 @@ import { Row } from '@trezor/components';
 import { AccountTransaction } from '@trezor/connect';
 import { spacings } from '@trezor/theme';
 
+import { Translation } from 'src/components/suite';
 import { UnstakingTxAmount } from 'src/components/suite/UnstakingTxAmount';
 import { useTranslation } from 'src/hooks/suite';
 import { WalletAccountTransaction } from 'src/types/wallet';
@@ -83,6 +84,10 @@ const getSolTransactionStakeTypeName = (stakeType: StakeType) => {
 
 export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderProps) => {
     const { translationString } = useTranslation();
+
+    if (isPending && transaction.ethereumSpecific) {
+        return <Translation id="TR_UNCONFIRMED_TX_LONG" />;
+    }
 
     if (
         transaction?.ethereumSpecific?.parsedData?.name &&

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3630,6 +3630,10 @@ export default defineMessages({
         defaultMessage: 'Unconfirmed',
         id: 'TR_UNCONFIRMED_TX',
     },
+    TR_UNCONFIRMED_TX_LONG: {
+        defaultMessage: 'Unconfirmed transaction',
+        id: 'TR_UNCONFIRMED_TX_LONG',
+    },
     TR_UNKNOWN_CONFIRMATION_TIME: {
         defaultMessage: 'unknown',
         id: 'TR_UNKNOWN_CONFIRMATION_TIME',

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
@@ -4,9 +4,8 @@ import { usePrevious } from 'react-use';
 import { ExchangeTradeStatus } from 'invity-api';
 import styled from 'styled-components';
 
-import { type TradingExchangeType, cryptoIdToNetwork } from '@suite-common/trading';
-import { getExplorerUrl } from '@suite-common/wallet-config';
-import { selectAccounts, selectExplorer } from '@suite-common/wallet-core';
+import { type TradingExchangeType } from '@suite-common/trading';
+import { selectAccounts } from '@suite-common/wallet-core';
 import { Card, Column, InfoItem } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
@@ -59,9 +58,6 @@ export const TradingDetailExchange = () => {
     const tradeStatus = trade?.data?.status || 'CONFIRMING';
     const previousTradeStatus = usePrevious(tradeStatus);
     const tradeStatusStep = getTradeStatusStep(tradeStatus);
-
-    const network = trade?.data.send && cryptoIdToNetwork(trade.data.send);
-    const explorer = useSelector(state => selectExplorer(state, network?.symbol));
 
     const exchange = trade?.data?.exchange;
     const provider =
@@ -119,8 +115,8 @@ export const TradingDetailExchange = () => {
                         <InfoItem label={<Translation id="TR_TXID" />}>
                             <TxAddress
                                 txAddress={trade.data.receiveTxHash}
-                                explorerUrl={getExplorerUrl(explorer, 'tx')}
-                                explorerUrlQueryString={explorer?.queryString}
+                                account={sendAccount}
+                                shouldAllowCopy={false}
                             />
                         </InfoItem>
                     )}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
@@ -3,12 +3,7 @@ import { usePrevious } from 'react-use';
 
 import styled, { DefaultTheme, keyframes } from 'styled-components';
 
-import {
-    TradingExchangeType,
-    cryptoIdToNetwork,
-    tradingExchangeActions,
-} from '@suite-common/trading';
-import { getExplorerUrl } from '@suite-common/wallet-config';
+import { TradingExchangeType, tradingExchangeActions } from '@suite-common/trading';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Button, Card, Column, Icon, IconVariant, Paragraph, Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
@@ -120,6 +115,7 @@ export const TradingFormApproval = ({
         form: {
             state: { isFormLoading },
         },
+        account,
     } = context;
 
     const currentQuoteStatus = selectedQuote?.status;
@@ -132,11 +128,6 @@ export const TradingFormApproval = ({
     const [isRefreshButtonLoading, setIsRefreshButtonLoading] = useState(false);
 
     const [approvalStep, setApprovalStep] = useState<ApprovalStep>();
-
-    const explorers = useSelector(state => state.wallet.explorer);
-    const network = selectedQuote?.send && cryptoIdToNetwork(selectedQuote.send);
-    const explorer =
-        network?.symbol && (explorers[network.symbol].custom ?? explorers[network.symbol].default);
 
     useTradingExchangeWatchApproval({
         selectedQuote,
@@ -348,10 +339,8 @@ export const TradingFormApproval = ({
                                                         variant="primary"
                                                         typographyStyle="body"
                                                         txAddress={selectedQuote.approvalSendTxHash}
-                                                        explorerUrl={getExplorerUrl(explorer, 'tx')}
-                                                        explorerUrlQueryString={
-                                                            explorer?.queryString
-                                                        }
+                                                        account={account}
+                                                        shouldAllowCopy={false}
                                                     />
                                                 )}
                                                 <Translation id="TR_EXCHANGE_APPROVAL_FORM_PENDING_SUFFIX" />

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -53,6 +53,7 @@ import {
     signRippleStellarSendFormTransactionThunk,
 } from './sendFormRippleStellarThunks';
 import {
+    selectPrecomposedSendForm,
     selectSendFormDrafts,
     selectSendPrecomposedTx,
     selectSendSerializedTx,
@@ -78,6 +79,7 @@ import {
 } from '../settings/walletSettingsReducer';
 import {
     addFakePendingCardanoTxThunk,
+    addFakePendingEvmTxThunk,
     addFakePendingTxThunk,
 } from '../transactions/transactionsThunks';
 
@@ -227,17 +229,18 @@ const synchronizeSentTransactionThunk = createThunk(
         {
             selectedAccount,
             precomposedTransaction,
+            precomposedForm,
             txid,
         }: {
             selectedAccount: Account;
             precomposedTransaction: GeneralPrecomposedTransactionFinal;
+            precomposedForm?: FormState;
             txid: string;
         },
         { dispatch },
     ) => {
         // notification from the backend may be delayed.
         // modify affected account balance.
-        // TODO: make it work with ETH accounts
         if (isCardanoTx(selectedAccount, precomposedTransaction)) {
             const pendingAccount = getPendingAccount({
                 account: selectedAccount,
@@ -262,6 +265,24 @@ const synchronizeSentTransactionThunk = createThunk(
                     account: selectedAccount,
                 }),
             );
+        } else if (selectedAccount.networkType === 'ethereum') {
+            const pendingAccount = getPendingAccount({
+                account: selectedAccount,
+                tx: precomposedTransaction,
+                txid,
+            });
+            if (pendingAccount) {
+                // manually add fake pending tx as we don't have the data about mempool txs
+                dispatch(
+                    addFakePendingEvmTxThunk({
+                        precomposedTransaction,
+                        precomposedForm,
+                        txid,
+                        account: selectedAccount,
+                    }),
+                );
+                dispatch(accountsActions.updateAccount(pendingAccount));
+            }
         } else {
             // there is no point in fetching account data right after tx submit
             //  as the account will update only after the tx is confirmed
@@ -283,6 +304,7 @@ export const pushSendFormTransactionThunk = createThunk<
         const {
             actions: { onModalCancel },
         } = extra;
+        const precomposedForm = selectPrecomposedSendForm(getState());
         const precomposedTransaction = selectSendPrecomposedTx(getState());
         const serializedTx = selectSendSerializedTx(getState());
         const device = selectSelectedDevice(getState());
@@ -338,6 +360,7 @@ export const pushSendFormTransactionThunk = createThunk<
                 synchronizeSentTransactionThunk({
                     selectedAccount,
                     precomposedTransaction,
+                    precomposedForm,
                     txid,
                 }),
             );

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -1,8 +1,11 @@
+import { toWei } from 'web3-utils';
+
 import { createSingleInstanceThunk, createThunk } from '@suite-common/redux-utils';
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import {
     Account,
     AccountKey,
+    FormState,
     PrecomposedTransactionCardanoFinal,
     PrecomposedTransactionFinal,
     PrecomposedTransactionFinalBumpFeeRbf,
@@ -11,17 +14,20 @@ import {
 } from '@suite-common/wallet-types';
 import {
     enhanceTransaction,
+    ensureHexPrefix,
     findAccountsByAddress,
     findTransactions,
     getPendingAccount,
     getRbfParams,
+    isEip1559,
     isRbfBumpFeeTransaction,
     isTrezorConnectBackendType,
     replaceEthereumSpecific,
     tryGetAccountIdentity,
 } from '@suite-common/wallet-utils';
+import { TokenInfo, TokenStandard } from '@trezor/blockchain-link-types';
 import { blockbookUtils } from '@trezor/blockchain-link-utils';
-import TrezorConnect, { AccountInfo } from '@trezor/connect';
+import TrezorConnect, { AccountInfo, AccountTransaction, TokenTransfer } from '@trezor/connect';
 
 import { TRANSACTIONS_MODULE_PREFIX, transactionsActions } from './transactionsActions';
 import {
@@ -35,6 +41,8 @@ import {
 import { accountsActions } from '../accounts/accountsActions';
 import { selectAccountByKey, selectAccounts } from '../accounts/accountsSelectors';
 import { selectBlockchainHeightBySymbol } from '../blockchain/blockchainReducer';
+import { selectRawNetworkFeeInfo } from '../fees/feesReducer';
+import { ethereumGetCurrentNonceThunk } from '../send/sendFormEthereumThunks';
 import { selectSendSignedTx } from '../send/sendFormSelectors';
 
 /**
@@ -187,6 +195,187 @@ export const addFakePendingTxThunk = createThunk(
                 dispatch(accountsActions.updateAccount(pendingAccount));
             }
         });
+    },
+);
+
+const buildFakePendingEvmTx = ({
+    precomposedTransaction,
+    precomposedForm,
+    txid,
+    account,
+    nonce,
+    blockHeight,
+    deadline,
+    token,
+}: {
+    precomposedTransaction: PrecomposedTransactionFinal;
+    precomposedForm: FormState;
+    txid: string;
+    account: Account;
+    nonce: string;
+    blockHeight: number;
+    deadline: number;
+    token?: TokenInfo;
+}): AccountTransaction & Partial<WalletAccountTransaction> => {
+    const output = precomposedTransaction.outputs[0];
+    const fromAddress = account.descriptor;
+    const toAddress = output.address!;
+    const amount = output.amount.toString();
+    const isLegacyTx = !isEip1559(precomposedTransaction);
+
+    const blockTime = Math.floor(Date.now() / 1000);
+    const common = {
+        descriptor: account.descriptor,
+        deviceState: account.deviceState,
+        symbol: account.symbol,
+        type: 'sent' as const,
+        txid,
+        blockTime,
+        blockHash: undefined,
+        deadline: blockHeight + deadline,
+        fee: precomposedTransaction.fee,
+        rbf: false,
+        internalTransfers: [],
+        ethereumSpecific: {
+            status: -1,
+            nonce: parseInt(nonce),
+            gasLimit: parseInt(precomposedTransaction.feeLimit ?? '0'),
+            gasPrice: isLegacyTx ? toWei(precomposedTransaction.feePerByte, 'gwei') : undefined,
+            maxFeePerGas: isLegacyTx
+                ? undefined
+                : toWei(precomposedTransaction.maxFeePerGas ?? '0', 'gwei'),
+            maxPriorityFeePerGas: isLegacyTx
+                ? undefined
+                : toWei(precomposedTransaction.maxPriorityFeePerGas ?? '0', 'gwei'),
+            data: ensureHexPrefix(precomposedForm?.ethereumDataHex),
+        },
+        details: {
+            vin: [
+                {
+                    n: 0,
+                    addresses: [fromAddress],
+                    isAddress: true,
+                    isOwn: true,
+                    isAccountOwned: true,
+                },
+            ],
+            vout: [],
+            size: 0,
+            totalInput: '0',
+            totalOutput: token ? '0' : amount,
+        },
+        // rbf not yet available for fake pending txs
+        // rbfParams: getRbfParams(tx, account),
+    };
+
+    if (token) {
+        const tokenTransfer: TokenTransfer = {
+            type: 'sent',
+            standard: token.standard as TokenStandard,
+            amount,
+            from: fromAddress,
+            to: toAddress,
+            contract: token.contract,
+            name: token.name,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            multiTokenValues: token.multiTokenValues,
+        };
+
+        return {
+            ...common,
+            amount: '0',
+            targets: [],
+            tokens: [tokenTransfer],
+            details: {
+                ...common.details,
+                vout: [
+                    {
+                        value: '0',
+                        n: 0,
+                        addresses: [token.contract],
+                        isAddress: true,
+                    },
+                ],
+            },
+        };
+    }
+
+    return {
+        ...common,
+        amount,
+        targets: [
+            {
+                n: 0,
+                addresses: [toAddress],
+                isAddress: true,
+                amount,
+            },
+        ],
+        tokens: [],
+        details: {
+            ...common.details,
+            vout: [
+                {
+                    value: amount,
+                    n: 0,
+                    addresses: [toAddress],
+                    isAddress: true,
+                },
+            ],
+        },
+    };
+};
+
+export const addFakePendingEvmTxThunk = createThunk(
+    `${TRANSACTIONS_MODULE_PREFIX}/addFakePendingTransaction`,
+    async (
+        {
+            precomposedTransaction,
+            precomposedForm,
+            txid,
+            account,
+        }: {
+            precomposedTransaction: PrecomposedTransactionFinal;
+            precomposedForm?: FormState;
+            txid: string;
+            account: Account;
+        },
+        { dispatch, getState },
+    ) => {
+        if (
+            account.networkType !== 'ethereum' ||
+            !precomposedForm ||
+            !precomposedTransaction.outputs.length
+        ) {
+            return;
+        }
+
+        const { nonce } = await dispatch(
+            ethereumGetCurrentNonceThunk({ selectedAccount: account }),
+        ).unwrap();
+
+        const blockHeight = selectBlockchainHeightBySymbol(getState(), account.symbol);
+        const rawFeeInfo = selectRawNetworkFeeInfo(getState(), account.symbol);
+
+        const FAKE_TX_TTL_MS = 15 * 60 * 1000; // keep fake tx for 15 minutes
+        const deadline = FAKE_TX_TTL_MS / rawFeeInfo!.blockTime;
+
+        const fakeTx = buildFakePendingEvmTx({
+            precomposedTransaction,
+            precomposedForm,
+            token:
+                precomposedTransaction.token && !precomposedForm.ethereumDataHex
+                    ? precomposedTransaction.token
+                    : undefined,
+            txid,
+            account,
+            nonce,
+            blockHeight,
+            deadline,
+        });
+
+        dispatch(transactionsActions.addTransaction({ transactions: [fakeTx], account }));
     },
 );
 

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -82,3 +82,9 @@ export const isEvmApprovalTx = (data?: string): boolean => {
 
     return result !== null;
 };
+
+export const ensureHexPrefix = (hex?: string): string => {
+    if (!hex) return '';
+
+    return hex.startsWith('0x') ? hex : `0x${hex}`;
+};


### PR DESCRIPTION
## Description

- introduce pre-pending transactions for EVM chain. When tx is successfully fetched from mempool, it is replaced
- prepending txs cannot be speed up (for now))
- prepending txs are available for 15 minutes, if not mined, they are discarded
- EVM pending txs are called `Unconfirmed transaction`
- tx address component opens modal if account is provided and if it should not copy tx address
- view details when tx is broadcasted opens tx modal (if tx available)

## Related Issue

Resolve #14673 
Resolve [#19056](https://github.com/trezor/trezor-suite/issues/19056)

## Screenshots
Swap:

https://github.com/user-attachments/assets/656a5b61-2040-4c6f-9ab3-4143f8f70b3d

Approve:

https://github.com/user-attachments/assets/6e9f7e3e-d9c2-4655-9d9c-85b0ca69e7c4

Solana no tx yet:

https://github.com/user-attachments/assets/22cea20e-07d8-4862-b6e4-5d21b95529ee




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/pre-pending-txs-evm-without-mempool&lookback=7)