### PR TITLE
feat(suite): allow to go back when renaming device label while onboarding

### DIFF
--- a/packages/suite/src/views/onboarding/steps/Final.tsx
+++ b/packages/suite/src/views/onboarding/steps/Final.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import useMeasure from 'react-use/lib/useMeasure';
 import styled, { css } from 'styled-components';
@@ -118,6 +118,18 @@ export const FinalStep = () => {
     };
 
     const [wrapperRef, { width }] = useMeasure<HTMLDivElement>();
+
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                setState(null);
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, []);
 
     if (!device?.features) return null;
 


### PR DESCRIPTION
Recreation of #18954 to run CI checks and merge it.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/cant-go-back-when-renaming-label-CI&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/cant-go-back-when-renaming-label-CI&lookback=7)