### PR TITLE
fix(suite-desktop-core): restart on linux on update with autostart

### DIFF
--- a/packages/suite-desktop-core/src/modules/auto-updater.ts
+++ b/packages/suite-desktop-core/src/modules/auto-updater.ts
@@ -16,7 +16,7 @@ import { verifySignature } from '../libs/update-checker';
 import { b2t } from '../libs/utils';
 import { app, ipcMain } from '../typed-electron';
 
-import type { ModuleInit } from './index';
+import { type ModuleInit, mainThreadEmitter } from './index';
 
 const defaultFeedURL = {
     // This should correspond with the value in electron-builder-config.js file.
@@ -242,12 +242,7 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
         setImmediate(() => {
             // Removing listeners & closing window (https://github.com/electron-userland/electron-builder/issues/1604)
             app.removeAllListeners('window-all-closed');
-            if (process.platform === 'linux') {
-                // On Linux there were some issues with re-opening the app, due to a possible race condition where the old app was not fully closed yet.
-                // This resolves the issue by removing the handlers and closing the app immediately.
-                app.removeAllListeners('before-quit');
-                app.removeAllListeners('second-instance');
-            }
+            mainThreadEmitter.emit('app/fully-quit');
             mainWindowProxy.getInstance()?.removeAllListeners('close');
             mainWindowProxy.getInstance()?.close();
 


### PR DESCRIPTION
## Description

@Ondra-Zik-SL reported that some processes are left hanging, this should improve it.
NixOS still has some issues but it worked on other distros.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/linux-update-autostart&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/linux-update-autostart&lookback=7)