### PR TITLE
chore(suite-native): Mobile Trade: mock useMountedRecentlyFlag in tests

### DIFF
--- a/suite-native/module-trading/src/components/buy/BuyForm.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyForm.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useState } from 'react';
+import { memo } from 'react';
 
 import { VStack } from '@suite-native/atoms';
 import { useDebouncedValue } from '@trezor/react-utils';
@@ -8,6 +8,7 @@ import { BuyCard } from './BuyCard';
 import { BuyHeader } from './BuyHeader';
 import { Confirmation } from './Confirmation';
 import { PaymentCard } from './PaymentCard';
+import { useMountedRecentlyFlag } from '../../hooks/useMountedRecentlyFlag';
 import { useQuotes } from '../../hooks/useQuotes';
 import { useTradingBuyFormContext } from '../../hooks/useTradingBuyFormContext';
 import { TradeHistoryButton } from '../general/TradeHistory/TradeHistoryButton';
@@ -15,17 +16,9 @@ import { TradingAlert } from '../general/TradingAlert';
 import { TradingFooter } from '../general/TradingFooter';
 
 const BuyFormMemoized = memo(({ isAmountInputActive }: { isAmountInputActive: boolean }) => {
-    // `isFormMountedRecently`  allows to use different animations for initial form load (FadeIn)
+    // `isFormMountedRecently` allows to use different animations for initial form load (FadeIn)
     // and when user interacts with the form (FadeInUp/FadeInDown)
-    const [isFormMountedRecently, setFormMountedRecently] = useState<boolean>(true);
-
-    useEffect(() => {
-        const timer = setTimeout(() => {
-            setFormMountedRecently(false);
-        }, 100);
-
-        return () => clearTimeout(timer);
-    }, []);
+    const isFormMountedRecently = useMountedRecentlyFlag();
 
     return (
         <VStack spacing="sp16">

--- a/suite-native/module-trading/src/hooks/__tests__/useMountedRecentlyFlag.test.ts
+++ b/suite-native/module-trading/src/hooks/__tests__/useMountedRecentlyFlag.test.ts
@@ -1,0 +1,34 @@
+import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
+
+import { RECENT_DURATION, useMountedRecentlyFlag } from '../useMountedRecentlyFlag';
+
+jest.mock('../useMountedRecentlyFlag', () => jest.requireActual('../useMountedRecentlyFlag'));
+
+describe('useMountedRecentlyFlag', () => {
+    const renderUseMountedRecentlyFlag = () =>
+        renderHookWithBasicProvider(() => useMountedRecentlyFlag());
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('should be true by default', () => {
+        const { result } = renderUseMountedRecentlyFlag();
+
+        expect(result.current).toEqual(true);
+    });
+
+    it('should be false after RECENT_DURATION time', () => {
+        const { result } = renderUseMountedRecentlyFlag();
+
+        act(() => {
+            jest.advanceTimersByTime(RECENT_DURATION);
+        });
+
+        expect(result.current).toEqual(false);
+    });
+});

--- a/suite-native/module-trading/src/hooks/useMountedRecentlyFlag.ts
+++ b/suite-native/module-trading/src/hooks/useMountedRecentlyFlag.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+export const RECENT_DURATION = 100;
+
+export const useMountedRecentlyFlag = () => {
+    const [isMountedRecently, setIsMountedRecently] = useState(true);
+
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            setIsMountedRecently(false);
+        }, RECENT_DURATION);
+
+        return () => clearTimeout(timer);
+    }, []);
+
+    return isMountedRecently;
+};

--- a/suite-native/module-trading/src/jest.setup.tsx
+++ b/suite-native/module-trading/src/jest.setup.tsx
@@ -6,3 +6,8 @@ const MockWebView = <View testID="mocked-webview">Mocked WebView</View>;
 jest.mock('react-native-webview', () => ({
     WebView: () => MockWebView,
 }));
+
+// avoid some unexpected re-renders in tests by disabling this hook logic
+jest.mock('./hooks/useMountedRecentlyFlag', () => ({
+    useMountedRecentlyFlag: () => false,
+}));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
"Mounted recently" logic is used solely for animations in Mobile Trade module.

- Refactor "mounted recently" logic to separate hook.
- Completely disable "mounted recently" logic  in tests to avoid unnecessary re-renders (and errors about missing act).
- Unit tests for "mounted recently" logic.


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mobile-trade-mounted-recently&lookback=7)