### PR TITLE
Fix re-render loop in Send Form caused by fee field watchers in useFees hook

### DIFF
--- a/packages/suite/src/hooks/wallet/form/useFees.ts
+++ b/packages/suite/src/hooks/wallet/form/useFees.ts
@@ -41,7 +41,6 @@ export const useFees = <TFieldValues extends FormState>({
     const feeLimitRef = useRef<string | undefined>('');
     const maxPriorityFeePerGasRef = useRef<string | undefined>('');
     const maxFeePerGasRef = useRef<string | undefined>('');
-    const estimatedFeeLimitRef = useRef<string | undefined>('');
 
     // Type assertion allowing to make the component reusable, see https://stackoverflow.com/a/73624072.
     const { clearErrors, getValues, register, setValue, watch } =
@@ -71,6 +70,7 @@ export const useFees = <TFieldValues extends FormState>({
     const baseFee = watch('baseFee');
     const maxPriorityFeePerGas = watch('maxPriorityFeePerGas');
     const maxFeePerGas = watch('maxFeePerGas');
+    const estimatedFeeLimit = watch('estimatedFeeLimit');
 
     useEffect(() => {
         if (selectedFeeRef.current !== 'custom') return;
@@ -102,6 +102,7 @@ export const useFees = <TFieldValues extends FormState>({
         }
     }, [
         dispatch,
+        estimatedFeeLimit,
         feePerUnit,
         feeLimit,
         maxPriorityFeePerGas,
@@ -111,20 +112,6 @@ export const useFees = <TFieldValues extends FormState>({
         composeRequest,
         setValue,
     ]);
-
-    // watch estimatedFee change
-    const estimatedFeeLimit = watch('estimatedFeeLimit');
-    useEffect(() => {
-        if (estimatedFeeLimitRef.current !== estimatedFeeLimit) {
-            estimatedFeeLimitRef.current = estimatedFeeLimit;
-            if (selectedFeeRef.current !== 'custom') return;
-            if (estimatedFeeLimit) {
-                // NOTE: do not update it here, so it can be properly processed by watch
-                // feeLimitRef.current = estimatedFeeLimit;
-                setValue('feeLimit', estimatedFeeLimit, { shouldValidate: true });
-            }
-        }
-    }, [estimatedFeeLimit, setValue]);
 
     // called from UI on click
     const changeFeeLevel = (level: FeeLevel['label']) => {


### PR DESCRIPTION
## Description

Selecting the "Advanced" fee option in the Send Form could cause an infinite re-render loop. The `useFees` hook watched form fields (like `feeLimit`) and triggered `composeRequest` on change. Since these values were reloaded after component mount (e.g. after discovery), it could lead to a cycle of updates and an infinite loop.

The issue was resolved by removing useEffect, which watched these form fields and triggered composeRequest. The fee values ​​are now loaded once when <Fees /> is attached.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18824
Resolve #16368


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sendform-advanced-fees-rerender-loop&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sendform-advanced-fees-rerender-loop&lookback=7)