### PR TITLE
fix(suite): warn in WalletConnect when networks are not activated

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
@@ -50,6 +50,10 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
         dispatch(sessionProposalRejectThunk({ eventId }));
         dispatch(onCancel());
     };
+    const handleGoToCoinSettings = async () => {
+        await dispatch(onCancel());
+        dispatch(goto('settings-coins'));
+    };
 
     const getTooltipContent = (network: PendingConnectionProposalNetwork) => {
         if (network.status !== 'active')
@@ -66,6 +70,13 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
 
     if (!pendingProposal) return null;
 
+    const requiredNetworksNotActivated = pendingProposal.networks.some(
+        network => network.required && network.status !== 'active',
+    );
+    const noNetworksActivated = !pendingProposal.networks.some(
+        network => network.status === 'active',
+    );
+
     return (
         <Modal
             onCancel={handleReject}
@@ -74,7 +85,9 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                     <Modal.Button
                         variant="primary"
                         onClick={handleAccept}
-                        isDisabled={pendingProposal.expired || pendingProposal.isScam}
+                        isDisabled={
+                            pendingProposal.expired || pendingProposal.isScam || noNetworksActivated
+                        }
                     >
                         <Translation id="TR_CONFIRM" />
                     </Modal.Button>
@@ -163,14 +176,12 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                     </Row>
                 </Card>
 
-                {pendingProposal.networks.some(
-                    network => network.required && network.status !== 'active',
-                ) && (
+                {(requiredNetworksNotActivated || noNetworksActivated) && (
                     <Banner
                         variant="warning"
                         rightContent={
                             <BannerButton
-                                onClick={() => dispatch(goto('settings-coins'))}
+                                onClick={() => handleGoToCoinSettings()}
                                 icon="arrowRight"
                                 iconAlignment="end"
                             >
@@ -178,7 +189,13 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                             </BannerButton>
                         }
                     >
-                        <Translation id="TR_WALLETCONNECT_REQUIRED_NETWORKS_NOT_ACTIVATED" />
+                        <Translation
+                            id={
+                                requiredNetworksNotActivated
+                                    ? 'TR_WALLETCONNECT_REQUIRED_NETWORKS_NOT_ACTIVATED'
+                                    : 'TR_WALLETCONNECT_NO_NETWORKS_ACTIVATED'
+                            }
+                        />
                     </Banner>
                 )}
 

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9823,7 +9823,12 @@ export default defineMessages({
     TR_WALLETCONNECT_REQUIRED_NETWORKS_NOT_ACTIVATED: {
         id: 'TR_WALLETCONNECT_REQUIRED_NETWORKS_NOT_ACTIVATED',
         defaultMessage:
-            'Some required networks are not activated. Please activate them to ensure proper compatibility with the app.',
+            'Some of the required networks are not activated in Suite. Please activate them to ensure proper compatibility with the app.',
+    },
+    TR_WALLETCONNECT_NO_NETWORKS_ACTIVATED: {
+        id: 'TR_WALLETCONNECT_NO_NETWORKS_ACTIVATED',
+        defaultMessage:
+            'None of the supported networks are activated in Suite. Please activate them to connect to the app.',
     },
     TR_REQUESTED_NETWORKS: {
         id: 'TR_REQUESTED_NETWORKS',


### PR DESCRIPTION
## Description

Users sometimes try to connect to WalletConnect even when they have no relevant networks activated in Suite. 
This won't work, so we should give a warning.

## Screenshots:

<img width="743" alt="Screenshot 2025-05-06 at 09 53 03" src="https://github.com/user-attachments/assets/34a6927c-a4c4-4b52-8b32-e603ffa39216" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/wc-warn-no-network-enabled&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/wc-warn-no-network-enabled&lookback=7)