### PR TITLE
fix(suite-native): better trade close handling

### DIFF
--- a/suite-native/module-trading/src/screens/TradingWebviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingWebviewScreen.tsx
@@ -19,10 +19,8 @@ import {
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { setTradeOrderIdToBeOpened } from '../tradingSlice';
-import {
-    TRADING_URL_DEFAULT_BACK,
-    getTradeTypeActionAndOrderIdFromUrl,
-} from '../utils/tradeFormUtils';
+import { getTradeTypeActionAndOrderIdFromUrl } from '../utils/tradeFormUtils';
+import { doesUrlContainCloseCallbackUrl } from '../utils/tradeUtils';
 
 type RouteProps = StackProps<RootStackParamList, RootStackRoutes.TradingWebView>['route'];
 
@@ -37,11 +35,11 @@ export const TradingWebViewScreen = () => {
     const dispatch = useDispatch();
     const receivedDeeplinkUrl = useURL();
 
-    // when url matches closeCallbackUrl or TRADING_URL_DEFAULT_BACK, go back and mark the trade to be opened
+    // when url contains closeCallbackUrl or TRADING_URL_DEFAULT_BACK, go back and mark the trade to be opened
     const checkForGoBackOnUrl = useCallback(
         (url: string | null) => {
             const urlString = url ?? '';
-            if ([closeCallbackUrl, TRADING_URL_DEFAULT_BACK].includes(urlString)) {
+            if (doesUrlContainCloseCallbackUrl(urlString, closeCallbackUrl)) {
                 const { orderId } = getTradeTypeActionAndOrderIdFromUrl(urlString);
                 if (orderId) {
                     dispatch(setTradeOrderIdToBeOpened(orderId));

--- a/suite-native/module-trading/src/utils/__tests__/tradeUtils.test.ts
+++ b/suite-native/module-trading/src/utils/__tests__/tradeUtils.test.ts
@@ -1,7 +1,13 @@
 import { BuyTradeStatus, ExchangeTradeStatus, SellTradeStatus } from 'invity-api';
 
 import { getBuyTrade, getExchangeTrade, getSellTrade } from '../../__fixtures__/trades';
-import { getTradeOperationData, getTradeStatusStep, isFinalStatus } from '../tradeUtils';
+import { TRADING_URL_DEFAULT_BACK } from '../tradeFormUtils';
+import {
+    doesUrlContainCloseCallbackUrl,
+    getTradeOperationData,
+    getTradeStatusStep,
+    isFinalStatus,
+} from '../tradeUtils';
 
 describe('tradeUtils', () => {
     describe('getTradeOperationData', () => {
@@ -121,6 +127,35 @@ describe('tradeUtils', () => {
         ])('should return correct step for sell trade with %s status', (status, expectedStep) => {
             const trade = getSellTrade({ status: status as SellTradeStatus });
             expect(getTradeStatusStep(trade)).toBe(expectedStep);
+        });
+    });
+
+    describe('doesUrlContainCloseCallbackUrl', () => {
+        const closeCallbackUrl = 'trezorsuitelite://trading';
+
+        it('should return true when URL contains closeCallbackUrl', () => {
+            const url = 'trezorsuitelite://trading?action=trade&tradeType=buy&orderId=123';
+            expect(doesUrlContainCloseCallbackUrl(url, closeCallbackUrl)).toBe(true);
+        });
+
+        it('should return true when URL contains TRADING_URL_DEFAULT_BACK', () => {
+            const url = `${TRADING_URL_DEFAULT_BACK}?action=trade&tradeType=buy&orderId=123`;
+            expect(doesUrlContainCloseCallbackUrl(url, closeCallbackUrl)).toBe(true);
+        });
+
+        it('should return false when URL contains neither closeCallbackUrl nor TRADING_URL_DEFAULT_BACK', () => {
+            const url = 'https://example.com/trading?action=trade&tradeType=buy&orderId=123';
+            expect(doesUrlContainCloseCallbackUrl(url, closeCallbackUrl)).toBe(false);
+        });
+
+        it('should handle empty URL', () => {
+            expect(doesUrlContainCloseCallbackUrl('', closeCallbackUrl)).toBe(false);
+        });
+
+        it('should handle URL with special characters', () => {
+            const url =
+                'trezorsuitelite://trading?action=trade&tradeType=buy&orderId=dd070b73-fe29-4769-8be1-4075d6b43265&transactionId=8c9476a7-958b-412b-a378-3a3f59b6105a&baseCurrencyCode=czk&baseCurrencyAmount=384.78&transactionStatus=completed';
+            expect(doesUrlContainCloseCallbackUrl(url, closeCallbackUrl)).toBe(true);
         });
     });
 });

--- a/suite-native/module-trading/src/utils/tradeUtils.ts
+++ b/suite-native/module-trading/src/utils/tradeUtils.ts
@@ -11,6 +11,8 @@ import {
 import { UnreachableCaseError } from '@suite-common/suite-utils';
 import { TradingTradeStatusType, TradingTransaction, TradingType } from '@suite-common/trading';
 
+import { TRADING_URL_DEFAULT_BACK } from './tradeFormUtils';
+
 export const tradeFinalStatuses: Record<TradingType, TradingTradeStatusType[]> = {
     buy: ['SUCCESS', 'ERROR', 'BLOCKED'] satisfies BuyTradeFinalStatus[],
     sell: ['SUCCESS', 'ERROR', 'BLOCKED', 'CANCELLED', 'REFUNDED'] satisfies SellTradeFinalStatus[],
@@ -149,3 +151,6 @@ export const getTradeStatusStep = (trade: TradingTransaction) => {
             throw new UnreachableCaseError(tradeType);
     }
 };
+
+export const doesUrlContainCloseCallbackUrl = (url: string, closeCallbackUrl: string) =>
+    url.includes(closeCallbackUrl) || url.includes(TRADING_URL_DEFAULT_BACK);


### PR DESCRIPTION
Moonpay was returning close url with some extra parameters and exact matching make it not work. This should do the trick



## Related Issue

Resolve #18332


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/webview-close&lookback=7)