### PR TITLE
fix(suite-native): Mobile Trade: fix amount inputs validation

### DIFF
--- a/suite-native/module-trading/src/components/buy/CryptoAmountInput.tsx
+++ b/suite-native/module-trading/src/components/buy/CryptoAmountInput.tsx
@@ -7,6 +7,7 @@ import { BoxSkeleton } from '@suite-native/atoms';
 import { useAmountInputTransformers } from '@suite-native/helpers';
 import { useTranslate } from '@suite-native/intl';
 
+import { MAX_CRYPTO_DECIMALS } from '../../consts';
 import { useTradingBuyFormContext } from '../../hooks/useTradingBuyFormContext';
 import { getSelectedSymbolFromBuyForm } from '../../utils/tradeableAssetUtils';
 import {
@@ -18,8 +19,6 @@ import {
 export type CryptoAmountInputProps = {
     showAssetsSheet: () => void;
 };
-
-const MAX_CRYPTO_DECIMALS = 9;
 
 export const CryptoAmountInput = forwardRef<TextInput, CryptoAmountInputProps>(
     ({ showAssetsSheet }, ref) => {

--- a/suite-native/module-trading/src/components/buy/FiatAmountInput.tsx
+++ b/suite-native/module-trading/src/components/buy/FiatAmountInput.tsx
@@ -5,14 +5,13 @@ import { BoxSkeleton } from '@suite-native/atoms';
 import { useAmountInputTransformers } from '@suite-native/helpers';
 import { useTranslate } from '@suite-native/intl';
 
+import { MAX_FIAT_DECIMALS } from '../../consts';
 import { useTradingBuyFormContext } from '../../hooks/useTradingBuyFormContext';
 import {
     MAX_INPUT_HEIGHT,
     MIN_INPUT_WIDTH,
     TradingAmountInput,
 } from '../general/TradingAmountInput';
-
-const MAX_FIAT_DECIMALS = 3;
 
 export const FiatAmountInput = () => {
     const { translate } = useTranslate();

--- a/suite-native/module-trading/src/components/general/TradingAmountInput.tsx
+++ b/suite-native/module-trading/src/components/general/TradingAmountInput.tsx
@@ -1,10 +1,11 @@
-import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react';
 import { LayoutChangeEvent, Pressable, TextInput, TextInputProps } from 'react-native';
 
 import { useField } from '@suite-native/forms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { useTradingBuyFormContext } from '../../hooks/useTradingBuyFormContext';
+import { truncateDecimals } from '../../utils/amountUtils';
 
 export type TradingAmountInputProps = {
     name: 'fiatValue' | 'cryptoValue';
@@ -107,23 +108,15 @@ const useInputFormControls = (
         setValue('focusedValue', name);
     }, [name, setValue]);
 
-    const maxDecimalRegex = useMemo(
-        () =>
-            maxDecimals !== undefined ? new RegExp(`[.](\\d{${maxDecimals}})(\\d+)$`) : undefined,
-        [maxDecimals],
-    );
-
     const handleTextChange = useCallback(
         (text: string) => {
             let transformedText = inputTransformer(text);
-            if (maxDecimalRegex) {
-                transformedText = transformedText.replace(maxDecimalRegex, '.$1');
-            }
+            transformedText = truncateDecimals(transformedText, maxDecimals);
             transformedText = transformedText.slice(0, maxLength);
 
             return onChange(transformedText === '' ? undefined : transformedText);
         },
-        [maxLength, maxDecimalRegex, inputTransformer, onChange],
+        [maxLength, maxDecimals, inputTransformer, onChange],
     );
 
     const clearFocusedValueAndBlur = useCallback(() => {

--- a/suite-native/module-trading/src/consts.ts
+++ b/suite-native/module-trading/src/consts.ts
@@ -1,0 +1,2 @@
+export const MAX_FIAT_DECIMALS = 3;
+export const MAX_CRYPTO_DECIMALS = 9;

--- a/suite-native/module-trading/src/hooks/__tests__/useQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/__tests__/useQuotes.test.ts
@@ -109,6 +109,29 @@ describe('useQuotes', () => {
         );
     });
 
+    it.each<string>(['0', '-1'])(
+        'should not query quotes when amount is zero or less',
+        async amount => {
+            const store = await getInitializedStore();
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const { result } = await renderUseQuotes(store);
+
+            act(() => {
+                result.current.setValue('asset', bnbAsset);
+                result.current.setValue('fiatCurrency', 'usd');
+            });
+            act(() => {
+                result.current.setValue('fiatValue', amount);
+            });
+
+            expect(dispatchSpy).not.toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'handleRequestThunkMock',
+                }),
+            );
+        },
+    );
+
     it('should accept amount in crypto when requested', async () => {
         const store = await getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');

--- a/suite-native/module-trading/src/hooks/__tests__/useTradingBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/__tests__/useTradingBuyForm.test.tsx
@@ -284,7 +284,7 @@ describe('useTradingBuyForm', () => {
             expect(result.current.getValues('cryptoValue')).toBe('1');
         });
 
-        it('should update cryptoValue when selected quote is changed', async () => {
+        it('should update cryptoValue when selected quote is changed and truncate it to 9 decimals', async () => {
             const store = await getInitializedStore();
             const { result } = await renderUseTradingBuyForm(store);
 
@@ -294,11 +294,11 @@ describe('useTradingBuyForm', () => {
                 result.current.setValue('quote', quotes[0] as BuyTrade);
             });
 
-            expect(result.current.getValues('cryptoValue')).toEqual('0.0010001683607972866');
+            expect(result.current.getValues('cryptoValue')).toEqual('0.001000168');
             expect(result.current.getValues('fiatValue')).toEqual('10');
         });
 
-        it('should update fiatAmount when selected quote is changed and user inserted cryptoAmount', async () => {
+        it('should update fiatAmount when selected quote is changed and user inserted cryptoAmount and truncate it to 3 decimals', async () => {
             const store = await getInitializedStore();
             const { result } = await renderUseTradingBuyForm(store);
 
@@ -310,11 +310,12 @@ describe('useTradingBuyForm', () => {
             });
 
             act(() => {
-                result.current.setValue('quote', quotes[0] as BuyTrade);
+                const newQuote = { ...quotes[0], fiatStringAmount: '10.123456789' } as BuyTrade;
+                result.current.setValue('quote', newQuote);
             });
 
             expect(result.current.getValues('cryptoValue')).toEqual('100');
-            expect(result.current.getValues('fiatValue')).toEqual('10');
+            expect(result.current.getValues('fiatValue')).toEqual('10.123');
         });
 
         describe('when quote is selected and new quotes are fetched', () => {

--- a/suite-native/module-trading/src/hooks/useQuotes.ts
+++ b/suite-native/module-trading/src/hooks/useQuotes.ts
@@ -55,7 +55,7 @@ const useShouldFetchQuotes = (form: TradingBuyForm): ShouldFetchQuotes => {
     ]);
 
     const amount = amountInCrypto ? cryptoValue : fiatValue;
-    const isFetchAllowed = !!(asset && fiatCurrency && amount);
+    const isFetchAllowed = !!(asset && fiatCurrency && amount && parseFloat(amount) > 0);
 
     if (
         asset?.cryptoId === prevState.current.cryptoId &&

--- a/suite-native/module-trading/src/hooks/useTradingBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/useTradingBuyForm.ts
@@ -16,6 +16,7 @@ import { useForm } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import { SettingsSliceRootState, selectIsAmountInSats } from '@suite-native/settings';
 
+import { MAX_CRYPTO_DECIMALS, MAX_FIAT_DECIMALS } from '../consts';
 import {
     selectBuyAmountLimits,
     selectBuyFormDefaultValues,
@@ -23,6 +24,7 @@ import {
 } from '../selectors/buySelectors';
 import { setBuySelectedReceiveAccount } from '../tradingSlice';
 import { TradingBuyForm, TradingBuyFormValues } from '../types';
+import { truncateDecimals } from '../utils/amountUtils';
 import { buyFormValidationSchema } from '../utils/buyFormValidationSchema';
 import { getSelectedSymbolFromBuyForm } from '../utils/tradeableAssetUtils';
 
@@ -146,16 +148,22 @@ const useQuoteChangeEffect = (form: TradingBuyForm) => {
             'fiatValue',
             'cryptoValue',
         ]);
+        const truncatedFiatAmount = truncateDecimals(quote?.fiatStringAmount, MAX_FIAT_DECIMALS);
 
-        if (amountInCrypto && fiatValue !== quote?.fiatStringAmount) {
-            setValue('fiatValue', quote?.fiatStringAmount);
+        const truncatedCryptoAmount = truncateDecimals(
+            quote?.receiveStringAmount,
+            MAX_CRYPTO_DECIMALS,
+        );
+
+        if (amountInCrypto && fiatValue !== truncatedFiatAmount) {
+            setValue('fiatValue', truncatedFiatAmount);
         }
 
-        if (!amountInCrypto && cryptoValue !== quote?.receiveStringAmount) {
+        if (!amountInCrypto && cryptoValue !== truncatedCryptoAmount) {
             const value =
-                isAmountInSats && quote?.receiveStringAmount && symbol
-                    ? amountToSmallestUnit(quote.receiveStringAmount, getNetwork(symbol).decimals)
-                    : quote?.receiveStringAmount;
+                isAmountInSats && truncatedCryptoAmount && symbol
+                    ? amountToSmallestUnit(truncatedCryptoAmount, getNetwork(symbol).decimals)
+                    : truncatedCryptoAmount;
             setValue('cryptoValue', value);
         }
     }, [quote, isAmountInSats, symbol, getValues, setValue]);

--- a/suite-native/module-trading/src/utils/__tests__/amountUtils.test.ts
+++ b/suite-native/module-trading/src/utils/__tests__/amountUtils.test.ts
@@ -1,0 +1,20 @@
+import { truncateDecimals } from '../amountUtils';
+
+describe('amountUtils', () => {
+    describe('truncateDecimals', () => {
+        it('should return unchanged value when decimals are undefined', () => {
+            expect(truncateDecimals('0.123456789', undefined)).toEqual('0.123456789');
+        });
+
+        it('should return undefined when value is undefined', () => {
+            expect(truncateDecimals(undefined, 2)).toEqual(undefined);
+        });
+
+        it.each<[string, string]>([
+            ['0.123456789', '0.12'],
+            ['123', '123'],
+        ])('should truncate decimal values', (value, expected) => {
+            expect(truncateDecimals(value, 2)).toEqual(expected);
+        });
+    });
+});

--- a/suite-native/module-trading/src/utils/__tests__/quotesUtils.test.ts
+++ b/suite-native/module-trading/src/utils/__tests__/quotesUtils.test.ts
@@ -70,7 +70,7 @@ describe('quotesUtils', () => {
                 const props = tradingBuyFormToTradingBuyFormProps(form, coins.bitcoin);
                 expect(props).toEqual({
                     fiatInput: '100',
-                    cryptoInput: '0.0010001683607972866',
+                    cryptoInput: '0.001000168',
                     currencySelect: {
                         value: 'czk',
                         label: 'Czech Koruna',

--- a/suite-native/module-trading/src/utils/amountUtils.ts
+++ b/suite-native/module-trading/src/utils/amountUtils.ts
@@ -1,0 +1,12 @@
+export const getMaxDecimalsRegex = (decimals: number) => new RegExp(`[.](\\d{${decimals}})(\\d+)$`);
+
+export const truncateDecimals = <T extends string | undefined>(
+    value: T,
+    decimals: number | undefined,
+): T => {
+    if (value === undefined || decimals === undefined) {
+        return value;
+    }
+
+    return value.replace(getMaxDecimalsRegex(decimals), '.$1') as T;
+};

--- a/suite-native/module-trading/src/utils/buyFormValidationSchema.ts
+++ b/suite-native/module-trading/src/utils/buyFormValidationSchema.ts
@@ -22,7 +22,7 @@ export const buyFormValidationSchema = yup.object({
         // This (untranslated) error will be hopefully never displayed to user,
         // but let's keep it here just to be safe
         .typeError('Invalid number')
-        .positive()
+        .min(0, 'Invalid value')
         .test('crypto-min', (value, testContext) => {
             const { currency, minCrypto, translate, CryptoAmountFormatter } =
                 getAmountLimitContext(testContext);
@@ -56,7 +56,7 @@ export const buyFormValidationSchema = yup.object({
         // This (untranslated) error will be hopefully never displayed to user,
         // but let's keep it here just to be safe
         .typeError('Invalid number')
-        .positive()
+        .min(0, 'Invalid value')
         .test('fiat-min', (value, testContext) => {
             const { currency, minFiat, translate, FiatAmountFormatter } =
                 getAmountLimitContext(testContext);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix validation issues with amount inputs.

<!--- Describe your changes in detail -->

## Related Issue

Resolve #16994

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=16994-mobile-trade-amount-selector&lookback=7)