### PR TITLE
chore(connect): enable entropy check for t1b1

### DIFF
--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -263,7 +263,7 @@ export const config = {
         },
         {
             capabilities: ['entropyCheck'],
-            min: { T1B1: '0', T2T1: '2.8.7', T2B1: '2.8.7', T3B1: '2.8.7', T3T1: '2.8.7' },
+            min: { T1B1: '1.13.1', T2T1: '2.8.7', T2B1: '2.8.7', T3B1: '2.8.7', T3T1: '2.8.7' },
         },
     ],
 };

--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -10,6 +10,19 @@ import {
     parseRevision,
 } from '../deviceFeaturesUtils';
 
+const T1B1_UPDATE_REQUIRED = {
+    amountUnit: 'update-required',
+    coinjoin: 'update-required',
+    decreaseOutput: 'update-required',
+    eip1559: 'update-required',
+    'eip712-domain-only': 'update-required',
+    entropyCheck: 'update-required',
+    getFirmwareHash: 'update-required',
+    replaceTransaction: 'update-required',
+    signMessageNoScriptType: 'update-required',
+    taproot: 'update-required',
+};
+
 describe('utils/deviceFeaturesUtils', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -156,17 +169,8 @@ describe('utils/deviceFeaturesUtils', () => {
                 xtz: 'no-support',
                 xvg: 'update-required',
                 zcr: 'update-required',
-                replaceTransaction: 'update-required',
-                amountUnit: 'update-required',
-                decreaseOutput: 'update-required',
-                eip1559: 'update-required',
-                'eip712-domain-only': 'update-required',
-                taproot: 'update-required',
-                coinjoin: 'update-required',
-                signMessageNoScriptType: 'update-required',
                 chunkify: 'no-support',
-                entropyCheck: 'no-support',
-                getFirmwareHash: 'update-required',
+                ...T1B1_UPDATE_REQUIRED,
             });
         });
 
@@ -174,30 +178,21 @@ describe('utils/deviceFeaturesUtils', () => {
             const coins2 = getAllNetworks();
 
             expect(getUnavailableCapabilities(featT2T1, coins2)).toEqual({
-                replaceTransaction: 'update-required',
-                amountUnit: 'update-required',
                 arb: 'update-required',
                 base: 'update-required',
                 bsc: 'update-required',
-                decreaseOutput: 'update-required',
-                eip1559: 'update-required',
-                'eip712-domain-only': 'update-required',
                 maid: 'no-capability',
                 pol: 'update-required',
                 omni: 'no-capability',
                 op: 'update-required',
-                taproot: 'update-required',
                 tsep: 'update-required',
                 thol: 'update-required',
                 trvn: 'update-required',
                 usdt: 'no-capability',
-                coinjoin: 'update-required',
-                signMessageNoScriptType: 'update-required',
                 sol: 'no-capability',
                 dsol: 'no-capability',
                 chunkify: 'update-required',
-                entropyCheck: 'update-required',
-                getFirmwareHash: 'update-required',
+                ...T1B1_UPDATE_REQUIRED,
             });
         });
 
@@ -304,17 +299,8 @@ describe('utils/deviceFeaturesUtils', () => {
             expect(result).toEqual({
                 eth: 'no-support',
                 bsc: 'update-required',
-                amountUnit: 'update-required',
                 chunkify: 'update-required',
-                coinjoin: 'update-required',
-                decreaseOutput: 'update-required',
-                eip1559: 'update-required',
-                'eip712-domain-only': 'update-required',
-                replaceTransaction: 'update-required',
-                signMessageNoScriptType: 'update-required',
-                taproot: 'update-required',
-                entropyCheck: 'update-required',
-                getFirmwareHash: 'update-required',
+                ...T1B1_UPDATE_REQUIRED,
             });
         });
 
@@ -337,17 +323,8 @@ describe('utils/deviceFeaturesUtils', () => {
             expect(result).toEqual({
                 eth: 'no-support',
                 bnb: 'no-support',
-                amountUnit: 'update-required',
                 chunkify: 'no-support',
-                coinjoin: 'update-required',
-                decreaseOutput: 'update-required',
-                eip1559: 'update-required',
-                'eip712-domain-only': 'update-required',
-                replaceTransaction: 'update-required',
-                signMessageNoScriptType: 'update-required',
-                taproot: 'update-required',
-                entropyCheck: 'no-support',
-                getFirmwareHash: 'update-required',
+                ...T1B1_UPDATE_REQUIRED,
             });
         });
 
@@ -371,17 +348,8 @@ describe('utils/deviceFeaturesUtils', () => {
                 eth: 'no-support',
                 bnb: 'no-support',
                 bsc: 'no-support',
-                amountUnit: 'update-required',
                 chunkify: 'no-support',
-                coinjoin: 'update-required',
-                decreaseOutput: 'update-required',
-                eip1559: 'update-required',
-                'eip712-domain-only': 'update-required',
-                replaceTransaction: 'update-required',
-                signMessageNoScriptType: 'update-required',
-                taproot: 'update-required',
-                entropyCheck: 'no-support',
-                getFirmwareHash: 'update-required',
+                ...T1B1_UPDATE_REQUIRED,
             });
         });
     });


### PR DESCRIPTION
QA: Failure can be tested with modified firmware or fake device (I don't have access to either of those). I tested by mocking test failure in Suite. But you will see a loading screen on device during any entropy check, irrespective of the result. Enabled for firmware 1.13.1 or newer.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/t1-entropy-check&lookback=7)