### PR TITLE
test(firmware-release-config): change test file name

### DIFF
--- a/packages/firmware-release-config/src/__tests__/firmwareReleaseConfig.test.ts
+++ b/packages/firmware-release-config/src/__tests__/firmwareReleaseConfig.test.ts
@@ -1,7 +1,7 @@
 import { jws as releasesJwsLocal } from '../../files/releases.v1';
 import { getFirmwareReleaseConfig } from '../index';
 
-describe('getFirmwareReleaseConfig returns releases signed file', () => {
+describe('getFirmwareReleaseConfig returns releases signed file correctly', () => {
     it('should return local JWS', async () => {
         const result = await getFirmwareReleaseConfig();
         expect(result).toEqual({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Change file name from `messageReleases` to `firmwareReleaseConfig` since the name of the package was changed.
Related https://github.com/trezor/trezor-suite/issues/19763