### PR TITLE
feat(suite-native): implement reset method for native USB device

### DIFF
--- a/packages/react-native-usb/android/src/main/java/io/trezor/rnusb/ReactNativeUsbModule.kt
+++ b/packages/react-native-usb/android/src/main/java/io/trezor/rnusb/ReactNativeUsbModule.kt
@@ -20,6 +20,7 @@ import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.core.errors.ModuleDestroyedException
 import java.nio.ByteBuffer
+import java.util.concurrent.ConcurrentHashMap
 
 // Convert Android USBDevice to JS compatible WebUSBDevice
 typealias WebUSBDevice = Map<String, Any?>
@@ -69,6 +70,10 @@ class ReactNativeUsbModule : Module() {
 
         AsyncFunction("open") { deviceName: String ->
             return@AsyncFunction openDevice(deviceName)
+        }
+
+        AsyncFunction("reset") { deviceName: String ->
+            return@AsyncFunction resetDevice(deviceName)
         }
 
         AsyncFunction("close") { deviceName: String ->
@@ -156,7 +161,7 @@ class ReactNativeUsbModule : Module() {
             for (device in devicesList) {
                 if (usbManager.hasPermission(device)) {
                     Log.d(LOG_TAG, "Has permission, send event onDeviceConnected: $device")
-                    
+
                     val webUsbDevice = if (hasOpenedConnection(device.deviceName)) {
                         Log.d(LOG_TAG, "Device already opened: $device")
                         getWebUSBDevice(device)
@@ -220,7 +225,8 @@ class ReactNativeUsbModule : Module() {
         get() = context.getSystemService(Context.USB_SERVICE) as UsbManager
 
 
-    private val openedConnections = mutableMapOf<String, UsbDeviceConnection>()
+    private val openedConnections = ConcurrentHashMap<String, UsbDeviceConnection>()
+    private val pendingRequests = ConcurrentHashMap<String, UsbRequest>()
 
     // We need to store device metadata because we can't access them in detached event
     private val devicesHistory = mutableMapOf<String, WebUSBDevice>()
@@ -248,6 +254,12 @@ class ReactNativeUsbModule : Module() {
         return getWebUSBDevice(device)
     }
 
+    private fun resetDevice(deviceName: String) {
+        Log.d(LOG_TAG, "Resetting device $deviceName")
+        val usbRequest = pendingRequests.remove(deviceName)
+        usbRequest?.cancel()
+    }
+
     private fun closeDevice(deviceName: String) {
         Log.d(LOG_TAG, "Closing device $deviceName")
         getOpenedConnection(deviceName).close()
@@ -256,12 +268,10 @@ class ReactNativeUsbModule : Module() {
 
     private fun closeAllOpenedDevices() {
         Log.d(LOG_TAG, "Closing all devices")
-        with(openedConnections.iterator()) {
-            forEach {
-                it.value.close()
-                remove()
-            }
-        }
+        pendingRequests.values.forEach { it.cancel() }
+        pendingRequests.clear()
+        openedConnections.values.forEach { it.close() }
+        openedConnections.clear()
     }
 
     private fun selectConfiguration(deviceName: String, configurationIndex: Int) {
@@ -352,7 +362,19 @@ class ReactNativeUsbModule : Module() {
         req.initialize(usbConnection, usbEndpoint)
         req.queue(buffer)
 
-        val result = usbConnection.requestWait()
+        if (pendingRequests.putIfAbsent(device.deviceName, req) != null) {
+            req.cancel()
+            req.close()
+            Log.e(LOG_TAG, "Transfer already in progress for device ${device.deviceName}")
+            throw Exception("Transfer already in progress for device ${device.deviceName}")
+        }
+
+        val result = try {
+            usbConnection.requestWait()
+        } finally {
+            pendingRequests.remove(device.deviceName)
+            req.close()
+        }
 
         if (result == null) {
             Log.e(LOG_TAG, "Failed to transfer data from device ${device.deviceName}")
@@ -377,7 +399,6 @@ class ReactNativeUsbModule : Module() {
         Log.d(LOG_TAG, "Device $deviceName hasOpenedConnection: $isConnectionOpened")
         return isConnectionOpened
     }
-
 
     private fun getDeviceByName(deviceName: String): UsbDevice {
         Log.d(LOG_TAG, "getDeviceByName: $deviceName")

--- a/packages/react-native-usb/src/ReactNativeUsb.types.ts
+++ b/packages/react-native-usb/src/ReactNativeUsb.types.ts
@@ -51,6 +51,7 @@ export interface WebUSBDevice {
     readonly configurations: USBConfiguration[];
     readonly opened: boolean;
     open(): Promise<void>;
+    reset(): Promise<void>;
     close(): Promise<void>;
     forget(): Promise<void>;
     selectConfiguration(configurationValue: number): Promise<void>;
@@ -77,7 +78,6 @@ export interface WebUSBDevice {
         data: BufferSource,
         packetLengths: number[],
     ): Promise<USBIsochronousOutTransferResult>;
-    reset(): Promise<void>;
 }
 
 export interface OnConnectEvent extends Event {

--- a/packages/react-native-usb/src/ReactNativeUsbModule.ts
+++ b/packages/react-native-usb/src/ReactNativeUsbModule.ts
@@ -10,6 +10,7 @@ type DeviceEvents = {
 
 declare class ReactNativeUsbModuleDeclaration extends NativeModule<DeviceEvents> {
     open: (deviceName: string) => Promise<void>;
+    reset: (deviceName: string) => Promise<void>;
     close: (deviceName: string) => Promise<void>;
     claimInterface: (deviceName: string, interfaceNumber: number) => Promise<void>;
     releaseInterface: (deviceName: string, interfaceNumber: number) => Promise<void>;

--- a/packages/react-native-usb/src/index.ts
+++ b/packages/react-native-usb/src/index.ts
@@ -17,6 +17,8 @@ export const setPriorityMode = (isInPriorityMode: boolean) =>
 
 const open = (deviceName: string) => ReactNativeUsbModule.open(deviceName);
 
+const reset = (deviceName: string) => ReactNativeUsbModule.reset(deviceName);
+
 const close = (deviceName: string) => ReactNativeUsbModule.close(deviceName);
 
 const claimInterface = (deviceName: string, interfaceNumber: number) =>
@@ -73,6 +75,7 @@ const createNoop = (methodName: string) => async () => {
 const createWebUSBDevice = (device: NativeDevice): WebUSBDevice => ({
     ...device,
     open: () => open(device.deviceName),
+    reset: () => reset(device.deviceName),
     close: () => close(device.deviceName),
     forget: createNoop('forget'),
     selectConfiguration: (configurationValue: number) =>
@@ -90,7 +93,6 @@ const createWebUSBDevice = (device: NativeDevice): WebUSBDevice => ({
         transferOut(device.deviceName, endpointNumber, data),
     isochronousTransferIn: createNoop('isochronousTransferIn'),
     isochronousTransferOut: createNoop('isochronousTransferOut'),
-    reset: createNoop('reset'),
 
     // TODO: Implement these properties, very low priority we are not using them anywhere
     usbVersionMajor: 2,


### PR DESCRIPTION
### Prerequisite for THP pairing

When the `reset()` method is called, an already queued `transferIn` operation needs to be cancelled while the underlying USB connection remains intact. To align with the WebUSB implementation, concurrent `transferIn` operations on a single USB connection are not permitted.

### Notes for QA
- Confirm that current USB flows remain unaffected.
- Confirm that cancelling any action on device behaves as expected.
- Confirm that entering an invalid PIN works as expected.