### PR TITLE
fix(suite-native): add close button to firmware update screen

### DIFF
--- a/suite-native/module-device-settings/src/screens/ConfirmFirmwareUpdateScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/ConfirmFirmwareUpdateScreen.tsx
@@ -9,6 +9,7 @@ import {
     DeviceSettingsStackParamList,
     DeviceStackRoutes,
     Screen,
+    ScreenHeader,
     StackNavigationProps,
 } from '@suite-native/navigation';
 
@@ -31,6 +32,7 @@ export const ConfirmFirmwareUpdateScreen = () => {
 
     return (
         <Screen
+            header={<ScreenHeader closeActionType="close" />}
             footer={
                 <ConfirmFirmwareUpdateScreenFooter
                     onUpdateConfirmation={handleUpdateConfirmation}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Firmware update screen is missing close button on current develop. This adds it there allowing users to navigate back using hardware button as well as in app navigation item.

## Screenshots:

https://github.com/user-attachments/assets/56910b8b-c309-4935-b749-1524bd966bb4



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/firmware-update-screen-header&lookback=7)