### PR TITLE
chore(suite-native): bump version to 25.5.1

### DIFF
--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@suite-native/app",
     "version": "1.0.0",
-    "suiteNativeVersion": "25.4.3",
+    "suiteNativeVersion": "25.5.1",
     "main": "index.js",
     "scripts": {
         "android": "expo run:android",


### PR DESCRIPTION
Automated version bump to follow YY.MM.MINOR convention

- Updates version in package.json to 25.5.1

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/bump-version-to-25.5.1&lookback=7)