### PR TITLE
fix(suite-native): crash related to RefreshControl

### DIFF
--- a/suite-native/module-home/src/screens/HomeScreen/useHomeRefreshControl.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/useHomeRefreshControl.tsx
@@ -21,6 +21,8 @@ export const useHomeRefreshControl = ({
     } = useNativeStyles();
 
     const handleRefresh = useCallback(async () => {
+        if (isDiscoveredDeviceAccountless) return;
+
         setIsRefreshing(true);
         try {
             await Promise.all([
@@ -31,19 +33,18 @@ export const useHomeRefreshControl = ({
             // Do nothing
         }
         setIsRefreshing(false);
-    }, [dispatch, portfolioContentRef]);
+    }, [dispatch, portfolioContentRef, isDiscoveredDeviceAccountless]);
 
-    const refreshControl = useMemo(() => {
-        if (isDiscoveredDeviceAccountless) return undefined;
-
-        return (
+    const refreshControl = useMemo(
+        () => (
             <RefreshControl
                 refreshing={isRefreshing}
                 onRefresh={handleRefresh}
                 colors={[colors.backgroundPrimaryDefault]}
             />
-        );
-    }, [isDiscoveredDeviceAccountless, handleRefresh, colors, isRefreshing]);
+        ),
+        [handleRefresh, colors, isRefreshing],
+    );
 
     return refreshControl;
 };


### PR DESCRIPTION
## Description

Fix crash on iOS due to `'NSInternalInconsistencyException', reason: 'we should only have exactly one subview'`

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/devicemanager-scrollview-one-child&lookback=7)