### PR TITLE
fix(nix): update to nixos-unstable to have electron_35

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,14 +1,14 @@
-# pinned to nixos-24.05 on commit https://github.com/NixOS/nixpkgs/commit/c6ce5bd4ab657df958ebd6f38723f81c5546a661
+# pinned to nixos-unstable on commit https://github.com/NixOS/nixpkgs/commit/8d92119c540d78599ba208010c722a60958810f4
+# we need to use nixos-unstable to be able to use electron_36, once there is a stable release with it we can change.
 with import
   (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/c6ce5bd4ab657df958ebd6f38723f81c5546a661.tar.gz";
-    sha256 = "0i5z7b087kr2hnkgs17d36c54arjbgwlwyxw1ibh03d1k1xfcyf2";
-  })
-{ };
+    url = "https://github.com/NixOS/nixpkgs/archive/8d92119c540d78599ba208010c722a60958810f4.tar.gz";
+    sha256 = "08w0arf23z6mdnipmpspmkwmmvskd9mjq6b5j8070ryqjpzwas05";
+   }) { system = builtins.currentSystem; };
 
 let
   # unstable packages
-  electron = electron_32;
+  electron = electron_36;
   nodejs = nodejs_22;
   # use older gcc. 10.2.0 with glibc 2.32 for node_modules bindings.
   # electron-builder is packing the app with glibc 2.32, bindings should not be compiled with newer version.
@@ -41,7 +41,7 @@ in
       pixman cairo giflib libjpeg libpng librsvg pango            # build dependencies for node-canvas
       shellcheck
     ] ++ lib.optionals stdenv.isLinux [
-      appimagekit nsis openjpeg osslsigncode p7zip squashfsTools gccPkgs.gcc # binaries used by node_module: electron-builder
+      nsis openjpeg osslsigncode p7zip squashfsTools gccPkgs.gcc # binaries used by node_module: electron-builder
       udev  # used by node_module: usb
     ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
       Cocoa


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Pinning to `nixos-unstable` so we have electron_36 in `shell.nix`. Also removing `appimagekit` since is not needed anymore and it has been removed from nixos packages.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/electron-35-shell.nix&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/electron-35-shell.nix&lookback=7)