### PR TITLE
fix(suite-desktop): macOS ARM build adhoc signing

### DIFF
--- a/packages/suite-desktop/electron-builder-config.js
+++ b/packages/suite-desktop/electron-builder-config.js
@@ -81,6 +81,9 @@ module.exports = {
         oneClick: false,
     },
     mac: {
+        // identity: undefined means default behavior (autodetect the ENV variables necessary for signing and perform it)
+        // identity: null means disable any signing – necessary for dev builds (default behavior is to adhoc sign ARM builds, which would fail in CI)
+        identity: isCodesignBuild ? undefined : null,
         files: ['entitlements.mac.inherit.plist'],
         extraResources: [
             {


### PR DESCRIPTION
## Description

Followup to #18819, which broke CI dev desktop build for macOS :apple: 

With [electron-builder 26.0.13](https://github.com/electron-userland/electron-builder/releases/tag/v26.0.13) a change was done in [#9007](https://github.com/electron-userland/electron-builder/pull/9007):
- if `identity` ENV is missing (as in dev builds) ARM builds are now adhoc signed by default
  - [docs here](https://github.com/electron-userland/electron-builder/blob/master/pages/code-signing-mac.md)
- [that crashes in CI](https://github.com/trezor/trezor-suite/actions/runs/14991949805/job/42117150993)
- so explicitly skip signing when not codesign build 

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/macos-arm-adhoc-signing&lookback=7)