### PR TITLE
Fix Explorer query string validation

### DIFF
--- a/packages/suite/src/hooks/settings/useExplorerForm.ts
+++ b/packages/suite/src/hooks/settings/useExplorerForm.ts
@@ -57,9 +57,7 @@ const useExplorerInput = (currentValues: Explorer) => {
         validate: validateSuffix,
     });
 
-    const { ref: queryStringInputRef, ...queryStringInputField } = register('queryString', {
-        validate: validateSuffix,
-    });
+    const { ref: queryStringInputRef, ...queryStringInputField } = register('queryString');
 
     return {
         validateBaseUrl,
@@ -143,7 +141,7 @@ export const useExplorerForm = (symbol: NetworkSymbol) => {
 
         (Object.keys(explorer) as (keyof Explorer)[]).forEach(key => {
             if (!explorer[key]) return;
-            explorer[key] = stripSlashes(explorer[key]);
+            explorer[key] = stripSlashes(explorer[key]).trim();
         });
 
         return explorer;

--- a/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
@@ -124,6 +124,13 @@ const connect = (draft: BlockchainState, info: BlockchainInfo) => {
                     ? info.url + getBlockExplorerUrlSuffix(network.explorer.address)
                     : network.explorer.address
             }`,
+            token: network.explorer.token
+                ? `${
+                      isHttp
+                          ? info.url + getBlockExplorerUrlSuffix(network.explorer.token)
+                          : network.explorer.token
+                  }`
+                : undefined,
         },
         connected: true,
         blockHash: info.blockHash,


### PR DESCRIPTION
## Description

Fix query string being validated as `required`.

Also remove unnecessary explorer/backend settings for Solana.

## Related Issue

Resolve #18938 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/explorer&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/explorer&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/explorer&lookback=7)