### PR TITLE
fix(suite): keep `reconnectRequested` flag after wipeDevice

### DIFF
--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceDisconnectRequired.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceDisconnectRequired.tsx
@@ -2,6 +2,7 @@ import { Translation, TroubleshootingTips } from 'src/components/suite';
 
 export const DeviceDisconnectRequired = () => (
     <TroubleshootingTips
+        initiallyIsOpen={true}
         label={<Translation id="TR_DISCONNECT_YOUR_DEVICE" />}
         items={[
             {

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -625,6 +625,16 @@ export const setDeviceAuthenticity = (
     };
 };
 
+// called after successful wipeDevice
+const requestDeviceReconnect = (draft: DeviceReducerState) => {
+    // only acquired devices
+    if (!draft.selectedDevice?.features) return;
+    const index = deviceUtils.findInstanceIndex(draft.devices, draft.selectedDevice);
+    if (!draft.devices[index]) return;
+    draft.selectedDevice.reconnectRequested = true;
+    draft.devices[index].reconnectRequested = true;
+};
+
 export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (builder, extra) => {
     builder
         .addCase(deviceActions.deviceChanged, (state, { payload }) => {
@@ -672,9 +682,7 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
             removeButtonRequests(state, payload.device, payload.buttonRequestCode);
         })
         .addCase(deviceActions.requestDeviceReconnect, state => {
-            if (state.selectedDevice) {
-                state.selectedDevice.reconnectRequested = true;
-            }
+            requestDeviceReconnect(state);
         })
         .addCase(deviceActions.selectDevice, (state, { payload }) => {
             updateTimestamp(state, payload);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

looks like this bug is been here since forever

After successful  wipeDevice `dispatch(deviceActions.requestDeviceReconnect());` is called, 
it sets `reconnectRequested` flag only for selectedDevice,  state.devices array is not updated therefore next trigger of `updateSelectedDevice`  action will remove that flag (see screenshot console logs)

im not sure if the comment in [deviceSettingsActions](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/actions/settings/deviceSettingsActions.ts#L136-L142) is still valid since DeviceDisconnectRequired was never shown. tagging @mroz22 here for further investigation :)
and @komret  since it also changes the behavior in suite

![Screenshot from 2025-05-05 16-40-44](https://github.com/user-attachments/assets/03dbc0e4-792e-417e-bc98-d6afd8e3c724)



this fix will render a proper view: `DeviceDisconnectRequired` component in which i've opened TroubleshootingTips by default it looks confusing with closed
![Screenshot from 2025-05-05 17-30-47](https://github.com/user-attachments/assets/856b3e8f-f5f7-427a-bce0-ac8e307ff967)



 


## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-wipe-device&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-wipe-device&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-wipe-device&lookback=7)