### PR TITLE
fix(suite-native): trade assets filter scrolling on Android

### DIFF
--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -26,6 +26,7 @@
         "expo-linear-gradient": "^14.0.1",
         "react": "18.2.0",
         "react-native": "0.76.9",
+        "react-native-gesture-handler": "^2.21.0",
         "react-native-reanimated": "^3.16.7",
         "react-native-safe-area-context": "^4.14.0",
         "react-native-webview": "13.12.5",

--- a/suite-native/module-trading/src/components/general/TradeableAssetsSheet/TradeableAssetsFilterTabs.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetsSheet/TradeableAssetsFilterTabs.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { FlatList } from 'react-native-gesture-handler';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
@@ -64,24 +65,27 @@ export const TradeableAssetsFilterTabs = ({
     };
 
     return (
-        <Animated.FlatList
+        <Animated.View
             entering={FadeIn.duration(animationDuration)}
             exiting={FadeOut.duration(animationDuration)}
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            data={filterItems}
-            keyExtractor={item => item.symbol ?? 'undefined'}
-            accessible={true}
-            accessibilityRole="tablist"
-            renderItem={({ item }) => (
-                <FilterTab
-                    active={activeTab === item.symbol}
-                    onPress={() => handleFilterTap(item.symbol)}
-                >
-                    {item.label}
-                </FilterTab>
-            )}
-            keyboardShouldPersistTaps="always"
-        />
+        >
+            <FlatList
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                data={filterItems}
+                keyExtractor={item => item.symbol ?? 'undefined'}
+                accessible={true}
+                accessibilityRole="tablist"
+                renderItem={({ item }) => (
+                    <FilterTab
+                        active={activeTab === item.symbol}
+                        onPress={() => handleFilterTap(item.symbol)}
+                    >
+                        {item.label}
+                    </FilterTab>
+                )}
+                keyboardShouldPersistTaps="always"
+            />
+        </Animated.View>
     );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10800,6 +10800,7 @@ __metadata:
     expo-linear-gradient: "npm:^14.0.1"
     react: "npm:18.2.0"
     react-native: "npm:0.76.9"
+    react-native-gesture-handler: "npm:^2.21.0"
     react-native-reanimated: "npm:^3.16.7"
     react-native-safe-area-context: "npm:^4.14.0"
     react-native-webview: "npm:13.12.5"


### PR DESCRIPTION
## Description

Fix network filter scrolling on Android

## Related Issue

Resolve #16992   

## Screenshots:

https://github.com/user-attachments/assets/f4a30863-6267-4b3e-bd2a-a4174888ff61



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=16992-mobile-trade-search-in-assets&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=16992-mobile-trade-search-in-assets&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=16992-mobile-trade-search-in-assets&lookback=7)