### PR TITLE
fix(suite-native): failed device check during onboarding

### DIFF
--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -111,7 +111,8 @@ export const useHandleDeviceConnection = () => {
 
     // any failing check should navigate to the DeviceCompromisedModal
     const shouldNavigateToDeviceCompromisedModal =
-        shouldDisplayEntropyCheckError || shouldDisplayFirmwareAuthenticityError;
+        isOnboardingFinished &&
+        (shouldDisplayEntropyCheckError || shouldDisplayFirmwareAuthenticityError);
     // but the DeviceCompromisedModal shall not be persistent for Entropy check, because you cannot exit the modal via normal means
     const shouldKeepDeviceCompromisedModal =
         isDeviceCompromisedModalFocused && !shouldDisplayEntropyCheckError;

--- a/suite-native/module-authenticity-checks/src/useRenderDeviceCompromisedBanner.ts
+++ b/suite-native/module-authenticity-checks/src/useRenderDeviceCompromisedBanner.ts
@@ -13,6 +13,7 @@ import {
     RootStackRoutes,
     useNavigationRouteMatch,
 } from '@suite-native/navigation';
+import { selectIsOnboardingFinished } from '@suite-native/settings';
 
 import { deviceCompromisedBannerAtom } from './DeviceCompromisedBannerAtoms';
 
@@ -24,12 +25,14 @@ export const useRenderDeviceCompromisedBanner = () => {
         HomeStackRoutes.Home,
     ]);
 
+    const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
     const revisionCheckError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
 
     const setBannerVariant = useSetAtom(deviceCompromisedBannerAtom);
 
     useEffect(() => {
         if (
+            !isOnboardingFinished ||
             isRouteExcluded ||
             revisionCheckError === null ||
             revisionCheckErrorScenarios[revisionCheckError].type === 'skipped'
@@ -42,5 +45,11 @@ export const useRenderDeviceCompromisedBanner = () => {
         }
 
         setBannerVariant(isExtendedBanner ? 'extended' : 'brief');
-    }, [isRouteExcluded, isExtendedBanner, revisionCheckError, setBannerVariant]);
+    }, [
+        isRouteExcluded,
+        isExtendedBanner,
+        revisionCheckError,
+        setBannerVariant,
+        isOnboardingFinished,
+    ]);
 };


### PR DESCRIPTION
## Description
- failed check message/screen is shown only after the onboarding (app welcome flow) is finished

## Related Issue

Resolve #17596 


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-failed-check-onboarding&lookback=7)