### PR TITLE
feat(trading): select Wordwide in Buy/Sell if tor is enabled

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.tsx
@@ -6,6 +6,7 @@ import {
     type TradingBuyInfoSelector,
     type TradingPaymentMethodListProps,
     getDefaultCountry,
+    regional,
     useTradingInfo,
 } from '@suite-common/trading';
 import { networks } from '@suite-common/wallet-config';
@@ -15,6 +16,7 @@ import {
     FORM_DEFAULT_PAYMENT_METHOD,
 } from 'src/constants/wallet/trading/form';
 import { useSelector } from 'src/hooks/suite';
+import { selectTorState } from 'src/reducers/suite/suiteReducer';
 import { TradingBuyFormDefaultValuesProps } from 'src/types/trading/tradingForm';
 import { Account } from 'src/types/wallet';
 import { buildFiatOption } from 'src/utils/wallet/trading/tradingUtils';
@@ -24,10 +26,11 @@ export const useTradingBuyFormDefaultValues = (
     buyInfo: TradingBuyInfoSelector | undefined,
 ): TradingBuyFormDefaultValuesProps => {
     const { buildDefaultCryptoOption } = useTradingInfo('buy');
+    const { isTorEnabled } = useSelector(selectTorState);
     const prefilledFromCryptoId = useSelector(state => state.wallet.trading.prefilledFromCryptoId);
     const cryptoId = prefilledFromCryptoId || networks[accountSymbol]?.tradeCryptoId;
 
-    const country = buyInfo?.buyInfo?.country;
+    const country = !isTorEnabled ? buyInfo?.buyInfo?.country : regional.UNKNOWN_COUNTRY;
     const defaultCountry = useMemo(() => getDefaultCountry(country), [country]);
     const defaultCrypto = useMemo(
         () => buildDefaultCryptoOption(cryptoId as CryptoId | undefined),

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellFormDefaultValues.ts
@@ -4,6 +4,7 @@ import {
     type TradingPaymentMethodListProps,
     cryptoIdToSymbol,
     getDefaultCountry,
+    regional,
 } from '@suite-common/trading';
 import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants';
 import { FormState, Output } from '@suite-common/wallet-types';
@@ -15,6 +16,7 @@ import {
 } from 'src/constants/wallet/trading/form';
 import { useSelector } from 'src/hooks/suite';
 import { useTradingBuildAccountGroups } from 'src/hooks/wallet/trading/form/common/useTradingBuildAccountGroups';
+import { selectTorState } from 'src/reducers/suite/suiteReducer';
 import { TradingSellFormDefaultValuesProps } from 'src/types/trading/tradingForm';
 import { Account } from 'src/types/wallet';
 import {
@@ -26,9 +28,10 @@ export const useTradingSellFormDefaultValues = (
     account: Account,
     sellInfo: TradingSellInfoSelector | undefined,
 ): TradingSellFormDefaultValuesProps => {
-    const country = sellInfo?.sellList?.country;
     const cryptoGroups = useTradingBuildAccountGroups('sell');
     const prefilledFromCryptoId = useSelector(state => state.wallet.trading.prefilledFromCryptoId);
+    const { isTorEnabled } = useSelector(selectTorState);
+
     const cryptoOptions = useMemo(
         () => cryptoGroups.flatMap(group => group.options),
         [cryptoGroups],
@@ -44,6 +47,7 @@ export const useTradingSellFormDefaultValues = (
             ),
         [account.descriptor, account.symbol, prefilledFromCryptoId, cryptoOptions],
     );
+    const country = !isTorEnabled ? sellInfo?.sellList?.country : regional.UNKNOWN_COUNTRY;
     const defaultCountry = useMemo(() => getDefaultCountry(country), [country]);
     const { address, token } =
         getAddressAndTokenFromAccountOptionsGroupProps(defaultSendCryptoSelect);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- in Buy/Sell should be now preselected Worldwide option for Country of residence when Tor is enabled

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/4801




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-select-unknow-country-tor&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-select-unknow-country-tor&lookback=7)