### PR TITLE
fix(connect): `BleUnpair` race condition

### DIFF
--- a/packages/connect/src/api/bleUnpair.ts
+++ b/packages/connect/src/api/bleUnpair.ts
@@ -1,6 +1,7 @@
 import { Assert } from '@trezor/schema-utils';
+import { TRANSPORT_ERROR } from '@trezor/transport';
 
-import { PROTO } from '../constants';
+import { ERRORS, PROTO } from '../constants';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI } from '../events';
 
@@ -22,8 +23,24 @@ export default class BleUnpair extends AbstractMethod<'bleUnpair', PROTO.BleUnpa
     async run() {
         const cmd = this.device.getCommands();
         // unpair current bluetooth connection session or all known sessions
-        const response = await cmd.typedCall('BleUnpair', 'Success', this.params);
+        try {
+            const response = await cmd.typedCall('BleUnpair', 'Success', this.params);
 
-        return response.message;
+            return response.message;
+        } catch (error) {
+            // bluetooth race condition between DeviceList disconnect event and transport read error
+            // this method is either interrupted from the core as result of disconnect event, TrezorConnect call respond before we gets here
+            // or fails here with transport read/write error
+            // in both cases Device_Disconnected error should be handled as "expected success"
+            if (
+                this.device.bluetoothProps &&
+                error.message === TRANSPORT_ERROR.INTERFACE_DATA_TRANSFER
+            ) {
+                // typed error is considered as "method failed successfully"
+                throw ERRORS.TypedError('Device_Disconnected');
+            }
+
+            throw error;
+        }
     }
 }

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -122,9 +122,9 @@ export class Device extends TypedEmitter<DeviceEvents> {
     public readonly transport: Transport;
     public readonly protocol: TransportProtocol;
     public readonly transportPath;
+    public readonly bluetoothProps;
     private thp: protocolThp.ThpState | undefined;
     private readonly transportDescriptorType;
-    private readonly bluetoothProps;
     private session;
     private transportSessionOwner;
     private lastAcquiredHere;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix `BleUnpair` race condition, discovered by the mobile implementation

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-bleunpair&lookback=7)