### PR TITLE
chore(trading): delete account from tradingTrades

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.ts
@@ -6,7 +6,6 @@ import {
     cryptoIdToSymbol,
     getUnusedAddressFromAccount,
     parseCryptoId,
-    tradingExchangeActions,
 } from '@suite-common/trading';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
@@ -130,7 +129,6 @@ const useTradingVerifyAccount = ({
 
     const selectAccountOption = (option: TradingVerifyFormAccountOptionProps) => {
         setSelectedAccountOption(option);
-        dispatch(tradingExchangeActions.setReceiveAccountKey(option.account?.key));
 
         if (option.account) {
             const { address } = getUnusedAddressFromAccount(option.account);

--- a/packages/suite/src/storage/index.ts
+++ b/packages/suite/src/storage/index.ts
@@ -5,7 +5,7 @@ import { reloadApp } from 'src/utils/suite/reload';
 import type { SuiteDBSchema } from './definitions';
 import { migrate } from './migrations';
 
-const VERSION = 55; // don't forget to add migration and CHANGELOG when changing versions!
+const VERSION = 56; // don't forget to add migration and CHANGELOG when changing versions!
 
 /**
  *  If the object stores don't already exist then creates them.

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -22,6 +22,7 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { migrationOfBnbNetwork } from 'src/storage/migrations/networks/bnb';
 import { migrationCoinmarketToTrading } from 'src/storage/migrations/trading/migrationCoinmarketToTrading';
+import { migrateToV56 } from 'src/storage/migrations/versions/migrateToV56';
 import type { BlockbookUrl, CustomBackend } from 'src/types/wallet/backend';
 
 import { updateAll } from './utils';
@@ -1283,5 +1284,9 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
     if (oldVersion < 55) {
         await migrateToV55(db, oldVersion, newVersion, transaction);
         db.createObjectStore('explorer');
+    }
+
+    if (oldVersion < 56) {
+        await migrateToV56(db, oldVersion, newVersion, transaction);
     }
 };

--- a/packages/suite/src/storage/migrations/versions/migrateToV55.ts
+++ b/packages/suite/src/storage/migrations/versions/migrateToV55.ts
@@ -12,7 +12,6 @@ import { OnUpgradeFunc } from '@trezor/suite-storage';
 import { SuiteDBSchema } from 'src/storage/definitions';
 
 import { updateAll } from '../utils';
-
 const findAccountForTrade = (
     accounts: Account[],
     address: string | undefined,
@@ -72,6 +71,7 @@ export const migrateToV55: OnUpgradeFunc<SuiteDBSchema> = async (
             trade.sendAccountKey = findAccountForTrade(
                 accounts,
                 // account may be incorrect because it may not be current, but the default
+                // @ts-expect-error - account deprecated property
                 trade.account.descriptor,
                 trade.data.cryptoCurrency,
             )?.key;
@@ -83,7 +83,7 @@ export const migrateToV55: OnUpgradeFunc<SuiteDBSchema> = async (
             if (trade.sendAccountKey === undefined) {
                 trade.sendAccountKey = findAccountForTrade(
                     accounts,
-                    // account may be incorrect because it may not be current, but the default
+                    // @ts-expect-error - account deprecated property
                     trade.account.descriptor,
                     trade.data.send,
                 )?.key;

--- a/packages/suite/src/storage/migrations/versions/migrateToV56.ts
+++ b/packages/suite/src/storage/migrations/versions/migrateToV56.ts
@@ -1,0 +1,54 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import type { Account } from '@suite-common/wallet-types';
+import { findAccountsByDescriptor, findAccountsByNetwork } from '@suite-common/wallet-utils';
+import { OnUpgradeFunc } from '@trezor/suite-storage';
+
+import { SuiteDBSchema } from 'src/storage/definitions';
+
+import { updateAll } from '../utils';
+
+const findAccountForTrade = (
+    accounts: Account[],
+    descriptor: string,
+    symbol: NetworkSymbol,
+): Account | undefined => {
+    const account = findAccountsByDescriptor(
+        descriptor,
+        findAccountsByNetwork(symbol, accounts),
+    ).at(0);
+
+    if (account) {
+        return account;
+    }
+
+    return undefined;
+};
+
+export const migrateToV56: OnUpgradeFunc<SuiteDBSchema> = async (
+    _db,
+    _oldVersion,
+    _newVersion,
+    transaction,
+) => {
+    const accountsStoreOld = transaction.objectStore('accounts');
+    const accounts = await accountsStoreOld.getAll();
+
+    await updateAll(transaction, 'tradingTrades', trade => {
+        if (trade.tradeType === 'buy') {
+            const selectAccountKey = findAccountForTrade(
+                accounts,
+                // @ts-expect-error - account deprecated property
+                trade.account.descriptor,
+                // @ts-expect-error - account deprecated property
+                trade.account.symbol,
+            )?.key;
+
+            trade.selectedAccountKey = selectAccountKey;
+        }
+
+        // @ts-expect-error - account deprecated property
+        delete trade.account;
+
+        return trade;
+    });
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoHeader.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoHeader.tsx
@@ -9,13 +9,13 @@ import { Translation } from 'src/components/suite';
 import { TradingCoinLogo } from 'src/views/wallet/trading/common/TradingCoinLogo';
 
 interface TradingInfoHeaderProps {
-    receiveCurrency?: CryptoId;
+    receiveCurrency: CryptoId;
 }
 
 export const TradingInfoHeader = ({ receiveCurrency }: TradingInfoHeaderProps) => {
     const { cryptoIdToPlatformName, cryptoIdToSymbolAndContractAddress } = useTradingInfo();
 
-    const { networkId } = parseCryptoId(receiveCurrency!);
+    const { networkId } = parseCryptoId(receiveCurrency);
     const platform = cryptoIdToPlatformName(networkId);
 
     const { coinSymbol, contractAddress } = cryptoIdToSymbolAndContractAddress(receiveCurrency);

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo.tsx
@@ -31,9 +31,9 @@ export const TradingSelectedOfferInfo = ({
 
     return (
         <Column gap={spacings.xl} data-testid="@trading/form/info">
-            {type !== 'exchange' && (
+            {type !== 'exchange' && quoteAmounts?.receiveCurrency && (
                 <>
-                    <TradingInfoHeader receiveCurrency={quoteAmounts?.receiveCurrency} />
+                    <TradingInfoHeader receiveCurrency={quoteAmounts.receiveCurrency} />
                     <Divider margin={{}} />
                 </>
             )}

--- a/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
@@ -29,12 +29,7 @@ const tradeBuy: TradingTransactionBuy = {
         maxCrypto: 0.19952,
         paymentMethod: 'creditCard',
     },
-    account: {
-        symbol: 'btc',
-        descriptor: 'asdfasdfasdfasdfas',
-        accountIndex: 0,
-        accountType: 'normal',
-    },
+    selectedAccountKey: 'xxx',
     receiveAccountKey: 'yyy',
 };
 
@@ -50,12 +45,6 @@ const tradeExchange: TradingTransactionExchange = {
         orderId: 'd369ba9e-7370-4a6e-87dc-aefd3851c735',
         exchange: 'changelly',
         status: 'CONFIRMING',
-    },
-    account: {
-        symbol: 'btc',
-        descriptor: 'asdfasdfasdfasdfas',
-        accountIndex: 0,
-        accountType: 'normal',
     },
     sendAccountKey: 'xxx',
     receiveAccountKey: 'yyy',

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -210,55 +210,32 @@ describe('tradingSelectors', () => {
                             tradeType: 'buy',
                             data: { orderId: 'orderId1' },
                             date: '2024-03-01T10:00:00Z',
-                            account: {
-                                descriptor: accountEth.descriptor,
-                                symbol: accountEth.symbol,
-                                accountType: accountEth.accountType,
-                                accountIndex: accountEth.index,
-                            },
+                            selectedAccountKey: accountEth.key,
                         },
                         {
                             tradeType: 'buy',
                             data: { orderId: 'orderId2' },
                             date: '2024-03-02T10:00:00Z',
-                            account: {
-                                descriptor: accountEth.descriptor,
-                                symbol: accountEth.symbol,
-                                accountType: accountEth.accountType,
-                                accountIndex: accountEth.index,
-                            },
+                            selectedAccountKey: accountEth.key,
                         },
                         {
                             tradeType: 'buy',
                             data: { orderId: 'orderId3' },
                             date: '2024-03-03T10:00:00Z',
-                            account: {
-                                descriptor: accountEth.descriptor,
-                                symbol: accountEth.symbol,
-                                accountType: accountEth.accountType,
-                                accountIndex: accountEth.index,
-                            },
+                            selectedAccountKey: accountEth.key,
                         },
                         {
                             tradeType: 'exchange',
                             data: { orderId: 'orderId4' },
                             date: '2024-03-04T10:00:00Z',
-                            account: {
-                                descriptor: accountEth.descriptor,
-                                symbol: accountEth.symbol,
-                                accountType: accountEth.accountType,
-                                accountIndex: accountEth.index,
-                            },
+                            sendAccountKey: accountEth.key,
+                            receiveAccountKey: accountBtc.key,
                         },
                         {
                             tradeType: 'exchange',
                             data: { orderId: 'orderId5' },
-                            account: {
-                                descriptor: accountEth.descriptor,
-                                symbol: accountEth.symbol,
-                                accountType: accountEth.accountType,
-                                accountIndex: accountEth.index,
-                            },
+                            sendAccountKey: accountEth.key,
+                            receiveAccountKey: accountBtc.key,
                         },
                     ],
                     composedTransactionInfo: {
@@ -1133,13 +1110,13 @@ describe('tradingSelectors', () => {
                         account: { deviceState: 'device1' },
                     },
                     accounts: [
-                        { descriptor: 'account1', deviceState: 'device1' },
-                        { descriptor: 'account2', deviceState: 'device2' },
+                        { key: 'key1', deviceState: 'device1' },
+                        { key: 'key2', deviceState: 'device2' },
                     ],
                     tradingNew: {
                         trades: [
-                            { account: { descriptor: 'account1' }, tradeType: 'buy' },
-                            { account: { descriptor: 'account2' }, tradeType: 'sell' },
+                            { selectedAccountKey: 'key1', tradeType: 'buy' },
+                            { sendAccountKey: 'key2', tradeType: 'sell' },
                         ],
                     },
                 },
@@ -1147,7 +1124,7 @@ describe('tradingSelectors', () => {
 
             const result = selectTradingTradesForSelectedDevice(mockState);
 
-            expect(result).toEqual([{ account: { descriptor: 'account1' }, tradeType: 'buy' }]);
+            expect(result).toEqual([{ selectedAccountKey: 'key1', tradeType: 'buy' }]);
         });
 
         it('should return an empty array if no trades match the selected device', () => {
@@ -1157,14 +1134,11 @@ describe('tradingSelectors', () => {
                         account: { deviceState: 'device3' },
                     },
                     accounts: [
-                        { descriptor: 'account1', deviceState: 'device1' },
-                        { descriptor: 'account2', deviceState: 'device2' },
+                        { key: 'key1', deviceState: 'device1' },
+                        { key: 'key2', deviceState: 'device2' },
                     ],
                     tradingNew: {
-                        trades: [
-                            { account: { descriptor: 'account1' }, tradeType: 'buy' },
-                            { account: { descriptor: 'account2' }, tradeType: 'sell' },
-                        ],
+                        trades: [{ tradeType: 'buy' }, { tradeType: 'sell' }],
                     },
                 },
             } as unknown as TradingRootState;
@@ -1181,8 +1155,8 @@ describe('tradingSelectors', () => {
                         account: { deviceState: 'device1' },
                     },
                     accounts: [
-                        { descriptor: 'account1', deviceState: 'device1' },
-                        { descriptor: 'account2', deviceState: 'device2' },
+                        { key: 'key1', deviceState: 'device1' },
+                        { key: 'key2', deviceState: 'device2' },
                     ],
                     tradingNew: {
                         trades: [],

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -288,9 +288,12 @@ export const selectTradingTradesForSelectedDevice = createMemoizedSelector(
     [selectAccounts, state => state.wallet.selectedAccount, selectTradingTrades],
     (accounts, selectedAccount, trades): TradingTransaction[] =>
         trades.filter(tx => {
-            const txDeviceId = accounts.find(
-                account => tx.account.descriptor === account.descriptor,
-            )?.deviceState;
+            const txDeviceId = accounts.find(account => {
+                const transactionAccountKey =
+                    'selectedAccountKey' in tx ? tx.selectedAccountKey : tx.sendAccountKey;
+
+                return transactionAccountKey === account.key;
+            })?.deviceState;
 
             return txDeviceId === selectedAccount.account?.deviceState;
         }),
@@ -306,14 +309,15 @@ export const selectDeviceTradingTrades: (
         (_, tradeType: TradingType) => tradeType,
     ],
     (accounts, trades, tradeType) => {
-        const accountDescriptors = new Set(accounts.map(({ descriptor }) => descriptor));
+        const accountKeys = new Set(accounts.map(({ key }) => key));
 
         return returnStableArrayIfEmpty(
-            trades.filter(
-                trade =>
-                    accountDescriptors.has(trade.account?.descriptor) &&
-                    trade.tradeType === tradeType,
-            ),
+            trades.filter(trade => {
+                const tradeKey =
+                    'selectedAccountKey' in trade ? trade.selectedAccountKey : trade.sendAccountKey;
+
+                return tradeKey && accountKeys.has(tradeKey) && trade.tradeType === tradeType;
+            }),
         );
     },
 );
@@ -536,6 +540,9 @@ export const selectValidTradingBuyQuotes = createMemoizedSelector(
         return quotes.filter(item => item.rate && item.rate !== 0);
     },
 );
+
+export const selectTradingBuyReceiveAccountKey = (state: TradingRootState) =>
+    state.wallet.tradingNew.buy.tradingAccountKey;
 
 export const selectTradingExchangeAccountKey = (state: TradingRootState) =>
     state.wallet.tradingNew.exchange.tradingAccountKey;

--- a/suite-common/trading/src/thunks/buy/__tests__/confirmBuyTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/__tests__/confirmBuyTradeThunk.test.ts
@@ -38,6 +38,7 @@ describe('confirmBuyTradeThunk', () => {
                             ...initialState.buy,
                             selectedQuote: MIN_MAX_QUOTES_OK[1],
                             ...(initialBuyState ?? {}),
+                            receiveAccountKey: 'xxx',
                         },
                     },
                 },
@@ -253,10 +254,7 @@ describe('confirmBuyTradeThunk', () => {
                 returnUrl: 'returnUrl',
                 address: 'address',
                 account: {
-                    symbol: 'btc',
-                    accountType: 'normal',
-                    descriptor: 'desc',
-                    index: 1,
+                    key: 'yyy',
                 } as Account,
                 triggerAnalyticsTradeConfirmation: mocktriggerAnalyticsTradeConfirmation,
                 processResponseData: mockProcessResponseData,
@@ -273,12 +271,7 @@ describe('confirmBuyTradeThunk', () => {
             date: dateString,
             data: MIN_MAX_QUOTES_OK[1],
             key: MIN_MAX_QUOTES_OK[1].paymentId,
-            account: {
-                descriptor: 'desc',
-                symbol: 'btc',
-                accountType: 'normal',
-                accountIndex: 1,
-            },
+            selectedAccountKey: 'yyy',
         });
         expect(store.getState().wallet.tradingNew.buy.isLoading).toBeFalsy();
     });

--- a/suite-common/trading/src/thunks/buy/confirmBuyTradeThunk.ts
+++ b/suite-common/trading/src/thunks/buy/confirmBuyTradeThunk.ts
@@ -9,8 +9,8 @@ import { invityAPI } from '../../invityAPI';
 import { tradingBuyActions } from '../../reducers/buyReducer';
 import { tradingActions } from '../../reducers/tradingReducer';
 import {
+    selectTradingBuyReceiveAccountKey,
     selectTradingBuySelectedQuote,
-    selectTradingExchangeReceiveAccountKey,
 } from '../../selectors/tradingSelectors';
 
 export type ConfirmTradeThunkProps = {
@@ -35,7 +35,7 @@ export const confirmBuyTradeThunk = createThunk(
         { dispatch, getState },
     ) => {
         const selectedQuote = selectTradingBuySelectedQuote(getState());
-        const receiveAccountKey = selectTradingExchangeReceiveAccountKey(getState());
+        const receiveAccountKey = selectTradingBuyReceiveAccountKey(getState());
 
         if (!selectedQuote) return;
 
@@ -73,14 +73,9 @@ export const confirmBuyTradeThunk = createThunk(
                     tradeType: 'buy',
                     date: new Date().toISOString(),
                     key: response.trade.paymentId,
-                    account: {
-                        descriptor: account.descriptor,
-                        symbol: account.symbol,
-                        accountType: account.accountType,
-                        accountIndex: account.index,
-                    },
                     data: response.trade,
                     receiveAccountKey,
+                    selectedAccountKey: account.key,
                 }),
             );
 

--- a/suite-common/trading/src/thunks/common/__tests__/verifyAddressThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/verifyAddressThunk.test.ts
@@ -76,7 +76,7 @@ describe('verifyAddressThunk', () => {
                 }),
             );
 
-            expect(store.getActions().length).toEqual(6);
+            expect(store.getActions().length).toEqual(7);
             expect(
                 store.getState().wallet.tradingNew[type as 'buy' | 'exchange'].addressVerified,
             ).toEqual(addressData?.address);

--- a/suite-common/trading/src/thunks/common/__tests__/watchTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/watchTradeThunk.test.ts
@@ -23,12 +23,6 @@ describe('watchTradeThunk', () => {
 
     const tradingReducer = prepareTradingReducer(extraDependenciesMock);
     const account = accountBtc as Account;
-    const accountData = {
-        symbol: account.symbol,
-        descriptor: account.descriptor,
-        accountIndex: account.index,
-        accountType: account.accountType,
-    };
     const refreshCount = 1;
 
     const getStore = (updatedState: Partial<TradingState>) =>
@@ -71,7 +65,6 @@ describe('watchTradeThunk', () => {
                     status: 'LOGIN_REQUEST',
                     paymentId: 'tradeKey',
                 },
-                account: accountData,
             } as TradingTransaction;
 
             const store = getStore({
@@ -104,7 +97,6 @@ describe('watchTradeThunk', () => {
                 status: 'LOGIN_REQUEST',
                 paymentId: 'tradeKey',
             },
-            account: accountData,
         } as TradingTransactionBuy;
 
         const store = getStore({
@@ -139,7 +131,6 @@ describe('watchTradeThunk', () => {
                 status: 'LOGIN_REQUEST',
                 paymentId: 'tradeKey',
             },
-            account: accountData,
         } as TradingTransactionBuy;
 
         const store = getStore({
@@ -167,12 +158,13 @@ describe('watchTradeThunk', () => {
             tradeType: 'buy',
             date: dateISO,
             key: 'tradeKey',
-            account: accountData,
             data: {
                 status: 'ERROR',
                 paymentId: 'tradeKey',
                 error: 'Some error occurred',
             },
+            receiveAccountKey: undefined,
+            selectedAccountKey: account.key,
         });
     });
 
@@ -201,7 +193,6 @@ describe('watchTradeThunk', () => {
                     status: 'LOGIN_REQUEST',
                     orderId: 'tradeKey',
                 },
-                account: accountData,
                 sendAccountKey: 'sendAccountKey',
             } as TradingTransactionSell;
 
@@ -230,7 +221,6 @@ describe('watchTradeThunk', () => {
                 tradeType: 'sell',
                 date: dateISO,
                 key: 'tradeKey',
-                account: accountData,
                 data: {
                     status: 'CONFIRM',
                     orderId: 'tradeKey',
@@ -260,7 +250,6 @@ describe('watchTradeThunk', () => {
                     status: 'SENDING',
                     orderId: 'tradeKey',
                 },
-                account: accountData,
             } as TradingTransactionExchange;
 
             const store = getStore({
@@ -288,7 +277,6 @@ describe('watchTradeThunk', () => {
                 tradeType: 'exchange',
                 date: dateISO,
                 key: 'tradeKey',
-                account: accountData,
                 data: {
                     status: 'CONFIRM',
                     orderId: 'tradeKey',

--- a/suite-common/trading/src/thunks/common/verifyAddressThunk.ts
+++ b/suite-common/trading/src/thunks/common/verifyAddressThunk.ts
@@ -33,6 +33,12 @@ export const verifyAddressThunk = createThunk(
 
         dispatch(tradingActions.setModalAccountKey(account.key));
 
+        if (tradingAction === tradingBuyActions.verifyAddress.type) {
+            dispatch(tradingBuyActions.setTradingAccountKey(account.key));
+        } else {
+            dispatch(tradingExchangeActions.setReceiveAccountKey(account.key));
+        }
+
         const addressDisplayType = extra.selectors.selectAddressDisplayType(getState());
 
         const { useEmptyPassphrase, connected, available } = device;

--- a/suite-common/trading/src/thunks/common/watchTradeThunk.ts
+++ b/suite-common/trading/src/thunks/common/watchTradeThunk.ts
@@ -54,12 +54,6 @@ export const watchTradeThunk = createThunk(
         invityAPI.createInvityAPIKey(account.descriptor);
 
         const { tradeType } = trade;
-        const accountData = {
-            descriptor: account.descriptor,
-            symbol: account.symbol,
-            accountType: account.accountType,
-            accountIndex: account.index,
-        };
         const date = new Date().toISOString();
 
         switch (tradeType) {
@@ -76,9 +70,9 @@ export const watchTradeThunk = createThunk(
                         tradeType,
                         date,
                         key: data.tradeData.paymentId,
-                        account: accountData,
                         data: data.tradeData,
                         receiveAccountKey: trade.receiveAccountKey,
+                        selectedAccountKey: account.key,
                     }),
                 );
 
@@ -107,7 +101,6 @@ export const watchTradeThunk = createThunk(
                         tradeType,
                         date,
                         key: data.tradeData.orderId,
-                        account: accountData,
                         data: data.tradeData,
                         sendAccountKey: trade.sendAccountKey,
                     }),
@@ -133,7 +126,6 @@ export const watchTradeThunk = createThunk(
                         tradeType,
                         date,
                         key: data.tradeData.orderId,
-                        account: accountData,
                         data: data.tradeData,
                         sendAccountKey: trade.sendAccountKey,
                         receiveAccountKey: trade.receiveAccountKey,

--- a/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
@@ -609,12 +609,6 @@ describe('confirmExchangeTradeThunk', () => {
             date: dateString,
             data: tradeResponse,
             key: mockResponse.orderId,
-            account: {
-                descriptor: 'btc-descriptor',
-                symbol: 'btc',
-                accountType: 'segwit',
-                accountIndex: 1,
-            },
         });
         expect(response).toBeTruthy();
     });
@@ -678,12 +672,6 @@ describe('confirmExchangeTradeThunk', () => {
             date: dateString,
             data: tradeResponse,
             key: mockResponse.orderId,
-            account: {
-                descriptor: 'btc-descriptor',
-                symbol: 'btc',
-                accountType: 'segwit',
-                accountIndex: 1,
-            },
         });
         expect(response).toBeTruthy();
     });
@@ -750,12 +738,6 @@ describe('confirmExchangeTradeThunk', () => {
             date: dateString,
             data: tradeResponse,
             key: mockResponse.orderId,
-            account: {
-                descriptor: 'btc-descriptor',
-                symbol: 'btc',
-                accountType: 'segwit',
-                accountIndex: 1,
-            },
         });
         expect(mockProcessResponseData).toHaveBeenCalledTimes(1);
         expect(response).toBeTruthy();
@@ -813,12 +795,6 @@ describe('confirmExchangeTradeThunk', () => {
             date: dateString,
             data: tradeResponse,
             key: mockResponse.orderId,
-            account: {
-                descriptor: 'btc-descriptor',
-                symbol: 'btc',
-                accountType: 'segwit',
-                accountIndex: 1,
-            },
         });
         expect(exchange.formStep).toEqual('SEND_TRANSACTION');
         expect(response).toBeTruthy();

--- a/suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts
@@ -234,12 +234,6 @@ describe('sendDexTransactionThunk', () => {
                 date: dateString,
                 data: trade,
                 key: trade.orderId,
-                account: {
-                    descriptor: 'btc-descriptor',
-                    symbol: 'btc',
-                    accountType: 'segwit',
-                    accountIndex: 1,
-                },
             },
         ]);
         expect(exchangeThunks.confirmTradeThunk).toHaveBeenCalledTimes(1);

--- a/suite-common/trading/src/thunks/exchange/__tests__/sendTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/sendTransactionThunk.test.ts
@@ -11,6 +11,7 @@ import { MIN_MAX_QUOTES_OK } from '../../../__fixtures__/exchangeUtils';
 import { accountBtc } from '../../../__fixtures__/utils';
 import { TradingExchangeState } from '../../../reducers/exchangeReducer';
 import { initialState, prepareTradingReducer } from '../../../reducers/tradingReducer';
+import { TradingTransactionExchange } from '../../../types';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesMock);
 
@@ -79,20 +80,17 @@ describe('sendTransactionThunk', () => {
 
         const account = accountBtc as Account;
 
-        const trade = {
+        const trade: TradingTransactionExchange = {
             tradeType: 'exchange' as const,
             date: new Date().toISOString(),
             key: getQuote().orderId,
-            account: {
-                descriptor: account.descriptor,
-                symbol: account.symbol,
-                accountType: account.accountType,
-                accountIndex: account.index,
-            },
+
             data: {
                 ...getQuote(),
                 sendAddress: '1',
             },
+            sendAccountKey: 'xxx',
+            receiveAccountKey: 'yyy',
         };
 
         return {
@@ -313,12 +311,6 @@ describe('sendTransactionThunk', () => {
                     partnerPaymentExtraId: undefined,
                 },
                 key: trade.data.orderId,
-                account: {
-                    descriptor: 'btc-descriptor',
-                    symbol: 'btc',
-                    accountType: 'segwit',
-                    accountIndex: 1,
-                },
             },
         ]);
         expect(store.getState().wallet.tradingNew.exchange.transactionId).toBe(trade.data.orderId);

--- a/suite-common/trading/src/thunks/exchange/__tests__/signDataAndConfirmThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/signDataAndConfirmThunk.test.ts
@@ -341,12 +341,6 @@ describe('signDataAndConfirmThunk', () => {
             date: dateString,
             data: trade,
             key: trade.orderId,
-            account: {
-                descriptor: 'eth-descriptor',
-                symbol: 'eth',
-                accountType: 'normal',
-                accountIndex: 1,
-            },
         });
     });
 });

--- a/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
@@ -149,12 +149,6 @@ export const confirmExchangeTradeThunk = createThunk(
                 tradeType: 'exchange',
                 date: new Date().toISOString(),
                 key: response.orderId,
-                account: {
-                    descriptor: account.descriptor,
-                    symbol: account.symbol,
-                    accountType: account.accountType,
-                    accountIndex: account.index,
-                },
                 data: response,
                 sendAccountKey,
                 receiveAccountKey,

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -106,12 +106,6 @@ export const sendDexTransactionThunk = createThunk<
                     tradeType: 'exchange',
                     date: new Date().toISOString(),
                     key: trade.orderId,
-                    account: {
-                        descriptor: account.descriptor,
-                        symbol: account.symbol,
-                        accountType: account.accountType,
-                        accountIndex: account.index,
-                    },
                     data: trade,
                     sendAccountKey,
                     receiveAccountKey,

--- a/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
@@ -120,12 +120,6 @@ export const sendTransactionThunk = createThunk<
                 tradeType: 'exchange',
                 date: new Date().toISOString(),
                 key: selectedTrade.orderId,
-                account: {
-                    descriptor: account.descriptor,
-                    symbol: account.symbol,
-                    accountType: account.accountType,
-                    accountIndex: account.index,
-                },
                 data: { ...selectedTrade, receiveTxHash: recomposeAndSignTx.payload.payload.txid },
                 sendAccountKey,
                 receiveAccountKey,

--- a/suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts
@@ -105,12 +105,6 @@ export const signDataAndConfirmThunk = createThunk(
                 tradeType: 'exchange',
                 date: new Date().toISOString(),
                 key: trade.orderId,
-                account: {
-                    descriptor: account.descriptor,
-                    symbol: account.symbol,
-                    accountType: account.accountType,
-                    accountIndex: account.index,
-                },
                 data: trade,
                 sendAccountKey,
                 receiveAccountKey,

--- a/suite-common/trading/src/thunks/sell/__tests__/handleSellTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/handleSellTradeThunk.test.ts
@@ -254,12 +254,6 @@ describe('handleSellTradeThunk', () => {
                 data: mockResponse.trade,
                 key: mockResponse.trade.orderId,
                 date: dateISO,
-                account: {
-                    descriptor: 'btc-descriptor',
-                    symbol: 'btc',
-                    accountType: 'segwit',
-                    accountIndex: 1,
-                },
                 sendAccountKey: 'btc-descriptor-btc',
             },
         ]);
@@ -308,12 +302,6 @@ describe('handleSellTradeThunk', () => {
                 data: mockResponse.trade,
                 key: mockResponse.trade.orderId,
                 date: dateISO,
-                account: {
-                    descriptor: 'btc-descriptor',
-                    symbol: 'btc',
-                    accountType: 'segwit',
-                    accountIndex: 1,
-                },
                 sendAccountKey: 'btc-descriptor-btc',
             },
         ]);

--- a/suite-common/trading/src/thunks/sell/__tests__/sendSellTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/sendSellTransactionThunk.test.ts
@@ -11,7 +11,7 @@ import { accountBtc } from '../../../__fixtures__/utils';
 import { invityAPI } from '../../../invityAPI';
 import { TradingSellState, sellInitialState } from '../../../reducers/sellReducer';
 import { initialState, prepareTradingReducer } from '../../../reducers/tradingReducer';
-import { TradingSellFormProps } from '../../../types';
+import { TradingSellFormProps, TradingTransactionSell } from '../../../types';
 import { sellUtilsFixtures } from '../../../utils/sell/__fixtures__/sellUtils';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesMock);
@@ -74,17 +74,12 @@ describe('sendSellTransactionThunk', () => {
         });
 
         const account = accountBtc as Account;
-        const trade = {
+        const trade: TradingTransactionSell = {
             tradeType: 'sell' as const,
             date: new Date().toISOString(),
             key: getQuote().orderId,
-            account: {
-                descriptor: account.descriptor,
-                symbol: account.symbol,
-                accountType: account.accountType,
-                accountIndex: account.index,
-            },
             data: getQuote(),
+            sendAccountKey: 'xxx',
         };
         const mockNextStep = jest.fn();
         const formValues = {
@@ -276,12 +271,6 @@ describe('sendSellTransactionThunk', () => {
                     ...responseData,
                 },
                 key: responseData.orderId,
-                account: {
-                    descriptor: 'btc-descriptor',
-                    symbol: 'btc',
-                    accountType: 'segwit',
-                    accountIndex: 1,
-                },
                 sendAccountKey: 'btc-descriptor-btc',
             },
         ]);
@@ -327,12 +316,6 @@ describe('sendSellTransactionThunk', () => {
                     ...responseData,
                 },
                 key: responseData.orderId,
-                account: {
-                    descriptor: 'btc-descriptor',
-                    symbol: 'btc',
-                    accountType: 'segwit',
-                    accountIndex: 1,
-                },
                 sendAccountKey: 'btc-descriptor-btc',
             },
         ]);
@@ -393,12 +376,6 @@ describe('sendSellTransactionThunk', () => {
                     ...responseData,
                 },
                 key: responseData.orderId,
-                account: {
-                    descriptor: 'btc-descriptor',
-                    symbol: 'btc',
-                    accountType: 'segwit',
-                    accountIndex: 1,
-                },
                 sendAccountKey: 'btc-descriptor-btc',
             },
         ]);
@@ -454,12 +431,6 @@ describe('sendSellTransactionThunk', () => {
                     ...responseData,
                 },
                 key: responseData.orderId,
-                account: {
-                    descriptor: 'btc-descriptor',
-                    symbol: 'btc',
-                    accountType: 'segwit',
-                    accountIndex: 1,
-                },
                 sendAccountKey: 'btc-descriptor-btc',
             },
         ]);

--- a/suite-common/trading/src/thunks/sell/handleSellTradeThunk.ts
+++ b/suite-common/trading/src/thunks/sell/handleSellTradeThunk.ts
@@ -79,12 +79,6 @@ export const handleSellTradeThunk = createThunk(
                     data: response.trade,
                     date: new Date().toISOString(),
                     key: response.trade.orderId,
-                    account: {
-                        descriptor: account.descriptor,
-                        symbol: account.symbol,
-                        accountType: account.accountType,
-                        accountIndex: account.index,
-                    },
                     sendAccountKey: account.key,
                 }),
             );

--- a/suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts
@@ -126,12 +126,6 @@ export const sendSellTransactionThunk = createThunk(
                 tradeType: 'sell',
                 date: new Date().toISOString(),
                 key: response.orderId,
-                account: {
-                    descriptor: account.descriptor,
-                    symbol: account.symbol,
-                    accountType: account.accountType,
-                    accountIndex: account.index,
-                },
                 data: response,
                 sendAccountKey: account.key,
             }),

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -82,16 +82,11 @@ export type TradingPaymentMethodListProps = {
 type TradingCommonTransaction = {
     date: string;
     key?: string;
-    account: {
-        descriptor: Account['descriptor'];
-        symbol: Account['symbol'];
-        accountType: Account['accountType'];
-        accountIndex: Account['index'];
-    };
 };
 export type TradingTransactionBuy = TradingCommonTransaction & {
     tradeType: TradingBuyType;
     data: BuyTrade;
+    selectedAccountKey: Account['key'] | undefined;
     receiveAccountKey: Account['key'] | undefined;
 };
 export type TradingTransactionSell = TradingCommonTransaction & {

--- a/suite-native/module-trading/src/__fixtures__/trades.ts
+++ b/suite-native/module-trading/src/__fixtures__/trades.ts
@@ -11,19 +11,12 @@ import {
     TradingTransactionExchange,
     TradingTransactionSell,
 } from '@suite-common/trading';
-import { AccountType, NetworkSymbol } from '@suite-common/wallet-config';
 
 export const getBuyTrade = ({
     status,
 }: {
     status: BuyTradeStatus | undefined;
 }): TradingTransactionBuy => ({
-    account: {
-        accountIndex: 0,
-        accountType: 'normal',
-        descriptor: 'eth1-normal',
-        symbol: 'eth',
-    },
     data: {
         country: 'CZ',
         exchange: 'mercuryo',
@@ -53,6 +46,7 @@ export const getBuyTrade = ({
     key: '7546b3a9-ba27-4c9c-b3ae-45524fe63a97',
     tradeType: 'buy',
     receiveAccountKey: 'eth1',
+    selectedAccountKey: 'eth1',
 });
 
 export const getExchangeTrade = ({
@@ -63,12 +57,6 @@ export const getExchangeTrade = ({
     tradeType: 'exchange' as const,
     date: '2025-02-12T20:11:03.042Z',
     key: 'exchange-key',
-    account: {
-        symbol: 'sol' as NetworkSymbol,
-        descriptor: 'sol1-normal',
-        accountIndex: 0,
-        accountType: 'normal' as AccountType,
-    },
     data: {
         status,
         orderId: '12ffba9e-7370-4a6e-87dc-aefd3851c735',
@@ -92,12 +80,6 @@ export const getSellTrade = ({
     tradeType: 'sell',
     date: '2025-01-01T20:12:25.042Z',
     key: 'sell-key',
-    account: {
-        symbol: 'btc',
-        descriptor: 'btc1-normal',
-        accountIndex: 0,
-        accountType: 'normal',
-    },
     data: {
         cryptoStringAmount: '1.22',
         fiatStringAmount: '100',

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailTransactionInfo.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailTransactionInfo.tsx
@@ -8,11 +8,7 @@ import {
     selectTradingTradeByOrderId,
 } from '@suite-common/trading';
 import { NetworkDisplaySymbol } from '@suite-common/wallet-config';
-import {
-    AccountsRootState,
-    DeviceRootState,
-    selectDeviceAccountByDescriptorAndNetworkSymbol,
-} from '@suite-common/wallet-core';
+import { AccountsRootState, DeviceRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { Card, HStack, Text } from '@suite-native/atoms';
 import { CryptoIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
@@ -53,10 +49,11 @@ export const TradeDetailTransactionInfo = ({ orderId }: TradeDetailTransactionIn
         selectTradingTradeByOrderId(state, orderId),
     );
     const account = useSelector((state: AccountsRootState & DeviceRootState) =>
-        selectDeviceAccountByDescriptorAndNetworkSymbol(
+        selectAccountByKey(
             state,
-            trade?.account.descriptor,
-            trade?.account.symbol,
+            trade && 'selectedAccountKey' in trade
+                ? trade.selectedAccountKey
+                : trade?.sendAccountKey,
         ),
     );
 

--- a/suite-native/module-trading/src/components/history/TradeHistoryListItem/TradeHistoryListItem.tsx
+++ b/suite-native/module-trading/src/components/history/TradeHistoryListItem/TradeHistoryListItem.tsx
@@ -1,10 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import {
-    AccountsRootState,
-    DeviceRootState,
-    selectDeviceAccountByDescriptorAndNetworkSymbol,
-} from '@suite-common/wallet-core';
+import { AccountsRootState, DeviceRootState, selectAccountByKey } from '@suite-common/wallet-core';
 
 import {
     TradeHistoryListItemMemoized,
@@ -19,10 +15,11 @@ export const TradeHistoryListItem = ({
     onPress,
 }: TradeHistoryListItemMemoizedProps) => {
     const account = useSelector((state: AccountsRootState & DeviceRootState) =>
-        selectDeviceAccountByDescriptorAndNetworkSymbol(
+        selectAccountByKey(
             state,
-            transaction.account.descriptor,
-            transaction.account.symbol,
+            'selectedAccountKey' in transaction
+                ? transaction.selectedAccountKey
+                : transaction.sendAccountKey,
         ),
     );
 

--- a/suite-native/module-trading/src/screens/TradingWebViewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingWebViewScreen.tsx
@@ -8,11 +8,7 @@ import { useURL } from 'expo-linking';
 import { WebViewSource } from 'react-native-webview/lib/WebViewTypes';
 
 import { TradingRootState, selectTradingTradeByOrderId } from '@suite-common/trading';
-import {
-    AccountsRootState,
-    DeviceRootState,
-    selectDeviceAccountByDescriptorAndNetworkSymbol,
-} from '@suite-common/wallet-core';
+import { AccountsRootState, DeviceRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -44,10 +40,10 @@ export const TradingWebViewScreen = () => {
         selectTradingTradeByOrderId(state, orderId ?? ''),
     );
     const account = useSelector((state: AccountsRootState & DeviceRootState) =>
-        selectDeviceAccountByDescriptorAndNetworkSymbol(
+        selectAccountByKey(
             state,
-            trade?.account.descriptor,
-            trade?.account.symbol,
+            trade &&
+                ('selectedAccountKey' in trade ? trade.selectedAccountKey : trade.sendAccountKey),
         ),
     );
 


### PR DESCRIPTION
## Description
- deleted account object from `tradingTrades`
- add `selectedAccountKey` to `buy`
- minor fixes

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18527

## Additional
- Is it necessary to make a migration for native @vytick @jbazant?


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/trading-delete-account&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/trading-delete-account&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/trading-delete-account&lookback=7)