### PR TITLE
fix(suite-native): add DOMException polyfill for Solana

### DIFF
--- a/suite-native/app/globalPolyfills.js
+++ b/suite-native/app/globalPolyfills.js
@@ -9,6 +9,11 @@ globalThis.Event = Event;
 globalThis.EventTarget = EventTarget;
 globalThis.CustomEvent = CustomEvent;
 
+// polyfill for `abortcontroller-polyfill`, which throws DOMException at occasions, and it'd crash the app
+if (typeof DOMException === 'undefined') {
+    global.DOMException = class DOMException extends Error {};
+}
+
 // Ensures that crypto functions required by Solana and device authenticity check are available.
 install();
 


### PR DESCRIPTION
## Description

Add a polyfill for `DOMException` to Suite Native
- it is required by [abortcontroller-polyfill](https://github.com/trezor/trezor-suite/blob/6356bafe6d0a0ada4cbc2a98251972a6d53aa159/suite-native/app/globalPolyfills.js#L5)
  - which is required by `@solana/kit`, resp. `@solana/web3.js` before 6356bafe6d0a0ada4cbc2a98251972a6d53aa159
- this problem occurred after ff5a7ad84c10b6ccf43ec0a1a481ecdd274caefc together with 2.8.10 FW
  - the fake-indexeddb used to leak into suite-native runtime, polluting its global scope, and I fixed that leak
  - but it caused Suite Lite to crash due to missing `DOMException`, as the leak of the web polyfills used to provide it
- why does it only break with 2.8.10? Haven't got the slightest idea. But I did not reproduce it with 2.8.9
  - probably, some calls to device are different, and it causes a `setTimeout` to abort
    - and at that point, [the polyfill lib throws a DOMException](https://github.com/mo/abortcontroller-polyfill/blob/b5c6843c03901088fbdd76df7ab775cb2e0cf2c4/src/abortcontroller.js#L102)

### QA instructions

Suite with a 2.8.10 device shall not crash


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/add-DOMException-polyfill-for-solana&lookback=7)