### PR TITLE
firmwareHash undefined check

### DIFF
--- a/packages/suite/src/utils/suite/storage.ts
+++ b/packages/suite/src/utils/suite/storage.ts
@@ -10,14 +10,14 @@ const filterInconclusiveAuthenticityChecks = (checks: AuthenticityChecks): Authe
     if (checks === undefined) return undefined;
     let { firmwareRevision, firmwareHash } = checks;
     if (
-        firmwareRevision !== null &&
+        firmwareRevision &&
         !firmwareRevision.success &&
         revisionCheckErrorScenarios[firmwareRevision.error].isConclusive === false
     ) {
         firmwareRevision = null;
     }
     if (
-        firmwareHash !== null &&
+        firmwareHash &&
         !firmwareHash.success &&
         hashCheckErrorScenarios[firmwareHash.error].isConclusive === false
     ) {


### PR DESCRIPTION
## Description

Should resolve new Sentry issue https://satoshilabs.sentry.io/issues/6609779026/

Nevertheless, I don't know where does `firmwareHash: undefined` come from. Some unmigrated stored data maybe?

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/firmware-hash-undefined&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/firmware-hash-undefined&lookback=7)