### PR TITLE
feat(e2e): update wording of device language test

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/manual/settings/device-language.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/settings/device-language.test.ts
@@ -28,7 +28,7 @@ test.describe.skip('Device language', { tag: ['@group=manual'] }, () => {
         {
             annotation: createTestAnnotation({
                 testCase:
-                    'Verifies that a user can change the language on a Trezor device during a firmware upgrade.',
+                    'Verifies that a user can upgrade device firmware when device translation is installed.',
                 prerequisites: [
                     'Seeded Trezor device with transactions (eg. with "all" seed)',
                     'Connected Trezor Suite',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated wording of test case to be more accurate 
## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=e2e-wording&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=e2e-wording&lookback=7)