### PR TITLE
feat:(suite): allow to go back when renaming device label while onboa…

### DIFF
--- a/packages/suite/src/views/onboarding/steps/Final.tsx
+++ b/packages/suite/src/views/onboarding/steps/Final.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { FormProvider } from 'react-hook-form';
 
 import useMeasure from 'react-use/lib/useMeasure';
@@ -117,6 +117,18 @@ export const FinalStep = () => {
     const { form, handleSubmit } = useChangeDeviceLabel();
 
     const [wrapperRef, { width }] = useMeasure<HTMLDivElement>();
+
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                setState(null);
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, []);
 
     if (!device?.features) return null;
 


### PR DESCRIPTION
## Description

Allow user to go back, when pressing the `Esc` key while he's renaming the device label during onboarding

## Related Issue

Resolve #14981 

## Screenshots:
![trezor-rename-esc](https://github.com/user-attachments/assets/50b8c96a-e705-4739-ac32-97b5061704f4)


