### PR TITLE
Add flake development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ packages/suite-data/files/translations/master.json
 
 # python
 .venv/
+
+#direnv
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,144 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1747542820,
+        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-u+rxA79a0lyhG+u+oPBRtTDtzz8kvkc9a6SWSt9ekVc=",
+        "path": "/nix/store/0283cbhm47kd3lr9zmc5fvdrx9qkav8s-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "old-gcc-nixpkgs": {
+      "locked": {
+        "lastModified": 1619215201,
+        "narHash": "sha256-dEfLrDVpLE3Iv916WaQaxqEECJC7qOPpYNqQuCINq1A=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a78ed5cbdd5427c30ca02a47ce6cccc9b7d17de4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a78ed5cbdd5427c30ca02a47ce6cccc9b7d17de4",
+        "type": "github"
+      }
+    },
+    "playwright-web-flake": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1741354899,
+        "narHash": "sha256-CkfoVCQQoRosUT/SqgbW3gGn8TWnKwsVozI7Egk8qwA=",
+        "owner": "pietdevries94",
+        "repo": "playwright-web-flake",
+        "rev": "e41a037c2a658bdb1af6dfb38f7ac3832f0a3770",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pietdevries94",
+        "ref": "1.51.0",
+        "repo": "playwright-web-flake",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "old-gcc-nixpkgs": "old-gcc-nixpkgs",
+        "playwright-web-flake": "playwright-web-flake"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,94 @@
+{
+  description = "Trezor Suite development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable"; 
+    flake-utils.url = "github:numtide/flake-utils";
+    playwright-web-flake.url = "github:pietdevries94/playwright-web-flake/1.51.0";
+    old-gcc-nixpkgs.url = "github:NixOS/nixpkgs/a78ed5cbdd5427c30ca02a47ce6cccc9b7d17de4";  # For GCC 10.2.0
+  };
+
+  outputs = { self, nixpkgs, flake-utils, playwright-web-flake, old-gcc-nixpkgs, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlay = final: prev: {
+          # Overlay playwright packages
+          inherit (playwright-web-flake.packages.${system}) playwright-test playwright-driver;
+          
+          # Override GCC with older version
+          gccPkgs = import old-gcc-nixpkgs { system = prev.system; };
+        };
+
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ overlay ];
+          config.allowUnfree = true;
+        };
+
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.bash
+            pkgs.git
+            pkgs.git-lfs
+            pkgs.gnupg
+            pkgs.mdbook
+            pkgs.xorg.xhost
+            pkgs.docker
+            pkgs.docker-compose
+            pkgs.nodejs_22
+            (pkgs.yarn.override { nodejs = null; })
+            pkgs.python3
+            pkgs.python3Packages.pip
+            pkgs.jre
+            pkgs.electron_36
+            pkgs.pkg-config
+            pkgs.pixman # build dependencies for node-canvas
+            pkgs.cairo # build dependencies for node-canvas
+            pkgs.giflib # build dependencies for node-canvas
+            pkgs.libjpeg # build dependencies for node-canvas
+            pkgs.libpng # build dependencies for node-canvas
+            pkgs.librsvg # build dependencies for node-canvas
+            pkgs.pango # build dependencies for node-canvas
+            pkgs.shellcheck
+            pkgs.playwright-test  # From playwright-web-flake
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+            pkgs.nsis
+            pkgs.p7zip
+            pkgs.openjpeg
+            pkgs.osslsigncode
+            pkgs.squashfsTools
+            pkgs.gccPkgs.gcc  # Older GCC
+            pkgs.udev # used by node_module: usb
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
+            Cocoa
+            CoreServices
+          ]);
+
+          NIX_PATCHELF_LIBRARY_PATH = "${pkgs.openssl.out}/lib:${pkgs.zlib}/lib:${pkgs.gcc.cc.lib}/lib";
+          NIX_CC = "${pkgs.gcc}";
+
+          shellHook = ''
+            export NODE_OPTIONS=--max_old_space_size=4096
+            export CURDIR="$(pwd)"
+            export PATH="$PATH:$CURDIR/node_modules/.bin"
+            export ELECTRON_BUILDER_CACHE="$CURDIR/.cache/electron-builder"
+            export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+            export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
+            export PLAYWRIGHT_BROWSERS_PATH="${pkgs.playwright-driver.browsers}"
+                        
+            echo "welcome to the Trezor Suite development environment"
+            echo "- Node.js $(node --version)"
+            echo "- npm $(npm --version)"
+            echo "- Yarn $(yarn --version)"
+            echo "- Playwright $(playwright --version)"
+            
+          '' + pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+            export ELECTRON_OVERRIDE_DIST_PATH="${pkgs.electron_36}/Applications/"
+          '' + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+            export ELECTRON_OVERRIDE_DIST_PATH="${pkgs.electron_36}/bin/"
+            export npm_config_build_from_source=true
+          '';
+        };
+      });
+}


### PR DESCRIPTION
This update introduces a Nix Flake-based development environment for the desktop version of Trezor Suite.

The flake is based on the current [shell.nix](https://github.com/trezor/trezor-suite/blob/develop/shell.nix)

The flake has been used by me on a daily basis, but feel free to suggest changes and improvements.



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=nix-flake-dev&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=nix-flake-dev&lookback=7)