### PR TITLE
fix(transport): assign logger to AbstractApiTransport super class

### DIFF
--- a/packages/transport-native-usb/src/nativeUsb.ts
+++ b/packages/transport-native-usb/src/nativeUsb.ts
@@ -13,6 +13,7 @@ export class NativeUsbTransport extends AbstractApiTransport {
                 usbInterface: new WebUSB(),
                 logger,
             }),
+            logger,
             ...rest,
         });
     }

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -61,7 +61,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
         // 1. transport api reports descriptors change
         this.api.on('transport-interface-change', descriptors => {
-            this?.logger?.debug('new descriptors from api', descriptors);
+            this.logger?.debug('new descriptors from api', descriptors);
             // 2. we signal this to sessions background
             this.sessionsClient.enumerateDone({
                 descriptors,
@@ -69,7 +69,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
         });
         // 3. based on 2.sessions background distributes information about descriptors change to all clients
         this.sessionsClient.on('descriptors', descriptors => {
-            this?.logger?.debug('new descriptors from background', descriptors);
+            this.logger?.debug('new descriptors from background', descriptors);
             // 4. we propagate new descriptors to higher levels
             this.handleDescriptorsChange(descriptors);
         });

--- a/packages/transport/src/transports/nodeusb.ts
+++ b/packages/transport/src/transports/nodeusb.ts
@@ -23,6 +23,7 @@ export class NodeUsbTransport extends AbstractApiTransport {
                 logger,
                 debugLink,
             }),
+            logger,
             ...rest,
         });
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`logger` was not passed down to `AbstractApiTransport` constructor


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/transport-logger&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/transport-logger&lookback=7)