### PR TITLE
feat(suite-common): add 2.8.10 + 1.13.1 fw binaries

### DIFF
--- a/packages/connect-common/files/firmware/t1b1/releases.json
+++ b/packages/connect-common/files/firmware/t1b1/releases.json
@@ -1,6 +1,19 @@
 [
     {
         "required": false,
+        "version": [1, 13, 1],
+        "bootloader_version": [1, 12, 1],
+        "min_firmware_version": [1, 12, 0],
+        "min_bootloader_version": [1, 12, 0],
+        "url": "firmware/t1b1/trezor-t1b1-1.13.1.bin",
+        "url_bitcoinonly": "firmware/t1b1/trezor-t1b1-1.13.1-bitcoinonly.bin",
+        "fingerprint": "f588657818ccf99b0046ede3f87eeaf17a0e6e6f1b7853344e18b846ca835328",
+        "fingerprint_bitcoinonly": "f27095f2e08278a209567e254b9921f6e34b28a9c0fc702a268f210e23057c27",
+        "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+        "changelog": "* Clear sign ETH staking transactions on Everstake pools\n* Use GWei when formatting large ETH amounts."
+    },
+    {
+        "required": false,
         "version": [1, 13, 0],
         "bootloader_version": [1, 12, 1],
         "min_firmware_version": [1, 12, 0],

--- a/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.13.0-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.13.0-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:370122a4ecc2d7a900585944b2c1ecf216dd39367e49ffc09f0debc228e0ec69
-size 404204

--- a/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.13.0.bin
+++ b/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.13.0.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a5f51f64c0ad8dac888ed5a1c5e6b64271b382b6ed73cfe6a569cfb874cd4545
-size 504172

--- a/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.13.1-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.13.1-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad30bfe60460eb7a226dfbe4a6f652bc150206494d688d06421228b9969eb9a5
+size 404580

--- a/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.13.1.bin
+++ b/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.13.1.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8a550b96350182949a4e4dcf4d0b5e57f571c6042b3de6bbd78d5a5daab1fa6
+size 505092

--- a/packages/connect-common/files/firmware/t2b1/releases.json
+++ b/packages/connect-common/files/firmware/t2b1/releases.json
@@ -1,6 +1,21 @@
 [
     {
         "required": false,
+        "version": [2, 8, 10],
+        "min_bootloader_version": [2, 1, 1],
+        "min_firmware_version": [2, 6, 1],
+        "bootloader_version": [2, 1, 8],
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR"],
+        "url": "firmware/t2b1/trezor-t2b1-2.8.10.bin",
+        "url_bitcoinonly": "firmware/t2b1/trezor-t2b1-2.8.10-bitcoinonly.bin",
+        "fingerprint": "db555520689b1af7c18cb20fc2631fbf07ce4f7dd735c7e64ab279e1ad03a33a",
+        "fingerprint_bitcoinonly": "5bd50bbcf6435f97b6dc46f96ad11235965cd8a78619c573c3c0aca6822e9ed2",
+        "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+        "changelog": "* Solana: rent fee calculation\n* Solana: loadable token definitions\n* Replaced \"next page\" icon with \"...\" ellipsis when confirming long message.\n* Fixed Solana staking dialog title.\n* Updated EIP-1559 fee-related labels.\n* Allow firmware upgrade even if language change failed.\n* Solana: fees calculation is now exact",
+        "changelog_bitcoinonly": "* Replaced \"next page\" icon with \"...\" ellipsis when confirming long message.\n* Allow firmware upgrade even if language change failed."
+    },
+    {
+        "required": false,
         "version": [2, 8, 9],
         "min_bootloader_version": [2, 1, 1],
         "min_firmware_version": [2, 6, 1],

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.10-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.10-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fcf27e4884efbceefd037ba47ebb603ce720575271e69ad0bb6f5b9dc565172
+size 1183744

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.10.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.10.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cc8e38f5ca715e3764553149614310b5fc941293e4864e0f9c9db5a76218e14
+size 1467904

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.9-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.9-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2dbfedb74091397617354335be294e46efe35f84e34053d218b4d6464d28d5a0
-size 1208320

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.9.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.9.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:437916c8af0a7cd64c2a7c6ac34ca7a249293ff397b68c1f2b560eca6dddb17a
-size 1512448

--- a/packages/connect-common/files/firmware/t2t1/releases.json
+++ b/packages/connect-common/files/firmware/t2t1/releases.json
@@ -1,6 +1,21 @@
 [
     {
         "required": false,
+        "version": [2, 8, 10],
+        "min_bootloader_version": [2, 0, 0],
+        "min_firmware_version": [2, 0, 8],
+        "bootloader_version": [2, 1, 8],
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR"],
+        "url": "firmware/t2t1/trezor-t2t1-2.8.10.bin",
+        "url_bitcoinonly": "firmware/t2t1/trezor-t2t1-2.8.10-bitcoinonly.bin",
+        "fingerprint": "91feae69ada0f98b72f19191f1d1e083b579c26079f7e6fcd751fae0902ec72f",
+        "fingerprint_bitcoinonly": "c280cfbe83b261ef30c64eb58f55538b3cceee01ba7d8f57d6e8cbf92527066b",
+        "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+        "changelog": "* Add Nostr support (in debug mode only!).\n* Solana: rent fee calculation\n* Solana: loadable token definitions\n* Replaced \"next page\" icon with \"...\" ellipsis when confirming long message.\n* Fixed upgrade confirmation text overflow.\n* Fixed Solana staking dialog fonts.\n* Updated EIP-1559 fee-related labels.\n* Allow firmware upgrade even if language change failed.\n* Solana: fees calculation is now exact",
+        "changelog_bitcoinonly": "* Replaced \"next page\" icon with \"...\" ellipsis when confirming long message.\n* Fixed upgrade confirmation text overflow.\n* Allow firmware upgrade even if language change failed."
+    },
+    {
+        "required": false,
         "version": [2, 8, 9],
         "min_bootloader_version": [2, 0, 0],
         "min_firmware_version": [2, 0, 8],

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.10-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.10-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b04bfb97723dbbc6db3edc2abe1daf603e2936cab6d180773645a2dd19f685c
+size 1273856

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.10.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.10.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f97b11599f68fe01f2f9414af6d876fb3dbedfc1e375e1e18486177e7523cb4d
+size 1589248

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.9-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.9-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eb7b60304dfcb5489e9c44a4546491c56fdfb94b55bdeced27d457da70650f44
-size 1300480

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.9.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.9.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:737779943fffd0cc74165b8c45339428892797d1ed2fb3a387c93389ca1e9285
-size 1637376

--- a/packages/connect-common/files/firmware/t3b1/releases.json
+++ b/packages/connect-common/files/firmware/t3b1/releases.json
@@ -1,6 +1,21 @@
 [
     {
         "required": false,
+        "version": [2, 8, 10],
+        "min_bootloader_version": [2, 1, 7],
+        "min_firmware_version": [2, 8, 3],
+        "bootloader_version": [2, 1, 8],
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR"],
+        "url": "firmware/t3b1/trezor-t3b1-2.8.10.bin",
+        "url_bitcoinonly": "firmware/t3b1/trezor-t3b1-2.8.10-bitcoinonly.bin",
+        "fingerprint": "ad763b0193bf2814bdb9807b51226e1c7639693e912e9334db3f446091943369",
+        "fingerprint_bitcoinonly": "5a0aa661b61d056f72b83bf0d5c7eb4ddc84d6370fb977be794b145e49e8ff3f",
+        "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+        "changelog": "* Upgrade bundled bootloader to 2.1.10.\n* Add Nostr support (in debug mode only!).\n* Solana: rent fee calculation\n* Solana: loadable token definitions\n* Replaced \"next page\" icon with \"...\" ellipsis when confirming long message.\n* Fixed Solana staking dialog title.\n* Updated EIP-1559 fee-related labels.\n* Allow firmware upgrade even if language change failed.\n* Solana: fees calculation is now exact",
+        "changelog_bitcoinonly": "* Upgrade bundled bootloader to 2.1.10.\n* Replaced \"next page\" icon with \"...\" ellipsis when confirming long message.\n* Allow firmware upgrade even if language change failed."
+    },
+    {
+        "required": false,
         "version": [2, 8, 9],
         "min_bootloader_version": [2, 1, 7],
         "min_firmware_version": [2, 8, 3],

--- a/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.10-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.10-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb64b3a6597b7bf27105cb4c303aaf4da6f6525bc78a75bdffcc5a3dd58c4303
+size 991744

--- a/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.10.bin
+++ b/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.10.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b082e2584c93ba815e3a4ca01e8906c126c87ea698c747b4a2138827fca95a7
+size 1345024

--- a/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.9-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.9-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0b162d339cbc3a2395b4ba98c7de69a4154ed73d38d0c62aab28140abccff36
-size 993280

--- a/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.9.bin
+++ b/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.9.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:44db2aeecb5de890d10294258d5203be43c8a21789b668dca8c507f406c1e282
-size 1359360

--- a/packages/connect-common/files/firmware/t3t1/releases.json
+++ b/packages/connect-common/files/firmware/t3t1/releases.json
@@ -1,6 +1,21 @@
 [
     {
         "required": false,
+        "version": [2, 8, 10],
+        "min_bootloader_version": [2, 1, 6],
+        "min_firmware_version": [2, 7, 2],
+        "bootloader_version": [2, 1, 10],
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR", "tr-TR"],
+        "url": "firmware/t3t1/trezor-t3t1-2.8.10.bin",
+        "url_bitcoinonly": "firmware/t3t1/trezor-t3t1-2.8.10-bitcoinonly.bin",
+        "fingerprint": "f6f50b4a419b041a59620ef681047c27af0902798e0227397c532dd70736694a",
+        "fingerprint_bitcoinonly": "11d3f68d08f3f95c04dd526826f81eb7918df85928cfcef73beeae3132342bf0",
+        "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+        "changelog": "* Add Nostr support (in debug mode only!).\n* Visual cues to distinguish unlocked state on Homescreen.\n* Solana: rent fee calculation\n* Solana: loadable token definitions\n* Replaced \"next page\" icon with \"...\" ellipsis when confirming long message.\n* Updated EIP-1559 fee-related labels.\n* Allow firmware upgrade even if language change failed.\n* Solana: fees calculation is now exact",
+        "changelog_bitcoinonly": "* Visual cues to distinguish unlocked state on Homescreen.\n* Replaced \"next page\" icon with \"...\" ellipsis when confirming long message.\n* Allow firmware upgrade even if language change failed."
+    },
+    {
+        "required": false,
         "version": [2, 8, 9],
         "min_bootloader_version": [2, 1, 6],
         "min_firmware_version": [2, 7, 2],

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.10-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.10-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad66099c6bf2dd037c9844a9236f6dc3bd8eab200d5b6b0138aa29bcb4f35628
+size 1150464

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.10.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.10.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd6b59f0cb501f8d372e2b8e7369195fdf1980f5915ca6fe61223fcd0601df6a
+size 1523200

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.9-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.9-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5763be9adf78ed2a1bcc7781d4fc720dbe2d5905bf9ec4ad12bf81aaaa699ffb
-size 1167360

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.9.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.9.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a511126fd1a10f761a6745a2cb6c0a113c3b37b29ea87d1a724581e6b6624d2e
-size 1553408


### PR DESCRIPTION
Honzo nemusíš to číst :D 


This pull request updates the firmware binaries in the `packages/connect-common/files/firmware` directory by removing outdated versions and adding new ones for various Trezor device models (`t1b1`, `t2b1`, `t2t1`, `t3b1`, and `t3t1`). The changes ensure the inclusion of the latest firmware versions while cleaning up older files.

### Firmware Updates by Device Model:

#### `t1b1` Firmware:
* Removed version `1.13.0` (both standard and Bitcoin-only builds). [[1]](diffhunk://#diff-f579f231db5a8a76ba3a9688ddfa56021c5e96710dd25b6c2bc3a927ec4bea5dL1-L3) [[2]](diffhunk://#diff-59b2bd8fb49b2041e698b4c500f01c5a0deb81fe42dcbd2f11ba42adf86c3dffL1-L3)
* Added version `1.13.1` (both standard and Bitcoin-only builds). [[1]](diffhunk://#diff-7c80648b0c0d70f6e9528639ba799679a7f23b589b792c1abec654ce8471ec9aR1-R3) [[2]](diffhunk://#diff-6f0984018a877e105f22fc5d6313d58f9c3f812e893b70166e5427042c0747c2R1-R3)

#### `t2b1` Firmware:
* Removed version `2.8.9` (both standard and Bitcoin-only builds). [[1]](diffhunk://#diff-fbe02737fa4f9d0239eead9f0cf4d920df4f6ad5fc850d08aca40ef7349cc76aL1-L3) [[2]](diffhunk://#diff-02e0650336f56f45d3ab80aba6841dceef51cb6c87ea4ebb171bd84424c413a0L1-L3)
* Added version `2.8.10` (both standard and Bitcoin-only builds). [[1]](diffhunk://#diff-2812f0493c2b04b0586240d4285173f8da9b10c2f21eba0052237b86f0809e98R1-R3) [[2]](diffhunk://#diff-d7759050894c26d43fd6c6d4cad5970832686924b8eda06fc065fe382743545bR1-R3)

#### `t2t1` Firmware:
* Removed version `2.8.9` (both standard and Bitcoin-only builds). [[1]](diffhunk://#diff-8a2f635d59ad3628a3109ab4f7caae76e75d333a2ee6be1148e969fb03d81b89L1-L3) [[2]](diffhunk://#diff-42614757bd476d8d4a4b380791a28074de34c0bad911d7d32c2601c6c6e7a19cL1-L3)
* Added version `2.8.10` (both standard and Bitcoin-only builds). [[1]](diffhunk://#diff-c39553071c18da11fa42ce836672e459ee66164a8eeda049035b3d924cc16702R1-R3) [[2]](diffhunk://#diff-af5f2b860a3784ba47cce33ccfe8759b91474bb8d868cd2b8c47daa0e051697dR1-R3)

#### `t3b1` Firmware:
* Removed version `2.8.9` (both standard and Bitcoin-only builds). [[1]](diffhunk://#diff-ce38e4412593c0aa30a38c2fea52d4e13252766f2cf8f5b8b5595dc4c843fbe3L1-L3) [[2]](diffhunk://#diff-411349bf5ba3f40cb06239a7d83f9da7f34a01eb39b5332ea2331b255421d858L1-L3)
* Added version `2.8.10` (both standard and Bitcoin-only builds). [[1]](diffhunk://#diff-c72c305f4564fc5e3fdfc1567321a5619ede226fd84c5ee8aa5c533a4d4994ccR1-R3) [[2]](diffhunk://#diff-ba2884f3232cebf042119a65bb31673abf4f05ef0f0feffb233b9a4ed27665adR1-R3)

#### `t3t1` Firmware:
* Removed version `2.8.9` (both standard and Bitcoin-only builds). [[1]](diffhunk://#diff-ff15bf986d60352fdfd8d5f186ecd1b3a7f208bc8bafd15c16a092006a02f89dL1-L3) [[2]](diffhunk://#diff-9b2e988475606dc0ba62632972b30dcc9bed9e9d94adfe988de7b93b5cd6d044L1-L3)
* Added version `2.8.10` (both standard and Bitcoin-only builds). [[1]](diffhunk://#diff-a28de5198d35acac2abe0fe23473e01daba0de5cf537ab85610a95cf0a26824bR1-R3) [[2]](diffhunk://#diff-415794d75d674276da6c7b117cb1159b71c29afc019862d6a4cecf7cc66b8248R1-R3)