### PR TITLE
feat: add  flag to device connect so other reducers can handle this differently (THP)

### DIFF
--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -1,6 +1,7 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 import { saveAs } from 'file-saver';
 
+import { selectFirmware } from '@suite-common/firmware';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import {
     TokenDefinitionsState,
@@ -96,6 +97,7 @@ export const extraDependencies: ExtraDependencies = {
         selectSelectedAccount: (state: AppState) => state.wallet.selectedAccount,
         selectSelectedAccountStatus: (state: AppState) => state.wallet.selectedAccount.status,
         selectSuiteSettings,
+        selectFirmwareInstallation: selectFirmware,
         selectIsWindowVisible,
         selectTradingEnvironment: (state: AppState) =>
             state.suite.settings.debug.invityServerEnvironment,

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -4,6 +4,7 @@ import {
     ActionCreatorWithoutPayload,
 } from '@reduxjs/toolkit';
 
+import { FirmwareUpdateState } from '@suite-common/firmware';
 import { MetadataAddPayload } from '@suite-common/metadata-types';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { AcquiredDevice, Route, TrezorDevice, UserContextPayload } from '@suite-common/suite-types';
@@ -88,6 +89,7 @@ export type ExtraDependencies = {
         selectSuiteSettings: SuiteCompatibleSelector<{
             defaultWalletLoading: WalletType;
         }>;
+        selectFirmwareInstallation: SuiteCompatibleSelector<FirmwareUpdateState>;
         selectTradingEnvironment: SuiteCompatibleSelector<
             'production' | 'staging' | 'dev' | 'localhost' | undefined
         >;

--- a/suite-common/test-utils/src/extraDependenciesMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesMock.ts
@@ -106,6 +106,11 @@ export const extraDependenciesMock: ExtraDependencies = {
         selectSuiteSettings: mockSelector('selectSuiteSettings', {
             defaultWalletLoading: 'standard',
         }),
+        selectFirmwareInstallation: mockSelector('selectFirmwareInstallation', {
+            status: 'initial',
+            error: undefined,
+            useDevkit: false,
+        }),
         selectIsWindowVisible: mockSelector('selectIsWindowVisible', true),
         selectTradingEnvironment: mockSelector('selectTradingEnvironment', 'localhost'),
     },

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -10,7 +10,11 @@ export type ConnectDeviceSettings = {
     defaultWalletLoading: WalletType;
 };
 
-export type DeviceConnectActionPayload = { device: Device; settings: ConnectDeviceSettings };
+export type DeviceConnectActionPayload = {
+    device: Device;
+    settings: ConnectDeviceSettings;
+    isDuringFirmwareInstallation: boolean;
+};
 
 const connectDevice = createAction(DEVICE.CONNECT, (payload: DeviceConnectActionPayload) => ({
     payload,

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -646,12 +646,23 @@ export const deviceConnectThunks = createThunk<void, DeviceConnectThunksParams, 
     ({ type, device }, { dispatch, getState, extra }) => {
         const settings = extra.selectors.selectSuiteSettings(getState());
 
+        const isDuringFirmwareInstallation =
+            extra.selectors.selectFirmwareInstallation(getState()).status !== 'initial';
+
         switch (type) {
             case DEVICE.CONNECT:
-                dispatch(deviceActions.connectDevice({ device, settings }));
+                dispatch(
+                    deviceActions.connectDevice({ device, settings, isDuringFirmwareInstallation }),
+                );
                 break;
             case DEVICE.CONNECT_UNACQUIRED:
-                dispatch(deviceActions.connectUnacquiredDevice({ device, settings }));
+                dispatch(
+                    deviceActions.connectUnacquiredDevice({
+                        device,
+                        settings,
+                        isDuringFirmwareInstallation,
+                    }),
+                );
                 break;
             default:
                 exhaustive(type);


### PR DESCRIPTION


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=add-flag-to-device-connect-for-fw-install&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=add-flag-to-device-connect-for-fw-install&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=add-flag-to-device-connect-for-fw-install&lookback=7)