### PR TITLE
chore(suite-native): do not allow reinstall on develop

### DIFF
--- a/suite-native/analytics/tsconfig.json
+++ b/suite-native/analytics/tsconfig.json
@@ -14,9 +14,7 @@
         {
             "path": "../../suite-common/suite-constants"
         },
-        {
-            "path": "../../suite-common/trading"
-        },
+        { "path": "../../suite-common/trading" },
         {
             "path": "../../suite-common/wallet-config"
         },

--- a/suite-native/module-device-settings/package.json
+++ b/suite-native/module-device-settings/package.json
@@ -18,7 +18,6 @@
         "@suite-common/wallet-core": "workspace:*",
         "@suite-native/alerts": "workspace:*",
         "@suite-native/atoms": "workspace:*",
-        "@suite-native/config": "workspace:*",
         "@suite-native/device": "workspace:*",
         "@suite-native/icons": "workspace:*",
         "@suite-native/intl": "workspace:*",

--- a/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
@@ -13,7 +13,6 @@ import {
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { HStack, InlineAlertBoxProps, Text, VStack } from '@suite-native/atoms';
-import { isDevelopOrDebugEnv } from '@suite-native/config';
 import { useIsFirmwareUpdateFeatureEnabled } from '@suite-native/firmware';
 import { deviceModelToIconName } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
@@ -53,9 +52,6 @@ type NavigationProp = StackNavigationProps<
     DeviceStackRoutes.ConfirmFirmwareUpdate
 >;
 
-// TODO: remove this once we finish debugging firmware update
-const allowReinstall = isDevelopOrDebugEnv();
-
 export const DeviceFirmwareCard = () => {
     const device = useSelector(selectSelectedDevice);
     const deviceModel = useSelector(selectDeviceModel);
@@ -83,7 +79,7 @@ export const DeviceFirmwareCard = () => {
         if (G.isNotNullable(deviceReleaseInfo)) {
             const isUpgradable = deviceReleaseInfo.isNewer ?? false;
 
-            if (isUpgradable || allowReinstall) {
+            if (isUpgradable) {
                 return {
                     title: (
                         <Translation

--- a/suite-native/module-device-settings/tsconfig.json
+++ b/suite-native/module-device-settings/tsconfig.json
@@ -10,7 +10,6 @@
         },
         { "path": "../alerts" },
         { "path": "../atoms" },
-        { "path": "../config" },
         { "path": "../device" },
         { "path": "../icons" },
         { "path": "../intl" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10665,7 +10665,6 @@ __metadata:
     "@suite-common/wallet-core": "workspace:*"
     "@suite-native/alerts": "workspace:*"
     "@suite-native/atoms": "workspace:*"
-    "@suite-native/config": "workspace:*"
     "@suite-native/device": "workspace:*"
     "@suite-native/icons": "workspace:*"
     "@suite-native/intl": "workspace:*"


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

It's more confusing than helpful.



## Screenshots:

Avoid this:
<img width="559" alt="image" src="https://github.com/user-attachments/assets/128c9ef8-b5a4-48a2-b964-f4800e9e2eef" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/remove-reinstall-option&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/remove-reinstall-option&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/remove-reinstall-option&lookback=7)