### PR TITLE
fix(suite-native): do not start discovery before device onboarding is  finished

### DIFF
--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -149,7 +149,8 @@ export const useHandleDeviceConnection = () => {
             !isPortfolioTrackerDevice &&
             !isDeviceConnectedAndAuthorized &&
             !isBiometricsOverlayVisible &&
-            !shouldNavigateToDeviceCompromisedModal
+            !shouldNavigateToDeviceCompromisedModal &&
+            !isDeviceOnboardingStackFocused
         ) {
             requestPrioritizedDeviceAccess({
                 deviceCallback: () => dispatch(authorizeDeviceThunk()),
@@ -170,6 +171,7 @@ export const useHandleDeviceConnection = () => {
         dispatch,
         failedCheck,
         isDeviceConnected,
+        isDeviceOnboardingStackFocused,
         isOnboardingFinished,
         isPortfolioTrackerDevice,
         isDeviceConnectedAndAuthorized,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

We don't need to authorize the device before Device Onboarding is completed.

- Prevent View Only popup over Device Onboarding
- Prevent early redirection to Connecting screen before PIN setup

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18949



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/discovery-during-device-onboarding&lookback=7)