### PR TITLE
fix(connect-popup): ethereumSignTransaction last confirmation step optional in e2e

### DIFF
--- a/packages/connect-popup/e2e/tests/__fixtures__/methods.ts
+++ b/packages/connect-popup/e2e/tests/__fixtures__/methods.ts
@@ -225,7 +225,15 @@ const ethereumSignTransaction = [
         device: initializedDevice,
         dir: 'ethereum',
         url: 'ethereumSignTransaction',
-        views: [followDevice, followDevice, followDevice],
+        views: [
+            followDevice,
+            followDevice,
+            {
+                nextEmu: {
+                    type: 'emulator-press-yes',
+                },
+            },
+        ],
     },
 ];
 

--- a/packages/connect-popup/e2e/tests/methods.test.ts
+++ b/packages/connect-popup/e2e/tests/methods.test.ts
@@ -164,34 +164,36 @@ filteredFixtures.forEach(f => {
 
         let screenshotCount = 1;
         for (const v of f.views) {
-            log(f.url, v.selector, 'expecting view');
+            if ('selector' in v) {
+                log(f.url, v.selector, 'expecting view');
 
-            if (v.selector) {
-                const element = popup.locator(v.selector);
-                await element.first().waitFor({ state: 'visible' });
+                if (v.selector) {
+                    const element = popup.locator(v.selector);
+                    await element.first().waitFor({ state: 'visible' });
 
-                if (v.screenshot) {
-                    const path = `${screenshotsPath}/3-${screenshotCount}-${v.screenshot.name}.png`;
+                    if (v.screenshot) {
+                        const path = `${screenshotsPath}/3-${screenshotCount}-${v.screenshot.name}.png`;
 
-                    await popup.screenshot({
-                        path,
-                        fullPage: true,
-                    });
-                    await screenshotEmu(path);
+                        await popup.screenshot({
+                            path,
+                            fullPage: true,
+                        });
+                        await screenshotEmu(path);
 
-                    screenshotCount++;
+                        screenshotCount++;
+                    }
                 }
-            }
 
-            if ('next' in v && v.next) {
-                const nextElement = popup.locator(v.next);
-                await nextElement.waitFor();
-                // useful for debugging tests
-                // await popup.pause();
-                await nextElement.click();
-            }
+                if ('next' in v && v.next) {
+                    const nextElement = popup.locator(v.next);
+                    await nextElement.waitFor();
+                    // useful for debugging tests
+                    // await popup.pause();
+                    await nextElement.click();
+                }
 
-            log(f.url, v.selector, 'view finished');
+                log(f.url, v.selector, 'view finished');
+            }
 
             if ('nextEmu' in v && v.nextEmu) {
                 // useful for debugging tests


### PR DESCRIPTION
## Description

Connect Popup `ethereumSignTransaction` test expects 3 confirmation steps. 
But on most device models there are 2 steps, only TS5 has 3 steps. 
This change removes the selector from the last step in the test fixture, meaning it won't fail and should work in both situations. 