### PR TITLE
Fix: mobile entropy check

### DIFF
--- a/packages/connect/src/api/resetDevice.ts
+++ b/packages/connect/src/api/resetDevice.ts
@@ -13,6 +13,8 @@ import { validatePath } from '../utils/pathUtils';
 type EntropyRequestData = PROTO.EntropyRequest & { host_entropy: string };
 
 export default class ResetDevice extends AbstractMethod<'resetDevice', PROTO.ResetDevice> {
+    private isEntropyCheckSuccessful: boolean = false;
+
     init() {
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
         this.useDeviceState = false;
@@ -117,17 +119,26 @@ export default class ResetDevice extends AbstractMethod<'resetDevice', PROTO.Res
                     // GetPublicKey > ResetDeviceContinue > EntropyRequest > EntropyAck > EntropyCheckReady
                     entropyData = await this.entropyCheck(entropyData);
                 }
+
+                // if this.entropyCheck hasn't thrown up to now, we may consider it successful
+                this.isEntropyCheckSuccessful = true;
+
                 // step 7 EntropyCheckContinue > Success
                 await cmd.typedCall('EntropyCheckContinue', 'Success', { finish: true });
             }
         } catch (error) {
-            // error.message should be one of these https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/transports/abstract.ts#L59
+            // permissible error.message during entropy check should be one of these: see ReadWriteError in packages/transport/src/transports/abstract.ts
             if (
                 error.cause === 'transport-error' &&
                 ERRORS_WITHOUT_DEVICE_INTERACTION.includes(error.message)
             ) {
                 throw error;
             }
+
+            // wallet backup flow may follow after successful entropy check, so don't consider errors thrown there as entropy check failure
+            if (this.isEntropyCheckSuccessful === true) throw error;
+
+            // else consider it an entropy check failure
             throw ERRORS.TypedError('Failure_EntropyCheck', error.message);
         }
 

--- a/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
@@ -18,7 +18,11 @@ import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboar
 import { WalletCreationHint } from '../components/WalletCreationHint';
 
 // Do not retry if user cancelled the flow via the app UI, or the Entropy check has failed
-const DEFINITIVE_ERRORS: ERRORS.ErrorCode[] = ['Method_Interrupted', 'Failure_EntropyCheck'];
+const DEFINITIVE_ERRORS: ERRORS.ErrorCode[] = [
+    'Method_Interrupted',
+    'Failure_ActionCancelled',
+    'Failure_EntropyCheck',
+];
 
 const SHOW_HINT_DELAY = 5000;
 


### PR DESCRIPTION
## Description

Fix problem where Connect considers cancelled backup check an entropy check failure :scream: 
Happens only on mobile, because `TrezorConnect.resetDevice` is called with `skip_backup: false`, so that the backup check is all part of the resetDevice call.

## Related Issue

Resolve #18994

## Screenshots:

Start wallet creation → entropy check succeeds → close UI during backup → repeat wallet creation, finish backup: 
[part1.webm](https://github.com/user-attachments/assets/e37d52b3-caef-4b13-b369-775c2e60ca50)
[part2.webm](https://github.com/user-attachments/assets/909c4250-9fcd-4691-980e-d5e7202cb017) _(had to stop to rewatch part1 so I could pass backup check xD )_

Mocked entropy check failure error (during wallet creation)
[entropy check failure.webm](https://github.com/user-attachments/assets/98a62beb-cec6-4ec9-88ff-a362b16fa90e)


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/mobile-entropy-check&lookback=7)