### PR TITLE
fix(suite): basic handling of some migration errors

### DIFF
--- a/packages/suite-storage/src/web/index.ts
+++ b/packages/suite-storage/src/web/index.ts
@@ -309,6 +309,17 @@ class CommonDB<TDBStructure> {
         filters?: { key?: any; offset?: number; count?: number; reverse?: boolean },
     ) => {
         const db = await this.getDB();
+
+        // Stores are expected to exist, but if migrations go wrong, the error mustn't go unhandled,
+        // because it crashes Suite and also the raw error doesn't bear enough info for debugging.
+        // This shall help pinpoint issues in Sentry to specific stores & their migrations.
+        if (!Object.values(db.objectStoreNames).includes(store)) {
+            console.error(`IDB store ${store} (indexName: ${indexName ?? ''}) not found!`);
+
+            // this fn always returns an Array, so falling back to an empty one gives a chance that Suite won't crash completely
+            return Promise.resolve([]);
+        }
+
         const tx = db.transaction(store);
         if (indexName) {
             const index = tx.store.index(indexName);

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -747,6 +747,9 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
 
     if (oldVersion < 41) {
         await updateAll(transaction, 'metadata', metadata => {
+            if (!metadata.selectedProvider) {
+                metadata.selectedProvider = { labels: '', passwords: '' };
+            }
             metadata.selectedProvider.passwords = '';
 
             return metadata;


### PR DESCRIPTION
## Description

We are having somewhat noisy migration errors – [example sentry issue](https://satoshilabs.sentry.io/issues/6525989047/events/c0f232871f9f400ea289df5b6d4f628f/?project=5193825).
Unfortunately it doesn't even say which store failed, just this, making it impossible to debug:
```
NotFoundError: Failed to execute 'objectStore' on 'IDBTransaction': The specified object store was not found.
NotFoundError: Failed to execute 'transaction' on 'IDBDatabase': One of the specified object stores was not found.
```

Now it shall emit [an issue like this](https://satoshilabs.sentry.io/issues/6578617512/), so we'll be able to debug after next release cycle :crossed_fingers: 

## Related Issue

Resolve #18601
:thought_balloon:  _(technically solves the issue, but really we'll need to followup on the new, more specific Sentry issues that'll arise)_

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/migration-error-handling&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/migration-error-handling&lookback=7)