### PR TITLE
fix(trading): eth priority fees

### DIFF
--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -95,6 +95,8 @@ export const recomposeAndSignTxThunk = createThunk<
             feePerUnit: composed.feePerByte,
             feeLimit: composed.feeLimit ?? '',
             estimatedFeeLimit: composed.estimatedFeeLimit,
+            maxFeePerGas: composed.maxFeePerGas,
+            maxPriorityFeePerGas: composed.maxPriorityFeePerGas,
             options,
             destinationTag,
             ethereumDataHex,


### PR DESCRIPTION
## Description

- Fixed priority fees in Trading when legacy fees were used instead of priority fees in the signing process

## Screenshots
### Setup 
![obrazek](https://github.com/user-attachments/assets/49f32eff-cb04-4c1e-bd1d-bd2bdd887798)

### Before (bug - legacy)
![obrazek](https://github.com/user-attachments/assets/f10ac598-cb01-4136-9143-ef14708fb6e7)

### After (correct - max fee per gas)
![obrazek](https://github.com/user-attachments/assets/4741db6c-93a6-4914-86ae-30b3ff6c5722)




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-evm-priority-fees&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-evm-priority-fees&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading-evm-priority-fees&lookback=7)