### PR TITLE
fix(suite): do not persist transient FW check errors for view-only devices

### DIFF
--- a/packages/suite/src/constants/suite/firmware.ts
+++ b/packages/suite/src/constants/suite/firmware.ts
@@ -6,7 +6,10 @@ import { FilterPropertiesByType } from '@trezor/type-utils';
  * see suite-native/device/src/config/firmware.ts for Suite Lite
  */
 
-type BehaviorBaseType = { shouldReport: boolean };
+type BehaviorBaseType = {
+    shouldReport: boolean; // whether to report the check result to Sentry
+    isConclusive: boolean; // result is considered final, not expected to change when check is rerun
+};
 
 // will be ignored completely
 type SkippedBehavior = BehaviorBaseType & { type: 'skipped' };
@@ -22,19 +25,23 @@ type HashErrorBehavior = SkippedBehavior | HardModalBehavior;
 type HashCheckErrorScenarios = Record<FirmwareHashCheckError, HashErrorBehavior>;
 
 export const revisionCheckErrorScenarios = {
-    'revision-mismatch': { type: 'hardModal', shouldReport: true },
-    'firmware-version-unknown': { type: 'hardModal', shouldReport: true },
-    'cannot-perform-check-offline': { type: 'softWarning', shouldReport: false },
-    'other-error': { type: 'softWarning', shouldReport: true },
+    'revision-mismatch': { type: 'hardModal', shouldReport: true, isConclusive: true },
+    'firmware-version-unknown': { type: 'hardModal', shouldReport: true, isConclusive: true },
+    'cannot-perform-check-offline': {
+        type: 'softWarning',
+        shouldReport: false,
+        isConclusive: false,
+    },
+    'other-error': { type: 'softWarning', shouldReport: true, isConclusive: false },
 } satisfies RevisionCheckErrorScenarios;
 
 export const hashCheckErrorScenarios = {
-    'hash-mismatch': { type: 'hardModal', shouldReport: true },
-    'check-skipped': { type: 'skipped', shouldReport: false },
-    'check-unsupported': { type: 'skipped', shouldReport: false },
+    'hash-mismatch': { type: 'hardModal', shouldReport: true, isConclusive: true },
+    'check-skipped': { type: 'skipped', shouldReport: false, isConclusive: false },
+    'check-unsupported': { type: 'skipped', shouldReport: false, isConclusive: false },
     // could mean counterfeit firmware, but it's also caught by revision check, which handles edge-cases better
-    'unknown-release': { type: 'skipped', shouldReport: false },
-    'other-error': { type: 'hardModal', shouldReport: true },
+    'unknown-release': { type: 'skipped', shouldReport: false, isConclusive: true },
+    'other-error': { type: 'hardModal', shouldReport: true, isConclusive: false },
 } satisfies HashCheckErrorScenarios;
 
 export type SkippedHashCheckError = keyof FilterPropertiesByType<

--- a/packages/suite/src/utils/suite/storage.ts
+++ b/packages/suite/src/utils/suite/storage.ts
@@ -1,8 +1,31 @@
 import { connectInitThunk } from '@suite-common/connect-init';
 import { DeviceWithEmptyPath } from '@suite-common/suite-types';
 
+import { hashCheckErrorScenarios, revisionCheckErrorScenarios } from 'src/constants/suite/firmware';
 import { AcquiredDevice } from 'src/types/suite';
 import { CoinjoinAccount } from 'src/types/wallet/coinjoin';
+
+type AuthenticityChecks = AcquiredDevice['authenticityChecks'];
+const filterInconclusiveAuthenticityChecks = (checks: AuthenticityChecks): AuthenticityChecks => {
+    if (checks === undefined) return undefined;
+    let { firmwareRevision, firmwareHash } = checks;
+    if (
+        firmwareRevision !== null &&
+        !firmwareRevision.success &&
+        revisionCheckErrorScenarios[firmwareRevision.error].isConclusive === false
+    ) {
+        firmwareRevision = null;
+    }
+    if (
+        firmwareHash !== null &&
+        !firmwareHash.success &&
+        hashCheckErrorScenarios[firmwareHash.error].isConclusive === false
+    ) {
+        firmwareHash = null;
+    }
+
+    return { firmwareRevision, firmwareHash };
+};
 
 /**
  * Strip fields from Device
@@ -18,6 +41,7 @@ export const serializeDevice = (
         remember: true,
         connected: false,
         buttonRequests: [],
+        authenticityChecks: filterInconclusiveAuthenticityChecks(device.authenticityChecks),
     };
     if (forceRemember) sd.forceRemember = true;
 

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -815,6 +815,11 @@ export const selectIsDeviceInitialized = createMemoizedSelector(
     },
 );
 
+export const selectIsDeviceConnected = createMemoizedSelector(
+    [selectSelectedDevice],
+    device => !!device?.connected,
+);
+
 export const selectIsConnectedDeviceUninitialized = createMemoizedSelector(
     [selectSelectedDevice, selectIsDeviceInitialized],
     (device, isDeviceInitialized) => device && !isDeviceInitialized,
@@ -926,8 +931,9 @@ export const selectIsEntropyCheckFailed = createMemoizedSelector(
 );
 
 export const selectWasFwHashCheckOtherErrorLastTime = createMemoizedSelector(
-    [state => state.device.lastConnectedAuthenticityChecks],
-    lastConnectedAuthenticityChecks => {
+    [state => state.device.lastConnectedAuthenticityChecks, selectIsDeviceConnected],
+    (lastConnectedAuthenticityChecks, isDeviceConnected) => {
+        if (!isDeviceConnected) return false;
         const lastHashCheck = lastConnectedAuthenticityChecks?.firmwareHash;
 
         return lastHashCheck && !lastHashCheck.success && lastHashCheck.error === 'other-error';
@@ -1048,11 +1054,6 @@ export const selectRememberedHiddenWalletsCount = createMemoizedSelector(
         returnStableArrayIfEmpty(
             devices.filter(device => device.remember && !device.useEmptyPassphrase),
         ).length,
-);
-
-export const selectIsDeviceConnected = createMemoizedSelector(
-    [selectSelectedDevice],
-    device => !!device?.connected,
 );
 
 export const selectIsDeviceInViewOnlyMode = createMemoizedSelector(


### PR DESCRIPTION
## Description

- Do not escalate FW hash check other-error when a remembered device has just been disconnected
- Suite will not remember transient checks for hash check & revision check (other-errors, offline)

## Related Issue

Resolve #18789

## Screenshots:

See the issue for bad `other-error` behavior.
Desired `hash-mismatch` behavior is unchanged.

`other-error` behavior is now fixed:
[forget other-error.webm](https://github.com/user-attachments/assets/bfc25085-128e-478f-a819-9af480b5570b)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/filter-inconclusive-checks-from-remembered-device&lookback=7)