### PR TITLE
feat(suite-native): Update trade status

### DIFF
--- a/suite-common/trading/src/__fixtures__/utils.ts
+++ b/suite-common/trading/src/__fixtures__/utils.ts
@@ -13,6 +13,7 @@ export const accountBtc = {
             },
         ],
     },
+    deviceState: 'staticSessionId',
 };
 
 export const accountEth = {
@@ -23,6 +24,7 @@ export const accountEth = {
     descriptor: 'eth-descriptor',
     key: 'eth-descriptor-eth',
     path: "m/44'/60'/0'/0/1",
+    deviceState: 'staticSessionId',
     tokens: [
         {
             type: 'ERC20',

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -4,6 +4,8 @@ import {
     TradingPaymentMethodProps,
     selectTradingBuyLoadingTimestampAndStatus,
 } from '@suite-common/trading';
+import { AccountsRootState, DeviceRootState } from '@suite-common/wallet-core';
+import { StaticSessionId } from '@trezor/connect';
 
 import coins from '../../__fixtures__/coins.json';
 import platforms from '../../__fixtures__/platforms.json';
@@ -16,7 +18,9 @@ import {
     TradingRootState,
     selectBestBuyQuoteByPaymentMethod,
     selectBuyQuotesByPaymentMethod,
-    selectHasTradingTradesOfTradeType,
+    selectDeviceHasTradingTradesOfTradeType,
+    selectDeviceTradingTradesByTradeType,
+    selectDeviceTradingTradesByTradeTypeOrderedByDate,
     selectTrading,
     selectTradingAccountAccordingActiveSection,
     selectTradingBuy,
@@ -44,13 +48,11 @@ import {
     selectTradingSymbolAndContractAddressByCryptoId,
     selectTradingTradeByOrderId,
     selectTradingTrades,
-    selectTradingTradesByTradeType,
-    selectTradingTradesByTradeTypeOrderedByDate,
     selectValidTradingBuyQuotes,
 } from '../tradingSelectors';
 
 describe('tradingSelectors', () => {
-    let state: TradingRootState;
+    let state: TradingRootState & DeviceRootState & AccountsRootState;
 
     const getBuyState = () =>
         ({
@@ -119,7 +121,6 @@ describe('tradingSelectors', () => {
                 },
             ],
         }) as TradingBuyState;
-
     const getState = () =>
         ({
             wallet: {
@@ -145,21 +146,55 @@ describe('tradingSelectors', () => {
                             tradeType: 'buy',
                             data: { orderId: 'orderId1' },
                             date: '2024-03-01T10:00:00Z',
+                            account: {
+                                descriptor: accountEth.descriptor,
+                                symbol: accountEth.symbol,
+                                accountType: accountEth.accountType,
+                                accountIndex: accountEth.index,
+                            },
                         },
                         {
                             tradeType: 'buy',
                             data: { orderId: 'orderId2' },
                             date: '2024-03-02T10:00:00Z',
+                            account: {
+                                descriptor: accountEth.descriptor,
+                                symbol: accountEth.symbol,
+                                accountType: accountEth.accountType,
+                                accountIndex: accountEth.index,
+                            },
                         },
                         {
                             tradeType: 'buy',
                             data: { orderId: 'orderId3' },
                             date: '2024-03-03T10:00:00Z',
+                            account: {
+                                descriptor: accountEth.descriptor,
+                                symbol: accountEth.symbol,
+                                accountType: accountEth.accountType,
+                                accountIndex: accountEth.index,
+                            },
                         },
                         {
                             tradeType: 'exchange',
                             data: { orderId: 'orderId4' },
                             date: '2024-03-04T10:00:00Z',
+                            account: {
+                                descriptor: accountEth.descriptor,
+                                symbol: accountEth.symbol,
+                                accountType: accountEth.accountType,
+                                accountIndex: accountEth.index,
+                            },
+                        },
+                        {
+                            tradeType: 'exchange',
+                            data: { orderId: 'orderId5' },
+                            account: {
+                                descriptor: accountEth.descriptor,
+                                symbol: accountEth.symbol,
+                                accountType: accountEth.accountType,
+                                accountIndex: accountEth.index,
+                            },
                         },
                     ],
                     composedTransactionInfo: {
@@ -172,6 +207,9 @@ describe('tradingSelectors', () => {
                 selectedAccount: {
                     account: accountBtc,
                     status: 'loaded',
+                    network: undefined,
+                    discovery: undefined,
+                    params: undefined,
                 },
                 accounts: [accountEth],
             },
@@ -181,7 +219,14 @@ describe('tradingSelectors', () => {
                     debug: { invityServerEnvironment: undefined },
                 },
             },
-        }) as TradingRootState;
+            device: {
+                selectedDevice: {
+                    state: {
+                        staticSessionId: 'staticSessionId' as StaticSessionId,
+                    },
+                },
+            },
+        }) as unknown as TradingRootState & DeviceRootState & AccountsRootState;
 
     beforeEach(() => {
         state = getState();
@@ -392,38 +437,19 @@ describe('tradingSelectors', () => {
         expect(selectTradingTrades(state)).toBe(state.wallet.tradingNew.trades);
     });
 
-    it('selectTradingTradesByTradeType should return only data for relevant tradeType', () => {
-        expect(selectTradingTradesByTradeType(state, 'buy')).toStrictEqual([
-            {
-                data: { orderId: 'orderId1' },
-                tradeType: 'buy',
-                date: '2024-03-01T10:00:00Z',
-            },
-            {
-                data: { orderId: 'orderId2' },
-                tradeType: 'buy',
-                date: '2024-03-02T10:00:00Z',
-            },
-            {
-                data: { orderId: 'orderId3' },
-                tradeType: 'buy',
-                date: '2024-03-03T10:00:00Z',
-            },
-        ]);
-        expect(selectTradingTradesByTradeType(state, 'exchange')).toStrictEqual([
-            {
-                data: { orderId: 'orderId4' },
-                tradeType: 'exchange',
-                date: '2024-03-04T10:00:00Z',
-            },
-        ]);
+    it('selectDeviceTradingTradesByTradeType should return only data for relevant tradeType', () => {
+        expect(
+            selectDeviceTradingTradesByTradeType(state, 'buy').map(t => t.data.orderId),
+        ).toStrictEqual(['orderId1', 'orderId2', 'orderId3']);
 
-        expect(selectTradingTradesByTradeType(state, 'sell')).toStrictEqual([]);
+        expect(
+            selectDeviceTradingTradesByTradeType(state, 'exchange').map(t => t.data.orderId),
+        ).toStrictEqual(['orderId4', 'orderId5']);
     });
 
-    describe('selectTradingTradesByTradeTypeOrderedByDate', () => {
+    describe('selectDeviceTradingTradesByTradeTypeOrderedByDate', () => {
         it('should return trades ordered by date in descending order', () => {
-            const result = selectTradingTradesByTradeTypeOrderedByDate(state, 'buy');
+            const result = selectDeviceTradingTradesByTradeTypeOrderedByDate(state, 'buy');
 
             expect(result).toHaveLength(3);
             expect(result[0].data.orderId).toBe('orderId3');
@@ -432,22 +458,22 @@ describe('tradingSelectors', () => {
         });
 
         it('should return empty array for trade type with no trades', () => {
-            const result = selectTradingTradesByTradeTypeOrderedByDate(state, 'sell');
+            const result = selectDeviceTradingTradesByTradeTypeOrderedByDate(state, 'sell');
 
             expect(result).toHaveLength(0);
         });
 
         it('should be stable', () => {
-            const first = selectTradingTradesByTradeTypeOrderedByDate(state, 'buy');
-            const second = selectTradingTradesByTradeTypeOrderedByDate(state, 'buy');
+            const first = selectDeviceTradingTradesByTradeTypeOrderedByDate(state, 'buy');
+            const second = selectDeviceTradingTradesByTradeTypeOrderedByDate(state, 'buy');
 
             expect(first).toBe(second);
         });
     });
 
-    it('selectHasTradingTradesOfTradeType should return correctly whether there is a trade', () => {
-        expect(selectHasTradingTradesOfTradeType(state, 'buy')).toBe(true);
-        expect(selectHasTradingTradesOfTradeType(state, 'sell')).toBe(false);
+    it('selectDeviceHasTradingTradesOfTradeType should return correctly whether there is a trade', () => {
+        expect(selectDeviceHasTradingTradesOfTradeType(state, 'buy')).toBe(true);
+        expect(selectDeviceHasTradingTradesOfTradeType(state, 'sell')).toBe(false);
     });
 
     it('selectTradingTradeByOrderId should find trade for correct orderId', () => {

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -2,6 +2,11 @@ import { Coins, CryptoId, FiatCurrencyCode } from 'invity-api';
 
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { NetworkSymbolExtended } from '@suite-common/wallet-config';
+import {
+    AccountsRootState,
+    DeviceRootState,
+    selectDeviceAccounts,
+} from '@suite-common/wallet-core';
 import { Account, SelectedAccountStatus } from '@suite-common/wallet-types';
 import { AddressDisplayOptions } from '@suite-common/wallet-types/src/settings';
 import addressValidator from '@trezor/address-validator';
@@ -77,6 +82,9 @@ export type TradingStateSelector = Omit<TradingState, 'buy' | 'exchange'> & {
 };
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<TradingRootState>();
+const createMemoizedSelectorWithDeviceAndAccounts = createWeakMapSelector.withTypes<
+    TradingRootState & DeviceRootState & AccountsRootState
+>();
 
 export const selectTradingBuyLoadingTimestampAndStatus = createMemoizedSelector(
     [
@@ -213,25 +221,46 @@ export const selectTradingPaymentMethods = (state: TradingRootState) =>
 export const selectTradingTrades = (state: TradingRootState) =>
     returnStableArrayIfEmpty(state.wallet.tradingNew.trades);
 
-export const selectTradingTradesByTradeType: (
-    state: TradingRootState,
+export const selectDeviceTradingTrades: (
+    state: TradingRootState & AccountsRootState & DeviceRootState,
     tradeType: TradingType,
-) => TradingTransaction[] = createMemoizedSelector(
-    [({ wallet }) => wallet.tradingNew.trades, (_, tradeType: TradingType) => tradeType],
+) => TradingTransaction[] = createMemoizedSelectorWithDeviceAndAccounts(
+    [
+        state => selectDeviceAccounts(state),
+        selectTradingTrades,
+        (_, tradeType: TradingType) => tradeType,
+    ],
+    (accounts, trades, tradeType) => {
+        const accountDescriptors = new Set(accounts.map(({ descriptor }) => descriptor));
+
+        return returnStableArrayIfEmpty(
+            trades.filter(
+                t => accountDescriptors.has(t.account?.descriptor) && t.tradeType === tradeType,
+            ),
+        );
+    },
+);
+
+export const selectDeviceTradingTradesByTradeType: (
+    state: TradingRootState & AccountsRootState & DeviceRootState,
+    tradeType: TradingType,
+) => TradingTransaction[] = createMemoizedSelectorWithDeviceAndAccounts(
+    [selectDeviceTradingTrades, (_, tradeType: TradingType) => tradeType],
     (trades, tradeType) => returnStableArrayIfEmpty(trades.filter(t => t.tradeType === tradeType)),
 );
 
-export const selectTradingTradesByTradeTypeOrderedByDate: (
-    state: TradingRootState,
+export const selectDeviceTradingTradesByTradeTypeOrderedByDate: (
+    state: TradingRootState & AccountsRootState & DeviceRootState,
     tradeType: TradingType,
-) => TradingTransaction[] = createMemoizedSelector([selectTradingTradesByTradeType], trades =>
-    trades.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()),
+) => TradingTransaction[] = createMemoizedSelectorWithDeviceAndAccounts(
+    [selectDeviceTradingTradesByTradeType],
+    trades => trades.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()),
 );
 
-export const selectHasTradingTradesOfTradeType = (
-    state: TradingRootState,
+export const selectDeviceHasTradingTradesOfTradeType = (
+    state: TradingRootState & AccountsRootState & DeviceRootState,
     tradeType: TradingType,
-) => selectTradingTradesByTradeType(state, tradeType).length > 0;
+) => selectDeviceTradingTradesByTradeType(state, tradeType).length > 0;
 
 export const selectTradingTradeByOrderId = (state: TradingRootState, orderId: string | undefined) =>
     selectTradingTrades(state).find(t => orderId && t.data.orderId === orderId);

--- a/suite-native/module-trading/src/components/general/TradeHistory/TradeHistoryButton.tsx
+++ b/suite-native/module-trading/src/components/general/TradeHistory/TradeHistoryButton.tsx
@@ -7,8 +7,9 @@ import { useNavigation } from '@react-navigation/native';
 import {
     TradingRootState,
     TradingType,
-    selectHasTradingTradesOfTradeType,
+    selectDeviceHasTradingTradesOfTradeType,
 } from '@suite-common/trading';
+import { AccountsRootState, DeviceRootState } from '@suite-common/wallet-core';
 import { AnimatedBox, HStack, Text } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
@@ -48,8 +49,8 @@ export const TradeHistoryButton = ({
 }: TradeHistoryButtonProps) => {
     const { applyStyle } = useNativeStyles();
     const navigation = useNavigation<NavigationProps>();
-    const hasTrades = useSelector((state: TradingRootState) =>
-        selectHasTradingTradesOfTradeType(state, tradeType),
+    const hasTrades = useSelector((state: TradingRootState & AccountsRootState & DeviceRootState) =>
+        selectDeviceHasTradingTradesOfTradeType(state, tradeType),
     );
 
     if (!hasTrades) {

--- a/suite-native/module-trading/src/components/general/TradeHistory/TradeHistoryListItem.tsx
+++ b/suite-native/module-trading/src/components/general/TradeHistory/TradeHistoryListItem.tsx
@@ -7,12 +7,18 @@ import {
     TradingTransaction,
     selectTradingProviderByNameAndTradeType,
 } from '@suite-common/trading';
+import {
+    AccountsRootState,
+    DeviceRootState,
+    selectDeviceAccountByDescriptorAndNetworkSymbol,
+} from '@suite-common/wallet-core';
 import { Card, HStack, Text, VStack } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 
 import { TradeStatusBadge } from './TradeStatusBadge';
 import { useChangeStringsExtractor } from '../../../hooks/useChangeStringsExtractor';
+import { useTradingWatchTrade } from '../../../hooks/useTradingWatchTrade';
 import { TradingProviderLogo } from '../TradingProviderLogo';
 
 type TradeHistoryListItemProps = {
@@ -24,6 +30,14 @@ export const TRADE_HISTORY_LIST_ITEM_HEIGHT = 148;
 
 export const TradeHistoryListItem = ({ transaction, onPress }: TradeHistoryListItemProps) => {
     const { DateFormatter, TimeFormatter } = useFormatters();
+    const account = useSelector((state: AccountsRootState & DeviceRootState) =>
+        selectDeviceAccountByDescriptorAndNetworkSymbol(
+            state,
+            transaction.account.descriptor,
+            transaction.account.symbol,
+        ),
+    );
+    useTradingWatchTrade({ account: account ?? undefined, trade: transaction });
     const providerInfo = useSelector((state: TradingRootState) =>
         selectTradingProviderByNameAndTradeType(
             state,

--- a/suite-native/module-trading/src/hooks/__tests__/useReloadTimer.test.ts
+++ b/suite-native/module-trading/src/hooks/__tests__/useReloadTimer.test.ts
@@ -13,7 +13,7 @@ jest.mock('@trezor/react-utils', () => ({
 
 describe('useReloadTimer', () => {
     const renderUseReloadTimer = (initialEnabled: boolean = true) =>
-        renderHook(({ isEnabled }) => useReloadTimer(isEnabled), {
+        renderHook(({ isEnabled }) => useReloadTimer({ isEnabled }), {
             initialProps: { isEnabled: initialEnabled },
         });
 

--- a/suite-native/module-trading/src/hooks/useQuotes.ts
+++ b/suite-native/module-trading/src/hooks/useQuotes.ts
@@ -189,7 +189,7 @@ export const useQuotes = (form: TradingBuyForm) => {
     const promiseRef = useRef<PromiseType | undefined>(undefined);
 
     const { isFetchAllowed, shouldFetchQuotes } = useShouldFetchQuotes(form);
-    const { timer, shouldReload } = useReloadTimer(isFetchAllowed);
+    const { timer, shouldReload } = useReloadTimer({ isEnabled: isFetchAllowed });
 
     useQuotesInvalidator(isFetchAllowed, promiseRef, debounce);
     useQuotesThunk(

--- a/suite-native/module-trading/src/hooks/useReloadTimer.ts
+++ b/suite-native/module-trading/src/hooks/useReloadTimer.ts
@@ -3,9 +3,17 @@ import { useEffect } from 'react';
 import { INVITY_API_RELOAD_QUOTES_AFTER_SECONDS } from '@suite-common/trading';
 import { useTimer } from '@trezor/react-utils';
 
+type UseReloadTimerProps = {
+    isEnabled?: boolean;
+    refreshLimitSeconds?: number;
+};
+
 export const MAX_RESET_COUNT = 40;
 
-export const useReloadTimer = (isEnabled: boolean) => {
+export const useReloadTimer = ({
+    isEnabled = true,
+    refreshLimitSeconds = INVITY_API_RELOAD_QUOTES_AFTER_SECONDS,
+}: UseReloadTimerProps) => {
     const timer = useTimer();
     const {
         timeSpent: { seconds },
@@ -30,13 +38,15 @@ export const useReloadTimer = (isEnabled: boolean) => {
         return {
             timer,
             shouldReload: false,
+            resetCount,
         };
     }
 
-    const shouldReload = seconds >= INVITY_API_RELOAD_QUOTES_AFTER_SECONDS;
+    const shouldReload = seconds >= refreshLimitSeconds;
 
     return {
         timer,
         shouldReload,
+        resetCount,
     };
 };

--- a/suite-native/module-trading/src/hooks/useTradingWatchTrade.ts
+++ b/suite-native/module-trading/src/hooks/useTradingWatchTrade.ts
@@ -1,0 +1,60 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useDispatch } from 'react-redux';
+
+import {
+    TradingTransaction,
+    TradingTransactionBuy,
+    TradingTransactionExchange,
+    TradingTransactionSell,
+    TradingType,
+    tradingThunks,
+} from '@suite-common/trading';
+import { Account } from '@suite-common/wallet-types';
+
+import { useReloadTimer } from './useReloadTimer';
+import { tradeFinalStatuses } from '../utils/tradeUtils';
+
+export type TradingTradeMapProps = {
+    buy: TradingTransactionBuy;
+    sell: TradingTransactionSell;
+    exchange: TradingTransactionExchange;
+};
+
+export interface TradingUseWatchTradeProps<T extends TradingType> {
+    account: Account | undefined;
+    trade: TradingTradeMapProps[T] | undefined;
+}
+const REFRESH_SECONDS = 30;
+
+export const shouldRefreshTrade = (trade: TradingTransaction | undefined) =>
+    trade && trade.data.status && !tradeFinalStatuses[trade.tradeType].includes(trade.data.status);
+
+export const useTradingWatchTrade = <T extends TradingType>({
+    account,
+    trade,
+}: TradingUseWatchTradeProps<T>) => {
+    const dispatch = useDispatch();
+    const shouldRefresh = useMemo(() => shouldRefreshTrade(trade), [trade]);
+    const { timer, shouldReload, resetCount } = useReloadTimer({
+        isEnabled: shouldRefresh,
+        refreshLimitSeconds: REFRESH_SECONDS,
+    });
+    const [hasRefreshed, setHasRefreshed] = useState(false);
+    const { reset } = timer;
+
+    useEffect(() => {
+        if (trade && account && (!hasRefreshed || shouldReload) && shouldRefresh) {
+            if (!hasRefreshed) {
+                setHasRefreshed(true);
+            }
+            dispatch(
+                tradingThunks.watchTradeThunk({
+                    account,
+                    trade,
+                    refreshCount: resetCount,
+                }),
+            );
+            reset();
+        }
+    }, [account, trade, resetCount, dispatch, shouldReload, reset, hasRefreshed, shouldRefresh]);
+};

--- a/suite-native/module-trading/src/screens/TradeHistoryScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradeHistoryScreen.tsx
@@ -8,8 +8,9 @@ import { FlashList } from '@shopify/flash-list';
 import {
     TradingRootState,
     TradingTransaction,
-    selectTradingTradesByTradeTypeOrderedByDate,
+    selectDeviceTradingTradesByTradeTypeOrderedByDate,
 } from '@suite-common/trading';
+import { AccountsRootState, DeviceRootState } from '@suite-common/wallet-core';
 import { useTranslate } from '@suite-native/intl';
 import {
     Screen,
@@ -46,10 +47,10 @@ export const TradeHistoryScreen = () => {
     const { bottom: insetBottom } = useSafeAreaInsets();
     const tradeToBeOpened = useSelector(selectTradeToBeOpened);
     const [detailOrderId, setDetailOrderId] = useState<string | undefined>(undefined);
-    const trades = useSelector((state: TradingRootState) =>
-        selectTradingTradesByTradeTypeOrderedByDate(state, tradeType),
-    );
     const { isSheetVisible, showSheet, hideSheet } = useBottomSheetControls();
+    const trades = useSelector((state: TradingRootState & AccountsRootState & DeviceRootState) =>
+        selectDeviceTradingTradesByTradeTypeOrderedByDate(state, tradeType),
+    );
 
     const handleSelectedTrade = useCallback(
         (trade: TradingTransaction) => {

--- a/suite-native/module-trading/src/screens/__tests__/TradeHistoryScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradeHistoryScreen.comp.test.tsx
@@ -1,6 +1,7 @@
 import { RouteProp } from '@react-navigation/native';
 
 import { TradingTransaction, TradingType } from '@suite-common/trading';
+import { Account } from '@suite-common/wallet-types';
 import { TradingStackParamList, TradingStackRoutes } from '@suite-native/navigation';
 import {
     PreloadedState,
@@ -8,7 +9,9 @@ import {
     fireEvent,
     renderWithStoreProviderAsync,
 } from '@suite-native/test-utils';
+import { StaticSessionId } from '@trezor/connect';
 
+import fixturesAccounts from '../../__fixtures__/accounts.json';
 import { getBuyTrade, getExchangeTrade } from '../../__fixtures__/trades';
 import { getInitializedTradingState } from '../../__fixtures__/tradingState';
 import { TradeHistoryScreen } from '../TradeHistoryScreen';
@@ -41,6 +44,14 @@ const getPreloadedState = (trades: TradingTransaction[]): PreloadedState => ({
         tradingNew: {
             ...getInitializedTradingState(),
             trades,
+        },
+        accounts: fixturesAccounts as Account[],
+    },
+    device: {
+        selectedDevice: {
+            state: {
+                staticSessionId: 'staticSessionId' as StaticSessionId,
+            },
         },
     },
 });


### PR DESCRIPTION
- filter trades by selected device
- fetch for trade status update unless it is final

## Related Issue

Resolve #18628



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=18628-mobile-trade-fetch-for-trade-status-changes&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=18628-mobile-trade-fetch-for-trade-status-changes&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=18628-mobile-trade-fetch-for-trade-status-changes&lookback=7)