### PR TITLE
fix(suite-native): wallet backup sheet buton copy

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -856,7 +856,7 @@ export const en = {
                     storage:
                         'Store your wallet backup in a secure, private place. Never share it with anyone or store it anywhere digital.',
                     callout: 'Upgradable to Multi-share Backup',
-                    submitButton: 'Continue with single-share',
+                    submitButton: 'Continue with Single-share Backup',
                 },
                 'shamir-advanced': {
                     title: 'Multi-share Backup',
@@ -866,7 +866,7 @@ export const en = {
                     storage:
                         'Store your shares separately in secure, private locations, or distribute them to trusted individuals. Never keep all shares together or store them digitally.',
                     callout: 'Requires increased attention',
-                    submitButton: 'Continue with multi-share',
+                    submitButton: 'Continue with Multi-share Backup',
                     alertButtonLabel: 'Learn more',
                 },
                 '12-words': {
@@ -876,7 +876,7 @@ export const en = {
                     storage:
                         'Store your wallet backup in a secure, private place. Never share it with anyone or store it anywhere digital.',
                     callout: 'Not easily upgradeable to\nMulti-share Backup',
-                    submitButton: 'Continue with 12 word backup',
+                    submitButton: 'Continue with 12-word backup',
                 },
                 '24-words': {
                     title: '24-word backup',
@@ -885,7 +885,7 @@ export const en = {
                     storage:
                         'Store your wallet backup in a secure, private place. Never share it with anyone or store it anywhere digital.',
                     callout: 'Not easily upgradeable to\nMulti-share Backup',
-                    submitButton: 'Continue with 24 word backup',
+                    submitButton: 'Continue with 24-word backup',
                 },
             },
         },


### PR DESCRIPTION
## Description
Just one small minor copy thing: the button copy when selecting the wallet backup types should be capitalized (as far as the proper name of the backup type: Single-share Backup, Multi-share Backup, etc.)
Ideally, like this :point_down:

![image](https://github.com/user-attachments/assets/02d6a489-46d8-442b-b77f-57707539e2d4)

> This fix can wait for the June release (25.6.1)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/wallet-backup-button-copy&lookback=7)