### PR TITLE
fix(ci): pass env var to allow debug keys in device auth check in e2e android tests

### DIFF
--- a/.github/workflows/test-suite-native-e2e-android.yml
+++ b/.github/workflows/test-suite-native-e2e-android.yml
@@ -136,6 +136,7 @@ jobs:
           EXPO_PUBLIC_IS_DETOX_BUILD: true
           EXPO_PUBLIC_FF_IS_REGTEST_ENABLED: true
           EXPO_PUBLIC_FF_IS_CONNECT_POPUP_ENABLED: true
+          EXPO_PUBLIC_FF_IS_DEBUG_KEYS_ALLOWED: true
           EXPO_PUBLIC_ENVIRONMENT: debug
         run: npx react-native bundle --platform android --dev false --entry-file $ENTRY_FILE_PATH --bundle-output $JS_BUNDLE_PATH --assets-dest $ASSETS_DEST_PATH
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Looks like having it in .evn.test is not enough 🤔


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/fix-android-e2e-device-auth-check&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/fix-android-e2e-device-auth-check&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/fix-android-e2e-device-auth-check&lookback=7)