### PR TITLE
Mobile Trade: make sure non-empty account descriptor is used for invityAPI

### DIFF
--- a/suite-native/module-trading/src/hooks/__tests__/useTradingBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/__tests__/useTradingBuyForm.test.tsx
@@ -22,6 +22,11 @@ import { setBuySelectedReceiveAccount } from '../../tradingSlice';
 import { TradeableAsset, TradingBuyForm } from '../../types';
 import { clearTradingBuyFormQuoteData, useTradingBuyForm } from '../useTradingBuyForm';
 
+jest.mock('../../utils/tradeUtils', () => ({
+    ...jest.requireActual('../../utils/tradeUtils'),
+    getRandomAccountDescriptor: () => 'random_string',
+}));
+
 describe('useTradingBuyForm', () => {
     const renderUseTradingBuyForm = (store: TestStore) =>
         renderHookWithStoreProviderAsync(() => useTradingBuyForm(), { store });
@@ -70,51 +75,120 @@ describe('useTradingBuyForm', () => {
         expect(result.current.getValues('receiveAccount')).toEqual({ account: { key: 'btc2' } });
     });
 
-    it('should update invityAPIKey when account is changed', async () => {
-        const store = await getInitializedStore();
-        await renderUseTradingBuyForm(store);
-        const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
+    describe('createInvityAPIKey', () => {
+        it('should set random value to invityAPIKey on mount', async () => {
+            const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
+            const store = await getInitializedStore();
 
-        act(() => {
-            store.dispatch(
-                setBuySelectedReceiveAccount({
-                    selectedReceiveAccount: {
-                        account: { key: 'btc2', descriptor: 'descriptor_btc2' } as Account,
-                    },
-                }),
-            );
+            await renderUseTradingBuyForm(store);
+
+            expect(invityAPISpy).toHaveBeenCalledWith('random_string');
         });
 
-        expect(invityAPISpy).toHaveBeenCalledWith('descriptor_btc2');
-    });
+        it('should update invityAPIKey when account is changed', async () => {
+            const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
+            const store = await getInitializedStore();
+            await renderUseTradingBuyForm(store);
+            invityAPISpy.mockClear();
 
-    it('should not call createInvityAPIKey when descriptor is not changed', async () => {
-        const store = await getInitializedStore();
-        const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
-        await renderUseTradingBuyForm(store);
+            act(() => {
+                store.dispatch(
+                    setBuySelectedReceiveAccount({
+                        selectedReceiveAccount: {
+                            account: { key: 'btc2', descriptor: 'descriptor_btc2' } as Account,
+                        },
+                    }),
+                );
+            });
 
-        act(() => {
-            store.dispatch(
-                setBuySelectedReceiveAccount({
-                    selectedReceiveAccount: {
-                        account: { key: 'btc1', descriptor: 'descriptor_btc1' } as Account,
-                    },
-                }),
-            );
+            expect(invityAPISpy).toHaveBeenCalledWith('descriptor_btc2');
         });
 
-        act(() => {
-            store.dispatch(
-                setBuySelectedReceiveAccount({
-                    selectedReceiveAccount: {
-                        account: { key: 'btc1', descriptor: 'descriptor_btc1' } as Account,
-                        address: { address: 'TEST_BTC_ADDRESS' } as Address,
-                    },
-                }),
-            );
+        it('should not call createInvityAPIKey when descriptor is not changed', async () => {
+            const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
+            const store = await getInitializedStore();
+            await renderUseTradingBuyForm(store);
+            invityAPISpy.mockClear();
+
+            act(() => {
+                store.dispatch(
+                    setBuySelectedReceiveAccount({
+                        selectedReceiveAccount: {
+                            account: { key: 'btc1', descriptor: 'descriptor_btc1' } as Account,
+                        },
+                    }),
+                );
+            });
+
+            act(() => {
+                store.dispatch(
+                    setBuySelectedReceiveAccount({
+                        selectedReceiveAccount: {
+                            account: { key: 'btc1', descriptor: 'descriptor_btc1' } as Account,
+                            address: { address: 'TEST_BTC_ADDRESS' } as Address,
+                        },
+                    }),
+                );
+            });
+
+            expect(invityAPISpy).toHaveBeenCalledTimes(1);
         });
 
-        expect(invityAPISpy).toHaveBeenCalledTimes(1);
+        it('should not call createInvityAPIKey when descriptor is empty string', async () => {
+            const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
+            const store = await getInitializedStore();
+            await renderUseTradingBuyForm(store);
+            invityAPISpy.mockClear();
+
+            act(() => {
+                store.dispatch(
+                    setBuySelectedReceiveAccount({
+                        selectedReceiveAccount: {
+                            account: { key: 'btc1', descriptor: '' } as Account,
+                        },
+                    }),
+                );
+            });
+
+            expect(invityAPISpy).toHaveBeenCalledTimes(0);
+        });
+
+        it('should not call createInvityAPIKey when descriptor is undefined ', async () => {
+            const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
+            const store = await getInitializedStore();
+            await renderUseTradingBuyForm(store);
+            invityAPISpy.mockClear();
+
+            act(() => {
+                store.dispatch(
+                    setBuySelectedReceiveAccount({
+                        selectedReceiveAccount: {
+                            account: { key: 'btc1', descriptor: 'descriptor_btc1' } as Account,
+                        },
+                    }),
+                );
+            });
+
+            act(() => {
+                store.dispatch(
+                    setBuySelectedReceiveAccount({
+                        selectedReceiveAccount: {
+                            account: { key: 'btc1' } as Account,
+                        },
+                    }),
+                );
+            });
+
+            act(() => {
+                store.dispatch(
+                    setBuySelectedReceiveAccount({
+                        selectedReceiveAccount: undefined,
+                    }),
+                );
+            });
+
+            expect(invityAPISpy).toHaveBeenCalledTimes(1);
+        });
     });
 
     it('should clear selected account on asset network change', async () => {

--- a/suite-native/module-trading/src/hooks/useTradingBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/useTradingBuyForm.ts
@@ -27,20 +27,26 @@ import { setBuySelectedReceiveAccount } from '../tradingSlice';
 import { TradingBuyForm, TradingBuyFormValues } from '../types';
 import { truncateDecimals } from '../utils/amountUtils';
 import { buyFormValidationSchema } from '../utils/buyFormValidationSchema';
+import { getRandomAccountDescriptor } from '../utils/tradeUtils';
 import { getSelectedSymbolFromBuyForm } from '../utils/tradeableAssetUtils';
 
 const useReceiveAccountChangeEffect = ({ getValues, setValue }: TradingBuyForm) => {
     const selectedReceiveAccount = useSelector(selectBuySelectedReceiveAccount);
 
+    // make sure invityAPIKey is initialized with some unique string on form mount
+    useEffect(() => {
+        invityAPI.createInvityAPIKey(getRandomAccountDescriptor());
+    }, []);
+
     useEffect(() => {
         const prevReceiveAccount = getValues('receiveAccount');
+        const descriptor = selectedReceiveAccount?.account?.descriptor;
 
         setValue('receiveAccount', selectedReceiveAccount);
 
-        if (
-            prevReceiveAccount?.account?.descriptor !== selectedReceiveAccount?.account?.descriptor
-        ) {
-            invityAPI.createInvityAPIKey(selectedReceiveAccount?.account?.descriptor || '');
+        // when user selects receive account set invityAPIKey accordingly
+        if (descriptor && descriptor !== prevReceiveAccount?.account?.descriptor) {
+            invityAPI.createInvityAPIKey(descriptor);
         }
     }, [selectedReceiveAccount, getValues, setValue]);
 };

--- a/suite-native/module-trading/src/utils/__tests__/tradeUtils.test.ts
+++ b/suite-native/module-trading/src/utils/__tests__/tradeUtils.test.ts
@@ -4,6 +4,7 @@ import { getBuyTrade, getExchangeTrade, getSellTrade } from '../../__fixtures__/
 import { TRADING_URL_DEFAULT_BACK } from '../tradeFormUtils';
 import {
     doesUrlContainCloseCallbackUrl,
+    getRandomAccountDescriptor,
     getTradeOperationData,
     getTradeStatusStep,
     isFinalStatus,
@@ -156,6 +157,16 @@ describe('tradeUtils', () => {
             const url =
                 'trezorsuitelite://trading?action=trade&tradeType=buy&orderId=dd070b73-fe29-4769-8be1-4075d6b43265&transactionId=8c9476a7-958b-412b-a378-3a3f59b6105a&baseCurrencyCode=czk&baseCurrencyAmount=384.78&transactionStatus=completed';
             expect(doesUrlContainCloseCallbackUrl(url, closeCallbackUrl)).toBe(true);
+        });
+    });
+
+    describe('getRandomAccountDescriptor', () => {
+        it('should return 20 characters', () => {
+            expect(getRandomAccountDescriptor().length).toBe(20);
+        });
+
+        it('should return different string on every call', () => {
+            expect(getRandomAccountDescriptor()).not.toBe(getRandomAccountDescriptor());
         });
     });
 });

--- a/suite-native/module-trading/src/utils/tradeUtils.ts
+++ b/suite-native/module-trading/src/utils/tradeUtils.ts
@@ -10,6 +10,7 @@ import {
 
 import { UnreachableCaseError } from '@suite-common/suite-utils';
 import { TradingTradeStatusType, TradingTransaction, TradingType } from '@suite-common/trading';
+import { getWeakRandomId } from '@trezor/utils';
 
 import { TRADING_URL_DEFAULT_BACK } from './tradeFormUtils';
 
@@ -154,3 +155,5 @@ export const getTradeStatusStep = (trade: TradingTransaction) => {
 
 export const doesUrlContainCloseCallbackUrl = (url: string, closeCallbackUrl: string) =>
     url.includes(closeCallbackUrl) || url.includes(TRADING_URL_DEFAULT_BACK);
+
+export const getRandomAccountDescriptor = () => getWeakRandomId(20);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve #18916

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=18916-Mobile-Trade-Random-invity-apiKey&lookback=7)