### PR TITLE
chore(suite-native): Mobile Trade: improve buy form entering animations

### DIFF
--- a/suite-native/module-trading/src/components/buy/BuyForm.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyForm.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useEffect, useState } from 'react';
 
 import { VStack } from '@suite-native/atoms';
 import { useDebouncedValue } from '@trezor/react-utils';
@@ -14,23 +14,40 @@ import { TradeHistoryButton } from '../general/TradeHistory/TradeHistoryButton';
 import { TradingAlert } from '../general/TradingAlert';
 import { TradingFooter } from '../general/TradingFooter';
 
-const BuyFormMemoized = memo(({ isAmountInputActive }: { isAmountInputActive: boolean }) => (
-    <VStack spacing="sp16">
-        {!isAmountInputActive && <BuyHeader />}
-        <TradingAlert />
-        <BuyCard isAmountInputActive={isAmountInputActive} />
-        {isAmountInputActive ? (
-            <AmountEditingDoneButton />
-        ) : (
-            <>
-                <PaymentCard />
-                <Confirmation />
-                <TradingFooter />
-                <TradeHistoryButton tradeType="buy" />
-            </>
-        )}
-    </VStack>
-));
+const BuyFormMemoized = memo(({ isAmountInputActive }: { isAmountInputActive: boolean }) => {
+    // `isFormMountedRecently`  allows to use different animations for initial form load (FadeIn)
+    // and when user interacts with the form (FadeInUp/FadeInDown)
+    const [isFormMountedRecently, setFormMountedRecently] = useState<boolean>(true);
+
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            setFormMountedRecently(false);
+        }, 100);
+
+        return () => clearTimeout(timer);
+    }, []);
+
+    return (
+        <VStack spacing="sp16">
+            {!isAmountInputActive && <BuyHeader isFormMountedRecently={isFormMountedRecently} />}
+            <TradingAlert />
+            <BuyCard isAmountInputActive={isAmountInputActive} />
+            {isAmountInputActive ? (
+                <AmountEditingDoneButton />
+            ) : (
+                <>
+                    <PaymentCard isFormMountedRecently={isFormMountedRecently} />
+                    <Confirmation isFormMountedRecently={isFormMountedRecently} />
+                    <TradingFooter isFormMountedRecently={isFormMountedRecently} />
+                    <TradeHistoryButton
+                        tradeType="buy"
+                        isFormMountedRecently={isFormMountedRecently}
+                    />
+                </>
+            )}
+        </VStack>
+    );
+});
 
 export const BuyForm = () => {
     const buyForm = useTradingBuyFormContext();

--- a/suite-native/module-trading/src/components/buy/BuyFormSkeleton.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFormSkeleton.tsx
@@ -45,6 +45,6 @@ export const BuyFormSkeleton = () => (
                 </HStack>
             </Card>
         </VStack>
-        <TradingFooter />
+        <TradingFooter isFormMountedRecently={true} />
     </VStack>
 );

--- a/suite-native/module-trading/src/components/buy/BuyHeader.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyHeader.tsx
@@ -1,10 +1,14 @@
-import { FadeInUp, FadeOutUp } from 'react-native-reanimated';
+import { FadeIn, FadeInUp, FadeOutUp } from 'react-native-reanimated';
 
 import { AnimatedBox, Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
-export const BuyHeader = () => (
-    <AnimatedBox entering={FadeInUp} exiting={FadeOutUp}>
+export type BuyHeaderProps = {
+    isFormMountedRecently?: boolean;
+};
+
+export const BuyHeader = ({ isFormMountedRecently }: BuyHeaderProps) => (
+    <AnimatedBox entering={isFormMountedRecently ? FadeIn : FadeInUp} exiting={FadeOutUp}>
         <Text variant="titleSmall" color="textDefault">
             <Translation id="moduleTrading.tradingScreen.buyTitle" />
         </Text>

--- a/suite-native/module-trading/src/components/buy/Confirmation.tsx
+++ b/suite-native/module-trading/src/components/buy/Confirmation.tsx
@@ -1,4 +1,4 @@
-import { FadeInDown, FadeOutDown } from 'react-native-reanimated';
+import { FadeIn, FadeInDown, FadeOutDown } from 'react-native-reanimated';
 
 import { AnimatedBox, Button } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -7,7 +7,11 @@ import { LegalSheet } from './LegalSheet';
 import { useTradingBuyFlow } from '../../hooks/useTradingBuyFlow';
 import { useTradingBuyFormContext } from '../../hooks/useTradingBuyFormContext';
 
-export const Confirmation = () => {
+export type ConfirmationProps = {
+    isFormMountedRecently?: boolean;
+};
+
+export const Confirmation = ({ isFormMountedRecently }: ConfirmationProps) => {
     const form = useTradingBuyFormContext();
 
     const { canProceed, selectQuote, isConsentRequested, giveConsent, cancelConsent } =
@@ -16,7 +20,7 @@ export const Confirmation = () => {
     const quote = form.watch('quote');
 
     return (
-        <AnimatedBox entering={FadeInDown} exiting={FadeOutDown}>
+        <AnimatedBox entering={isFormMountedRecently ? FadeIn : FadeInDown} exiting={FadeOutDown}>
             {canProceed && (
                 <Button onPress={selectQuote} disabled={!canProceed}>
                     <Translation id="moduleTrading.tradingScreen.continueButton" />

--- a/suite-native/module-trading/src/components/buy/PaymentCard.tsx
+++ b/suite-native/module-trading/src/components/buy/PaymentCard.tsx
@@ -1,4 +1,4 @@
-import { FadeInDown, FadeOutDown } from 'react-native-reanimated';
+import { FadeIn, FadeInDown, FadeOutDown } from 'react-native-reanimated';
 
 import { AnimatedBox, Card } from '@suite-native/atoms';
 
@@ -6,8 +6,12 @@ import { CountryOfResidencePicker } from './CountryOfResidencePicker';
 import { PaymentMethodPicker } from './PaymentMethodPicker';
 import { TradingProviderPicker } from './TradingProviderPicker';
 
-export const PaymentCard = () => (
-    <AnimatedBox entering={FadeInDown} exiting={FadeOutDown}>
+export type PaymentCardProps = {
+    isFormMountedRecently?: boolean;
+};
+
+export const PaymentCard = ({ isFormMountedRecently }: PaymentCardProps) => (
+    <AnimatedBox entering={isFormMountedRecently ? FadeIn : FadeInDown} exiting={FadeOutDown}>
         <Card noPadding>
             <PaymentMethodPicker />
             <CountryOfResidencePicker />

--- a/suite-native/module-trading/src/components/general/TradeHistory/TradeHistoryButton.tsx
+++ b/suite-native/module-trading/src/components/general/TradeHistory/TradeHistoryButton.tsx
@@ -1,4 +1,5 @@
 import { Pressable } from 'react-native';
+import { FadeIn, FadeInDown, FadeOutDown } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
@@ -8,7 +9,7 @@ import {
     TradingType,
     selectHasTradingTradesOfTradeType,
 } from '@suite-common/trading';
-import { HStack, Text } from '@suite-native/atoms';
+import { AnimatedBox, HStack, Text } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import {
@@ -21,6 +22,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles/src';
 
 type TradeHistoryButtonProps = {
     tradeType: TradingType;
+    isFormMountedRecently?: boolean;
 };
 
 const buttonStyle = prepareNativeStyle(utils => ({
@@ -40,7 +42,10 @@ export type NavigationProps = StackToStackCompositeNavigationProps<
     RootStackParamList
 >;
 
-export const TradeHistoryButton = ({ tradeType }: TradeHistoryButtonProps) => {
+export const TradeHistoryButton = ({
+    tradeType,
+    isFormMountedRecently,
+}: TradeHistoryButtonProps) => {
     const { applyStyle } = useNativeStyles();
     const navigation = useNavigation<NavigationProps>();
     const hasTrades = useSelector((state: TradingRootState) =>
@@ -54,13 +59,15 @@ export const TradeHistoryButton = ({ tradeType }: TradeHistoryButtonProps) => {
     const handleOnPress = () => navigation.navigate(TradingStackRoutes.TradeHistory, { tradeType });
 
     return (
-        <Pressable onPress={handleOnPress}>
-            <HStack style={applyStyle(buttonStyle)}>
-                <Text variant="body" color="textSubdued">
-                    <Translation id="moduleTrading.tradeHistory.button.title" />
-                </Text>
-                <Icon name="caretCircleRight" color="iconSubdued" />
-            </HStack>
-        </Pressable>
+        <AnimatedBox entering={isFormMountedRecently ? FadeIn : FadeInDown} exiting={FadeOutDown}>
+            <Pressable onPress={handleOnPress}>
+                <HStack style={applyStyle(buttonStyle)}>
+                    <Text variant="body" color="textSubdued">
+                        <Translation id="moduleTrading.tradeHistory.button.title" />
+                    </Text>
+                    <Icon name="caretCircleRight" color="iconSubdued" />
+                </HStack>
+            </Pressable>
+        </AnimatedBox>
     );
 };

--- a/suite-native/module-trading/src/components/general/TradingFooter.tsx
+++ b/suite-native/module-trading/src/components/general/TradingFooter.tsx
@@ -1,34 +1,41 @@
 import { useMemo } from 'react';
 import { TouchableOpacity } from 'react-native';
+import { FadeIn, FadeInDown, FadeOutDown } from 'react-native-reanimated';
 
-import { Button, HStack, Image, Text } from '@suite-native/atoms';
+import { AnimatedBox, Button, HStack, Image, Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
 
-export const TradingFooter = () => {
+export type TradingFooterProps = {
+    isFormMountedRecently?: boolean;
+};
+
+export const TradingFooter = ({ isFormMountedRecently }: TradingFooterProps) => {
     const openLink = useOpenLink();
 
     const imageSource = useMemo(() => require('../../../assets/InvityLogo.png'), []);
     const openLinkToInvity = () => openLink('https://invity.io');
 
     return (
-        <HStack justifyContent="space-between" alignItems="center">
-            <HStack alignItems="center" spacing="sp4">
-                <Text variant="label" color="textSubdued">
-                    <Translation id="moduleTrading.tradingScreen.footer.poweredBy" />
-                </Text>
-                <TouchableOpacity onPress={openLinkToInvity}>
-                    <Image source={imageSource} contentFit="contain" width={44} height={18} />
-                </TouchableOpacity>
+        <AnimatedBox entering={isFormMountedRecently ? FadeIn : FadeInDown} exiting={FadeOutDown}>
+            <HStack justifyContent="space-between" alignItems="center">
+                <HStack alignItems="center" spacing="sp4">
+                    <Text variant="label" color="textSubdued">
+                        <Translation id="moduleTrading.tradingScreen.footer.poweredBy" />
+                    </Text>
+                    <TouchableOpacity onPress={openLinkToInvity}>
+                        <Image source={imageSource} contentFit="contain" width={44} height={18} />
+                    </TouchableOpacity>
+                </HStack>
+                <Button
+                    colorScheme="tertiaryElevation0"
+                    size="tiny"
+                    onPress={openLinkToInvity}
+                    viewRight="arrowUpRight"
+                >
+                    <Translation id="moduleTrading.tradingScreen.footer.learnMore" />
+                </Button>
             </HStack>
-            <Button
-                colorScheme="tertiaryElevation0"
-                size="tiny"
-                onPress={openLinkToInvity}
-                viewRight="arrowUpRight"
-            >
-                <Translation id="moduleTrading.tradingScreen.footer.learnMore" />
-            </Button>
-        </HStack>
+        </AnimatedBox>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Improves animations. Simple animation when form is opened. "composed" animation on input focus.

<!--- Describe your changes in detail -->

## Screenshots:

https://github.com/user-attachments/assets/0a104520-57c9-4165-accc-796cf8c5f137




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mobile-trade-improve-animations&lookback=7)