### PR TITLE
Add useClickCooldown and useAsyncClickHandler hooks and use it to prevent multiple clicks

### DIFF
--- a/packages/react-utils/src/hooks/useAsyncClickHandler.ts
+++ b/packages/react-utils/src/hooks/useAsyncClickHandler.ts
@@ -1,0 +1,34 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * Hook to handle async click actions and prevent repeated triggering while the action is running.
+ * Useful for preventing double submits or accidental multiple async calls on buttons.
+ *
+ * @returns An object with `handleClick` function and a `disabled` flag.
+ *
+ * @example
+ * const { handleClick, disabled } = useAsyncClickHandler();
+ *
+ * <Button isDisabled={disabled} onClick={() => handleClick(myAsyncFn)}>
+ *     Send
+ * </Button>
+ */
+export const useAsyncClickHandler = <T>() => {
+    const [disabled, setDisabled] = useState(false);
+
+    const handleClick = useCallback(
+        async (fn: () => Promise<T>) => {
+            if (disabled) return;
+
+            setDisabled(true);
+            try {
+                await fn();
+            } finally {
+                setDisabled(false);
+            }
+        },
+        [disabled],
+    );
+
+    return { handleClick, disabled };
+};

--- a/packages/react-utils/src/hooks/useClickCooldown.ts
+++ b/packages/react-utils/src/hooks/useClickCooldown.ts
@@ -1,0 +1,44 @@
+import { useCallback, useRef, useState } from 'react';
+
+const DEFAULT_COOLDOWN_MS = 3000;
+
+/**
+ * Hook to prevent repeated calls of an action for a specified cooldown duration.
+ * Useful for buttons where you want to prevent rapid multiple clicks.
+ *
+ * @param cooldownMs Cooldown duration in milliseconds (default: 3000 ms)
+ * @returns An object with `handleClick` function and a `disabled` flag.
+ *
+ * @example
+ * const { handleClick, disabled } = useClickCooldown();
+ *
+ * <Button isDisabled={disabled} onClick={() => handleClick(() => doSomething())}>
+ *     Retry
+ * </Button>
+ */
+export const useClickCooldown = (cooldownMs: number = DEFAULT_COOLDOWN_MS) => {
+    const lastClickRef = useRef<number>(0);
+    const [disabled, setDisabled] = useState(false);
+
+    const handleClick = useCallback(
+        (fn: () => void) => {
+            const now = Date.now();
+
+            if (now - lastClickRef.current < cooldownMs) {
+                return;
+            }
+
+            lastClickRef.current = now;
+            setDisabled(true);
+
+            fn();
+
+            setTimeout(() => {
+                setDisabled(false);
+            }, cooldownMs);
+        },
+        [cooldownMs],
+    );
+
+    return { handleClick, disabled };
+};

--- a/packages/react-utils/src/index.ts
+++ b/packages/react-utils/src/index.ts
@@ -7,4 +7,5 @@ export { useOnClickOutside } from './hooks/useOnClickOutside';
 export { useTimer } from './hooks/useTimer';
 export { useWindowFocus } from './hooks/useWindowFocus';
 export { useClickCooldown } from './hooks/useClickCooldown';
+export { useAsyncClickHandler } from './hooks/useAsyncClickHandler';
 export type { Timer } from './hooks/useTimer';

--- a/packages/react-utils/src/index.ts
+++ b/packages/react-utils/src/index.ts
@@ -6,4 +6,5 @@ export { useOnce } from './hooks/useOnce';
 export { useOnClickOutside } from './hooks/useOnClickOutside';
 export { useTimer } from './hooks/useTimer';
 export { useWindowFocus } from './hooks/useWindowFocus';
+export { useClickCooldown } from './hooks/useClickCooldown';
 export type { Timer } from './hooks/useTimer';

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputTimer.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputTimer.tsx
@@ -1,13 +1,12 @@
-import React, { useRef } from 'react';
+import React from 'react';
 
 import styled from 'styled-components';
 
 import { Badge, Banner, Button, Text } from '@trezor/components';
+import { useClickCooldown } from '@trezor/react-utils';
 
 import { CountdownTimer } from 'src/components/suite/CountdownTimer';
 import { Translation } from 'src/components/suite/Translation';
-
-const RETRY_THROTTLE_TIMEOUT_MS = 3000;
 
 const TimerBox = styled.div`
     font-variant-numeric: tabular-nums;
@@ -26,18 +25,7 @@ export const TransactionReviewOutputTimer = ({
     onTryAgain,
     isSending,
 }: TransactionReviewOutputTimerProps) => {
-    const lastRetryRef = useRef<number>(0);
-
-    const handleTryAgain = () => {
-        const now = Date.now();
-
-        if (now - lastRetryRef.current < RETRY_THROTTLE_TIMEOUT_MS) {
-            return;
-        }
-
-        lastRetryRef.current = now;
-        onTryAgain(true);
-    };
+    const { handleClick, disabled } = useClickCooldown();
 
     if (isMinimal) {
         return (
@@ -47,8 +35,8 @@ export const TransactionReviewOutputTimer = ({
                     variant="tertiary"
                     type="button"
                     size="tiny"
-                    isDisabled={isSending}
-                    onClick={handleTryAgain}
+                    isDisabled={isSending || disabled}
+                    onClick={() => handleClick(() => onTryAgain(true))}
                 >
                     <Translation id="TR_RETRY" />
                 </Button>

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSend.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSend.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 
 import type { TradingExchangeType } from '@suite-common/trading';
 import { Button, Column, Divider, InfoItem, Spinner, Text } from '@trezor/components';
+import { useAsyncClickHandler } from '@trezor/react-utils';
 import { spacings } from '@trezor/theme';
 
 import { AccountLabeling, Address, Translation } from 'src/components/suite';
@@ -10,6 +11,8 @@ import { useTradingWatchTrade } from 'src/hooks/wallet/trading/useTradingWatchTr
 import { useTradingNavigation } from 'src/hooks/wallet/useTradingNavigation';
 
 export const TradingOfferExchangeSend = () => {
+    const { handleClick, disabled } = useAsyncClickHandler();
+
     const { device, account, callInProgress, selectedQuote, exchangeInfo, sendTransaction, trade } =
         useTradingFormContext<TradingExchangeType>();
     useTradingWatchTrade({
@@ -53,9 +56,9 @@ export const TradingOfferExchangeSend = () => {
                         <Divider margin={{ top: spacings.xs, bottom: spacings.lg }} />
                         <Button
                             data-testid="@trading/offer/confirm-on-trezor-and-send"
-                            isLoading={callInProgress}
-                            isDisabled={!device?.connected}
-                            onClick={sendTransaction}
+                            isLoading={callInProgress || disabled}
+                            isDisabled={!device?.connected || disabled}
+                            onClick={() => handleClick(() => sendTransaction())}
                         >
                             <Translation id="TR_EXCHANGE_CONFIRM_ON_TREZOR_SEND" />
                         </Button>

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendSwap.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendSwap.tsx
@@ -21,6 +21,7 @@ import {
     Tooltip,
 } from '@trezor/components';
 import { BottomText } from '@trezor/components/src/components/form/BottomText';
+import { useAsyncClickHandler } from '@trezor/react-utils';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
@@ -74,6 +75,8 @@ const formatCryptoAmountAsAmount = (amount: number, baseAmount: number, decimals
 };
 
 export const TradingOfferExchangeSendSwap = () => {
+    const { handleClick, disabled } = useAsyncClickHandler();
+
     const {
         type,
         device,
@@ -305,9 +308,9 @@ export const TradingOfferExchangeSendSwap = () => {
             <Column>
                 <Divider margin={{ top: spacings.xs, bottom: spacings.lg }} />
                 <Button
-                    isLoading={callInProgress}
-                    isDisabled={!device?.connected}
-                    onClick={confirmAndSend}
+                    isLoading={callInProgress || disabled}
+                    isDisabled={!device?.connected || disabled}
+                    onClick={() => handleClick(() => confirmAndSend())}
                 >
                     <Translation id="TR_EXCHANGE_CONFIRM_ON_TREZOR_SEND" />
                 </Button>

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellTransaction.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellTransaction.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 import type { TradingSellType } from '@suite-common/trading';
 import { Button, Column, Spinner, Text } from '@trezor/components';
+import { useAsyncClickHandler } from '@trezor/react-utils';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings, spacingsPx, typography } from '@trezor/theme';
 
@@ -41,6 +42,7 @@ const Row = styled.div`
 const Address = styled.div``;
 
 export const TradingSelectedOfferSellTransaction = () => {
+    const { handleClick, disabled } = useAsyncClickHandler();
     const { device, account, callInProgress, selectedQuote, sellInfo, sendTransaction, trade } =
         useTradingFormContext<TradingSellType>();
     useTradingWatchTrade({
@@ -116,9 +118,9 @@ export const TradingSelectedOfferSellTransaction = () => {
                     <ButtonWrapper>
                         <Button
                             minWidth={200}
-                            isLoading={callInProgress}
-                            isDisabled={!device?.connected}
-                            onClick={onConfirmAndSendClick}
+                            isLoading={callInProgress || disabled}
+                            isDisabled={!device?.connected || disabled}
+                            onClick={() => handleClick(() => onConfirmAndSendClick())}
                             data-testid="@trading/offer/confirm-on-trezor-and-send"
                         >
                             <Translation id="TR_SELL_CONFIRM_ON_TREZOR_SEND" />

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerify.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerify.tsx
@@ -12,6 +12,7 @@ import { getDisplaySymbol } from '@suite-common/wallet-config';
 import { isHexValid, isInteger } from '@suite-common/wallet-utils';
 import addressValidator from '@trezor/address-validator';
 import { Button, Column, Divider, Input, Paragraph, Tooltip } from '@trezor/components';
+import { useClickCooldown } from '@trezor/react-utils';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
@@ -36,6 +37,8 @@ interface TradingVerifyProps {
 }
 
 export const TradingVerify = ({ tradingVerifyAccount, cryptoId }: TradingVerifyProps) => {
+    const { handleClick, disabled } = useClickCooldown();
+
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
     const context = useTradingFormContext<TradingTradeBuyExchangeType>();
@@ -244,21 +247,24 @@ export const TradingVerify = ({ tradingVerifyAccount, cryptoId }: TradingVerifyP
                         selectedAccountOption.account && (
                             <Button
                                 data-testid="@trading/offer/confirm-on-trezor-button"
-                                isLoading={callInProgress}
+                                isLoading={callInProgress || disabled}
                                 isDisabled={
+                                    disabled ||
                                     callInProgress ||
                                     (!device?.connected && !isTradingBuyContext(context))
                                 }
                                 onClick={() => {
-                                    if (selectedAccountOption.account && accountAddress) {
-                                        dispatch(
-                                            verifyAddress(
-                                                selectedAccountOption.account,
-                                                accountAddress.address,
-                                                accountAddress.path,
-                                            ),
-                                        );
-                                    }
+                                    handleClick(() => {
+                                        if (selectedAccountOption.account && accountAddress) {
+                                            dispatch(
+                                                verifyAddress(
+                                                    selectedAccountOption.account,
+                                                    accountAddress.address,
+                                                    accountAddress.path,
+                                                ),
+                                            );
+                                        }
+                                    });
                                 }}
                             >
                                 <Translation


### PR DESCRIPTION
## Description

Created two reusable React hooks to prevent multiple button clicks:
- `useClickCooldown` – handles simple cooldown logic for click actions. Disables a button for a set duration after it's clicked
- `useAsyncClickHandler` – manages async click actions by disabling the button while the action is in progress

### Applied in the following components:

**useClickCooldown**
- `TransactionReviewOutputTimer`
- `TradingVerify`

 **useAsyncClickHandler**
- `TradingOfferExchangeSend`
- `TradingOfferExchangeSendSwap`
- `TradingSelectedOfferSellTransaction`


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15650

## Screenshots:

https://github.com/user-attachments/assets/89e17392-6426-4c8e-b16e-dced709ae8e0

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/click-cooldown-hook&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/click-cooldown-hook&lookback=7)