### PR TITLE
fix(suite): handle autostart before quit modal in Electron teardown

### DIFF
--- a/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts
@@ -45,7 +45,7 @@ const electronSetup = async (
     return suite;
 };
 
-const electronTeardown = async (suite: Suite, testInfo: TestInfo) => {
+const electronTeardown = async (suite: Suite, testInfo: TestInfo, electronConf: ElectronConf) => {
     const tracePath = `${testInfo.outputDir}/trace.electron.zip`;
     await suite.window.context().tracing.stop({ path: tracePath });
     testInfo.attachments.push({
@@ -63,7 +63,12 @@ const electronTeardown = async (suite: Suite, testInfo: TestInfo) => {
         path: getVideoPath(testInfo.outputDir),
         contentType: 'video/webm',
     });
-    await suite.electronApp.close();
+    const closePromise = suite.electronApp.close();
+    // Handle modal that asks to enable auto-start
+    if (electronConf.exposeConnectWs) {
+        await suite.window.getByTestId('@auto-start-before-quit/button-quit').click();
+    }
+    await closePromise;
 };
 
 const webSetup = async (browserContext: BrowserContext) => {
@@ -160,7 +165,7 @@ const suiteBaseTest = base.extend<suiteBaseFixture>({
             const suite = await electronSetup(testInfo, locale, colorScheme, electronConf);
             enhancePage(suite.window);
             await use(suite.window);
-            await electronTeardown(suite, testInfo);
+            await electronTeardown(suite, testInfo, electronConf);
         } else {
             const browserContext = await browser.newContext({
                 recordVideo: {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AutoStartBeforeQuitModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AutoStartBeforeQuitModal.tsx
@@ -32,13 +32,13 @@ export const AutoStartBeforeQuitModal = () => {
                 <>
                     <Modal.Button
                         onClick={() => handleBackground()}
-                        data-test="@auto-start-before-quit/button-background"
+                        data-testid="@auto-start-before-quit/button-background"
                     >
                         <Translation id="TR_RUN_IN_BACKGROUND" />
                     </Modal.Button>
                     <Modal.Button
                         onClick={() => handleQuit()}
-                        data-test="@auto-start-before-quit/button-quit"
+                        data-testid="@auto-start-before-quit/button-quit"
                         variant="tertiary"
                     >
                         <Translation id="TR_QUIT_NOW" />


### PR DESCRIPTION
## Description

Handle autostart before quit modal in Electron teardown


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-connect-test-autostart-modal&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-connect-test-autostart-modal&lookback=7)