### PR TITLE
fix(trading): delete best rate quote for swap

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -7,7 +7,6 @@ import {
     TRADING_EXCHANGE_FORM_DEX,
     type TradingTradeType,
     type TradingType,
-    getBestRatedQuote,
     parseCryptoId,
     useTradingInfo,
 } from '@suite-common/trading';
@@ -63,7 +62,6 @@ export const TradingFormOffer = () => {
     const providers = getProvidersInfoProps(context);
     const bestScoredQuote = quotes?.[0];
     const quote = getSelectedQuote(context, bestScoredQuote);
-    const bestRatedQuote = getBestRatedQuote(quotes, type);
     const bestScoredQuoteAmounts = getCryptoQuoteAmountProps(quote, context);
 
     const selectedCrypto = getSelectedCrypto(context);
@@ -146,7 +144,6 @@ export const TradingFormOffer = () => {
                         isFormLoading={state.isFormLoading}
                         isFormInvalid={state.isFormInvalid}
                         providers={providers}
-                        bestRatedQuote={bestRatedQuote}
                     />
                 ) : (
                     <TradingFormOfferItem
@@ -154,7 +151,6 @@ export const TradingFormOffer = () => {
                         isFormLoading={state.isFormLoading}
                         isFormInvalid={state.isFormInvalid}
                         providers={providers}
-                        isBestRate={bestRatedQuote?.orderId === quote?.orderId}
                     />
                 )}
             </Column>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffersSwitcher.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffersSwitcher.tsx
@@ -4,7 +4,6 @@ import {
     TRADING_EXCHANGE_FORM_DEX,
     TRADING_EXCHANGE_RATE,
     TRADING_EXCHANGE_RATE_FLOATING,
-    type TradingTradeType,
     type TradingUtilsProvidersProps,
 } from '@suite-common/trading';
 import { Card, Column, Paragraph, Row, Spinner } from '@trezor/components';
@@ -19,7 +18,6 @@ interface TradingFormOffersSwitcherProps {
     isFormLoading: boolean;
     isFormInvalid: boolean;
     providers: TradingUtilsProvidersProps | undefined;
-    bestRatedQuote: TradingTradeType | undefined;
 }
 
 export const TradingFormOffersSwitcher = ({
@@ -27,7 +25,6 @@ export const TradingFormOffersSwitcher = ({
     isFormLoading,
     isFormInvalid,
     providers,
-    bestRatedQuote,
 }: TradingFormOffersSwitcherProps) => {
     const { setValue, getValues, dexQuotes, cexQuotes } = context;
     const { exchangeType } = getValues();
@@ -83,7 +80,6 @@ export const TradingFormOffersSwitcher = ({
                         onSelect={() => setValue(TRADING_EXCHANGE_FORM, TRADING_EXCHANGE_FORM_CEX)}
                         providers={providers}
                         quote={cexQuote}
-                        isBestRate={bestRatedQuote?.orderId === cexQuote?.orderId}
                     />
                 ) : (
                     <Paragraph
@@ -105,7 +101,6 @@ export const TradingFormOffersSwitcher = ({
                         }}
                         providers={providers}
                         quote={dexQuote}
-                        isBestRate={bestRatedQuote?.orderId === dexQuote?.orderId}
                     />
                 ) : (
                     <Paragraph


### PR DESCRIPTION


## Description
- deleted `Best rate` badge from swap - it doesn't make sense because there is a huge difference between CEX & DEX fees, so DEX would always be on a better level than CEX
- should be added after refactod design of Swap

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/14836


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/best-rate-quote&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/best-rate-quote&lookback=7)