### PR TITLE
feat: Add 'Show full address' button and modal

### DIFF
--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.test.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.test.tsx
@@ -1,0 +1,241 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider } from 'styled-components';
+import { trezorTheme } from '@trezor/theme';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+import { FreshAddress } from './FreshAddress';
+import { FullAddressModal } from './FullAddressModal'; // To access its mock
+import * as walletUtils from '@suite-common/wallet-utils';
+import * as receiveActions from 'src/actions/wallet/receiveActions';
+import * as suiteHooks from 'src/hooks/suite'; // To mock useSelector and useDispatch
+
+// --- Mocks ---
+jest.mock('./FullAddressModal', () => ({
+  FullAddressModal: jest.fn(() => <div data-testid="mock-full-address-modal">FullAddressModal</div>),
+}));
+
+jest.mock('src/components/suite/Translation', () => ({
+  Translation: ({ id, children }: { id: string; children?: React.ReactNode }) => (
+    <>{children || id}</>
+  ),
+}));
+
+jest.mock('@suite-common/wallet-utils', () => ({
+  getFirstFreshAddress: jest.fn(),
+}));
+
+// Mocking @trezor/components that are not central to this component's logic
+jest.mock('@trezor/components', () => {
+  const original = jest.requireActual('@trezor/components');
+  return {
+    ...original,
+    Banner: jest.fn(({ children }) => <div data-testid="mock-banner">{children}</div>),
+    Tooltip: jest.fn(({ children, content }) => (
+      <div data-testid="mock-tooltip">
+        {children}
+        {content && <div data-testid="mock-tooltip-content">{content}</div>}
+      </div>
+    )),
+    GradientOverlay: jest.fn(() => <div data-testid="mock-gradient-overlay"></div>),
+  };
+});
+
+jest.mock('@suite-common/wallet-config', () => ({
+    getNetwork: jest.fn(symbol => ({ name: `${symbol} Network` })),
+}));
+
+
+// Mock Redux hooks
+jest.mock('src/hooks/suite');
+const mockUseDispatch = jest.fn();
+const mockUseSelector = jest.fn();
+
+(suiteHooks.useDispatch as jest.Mock).mockReturnValue(mockUseDispatch);
+(suiteHooks.useSelector as jest.Mock).mockImplementation(selector => mockUseSelector(selector));
+
+
+// --- Test Setup ---
+const mockStore = configureStore([]);
+const defaultStore = mockStore({
+  // Initial minimal store state, can be overridden in tests
+  wallet: {
+    selectedAccount: {
+      account: {
+        key: 'account-key',
+        symbol: 'btc',
+        accountType: 'segwit',
+        networkType: 'bitcoin',
+        addresses: { used: [], unused: [{ address: 'initialUnusedAddress', path: 'm/0/1'}] },
+      },
+    },
+    receive: {}, // receive state
+  },
+  suite: {
+    isFirmwareAuthenticityCheckEnabledAndHardFailed: false, // Example for selectIsFirmwareAuthenticityCheckEnabledAndHardFailed
+  },
+  // Add other necessary state slices
+});
+
+const defaultAccount = {
+  key: 'btc-segwit-account',
+  symbol: 'btc',
+  accountType: 'segwit',
+  networkType: 'bitcoin',
+  addresses: { used: [], unused: [{ address: 'unusedAddress0', path: 'm/0/0' }] },
+  balance: '0',
+  path: "m/49'/0'/0'",
+  name: 'BTC Account 1',
+};
+
+const defaultProps = {
+  account: defaultAccount as any,
+  addresses: {} as any, // This will be populated by getFirstFreshAddress mock
+  disabled: false,
+  locked: false,
+  pendingAddresses: [],
+  isDeviceConnected: true,
+};
+
+const renderWithProviders = (ui: React.ReactElement, customStore?: any) => {
+  return render(
+    <Provider store={customStore || defaultStore}>
+      <ThemeProvider theme={trezorTheme}>{ui}</ThemeProvider>
+    </Provider>
+  );
+};
+
+
+describe('FreshAddress', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default selector mocks
+    mockUseSelector.mockImplementation(selector => {
+      if (selector.name === 'selectIsAccountUtxoBased') return true;
+      if (selector.name === 'selectIsFirmwareAuthenticityCheckEnabledAndHardFailed') return false;
+      return undefined;
+    });
+  });
+
+  describe('"Show full address" button', () => {
+    it('does not render "Show full address" button when no address is available', () => {
+      (walletUtils.getFirstFreshAddress as jest.Mock).mockReturnValue(null);
+      renderWithProviders(<FreshAddress {...defaultProps} />);
+      expect(screen.queryByTestId('@freshAddress/show-full-address-button')).not.toBeInTheDocument();
+    });
+
+    it('renders "Show full address" button when an address is available', () => {
+      (walletUtils.getFirstFreshAddress as jest.Mock).mockReturnValue({
+        address: 'testAddressShort',
+        path: 'm/0/0',
+      });
+      renderWithProviders(<FreshAddress {...defaultProps} />);
+      expect(screen.getByTestId('@freshAddress/show-full-address-button')).toBeInTheDocument();
+      expect(screen.getByText('SHOW_FULL_ADDRESS_BUTTON_LABEL')).toBeInTheDocument();
+    });
+
+    it('clicking "Show full address" button makes FullAddressModal visible by setting isOpen to true', () => {
+      const freshAddressData = { address: 'testAddressFull', path: 'm/0/0' };
+      (walletUtils.getFirstFreshAddress as jest.Mock).mockReturnValue(freshAddressData);
+      
+      renderWithProviders(<FreshAddress {...defaultProps} />);
+
+      // Initially, modal should not be open
+      expect(FullAddressModal).toHaveBeenLastCalledWith(
+        expect.objectContaining({ isOpen: false }),
+        expect.anything()
+      );
+
+      const showFullAddressButton = screen.getByTestId('@freshAddress/show-full-address-button');
+      fireEvent.click(showFullAddressButton);
+
+      // Modal should now be open
+      expect(FullAddressModal).toHaveBeenLastCalledWith(
+        expect.objectContaining({ isOpen: true, fullAddress: freshAddressData.address }),
+        expect.anything()
+      );
+    });
+  });
+
+  describe('FullAddressModal integration', () => {
+    const freshAddressData = { address: 'fullMockAddressForModal', path: 'm/0/0' };
+
+    beforeEach(() => {
+        (walletUtils.getFirstFreshAddress as jest.Mock).mockReturnValue(freshAddressData);
+    });
+
+    it('FullAddressModal is rendered with correct props when "Show full address" is clicked', () => {
+      renderWithProviders(<FreshAddress {...defaultProps} />);
+      const showFullAddressButton = screen.getByTestId('@freshAddress/show-full-address-button');
+      fireEvent.click(showFullAddressButton);
+
+      expect(FullAddressModal).toHaveBeenCalledTimes(2); // Initial render (closed) + after click (open)
+      expect(FullAddressModal).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          isOpen: true,
+          fullAddress: freshAddressData.address,
+          onClose: expect.any(Function),
+        }),
+        expect.anything()
+      );
+    });
+
+    it('FullAddressModal is hidden when its onClose prop is called', () => {
+      renderWithProviders(<FreshAddress {...defaultProps} />);
+      const showFullAddressButton = screen.getByTestId('@freshAddress/show-full-address-button');
+      
+      // Open the modal
+      fireEvent.click(showFullAddressButton);
+      expect(FullAddressModal).toHaveBeenLastCalledWith(expect.objectContaining({ isOpen: true }), {});
+
+      // Simulate onClose call from FullAddressModal
+      // Get the last call to FullAddressModal mock and extract the onClose prop
+      const lastCallArgs = (FullAddressModal as jest.Mock).mock.calls.slice(-1)[0];
+      const onCloseCallback = lastCallArgs[0].onClose;
+
+      act(() => {
+        onCloseCallback();
+      });
+      
+      // Now check if FullAddressModal is called with isOpen: false
+      // It will be called again due to state update causing re-render
+      expect(FullAddressModal).toHaveBeenLastCalledWith(expect.objectContaining({ isOpen: false }), {});
+    });
+
+    it('FullAddressModal is initially rendered with isOpen: false', () => {
+        renderWithProviders(<FreshAddress {...defaultProps} />);
+        expect(FullAddressModal).toHaveBeenCalledTimes(1);
+        expect(FullAddressModal).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                isOpen: false,
+                fullAddress: freshAddressData.address, // it gets the address even if closed
+                onClose: expect.any(Function),
+            }),
+            expect.anything()
+        );
+    });
+  });
+
+  // Test for "Reveal Address" button to ensure basic functionality is still there
+  describe('Reveal Address button functionality', () => {
+    it('dispatches showAddress action when "Reveal address" button is clicked', () => {
+        const freshAddressData = { address: 'revealThisAddress', path: 'm/49/0/0/0/0' };
+        (walletUtils.getFirstFreshAddress as jest.Mock).mockReturnValue(freshAddressData);
+        jest.spyOn(receiveActions, 'showAddress'); // Spy on the actual action creator
+
+        renderWithProviders(<FreshAddress {...defaultProps} />);
+
+        // The button text is "RECEIVE_ADDRESS_REVEAL"
+        const revealButton = screen.getByText('RECEIVE_ADDRESS_REVEAL').closest('button');
+        expect(revealButton).toBeInTheDocument();
+        
+        if (revealButton) {
+            fireEvent.click(revealButton);
+        }
+
+        expect(mockUseDispatch).toHaveBeenCalledWith(receiveActions.showAddress(freshAddressData.path, freshAddressData.address));
+    });
+  });
+});

--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -24,6 +24,8 @@ import { ReadMoreLink, Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite/';
 import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/reducers/suite/suiteReducer';
 import { AppState } from 'src/types/suite';
+
+import { FullAddressModal } from './FullAddressModal';
 
 const FreshAddressWrapper = styled.div`
     position: relative;
@@ -97,6 +99,8 @@ export const FreshAddress = ({
     );
     const dispatch = useDispatch();
 
+    const [isFullAddressModalOpen, setIsFullAddressModalOpen] = useState(false);
+
     const firstFreshAddress = useMemo(() => {
         if (account) {
             return getFirstFreshAddress(account, addresses, pendingAddresses, isAccountUtxoBased);
@@ -145,10 +149,15 @@ export const FreshAddress = ({
         isLoading: locked,
     };
 
+    const handleCloseFullAddressModal = () => {
+        setIsFullAddressModalOpen(false);
+    };
+
     return (
-        <Card>
-            <Row gap={spacings.lg} flexWrap="wrap">
-                <InfoItem
+        <>
+            <Card>
+                <Row gap={spacings.lg} flexWrap="wrap">
+                    <InfoItem
                     label={
                         <TooltipLabel
                             multipleAddresses={isAccountUtxoBased}
@@ -177,6 +186,19 @@ export const FreshAddress = ({
                     )}
                 </Tooltip>
             </Row>
+            {addressValue && (
+                <Row justifyContent="flex-end" margin={{ top: spacings.md }}>
+                    <Button
+                        variant="secondary"
+                        onClick={() => setIsFullAddressModalOpen(true)}
+                        data-testid="@freshAddress/show-full-address-button"
+                    >
+                        <Translation id="SHOW_FULL_ADDRESS_BUTTON_LABEL">
+                            Show full address
+                        </Translation>
+                    </Button>
+                </Row>
+            )}
             {account.networkType === 'ethereum' && (
                 <Banner icon variant="info" margin={{ top: spacings.xxl }}>
                     <H4>
@@ -197,6 +219,12 @@ export const FreshAddress = ({
                     </Paragraph>
                 </Banner>
             )}
-        </Card>
+            </Card>
+            <FullAddressModal
+                isOpen={isFullAddressModalOpen}
+                onClose={handleCloseFullAddressModal}
+                fullAddress={firstFreshAddress?.address ?? ''}
+            />
+        </>
     );
 };

--- a/packages/suite/src/views/wallet/receive/components/FullAddressModal.test.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FullAddressModal.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider } from 'styled-components';
+import { trezorTheme } from '@trezor/theme';
+
+import { FullAddressModal } from './FullAddressModal';
+import { copyToClipboard } from '@trezor/dom-utils';
+
+// Mock dependencies
+jest.mock('@trezor/dom-utils', () => ({
+  copyToClipboard: jest.fn(),
+}));
+
+jest.mock('src/components/suite/Translation', () => ({
+  Translation: ({ id, children }: { id: string; children?: React.ReactNode }) => (
+    <>{children || id}</> // Simplified mock for easier text assertion
+  ),
+}));
+
+jest.mock('src/components/suite/Address', () => ({
+  Address: jest.fn(({ address, "data-testid": dataTestId }) => <div data-testid={dataTestId || "mock-address"}>{address}</div>),
+}));
+
+jest.mock('src/components/suite/QrCode', () => ({
+  QrCode: jest.fn(({ data }) => <div data-testid="mock-qrcode">{data}</div>),
+}));
+
+
+const mockAddress = 'testAddress1234567890';
+
+const renderWithTheme = (ui: React.ReactElement) => {
+  return render(<ThemeProvider theme={trezorTheme}>{ui}</ThemeProvider>);
+};
+
+describe('FullAddressModal', () => {
+  beforeEach(() => {
+    // Clear mock calls before each test
+    (copyToClipboard as jest.Mock).mockClear();
+  });
+
+  describe('Rendering', () => {
+    it('renders correctly when isOpen is true', () => {
+      const handleClose = jest.fn();
+      renderWithTheme(
+        <FullAddressModal isOpen={true} onClose={handleClose} fullAddress={mockAddress} />
+      );
+
+      expect(screen.getByText('FULL_ADDRESS_MODAL_TITLE')).toBeInTheDocument();
+      expect(screen.getByTestId('mock-address')).toHaveTextContent(mockAddress);
+      expect(screen.getByTestId('mock-qrcode')).toHaveTextContent(mockAddress);
+      expect(screen.getByText('COPY_ADDRESS_BUTTON_LABEL')).toBeInTheDocument();
+      // The Modal component might render the label directly or via the Translation mock
+      expect(screen.getByText((content, element) => {
+        // Check if the content is 'Close' and the element is a button or part of the footer
+        return content === 'CLOSE_BUTTON_LABEL' && (element?.tagName.toLowerCase() === 'span' || element?.tagName.toLowerCase() === 'button');
+      })).toBeInTheDocument();
+    });
+
+    it('does not render when isOpen is false', () => {
+      const handleClose = jest.fn();
+      const { container } = renderWithTheme(
+        <FullAddressModal isOpen={false} onClose={handleClose} fullAddress={mockAddress} />
+      );
+      // When isOpen is false, the component returns null
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe('Actions', () => {
+    it('calls onClose when the close button is clicked', () => {
+      const handleClose = jest.fn();
+      renderWithTheme(
+        <FullAddressModal isOpen={true} onClose={handleClose} fullAddress={mockAddress} />
+      );
+
+      // Find the close button by its data-testid from the component
+      // The actual button is rendered by the Modal component, we look for its label
+      // The buttonProps in FullAddressModal passes data-testid to the underlying button component
+      const closeButton = screen.getByTestId('@fullAddressModal/close-button');
+      fireEvent.click(closeButton);
+      expect(handleClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls copyToClipboard with fullAddress when copy button is clicked', () => {
+      const handleClose = jest.fn();
+      renderWithTheme(
+        <FullAddressModal isOpen={true} onClose={handleClose} fullAddress={mockAddress} />
+      );
+
+      const copyButton = screen.getByTestId('@fullAddressModal/copy-button');
+      fireEvent.click(copyButton);
+
+      expect(copyToClipboard).toHaveBeenCalledWith(mockAddress);
+      expect(copyToClipboard).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows "Copied!" feedback when copy button is clicked and resets', async () => {
+      jest.useFakeTimers();
+      const handleClose = jest.fn();
+      renderWithTheme(
+        <FullAddressModal isOpen={true} onClose={handleClose} fullAddress={mockAddress} />
+      );
+
+      const copyButton = screen.getByTestId('@fullAddressModal/copy-button');
+      expect(copyButton).toHaveTextContent('COPY_ADDRESS_BUTTON_LABEL');
+
+      fireEvent.click(copyButton);
+      expect(copyButton).toHaveTextContent('COPIED_FEEDBACK_TEXT');
+
+      // Fast-forward timers
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+      
+      expect(copyButton).toHaveTextContent('COPY_ADDRESS_BUTTON_LABEL');
+      jest.useRealTimers();
+    });
+  });
+});

--- a/packages/suite/src/views/wallet/receive/components/FullAddressModal.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FullAddressModal.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+import { Address } from 'src/components/suite/Address';
+import { QrCode } from 'src/components/suite/QrCode';
+import { Translation } from 'src/components/suite/Translation';
+import { copyToClipboard } from '@trezor/dom-utils';
+import { Button, Modal, Column } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
+interface FullAddressModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  fullAddress: string;
+}
+
+const ContentWrapper = styled(Column)`
+  gap: ${spacings.xl};
+  align-items: center;
+`;
+
+const StyledAddress = styled(Address)`
+  // Overriding default Address component styles if necessary,
+  // for example, to ensure it does not truncate.
+  // However, the Address component should ideally take a prop for this.
+  // For now, assuming it shows the full address by default or via a prop.
+  // If Address component truncates by default, we might need a different approach
+  // or use a simple Text component. Let's assume `showFull` prop exists or it shows full by default.
+  word-break: break-all; // Ensure long addresses wrap and don't overflow
+  margin-bottom: ${spacings.lg};
+`;
+
+const QrCodeWrapper = styled.div`
+  padding: ${spacings.sm}; // Adjusted padding slightly
+  background-color: white; // QR codes are typically black on white
+  border-radius: ${spacings.xs};
+  display: inline-block; // To make the background fit the QR code size
+  margin: ${spacings.md} 0 ${spacings.lg};
+`;
+
+export const FullAddressModal: React.FC<FullAddressModalProps> = ({
+  isOpen,
+  onClose,
+  fullAddress,
+}) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    copyToClipboard(fullAddress);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000); // Reset after 2 seconds
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={<Translation id="FULL_ADDRESS_MODAL_TITLE">Full Address</Translation>}
+      footerActions={[
+        {
+          label: <Translation id="CLOSE_BUTTON_LABEL">Close</Translation>,
+          onClick: onClose,
+          variant: 'secondary', // Changed to secondary
+          buttonProps: { 'data-testid': '@fullAddressModal/close-button' },
+        },
+      ]}
+    >
+      <ContentWrapper>
+        <QrCodeWrapper>
+          <QrCode data={fullAddress} size={150} />
+        </QrCodeWrapper>
+
+        {/* Assuming Address component can show full address with `showFull` prop.
+            If not, this might need adjustment or use a simple Text component.
+        */}
+        <StyledAddress address={fullAddress} showFull data-testid="@fullAddressModal/address" />
+
+        <Button
+          variant="primary" // Added primary variant
+          onClick={handleCopy}
+          data-testid="@fullAddressModal/copy-button"
+          minWidth={180} // Retained minWidth, can be adjusted if "Copied!" text is too long
+        >
+          {copied ? (
+            <Translation id="COPIED_FEEDBACK_TEXT">Copied!</Translation>
+          ) : (
+            <Translation id="COPY_ADDRESS_BUTTON_LABEL">Copy Address</Translation>
+          )}
+        </Button>
+      </ContentWrapper>
+    </Modal>
+  );
+};


### PR DESCRIPTION
This commit introduces a 'Show full address' button in the receive address view.

When an address is revealed, you can click this new button to open a modal window that displays:
- The full, untruncated address.
- A QR code representation of the full address.
- A 'Copy Address' button to copy the full address to the clipboard.

This addresses issue #18855 by providing you with an easy way to view and copy the complete address and its QR code, reducing potential confusion from truncated views.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
