### PR TITLE
feat(suite): always indicate when dust prevention occurs

### DIFF
--- a/packages/suite/src/components/wallet/Fees/CustomFee/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CustomFee.tsx
@@ -32,7 +32,7 @@ export type CustomFeeBasicProps<TFieldValues extends FormState> = {
     errors: FieldErrors<TFieldValues>;
     register: UseFormRegister<TFieldValues>;
     control: Control;
-    composedFeePerByte: string;
+    composedFeePerByte: string | undefined;
     setValue: UseFormSetValue<TFieldValues>;
     getValues: UseFormGetValues<TFieldValues>;
     translationString: TranslationFunction;
@@ -108,7 +108,9 @@ export const CustomFee = <TFieldValues extends FormState>({
                         register={register}
                         control={control}
                         composedFeePerByte={
-                            transactionInfo?.type === 'final' ? transactionInfo.feePerByte : ''
+                            transactionInfo?.type === 'final'
+                                ? transactionInfo.feePerByte
+                                : undefined
                         }
                         feeUnits={feeUnits}
                         translationString={translationString}

--- a/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeMisc.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeMisc.tsx
@@ -3,15 +3,15 @@ import { useSelector } from 'react-redux';
 
 import { FormState } from '@suite-common/wallet-types';
 import { getInputState } from '@suite-common/wallet-utils';
-import { Note, Text } from '@trezor/components';
+import { Text } from '@trezor/components';
 import { NumberInput } from '@trezor/product-components';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { Translation } from 'src/components/suite';
 import { selectLanguage } from 'src/reducers/suite/suiteReducer';
 import { validateDecimals } from 'src/utils/suite/validation';
 
 import { CustomFeeBasicProps, FEE_LIMIT, FEE_PER_UNIT } from './CustomFee';
+import { DustPreventionNotice } from '../DustPreventionNotice';
 
 export const CustomFeeMisc = <TFieldValues extends FormState>({
     networkType,
@@ -35,25 +35,7 @@ export const CustomFeeMisc = <TFieldValues extends FormState>({
     const feePerUnitValue = getValues(FEE_PER_UNIT);
     const feePerUnitError = errors.feePerUnit;
 
-    const isComposedFeeRateDifferent =
-        !feePerUnitError && composedFeePerByte && feePerUnitValue !== composedFeePerByte;
-
-    let feeDifferenceWarning;
-    if (isComposedFeeRateDifferent && networkType === 'bitcoin') {
-        const baseFee = getValues('baseFee');
-        feeDifferenceWarning = (
-            <Translation
-                id={baseFee ? 'TR_FEE_ROUNDING_BASEFEE_WARNING' : 'TR_FEE_ROUNDING_DEFAULT_WARNING'}
-                values={{
-                    feeRate: (
-                        <>
-                            <strong>{composedFeePerByte}</strong> {feeUnits}
-                        </>
-                    ),
-                }}
-            />
-        );
-    }
+    const isDustPreventionRelevant = feePerUnitError !== undefined && networkType === 'bitcoin';
 
     const feeRules = {
         ...sharedRules,
@@ -93,7 +75,14 @@ export const CustomFeeMisc = <TFieldValues extends FormState>({
                 rules={feeRules}
                 bottomText={feePerUnitError?.message || null}
             />
-            {feeDifferenceWarning && <Note>{feeDifferenceWarning}</Note>}
+            {isDustPreventionRelevant && (
+                <DustPreventionNotice
+                    chosenFeePerByte={feePerUnitValue}
+                    composedFeePerByte={composedFeePerByte}
+                    baseFee={getValues('baseFee')}
+                    feeUnits={feeUnits}
+                />
+            )}
         </>
     );
 };

--- a/packages/suite/src/components/wallet/Fees/DustPreventionNotice.tsx
+++ b/packages/suite/src/components/wallet/Fees/DustPreventionNotice.tsx
@@ -1,0 +1,43 @@
+import { Note } from '@trezor/components';
+
+import { Translation } from '../../suite';
+
+type DustPreventionNoticeProps = {
+    chosenFeePerByte: string | undefined;
+    composedFeePerByte: string | undefined;
+    baseFee: number | undefined;
+    feeUnits: string;
+};
+
+export const DustPreventionNotice = ({
+    chosenFeePerByte,
+    composedFeePerByte,
+    baseFee,
+    feeUnits,
+}: DustPreventionNoticeProps) => {
+    const isComposedFeeRateDifferent =
+        composedFeePerByte !== undefined &&
+        composedFeePerByte !== '' &&
+        chosenFeePerByte !== composedFeePerByte;
+
+    if (!isComposedFeeRateDifferent) return null;
+
+    return (
+        <Note>
+            <Translation
+                id={
+                    baseFee !== undefined
+                        ? 'TR_FEE_ROUNDING_BASEFEE_WARNING'
+                        : 'TR_FEE_ROUNDING_DEFAULT_WARNING'
+                }
+                values={{
+                    feeRate: (
+                        <>
+                            <strong>{composedFeePerByte}</strong> {feeUnits}
+                        </>
+                    ),
+                }}
+            />
+        </Note>
+    );
+};

--- a/packages/suite/src/components/wallet/Fees/Fees.tsx
+++ b/packages/suite/src/components/wallet/Fees/Fees.tsx
@@ -228,6 +228,7 @@ export const Fees = <TFieldValues extends FormState>({
                     feeOptions={feeOptions}
                     symbol={symbol}
                     changeFeeLevel={changeFeeLevel}
+                    getValues={getValues}
                 />
             )}
             {isCustomFee && (

--- a/packages/suite/src/components/wallet/Fees/StandardFee/BitcoinFeeCards.tsx
+++ b/packages/suite/src/components/wallet/Fees/StandardFee/BitcoinFeeCards.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { formatDurationStrict } from '@suite-common/suite-utils';
+import { getFeeUnits } from '@suite-common/wallet-utils';
 import { Row, Text } from '@trezor/components';
 import { FeeRate } from '@trezor/product-components';
 
@@ -10,6 +11,7 @@ import { useLocales } from 'src/hooks/suite';
 
 import { FeeCard } from './FeeCard';
 import { FeeCardsWrapper, StandardFeeProps } from './StandardFee';
+import { DustPreventionNotice } from '../DustPreventionNotice';
 import { FeeOptionType, getFeeLevelTranslationId } from '../Fees';
 
 export const BitcoinFeeCards = ({
@@ -21,6 +23,7 @@ export const BitcoinFeeCards = ({
     changeFeeLevel,
     symbol,
     isDirty,
+    getValues,
 }: StandardFeeProps) => {
     const locale = useLocales();
 
@@ -80,6 +83,14 @@ export const BitcoinFeeCards = ({
                     />
                 ))}
             </FeeCardsWrapper>
+            <DustPreventionNotice
+                chosenFeePerByte={selectedLevel.feePerUnit}
+                composedFeePerByte={
+                    transactionInfo?.type === 'final' ? transactionInfo.feePerByte : undefined
+                }
+                baseFee={getValues('baseFee')}
+                feeUnits={getFeeUnits(networkType)}
+            />
             {cachedBytes && (
                 <Row alignItems="baseline" justifyContent="space-between">
                     <Text variant="tertiary" typographyStyle="hint">

--- a/packages/suite/src/components/wallet/Fees/StandardFee/StandardFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/StandardFee/StandardFee.tsx
@@ -1,8 +1,11 @@
+import { UseFormGetValues } from 'react-hook-form';
+
 import styled from 'styled-components';
 
 import { NetworkSymbol, NetworkType } from '@suite-common/wallet-config';
 import {
     FeeInfo,
+    FormState,
     PrecomposedTransaction,
     PrecomposedTransactionCardano,
 } from '@suite-common/wallet-types';
@@ -24,6 +27,7 @@ export type StandardFeeProps = {
     changeFeeLevel: (level: FeeLevel['label']) => void;
     transactionInfo?: PrecomposedTransaction | PrecomposedTransactionCardano;
     isDirty: boolean;
+    getValues: UseFormGetValues<FormState>;
 };
 
 export const FeeCardsWrapper = styled.div`

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7788,13 +7788,11 @@ export default defineMessages({
     TR_FEE_ROUNDING_DEFAULT_WARNING: {
         id: 'TR_FEE_ROUNDING_DEFAULT_WARNING',
         defaultMessage: 'The fee rate has been adjusted to {feeRate} to prevent unusable amounts.',
-        description: 'previously stored under key TR_FEE_ROUNDING_WARNING',
     },
     TR_FEE_ROUNDING_BASEFEE_WARNING: {
         id: 'TR_FEE_ROUNDING_BASEFEE_WARNING',
         defaultMessage:
             'The fee rate of {feeRate} has been increased to pay for the chained transactions within the mempool',
-        description: 'previously stored under key TR_FEE_ROUNDING_WARNING',
     },
     TR_FEE_RATE_CHANGED: {
         id: 'TR_FEE_RATE_CHANGED',


### PR DESCRIPTION
## Description

Always indicate dust prevention fee increase, not just with custom fees.
Note that the same UI also applies for increased fee to cancel/bump chained Txs. 

## Related Issue

Resolve #18317

## Screenshots:

Dust prevention
[dust coalescence.webm](https://github.com/user-attachments/assets/96aa123e-3b17-4578-b0f1-4b345312eab4)

Chained Tx
[chained.webm](https://github.com/user-attachments/assets/1d706195-d375-4bab-90b0-9d90ffec4518)



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/indicate-dust-prevention&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/indicate-dust-prevention&lookback=7)