### PR TITLE
fix(suite): stake max sol

### DIFF
--- a/packages/suite/src/hooks/wallet/useStakeEthForm.ts
+++ b/packages/suite/src/hooks/wallet/useStakeEthForm.ts
@@ -297,10 +297,20 @@ export const useStakeEthForm = ({ selectedAccount }: UseStakeFormsProps): StakeC
             setIsLessAmountForWithdrawalWarningShown(true);
         }
 
-        setValue(OUTPUT_AMOUNT, amount || '', { shouldDirty: true });
+        setValue(OUTPUT_AMOUNT, new BigNumber(amount).minus(MIN_FOR_WITHDRAWALS).toString() || '', {
+            shouldDirty: true,
+        });
+
         await composeRequest(CRYPTO_INPUT);
         setIsAmountForWithdrawalWarningShown(true);
-    }, [account.formattedBalance, clearErrors, composeRequest, setValue, MIN_BALANCE_FOR_STAKING]);
+    }, [
+        account.formattedBalance,
+        clearErrors,
+        composeRequest,
+        setValue,
+        MIN_BALANCE_FOR_STAKING,
+        MIN_FOR_WITHDRAWALS,
+    ]);
 
     useEffect(() => {
         if (formState.errors[CRYPTO_INPUT]) {


### PR DESCRIPTION
## Description

- max button was not working for solana because the amount resulted in not enough fee

## Related Issue

Resolve #18898


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sol-max-stake&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sol-max-stake&lookback=7)