### PR TITLE
feat(suite-native): distinguish checks by DeviceCompromisedModal subtitle

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -1521,8 +1521,11 @@ export const en = {
     moduleAuthenticityChecks: {
         deviceCompromised: {
             title: 'Your device may have been compromised',
-            subtitle:
-                'Contact our support to learn what’s going on with your device and what to do next.',
+            subtitle: {
+                fwRevision: 'Your device firmware revision check failed.',
+                deviceAuthenticity: 'Your device authentication check failed.',
+                entropy: 'Security check (entropy verification) failed.',
+            },
             steps: {
                 disconnectDevice: 'Disconnect your device from your phone.',
                 avoidUsingDevice: 'Avoid using this device or sending any funds to it.',

--- a/suite-native/module-authenticity-checks/src/components/DeviceAuthenticityCheckFailModalContent.tsx
+++ b/suite-native/module-authenticity-checks/src/components/DeviceAuthenticityCheckFailModalContent.tsx
@@ -1,6 +1,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 
 import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
+import { Translation } from '@suite-native/intl';
 import { ScreenHeader, useNavigateToInitialScreen } from '@suite-native/navigation';
 import { TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_MOBILE_URL } from '@trezor/urls';
 
@@ -25,6 +26,9 @@ export const DeviceAuthenticityCheckFailModalContent = () => {
         <DeviceCompromisedModalContent
             contactSupportUrl={supportUrlWithChat}
             screenHeaderContent={screenHeaderContent}
+            subtitleContent={
+                <Translation id="moduleAuthenticityChecks.deviceCompromised.subtitle.deviceAuthenticity" />
+            }
         />
     );
 };

--- a/suite-native/module-authenticity-checks/src/components/DeviceCompromisedModalContent.tsx
+++ b/suite-native/module-authenticity-checks/src/components/DeviceCompromisedModalContent.tsx
@@ -25,12 +25,14 @@ type DeviceCompromisedModalContentProps = {
     contactSupportUrl: string;
     screenHeaderContent: ReactNode;
     closeButtonContent?: ReactNode;
+    subtitleContent?: ReactNode;
 };
 
 export const DeviceCompromisedModalContent = ({
     contactSupportUrl,
     screenHeaderContent,
     closeButtonContent,
+    subtitleContent,
 }: DeviceCompromisedModalContentProps) => {
     const openLink = useOpenLink();
 
@@ -43,9 +45,7 @@ export const DeviceCompromisedModalContent = ({
                     titleVariant="titleMedium"
                     titleSpacing="sp12"
                     title={<Translation id="moduleAuthenticityChecks.deviceCompromised.title" />}
-                    subtitle={
-                        <Translation id="moduleAuthenticityChecks.deviceCompromised.subtitle" />
-                    }
+                    subtitle={subtitleContent}
                 />
                 <InformativeList />
             </VStack>

--- a/suite-native/module-authenticity-checks/src/components/EntropyCheckFailModalContent.tsx
+++ b/suite-native/module-authenticity-checks/src/components/EntropyCheckFailModalContent.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 
 import { useNavigation } from '@react-navigation/core';
 
+import { Translation } from '@suite-native/intl';
 import { ScreenHeader } from '@suite-native/navigation';
 import { HELP_CENTER_ENTROPY_CHECK_URL } from '@trezor/urls';
 
@@ -27,6 +28,9 @@ export const EntropyCheckFailModalContent = () => {
         <DeviceCompromisedModalContent
             contactSupportUrl={supportUrlWithChat}
             screenHeaderContent={<ScreenHeader leftIcon={null} />}
+            subtitleContent={
+                <Translation id="moduleAuthenticityChecks.deviceCompromised.subtitle.entropy" />
+            }
         />
     );
 };

--- a/suite-native/module-authenticity-checks/src/components/FirmwareAuthenticityCheckFailModalContent.tsx
+++ b/suite-native/module-authenticity-checks/src/components/FirmwareAuthenticityCheckFailModalContent.tsx
@@ -65,6 +65,9 @@ export const FirmwareAuthenticityCheckFailModalContent = () => {
             contactSupportUrl={supportUrlWithChat}
             screenHeaderContent={screenHeaderContent}
             closeButtonContent={closeButtonContent}
+            subtitleContent={
+                <Translation id="moduleAuthenticityChecks.deviceCompromised.subtitle.fwRevision" />
+            }
         />
     );
 };


### PR DESCRIPTION
## Description

Distinguish which security check has failed in `DeviceCompromisedModal` subtitle.

Use the same copies as in Suite Web/Desktop (done in https://github.com/trezor/trezor-suite/pull/16599 + https://github.com/trezor/trezor-suite/pull/16737)

## Related Issue

Resolve #18989

## Screenshots:

![image](https://github.com/user-attachments/assets/1e67ac9e-7b13-44ce-824e-8e2bfd265730)
![image](https://github.com/user-attachments/assets/84f54c26-fbd1-4c6b-bc76-1518176dc799)
![image](https://github.com/user-attachments/assets/2217b3e1-b1ed-4866-852c-9e760d47d759)


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native-distinguish-check-DeviceCompromisedModal&lookback=7)