### PR TITLE
feat(suite-native): handle trade closing using deeplinks

### DIFF
--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -42,6 +42,7 @@ import {
     selectTradingTradeByOrderId,
     selectTradingTrades,
     selectTradingTradesByTradeType,
+    selectTradingTradesByTradeTypeOrderedByDate,
     selectValidTradingBuyQuotes,
 } from '../tradingSelectors';
 
@@ -137,8 +138,26 @@ describe('tradingSelectors', () => {
                         tradingAccountKey: accountEth.key,
                     },
                     trades: [
-                        { tradeType: 'buy', data: { orderId: 'orderId1' } },
-                        { tradeType: 'exchange', data: { orderId: 'orderId2' } },
+                        {
+                            tradeType: 'buy',
+                            data: { orderId: 'orderId1' },
+                            date: '2024-03-01T10:00:00Z',
+                        },
+                        {
+                            tradeType: 'buy',
+                            data: { orderId: 'orderId2' },
+                            date: '2024-03-02T10:00:00Z',
+                        },
+                        {
+                            tradeType: 'buy',
+                            data: { orderId: 'orderId3' },
+                            date: '2024-03-03T10:00:00Z',
+                        },
+                        {
+                            tradeType: 'exchange',
+                            data: { orderId: 'orderId4' },
+                            date: '2024-03-04T10:00:00Z',
+                        },
                     ],
                     composedTransactionInfo: {
                         composed: {
@@ -375,16 +394,52 @@ describe('tradingSelectors', () => {
             {
                 data: { orderId: 'orderId1' },
                 tradeType: 'buy',
+                date: '2024-03-01T10:00:00Z',
+            },
+            {
+                data: { orderId: 'orderId2' },
+                tradeType: 'buy',
+                date: '2024-03-02T10:00:00Z',
+            },
+            {
+                data: { orderId: 'orderId3' },
+                tradeType: 'buy',
+                date: '2024-03-03T10:00:00Z',
             },
         ]);
         expect(selectTradingTradesByTradeType(state, 'exchange')).toStrictEqual([
             {
-                data: { orderId: 'orderId2' },
+                data: { orderId: 'orderId4' },
                 tradeType: 'exchange',
+                date: '2024-03-04T10:00:00Z',
             },
         ]);
 
         expect(selectTradingTradesByTradeType(state, 'sell')).toStrictEqual([]);
+    });
+
+    describe('selectTradingTradesByTradeTypeOrderedByDate', () => {
+        it('should return trades ordered by date in descending order', () => {
+            const result = selectTradingTradesByTradeTypeOrderedByDate(state, 'buy');
+
+            expect(result).toHaveLength(3);
+            expect(result[0].data.orderId).toBe('orderId3');
+            expect(result[1].data.orderId).toBe('orderId2');
+            expect(result[2].data.orderId).toBe('orderId1');
+        });
+
+        it('should return empty array for trade type with no trades', () => {
+            const result = selectTradingTradesByTradeTypeOrderedByDate(state, 'sell');
+
+            expect(result).toHaveLength(0);
+        });
+
+        it('should be stable', () => {
+            const first = selectTradingTradesByTradeTypeOrderedByDate(state, 'buy');
+            const second = selectTradingTradesByTradeTypeOrderedByDate(state, 'buy');
+
+            expect(first).toBe(second);
+        });
     });
 
     it('selectHasTradingTradesOfTradeType should return correctly whether there is a trade', () => {
@@ -397,7 +452,7 @@ describe('tradingSelectors', () => {
     });
 
     it('selectTradingTradeByOrderId should return undefined when orderId is not found', () => {
-        expect(selectTradingTradeByOrderId(state, 'orderId4')).toBeUndefined();
+        expect(selectTradingTradeByOrderId(state, 'unknown_order')).toBeUndefined();
     });
 
     it('selectTradingCoinInfoByCryptoId should return coin data', () => {

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -218,6 +218,13 @@ export const selectTradingTradesByTradeType: (
     (trades, tradeType) => returnStableArrayIfEmpty(trades.filter(t => t.tradeType === tradeType)),
 );
 
+export const selectTradingTradesByTradeTypeOrderedByDate: (
+    state: TradingRootState,
+    tradeType: TradingType,
+) => TradingTransaction[] = createMemoizedSelector([selectTradingTradesByTradeType], trades =>
+    trades.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()),
+);
+
 export const selectHasTradingTradesOfTradeType = (
     state: TradingRootState,
     tradeType: TradingType,

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -24,6 +24,7 @@
         "@trezor/connect": "workspace:*",
         "@trezor/utils": "workspace:*",
         "expo-linear-gradient": "^14.0.1",
+        "expo-linking": "^7.0.5",
         "react": "18.2.0",
         "react-native": "0.76.9",
         "react-native-reanimated": "^3.16.7",

--- a/suite-native/module-trading/src/__tests__/tradingSlice.test.ts
+++ b/suite-native/module-trading/src/__tests__/tradingSlice.test.ts
@@ -8,9 +8,11 @@ import { adaAsset, btcAsset, usdcAsset } from '../__fixtures__/tradeableAssets';
 import {
     TradingState,
     addTradeableAssetToFavourites,
+    clearTradeOrderIdToBeOpened,
     initialState,
     removeTradeableAssetFromFavourites,
     setBuySelectedReceiveAccount,
+    setTradeOrderIdToBeOpened,
     setTradingEnvironment,
     tradingSlice,
 } from '../tradingSlice';
@@ -120,10 +122,19 @@ describe('tradingSlice', () => {
             expect(state.tradingEnvironment).toBe('production');
         });
 
-        it('setTradingEnvironment should set trading environment', () => {
+        it('setTradingEnvironment should set trading environment and clear buy state', () => {
             const state = tradingReducer(undefined, setTradingEnvironment('dev'));
 
             expect(state.tradingEnvironment).toBe('dev');
+            expect(state.buy).toEqual({
+                selectedReceiveAccount: undefined,
+                quotesRequest: undefined,
+                quotes: [],
+                selectedQuote: undefined,
+                amountLimits: undefined,
+                isFromRedirect: false,
+                isLoading: false,
+            });
         });
     });
 
@@ -193,6 +204,30 @@ describe('tradingSlice', () => {
                 quotes: [],
                 selectedQuote: expect.any(Object),
             });
+        });
+    });
+
+    describe('tradeOrderIdToBeOpened', () => {
+        it('should have undefined as initial tradeOrderIdToBeOpened', () => {
+            const state = tradingReducer(undefined, { type: 'undefined_action' });
+
+            expect(state.tradeOrderIdToBeOpened).toBeUndefined();
+        });
+
+        it('setTradeOrderIdToBeOpened should set tradeOrderIdToBeOpened', () => {
+            const state = tradingReducer(undefined, setTradeOrderIdToBeOpened('orderId'));
+
+            expect(state.tradeOrderIdToBeOpened).toBe('orderId');
+        });
+    });
+
+    describe('clearTradeOrderIdToBeOpened', () => {
+        it('should clear tradeOrderIdToBeOpened', () => {
+            const actions = [setTradeOrderIdToBeOpened('orderId'), clearTradeOrderIdToBeOpened()];
+
+            const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+            expect(state.tradeOrderIdToBeOpened).toBeUndefined();
         });
     });
 });

--- a/suite-native/module-trading/src/components/general/TradeDetailSheet/__tests__/TradeDetailFooter.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeDetailSheet/__tests__/TradeDetailFooter.comp.test.tsx
@@ -72,7 +72,7 @@ describe('TradeDetailFooter', () => {
 
         expect(mockNavigation.navigate).toHaveBeenCalledWith('TradingWebView', {
             closeCallbackUrl:
-                'trezorsuitelite://trading?action=trade&tradeType=buy&&orderId=d3ef3451-8f68-4250-9e08-580ece5e7d12',
+                'trezorsuitelite://trading?action=trade&tradeType=buy&orderId=d3ef3451-8f68-4250-9e08-580ece5e7d12',
             source: { uri: (buyTrade.data as BuyTrade).partnerData },
         });
     });

--- a/suite-native/module-trading/src/components/general/TradeDetailSheet/__tests__/TradeDetailFooter.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeDetailSheet/__tests__/TradeDetailFooter.comp.test.tsx
@@ -72,7 +72,7 @@ describe('TradeDetailFooter', () => {
 
         expect(mockNavigation.navigate).toHaveBeenCalledWith('TradingWebView', {
             closeCallbackUrl:
-                'suitetrading://buy/trade?orderId=d3ef3451-8f68-4250-9e08-580ece5e7d12',
+                'trezorsuitelite://trading?action=trade&tradeType=buy&&orderId=d3ef3451-8f68-4250-9e08-580ece5e7d12',
             source: { uri: (buyTrade.data as BuyTrade).partnerData },
         });
     });

--- a/suite-native/module-trading/src/screens/TradeHistoryScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradeHistoryScreen.tsx
@@ -8,7 +8,7 @@ import { FlashList } from '@shopify/flash-list';
 import {
     TradingRootState,
     TradingTransaction,
-    selectTradingTradesByTradeType,
+    selectTradingTradesByTradeTypeOrderedByDate,
 } from '@suite-common/trading';
 import { useTranslate } from '@suite-native/intl';
 import {
@@ -45,7 +45,7 @@ export const TradeHistoryScreen = () => {
     const [detailOrderId, setDetailOrderId] = useState<string | undefined>(undefined);
     const { isSheetVisible, showSheet, hideSheet } = useBottomSheetControls();
     const trades = useSelector((state: TradingRootState) =>
-        selectTradingTradesByTradeType(state, tradeType),
+        selectTradingTradesByTradeTypeOrderedByDate(state, tradeType),
     );
 
     const handleSelectedTrade = useCallback(

--- a/suite-native/module-trading/src/screens/TradeHistoryScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradeHistoryScreen.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { RouteProp, useRoute } from '@react-navigation/native';
 import { FlashList } from '@shopify/flash-list';
@@ -25,6 +25,8 @@ import {
     TradeHistoryListItem,
 } from '../components/general/TradeHistory/TradeHistoryListItem';
 import { useBottomSheetControls } from '../hooks/useBottomSheetControls';
+import { selectTradeToBeOpened } from '../selectors/commonSelectors';
+import { clearTradeOrderIdToBeOpened } from '../tradingSlice';
 
 const contentContainerStyle = prepareNativeStyle<{
     insetBottom: number;
@@ -40,13 +42,14 @@ export const TradeHistoryScreen = () => {
     } = useRoute<RouteProp<TradingStackParamList, TradingStackRoutes.TradeHistory>>();
     const { applyStyle } = useNativeStyles();
     const { translate } = useTranslate();
+    const dispatch = useDispatch();
     const { bottom: insetBottom } = useSafeAreaInsets();
-
+    const tradeToBeOpened = useSelector(selectTradeToBeOpened);
     const [detailOrderId, setDetailOrderId] = useState<string | undefined>(undefined);
-    const { isSheetVisible, showSheet, hideSheet } = useBottomSheetControls();
     const trades = useSelector((state: TradingRootState) =>
         selectTradingTradesByTradeTypeOrderedByDate(state, tradeType),
     );
+    const { isSheetVisible, showSheet, hideSheet } = useBottomSheetControls();
 
     const handleSelectedTrade = useCallback(
         (trade: TradingTransaction) => {
@@ -59,6 +62,14 @@ export const TradeHistoryScreen = () => {
         },
         [isSheetVisible, showSheet],
     );
+
+    useEffect(() => {
+        // if there was trade to be opened, open it right away and clear the tradeOrderIdToBeOpened
+        if (tradeToBeOpened) {
+            handleSelectedTrade(tradeToBeOpened);
+            dispatch(clearTradeOrderIdToBeOpened());
+        }
+    }, [tradeToBeOpened, handleSelectedTrade, dispatch]);
 
     const renderItem = ({ item }: { item: TradingTransaction }) => (
         <TradeHistoryListItem transaction={item} onPress={() => handleSelectedTrade(item)} />

--- a/suite-native/module-trading/src/screens/TradingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingScreen.tsx
@@ -1,21 +1,35 @@
+import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
 
 import { Context } from '@suite-common/message-system';
 import { DeviceManagerScreenHeader } from '@suite-native/device-manager';
 import { ContextMessage } from '@suite-native/message-system';
-import { Screen } from '@suite-native/navigation';
+import { Screen, TradingStackRoutes } from '@suite-native/navigation';
 
 import { BuyForm } from '../components/buy/BuyForm';
 import { BuyFormContextProvider } from '../components/buy/BuyFormContextProvider';
 import { BuyFormSkeleton } from '../components/buy/BuyFormSkeleton';
+import { NavigationProps } from '../components/general/TradeHistory/TradeHistoryButton';
 import { useTradingBuyData } from '../hooks/useTradingBuyData';
-import { selectIsTradingBuyEnabled } from '../selectors/commonSelectors';
+import { selectIsTradingBuyEnabled, selectTradeToBeOpened } from '../selectors/commonSelectors';
 
 export const TradingScreen = () => {
     const isTradingBuyEnabled = useSelector(selectIsTradingBuyEnabled);
     const { isLoading, lastLoadedTimestamp } = useTradingBuyData();
+    const tradeToBeOpened = useSelector(selectTradeToBeOpened);
+    const navigation = useNavigation<NavigationProps>();
 
     const displaySkeleton = isLoading || lastLoadedTimestamp === 0;
+
+    useEffect(() => {
+        if (tradeToBeOpened) {
+            navigation.navigate(TradingStackRoutes.TradeHistory, {
+                tradeType: tradeToBeOpened.tradeType,
+            });
+        }
+    }, [tradeToBeOpened, navigation]);
 
     return (
         <Screen header={<DeviceManagerScreenHeader />}>

--- a/suite-native/module-trading/src/screens/TradingWebviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingWebviewScreen.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect } from 'react';
 import { ActivityIndicator } from 'react-native';
 import { WebView } from 'react-native-webview';
+import { useDispatch } from 'react-redux';
 
 import { useNavigation, useRoute } from '@react-navigation/native';
-import * as ExpoLinking from 'expo-linking';
+import { useURL } from 'expo-linking';
 import { WebViewSource } from 'react-native-webview/lib/WebViewTypes';
 
 import { Text } from '@suite-native/atoms';
@@ -17,7 +18,11 @@ import {
 } from '@suite-native/navigation';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
-import { TRADING_URL_DEFAULT_BACK } from '../utils/tradeFormUtils';
+import { setTradeOrderIdToBeOpened } from '../tradingSlice';
+import {
+    TRADING_URL_DEFAULT_BACK,
+    getTradeTypeActionAndOrderIdFromUrl,
+} from '../utils/tradeFormUtils';
 
 type RouteProps = StackProps<RootStackParamList, RootStackRoutes.TradingWebView>['route'];
 
@@ -29,20 +34,26 @@ export const TradingWebViewScreen = () => {
     } = useRoute<RouteProps>();
     const navigation = useNavigation();
     const { applyStyle } = useNativeStyles();
-    const receivedDeeplinkUrl = ExpoLinking.useURL();
+    const dispatch = useDispatch();
+    const receivedDeeplinkUrl = useURL();
 
-    // when url matches closeCallbackUrl or TRADING_URL_DEFAULT_BACK, go back
+    // when url matches closeCallbackUrl or TRADING_URL_DEFAULT_BACK, go back and mark the trade to be opened
     const checkForGoBackOnUrl = useCallback(
         (url: string | null) => {
-            if ([closeCallbackUrl, TRADING_URL_DEFAULT_BACK].includes(url ?? '')) {
+            const urlString = url ?? '';
+            if ([closeCallbackUrl, TRADING_URL_DEFAULT_BACK].includes(urlString)) {
+                const { orderId } = getTradeTypeActionAndOrderIdFromUrl(urlString);
+                if (orderId) {
+                    dispatch(setTradeOrderIdToBeOpened(orderId));
+                }
                 navigation.goBack();
 
-                return true;
+                return false;
             }
 
-            return false;
+            return true;
         },
-        [closeCallbackUrl, navigation],
+        [closeCallbackUrl, dispatch, navigation],
     );
 
     useEffect(() => {
@@ -75,7 +86,7 @@ export const TradingWebViewScreen = () => {
                 style={applyStyle(webViewStyle)}
                 source={{ ...sourceData }}
                 onShouldStartLoadWithRequest={(request: { url: string }) =>
-                    !checkForGoBackOnUrl(request.url)
+                    checkForGoBackOnUrl(request.url)
                 }
                 startInLoadingState={true}
                 renderLoading={() => <ActivityIndicator size="large" />}

--- a/suite-native/module-trading/src/screens/TradingWebviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingWebviewScreen.tsx
@@ -1,7 +1,9 @@
+import { useCallback, useEffect } from 'react';
 import { ActivityIndicator } from 'react-native';
 import { WebView } from 'react-native-webview';
 
 import { useNavigation, useRoute } from '@react-navigation/native';
+import * as ExpoLinking from 'expo-linking';
 import { WebViewSource } from 'react-native-webview/lib/WebViewTypes';
 
 import { Text } from '@suite-native/atoms';
@@ -15,6 +17,8 @@ import {
 } from '@suite-native/navigation';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
+import { TRADING_URL_DEFAULT_BACK } from '../utils/tradeFormUtils';
+
 type RouteProps = StackProps<RootStackParamList, RootStackRoutes.TradingWebView>['route'];
 
 const webViewStyle = prepareNativeStyle(_ => ({ flex: 1 }));
@@ -25,6 +29,25 @@ export const TradingWebViewScreen = () => {
     } = useRoute<RouteProps>();
     const navigation = useNavigation();
     const { applyStyle } = useNativeStyles();
+    const receivedDeeplinkUrl = ExpoLinking.useURL();
+
+    // when url matches closeCallbackUrl or TRADING_URL_DEFAULT_BACK, go back
+    const checkForGoBackOnUrl = useCallback(
+        (url: string | null) => {
+            if ([closeCallbackUrl, TRADING_URL_DEFAULT_BACK].includes(url ?? '')) {
+                navigation.goBack();
+
+                return true;
+            }
+
+            return false;
+        },
+        [closeCallbackUrl, navigation],
+    );
+
+    useEffect(() => {
+        checkForGoBackOnUrl(receivedDeeplinkUrl);
+    }, [checkForGoBackOnUrl, receivedDeeplinkUrl]);
 
     if (!source?.uri && !source?.html) {
         return (
@@ -51,16 +74,9 @@ export const TradingWebViewScreen = () => {
             <WebView
                 style={applyStyle(webViewStyle)}
                 source={{ ...sourceData }}
-                // go back on closeCallbackUrl
-                onShouldStartLoadWithRequest={(request: { url: string }) => {
-                    if (closeCallbackUrl && request.url.startsWith(closeCallbackUrl)) {
-                        navigation.goBack();
-
-                        return false; // Prevent WebView from loading the URL
-                    }
-
-                    return true; // Allow navigation
-                }}
+                onShouldStartLoadWithRequest={(request: { url: string }) =>
+                    !checkForGoBackOnUrl(request.url)
+                }
                 startInLoadingState={true}
                 renderLoading={() => <ActivityIndicator size="large" />}
             />

--- a/suite-native/module-trading/src/selectors/commonSelectors.ts
+++ b/suite-native/module-trading/src/selectors/commonSelectors.ts
@@ -30,3 +30,11 @@ export const selectIsTradingEnabled = (state: MessageSystemRootState & FeatureFl
     selectIsTradingBuyEnabled(state) ||
     selectIsTradingSwapEnabled(state) ||
     selectIsTradingSellEnabled(state);
+
+// trade for opening in detail
+export const selectTradeToBeOpened = (state: TradingRootState) => {
+    const orderId = state.wallet.tradingNew.tradeOrderIdToBeOpened;
+    if (!orderId) return undefined;
+
+    return state.wallet.tradingNew.trades.find(trade => trade.data.orderId === orderId);
+};

--- a/suite-native/module-trading/src/tradingSlice.ts
+++ b/suite-native/module-trading/src/tradingSlice.ts
@@ -20,6 +20,7 @@ export interface TradingState extends CommonTradingState {
     buy: TradingBuyState;
     favouriteAssets: Record<CryptoId, true>;
     tradingEnvironment: InvityServerEnvironment;
+    tradeOrderIdToBeOpened: string | undefined;
 }
 
 export type TradingRootState = {
@@ -33,6 +34,7 @@ export const initialState: TradingState = {
     buy: { ...commonInitialState.buy, selectedReceiveAccount: undefined },
     favouriteAssets: {},
     tradingEnvironment: 'production',
+    tradeOrderIdToBeOpened: undefined,
 };
 
 export const tradingSlice = createSliceWithExtraDeps({
@@ -53,6 +55,13 @@ export const tradingSlice = createSliceWithExtraDeps({
         },
         setTradingEnvironment: (state, { payload }: PayloadAction<InvityServerEnvironment>) => {
             state.tradingEnvironment = payload;
+            // clear buy state so everything is fetched for new environment
+            state.buy.selectedReceiveAccount = undefined;
+            state.buy.quotesRequest = undefined;
+            state.buy.quotes = [];
+            state.buy.selectedQuote = undefined;
+            state.buy.amountLimits = undefined;
+            state.tradeOrderIdToBeOpened = undefined;
         },
         clearBuyState: state => {
             state.buy.selectedReceiveAccount = undefined;
@@ -60,10 +69,17 @@ export const tradingSlice = createSliceWithExtraDeps({
             state.buy.quotes = [];
             state.buy.selectedQuote = undefined;
             state.buy.amountLimits = undefined;
+            state.tradeOrderIdToBeOpened = undefined;
         },
         clearQuotesAndQuotesRequest: state => {
             state.buy.quotesRequest = undefined;
             state.buy.quotes = [];
+        },
+        setTradeOrderIdToBeOpened: (state, { payload }: PayloadAction<string>) => {
+            state.tradeOrderIdToBeOpened = payload;
+        },
+        clearTradeOrderIdToBeOpened: state => {
+            state.tradeOrderIdToBeOpened = undefined;
         },
     },
     extraReducers: (builder, extra) => {
@@ -83,6 +99,8 @@ export const {
     setTradingEnvironment,
     clearBuyState,
     clearQuotesAndQuotesRequest,
+    setTradeOrderIdToBeOpened,
+    clearTradeOrderIdToBeOpened,
 } = tradingSlice.actions;
 
 export const createMemoizedSelector = createWeakMapSelector.withTypes<TradingRootState>();

--- a/suite-native/module-trading/src/utils/__tests__/tradeFormUtils.test.ts
+++ b/suite-native/module-trading/src/utils/__tests__/tradeFormUtils.test.ts
@@ -1,10 +1,12 @@
 import { trezorLogo } from '@suite-common/suite-constants';
 
 import {
+    BuildTradingUrlProps,
     applyHtmlTemplate,
     buildTradingUrl,
     getRequestFormSource,
     getSourceForForm,
+    getTradeTypeAndOrderIdFromUrl,
 } from '../tradeFormUtils';
 
 describe('tradeFormUtils', () => {
@@ -44,7 +46,7 @@ describe('tradeFormUtils', () => {
             <body>
                 <img style="margin-bottom:40px" alt="trezor logo" src="data:image/png;base64, ${trezorLogo}" />
                 CONTENT_TO_EMBED
-                <a style="margin-top:40px" href="suitetrading://">Go back</a>
+                <a style="margin-top:40px" href="trezorsuitelite://trading/back">Go back</a>
             </body>
         </html>
     `);
@@ -191,6 +193,73 @@ describe('buildTradingUrl', () => {
                 tradeType: 'buy',
                 orderId: '1234',
             }),
-        ).toBe('suitetrading://buy/quote?orderId=1234');
+        ).toBe('trezorsuitelite://trading?action=quote&tradeType=buy&&orderId=1234');
+    });
+});
+
+describe('getTradeTypeAndOrderIdFromUrl', () => {
+    it('should extract tradeType and orderId from valid URL', () => {
+        const url = 'trezorsuitelite://trading?action=trade&tradeType=buy&orderId=1234';
+        const result = getTradeTypeAndOrderIdFromUrl(url);
+
+        expect(result).toEqual({
+            tradeType: 'buy',
+            orderId: '1234',
+        });
+    });
+
+    it('should return null values when parameters are missing', () => {
+        const url = 'trezorsuitelite://trading?action=trade';
+        const result = getTradeTypeAndOrderIdFromUrl(url);
+
+        expect(result).toEqual({
+            tradeType: null,
+            orderId: null,
+        });
+    });
+
+    it('should handle URL with only tradeType', () => {
+        const url = 'trezorsuitelite://trading?action=trade&tradeType=sell';
+        const result = getTradeTypeAndOrderIdFromUrl(url);
+
+        expect(result).toEqual({
+            tradeType: 'sell',
+            orderId: null,
+        });
+    });
+
+    it('should handle URL with only orderId', () => {
+        const url = 'trezorsuitelite://trading?action=trade&orderId=5678';
+        const result = getTradeTypeAndOrderIdFromUrl(url);
+
+        expect(result).toEqual({
+            tradeType: null,
+            orderId: '5678',
+        });
+    });
+
+    it('should handle URL with multiple parameters', () => {
+        const url =
+            'trezorsuitelite://trading?action=trade&tradeType=exchange&orderId=9012&otherParam=value';
+        const result = getTradeTypeAndOrderIdFromUrl(url);
+
+        expect(result).toEqual({
+            tradeType: 'exchange',
+            orderId: '9012',
+        });
+    });
+
+    it.each<BuildTradingUrlProps>([
+        { actionType: 'quote', tradeType: 'buy', orderId: '1234' },
+        { actionType: 'trade', tradeType: 'sell', orderId: '5678' },
+        { actionType: 'quote', tradeType: 'exchange', orderId: '9012' },
+    ])('should correctly parse URL built by buildTradingUrl for %j', testCase => {
+        const url = buildTradingUrl(testCase);
+        const result = getTradeTypeAndOrderIdFromUrl(url);
+
+        expect(result).toEqual({
+            tradeType: testCase.tradeType,
+            orderId: testCase.orderId,
+        });
     });
 });

--- a/suite-native/module-trading/src/utils/__tests__/tradeFormUtils.test.ts
+++ b/suite-native/module-trading/src/utils/__tests__/tradeFormUtils.test.ts
@@ -6,7 +6,7 @@ import {
     buildTradingUrl,
     getRequestFormSource,
     getSourceForForm,
-    getTradeTypeAndOrderIdFromUrl,
+    getTradeTypeActionAndOrderIdFromUrl,
 } from '../tradeFormUtils';
 
 describe('tradeFormUtils', () => {
@@ -193,59 +193,64 @@ describe('buildTradingUrl', () => {
                 tradeType: 'buy',
                 orderId: '1234',
             }),
-        ).toBe('trezorsuitelite://trading?action=quote&tradeType=buy&&orderId=1234');
+        ).toBe('trezorsuitelite://trading?action=quote&tradeType=buy&orderId=1234');
     });
 });
 
-describe('getTradeTypeAndOrderIdFromUrl', () => {
+describe('getTradeTypeActionAndOrderIdFromUrl', () => {
     it('should extract tradeType and orderId from valid URL', () => {
         const url = 'trezorsuitelite://trading?action=trade&tradeType=buy&orderId=1234';
-        const result = getTradeTypeAndOrderIdFromUrl(url);
+        const result = getTradeTypeActionAndOrderIdFromUrl(url);
 
         expect(result).toEqual({
             tradeType: 'buy',
             orderId: '1234',
+            action: 'trade',
         });
     });
 
     it('should return null values when parameters are missing', () => {
-        const url = 'trezorsuitelite://trading?action=trade';
-        const result = getTradeTypeAndOrderIdFromUrl(url);
+        const url = 'trezorsuitelite://trading';
+        const result = getTradeTypeActionAndOrderIdFromUrl(url);
 
         expect(result).toEqual({
             tradeType: null,
             orderId: null,
+            action: null,
         });
     });
 
     it('should handle URL with only tradeType', () => {
         const url = 'trezorsuitelite://trading?action=trade&tradeType=sell';
-        const result = getTradeTypeAndOrderIdFromUrl(url);
+        const result = getTradeTypeActionAndOrderIdFromUrl(url);
 
         expect(result).toEqual({
             tradeType: 'sell',
             orderId: null,
+            action: 'trade',
         });
     });
 
     it('should handle URL with only orderId', () => {
         const url = 'trezorsuitelite://trading?action=trade&orderId=5678';
-        const result = getTradeTypeAndOrderIdFromUrl(url);
+        const result = getTradeTypeActionAndOrderIdFromUrl(url);
 
         expect(result).toEqual({
             tradeType: null,
             orderId: '5678',
+            action: 'trade',
         });
     });
 
     it('should handle URL with multiple parameters', () => {
         const url =
             'trezorsuitelite://trading?action=trade&tradeType=exchange&orderId=9012&otherParam=value';
-        const result = getTradeTypeAndOrderIdFromUrl(url);
+        const result = getTradeTypeActionAndOrderIdFromUrl(url);
 
         expect(result).toEqual({
             tradeType: 'exchange',
             orderId: '9012',
+            action: 'trade',
         });
     });
 
@@ -255,11 +260,12 @@ describe('getTradeTypeAndOrderIdFromUrl', () => {
         { actionType: 'quote', tradeType: 'exchange', orderId: '9012' },
     ])('should correctly parse URL built by buildTradingUrl for %j', testCase => {
         const url = buildTradingUrl(testCase);
-        const result = getTradeTypeAndOrderIdFromUrl(url);
+        const result = getTradeTypeActionAndOrderIdFromUrl(url);
 
         expect(result).toEqual({
             tradeType: testCase.tradeType,
             orderId: testCase.orderId,
+            action: testCase.actionType,
         });
     });
 });

--- a/suite-native/module-trading/src/utils/tradeFormUtils.ts
+++ b/suite-native/module-trading/src/utils/tradeFormUtils.ts
@@ -118,13 +118,23 @@ export const getSourceForForm = (form: FormResponse['form'] | undefined, backUrl
     return null;
 };
 
-export const buildTradingUrl = ({ actionType, tradeType, orderId }: BuildTradingUrlProps) =>
-    `${TRADING_URL_BASE}?action=${actionType}&tradeType=${tradeType}&${orderId ? `&orderId=${orderId}` : ''}`;
+export const buildTradingUrl = ({ actionType, tradeType, orderId }: BuildTradingUrlProps) => {
+    const url = new URL(TRADING_URL_BASE);
+    const { searchParams } = url;
+    searchParams.set('action', actionType);
+    searchParams.set('tradeType', tradeType);
+    if (orderId) {
+        searchParams.set('orderId', orderId);
+    }
 
-export const getTradeTypeAndOrderIdFromUrl = (url: string) => {
+    return url.toString();
+};
+
+export const getTradeTypeActionAndOrderIdFromUrl = (url: string) => {
     const urlObj = new URL(url);
     const tradeType = urlObj.searchParams.get('tradeType');
+    const action = urlObj.searchParams.get('action');
     const orderId = urlObj.searchParams.get('orderId');
 
-    return { tradeType, orderId };
+    return { tradeType, action, orderId };
 };

--- a/suite-native/module-trading/src/utils/tradeFormUtils.ts
+++ b/suite-native/module-trading/src/utils/tradeFormUtils.ts
@@ -15,13 +15,14 @@ type RequestFormSourceReturnType = {
     html?: string;
 };
 
-type BuildTradingUrlProps = {
+export type BuildTradingUrlProps = {
     actionType: 'quote' | 'trade';
     tradeType: TradingType;
     orderId: string | undefined;
 };
 
-export const TRADING_URL_SCHEME = 'suitetrading';
+export const TRADING_URL_BASE = 'trezorsuitelite://trading';
+export const TRADING_URL_DEFAULT_BACK = `${TRADING_URL_BASE}/back`;
 
 export const applyHtmlTemplate = (
     content = 'You may now close this window.',
@@ -61,7 +62,7 @@ export const applyHtmlTemplate = (
             <body>
                 <img style="margin-bottom:40px" alt="trezor logo" src="data:image/png;base64, ${trezorLogo}" />
                 ${content}
-                <a style="margin-top:40px" href="${options?.backUrl ?? `${TRADING_URL_SCHEME}://`}">Go back</a>
+                <a style="margin-top:40px" href="${options?.backUrl ?? TRADING_URL_DEFAULT_BACK}">Go back</a>
             </body>
         </html>
     `;
@@ -118,4 +119,12 @@ export const getSourceForForm = (form: FormResponse['form'] | undefined, backUrl
 };
 
 export const buildTradingUrl = ({ actionType, tradeType, orderId }: BuildTradingUrlProps) =>
-    `${TRADING_URL_SCHEME}://${tradeType}/${actionType}${orderId ? `?orderId=${orderId}` : ''}`;
+    `${TRADING_URL_BASE}?action=${actionType}&tradeType=${tradeType}&${orderId ? `&orderId=${orderId}` : ''}`;
+
+export const getTradeTypeAndOrderIdFromUrl = (url: string) => {
+    const urlObj = new URL(url);
+    const tradeType = urlObj.searchParams.get('tradeType');
+    const orderId = urlObj.searchParams.get('orderId');
+
+    return { tradeType, orderId };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -10798,6 +10798,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/utils": "workspace:*"
     expo-linear-gradient: "npm:^14.0.1"
+    expo-linking: "npm:^7.0.5"
     react: "npm:18.2.0"
     react-native: "npm:0.76.9"
     react-native-reanimated: "npm:^3.16.7"


### PR DESCRIPTION
- close webview by using deeplinks to make it work
- on closing webview, open trade detail

Resolve #18332




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=18332-mobile-trade-webview-does-not-close-on-finished-buy&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=18332-mobile-trade-webview-does-not-close-on-finished-buy&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=18332-mobile-trade-webview-does-not-close-on-finished-buy&lookback=7)