### PR TITLE
feat(suite): add banner to inform user that only 1 year old txs are visible on the Stellar tx page.

### DIFF
--- a/packages/suite-data/files/translations/en.json
+++ b/packages/suite-data/files/translations/en.json
@@ -1839,6 +1839,8 @@
   "TR_STEP_OF_TOTAL": "Step {index} of {total}",
   "TR_STILL_DONT_SEE_YOUR_TREZOR": "Don’t see your Trezor?",
   "TR_STELLAR_FEE_DESC": "The maximum fee you're willing to pay for the transaction. You'll only pay what's necessary — typically the minimum fee during light network traffic. Higher fees help prioritize your transaction during network congestion.",
+  "TR_STELLAR_LIMIT_HISTORY_DESCRIPTION": "Only transactions from the past 12 months are available in this view. To explore older activity, use the blockchain explorer.",
+  "TR_STELLAR_LIMIT_HISTORY_TITLE": "Transaction history limited to 12 months",
   "TR_STOP": "Stop",
   "TR_STOPPING": "Stopping",
   "TR_STORAGE_CLEARED": "Storage cleared",

--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -217,6 +217,7 @@ const initialRun = [
                 enableAutoupdateOnNextRun: false,
                 isBluetoothEnabled: false,
                 showBluetoothDebugInfo: false,
+                stellarLimitedHistoryBannerClosed: false,
             },
         },
     },

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx
@@ -18,6 +18,7 @@ import { DeviceUnavailable } from './DeviceUnavailable';
 import { EvmExplanationBanner } from './EvmExplanationBanner';
 import { ReserveBanner } from './ReserveBanner';
 import { StakingBanner } from './StakingBanner';
+import { StellarLimitedHistoryBanner } from './StellarLimitedHistoryBanner';
 import { TaprootBanner } from './TaprootBanner';
 import { TorDisconnected } from './TorDisconnected';
 
@@ -46,6 +47,7 @@ export const AccountBanners = ({ account }: AccountBannersProps) => {
             <AccountOutOfSync account={account} />
             <EvmExplanationBanner account={account} />
             <TaprootBanner account={account} />
+            {account?.networkType === 'stellar' && <StellarLimitedHistoryBanner />}
             {account?.symbol && <StakingBanner account={account} />}
         </Column>
     );

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StellarLimitedHistoryBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StellarLimitedHistoryBanner.tsx
@@ -1,0 +1,39 @@
+import { setFlag } from 'src/actions/suite/suiteActions';
+import { Translation } from 'src/components/suite';
+import { useDispatch } from 'src/hooks/suite/useDispatch';
+import { useSelector } from 'src/hooks/suite/useSelector';
+import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
+
+import { BannerPoints } from './BannerPoints';
+import { CloseableBanner } from './CloseableBanner';
+
+export const StellarLimitedHistoryBanner = () => {
+    const dispatch = useDispatch();
+    const { stellarLimitedHistoryBannerClosed } = useSelector(selectSuiteFlags);
+
+    if (stellarLimitedHistoryBannerClosed) {
+        return null;
+    }
+
+    const handleClose = () => {
+        dispatch(setFlag('stellarLimitedHistoryBannerClosed', true));
+    };
+
+    const points = [
+        <Translation
+            id="TR_STELLAR_LIMIT_HISTORY_DESCRIPTION"
+            key="TR_STELLAR_LIMIT_HISTORY_DESCRIPTION"
+        />,
+    ];
+
+    return (
+        <CloseableBanner
+            onClose={handleClose}
+            variant="info"
+            title={<Translation id="TR_STELLAR_LIMIT_HISTORY_TITLE" />}
+            hasIcon={true}
+        >
+            <BannerPoints points={points} />
+        </CloseableBanner>
+    );
+};

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -87,6 +87,7 @@ export interface Flags {
     enableAutoupdateOnNextRun: boolean;
     isBluetoothEnabled: boolean;
     showBluetoothDebugInfo: boolean;
+    stellarLimitedHistoryBannerClosed: boolean; // banner in account view (Overview tab) presenting limited history for Stellar
 }
 
 export interface EvmSettings {
@@ -171,6 +172,7 @@ const initialState: SuiteState = {
         enableAutoupdateOnNextRun: false,
         isBluetoothEnabled: false,
         showBluetoothDebugInfo: false,
+        stellarLimitedHistoryBannerClosed: false,
     },
     evmSettings: {
         confirmExplanationModalClosed: {},

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9112,6 +9112,15 @@ export default defineMessages({
         defaultMessage:
             "The maximum fee you're willing to pay for the transaction. You'll only pay what's necessary — typically the minimum fee during light network traffic. Higher fees help prioritize your transaction during network congestion.",
     },
+    TR_STELLAR_LIMIT_HISTORY_TITLE: {
+        id: 'TR_STELLAR_LIMIT_HISTORY_TITLE',
+        defaultMessage: 'Transaction history limited to 12 months',
+    },
+    TR_STELLAR_LIMIT_HISTORY_DESCRIPTION: {
+        id: 'TR_STELLAR_LIMIT_HISTORY_DESCRIPTION',
+        defaultMessage:
+            'Only transactions from the past 12 months are available in this view. To explore older activity, use the blockchain explorer.',
+    },
     TR_TRANSACTION_FEE_DESC: {
         id: 'TR_TRANSACTION_FEE_DESC',
         defaultMessage:


### PR DESCRIPTION
## Description

add banner to inform user that only 1 year old txs are visible on the Stellar tx page.

## Related Issue

Resolve #18746

## Screenshots:
<img width="1280" alt="Snipaste_2025-05-21_11-13-21" src="https://github.com/user-attachments/assets/62c56962-bbb9-42e1-b866-64a91b43171b" />
