### PR TITLE
fix: clear the URL when going back to the suite-start route to preven…

### DIFF
--- a/packages/suite/src/actions/suite/routerActions.ts
+++ b/packages/suite/src/actions/suite/routerActions.ts
@@ -137,6 +137,13 @@ export const goto =
         if (route?.isForegroundApp) {
             dispatch(suiteActions.lockRouter(true));
 
+            // NOTE: this is useful eg. on welcome screen / logged out screen
+            // where we want to have suite-start router clearing the URL to ensure
+            // that there isn't a state stuck
+            if (route?.clearUrl) {
+                history.push(urlBase);
+            }
+
             return;
         }
 

--- a/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
@@ -140,6 +140,7 @@ describe('redirectMiddleware', () => {
                             isForegroundApp: undefined,
                             isFullscreenApp: undefined,
                             isNestedRoute: undefined,
+                            clearUrl: undefined,
                             exact: true,
                         },
                     },

--- a/packages/suite/src/middlewares/suite/__tests__/suiteMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/suiteMiddleware.test.ts
@@ -118,6 +118,7 @@ describe('suite middleware', () => {
                         app: 'onboarding',
                         isForegroundApp: true,
                         isFullscreenApp: true,
+                        clearUrl: undefined,
                         isNestedRoute: undefined,
                         params: undefined,
                         exact: undefined,

--- a/suite-common/suite-config/src/routes.ts
+++ b/suite-common/suite-config/src/routes.ts
@@ -14,6 +14,7 @@ export const routes = [
         app: 'start',
         isFullscreenApp: true,
         isForegroundApp: true,
+        clearUrl: true,
     },
     {
         name: 'suite-index',

--- a/suite-common/suite-types/src/route.ts
+++ b/suite-common/suite-types/src/route.ts
@@ -7,7 +7,8 @@ type RouteKeys =
     | 'exact'
     | 'isForegroundApp'
     | 'isNestedRoute'
-    | 'isFullscreenApp';
+    | 'isFullscreenApp'
+    | 'clearUrl';
 
 export type Route = ArrayElement<ConstWithOptionalFields<typeof routes, RouteKeys>>;
 


### PR DESCRIPTION
…t stale-state in the url

<!--- Provide a general summary of your changes in the Title above -->

## Description

The problem is taht `suite-start` is a "foreground app" route. Meaning, the URL / history isn't change when navigating to it. It makes sense, coz we want it to have `/` url but internally, it should have some distinguished url, especially for the web version.

But the problem is that on this `suite-start` page, `settings` are availabe as route. And these require the url to be change to properly working.

So likely, only possible solution would be to have a parameter for this particular case that would say that "hey, for this route I want to reset the URL".

I solved by a static param on the `suite-start` route.

Better ideas are appreaciated.

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13417

Also closes the issue with comment here: https://github.com/trezor/trezor-suite/issues/9925#issuecomment-2872267114

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=13417-prevent-going-back-settings-on-welcome&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=13417-prevent-going-back-settings-on-welcome&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=13417-prevent-going-back-settings-on-welcome&lookback=7)