### PR TITLE
Multi-transport device

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -6,6 +6,7 @@ import { TransportProtocol, thp as protocolThp, v1 as protocolV1 } from '@trezor
 import { Session, TRANSPORT, TRANSPORT_ERROR } from '@trezor/transport';
 import { type Descriptor, type Transport } from '@trezor/transport';
 import { TransportDeviceEvent } from '@trezor/transport/src/transports/abstract';
+import type { PathPublic } from '@trezor/transport/src/types';
 import {
     Deferred,
     TypedEmitter,
@@ -120,11 +121,11 @@ type DeviceParams = {
 };
 
 export class Device extends TypedEmitter<DeviceEvents> {
-    public readonly transport: Transport;
-    public readonly transportPath;
-    public readonly bluetoothProps;
+    public transport: Transport;
+    public transportPath: PathPublic;
+    public bluetoothProps;
     private thp: protocolThp.ThpState | undefined;
-    private readonly possibleHIDdevice;
+    private possibleHIDdevice;
     private sessionAcquired: Session | null;
 
     // protocol related
@@ -241,6 +242,17 @@ export class Device extends TypedEmitter<DeviceEvents> {
             }
         }
     };
+
+    private mergedInto?: DeviceUniquePath;
+    private readonly backupTransports: [Transport, PathPublic][] = [];
+
+    mergeWith(another: Device) {
+        this.backupTransports.push([another.transport, another.transportPath]);
+        this.emitLifecycle(DEVICE.CHANGED);
+
+        another.mergedInto = this.uniquePath;
+        another.emitLifecycle(DEVICE.DISCONNECT);
+    }
 
     private getSessionChangePromise() {
         if (!this.sessionDfd) {
@@ -990,13 +1002,32 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
         this.transport.off(TRANSPORT.STOPPED, this.onTransportStopped);
         this.transport.deviceEvents.off(this.transportPath, this.onTransportDeviceEvent);
-        this.removeAllListeners();
+        this.removeAllListeners(); // TODO maybe not?
 
         this.sessionDfd?.reject(new Error());
 
         if (this.sessionAcquired) {
             this.transport.releaseSync(this.sessionAcquired);
             this.sessionAcquired = null; // set to null to prevent transport.release and cancelableAction
+        }
+
+        // yolo
+        for (let next = this.backupTransports.shift(); next; next = this.backupTransports.shift()) {
+            const [transport, transportPath] = next;
+            const descriptor = transport.getDescriptor(transportPath);
+            if (descriptor) {
+                this.transport = transport;
+                this.transportPath = transportPath;
+                this.possibleHIDdevice = [0, 2].includes(descriptor.type);
+                this.bluetoothProps = descriptor.id ? { id: descriptor.id } : undefined;
+
+                transport.on(TRANSPORT.STOPPED, this.onTransportStopped);
+                transport.deviceEvents.on(transportPath, this.onTransportDeviceEvent);
+
+                this.emitLifecycle(DEVICE.CHANGED);
+
+                return;
+            }
         }
 
         this.emitLifecycle(DEVICE.DISCONNECT);
@@ -1089,8 +1120,8 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     // simplified object to pass via postMessage
     toMessageObject(): DeviceTyped {
-        const { name, uniquePath: path } = this;
-        const base = { path, name };
+        const { name, mergedInto, uniquePath: path } = this;
+        const base = { path, name, mergedInto };
 
         if (this.unreadableError) {
             return {

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -147,6 +147,19 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
             transport,
             descriptor,
             listener: lifecycle => {
+                if (lifecycle === DEVICE.CONNECT) {
+                    const dup = this.devices.find(
+                        d =>
+                            d.features?.device_id &&
+                            d.features.device_id === device.features?.device_id &&
+                            d.getUniquePath() !== device.getUniquePath(),
+                    );
+
+                    if (dup) {
+                        return dup.mergeWith(device);
+                    }
+                }
+
                 if (lifecycle === DEVICE.DISCONNECT) {
                     this.authPenaltyManager.remove(device);
                     const index = this.devices.indexOf(device);

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -76,6 +76,7 @@ export const DeviceUniquePath = (id: string) => id as DeviceUniquePath;
 type BaseDevice = {
     path: DeviceUniquePath;
     name: string;
+    mergedInto?: DeviceUniquePath;
 };
 
 export type BluetoothDeviceProps = {


### PR DESCRIPTION
## Description

This PR should allow to have one device accessible by more transports (typically usb+bluetooth) and switching between them when one becomes disabled.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/multi-transport-device&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/multi-transport-device&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/multi-transport-device&lookback=7)