### PR TITLE
fix(suite-desktop-core): add Ripple domains to whitelist

### DIFF
--- a/packages/suite-desktop-core/src/config.ts
+++ b/packages/suite-desktop-core/src/config.ts
@@ -33,6 +33,9 @@ export const allowedDomains = [
     'verify.walletconnect.org', // WalletConnect
     'horizon.stellar.org', // Stellar Horizon, hosted by SDF
     'horizon-testnet.stellar.org', // Stellar Horizon (testnet), hosted by SDF
+    'xrplcluster.com', // XRP Ledger cluster, hosted by XRP Ledger Foundation
+    'xrpl.ws', // XRP Ledger cluster, hosted by XRP Ledger Foundation
+    's2.ripple.com', // XRP Ledger cluster, hosted by Ripple
 ];
 
 export const silentlyBlockedDomains = [


### PR DESCRIPTION
## Description

Added `xrplcluster.com`, `xrpl.ws`, and `s2.ripple.com` to the list of allowed domains to enable XRP Ledger requests from the desktop app.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18293
Resolve https://github.com/trezor/trezor-suite/issues/18295
Resolve https://github.com/trezor/trezor-suite/issues/18294


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ripple-allowed-domains&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ripple-allowed-domains&lookback=7)