### PR TITLE
Select correct device for initialization

### DIFF
--- a/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
@@ -95,6 +95,7 @@ export const NeedsAttentionBanner = ({
     const onSolveIssueClick = (): void => {
         switch (deviceStatus) {
             case 'initialize': // wiped device
+                selectDevice();
                 dispatch(goto('onboarding-index'));
                 break;
 


### PR DESCRIPTION
## Description

When one initialized device is already connected and the second, uninitialized, is freshly added and the initialization is started by clicking the blue button, initialization process is run on the first (already selected) one.

The issue first appeared in https://github.com/trezor/trezor-suite/commit/eadd675d290eb789a2bdfdb70b5ef161954cf2bb / #18178 , where `selectDevice` action is **not** dispatched for `initialize` status.

Dispatching it resolves the issue for me, anyway, I'm not sure that nothing else breaks or that it's not contradicting the previous PR's intention somehow. **WDYT** @peter-sanderson ?

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/two-device-initialize&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/two-device-initialize&lookback=7)