### PR TITLE
Mobile trade visual fixes

### DIFF
--- a/suite-native/atoms/src/Card/Card.tsx
+++ b/suite-native/atoms/src/Card/Card.tsx
@@ -15,6 +15,7 @@ export type CardProps = {
     children: ReactNode;
     style?: NativeStyleObject;
     noPadding?: boolean;
+    noShadow?: boolean;
     borderColor?: Color;
     alertProps?: InlineAlertBoxProps;
     alertPosition?: AlertPosition;
@@ -30,11 +31,11 @@ const cardInnerContainerStyle = prepareNativeStyle<{
     alertPosition?: AlertPosition;
     noPadding: boolean;
     borderColor?: Color;
-}>((utils, { alertPosition, noPadding, borderColor }) => ({
+    noShadow?: boolean;
+}>((utils, { alertPosition, noPadding, borderColor, noShadow }) => ({
     backgroundColor: utils.colors.backgroundSurfaceElevation1,
     borderRadius: utils.borders.radii.r16,
     padding: noPadding ? 0 : utils.spacings.sp16,
-    ...utils.boxShadows.small,
 
     extend: [
         {
@@ -57,6 +58,10 @@ const cardInnerContainerStyle = prepareNativeStyle<{
                 borderColor: utils.colors[borderColor!],
                 borderWidth: utils.borders.widths.small,
             },
+        },
+        {
+            condition: !noShadow,
+            style: utils.boxShadows.small,
         },
     ],
 }));
@@ -88,7 +93,15 @@ const alertBoxWrapperStyle = prepareNativeStyle<{
 
 export const Card = React.forwardRef<View, CardProps>(
     (
-        { children, style, alertProps, alertPosition, borderColor, noPadding = false }: CardProps,
+        {
+            children,
+            style,
+            alertProps,
+            alertPosition,
+            borderColor,
+            noPadding = false,
+            noShadow = false,
+        }: CardProps,
         ref,
     ) => {
         const { applyStyle } = useNativeStyles();
@@ -107,6 +120,7 @@ export const Card = React.forwardRef<View, CardProps>(
                             alertPosition,
                             noPadding,
                             borderColor,
+                            noShadow,
                         }),
                         style,
                     ]}

--- a/suite-native/module-trading/src/components/buy/BuyCard.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyCard.tsx
@@ -1,6 +1,6 @@
+import { Platform } from 'react-native';
 import {
     FadeIn,
-    FadeOut,
     LinearTransition,
     interpolateColor,
     useAnimatedStyle,
@@ -23,6 +23,7 @@ import { useTradingBuyFormContext } from '../../hooks/useTradingBuyFormContext';
 
 type BuyCardProps = {
     isAmountInputActive: boolean;
+    shouldAnimateEntering?: boolean;
 };
 
 const BUY_CARD_TEST_ID = '@trading/buyCard';
@@ -52,15 +53,18 @@ const useAnimatedBorderStyle = (isAmountInputActive: boolean) => {
     }));
 };
 
-export const BuyCard = ({ isAmountInputActive }: BuyCardProps) => {
+export const BuyCard = ({ isAmountInputActive, shouldAnimateEntering }: BuyCardProps) => {
     const { applyStyle } = useNativeStyles();
     const animatedStyle = useAnimatedBorderStyle(isAmountInputActive);
     const { watch } = useTradingBuyFormContext();
 
     const asset = watch('asset');
 
+    // on android fade animation looks ugly on view with shadows, better to skip it
+    const enteringAnimation = shouldAnimateEntering && Platform.OS === 'ios' ? FadeIn : undefined;
+
     return (
-        <AnimatedBox entering={FadeIn} exiting={FadeOut} layout={LinearTransition}>
+        <AnimatedBox entering={enteringAnimation} layout={LinearTransition}>
             <AnimatedCard style={animatedStyle} noPadding>
                 <VStack
                     style={applyStyle(buySectionStyle, { bottomBorder: true })}

--- a/suite-native/module-trading/src/components/buy/BuyForm.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyForm.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { FadeIn, FadeInDown, FadeOutDown } from 'react-native-reanimated';
 
 import { VStack } from '@suite-native/atoms';
 import { useDebouncedValue } from '@trezor/react-utils';
@@ -15,41 +16,82 @@ import { TradeHistoryButton } from '../general/TradeHistory/TradeHistoryButton';
 import { TradingAlert } from '../general/TradingAlert';
 import { TradingFooter } from '../general/TradingFooter';
 
+type BuyFormProps = {
+    shouldAnimateEntering?: boolean;
+};
+
+type BuyFormMemoizedProps = {
+    isAmountInputActive: boolean;
+    shouldAnimateEntering?: boolean;
+};
+
 const BUY_FORM_TEST_ID = '@trading/buy/form';
 
-const BuyFormMemoized = memo(({ isAmountInputActive }: { isAmountInputActive: boolean }) => {
-    // `isFormMountedRecently` allows to use different animations for initial form load (FadeIn)
-    // and when user interacts with the form (FadeInUp/FadeInDown)
-    const isFormMountedRecently = useMountedRecentlyFlag();
+const getEnteringAnimationForItemsUnderBuyCard = (
+    isFormMountedRecently?: boolean,
+    shouldAnimateEntering?: boolean,
+) => {
+    if (!isFormMountedRecently) {
+        return FadeInDown;
+    }
 
-    return (
-        <VStack spacing="sp16" testID={BUY_FORM_TEST_ID}>
-            {!isAmountInputActive && <BuyHeader isFormMountedRecently={isFormMountedRecently} />}
-            <TradingAlert />
-            <BuyCard isAmountInputActive={isAmountInputActive} />
-            {isAmountInputActive ? (
-                <AmountEditingDoneButton />
-            ) : (
-                <>
-                    <PaymentCard isFormMountedRecently={isFormMountedRecently} />
-                    <Confirmation isFormMountedRecently={isFormMountedRecently} />
-                    <TradingFooter isFormMountedRecently={isFormMountedRecently} />
-                    <TradeHistoryButton
-                        tradeType="buy"
-                        isFormMountedRecently={isFormMountedRecently}
-                    />
-                </>
-            )}
-        </VStack>
-    );
-});
+    return shouldAnimateEntering ? FadeIn : undefined;
+};
 
-export const BuyForm = () => {
+const BuyFormMemoized = memo(
+    ({ isAmountInputActive, shouldAnimateEntering }: BuyFormMemoizedProps) => {
+        // `isFormMountedRecently` allows to use different animations for initial form load (FadeIn)
+        // and when user interacts with the form (FadeInUp/FadeInDown)
+        const isFormMountedRecently = useMountedRecentlyFlag();
+
+        const enteringAnimation = getEnteringAnimationForItemsUnderBuyCard(
+            isFormMountedRecently,
+            shouldAnimateEntering,
+        );
+
+        return (
+            <VStack spacing="sp16" testID={BUY_FORM_TEST_ID}>
+                {!isAmountInputActive && (
+                    <BuyHeader isFormMountedRecently={isFormMountedRecently} />
+                )}
+                <TradingAlert />
+                <BuyCard
+                    isAmountInputActive={isAmountInputActive}
+                    shouldAnimateEntering={shouldAnimateEntering}
+                />
+                {isAmountInputActive ? (
+                    <AmountEditingDoneButton />
+                ) : (
+                    <>
+                        <PaymentCard
+                            isFormMountedRecently={isFormMountedRecently}
+                            shouldAnimateEntering={shouldAnimateEntering}
+                        />
+                        <Confirmation enteringAnimation={enteringAnimation} />
+                        <TradingFooter enteringAnimation={enteringAnimation} />
+                        <TradeHistoryButton
+                            tradeType="buy"
+                            enteringAnimation={enteringAnimation}
+                            exitingAnimation={FadeOutDown}
+                        />
+                    </>
+                )}
+            </VStack>
+        );
+    },
+);
+
+export const BuyForm = ({ shouldAnimateEntering }: BuyFormProps) => {
     const buyForm = useTradingBuyFormContext();
     useBuyQuotes(buyForm);
 
     const isAmountInputActive = !!buyForm.watch('focusedValue');
     const isAmountInputActiveDebounced = useDebouncedValue(isAmountInputActive);
 
-    return <BuyFormMemoized isAmountInputActive={isAmountInputActiveDebounced} />;
+    return (
+        <BuyFormMemoized
+            isAmountInputActive={isAmountInputActiveDebounced}
+            shouldAnimateEntering={shouldAnimateEntering}
+        />
+    );
 };

--- a/suite-native/module-trading/src/components/buy/BuyForm.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyForm.tsx
@@ -50,7 +50,7 @@ const BuyFormMemoized = memo(
         );
 
         return (
-            <VStack spacing="sp16" testID={BUY_FORM_TEST_ID}>
+            <VStack spacing="sp16" paddingTop="sp16" testID={BUY_FORM_TEST_ID}>
                 {!isAmountInputActive && (
                     <BuyHeader isFormMountedRecently={isFormMountedRecently} />
                 )}

--- a/suite-native/module-trading/src/components/buy/BuyFormSkeleton.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFormSkeleton.tsx
@@ -5,44 +5,54 @@ import { BoxSkeleton, Card, HStack, VStack } from '@suite-native/atoms';
 import { BuyHeader } from './BuyHeader';
 import { TradingFooter } from '../general/TradingFooter';
 
-const SKELETON_LARGE_WIDTH = Dimensions.get('window').width * 0.3;
 const SKELETON_LARGE_HEIGHT = 60;
-const SKELETON_SMALL_WIDTH = Dimensions.get('window').width * 0.2;
 const SKELETON_SMALL_HEIGHT = 20;
 
-const SkeletonSmall = () => (
-    <BoxSkeleton width={SKELETON_SMALL_WIDTH} height={SKELETON_SMALL_HEIGHT} />
+type SkeletonProps = {
+    widthPercentage: number;
+};
+
+type SkeletonRowProps = {
+    leftWidthPercentage: number;
+    rightWidthPercentage: number;
+};
+
+const SkeletonSmall = ({ widthPercentage }: SkeletonProps) => (
+    <BoxSkeleton
+        width={Dimensions.get('window').width * widthPercentage}
+        height={SKELETON_SMALL_HEIGHT}
+    />
 );
 
-const SkeletonLarge = () => (
-    <BoxSkeleton width={SKELETON_LARGE_WIDTH} height={SKELETON_LARGE_HEIGHT} borderRadius="r16" />
+const SkeletonLarge = ({ widthPercentage }: SkeletonProps) => (
+    <BoxSkeleton
+        width={Dimensions.get('window').width * widthPercentage}
+        height={SKELETON_LARGE_HEIGHT}
+        borderRadius="r16"
+    />
+);
+
+const SkeletonLargeRow = ({ leftWidthPercentage, rightWidthPercentage }: SkeletonRowProps) => (
+    <HStack justifyContent="space-between" alignItems="center">
+        <SkeletonLarge widthPercentage={leftWidthPercentage} />
+        <SkeletonLarge widthPercentage={rightWidthPercentage} />
+    </HStack>
 );
 
 export const BuyFormSkeleton = () => (
     <VStack spacing="sp16" paddingTop="sp16">
         <BuyHeader isFormMountedRecently={true} />
-        <VStack spacing="sp16">
-            <Card>
-                <VStack>
-                    <SkeletonSmall />
-                    <HStack justifyContent="space-between" alignItems="center">
-                        <SkeletonLarge />
-                        <SkeletonLarge />
-                    </HStack>
-                    <SkeletonSmall />
-                    <HStack justifyContent="space-between" alignItems="center">
-                        <SkeletonLarge />
-                        <SkeletonLarge />
-                    </HStack>
-                </VStack>
-            </Card>
-            <Card>
-                <HStack justifyContent="space-between" alignItems="center">
-                    <SkeletonLarge />
-                    <SkeletonLarge />
-                </HStack>
-            </Card>
-        </VStack>
+        <Card>
+            <VStack>
+                <SkeletonSmall widthPercentage={0.2} />
+                <SkeletonLargeRow leftWidthPercentage={0.3} rightWidthPercentage={0.35} />
+                <SkeletonSmall widthPercentage={0.25} />
+                <SkeletonLargeRow leftWidthPercentage={0.4} rightWidthPercentage={0.3} />
+            </VStack>
+        </Card>
+        <Card>
+            <SkeletonLargeRow leftWidthPercentage={0.35} rightWidthPercentage={0.35} />
+        </Card>
         <TradingFooter />
     </VStack>
 );

--- a/suite-native/module-trading/src/components/buy/BuyFormSkeleton.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFormSkeleton.tsx
@@ -1,8 +1,8 @@
 import { Dimensions } from 'react-native';
 
-import { BoxSkeleton, Card, HStack, Text, VStack } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
+import { BoxSkeleton, Card, HStack, VStack } from '@suite-native/atoms';
 
+import { BuyHeader } from './BuyHeader';
 import { TradingFooter } from '../general/TradingFooter';
 
 const SKELETON_LARGE_WIDTH = Dimensions.get('window').width * 0.3;
@@ -19,10 +19,8 @@ const SkeletonLarge = () => (
 );
 
 export const BuyFormSkeleton = () => (
-    <VStack spacing="sp16">
-        <Text variant="titleSmall" color="textDefault">
-            <Translation id="moduleTrading.tradingScreen.buyTitle" />
-        </Text>
+    <VStack spacing="sp16" paddingTop="sp16">
+        <BuyHeader isFormMountedRecently={true} />
         <VStack spacing="sp16">
             <Card>
                 <VStack>

--- a/suite-native/module-trading/src/components/buy/BuyFormSkeleton.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFormSkeleton.tsx
@@ -45,6 +45,6 @@ export const BuyFormSkeleton = () => (
                 </HStack>
             </Card>
         </VStack>
-        <TradingFooter isFormMountedRecently={true} />
+        <TradingFooter />
     </VStack>
 );

--- a/suite-native/module-trading/src/components/buy/BuyHeader.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyHeader.tsx
@@ -8,7 +8,11 @@ export type BuyHeaderProps = {
 };
 
 export const BuyHeader = ({ isFormMountedRecently }: BuyHeaderProps) => (
-    <AnimatedBox entering={isFormMountedRecently ? undefined : FadeInUp} exiting={FadeOutUp}>
+    <AnimatedBox
+        entering={isFormMountedRecently ? undefined : FadeInUp}
+        exiting={FadeOutUp}
+        paddingHorizontal="sp16"
+    >
         <Text variant="titleSmall" color="textDefault">
             <Translation id="moduleTrading.tradingScreen.buyTitle" />
         </Text>

--- a/suite-native/module-trading/src/components/buy/BuyHeader.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyHeader.tsx
@@ -1,4 +1,4 @@
-import { FadeIn, FadeInUp, FadeOutUp } from 'react-native-reanimated';
+import { FadeInUp, FadeOutUp } from 'react-native-reanimated';
 
 import { AnimatedBox, Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -8,7 +8,7 @@ export type BuyHeaderProps = {
 };
 
 export const BuyHeader = ({ isFormMountedRecently }: BuyHeaderProps) => (
-    <AnimatedBox entering={isFormMountedRecently ? FadeIn : FadeInUp} exiting={FadeOutUp}>
+    <AnimatedBox entering={isFormMountedRecently ? undefined : FadeInUp} exiting={FadeOutUp}>
         <Text variant="titleSmall" color="textDefault">
             <Translation id="moduleTrading.tradingScreen.buyTitle" />
         </Text>

--- a/suite-native/module-trading/src/components/buy/Confirmation.tsx
+++ b/suite-native/module-trading/src/components/buy/Confirmation.tsx
@@ -1,4 +1,4 @@
-import { FadeIn, FadeInDown, FadeOutDown } from 'react-native-reanimated';
+import { AnimatedProps, FadeIn, FadeOutDown } from 'react-native-reanimated';
 
 import { AnimatedBox, Button } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -8,12 +8,12 @@ import { useTradingBuyFlow } from '../../hooks/useTradingBuyFlow';
 import { useTradingBuyFormContext } from '../../hooks/useTradingBuyFormContext';
 
 export type ConfirmationProps = {
-    isFormMountedRecently?: boolean;
+    enteringAnimation?: AnimatedProps<any>['entering'];
 };
 
 const CONFIRMATION_TEST_ID = '@trading/buy/continue-button';
 
-export const Confirmation = ({ isFormMountedRecently }: ConfirmationProps) => {
+export const Confirmation = ({ enteringAnimation }: ConfirmationProps) => {
     const form = useTradingBuyFormContext();
 
     const { canProceed, selectQuote, isConsentRequested, giveConsent, cancelConsent } =
@@ -22,7 +22,7 @@ export const Confirmation = ({ isFormMountedRecently }: ConfirmationProps) => {
     const quote = form.watch('quote');
 
     return (
-        <AnimatedBox entering={isFormMountedRecently ? FadeIn : FadeInDown} exiting={FadeOutDown}>
+        <AnimatedBox entering={enteringAnimation} exiting={FadeOutDown}>
             {canProceed && (
                 <AnimatedBox entering={FadeIn}>
                     <Button onPress={selectQuote} testID={CONFIRMATION_TEST_ID}>

--- a/suite-native/module-trading/src/components/buy/PaymentCard.tsx
+++ b/suite-native/module-trading/src/components/buy/PaymentCard.tsx
@@ -1,4 +1,5 @@
-import { FadeIn, FadeInDown, FadeOutDown } from 'react-native-reanimated';
+import { Platform } from 'react-native';
+import { FadeIn, FadeInDown, FadeOutUp, StretchInY, StretchOutY } from 'react-native-reanimated';
 
 import { AnimatedBox, Card } from '@suite-native/atoms';
 
@@ -8,14 +9,37 @@ import { TradingProviderPicker } from './TradingProviderPicker';
 
 export type PaymentCardProps = {
     isFormMountedRecently?: boolean;
+    shouldAnimateEntering?: boolean;
 };
 
-export const PaymentCard = ({ isFormMountedRecently }: PaymentCardProps) => (
-    <AnimatedBox entering={isFormMountedRecently ? FadeIn : FadeInDown} exiting={FadeOutDown}>
-        <Card noPadding>
-            <PaymentMethodPicker />
-            <CountryOfResidencePicker />
-            <TradingProviderPicker />
-        </Card>
-    </AnimatedBox>
-);
+const getEnteringAnimation = (isFormMountedRecently?: boolean, shouldAnimateEntering?: boolean) => {
+    // on android fade animation looks ugly on view with shadows, better to skip the initial one
+    // and use stretch animation instead for the rest of the time
+    if (Platform.OS === 'android') {
+        return isFormMountedRecently ? undefined : StretchInY;
+    }
+
+    if (isFormMountedRecently) {
+        return shouldAnimateEntering ? FadeIn : undefined;
+    }
+
+    return FadeInDown;
+};
+
+// on android fade animation looks ugly on view with shadows, better to use stretch one here
+const getExitingAnimation = () => (Platform.OS === 'android' ? StretchOutY : FadeOutUp);
+
+export const PaymentCard = ({ isFormMountedRecently, shouldAnimateEntering }: PaymentCardProps) => {
+    const enteringAnimation = getEnteringAnimation(isFormMountedRecently, shouldAnimateEntering);
+    const exitingAnimation = getExitingAnimation();
+
+    return (
+        <AnimatedBox entering={enteringAnimation} exiting={exitingAnimation}>
+            <Card noPadding>
+                <PaymentMethodPicker />
+                <CountryOfResidencePicker />
+                <TradingProviderPicker />
+            </Card>
+        </AnimatedBox>
+    );
+};

--- a/suite-native/module-trading/src/components/general/CountrySheet/CountryListItem.tsx
+++ b/suite-native/module-trading/src/components/general/CountrySheet/CountryListItem.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { Pressable } from 'react-native';
+import { Platform, Pressable } from 'react-native';
 import { FadeIn, FadeOut } from 'react-native-reanimated';
 
 import { AnimatedBox, Card, HStack, Radio, Text } from '@suite-native/atoms';
@@ -20,11 +20,14 @@ const wrapperStyle = prepareNativeStyle(({ spacings }) => ({
 
 export const CountryListItem = ({ label, onPress, value, isSelected }: CountryListItemProps) => {
     const { applyStyle } = useNativeStyles();
+    // on android fade animation looks ugly on view with shadows, but without animation it looks even worse
+    // do not display shadow on android and keep animating
+    const noShadow = Platform.OS === 'android';
 
     return (
         <AnimatedBox entering={FadeIn} exiting={FadeOut}>
             <Pressable onPress={onPress} style={applyStyle(wrapperStyle)}>
-                <Card>
+                <Card noShadow={noShadow}>
                     <HStack alignItems="center" justifyContent="space-between">
                         <HStack>
                             <Text variant="body" color="textDefault">

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProvidersSheet.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProvidersSheet.tsx
@@ -62,7 +62,7 @@ export const ProvidersSheet = ({
                         companyName={companyName ?? ''}
                         logo={logo ?? ''}
                         onPress={() => onQuoteSelectCallback(item)}
-                        isSelected={item.orderId === selectedQuote?.orderId}
+                        isSelected={item.exchange === selectedQuote?.exchange}
                     />
                 );
             }}

--- a/suite-native/module-trading/src/components/general/TradeHistory/TradeHistoryButton.tsx
+++ b/suite-native/module-trading/src/components/general/TradeHistory/TradeHistoryButton.tsx
@@ -1,5 +1,5 @@
 import { Pressable } from 'react-native';
-import { FadeIn, FadeInDown, FadeOutDown } from 'react-native-reanimated';
+import { AnimatedProps } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
@@ -23,7 +23,8 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles/src';
 
 type TradeHistoryButtonProps = {
     tradeType: TradingType;
-    isFormMountedRecently?: boolean;
+    enteringAnimation: AnimatedProps<Record<never, unknown>>['entering'];
+    exitingAnimation: AnimatedProps<Record<never, unknown>>['exiting'];
 };
 
 export type NavigationProps = StackToStackCompositeNavigationProps<
@@ -48,7 +49,8 @@ const buttonStyle = prepareNativeStyle(utils => ({
 
 export const TradeHistoryButton = ({
     tradeType,
-    isFormMountedRecently,
+    enteringAnimation,
+    exitingAnimation,
 }: TradeHistoryButtonProps) => {
     const { applyStyle } = useNativeStyles();
     const navigation = useNavigation<NavigationProps>();
@@ -63,7 +65,7 @@ export const TradeHistoryButton = ({
     const handleOnPress = () => navigation.navigate(TradingStackRoutes.TradeHistory, { tradeType });
 
     return (
-        <AnimatedBox entering={isFormMountedRecently ? FadeIn : FadeInDown} exiting={FadeOutDown}>
+        <AnimatedBox entering={enteringAnimation} exiting={exitingAnimation}>
             <Pressable onPress={handleOnPress} testID={TRADE_HISTORY_BUTTON_TEST_ID}>
                 <HStack style={applyStyle(buttonStyle)}>
                     <Text variant="body" color="textSubdued">

--- a/suite-native/module-trading/src/components/general/TradingFooter.tsx
+++ b/suite-native/module-trading/src/components/general/TradingFooter.tsx
@@ -1,23 +1,24 @@
 import { useMemo } from 'react';
 import { TouchableOpacity } from 'react-native';
-import { FadeIn, FadeInDown, FadeOutDown } from 'react-native-reanimated';
+import { AnimatedProps } from 'react-native-reanimated';
 
 import { AnimatedBox, Button, HStack, Image, Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
 
 export type TradingFooterProps = {
-    isFormMountedRecently?: boolean;
+    enteringAnimation?: AnimatedProps<any>['entering'];
+    exitingAnimation?: AnimatedProps<any>['exiting'];
 };
 
-export const TradingFooter = ({ isFormMountedRecently }: TradingFooterProps) => {
+export const TradingFooter = ({ enteringAnimation, exitingAnimation }: TradingFooterProps) => {
     const openLink = useOpenLink();
 
     const imageSource = useMemo(() => require('../../../assets/InvityLogo.png'), []);
     const openLinkToInvity = () => openLink('https://invity.io');
 
     return (
-        <AnimatedBox entering={isFormMountedRecently ? FadeIn : FadeInDown} exiting={FadeOutDown}>
+        <AnimatedBox entering={enteringAnimation} exiting={exitingAnimation}>
             <HStack justifyContent="space-between" alignItems="center">
                 <HStack alignItems="center" spacing="sp4">
                     <Text variant="label" color="textSubdued">

--- a/suite-native/module-trading/src/hooks/useSectionList.tsx
+++ b/suite-native/module-trading/src/hooks/useSectionList.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, ReactNode, useMemo } from 'react';
-import { FadeIn, FadeInUp, FadeOut, FadeOutUp } from 'react-native-reanimated';
+import { FadeIn, FadeOut } from 'react-native-reanimated';
 
 import { UnreachableCaseError } from '@suite-common/suite-utils';
 import { AnimatedBox, Text } from '@suite-native/atoms';
@@ -109,7 +109,7 @@ const renderInternalItem = <T, U>(
     switch (item[0]) {
         case 'sectionHeader':
             return (
-                <AnimatedBox paddingVertical="sp12" entering={FadeInUp} exiting={FadeOutUp}>
+                <AnimatedBox paddingVertical="sp12" entering={FadeIn} exiting={FadeOut}>
                     <Text variant="hint" color="textSubdued">
                         {item[1]}
                     </Text>

--- a/suite-native/module-trading/src/screens/TradingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useNetInfo } from '@react-native-community/netinfo';
@@ -38,11 +38,14 @@ const TradingScreenContent = () => {
         }
     }, [tradeToBeOpened, navigation]);
 
+    const isLoadingFinished = !isLoading && lastLoadedTimestamp > 0;
+
+    const wasSkeletonDisplayed = useRef(!isLoadingFinished);
+
     if (isInternetReachable === false) {
         return <DeviceOffline />;
     }
 
-    const isLoadingFinished = !isLoading && lastLoadedTimestamp > 0;
     if (isLoadingFinished && !isFullyLoaded) {
         return <ServerOffline onRetryPress={() => setReloadOrdinal(reloadOrdinal + 1)} />;
     }
@@ -52,7 +55,7 @@ const TradingScreenContent = () => {
             <ContextMessage context={Context.tradingBuy} />
             {isFullyLoaded ? (
                 <BuyFormContextProvider>
-                    <BuyForm />
+                    <BuyForm shouldAnimateEntering={wasSkeletonDisplayed.current} />
                 </BuyFormContextProvider>
             ) : (
                 <BuyFormSkeleton />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Fixed bug that provider was sometimes not visually selected in provider sheet.
- Changed "Favourites" and "All assets" animation from FadeInUp to FadeIn.
- When buy form is displayed immediately after navigation there are no animations (animations after skeleton are still present).
- Fixed animations on footer (was always FadeInDown).
- Buy header does never FadeIn (FadeInUp still present as before).
- Buy header is now positioned same way as e.g. Preferences header.
- Skeleton visual updated (again).
- Android only changes:
  - No ugly shadow fade animations.
  - Shadow removed for country list to allow FadeIn of items.
  - Animations changed for Cards on buy form screen (to allow to still keep shadows).

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

### Android before changes
https://github.com/user-attachments/assets/aee64c1c-2367-4f25-9e3a-dcd22c7b95c7

### Android after changes
https://github.com/user-attachments/assets/0d20cee9-6bb2-4495-879f-a2b40adbaf36

### iOS after changes
https://github.com/user-attachments/assets/30b9c5c8-44ec-40af-91bd-eb0ae2a05ba8




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mobile-trade-visual-fixes&lookback=7)