### PR TITLE
fix(suite-native): select fresh account memoization issue

### DIFF
--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -208,20 +208,11 @@ export const selectAccountListSections = createMemoizedSelector(
     },
 );
 
-export const selectFreshAccountAddress = (
-    state: NativeAccountsRootState & TransactionsRootState,
-    accountKey: AccountKey,
-) => {
-    const account = selectAccountByKey(state, accountKey);
-
-    if (!account) return null;
-
-    const pendingAddresses = selectPendingAccountAddresses(state, accountKey);
-
-    const isAccountUtxoBased = selectIsAccountUtxoBased(state, accountKey);
-
-    return getFirstFreshAddress(account, [], pendingAddresses, isAccountUtxoBased);
-};
+export const selectFreshAccountAddress = createMemoizedSelector(
+    [selectAccountByKey, selectPendingAccountAddresses, selectIsAccountUtxoBased],
+    (account, pendingAddresses, isAccountUtxoBased) =>
+        account ? getFirstFreshAddress(account, [], pendingAddresses, isAccountUtxoBased) : null,
+);
 
 export const selectHasDeviceAnySendAvailableAccount = createMemoizedSelector(
     [selectIsPortfolioTrackerDevice, selectVisibleDeviceAccounts],

--- a/suite-native/accounts/src/tests/selectors.test.ts
+++ b/suite-native/accounts/src/tests/selectors.test.ts
@@ -1,5 +1,6 @@
 import { Account } from '@suite-common/wallet-types';
 
+import { selectFreshAccountAddress } from '../selectors';
 import {
     groupAccountsByNetworkAccountType,
     isFilterValueMatchingAccount,
@@ -110,5 +111,143 @@ describe('sortAccountsByNetworksAndAccountTypes', () => {
             { symbol: 'ltc', accountType: 'normal' },
             { symbol: 'ltc', accountType: 'segwit' },
         ]);
+    });
+});
+
+describe('selectFreshAccountAddress', () => {
+    const mockAccount = {
+        symbol: 'btc',
+        key: 'btc-1',
+        addresses: {
+            unused: [
+                {
+                    address: 'unused1',
+                    path: "m/44'/0'/0'/0/0",
+                    transfers: 0,
+                    balance: '0',
+                    sent: '0',
+                    received: '0',
+                },
+                {
+                    address: 'unused2',
+                    path: "m/44'/0'/0'/0/1",
+                    transfers: 0,
+                    balance: '0',
+                    sent: '0',
+                    received: '0',
+                },
+            ],
+            used: [
+                {
+                    address: 'used1',
+                    path: "m/44'/0'/0'/0/2",
+                    transfers: 1,
+                    balance: '0',
+                    sent: '0',
+                    received: '0',
+                },
+                {
+                    address: 'used2',
+                    path: "m/44'/0'/0'/0/3",
+                    transfers: 1,
+                    balance: '0',
+                    sent: '0',
+                    received: '0',
+                },
+            ],
+            change: [],
+        },
+        deviceState: 'device@state:1',
+        index: 0,
+        path: "m/44'/0'/0'",
+        descriptor: 'descriptor',
+        accountType: 'normal',
+        empty: false,
+        visible: true,
+        balance: '0',
+        availableBalance: '0',
+        formattedBalance: '0',
+        tokens: [],
+        utxo: [],
+        history: {
+            total: 0,
+            unconfirmed: 0,
+        },
+        metadata: {
+            key: 'btc-1',
+        },
+        ts: 0,
+        networkType: 'bitcoin',
+        misc: undefined,
+        marker: undefined,
+        page: undefined,
+    } as Account;
+
+    const mockState = {
+        wallet: {
+            accounts: [mockAccount],
+            pendingAccountAddresses: {},
+            transactions: {
+                transactions: {},
+                fetchStatusDetail: {},
+            },
+        },
+    };
+
+    it('should return null when account is not provided', () => {
+        const result = selectFreshAccountAddress(mockState, 'non-existent-key');
+        expect(result).toBeNull();
+    });
+
+    it('should return first unused address for account', () => {
+        const result = selectFreshAccountAddress(mockState, mockAccount.key);
+        expect(result).toEqual({
+            address: 'unused1',
+            path: "m/44'/0'/0'/0/0",
+            transfers: 0,
+            balance: '0',
+            sent: '0',
+            received: '0',
+        });
+    });
+
+    it('should return undefined when no unused addresses are available', () => {
+        const accountWithoutUnused = {
+            ...mockAccount,
+            addresses: {
+                unused: [],
+                used: [
+                    {
+                        address: 'used1',
+                        path: "m/44'/0'/0'/0/2",
+                        transfers: 1,
+                        balance: '0',
+                        sent: '0',
+                        received: '0',
+                    },
+                ],
+                change: [],
+            },
+        };
+        const stateWithoutUnused = {
+            wallet: {
+                accounts: [accountWithoutUnused],
+                pendingAccountAddresses: {},
+                transactions: {
+                    transactions: {},
+                    fetchStatusDetail: {},
+                },
+            },
+        };
+        const result = selectFreshAccountAddress(stateWithoutUnused, accountWithoutUnused.key);
+        expect(result).toBeUndefined();
+    });
+
+    it('should return stable results for same inputs', () => {
+        const result1 = selectFreshAccountAddress(mockState, mockAccount.key);
+        const result2 = selectFreshAccountAddress(mockState, mockAccount.key);
+
+        expect(result1).toEqual(result2);
+        expect(result1).toBe(result2);
     });
 });


### PR DESCRIPTION
selector was not memoized

Resolve #18939


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=18939-fix-memoization-for-sendreceive-eth-token-screens&lookback=7)