### PR TITLE
fix(suite-native): selectDeviceAuthenticity memoization

### DIFF
--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -920,10 +920,7 @@ export const selectDeviceById = createMemoizedSelector(
     (devices, deviceId) => devices.find(device => device.id === deviceId),
 );
 
-export const selectDeviceAuthenticity = createMemoizedSelector(
-    [state => state.device.deviceAuthenticity],
-    deviceAuthenticity => deviceAuthenticity,
-);
+export const selectDeviceAuthenticity = (state: DeviceRootState) => state.device.deviceAuthenticity;
 
 export const selectSelectedDeviceAuthenticity = createMemoizedSelector(
     [selectSelectedDevice, selectDeviceAuthenticity],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix unnecessary re-render caused by device authenticity selector.
```
WARN  The result function returned its own inputs without modification. e.g
`createSelector([state => state.todos], todos => todos)`
This could lead to inefficient memoization and unnecessary re-renders.
Ensure transformation logic is in the result function, and extraction logic is in the input selectors. {"stack": "Error
    at runIdentityFunctionCheck (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:553749:26)
    at dependenciesChecker (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:554424:38)
    at apply (native)
    at memoized (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:554344:28)
    at apply (native)
    at collectInputSelectorResults (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:553828:54)
    at dependenciesChecker (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:554417:63)
    at apply (native)
    at memoized (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:554344:28)
    at selectIsDeviceAuthenticityCheckFailed (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:673770:131)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:549554:34)
    at memoizedSelector (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:549736:36)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:549755:34)
    at mountSyncExternalStore (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:92091:37)
    at useSyncExternalStore (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:92916:42)
    at useSyncExternalStore (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:3335:47)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:549760:39)
    at useSelector2 (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:549604:135)
    at useDeviceChecks (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:675158:101)
    at useHandleDeviceConnection (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:669750:97)
    at useGlobalHooks (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:798796:86)
    at RootStackNavigator (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:798575:78)
    at renderWithHooks (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:91539:33)
    at mountIndeterminateComponent (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:95418:34)
    at beginWork (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:96655:49)
    at performUnitOfWork (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:101648:27)
    at workLoopSync (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:101417:28)
    at renderRootSync (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:101383:25)
    at performSyncWorkOnRoot (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:100951:40)
    at flushSyncWorkAcrossRoots_impl (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:88568:40)
    at flushSyncWorkOnLegacyRootsOnly (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:88539:38)
    at scheduleUpdateOnFiber (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:100599:45)
    at forceStoreRerender (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:92245:32)
    at handleStoreChange (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:92226:31)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:548917:30)
    at defaultNoopBatch (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:548901:13)
    at notify (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:548914:25)
    at notifyNestedSubs (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:548982:23)
    at handleChangeWrapper (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:548986:35)
    at wrappedListener (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:550623:61)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:554700:17)
    at forEach (native)
    at dispatch (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:554699:24)
    at dispatch (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:682443:27)
    at dispatch (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:550644:34)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:757368:9)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:605338:30)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:686854:9)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:605349:30)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:669684:9)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:605349:30)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:660894:9)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:605349:30)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:666555:9)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:605349:30)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:735630:16)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:605338:30)
    at ?anon_0_ (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:686752:11)
    at next (native)
    at asyncGeneratorStep (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:29516:19)
    at _next (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:29530:29)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:29535:14)
    at tryCallTwo (address at InternalBytecode.js:1:1222)
    at doResolve (address at InternalBytecode.js:1:2541)
    at Promise (address at InternalBytecode.js:1:1318)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:29527:25)
    at apply (native)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:686776:25)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:605338:30)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:554995:20)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:550177:18)
    at apply (native)
    at dispatch (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:554920:26)
    at ?anon_0_ (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:774053:15)
    at next (native)
    at asyncGeneratorStep (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:29516:19)
    at _next (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:29530:29)
    at tryCallOne (address at InternalBytecode.js:1:1180)
    at anonymous (address at InternalBytecode.js:1:1874)
    at apply (native)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:34568:50)
    at _callTimer (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:34492:17)
    at _callReactNativeMicrotasksPass (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:34522:17)
    at callReactNativeMicrotasks (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:34677:44)
    at __callReactNativeMicrotasks (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:4913:48)
    at anonymous (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:4727:43)
    at __guard (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:4896:15)
    at flushedQueue (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:4726:21)
    at callFunctionReturnFlushedQueue (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:4713:33)"} 
    at RootStackNavigator (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:798575:78)
    at PortalProviderComponent (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:621913:33)
    at BottomSheetModalProviderWrapper (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:622089:24)
    at FormatterProvider (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:689363:22)
    at AppComponent (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:173025:78)
    at EnsureSingleNavigator (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:626179:24)
    at BaseNavigationContainer (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:625778:28)
    at ThemeProvider (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:631280:21)
    at NavigationContainerInner (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:631159:26)
    at NavigationContainerWithAnalytics (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:645947:24)
    at ThemeProvider (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:542628:28)
    at RendererProvider (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:541546:24)
    at StylesProvider (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:538038:24)
    at StylesProvider (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:869083:24)
    at RNCSafeAreaProvider
    at SafeAreaProvider (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:624292:24)
    at KeyboardControllerView
    at Animated(Anonymous) (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:72857:62)
    at AnimatedComponent(Animated(Anonymous)) (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:132636:38)
    at KeyboardProvider (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:634701:24)
    at PersistGate (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:604728:22)
    at StorageProvider (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:604589:24)
    at Provider (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:549433:33)
    at StoreProvider (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:681376:24)
    at IntlProvider (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:563553:50)
    at IntlProvider (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:563834:24)
    at RNGestureHandlerRootView
    at GestureHandlerRootView (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:143531:21)
    at PureApp
    at FeedbackWidgetProvider (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:255608:36)
    at ReactNativeProfiler (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:250299:36)
    at RCTView
    at View (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:60579:43)
    at __Sentry.TouchEventBoundary (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:251981:36)
    at RootApp
    at withDevTools(RootApp) (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:172801:27)
    at RCTView
    at View (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:60579:43)
    at RCTView
    at View (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:60579:43)
    at AppContainer (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:60452:25)
    at main(RootComponent) (http://192.168.0.103:8081/suite-native/app/index.bundle//&platform=android&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:80596:28)
```

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/device-authenticity-selector&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/device-authenticity-selector&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-authenticity-selector&lookback=7)