### PR TITLE
chore(suite-native): upgrade redux devtools plugin

### DIFF
--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -40,7 +40,7 @@
         "react": "18.2.0",
         "react-native": "0.76.9",
         "react-redux": "9.2.0",
-        "redux-devtools-expo-dev-plugin": "1.0.0",
+        "redux-devtools-expo-dev-plugin": "2.0.0",
         "redux-logger": "^3.0.6",
         "redux-persist": "6.0.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1611,7 +1611,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.5, @babel/runtime@npm:^7.23.8, @babel/runtime@npm:^7.25.0, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.27.1, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.8, @babel/runtime@npm:^7.25.0, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.26.9, @babel/runtime@npm:^7.27.1, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.27.1
   resolution: "@babel/runtime@npm:7.27.1"
   checksum: 10/34cefcbf781ea5a4f1b93f8563327b9ac82694bebdae91e8bd9d7f58d084cbe5b9a6e7f94d77076e15b0bcdaa0040a36cb30737584028df6c4673b4c67b2a31d
@@ -7115,18 +7115,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@redux-devtools/core@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@redux-devtools/core@npm:4.0.0"
+"@redux-devtools/core@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@redux-devtools/core@npm:4.1.1"
   dependencies:
-    "@babel/runtime": "npm:^7.23.5"
+    "@babel/runtime": "npm:^7.26.9"
     "@redux-devtools/instrument": "npm:^2.2.0"
-    lodash: "npm:^4.17.21"
   peerDependencies:
-    react: ^16.8.4 || ^17.0.0 || ^18.0.0
+    react: ^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-redux: ^7.0.0 || ^8.0.0 || ^9.0.0
     redux: ^3.5.2 || ^4.0.0 || ^5.0.0
-  checksum: 10/4206c1cff3dafe2b16843f396f939f4ffb4d92714f4bb3ea3a2f1860add919d0b40757ffd43e59cc8b7c0d9c5427e8fe9247a6a3c6c3c67dda419b5d6320de6e
+  checksum: 10/966e89c649c2c8c9013681e55b6ff43b49e75c17e3fd70b001bcefc06d45c5789aae0a47add0867d3d18364e3dffd478e61625ee13f31fa50ac2fc65c680bd6e
   languageName: node
   linkType: hard
 
@@ -7154,25 +7153,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@redux-devtools/utils@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@redux-devtools/utils@npm:3.0.0"
+"@redux-devtools/utils@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@redux-devtools/utils@npm:3.1.1"
   dependencies:
-    "@babel/runtime": "npm:^7.23.5"
-    "@redux-devtools/core": "npm:^4.0.0"
+    "@babel/runtime": "npm:^7.26.9"
+    "@redux-devtools/core": "npm:^4.1.1"
     "@redux-devtools/serialize": "npm:^0.4.2"
     "@types/get-params": "npm:^0.1.2"
     get-params: "npm:^0.1.2"
-    immutable: "npm:^4.3.4"
+    immutable: "npm:^4.3.7"
     jsan: "npm:^3.1.14"
-    lodash: "npm:^4.17.21"
-    nanoid: "npm:^5.0.4"
-    redux: "npm:^4.2.1"
+    nanoid: "npm:^5.1.2"
+    redux: "npm:^5.0.1"
   peerDependencies:
-    "@redux-devtools/core": ^4.0.0
-    immutable: ^4.3.4
+    "@redux-devtools/core": ^4.1.1
+    immutable: ^4.3.7
     redux: ^4.0.0 || ^5.0.0
-  checksum: 10/8c465ddc91ebbef69db447de617b0b8c1b208103151821f2a749d05410c270e4301d32d783c849713d32007643873f1539254fc0f1bf573a7f1812ffac02f5f2
+  checksum: 10/23042d0582267a3df5789f8e5420a08f09fce3cee2615a64ee0db12d105cd2a04e6dbc7672cfd6535f8d0ed5e5480ad20bd645a6145cd97e8421c66b9832993b
   languageName: node
   linkType: hard
 
@@ -11084,7 +11082,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.76.9"
     react-redux: "npm:9.2.0"
-    redux-devtools-expo-dev-plugin: "npm:1.0.0"
+    redux-devtools-expo-dev-plugin: "npm:2.0.0"
     redux-logger: "npm:^3.0.6"
     redux-persist: "npm:6.0.0"
   languageName: unknown
@@ -25756,10 +25754,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:^4.3.4":
-  version: 4.3.6
-  resolution: "immutable@npm:4.3.6"
-  checksum: 10/59fedb67f26e265035616b27e33ef90b53b434cf76fb09212ec2d6ae32ee8d2fe2641e6dc32dbc78498c521fbf5f72c6740d39affba63a0a36a3884272371857
+"immutable@npm:^4.3.7":
+  version: 4.3.7
+  resolution: "immutable@npm:4.3.7"
+  checksum: 10/37d963c5050f03ae5f3714ba7a43d469aa482051087f4c65d673d1501c309ea231d87480c792e19fa85e2eaf965f76af5d0aa92726505f3cfe4af91619dfb80b
   languageName: node
   linkType: hard
 
@@ -31631,7 +31629,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^5.0.4":
+"nanoid@npm:^5.1.2":
   version: 5.1.5
   resolution: "nanoid@npm:5.1.5"
   bin:
@@ -35879,17 +35877,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redux-devtools-expo-dev-plugin@npm:1.0.0":
-  version: 1.0.0
-  resolution: "redux-devtools-expo-dev-plugin@npm:1.0.0"
+"redux-devtools-expo-dev-plugin@npm:2.0.0":
+  version: 2.0.0
+  resolution: "redux-devtools-expo-dev-plugin@npm:2.0.0"
   dependencies:
     "@redux-devtools/instrument": "npm:^2.2.0"
-    "@redux-devtools/utils": "npm:^3.0.0"
+    "@redux-devtools/utils": "npm:^3.1.1"
     jsan: "npm:^3.1.14"
   peerDependencies:
-    expo: ">=52"
+    expo: ">=53"
     redux: "*"
-  checksum: 10/d77032f131703e68c8bc14e45b5981b5d817ad34d17abc6af3bc55b01b4c0e34050445a028de2b776d3f44a23a03314563d6e4e760634cb76ec473dcac4acfa1
+  checksum: 10/00fe947bef2fbe1a54680ff67fd67f183dc54af59986544a3906c80215468429bd9d06e5791a9585d76c7ad6032cce2d2c3ca78421f400abf9c1f0af869cb0c1
   languageName: node
   linkType: hard
 
@@ -35940,7 +35938,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redux@npm:^4.0.5, redux@npm:^4.2.1":
+"redux@npm:^4.0.5":
   version: 4.2.1
   resolution: "redux@npm:4.2.1"
   dependencies:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
On current develop with version `1.0.0`, the plugin is not working properly due to a failed handshake. New version works as expected.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/redux-devtools-upgrade&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/redux-devtools-upgrade&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/redux-devtools-upgrade&lookback=7)