### PR TITLE
chore(suite-desktop): rewrite builder hooks to ESM

### DIFF
--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -7,7 +7,7 @@
     "homepage": "https://trezor.io/",
     "main": "src/app.ts",
     "scripts": {
-        "build:scripts": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.scripts.json",
+        "build:scripts": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.scripts.json && find ./lib -name '*.js' -exec bash -c 'mv \"$0\" \"${0%.js}.mjs\"' {} \\;",
         "build:core": "yarn g:rimraf dist && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/core.webpack.config.ts",
         "type-check": "yarn g:tsc --build tsconfig.json",
         "test:unit": "yarn g:jest",
@@ -57,7 +57,7 @@
     "devDependencies": {
         "@currents/playwright": "^1.11.3",
         "@electron/fuses": "^1.8.0",
-        "@electron/notarize": "2.5.0",
+        "@electron/notarize": "3.0.1",
         "@octokit/rest": "^21.1.1",
         "@playwright/browser-chromium": "^1.51.0",
         "@playwright/browser-firefox": "^1.51.0",

--- a/packages/suite-desktop-core/scripts/notarize.ts
+++ b/packages/suite-desktop-core/scripts/notarize.ts
@@ -18,7 +18,6 @@ const notarizeAfterSignHook: Hooks['afterSign'] = context => {
     console.log(`notarizing ${appPath} ...`);
 
     return notarize({
-        tool: 'notarytool',
         appPath,
         appleId: process.env.APPLEID,
         appleIdPassword: process.env.APPLEIDPASS,

--- a/packages/suite-desktop-core/scripts/setElectronFuses.ts
+++ b/packages/suite-desktop-core/scripts/setElectronFuses.ts
@@ -1,6 +1,6 @@
 import { FuseV1Options, FuseVersion, flipFuses } from '@electron/fuses';
 import type { Hooks } from 'app-builder-lib';
-import path from 'path';
+import path from 'node:path';
 
 // copied from https://github.com/electron-userland/electron-builder/blob/04be5699c664e6a93e093b820a16ad516355b5c7/packages/app-builder-lib/src/platformPackager.ts#L430-L434
 const binaryExtensionByPlaformNameMap = {

--- a/packages/suite-desktop-core/scripts/sign-windows.ts
+++ b/packages/suite-desktop-core/scripts/sign-windows.ts
@@ -1,4 +1,5 @@
 import type { CustomWindowsSign } from 'app-builder-lib';
+import { execSync } from 'node:child_process';
 
 // electron-builder TS requires the function to return Promise, but jsign MUST be called with execSync!
 // eslint-disable-next-line require-await
@@ -15,7 +16,7 @@ const signWindows: CustomWindowsSign = async configuration => {
     const CERTIFICATE_NAME = process.env.WINDOWS_SIGN_CERTIFICATE_NAME;
     const TOKEN_PASSWORD = process.env.WINDOWS_SIGN_TOKEN_PASSWORD;
 
-    require('child_process').execSync(
+    execSync(
         `java -jar ../suite-desktop-core/scripts/jsign-6.0.jar --keystore ../suite-desktop-core/scripts/hardwareToken.cfg --storepass '${TOKEN_PASSWORD}' --storetype PKCS11 --tsaurl http://timestamp.digicert.com --alias "${CERTIFICATE_NAME}" "${configuration.path}"`,
         {
             stdio: 'inherit',

--- a/packages/suite-desktop-core/tsconfig.scripts.json
+++ b/packages/suite-desktop-core/tsconfig.scripts.json
@@ -1,6 +1,10 @@
 {
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
+        "module": "ESNext",
+        "declaration": false,
+        "sourceMap": false,
+        "declarationMap": false,
         "outDir": "lib"
     },
     "include": ["./scripts"],

--- a/packages/suite-desktop/electron-builder-config.js
+++ b/packages/suite-desktop/electron-builder-config.js
@@ -134,7 +134,8 @@ module.exports = {
         target: ['nsis'],
         signtoolOptions: {
             publisherName: ['SatoshiLabs, s.r.o.', 'Trezor Company s.r.o.'],
-            sign: '../suite-desktop-core/lib/sign-windows.js',
+            // TODO #14482: when Electron-main is migrated to ESM, and we declare whole suite-desktop package as ESM, rename .mjs files back to .js
+            sign: '../suite-desktop-core/lib/sign-windows.mjs',
         },
     },
     linux: {
@@ -162,6 +163,7 @@ module.exports = {
         category: 'Utility',
         target: ['AppImage'],
     },
-    afterPack: '../suite-desktop-core/lib/setElectronFuses.js',
-    afterSign: '../suite-desktop-core/lib/notarize.js',
+    // TODO #14482: when Electron-main is migrated to ESM, and we declare whole suite-desktop package as ESM, rename .mjs files back to .js
+    afterPack: '../suite-desktop-core/lib/setElectronFuses.mjs',
+    afterSign: '../suite-desktop-core/lib/notarize.mjs',
 };

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -31,7 +31,7 @@
     },
     "devDependencies": {
         "@electron/fuses": "^1.8.0",
-        "@electron/notarize": "2.5.0",
+        "@electron/notarize": "3.0.1",
         "electron": "35.1.2",
         "electron-builder": "26.0.3",
         "glob": "^10.3.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2172,6 +2172,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@electron/notarize@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@electron/notarize@npm:3.0.1"
+  dependencies:
+    debug: "npm:^4.4.0"
+    promise-retry: "npm:^2.0.1"
+  checksum: 10/d908dd1d5db9499072e65a518de722dd85b23b8dacc8992e48d37adf2ee9b92f589b08e105d46ffa574b0713efa5b25744ea4ef03c0de99398ee655029dec3bf
+  languageName: node
+  linkType: hard
+
 "@electron/osx-sign@npm:1.3.1":
   version: 1.3.1
   resolution: "@electron/osx-sign@npm:1.3.1"
@@ -12255,7 +12265,7 @@ __metadata:
   dependencies:
     "@currents/playwright": "npm:^1.11.3"
     "@electron/fuses": "npm:^1.8.0"
-    "@electron/notarize": "npm:2.5.0"
+    "@electron/notarize": "npm:3.0.1"
     "@octokit/rest": "npm:^21.1.1"
     "@playwright/browser-chromium": "npm:^1.51.0"
     "@playwright/browser-firefox": "npm:^1.51.0"
@@ -12347,7 +12357,7 @@ __metadata:
   resolution: "@trezor/suite-desktop@workspace:packages/suite-desktop"
   dependencies:
     "@electron/fuses": "npm:^1.8.0"
-    "@electron/notarize": "npm:2.5.0"
+    "@electron/notarize": "npm:3.0.1"
     blake-hash: "npm:^2.0.0"
     electron: "npm:35.1.2"
     electron-builder: "npm:26.0.3"


### PR DESCRIPTION
## Description

- bump `@electron/notarize` to 3, which is now available only as ESM 
- and so transpile all builder hooks to ESM instead of CJS

## Related Issue

Resolve #18091

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bump-electron-notarize&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bump-electron-notarize&lookback=7)