### PR TITLE
chore(trading): fix styling for copy button in transactions

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingTransactionId.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactionId.tsx
@@ -1,27 +1,10 @@
-import styled from 'styled-components';
-
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { Button, Row } from '@trezor/components';
+import { Button, Row, Text } from '@trezor/components';
 import { copyToClipboard } from '@trezor/dom-utils';
-import { spacings, spacingsPx, typography } from '@trezor/theme';
+import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
-
-const LabelWrapper = styled.div`
-    width: 100%;
-    flex: auto;
-    padding-right: ${spacingsPx.sm};
-    ${typography.label}
-    color: ${({ theme }) => theme.textSubdued};
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-`;
-
-const ButtonWrapper = styled.div`
-    flex: none;
-`;
 
 interface TradingTransactionIdProps {
     transactionId: string;
@@ -37,15 +20,19 @@ export const TradingTransactionId = ({ transactionId }: TradingTransactionIdProp
     };
 
     return (
-        <Row alignItems="center" justifyContent="space-between" margin={{ top: spacings.sm }}>
-            <LabelWrapper data-testid="@trading/transaction-id">
+        <Row margin={{ top: spacings.sm }} gap={spacings.xs}>
+            <Text
+                variant="tertiary"
+                typographyStyle="label"
+                as="div"
+                data-testid="@trading/transaction-id"
+                ellipsisLineCount={1}
+            >
                 <Translation id="TR_TRADING_TRANS_ID" /> {transactionId}
-            </LabelWrapper>
-            <ButtonWrapper>
-                <Button size="tiny" variant="tertiary" onClick={copy}>
-                    <Translation id="TR_COPY_TO_CLIPBOARD" />
-                </Button>
-            </ButtonWrapper>
+            </Text>
+            <Button size="tiny" variant="tertiary" onClick={copy}>
+                <Translation id="TR_COPY_TO_CLIPBOARD" />
+            </Button>
         </Row>
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionExchange.tsx
@@ -9,9 +9,9 @@ import { Translation } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
 import { useTradingWatchTrade } from 'src/hooks/wallet/trading/useTradingWatchTrade';
 import { Account } from 'src/types/wallet';
+import { TradingTransactionId } from 'src/views/wallet/trading/common';
 import { TradingTransactionAmounts } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionAmounts';
 import { TradingTransactionContainer } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionContainer';
-import { TradingTransactionId } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionId';
 import { TradingTransactionInfo } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionInfo';
 import { TradingTransactionProvider } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionProvider';
 

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsBuy.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsBuy.tsx
@@ -11,9 +11,9 @@ import { useDispatch } from 'src/hooks/suite';
 import { useTradingWatchTrade } from 'src/hooks/wallet/trading/useTradingWatchTrade';
 import { useTradingNavigation } from 'src/hooks/wallet/useTradingNavigation';
 import { Account } from 'src/types/wallet';
+import { TradingTransactionId } from 'src/views/wallet/trading/common';
 import { TradingTransactionAmounts } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionAmounts';
 import { TradingTransactionContainer } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionContainer';
-import { TradingTransactionId } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionId';
 import { TradingTransactionInfo } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionInfo';
 import { TradingTransactionProvider } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionProvider';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes `Copy` button in last transactions section misalignment

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15879

## Screenshots:
### Before
<img width="1156" alt="394331071-07cc4f1f-d41d-4cb2-aa36-54c03cf92822" src="https://github.com/user-attachments/assets/6b2a73a1-da78-4ec7-b823-37fd6f6759c1" />

### After
![Screenshot 2025-05-15 at 1 08 24 PM](https://github.com/user-attachments/assets/9fe65475-26a9-495e-8003-28f41170a8a1)
![Screenshot 2025-05-15 at 1 08 04 PM](https://github.com/user-attachments/assets/39a44c7d-655c-4905-8689-f27bab2d25f8)
![Screenshot 2025-05-15 at 1 07 57 PM](https://github.com/user-attachments/assets/698b8999-ea23-4f86-ac2b-9cafaceca794)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/copy-button-in-transactions-style-alignment&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/copy-button-in-transactions-style-alignment&lookback=7)