### PR TITLE
fix(wallet-constants): solana epoch 2 days

### DIFF
--- a/packages/suite/src/components/suite/StakingProcess/StakingInfo.tsx
+++ b/packages/suite/src/components/suite/StakingProcess/StakingInfo.tsx
@@ -112,7 +112,9 @@ export const StakingInfo = ({ isExpanded }: StakingInfoProps) => {
         {
             heading: infoRowsData?.rewardsEarningHeading,
             subheading: <Translation id="TR_STAKING_REWARDS_ARE_RESTAKED" />,
-            content: { text: `~${apy}% p.a.` },
+            content: {
+                text: <Translation id="TR_STAKE_APY_APPROX" values={{ apyPercent: apy }} />,
+            },
         },
     ];
 

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -8837,6 +8837,10 @@ export default defineMessages({
         id: 'TR_STAKE_NETWORK_SEE_MONEY_DANCE_DESC',
         defaultMessage: 'Earn {apyPercent}% <t>APY</t> by staking your {symbol} with Trezor.',
     },
+    TR_STAKE_APY_APPROX: {
+        id: 'TR_STAKE_APY_APPROX',
+        defaultMessage: '~{apyPercent}% APY',
+    },
     TR_STAKE_APY_DESC: {
         id: 'TR_STAKE_APY_DESC',
         defaultMessage: '*Annual percentage yield',

--- a/suite-common/wallet-constants/src/solanaStakingConstants.ts
+++ b/suite-common/wallet-constants/src/solanaStakingConstants.ts
@@ -9,4 +9,4 @@ export const SOL_STAKING_OPERATION_FEE = new BigNumber(70_000); // 0.00007 SOL
 export const SOL_COMPUTE_UNIT_PRICE = 100000;
 export const SOL_COMPUTE_UNIT_LIMIT = 200000;
 
-export const SOLANA_EPOCH_DAYS = 3;
+export const SOLANA_EPOCH_DAYS = 2;

--- a/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
+++ b/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
@@ -308,7 +308,7 @@ describe('selectors', () => {
                     },
                     'sol1',
                 ),
-            ).toEqual('0.000564658');
+            ).toEqual('0.000376438');
         });
 
         it('should return "0" for account without activated or deactivating stake', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- texts will be changed in crowdin
- epoch time is 2 days
- there is no `$` in image anymore

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17982

## Screenshots:

![Screenshot 2025-05-05 at 13 18 58](https://github.com/user-attachments/assets/ba7ac223-3b41-44e3-9283-862c8ab25619)



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/staking3&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/staking3&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/staking3&lookback=7)