### PR TITLE
feat(suite-native): track buy form parameter changes in analytics

### DIFF
--- a/suite-native/analytics/src/constants.ts
+++ b/suite-native/analytics/src/constants.ts
@@ -65,6 +65,7 @@ export enum EventType {
     TradingExchange = 'trading/exchange',
     TradingBuy = 'trading/buy',
     TradingSell = 'trading/sell',
+    TradingParameterChanged = 'trading/parameter_changed',
     DeviceSetupStarted = 'device_setup/started',
     DeviceSetupCompleted = 'device_setup/completed',
     DeviceSetupSecurityCheck = 'device_setup/security_check',

--- a/suite-native/analytics/src/events.ts
+++ b/suite-native/analytics/src/events.ts
@@ -481,6 +481,19 @@ export type SuiteNativeAnalyticsEvent =
           };
       }
     | {
+          type: EventType.TradingParameterChanged;
+          payload: {
+              type: TradingType;
+              parameter:
+                  | 'fiat'
+                  | 'cryptoFrom'
+                  | 'cryptoTo'
+                  | 'paymentMethod'
+                  | 'country'
+                  | 'provider';
+          };
+      }
+    | {
           type: EventType.DeviceSetupStarted;
           payload: {
               osName: string;

--- a/suite-native/module-trading/src/components/buy/CountryOfResidencePicker.tsx
+++ b/suite-native/module-trading/src/components/buy/CountryOfResidencePicker.tsx
@@ -1,8 +1,10 @@
+import { EventType, analytics } from '@suite-native/analytics';
 import { HStack, Text } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 
 import { useTradeSheetControls } from '../../hooks/useTradeSheetControls';
 import { useTradingBuyFormContext } from '../../hooks/useTradingBuyFormContext';
+import { Country } from '../../types';
 import { CountrySheet } from '../general/CountrySheet/CountrySheet';
 import { TradingOverviewRow } from '../general/TradingOverviewRow';
 
@@ -13,6 +15,20 @@ export const CountryOfResidencePicker = () => {
     const form = useTradingBuyFormContext();
     const { isSheetVisible, hideSheet, showSheet, setSelectedValue, selectedValue } =
         useTradeSheetControls(form, 'country');
+
+    const handleCountrySelect = (country: Country) => {
+        setSelectedValue(country);
+
+        if (selectedValue === country) return;
+
+        analytics.report({
+            type: EventType.TradingParameterChanged,
+            payload: {
+                type: 'buy',
+                parameter: 'country',
+            },
+        });
+    };
 
     return (
         <>
@@ -50,7 +66,7 @@ export const CountryOfResidencePicker = () => {
             <CountrySheet
                 isVisible={isSheetVisible}
                 onClose={hideSheet}
-                onCountrySelect={setSelectedValue}
+                onCountrySelect={handleCountrySelect}
                 selectedCountryId={selectedValue?.value}
             />
         </>

--- a/suite-native/module-trading/src/components/buy/PaymentMethodPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/PaymentMethodPicker.tsx
@@ -1,6 +1,9 @@
 import { useSelector } from 'react-redux';
 
+import { BuyTrade } from 'invity-api';
+
 import { selectTradingBuyIsLoading } from '@suite-common/trading';
+import { EventType, analytics } from '@suite-native/analytics';
 import { Text } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 
@@ -10,7 +13,6 @@ import { selectBuyBestQuotesForAvailablePaymentMethods } from '../../selectors/b
 import { PaymentMethodsSheet } from '../general/PaymentMethodsSheet/PaymentMethodsSheet';
 import { TradingOverviewRow } from '../general/TradingOverviewRow';
 import { TradingOverviewValueSkeleton } from '../general/TradingOverviewValueSkeleton';
-
 const PAYMENT_METHOD_PICKER_TEST_ID = '@trading/buy/payment-method-picker';
 
 export const PaymentMethodPicker = () => {
@@ -35,6 +37,20 @@ export const PaymentMethodPicker = () => {
     if (quotes.length === 0) {
         return null;
     }
+
+    const handleQuoteSelect = (quote: BuyTrade) => {
+        setSelectedValue(quote);
+
+        if (selectedValue?.paymentMethod === quote.paymentMethod) return;
+
+        analytics.report({
+            type: EventType.TradingParameterChanged,
+            payload: {
+                type: 'buy',
+                parameter: 'paymentMethod',
+            },
+        });
+    };
 
     return (
         <>
@@ -70,7 +86,7 @@ export const PaymentMethodPicker = () => {
                 quotes={quotes}
                 isVisible={isSheetVisible}
                 onClose={hideSheet}
-                onQuoteSelect={setSelectedValue}
+                onQuoteSelect={handleQuoteSelect}
                 selectedQuote={selectedValue}
             />
         </>

--- a/suite-native/module-trading/src/components/buy/TradingProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/TradingProviderPicker.tsx
@@ -1,8 +1,9 @@
 import { useSelector } from 'react-redux';
 
+import { BuyTrade } from 'invity-api';
+
 import {
     TradingRootState,
-    TradingTradeType,
     selectBuyQuotesByPaymentMethod,
     selectTradingBuyIsLoading,
     selectTradingBuyProviders,
@@ -42,6 +43,20 @@ export const TradingProviderPicker = () => {
             },
         });
         showSheet();
+    };
+
+    const handleQuoteSelect = (quote: BuyTrade) => {
+        setSelectedValue(quote);
+
+        if (selectedValue?.exchange === quote.exchange) return;
+
+        analytics.report({
+            type: EventType.TradingParameterChanged,
+            payload: {
+                type: 'buy',
+                parameter: 'provider',
+            },
+        });
     };
 
     if (isLoading) {
@@ -90,7 +105,7 @@ export const TradingProviderPicker = () => {
                 providerInfos={providers}
                 isVisible={isSheetVisible}
                 onClose={hideSheet}
-                onQuoteSelect={setSelectedValue as (quote: TradingTradeType) => void}
+                onQuoteSelect={handleQuoteSelect}
                 selectedQuote={selectedValue}
             />
         </>

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProvidersSheet.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProvidersSheet.tsx
@@ -1,3 +1,5 @@
+import { BuyTrade, ExchangeTrade, SellFiatTrade } from 'invity-api';
+
 import { TradingProviderInfo, TradingTradeType } from '@suite-common/trading';
 import { BottomSheetFlashList } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
@@ -5,46 +7,46 @@ import { useTranslate } from '@suite-native/intl';
 import { ESTIMATED_HEADER_HEIGHT, SimpleSheetHeader } from '../SimpleSheetHeader';
 import { PROVIDER_LIST_ITEM_HEIGHT, ProviderListItem } from './ProviderListItem';
 
-export type ProvidersSheetProps = {
-    quotes: TradingTradeType[];
+export type ProvidersSheetProps<T extends BuyTrade | SellFiatTrade | ExchangeTrade> = {
+    quotes: T[];
     isVisible: boolean;
     onClose: () => void;
-    onQuoteSelect: (quote: TradingTradeType) => void;
-    selectedQuote?: TradingTradeType;
+    onQuoteSelect: (quote: T) => void;
+    selectedQuote?: T;
     providerInfos: { [name: string]: TradingProviderInfo };
 };
 
 const EXTRA_LIST_PADDING = 20;
 
-const keyExtractor = (item: TradingTradeType) => item.orderId ?? '';
+const keyExtractor = <T extends TradingTradeType>(item: T) => item.orderId ?? '';
 const getEstimatedListHeight = (itemsCount: number) =>
     itemsCount * PROVIDER_LIST_ITEM_HEIGHT + ESTIMATED_HEADER_HEIGHT + EXTRA_LIST_PADDING;
 
 const getProviderInfo = (
     id: string | undefined,
-    providerInfos: ProvidersSheetProps['providerInfos'],
+    providerInfos: ProvidersSheetProps<TradingTradeType>['providerInfos'],
 ) =>
     providerInfos[id ?? ''] ?? {
         companyName: '',
         logo: '',
     };
 
-export const ProvidersSheet = ({
+export const ProvidersSheet = <T extends BuyTrade | SellFiatTrade | ExchangeTrade>({
     quotes,
     isVisible,
     onClose,
     onQuoteSelect,
     selectedQuote,
     providerInfos,
-}: ProvidersSheetProps) => {
+}: ProvidersSheetProps<T>) => {
     const { translate } = useTranslate();
-    const onQuoteSelectCallback = (quote: TradingTradeType) => {
+    const onQuoteSelectCallback = (quote: T) => {
         onQuoteSelect(quote);
         onClose();
     };
 
     return (
-        <BottomSheetFlashList<TradingTradeType>
+        <BottomSheetFlashList<T>
             isVisible={isVisible}
             onClose={onClose}
             renderItem={({ item }) => {

--- a/suite-native/module-trading/src/hooks/useTradingBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/useTradingBuyForm.ts
@@ -13,6 +13,7 @@ import {
 } from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';
 import { amountToSmallestUnit } from '@suite-common/wallet-utils';
+import { EventType, analytics } from '@suite-native/analytics';
 import { useForm } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import { SettingsSliceRootState, selectIsAmountInSats } from '@suite-native/settings';
@@ -80,6 +81,13 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: 
 
                     case 'fiatCurrency':
                         if (fiatCurrency !== prevFiatCurrency.current) {
+                            analytics.report({
+                                type: EventType.TradingParameterChanged,
+                                payload: {
+                                    type: 'buy',
+                                    parameter: 'fiat',
+                                },
+                            });
                             prevFiatCurrency.current = fiatCurrency;
                             setValue('fiatValue', undefined, { shouldValidate: true });
                             setValue('cryptoValue', undefined, { shouldValidate: true });
@@ -88,6 +96,13 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: 
 
                     case 'asset': {
                         if (asset?.cryptoId !== prevCryptoId.current) {
+                            analytics.report({
+                                type: EventType.TradingParameterChanged,
+                                payload: {
+                                    type: 'buy',
+                                    parameter: 'cryptoTo',
+                                },
+                            });
                             prevCryptoId.current = asset?.cryptoId as CryptoId | undefined;
                             setValue('cryptoValue', undefined, { shouldValidate: true });
                             dispatch(


### PR DESCRIPTION
Track buy form when user picks:

- different fiat currency
- different crypto currency
- different payment method
- different country of residence
- different provider

Introduced `trading/parameter_changed`

Resolve #19000


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19000-mobile-trade-buy-analytics-enhancement&lookback=7)