### PR TITLE
fix(scripts): prepublish script path

### DIFF
--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -23,7 +23,7 @@ if (!isValidPackageName) {
 //  1. rename "packages" folder in monorepo to "@trezor"
 //  2. find and replace all the problematic occurrences before actual release.
 //     not very good solution and yarn advices against doing it https://yarnpkg.com/advanced/lifecycle-scripts
-const scriptPath = path.join(__dirname, '..', 'replace-imports.sh');
+const scriptPath = path.join(__dirname, 'replace-imports.sh');
 const args = [path.join(__dirname, '..', 'packages', packageName, 'lib')];
 execFileSync(scriptPath, args, {
     encoding: 'utf-8',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The PR to add validation to script arguments broke because the path was wrong. https://github.com/trezor/trezor-suite/pull/18256/files

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/prepublish-script-path&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/prepublish-script-path&lookback=7)