### PR TITLE
Change Ripple endpoints to public servers

### DIFF
--- a/packages/blockchain-link/src/ui/config.ts
+++ b/packages/blockchain-link/src/ui/config.ts
@@ -6,8 +6,9 @@ export default [
             server: [
                 'wss://xrp1.trezor.io',
                 'wss://xrp2.trezor.io',
-                'wss://xrp3.trezor.io',
-                'wss://xrp4.trezor.io',
+                'wss://xrplcluster.com',
+                'wss://xrpl.ws',
+                'wss://s2.ripple.com',
             ],
             debug: true,
         },

--- a/packages/connect-common/files/coins.json
+++ b/packages/connect-common/files/coins.json
@@ -2874,8 +2874,9 @@
                 "url": [
                     "wss://xrp1.trezor.io",
                     "wss://xrp2.trezor.io",
-                    "wss://xrp3.trezor.io",
-                    "wss://xrp4.trezor.io"
+                    "wss://xrplcluster.com",
+                    "wss://xrpl.ws",
+                    "wss://s2.ripple.com"
                 ]
             },
             "curve": "secp256k1",


### PR DESCRIPTION
## Description

Ripple websocket endpoints have been replaced with public ones due to recurring timeout and disconnect errors reported in Sentry.

xrp3 and xrp4 went to public servers but with trezor io, so there was rate limit per ip

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18293
Resolve https://github.com/trezor/trezor-suite/issues/18295
Resolve https://github.com/trezor/trezor-suite/issues/18294


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ripple-change-server-endpoints&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ripple-change-server-endpoints&lookback=7)