### PR TITLE
chore(suite-desktop): node-bridge rollout set to 10%

### DIFF
--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -101,8 +101,7 @@ const shouldUseLegacyBridge = (store: Dependencies['store']) => {
         store.setBridgeSettings({ ...store.getBridgeSettings(), newBridgeRollout });
     }
     const newBridgeRollout = store.getBridgeSettings().newBridgeRollout || 0;
-    // note that this variable is duplicated with UI
-    const NEW_BRIDGE_ROLLOUT_THRESHOLD = 0.01;
+    const NEW_BRIDGE_ROLLOUT_THRESHOLD = 0.1;
     const legacyBridgeReasonRollout = newBridgeRollout >= NEW_BRIDGE_ROLLOUT_THRESHOLD;
 
     return legacyBridgeReasonRollout;


### PR DESCRIPTION
or maybe 5% makes more sense 🤔. in that way that this time it would be increased 5times and next time 20times.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=node-bridge-rollout-bump&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=node-bridge-rollout-bump&lookback=7)