### PR TITLE
Chore/replace t2b1 with t3b1

### DIFF
--- a/docs/packages/connect/check-connect-data.md
+++ b/docs/packages/connect/check-connect-data.md
@@ -3,6 +3,6 @@
 This is an automatically created PR.
 
 - [ ] Sanity check t2b1 https://github.com/trezor/data/blob/master/firmware/t2b1/authenticity.json
-- [ ] Sanity check t3t1 https://github.com/trezor/data/blob/master/firmware/t3t1/authenticity.json
 - [ ] Sanity check t3b1 https://github.com/trezor/data/blob/master/firmware/t3b1/authenticity.json
+- [ ] Sanity check t3t1 https://github.com/trezor/data/blob/master/firmware/t3t1/authenticity.json
 - [ ] Merge this PR into develop

--- a/packages/connect/e2e/__fixtures__/getFeatures.ts
+++ b/packages/connect/e2e/__fixtures__/getFeatures.ts
@@ -24,7 +24,7 @@ const customFirmwareBuild =
 
 const tests = [
     {
-        description: 'T2T1/T2B1 features',
+        description: 'core devices features',
         skip: ['1'],
         params: {},
         result: {
@@ -74,7 +74,7 @@ const tests = [
                 'Capability_EOS',
             ]),
             backup_type: 'Bip39',
-            sd_card_present: expect.any(Boolean), // T2T1 true, T2B1 false
+            sd_card_present: expect.any(Boolean),
             sd_protection: false,
             wipe_code_protection: false,
             session_id: expect.any(String),

--- a/packages/connect/e2e/globals.d.ts
+++ b/packages/connect/e2e/globals.d.ts
@@ -9,7 +9,7 @@ declare namespace globalThis {
     var firmwareArg: string | undefined;
     var emulatorStartOpts: {
         version: string;
-        model: 'T1B1' | 'T2T1' | 'T2B1' | 'T3T1';
+        model: 'T1B1' | 'T2T1' | 'T3B1' | 'T3T1';
     };
 
     type LegacyResult = {

--- a/packages/connect/e2e/tests/device/authenticateDevice.test.ts
+++ b/packages/connect/e2e/tests/device/authenticateDevice.test.ts
@@ -22,7 +22,7 @@ describe('TrezorConnect.authenticateDevice', () => {
     const config = {
         version: 1,
         timestamp: '2023-09-07T14:00:00+00:00',
-        T2B1: {
+        T3B1: {
             rootPubKeys: [
                 '047f77368dea2d4d61e989f474a56723c3212dacf8a808d8795595ef38441427c4389bc454f02089d7f08b873005e4c28d432468997871c0bf286fd3861e21e96a',
             ],
@@ -58,8 +58,8 @@ describe('TrezorConnect.authenticateDevice', () => {
         const result = await TrezorConnect.authenticateDevice({
             config: {
                 ...config,
-                T2B1: {
-                    ...config.T2B1,
+                T3B1: {
+                    ...config.T3B1,
                     rootPubKeys: [],
                 },
             },
@@ -75,8 +75,8 @@ describe('TrezorConnect.authenticateDevice', () => {
         const result = await TrezorConnect.authenticateDevice({
             config: {
                 ...config,
-                T2B1: {
-                    ...config.T2B1,
+                T3B1: {
+                    ...config.T3B1,
                     caPubKeys: [],
                 },
             },

--- a/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
@@ -166,7 +166,7 @@ export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignT
         const { data, metamask_v4_compat } = this.params;
         const { types, primaryType, domain, message } = data;
 
-        // For T2T1, T2B1 we use EthereumSignTypedData
+        // For core devices, we use EthereumSignTypedData
         let response = await cmd.typedCall(
             'EthereumSignTypedData',
             [

--- a/packages/product-components/src/components/ConfirmOnDevice/ConfirmOnDevice.stories.tsx
+++ b/packages/product-components/src/components/ConfirmOnDevice/ConfirmOnDevice.stories.tsx
@@ -45,7 +45,7 @@ export const ConfirmOnDevice: StoryFn = () => (
                 successText="confirmed"
                 title="With 3 steps no active"
                 steps={3}
-                deviceModelInternal={DeviceModelInternal.T2B1}
+                deviceModelInternal={DeviceModelInternal.T3B1}
                 deviceUnitColor={1}
             />
         </StoryColumn>
@@ -54,7 +54,7 @@ export const ConfirmOnDevice: StoryFn = () => (
                 successText="confirmed"
                 title="With 2 steps no active"
                 steps={2}
-                deviceModelInternal={DeviceModelInternal.T2B1}
+                deviceModelInternal={DeviceModelInternal.T3B1}
                 deviceUnitColor={2}
             />
         </StoryColumn>
@@ -64,7 +64,7 @@ export const ConfirmOnDevice: StoryFn = () => (
                 title="With 5 steps - active 4"
                 steps={5}
                 activeStep={4}
-                deviceModelInternal={DeviceModelInternal.T2B1}
+                deviceModelInternal={DeviceModelInternal.T3B1}
                 deviceUnitColor={3}
             />
         </StoryColumn>
@@ -74,7 +74,7 @@ export const ConfirmOnDevice: StoryFn = () => (
                 title="With 3 steps - active 1"
                 steps={3}
                 activeStep={1}
-                deviceModelInternal={DeviceModelInternal.T2B1}
+                deviceModelInternal={DeviceModelInternal.T3B1}
                 deviceUnitColor={4}
             />
         </StoryColumn>
@@ -85,7 +85,7 @@ export const ConfirmOnDevice: StoryFn = () => (
                 steps={5}
                 activeStep={3}
                 onCancel={() => {}}
-                deviceModelInternal={DeviceModelInternal.T2B1}
+                deviceModelInternal={DeviceModelInternal.T3B1}
                 deviceUnitColor={5}
             />
         </StoryColumn>

--- a/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -38,7 +38,7 @@ export class OnboardingPage {
     readonly selectSeedConfirmButton: Locator;
     readonly continueAtYourOwnRiskButton: Locator;
 
-    isModelWithSecureElement = () => ['T3B1', 'T3T1'].includes(this.model);
+    isModelWithSecureElement = () => ['T3B1', 'T3T1', 'T3W1'].includes(this.model);
 
     constructor(
         public page: Page,

--- a/packages/suite/src/utils/device/__tests__/modelUtils.test.ts
+++ b/packages/suite/src/utils/device/__tests__/modelUtils.test.ts
@@ -26,7 +26,7 @@ const fixtures = [
     },
     {
         description: 'should return default when deviceModelInternal is not among options',
-        deviceModelInternal: DeviceModelInternal.T2B1,
+        deviceModelInternal: DeviceModelInternal.T3B1,
         expectedResult: 'default',
     },
 ];

--- a/packages/suite/src/utils/firmware/__tests__/firmware.test.ts
+++ b/packages/suite/src/utils/firmware/__tests__/firmware.test.ts
@@ -44,7 +44,7 @@ describe('validateFirmware', () => {
     it('should return TR_FIRMWARE_VALIDATION_UNMATCHING_DEVICE if firmware format does not match the device model', () => {
         const fw = getT1V2FW();
 
-        const device = { features: { internal_model: DeviceModelInternal.T2B1 } } as TrezorDevice;
+        const device = { features: { internal_model: DeviceModelInternal.T3B1 } } as TrezorDevice;
 
         expect(validateFirmware(fw, device)).toBe('TR_FIRMWARE_VALIDATION_UNMATCHING_DEVICE');
     });

--- a/packages/suite/src/utils/onboarding/__tests__/steps.test.ts
+++ b/packages/suite/src/utils/onboarding/__tests__/steps.test.ts
@@ -21,7 +21,7 @@ const backupStep: Step = {
     id: STEP.ID_BACKUP_STEP,
     path: [],
     supportedModels: [
-        DeviceModelInternal.T2B1,
+        DeviceModelInternal.T3B1,
         { model: DeviceModelInternal.T3T1, minFwVersion: '2.8.0' },
     ],
 };
@@ -90,11 +90,11 @@ describe('steps', () => {
         });
 
         it('should exclude steps not supported by device', () => {
-            const deviceT2B1 = {
-                features: { internal_model: DeviceModelInternal.T2B1 },
+            const deviceT3B1 = {
+                features: { internal_model: DeviceModelInternal.T3B1 },
             } as AcquiredDevice;
-            const propsWithT2B1 = { ...propsMock, device: deviceT2B1 };
-            expect(isStepUsed(backupStep, propsWithT2B1)).toEqual(true);
+            const propsWithT3B1 = { ...propsMock, device: deviceT3B1 };
+            expect(isStepUsed(backupStep, propsWithT3B1)).toEqual(true);
 
             const deviceT1B1 = {
                 features: { internal_model: DeviceModelInternal.T1B1 },

--- a/packages/suite/src/utils/suite/__tests__/homescreen.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/homescreen.test.ts
@@ -122,7 +122,7 @@ describe('homescreen', () => {
     describe('isValidImageSize', () => {
         it('should return true for non-T2T1 device models', () => {
             const file = new File([], 'test.png', { type: 'image/png', lastModified: 0 });
-            expect(isValidImageSize(file, DeviceModelInternal.T2B1)).toBe(true);
+            expect(isValidImageSize(file, DeviceModelInternal.T3B1)).toBe(true);
             expect(isValidImageSize(file, DeviceModelInternal.T1B1)).toBe(true);
         });
 

--- a/packages/suite/src/views/settings/SettingsDevice/DisplayRotation.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/DisplayRotation.tsx
@@ -46,7 +46,7 @@ const DISPLAY_ROTATIONS: Array<Rotation> = [
     },
 ];
 
-// features.display_rotation cannot be used to determine support because can be defined for devices not supporting rotation (e.g. T2B1).
+// features.display_rotation cannot be used to determine support because can be defined for devices not supporting rotation (e.g. T3B1).
 const DEVICES_SUPPORTING_ROTATION = [DeviceModelInternal.T2T1, DeviceModelInternal.T3T1];
 
 interface DisplayRotationProps {

--- a/suite-common/message-system/src/__fixtures__/messageSystemUtils.ts
+++ b/suite-common/message-system/src/__fixtures__/messageSystemUtils.ts
@@ -1180,7 +1180,7 @@ export const isDeviceCompatible = [
         description: 'isDeviceCompatible case 24',
         deviceConditions: [
             {
-                model: DeviceModelInternal.T2B1,
+                model: DeviceModelInternal.T3B1,
                 firmware: '2.6.0',
                 bootloader: '2.1.5',
                 firmwareRevision: '*',
@@ -1192,7 +1192,7 @@ export const isDeviceCompatible = [
             features: {
                 ...getDeviceFeatures({
                     vendor: 'trezor.io',
-                    internal_model: DeviceModelInternal.T2B1,
+                    internal_model: DeviceModelInternal.T3B1,
                     major_version: 2,
                     minor_version: 1,
                     patch_version: 5,
@@ -1210,7 +1210,7 @@ export const isDeviceCompatible = [
         description: 'isDeviceCompatible case 25',
         deviceConditions: [
             {
-                model: DeviceModelInternal.T2B1,
+                model: DeviceModelInternal.T3B1,
                 firmware: '2',
                 bootloader: '*',
                 firmwareRevision: '123456',
@@ -1222,7 +1222,7 @@ export const isDeviceCompatible = [
             features: {
                 ...getDeviceFeatures({
                     vendor: 'trezor.io',
-                    internal_model: DeviceModelInternal.T2B1,
+                    internal_model: DeviceModelInternal.T3B1,
                     major_version: 2,
                     minor_version: 6,
                     patch_version: 0,

--- a/suite-common/suite-utils/src/__fixtures__/device.ts
+++ b/suite-common/suite-utils/src/__fixtures__/device.ts
@@ -498,11 +498,11 @@ const getChangelogUrl = [
         device: {
             ...SUITE_DEVICE,
             features: {
-                internal_model: DeviceModelInternal.T2B1,
+                internal_model: DeviceModelInternal.T3B1,
             },
         } as TrezorDevice,
         revision: 'ab12cd',
-        result: 'https://github.com/trezor/trezor-firmware/blob/ab12cd/core/CHANGELOG.T2B1.md',
+        result: 'https://github.com/trezor/trezor-firmware/blob/ab12cd/core/CHANGELOG.T3B1.md',
     },
     {
         description: 'Missing revision, master/legacy firmware',
@@ -537,7 +537,7 @@ const getCheckBackupUrl = [
         device: {
             ...SUITE_DEVICE,
             features: {
-                internal_model: DeviceModelInternal.T2B1,
+                internal_model: DeviceModelInternal.T3B1,
             },
         } as TrezorDevice,
         result: URLS[`HELP_CENTER_DRY_RUN_${DeviceModelInternal.T3B1}_URL`],
@@ -555,7 +555,7 @@ const getPackagingUrl = [
         device: {
             ...SUITE_DEVICE,
             features: {
-                internal_model: DeviceModelInternal.T2B1,
+                internal_model: DeviceModelInternal.T3B1,
             },
         } as TrezorDevice,
         result: URLS[`HELP_CENTER_PACKAGING_${DeviceModelInternal.T3B1}_URL`],
@@ -573,7 +573,7 @@ const getFirmwareDowngradeUrl = [
         device: {
             ...SUITE_DEVICE,
             features: {
-                internal_model: DeviceModelInternal.T2B1,
+                internal_model: DeviceModelInternal.T3B1,
             },
         } as TrezorDevice,
         result: URLS[`HELP_CENTER_FW_DOWNGRADE_${DeviceModelInternal.T3B1}_URL`],

--- a/suite-native/module-home/src/screens/HomeScreen/components/__tests__/EmptyHomeRenderer.comp.test.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/__tests__/EmptyHomeRenderer.comp.test.tsx
@@ -52,7 +52,7 @@ describe('EmptyHomeRenderer', () => {
                 device: {
                     selectedDevice: {
                         connected: true,
-                        features: { initialized: false, internal_model: DeviceModelInternal.T2B1 },
+                        features: { initialized: false, internal_model: DeviceModelInternal.T3B1 },
                     },
                     devices: [{ id: 'device_id' }],
                 },
@@ -97,7 +97,7 @@ describe('EmptyHomeRenderer', () => {
                 device: {
                     selectedDevice: {
                         connected: true,
-                        features: { initialized: false, internal_model: DeviceModelInternal.T2B1 },
+                        features: { initialized: false, internal_model: DeviceModelInternal.T3B1 },
                     },
                     devices: [{ id: 'device_id' }],
                 },


### PR DESCRIPTION
We're dropping T2B1 emulators in favour of T3B1, the change has already been done in [trezor-user-env](https://github.com/trezor/trezor-user-env/issues/308).
Also some cleanup in unit tests etc. to use T3B1 over T2B1.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/replace-t2b1-with-t3b1&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/replace-t2b1-with-t3b1&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/replace-t2b1-with-t3b1&lookback=7)