### PR TITLE
fix(suite-native): Mobile Trade: mock analytics in unit tests

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -94,8 +94,7 @@ jobs:
       - name: "Minimal yarn install"
         uses: ./.github/actions/minimal-yarn-install
       - name: Unit Tests
-        # We are --skip-nx-cache for now to avoid issues with cache in NX cloud.
-        run: yarn nx:test-unit --output-style=stream --skip-nx-cache
+        run: yarn nx:test-unit --output-style=stream
 
   build-libs-for-publishing:
     name: "Build libs for publishing"

--- a/jest.config.native.js
+++ b/jest.config.native.js
@@ -37,6 +37,7 @@ module.exports = {
         '<rootDir>/../../suite-native/connection-status/src/jestSetup.js',
         '<rootDir>/../../suite-native/react-native-graph/src/jestSetup.js',
         '<rootDir>/../../suite-native/atoms/src/jestSetup.jsx',
+        '<rootDir>/../../suite-native/analytics/src/jest.setup.ts',
         '<rootDir>/../../suite-native/module-trading/src/jest.setup.tsx',
     ],
 };

--- a/packages/firmware-release-config/package.json
+++ b/packages/firmware-release-config/package.json
@@ -25,5 +25,14 @@
     "devDependencies": {
         "@types/fs-extra": "^11.0.4",
         "@types/jws": "^3.2.10"
+    },
+    "nx": {
+        "targets": {
+            "build:lib": {
+                "outputs": [
+                    "{projectRoot}/files"
+                ]
+            }
+        }
     }
 }

--- a/suite-native/analytics/src/jest.setup.ts
+++ b/suite-native/analytics/src/jest.setup.ts
@@ -1,1 +1,1 @@
-//jest.mock('./analytics');
+jest.mock('./analytics');


### PR DESCRIPTION
DO NOT MERGE 

TEST NX cache issue resolution

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/mobile-trade-fix-tests-test-nx-cache&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/mobile-trade-fix-tests-test-nx-cache&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/mobile-trade-fix-tests-test-nx-cache&lookback=7)