### PR TITLE
fix(suite): dashboard asset error margins

### DIFF
--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -38,6 +38,7 @@ import { AssetTable } from './AssetTable/AssetTable';
 
 const InfoMessage = styled.div`
     padding: ${spacingsPx.md} ${spacingsPx.xl};
+    align-items: center;
     display: flex;
     color: ${({ theme }) => theme.textAlertRed};
     ${typography.label}
@@ -265,7 +266,12 @@ export const AssetsView = () => {
                     />
                     {isError && (
                         <InfoMessage>
-                            <Icon name="warning" color={theme.iconAlertRed} size={14} />
+                            <Icon
+                                name="warning"
+                                color={theme.iconAlertRed}
+                                size={14}
+                                margin={{ right: spacings.xxs }}
+                            />
                             <Translation id="TR_DASHBOARD_ASSETS_ERROR" />
                         </InfoMessage>
                     )}


### PR DESCRIPTION



## Screenshots:
Before
<img width="371" alt="Screenshot 2025-05-11 at 12 06 02" src="https://github.com/user-attachments/assets/6df34fd1-6c88-49b0-91dc-469ba0f3f311" />

After
<img width="735" alt="Screenshot 2025-05-11 at 12 11 10" src="https://github.com/user-attachments/assets/89c7493f-4ec5-4db0-bca4-92ec457bcc63" />

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/dashboard-asset-error&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/dashboard-asset-error&lookback=7)