### PR TITLE
feat(e2e): new specific firmware-ready tests

### DIFF
--- a/.github/workflows/test-suite-desktop-e2e-pr.yml
+++ b/.github/workflows/test-suite-desktop-e2e-pr.yml
@@ -126,7 +126,7 @@ jobs:
           containers: "trezor-user-env-unix bitcoin-regtest"
           workspace-dependencies: "@trezor/suite-desktop"
           test-group: ${{ matrix.TEST_GROUP }}
-          fail-fast: 3
+          fail-fast: 7
           currents-project-id: "4ytF0E"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}

--- a/.github/workflows/test-suite-web-e2e-pr.yml
+++ b/.github/workflows/test-suite-web-e2e-pr.yml
@@ -132,7 +132,7 @@ jobs:
           containers: "trezor-user-env-unix bitcoin-regtest"
           test-group: ${{ matrix.TEST_GROUP }}
           additional-grep: "(?=.*@webOnly)"
-          fail-fast: 3
+          fail-fast: 7
           currents-project-id: "Og0NOQ"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}

--- a/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/firmwareSection.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/firmwareSection.ts
@@ -23,10 +23,18 @@ export class FirmwareSection {
         await this.skipConfirmButton.click();
     }
 
+    @step()
+    async continueThroughFirmware() {
+        await expect(this.onboardingLayout).toBeVisible();
+        // Test using this method do not care if we have current firmware or not
+        // that is way we are using Promise.race to get thru firmware check either way
+        await Promise.race([this.continueButton.click(), this.skip()]);
+    }
+
     // This methods serves as watchdog for situation where new firmware is released to suite desktop and web
     // But is not yet available in our TrezorEnv that is used by the test CIs.
     @step()
-    async continueThroughFirmware() {
+    async expectFirmwareToBeReady() {
         await expect(this.onboardingLayout).toBeVisible();
         const isInstallButtonVisible = await this.installFirmwareButton.isVisible();
         const isInstallTitleVisible = await this.page.getByText('Installing firmware').isVisible();

--- a/packages/suite-desktop-core/e2e/tests/onboarding/firware-check.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/firware-check.test.ts
@@ -1,0 +1,36 @@
+import { Model } from '@trezor/trezor-user-env-link';
+
+import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
+import { test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
+
+const models: Model[] = ['T1B1', 'T2T1', 'T3B1', 'T3T1'];
+
+test.describe(
+    'Firmware - check readiness',
+    { tag: ['@group=device-management', '@firmware-ready'] },
+    () => {
+        for (const model of models) {
+            test.use({
+                emulatorStartConf: { model, wipe: true },
+                setupEmulator: false,
+            });
+
+            test(
+                `${model} Suite detects that firmware is ready`,
+                {
+                    annotation: createTestAnnotation({
+                        testCase: 'Verify Suite detects that firmware is ready.',
+                        category: TestCategory.Onboarding,
+                        priority: TestPriority.Critical,
+                    }),
+                },
+                async ({ analyticsSection, onboardingPage }) => {
+                    await onboardingPage.disableNecessaryFirmwareChecks();
+                    await analyticsSection.passThroughAnalytics();
+                    await onboardingPage.firmware.expectFirmwareToBeReady();
+                },
+            );
+        }
+    },
+);


### PR DESCRIPTION
general tests wont fail on firmware mismatch
new tag for easier quarantine


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/e2e-lessens-impact-of-older-firmware&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/e2e-lessens-impact-of-older-firmware&lookback=7)