### PR TITLE
Feat reporter manual dispatch

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -2,7 +2,7 @@ name: "Run Playwright E2E Tests"
 description: "Runs Playwright E2E tests with Docker and uploads logs"
 inputs:
   project:
-    description: "Playwright project name. (web|web:release|desktop|desktop:release)"
+    description: "Playwright project name. (web|desktop)"
     required: true
   base-url:
     description: "Base URL for E2E tests. Default: https://dev.suite.sldev.cz/suite-web/BRANCH_NAME/web/"
@@ -44,6 +44,9 @@ inputs:
   release-build:
     description: "Information for GitHub Reporter, only on Release workflows"
     required: false
+  run-reporter:
+    description: "Flag to run GitHub Reporter, only on Release workflows"
+    required: false
 
 runs:
   using: "composite"
@@ -59,7 +62,7 @@ runs:
     # without requiring elevated privileges, which is essential for running the application.
     # This is workaround until electron builder solves this issue in future release.
     - name: Disable security rule 'Restricted unprivileged user namespaces'
-      if: ${{ inputs.project == 'desktop' || inputs.project == 'desktop:release' }}
+      if: ${{ inputs.project == 'desktop' }}
       shell: bash
       run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
@@ -75,7 +78,7 @@ runs:
         echo "::group::Install PW Dependencies"
         echo "Silently installing Playwright dependencies"
         yarn workspaces focus @trezor/suite-desktop-core ${{ inputs.workspace-dependencies }} > /dev/null
-        if [[ "${{ inputs.project }}" == "web" || "${{ inputs.project }}" == "web:release" ]]; then
+        if [[ "${{ inputs.project }}" == "web" ]]; then
           npx playwright install --with-deps > /dev/null
         fi
         echo "::endgroup::"
@@ -102,6 +105,7 @@ runs:
         PASSPHRASE: ${{ inputs.e2e-passphrase }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
         RELEASE_BUILD: ${{ inputs.release-build }}
+        RUN_REPORTER: ${{ inputs.run-reporter }}
       run: |
         if [[ -z "${{ inputs.base-url }}" ]]; then
           BASE_URL="https://dev.suite.sldev.cz/suite-web/${{ env.branch }}/web/"

--- a/.github/workflows/test-suite-desktop-e2e-release.yml
+++ b/.github/workflows/test-suite-desktop-e2e-release.yml
@@ -83,3 +83,4 @@ jobs:
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}
           github-token: ${{ steps.trezor-bot-token.outputs.token }}
           release-build: ${{ env.release_build }}
+          run-reporter: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/test-suite-desktop-e2e-release.yml
+++ b/.github/workflows/test-suite-desktop-e2e-release.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - release/2*
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -83,4 +84,4 @@ jobs:
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}
           github-token: ${{ steps.trezor-bot-token.outputs.token }}
           release-build: ${{ env.release_build }}
-          run-reporter: ${{ github.event_name == 'workflow_dispatch' }}
+          run-reporter: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -3,9 +3,6 @@ name: "[Test] Release Suite Regression test publisher"
 # Runs Playwright reporter, creating manual regressions release suite in GitHub"
 
 on:
-  push:
-    branches:
-      - release/2*
   workflow_dispatch:
 
 concurrency:
@@ -59,4 +56,4 @@ jobs:
           RELEASE_BUILD: ${{ env.release_build }}
         run: |
           echo "Starting Playwright Reporter for manual regression suite"
-          yarn workspace @trezor/suite-desktop-core test:e2e:manual
+          yarn workspace @trezor/suite-desktop-core github:report:manual

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -4,6 +4,7 @@ name: "[Test] Release Suite Regression test publisher"
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/test-suite-release-e2e-report-orchestration.yml
+++ b/.github/workflows/test-suite-release-e2e-report-orchestration.yml
@@ -1,0 +1,16 @@
+name: "[Test] Release Suite Report orchestration"
+# Orchestration workflow that triggers relevant release workflows to create full report in GitHub
+# Desktop, Web and Manual regression suites are run in parallel with reporter enabled
+
+on:
+  workflow_dispatch:
+
+jobs:
+  call-test-suite-manual-release:
+    uses: ./.github/workflows/test-suite-manual-release.yml
+
+  call-test-suite-desktop-e2e-release:
+    uses: ./.github/workflows/test-suite-desktop-e2e-release.yml
+
+  call-test-suite-web-e2e-release:
+    uses: ./.github/workflows/test-suite-web-e2e-release.yml

--- a/.github/workflows/test-suite-web-e2e-release.yml
+++ b/.github/workflows/test-suite-web-e2e-release.yml
@@ -75,3 +75,4 @@ jobs:
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}
           github-token: ${{ steps.trezor-bot-token.outputs.token }}
           release-build: ${{ env.release_build }}
+          run-reporter: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/test-suite-web-e2e-release.yml
+++ b/.github/workflows/test-suite-web-e2e-release.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - release/2*
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -75,4 +76,4 @@ jobs:
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}
           github-token: ${{ steps.trezor-bot-token.outputs.token }}
           release-build: ${{ env.release_build }}
-          run-reporter: ${{ github.event_name == 'workflow_dispatch' }}
+          run-reporter: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}

--- a/docs/tests/e2e-playwright-github-reporter.md
+++ b/docs/tests/e2e-playwright-github-reporter.md
@@ -1,6 +1,6 @@
 # GitHub Test Reporter
 
-The GitHub Test Reporter is a unified test documentation and reporting framework designed to create a single source of truth for both automated and manual tests in our repository. This framework uses structured test annotations to document tests directly in the codebase and automatically generates GitHub project items during release builds for efficient QA workflows.
+The GitHub Test Reporter is a unified test documentation and reporting framework designed to create a single source of truth for both automated and manual tests in our repository. This framework uses structured test annotations to document tests directly in the codebase and automatically generates GitHub project items during release for efficient QA regression testing and single overview of both manual and automated results of release testing.
 
 ## Purpose
 
@@ -8,8 +8,14 @@ The primary goals of this reporter are to:
 
 1. **Unify Test Documentation** - Keep all test cases (both automated and manual) in one place within the repository
 2. **Streamline QA Regression** - Populate a GitHub project with all tests as draft issues for release regression testing
+3. **One overview of Release testing** - Github project contains results of both manual and regression release testing
 
 When executed during release builds, the reporter adds new draft issues to a GitHub project. These issues contain all relevant test metadata and results, providing QA teams with a comprehensive dashboard for regression testing and quality assurance.
+
+## How to run
+
+Reporter no longer has automatic trigger. It needs to be triggered manually by running its orchestration workflow **[Test] Release Suite Report orchestration** which will run 3 relevant workflows (Web, Desktop and Manual). All automated tests will be run on the release again, their results reported to GitHub project and issues for manual regression will be generated as well.
+You can also run the specific workflow one by one.
 
 ## Overview
 
@@ -18,8 +24,6 @@ The framework consists of three main components:
 1. **Test Annotations** - Define metadata about tests
 2. **TestReportProvider** - Extracts and formats test metadata
 3. **GitHub Reporter** - Populates GitHub project with test results as draft issues
-
-The reporter automatically creates draft issues in a GitHub project board when tests run, complete with test metadata, status, and other customizable fields.
 
 ## Annotation Types
 
@@ -104,7 +108,7 @@ The reporter can be run from a local environment for troubleshooting and develop
 
 - `yarn test:e2e:web --reporter=./e2e/support/reporters/gitHubReporter.ts`
 - `yarn test:e2e:desktop --reporter=./e2e/support/reporters/gitHubReporter.ts`
-- `yarn test:e2e:manual`
+- `yarn github:report:manual`
 
 ## Implementation Notes
 
@@ -155,5 +159,8 @@ The reporter is integrated into release branch CI workflows:
 - `test-suite-web-e2e-release.yml` for Suite Web tests
 - `test-suite-desktop-e2e-release.yml` for Suite Desktop tests
 - `test-suite-manual-release.yml` for manual tests
+- `test-suite-release-e2e-report-orchestration` servers to run all relevant workflows
 
 Each workflow passes the `RELEASE_BUILD` and `GITHUB_TOKEN` environment variables to enable test reporting.
+On the Web and Desktop workflows, reporter is enabled only when workflow is run manually. Otherwise only test are run. That way we have full control on the generation of issues in GitHub. We had a problem of duplicate and unwanted triggers when it was based on push to release branch.
+Implemented by this condition: `run-reporter: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}`

--- a/packages/suite-desktop-core/e2e/playwright.config.ts
+++ b/packages/suite-desktop-core/e2e/playwright.config.ts
@@ -23,6 +23,26 @@ function getTimeout(): number {
     return process.env.GITHUB_ACTION ? CI_TIMEOUT : LOCAL_TIMEOUT;
 }
 
+function getReporter(): PlaywrightTestConfig['reporter'] {
+    // Local run
+    if (!process.env.GITHUB_ACTION) {
+        return [['list'], ['html', { open: 'never' }]];
+    }
+
+    // Release - Manual regression: Generate manual suite in GitHub, without currents involvement
+    if (process.env.RUN_REPORTER === 'manual') {
+        return [['./e2e/support/reporters/gitHubReporter.ts']];
+    }
+
+    // Release - Automated CI run: Report results both in Currents and GitHub
+    if (process.env.RUN_REPORTER === 'true') {
+        return [['@currents/playwright'], ['./e2e/support/reporters/gitHubReporter.ts']];
+    }
+
+    // Default run on CI: Report results only in Currents
+    return [['@currents/playwright']];
+}
+
 const config: PlaywrightTestConfig = defineConfig<CurrentsFixtures, CurrentsWorkerFixtures>({
     projects: [
         {
@@ -58,9 +78,7 @@ const config: PlaywrightTestConfig = defineConfig<CurrentsFixtures, CurrentsWork
         currentsFixturesEnabled: !!process.env.GITHUB_ACTION,
     },
     reportSlowTests: null,
-    reporter: process.env.GITHUB_ACTION
-        ? [['@currents/playwright']]
-        : [['list'], ['html', { open: 'never' }]],
+    reporter: getReporter(),
     timeout: getTimeout(),
     outputDir: path.join(__dirname, 'test-results'),
     snapshotPathTemplate: 'snapshots/{projectName}/{testFilePath}/{arg}{ext}',

--- a/packages/suite-desktop-core/e2e/playwright.config.ts
+++ b/packages/suite-desktop-core/e2e/playwright.config.ts
@@ -24,19 +24,19 @@ function getTimeout(): number {
 }
 
 function getReporter(): PlaywrightTestConfig['reporter'] {
+    // Release - Manual regression: Generate manual suite in GitHub, without currents involvement
+    if (process.env.RUN_REPORTER === 'manual') {
+        return [['./support/reporters/gitHubReporter.ts']];
+    }
+
     // Local run
     if (!process.env.GITHUB_ACTION) {
         return [['list'], ['html', { open: 'never' }]];
     }
 
-    // Release - Manual regression: Generate manual suite in GitHub, without currents involvement
-    if (process.env.RUN_REPORTER === 'manual') {
-        return [['./e2e/support/reporters/gitHubReporter.ts']];
-    }
-
     // Release - Automated CI run: Report results both in Currents and GitHub
     if (process.env.RUN_REPORTER === 'true') {
-        return [['@currents/playwright'], ['./e2e/support/reporters/gitHubReporter.ts']];
+        return [['@currents/playwright'], ['./support/reporters/gitHubReporter.ts']];
     }
 
     // Default run on CI: Report results only in Currents

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -13,13 +13,11 @@
         "test:unit": "yarn g:jest",
         "test:e2e:desktop": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --project=desktop",
         "test:e2e:web": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --project=web",
-        "test:e2e:manual": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --project=manual --reporter=./e2e/support/reporters/gitHubReporter.ts",
         "test:e2e:update-snapshots": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --grep @snapshot --update-snapshots",
         "test:orchestrated:e2e:desktop": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=desktop",
-        "test:orchestrated:e2e:desktop:release": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=desktop --reporter=@currents/playwright,./e2e/support/reporters/gitHubReporter.ts",
         "test:orchestrated:e2e:web": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=web",
-        "test:orchestrated:e2e:web:release": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=web --reporter=@currents/playwright,./e2e/support/reporters/gitHubReporter.ts",
-        "github:create-project": "tsx ./e2e/support/reporters/scriptCreateProject.ts"
+        "github:report:manual": "RUN_REPORTER=manual yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --project=manual",
+        "github:create:project": "tsx ./e2e/support/reporters/scriptCreateProject.ts"
     },
     "dependencies": {
         "@sentry/electron": "^5.12.0",


### PR DESCRIPTION
Switch the e2e reporter to a manual dispatch only and provide one orchestration workflow for more convenient use.
The reporter is run only when relevant workflow are run by this event
`run-reporter: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}`

Allowing the web and desktop automated tests still be run on each release build.

Refactors logic to choose right reporter to be in playwright conf.
Ditching few previous changes that became irrelevant.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-reporter-manual-dispatch&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-reporter-manual-dispatch&lookback=7)