### PR TITLE
Unify logic for default wallet backup preselection and apply it on mobile

### DIFF
--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -1,3 +1,4 @@
+import { BackupType } from '@suite-common/suite-types';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 import { OnboardingAnalytics } from '@trezor/suite-analytics';
@@ -5,7 +6,7 @@ import { OnboardingAnalytics } from '@trezor/suite-analytics';
 import { ONBOARDING } from 'src/actions/onboarding/constants';
 import { stepCategories } from 'src/config/onboarding/steps';
 import * as STEP from 'src/constants/onboarding/steps';
-import { BackupType, DeviceTutorialStatus } from 'src/reducers/onboarding/onboardingReducer';
+import { DeviceTutorialStatus } from 'src/reducers/onboarding/onboardingReducer';
 import { AnyPath, AnyStepId } from 'src/types/onboarding';
 import { Dispatch, GetState } from 'src/types/suite';
 import { findNextStep, findPrevStep, isStepUsed } from 'src/utils/onboarding/steps';

--- a/packages/suite/src/reducers/onboarding/onboardingReducer.ts
+++ b/packages/suite/src/reducers/onboarding/onboardingReducer.ts
@@ -1,5 +1,6 @@
 import { produce } from 'immer';
 
+import { BackupType } from '@suite-common/suite-types';
 import { DEVICE } from '@trezor/connect';
 import { OnboardingAnalytics } from '@trezor/suite-analytics';
 
@@ -13,15 +14,6 @@ export interface OnboardingRootState {
 }
 
 export type DeviceTutorialStatus = 'active' | 'completed' | 'cancelled' | null;
-
-export const selectBackupTypes = [
-    'shamir-single',
-    'shamir-advanced',
-    '12-words',
-    '24-words',
-] as const;
-
-export type BackupType = (typeof selectBackupTypes)[number];
 
 export interface OnboardingState {
     backupType: BackupType;

--- a/packages/suite/src/views/onboarding/steps/ResetDevice.tsx
+++ b/packages/suite/src/views/onboarding/steps/ResetDevice.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { BackupType } from '@suite-common/suite-types';
+import { selectDeviceDefaultBackupType, selectSelectedDevice } from '@suite-common/wallet-core';
 import { Button, Divider, Text, Tooltip } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
@@ -13,12 +14,7 @@ import * as STEP from 'src/constants/onboarding/steps';
 import { useDevice, useDispatch, useOnboarding, useSelector } from 'src/hooks/suite';
 import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
 
-import {
-    SelectBackupType,
-    getDefaultBackupType,
-    isShamirBackupType,
-} from './SelectBackupType/SelectBackupType';
-import { BackupType } from '../../../reducers/onboarding/onboardingReducer';
+import { SelectBackupType, isShamirBackupType } from './SelectBackupType/SelectBackupType';
 
 const SelectWrapper = styled.div`
     width: 100%;
@@ -37,18 +33,11 @@ const canChooseBackupType = (device: DeviceModelInternal) => device !== DeviceMo
 export const ResetDeviceStep = () => {
     const { isLocked } = useDevice();
     const device = useSelector(selectSelectedDevice);
+    const deviceDefaultBackupType = useSelector(selectDeviceDefaultBackupType);
     const isActionAbortable = useSelector(selectIsActionAbortable);
 
     const deviceModel = device?.features?.internal_model;
     const unitPackaging = device?.features?.unit_packaging ?? 0;
-
-    const deviceDefaultBackupType: BackupType =
-        deviceModel !== undefined
-            ? getDefaultBackupType({
-                  model: deviceModel,
-                  packaging: unitPackaging,
-              })
-            : 'shamir-single';
 
     const [submitted, setSubmitted] = useState(false);
     const [backupType, setBackupType] = useState<BackupType>(deviceDefaultBackupType);
@@ -103,9 +92,9 @@ export const ResetDeviceStep = () => {
 
     useEffect(() => {
         if (deviceModel !== undefined && !canChooseBackupType(deviceModel)) {
-            handleSubmit(getDefaultBackupType({ model: deviceModel, packaging: unitPackaging }));
+            handleSubmit(deviceDefaultBackupType);
         }
-    }, [deviceModel, handleSubmit, unitPackaging]);
+    }, [deviceModel, handleSubmit, unitPackaging, deviceDefaultBackupType]);
 
     // this step expects device
     if (!device || !device.features) {

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/FloatingSelections.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/FloatingSelections.tsx
@@ -2,6 +2,7 @@ import { CSSProperties, forwardRef, useRef } from 'react';
 
 import styled from 'styled-components';
 
+import { BackupType } from '@suite-common/suite-types';
 import {
     Banner,
     CollapsibleBox,
@@ -26,7 +27,6 @@ import { Translation, TrezorLink } from 'src/components/suite';
 import { LegacyOptions } from './LegacyOptions';
 import { isShamirBackupType } from './SelectBackupType';
 import { ShamirOptions } from './ShamirOptions';
-import { BackupType } from '../../../../reducers/onboarding/onboardingReducer';
 
 const OptionGroupHeading = styled.div`
     display: flex;

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/LegacyOptions.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/LegacyOptions.tsx
@@ -1,10 +1,10 @@
+import { BackupType } from '@suite-common/suite-types';
 import { Tooltip } from '@trezor/components';
 
 import { Translation } from 'src/components/suite';
 
 import { DefaultTag } from './DefaultTag';
 import { OptionWithContent } from './OptionWithContent';
-import { BackupType } from '../../../../reducers/onboarding/onboardingReducer';
 
 type LegacyOptionsProps = {
     selected: BackupType;

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/OptionWithContent.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/OptionWithContent.tsx
@@ -2,6 +2,7 @@ import { ReactNode, forwardRef } from 'react';
 
 import styled, { css } from 'styled-components';
 
+import { BackupType } from '@suite-common/suite-types';
 import { Icon, Radio, Row, Text, Tooltip, useElevation, variables } from '@trezor/components';
 import {
     Elevation,
@@ -15,7 +16,6 @@ import { Translation } from 'src/components/suite';
 import { useLayoutSize } from 'src/hooks/suite';
 
 import { typesToLabelMap } from './typesToLabelMap';
-import { BackupType } from '../../../../reducers/onboarding/onboardingReducer';
 
 export const OptionText = styled.div`
     display: flex;

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/SelectBackupType.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/SelectBackupType.tsx
@@ -15,9 +15,9 @@ import {
 import styled from 'styled-components';
 
 import { TranslationKey } from '@suite-common/intl-types';
-import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { BackupType } from '@suite-common/suite-types';
+import { selectDeviceDefaultBackupType } from '@suite-common/wallet-core';
 import { Banner, ElevationUp, Text, useElevation } from '@trezor/components';
-import { DeviceModelInternal } from '@trezor/device-utils';
 import {
     Elevation,
     borders,
@@ -31,7 +31,6 @@ import { OptionText, SelectedOption } from './OptionWithContent';
 import { typesToLabelMap } from './typesToLabelMap';
 import { Translation } from '../../../../components/suite';
 import { useLayoutSize, useSelector } from '../../../../hooks/suite';
-import { BackupType } from '../../../../reducers/onboarding/onboardingReducer';
 
 const SELECT_ELEMENT_HEIGHT = 84;
 const SELECT_ELEMENT_HEIGHT_MOBILE = 62;
@@ -39,30 +38,6 @@ const SELECT_ELEMENT_HEIGHT_MOBILE = 62;
 const SHAMIR_TYPES: BackupType[] = ['shamir-single', 'shamir-advanced'];
 
 export const isShamirBackupType = (type: BackupType) => SHAMIR_TYPES.includes(type);
-
-export const defaultBackupTypeMap: Record<DeviceModelInternal, BackupType> = {
-    [DeviceModelInternal.UNKNOWN]: '12-words', // just to have something
-    [DeviceModelInternal.T1B1]: '24-words',
-    [DeviceModelInternal.T2T1]: '12-words',
-    [DeviceModelInternal.T2B1]: 'shamir-single',
-    [DeviceModelInternal.T3B1]: 'shamir-single',
-    [DeviceModelInternal.T3T1]: 'shamir-single',
-    [DeviceModelInternal.T3W1]: 'shamir-single',
-};
-
-type GetDefaultBackupTypeParams = { model: DeviceModelInternal; packaging: number };
-
-export const getDefaultBackupType = ({
-    model,
-    packaging,
-}: GetDefaultBackupTypeParams): BackupType => {
-    // Original package of Trezor Safe 3 has a card with just 12 words.
-    if (model === DeviceModelInternal.T2B1 && packaging === 0) {
-        return '12-words';
-    }
-
-    return defaultBackupTypeMap[model];
-};
 
 const Wrapper = styled.div`
     width: 100%;
@@ -102,18 +77,11 @@ export const SelectBackupType = ({
 }: SelectBackupTypeProps) => {
     const { elevation } = useElevation();
     const [isOpen, setIsOpen] = useState(false);
-    const device = useSelector(selectSelectedDevice);
+    const deviceDefaultBackupType = useSelector(selectDeviceDefaultBackupType);
     const { isMobileLayout } = useLayoutSize();
 
-    const defaultBackupType: BackupType = device?.features?.internal_model
-        ? getDefaultBackupType({
-              model: device.features.internal_model,
-              packaging: device.features.unit_packaging ?? 0,
-          })
-        : 'shamir-single';
-
-    const isDefault = defaultBackupType === selected;
-    const isShamirDefault = isShamirBackupType(defaultBackupType);
+    const isDefault = deviceDefaultBackupType === selected;
+    const isShamirDefault = isShamirBackupType(deviceDefaultBackupType);
     const isShamirSelected = isShamirBackupType(selected);
 
     const { refs, floatingStyles, context } = useFloating({
@@ -170,7 +138,7 @@ export const SelectBackupType = ({
                         <FloatingPortal>
                             <FloatingFocusManager context={context} modal={false}>
                                 <FloatingSelections
-                                    defaultType={defaultBackupType}
+                                    defaultType={deviceDefaultBackupType}
                                     ref={refs.setFloating}
                                     style={floatingStyles}
                                     {...getFloatingProps()}

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/ShamirOptions.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/ShamirOptions.tsx
@@ -1,5 +1,6 @@
 import { satisfies } from 'semver';
 
+import { BackupType } from '@suite-common/suite-types';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Badge, Tooltip } from '@trezor/components';
 import { getFirmwareVersion } from '@trezor/device-utils';
@@ -9,7 +10,6 @@ import { DefaultTag } from './DefaultTag';
 import { OptionWithContent } from './OptionWithContent';
 import { Translation } from '../../../../components/suite';
 import { useLayoutSize, useSelector } from '../../../../hooks/suite';
-import { BackupType } from '../../../../reducers/onboarding/onboardingReducer';
 
 const UpgradableToMultiTag = () => {
     const { isMobileLayout } = useLayoutSize();

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/typesToLabelMap.ts
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/typesToLabelMap.ts
@@ -1,6 +1,5 @@
 import { TranslationKey } from '@suite-common/intl-types';
-
-import { BackupType } from '../../../../reducers/onboarding/onboardingReducer';
+import { BackupType } from '@suite-common/suite-types';
 
 export const typesToLabelMap: Record<BackupType, TranslationKey> = {
     'shamir-single': 'TR_ONBOARDING_SEED_TYPE_SINGLE_SEED',

--- a/suite-common/suite-types/src/index.ts
+++ b/suite-common/suite-types/src/index.ts
@@ -8,6 +8,7 @@ export * from './modal';
 export * from './github';
 export * from './messageSystem';
 export * from './route';
+export * from './walletBackupType';
 
 export type Selector<TReturnValue> = (state: any) => TReturnValue;
 export type SuiteCompatibleAction<TPayload> = (

--- a/suite-common/suite-types/src/walletBackupType.ts
+++ b/suite-common/suite-types/src/walletBackupType.ts
@@ -1,0 +1,8 @@
+export const selectBackupTypes = [
+    'shamir-single',
+    'shamir-advanced',
+    '12-words',
+    '24-words',
+] as const;
+
+export type BackupType = (typeof selectBackupTypes)[number];

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -10,7 +10,7 @@ import {
     createWeakMapSelector,
     returnStableArrayIfEmpty,
 } from '@suite-common/redux-utils';
-import { AcquiredDevice, ButtonRequest, TrezorDevice } from '@suite-common/suite-types';
+import { AcquiredDevice, BackupType, ButtonRequest, TrezorDevice } from '@suite-common/suite-types';
 import * as deviceUtils from '@suite-common/suite-utils';
 import {
     getDeviceInstances,
@@ -21,6 +21,7 @@ import {
 import { networkSymbolCollection } from '@suite-common/wallet-config';
 import { Device, DeviceState, Features, KnownDevice, StaticSessionId, UI } from '@trezor/connect';
 import {
+    DeviceModelInternal,
     getFirmwareVersion,
     getFirmwareVersionArray,
     hasBitcoinOnlyFirmware,
@@ -1153,3 +1154,30 @@ export const selectFirmwareChangelog = (state: DeviceRootState) => {
 
     return device?.firmwareRelease?.changelog?.[0]?.changelog;
 };
+
+export const selectDeviceUnitPackaging = createMemoizedSelector(
+    [selectDeviceFeatures],
+    features => features?.unit_packaging ?? 0,
+);
+
+const defaultBackupTypeMap: Record<DeviceModelInternal, BackupType> = {
+    [DeviceModelInternal.UNKNOWN]: '12-words', // just to have something
+    [DeviceModelInternal.T1B1]: '24-words',
+    [DeviceModelInternal.T2T1]: '12-words',
+    [DeviceModelInternal.T2B1]: 'shamir-single',
+    [DeviceModelInternal.T3B1]: 'shamir-single',
+    [DeviceModelInternal.T3T1]: 'shamir-single',
+    [DeviceModelInternal.T3W1]: 'shamir-single',
+};
+
+export const selectDeviceDefaultBackupType = createMemoizedSelector(
+    [selectDeviceModel, selectDeviceUnitPackaging],
+    (deviceModel, deviceUnitPackaging) => {
+        // Original package of Trezor Safe 3 has a card with just 12 words.
+        if (deviceModel === DeviceModelInternal.T2B1 && deviceUnitPackaging === 0) {
+            return '12-words';
+        }
+
+        return deviceModel ? defaultBackupTypeMap[deviceModel] : 'shamir-single';
+    },
+);

--- a/suite-native/module-device-onboarding/src/screens/WalletBackupTutorialScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletBackupTutorialScreen.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/core';
 
-import { selectDeviceModel } from '@suite-common/wallet-core';
+import { selectDeviceDefaultBackupType } from '@suite-common/wallet-core';
 import { WalletBackupType } from '@suite-native/device';
 import {
     DeviceOnboardingStackParamList,
@@ -13,7 +13,6 @@ import {
     Screen,
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
-import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { SwipeableWalkthrough } from '../components/SwipeableWalkthrough/SwipeableWalkthrough';
 import { SwipeableWalkthroughScreenHeader } from '../components/SwipeableWalkthrough/SwipeableWalkthroughScreenHeader';
@@ -33,10 +32,9 @@ type NavigationProps = StackToStackCompositeNavigationProps<
 
 export const WalletBackupTutorialScreen = () => {
     const currentStepIndex = useSharedValue(0);
-    const deviceModel = useSelector(selectDeviceModel);
-    const [selectedBackupType, setSelectedBackupType] = useState<WalletBackupType>(
-        deviceModel === DeviceModelInternal.T2T1 ? '12-words' : 'shamir-single',
-    );
+    const defaultBackupType = useSelector(selectDeviceDefaultBackupType);
+    const [selectedBackupType, setSelectedBackupType] =
+        useState<WalletBackupType>(defaultBackupType);
 
     const navigation = useNavigation<NavigationProps>();
 

--- a/suite-native/navigation/package.json
+++ b/suite-native/navigation/package.json
@@ -16,6 +16,7 @@
         "@react-navigation/native": "6.1.18",
         "@react-navigation/native-stack": "6.11.0",
         "@suite-common/message-system": "workspace:*",
+        "@suite-common/suite-types": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@suite-native/analytics": "workspace:*",

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -1,6 +1,7 @@
 import { NavigatorScreenParams } from '@react-navigation/native';
 import { RequireAllOrNone } from 'type-fest';
 
+import { BackupType } from '@suite-common/suite-types';
 import { AccountType, NetworkSymbol } from '@suite-common/wallet-config';
 import {
     AccountKey,
@@ -137,7 +138,7 @@ export type DeviceOnboardingStackParamList = {
     [DeviceOnboardingStackRoutes.CreateWalletLoading]: undefined;
     [DeviceOnboardingStackRoutes.WalletBackupTutorial]: undefined;
     [DeviceOnboardingStackRoutes.WalletCreation]: {
-        walletBackupType: 'shamir-single' | 'shamir-advanced' | '12-words' | '24-words';
+        walletBackupType: BackupType;
     };
     [DeviceOnboardingStackRoutes.Recovery]: undefined;
     [DeviceOnboardingStackRoutes.WalletCreatedSuccess]: undefined;

--- a/suite-native/navigation/tsconfig.json
+++ b/suite-native/navigation/tsconfig.json
@@ -6,6 +6,9 @@
             "path": "../../suite-common/message-system"
         },
         {
+            "path": "../../suite-common/suite-types"
+        },
+        {
             "path": "../../suite-common/wallet-config"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10845,6 +10845,7 @@ __metadata:
     "@react-navigation/native": "npm:6.1.18"
     "@react-navigation/native-stack": "npm:6.11.0"
     "@suite-common/message-system": "workspace:*"
+    "@suite-common/suite-types": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@suite-native/analytics": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Move the logic for selecting default wallet backup type to suite-common and apply it on mobile to fix default option for T2B1 with unit_packaging==0.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18795



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/default-wallet-backup-type&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/default-wallet-backup-type&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/default-wallet-backup-type&lookback=7)