### PR TITLE
fix(suite-native): better handling of cancellation of device auth check on the device

### DIFF
--- a/suite-native/module-device-onboarding/src/components/DeviceOnboardingScreenWithExitButton.tsx
+++ b/suite-native/module-device-onboarding/src/components/DeviceOnboardingScreenWithExitButton.tsx
@@ -21,9 +21,15 @@ type NavigationProps = StackToStackCompositeNavigationProps<
     RootStackParamList
 >;
 
-const DeviceOnboardingExitButtonScreenHeader = () => {
+type DeviceOnboardingExitButtonScreenHeaderProps = {
+    onAlertContinueButtonPress?: () => void;
+};
+
+const DeviceOnboardingExitButtonScreenHeader = ({
+    onAlertContinueButtonPress,
+}: DeviceOnboardingExitButtonScreenHeaderProps) => {
     const navigation = useNavigation<NavigationProps>();
-    const { handleExitButtonPress } = useExitAlert();
+    const { handleExitButtonPress } = useExitAlert(onAlertContinueButtonPress);
 
     useEffect(() => {
         // Override default navigation GO_BACK action to align it with the exit button behavior.
@@ -40,8 +46,19 @@ const DeviceOnboardingExitButtonScreenHeader = () => {
     return <ScreenHeader closeActionType="close" closeAction={handleExitButtonPress} />;
 };
 
-export const DeviceOnboardingScreenWithExitButton = ({ children, ...screenProps }: ScreenProps) => (
-    <Screen header={<DeviceOnboardingExitButtonScreenHeader />} {...screenProps}>
+export const DeviceOnboardingScreenWithExitButton = ({
+    children,
+    onAlertContinueButtonPress,
+    ...screenProps
+}: ScreenProps & DeviceOnboardingExitButtonScreenHeaderProps) => (
+    <Screen
+        header={
+            <DeviceOnboardingExitButtonScreenHeader
+                onAlertContinueButtonPress={onAlertContinueButtonPress}
+            />
+        }
+        {...screenProps}
+    >
         <Box flex={1} marginTop="sp16">
             {children}
         </Box>

--- a/suite-native/module-device-onboarding/src/hooks/useExitAlert.ts
+++ b/suite-native/module-device-onboarding/src/hooks/useExitAlert.ts
@@ -24,7 +24,7 @@ type NavigationProps = StackToStackCompositeNavigationProps<
     DeviceOnboardingStackRoutes,
     RootStackParamList
 >;
-export const useExitAlert = () => {
+export const useExitAlert = (handleContinueButtonPress?: () => void) => {
     const navigation = useNavigation<NavigationProps>();
     const { showAlert } = useAlert();
     const { translate } = useTranslate();
@@ -57,8 +57,14 @@ export const useExitAlert = () => {
                     TrezorConnect.cancel();
                 }
             },
+            onPressSecondaryButton: () => {
+                if (handleContinueButtonPress) {
+                    handleContinueButtonPress();
+                }
+            },
         });
     }, [
+        handleContinueButtonPress,
         selectedDevice,
         setWasDeviceOnboardingCancelled,
         setIsFirmwareInstallationRunning,

--- a/suite-native/module-device-onboarding/src/screens/ConnectAndUnlockDeviceScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ConnectAndUnlockDeviceScreen.tsx
@@ -76,6 +76,17 @@ export const ConnectAndUnlockDeviceScreen = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    useEffect(() => {
+        const unsubscribe = navigation.addListener('beforeRemove', e => {
+            if (e.data.action.type === 'GO_BACK') {
+                // Prevent going back to device onboarding without device connected.
+                e.preventDefault();
+            }
+        });
+
+        return unsubscribe;
+    }, [navigation]);
+
     return (
         <Screen
             noHorizontalPadding

--- a/suite-native/module-device-onboarding/src/screens/DeviceAuthenticityScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/DeviceAuthenticityScreen.tsx
@@ -1,7 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useCallback, useEffect } from 'react';
 
-import { selectSelectedDeviceAuthenticity } from '@suite-common/wallet-core';
 import { ContinueOnTrezorScreenContent, useDeviceAuthenticityCheck } from '@suite-native/device';
 import {
     DeviceOnboardingStackParamList,
@@ -14,37 +12,27 @@ import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboar
 export const DeviceAuthenticityScreen = ({
     navigation,
 }: StackProps<DeviceOnboardingStackParamList, DeviceOnboardingStackRoutes.DeviceAuthenticity>) => {
-    const [isCheckActive, setIsCheckActive] = useState(false);
     const { checkDeviceAuthenticity } = useDeviceAuthenticityCheck();
-    const selectedDeviceAuthenticity = useSelector(selectSelectedDeviceAuthenticity);
-
-    // Soft error meaning we are not sure if the device is compromised.
-    // We need to retry, and the user cannot proceed past this screen,
-    // but we do not report this to the user as a compromised device.
-    // This includes actions such as canceling on the device or disconnecting the device.
-    const hasSoftError: boolean =
-        !!selectedDeviceAuthenticity?.error && selectedDeviceAuthenticity?.valid !== false;
 
     const handleSuccess = useCallback(() => {
         navigation.navigate(DeviceOnboardingStackRoutes.DeviceAuthenticitySuccess);
     }, [navigation]);
 
-    useEffect(() => {
-        if (hasSoftError) {
-            // If authenticity check failed retry the check automatically.
-            setIsCheckActive(false);
-        }
-    }, [hasSoftError]);
+    const startCheckDeviceAuthenticity = useCallback(() => {
+        checkDeviceAuthenticity(handleSuccess);
+    }, [checkDeviceAuthenticity, handleSuccess]);
 
     useEffect(() => {
-        if (!isCheckActive) {
-            setIsCheckActive(true);
-            checkDeviceAuthenticity(handleSuccess);
-        }
-    }, [checkDeviceAuthenticity, handleSuccess, isCheckActive]);
+        startCheckDeviceAuthenticity();
+
+        // Start the check automatically on first render only
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     return (
-        <DeviceOnboardingScreenWithExitButton>
+        <DeviceOnboardingScreenWithExitButton
+            onAlertContinueButtonPress={startCheckDeviceAuthenticity}
+        >
             <ContinueOnTrezorScreenContent />
         </DeviceOnboardingScreenWithExitButton>
     );


### PR DESCRIPTION
## Description

The previous implementation restarted the device auth check immediately after cancellation, which resulted in a strange UX (the user cancelled the action, and it was immediately initiated again).
Now, it is only triggered after the user clicks the “Continue setup” button. See the video.


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18980, https://github.com/trezor/trezor-suite/issues/18984

## Screenshots:

https://github.com/user-attachments/assets/ede2947e-7955-40ba-8c87-475c43465e39



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-auth-check-in-onboarding-cancelation&lookback=7)