### PR TITLE
fix(suite-native): fix styles of Card with top Alert

### DIFF
--- a/suite-native/atoms/src/Card/Card.tsx
+++ b/suite-native/atoms/src/Card/Card.tsx
@@ -9,6 +9,9 @@ import { Color } from '@trezor/theme';
 
 import { InlineAlertBox, InlineAlertBoxProps } from '../InlineAlertBox/InlineAlertBox';
 
+const CARD_CONTAINER_TEST_ID = '@atom/card/container';
+const ALERT_TEST_ID = '@atom/card/alert/';
+
 type AlertPosition = 'top' | 'bottom';
 
 export type CardProps = {
@@ -103,7 +106,7 @@ export const Card = React.forwardRef<View, CardProps>(
             children,
             style,
             alertProps,
-            alertPosition,
+            alertPosition: alertPositionProp,
             borderColor,
             noPadding = false,
             noShadow = false,
@@ -112,10 +115,18 @@ export const Card = React.forwardRef<View, CardProps>(
     ) => {
         const { applyStyle } = useNativeStyles();
 
+        const isAlertDisplayed = !!alertProps;
+        const alertPosition = isAlertDisplayed ? (alertPositionProp ?? 'top') : undefined;
+
         return (
             <View style={applyStyle(cardOuterContainerStyle, { flex: style?.flex })}>
-                {!!alertProps && alertPosition !== 'bottom' && (
-                    <View style={applyStyle(alertBoxWrapperStyle, { alertPosition })}>
+                {isAlertDisplayed && alertPosition === 'top' && (
+                    <View
+                        style={applyStyle(alertBoxWrapperStyle, {
+                            alertPosition,
+                        })}
+                        testID={ALERT_TEST_ID + 'top'}
+                    >
                         <InlineAlertBox {...alertProps} />
                     </View>
                 )}
@@ -130,13 +141,19 @@ export const Card = React.forwardRef<View, CardProps>(
                         }),
                         style,
                     ]}
+                    testID={CARD_CONTAINER_TEST_ID}
                     // Ref must be here otherwise the animation will not work
                     ref={ref}
                 >
                     {children}
                 </View>
-                {!!alertProps && alertPosition === 'bottom' && (
-                    <View style={applyStyle(alertBoxWrapperStyle, { alertPosition })}>
+                {isAlertDisplayed && alertPosition === 'bottom' && (
+                    <View
+                        style={applyStyle(alertBoxWrapperStyle, {
+                            alertPosition,
+                        })}
+                        testID={ALERT_TEST_ID + 'bottom'}
+                    >
                         <InlineAlertBox {...alertProps} />
                     </View>
                 )}

--- a/suite-native/atoms/src/Card/__tests__/Card.comp.test.tsx
+++ b/suite-native/atoms/src/Card/__tests__/Card.comp.test.tsx
@@ -20,10 +20,61 @@ describe('Card', () => {
         expect(getByText('hello')).toBeTruthy();
     });
 
-    it('should render children and alert, when alert props are specified', () => {
-        const { getByText } = renderComponent({ alertProps: { title: 'alert', variant: 'info' } });
+    it('should render only children if alertProps are not provided, even if alertPosition is set', () => {
+        const { queryByTestId, getByText } = renderComponent({ alertPosition: 'bottom' });
 
         expect(getByText('hello')).toBeTruthy();
+        expect(queryByTestId('@atom/card/alert/top')).toBeNull();
+        expect(queryByTestId('@atom/card/alert/bottom')).toBeNull();
+    });
+
+    it('should render alert only on top when alertPosition is not specified', () => {
+        const { getByTestId, getByText, queryByTestId } = renderComponent({
+            alertProps: { title: 'alert', variant: 'info' },
+        });
+
+        expect(getByText('hello')).toBeTruthy();
+
         expect(getByText('alert')).toBeTruthy();
+        expect(getByTestId('@atom/card/alert/top')).toBeTruthy();
+        expect(queryByTestId('@atom/card/alert/bottom')).toBeNull();
+    });
+
+    it('should render alert only on top when alertPosition is top', () => {
+        const { getByTestId, getByText, queryByTestId } = renderComponent({
+            alertProps: { title: 'alert', variant: 'info' },
+            alertPosition: 'top',
+        });
+
+        expect(getByText('hello')).toBeTruthy();
+
+        expect(getByText('alert')).toBeTruthy();
+        expect(getByTestId('@atom/card/alert/top')).toBeTruthy();
+        expect(queryByTestId('@atom/card/alert/bottom')).toBeNull();
+    });
+
+    it('should render alert only on bottom when alertPosition is bottom', () => {
+        const { getByTestId, getByText, queryByTestId } = renderComponent({
+            alertProps: { title: 'alert', variant: 'info' },
+            alertPosition: 'bottom',
+        });
+
+        expect(getByText('hello')).toBeTruthy();
+
+        expect(getByText('alert')).toBeTruthy();
+        expect(getByTestId('@atom/card/alert/bottom')).toBeTruthy();
+        expect(queryByTestId('@atom/card/alert/top')).toBeNull();
+    });
+
+    it('should not reset border radiuses if alert is not present', () => {
+        const { queryByTestId } = renderComponent({});
+
+        expect(queryByTestId('@atom/card/alert/top')).toBeNull();
+        expect(queryByTestId('@atom/card/alert/bottom')).toBeNull();
+
+        expect(queryByTestId('@atom/card/container')).not.toHaveStyle({ borderTopLeftRadius: 0 });
+        expect(queryByTestId('@atom/card/container')).not.toHaveStyle({
+            borderBottomLeftRadius: 0,
+        });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix the styles of Card if there is an Alert in top position. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19068

## Screenshots:
<img width="330" alt="image" src="https://github.com/user-attachments/assets/9d959e90-da36-40aa-9109-beb3358d1200" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/card-styles-with-alert&lookback=7)