### PR TITLE
Fix e2e workflow duplicate check

### DIFF
--- a/.github/actions/check-duplicate-run/action.yml
+++ b/.github/actions/check-duplicate-run/action.yml
@@ -1,0 +1,59 @@
+name: "Check Duplicate Runs"
+description: "Check if there is duplicate run of this workflow on same commit Hash"
+
+inputs:
+  github_token:
+    description: "GitHub token for accessing the API"
+    required: true
+  commit_sha:
+    description: "The commit hash to check"
+    required: true
+  repo:
+    description: "The repository name (format: owner/repo)"
+    required: true
+  workflow_name:
+    description: "The workflow name to filter runs"
+    required: true
+  current_run_id:
+    description: "ID of the current workflow run (to exclude from results)"
+    required: true
+
+outputs:
+  skip_run:
+    description: "Indicates whether workflow should be skipped"
+    value: ${{ steps.check-duplicate-run.outputs.skip_run }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check Duplicate Run
+      id: check-duplicate-run
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        COMMIT_SHA: "${{ inputs.commit_sha }}"
+        REPO: "${{ inputs.repo }}"
+        WORKFLOW_NAME: "${{ inputs.workflow_name }}"
+        CURRENT_RUN_ID: "${{ inputs.current_run_id }}"
+      shell: bash
+      run: |
+        # Fetch workflow ID
+        WORKFLOW_ID=$(gh workflow list \
+          --repo "$REPO" \
+          --json id,name \
+          --limit 100 \
+          --jq ".[] | select(.name == \"${WORKFLOW_NAME}\") | .id")
+
+        # Check for previous runs on this commit
+        API_URL="https://api.github.com/repos/${REPO}/actions/workflows/${WORKFLOW_ID}/runs?head_sha=${COMMIT_SHA}"
+        RESPONSE=$(curl -s -H "Authorization: Bearer ${GH_TOKEN}" "${API_URL}")
+
+        PREVIOUS_RUNS=$(echo "$RESPONSE" | jq --arg current_id "${CURRENT_RUN_ID}" '[.workflow_runs[] | select(.id != ($current_id | tonumber))] | length')
+  
+        if [ "${PREVIOUS_RUNS}" -gt 0 ]; then
+          echo "Found ${PREVIOUS_RUNS} previous runs for commit ${COMMIT_SHA}"
+          echo "skip_run=true" >> $GITHUB_OUTPUT
+        else
+          echo "No previous runs found for commit ${COMMIT_SHA}"
+          echo "skip_run=false" >> $GITHUB_OUTPUT
+        fi

--- a/.github/actions/check-duplicate-run/action.yml
+++ b/.github/actions/check-duplicate-run/action.yml
@@ -17,6 +17,9 @@ inputs:
   current_run_id:
     description: "ID of the current workflow run (to exclude from results)"
     required: true
+  run_attempt:
+    description: "The run attempt number"
+    required: true
 
 outputs:
   skip_run:
@@ -35,8 +38,15 @@ runs:
         REPO: "${{ inputs.repo }}"
         WORKFLOW_NAME: "${{ inputs.workflow_name }}"
         CURRENT_RUN_ID: "${{ inputs.current_run_id }}"
+        RUN_ATTEMPT: "${{ inputs.run_attempt }}"
       shell: bash
       run: |
+        if [ "${RUN_ATTEMPT}" -gt 1 ]; then
+          echo "Manually triggered re-run."
+          echo "skip_run=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
         # Fetch workflow ID
         WORKFLOW_ID=$(gh workflow list \
           --repo "$REPO" \
@@ -49,7 +59,7 @@ runs:
         RESPONSE=$(curl -s -H "Authorization: Bearer ${GH_TOKEN}" "${API_URL}")
 
         PREVIOUS_RUNS=$(echo "$RESPONSE" | jq --arg current_id "${CURRENT_RUN_ID}" '[.workflow_runs[] | select(.id != ($current_id | tonumber))] | length')
-  
+
         if [ "${PREVIOUS_RUNS}" -gt 0 ]; then
           echo "Found ${PREVIOUS_RUNS} previous runs for commit ${COMMIT_SHA}"
           echo "skip_run=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-suite-desktop-e2e-release.yml
+++ b/.github/workflows/test-suite-desktop-e2e-release.yml
@@ -37,6 +37,13 @@ jobs:
       matrix:
         TEST_GROUP: [1, 2, 3, 4, 5, 6, 7]
     steps:
+      - name: Generate GitHub App token
+        id: trezor-bot-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TREZOR_BOT_APP_ID }}
+          private-key: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -74,5 +81,5 @@ jobs:
           currents-project-id: "4ytF0E"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}
-          github-token: ${{ secrets.TREZOR_BOT_TOKEN }}
+          github-token: ${{ steps.trezor-bot-token.outputs.token }}
           release-build: ${{ env.release_build }}

--- a/.github/workflows/test-suite-desktop-e2e-release.yml
+++ b/.github/workflows/test-suite-desktop-e2e-release.yml
@@ -18,8 +18,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-duplicate-run:
+    if: github.repository == 'trezor/trezor-suite' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      skip_run: ${{ steps.check-duplicate-run.outputs.skip_run }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate GitHub App token
+        id: trezor-bot-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TREZOR_BOT_APP_ID }}
+          private-key: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
+
+      - name: Check duplicate run
+        id: check-duplicate-run
+        uses: "./.github/actions/check-duplicate-run"
+        with:
+          github_token: ${{ steps.trezor-bot-token.outputs.token }}
+          commit_sha: ${{ github.sha }}
+          repo: ${{ github.repository }}
+          workflow_name: ${{ github.workflow }}
+          current_run_id: ${{ github.run_id }}
+          run_attempt: ${{ github.run_attempt }}
+
   build-app:
-    if: github.repository == 'trezor/trezor-suite'
+    needs: check-duplicate-run
+    if: github.repository == 'trezor/trezor-suite' && needs.check-duplicate-run.outputs.skip_run != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -28,10 +56,11 @@ jobs:
         uses: ./.github/actions/build-desktop
 
   run-e2e-suite-desktop-tests:
-    if: github.repository == 'trezor/trezor-suite'
+    if: github.repository == 'trezor/trezor-suite' && needs.check-duplicate-run.outputs.skip_run != 'true'
     runs-on: ubuntu-24.04
     needs:
       - build-app
+      - check-duplicate-run
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -38,6 +38,7 @@ jobs:
           repo: ${{ github.repository }}
           workflow_name: ${{ github.workflow }}
           current_run_id: ${{ github.run_id }}
+          run_attempt: ${{ github.run_attempt }}
 
   run-e2e-suite-manual-tests:
     needs: check-duplicate-run

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -46,6 +46,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: trezor-bot-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TREZOR_BOT_APP_ID }}
+          private-key: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -75,7 +82,7 @@ jobs:
         shell: bash
         env:
           GITHUB_ACTION: true
-          GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
           GITHUB_REPORTER_VERBOSE: true
           RELEASE_BUILD: ${{ env.release_build }}
         run: |

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - release/2*
+      - fix-e2e-workflow-duplicate-check
   workflow_dispatch:
 
 concurrency:
@@ -13,8 +14,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-duplicate-run:
+    if: github.repository == 'trezor/trezor-suite' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      skip_run: ${{ steps.check-duplicate-run.outputs.skip_run }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate GitHub App token
+        id: trezor-bot-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TREZOR_BOT_APP_ID }}
+          private-key: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
+
+      - name: Check duplicate run
+        id: check-duplicate-run
+        uses: "./.github/actions/check-duplicate-run"
+        with:
+          github_token: ${{ steps.trezor-bot-token.outputs.token }}
+          commit_sha: ${{ github.sha }}
+          repo: ${{ github.repository }}
+          workflow_name: ${{ github.workflow }}
+          current_run_id: ${{ github.run_id }}
+
   run-e2e-suite-manual-tests:
-    if: github.repository == 'trezor/trezor-suite'
+    needs: check-duplicate-run
+    if: github.repository == 'trezor/trezor-suite' && needs.check-duplicate-run.outputs.skip_run != 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - release/2*
-      - fix-e2e-workflow-duplicate-check
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-suite-web-e2e-release.yml
+++ b/.github/workflows/test-suite-web-e2e-release.yml
@@ -43,6 +43,13 @@ jobs:
         TEST_GROUP: [1, 2, 3, 4, 5, 6, 7]
 
     steps:
+      - name: Generate GitHub App token
+        id: trezor-bot-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TREZOR_BOT_APP_ID }}
+          private-key: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -66,5 +73,5 @@ jobs:
           currents-project-id: "Og0NOQ"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}
-          github-token: ${{ secrets.TREZOR_BOT_TOKEN }}
+          github-token: ${{ steps.trezor-bot-token.outputs.token }}
           release-build: ${{ env.release_build }}

--- a/.github/workflows/test-suite-web-e2e-release.yml
+++ b/.github/workflows/test-suite-web-e2e-release.yml
@@ -22,8 +22,36 @@ env:
   STAGING_SUITE_SERVER_URL: "https://staging-suite.trezor.io"
 
 jobs:
+  check-duplicate-run:
+    if: github.repository == 'trezor/trezor-suite' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      skip_run: ${{ steps.check-duplicate-run.outputs.skip_run }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate GitHub App token
+        id: trezor-bot-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TREZOR_BOT_APP_ID }}
+          private-key: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
+
+      - name: Check duplicate run
+        id: check-duplicate-run
+        uses: "./.github/actions/check-duplicate-run"
+        with:
+          github_token: ${{ steps.trezor-bot-token.outputs.token }}
+          commit_sha: ${{ github.sha }}
+          repo: ${{ github.repository }}
+          workflow_name: ${{ github.workflow }}
+          current_run_id: ${{ github.run_id }}
+          run_attempt: ${{ github.run_attempt }}
+
   build-web:
-    if: github.repository == 'trezor/trezor-suite'
+    needs: check-duplicate-run
+    if: github.repository == 'trezor/trezor-suite' && needs.check-duplicate-run.outputs.skip_run != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,10 +61,11 @@ jobs:
         uses: ./.github/actions/build-web
 
   run-e2e-suite-web-tests:
-    if: github.repository == 'trezor/trezor-suite'
+    if: github.repository == 'trezor/trezor-suite' && needs.check-duplicate-run.outputs.skip_run != 'true'
     runs-on: ubuntu-latest
     needs:
       - build-web
+      - check-duplicate-run
     strategy:
       fail-fast: false
       matrix:

--- a/packages/suite-desktop-core/e2e/support/reporters/annotations.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/annotations.ts
@@ -97,7 +97,7 @@ export class TestReportProvider {
     }
 
     get status(): string {
-        // This condition covers manual and automated tests that are skipped
+        // This condition covers all manual test and skipped automated tests
         if (this.test.outcome() === 'skipped') {
             return TestStatus.Todo;
         }
@@ -186,6 +186,10 @@ export class TestReportProvider {
 
     get useOsEmoticons(): boolean {
         return this.isManual && this.osMatrix.length > 1;
+    }
+
+    get isAutomatedAndPassed(): boolean {
+        return this.status === TestStatus.AutoPass;
     }
 
     get bodyDescription(): string {


### PR DESCRIPTION
In our past release, due to dropping of a commit, we got second trigger for same commit.
As a result, reporter generated duplicate entries in our regression suite.
This implements prevention of that.

Here you can see a test run of this branch on commit `ac1d65e`: [Run](https://github.com/trezor/trezor-suite/actions/runs/14975366311/attempts/1)
I then pushed another commit and then dropped it.
That triggered another run for commit `ac1d65e`: [Run](https://github.com/trezor/trezor-suite/actions/runs/14975546756/attempts/1)
There check identified duplicate run for commit and skipped the rest of the run.

There were also few remaining uses of old github token. So I changed that.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-workflow-duplicate-check&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-workflow-duplicate-check&lookback=7)