### PR TITLE
fix(suite-native): Display actual minimum fee instead of "undefined" on custom fee page.

### DIFF
--- a/suite-native/module-send/src/components/CustomFeeInputs.tsx
+++ b/suite-native/module-send/src/components/CustomFeeInputs.tsx
@@ -19,7 +19,7 @@ type CustomFeeInputsProps = {
 
 export const CustomFeeInputs = ({ symbol }: CustomFeeInputsProps) => {
     const { translate } = useTranslate();
-    const feeInfo = useSelector((state: FeesRootState) => selectNetworkFeeInfo(state, 'btc'));
+    const feeInfo = useSelector((state: FeesRootState) => selectNetworkFeeInfo(state, symbol));
     const { cryptoAmountTransformer } = useAmountInputTransformers(symbol);
     const debounce = useDebounce();
     const {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously, the Custom Fee page on Stellar and Ripple (perhaps other tokens are also affected.) displayed "undefined" instead of the correct minimum fee; this PR fixes that.

## Related Issue

Resolve #18879

## Screenshots:
![Screenshot_20250516-140958_Trezor_Suite_Lite_Debug](https://github.com/user-attachments/assets/e53f15fe-2d21-4d81-9b50-cc8e7608bc3b)
![Screenshot_20250516-141034_Trezor_Suite_Lite_Debug](https://github.com/user-attachments/assets/8d6fb413-72f7-43be-80b1-5846f9a3059d)

