### PR TITLE
Possibility to turn off Device Authenticity Check from advanced settings on mobile

### DIFF
--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -102,6 +102,8 @@ export const HELP_CENTER_ZERO_VALUE_ATTACKS: Url =
 export const HELP_CENTER_LABELING: Url = 'https://trezor.io/learn/a/labels-in-trezor-suite-app';
 export const HELP_CENTER_DEVICE_AUTHENTICATION: Url =
     'https://trezor.io/learn/a/trezor-safe-device-authentication-check';
+export const HELP_CENTER_DEVICE_AUTHENTICATION_MOBILE: Url =
+    'https://trezor.io/learn/a/trezor-safe-device-authentication-check'; // FIXME: mobile specific
 export const HELP_CENTER_ETH_STAKING: Url =
     'https://trezor.io/learn/a/stake-ethereum-eth-in-trezor-suite';
 export const HELP_CENTER_SOL_STAKING: Url =

--- a/suite-native/atoms/src/Card/Card.tsx
+++ b/suite-native/atoms/src/Card/Card.tsx
@@ -9,12 +9,15 @@ import { Color } from '@trezor/theme';
 
 import { InlineAlertBox, InlineAlertBoxProps } from '../InlineAlertBox/InlineAlertBox';
 
+type AlertPosition = 'top' | 'bottom';
+
 export type CardProps = {
     children: ReactNode;
     style?: NativeStyleObject;
     noPadding?: boolean;
     borderColor?: Color;
     alertProps?: InlineAlertBoxProps;
+    alertPosition?: AlertPosition;
 };
 
 const cardOuterContainerStyle = prepareNativeStyle<{
@@ -24,10 +27,10 @@ const cardOuterContainerStyle = prepareNativeStyle<{
 }));
 
 const cardInnerContainerStyle = prepareNativeStyle<{
-    isAlertDisplayed: boolean;
+    alertPosition?: AlertPosition;
     noPadding: boolean;
     borderColor?: Color;
-}>((utils, { isAlertDisplayed, noPadding, borderColor }) => ({
+}>((utils, { alertPosition, noPadding, borderColor }) => ({
     backgroundColor: utils.colors.backgroundSurfaceElevation1,
     borderRadius: utils.borders.radii.r16,
     padding: noPadding ? 0 : utils.spacings.sp16,
@@ -35,10 +38,17 @@ const cardInnerContainerStyle = prepareNativeStyle<{
 
     extend: [
         {
-            condition: isAlertDisplayed,
+            condition: alertPosition === 'top',
             style: {
                 borderTopLeftRadius: 0,
                 borderTopRightRadius: 0,
+            },
+        },
+        {
+            condition: alertPosition === 'bottom',
+            style: {
+                borderBottomLeftRadius: 0,
+                borderBottomRightRadius: 0,
             },
         },
         {
@@ -51,32 +61,50 @@ const cardInnerContainerStyle = prepareNativeStyle<{
     ],
 }));
 
-const alertBoxWrapperStyle = prepareNativeStyle(utils => ({
+const alertBoxWrapperStyle = prepareNativeStyle<{
+    alertPosition?: AlertPosition;
+}>((utils, { alertPosition = 'top' }) => ({
     backgroundColor: utils.colors.backgroundSurfaceElevation1,
-    borderTopLeftRadius: utils.borders.radii.r16,
-    borderTopRightRadius: utils.borders.radii.r16,
     paddingHorizontal: utils.spacings.sp4,
-    paddingTop: utils.spacings.sp4,
+    extend: [
+        {
+            condition: alertPosition === 'top',
+            style: {
+                borderTopLeftRadius: utils.borders.radii.r16,
+                borderTopRightRadius: utils.borders.radii.r16,
+                paddingTop: utils.spacings.sp4,
+            },
+        },
+        {
+            condition: alertPosition === 'bottom',
+            style: {
+                borderBottomLeftRadius: utils.borders.radii.r16,
+                borderBottomRightRadius: utils.borders.radii.r16,
+                paddingBottom: utils.spacings.sp4,
+            },
+        },
+    ],
 }));
 
 export const Card = React.forwardRef<View, CardProps>(
-    ({ children, style, alertProps, borderColor, noPadding = false }: CardProps, ref) => {
+    (
+        { children, style, alertProps, alertPosition, borderColor, noPadding = false }: CardProps,
+        ref,
+    ) => {
         const { applyStyle } = useNativeStyles();
-
-        const isAlertDisplayed = !!alertProps;
 
         return (
             <View style={applyStyle(cardOuterContainerStyle, { flex: style?.flex })}>
-                {isAlertDisplayed && (
-                    <View style={applyStyle(alertBoxWrapperStyle)}>
+                {!!alertProps && alertPosition !== 'bottom' && (
+                    <View style={applyStyle(alertBoxWrapperStyle, { alertPosition })}>
                         <InlineAlertBox {...alertProps} />
                     </View>
                 )}
-                {/* CAUTION: in case that alert is displayed, it is not possible to change styles of the top borders by the `style` prop. */}
                 <View
                     style={[
+                        /* CAUTION: in case that alert is displayed, it is not possible to change styles of the borders by the `style` prop. */
                         applyStyle(cardInnerContainerStyle, {
-                            isAlertDisplayed,
+                            alertPosition,
                             noPadding,
                             borderColor,
                         }),
@@ -87,6 +115,11 @@ export const Card = React.forwardRef<View, CardProps>(
                 >
                     {children}
                 </View>
+                {!!alertProps && alertPosition === 'bottom' && (
+                    <View style={applyStyle(alertBoxWrapperStyle, { alertPosition })}>
+                        <InlineAlertBox {...alertProps} />
+                    </View>
+                )}
             </View>
         );
     },

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -583,9 +583,9 @@ export const en = {
                     title: 'Enabled coins',
                     subtitle: 'Manage coins that you use',
                 },
-                deviceChecks: {
-                    title: 'Device checks',
-                    subtitle: 'Authenticity and security checks',
+                advanced: {
+                    title: 'Advanced',
+                    subtitle: 'Expert features for power users ',
                 },
                 walletConnect: {
                     title: 'WalletConnect',
@@ -757,8 +757,8 @@ export const en = {
                 defaultPassphrase: 'Passphrase wallet #{index}',
             },
         },
-        deviceChecks: {
-            title: 'Device checks',
+        advanced: {
+            title: 'Advanced',
             firmwareAuthenticityCheck: {
                 title: 'Turn off firmware authenticity check',
                 subtitle:

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -760,16 +760,13 @@ export const en = {
         advanced: {
             title: 'Advanced',
             goodAdvice: 'We strongly recommend leaving these checks turned on.',
-            firmwareAuthenticityCheck: {
-                title: 'Firmware authenticity check',
-                subtitle:
-                    'This check ensures that your firmware is legitimate. Compromised firmware won’t be able to communicate with Suite.',
+            authenticityChecks: {
                 buttonTurnOff: 'Turn off',
                 buttonTurnOn: 'Turn on',
                 buttonLearnMore: 'Learn more',
-
-                turnOffModal: {
-                    title: 'Turn off firmware authenticity check',
+                toastOn: 'Check turned on',
+                toastOff: 'Check turned off',
+                turnOff: {
                     content: 'This feature is designed to protect your security.',
                     item1: 'Only continue if the device has passed this check before',
                     item1Explanation:
@@ -780,6 +777,18 @@ export const en = {
                     acknowledgement: 'I’ve read and understood the above',
                     acknowledgementNote: 'Trezor Support will never ask you to turn this off.',
                     buttonTurnOff: 'Turn off',
+                },
+                firmware: {
+                    title: 'Firmware authenticity check',
+                    subtitle:
+                        'This check ensures that your firmware is legitimate. Compromised firmware won’t be able to communicate with Suite.',
+                    turnOffTitle: 'Turn off firmware authenticity check',
+                },
+                device: {
+                    title: 'Device authenticity check',
+                    subtitle:
+                        'This check verifies that your Trezor device is genuine. It helps ensure you never use a compromised or fake device. ',
+                    turnOffTitle: 'Turn off device authenticity check',
                 },
             },
         },

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -759,25 +759,26 @@ export const en = {
         },
         advanced: {
             title: 'Advanced',
+            goodAdvice: 'We strongly recommend leaving these checks turned on.',
             firmwareAuthenticityCheck: {
-                title: 'Turn off firmware authenticity check',
+                title: 'Firmware authenticity check',
                 subtitle:
-                    'Firmware authenticity check is a crucial security feature. We strongly recommend keeping it turned on.',
+                    'This check ensures that your firmware is legitimate. Compromised firmware won’t be able to communicate with Suite.',
                 buttonTurnOff: 'Turn off',
                 buttonTurnOn: 'Turn on',
                 buttonLearnMore: 'Learn more',
 
                 turnOffModal: {
                     title: 'Turn off firmware authenticity check',
-                    content:
-                        'Trezor Support will never ask you to turn off the firmware revision check. This feature is designed to protect your security.',
-                    item1: 'Only if the device has passed the check before',
+                    content: 'This feature is designed to protect your security.',
+                    item1: 'Only continue if the device has passed this check before',
                     item1Explanation:
-                        'Using an unverified device could result in the loss of funds.',
-                    item2: 'Only for testing and development',
+                        'Using an unverified device could compromise the security of your funds.',
+                    item2: 'Only use for testing and development',
                     item2Explanation:
-                        'These security checks should only be disabled for testing and development purposes.',
+                        'This security check should only be disabled for testing and development purposes.',
                     acknowledgement: 'I’ve read and understood the above',
+                    acknowledgementNote: 'Trezor Support will never ask you to turn this off.',
                     buttonTurnOff: 'Turn off',
                 },
             },

--- a/suite-native/module-device-onboarding/package.json
+++ b/suite-native/module-device-onboarding/package.json
@@ -22,6 +22,7 @@
         "@suite-native/icons": "workspace:*",
         "@suite-native/intl": "workspace:*",
         "@suite-native/navigation": "workspace:*",
+        "@suite-native/settings": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",

--- a/suite-native/module-device-onboarding/src/hooks/useNavigateToNextScreenAfterFirmwareInstallation.ts
+++ b/suite-native/module-device-onboarding/src/hooks/useNavigateToNextScreenAfterFirmwareInstallation.ts
@@ -1,0 +1,47 @@
+import { useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { SUPPORTS_DEVICE_AUTHENTICITY_CHECK } from '@suite-common/suite-constants';
+import { selectDeviceModel } from '@suite-common/wallet-core';
+import {
+    DeviceOnboardingStackParamList,
+    DeviceOnboardingStackRoutes,
+    StackToStackCompositeNavigationProps,
+} from '@suite-native/navigation';
+import { selectIsDeviceAuthenticityCheckEnabled } from '@suite-native/settings';
+import { DeviceModelInternal } from '@trezor/device-utils';
+
+type NavigationProps = StackToStackCompositeNavigationProps<
+    DeviceOnboardingStackParamList,
+    DeviceOnboardingStackRoutes,
+    DeviceOnboardingStackParamList
+>;
+
+export const useNavigateToNextScreenAfterFirmwareInstallation = () => {
+    const navigation = useNavigation<NavigationProps>();
+    const deviceModel = useSelector(selectDeviceModel);
+    const isDeviceAuthenticityCheckEnabled = useSelector(selectIsDeviceAuthenticityCheckEnabled);
+
+    const supportsDeviceAuthentication = deviceModel
+        ? SUPPORTS_DEVICE_AUTHENTICITY_CHECK[deviceModel]
+        : true; // We must require device authenticity check so it cannot be used as an exploit to bypass it
+
+    const shouldAuthenticateSelectedDevice =
+        supportsDeviceAuthentication && isDeviceAuthenticityCheckEnabled;
+
+    const navigateToNextScreenAfterFirmwareInstallation = () => {
+        if (deviceModel === DeviceModelInternal.T2T1) {
+            // T2T1 does not support device tutorial and device authenticity check so those screens are skipped.
+            navigation.navigate(DeviceOnboardingStackRoutes.CreateOrRecoverCrossroads);
+        } else {
+            navigation.navigate(
+                shouldAuthenticateSelectedDevice
+                    ? DeviceOnboardingStackRoutes.DeviceAuthenticity
+                    : DeviceOnboardingStackRoutes.DeviceTutorial,
+            );
+        }
+    };
+
+    return { navigateToNextScreenAfterFirmwareInstallation };
+};

--- a/suite-native/module-device-onboarding/src/screens/ConfirmFirmwareUpdateScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ConfirmFirmwareUpdateScreen.tsx
@@ -2,8 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { useSetAtom } from 'jotai';
 
-import { SUPPORTS_DEVICE_AUTHENTICITY_CHECK } from '@suite-common/suite-constants';
-import { selectDeviceModel, selectHasDeviceFirmwareInstalled } from '@suite-common/wallet-core';
+import { selectHasDeviceFirmwareInstalled } from '@suite-common/wallet-core';
 import { selectIsDeviceFirmwareSupported } from '@suite-native/device';
 import {
     ConfirmFirmwareUpdateScreenContent,
@@ -17,7 +16,7 @@ import {
 
 import { updateOnboardingAnalyticsAtom } from '../../atoms';
 import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboardingScreenWithExitButton';
-
+import { useNavigateToNextScreenAfterFirmwareInstallation } from '../hooks/useNavigateToNextScreenAfterFirmwareInstallation';
 export const ConfirmFirmwareUpdateScreen = ({
     navigation,
 }: StackProps<
@@ -27,7 +26,9 @@ export const ConfirmFirmwareUpdateScreen = ({
     const hasDeviceFirmwareInstalled = useSelector(selectHasDeviceFirmwareInstalled);
     const isDeviceFirmwareSupported = useSelector(selectIsDeviceFirmwareSupported);
     const updateOnboardingAnalytics = useSetAtom(updateOnboardingAnalyticsAtom);
-    const deviceModel = useSelector(selectDeviceModel);
+
+    const { navigateToNextScreenAfterFirmwareInstallation } =
+        useNavigateToNextScreenAfterFirmwareInstallation();
 
     const handleUpdateConfirmation = () => {
         updateOnboardingAnalytics({
@@ -36,19 +37,11 @@ export const ConfirmFirmwareUpdateScreen = ({
         navigation.navigate(DeviceOnboardingStackRoutes.FirmwareInstallation);
     };
 
-    const supportsDeviceAuthentication = deviceModel
-        ? SUPPORTS_DEVICE_AUTHENTICITY_CHECK[deviceModel]
-        : true;
-
     const handleSkipUpdate = () => {
         updateOnboardingAnalytics({
             firmware: 'skip',
         });
-        navigation.navigate(
-            supportsDeviceAuthentication // TODO: check not only if supported, but also if allowed.
-                ? DeviceOnboardingStackRoutes.DeviceAuthenticity
-                : DeviceOnboardingStackRoutes.DeviceTutorial,
-        );
+        navigateToNextScreenAfterFirmwareInstallation();
     };
 
     return (

--- a/suite-native/module-device-onboarding/src/screens/FirmwareInstallationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/FirmwareInstallationScreen.tsx
@@ -1,31 +1,16 @@
 import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import { firmwareActions } from '@suite-common/firmware';
-import { SUPPORTS_DEVICE_AUTHENTICITY_CHECK } from '@suite-common/suite-constants';
-import { selectDeviceModel } from '@suite-common/wallet-core';
 import { FirmwareInstallationScreenContent } from '@suite-native/firmware';
-import {
-    DeviceOnboardingStackParamList,
-    DeviceOnboardingStackRoutes,
-    StackProps,
-} from '@suite-native/navigation';
-import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboardingScreenWithExitButton';
+import { useNavigateToNextScreenAfterFirmwareInstallation } from '../hooks/useNavigateToNextScreenAfterFirmwareInstallation';
 
-export const FirmwareInstallationScreen = ({
-    navigation,
-}: StackProps<
-    DeviceOnboardingStackParamList,
-    DeviceOnboardingStackRoutes.FirmwareInstallation
->) => {
+export const FirmwareInstallationScreen = () => {
     const dispatch = useDispatch();
-    const deviceModel = useSelector(selectDeviceModel);
-
-    const supportsDeviceAuthentication = deviceModel
-        ? SUPPORTS_DEVICE_AUTHENTICITY_CHECK[deviceModel]
-        : true;
+    const { navigateToNextScreenAfterFirmwareInstallation } =
+        useNavigateToNextScreenAfterFirmwareInstallation();
 
     useEffect(() => {
         // On first render, set the firmware installation status to 'initial'. Some previous failed firmware updates might
@@ -33,23 +18,10 @@ export const FirmwareInstallationScreen = ({
         dispatch(firmwareActions.setStatus('initial'));
     }, [dispatch]);
 
-    const handleFirmwareInstallationSuccess = () => {
-        if (deviceModel === DeviceModelInternal.T2T1) {
-            // T2T1 does not support device tutorial and device authenticity check so those screens are skipped.
-            navigation.navigate(DeviceOnboardingStackRoutes.CreateOrRecoverCrossroads);
-        } else {
-            navigation.navigate(
-                supportsDeviceAuthentication // TODO: check not only if supported, but also if allowed.
-                    ? DeviceOnboardingStackRoutes.DeviceAuthenticity
-                    : DeviceOnboardingStackRoutes.DeviceTutorial,
-            );
-        }
-    };
-
     return (
         <DeviceOnboardingScreenWithExitButton>
             <FirmwareInstallationScreenContent
-                onFirmwareInstallationSuccess={handleFirmwareInstallationSuccess}
+                onFirmwareInstallationSuccess={navigateToNextScreenAfterFirmwareInstallation}
                 isCancellationAllowed={false}
                 isRetryAllowed={false}
                 isTemporaryRememeberAllowed={false}

--- a/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 
 import { useSetAtom } from 'jotai';
 
-import { SUPPORTS_DEVICE_AUTHENTICITY_CHECK } from '@suite-common/suite-constants';
 import {
     selectDeviceModel,
     selectHasDeviceFirmwareInstalled,
@@ -26,7 +25,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { resetOnboardingAnalyticsAtom, updateOnboardingAnalyticsAtom } from '../../atoms';
 import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboardingScreenWithExitButton';
 import { HeaderUnderlineSvg } from '../components/HeaderUnderlineSvg';
-
+import { useNavigateToNextScreenAfterFirmwareInstallation } from '../hooks/useNavigateToNextScreenAfterFirmwareInstallation';
 const trezorImageStyle = prepareNativeStyle<{ hasDeviceFirmwareInstalled: boolean }>(
     (_, { hasDeviceFirmwareInstalled }) => ({
         width: '100%',
@@ -94,11 +93,8 @@ export const UninitializedDeviceLandingScreen = ({
     const deviceModel = useSelector(selectDeviceModel);
     const resetOnboardingAnalytics = useSetAtom(resetOnboardingAnalyticsAtom);
     const updateOnboardingAnalytics = useSetAtom(updateOnboardingAnalyticsAtom);
-
-    const supportsDeviceAuthentication = deviceModel
-        ? SUPPORTS_DEVICE_AUTHENTICITY_CHECK[deviceModel]
-        : true;
-
+    const { navigateToNextScreenAfterFirmwareInstallation } =
+        useNavigateToNextScreenAfterFirmwareInstallation();
     const handleConfirmButtonPress = () => {
         if (hasDeviceFirmwareInstalled) {
             if (isLatestFirmwareInstalled) {
@@ -107,16 +103,7 @@ export const UninitializedDeviceLandingScreen = ({
                     firmware: 'up-to-date',
                 });
 
-                if (deviceModel === DeviceModelInternal.T2T1) {
-                    // T2T1 does not support device tutorial and device authenticity check so those screens are skipped.
-                    navigation.navigate(DeviceOnboardingStackRoutes.CreateOrRecoverCrossroads);
-                } else {
-                    navigation.navigate(
-                        supportsDeviceAuthentication // TODO: check not only if supported, but also if allowed.
-                            ? DeviceOnboardingStackRoutes.DeviceAuthenticity
-                            : DeviceOnboardingStackRoutes.DeviceTutorial,
-                    );
-                }
+                navigateToNextScreenAfterFirmwareInstallation();
             } else {
                 navigation.navigate(DeviceOnboardingStackRoutes.ConfirmFirmwareUpdate);
             }

--- a/suite-native/module-device-onboarding/tsconfig.json
+++ b/suite-native/module-device-onboarding/tsconfig.json
@@ -8,6 +8,7 @@
         { "path": "../icons" },
         { "path": "../intl" },
         { "path": "../navigation" },
+        { "path": "../settings" },
         { "path": "../../packages/connect" },
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/env-utils" },

--- a/suite-native/module-settings/src/components/FeaturesSettings.tsx
+++ b/suite-native/module-settings/src/components/FeaturesSettings.tsx
@@ -72,12 +72,10 @@ export const FeaturesSettings = () => {
                         testID="@settings/coin-enabling"
                     />
                     <SettingsSectionItem
-                        iconName="trezorDevices"
-                        title={
-                            <Translation id="moduleSettings.items.features.deviceChecks.title" />
-                        }
+                        iconName="shieldWarning"
+                        title={<Translation id="moduleSettings.items.features.advanced.title" />}
                         subtitle={
-                            <Translation id="moduleSettings.items.features.deviceChecks.subtitle" />
+                            <Translation id="moduleSettings.items.features.advanced.subtitle" />
                         }
                         onPress={() => navigateTo(SettingsStackRoutes.SettingsDeviceChecks)}
                     />

--- a/suite-native/module-settings/src/components/SettingsSectionItem.tsx
+++ b/suite-native/module-settings/src/components/SettingsSectionItem.tsx
@@ -44,7 +44,7 @@ export const SettingsSectionItem = ({
                     {isLoading ? (
                         <ActivityIndicator size="small" color={utils.colors.iconSubdued} />
                     ) : (
-                        <Icon name="caretCircleRight" color="iconPrimaryDefault" />
+                        <Icon name="caretRight" color="iconSubdued" />
                     )}
                 </View>
             </Box>

--- a/suite-native/module-settings/src/components/TurnOffCheckCard.tsx
+++ b/suite-native/module-settings/src/components/TurnOffCheckCard.tsx
@@ -1,0 +1,85 @@
+import { ReactNode } from 'react';
+
+import { Button, HStack, Text, VStack } from '@suite-native/atoms';
+import { IconName } from '@suite-native/icons';
+import { Translation } from '@suite-native/intl';
+import { useOpenLink } from '@suite-native/link';
+import { SettingsCardWithIconLayout } from '@suite-native/settings';
+import { useToast } from '@suite-native/toasts';
+
+interface AuthenticityCheckCardProps {
+    isEnabled: boolean;
+    title: ReactNode;
+    subtitle: ReactNode;
+    icon: IconName;
+    learnMoreUrl: string;
+    onTurnOn: () => void;
+    onTurnOff: () => void;
+}
+
+const TurnOnButton = ({ onTurnOn }: { onTurnOn: () => void }) => {
+    const { showToast } = useToast();
+    const handleButtonPress = () => {
+        onTurnOn();
+        showToast({
+            variant: 'default',
+            message: <Translation id="moduleSettings.advanced.authenticityChecks.toastOn" />,
+            icon: 'check',
+        });
+    };
+
+    return (
+        <Button size="small" flex={1} onPress={handleButtonPress} colorScheme="primary">
+            <Translation id="moduleSettings.advanced.authenticityChecks.buttonTurnOn" />
+        </Button>
+    );
+};
+
+const TurnOffButton = ({ onTurnOff }: { onTurnOff: () => void }) => (
+    <Button size="small" flex={1} onPress={onTurnOff} colorScheme="yellowElevation0">
+        <Translation id="moduleSettings.advanced.authenticityChecks.buttonTurnOff" />
+    </Button>
+);
+
+const LearnMoreButton = ({ learnMoreUrl }: { learnMoreUrl: string }) => {
+    const openLink = useOpenLink();
+    const handleButtonPress = () => openLink(learnMoreUrl);
+
+    return (
+        <Button
+            size="small"
+            flex={1}
+            viewLeft="arrowSquareOut"
+            onPress={handleButtonPress}
+            colorScheme="tertiaryElevation0"
+        >
+            <Translation id="moduleSettings.advanced.authenticityChecks.buttonLearnMore" />
+        </Button>
+    );
+};
+
+export const TurnOffCheckCard = ({
+    isEnabled,
+    title,
+    subtitle,
+    icon,
+    learnMoreUrl,
+    onTurnOn,
+    onTurnOff,
+}: AuthenticityCheckCardProps) => (
+    <SettingsCardWithIconLayout icon={icon} title={title}>
+        <VStack spacing="sp16">
+            <Text variant="hint" color="textSubdued">
+                {subtitle}
+            </Text>
+            <HStack spacing="sp8">
+                <LearnMoreButton learnMoreUrl={learnMoreUrl} />
+                {isEnabled ? (
+                    <TurnOffButton onTurnOff={onTurnOff} />
+                ) : (
+                    <TurnOnButton onTurnOn={onTurnOn} />
+                )}
+            </HStack>
+        </VStack>
+    </SettingsCardWithIconLayout>
+);

--- a/suite-native/module-settings/src/components/TurnOffCheckScreenContent.tsx
+++ b/suite-native/module-settings/src/components/TurnOffCheckScreenContent.tsx
@@ -1,0 +1,129 @@
+import { ReactNode, useState } from 'react';
+import { Pressable } from 'react-native';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+
+import { useNavigation } from '@react-navigation/native';
+
+import {
+    Button,
+    Card,
+    CheckBox,
+    HStack,
+    IconListItem,
+    Text,
+    TitleHeader,
+    VStack,
+} from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import {
+    Screen,
+    ScreenHeader,
+    SettingsStackParamList,
+    SettingsStackRoutes,
+    StackNavigationProps,
+} from '@suite-native/navigation';
+import { useToast } from '@suite-native/toasts';
+
+const CHECKBOX_ANIMATION_DURATION = 200; // same as in useAccordionAnimation
+
+const InformativeList = () => (
+    <VStack spacing="sp24">
+        <IconListItem icon="warning" variant="yellow" iconSize="large" verticalAlign="flex-start">
+            <VStack spacing="sp4">
+                <Text variant="highlight">
+                    <Translation id="moduleSettings.advanced.authenticityChecks.turnOff.item1" />
+                </Text>
+                <Text variant="hint" color="textSubdued">
+                    <Translation id="moduleSettings.advanced.authenticityChecks.turnOff.item1Explanation" />
+                </Text>
+            </VStack>
+        </IconListItem>
+        <IconListItem icon="code" variant="yellow" iconSize="large" verticalAlign="flex-start">
+            <VStack spacing="sp4">
+                <Text variant="highlight">
+                    <Translation id="moduleSettings.advanced.authenticityChecks.turnOff.item2" />
+                </Text>
+                <Text variant="hint" color="textSubdued">
+                    <Translation id="moduleSettings.advanced.authenticityChecks.turnOff.item2Explanation" />
+                </Text>
+            </VStack>
+        </IconListItem>
+    </VStack>
+);
+
+type NavigationProp = StackNavigationProps<
+    SettingsStackParamList,
+    SettingsStackRoutes.SettingsDeviceChecks
+>;
+
+type TurnOffCheckScreenContentProps = {
+    title: ReactNode;
+    onConfirm: () => void;
+};
+
+export const TurnOffCheckScreenContent = ({ title, onConfirm }: TurnOffCheckScreenContentProps) => {
+    const [isChecked, setIsChecked] = useState(false);
+    const navigation = useNavigation<NavigationProp>();
+    const { showToast } = useToast();
+
+    const handleCheckboxPress = () => setIsChecked(prev => !prev);
+
+    const handleButtonPress = () => {
+        onConfirm();
+        if (navigation.canGoBack()) {
+            navigation.goBack();
+        } else {
+            navigation.navigate(SettingsStackRoutes.SettingsDeviceChecks);
+        }
+        showToast({
+            variant: 'default',
+            message: <Translation id="moduleSettings.advanced.authenticityChecks.toastOff" />,
+            icon: 'check',
+        });
+    };
+
+    return (
+        <Screen header={<ScreenHeader closeActionType="close" />}>
+            <VStack spacing="sp32" marginTop="sp8" flex={1}>
+                <TitleHeader
+                    titleVariant="titleMedium"
+                    title={title}
+                    subtitle={
+                        <Translation id="moduleSettings.advanced.authenticityChecks.turnOff.content" />
+                    }
+                />
+                <InformativeList />
+                <Pressable onPress={handleCheckboxPress}>
+                    <Card
+                        alertProps={{
+                            variant: 'warning',
+                            title: (
+                                <Text variant="callout">
+                                    <Translation id="moduleSettings.advanced.authenticityChecks.turnOff.acknowledgementNote" />
+                                </Text>
+                            ),
+                        }}
+                        alertPosition="bottom"
+                    >
+                        <HStack spacing="sp16" justifyContent="space-between">
+                            <Text>
+                                <Translation id="moduleSettings.advanced.authenticityChecks.turnOff.acknowledgement" />
+                            </Text>
+                            <CheckBox isChecked={isChecked} onChange={handleCheckboxPress} />
+                        </HStack>
+                    </Card>
+                </Pressable>
+            </VStack>
+            {isChecked && (
+                <Animated.View
+                    entering={FadeIn.duration(CHECKBOX_ANIMATION_DURATION)}
+                    exiting={FadeOut.duration(CHECKBOX_ANIMATION_DURATION)}
+                >
+                    <Button colorScheme="yellowBold" onPress={handleButtonPress}>
+                        <Translation id="moduleSettings.advanced.authenticityChecks.buttonTurnOff" />
+                    </Button>
+                </Animated.View>
+            )}
+        </Screen>
+    );
+};

--- a/suite-native/module-settings/src/components/TurnOffDeviceAuthenticityCheckCard.tsx
+++ b/suite-native/module-settings/src/components/TurnOffDeviceAuthenticityCheckCard.tsx
@@ -1,0 +1,40 @@
+import { useDispatch, useSelector } from 'react-redux';
+
+import { Translation } from '@suite-native/intl';
+import { SettingsStackRoutes } from '@suite-native/navigation';
+import {
+    selectIsDeviceAuthenticityCheckEnabled,
+    setDeviceAuthenticityCheckEnabled,
+} from '@suite-native/settings';
+import { HELP_CENTER_DEVICE_AUTHENTICATION_MOBILE } from '@trezor/urls';
+
+import { TurnOffCheckCard } from './TurnOffCheckCard';
+import { useSettingsNavigateTo } from '../navigation/useSettingsNavigateTo';
+
+export const TurnOffDeviceAuthenticityCheckCard = () => {
+    const isDeviceAuthenticityCheckEnabled = useSelector(selectIsDeviceAuthenticityCheckEnabled);
+    const dispatch = useDispatch();
+    const navigateTo = useSettingsNavigateTo();
+
+    const handleTurnOn = () => {
+        dispatch(setDeviceAuthenticityCheckEnabled(true));
+    };
+
+    const handleTurnOff = () => {
+        navigateTo(SettingsStackRoutes.TurnOffDeviceAuthenticityCheck);
+    };
+
+    return (
+        <TurnOffCheckCard
+            isEnabled={isDeviceAuthenticityCheckEnabled}
+            title={<Translation id="moduleSettings.advanced.authenticityChecks.device.title" />}
+            subtitle={
+                <Translation id="moduleSettings.advanced.authenticityChecks.device.subtitle" />
+            }
+            icon="trezorDevices"
+            learnMoreUrl={HELP_CENTER_DEVICE_AUTHENTICATION_MOBILE}
+            onTurnOn={handleTurnOn}
+            onTurnOff={handleTurnOff}
+        />
+    );
+};

--- a/suite-native/module-settings/src/components/TurnOffFirmwareAuthenticityCheckCard.tsx
+++ b/suite-native/module-settings/src/components/TurnOffFirmwareAuthenticityCheckCard.tsx
@@ -68,7 +68,7 @@ const TurnOffButton = () => {
     const navigateTo = useSettingsNavigateTo();
 
     const handleButtonPress = () => {
-        navigateTo(SettingsStackRoutes.TurnOffFirmwareAuthenticityCheckModal);
+        navigateTo(SettingsStackRoutes.TurnOffFirmwareAuthenticityCheck);
     };
 
     return (

--- a/suite-native/module-settings/src/components/TurnOffFirmwareAuthenticityCheckCard.tsx
+++ b/suite-native/module-settings/src/components/TurnOffFirmwareAuthenticityCheckCard.tsx
@@ -1,114 +1,40 @@
 import { useDispatch, useSelector } from 'react-redux';
 
-import { Button, HStack, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
-import { useOpenLink } from '@suite-native/link';
 import { SettingsStackRoutes } from '@suite-native/navigation';
 import {
-    SettingsCardWithIconLayout,
     selectIsFirmwareAuthenticityCheckEnabled,
     setCheckFirmwareAuthenticityEnabled,
 } from '@suite-native/settings';
-import { useToast } from '@suite-native/toasts';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { HELP_CENTER_FIRMWARE_REVISION_CHECK_MOBILE } from '@trezor/urls';
 
+import { TurnOffCheckCard } from './TurnOffCheckCard';
 import { useSettingsNavigateTo } from '../navigation/useSettingsNavigateTo';
 
-const fullWidthButtonStyle = prepareNativeStyle(() => ({ flex: 1 }));
-const shrinkedButtonStyle = prepareNativeStyle(utils => ({
-    paddingHorizontal: utils.spacings.sp16,
-}));
-
-const LearnMoreButton = ({ fullWidth }: { fullWidth?: boolean }) => {
-    const { applyStyle } = useNativeStyles();
-    const openLink = useOpenLink();
-    const handleButtonPress = () => openLink(HELP_CENTER_FIRMWARE_REVISION_CHECK_MOBILE);
-
-    return (
-        <Button
-            size="small"
-            viewLeft="arrowSquareOut"
-            onPress={handleButtonPress}
-            colorScheme="tertiaryElevation0"
-            style={applyStyle(fullWidth ? fullWidthButtonStyle : shrinkedButtonStyle)}
-        >
-            <Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.buttonLearnMore" />
-        </Button>
-    );
-};
-
-const TurnOnButton = () => {
-    const { applyStyle } = useNativeStyles();
+export const TurnOffFirmwareAuthenticityCheckCard = () => {
+    const isFwAuthenticityCheckEnabled = useSelector(selectIsFirmwareAuthenticityCheckEnabled);
     const dispatch = useDispatch();
-    const { showToast } = useToast();
-    const handleButtonPress = () => {
-        dispatch(setCheckFirmwareAuthenticityEnabled(true));
-        showToast({
-            variant: 'default',
-            message: 'Authenticity check turned on',
-            icon: 'check',
-        });
-    };
-
-    return (
-        <Button
-            size="small"
-            onPress={handleButtonPress}
-            colorScheme="primary"
-            style={applyStyle(fullWidthButtonStyle)}
-        >
-            <Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.buttonTurnOn" />
-        </Button>
-    );
-};
-
-const TurnOffButton = () => {
-    const { applyStyle } = useNativeStyles();
     const navigateTo = useSettingsNavigateTo();
 
-    const handleButtonPress = () => {
+    const handleTurnOn = () => {
+        dispatch(setCheckFirmwareAuthenticityEnabled(true));
+    };
+
+    const handleTurnOff = () => {
         navigateTo(SettingsStackRoutes.TurnOffFirmwareAuthenticityCheck);
     };
 
     return (
-        <Button
-            size="small"
-            onPress={handleButtonPress}
-            colorScheme="redElevation0"
-            style={applyStyle(shrinkedButtonStyle)}
-        >
-            <Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.buttonTurnOff" />
-        </Button>
-    );
-};
-
-export const TurnOffFirmwareAuthenticityCheckCard = () => {
-    const isFwAuthenticityCheckEnabled = useSelector(selectIsFirmwareAuthenticityCheckEnabled);
-
-    return (
-        <SettingsCardWithIconLayout
+        <TurnOffCheckCard
+            isEnabled={isFwAuthenticityCheckEnabled}
+            title={<Translation id="moduleSettings.advanced.authenticityChecks.firmware.title" />}
+            subtitle={
+                <Translation id="moduleSettings.advanced.authenticityChecks.firmware.subtitle" />
+            }
             icon="shieldCheck"
-            title={<Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.title" />}
-        >
-            <VStack spacing="sp16">
-                <Text variant="hint" color="textSubdued">
-                    <Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.subtitle" />
-                </Text>
-                <HStack spacing="sp8">
-                    {isFwAuthenticityCheckEnabled ? (
-                        <>
-                            <TurnOffButton />
-                            <LearnMoreButton fullWidth />
-                        </>
-                    ) : (
-                        <>
-                            <LearnMoreButton />
-                            <TurnOnButton />
-                        </>
-                    )}
-                </HStack>
-            </VStack>
-        </SettingsCardWithIconLayout>
+            learnMoreUrl={HELP_CENTER_FIRMWARE_REVISION_CHECK_MOBILE}
+            onTurnOn={handleTurnOn}
+            onTurnOff={handleTurnOff}
+        />
     );
 };

--- a/suite-native/module-settings/src/components/TurnOffFirmwareAuthenticityCheckCard.tsx
+++ b/suite-native/module-settings/src/components/TurnOffFirmwareAuthenticityCheckCard.tsx
@@ -33,7 +33,7 @@ const LearnMoreButton = ({ fullWidth }: { fullWidth?: boolean }) => {
             colorScheme="tertiaryElevation0"
             style={applyStyle(fullWidth ? fullWidthButtonStyle : shrinkedButtonStyle)}
         >
-            <Translation id="moduleSettings.deviceChecks.firmwareAuthenticityCheck.buttonLearnMore" />
+            <Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.buttonLearnMore" />
         </Button>
     );
 };
@@ -58,7 +58,7 @@ const TurnOnButton = () => {
             colorScheme="primary"
             style={applyStyle(fullWidthButtonStyle)}
         >
-            <Translation id="moduleSettings.deviceChecks.firmwareAuthenticityCheck.buttonTurnOn" />
+            <Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.buttonTurnOn" />
         </Button>
     );
 };
@@ -78,7 +78,7 @@ const TurnOffButton = () => {
             colorScheme="redElevation0"
             style={applyStyle(shrinkedButtonStyle)}
         >
-            <Translation id="moduleSettings.deviceChecks.firmwareAuthenticityCheck.buttonTurnOff" />
+            <Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.buttonTurnOff" />
         </Button>
     );
 };
@@ -89,11 +89,11 @@ export const TurnOffFirmwareAuthenticityCheckCard = () => {
     return (
         <SettingsCardWithIconLayout
             icon="shieldCheck"
-            title={<Translation id="moduleSettings.deviceChecks.firmwareAuthenticityCheck.title" />}
+            title={<Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.title" />}
         >
             <VStack spacing="sp16">
                 <Text variant="hint" color="textSubdued">
-                    <Translation id="moduleSettings.deviceChecks.firmwareAuthenticityCheck.subtitle" />
+                    <Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.subtitle" />
                 </Text>
                 <HStack spacing="sp8">
                     {isFwAuthenticityCheckEnabled ? (

--- a/suite-native/module-settings/src/navigation/SettingsStackNavigator.tsx
+++ b/suite-native/module-settings/src/navigation/SettingsStackNavigator.tsx
@@ -14,7 +14,7 @@ import { SettingsFAQScreen } from '../screens/SettingsFAQScreen';
 import { SettingsLocalizationScreen } from '../screens/SettingsLocalizationScreen';
 import { SettingsPrivacyAndSecurityScreen } from '../screens/SettingsPrivacyAndSecurityScreen';
 import { SettingsViewOnlyScreen } from '../screens/SettingsViewOnlyScreen';
-import { TurnOffFirmwareAuthenticityCheckModalScreen } from '../screens/TurnOffFirmwareAuthenticityCheckModalScreen';
+import { TurnOffFirmwareAuthenticityCheckScreen } from '../screens/TurnOffFirmwareAuthenticityCheckScreen';
 
 const SettingsStack = createNativeStackNavigator<SettingsStackParamList>();
 
@@ -60,8 +60,8 @@ export const SettingsStackNavigator = () => (
             component={SettingsDeviceChecksScreen}
         />
         <SettingsStack.Screen
-            name={SettingsStackRoutes.TurnOffFirmwareAuthenticityCheckModal}
-            component={TurnOffFirmwareAuthenticityCheckModalScreen}
+            name={SettingsStackRoutes.TurnOffFirmwareAuthenticityCheck}
+            component={TurnOffFirmwareAuthenticityCheckScreen}
         />
     </SettingsStack.Navigator>
 );

--- a/suite-native/module-settings/src/navigation/SettingsStackNavigator.tsx
+++ b/suite-native/module-settings/src/navigation/SettingsStackNavigator.tsx
@@ -14,6 +14,7 @@ import { SettingsFAQScreen } from '../screens/SettingsFAQScreen';
 import { SettingsLocalizationScreen } from '../screens/SettingsLocalizationScreen';
 import { SettingsPrivacyAndSecurityScreen } from '../screens/SettingsPrivacyAndSecurityScreen';
 import { SettingsViewOnlyScreen } from '../screens/SettingsViewOnlyScreen';
+import { TurnOffDeviceAuthenticityCheckScreen } from '../screens/TurnOffDeviceAuthenticityCheckScreen';
 import { TurnOffFirmwareAuthenticityCheckScreen } from '../screens/TurnOffFirmwareAuthenticityCheckScreen';
 
 const SettingsStack = createNativeStackNavigator<SettingsStackParamList>();
@@ -62,6 +63,10 @@ export const SettingsStackNavigator = () => (
         <SettingsStack.Screen
             name={SettingsStackRoutes.TurnOffFirmwareAuthenticityCheck}
             component={TurnOffFirmwareAuthenticityCheckScreen}
+        />
+        <SettingsStack.Screen
+            name={SettingsStackRoutes.TurnOffDeviceAuthenticityCheck}
+            component={TurnOffDeviceAuthenticityCheckScreen}
         />
     </SettingsStack.Navigator>
 );

--- a/suite-native/module-settings/src/screens/SettingsDeviceChecksScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsDeviceChecksScreen.tsx
@@ -3,6 +3,7 @@ import { Icon } from '@suite-native/icons';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { Screen, ScreenHeader } from '@suite-native/navigation';
 
+import { TurnOffDeviceAuthenticityCheckCard } from '../components/TurnOffDeviceAuthenticityCheckCard';
 import { TurnOffFirmwareAuthenticityCheckCard } from '../components/TurnOffFirmwareAuthenticityCheckCard';
 
 export const SettingsDeviceChecksScreen = () => {
@@ -12,6 +13,7 @@ export const SettingsDeviceChecksScreen = () => {
         <Screen header={<ScreenHeader content={translate('moduleSettings.advanced.title')} />}>
             <VStack spacing="sp16">
                 <TurnOffFirmwareAuthenticityCheckCard />
+                <TurnOffDeviceAuthenticityCheckCard />
                 <VStack alignItems="center" spacing="sp12">
                     <Icon name="warning" color="textAlertYellow" size="extraLarge" />
                     <Text variant="hint" color="textAlertYellow" textAlign="center">

--- a/suite-native/module-settings/src/screens/SettingsDeviceChecksScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsDeviceChecksScreen.tsx
@@ -7,7 +7,7 @@ export const SettingsDeviceChecksScreen = () => {
     const { translate } = useTranslate();
 
     return (
-        <Screen header={<ScreenHeader content={translate('moduleSettings.deviceChecks.title')} />}>
+        <Screen header={<ScreenHeader content={translate('moduleSettings.advanced.title')} />}>
             <TurnOffFirmwareAuthenticityCheckCard />
         </Screen>
     );

--- a/suite-native/module-settings/src/screens/SettingsDeviceChecksScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsDeviceChecksScreen.tsx
@@ -1,4 +1,6 @@
-import { useTranslate } from '@suite-native/intl';
+import { Text, VStack } from '@suite-native/atoms';
+import { Icon } from '@suite-native/icons';
+import { Translation, useTranslate } from '@suite-native/intl';
 import { Screen, ScreenHeader } from '@suite-native/navigation';
 
 import { TurnOffFirmwareAuthenticityCheckCard } from '../components/TurnOffFirmwareAuthenticityCheckCard';
@@ -8,7 +10,15 @@ export const SettingsDeviceChecksScreen = () => {
 
     return (
         <Screen header={<ScreenHeader content={translate('moduleSettings.advanced.title')} />}>
-            <TurnOffFirmwareAuthenticityCheckCard />
+            <VStack spacing="sp16">
+                <TurnOffFirmwareAuthenticityCheckCard />
+                <VStack alignItems="center" spacing="sp12">
+                    <Icon name="warning" color="textAlertYellow" size="extraLarge" />
+                    <Text variant="hint" color="textAlertYellow" textAlign="center">
+                        <Translation id="moduleSettings.advanced.goodAdvice" />
+                    </Text>
+                </VStack>
+            </VStack>
         </Screen>
     );
 };

--- a/suite-native/module-settings/src/screens/TurnOffDeviceAuthenticityCheckScreen.tsx
+++ b/suite-native/module-settings/src/screens/TurnOffDeviceAuthenticityCheckScreen.tsx
@@ -1,21 +1,21 @@
 import { useDispatch } from 'react-redux';
 
 import { Translation } from '@suite-native/intl';
-import { setCheckFirmwareAuthenticityEnabled } from '@suite-native/settings';
+import { setDeviceAuthenticityCheckEnabled } from '@suite-native/settings';
 
 import { TurnOffCheckScreenContent } from '../components/TurnOffCheckScreenContent';
 
-export const TurnOffFirmwareAuthenticityCheckScreen = () => {
+export const TurnOffDeviceAuthenticityCheckScreen = () => {
     const dispatch = useDispatch();
 
     const handleConfirm = () => {
-        dispatch(setCheckFirmwareAuthenticityEnabled(false));
+        dispatch(setDeviceAuthenticityCheckEnabled(false));
     };
 
     return (
         <TurnOffCheckScreenContent
             title={
-                <Translation id="moduleSettings.advanced.authenticityChecks.firmware.turnOffTitle" />
+                <Translation id="moduleSettings.advanced.authenticityChecks.device.turnOffTitle" />
             }
             onConfirm={handleConfirm}
         />

--- a/suite-native/module-settings/src/screens/TurnOffFirmwareAuthenticityCheckModalScreen.tsx
+++ b/suite-native/module-settings/src/screens/TurnOffFirmwareAuthenticityCheckModalScreen.tsx
@@ -33,20 +33,20 @@ const InformativeList = () => (
         <IconListItem icon="warning" variant="yellow" iconSize="large" verticalAlign="flex-start">
             <VStack spacing="sp4">
                 <Text variant="highlight">
-                    <Translation id="moduleSettings.deviceChecks.firmwareAuthenticityCheck.turnOffModal.item1" />
+                    <Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.turnOffModal.item1" />
                 </Text>
                 <Text variant="hint" color="textSubdued">
-                    <Translation id="moduleSettings.deviceChecks.firmwareAuthenticityCheck.turnOffModal.item1Explanation" />
+                    <Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.turnOffModal.item1Explanation" />
                 </Text>
             </VStack>
         </IconListItem>
         <IconListItem icon="code" variant="yellow" iconSize="large" verticalAlign="flex-start">
             <VStack spacing="sp4">
                 <Text variant="highlight">
-                    <Translation id="moduleSettings.deviceChecks.firmwareAuthenticityCheck.turnOffModal.item2" />
+                    <Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.turnOffModal.item2" />
                 </Text>
                 <Text variant="hint" color="textSubdued">
-                    <Translation id="moduleSettings.deviceChecks.firmwareAuthenticityCheck.turnOffModal.item2Explanation" />
+                    <Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.turnOffModal.item2Explanation" />
                 </Text>
             </VStack>
         </IconListItem>
@@ -86,10 +86,10 @@ export const TurnOffFirmwareAuthenticityCheckModalScreen = () => {
                 <TitleHeader
                     titleVariant="titleMedium"
                     title={
-                        <Translation id="moduleSettings.deviceChecks.firmwareAuthenticityCheck.turnOffModal.title" />
+                        <Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.turnOffModal.title" />
                     }
                     subtitle={
-                        <Translation id="moduleSettings.deviceChecks.firmwareAuthenticityCheck.turnOffModal.content" />
+                        <Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.turnOffModal.content" />
                     }
                 />
                 <InformativeList />
@@ -98,7 +98,7 @@ export const TurnOffFirmwareAuthenticityCheckModalScreen = () => {
                         <HStack spacing="sp16">
                             <CheckBox isChecked={isChecked} onChange={handleCheckboxPress} />
                             <Text variant="highlight">
-                                <Translation id="moduleSettings.deviceChecks.firmwareAuthenticityCheck.turnOffModal.acknowledgement" />
+                                <Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.turnOffModal.acknowledgement" />
                             </Text>
                         </HStack>
                     </Card>
@@ -110,7 +110,7 @@ export const TurnOffFirmwareAuthenticityCheckModalScreen = () => {
                     exiting={FadeOut.duration(CHECKBOX_ANIMATION_DURATION)}
                 >
                     <Button colorScheme="yellowBold" onPress={handleButtonPress}>
-                        <Translation id="moduleSettings.deviceChecks.firmwareAuthenticityCheck.turnOffModal.buttonTurnOff" />
+                        <Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.turnOffModal.buttonTurnOff" />
                     </Button>
                 </Animated.View>
             )}

--- a/suite-native/module-settings/src/screens/TurnOffFirmwareAuthenticityCheckModalScreen.tsx
+++ b/suite-native/module-settings/src/screens/TurnOffFirmwareAuthenticityCheckModalScreen.tsx
@@ -94,12 +94,22 @@ export const TurnOffFirmwareAuthenticityCheckModalScreen = () => {
                 />
                 <InformativeList />
                 <Pressable onPress={handleCheckboxPress}>
-                    <Card>
-                        <HStack spacing="sp16">
-                            <CheckBox isChecked={isChecked} onChange={handleCheckboxPress} />
-                            <Text variant="highlight">
+                    <Card
+                        alertProps={{
+                            variant: 'warning',
+                            title: (
+                                <Text variant="callout">
+                                    <Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.turnOffModal.acknowledgementNote" />
+                                </Text>
+                            ),
+                        }}
+                        alertPosition="bottom"
+                    >
+                        <HStack spacing="sp16" justifyContent="space-between">
+                            <Text>
                                 <Translation id="moduleSettings.advanced.firmwareAuthenticityCheck.turnOffModal.acknowledgement" />
                             </Text>
+                            <CheckBox isChecked={isChecked} onChange={handleCheckboxPress} />
                         </HStack>
                     </Card>
                 </Pressable>

--- a/suite-native/module-settings/src/screens/TurnOffFirmwareAuthenticityCheckScreen.tsx
+++ b/suite-native/module-settings/src/screens/TurnOffFirmwareAuthenticityCheckScreen.tsx
@@ -58,7 +58,7 @@ type NavigationProp = StackNavigationProps<
     SettingsStackRoutes.SettingsDeviceChecks
 >;
 
-export const TurnOffFirmwareAuthenticityCheckModalScreen = () => {
+export const TurnOffFirmwareAuthenticityCheckScreen = () => {
     const [isChecked, setIsChecked] = useState(false);
     const navigation = useNavigation<NavigationProp>();
     const dispatch = useDispatch();

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -72,7 +72,7 @@ export type SettingsStackParamList = {
     [SettingsStackRoutes.SettingsFAQ]: undefined;
     [SettingsStackRoutes.SettingsCoinEnabling]: undefined;
     [SettingsStackRoutes.SettingsDeviceChecks]: undefined;
-    [SettingsStackRoutes.TurnOffFirmwareAuthenticityCheckModal]: undefined;
+    [SettingsStackRoutes.TurnOffFirmwareAuthenticityCheck]: undefined;
 };
 
 export type ReceiveStackParamList = {

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -72,6 +72,7 @@ export type SettingsStackParamList = {
     [SettingsStackRoutes.SettingsFAQ]: undefined;
     [SettingsStackRoutes.SettingsCoinEnabling]: undefined;
     [SettingsStackRoutes.SettingsDeviceChecks]: undefined;
+    [SettingsStackRoutes.TurnOffDeviceAuthenticityCheck]: undefined;
     [SettingsStackRoutes.TurnOffFirmwareAuthenticityCheck]: undefined;
 };
 

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -143,7 +143,7 @@ export enum SettingsStackRoutes {
     SettingsFAQ = 'SettingsFAQ',
     SettingsCoinEnabling = 'SettingsCoinEnabling',
     SettingsDeviceChecks = 'SettingsDeviceChecks',
-    TurnOffFirmwareAuthenticityCheckModal = 'TurnOffFirmwareAuthenticityCheckModal',
+    TurnOffFirmwareAuthenticityCheck = 'TurnOffFirmwareAuthenticityCheck',
 }
 
 export enum TradingStackRoutes {

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -143,6 +143,7 @@ export enum SettingsStackRoutes {
     SettingsFAQ = 'SettingsFAQ',
     SettingsCoinEnabling = 'SettingsCoinEnabling',
     SettingsDeviceChecks = 'SettingsDeviceChecks',
+    TurnOffDeviceAuthenticityCheck = 'TurnOffDeviceAuthenticityCheck',
     TurnOffFirmwareAuthenticityCheck = 'TurnOffFirmwareAuthenticityCheck',
 }
 

--- a/suite-native/settings/src/settingsSlice.ts
+++ b/suite-native/settings/src/settingsSlice.ts
@@ -9,6 +9,7 @@ export interface AppSettingsState {
     fiatCurrencyCode: FiatCurrencyCode;
     bitcoinUnits: PROTO.AmountUnit;
     viewOnlyCancelationTimestamp?: number;
+    isDeviceAuthenticityCheckEnabled: boolean;
     isFirmwareRevisionCheckEnabled: boolean;
     isFirmwareHashCheckEnabled: boolean;
 }
@@ -22,6 +23,7 @@ export const appSettingsInitialState: AppSettingsState = {
     bitcoinUnits: PROTO.AmountUnit.BITCOIN,
     isOnboardingFinished: false,
     viewOnlyCancelationTimestamp: undefined,
+    isDeviceAuthenticityCheckEnabled: true,
     isFirmwareRevisionCheckEnabled: true,
     isFirmwareHashCheckEnabled: true,
 };
@@ -31,6 +33,7 @@ export const appSettingsPersistWhitelist: Array<keyof AppSettingsState> = [
     'fiatCurrencyCode',
     'bitcoinUnits',
     'viewOnlyCancelationTimestamp',
+    'isDeviceAuthenticityCheckEnabled',
     'isFirmwareRevisionCheckEnabled',
     'isFirmwareHashCheckEnabled',
 ];
@@ -58,6 +61,9 @@ export const appSettingsSlice = createSlice({
             state.isFirmwareRevisionCheckEnabled = payload;
             state.isFirmwareHashCheckEnabled = payload;
         },
+        setDeviceAuthenticityCheckEnabled: (state, { payload }: PayloadAction<boolean>) => {
+            state.isDeviceAuthenticityCheckEnabled = payload;
+        },
     },
 });
 
@@ -70,6 +76,8 @@ export const selectIsOnboardingFinished = (state: SettingsSliceRootState) =>
     state.appSettings.isOnboardingFinished;
 export const selectViewOnlyCancelationTimestamp = (state: SettingsSliceRootState) =>
     state.appSettings.viewOnlyCancelationTimestamp;
+export const selectIsDeviceAuthenticityCheckEnabled = (state: SettingsSliceRootState) =>
+    state.appSettings.isDeviceAuthenticityCheckEnabled;
 
 /**
  * Determine if either FW revision or FW hash check is disabled
@@ -98,6 +106,7 @@ export const {
     setFiatCurrency,
     setBitcoinUnits,
     setViewOnlyCancelationTimestamp,
+    setDeviceAuthenticityCheckEnabled,
     setCheckFirmwareAuthenticityEnabled,
 } = appSettingsSlice.actions;
 export const appSettingsReducer = appSettingsSlice.reducer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10586,6 +10586,7 @@ __metadata:
     "@suite-native/icons": "workspace:*"
     "@suite-native/intl": "workspace:*"
     "@suite-native/navigation": "workspace:*"
+    "@suite-native/settings": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"


### PR DESCRIPTION
## Description

Adding possibility to turn off Device Auth check for special use cases. 
There were minor UI and copy updates for the current Turn off firmware authenticity settings too.

Review can be easier commit by commit.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17860

## Screenshots:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/e2b81fbf-7f6a-470b-bab5-e9c636c9efb1" />


<img width="300" alt="image" src="https://github.com/user-attachments/assets/d2c09e6c-42a6-4874-a966-8373b127f5f8" />




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/device-auth-check-turn-off&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/device-auth-check-turn-off&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/device-auth-check-turn-off&lookback=7)