### PR TITLE
test(suite): change T2B1 to T3B1 to fix e2e

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -38,7 +38,7 @@ export class OnboardingPage {
     readonly selectSeedConfirmButton: Locator;
     readonly continueAtYourOwnRiskButton: Locator;
 
-    isModelWithSecureElement = () => ['T2B1', 'T3T1'].includes(this.model);
+    isModelWithSecureElement = () => ['T3B1', 'T3T1'].includes(this.model);
 
     constructor(
         public page: Page,

--- a/packages/suite-desktop-core/e2e/tests/settings/t3b1-device-settings.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/t3b1-device-settings.test.ts
@@ -1,15 +1,15 @@
 // TODOS:
 // - focus this test on testing what is different from T2T1: (background image, display rotation)
-// - implement these differences in suite in the first place. both suite and T2B1 will happily accept
+// - implement these differences in suite in the first place. both suite and T3B1 will happily accept
 //   request to change display rotation but it has no effect. It should be at least hidden on client.
 // https://github.com/trezor/trezor-suite/issues/6567
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
-test.describe.serial('T2B1 - Device settings', { tag: ['@group=settings'] }, () => {
+test.describe.serial('T3B1 - Device settings', { tag: ['@group=settings'] }, () => {
     test.use({
-        emulatorStartConf: { model: 'T2B1', wipe: true },
+        emulatorStartConf: { model: 'T3B1', wipe: true },
     });
 
     test.beforeEach(async ({ onboardingPage, settingsPage }) => {

--- a/packages/trezor-user-env-link/src/types.ts
+++ b/packages/trezor-user-env-link/src/types.ts
@@ -1,4 +1,4 @@
 /** device model as expected by trezor-user-env */
-export type Model = 'T1B1' | 'T2T1' | 'T2B1' | 'T3T1';
+export type Model = 'T1B1' | 'T2T1' | 'T3B1' | 'T3T1';
 
 export type Firmwares = Record<Model, string[]>;


### PR DESCRIPTION
## Description

Fix (one of) failing playwright tests because latest trezor user env does not accept T2B1 anymore


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/fix-e2e-with-T2B1&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/fix-e2e-with-T2B1&lookback=7)