### PR TITLE
Trading - copyable contract with font matching to txid font

### DIFF
--- a/packages/suite/src/components/suite/copy/TxAddress.tsx
+++ b/packages/suite/src/components/suite/copy/TxAddress.tsx
@@ -7,6 +7,8 @@ import { copyToClipboard } from '@trezor/dom-utils';
 
 import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
 import { TrezorLink } from 'src/components/suite/TrezorLink';
+import { useSelector } from 'src/hooks/suite';
+import { selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
 
 const IconWrapper = styled.div`
     display: none;
@@ -60,14 +62,17 @@ interface IOAddressProps {
     txAddress?: string;
     explorerUrlQueryString?: string;
     shouldAllowCopy?: boolean;
+    shouldChunk?: boolean;
 }
 
-export const IOAddress = ({
+export const TxAddress = ({
     txAddress,
     explorerUrl,
     explorerUrlQueryString = '',
     shouldAllowCopy = true,
+    shouldChunk = false,
 }: IOAddressProps) => {
+    const isChunkedSettings = useSelector(selectAddressDisplayType);
     const [isClicked, setIsClicked] = useState(false);
     const theme = useTheme();
 
@@ -81,9 +86,14 @@ export const IOAddress = ({
         setIsClicked(true);
     };
 
+    const addSpacing = (value: string) => value.match(/.{1,4}/g)?.join(' ') || value;
+
     if (!txAddress) {
         return null;
     }
+
+    const formattedTxAddress =
+        shouldChunk && isChunkedSettings === 'chunked' ? addSpacing(txAddress) : txAddress;
 
     // HiddenPlaceholder disableKeepingWidth: it isn't needed (no numbers to redact), but inline-block disrupts overflow behavior
     return (
@@ -96,7 +106,7 @@ export const IOAddress = ({
                     $shouldAllowCopy={shouldAllowCopy}
                 >
                     <Text wordBreak="break-all" onClick={copy}>
-                        {txAddress}
+                        {formattedTxAddress}
                     </Text>
                     {shouldAllowCopy ? (
                         <IconWrapper onClick={copy}>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -22,7 +22,7 @@ import { Elevation, borders, mapElevationToBorder, spacings, spacingsPx } from '
 import { BigNumber } from '@trezor/utils';
 
 import { FormattedDateWithBullet, Translation } from 'src/components/suite';
-import { IOAddress } from 'src/components/suite/copy/IOAddress';
+import { TxAddress } from 'src/components/suite/copy/TxAddress';
 import { TransactionHeader } from 'src/components/wallet/TransactionItem/TransactionHeader';
 import { WalletAccountTransaction } from 'src/types/wallet';
 
@@ -140,7 +140,7 @@ export const BasicTxDetails = ({
 
                 {/* TX ID */}
                 <Item label={<Translation id="TR_TXID" />} iconName="fingerprint">
-                    <IOAddress
+                    <TxAddress
                         txAddress={tx.txid}
                         explorerUrl={explorerUrl}
                         explorerUrlQueryString={explorerUrlQueryString}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
@@ -22,7 +22,7 @@ import {
 import { spacings } from '@trezor/theme';
 
 import { FormattedCryptoAmount, FormattedNftAmount, Translation } from 'src/components/suite';
-import { IOAddress } from 'src/components/suite/copy/IOAddress';
+import { TxAddress } from 'src/components/suite/copy/TxAddress';
 import { UtxoAnonymity } from 'src/components/wallet';
 import { useSelector } from 'src/hooks/suite/useSelector';
 
@@ -64,7 +64,7 @@ const IOItem = ({
 
     return (
         <Column>
-            <IOAddress
+            <TxAddress
                 txAddress={address ?? ''}
                 explorerUrl={getExplorerUrl(explorer, 'address')}
                 explorerUrlQueryString={explorer?.queryString}

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
@@ -11,7 +11,7 @@ import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { goto } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite';
-import { IOAddress } from 'src/components/suite/copy/IOAddress';
+import { TxAddress } from 'src/components/suite/copy/TxAddress';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingDetailContext } from 'src/hooks/wallet/trading/useTradingDetail';
 import { tradeFinalStatuses } from 'src/hooks/wallet/trading/useTradingWatchTrade';
@@ -113,7 +113,7 @@ export const TradingDetailExchange = () => {
             <Card>
                 {receiveTxHash && (
                     <InfoItem label={<Translation id="TR_TXID" />}>
-                        <IOAddress
+                        <TxAddress
                             txAddress={receiveTxHash}
                             explorerUrl={network?.explorer.tx}
                             explorerUrlQueryString={network?.explorer.queryString}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendApproval.tsx
@@ -27,8 +27,8 @@ import {
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
-import { AccountLabeling, Address, Translation } from 'src/components/suite';
-import { IOAddress } from 'src/components/suite/copy/IOAddress';
+import { AccountLabeling, Translation } from 'src/components/suite';
+import { TxAddress } from 'src/components/suite/copy/TxAddress';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingExchangeWatchSendApproval } from 'src/hooks/wallet/trading/form/useTradingExchangeWatchSendApproval';
@@ -178,11 +178,11 @@ export const TradingOfferExchangeSendApproval = () => {
                     />
                 }
             >
-                <Address value={dexTx.to} />
+                <TxAddress txAddress={dexTx.to} shouldChunk />
             </InfoItem>
             {selectedQuote.approvalSendTxHash && (
                 <InfoItem label={<Translation id="TR_EXCHANGE_APPROVAL_TXID" />}>
-                    <IOAddress
+                    <TxAddress
                         txAddress={selectedQuote.approvalSendTxHash}
                         explorerUrl={getExplorerUrl(explorer, 'tx')}
                         explorerUrlQueryString={explorer?.queryString}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendSwap.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendSwap.tsx
@@ -26,7 +26,8 @@ import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { AccountLabeling, Address, FormattedCryptoAmount, Translation } from 'src/components/suite';
+import { AccountLabeling, FormattedCryptoAmount, Translation } from 'src/components/suite';
+import { TxAddress } from 'src/components/suite/copy/TxAddress';
 import { FORM_SEND_CRYPTO_CURRENCY_SELECT } from 'src/constants/wallet/trading/form';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { getTradingNetworkDecimals } from 'src/utils/wallet/trading/tradingUtils';
@@ -219,7 +220,7 @@ export const TradingOfferExchangeSendSwap = () => {
             <InfoItem
                 label={<Translation id="TR_EXCHANGE_SWAP_SEND_TO" values={translationValues} />}
             >
-                <Address value={dexTx.to} />
+                <TxAddress txAddress={dexTx.to} shouldChunk />
             </InfoItem>
 
             <Card


### PR DESCRIPTION
## Description

Changed contract font to match txid font + added option to copy it to clipboard.

## Related Issue

Resolve #18239 

## Screenshots:

<img width="735" alt="Screenshot 2025-05-05 at 15 10 42" src="https://github.com/user-attachments/assets/57562dfc-571e-4ea7-a4d5-733423940c34" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-contract-font&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-contract-font&lookback=7)