### PR TITLE
refactor(suite-native): replace useRef with useBottomSheetModal

### DIFF
--- a/suite-native/module-trading/src/components/buy/LegalSheet.tsx
+++ b/suite-native/module-trading/src/components/buy/LegalSheet.tsx
@@ -1,10 +1,16 @@
-import { ReactNode, memo, useCallback, useEffect, useRef } from 'react';
+import { ReactNode, memo, useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
-import { type BottomSheetModal as BottomSheetModalType } from '@gorhom/bottom-sheet';
-
 import { selectTradingBuyProviders } from '@suite-common/trading';
-import { BottomSheetModal, Box, BulletListItem, Button, Text, VStack } from '@suite-native/atoms';
+import {
+    BottomSheetModal,
+    Box,
+    BulletListItem,
+    Button,
+    Text,
+    VStack,
+    useBottomSheetModal,
+} from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 
 export type LegalSheetProps = {
@@ -28,25 +34,25 @@ const Info = ({ children }: { children: ReactNode }) => (
 
 export const LegalSheet = memo(
     ({ isVisible, onConsent, onDismiss, tradeProvider }: LegalSheetProps) => {
-        const bottomSheetModalRef = useRef<BottomSheetModalType>(null);
+        const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
         const providers = useSelector(selectTradingBuyProviders);
         const { companyName } = providers?.[tradeProvider] ?? {};
         const { translate } = useTranslate();
 
         useEffect(() => {
             if (isVisible) {
-                bottomSheetModalRef.current?.present();
+                openModal();
             }
-        }, [isVisible]);
+        }, [isVisible, openModal]);
 
         const closeWithConsent = useCallback(() => {
             onConsent();
-            bottomSheetModalRef.current?.close();
-        }, [onConsent]);
+            closeModal();
+        }, [onConsent, closeModal]);
 
         return (
             <BottomSheetModal
-                ref={bottomSheetModalRef}
+                ref={bottomSheetRef}
                 title={translate('moduleTrading.legalSheet.title', { companyName })}
                 onDismiss={onDismiss}
                 isCloseDisplayed

--- a/suite-native/module-trading/src/components/general/TradeDetailSheet/TradeDetailSheet.tsx
+++ b/suite-native/module-trading/src/components/general/TradeDetailSheet/TradeDetailSheet.tsx
@@ -1,10 +1,8 @@
-import { memo, useEffect, useRef } from 'react';
+import { memo, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
-import { type BottomSheetModal as BottomSheetModalType } from '@gorhom/bottom-sheet';
-
 import { TradingRootState, selectTradingTradeByOrderId } from '@suite-common/trading';
-import { BottomSheetModal } from '@suite-native/atoms';
+import { BottomSheetModal, useBottomSheetModal } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { TradeDetailFooter } from './TradeDetailFooter';
@@ -28,25 +26,25 @@ export const TradeDetailSheet = memo(({ orderId, isVisible, onDismiss }: TradeDe
     const trade = useSelector((state: TradingRootState) =>
         selectTradingTradeByOrderId(state, orderId),
     );
-    const bottomSheetModalRef = useRef<BottomSheetModalType>(null);
+    const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
 
     useEffect(() => {
         if (isVisible) {
-            bottomSheetModalRef.current?.present();
+            openModal();
         }
-    }, [isVisible]);
+    }, [isVisible, openModal]);
 
     if (!orderId || !trade) {
         return null;
     }
 
     const onOpenedWebview = () => {
-        bottomSheetModalRef.current?.close();
+        closeModal();
     };
 
     return (
         <BottomSheetModal
-            ref={bottomSheetModalRef}
+            ref={bottomSheetRef}
             onDismiss={onDismiss}
             style={applyStyle(bottomSheetStyle)}
             isCloseDisplayed


### PR DESCRIPTION
Replace useRef with useBottomSheetModal for modal handling in LegalSheet and TradeDetailSheet

## Related Issue

Resolve #18891 


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=18891-mobile-trade-refactor-trade-bottomsheets-handling-to-use-usebottomsheetmodal&lookback=7)