### PR TITLE
Device events emitted after handshake

### DIFF
--- a/packages/connect/src/core/__tests__/Core.test.ts
+++ b/packages/connect/src/core/__tests__/Core.test.ts
@@ -57,7 +57,7 @@ describe('Core', () => {
         expect(eventsSpy).toHaveBeenCalledTimes(0);
         await new Promise(resolve => setTimeout(resolve, 1));
         // device + transport events emitted in next tick
-        expect(eventsSpy).toHaveBeenCalledTimes(4);
+        expect(eventsSpy).toHaveBeenCalledTimes(2);
 
         coreManager.dispose();
     });

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -92,11 +92,7 @@ const waitForReconnectedDevice = async (
         // 3. listen now reported a new device in bootloader mode but it still has the session from the previous device in normal mode
         // 4. now we automatically take the device, as if user clicked on the "use device here button"
 
-        if (
-            reconnectedDevice &&
-            !reconnectedDevice.features &&
-            reconnectedDevice.handshakeFinished
-        ) {
+        if (reconnectedDevice && !reconnectedDevice.features) {
             log.debug(
                 'onCallFirmwareUpdate',
                 'we were unable to read device.features on the first interaction after seeing it, retrying...',

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -16,7 +16,6 @@ import {
     TypedEmitter,
     createDeferred,
     isArrayMember,
-    resolveAfter,
     serializeError,
     versionUtils,
 } from '@trezor/utils';
@@ -206,9 +205,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     private sessionDfd?: Deferred<Session | null>;
 
-    // todo: marek will solve this
-    public handshakeFinished = false;
-
     constructor({ id, transport, descriptor }: DeviceParams) {
         super();
 
@@ -351,61 +347,39 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     // call only once, right after device creation
-    async handshake(delay?: number) {
-        if (delay) {
-            await resolveAfter(501 + delay);
+    async handshake() {
+        if (this.isUsedElsewhere()) {
+            return true;
         }
 
-        while (true) {
-            if (this.isUsedElsewhere()) {
-                this.lifecycle.emit(DEVICE.CONNECT_UNACQUIRED);
-            } else {
-                try {
-                    await this.run();
-                } catch (error) {
-                    _log.warn(`device.run error.message: ${error.message}, code: ${error.code}`);
+        try {
+            await this.run();
+        } catch (error) {
+            _log.warn(`device.run error.message: ${error.message}, code: ${error.code}`);
 
-                    if (
-                        error.code === 'Device_NotFound' ||
-                        error.code === 'Device_Disconnected' ||
-                        error.message === TRANSPORT_ERROR.DEVICE_NOT_FOUND ||
-                        error.message === TRANSPORT_ERROR.DEVICE_DISCONNECTED_DURING_ACTION ||
-                        error.message === TRANSPORT_ERROR.HTTP_ERROR // bridge died during device initialization
-                    ) {
-                        // disconnected, do nothing
-                    } else if (
-                        // if unable to open device and it's HID -> device is unreadable
-                        (this.possibleHIDdevice &&
-                            error.message === TRANSPORT_ERROR.INTERFACE_UNABLE_TO_OPEN_DEVICE) ||
-                        // catch LIBUSB_ERROR_ACCESS -> missing udev rules usually
-                        error.message === TRANSPORT_ERROR.LIBUSB_ERROR_ACCESS
-                    ) {
-                        this.unreadableError = error.message;
-                        this.lifecycle.emit(DEVICE.CONNECT_UNACQUIRED);
-                    } else if (
-                        // device was claimed by another application on transport api layer (claimInterface in usb nomenclature) but never released (releaseInterface in usb nomenclature)
-                        error.message === TRANSPORT_ERROR.INTERFACE_UNABLE_TO_OPEN_DEVICE ||
-                        // we don't know what really happened
-                        error.message === TRANSPORT_ERROR.UNEXPECTED_ERROR ||
-                        // someone else took the device at the same time
-                        error.message === TRANSPORT_ERROR.SESSION_WRONG_PREVIOUS ||
-                        // device had some session when first seen -> we do not read it so that we don't interrupt somebody else's flow
-                        error.code === 'Device_UsedElsewhere' ||
-                        // TODO: is this needed? can't I just use transport error?
-                        error.code === 'Device_InitializeFailed'
-                    ) {
-                        this.lifecycle.emit(DEVICE.CONNECT_UNACQUIRED);
-                    } else {
-                        await resolveAfter(501);
-                        continue;
-                    }
-                }
+            if (
+                error.code === 'Device_NotFound' ||
+                error.code === 'Device_Disconnected' ||
+                error.message === TRANSPORT_ERROR.DEVICE_NOT_FOUND ||
+                error.message === TRANSPORT_ERROR.DEVICE_DISCONNECTED_DURING_ACTION ||
+                error.message === TRANSPORT_ERROR.HTTP_ERROR // bridge died during device initialization
+            ) {
+                // disconnected, do nothing
+                return false;
             }
 
-            this.handshakeFinished = true;
-
-            return;
+            if (
+                // if unable to open device and it's HID -> device is unreadable
+                (this.possibleHIDdevice &&
+                    error.message === TRANSPORT_ERROR.INTERFACE_UNABLE_TO_OPEN_DEVICE) ||
+                // catch LIBUSB_ERROR_ACCESS -> missing udev rules usually
+                error.message === TRANSPORT_ERROR.LIBUSB_ERROR_ACCESS
+            ) {
+                this.unreadableError = error.message;
+            }
         }
+
+        return true;
     }
 
     private async updateDescriptor(descriptor: Descriptor) {
@@ -462,8 +436,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
             .then(() => {
                 if (wasUnacquired && !this.isUnacquired()) {
                     this.lifecycle.emit(DEVICE.CONNECT);
-                } else if (wasUnacquired && this.isUnacquired() && this.thp?.properties) {
-                    this.lifecycle.emit(DEVICE.CONNECT_UNACQUIRED);
                 }
             });
 

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -106,19 +106,17 @@ export interface DeviceEvents {
     [DEVICE.THP_CREDENTIALS_CHANGED]: DeviceThpCredentialsChangedPayload;
 }
 
-type DeviceLifecycle =
-    | typeof DEVICE.CONNECT
-    | typeof DEVICE.CONNECT_UNACQUIRED
-    | typeof DEVICE.DISCONNECT
-    | typeof DEVICE.CHANGED;
-
-type DeviceLifecycleListener = (lifecycle: DeviceLifecycle) => void;
+interface DeviceLifecycleEvents {
+    [DEVICE.CONNECT]: void;
+    [DEVICE.CONNECT_UNACQUIRED]: void;
+    [DEVICE.CHANGED]: void;
+    [DEVICE.DISCONNECT]: void;
+}
 
 type DeviceParams = {
     id: DeviceUniquePath;
     transport: Transport;
     descriptor: Descriptor;
-    listener: DeviceLifecycleListener;
 };
 
 export class Device extends TypedEmitter<DeviceEvents> {
@@ -204,17 +202,16 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     private readonly uniquePath;
 
-    private emitLifecycle;
+    readonly lifecycle = new TypedEmitter<DeviceLifecycleEvents>();
 
     private sessionDfd?: Deferred<Session | null>;
 
     // todo: marek will solve this
     public handshakeFinished = false;
 
-    constructor({ id, transport, descriptor, listener }: DeviceParams) {
+    constructor({ id, transport, descriptor }: DeviceParams) {
         super();
 
-        this.emitLifecycle = listener;
         this._protocol = protocolV1;
 
         // === immutable properties
@@ -361,7 +358,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
         while (true) {
             if (this.isUsedElsewhere()) {
-                this.emitLifecycle(DEVICE.CONNECT_UNACQUIRED);
+                this.lifecycle.emit(DEVICE.CONNECT_UNACQUIRED);
             } else {
                 try {
                     await this.run();
@@ -384,7 +381,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
                         error.message === TRANSPORT_ERROR.LIBUSB_ERROR_ACCESS
                     ) {
                         this.unreadableError = error.message;
-                        this.emitLifecycle(DEVICE.CONNECT_UNACQUIRED);
+                        this.lifecycle.emit(DEVICE.CONNECT_UNACQUIRED);
                     } else if (
                         // device was claimed by another application on transport api layer (claimInterface in usb nomenclature) but never released (releaseInterface in usb nomenclature)
                         error.message === TRANSPORT_ERROR.INTERFACE_UNABLE_TO_OPEN_DEVICE ||
@@ -397,7 +394,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
                         // TODO: is this needed? can't I just use transport error?
                         error.code === 'Device_InitializeFailed'
                     ) {
-                        this.emitLifecycle(DEVICE.CONNECT_UNACQUIRED);
+                        this.lifecycle.emit(DEVICE.CONNECT_UNACQUIRED);
                     } else {
                         await resolveAfter(501);
                         continue;
@@ -430,7 +427,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
             this.keepTransportSession = false;
         }
 
-        this.emitLifecycle(DEVICE.CHANGED);
+        this.lifecycle.emit(DEVICE.CHANGED);
     }
 
     // TODO empty fn variant can be split/removed
@@ -464,9 +461,9 @@ export class Device extends TypedEmitter<DeviceEvents> {
             })
             .then(() => {
                 if (wasUnacquired && !this.isUnacquired()) {
-                    this.emitLifecycle(DEVICE.CONNECT);
+                    this.lifecycle.emit(DEVICE.CONNECT);
                 } else if (wasUnacquired && this.isUnacquired() && this.thp?.properties) {
-                    this.emitLifecycle(DEVICE.CONNECT_UNACQUIRED);
+                    this.lifecycle.emit(DEVICE.CONNECT_UNACQUIRED);
                 }
             });
 
@@ -1009,8 +1006,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
             this.sessionAcquired = null; // set to null to prevent transport.release and cancelableAction
         }
 
-        this.emitLifecycle(DEVICE.DISCONNECT);
-        this.emitLifecycle = () => {};
+        this.lifecycle.emit(DEVICE.DISCONNECT);
 
         return this.interrupt(ERRORS.TypedError('Device_Disconnected'));
     }

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -9,6 +9,7 @@ import {
     createDeferred,
     getSynchronize,
     isNotUndefined,
+    resolveAfter,
     typedObjectKeys,
 } from '@trezor/utils';
 
@@ -140,9 +141,23 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         });
     }
 
-    private onDeviceConnected(descriptor: Descriptor, transport: Transport) {
+    private async onDeviceConnected(descriptor: Descriptor, transport: Transport) {
         const id = (this.deviceCounter++).toString(16).slice(-8);
         const device = new Device({ id: DeviceUniquePath(id), transport, descriptor });
+
+        const penalty = this.authPenaltyManager.get();
+        const stillConnected = await this.handshakeLock(() =>
+            resolveAfter(penalty && penalty + 501).then(() => device.handshake()),
+        );
+
+        if (!stillConnected) {
+            // this emit is here solely for waitForDevices to work; it would be nice to remove it
+            this.emit(DEVICE.DISCONNECT, device);
+
+            return;
+        }
+
+        this.devices.push(device);
 
         device.lifecycle.on(DEVICE.CONNECT, () => this.emit(DEVICE.CONNECT, device));
         device.lifecycle.on(DEVICE.CHANGED, () => this.emit(DEVICE.CHANGED, device));
@@ -157,15 +172,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
             this.emit(DEVICE.DISCONNECT, device);
         });
 
-        this.devices.push(device);
-
-        const penalty = this.authPenaltyManager.get();
-        this.handshakeLock(async () => {
-            if (this.devices.includes(device)) {
-                // device wasn't removed while waiting for lock
-                await device.handshake(penalty);
-            }
-        });
+        this.emit(device.isUnacquired() ? DEVICE.CONNECT_UNACQUIRED : DEVICE.CONNECT, device);
     }
 
     private getOrCreateTransportManager(apiType: TransportApiType) {

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -151,9 +151,6 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         );
 
         if (!stillConnected) {
-            // this emit is here solely for waitForDevices to work; it would be nice to remove it
-            this.emit(DEVICE.DISCONNECT, device);
-
             return;
         }
 
@@ -232,20 +229,17 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
         const descriptors = enumerateResult.payload;
 
-        const waitForDevicesPromise =
-            pendingTransportEvent && descriptors.length
-                ? this.waitForDevices(transport, descriptors, signal)
-                : Promise.resolve();
-
         transport.handleDescriptorsChange(descriptors);
         transport.listen();
 
-        await waitForDevicesPromise;
+        if (pendingTransportEvent && descriptors.length) {
+            await this.waitForDevices(transport, signal);
+        }
     }
 
     /**
      * Returned promise:
-     * - resolves when all the devices visible from given transport were acquired (or at least tried to)
+     * - resolves when all the devices visible from given transport were handshaked
      * - resolves after 10 secs (in order not to get stuck waiting for devices)
      * - rejects when aborted (e.g. because of DeviceList reinit)
      * - rejects when given transport emits an error
@@ -256,7 +250,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
      * implementator could get stuck waiting from TRANSPORT.START event forever. To avoid this,
      * we emit TRANSPORT.START event after autoResolveTransportEventTimeout
      */
-    private waitForDevices(transport: Transport, descriptors: Descriptor[], signal: AbortSignal) {
+    private waitForDevices(transport: Transport, signal: AbortSignal) {
         const { promise, reject, resolve } = createDeferred();
 
         const onAbort = () => reject(signal.reason);
@@ -267,28 +261,15 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
         const autoResolveTransportEventTimeout = setTimeout(resolve, 10000);
 
-        const remaining = descriptors.slice();
-
-        const onDeviceEvent = (device: Device) => {
-            const index = remaining.findIndex(
-                d => d.path === device.transportPath && transport === device.transport,
-            );
-            if (index >= 0) remaining.splice(index, 1);
-            if (!remaining.length) resolve();
-        };
-
-        // listen for self emitted events and resolve pending transport event if needed
-        this.on(DEVICE.CONNECT, onDeviceEvent);
-        this.on(DEVICE.CONNECT_UNACQUIRED, onDeviceEvent);
-        this.on(DEVICE.DISCONNECT, onDeviceEvent);
+        // this works because all initial device handshakes are started synchronously from
+        // initializeTransport -> transport.handleDescriptorsChange so this `resolve`
+        // in handshakeLock cannot be called before all of them are resolved
+        this.handshakeLock(resolve);
 
         return promise.finally(() => {
             transport.off(TRANSPORT.ERROR, onError);
             signal.removeEventListener('abort', onAbort);
             clearTimeout(autoResolveTransportEventTimeout);
-            this.off(DEVICE.CONNECT, onDeviceEvent);
-            this.off(DEVICE.CONNECT_UNACQUIRED, onDeviceEvent);
-            this.off(DEVICE.DISCONNECT, onDeviceEvent);
         });
     }
 

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -142,19 +142,21 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
     private onDeviceConnected(descriptor: Descriptor, transport: Transport) {
         const id = (this.deviceCounter++).toString(16).slice(-8);
-        const device = new Device({
-            id: DeviceUniquePath(id),
-            transport,
-            descriptor,
-            listener: lifecycle => {
-                if (lifecycle === DEVICE.DISCONNECT) {
-                    this.authPenaltyManager.remove(device);
-                    const index = this.devices.indexOf(device);
-                    if (index >= 0) this.devices.splice(index, 1);
-                }
-                this.emit(lifecycle, device);
-            },
+        const device = new Device({ id: DeviceUniquePath(id), transport, descriptor });
+
+        device.lifecycle.on(DEVICE.CONNECT, () => this.emit(DEVICE.CONNECT, device));
+        device.lifecycle.on(DEVICE.CHANGED, () => this.emit(DEVICE.CHANGED, device));
+        device.lifecycle.on(DEVICE.CONNECT_UNACQUIRED, () =>
+            this.emit(DEVICE.CONNECT_UNACQUIRED, device),
+        );
+        device.lifecycle.on(DEVICE.DISCONNECT, () => {
+            device.lifecycle.removeAllListeners();
+            this.authPenaltyManager.remove(device);
+            const index = this.devices.indexOf(device);
+            if (index >= 0) this.devices.splice(index, 1);
+            this.emit(DEVICE.DISCONNECT, device);
         });
+
         this.devices.push(device);
 
         const penalty = this.authPenaltyManager.get();

--- a/packages/connect/src/device/__tests__/DeviceList.test.ts
+++ b/packages/connect/src/device/__tests__/DeviceList.test.ts
@@ -18,12 +18,11 @@ const waitForNthEventOfType = (
             }
         });
     });
-const DEVICE_CONNECTION_SEQUENCE = ['device-changed', 'device-changed', 'device-connect'];
 
 describe('DeviceList', () => {
-    beforeAll(async () => {
+    beforeAll(() => {
         // todo: I don't get it. If we pass empty messages: {} (see getDeviceListParams), tests behave differently.
-        await DataManager.load({
+        DataManager.load({
             ...parseConnectSettings({}),
         });
     });
@@ -34,20 +33,23 @@ describe('DeviceList', () => {
     beforeEach(() => {
         list = new DeviceList({
             ...parseConnectSettings({}),
+            priority: 0,
             messages: DataManager.getProtobufMessages(),
         });
         eventsSpy = jest.fn();
+        list.on('transport-start', ({ apiType }) => eventsSpy('transport-start', apiType));
+        list.on('transport-error', ({ apiType }) => eventsSpy('transport-error', apiType));
         (
             [
-                'transport-start',
-                'transport-error',
                 'device-connect',
                 'device-connect_unacquired',
                 'device-changed',
                 'device-disconnect',
             ] as const
         ).forEach(event => {
-            list.on(event, data => eventsSpy(event, data));
+            list.on(event, device =>
+                eventsSpy(event, device.transport.apiType, device.transportPath),
+            );
         });
     });
 
@@ -132,19 +134,7 @@ describe('DeviceList', () => {
         });
 
         list.init({ transports: [transport], pendingTransportEvent: true });
-        const transportFirstEvent = list.pendingConnection();
-
-        // NOTE: this behavior is wrong, if device creation fails DeviceList shouldn't wait 10 secs.
-        jest.useFakeTimers();
-        // move 9 sec forward
-        await jest.advanceTimersByTimeAsync(9 * 1000);
-        // no events yet
-        expect(eventsSpy).toHaveBeenCalledTimes(0);
-        // move 2 sec forward
-        await jest.advanceTimersByTimeAsync(2 * 1000);
-        // promise should be resolved by now
-        await transportFirstEvent;
-        jest.useRealTimers();
+        await list.pendingConnection();
 
         expect(eventsSpy).toHaveBeenCalledTimes(1);
         expect(eventsSpy.mock.calls[0][0]).toEqual('transport-start');
@@ -163,12 +153,7 @@ describe('DeviceList', () => {
         await list.pendingConnection();
 
         const events = eventsSpy.mock.calls.map(call => call[0]);
-        expect(events).toEqual([
-            'device-changed',
-            'device-changed',
-            'device-connect_unacquired',
-            'transport-start',
-        ]);
+        expect(events).toEqual(['device-connect_unacquired', 'transport-start']);
     });
 
     it('.init() with pendingTransportEvent (multiple acquired devices)', async () => {
@@ -182,47 +167,50 @@ describe('DeviceList', () => {
         list.init({ transports: [transport], pendingTransportEvent: true });
         await list.pendingConnection();
 
-        const events = eventsSpy.mock.calls.map(([event, { path }]) => [event, path]);
-
         // note: acquire - release - connect should be ok.
         // acquire - deviceList._takeAndCreateDevice start (run -> rurInner -> getFeatures -> release) -> deviceList._takeAndCreateDevice end => emit DEVICE.CONNECT
-        expect(events).toEqual([
-            ...DEVICE_CONNECTION_SEQUENCE.map(e => [e, events[0][1]]), // path 1
-            ...DEVICE_CONNECTION_SEQUENCE.map(e => [e, events[3][1]]), // path 2
-            ...DEVICE_CONNECTION_SEQUENCE.map(e => [e, events[6][1]]), // path 3
-            ['transport-start', undefined],
+        expect(eventsSpy.mock.calls).toEqual([
+            ['device-connect', 'usb', '1'],
+            ['device-connect', 'usb', '2'],
+            ['device-connect', 'usb', '3'],
+            ['transport-start', 'usb', undefined],
         ]);
     });
 
-    it('.init() with pendingTransportEvent (device acquired after retry)', async () => {
-        let openTries = 0;
-        const transport = createTestTransport({
-            openDevice: (path: string) => {
-                if (openTries < 1) {
-                    openTries++;
-
-                    return { success: false, error: 'totally unexpected' };
-                }
-
-                return { success: true, payload: [{ path }] };
-            },
+    it('.init() with pendingTransportEvent (multiple transports)', async () => {
+        const transportA = createTestTransport({
+            enumerate: () => ({ success: true, payload: [{ path: '1' }, { path: '2' }] }),
+            openDevice: (path: string) =>
+                (path === '2'
+                    ? new Promise(resolve => setTimeout(resolve, 500))
+                    : Promise.resolve()
+                ).then(() => ({ success: true, payload: [{ path }] })),
+        });
+        const transportB = createTestTransport({
+            enumerate: () => ({
+                success: true,
+                payload: [{ path: '1' }, { path: '2' }, { path: '3' }],
+            }),
+            openDevice: (path: string) =>
+                path === '2'
+                    ? Promise.resolve({ success: false, error: 'device not found' })
+                    : Promise.resolve({ success: true, payload: [{ path }] }),
         });
 
-        // NOTE: this behavior is wrong
-        jest.useFakeTimers();
-        list.init({ transports: [transport], pendingTransportEvent: true });
-        const transportFirstEvent = list.pendingConnection();
-        await jest.advanceTimersByTimeAsync(6 * 1000); // TODO: this is wrong
-        await transportFirstEvent;
-        jest.useRealTimers();
+        // @ts-expect-error
+        transportB.apiType = 'usb2';
 
-        // expect(eventsSpy).toHaveBeenCalledTimes(5);
-        const events = eventsSpy.mock.calls.map(([event]) => event);
-        expect(events).toEqual([
-            'device-changed',
-            'device-changed',
-            'device-connect',
-            'transport-start',
+        list.init({ transports: [transportA, transportB], pendingTransportEvent: true });
+
+        await list.pendingConnection();
+
+        expect(eventsSpy.mock.calls).toEqual([
+            ['device-connect', 'usb', '1'],
+            ['device-connect', 'usb', '2'],
+            ['transport-start', 'usb', undefined],
+            ['device-connect', 'usb2', '1'],
+            ['device-connect', 'usb2', '3'],
+            ['transport-start', 'usb2', undefined],
         ]);
     });
 
@@ -238,7 +226,7 @@ describe('DeviceList', () => {
         await new Promise(resolve => list.on('device-connect', resolve));
 
         const events = eventsSpy.mock.calls.map(call => call[0]);
-        expect(events).toEqual(['transport-start', ...DEVICE_CONNECTION_SEQUENCE]);
+        expect(events).toEqual(['transport-start', 'device-connect']);
     });
 
     it('multiple devices connected after .init()', async () => {
@@ -263,14 +251,11 @@ describe('DeviceList', () => {
         // wait for all device-connect events
         await waitForNthEventOfType(list, 'device-connect', 3);
 
-        const events = eventsSpy.mock.calls.map(([event, { path }]) => [event, path]);
-
-        expect(events).toEqual([
-            ['transport-start', undefined],
-            ['device-disconnect', events[1][1]],
-            ...DEVICE_CONNECTION_SEQUENCE.map(e => [e, events[2][1]]), // path 1
-            ...DEVICE_CONNECTION_SEQUENCE.map(e => [e, events[5][1]]), // path 3
-            ...DEVICE_CONNECTION_SEQUENCE.map(e => [e, events[8][1]]), // path 4
+        expect(eventsSpy.mock.calls).toEqual([
+            ['transport-start', 'usb', undefined],
+            ['device-connect', 'usb', '1'],
+            ['device-connect', 'usb', '3'],
+            ['device-connect', 'usb', '4'],
         ]);
     });
 

--- a/packages/connect/src/device/__tests__/handshakeWorkflow.test.ts
+++ b/packages/connect/src/device/__tests__/handshakeWorkflow.test.ts
@@ -31,7 +31,6 @@ const getAcquiredDevice = async (apiMethods: any = {}) => {
         id: 'ABCD' as any, // any = DeviceUniquePath
         transport,
         descriptor: { path: '1' as any, type: 3, session: null }, // any = PathPublic
-        listener: () => {},
     });
     await device.acquire();
 


### PR DESCRIPTION
## Description

Rather small changes which could help with device handling in Connect.

1) lifecycle callback in `DeviceList` replaced by standard emitter, which is easier to handle (subscribe later/unsubscribe)
2) device is added into `DeviceList` after handshake is (successfully or not) finished and `CONNECT`/`CONNECT_UNACQUIRED` event is fired after that, so it shouldn't be possible to work with already created device while handshake hasn't ended (`handshakeFinished` not needed anymore)
3) waiting for initial devices handshake (a.k.a. `pendingTransportEvent`) simplified by using inherent properties of `handshakeLock`, so now we're sure that the first event related to any device is always `device-connect` or `device-connect_unacquired`


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/device_v2&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/device_v2&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/device_v2&lookback=7)