### PR TITLE
fix(trading): do not show offers for invalid form state

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOfferItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOfferItem.tsx
@@ -19,7 +19,7 @@ export const TradingFormOfferItem = ({
     isFormInvalid,
     providers,
 }: TradingFormOfferItemProps) => {
-    if (!bestQuote || isFormLoading) {
+    if (!bestQuote || isFormLoading || isFormInvalid) {
         if (isFormLoading && !isFormInvalid) {
             return (
                 <Card>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffersSwitcher.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffersSwitcher.tsx
@@ -33,7 +33,7 @@ export const TradingFormOffersSwitcher = ({
     const hasSingleOption = !cexQuote !== !dexQuote;
     const bestQuote = cexQuote ?? dexQuote;
 
-    if (!bestQuote || isFormLoading) {
+    if (!bestQuote || isFormLoading || isFormInvalid) {
         if (isFormLoading && !isFormInvalid) {
             return (
                 <Card>


### PR DESCRIPTION
Do not show offers for invalid form state

## Related Issue

Resolve #16853
Resolve #18240

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-previous-offers&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-previous-offers&lookback=7)