### PR TITLE
fix(suite-native): TradeDetailSheet scrolling issues

### DIFF
--- a/suite-native/atoms/src/Sheet/BottomSheetModal.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetModal.tsx
@@ -1,13 +1,10 @@
-import { ReactNode, forwardRef, useCallback, useRef } from 'react';
+import { ReactNode, forwardRef, useCallback } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
     BottomSheetBackdrop,
     BottomSheetBackdropProps,
     BottomSheetModal as BottomSheetModalBase,
-    BottomSheetScrollView,
-    BottomSheetScrollViewMethods,
 } from '@gorhom/bottom-sheet';
 import { BottomSheetModalMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
 
@@ -15,8 +12,9 @@ import { useScrollDivider } from '@suite-native/navigation';
 import { getScreenHeight } from '@trezor/env-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
-import { AnimatedBox, BoxProps } from '../Box';
+import { BoxProps } from '../Box';
 import { BottomSheetHeader } from './BottomSheetHeader';
+import { BottomSheetModalContent } from './BottomSheetModalContent';
 
 const SCREEN_HEIGHT = getScreenHeight();
 const MAX_HEIGHT = SCREEN_HEIGHT * 0.9;
@@ -34,13 +32,6 @@ const containerStyle = prepareNativeStyle(() => ({
     flex: 1,
 }));
 
-const childWrapperStyle = prepareNativeStyle<{ bottomInset?: number }>(
-    (utils, { bottomInset }) => ({
-        flex: 1,
-        paddingBottom: bottomInset || utils.spacings.sp16,
-    }),
-);
-
 const backgroundStyle = prepareNativeStyle(utils => ({
     backgroundColor: utils.colors.backgroundSurfaceElevation0,
 }));
@@ -51,9 +42,6 @@ export const BottomSheetModal = forwardRef<BottomSheetModalMethods, BottomSheetM
         ref,
     ) => {
         const { applyStyle } = useNativeStyles();
-        const { bottom } = useSafeAreaInsets();
-
-        const scrollViewRef = useRef<BottomSheetScrollViewMethods>(null);
 
         const { scrollDivider, handleScroll } = useScrollDivider();
 
@@ -91,20 +79,9 @@ export const BottomSheetModal = forwardRef<BottomSheetModalMethods, BottomSheetM
                     )}
                     onDismiss={onDismiss}
                 >
-                    <BottomSheetScrollView
-                        style={applyStyle(containerStyle)}
-                        ref={scrollViewRef}
-                        onScroll={handleScroll}
-                        testID="@bottom-sheet/scroll-view"
-                    >
-                        <AnimatedBox
-                            paddingHorizontal="sp16"
-                            style={[applyStyle(childWrapperStyle, { bottomInset: bottom }), style]}
-                            {...rest}
-                        >
-                            {children}
-                        </AnimatedBox>
-                    </BottomSheetScrollView>
+                    <BottomSheetModalContent handleScroll={handleScroll} style={style} {...rest}>
+                        {children}
+                    </BottomSheetModalContent>
                     {footer}
                 </BottomSheetModalBase>
             </GestureHandlerRootView>

--- a/suite-native/atoms/src/Sheet/BottomSheetModal.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetModal.tsx
@@ -46,7 +46,10 @@ const backgroundStyle = prepareNativeStyle(utils => ({
 }));
 
 export const BottomSheetModal = forwardRef<BottomSheetModalMethods, BottomSheetModalProps>(
-    ({ children, footer, style, title, isCloseDisplayed = false, subtitle, onDismiss }, ref) => {
+    (
+        { children, footer, style, title, isCloseDisplayed = false, subtitle, onDismiss, ...rest },
+        ref,
+    ) => {
         const { applyStyle } = useNativeStyles();
         const { bottom } = useSafeAreaInsets();
 
@@ -97,6 +100,7 @@ export const BottomSheetModal = forwardRef<BottomSheetModalMethods, BottomSheetM
                         <AnimatedBox
                             paddingHorizontal="sp16"
                             style={[applyStyle(childWrapperStyle, { bottomInset: bottom }), style]}
+                            {...rest}
                         >
                             {children}
                         </AnimatedBox>

--- a/suite-native/atoms/src/Sheet/BottomSheetModalContent.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetModalContent.tsx
@@ -1,0 +1,48 @@
+import { memo } from 'react';
+import { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+import { AnimatedBox, BoxProps } from '../Box';
+
+const childWrapperStyle = prepareNativeStyle<{ bottomInset?: number }>(
+    (utils, { bottomInset }) => ({
+        flex: 1,
+        paddingBottom: bottomInset || utils.spacings.sp16,
+        paddingHorizontal: utils.spacings.sp16,
+    }),
+);
+
+const containerStyle = prepareNativeStyle(() => ({
+    flex: 1,
+}));
+
+interface BottomSheetModalContentProps extends BoxProps {
+    handleScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+}
+
+export const BottomSheetModalContent = memo<BottomSheetModalContentProps>(
+    ({ handleScroll, style, children, ...rest }) => {
+        const { applyStyle } = useNativeStyles();
+
+        const { bottom } = useSafeAreaInsets();
+
+        return (
+            <BottomSheetScrollView
+                style={applyStyle(containerStyle)}
+                onScroll={handleScroll}
+                testID="@bottom-sheet/scroll-view"
+            >
+                <AnimatedBox
+                    style={[applyStyle(childWrapperStyle, { bottomInset: bottom }), style]}
+                    {...rest}
+                >
+                    {children}
+                </AnimatedBox>
+            </BottomSheetScrollView>
+        );
+    },
+);

--- a/suite-native/module-trading/src/components/general/TradeDetailSheet/TradeDetailSheet.tsx
+++ b/suite-native/module-trading/src/components/general/TradeDetailSheet/TradeDetailSheet.tsx
@@ -1,7 +1,10 @@
+import { memo, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 
+import { type BottomSheetModal as BottomSheetModalType } from '@gorhom/bottom-sheet';
+
 import { TradingRootState, selectTradingTradeByOrderId } from '@suite-common/trading';
-import { BottomSheet } from '@suite-native/atoms';
+import { BottomSheetModal } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { TradeDetailFooter } from './TradeDetailFooter';
@@ -12,29 +15,46 @@ import { TradeDetailTransactionInfo } from './TradeDetailTransactionInfo';
 type TradeDetailSheetProps = {
     orderId?: string;
     isVisible: boolean;
-    onClose: () => void;
+    onDismiss: () => void;
 };
 
 const bottomSheetStyle = prepareNativeStyle(({ spacings }) => ({
     gap: spacings.sp16,
+    marginVertical: spacings.sp10,
 }));
 
-export const TradeDetailSheet = ({ orderId, isVisible, onClose }: TradeDetailSheetProps) => {
+export const TradeDetailSheet = memo(({ orderId, isVisible, onDismiss }: TradeDetailSheetProps) => {
     const { applyStyle } = useNativeStyles();
     const trade = useSelector((state: TradingRootState) =>
         selectTradingTradeByOrderId(state, orderId),
     );
+    const bottomSheetModalRef = useRef<BottomSheetModalType>(null);
+
+    useEffect(() => {
+        if (isVisible) {
+            bottomSheetModalRef.current?.present();
+        }
+    }, [isVisible]);
 
     if (!orderId || !trade) {
         return null;
     }
 
+    const onOpenedWebview = () => {
+        bottomSheetModalRef.current?.close();
+    };
+
     return (
-        <BottomSheet isVisible={isVisible} onClose={onClose} style={applyStyle(bottomSheetStyle)}>
-            <TradeDetailHeader orderId={orderId} onOpenedWebview={onClose} />
+        <BottomSheetModal
+            ref={bottomSheetModalRef}
+            onDismiss={onDismiss}
+            style={applyStyle(bottomSheetStyle)}
+            isCloseDisplayed
+        >
+            <TradeDetailHeader orderId={orderId} onOpenedWebview={onOpenedWebview} />
             <TradeDetailTransactionInfo orderId={orderId} />
             <TradeDetailInfo orderId={orderId} />
             <TradeDetailFooter orderId={orderId} />
-        </BottomSheet>
+        </BottomSheetModal>
     );
-};
+});

--- a/suite-native/module-trading/src/screens/TradeHistoryScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradeHistoryScreen.tsx
@@ -97,7 +97,7 @@ export const TradeHistoryScreen = () => {
             <TradeDetailSheet
                 isVisible={isSheetVisible}
                 orderId={detailOrderId}
-                onClose={hideSheet}
+                onDismiss={hideSheet}
             />
         </Screen>
     );


### PR DESCRIPTION


## Description

- c77ef73 Switches from BottomSheet to BottomSheetModal in TradeDetailSheet to address problems with unscrollable content.

- e6ff633 Extracts the scrollable content of BottomSheetModal into a separate memoized BottomSheetModalContent component. This prevents unnecessary rerenders of BottomSheetScrollView when scrollDivider changes, resolving scroll jump issues caused by rerendering.

## Related Issue

Resolve #18792 

### Before

https://github.com/user-attachments/assets/b3cab653-61f9-419d-b2fc-eea47bcba95f

https://github.com/user-attachments/assets/c5462e71-38a8-44d4-be91-51406860c576

### After 

https://github.com/user-attachments/assets/3fdf214b-fda6-4964-8e7f-56eda09b17e8




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=18792-mobile-trade-refactor-tradedetailsheet-to-use-bottomsheetmodal-instead-of-bottomsheet&lookback=7)