### PR TITLE
feat(suite): connect popup analytics

### DIFF
--- a/packages/suite-analytics/src/constants.ts
+++ b/packages/suite-analytics/src/constants.ts
@@ -125,4 +125,6 @@ export enum EventType {
     ConnectPopupPermissions = 'connect-popup/permissions',
     ConnectPopupCall = 'connect-popup/call',
     ConnectPopupError = 'connect-popup/error',
+
+    AutostartModal = 'autostart-modal',
 }

--- a/packages/suite-analytics/src/constants.ts
+++ b/packages/suite-analytics/src/constants.ts
@@ -112,4 +112,12 @@ export enum EventType {
     GetMobileApp = 'promo/mobile',
 
     T3T1DashboardPromo = 'promo/t3t1-dashboard',
+
+    WalletConnectInit = 'wallet-connect/init',
+    WalletConnectPaired = 'wallet-connect/paired',
+    WalletConnectProposal = 'wallet-connect/proposal',
+    WalletConnectProposalApproved = 'wallet-connect/proposal-approved',
+    WalletConnectProposalRejected = 'wallet-connect/proposal-rejected',
+    WalletConnectSessionRequest = 'wallet-connect/session-request',
+    WalletConnectError = 'wallet-connect/error',
 }

--- a/packages/suite-analytics/src/constants.ts
+++ b/packages/suite-analytics/src/constants.ts
@@ -120,4 +120,9 @@ export enum EventType {
     WalletConnectProposalRejected = 'wallet-connect/proposal-rejected',
     WalletConnectSessionRequest = 'wallet-connect/session-request',
     WalletConnectError = 'wallet-connect/error',
+
+    ConnectPopupInit = 'connect-popup/init',
+    ConnectPopupPermissions = 'connect-popup/permissions',
+    ConnectPopupCall = 'connect-popup/call',
+    ConnectPopupError = 'connect-popup/error',
 }

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -691,4 +691,30 @@ export type SuiteAnalyticsEvent =
           payload: {
               error: string;
           };
+      }
+    | {
+          type: EventType.ConnectPopupInit;
+      }
+    | {
+          type: EventType.ConnectPopupPermissions;
+          payload: {
+              origin: string;
+              method: string;
+              approved: boolean;
+          };
+      }
+    | {
+          type: EventType.ConnectPopupCall;
+          payload: {
+              origin: string;
+              method: string;
+          };
+      }
+    | {
+          type: EventType.ConnectPopupError;
+          payload: {
+              origin: string;
+              method: string;
+              error: string;
+          };
       };

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -717,4 +717,10 @@ export type SuiteAnalyticsEvent =
               method: string;
               error: string;
           };
+      }
+    | {
+          type: EventType.AutostartModal;
+          payload: {
+              action: 'background-always' | 'background-now' | 'quit-always' | 'quit-now';
+          };
       };

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -651,4 +651,44 @@ export type SuiteAnalyticsEvent =
           payload: {
               wasAccepted: boolean;
           };
+      }
+    | {
+          type: EventType.WalletConnectInit;
+      }
+    | {
+          type: EventType.WalletConnectPaired;
+      }
+    | {
+          type: EventType.WalletConnectSessionRequest;
+          payload: {
+              origin: string;
+              chainId: string;
+              method: string;
+          };
+      }
+    | {
+          type: EventType.WalletConnectProposal;
+          payload: {
+              origin: string;
+              validation: 'UNKNOWN' | 'VALID' | 'INVALID';
+              networks: string[];
+          };
+      }
+    | {
+          type: EventType.WalletConnectProposalApproved;
+          payload: {
+              origin?: string;
+          };
+      }
+    | {
+          type: EventType.WalletConnectProposalRejected;
+          payload: {
+              origin?: string;
+          };
+      }
+    | {
+          type: EventType.WalletConnectError;
+          payload: {
+              error: string;
+          };
       };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AutoStartBeforeQuitModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AutoStartBeforeQuitModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { Card, Checkbox, Column, Modal, Paragraph } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { spacings } from '@trezor/theme';
 
@@ -13,13 +14,23 @@ export const AutoStartBeforeQuitModal = () => {
     const [dontAskAgain, setDontAskAgain] = useState(false);
     if (!desktopApi.available) return null;
 
-    const handleBackground = () => {
-        desktopApi.appAutoStartPopupResponse(dontAskAgain ? 'background-always' : 'background-now');
+    const handleResponse = (
+        action: 'background-always' | 'background-now' | 'quit-always' | 'quit-now',
+    ) => {
+        desktopApi.appAutoStartPopupResponse(action);
         dispatch(modalActions.onCancel());
+        analytics.report({
+            type: EventType.AutostartModal,
+            payload: {
+                action,
+            },
+        });
+    };
+    const handleBackground = () => {
+        handleResponse(dontAskAgain ? 'background-always' : 'background-now');
     };
     const handleQuit = () => {
-        desktopApi.appAutoStartPopupResponse(dontAskAgain ? 'quit-always' : 'quit-now');
-        dispatch(modalActions.onCancel());
+        handleResponse(dontAskAgain ? 'quit-always' : 'quit-now');
     };
 
     return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
@@ -14,6 +14,7 @@ import {
     Text,
 } from '@trezor/components';
 import { ERRORS } from '@trezor/connect';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
@@ -28,7 +29,7 @@ export const ConnectPermissionsModal = () => {
     const popupCall = useSelector(selectConnectPopupCall);
     if (!popupCall || popupCall?.state !== 'permission-request') return null;
 
-    const { methodInfo, source } = popupCall;
+    const { method, methodInfo, source } = popupCall;
     const { confirmLabel, permissionTypes } = methodInfo;
 
     const rememberPayload = {
@@ -40,9 +41,27 @@ export const ConnectPermissionsModal = () => {
             dispatch(connectPopupActions.rememberAppPermissions(rememberPayload));
         }
         dispatch(connectPopupActions.approvePermissions());
+        analytics.report({
+            type: EventType.ConnectPopupPermissions,
+            payload: {
+                method,
+                origin: source.origin,
+                approved: true,
+            },
+        });
     };
-    const onCancel = () =>
+    const onCancel = () => {
         dispatch(connectPopupActions.rejectPermissions(ERRORS.TypedError('Method_Cancel')));
+
+        analytics.report({
+            type: EventType.ConnectPopupPermissions,
+            payload: {
+                method,
+                origin: source.origin,
+                approved: false,
+            },
+        });
+    };
 
     return (
         <Modal

--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -7,6 +7,7 @@ import {
 } from '@suite-common/connect-popup';
 import { CALL_SOURCE_DESKTOP_WS } from '@suite-common/connect-popup/src/connectPopupTypes';
 import TrezorConnect from '@trezor/connect';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { SUITE } from 'src/actions/suite/constants';
@@ -53,6 +54,10 @@ export const useConnectPopupDesktop = () => {
                     initialized.current = true;
 
                     desktopApi.connectPopupReady();
+
+                    analytics.report({
+                        type: EventType.ConnectPopupInit,
+                    });
 
                     // Update experimental features value
                     // TODO: remove this when out of experimental

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -7,6 +7,7 @@ import TrezorConnect, { CallMethodParams, CallMethodResponse } from '@trezor/con
 import { TypedError, serializeError } from '@trezor/connect/src/constants/errors';
 import { MethodPermission } from '@trezor/connect/src/core/AbstractMethod';
 import { DEEPLINK_VERSION } from '@trezor/connect/src/data/version';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { createDeferred } from '@trezor/utils';
 
 import { connectPopupActions } from './connectPopupActions';
@@ -134,6 +135,14 @@ export const connectPopupCallThunkInner = createThunk<
                 dispatch(connectPopupActions.finishCall());
             }
 
+            analytics.report({
+                type: EventType.ConnectPopupCall,
+                payload: {
+                    method,
+                    origin: source.origin,
+                },
+            });
+
             return response;
         } catch (error) {
             console.error('connectPopupCallThunk', error);
@@ -142,6 +151,15 @@ export const connectPopupCallThunkInner = createThunk<
             } else {
                 dispatch(connectPopupActions.setError(serializeError(error)));
             }
+
+            analytics.report({
+                type: EventType.ConnectPopupError,
+                payload: {
+                    method,
+                    origin: source.origin,
+                    error: error?.code,
+                },
+            });
 
             return {
                 success: false,

--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -15,6 +15,7 @@ import { getNetwork, networksCollection } from '@suite-common/wallet-config';
 import { selectAccounts, selectSelectedDevice } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import TrezorConnect from '@trezor/connect';
+import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { getAdapterByMethod, getNamespaces } from './adapters';
 import { walletConnectActions } from './walletConnectActions';
@@ -134,6 +135,14 @@ export const sessionProposalThunk = createThunk<
             ...event.verifyContext.verified,
         }),
     );
+    analytics.report({
+        type: EventType.WalletConnectProposal,
+        payload: {
+            origin: event.verifyContext.verified.origin,
+            validation: event.verifyContext.verified.validation,
+            networks: networks.map(network => network.namespaceId),
+        },
+    });
 });
 
 export const sessionRequestThunk = createThunk<
@@ -161,6 +170,14 @@ export const sessionRequestThunk = createThunk<
                 result: result.payload,
             },
         });
+        analytics.report({
+            type: EventType.WalletConnectSessionRequest,
+            payload: {
+                origin: event.verifyContext.verified.origin,
+                chainId: event.params.chainId,
+                method: event.params.request.method,
+            },
+        });
     } catch (error) {
         await walletKit.respondSessionRequest({
             topic: event.topic,
@@ -172,6 +189,10 @@ export const sessionRequestThunk = createThunk<
                     message: error.message,
                 },
             },
+        });
+        analytics.report({
+            type: EventType.WalletConnectError,
+            payload: { error: error.message },
         });
     }
 });
@@ -223,12 +244,22 @@ export const sessionProposalApproveThunk = createThunk<
                     validation: pendingProposal.validation,
                 }),
             );
+            analytics.report({
+                type: EventType.WalletConnectProposalApproved,
+                payload: {
+                    origin: pendingProposal.origin,
+                },
+            });
         } catch (error) {
             console.error(error);
 
             await walletKit.rejectSession({
                 id: eventId,
                 reason: getSdkError('USER_REJECTED'),
+            });
+            analytics.report({
+                type: EventType.WalletConnectError,
+                payload: { error: error.message },
             });
         }
     },
@@ -239,10 +270,17 @@ export const sessionProposalRejectThunk = createThunk<
     {
         eventId: number;
     }
->(`${WALLETCONNECT_MODULE}/sessionProposalRejectThunk`, async ({ eventId }) => {
+>(`${WALLETCONNECT_MODULE}/sessionProposalRejectThunk`, async ({ eventId }, { getState }) => {
+    const pendingProposal = selectPendingProposal(getState());
     await walletKit.rejectSession({
         id: eventId,
         reason: getSdkError('USER_REJECTED'),
+    });
+    analytics.report({
+        type: EventType.WalletConnectProposalRejected,
+        payload: {
+            origin: pendingProposal?.origin,
+        },
     });
 });
 
@@ -348,6 +386,9 @@ export const walletConnectInitThunk = createThunk(
         for (const proposal of Object.values(proposals)) {
             dispatch(sessionProposalRejectThunk({ eventId: proposal.id }));
         }
+        analytics.report({
+            type: EventType.WalletConnectInit,
+        });
     },
 );
 
@@ -356,6 +397,9 @@ export const walletConnectPairThunk = createThunk<void, { uri: string }>(
     async ({ uri }, { dispatch }) => {
         try {
             await walletKit.pair({ uri });
+            analytics.report({
+                type: EventType.WalletConnectPaired,
+            });
         } catch (error) {
             console.error('WalletKit.pair:', error);
             // TODO: make this a friendly localized message
@@ -365,6 +409,11 @@ export const walletConnectPairThunk = createThunk<void, { uri: string }>(
                     error: `WalletConnect pairing failed - ${error.message}`,
                 }),
             );
+
+            analytics.report({
+                type: EventType.WalletConnectError,
+                payload: { error: error.message },
+            });
         }
     },
 );


### PR DESCRIPTION
## Description

We should have analytics for Connect in Suite and WalletConnect before we release it...


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-in-suite-analytics&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connect-in-suite-analytics&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-in-suite-analytics&lookback=7)