### PR TITLE
fix(suite): custom fee dust prevention notice

### DIFF
--- a/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeMisc.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeMisc.tsx
@@ -35,7 +35,7 @@ export const CustomFeeMisc = <TFieldValues extends FormState>({
     const feePerUnitValue = getValues(FEE_PER_UNIT);
     const feePerUnitError = errors.feePerUnit;
 
-    const isDustPreventionRelevant = feePerUnitError !== undefined && networkType === 'bitcoin';
+    const isDustPreventionRelevant = feePerUnitError === undefined && networkType === 'bitcoin';
 
     const feeRules = {
         ...sharedRules,


### PR DESCRIPTION
## Description

Followup to #18673 : fix condition accidentally inverted in a fixup commit ([this diff](https://github.com/trezor/trezor-suite/pull/18673/files#diff-80fa5abd6eae219e8a0e746f100013e6b648e5f3ab88e0c9909c274fe6645a17): L38)

## Related Issue

Resolve #18317

## Screenshots 

Dust prevention in Send Form with both fee types (works as before the fixup commit in orig PR):
[dust coalescence.webm](https://github.com/user-attachments/assets/96aa123e-3b17-4578-b0f1-4b345312eab4)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/custom-fee-dust-prevention-notice&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/custom-fee-dust-prevention-notice&lookback=7)