### PR TITLE
chore(suite-data): update tor to 0.4.8.14

### DIFF
--- a/packages/suite-data/files/bin/tor/linux-arm64/tor
+++ b/packages/suite-data/files/bin/tor/linux-arm64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82ddfb86fe99127bf19cb5dea9ea781c9e124e8b41d306ccff31efd257bbca07
-size 18520064
+oid sha256:b28a7ca0caff7bc264b104f6d0702e080993442d89b3199c55c381622ff6bd2a
+size 18523504

--- a/packages/suite-data/files/bin/tor/linux-x64/tor
+++ b/packages/suite-data/files/bin/tor/linux-x64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:89241f5929d9d079226ec5ce6cea42fb83a7126385499fab18d56ab8a47525e7
-size 19087096
+oid sha256:9cbf2ba586ae087df01e43e5624fb7f42207e5a982811e0d3cad7cbce96c9dce
+size 19094608

--- a/packages/suite-data/files/bin/tor/mac-arm64/tor
+++ b/packages/suite-data/files/bin/tor/mac-arm64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:26ce86208fa78681614e1e480a35c175573c2b8d16c17a6bfb1703f4ac6f5db8
-size 6558128
+oid sha256:4abe5676e7f4cba6e1083e3e02e172bf8971a53e33d948b81551c82f7fef03dd
+size 6558224

--- a/packages/suite-data/files/bin/tor/mac-x64/tor
+++ b/packages/suite-data/files/bin/tor/mac-x64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:796bc2263c455aeb15c2282902fa9c89cbe011ed084fd86592a31e74eae80870
-size 7086544
+oid sha256:5e38458e276d77afa75ca7b65ab922fcd7e8f9574e8eac9fdec7dd191600f60d
+size 7086640

--- a/packages/suite-data/files/bin/tor/update.sh
+++ b/packages/suite-data/files/bin/tor/update.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-CRX_VER=1_0_37
-CRX_LINUX_ARM_VER=1_0_6
+CRX_VER=1_0_38
+CRX_LINUX_ARM_VER=1_0_7
 
 # check whether we have all required commands
 for cmd in 7z curl lipo shasum ; do

--- a/packages/suite-data/files/bin/tor/win-x64/tor.exe
+++ b/packages/suite-data/files/bin/tor/win-x64/tor.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f9d6733b0528103b6c7355e0ce6da47ff1c88bb19108586d7c642edc96705d1f
-size 18164728
+oid sha256:f62c93694d1e723a3e6a91cd788d4de9205a192e6c3b4102fd728468bf7be0f6
+size 18173920


### PR DESCRIPTION
Update Tor binaries.

Previous update: https://github.com/trezor/trezor-suite/pull/16806


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/tor-update-0.4.8.14&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/tor-update-0.4.8.14&lookback=7)