### PR TITLE
Refactor e2e reporter to run less requests

### DIFF
--- a/packages/suite-desktop-core/e2e/support/reporters/gitHubReporter.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/gitHubReporter.ts
@@ -30,8 +30,8 @@ class GitHubReporter implements Reporter, LoggingFunctions {
     private _octokit: Octokit | null = null;
     private _issueRequests: IssueRequests | null = null;
     private _gitHubProject: GitHubProject | null = null;
+    private _fieldsInGitHub: ProjectField[] | null = null;
     private pendingOperations: Promise<any>[] = [];
-    private cachedFields: ProjectField[] | null = null;
     private initState: InitializationState = InitializationState.NOT_STARTED;
     private createdIssuesMap: Map<string, string> = new Map();
 
@@ -80,6 +80,16 @@ class GitHubReporter implements Reporter, LoggingFunctions {
         return this._gitHubProject;
     }
 
+    private get fieldsInGitHub(): ProjectField[] {
+        if (!this._fieldsInGitHub) {
+            throw new Error(
+                'Project fields are not initialized. Ensure onBegin() is called first.',
+            );
+        }
+
+        return this._fieldsInGitHub;
+    }
+
     // Tracks asynchronous operations and logs their completion
     // Otherwise, playwright would not wait for them to finish
     private trackOperation<T>(operation: Promise<T>): Promise<T> {
@@ -113,6 +123,7 @@ class GitHubReporter implements Reporter, LoggingFunctions {
 
             try {
                 await this.gitHubProject.init();
+                await scheduleAction(() => this.getProjectFields(), RETRY_CONF);
                 this.initState = InitializationState.COMPLETED;
             } catch (error) {
                 this.initState = InitializationState.FAILED;
@@ -185,11 +196,9 @@ class GitHubReporter implements Reporter, LoggingFunctions {
             `[${issueNodeId}] Updating GitHub draft issue with a retry of test "${test.title}"...`,
         );
 
-        const fields = await scheduleAction(() => this.getProjectFields(), RETRY_CONF);
-
         this.log(`[${issueNodeId}] Updating field Status:"${report.status}"...`);
         const { fieldId: statusFieldId, valueOrOptionId: statusOptionId } =
-            this.resolveFieldAndValue(fields, statusAnnotation.name, report.status);
+            this.resolveFieldAndValue(statusAnnotation.name, report.status);
         await scheduleAction(
             () =>
                 this.issueRequests.setItemValue(
@@ -205,8 +214,6 @@ class GitHubReporter implements Reporter, LoggingFunctions {
     }
 
     private async createIssuePerOs(test: TestCase, report: TestReportProvider): Promise<void> {
-        const fields = await scheduleAction(() => this.getProjectFields(), RETRY_CONF);
-
         for (const operationSystem of report.osMatrix) {
             const issueNodeId = await scheduleAction(() => {
                 this.log(
@@ -231,7 +238,6 @@ class GitHubReporter implements Reporter, LoggingFunctions {
 
             for (const { name, value } of report.projectValues) {
                 const { fieldId, valueOrOptionId } = this.resolveFieldAndValue(
-                    fields,
                     name,
                     value,
                     operationSystem,
@@ -255,30 +261,22 @@ class GitHubReporter implements Reporter, LoggingFunctions {
         }
     }
 
-    private async getProjectFields(): Promise<ProjectField[]> {
-        if (this.cachedFields) {
-            return this.cachedFields;
-        }
-
+    private async getProjectFields() {
         this.log(`Fetching fields for project ${this.gitHubProject.id}...`);
-        const fields = await this.issueRequests.getProjectFields(this.gitHubProject.id);
+        this._fieldsInGitHub = await this.issueRequests.getProjectFields(this.gitHubProject.id);
         this.log(`Successfully retrieved fields for project ${this.gitHubProject.id}`);
-        this.cachedFields = fields;
-
-        return fields;
     }
 
     private resolveFieldAndValue(
-        fieldsInGitHub: ProjectField[],
         fieldNameToResolve: string,
         fieldValueToResolve: string,
         operationSystem?: string,
     ): { fieldId: string; valueOrOptionId: string } {
-        const resolvedField = fieldsInGitHub.find(f => f.name === fieldNameToResolve);
+        const resolvedField = this.fieldsInGitHub.find(f => f.name === fieldNameToResolve);
 
         if (!resolvedField) {
             throw new Error(
-                `Field "${fieldNameToResolve}" not found in project fields: \n ${JSON.stringify(fieldsInGitHub, null, 2)}`,
+                `Field "${fieldNameToResolve}" not found in project fields: \n ${JSON.stringify(this.fieldsInGitHub, null, 2)}`,
             );
         }
 

--- a/packages/suite-desktop-core/e2e/support/reporters/gitHubReporter.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/gitHubReporter.ts
@@ -217,7 +217,7 @@ class GitHubReporter implements Reporter, LoggingFunctions {
         for (const operationSystem of report.osMatrix) {
             const issueNodeId = await scheduleAction(() => {
                 this.log(
-                    `Creating GitHub draft issue for test "(${operationSystem}) ${test.title}"...`,
+                    `Creating GitHub draft issue for test "(OS ${operationSystem}) ${test.title}"...`,
                 );
 
                 const titleWithOptionalEmoticons = report.useOsEmoticons
@@ -233,30 +233,30 @@ class GitHubReporter implements Reporter, LoggingFunctions {
 
             this.createdIssuesMap.set(test.id, issueNodeId);
             this.log(
-                `[${issueNodeId}] Successfully created issue "(${operationSystem}) ${test.title}"`,
+                `[${issueNodeId}] Successfully created issue "(OS ${operationSystem}) ${test.title}"`,
             );
 
-            for (const { name, value } of report.projectValues) {
-                const { fieldId, valueOrOptionId } = this.resolveFieldAndValue(
-                    name,
-                    value,
-                    operationSystem,
+            const resolvedFieldsAndValues = report.projectValues.map(({ name, value }) =>
+                this.resolveFieldAndValue(name, value, operationSystem),
+            );
+            await scheduleAction(() => {
+                this.log(
+                    `[${issueNodeId}] Updating values of issue "(OS ${operationSystem}) ${test.title}"...`,
                 );
-                await scheduleAction(() => {
-                    this.log(`[${issueNodeId}] Updating field ${name}:"${value}"...`);
 
-                    return this.issueRequests.setItemValue(
-                        this.gitHubProject.id,
-                        issueNodeId,
-                        fieldId,
-                        valueOrOptionId,
-                    );
-                }, RETRY_CONF);
-                this.log(`[${issueNodeId}] Successfully updated field ${name}:"${value}"`);
-            }
+                return this.issueRequests.setMultipleValues(
+                    this.gitHubProject.id,
+                    issueNodeId,
+                    resolvedFieldsAndValues,
+                );
+            }, RETRY_CONF);
 
             this.log(
-                `[${issueNodeId}] Successfully recorded test result for "(${operationSystem}) ${test.title}"`,
+                `[${issueNodeId}] Successfully updated values of issue "(OS ${operationSystem}) ${test.title}"`,
+            );
+
+            this.log(
+                `[${issueNodeId}] Successfully recorded test result for "(OS ${operationSystem}) ${test.title}"`,
             );
         }
     }
@@ -267,6 +267,8 @@ class GitHubReporter implements Reporter, LoggingFunctions {
         this.log(`Successfully retrieved fields for project ${this.gitHubProject.id}`);
     }
 
+    // Looks in project for filedId and OptionId for a specific values the test have.
+    // These Ids are used to update the issue with values like status, stream, etc.
     private resolveFieldAndValue(
         fieldNameToResolve: string,
         fieldValueToResolve: string,

--- a/packages/suite-desktop-core/e2e/support/reporters/issueRequests.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/issueRequests.ts
@@ -3,7 +3,6 @@ import type { Octokit } from '@octokit/rest';
 import { getProjectFields } from './projectRequests';
 import {
     AddDraftIssueResponse,
-    AddIssueToProjectResponse,
     ProjectField,
     UpdateProjectItemFieldResponse,
     ValueOrOptionId,
@@ -11,26 +10,6 @@ import {
 
 export class IssueRequests {
     constructor(private readonly octokit: Octokit) {}
-
-    async addIssueToProject(projectId: string, issueNodeId: string): Promise<string> {
-        const mutation = `
-            mutation {
-              addProjectV2ItemById(
-              input: {
-                projectId: "${projectId}"
-                contentId: "${issueNodeId}"
-              }) {
-                item {
-                  id
-                }
-              }
-            }
-        `;
-
-        const response = await this.octokit.graphql<AddIssueToProjectResponse>(mutation);
-
-        return response.addProjectV2ItemById.item.id;
-    }
 
     getProjectFields(projectId: string): Promise<ProjectField[]> {
         return getProjectFields(this.octokit, projectId);
@@ -93,5 +72,40 @@ export class IssueRequests {
         const issueId = response.addProjectV2DraftIssue.projectItem.id;
 
         return issueId;
+    }
+
+    async setMultipleValues(
+        projectId: string,
+        itemId: string,
+        resolvedFieldsAndValues: { fieldId: string; valueOrOptionId: ValueOrOptionId }[],
+    ): Promise<void> {
+        // Start building the mutation
+        let mutation = `
+        mutation UpdateMultipleFields($projectId: ID!, $itemId: ID!) {
+      `;
+
+        // Add each field update as an aliased operation
+        resolvedFieldsAndValues.forEach(({ fieldId, valueOrOptionId }, index) => {
+            mutation += `
+          update${index}: updateProjectV2ItemFieldValue(
+            input: {
+              projectId: $projectId
+              itemId: $itemId
+              fieldId: "${fieldId}"
+              value: ${valueOrOptionId}
+            }
+          ) {
+            projectV2Item {
+              id
+            }
+          }
+        `;
+        });
+
+        // Close the mutation
+        mutation += `}`;
+
+        // Execute the combined mutation
+        await this.octokit.graphql(mutation, { projectId, itemId });
     }
 }

--- a/packages/suite-desktop-core/e2e/support/reporters/types.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/types.ts
@@ -27,14 +27,6 @@ export interface ProjectQueryResponse {
     };
 }
 
-export interface AddIssueToProjectResponse {
-    addProjectV2ItemById: {
-        item: {
-            id: string;
-        };
-    };
-}
-
 export interface FieldOption {
     id: string;
     name: string;


### PR DESCRIPTION
Reduce the amount of request for reporter run. Update of the issue is done in one request and query `getProjectFields` is run on onBegin() and cached for all onTestEnd(). The improvement is:

From `10*T+1` to `2*T+2`
T = Test number
plus one request per Test retries done by Playwright
plus every request has at max 2 retries in case of failure

With current test numbers this means we call per run:
Manual suite: 106 requests
Desktop: 216 requests
Web: 276 requests

Total: 598 requests

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-e2e-reporter-less-requests&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-e2e-reporter-less-requests&lookback=7)