### PR TITLE
fix(suite): Fix settings button full width issue

### DIFF
--- a/packages/suite/src/components/suite/section/sectionStyles.tsx
+++ b/packages/suite/src/components/suite/section/sectionStyles.tsx
@@ -51,16 +51,18 @@ export const ActionButton = styled(
         children,
         ...buttonProps
     }: WithTooltipProps & ButtonProps) => (
-        <Tooltip content={tooltipContent} isActive={isTooltipActive} cursor="inherit">
-            <Button
-                {...buttonProps}
-                size="small"
-                margin={{ top: spacings.xxs, bottom: spacings.xxs, left: spacings.xxs }}
-                minWidth={140}
-            >
-                {children}
-            </Button>
-        </Tooltip>
+        <div>
+            <Tooltip content={tooltipContent} isActive={isTooltipActive} cursor="inherit">
+                <Button
+                    {...buttonProps}
+                    size="small"
+                    margin={{ top: spacings.xxs, bottom: spacings.xxs, left: spacings.xxs }}
+                    minWidth={140}
+                >
+                    {children}
+                </Button>
+            </Tooltip>
+        </div>
     ),
 )`
     &:not(:first-child) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before
![image](https://github.com/user-attachments/assets/3e844cfe-2111-42e9-9fd6-b9bcc63554ac)

after
<img width="408" alt="image" src="https://github.com/user-attachments/assets/ba63611f-d413-43de-b452-25ee72111c06" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-settings-button-full-width-issue&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-settings-button-full-width-issue&lookback=7)