### PR TITLE
Fix race condition in block subscription

### DIFF
--- a/packages/blockchain-link/src/workers/blockbook/index.ts
+++ b/packages/blockchain-link/src/workers/blockbook/index.ts
@@ -260,8 +260,8 @@ const subscribeAddresses = async (ctx: Context, addresses: string[]) => {
 
 const subscribeBlock = async (ctx: Context) => {
     if (ctx.state.getSubscription('block')) return { subscribed: true };
-    const api = await ctx.connect();
     ctx.state.addSubscription('block');
+    const api = await ctx.connect();
     api.on('block', ev => onNewBlock(ctx, ev));
 
     return api.subscribeBlock();


### PR DESCRIPTION
## Description

Sometimes, block events were subscribed twice, so they were coming with wrong message id and therefore ignored.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/blockchain-link-block-subscribe&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/blockchain-link-block-subscribe&lookback=7)