### PR TITLE
fix(wallet-core): account timestamp update was not updated

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsMiddleware.ts
+++ b/suite-common/wallet-core/src/accounts/accountsMiddleware.ts
@@ -1,8 +1,10 @@
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
+import { DiscoveryStatus } from '@suite-common/wallet-constants';
 
 import { accountsActions } from './accountsActions';
 import { fetchAndUpdateAccountThunk } from './accountsThunks';
-import { DEFAULT_ACCOUNT_SYNC_INTERVAL } from '../blockchain/blockchainThunks';
+
+const UPDATE_SELECTED_ACCOUNT_INTERVAL = 10_000;
 
 export const prepareAccountsMiddleware = createMiddlewareWithExtraDeps(
     (action, { dispatch, next }) => {
@@ -12,14 +14,15 @@ export const prepareAccountsMiddleware = createMiddlewareWithExtraDeps(
 
         if (
             accountsActions.updateSelectedAccount.match(action) &&
-            action.payload.status === 'loaded'
+            action.payload.status === 'loaded' &&
+            action.payload.discovery.status === DiscoveryStatus.COMPLETED
         ) {
             const accountKey = action.payload.account.key;
             const updatedAt = action.payload.account.ts || 0; // safety, old versions of Suite does not have this attribute
-            const isLessThanDefaultSyncInterval =
-                Date.now() - updatedAt < DEFAULT_ACCOUNT_SYNC_INTERVAL;
 
-            if (!isLessThanDefaultSyncInterval) {
+            const shouldUpdateAccount = Date.now() - updatedAt >= UPDATE_SELECTED_ACCOUNT_INTERVAL; // update account on enter
+
+            if (shouldUpdateAccount) {
                 dispatch(fetchAndUpdateAccountThunk({ accountKey }));
             }
         }

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -122,6 +122,9 @@ export const prepareAccountsReducer = createReducerWithExtraDeps(
             .addCase(accountsActions.updateAccount, (state, action) => {
                 update(state, action.payload);
             })
+            .addCase(accountsActions.updateAccountRefreshTimestamp, (state, action) => {
+                update(state, action.payload);
+            })
             .addCase(accountsActions.renameAccount, (state, action) => {
                 const { accountKey, accountLabel } = action.payload;
                 const accountByAccountKey = state.find(account => account.key === accountKey);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- after one minute in the app, account was update on each visit
- it was planned to have it 1 minute. However, it never worked. Setting it to 10 seconds and making it work

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/update-account&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/update-account&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/update-account&lookback=7)