### PR TITLE
fix(suite-desktop-core): connect event was unsubscribed

### DIFF
--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
 
-import TrezorConnect, { DEVICE_EVENT } from '@trezor/connect';
+import TrezorConnect from '@trezor/connect';
 import { IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
 import { parseElectrumUrl } from '@trezor/utils';
 
@@ -86,9 +86,7 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
     const unregisterProxy = createIpcProxyHandler(ipcMain, 'TrezorConnect', ipcProxyOptions);
 
     const onLoad = () => {
-        TrezorConnect.on(DEVICE_EVENT, event => {
-            mainThreadEmitter.emit('module/trezor-connect/device-event', event);
-        });
+        // TODO: doing nothing for now.
     };
 
     const onQuit = () => {
@@ -103,6 +101,13 @@ export const init: ModuleInit = () => {
     const onLoad = () => {
         // reset previous instance, possible left over after renderer refresh (F5)
         TrezorConnect.dispose();
+
+        // Subscribe to events afer dispose since `dispose` unsubscribes all of them.
+
+        // TODO: This `DEVICE_EVENT` is currently not used, but it might be used to display events on tray.
+        // TrezorConnect.on(DEVICE_EVENT, event => {
+        //     mainThreadEmitter.emit('module/trezor-connect/device-event', event);
+        // });
     };
 
     return { onLoad };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I am not really familiar with `initBackground` but it looks to me that subscription to `DEVICE_EVENT` is not working since after there is `TrezorConnect.dispose();` that unsubscribe those events. WDYT @martykan ?

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/is-trezor-event-working&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/is-trezor-event-working&lookback=7)