### PR TITLE
Skeleton account balance loading

### DIFF
--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -70,8 +70,9 @@ export const PortfolioCard = memo(() => {
     const goToReceive = () => dispatch(goto('wallet-receive'));
     const heading = <Translation id="TR_MY_PORTFOLIO" />;
     const header =
-        discoveryStatus && discoveryStatus.status === 'exception' ? null : (
+        discovery && discoveryStatus?.status === 'exception' ? null : (
             <PortfolioCardHeader
+                discovery={discovery}
                 showGraphControls={showGraphControls}
                 fiatAmount={walletBalance}
                 localCurrency={localCurrency}

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { Button, LoadingContent, Row } from '@trezor/components';
+import { Button, LoadingContent, Row, SkeletonRectangle } from '@trezor/components';
 
 import { updateGraphData } from 'src/actions/wallet/graphActions';
 import { GraphRangeSelector, Translation } from 'src/components/suite';
@@ -62,15 +62,21 @@ export const PortfolioCardHeader = ({
         }
     }
 
+    const valueLoading = isDiscoveryRunning || isMissingFiatRate;
+
     return (
         <Row justifyContent="space-between">
-            <LoadingContent size={24} isLoading={isDiscoveryRunning || isMissingFiatRate}>
-                <FiatHeader
-                    data-testid="@dashboard/portfolio/fiat-amount"
-                    size="large"
-                    amount={fiatAmount}
-                    localCurrency={localCurrency}
-                />
+            <LoadingContent size={24} isLoading={valueLoading}>
+                {valueLoading ? (
+                    <SkeletonRectangle width={140} height={53} />
+                ) : (
+                    <FiatHeader
+                        data-testid="@dashboard/portfolio/fiat-amount"
+                        size="large"
+                        amount={fiatAmount}
+                        localCurrency={localCurrency}
+                    />
+                )}
             </LoadingContent>
             {actions}
         </Row>

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
@@ -1,14 +1,16 @@
 import { useCallback } from 'react';
 
-import { Button, LoadingContent, Row, SkeletonRectangle } from '@trezor/components';
+import { Button, Row, SkeletonRectangle } from '@trezor/components';
 
 import { updateGraphData } from 'src/actions/wallet/graphActions';
 import { GraphRangeSelector, Translation } from 'src/components/suite';
 import { FiatHeader } from 'src/components/wallet/FiatHeader';
 import { useFastAccounts } from 'src/hooks/wallet';
+import { Discovery } from 'src/types/wallet';
 import { GraphRange } from 'src/types/wallet/graph';
 
 export type PortfolioCardHeaderProps = {
+    discovery?: Discovery;
     fiatAmount: string;
     localCurrency: string;
     isWalletEmpty: boolean;
@@ -21,6 +23,7 @@ export type PortfolioCardHeaderProps = {
 };
 
 export const PortfolioCardHeader = ({
+    discovery,
     fiatAmount,
     localCurrency,
     isWalletEmpty,
@@ -62,22 +65,21 @@ export const PortfolioCardHeader = ({
         }
     }
 
-    const valueLoading = isDiscoveryRunning || isMissingFiatRate;
+    const valueLoading =
+        isDiscoveryRunning || isMissingFiatRate || (!discovery && !Number(fiatAmount));
 
     return (
         <Row justifyContent="space-between">
-            <LoadingContent size={24} isLoading={valueLoading}>
-                {valueLoading ? (
-                    <SkeletonRectangle width={140} height={53} />
-                ) : (
-                    <FiatHeader
-                        data-testid="@dashboard/portfolio/fiat-amount"
-                        size="large"
-                        amount={fiatAmount}
-                        localCurrency={localCurrency}
-                    />
-                )}
-            </LoadingContent>
+            {valueLoading ? (
+                <SkeletonRectangle width={140} height={53} />
+            ) : (
+                <FiatHeader
+                    data-testid="@dashboard/portfolio/fiat-amount"
+                    size="large"
+                    amount={fiatAmount}
+                    localCurrency={localCurrency}
+                />
+            )}
             {actions}
         </Row>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes:
- added skeleton over the total fiat value on the dashboard during discovery running
- skeleton also displayed when the there is no discovery at all (the total fiat amount is completely unknown and was never acquired)

## Related Issue

Discussed in the office, reason for change: people are complaining that they see first 0 as their fiat balance , as the balances are being loaded and they are logically scared.

## Screenshots:


https://github.com/user-attachments/assets/594d5f23-9ac1-4036-bf97-9ca75ecac3c8




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=skeleton-account-balance-loading&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=skeleton-account-balance-loading&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=skeleton-account-balance-loading&lookback=7)