### PR TITLE
chore(e2e): Missing two models in annotation

### DIFF
--- a/packages/suite-desktop-core/e2e/support/enums/testAnnotations.ts
+++ b/packages/suite-desktop-core/e2e/support/enums/testAnnotations.ts
@@ -89,7 +89,9 @@ export enum DeviceModel {
     T1B1 = 'T1B1',
     T2T1 = 'T2T1',
     T2B1 = 'T2B1',
+    T3B1 = 'T3B1',
     T3T1 = 'T3T1',
+    T3W1 = 'T3W1',
     Unknown = 'Unknown',
 }
 


### PR DESCRIPTION
Expands models enum by T3B1 and T3W1

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore-e2e-missing-models-annotation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore-e2e-missing-models-annotation&lookback=7)