### PR TITLE
feat(trading): filter trading tx history by selected wallet

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.tsx
@@ -5,7 +5,7 @@ import {
     selectTradingBuyProviders,
     selectTradingExchangeInfo,
     selectTradingSellInfo,
-    selectTradingTrades,
+    selectTradingTradesForSelectedDevice,
 } from '@suite-common/trading';
 import { H3, Paragraph, variables } from '@trezor/components';
 import { spacingsPx, typography } from '@trezor/theme';
@@ -36,7 +36,7 @@ const TransactionCount = styled.div`
 
 export const TradingTransactionsList = () => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
-    const trades = useSelector(selectTradingTrades);
+    const trades = useSelector(selectTradingTradesForSelectedDevice);
     const buyProviders = useSelector(selectTradingBuyProviders);
     const exchangeProviders = useSelector(selectTradingExchangeInfo)?.providerInfos;
     const sellProviders = useSelector(selectTradingSellInfo)?.providerInfos;

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -3,6 +3,7 @@ import { Coins, CryptoId, FiatCurrencyCode } from 'invity-api';
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { UnreachableCaseError } from '@suite-common/suite-utils';
 import { NetworkSymbolExtended } from '@suite-common/wallet-config';
+import { selectAccounts } from '@suite-common/wallet-core';
 import { Account, SelectedAccountStatus } from '@suite-common/wallet-types';
 import { AddressDisplayOptions } from '@suite-common/wallet-types/src/settings';
 import addressValidator from '@trezor/address-validator';
@@ -258,6 +259,18 @@ export const selectTradingPaymentMethods = (state: TradingRootState) =>
 
 export const selectTradingTrades = (state: TradingRootState) =>
     returnStableArrayIfEmpty(state.wallet.tradingNew.trades);
+
+export const selectTradingTradesForSelectedDevice = createMemoizedSelector(
+    [selectAccounts, state => state.wallet.selectedAccount, selectTradingTrades],
+    (accounts, selectedAccount, trades): TradingTransaction[] =>
+        trades.filter(tx => {
+            const txDeviceId = accounts.find(
+                account => tx.account.descriptor === account.descriptor,
+            )?.deviceState;
+
+            return txDeviceId === selectedAccount.account?.deviceState;
+        }),
+);
 
 export const selectTradingTradesByTradeType: (
     state: TradingRootState,

--- a/suite-common/trading/src/thunks/common/__tests__/verifyAddressThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/verifyAddressThunk.test.ts
@@ -24,6 +24,7 @@ const mockedSuiteReducer = createReducerWithExtraDeps(
 jest.mock('@suite-common/wallet-core', () => ({
     confirmAddressOnDeviceThunk: jest.fn(),
     selectSelectedDevice: jest.fn(),
+    selectAccounts: jest.fn(),
 }));
 
 describe('verifyAddressThunk', () => {


### PR DESCRIPTION
Filter trading tx history by selected wallet.
(merging to refactor PR to avoid conflicts)

## Related Issue

Resolve #18720

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/trading-tx-history-for-selected-wallet&lookback=7)