### PR TITLE
chore(transport): usb: remove device.selectConfiguration since there …

### DIFF
--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -2,7 +2,6 @@ import { arrayPartition, createDeferred, getSynchronize, resolveAfter } from '@t
 
 import { AbstractApi, AbstractApiConstructorParams, DEVICE_TYPE } from './abstract';
 import {
-    CONFIGURATION_ID,
     DEBUGLINK_ENDPOINT_ID,
     DEBUGLINK_INTERFACE_ID,
     ENDPOINT_ID,
@@ -311,20 +310,6 @@ export class UsbApi extends AbstractApi {
                 error: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE,
                 message: err.message,
             });
-        }
-
-        if (device.configuration?.configurationValue !== CONFIGURATION_ID) {
-            try {
-                this.logger?.debug(`usb: device.selectConfiguration ${CONFIGURATION_ID}`);
-                await this.abortableMethod(() => device.selectConfiguration(CONFIGURATION_ID), {
-                    signal,
-                });
-                this.logger?.debug(`usb: device.selectConfiguration done: ${CONFIGURATION_ID}.`);
-            } catch (err) {
-                this.logger?.error(
-                    `usb: device.selectConfiguration error ${err}. device: ${this.formatDeviceForLog(device)}`,
-                );
-            }
         }
 
         if (reset) {

--- a/packages/transport/src/constants.ts
+++ b/packages/transport/src/constants.ts
@@ -1,5 +1,4 @@
 // usb const
-export const CONFIGURATION_ID = 1;
 export const INTERFACE_ID = 0;
 export const ENDPOINT_ID = 1;
 export const DEBUGLINK_INTERFACE_ID = 1;


### PR DESCRIPTION
It appears that when there is only one USB configuration we don't need to select it explicitly. And since there is a bug in device.selectConfiguration implementation in mobile code (@yanascz) it might make sense to remove the call all together

to test:
- [ ] android
- [ ] node-bridge (windows, linux, mac)
- [ ] webusb in browser (windows, linux, mac)

resolve #18743

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=usb-select-configuration&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=usb-select-configuration&lookback=7)