### PR TITLE
chore(suite-desktop): correctly log info about legacy bridge

### DIFF
--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -125,7 +125,7 @@ const loadBridge = async (store: Dependencies['store']) => {
     try {
         logger.info(
             SERVICE_NAME,
-            `Starting (Legacy: ${b2t(bridgeLegacy)}, Test: ${b2t(bridgeTest)}, Dev: ${b2t(bridgeDev)})`,
+            `Starting (Legacy: ${b2t(shouldUseLegacyBridge(store))}, Test: ${b2t(bridgeTest)}, Dev: ${b2t(bridgeDev)})`,
         );
         await start(bridge);
     } catch (err) {


### PR DESCRIPTION
before 
![image](https://github.com/user-attachments/assets/c9284a82-3f2b-4649-802a-a606912c7d8b)

after

```
2025-05-14T08:23:47.575Z - INFO(bridge): Starting (Legacy: Yes, Test: No, Dev: No)
2025-05-14T08:23:47.591Z - DEBUG(modules): Loaded @trezor/connect
2025-05-14T08:23:47.591Z - DEBUG(modules): Loaded tray
2025-05-14T08:23:47.594Z - INFO(http-receiver): Server started
2025-05-14T08:23:47.594Z - DEBUG(modules): Loaded http-receiver
2025-05-14T08:23:47.674Z - DEBUG(process-trezord): Status error: fetch failed
2025-05-14T08:23:47.675Z - DEBUG(process-trezord): Setting a restart throttle (3)
2025-05-14T08:23:47.675Z - INFO(process-trezord): Starting process:
2025-05-14T08:23:47.675Z - INFO(process-trezord): - Path: /.../trezor-suite/packages/suite-desktop/build/static/bin/bridge/mac-arm64/trezord
2025-05-14T08:23:47.675Z - INFO(process-trezord): - Params: 
2025-05-14T08:23:47.675Z - INFO(process-trezord): - CWD: /...trezor-suite/packages/suite-desktop/build/static/bin/bridge/mac-arm64
```

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=nits&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=nits&lookback=7)