### PR TITLE
feat(suite-native): analytics of entereing send/receive flow

### DIFF
--- a/suite-native/accounts/src/components/AccountSelectBottomSheet.tsx
+++ b/suite-native/accounts/src/components/AccountSelectBottomSheet.tsx
@@ -77,6 +77,7 @@ export const AccountSelectBottomSheet = React.memo(
                                     onSelectAccount({
                                         account,
                                         tokenAddress: token.contract,
+                                        tokenSymbol: token.symbol,
                                         hasAnyKnownTokens: true,
                                     })
                                 }

--- a/suite-native/accounts/src/types.ts
+++ b/suite-native/accounts/src/types.ts
@@ -1,4 +1,4 @@
-import { Account, TokenAddress, TokenInfoBranded } from '@suite-common/wallet-types';
+import { Account, TokenAddress, TokenInfoBranded, TokenSymbol } from '@suite-common/wallet-types';
 
 export type GroupedByTypeAccounts = Record<string, [Account, ...Account[]]>;
 
@@ -9,6 +9,7 @@ export type OnSelectAccount = (params: {
     // if account has staking
     hasStaking?: boolean;
     tokenAddress?: TokenAddress;
+    tokenSymbol?: TokenSymbol;
     hasAnyKnownTokens: boolean;
 }) => void;
 

--- a/suite-native/analytics/src/constants.ts
+++ b/suite-native/analytics/src/constants.ts
@@ -48,6 +48,8 @@ export enum EventType {
     SendFeeLevelChanged = 'send/fee_level_changed',
     SendTransactionDispatched = 'send/transaction_dispatched',
     SendFlowExited = 'send/flow_exited',
+    SendFlowEntered = 'send/flow_entered',
+    ReceiveFlowEntered = 'receive/flow_entered',
     DeviceSettingsPinProtectionChange = 'device_settings/pin_protection_change',
     DeviceSettingsAuthenticityCheck = 'device_settings/authenticity_check',
     FirmwareUpdateStarted = 'firmware/firmware_update_started',

--- a/suite-native/analytics/src/events.ts
+++ b/suite-native/analytics/src/events.ts
@@ -316,6 +316,24 @@ export type SuiteNativeAnalyticsEvent =
           };
       }
     | {
+          type: EventType.SendFlowEntered;
+          payload: {
+              location: 'dashboard' | 'accountDetail';
+              assetSymbol: NetworkSymbol;
+              tokenSymbol?: TokenSymbol;
+              tokenContract?: TokenAddress;
+          };
+      }
+    | {
+          type: EventType.ReceiveFlowEntered;
+          payload: {
+              location: 'dashboard' | 'accountDetail';
+              assetSymbol: NetworkSymbol;
+              tokenSymbol?: TokenSymbol;
+              tokenContract?: TokenAddress;
+          };
+      }
+    | {
           type: EventType.DeviceSettingsPinProtectionChange;
           payload: {
               action: 'enable' | 'change' | 'disable';

--- a/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
@@ -11,6 +11,7 @@ import {
     selectIsTestnetAccount,
 } from '@suite-common/wallet-core';
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
+import { EventType, analytics } from '@suite-native/analytics';
 import { Box, Button, HStack, Text, VStack } from '@suite-native/atoms';
 import { selectHasFirmwareAuthenticityCheckHardFailed } from '@suite-native/device';
 import { FeatureFlag, FeatureFlagsRootState, useFeatureFlag } from '@suite-native/feature-flags';
@@ -22,7 +23,7 @@ import {
     SendStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
-import { TokensRootState } from '@suite-native/tokens';
+import { TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
 import { selectHasAccountAnyTransactions } from '@suite-native/transactions';
 
 import { AccountDetailCryptoValue } from './AccountDetailCryptoValue';
@@ -103,10 +104,22 @@ export const TransactionListHeader = memo(
         const hasFirmwareAuthenticityCheckHardFailed = useSelector(
             selectHasFirmwareAuthenticityCheckHardFailed,
         );
+        const token = useSelector((state: TokensRootState) =>
+            selectAccountTokenInfo(state, accountKey, tokenContract),
+        );
 
         if (!account) return null;
 
         const handleReceive = () => {
+            analytics.report({
+                type: EventType.ReceiveFlowEntered,
+                payload: {
+                    location: 'accountDetail',
+                    assetSymbol: account.symbol,
+                    tokenSymbol: token?.symbol,
+                    tokenContract,
+                },
+            });
             navigation.navigate(RootStackRoutes.ReceiveStack, {
                 screen: ReceiveStackRoutes.ReceiveAccount,
                 params: {
@@ -118,6 +131,15 @@ export const TransactionListHeader = memo(
         };
 
         const handleSend = () => {
+            analytics.report({
+                type: EventType.SendFlowEntered,
+                payload: {
+                    location: 'accountDetail',
+                    assetSymbol: account.symbol,
+                    tokenSymbol: token?.symbol,
+                    tokenContract,
+                },
+            });
             navigation.navigate(RootStackRoutes.SendStack, {
                 screen: SendStackRoutes.SendOutputs,
                 params: {

--- a/suite-native/module-send/src/screens/SendAccountsScreen.tsx
+++ b/suite-native/module-send/src/screens/SendAccountsScreen.tsx
@@ -1,4 +1,5 @@
 import { AccountsList, OnSelectAccount } from '@suite-native/accounts';
+import { EventType, analytics } from '@suite-native/analytics';
 import { useTranslate } from '@suite-native/intl';
 import {
     Screen,
@@ -13,11 +14,22 @@ export const SendAccountsScreen = ({
 }: StackProps<SendStackParamList, SendStackRoutes.SendAccounts>) => {
     const { translate } = useTranslate();
 
-    const navigateToSendFormScreen: OnSelectAccount = ({ account, tokenAddress }) =>
+    const navigateToSendFormScreen: OnSelectAccount = ({ account, tokenAddress, tokenSymbol }) => {
+        analytics.report({
+            type: EventType.SendFlowEntered,
+            payload: {
+                location: 'dashboard',
+                assetSymbol: account.symbol,
+                tokenContract: tokenAddress,
+                tokenSymbol,
+            },
+        });
+
         navigation.navigate(SendStackRoutes.SendOutputs, {
             accountKey: account.key,
             tokenContract: tokenAddress,
         });
+    };
 
     return (
         <Screen

--- a/suite-native/receive/src/screens/ReceiveAccountsScreen.tsx
+++ b/suite-native/receive/src/screens/ReceiveAccountsScreen.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
 import { AccountsList, AddAccountButton, OnSelectAccount } from '@suite-native/accounts';
+import { EventType, analytics } from '@suite-native/analytics';
 import { selectHasFirmwareAuthenticityCheckHardFailed } from '@suite-native/device';
 import { useTranslate } from '@suite-native/intl';
 import {
@@ -28,12 +29,23 @@ export const ReceiveAccountsScreen = () => {
     );
     if (hasFirmwareAuthenticityCheckHardFailed) return <ReceiveBlockedDeviceCompromisedScreen />;
 
-    const navigateToReceiveScreen: OnSelectAccount = ({ account, tokenAddress }) =>
+    const navigateToReceiveScreen: OnSelectAccount = ({ account, tokenAddress, tokenSymbol }) => {
+        analytics.report({
+            type: EventType.ReceiveFlowEntered,
+            payload: {
+                location: 'dashboard',
+                assetSymbol: account.symbol,
+                tokenContract: tokenAddress,
+                tokenSymbol,
+            },
+        });
+
         navigation.navigate(ReceiveStackRoutes.ReceiveAccount, {
             accountKey: account.key,
             tokenContract: tokenAddress,
             closeActionType: 'back',
         });
+    };
 
     return (
         <Screen


### PR DESCRIPTION
## Description
- analytics for entering send/receive flow added
- the events contain a `location` parameter, that specifies if the flow was entered from the dashboard or account detail
- info was not added to the Notion documentation added yet, I will do it after freeze when there is more time

### receive flow entered example
```jsx
{"payload": {"assetSymbol": "btc", "location": "accountDetail", "tokenContract": undefined, "tokenSymbol": undefined}, 
 "type": "receive/flow_entered"}
```

### send flow entered example
```tsx
{"payload": {"assetSymbol": "btc", "location": "dashboard", "tokenContract": undefined, "tokenSymbol": undefined}, "type": "send/flow_entered"}
```

## Related Issue

Resolve #17070 



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/send-receive-init-analytics&lookback=7)