### PR TITLE
chore(ci): sanitize branch names for connect popup build

### DIFF
--- a/.github/workflows/test-connect-popup.yml
+++ b/.github/workflows/test-connect-popup.yml
@@ -42,12 +42,18 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
+      sanitized_branch: ${{ steps.sanitize_branch.outputs.sanitized_branch }}
     steps:
       - name: Extract branch name
         id: extract_branch
         run: |
           BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: Sanitize branch name for URLs
+        id: sanitize_branch
+        run: |
+          echo "sanitized_branch=$(echo '${{ steps.extract_branch.outputs.branch }}' | tr -d '+#@&=?\\:*')" >> "$GITHUB_OUTPUT"
 
   build-deploy:
     needs: [extract-branch]
@@ -64,7 +70,7 @@ jobs:
           awsRoleToAssume: "arn:aws:iam::538326561891:role/gh_actions_trezor_suite_dev_deploy"
           awsRegion: "eu-central-1"
           serverHostname: "dev.suite.sldev.cz"
-          serverPath: "connect/${{ needs.extract-branch.outputs.branch }}"
+          serverPath: "connect/${{ needs.extract-branch.outputs.sanitized_branch }}"
           uploadArtifacts: "true"
           buildArtifacts: "true"
           nodeEnv: "development"


### PR DESCRIPTION
## Description

Sanitize branch names for connect popup build base URL
- otherwise it can crash with a cryptic error ([example](https://github.com/trezor/trezor-suite/actions/runs/14790555386/job/41537324275?pr=18677)) that can be hard to debug.
- now it will strip those characters: [run for `invalid+#@&=branch`](https://github.com/trezor/trezor-suite/actions/runs/14802000612/job/41562664577), successfully [deployed here](https://dev.suite.sldev.cz/connect/invalidbranch/)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/connect-popup-build-sanitize-branch-name&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/connect-popup-build-sanitize-branch-name&lookback=7)