### PR TITLE
fix(suite-native): use correct size for the wipe device button

### DIFF
--- a/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
+++ b/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
@@ -33,7 +33,7 @@ export const WipeDeviceCard = () => {
                     <Translation id="moduleDeviceSettings.wipeDevice.content" />
                 </Text>
                 <Box flex={1}>
-                    <Button colorScheme="redBold" onPress={handleRedirect}>
+                    <Button size="small" colorScheme="redBold" onPress={handleRedirect}>
                         <Translation id="moduleDeviceSettings.wipeDevice.buttonTitle" />
                     </Button>
                 </Box>


### PR DESCRIPTION


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/wipe-device-button-size&lookback=7)