### PR TITLE
feat(suite): hide ConnectDeviceReceivePromo when firmware checks hard fail

### DIFF
--- a/packages/suite/src/views/wallet/receive/Receive.tsx
+++ b/packages/suite/src/views/wallet/receive/Receive.tsx
@@ -5,6 +5,7 @@ import { spacings } from '@trezor/theme';
 import { ConfirmEvmExplanationModal } from 'src/components/suite/modals';
 import { WalletLayout, WalletSubpageHeading } from 'src/components/wallet';
 import { useDevice, useSelector } from 'src/hooks/suite';
+import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/reducers/suite/suiteReducer';
 
 import { CoinjoinReceiveWarning } from './components/CoinjoinReceiveWarning';
 import { ConnectDeviceReceivePromo } from './components/ConnectDevicePromo';
@@ -18,6 +19,10 @@ export const Receive = () => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const receive = useSelector(state => state.wallet.receive);
     const device = useSelector(selectSelectedDevice);
+
+    const isAuthenticityCheckFailed = useSelector(
+        selectIsFirmwareAuthenticityCheckEnabledAndHardFailed,
+    );
 
     const { account } = selectedAccount;
 
@@ -37,10 +42,12 @@ export const Receive = () => {
     const showCexWarning = account?.accountType === 'coinjoin' && !isCoinjoinReceiveWarningHidden;
 
     const isDeviceConnected = device.connected && device.available;
+    // FW check hard failure is persisted for view-only → severe banner is shown & Receive button disabled, so this weaker banner is superfluous
+    const isConnectDevicePromoDisplayed = !isDeviceConnected && !isAuthenticityCheckFailed;
 
     return (
         <WalletLayout title="TR_NAV_RECEIVE" isSubpage account={selectedAccount}>
-            {!isDeviceConnected && <ConnectDeviceReceivePromo />}
+            {isConnectDevicePromoDisplayed && <ConnectDeviceReceivePromo />}
             {showCexWarning && <CoinjoinReceiveWarning />}
             <Column gap={spacings.xl}>
                 <WalletSubpageHeading title="TR_NAV_RECEIVE" />


### PR DESCRIPTION
## Related Issue

Resolve #18857

## Screenshots:
View only device & FW hash check failed:
![image](https://github.com/user-attachments/assets/ca96d903-10e0-460e-b6e1-cd49bf08d36d)

View only device & FW hash check ok (success or disabled):
![image](https://github.com/user-attachments/assets/03b1d276-ec97-4fc6-85a5-41f770a2e764)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/deduplicate-receive-warnings&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/deduplicate-receive-warnings&lookback=7)