### PR TITLE
fix(suite): Fix coins filter bug

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
@@ -86,7 +86,7 @@ export const AccountsMenuHeader = ({ discovery }: { discovery: Discovery }) => {
                             </>
                         )}
                     </Row>
-                    {isCoinsFilterVisible && <CoinsFilter />}
+                    {isCoinsFilterVisible && showCoinFilter && <CoinsFilter />}
                 </ExpandedSidebarOnly>
                 <CollapsedSidebarOnly>
                     <Column alignItems="center" margin={{ bottom: spacings.sm }}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In case of having 1 account we hide filter button but filter was still present

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before

<img width="272" alt="Screenshot 2025-05-06 at 7 43 46" src="https://github.com/user-attachments/assets/ced91aff-b8c8-4132-a89d-418afcfaa127" />

after

<img width="279" alt="Screenshot 2025-05-06 at 7 42 31" src="https://github.com/user-attachments/assets/162c222e-a39b-49fd-94a1-cf714cbd3fb1" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-filter-bug&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-filter-bug&lookback=7)