### PR TITLE
feat(suite): return back icon indicating availability of the suite up…

### DIFF
--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -3,6 +3,7 @@ import { screen } from '@testing-library/react';
 import { AnalyticsState } from '@suite-common/analytics';
 import { FirmwareUpdateState } from '@suite-common/firmware/libDev/src';
 import { MetadataState } from '@suite-common/metadata-types/libDev/src';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { DeviceReducerState } from '@suite-common/wallet-core';
 import { TransportInfo } from '@trezor/connect';
 import * as envUtils from '@trezor/env-utils';
@@ -210,7 +211,9 @@ const getInitialState = ({
     wallet: {
         discovery: {},
         accountSearch: {},
-        settings: {},
+        settings: {
+            enabledNetworks: [] as NetworkSymbol[],
+        },
         blockchain: {},
     } as ReturnType<typeof WalletReducers>, // Todo: maybe one day, fix types
     desktopUpdate: desktopUpdateInitialState,

--- a/packages/suite/src/components/suite/layouts/LoggedOutSidebar.tsx
+++ b/packages/suite/src/components/suite/layouts/LoggedOutSidebar.tsx
@@ -51,7 +51,7 @@ export const LoggedOutSidebar = () => {
                                     data-testid="@suite/menu/settings"
                                 />
                             </Nav>
-                            <QuickActions hideUpdateStatusBar isSidebarCollapsed />
+                            <QuickActions hideDeviceUpdateStatusBar isSidebarCollapsed />
                         </Column>
                     </TrafficLightOffset>
                 </SidebarNavColumn>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/QuickActionButton.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/QuickActionButton.tsx
@@ -15,7 +15,7 @@ const Container = styled.div`
 type ActionButtonProps = {
     onClick?: () => void;
     children: ReactNode;
-    tooltip: Partial<ManagedTooltipProps>;
+    tooltip?: Partial<ManagedTooltipProps>;
     'data-testid'?: string;
     isOpen?: boolean;
 };
@@ -26,10 +26,15 @@ export const QuickActionButton = ({
     tooltip,
     'data-testid': dataTest,
     isOpen,
-}: ActionButtonProps) => (
-    <Tooltip content={tooltip?.content} cursor="pointer" {...tooltip} isOpen={isOpen}>
+}: ActionButtonProps) =>
+    tooltip ? (
+        <Tooltip content={tooltip?.content} cursor="pointer" {...tooltip} isOpen={isOpen}>
+            <Container data-testid={dataTest} onClick={onClick}>
+                {children}
+            </Container>
+        </Tooltip>
+    ) : (
         <Container data-testid={dataTest} onClick={onClick}>
             {children}
         </Container>
-    </Tooltip>
-);
+    );

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/QuickActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/QuickActions.tsx
@@ -24,22 +24,21 @@ const ActionsContainer = styled.div<{ $isSidebarCollapsed: boolean }>`
 `;
 
 type QuickActionsProps = {
-    hideUpdateStatusBar?: boolean;
+    hideDeviceUpdateStatusBar?: boolean;
     isSidebarCollapsed: boolean;
     showUpdateBannerNotification?: boolean;
 };
 
 export const QuickActions = ({
-    hideUpdateStatusBar,
+    hideDeviceUpdateStatusBar,
     isSidebarCollapsed,
     showUpdateBannerNotification,
 }: QuickActionsProps) => (
     <ActionsContainer $isSidebarCollapsed={isSidebarCollapsed}>
-        {!hideUpdateStatusBar && (
-            <UpdateStatusActionBarIcon
-                showUpdateBannerNotification={Boolean(showUpdateBannerNotification)}
-            />
-        )}
+        <UpdateStatusActionBarIcon
+            hideDeviceUpdateStatusBar={Boolean(hideDeviceUpdateStatusBar)}
+            showUpdateBannerNotification={Boolean(showUpdateBannerNotification)}
+        />
         <DebugAndExperimental />
         <CustomBackend />
         <Tor />

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/UpdateStatusActionBarIcon.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/UpdateStatusActionBarIcon.tsx
@@ -7,6 +7,7 @@ import {
     Icon,
     IconSize,
     ManagedTooltipProps,
+    Tooltip,
     getIconSize,
     iconSizes,
 } from '@trezor/components';
@@ -29,7 +30,6 @@ import {
     mapUpdateStatusToVariant,
 } from './updateQuickActionTypes';
 import { useUpdateStatus } from './useUpdateStatus';
-import { Translation } from '../../../../../Translation';
 
 type MapArgs = {
     $variant: UpdateVariant;
@@ -147,7 +147,7 @@ const SuiteUpdateIcon = ({ iconSize, updateStatus, variant }: SuiteUpdateIconPro
         >
             <Highlighted $isHighlighted={updateStatus !== 'up-to-date'}>
                 <Icon
-                    name="trezorDevices"
+                    name="trezorLogo"
                     size={iconSizes.small}
                     color={theme['iconDefaultInverted']}
                 />
@@ -158,10 +158,12 @@ const SuiteUpdateIcon = ({ iconSize, updateStatus, variant }: SuiteUpdateIconPro
 
 type UpdateStatusActionBarIconProps = {
     showUpdateBannerNotification: boolean;
+    hideDeviceUpdateStatusBar?: boolean;
 };
 
 export const UpdateStatusActionBarIcon = ({
     showUpdateBannerNotification,
+    hideDeviceUpdateStatusBar,
 }: UpdateStatusActionBarIconProps) => {
     const theme = useTheme();
 
@@ -178,10 +180,6 @@ export const UpdateStatusActionBarIcon = ({
 
     const isDesktopSuite = isDesktop();
 
-    if (device?.features === undefined) {
-        return null;
-    }
-
     const suiteOnClick = mapSuiteUpdateToClick[updateStatusSuite];
     const deviceOnClick = mapDeviceUpdateToClick[updateStatusDevice];
 
@@ -196,33 +194,32 @@ export const UpdateStatusActionBarIcon = ({
         }
     };
 
-    const getTooltip = (): Partial<ManagedTooltipProps> => {
-        if (discoveryInProgress) {
-            return {
-                cursor: 'not-allowed',
-                content: <Translation id="TR_UNAVAILABLE_WHILE_LOADING" />,
-            };
-        }
+    const displayDeviceUpdateStatusBar = !hideDeviceUpdateStatusBar && !discoveryInProgress;
 
-        return {
-            isActive: !showUpdateBannerNotification,
-            content: (
-                <UpdateTooltip
-                    updateStatusDevice={updateStatusDevice}
-                    onClickSuite={suiteOnClickHandler}
-                    updateStatusSuite={updateStatusSuite}
-                    onClickDevice={deviceOnClickHandler}
-                />
-            ),
-        };
-    };
+    const anyUpdateInfoAvailable = isDesktopSuite || displayDeviceUpdateStatusBar;
+
+    const getTooltip = (): Partial<ManagedTooltipProps> => ({
+        isActive: !showUpdateBannerNotification,
+        content: (
+            <UpdateTooltip
+                displayDeviceUpdateStatus={displayDeviceUpdateStatusBar}
+                updateStatusDevice={updateStatusDevice}
+                onClickSuite={suiteOnClickHandler}
+                updateStatusSuite={updateStatusSuite}
+                onClickDevice={deviceOnClickHandler}
+            />
+        ),
+    });
+
+    const tooltip = getTooltip();
+
+    if (!anyUpdateInfoAvailable) {
+        return null;
+    }
 
     return (
         <div>
-            <QuickActionButton
-                tooltip={getTooltip()}
-                onClick={discoveryInProgress ? undefined : handleClick}
-            >
+            <QuickActionButton onClick={handleClick}>
                 <ComponentWithSubIcon
                     variant={variant}
                     subIconProps={{
@@ -231,20 +228,24 @@ export const UpdateStatusActionBarIcon = ({
                         size: iconSizes.extraSmall,
                     }}
                 >
-                    <UpdateIconGroup $variant={variant}>
-                        <DeviceUpdateIcon
-                            iconSize={iconSize}
-                            updateStatus={updateStatusDevice}
-                            variant={variant}
-                        />
-                        {isDesktopSuite && (
-                            <SuiteUpdateIcon
-                                iconSize={iconSize}
-                                updateStatus={updateStatusDevice}
-                                variant={variant}
-                            />
-                        )}
-                    </UpdateIconGroup>
+                    <Tooltip content={tooltip?.content} cursor="pointer" {...tooltip}>
+                        <UpdateIconGroup $variant={variant}>
+                            {device?.features !== undefined && (
+                                <DeviceUpdateIcon
+                                    iconSize={iconSize}
+                                    updateStatus={updateStatusDevice}
+                                    variant={variant}
+                                />
+                            )}
+                            {isDesktopSuite && (
+                                <SuiteUpdateIcon
+                                    iconSize={iconSize}
+                                    updateStatus={updateStatusSuite}
+                                    variant={variant}
+                                />
+                            )}
+                        </UpdateIconGroup>
+                    </Tooltip>
                 </ComponentWithSubIcon>
             </QuickActionButton>
         </div>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/UpdateTooltip.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/UpdateTooltip.tsx
@@ -115,6 +115,7 @@ const SuiteRow = ({ updateStatus, onClick }: SuiteRowProps) => {
 };
 
 type UpdateTooltipProps = {
+    displayDeviceUpdateStatus: boolean;
     updateStatusDevice: UpdateStatusDevice;
     onClickDevice?: () => void;
     updateStatusSuite: UpdateStatusSuite;
@@ -122,6 +123,7 @@ type UpdateTooltipProps = {
 };
 
 export const UpdateTooltip = ({
+    displayDeviceUpdateStatus,
     updateStatusDevice,
     onClickDevice,
     updateStatusSuite,
@@ -131,7 +133,9 @@ export const UpdateTooltip = ({
 
     return (
         <Column gap={spacings.md} padding={spacings.xxs} alignItems="start">
-            <DeviceRow updateStatus={updateStatusDevice} onClick={onClickDevice} />
+            {displayDeviceUpdateStatus && (
+                <DeviceRow updateStatus={updateStatusDevice} onClick={onClickDevice} />
+            )}
             {isDesktopSuite && <SuiteRow updateStatus={updateStatusSuite} onClick={onClickSuite} />}
         </Column>
     );


### PR DESCRIPTION
…date

<!--- Provide a general summary of your changes in the Title above -->

## Description

The update status of device / suite weren't displayed in the welcome screen intentialny

Displaying the suite status makes sense.

The component relied on the device to be connected and discovered, that's not needed to display the suite state though

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17579

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=17579-update-suite-for-welcome-screen&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=17579-update-suite-for-welcome-screen&lookback=7)