### PR TITLE
fix(suite-native): mock analytics in unit tests

### DIFF
--- a/jest.config.native.js
+++ b/jest.config.native.js
@@ -37,6 +37,7 @@ module.exports = {
         '<rootDir>/../../suite-native/connection-status/src/jestSetup.js',
         '<rootDir>/../../suite-native/react-native-graph/src/jestSetup.js',
         '<rootDir>/../../suite-native/atoms/src/jestSetup.jsx',
+        '<rootDir>/../../suite-native/analytics/src/jest.setup.ts',
         '<rootDir>/../../suite-native/module-trading/src/jest.setup.tsx',
     ],
 };

--- a/suite-native/analytics/src/jest.setup.ts
+++ b/suite-native/analytics/src/jest.setup.ts
@@ -1,1 +1,1 @@
-//jest.mock('./analytics');
+jest.mock('./analytics');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use mock instead of actual analytics implementation in unit tests. Prevents action from spamming `console.error` with `Analytics is not initialized!` messages.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mobile-trade-fix-tests&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mobile-trade-fix-tests&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mobile-trade-fix-tests&lookback=7)