### PR TITLE
Tx speed up modal improvements for evms

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { fromWei } from 'web3-utils';
 
 import { Network } from '@suite-common/wallet-config';
-import { getFeeRate, getTxIcon, isPending } from '@suite-common/wallet-utils';
+import { getFeeRate, getTxIcon, isEip1559, isPending } from '@suite-common/wallet-utils';
 import {
     Box,
     Card,
@@ -196,7 +196,7 @@ export const BasicTxDetails = ({
                         </Item>
 
                         <Item label={<Translation id="TR_GAS_PRICE" />} iconName="gasPump">
-                            {isConfirmed ? (
+                            {isConfirmed || !isEip1559(tx.ethereumSpecific) ? (
                                 <FeeRate
                                     feeRate={fromWei(tx.ethereumSpecific?.gasPrice || 0, 'gwei')}
                                     networkType="ethereum"

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 
-import { NetworkType } from '@suite-common/wallet-config';
+import { NetworkType, getNetwork } from '@suite-common/wallet-config';
 import { WalletAccountTransaction } from '@suite-common/wallet-types';
 import { formatNetworkAmount, isEip1559 } from '@suite-common/wallet-utils';
 import { Card, Divider, InfoItem, Row, Text } from '@trezor/components';
@@ -64,7 +64,16 @@ const ChangeFeeLoaded = (props: ChangeFeeProps) => {
                     direction="row"
                     label={
                         <>
-                            <Translation id="TR_CURRENT_FEE" /> {getFeeRate(tx, networkType)}
+                            <Translation
+                                id={
+                                    getNetwork(tx.symbol).networkType === 'ethereum'
+                                        ? 'TR_CURRENT_MAXIMUM_FEE_SPEED_UP'
+                                        : 'TR_CURRENT_FEE_SPEED_UP'
+                                }
+                                values={{
+                                    feeRate: getFeeRate(tx, networkType),
+                                }}
+                            />
                         </>
                     }
                     typographyStyle="body"

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/RbfFees.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/RbfFees.tsx
@@ -1,3 +1,5 @@
+import { getNetwork } from '@suite-common/wallet-config';
+
 import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useRbfContext } from 'src/hooks/wallet/useRbfForm';
 
@@ -27,7 +29,11 @@ export const RbfFees = () => {
             account={account}
             composedLevels={composedLevels}
             changeFeeLevel={changeFeeLevel}
-            label="TR_NEW_FEE"
+            label={
+                getNetwork(account.symbol).networkType === 'ethereum'
+                    ? 'TR_NEW_MAXIMUM_FEE'
+                    : 'TR_NEW_FEE'
+            }
             rbfForm
         />
     );

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6691,13 +6691,21 @@ export default defineMessages({
         id: 'TR_CONFIRMING_TX',
         defaultMessage: 'Confirming transaction',
     },
-    TR_CURRENT_FEE: {
-        id: 'TR_CURRENT_FEE',
-        defaultMessage: 'Current',
+    TR_CURRENT_FEE_SPEED_UP: {
+        id: 'TR_CURRENT_FEE_SPEED_UP',
+        defaultMessage: 'Current fee {feeRate}',
+    },
+    TR_CURRENT_MAXIMUM_FEE_SPEED_UP: {
+        id: 'TR_CURRENT_MAXIMUM_FEE_SPEED_UP',
+        defaultMessage: 'Current maximum fee',
     },
     TR_NEW_FEE: {
         id: 'TR_NEW_FEE',
         defaultMessage: 'New fee',
+    },
+    TR_NEW_MAXIMUM_FEE: {
+        id: 'TR_NEW_MAXIMUM_FEE',
+        defaultMessage: 'New maximum fee',
     },
     TR_INCREASE_FEE_BY: {
         id: 'TR_INCREASE_FEE_BY',

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -615,8 +615,9 @@ const getEthereumRbfParams = (
               formattedAmount: formatNetworkAmount(vout[0].value!, account.symbol),
           };
 
-    const ethereumData =
-        tx.ethereumSpecific.data?.indexOf('0x') === 0 ? tx.ethereumSpecific.data.substring(2) : '';
+    const { data, nonce, gasPrice, maxFeePerGas, maxPriorityFeePerGas } = tx.ethereumSpecific;
+
+    const ethereumData = data?.indexOf('0x') === 0 ? data.substring(2) : '';
 
     return {
         type: 'ethereum',
@@ -627,11 +628,11 @@ const getEthereumRbfParams = (
                 ...output,
             },
         ],
-        ethereumNonce: tx.ethereumSpecific.nonce,
+        ethereumNonce: nonce,
         ethereumData,
-        gasPrice: fromWei(tx.ethereumSpecific?.gasPrice ?? '0', 'gwei'),
-        maxFeePerGas: fromWei(tx.ethereumSpecific?.maxFeePerGas ?? '0', 'gwei'),
-        maxPriorityFeePerGas: fromWei(tx.ethereumSpecific?.maxPriorityFeePerGas ?? '0', 'gwei'),
+        gasPrice: gasPrice ? fromWei(gasPrice, 'gwei') : '',
+        maxFeePerGas: maxFeePerGas ? fromWei(maxFeePerGas, 'gwei') : '',
+        maxPriorityFeePerGas: maxPriorityFeePerGas ? fromWei(maxPriorityFeePerGas, 'gwei') : '',
     };
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- fix legacy fees incorrectly detected as eip1559 because there was `'0'` in data which resulted into `true`
  - `fromWei` creates `'0'` from `undefined`
- use `maximum` wording for evm fees in bump fee modal
- remove current gas fee from the `Current` text for evms as user can see it in the detail above
  - gas price is now visible for pending txs in the details 
 

## Related Issue

Resolve #18066

## Screenshots:

Before legacy:
![Screenshot 2025-05-20 at 16 40 56](https://github.com/user-attachments/assets/10149b24-9b39-451a-8163-7513a23d7724)

After:
Legacy:
![Screenshot 2025-05-20 at 17 16 47](https://github.com/user-attachments/assets/a9402c82-9fe4-49e7-b214-9f95f56f889f)

EIP1559
![Screenshot 2025-05-20 at 17 15 33](https://github.com/user-attachments/assets/07f92ec1-c7fb-41fa-8687-f901bb05792a)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bump-fee-evm&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bump-fee-evm&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/bump-fee-evm&lookback=7)