### PR TITLE
feat(suite-native): Mobile Trade: Error states when api is unreachabl…

### DIFF
--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -1,6 +1,9 @@
 import { Coins, CryptoId, FiatCurrenciesProps, Platforms } from 'invity-api';
 
-import { TradingPaymentMethodProps } from '@suite-common/trading';
+import {
+    TradingPaymentMethodProps,
+    selectTradingBuyLoadingTimestampAndStatus,
+} from '@suite-common/trading';
 
 import coins from '../../__fixtures__/coins.json';
 import platforms from '../../__fixtures__/platforms.json';
@@ -721,6 +724,46 @@ describe('tradingSelectors', () => {
 
         it('should be stable', () => {
             expect(selectValidTradingBuyQuotes(state)).toBe(selectValidTradingBuyQuotes(state));
+        });
+    });
+
+    describe('selectTradingBuyLoadingTimestampAndStatus', () => {
+        it.each<[boolean, number]>([
+            [true, 0],
+            [false, 123456789],
+        ])(
+            'should return values from tradingNew state, case %#',
+            (isLoading, lastLoadedTimestamp) => {
+                state.wallet.tradingNew.isLoading = isLoading;
+                state.wallet.tradingNew.lastLoadedTimestamp = lastLoadedTimestamp;
+
+                expect(selectTradingBuyLoadingTimestampAndStatus(state)).toEqual(
+                    expect.objectContaining({
+                        isLoading,
+                        lastLoadedTimestamp,
+                    }),
+                );
+            },
+        );
+
+        describe('isFullyLoaded', () => {
+            it('should be false when trading info is empty', () => {
+                state.wallet.tradingNew.info = {
+                    paymentMethods: [],
+                };
+
+                expect(selectTradingBuyLoadingTimestampAndStatus(state).isFullyLoaded).toBe(false);
+            });
+
+            it('should be false when trading buyInfo is empty', () => {
+                state.wallet.tradingNew.buy.buyInfo = undefined;
+
+                expect(selectTradingBuyLoadingTimestampAndStatus(state).isFullyLoaded).toBe(false);
+            });
+
+            it('should be true otherwise', () => {
+                expect(selectTradingBuyLoadingTimestampAndStatus(state).isFullyLoaded).toBe(true);
+            });
         });
     });
 });

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -78,14 +78,17 @@ export type TradingStateSelector = Omit<TradingState, 'buy' | 'exchange'> & {
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<TradingRootState>();
 
-export const selectTradingLoadingAndTimestamp = createMemoizedSelector(
+export const selectTradingBuyLoadingTimestampAndStatus = createMemoizedSelector(
     [
         (state: TradingRootState) => state.wallet.tradingNew.isLoading,
         (state: TradingRootState) => state.wallet.tradingNew.lastLoadedTimestamp,
+        (state: TradingRootState) => state.wallet.tradingNew.info,
+        (state: TradingRootState) => state.wallet.tradingNew.buy.buyInfo,
     ],
-    (isLoading, lastLoadedTimestamp) => ({
+    (isLoading, lastLoadedTimestamp, info, buyInfo) => ({
         isLoading,
         lastLoadedTimestamp,
+        isFullyLoaded: !!(buyInfo && info?.coins && info?.platforms),
     }),
 );
 

--- a/suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
+++ b/suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
@@ -9,9 +9,9 @@ import { tradingActions } from '../../reducers/tradingReducer';
 import {
     selectTradingAccountAccordingActiveSection,
     selectTradingBuyInfo,
+    selectTradingBuyLoadingTimestampAndStatus,
     selectTradingExchangeInfo,
     selectTradingInfo,
-    selectTradingLoadingAndTimestamp,
 } from '../../selectors/tradingSelectors';
 import { TradingType } from '../../types';
 
@@ -30,7 +30,8 @@ export const loadInitialDataThunk = createThunk(
         );
         const buyInfo = selectTradingBuyInfo(getState());
         const exchangeInfo = selectTradingExchangeInfo(getState());
-        const { isLoading, lastLoadedTimestamp } = selectTradingLoadingAndTimestamp(getState());
+        const { isLoading, lastLoadedTimestamp } =
+            selectTradingBuyLoadingTimestampAndStatus(getState());
         const { platforms, coins } = selectTradingInfo(getState());
 
         const currentAccountDescriptor = invityAPI.getCurrentAccountDescriptor();

--- a/suite-native/app/src/navigation/__tests__/AppTabNavigator.comp.test.tsx
+++ b/suite-native/app/src/navigation/__tests__/AppTabNavigator.comp.test.tsx
@@ -1,10 +1,5 @@
 import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
-import {
-    PreloadedState,
-    fireEvent,
-    renderWithStoreProviderAsync,
-    waitFor,
-} from '@suite-native/test-utils';
+import { PreloadedState, fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 
 import { AppTabNavigator } from '../AppTabNavigator';
 
@@ -41,7 +36,7 @@ describe('AppTabNavigator', () => {
     });
 
     it('should render Trade tab when at least one trading flag is enabled', async () => {
-        const { getByText, getAllByText } = await renderTabs({
+        const { getByText, getByTestId } = await renderTabs({
             featureFlags: {
                 ...featureFlagsInitialState,
                 [FeatureFlag.IsTradingBuyEnabled]: true,
@@ -51,8 +46,6 @@ describe('AppTabNavigator', () => {
         const tradeTab = getByText('Trade');
         fireEvent.press(tradeTab);
 
-        await waitFor(() => {
-            expect(getAllByText('Buy').length).toBe(2);
-        });
+        expect(getByTestId('@screen/Trading')).toBeTruthy();
     });
 });

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -1661,6 +1661,15 @@ export const en = {
                 },
             },
         },
+        error: {
+            deviceOfflineTitle: 'Trading is not available offline',
+            deviceOfflineDescription:
+                'Trading needs an internet connection to be available. Check your mobile phone settings and try again.',
+            serverOfflineTitle: "It's not you, it's us.",
+            serverOfflineDescription:
+                'Something is wrong on our end. Please, wait a minute or try again later.',
+            serverOfflineRetry: 'Try again',
+        },
         defaultSearchLabel: 'Search',
         notSelected: 'Not selected',
         networkName: 'Network name',

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -12,6 +12,7 @@
     },
     "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
+        "@react-native-community/netinfo": "^11.4.1",
         "@react-navigation/native": "6.1.18",
         "@react-navigation/native-stack": "6.11.0",
         "@reduxjs/toolkit": "2.6.0",

--- a/suite-native/module-trading/src/components/general/Offline/DeviceOffline.tsx
+++ b/suite-native/module-trading/src/components/general/Offline/DeviceOffline.tsx
@@ -1,0 +1,10 @@
+import { Translation } from '@suite-native/intl';
+
+import { OfflineCard } from './OfflineCard';
+
+export const DeviceOffline = () => (
+    <OfflineCard
+        title={<Translation id="moduleTrading.error.deviceOfflineTitle" />}
+        description={<Translation id="moduleTrading.error.deviceOfflineDescription" />}
+    />
+);

--- a/suite-native/module-trading/src/components/general/Offline/OfflineCard.tsx
+++ b/suite-native/module-trading/src/components/general/Offline/OfflineCard.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from 'react';
+
+import { Box, Card, PictogramTitleHeader, Text, VStack } from '@suite-native/atoms';
+
+export type OfflineCardProps = {
+    title: ReactNode;
+    description: ReactNode;
+    children?: ReactNode;
+};
+
+export const OfflineCard = ({ title, description, children }: OfflineCardProps) => (
+    <Box flex={1} alignItems="center" justifyContent="center">
+        <Card>
+            <VStack spacing="sp24" paddingVertical="sp8">
+                <PictogramTitleHeader
+                    variant="warning"
+                    title={title}
+                    titleVariant="highlight"
+                    subtitle={
+                        <Text variant="hint" color="textSubdued" textAlign="center">
+                            {description}
+                        </Text>
+                    }
+                />
+                {children}
+            </VStack>
+        </Card>
+    </Box>
+);

--- a/suite-native/module-trading/src/components/general/Offline/ServerOffline.tsx
+++ b/suite-native/module-trading/src/components/general/Offline/ServerOffline.tsx
@@ -1,0 +1,23 @@
+import { Button } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+import { OfflineCard } from './OfflineCard';
+
+export type ServerOfflineProps = {
+    onRetryPress: () => void;
+};
+
+export const ServerOffline = ({ onRetryPress }: ServerOfflineProps) => (
+    <OfflineCard
+        title={<Translation id="moduleTrading.error.serverOfflineTitle" />}
+        description={<Translation id="moduleTrading.error.serverOfflineDescription" />}
+    >
+        <Button
+            colorScheme="tertiaryElevation0"
+            onPress={onRetryPress}
+            viewLeft="arrowsCounterClockwise"
+        >
+            <Translation id="moduleTrading.error.serverOfflineRetry" />
+        </Button>
+    </OfflineCard>
+);

--- a/suite-native/module-trading/src/components/general/Offline/__tests__/ServerOffline.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/Offline/__tests__/ServerOffline.comp.test.tsx
@@ -1,0 +1,21 @@
+import { act, fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+
+import { ServerOffline, ServerOfflineProps } from '../ServerOffline';
+
+describe('ServerOffline', () => {
+    const renderServerOffline = (props: Partial<ServerOfflineProps>) =>
+        renderWithBasicProvider(<ServerOffline onRetryPress={jest.fn()} {...props} />);
+
+    it('should call onRetryPress when "Try again" button is pressed', () => {
+        const retryPressMock = jest.fn();
+        const { getByText } = renderServerOffline({ onRetryPress: retryPressMock });
+
+        const retryButton = getByText('Try again');
+
+        act(() => {
+            fireEvent.press(retryButton);
+        });
+
+        expect(retryPressMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/suite-native/module-trading/src/hooks/__tests__/useTradingBuyData.test.tsx
+++ b/suite-native/module-trading/src/hooks/__tests__/useTradingBuyData.test.tsx
@@ -4,9 +4,16 @@ import { renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
 import { useTradingBuyData } from '../useTradingBuyData';
 
 describe('useTradingBuyData', () => {
-    const renderUseTradingData = () => renderHookWithStoreProviderAsync(() => useTradingBuyData());
+    const renderUseTradingData = (reloadRequestOrdinalInitialValue: number = 0) =>
+        renderHookWithStoreProviderAsync(
+            ({ reloadRequestOrdinal }) => useTradingBuyData(reloadRequestOrdinal),
+            {
+                initialProps: { reloadRequestOrdinal: reloadRequestOrdinalInitialValue },
+            },
+        );
 
     beforeEach(() => {
+        jest.resetAllMocks();
         global.fetch = jest.fn().mockImplementation(() =>
             Promise.resolve({
                 json: () => Promise.resolve({}),
@@ -45,10 +52,19 @@ describe('useTradingBuyData', () => {
 
         const { result, rerender } = await renderUseTradingData();
         const firstTimestamp = result.current.lastLoadedTimestamp;
-        rerender({});
+        rerender({ reloadRequestOrdinal: 0 });
 
         expect(result.current.isLoading).toBe(false);
         expect(result.current.lastLoadedTimestamp).toBe(firstTimestamp);
         expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should dispatch loadInitialDataThunk when reloadRequestOrdinal changes', async () => {
+        const initialThunkLoadActionSpy = jest.spyOn(tradingThunks, 'loadInitialDataThunk');
+
+        const { rerender } = await renderUseTradingData();
+        rerender({ reloadRequestOrdinal: 1 });
+
+        expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(2);
     });
 });

--- a/suite-native/module-trading/src/hooks/useTradingBuyData.ts
+++ b/suite-native/module-trading/src/hooks/useTradingBuyData.ts
@@ -1,14 +1,14 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { selectTradingLoadingAndTimestamp, tradingThunks } from '@suite-common/trading';
+import { selectTradingBuyLoadingTimestampAndStatus, tradingThunks } from '@suite-common/trading';
 
-export const useTradingBuyData = () => {
+export const useTradingBuyData = (reloadRequestOrdinal: number) => {
     const dispatch = useDispatch();
 
     useEffect(() => {
         dispatch(tradingThunks.loadInitialDataThunk({ activeSection: 'buy' }));
-    }, [dispatch]);
+    }, [dispatch, reloadRequestOrdinal]);
 
-    return useSelector(selectTradingLoadingAndTimestamp);
+    return useSelector(selectTradingBuyLoadingTimestampAndStatus);
 };

--- a/suite-native/module-trading/src/navigation/__tests__/TradingStackNavigator.comp.test.tsx
+++ b/suite-native/module-trading/src/navigation/__tests__/TradingStackNavigator.comp.test.tsx
@@ -1,3 +1,4 @@
+import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
 import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
 
 import { TradingStackNavigator } from '../TradingStackNavigator';
@@ -6,12 +7,20 @@ jest.mock('../../hooks/useTradingBuyData', () => ({
     useTradingBuyData: () => ({
         isLoading: true,
         lastLoadedTimestamp: 0,
+        isFullyLoaded: false,
     }),
 }));
 
 describe('TradingStackNavigator', () => {
     it('should render', async () => {
-        const { getByTestId } = await renderWithStoreProviderAsync(<TradingStackNavigator />);
+        const { getByTestId } = await renderWithStoreProviderAsync(<TradingStackNavigator />, {
+            preloadedState: {
+                featureFlags: {
+                    ...featureFlagsInitialState,
+                    [FeatureFlag.IsTradingBuyEnabled]: true,
+                },
+            },
+        });
 
         expect(getByTestId('@screen/Trading')).toBeTruthy();
     });

--- a/suite-native/module-trading/src/screens/TradingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingScreen.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
+import { useNetInfo } from '@react-native-community/netinfo';
 import { useNavigation } from '@react-navigation/native';
 
 import { Context } from '@suite-common/message-system';
@@ -11,17 +12,18 @@ import { Screen, TradingStackRoutes } from '@suite-native/navigation';
 import { BuyForm } from '../components/buy/BuyForm';
 import { BuyFormContextProvider } from '../components/buy/BuyFormContextProvider';
 import { BuyFormSkeleton } from '../components/buy/BuyFormSkeleton';
+import { DeviceOffline } from '../components/general/Offline/DeviceOffline';
+import { ServerOffline } from '../components/general/Offline/ServerOffline';
 import { NavigationProps } from '../components/general/TradeHistory/TradeHistoryButton';
 import { useTradingBuyData } from '../hooks/useTradingBuyData';
 import { selectIsTradingBuyEnabled, selectTradeToBeOpened } from '../selectors/commonSelectors';
 
-export const TradingScreen = () => {
-    const isTradingBuyEnabled = useSelector(selectIsTradingBuyEnabled);
-    const { isLoading, lastLoadedTimestamp } = useTradingBuyData();
+const TradingScreenContent = () => {
+    const [reloadOrdinal, setReloadOrdinal] = useState(0);
+    const { isLoading, lastLoadedTimestamp, isFullyLoaded } = useTradingBuyData(reloadOrdinal);
+    const { isInternetReachable } = useNetInfo();
     const tradeToBeOpened = useSelector(selectTradeToBeOpened);
     const navigation = useNavigation<NavigationProps>();
-
-    const displaySkeleton = isLoading || lastLoadedTimestamp === 0;
 
     useEffect(() => {
         if (tradeToBeOpened) {
@@ -31,20 +33,39 @@ export const TradingScreen = () => {
         }
     }, [tradeToBeOpened, navigation]);
 
+    if (isInternetReachable === false) {
+        return <DeviceOffline />;
+    }
+
+    const isLoadingFinished = !isLoading && lastLoadedTimestamp > 0;
+    if (isLoadingFinished && !isFullyLoaded) {
+        return <ServerOffline onRetryPress={() => setReloadOrdinal(reloadOrdinal + 1)} />;
+    }
+
+    return (
+        <>
+            <ContextMessage context={Context.tradingBuy} />
+            {isFullyLoaded ? (
+                <BuyFormContextProvider>
+                    <BuyForm />
+                </BuyFormContextProvider>
+            ) : (
+                <BuyFormSkeleton />
+            )}
+        </>
+    );
+};
+
+export const TradingScreen = () => {
+    const isTradingBuyEnabled = useSelector(selectIsTradingBuyEnabled);
+
+    if (!isTradingBuyEnabled) {
+        return null;
+    }
+
     return (
         <Screen header={<DeviceManagerScreenHeader />}>
-            {isTradingBuyEnabled && (
-                <>
-                    <ContextMessage context={Context.tradingBuy} />
-                    {displaySkeleton ? (
-                        <BuyFormSkeleton />
-                    ) : (
-                        <BuyFormContextProvider>
-                            <BuyForm />
-                        </BuyFormContextProvider>
-                    )}
-                </>
-            )}
+            <TradingScreenContent />
         </Screen>
     );
 };

--- a/suite-native/module-trading/src/screens/__tests__/TradingScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingScreen.comp.test.tsx
@@ -1,9 +1,17 @@
 import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
-import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import {
+    PreloadedState,
+    act,
+    fireEvent,
+    renderWithStoreProviderAsync,
+    screen,
+} from '@suite-native/test-utils';
 
 import { TradingScreen } from '../TradingScreen';
 
-let mockUseTradingBuyDataValue: { isLoading: boolean; lastLoadedTimestamp: number };
+let mockUseTradingBuyData: jest.Mock;
+
+let mockIsInternetReachable: boolean | null = true;
 
 jest.mock('@react-navigation/native', () => ({
     ...jest.requireActual('@react-navigation/native'),
@@ -11,7 +19,13 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 jest.mock('../../hooks/useTradingBuyData', () => ({
-    useTradingBuyData: () => mockUseTradingBuyDataValue,
+    useTradingBuyData: (...params: unknown[]) => mockUseTradingBuyData(...params),
+}));
+
+jest.mock('@react-native-community/netinfo', () => ({
+    useNetInfo: () => ({
+        isInternetReachable: mockIsInternetReachable,
+    }),
 }));
 
 const stateWithEnabledBuy = {
@@ -30,41 +44,126 @@ const stateWithDisabledBuy = {
 
 describe('TradingScreen', () => {
     beforeEach(() => {
-        mockUseTradingBuyDataValue = { isLoading: false, lastLoadedTimestamp: 0 };
+        mockUseTradingBuyData = jest.fn(() => ({
+            isLoading: false,
+            lastLoadedTimestamp: 0,
+            isFullyLoaded: false,
+        }));
+
+        mockIsInternetReachable = true;
     });
 
     const renderTradingScreen = (preloadedState?: PreloadedState) =>
         renderWithStoreProviderAsync(<TradingScreen />, { preloadedState });
 
+    const expectSkeleton = () => {
+        expect(screen.getByText('Buy')).toBeTruthy();
+    };
+
+    const expectBuyForm = () => {
+        expect(screen.getByText('Fund')).toBeTruthy();
+    };
+
+    const expectDeviceOffline = () => {
+        expect(screen.getByText('Trading is not available offline')).toBeTruthy();
+    };
+
+    const expectServerOffline = () => {
+        expect(screen.getByText("It's not you, it's us.")).toBeTruthy();
+    };
+
     it('should render Buy skeleton when isLoading is true', async () => {
-        mockUseTradingBuyDataValue = { isLoading: true, lastLoadedTimestamp: 1 };
+        mockUseTradingBuyData.mockReturnValue({
+            isLoading: true,
+            lastLoadedTimestamp: 1,
+            isFullyLoaded: false,
+        });
 
-        const { getAllByText } = await renderTradingScreen(stateWithEnabledBuy);
+        await renderTradingScreen(stateWithEnabledBuy);
 
-        expect(getAllByText('Buy').length).toBe(1);
+        expectSkeleton();
     });
 
     it('should render Buy skeleton when lastLoadedTimestamp is 0', async () => {
-        mockUseTradingBuyDataValue = { isLoading: false, lastLoadedTimestamp: 0 };
+        mockUseTradingBuyData.mockReturnValue({
+            isLoading: false,
+            lastLoadedTimestamp: 0,
+            isFullyLoaded: false,
+        });
 
-        const { getAllByText } = await renderTradingScreen(stateWithEnabledBuy);
+        await renderTradingScreen(stateWithEnabledBuy);
 
-        expect(getAllByText('Buy').length).toBe(1);
+        expectSkeleton();
     });
 
-    it('should render Buy form when isLoading is false and lastLoadedTimestamp is greater than 0', async () => {
-        mockUseTradingBuyDataValue = { isLoading: false, lastLoadedTimestamp: 1 };
+    it('should render Buy form when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded true', async () => {
+        mockUseTradingBuyData.mockReturnValue({
+            isLoading: false,
+            lastLoadedTimestamp: 1,
+            isFullyLoaded: true,
+        });
 
-        const { getAllByText } = await renderTradingScreen(stateWithEnabledBuy);
+        await renderTradingScreen(stateWithEnabledBuy);
 
-        expect(getAllByText('Buy').length).toBe(2);
+        expectBuyForm();
     });
 
     it('should not render Buy form when feature flag is not enabled', async () => {
-        mockUseTradingBuyDataValue = { isLoading: false, lastLoadedTimestamp: 1 };
+        mockUseTradingBuyData.mockReturnValue({
+            isLoading: false,
+            lastLoadedTimestamp: 1,
+            isFullyLoaded: true,
+        });
 
         const { queryByText } = await renderTradingScreen(stateWithDisabledBuy);
 
         expect(queryByText('Buy')).toBeNull();
+    });
+
+    it('should render error screen when isInternetReachable is false', async () => {
+        mockIsInternetReachable = false;
+
+        await renderTradingScreen(stateWithEnabledBuy);
+
+        expectDeviceOffline();
+    });
+
+    it('should render server error info when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded false', async () => {
+        mockUseTradingBuyData.mockReturnValue({
+            isLoading: false,
+            lastLoadedTimestamp: 1,
+            isFullyLoaded: false,
+        });
+
+        await renderTradingScreen(stateWithEnabledBuy);
+
+        expectServerOffline();
+    });
+
+    it('should reload data when server error info is displayed and user presses "Try again" button', async () => {
+        mockUseTradingBuyData
+            .mockReturnValueOnce({
+                isLoading: false,
+                lastLoadedTimestamp: 1,
+                isFullyLoaded: false,
+            })
+            .mockReturnValue({
+                isLoading: false,
+                lastLoadedTimestamp: 1,
+                isFullyLoaded: true,
+            });
+
+        const { getByText } = await renderTradingScreen(stateWithEnabledBuy);
+
+        const reloadButton = getByText('Try again');
+
+        act(() => {
+            fireEvent.press(reloadButton);
+        });
+
+        expectBuyForm();
+        expect(mockUseTradingBuyData).toHaveBeenCalledTimes(2);
+        expect(mockUseTradingBuyData).toHaveBeenCalledWith(0);
+        expect(mockUseTradingBuyData).toHaveBeenCalledWith(1);
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10786,6 +10786,7 @@ __metadata:
   resolution: "@suite-native/module-trading@workspace:suite-native/module-trading"
   dependencies:
     "@mobily/ts-belt": "npm:^3.13.1"
+    "@react-native-community/netinfo": "npm:^11.4.1"
     "@react-navigation/native": "npm:6.1.18"
     "@react-navigation/native-stack": "npm:6.11.0"
     "@reduxjs/toolkit": "npm:2.6.0"


### PR DESCRIPTION
…e/offline

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve [#18326](https://github.com/trezor/trezor-suite/issues/18326)

## Screenshots:
![Screenshot 2025-05-06 at 13 18 57](https://github.com/user-attachments/assets/decb5ee4-558f-4646-b774-33de37b7a6f7)
![Screenshot 2025-05-06 at 13 19 11](https://github.com/user-attachments/assets/b9885711-06c7-4b18-bc05-dab99496342a)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=18326-Mobile-Trade-Error-states-when-api-is-unreachable&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=18326-Mobile-Trade-Error-states-when-api-is-unreachable&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=18326-Mobile-Trade-Error-states-when-api-is-unreachable&lookback=7)