### PR TITLE
fix(suite-native): Device Onboarding: fix swipeableWalkgrough Screen offset

### DIFF
--- a/suite-native/module-device-onboarding/src/components/SwipeableWalkthrough/SwipeableWalkthrough.tsx
+++ b/suite-native/module-device-onboarding/src/components/SwipeableWalkthrough/SwipeableWalkthrough.tsx
@@ -1,8 +1,11 @@
-import { ReactNode } from 'react';
+import { ReactNode, useRef } from 'react';
+import { View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { SharedValue } from 'react-native-reanimated';
 
 import { AnimatedBox } from '@suite-native/atoms';
+
+import { useSwipeableWalkthroughStepHeight } from '../../hooks/useSwipeableWalkthroughStepHeight';
 
 type SwipeableWalkthroughProps = {
     children: ReactNode;
@@ -17,6 +20,8 @@ export const SwipeableWalkthrough = ({
     currentStepIndex,
     totalSteps,
 }: SwipeableWalkthroughProps) => {
+    const breakpointRef = useRef<View>(null);
+    const { setStepLayoutHeight } = useSwipeableWalkthroughStepHeight();
     const panGesture = Gesture.Pan().onEnd(event => {
         const { translationY } = event;
 
@@ -30,10 +35,18 @@ export const SwipeableWalkthrough = ({
         }
     });
 
+    const onLayout = () => {
+        breakpointRef?.current?.measure((_x, _y, _width, height) => {
+            setStepLayoutHeight(height);
+        });
+    };
+
     return (
         <>
             <GestureDetector gesture={panGesture}>
-                <AnimatedBox flex={1}>{children}</AnimatedBox>
+                <AnimatedBox onLayout={onLayout} ref={breakpointRef} flex={1}>
+                    {children}
+                </AnimatedBox>
             </GestureDetector>
         </>
     );

--- a/suite-native/module-device-onboarding/src/components/SwipeableWalkthrough/SwipeableWalkthroughStep.tsx
+++ b/suite-native/module-device-onboarding/src/components/SwipeableWalkthrough/SwipeableWalkthroughStep.tsx
@@ -1,14 +1,13 @@
 import { ReactNode } from 'react';
-import { Platform } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { SharedValue, useAnimatedStyle, withSpring } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { AnimatedBox, IconButton, VStack } from '@suite-native/atoms';
-import { getWindowHeight } from '@trezor/env-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { SwipeableWalkthroughStepHeader } from './SwipeableWalkthroughStepHeader';
+import { useSwipeableWalkthroughStepHeight } from '../../hooks/useSwipeableWalkthroughStepHeight';
 
 export type SwipeableWalkthroughStepProps = {
     children: ReactNode;
@@ -19,8 +18,6 @@ export type SwipeableWalkthroughStepProps = {
     description?: ReactNode;
     continueButton?: ReactNode;
 };
-
-const SCREEN_HEADER_HEIGHT = 80;
 
 const SPRING_ANIMATION_CONFIG = {
     damping: 24,
@@ -39,7 +36,7 @@ const scrollViewContentStyle = prepareNativeStyle<{
     minHeight: height,
     paddingHorizontal: utils.spacings.sp16,
     // On iOS is the bottom bar transparent, so we need to add extra bottom padding to avoid content being rendered in the bottom bar.
-    paddingBottom: Platform.OS === 'ios' ? safeAreaInsetBottom + utils.spacings.sp16 : 0,
+    paddingBottom: safeAreaInsetBottom,
 }));
 
 export const SwipeableWalkthroughStep = ({
@@ -51,12 +48,10 @@ export const SwipeableWalkthroughStep = ({
     currentStepIndex,
     continueButton,
 }: SwipeableWalkthroughStepProps) => {
-    const { top: topSafeAreaInset, bottom: bottomSafeAreaInset } = useSafeAreaInsets();
+    const { bottom: bottomSafeAreaInset } = useSafeAreaInsets();
+    const { swipeableWalkthroughStepHeight } = useSwipeableWalkthroughStepHeight();
 
-    const stepContainerHeight =
-        getWindowHeight() -
-        (SCREEN_HEADER_HEIGHT -
-            (Platform.OS === 'ios' ? bottomSafeAreaInset - topSafeAreaInset : 0));
+    const stepContainerHeight = swipeableWalkthroughStepHeight;
 
     const { applyStyle } = useNativeStyles();
 

--- a/suite-native/module-device-onboarding/src/hooks/useSwipeableWalkthroughStepHeight.ts
+++ b/suite-native/module-device-onboarding/src/hooks/useSwipeableWalkthroughStepHeight.ts
@@ -1,0 +1,20 @@
+import { useMemo } from 'react';
+import { Platform } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { atom, useAtomValue, useSetAtom } from 'jotai';
+
+const swipeableWalkthroughStepScrennLayoutHeightAtom = atom(0);
+
+export const useSwipeableWalkthroughStepHeight = () => {
+    const stepOffset = useAtomValue(swipeableWalkthroughStepScrennLayoutHeightAtom);
+    const setStepLayoutHeight = useSetAtom(swipeableWalkthroughStepScrennLayoutHeightAtom);
+    const { bottom, top } = useSafeAreaInsets();
+
+    const swipeableWalkthroughStepHeight = useMemo(
+        () => stepOffset + top + (Platform.OS === 'android' ? bottom : 0),
+        [bottom, stepOffset, top],
+    );
+
+    return { setStepLayoutHeight, swipeableWalkthroughStepHeight };
+};


### PR DESCRIPTION



## Description

calculate correct screen height based on the offset

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18427

## Screenshots:
![Screenshot 2025-04-30 at 15 52 44](https://github.com/user-attachments/assets/534ab5df-06ce-4d27-b964-67388fcb42b3)
![Screenshot 2025-04-30 at 15 46 54](https://github.com/user-attachments/assets/aed4b1a2-0f96-4bfb-912c-250d5bc31726)


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/device-onboarding-tutorial-banner-handling&lookback=7)