### PR TITLE
chore(connect): inform only once per 10 seconds about new evm block

### DIFF
--- a/packages/connect/src/backend/Blockchain.ts
+++ b/packages/connect/src/backend/Blockchain.ts
@@ -90,6 +90,7 @@ export class Blockchain {
             debug: options.debug,
             proxy: options.proxy,
             ...(blockchainLink.type === 'ripple' ? { throttleBlockEvent: 60 * 1000 } : {}),
+            ...(this.coinInfo.type === 'ethereum' ? { throttleBlockEvent: 10 * 1000 } : {}), // register EVM block once per 10+ seconds
         });
     }
 


### PR DESCRIPTION
## Description

Slowdown update of EVM blocks in redux
- ETH will get every block
- BSC every 4th block
- POL, BASE, OP every 5th block
- ARB every 30th

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/evm-reduce-blocks&lookback=7)