### PR TITLE
ci(github): lets not use nx cloud cache in CI

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -94,7 +94,8 @@ jobs:
       - name: "Minimal yarn install"
         uses: ./.github/actions/minimal-yarn-install
       - name: Unit Tests
-        run: yarn nx:test-unit --output-style=stream
+        # We are --skip-nx-cache for now to avoid issues with cache in NX cloud.
+        run: yarn nx:test-unit --output-style=stream --skip-nx-cache
 
   build-libs-for-publishing:
     name: "Build libs for publishing"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We have a PR that is stuck because NX cloud caching issues, let disable it for now. 

https://github.com/trezor/trezor-suite/actions/runs/15067913892/job/42361371575?pr=18988

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/make-ci-work-again&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/make-ci-work-again&lookback=7)