### PR TITLE
fix(suite): solana send-max fee handling

### DIFF
--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -1,5 +1,6 @@
 import { createThunk } from '@suite-common/redux-utils';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { SOL_COMPUTE_UNIT_LIMIT } from '@suite-common/wallet-constants';
 import {
     Account,
     ExternalOutput,
@@ -133,6 +134,8 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
         const { blockhash: blockHash, blockHeight: lastValidBlockHeight } =
             selectBlockchainBlockInfoBySymbol(getState(), account.symbol);
 
+        assertIsSolanaAccount(account);
+
         // invalid token transfer -- should never happen
         if (tokenInfo && !tokenInfo.accounts)
             return rejectWithValue({
@@ -144,8 +147,8 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
             if (tokenInfo?.balance) {
                 formState.outputs[0].amount = tokenInfo.balance;
             } else {
-                // small amount for purpose of fee estimation
-                formState.outputs[0].amount = '0.000000001';
+                // minimal amount for purpose of fee estimation, at least to cover rent + 1 lamport
+                formState.outputs[0].amount = formatAmount((account.misc?.rent ?? 0) + 1, decimals);
             }
         }
 
@@ -169,6 +172,11 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
             lastValidBlockHeight,
             coin: account.symbol,
             identity: getAccountIdentity(account),
+            priorityFees: {
+                // dummy value so simulation always passes
+                computeUnitPrice: formState.feePerUnit || '1',
+                computeUnitLimit: formState.feeLimit || SOL_COMPUTE_UNIT_LIMIT.toString(),
+            },
         });
 
         if (!transaction.success) {
@@ -215,8 +223,6 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
             }));
 
         const resultLevels: PrecomposedLevels = {};
-
-        assertIsSolanaAccount(account);
 
         const response = predefinedLevels.map(level =>
             calculate(


### PR DESCRIPTION
## Description

Fix issue with fees when doing send max in Solana, both in send form and trade section. 

One part of the issue was that the dummy amount used to test with was too low to pay rent, so I changed it to equal rent + small dummy amount. 

Other part of the issue was that default fees were used for the fee estimation, which are higher, causing the simulation to fail. Now we use values from state or lower dummy units. 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/solana-send-max-new-addr&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/solana-send-max-new-addr&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/solana-send-max-new-addr&lookback=7)