### PR TITLE
feat(suite-native): Mobile Trade: hide bottom sheet on back press

### DIFF
--- a/suite-native/module-trading/src/components/buy/LegalSheet.tsx
+++ b/suite-native/module-trading/src/components/buy/LegalSheet.tsx
@@ -7,6 +7,8 @@ import { selectTradingBuyProviders } from '@suite-common/trading';
 import { BottomSheetModal, Box, BulletListItem, Button, Text, VStack } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 
+import { useBottomSheetBackButtonSubscription } from '../../hooks/useBottomSheetBackButtonSubscription';
+
 export type LegalSheetProps = {
     isVisible: boolean;
     onConsent: () => void;
@@ -38,6 +40,13 @@ export const LegalSheet = memo(
                 bottomSheetModalRef.current?.present();
             }
         }, [isVisible]);
+
+        const dismissSheet = useCallback(() => {
+            onDismiss();
+            bottomSheetModalRef.current?.close();
+        }, [onDismiss]);
+
+        useBottomSheetBackButtonSubscription(isVisible, dismissSheet);
 
         const closeWithConsent = useCallback(() => {
             onConsent();

--- a/suite-native/module-trading/src/hooks/__tests__/useBottomSheetControls.test.ts
+++ b/suite-native/module-trading/src/hooks/__tests__/useBottomSheetControls.test.ts
@@ -1,6 +1,6 @@
 import { Keyboard } from 'react-native';
 
-import { act, renderHook } from '@suite-native/test-utils';
+import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
 
 import { useBottomSheetControls } from '../useBottomSheetControls';
 
@@ -11,13 +11,13 @@ describe('useBottomSheetControls', () => {
 
     describe('isSheetVisible', () => {
         it('should be false by default', () => {
-            const { result } = renderHook(() => useBottomSheetControls());
+            const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
 
             expect(result.current.isSheetVisible).toBe(false);
         });
 
         it('should be true after showTradeableAssetsSheet call and Keyboard.dismiss should be called one time', () => {
-            const { result } = renderHook(() => useBottomSheetControls());
+            const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
             const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
             act(() => {
@@ -29,7 +29,7 @@ describe('useBottomSheetControls', () => {
         });
 
         it('should be false after hideTradeableAssetsSheet call and Keyboard.dismiss should be called one time', () => {
-            const { result } = renderHook(() => useBottomSheetControls());
+            const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
             const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
             act(() => {

--- a/suite-native/module-trading/src/hooks/useBottomSheetBackButtonSubscription.ts
+++ b/suite-native/module-trading/src/hooks/useBottomSheetBackButtonSubscription.ts
@@ -1,0 +1,25 @@
+import { useCallback } from 'react';
+import { BackHandler } from 'react-native';
+
+import { useFocusEffect } from '@react-navigation/native';
+
+export const useBottomSheetBackButtonSubscription = (
+    isSheetVisible: boolean,
+    dismissSheet: () => void,
+) => {
+    useFocusEffect(
+        useCallback(() => {
+            const onBackPress = () => {
+                if (isSheetVisible) {
+                    dismissSheet();
+                }
+
+                return isSheetVisible;
+            };
+
+            const subscription = BackHandler.addEventListener('hardwareBackPress', onBackPress);
+
+            return () => subscription.remove();
+        }, [isSheetVisible, dismissSheet]),
+    );
+};

--- a/suite-native/module-trading/src/hooks/useBottomSheetControls.ts
+++ b/suite-native/module-trading/src/hooks/useBottomSheetControls.ts
@@ -1,6 +1,8 @@
 import { useCallback, useState } from 'react';
 import { Keyboard } from 'react-native';
 
+import { useBottomSheetBackButtonSubscription } from './useBottomSheetBackButtonSubscription';
+
 export const useBottomSheetControls = () => {
     const [isSheetVisible, setIsSheetVisible] = useState(false);
 
@@ -12,6 +14,8 @@ export const useBottomSheetControls = () => {
     const hideSheet = useCallback(() => {
         setIsSheetVisible(false);
     }, []);
+
+    useBottomSheetBackButtonSubscription(isSheetVisible, hideSheet);
 
     return {
         isSheetVisible,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hides visible sheet on back press.

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mobile-trade-android-back&lookback=7)