### PR TITLE
fix(suite-native): reanimated shadow warning

### DIFF
--- a/suite-native/atoms/src/Card/Card.tsx
+++ b/suite-native/atoms/src/Card/Card.tsx
@@ -35,7 +35,7 @@ const cardInnerContainerStyle = prepareNativeStyle<{
 }>((utils, { alertPosition, noPadding, borderColor, noShadow }) => ({
     backgroundColor: utils.colors.backgroundSurfaceElevation1,
     borderRadius: utils.borders.radii.r16,
-    padding: noPadding ? 0 : utils.spacings.sp16,
+    padding: utils.spacings.sp16,
 
     extend: [
         {
@@ -60,8 +60,14 @@ const cardInnerContainerStyle = prepareNativeStyle<{
             },
         },
         {
+            condition: noPadding,
+            style: {
+                padding: 0,
+            },
+        },
+        {
             condition: !noShadow,
-            style: utils.boxShadows.small,
+            style: { ...utils.boxShadows.small },
         },
     ],
 }));


### PR DESCRIPTION
## Description
- fixes reanimated warning complaining about adding style props conditionally to the `AnimatedCard`  component that is evaluated in the worklet


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/reanimated-shadow-warning&lookback=7)