### PR TITLE
Add tooltip explaining provider-adjusted sell amount in offer list

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -799,6 +799,10 @@ export default defineMessages({
         defaultMessage: 'Pending',
         id: 'TR_SELL_STATUS_PENDING',
     },
+    TR_SELL_PROVIDER_ADJUSTED_AMOUNT: {
+        defaultMessage: 'Provider adjusted your amount to {roundedAmountWithSymbol}',
+        id: 'TR_SELL_PROVIDER_ADJUSTED_AMOUNT',
+    },
     TR_REQUIRED_FIELD: {
         defaultMessage: 'Required',
         id: 'TR_REQUIRED_FIELD',

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -10,7 +10,7 @@ import {
     parseCryptoId,
     useTradingInfo,
 } from '@suite-common/trading';
-import { Button, Column, Paragraph, Row, TextButton } from '@trezor/components';
+import { Button, Column, Paragraph, Row, TextButton, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
@@ -23,12 +23,14 @@ import {
     getSelectQuoteTyped,
     getSelectedCrypto,
     isTradingExchangeContext,
+    isTradingSellContext,
 } from 'src/utils/wallet/trading/tradingTypingUtils';
 import {
     tradingGetAmountLabels,
     tradingGetRoundedFiatAmount,
     tradingGetSectionActionLabel,
 } from 'src/utils/wallet/trading/tradingUtils';
+import { TradingCryptoAmount } from 'src/views/wallet/trading/common/TradingCryptoAmount';
 import { TradingFormOfferCryptoAmount } from 'src/views/wallet/trading/common/TradingForm/TradingFormOfferCryptoAmount';
 import { TradingFormOfferFiatAmount } from 'src/views/wallet/trading/common/TradingForm/TradingFormOfferFiatAmount';
 import { TradingFormOfferItem } from 'src/views/wallet/trading/common/TradingForm/TradingFormOfferItem';
@@ -80,6 +82,9 @@ export const TradingFormOffer = () => {
 
     const { tradingDeviceDisconnected } = useTradingDeviceDisconnected();
 
+    const showProviderAdjustedAmountTooltip =
+        isTradingSellContext(context) && bestScoredQuoteAmounts && !state.isFormLoading;
+
     const onSelectQuote = () => {
         if (!quote) {
             return;
@@ -126,7 +131,31 @@ export const TradingFormOffer = () => {
             </Column>
             <Column gap={spacings.xxs} margin={{ vertical: spacings.md }}>
                 <Row justifyContent="space-between">
-                    <Translation id="TR_TRADING_YOUR_BEST_OFFER" />
+                    {showProviderAdjustedAmountTooltip ? (
+                        <Tooltip
+                            hasIcon
+                            placement="right"
+                            content={
+                                <Translation
+                                    id="TR_SELL_PROVIDER_ADJUSTED_AMOUNT"
+                                    values={{
+                                        roundedAmountWithSymbol: (
+                                            <TradingCryptoAmount
+                                                amount={bestScoredQuoteAmounts.receiveAmount}
+                                                cryptoId={
+                                                    bestScoredQuoteAmounts.receiveCurrency as CryptoId
+                                                }
+                                            />
+                                        ),
+                                    }}
+                                />
+                            }
+                        >
+                            <Translation id="TR_TRADING_YOUR_BEST_OFFER" />
+                        </Tooltip>
+                    ) : (
+                        <Translation id="TR_TRADING_YOUR_BEST_OFFER" />
+                    )}
                     <TextButton
                         onClick={onCompareAllOffersClick}
                         size="small"

--- a/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersItem.tsx
@@ -150,6 +150,7 @@ export const TradingOffersItem = ({ quote }: TradingOffersItemProps) => {
                     <AmountOfferColumn>
                         <Row alignItems="flex-end" data-testid="@trading/offer/amount">
                             <TradingUtilsPrice {...cryptoAmountProps} />
+
                             {isTradingExchangeContext(context) && (
                                 <TradingUtilsKyc
                                     exchange={exchange}

--- a/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsPrice.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsPrice.tsx
@@ -1,5 +1,7 @@
+import { CryptoId } from 'invity-api';
 import styled from 'styled-components';
 
+import { Tooltip } from '@trezor/components';
 import { FONT_SIZE, SCREEN_QUERY } from '@trezor/components/src/config/variables';
 import { spacingsPx, typography } from '@trezor/theme';
 
@@ -46,14 +48,43 @@ export const TradingUtilsPrice = ({
     return (
         <PriceWrap>
             <PriceTitle>
-                <Translation
-                    id={
-                        tradingGetAmountLabels({
-                            type,
-                            amountInCrypto: !!amountInCrypto,
-                        }).labelComparatorOffer
-                    }
-                />
+                {type === 'sell' ? (
+                    <Tooltip
+                        hasIcon
+                        placement="right"
+                        content={
+                            <Translation
+                                id="TR_SELL_PROVIDER_ADJUSTED_AMOUNT"
+                                values={{
+                                    roundedAmountWithSymbol: (
+                                        <TradingCryptoAmount
+                                            amount={receiveAmount}
+                                            cryptoId={receiveCurrency as CryptoId}
+                                        />
+                                    ),
+                                }}
+                            />
+                        }
+                    >
+                        <Translation
+                            id={
+                                tradingGetAmountLabels({
+                                    type,
+                                    amountInCrypto: !!amountInCrypto,
+                                }).labelComparatorOffer
+                            }
+                        />
+                    </Tooltip>
+                ) : (
+                    <Translation
+                        id={
+                            tradingGetAmountLabels({
+                                type,
+                                amountInCrypto: !!amountInCrypto,
+                            }).labelComparatorOffer
+                        }
+                    />
+                )}
             </PriceTitle>
             <PriceValueWrap data-testid="@trading/offers/quote/amount">
                 <PriceValue>


### PR DESCRIPTION
## Description

Sell offers now include a tooltip when the provider's offered crypto amount differs from the user input.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16669

## Screenshots:

<img width="1228" alt="image" src="https://github.com/user-attachments/assets/a25eb8d7-0837-48e5-938e-5255e4d77a91" />

<img width="1234" alt="image" src="https://github.com/user-attachments/assets/481aee8b-09d7-4f52-b736-d84988d71b3e" />

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sell-provider-amount-tooltip&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sell-provider-amount-tooltip&lookback=7)