### PR TITLE
fix(suite-desktop-core): clear old handler in autostart modal

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -106,6 +106,7 @@ export interface InvokeChannels {
     'user-data/open': (directory?: string) => InvokeResult;
     'udev/install': () => InvokeResult;
     'app/auto-start/is-enabled': () => InvokeResult<boolean>;
+    'app/auto-start/popup-ack': () => void;
     'app/auto-start/popup-response': (
         response: 'background-always' | 'background-now' | 'quit-always' | 'quit-now',
     ) => void;
@@ -136,6 +137,7 @@ export interface DesktopApi {
     appHide: DesktopApiSend<'app/hide'>;
     appAutoStart: DesktopApiSend<'app/auto-start'>;
     getAppAutoStartIsEnabled: DesktopApiInvoke<'app/auto-start/is-enabled'>;
+    appAutoStartPopupAck: DesktopApiInvoke<'app/auto-start/popup-ack'>;
     appAutoStartPopupResponse: DesktopApiInvoke<'app/auto-start/popup-response'>;
     appIsVisible: DesktopApiInvoke<'app/is-visible'>;
     // Auto-updater

--- a/packages/suite-desktop-api/src/factory.ts
+++ b/packages/suite-desktop-api/src/factory.ts
@@ -49,6 +49,7 @@ export const factory = <R extends StrictIpcRenderer<any, IpcRendererEvent>>(
         appHide: () => ipcRenderer.send('app/hide'),
         appAutoStart: (enabled: boolean) => ipcRenderer.send('app/auto-start', enabled),
         getAppAutoStartIsEnabled: () => ipcRenderer.invoke('app/auto-start/is-enabled'),
+        appAutoStartPopupAck: () => ipcRenderer.invoke('app/auto-start/popup-ack'),
         appAutoStartPopupResponse: response =>
             ipcRenderer.invoke('app/auto-start/popup-response', response),
         appIsVisible: () => ipcRenderer.invoke('app/is-visible'),

--- a/packages/suite-desktop-api/src/ipc.ts
+++ b/packages/suite-desktop-api/src/ipc.ts
@@ -18,7 +18,7 @@ type StrictIpcModule<Module, Channel extends StrictChannel, Evt> = Omit<
 export type StrictIpcMain<Module, Evt> = StrictIpcModule<Module, MainChannels, Evt> & {
     handle: HandleMethod<InvokeChannels, Evt>;
     handleOnce: HandleMethod<InvokeChannels, Evt>;
-    removeHandler: HandleMethod<InvokeChannels, Evt>;
+    removeHandler: (channel: keyof InvokeChannels) => void;
 };
 
 // Module = Omit<Electron.IpcRenderer, 'invoke' | 'send'>

--- a/packages/suite-desktop-core/src/hang-detect.ts
+++ b/packages/suite-desktop-core/src/hang-detect.ts
@@ -58,7 +58,7 @@ export const hangDetect = (mainWindow: BrowserWindow, statePatch?: Record<string
         mainWindow.loadURL(APP_SRC);
     });
     const cleanup = () => {
-        ipcMain.removeHandler('handshake/client', handshakeHandler);
+        ipcMain.removeHandler('handshake/client');
     };
 
     return { handshake, cleanup };

--- a/packages/suite-desktop-core/src/modules/auto-start.ts
+++ b/packages/suite-desktop-core/src/modules/auto-start.ts
@@ -97,16 +97,29 @@ export const promptForAutoStartBeforeQuit = async (mainWindow: BrowserWindow, st
     }
 
     // Display popup in renderer and wait for response
-    const deferred = createDeferred<
+    const deferredResponse = createDeferred<
         'background-always' | 'background-now' | 'quit-always' | 'quit-now'
     >();
+    let modalShown = false;
+    ipcMain.removeHandler('app/auto-start/popup-ack');
     ipcMain.removeHandler('app/auto-start/popup-response');
+    ipcMain.handleOnce('app/auto-start/popup-ack', ipcEvent => {
+        validateIpcMessage(ipcEvent);
+        modalShown = true;
+    });
     ipcMain.handleOnce('app/auto-start/popup-response', (ipcEvent, response) => {
         validateIpcMessage(ipcEvent);
-        deferred.resolve(response);
+        deferredResponse.resolve(response);
     });
     mainWindow.webContents.send('app/auto-start/popup-request');
-    const response = await deferred.promise;
+
+    // Fallback if modal not shown at the moment
+    // This can happen on some screens like onboarding, where normal modal might not be shown
+    setTimeout(() => {
+        if (!modalShown) deferredResponse.resolve('quit-now');
+    }, 1000);
+
+    const response = await deferredResponse.promise;
 
     switch (response) {
         case 'background-always': {

--- a/packages/suite-desktop-core/src/modules/auto-start.ts
+++ b/packages/suite-desktop-core/src/modules/auto-start.ts
@@ -100,6 +100,7 @@ export const promptForAutoStartBeforeQuit = async (mainWindow: BrowserWindow, st
     const deferred = createDeferred<
         'background-always' | 'background-now' | 'quit-always' | 'quit-now'
     >();
+    ipcMain.removeHandler('app/auto-start/popup-response');
     ipcMain.handleOnce('app/auto-start/popup-response', (ipcEvent, response) => {
         validateIpcMessage(ipcEvent);
         deferred.resolve(response);

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AutoStartBeforeQuitModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AutoStartBeforeQuitModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Card, Checkbox, Column, Modal, Paragraph } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
@@ -12,6 +12,10 @@ import { useDispatch } from 'src/hooks/suite';
 export const AutoStartBeforeQuitModal = () => {
     const dispatch = useDispatch();
     const [dontAskAgain, setDontAskAgain] = useState(false);
+    useEffect(() => {
+        if (desktopApi.available) desktopApi.appAutoStartPopupAck();
+    }, []);
+
     if (!desktopApi.available) return null;
 
     const handleResponse = (


### PR DESCRIPTION
## Description

If the autostart before quit modal was interrupted unexpectedly, it wouldn't show up again due to duplicate handler registration. 
This PR removes the handler first and allows it to work as expected on subsequent calls.

## Related Issue

Resolve #18869


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/18869-quit-suite-modal-interrrupted&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/18869-quit-suite-modal-interrrupted&lookback=7)