### PR TITLE
fix(suite): load fresh tx data from store instead of stale payload

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
@@ -1,12 +1,17 @@
 import { useMemo, useState } from 'react';
 
 import { getNetwork } from '@suite-common/wallet-config';
-import { selectAccountByKey, selectAllPendingTransactions } from '@suite-common/wallet-core';
+import {
+    selectAccountByKey,
+    selectAllPendingTransactions,
+    selectTransactionByAccountKeyAndTxid,
+} from '@suite-common/wallet-core';
 import { WalletAccountTransactionWithRequiredRbfParams } from '@suite-common/wallet-types';
 import { findChainedTransactions, getAccountKey, isPending } from '@suite-common/wallet-utils';
 
 import { useSelector } from 'src/hooks/suite';
 import { Account, WalletAccountTransaction } from 'src/types/wallet';
+import { getInstantStakeType } from 'src/utils/suite/ethereumStaking';
 
 import { CancelTransactionModal } from './CancelTransaction/CancelTransactionModal';
 import { BumpFeeModal } from './ChangeFee/BumpFeeModal';
@@ -18,16 +23,49 @@ const hasRbfParams = (
 ): tx is WalletAccountTransactionWithRequiredRbfParams => tx.rbfParams !== undefined;
 
 type TxDetailModalProps = {
-    tx: WalletAccountTransaction;
+    txid: string;
+    descriptor: Account['descriptor'];
+    symbol: Account['symbol'];
+    deviceState: Account['deviceState'];
     flow: 'detail' | 'bump-fee' | 'cancel-transaction';
     onCancel: () => void;
 };
 
-export const TxDetailModal = ({ tx, flow, onCancel }: TxDetailModalProps) => {
+export const TxDetailModal = ({
+    txid,
+    descriptor,
+    symbol,
+    deviceState,
+    flow,
+    onCancel,
+}: TxDetailModalProps) => {
     const [section, setSection] = useState<TxDetailModalProps['flow']>(flow);
     const [tab, setTab] = useState<TabID | undefined>(undefined);
 
-    const accountKey = getAccountKey(tx.descriptor, tx.symbol, tx.deviceState);
+    const accountKey = getAccountKey(descriptor, symbol, deviceState);
+    const originalTx = useSelector(state =>
+        selectTransactionByAccountKeyAndTxid(state, accountKey, txid),
+    ) as WalletAccountTransaction;
+
+    // Filter out internal transfers that are instant staking transactions
+    const filteredInternalTransfers = useMemo(
+        () =>
+            originalTx.internalTransfers.filter(t => {
+                const stakeType = getInstantStakeType(t, descriptor, symbol);
+
+                return stakeType !== 'stake';
+            }),
+        [originalTx.internalTransfers, descriptor, symbol],
+    );
+
+    const tx = useMemo(
+        () => ({
+            ...originalTx,
+            internalTransfers: filteredInternalTransfers,
+        }),
+        [originalTx, filteredInternalTransfers],
+    );
+
     const account = useSelector(state => selectAccountByKey(state, accountKey)) as Account;
     const network = getNetwork(account.symbol);
     const networkFeatures = network.accountTypes[account.accountType]?.features ?? network.features;

--- a/packages/suite/src/components/wallet/TransactionItem/CoinjoinBatchItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/CoinjoinBatchItem.tsx
@@ -55,7 +55,10 @@ const Round = ({ transaction }: { transaction: WalletAccountTransaction }) => {
         dispatch(
             openModal({
                 type: 'transaction-detail',
-                tx: transaction,
+                txid: transaction.txid,
+                descriptor: transaction.descriptor,
+                symbol: transaction.symbol,
+                deviceState: transaction.deviceState,
                 flow: 'detail',
             }),
         );

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -156,7 +156,10 @@ export const TransactionItem = memo(
             dispatch(
                 openModal({
                     type: 'transaction-detail',
-                    tx: { ...transaction, internalTransfers: filteredInternalTransfers },
+                    txid: transaction.txid,
+                    descriptor: transaction.descriptor,
+                    symbol: transaction.symbol,
+                    deviceState: transaction.deviceState,
                     flow,
                 }),
             );

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
@@ -203,7 +203,16 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
     const showTransactionDetail: MouseEventHandler = e => {
         e.stopPropagation(); // do not trigger the checkbox
         if (transaction) {
-            dispatch(openModal({ type: 'transaction-detail', tx: transaction, flow: 'detail' }));
+            dispatch(
+                openModal({
+                    type: 'transaction-detail',
+                    txid: transaction.txid,
+                    descriptor: transaction.descriptor,
+                    symbol: transaction.symbol,
+                    deviceState: transaction.deviceState,
+                    flow: 'detail',
+                }),
+            );
         }
     };
 

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -1,6 +1,6 @@
 import { RequestEnableTorResponse } from '@suite-common/suite-config';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { Account, AddressType, WalletAccountTransaction } from '@suite-common/wallet-types';
+import { Account, AddressType } from '@suite-common/wallet-types';
 import { Deferred } from '@trezor/utils';
 
 import { TrezorDevice } from './device';
@@ -51,7 +51,10 @@ export type UserContextPayload =
       }
     | {
           type: 'transaction-detail';
-          tx: WalletAccountTransaction;
+          txid: string;
+          descriptor: Account['descriptor'];
+          symbol: Account['symbol'];
+          deviceState: Account['deviceState'];
           flow: 'detail' | 'bump-fee' | 'cancel-transaction';
       }
     | {


### PR DESCRIPTION
## Description

`TxDetailModal` previously received full transaction data in the payload when opened, which caused it to use stale data and not react to updates (e.g. confirmations or status changes).

This has been fixed by changing the payload to include only identifiers (txid, descriptor, symbol, deviceState) and selecting the latest transaction data from the store when rendering the model.


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17992


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tx-detail-modal-stale-data&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tx-detail-modal-stale-data&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/tx-detail-modal-stale-data&lookback=7)