### PR TITLE
Fix token selection from wrong account in Swap form

### DIFF
--- a/packages/suite/src/actions/wallet/constants/tradingCommonConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/tradingCommonConstants.ts
@@ -5,5 +5,5 @@ export const SET_LOADING = '@trading-common/set_loading';
 export const SET_MODAL_CRYPTO_CURRENCY = '@trading-common/set_modal_crypto_currency';
 export const SET_MODAL_ACCOUNT_KEY = '@trading-common/set_modal_account_key';
 export const SET_TRADING_ACTIVE_SECTION = '@trading-common/set_trading_active_section';
-export const SET_TRADING_FROM_PREFILLED_CRYPTO_ID =
-    '@trading-common/set_trading_from_prefilled_crypto_id';
+export const SET_TRADING_FROM_PREFILLED_ACCOUNT =
+    '@trading-common/set_trading_from_prefilled_account';

--- a/packages/suite/src/actions/wallet/trading/tradingCommonActions.ts
+++ b/packages/suite/src/actions/wallet/trading/tradingCommonActions.ts
@@ -1,6 +1,6 @@
 import { CryptoId } from 'invity-api';
 
-import { type TradingType } from '@suite-common/trading';
+import { TradingPreffiledFromAccount, type TradingType } from '@suite-common/trading';
 import { selectSelectedDevice, toggleRememberDevice } from '@suite-common/wallet-core';
 import { AccountKey, Output } from '@suite-common/wallet-types/src';
 import {
@@ -45,8 +45,8 @@ export type TradingCommonAction =
           activeSection: TradingType;
       }
     | {
-          type: typeof TRADING_COMMON.SET_TRADING_FROM_PREFILLED_CRYPTO_ID;
-          prefilledFromCryptoId: CryptoId | undefined;
+          type: typeof TRADING_COMMON.SET_TRADING_FROM_PREFILLED_ACCOUNT;
+          preffiledFromAccount: TradingPreffiledFromAccount;
       };
 
 type FormState = {
@@ -149,9 +149,10 @@ export const convertDrafts = () => (dispatch: Dispatch, getState: GetState) => {
     });
 };
 
-export const setTradingPrefilledFromCryptoId = (
-    prefilledFromCryptoId: CryptoId | undefined,
+export const setTradingPrefilledFromAccount = (
+    descriptor: string | undefined,
+    cryptoId: CryptoId | undefined,
 ): TradingCommonAction => ({
-    type: TRADING_COMMON.SET_TRADING_FROM_PREFILLED_CRYPTO_ID,
-    prefilledFromCryptoId,
+    type: TRADING_COMMON.SET_TRADING_FROM_PREFILLED_ACCOUNT,
+    preffiledFromAccount: { descriptor, cryptoId },
 });

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.tsx
@@ -27,7 +27,9 @@ export const useTradingBuyFormDefaultValues = (
 ): TradingBuyFormDefaultValuesProps => {
     const { buildDefaultCryptoOption } = useTradingInfo('buy');
     const { isTorEnabled } = useSelector(selectTorState);
-    const prefilledFromCryptoId = useSelector(state => state.wallet.trading.prefilledFromCryptoId);
+    const prefilledFromCryptoId = useSelector(
+        state => state.wallet.trading.prefilledFromAccount.cryptoId,
+    );
     const cryptoId = prefilledFromCryptoId || networks[accountSymbol]?.tradeCryptoId;
 
     const country = !isTorEnabled ? buyInfo?.buyInfo?.country : regional.UNKNOWN_COUNTRY;

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeFormDefaultValues.ts
@@ -35,24 +35,32 @@ export const useTradingExchangeFormDefaultValues = (
 ): TradingExchangeFormDefaultValuesProps => {
     const { buildDefaultCryptoOption } = useTradingInfo('exchange');
     const localCurrency = useSelector(selectLocalCurrency);
-    const prefilledFromCryptoId = useSelector(state => state.wallet.trading.prefilledFromCryptoId);
+    const prefilledFromCryptoId = useSelector(
+        state => state.wallet.trading.prefilledFromAccount.cryptoId,
+    );
+    const descriptor = useSelector(state => state.wallet.trading.prefilledFromAccount.descriptor);
     const defaultCurrency = useMemo(() => buildFiatOption(localCurrency), [localCurrency]);
     const cryptoGroups = useTradingBuildAccountGroups('exchange');
     const cryptoOptions = useMemo(
         () => cryptoGroups.flatMap(group => group.options),
         [cryptoGroups],
     );
+
     const defaultSendCryptoSelect = useMemo(
         () =>
             (prefilledFromCryptoId &&
-                cryptoOptions.find(option => option.value === prefilledFromCryptoId)) ||
+                cryptoOptions.find(
+                    option =>
+                        option.value === prefilledFromCryptoId && option.descriptor === descriptor,
+                )) ||
             cryptoOptions.find(
                 option =>
                     option.descriptor === account.descriptor &&
                     cryptoIdToSymbol(option.value) === account.symbol,
             ),
-        [account.descriptor, account.symbol, prefilledFromCryptoId, cryptoOptions],
+        [account.descriptor, account.symbol, prefilledFromCryptoId, descriptor, cryptoOptions],
     );
+
     const { address, token } =
         getAddressAndTokenFromAccountOptionsGroupProps(defaultSendCryptoSelect);
 

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellFormDefaultValues.ts
@@ -29,7 +29,9 @@ export const useTradingSellFormDefaultValues = (
     sellInfo: TradingSellInfoSelector | undefined,
 ): TradingSellFormDefaultValuesProps => {
     const cryptoGroups = useTradingBuildAccountGroups('sell');
-    const prefilledFromCryptoId = useSelector(state => state.wallet.trading.prefilledFromCryptoId);
+    const prefilledFromCryptoId = useSelector(
+        state => state.wallet.trading.prefilledFromAccount.cryptoId,
+    );
     const { isTorEnabled } = useSelector(selectTorState);
 
     const cryptoOptions = useMemo(

--- a/packages/suite/src/middlewares/wallet/tradingMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/tradingMiddleware.ts
@@ -154,12 +154,19 @@ export const tradingMiddleware =
             const isSellToBuy = wasSell && isBuy;
 
             const cleanupPrefilledFromCryptoId =
-                !!newState.wallet.trading.prefilledFromCryptoId &&
+                !!newState.wallet.trading.prefilledFromAccount.cryptoId &&
                 ((!isSell && !isExchange && !isBuy) || isBuyToSell || isSellToBuy);
 
             if (cleanupPrefilledFromCryptoId) {
-                api.dispatch(tradingCommonActions.setTradingPrefilledFromCryptoId(undefined));
-                api.dispatch(tradingActions.setTradingFromPrefilledCryptoId(undefined));
+                api.dispatch(
+                    tradingCommonActions.setTradingPrefilledFromAccount(undefined, undefined),
+                );
+                api.dispatch(
+                    tradingActions.setTradingFromPrefilledAccount({
+                        descriptor: undefined,
+                        cryptoId: undefined,
+                    }),
+                );
             }
         }
 

--- a/packages/suite/src/reducers/wallet/tradingReducer.ts
+++ b/packages/suite/src/reducers/wallet/tradingReducer.ts
@@ -10,6 +10,7 @@ import type {
 import { createWeakMapSelector } from '@suite-common/redux-utils';
 import {
     type TradingPaymentMethodListProps,
+    TradingPreffiledFromAccount,
     type TradingTransaction,
     type TradingType,
     selectTradingBuyInfo,
@@ -69,7 +70,7 @@ export interface State {
     isLoading: boolean;
     lastLoadedTimestamp: number;
     activeSection?: TradingType;
-    prefilledFromCryptoId: CryptoId | undefined;
+    prefilledFromAccount: TradingPreffiledFromAccount;
 }
 
 export const initialState: State = {
@@ -94,7 +95,10 @@ export const initialState: State = {
     modalCryptoId: undefined,
     lastLoadedTimestamp: 0,
     activeSection: 'sell',
-    prefilledFromCryptoId: undefined,
+    prefilledFromAccount: {
+        cryptoId: undefined,
+        descriptor: undefined,
+    },
 };
 
 export const tradingReducer = (state: State = initialState, action: Action): State =>
@@ -110,8 +114,9 @@ export const tradingReducer = (state: State = initialState, action: Action): Sta
             case TRADING_INFO.SAVE_PAYMENT_METHODS:
                 draft.info.paymentMethods = action.paymentMethods;
                 break;
-            case TRADING_COMMON.SET_TRADING_FROM_PREFILLED_CRYPTO_ID:
-                draft.prefilledFromCryptoId = action.prefilledFromCryptoId;
+            case TRADING_COMMON.SET_TRADING_FROM_PREFILLED_ACCOUNT:
+                draft.prefilledFromAccount.cryptoId = action.preffiledFromAccount.cryptoId;
+                draft.prefilledFromAccount.descriptor = action.preffiledFromAccount.descriptor;
                 break;
             case TRADING_COMMON.SAVE_TRADE:
                 if (action.key) {

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -36,7 +36,7 @@ import { copyAddressToClipboard, showCopyAddressModal } from 'src/actions/suite/
 import { openModal } from 'src/actions/suite/modalActions';
 import { goto } from 'src/actions/suite/routerActions';
 import { showAddress } from 'src/actions/wallet/receiveActions';
-import { setTradingPrefilledFromCryptoId } from 'src/actions/wallet/trading/tradingCommonActions';
+import { setTradingPrefilledFromAccount } from 'src/actions/wallet/trading/tradingCommonActions';
 import {
     FiatValue,
     FormattedCryptoAmount,
@@ -148,7 +148,7 @@ export const TokenRow = ({
     const canSellToken = !!tokenTradingOptions && tokenTradingOptions.sell;
 
     const onTradeButtonClick = (type: TradingType, ...[routeName]: Parameters<typeof goto>) => {
-        dispatch(setTradingPrefilledFromCryptoId(tokenCryptoId));
+        dispatch(setTradingPrefilledFromAccount(account.descriptor, tokenCryptoId));
 
         goToWithAnalytics(routeName, {
             params: {

--- a/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
@@ -230,17 +230,23 @@ export const tradingFixtures = [
         },
     },
     {
-        description: 'should set prefilled crypto id',
+        description: 'should set prefilled account',
         initialState,
         actions: [
             {
-                type: tradingActions.setTradingFromPrefilledCryptoId.type,
-                payload: 'ankr' as CryptoId,
+                type: tradingActions.setTradingFromPrefilledAccount.type,
+                payload: {
+                    cryptoId: 'ankr' as CryptoId,
+                    descriptor: 'abc',
+                },
             },
         ],
         result: {
             ...initialState,
-            prefilledFromCryptoId: 'ankr',
+            prefilledFromAccount: {
+                cryptoId: 'ankr',
+                descriptor: 'abc',
+            },
         },
     },
     {

--- a/suite-common/trading/src/reducers/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/tradingReducer.ts
@@ -36,6 +36,11 @@ export interface TradingInfo {
     paymentMethods: TradingPaymentMethodListProps[];
 }
 
+export interface TradingPreffiledFromAccount {
+    cryptoId: CryptoId | undefined;
+    descriptor: string | undefined;
+}
+
 export interface TradingState {
     info: TradingInfo;
     buy: TradingBuyState;
@@ -48,7 +53,7 @@ export interface TradingState {
     isLoading: boolean;
     lastLoadedTimestamp: number;
     activeSection?: TradingType;
-    prefilledFromCryptoId: CryptoId | undefined;
+    prefilledFromAccount: TradingPreffiledFromAccount;
 }
 
 export const initialState: TradingState = {
@@ -67,7 +72,10 @@ export const initialState: TradingState = {
     modalCryptoId: undefined,
     lastLoadedTimestamp: 0,
     activeSection: 'buy',
-    prefilledFromCryptoId: undefined,
+    prefilledFromAccount: {
+        cryptoId: undefined,
+        descriptor: undefined,
+    },
 };
 
 type StorageActionPayload = {
@@ -112,8 +120,15 @@ export const tradingSlice = createSliceWithExtraDeps({
         setTradingActiveSection(state, action: PayloadAction<TradingType>) {
             state.activeSection = action.payload;
         },
-        setTradingFromPrefilledCryptoId(state, action: PayloadAction<CryptoId | undefined>) {
-            state.prefilledFromCryptoId = action.payload;
+        setTradingFromPrefilledAccount(
+            state,
+            action: PayloadAction<{
+                cryptoId: CryptoId | undefined;
+                descriptor: string | undefined;
+            }>,
+        ) {
+            state.prefilledFromAccount.cryptoId = action.payload.cryptoId;
+            state.prefilledFromAccount.descriptor = action.payload.descriptor;
         },
     },
     extraReducers: (builder, extra) => {


### PR DESCRIPTION
## Description

Fixes an issue where the wrong account was selected when swapping tokens from the token tab in cases where multiple accounts held the same token. The reducer was updated to store both `cryptoId` and `descriptor`, allowing the selection logic to identify and prefill the intended account correctly. The action name in the reducer was also renamed to `SET_TRADING_FROM_PREFILLED_ACCOUNT`.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18411

## Video:

https://github.com/user-attachments/assets/9591cf38-2827-4b0a-9c71-3399abe406dc

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-prefilled-account-selection&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-prefilled-account-selection&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading-prefilled-account-selection&lookback=7)