### PR TITLE
chore(suite): remove standalone bridge link from /bridge page

### DIFF
--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -452,8 +452,6 @@ export const selectTransportOfType = (type: TransportInfo['type']) => (state: Su
 
 export const selectUdevInstaller = (state: SuiteRootState) => state.suite.transport?.udev;
 
-export const selectBridgeInstaller = (state: SuiteRootState) => state.suite.transport?.bridge;
-
 export const selectIsActionAbortable = (state: SuiteRootState) => {
     const bridge = state.suite.transport?.transports.find(t => t.type === 'BridgeTransport');
 

--- a/packages/suite/src/views/suite/bridge/index.tsx
+++ b/packages/suite/src/views/suite/bridge/index.tsx
@@ -1,13 +1,11 @@
-import { Column, H3, Link, Modal, Paragraph } from '@trezor/components';
+import { Column, H3, Modal, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
-import { DATA_URL } from '@trezor/urls';
 
 import { goto } from 'src/actions/suite/routerActions';
 import { Metadata, Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useOpenSuiteDesktop } from 'src/hooks/suite/useOpenSuiteDesktop';
 import {
-    selectBridgeInstaller,
     selectHasActiveTransport,
     selectHasTransportOfType,
     selectTransportOfType,
@@ -18,13 +16,7 @@ export const BridgeUnavailable = () => {
     const hasTransport = useSelector(selectHasActiveTransport);
     const isWebUsb = useSelector(selectHasTransportOfType('WebUsbTransport'));
     const bridge = useSelector(selectTransportOfType('BridgeTransport'));
-    const bridgeInstaller = useSelector(selectBridgeInstaller);
     const dispatch = useDispatch();
-
-    const preferredTarget = bridgeInstaller?.packages?.find(i => i.preferred === true);
-    const target = preferredTarget
-        ? `${DATA_URL}${preferredTarget.url}`
-        : 'https://github.com/trezor/data/tree/master/bridge/2.0.27';
 
     const handleOpenSuite = useOpenSuiteDesktop();
 
@@ -66,13 +58,6 @@ export const BridgeUnavailable = () => {
                 </H3>
                 <Paragraph variant="tertiary">
                     {hasTransport ? description : <Translation id="TR_BRIDGE_NEEDED_DESCRIPTION" />}
-                </Paragraph>
-                <Paragraph variant="tertiary">
-                    Alternatively you may{' '}
-                    <Link variant="underline" href={target}>
-                        download
-                    </Link>{' '}
-                    a standalone Trezor Bridge binary.
                 </Paragraph>
             </Column>
         </Modal>


### PR DESCRIPTION
before:  (textwise)
![image](https://github.com/user-attachments/assets/acc9653d-aa59-4a5d-8334-3f9fa044fab5)

after: 
![image](https://github.com/user-attachments/assets/2b6b4baa-c986-48f6-8bc0-cb029bf4bbb5)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=remove-standalone-bridge-link&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=remove-standalone-bridge-link&lookback=7)