### PR TITLE
fix(suite-native): update account picker text for portfolio tracker

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -1565,13 +1565,18 @@ export const en = {
         accountScreen: {
             accountEmpty: {
                 viewOnly: {
-                    title: 'No account found',
+                    title: 'Account not found',
                     description: 'You need to connect your device to add new account.',
                 },
                 networkNotEnabled: {
-                    title: 'No account found',
+                    title: 'Account not found',
                     description:
-                        "It seems that you don't have any account matching selected asset.",
+                        'It seems that you don’t have any account matching selected asset.',
+                },
+                portfolioTracker: {
+                    title: 'Account not found',
+                    description:
+                        'You don’t have an account for this asset imported in Portfolio Tracker.',
                 },
             },
             addressEmpty: {

--- a/suite-native/module-trading/src/components/general/AccountSheet/NoAccountsComponent.tsx
+++ b/suite-native/module-trading/src/components/general/AccountSheet/NoAccountsComponent.tsx
@@ -1,8 +1,11 @@
 import { useSelector } from 'react-redux';
 
-import { selectIsDeviceInViewOnlyMode } from '@suite-common/wallet-core';
+import {
+    selectIsDeviceInViewOnlyMode,
+    selectIsPortfolioTrackerDevice,
+} from '@suite-common/wallet-core';
 import { Text, VStack } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
+import { Translation, TxKeyPath } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type NoAccountsComponentProps = {
@@ -34,33 +37,39 @@ const contentStyle = prepareNativeStyle<{ isBottomRounded: boolean }>(
 export const NoAccountsComponent = ({ isBottomRounded }: NoAccountsComponentProps) => {
     const { applyStyle } = useNativeStyles();
     const isDeviceInViewOnlyMode = useSelector(selectIsDeviceInViewOnlyMode);
+    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
 
-    const title = (
-        <Translation
-            id={
-                isDeviceInViewOnlyMode
-                    ? 'moduleTrading.accountScreen.accountEmpty.viewOnly.title'
-                    : 'moduleTrading.accountScreen.accountEmpty.networkNotEnabled.title'
-            }
-        />
-    );
-    const description = (
-        <Translation
-            id={
-                isDeviceInViewOnlyMode
-                    ? 'moduleTrading.accountScreen.accountEmpty.viewOnly.description'
-                    : 'moduleTrading.accountScreen.accountEmpty.networkNotEnabled.description'
-            }
-        />
-    );
+    const getContent = (): { title: TxKeyPath; description: TxKeyPath } => {
+        if (isPortfolioTrackerDevice) {
+            return {
+                title: 'moduleTrading.accountScreen.accountEmpty.portfolioTracker.title',
+                description:
+                    'moduleTrading.accountScreen.accountEmpty.portfolioTracker.description',
+            };
+        }
+
+        if (isDeviceInViewOnlyMode) {
+            return {
+                title: 'moduleTrading.accountScreen.accountEmpty.viewOnly.title',
+                description: 'moduleTrading.accountScreen.accountEmpty.viewOnly.description',
+            };
+        }
+
+        return {
+            title: 'moduleTrading.accountScreen.accountEmpty.networkNotEnabled.title',
+            description: 'moduleTrading.accountScreen.accountEmpty.networkNotEnabled.description',
+        };
+    };
+
+    const { title, description } = getContent();
 
     return (
         <VStack style={applyStyle(contentStyle, { isBottomRounded })}>
             <Text variant="body" color="textDefault" textAlign="center">
-                {title}
+                <Translation id={title} />
             </Text>
             <Text variant="hint" color="textSubdued" textAlign="center">
-                {description}
+                <Translation id={description} />
             </Text>
         </VStack>
     );

--- a/suite-native/module-trading/src/components/general/AccountSheet/__tests__/NoAccountsComponent.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountSheet/__tests__/NoAccountsComponent.comp.test.tsx
@@ -3,13 +3,20 @@ import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
 import { NoAccountsComponent } from '../NoAccountsComponent';
 
 describe('NoAccountsComponent', () => {
-    const renderNoAccountsComponent = ({ isConnected }: { isConnected: boolean }) =>
+    const renderNoAccountsComponent = ({
+        isConnected,
+        id,
+    }: {
+        isConnected: boolean;
+        id?: string;
+    }) =>
         renderWithStoreProviderAsync(<NoAccountsComponent isBottomRounded />, {
             preloadedState: {
                 device: {
                     selectedDevice: {
                         remember: true,
                         connected: isConnected,
+                        id,
                     },
                 },
             },
@@ -25,7 +32,18 @@ describe('NoAccountsComponent', () => {
         const { queryByText } = await renderNoAccountsComponent({ isConnected: true });
 
         expect(
-            queryByText("It seems that you don't have any account matching selected asset."),
+            queryByText('It seems that you don’t have any account matching selected asset.'),
+        ).toBeTruthy();
+    });
+
+    it('should render for portfolio tracker', async () => {
+        const { queryByText } = await renderNoAccountsComponent({
+            isConnected: false,
+            id: 'hiddenDeviceWithImportedAccounts',
+        });
+
+        expect(
+            queryByText('You don’t have an account for this asset imported in Portfolio Tracker.'),
         ).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/screens/__tests__/ReceiveAccountsPickerScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/ReceiveAccountsPickerScreen.comp.test.tsx
@@ -70,7 +70,7 @@ describe('ReceiveAccountsPickerScreen', () => {
 
         const { getByText } = await renderScreen(getPreloadedState([]));
 
-        expect(getByText('No account found')).toBeTruthy();
+        expect(getByText('Account not found')).toBeTruthy();
     });
 
     it('should render add account button', async () => {


### PR DESCRIPTION
## Description

Update account picker text for portfolio tracker

## Related Issue

Resolve #18524  

## Screenshots:
<img src="https://github.com/user-attachments/assets/d61ebba8-fcf8-40e4-8cae-972c4fb198e5" width="300">





🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=18524-mobile-trade-buy-suggests-connecting-a-trezor-device-for-iphone&lookback=7)