### PR TITLE
refactor(trading): adds tradingAccountKey to TradingBuyState

### DIFF
--- a/suite-common/trading/src/reducers/__fixtures__/buyTradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/buyTradingReducer.ts
@@ -221,4 +221,18 @@ export const buyTradingFixtures = [
             amountLimits,
         },
     },
+    {
+        description: 'should set trading account key',
+        initialState: buyInitialState,
+        actions: [
+            {
+                type: tradingBuyActions.setTradingAccountKey.type,
+                payload: '123456',
+            },
+        ],
+        result: {
+            ...buyInitialState,
+            tradingAccountKey: '123456',
+        },
+    },
 ];

--- a/suite-common/trading/src/reducers/buyReducer.ts
+++ b/suite-common/trading/src/reducers/buyReducer.ts
@@ -7,6 +7,8 @@ import type {
     CryptoId,
 } from 'invity-api';
 
+import { AccountKey } from '@suite-common/wallet-types';
+
 import { TRADING_BUY_PREFIX } from '../constants';
 import { TradingAmountLimitProps } from '../types';
 
@@ -24,6 +26,7 @@ export interface TradingBuyState {
     quotes: BuyTrade[];
     selectedQuote: BuyTrade | undefined;
     addressVerified: string | undefined;
+    tradingAccountKey?: AccountKey;
     isLoading: boolean;
     amountLimits: TradingAmountLimitProps | undefined;
 
@@ -38,6 +41,7 @@ export const buyInitialState: TradingBuyState = {
     selectedQuote: undefined,
     quotes: [],
     addressVerified: undefined,
+    tradingAccountKey: undefined,
     isLoading: false,
     amountLimits: undefined,
 };
@@ -78,6 +82,9 @@ const tradingBuySlice = createSlice({
         },
         setAmountLimits(state, action: PayloadAction<TradingAmountLimitProps | undefined>) {
             state.amountLimits = action.payload;
+        },
+        setTradingAccountKey(state, action: PayloadAction<AccountKey | undefined>) {
+            state.tradingAccountKey = action.payload;
         },
     },
 });

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -63,6 +63,7 @@ describe('tradingSelectors', () => {
     const getBuyState = () =>
         ({
             ...initialState.buy,
+            tradingAccountKey: accountBtc.key,
             quotesRequest: {
                 wantCrypto: true,
                 fiatCurrency: 'fiatCurrency',
@@ -741,14 +742,18 @@ describe('tradingSelectors', () => {
     });
 
     describe('selectTradingAccountAccordingActiveSection', () => {
-        it('should return correct account for buy', () => {
+        it('should return correct account for buy according to tradingAccountKey', () => {
             expect(
                 selectTradingAccountAccordingActiveSection(
                     state,
                     'buy',
                     state.wallet.selectedAccount,
                 ),
-            ).toEqual(state.wallet.selectedAccount.account);
+            ).toEqual(
+                state.wallet.accounts.find(
+                    account => account.key === state.wallet.tradingNew.buy.tradingAccountKey,
+                ),
+            );
         });
 
         it('should return correct account for exchange according to tradingAccountKey', () => {

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -445,21 +445,26 @@ export const selectTradingAccountAccordingActiveSection = createMemoizedSelector
     [
         selectTradingExchange,
         selectTradingSell,
+        selectTradingBuy,
         ({ wallet }) => wallet.accounts,
         (_: TradingRootState, activeSection: TradingType) => activeSection,
         (_: TradingRootState, __: TradingType, selectedAccount: SelectedAccountStatus) =>
             selectedAccount,
     ],
-    (tradingExchange, tradingSell, accounts, activeSection, selectedAccount) => {
-        if (activeSection === 'exchange') {
-            return accounts.find(account => account.key === tradingExchange.tradingAccountKey);
-        }
+    (tradingExchange, tradingSell, tradingBuy, accounts, activeSection, selectedAccount) => {
+        const tradingSectionMap = {
+            buy: tradingBuy.tradingAccountKey,
+            sell: tradingSell.tradingAccountKey,
+            exchange: tradingExchange.tradingAccountKey,
+        };
 
-        if (activeSection === 'sell') {
-            return accounts.find(account => account.key === tradingSell.tradingAccountKey);
-        }
+        const tradingAccountKey = tradingSectionMap[activeSection];
 
-        return selectedAccount.account;
+        const account = tradingAccountKey
+            ? accounts.find(acc => acc.key === tradingAccountKey)
+            : null;
+
+        return account ?? selectedAccount.account; // TODO: trading - delete selectedAccount and set tradingAccountKey on desktop
     },
 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Similar to TradingSellState and TradingExchangeState adds tradingAccountKey to suite-common TradingBuyState

<!--- Describe your changes in detail -->

## Related Issue
Resolve https://github.com/trezor/trezor-suite/issues/18917


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/add-trading-account-key-to-trading-buy-state&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/add-trading-account-key-to-trading-buy-state&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/add-trading-account-key-to-trading-buy-state&lookback=7)