### PR TITLE
fix(suite-native): Mobile Trade: display error on providers loading error

### DIFF
--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -1,4 +1,4 @@
-import { Coins, CryptoId, FiatCurrenciesProps, Platforms } from 'invity-api';
+import { type BuyTrade, Coins, CryptoId, FiatCurrenciesProps, Platforms } from 'invity-api';
 
 import {
     TradingPaymentMethodProps,
@@ -8,6 +8,7 @@ import { AccountsRootState, DeviceRootState } from '@suite-common/wallet-core';
 import { StaticSessionId } from '@trezor/connect';
 
 import coins from '../../__fixtures__/coins.json';
+import { invityAPIFixtures } from '../../__fixtures__/invityAPI';
 import platforms from '../../__fixtures__/platforms.json';
 import { accountBtc, accountEth } from '../../__fixtures__/utils';
 import { TradingBuyState } from '../../reducers/buyReducer';
@@ -69,7 +70,7 @@ describe('tradingSelectors', () => {
             buyInfo: {
                 buyInfo: {
                     country: 'CZ',
-                    providers: [] as any[],
+                    providers: invityAPIFixtures.buyList,
                     defaultAmountsOfFiatCurrencies: { usd: 150, eur: 100 } as FiatCurrenciesProps,
                     suggestedFiatCurrency: 'CZK',
                 },
@@ -82,7 +83,7 @@ describe('tradingSelectors', () => {
                     'base--0x0000000000000000000000000000000000000000',
                     'ethereum--0xWithoutObjectInCoinsInfo', // there are values not presented in info.coins map
                 ] as CryptoId[],
-                providerInfos: {},
+                providerInfos: { test: invityAPIFixtures.buyList[0] },
                 supportedFiatCurrencies: ['usd', 'eur', 'czk'],
             },
             quotes: [
@@ -119,7 +120,7 @@ describe('tradingSelectors', () => {
                     orderId: 'orderId3',
                     exchange: 'invity',
                 },
-            ],
+            ] as BuyTrade[],
         }) as TradingBuyState;
     const getState = () =>
         ({
@@ -783,6 +784,13 @@ describe('tradingSelectors', () => {
 
             it('should be false when trading buyInfo is empty', () => {
                 state.wallet.tradingNew.buy.buyInfo = undefined;
+
+                expect(selectTradingBuyLoadingTimestampAndStatus(state).isFullyLoaded).toBe(false);
+            });
+
+            it('should be false when providers info is empty', () => {
+                state.wallet.tradingNew.buy.buyInfo!.providerInfos = {};
+                state.wallet.tradingNew.buy.buyInfo!.buyInfo.providers = [];
 
                 expect(selectTradingBuyLoadingTimestampAndStatus(state).isFullyLoaded).toBe(false);
             });

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -96,7 +96,8 @@ export const selectTradingBuyLoadingTimestampAndStatus = createMemoizedSelector(
     (isLoading, lastLoadedTimestamp, info, buyInfo) => ({
         isLoading,
         lastLoadedTimestamp,
-        isFullyLoaded: !!(buyInfo && info?.coins && info?.platforms),
+        isFullyLoaded:
+            !!(info?.coins && info?.platforms && buyInfo) && buyInfo.buyInfo?.providers.length > 0,
     }),
 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve #18326


## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=18326-mobile-trade-error-states&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=18326-mobile-trade-error-states&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=18326-mobile-trade-error-states&lookback=7)