### PR TITLE
fix(suite-native): Device setting: fixing various issues related to navigation behaviour

### DIFF
--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -1,6 +1,7 @@
 import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
 import { createThunk } from '@suite-common/redux-utils';
 import {
+    ConnectDeviceSettings,
     deviceActions,
     selectDevicePath,
     selectIsDeviceInitialized,
@@ -30,6 +31,15 @@ export const setTemporaryRememberedDeviceThunk = createThunk(
                 temporaryRemember,
             }),
         );
+
+        // if the device is not connected and it was remembered only temporarily, we need to forget it
+        if (!device.connected && device.temporaryRemember && !temporaryRemember) {
+            const settings: ConnectDeviceSettings = {
+                defaultWalletLoading: 'standard',
+            };
+
+            dispatch(deviceActions.forgetDevice({ device, settings }));
+        }
 
         return;
     },

--- a/suite-native/device/src/hooks/usePinAction.tsx
+++ b/suite-native/device/src/hooks/usePinAction.tsx
@@ -110,15 +110,21 @@ export const usePinAction = ({ type, onSuccess }: PinActionProps) => {
             onSuccess();
         } else {
             const errorCode = payload.code;
-            if (errorCode === 'Failure_ActionCancelled' || errorCode === 'Failure_PinCancelled') {
+            if (
+                errorCode === 'Failure_ActionCancelled' ||
+                errorCode === 'Failure_PinCancelled' ||
+                errorCode === 'Method_Interrupted'
+            ) {
                 showError(canceledMessageKey, handlePinAction);
             } else if (errorCode === 'Failure_PinInvalid') {
                 showError('moduleDeviceSettings.pinProtection.errors.pinInvalid', handlePinAction);
             } else if (errorCode === 'Failure_PinMismatch') {
                 showError('moduleDeviceSettings.pinProtection.errors.pinMismatch', handlePinAction);
+            } else {
+                navigation.goBack();
             }
         }
-    }, [device, dispatch, onSuccess, showError, showSuccess, type]);
+    }, [device, dispatch, navigation, onSuccess, showError, showSuccess, type]);
 
     useEffect(() => {
         if (isDeviceConnected) handlePinAction();

--- a/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
+++ b/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
@@ -100,8 +100,9 @@ export const FirmwareInstallationScreenContent = ({
         return () => {
             dispatch(setTemporaryRememberedDeviceThunk({ temporaryRemember: false }));
             resetReducer();
+            setIsFirmwareInstallationRunning(false);
         };
-    }, [dispatch, resetReducer, isTemporaryRememeberAllowed]);
+    }, [dispatch, isTemporaryRememeberAllowed, resetReducer, setIsFirmwareInstallationRunning]);
 
     const handleFirmwareUpdateFinished = useCallback(async () => {
         await requestPrioritizedDeviceAccess({

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -457,15 +457,15 @@ export const en = {
             actions: {
                 enable: {
                     success: 'Device PIN has been enabled.',
-                    canceled: 'Enable PIN has been canceled on your Trezor.',
+                    canceled: 'Enable PIN has been canceled.',
                 },
                 change: {
                     success: 'Device PIN has been changed.',
-                    canceled: 'Change PIN has been canceled on your Trezor.',
+                    canceled: 'Change PIN has been canceled.',
                 },
                 disable: {
                     success: 'Device PIN has been disabled.',
-                    canceled: 'Disable PIN has been canceled on your Trezor.',
+                    canceled: 'Disable PIN has been canceled.',
                 },
             },
             errors: {

--- a/suite-native/module-device-settings/src/components/DeviceInteractionScreenWrapper.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceInteractionScreenWrapper.tsx
@@ -1,8 +1,6 @@
 import { ReactNode, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/native';
-
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Screen, ScreenHeader } from '@suite-native/navigation';
 import TrezorConnect from '@trezor/connect';
@@ -14,14 +12,11 @@ type DeviceInteractionScreenWrapperProps = {
 export const DeviceInteractionScreenWrapper = ({
     children,
 }: DeviceInteractionScreenWrapperProps) => {
-    const navigation = useNavigation();
-
     const device = useSelector(selectSelectedDevice);
 
     const closeAction = useCallback(() => {
         TrezorConnect.cancel();
-        navigation.goBack();
-    }, [navigation]);
+    }, []);
 
     if (!device) {
         return null;

--- a/suite-native/module-device-settings/src/hooks/useDeviceConnectionGuard.ts
+++ b/suite-native/module-device-settings/src/hooks/useDeviceConnectionGuard.ts
@@ -1,7 +1,7 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 
 import { selectIsDeviceConnected } from '@suite-common/wallet-core';
 import {
@@ -36,10 +36,13 @@ export const useDeviceConnectionGuard = () => {
         });
     }, [navigation]);
 
-    useEffect(() => {
-        if (!isDeviceConnected) return redirectToConnectAndUnlockScreen();
-        // The check should be conducted only once when the screen is shown
-    }, [redirectToConnectAndUnlockScreen]); // eslint-disable-line react-hooks/exhaustive-deps
+    useFocusEffect(
+        useCallback(() => {
+            if (!isDeviceConnected) {
+                redirectToConnectAndUnlockScreen();
+            }
+        }, [isDeviceConnected, redirectToConnectAndUnlockScreen]),
+    );
 
     return { isDeviceConnected };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fix back navigation on the PIN screen
- Fix back navigation behavior when going back from the firmware update screen while the device is disconnected
- Forget temporarily remembered device if leaving fw screen without connected device
- Reset firmwareRunning state on screen unmount
- Fix cancel action for T1 on pin Screen

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16510

## Screenshots:

FW issue:

https://github.com/user-attachments/assets/e44024b5-6019-4634-8a50-7ab1929b6242

FW: temporary remembered device issue


https://github.com/user-attachments/assets/474417b4-de12-44c8-a5c7-cf626fb56b85

Pin issue

https://github.com/user-attachments/assets/e0d6a534-7b8e-45c5-9ac3-06d91f1fa640



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/unable-to-connect-after-failed-fw-update&lookback=7)