### PR TITLE
chore(suite-native): Mobile Trade: types renaming, generic trade input

### DIFF
--- a/suite-native/forms/src/Form.tsx
+++ b/suite-native/forms/src/Form.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, createContext } from 'react';
 import { FieldValues, UseFormReturn } from 'react-hook-form';
 
-export type { FieldValues, UseFormReturn } from 'react-hook-form';
+export type { FieldPath, FieldValues, UseFormReturn } from 'react-hook-form';
 
 export interface FormProps<TFieldValues extends FieldValues> {
     children?: ReactNode;

--- a/suite-native/module-trading/src/__fixtures__/tradeableAssets.ts
+++ b/suite-native/module-trading/src/__fixtures__/tradeableAssets.ts
@@ -2,7 +2,7 @@ import { CryptoId } from 'invity-api';
 
 import { TokenAddress } from '@suite-common/wallet-types';
 
-import { TradeableAsset } from '../types';
+import { TradeableAsset } from '../types/general';
 
 export const btcAsset: TradeableAsset = {
     symbol: 'btc',

--- a/suite-native/module-trading/src/components/buy/BuyAmountInput.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyAmountInput.tsx
@@ -1,183 +1,20 @@
-import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react';
-import { LayoutChangeEvent, Pressable, TextInput, TextInputProps } from 'react-native';
+import { forwardRef } from 'react';
+import { TextInput } from 'react-native';
 
-import { useField } from '@suite-native/forms';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import type { UseFormReturn } from '@suite-native/forms';
 
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
-import { truncateDecimals } from '../../utils/general/amountUtils';
+import { FocusableFormValues } from '../../types/general';
+import { AmountInput, AmountInputProps } from '../general/AmountInput';
 
-export type TradingAmountInputProps = {
-    name: 'fiatValue' | 'cryptoValue';
-    inputTransformer: (value: string) => string;
-    maxDecimals?: number;
-} & Omit<
-    TextInputProps,
-    'value' | 'style' | 'onBlur' | 'onFocus' | 'onChangeText' | 'onLayout' | 'onContentSizeChange'
->;
+type InputKey = 'fiatValue' | 'cryptoValue';
 
-const MAX_FONT_SIZE = 34;
-const MIN_FONT_SIZE = Math.ceil(MAX_FONT_SIZE / 2);
-const FONT_TO_LINE_HEIGHT_RATIO = 1.235;
-const FONT_SIZE_SHRINK_THRESHOLD = 20;
-const FONT_SIZE_GROW_HYSTERESIS = 20;
+export type BuyAmountInputProps = Omit<AmountInputProps<InputKey>, 'form'>;
 
-export const MIN_INPUT_WIDTH = 70;
-export const MAX_INPUT_HEIGHT = Math.floor(MAX_FONT_SIZE * FONT_TO_LINE_HEIGHT_RATIO);
+export { MAX_INPUT_HEIGHT, MIN_INPUT_WIDTH } from '../general/AmountInput';
 
-const boxStyle = prepareNativeStyle(() => ({
-    flex: 1,
-    alignItems: 'flex-end',
-    paddingLeft: 0,
-    marginLeft: 0,
-    overflow: 'visible',
-}));
+export const BuyAmountInput = forwardRef<TextInput, BuyAmountInputProps>((props, ref) => {
+    const form = useBuyFormContext() as unknown as UseFormReturn<FocusableFormValues<string>>;
 
-const inputStyle = prepareNativeStyle<{ hasError: boolean; fontSize: number }>(
-    ({ colors, typography }, { hasError, fontSize }) => ({
-        ...typography.body,
-        color: hasError ? colors.textAlertRed : colors.textDefault,
-        textAlign: 'right',
-        fontSize,
-        lineHeight: Math.floor(fontSize * FONT_TO_LINE_HEIGHT_RATIO),
-        minWidth: MIN_INPUT_WIDTH,
-    }),
-);
-
-const useInputLayoutControls = () => {
-    const [availableWidth, setAvailableWidth] = useState(
-        MIN_INPUT_WIDTH + FONT_SIZE_SHRINK_THRESHOLD,
-    );
-    const [fontSize, setFontSize] = useState(MAX_FONT_SIZE);
-
-    const handleAvailableWith = useCallback(({ nativeEvent }: LayoutChangeEvent) => {
-        const { width } = nativeEvent.layout;
-        setAvailableWidth(width);
-    }, []);
-
-    const handleFontSizeOnContentChange = useCallback(
-        ({ nativeEvent }: LayoutChangeEvent) => {
-            const contentWidth = nativeEvent.layout.width;
-
-            if (contentWidth === 0 || availableWidth === 0) {
-                setFontSize(MAX_FONT_SIZE);
-
-                return;
-            }
-
-            const shrinkThreshold = availableWidth - FONT_SIZE_SHRINK_THRESHOLD;
-            if (contentWidth > shrinkThreshold) {
-                const newFontSize = Math.max(
-                    Math.floor((shrinkThreshold / contentWidth) * fontSize),
-                    MIN_FONT_SIZE,
-                );
-                setFontSize(newFontSize);
-            }
-
-            const growThreshold = shrinkThreshold - FONT_SIZE_GROW_HYSTERESIS;
-            if (contentWidth < growThreshold) {
-                const newFontSize = Math.min(
-                    Math.floor((shrinkThreshold / contentWidth) * fontSize),
-                    MAX_FONT_SIZE,
-                );
-                setFontSize(newFontSize);
-            }
-        },
-        [availableWidth, fontSize],
-    );
-
-    return {
-        fontSize,
-        onBoxLayout: handleAvailableWith,
-        onInputLayout: handleFontSizeOnContentChange,
-    };
-};
-
-const useInputFormControls = (
-    name: 'fiatValue' | 'cryptoValue',
-    inputTransformer: (value: string) => string,
-    maxLength: number | undefined,
-    maxDecimals: number | undefined,
-) => {
-    const { getValues, setValue } = useBuyFormContext();
-    // do not use `value` from `useField` here, because it does not work properly with `undefined`
-    const value = getValues(name);
-    const { onChange, onBlur, hasError } = useField({ name });
-
-    const setFocusedValue = useCallback(() => {
-        setValue('focusedValue', name);
-    }, [name, setValue]);
-
-    const handleTextChange = useCallback(
-        (text: string) => {
-            let transformedText = inputTransformer(text);
-            transformedText = truncateDecimals(transformedText, maxDecimals);
-            transformedText = transformedText.slice(0, maxLength);
-
-            return onChange(transformedText === '' ? undefined : transformedText);
-        },
-        [maxLength, maxDecimals, inputTransformer, onChange],
-    );
-
-    const clearFocusedValueAndBlur = useCallback(() => {
-        onBlur();
-        setValue('focusedValue', undefined);
-    }, [onBlur, setValue]);
-
-    return {
-        value,
-        hasError,
-        onFocus: setFocusedValue,
-        onChangeText: handleTextChange,
-        onBlur: clearFocusedValueAndBlur,
-    };
-};
-
-export const BuyAmountInput = forwardRef<TextInput, TradingAmountInputProps>(
-    ({ name, inputTransformer, maxLength, maxDecimals, onPress, ...inputProps }, ref) => {
-        const innerRef = useRef<TextInput>(null);
-        useImperativeHandle(ref, () => innerRef.current!, []);
-
-        const { applyStyle, utils } = useNativeStyles();
-        const { fontSize, onBoxLayout, onInputLayout } = useInputLayoutControls();
-        const { value, hasError, onFocus, onChangeText, onBlur } = useInputFormControls(
-            name,
-            inputTransformer,
-            maxLength,
-            maxDecimals,
-        );
-
-        const focusInputCallback = useCallback(() => {
-            innerRef.current?.focus();
-        }, [innerRef]);
-        const wrapperOnPress = onPress ?? focusInputCallback;
-
-        // Note: it would be nice to use `onContentSizeChange` instead of `onLayout` on `<Pressable />` once this bug is fixed https://github.com/facebook/react-native/issues/29702.
-        // It would also allow us to remove `innerRef` and `useImperativeHandle` logic.
-        return (
-            <Pressable
-                style={applyStyle(boxStyle)}
-                onLayout={onBoxLayout}
-                testID="@trading/amountInput/wrapper"
-                onPress={wrapperOnPress}
-            >
-                <TextInput
-                    ref={innerRef}
-                    style={applyStyle(inputStyle, { hasError, fontSize })}
-                    keyboardType="decimal-pad"
-                    inputMode="decimal"
-                    placeholder="0.0"
-                    placeholderTextColor={utils.colors.textDisabled}
-                    value={value ?? ''}
-                    maxLength={maxLength}
-                    onChangeText={onChangeText}
-                    onFocus={onFocus}
-                    onBlur={onBlur}
-                    onLayout={onInputLayout}
-                    onPress={onPress}
-                    {...inputProps}
-                />
-            </Pressable>
-        );
-    },
-);
+    return <AmountInput ref={ref} form={form} {...props} />;
+});

--- a/suite-native/module-trading/src/components/buy/BuyCountryOfResidencePicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyCountryOfResidencePicker.tsx
@@ -4,7 +4,7 @@ import { useTranslate } from '@suite-native/intl';
 
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
 import { useSheetControls } from '../../hooks/general/useSheetControls';
-import { Country } from '../../types';
+import { Country } from '../../types/general';
 import { CountrySheet } from '../general/CountrySheet/CountrySheet';
 import { OverviewRow } from '../general/OverviewRow';
 

--- a/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.tsx
@@ -1,10 +1,10 @@
 import { Badge } from '@suite-native/atoms';
 import { useField } from '@suite-native/forms';
 
-import { TradingBuyFormValues } from '../../types';
+import { BuyFormValues } from '../../types/buy';
 
 export type BuyFormFieldErrorBadgeProps = {
-    fieldName: keyof TradingBuyFormValues;
+    fieldName: keyof BuyFormValues;
 };
 
 export const BuyFormFieldErrorBadge = ({ fieldName }: BuyFormFieldErrorBadgeProps) => {

--- a/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.tsx
@@ -10,7 +10,7 @@ import { BuyTradeableAssetsSheet } from './BuyTradeableAssetsSheet';
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
 import { useSheetControls } from '../../hooks/general/useSheetControls';
 import { selectBuyTradeableAssetsSorted } from '../../selectors/buySelectors';
-import { TradeableAsset } from '../../types';
+import { TradeableAsset } from '../../types/general';
 import { SelectTradeableAssetButton } from '../general/SelectTradeableAssetButton';
 
 const ASSET_PICKER_TEST_ID = '@trading/buy/asset-button';

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyAlert.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyAlert.comp.test.tsx
@@ -6,11 +6,11 @@ import {
 } from '@suite-native/test-utils';
 
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { TradingBuyForm } from '../../../types';
+import { BuyForm } from '../../../types/buy';
 import { BuyAlert } from '../BuyAlert';
 
 describe('BuyAlert', () => {
-    let form: TradingBuyForm;
+    let form: BuyForm;
 
     const renderFormHook = () => renderHookWithStoreProviderAsync(() => useBuyForm());
 

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyAmountInput.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyAmountInput.comp.test.tsx
@@ -9,15 +9,12 @@ import {
 import { paletteV1 } from '@trezor/theme';
 
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { TradingBuyForm } from '../../../types';
-import { BuyAmountInput, TradingAmountInputProps } from '../BuyAmountInput';
+import { BuyForm } from '../../../types/buy';
+import { BuyAmountInput, BuyAmountInputProps } from '../BuyAmountInput';
 
 describe('BuyAmountInput', () => {
     const renderBuyFormHook = () => renderHookWithStoreProviderAsync(() => useBuyForm());
-    const renderTradingAmountInput = (
-        props: Partial<TradingAmountInputProps>,
-        form: TradingBuyForm,
-    ) =>
+    const renderTradingAmountInput = (props: Partial<BuyAmountInputProps>, form: BuyForm) =>
         renderWithBasicProvider(
             <Form form={form}>
                 <BuyAmountInput

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyAssetNetworkInfo.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyAssetNetworkInfo.comp.test.tsx
@@ -7,11 +7,11 @@ import {
 
 import { btcAsset, ethOnBaseAsset, usdcAsset } from '../../../__fixtures__/tradeableAssets';
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { TradingBuyForm } from '../../../types';
+import { BuyForm } from '../../../types/buy';
 import { BuyAssetNetworkInfo } from '../BuyAssetNetworkInfo';
 
 describe('BuyAssetNetworkInfo', () => {
-    let form: TradingBuyForm;
+    let form: BuyForm;
 
     const renderNetworkIconForToken = () =>
         renderWithBasicProvider(

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyCryptoAmountInput.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyCryptoAmountInput.comp.test.tsx
@@ -11,13 +11,13 @@ import { PROTO } from '@trezor/connect';
 import { btcAsset } from '../../../__fixtures__/tradeableAssets';
 import { getInitializedTradingState } from '../../../__fixtures__/tradingState';
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { TradingBuyForm } from '../../../types';
+import { BuyForm } from '../../../types/buy';
 import { BuyCryptoAmountInput, CryptoAmountInputProps } from '../BuyCryptoAmountInput';
 
 describe('BuyCryptoAmountInput', () => {
     const renderCryptoAmountInput = (
         props: Partial<CryptoAmountInputProps>,
-        form: TradingBuyForm,
+        form: BuyForm,
         preloadedState: PreloadedState = {},
     ) =>
         renderWithStoreProviderAsync(
@@ -27,7 +27,7 @@ describe('BuyCryptoAmountInput', () => {
             { preloadedState },
         );
 
-    const renderUseTradingBuyForm = async (preloadedState: PreloadedState = {}) => {
+    const renderUseBuyForm = async (preloadedState: PreloadedState = {}) => {
         const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm(), {
             preloadedState,
         });
@@ -36,7 +36,7 @@ describe('BuyCryptoAmountInput', () => {
     };
 
     it('should set fiat value in form', async () => {
-        const form = await renderUseTradingBuyForm();
+        const form = await renderUseBuyForm();
         act(() => {
             form.setValue('asset', btcAsset);
         });
@@ -48,7 +48,7 @@ describe('BuyCryptoAmountInput', () => {
     });
 
     it('should be disabled when asset is not selected', async () => {
-        const form = await renderUseTradingBuyForm();
+        const form = await renderUseBuyForm();
         const { getByLabelText } = await renderCryptoAmountInput({}, form);
 
         expect(getByLabelText('You get')).toBeDisabled();
@@ -56,7 +56,7 @@ describe('BuyCryptoAmountInput', () => {
 
     it('should call showAssetsSheet when disabled and pressed', async () => {
         const showAssetsSheet = jest.fn();
-        const form = await renderUseTradingBuyForm();
+        const form = await renderUseBuyForm();
         const { getByLabelText } = await renderCryptoAmountInput({ showAssetsSheet }, form);
 
         await userEvent.press(getByLabelText('You get'));
@@ -66,7 +66,7 @@ describe('BuyCryptoAmountInput', () => {
 
     it('should not call showAssetsSheet when enabled and pressed', async () => {
         const showAssetsSheet = jest.fn();
-        const form = await renderUseTradingBuyForm();
+        const form = await renderUseBuyForm();
         act(() => {
             form.setValue('asset', btcAsset);
         });
@@ -78,7 +78,7 @@ describe('BuyCryptoAmountInput', () => {
     });
 
     it('should format input value to be decimal by default', async () => {
-        const form = await renderUseTradingBuyForm();
+        const form = await renderUseBuyForm();
         act(() => {
             form.setValue('asset', btcAsset);
         });
@@ -94,7 +94,7 @@ describe('BuyCryptoAmountInput', () => {
         const preloadedState = {
             wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
         };
-        const form = await renderUseTradingBuyForm();
+        const form = await renderUseBuyForm();
         act(() => {
             form.setValue('asset', btcAsset);
         });
@@ -110,7 +110,7 @@ describe('BuyCryptoAmountInput', () => {
         const preloadedState = {
             wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
         };
-        const form = await renderUseTradingBuyForm();
+        const form = await renderUseBuyForm();
         act(() => {
             form.setValue('asset', btcAsset);
         });
@@ -125,7 +125,7 @@ describe('BuyCryptoAmountInput', () => {
     it('should display loading skeleton while amountInCrypto is false and buyInfo is loading', async () => {
         const preloadedState = { wallet: { tradingNew: getInitializedTradingState() } };
         preloadedState.wallet.tradingNew.buy.isLoading = true;
-        const form = await renderUseTradingBuyForm();
+        const form = await renderUseBuyForm();
 
         const { getByLabelText } = await renderCryptoAmountInput({}, form, preloadedState);
 
@@ -135,7 +135,7 @@ describe('BuyCryptoAmountInput', () => {
     it('should not display loading skeleton while amountInCrypto is true and buyInfo is loading', async () => {
         const preloadedState = { wallet: { tradingNew: getInitializedTradingState() } };
         preloadedState.wallet.tradingNew.buy.isLoading = true;
-        const form = await renderUseTradingBuyForm();
+        const form = await renderUseBuyForm();
         act(() => {
             form.setValue('amountInCrypto', true);
         });
@@ -146,7 +146,7 @@ describe('BuyCryptoAmountInput', () => {
     });
 
     it('should limit value to 9 decimals', async () => {
-        const form = await renderUseTradingBuyForm();
+        const form = await renderUseBuyForm();
         act(() => {
             form.setValue('asset', btcAsset);
         });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFiatAmountInput.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFiatAmountInput.comp.test.tsx
@@ -9,11 +9,11 @@ import {
 
 import { getInitializedTradingState } from '../../../__fixtures__/tradingState';
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { TradingBuyForm } from '../../../types';
+import { BuyForm } from '../../../types/buy';
 import { BuyFiatAmountInput } from '../BuyFiatAmountInput';
 
 describe('BuyFiatAmountInput', () => {
-    const renderFiatAmountInput = (form: TradingBuyForm, preloadedState: PreloadedState = {}) =>
+    const renderFiatAmountInput = (form: BuyForm, preloadedState: PreloadedState = {}) =>
         renderWithStoreProviderAsync(
             <Form form={form}>
                 <BuyFiatAmountInput />
@@ -21,7 +21,7 @@ describe('BuyFiatAmountInput', () => {
             { preloadedState },
         );
 
-    const renderUseTradingBuyForm = async (preloadedState: PreloadedState = {}) => {
+    const renderUseBuyForm = async (preloadedState: PreloadedState = {}) => {
         const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm(), {
             preloadedState,
         });
@@ -30,7 +30,7 @@ describe('BuyFiatAmountInput', () => {
     };
 
     it('should set fiat value in form', async () => {
-        const form = await renderUseTradingBuyForm();
+        const form = await renderUseBuyForm();
         const { getByLabelText } = await renderFiatAmountInput(form);
 
         await userEvent.type(getByLabelText('You pay'), '100');
@@ -39,7 +39,7 @@ describe('BuyFiatAmountInput', () => {
     });
 
     it('should format input value to be decimal', async () => {
-        const form = await renderUseTradingBuyForm();
+        const form = await renderUseBuyForm();
         const { getByLabelText } = await renderFiatAmountInput(form);
 
         await userEvent.type(getByLabelText('You pay'), 'asd1.123');
@@ -49,7 +49,7 @@ describe('BuyFiatAmountInput', () => {
     });
 
     it('should always escape non-numeric characters', async () => {
-        const form = await renderUseTradingBuyForm();
+        const form = await renderUseBuyForm();
         const { getByLabelText } = await renderFiatAmountInput(form);
 
         await userEvent.type(getByLabelText('You pay'), 'asd');
@@ -61,7 +61,7 @@ describe('BuyFiatAmountInput', () => {
     it('should display loading skeleton while amountInCrypto is true and buyInfo is loading', async () => {
         const preloadedState = { wallet: { tradingNew: getInitializedTradingState() } };
         preloadedState.wallet.tradingNew.buy.isLoading = true;
-        const form = await renderUseTradingBuyForm();
+        const form = await renderUseBuyForm();
         act(() => {
             form.setValue('amountInCrypto', true);
         });
@@ -74,7 +74,7 @@ describe('BuyFiatAmountInput', () => {
     it('should not display loading skeleton while amountInCrypto is false and buyInfo is loading', async () => {
         const preloadedState = { wallet: { tradingNew: getInitializedTradingState() } };
         preloadedState.wallet.tradingNew.buy.isLoading = true;
-        const form = await renderUseTradingBuyForm();
+        const form = await renderUseBuyForm();
 
         const { queryByLabelText } = await renderFiatAmountInput(form, preloadedState);
 
@@ -82,7 +82,7 @@ describe('BuyFiatAmountInput', () => {
     });
 
     it('should limit value to 3 decimals', async () => {
-        const form = await renderUseTradingBuyForm();
+        const form = await renderUseBuyForm();
         const { getByLabelText } = await renderFiatAmountInput(form);
 
         await userEvent.type(getByLabelText('You pay'), '1.0123456789');

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyForm.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyForm.comp.test.tsx
@@ -9,14 +9,14 @@ import {
 import { btcAsset } from '../../../__fixtures__/tradeableAssets';
 import { getInitializedTradingState } from '../../../__fixtures__/tradingState';
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { TradingBuyForm } from '../../../types';
+import { BuyForm as BuyFormType } from '../../../types/buy';
 import { BuyForm } from '../BuyForm';
 
 describe('BuyForm', () => {
     const renderFormHook = (preloadedState: PreloadedState) =>
         renderHookWithStoreProviderAsync(() => useBuyForm(), { preloadedState });
 
-    const renderBuyForm = (preloadedState: PreloadedState, form: TradingBuyForm) =>
+    const renderBuyForm = (preloadedState: PreloadedState, form: BuyFormType) =>
         renderWithStoreProviderAsync(
             <Form form={form}>
                 <BuyForm />
@@ -40,7 +40,7 @@ describe('BuyForm', () => {
     });
 
     describe('with preloaded buy data', () => {
-        let form: TradingBuyForm;
+        let form: BuyFormType;
         const preloadedState = { wallet: { tradingNew: getInitializedTradingState() } };
 
         beforeEach(async () => {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFormFieldErrorBadge.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFormFieldErrorBadge.comp.test.tsx
@@ -7,13 +7,13 @@ import {
 } from '@suite-native/test-utils';
 
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { TradingBuyForm } from '../../../types';
+import { BuyForm } from '../../../types/buy';
 import { BuyFormFieldErrorBadge, BuyFormFieldErrorBadgeProps } from '../BuyFormFieldErrorBadge';
 
 describe('BuyFormFieldErrorBadge', () => {
-    let tradingForm: TradingBuyForm;
+    let tradingForm: BuyForm;
 
-    const renderUseTradingBuyForm = async (preloadedState: PreloadedState = {}) => {
+    const renderUseBuyForm = async (preloadedState: PreloadedState = {}) => {
         const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm(), {
             preloadedState,
         });
@@ -21,10 +21,7 @@ describe('BuyFormFieldErrorBadge', () => {
         return result.current;
     };
 
-    const renderBuyFormFieldErrorBadge = (
-        props: BuyFormFieldErrorBadgeProps,
-        form: TradingBuyForm,
-    ) =>
+    const renderBuyFormFieldErrorBadge = (props: BuyFormFieldErrorBadgeProps, form: BuyForm) =>
         renderWithBasicProvider(
             <Form form={form}>
                 <BuyFormFieldErrorBadge {...props} />
@@ -32,7 +29,7 @@ describe('BuyFormFieldErrorBadge', () => {
         );
 
     beforeEach(async () => {
-        tradingForm = await renderUseTradingBuyForm();
+        tradingForm = await renderUseBuyForm();
     });
 
     it('should render nothing where there is no error in form', () => {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.comp.test.tsx
@@ -11,19 +11,16 @@ import {
 import quotes from '../../../__fixtures__/quotes.json';
 import { getInitializedTradingStateWithQuotes } from '../../../__fixtures__/tradingState';
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { TradingBuyForm } from '../../../types';
+import { BuyForm } from '../../../types/buy';
 import { BuyProviderPicker } from '../BuyProviderPicker';
 
 describe('BuyProviderPicker', () => {
-    const renderUseTradingBuyForm = (preloadedState: PreloadedState = {}) =>
+    const renderUseBuyForm = (preloadedState: PreloadedState = {}) =>
         renderHookWithStoreProviderAsync(() => useBuyForm(), {
             preloadedState,
         });
 
-    const renderTradingProviderPicker = (
-        form: TradingBuyForm,
-        preloadedState: PreloadedState = {},
-    ) =>
+    const renderTradingProviderPicker = (form: BuyForm, preloadedState: PreloadedState = {}) =>
         renderWithStoreProviderAsync(
             <Form form={form}>
                 <BuyProviderPicker />
@@ -32,14 +29,14 @@ describe('BuyProviderPicker', () => {
         );
 
     it('should display nothing when in default state', async () => {
-        const { result } = await renderUseTradingBuyForm();
+        const { result } = await renderUseBuyForm();
         const { toJSON } = await renderTradingProviderPicker(result.current);
         expect(toJSON()).toBeNull();
     });
 
     it('should display selected provider according to quotes', async () => {
         const preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
-        const { result } = await renderUseTradingBuyForm(preloadedState);
+        const { result } = await renderUseBuyForm(preloadedState);
         act(() => {
             result.current.setValue('quote', quotes[2] as BuyTrade);
         });
@@ -55,7 +52,7 @@ describe('BuyProviderPicker', () => {
     it('should display loader while quotes are fetched', async () => {
         const preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
         preloadedState!.wallet!.tradingNew!.buy!.isLoading = true;
-        const { result } = await renderUseTradingBuyForm(preloadedState);
+        const { result } = await renderUseBuyForm(preloadedState);
         act(() => {
             result.current.setValue('quote', quotes[2] as BuyTrade);
         });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountCryptoBalance.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountCryptoBalance.comp.test.tsx
@@ -7,14 +7,14 @@ import {
 
 import { btcAsset } from '../../../__fixtures__/tradeableAssets';
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { TradingBuyForm } from '../../../types';
+import { BuyForm } from '../../../types/buy';
 import {
     BuyReceiveAccountCryptoBalance,
     RECEIVE_ACCOUNT_BALANCE_TEST_ID,
 } from '../BuyReceiveAccountCryptoBalance';
 
 describe('BuyReceiveAccountCryptoBalance', () => {
-    let buyForm: TradingBuyForm;
+    let buyForm: BuyForm;
 
     const renderBuyForm = async () => {
         const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm());

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountPicker.comp.test.tsx
@@ -9,7 +9,8 @@ import {
 
 import { getBtcAccount } from '../../../__fixtures__/account';
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { ReceiveAccount, TradingBuyForm } from '../../../types';
+import { BuyForm } from '../../../types/buy';
+import { ReceiveAccount } from '../../../types/general';
 import { BuyReceiveAccountPicker } from '../BuyReceiveAccountPicker';
 
 let mockNavigate: jest.Mock;
@@ -35,7 +36,7 @@ const getBuyState = (selectedReceiveAccount: ReceiveAccount | undefined) => ({
 });
 
 describe('BuyReceiveAccountPicker', () => {
-    let buyForm: TradingBuyForm;
+    let buyForm: BuyForm;
 
     beforeEach(() => {
         jest.resetAllMocks();

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyTradeableAssetPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyTradeableAssetPicker.comp.test.tsx
@@ -12,12 +12,12 @@ import { FirmwareType } from '@trezor/connect';
 
 import { getInitializedTradingState } from '../../../__fixtures__/tradingState';
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { TradingBuyForm } from '../../../types';
+import { BuyForm } from '../../../types/buy';
 import { BuyTradeableAssetPicker } from '../BuyTradeableAssetPicker';
 
 describe('BuyTradeableAssetPicker', () => {
     let store: EnhancedStore;
-    let form: TradingBuyForm;
+    let form: BuyForm;
 
     const initPreloadedStore = (firmwareType: FirmwareType) =>
         initStore({

--- a/suite-native/module-trading/src/components/general/AccountList/AccountList.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountList.tsx
@@ -27,7 +27,7 @@ import {
 import { useSectionList } from '../../../hooks/general/useSectionList';
 import { selectBuySelectedReceiveAccount } from '../../../selectors/buySelectors';
 import { setBuySelectedReceiveAccount } from '../../../tradingSlice';
-import { ReceiveAccount } from '../../../types';
+import { ReceiveAccount } from '../../../types/general';
 
 type NavigationProp = StackToStackCompositeNavigationProps<
     TradingStackParamList,

--- a/suite-native/module-trading/src/components/general/AccountList/AccountListAddressItem.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListAddressItem.tsx
@@ -1,7 +1,7 @@
 import { Text } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
-import { ReceiveAccount } from '../../../types';
+import { ReceiveAccount } from '../../../types/general';
 import { AccountAddress } from '../AccountAddress';
 import { AccountListBaseItem } from './AccountListBaseItem';
 

--- a/suite-native/module-trading/src/components/general/AccountList/AccountListBaseItem.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListBaseItem.tsx
@@ -8,7 +8,7 @@ import { CryptoIcon, Icon } from '@suite-native/icons';
 import { useTranslate } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
-import { ReceiveAccount } from '../../../types';
+import { ReceiveAccount } from '../../../types/general';
 
 export type AccountListBaseItemProps = {
     receiveAccount: ReceiveAccount;

--- a/suite-native/module-trading/src/components/general/AccountList/AccountListItem.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListItem.tsx
@@ -4,7 +4,7 @@ import { AccountsRootState, selectFormattedAccountType } from '@suite-common/wal
 import { Badge } from '@suite-native/atoms';
 
 import { AccountListBaseItem } from './AccountListBaseItem';
-import { ReceiveAccount } from '../../../types';
+import { ReceiveAccount } from '../../../types/general';
 
 export type AccountListItemProps = {
     receiveAccount: ReceiveAccount;

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountList.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountList.comp.test.tsx
@@ -6,7 +6,7 @@ import { Address } from '@trezor/blockchain-link-types';
 import { StaticSessionId } from '@trezor/connect';
 
 import fixturesAccounts from '../../../../__fixtures__/accounts.json';
-import { ReceiveAccount } from '../../../../types';
+import { ReceiveAccount } from '../../../../types/general';
 import { AccountList, AccountsListProps, keyExtractor } from '../AccountList';
 
 const accounts = fixturesAccounts as Account[];

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListAddressItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListAddressItem.test.tsx
@@ -2,7 +2,7 @@ import { Account } from '@suite-common/wallet-types';
 import { fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 import { Address } from '@trezor/blockchain-link-types';
 
-import { ReceiveAccount } from '../../../../types';
+import { ReceiveAccount } from '../../../../types/general';
 import { AccountListAddressItem } from '../AccountListAddressItem';
 
 jest.mock('@suite-common/wallet-core', () => {

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListItem.comp.test.tsx
@@ -1,7 +1,7 @@
 import { Account } from '@suite-common/wallet-types';
 import { fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 
-import { ReceiveAccount } from '../../../../types';
+import { ReceiveAccount } from '../../../../types/general';
 import { AccountListItem } from '../AccountListItem';
 
 jest.mock('@suite-common/wallet-core', () => {

--- a/suite-native/module-trading/src/components/general/AmountInput.tsx
+++ b/suite-native/module-trading/src/components/general/AmountInput.tsx
@@ -1,0 +1,185 @@
+import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react';
+import { LayoutChangeEvent, Pressable, TextInput, TextInputProps } from 'react-native';
+
+import { UseFormReturn, useField } from '@suite-native/forms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+import { FocusableFormValues, GenericForm } from '../../types/general';
+import { truncateDecimals } from '../../utils/general/amountUtils';
+
+export type AmountInputProps<T extends string> = {
+    name: T;
+    inputTransformer: (value: string) => string;
+    maxDecimals?: number;
+    form: UseFormReturn<FocusableFormValues<T>>;
+} & Omit<
+    TextInputProps,
+    'value' | 'style' | 'onBlur' | 'onFocus' | 'onChangeText' | 'onLayout' | 'onContentSizeChange'
+>;
+
+const MAX_FONT_SIZE = 34;
+const MIN_FONT_SIZE = Math.ceil(MAX_FONT_SIZE / 2);
+const FONT_TO_LINE_HEIGHT_RATIO = 1.235;
+const FONT_SIZE_SHRINK_THRESHOLD = 20;
+const FONT_SIZE_GROW_HYSTERESIS = 20;
+
+export const MIN_INPUT_WIDTH = 70;
+export const MAX_INPUT_HEIGHT = Math.floor(MAX_FONT_SIZE * FONT_TO_LINE_HEIGHT_RATIO);
+
+const boxStyle = prepareNativeStyle(() => ({
+    flex: 1,
+    alignItems: 'flex-end',
+    paddingLeft: 0,
+    marginLeft: 0,
+    overflow: 'visible',
+}));
+
+const inputStyle = prepareNativeStyle<{ hasError: boolean; fontSize: number }>(
+    ({ colors, typography }, { hasError, fontSize }) => ({
+        ...typography.body,
+        color: hasError ? colors.textAlertRed : colors.textDefault,
+        textAlign: 'right',
+        fontSize,
+        lineHeight: Math.floor(fontSize * FONT_TO_LINE_HEIGHT_RATIO),
+        minWidth: MIN_INPUT_WIDTH,
+    }),
+);
+
+const useInputLayoutControls = () => {
+    const [availableWidth, setAvailableWidth] = useState(
+        MIN_INPUT_WIDTH + FONT_SIZE_SHRINK_THRESHOLD,
+    );
+    const [fontSize, setFontSize] = useState(MAX_FONT_SIZE);
+
+    const handleAvailableWith = useCallback(({ nativeEvent }: LayoutChangeEvent) => {
+        const { width } = nativeEvent.layout;
+        setAvailableWidth(width);
+    }, []);
+
+    const handleFontSizeOnContentChange = useCallback(
+        ({ nativeEvent }: LayoutChangeEvent) => {
+            const contentWidth = nativeEvent.layout.width;
+
+            if (contentWidth === 0 || availableWidth === 0) {
+                setFontSize(MAX_FONT_SIZE);
+
+                return;
+            }
+
+            const shrinkThreshold = availableWidth - FONT_SIZE_SHRINK_THRESHOLD;
+            if (contentWidth > shrinkThreshold) {
+                const newFontSize = Math.max(
+                    Math.floor((shrinkThreshold / contentWidth) * fontSize),
+                    MIN_FONT_SIZE,
+                );
+                setFontSize(newFontSize);
+            }
+
+            const growThreshold = shrinkThreshold - FONT_SIZE_GROW_HYSTERESIS;
+            if (contentWidth < growThreshold) {
+                const newFontSize = Math.min(
+                    Math.floor((shrinkThreshold / contentWidth) * fontSize),
+                    MAX_FONT_SIZE,
+                );
+                setFontSize(newFontSize);
+            }
+        },
+        [availableWidth, fontSize],
+    );
+
+    return {
+        fontSize,
+        onBoxLayout: handleAvailableWith,
+        onInputLayout: handleFontSizeOnContentChange,
+    };
+};
+
+const useInputFormControls = <T extends string>(
+    { getValues, setValue }: GenericForm<string>,
+    name: T,
+    inputTransformer: (value: string) => string,
+    maxLength: number | undefined,
+    maxDecimals: number | undefined,
+) => {
+    // do not use `value` from `useField` here, because it does not work properly with `undefined`
+    const value = getValues(name);
+    const { onChange, onBlur, hasError } = useField({ name });
+
+    const setFocusedValue = useCallback(() => {
+        setValue('focusedValue', name);
+    }, [name, setValue]);
+
+    const handleTextChange = useCallback(
+        (text: string) => {
+            let transformedText = inputTransformer(text);
+            transformedText = truncateDecimals(transformedText, maxDecimals);
+            transformedText = transformedText.slice(0, maxLength);
+
+            return onChange(transformedText === '' ? undefined : transformedText);
+        },
+        [maxLength, maxDecimals, inputTransformer, onChange],
+    );
+
+    const clearFocusedValueAndBlur = useCallback(() => {
+        onBlur();
+        setValue('focusedValue', undefined);
+    }, [onBlur, setValue]);
+
+    return {
+        value,
+        hasError,
+        onFocus: setFocusedValue,
+        onChangeText: handleTextChange,
+        onBlur: clearFocusedValueAndBlur,
+    };
+};
+
+export const AmountInput = forwardRef<TextInput, AmountInputProps<string>>(
+    ({ name, inputTransformer, maxLength, maxDecimals, onPress, form, ...inputProps }, ref) => {
+        const innerRef = useRef<TextInput>(null);
+        useImperativeHandle(ref, () => innerRef.current!, []);
+
+        const { applyStyle, utils } = useNativeStyles();
+        const { fontSize, onBoxLayout, onInputLayout } = useInputLayoutControls();
+        const { value, hasError, onFocus, onChangeText, onBlur } = useInputFormControls(
+            form,
+            name,
+            inputTransformer,
+            maxLength,
+            maxDecimals,
+        );
+
+        const focusInputCallback = useCallback(() => {
+            innerRef.current?.focus();
+        }, [innerRef]);
+        const wrapperOnPress = onPress ?? focusInputCallback;
+
+        // Note: it would be nice to use `onContentSizeChange` instead of `onLayout` on `<Pressable />` once this bug is fixed https://github.com/facebook/react-native/issues/29702.
+        // It would also allow us to remove `innerRef` and `useImperativeHandle` logic.
+        return (
+            <Pressable
+                style={applyStyle(boxStyle)}
+                onLayout={onBoxLayout}
+                testID="@trading/amountInput/wrapper"
+                onPress={wrapperOnPress}
+            >
+                <TextInput
+                    ref={innerRef}
+                    style={applyStyle(inputStyle, { hasError, fontSize })}
+                    keyboardType="decimal-pad"
+                    inputMode="decimal"
+                    placeholder="0.0"
+                    placeholderTextColor={utils.colors.textDisabled}
+                    value={value ?? ''}
+                    maxLength={maxLength}
+                    onChangeText={onChangeText}
+                    onFocus={onFocus}
+                    onBlur={onBlur}
+                    onLayout={onInputLayout}
+                    onPress={onPress}
+                    {...inputProps}
+                />
+            </Pressable>
+        );
+    },
+);

--- a/suite-native/module-trading/src/components/general/CountrySheet/CountrySheet.tsx
+++ b/suite-native/module-trading/src/components/general/CountrySheet/CountrySheet.tsx
@@ -5,7 +5,7 @@ import { BottomSheetFlashList } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 
 import { useCountryFilteredData } from '../../../hooks/general/useCountryFilteredData';
-import { Country } from '../../../types';
+import { Country } from '../../../types/general';
 import { SearchableSheetHeader } from '../SearchableSheetHeader';
 import { CountryListEmptyComponent } from './CountryListEmptyComponent';
 import { COUNTRY_LIST_ITEM_HEIGHT, CountryListItem } from './CountryListItem';

--- a/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencySheet.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencySheet.tsx
@@ -5,7 +5,7 @@ import { FiatCurrencyCode } from 'invity-api';
 import { Translation, useTranslate } from '@suite-native/intl';
 
 import { useFiatCurrencyFilteredData } from '../../../hooks/general/useFiatCurrencyFilteredData';
-import { FiatCurrencyItem } from '../../../types';
+import { FiatCurrencyItem } from '../../../types/general';
 import { BottomSheetSectionList } from '../BottomSheetSectionList';
 import { SearchableSheetHeader } from '../SearchableSheetHeader';
 import { FiatCurrencyListEmptyComponent } from './FiatCurrencyListEmptyComponent';

--- a/suite-native/module-trading/src/components/general/SelectTradeableAssetButton.tsx
+++ b/suite-native/module-trading/src/components/general/SelectTradeableAssetButton.tsx
@@ -3,7 +3,7 @@ import { Icon } from '@suite-native/icons';
 import { Translation, useTranslate } from '@suite-native/intl';
 
 import { TradeableAssetButton } from './TradeableAssetButton';
-import { TradeableAsset } from '../../types';
+import { TradeableAsset } from '../../types/general';
 
 export type SelectAssetButtonProps = {
     onPress: () => void;

--- a/suite-native/module-trading/src/components/general/TradeableAssetButton.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetButton.tsx
@@ -13,7 +13,7 @@ import { hexToRgba } from '@trezor/utils';
 
 import { NetworkSymbolExtendedFormatter } from './NetworkSymbolExtendedFormatter';
 import { useTradeableAssetDominantColor } from '../../hooks/general/useTradeableAssetDominantColor';
-import { TradeableAsset } from '../../types';
+import { TradeableAsset } from '../../types/general';
 
 export type TradeableAssetButtonProps = {
     asset: TradeableAsset;

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetListItem.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetListItem.tsx
@@ -17,7 +17,7 @@ import {
     addTradeableAssetToFavourites,
     removeTradeableAssetFromFavourites,
 } from '../../../tradingSlice';
-import { TradeableAsset } from '../../../types';
+import { TradeableAsset } from '../../../types/general';
 
 export type TradeableAssetListItemProps = {
     asset: TradeableAsset;

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheet.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheet.tsx
@@ -11,7 +11,7 @@ import { TradeableAssetListEmptyComponent } from './TradeableAssetListEmptyCompo
 import { ASSET_ITEM_HEIGHT, TradeableAssetListItem } from './TradeableAssetListItem';
 import { TradeableAssetSheetHeader } from './TradeableAssetSheetHeader';
 import { ItemRenderConfig } from '../../../hooks/general/useSectionList';
-import { TradeableAsset } from '../../../types';
+import { TradeableAsset } from '../../../types/general';
 
 export type TradeableAssetsSheetProps = {
     isVisible: boolean;

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheet.comp.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 
 import { adaAsset, btcAsset, usdcAsset } from '../../../../__fixtures__/tradeableAssets';
-import { TradeableAsset } from '../../../../types';
+import { TradeableAsset } from '../../../../types/general';
 import { TradeableAssetSheet, TradeableAssetsSheetProps } from '../TradeableAssetSheet';
 
 describe('TradeableAssetSheet', () => {

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyFlow.test.ts
@@ -13,7 +13,7 @@ import {
 import { getBtcAccount } from '../../../__fixtures__/account';
 import quotes from '../../../__fixtures__/quotes.json';
 import { getInitializedTradingStateWithQuotes } from '../../../__fixtures__/tradingState';
-import { TradingBuyFormValues } from '../../../types';
+import { BuyFormValues } from '../../../types/buy';
 import { useBuyFlow } from '../useBuyFlow';
 import { useBuyForm } from '../useBuyForm';
 
@@ -46,7 +46,7 @@ describe('useBuyFlow', () => {
     const renderUseTradingBuyFlow = ({
         store,
         ...formValues
-    }: Partial<TradingBuyFormValues> & { store: TestStore }) =>
+    }: Partial<BuyFormValues> & { store: TestStore }) =>
         renderHookWithStoreProviderAsync(
             () => {
                 const form = useBuyForm();
@@ -56,7 +56,7 @@ describe('useBuyFlow', () => {
                     // Set all provided form values
                     Object.entries(formValues).forEach(([key, value]) => {
                         act(() => {
-                            setValue(key as keyof TradingBuyFormValues, value);
+                            setValue(key as keyof BuyFormValues, value);
                         });
                     });
                 }, [setValue]);

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
@@ -19,8 +19,9 @@ import quotes from '../../../__fixtures__/quotes.json';
 import { btcAsset, usdcAsset } from '../../../__fixtures__/tradeableAssets';
 import { getInitializedTradingState } from '../../../__fixtures__/tradingState';
 import { setBuySelectedReceiveAccount } from '../../../tradingSlice';
-import { TradeableAsset, TradingBuyForm } from '../../../types';
-import { clearTradingBuyFormQuoteData, useBuyForm } from '../useBuyForm';
+import { BuyForm } from '../../../types/buy';
+import { TradeableAsset } from '../../../types/general';
+import { clearBuyFormQuoteData, useBuyForm } from '../useBuyForm';
 
 jest.mock('../../../utils/general/utils', () => ({
     ...jest.requireActual('../../../utils/general/utils'),
@@ -28,7 +29,7 @@ jest.mock('../../../utils/general/utils', () => ({
 }));
 
 describe('useBuyForm', () => {
-    const renderUseTradingBuyForm = (store: TestStore) =>
+    const renderUseBuyForm = (store: TestStore) =>
         renderHookWithStoreProviderAsync(() => useBuyForm(), { store });
 
     const getInitializedStore = async (amountInSats = false) => {
@@ -49,7 +50,7 @@ describe('useBuyForm', () => {
         return await initStore(preloadedState);
     };
 
-    const initFormAndQuotes = (form: TradingBuyForm, store: EnhancedStore) => {
+    const initFormAndQuotes = (form: BuyForm, store: EnhancedStore) => {
         act(() => {
             form.setValue('fiatValue', '10');
             form.setValue('asset', btcAsset);
@@ -66,7 +67,7 @@ describe('useBuyForm', () => {
 
     it('should update form value when account in redux store is changed', async () => {
         const store = await getInitializedStore();
-        const { result } = await renderUseTradingBuyForm(store);
+        const { result } = await renderUseBuyForm(store);
 
         act(() => {
             store.dispatch(
@@ -84,7 +85,7 @@ describe('useBuyForm', () => {
             const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
             const store = await getInitializedStore();
 
-            await renderUseTradingBuyForm(store);
+            await renderUseBuyForm(store);
 
             expect(invityAPISpy).toHaveBeenCalledWith('random_string');
         });
@@ -92,7 +93,7 @@ describe('useBuyForm', () => {
         it('should update invityAPIKey when account is changed', async () => {
             const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
             const store = await getInitializedStore();
-            await renderUseTradingBuyForm(store);
+            await renderUseBuyForm(store);
             invityAPISpy.mockClear();
 
             act(() => {
@@ -111,7 +112,7 @@ describe('useBuyForm', () => {
         it('should not call createInvityAPIKey when descriptor is not changed', async () => {
             const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
             const store = await getInitializedStore();
-            await renderUseTradingBuyForm(store);
+            await renderUseBuyForm(store);
             invityAPISpy.mockClear();
 
             act(() => {
@@ -141,7 +142,7 @@ describe('useBuyForm', () => {
         it('should not call createInvityAPIKey when descriptor is empty string', async () => {
             const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
             const store = await getInitializedStore();
-            await renderUseTradingBuyForm(store);
+            await renderUseBuyForm(store);
             invityAPISpy.mockClear();
 
             act(() => {
@@ -160,7 +161,7 @@ describe('useBuyForm', () => {
         it('should not call createInvityAPIKey when descriptor is undefined ', async () => {
             const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
             const store = await getInitializedStore();
-            await renderUseTradingBuyForm(store);
+            await renderUseBuyForm(store);
             invityAPISpy.mockClear();
 
             act(() => {
@@ -197,7 +198,7 @@ describe('useBuyForm', () => {
 
     it('should clear selected account on asset network change', async () => {
         const store = await getInitializedStore();
-        const { result } = await renderUseTradingBuyForm(store);
+        const { result } = await renderUseBuyForm(store);
 
         act(() => {
             store.dispatch(
@@ -216,7 +217,7 @@ describe('useBuyForm', () => {
 
     it('should not clear selected account when asset is set to undefined', async () => {
         const store = await getInitializedStore();
-        const { result } = await renderUseTradingBuyForm(store);
+        const { result } = await renderUseBuyForm(store);
 
         act(() => {
             store.dispatch(
@@ -232,7 +233,7 @@ describe('useBuyForm', () => {
 
     it('should clear crypto amount on coin change', async () => {
         const store = await getInitializedStore();
-        const { result } = await renderUseTradingBuyForm(store);
+        const { result } = await renderUseBuyForm(store);
 
         act(() => {
             result.current.setValue('asset', btcAsset);
@@ -245,7 +246,7 @@ describe('useBuyForm', () => {
 
     it('should clear crypto amount on fiat currency change', async () => {
         const store = await getInitializedStore();
-        const { result } = await renderUseTradingBuyForm(store);
+        const { result } = await renderUseBuyForm(store);
 
         act(() => {
             result.current.setValue('cryptoValue', '10');
@@ -257,7 +258,7 @@ describe('useBuyForm', () => {
 
     it('should clear fiat amount on fiat currency change', async () => {
         const store = await getInitializedStore();
-        const { result } = await renderUseTradingBuyForm(store);
+        const { result } = await renderUseBuyForm(store);
 
         act(() => {
             result.current.setValue('fiatValue', '10');
@@ -269,7 +270,7 @@ describe('useBuyForm', () => {
 
     it('should clear cryptoValue when user edits fiatValue', async () => {
         const store = await getInitializedStore();
-        const { result } = await renderUseTradingBuyForm(store);
+        const { result } = await renderUseBuyForm(store);
         const { result: fieldResult } = renderHook(() => useField({ name: 'fiatValue' }), {
             wrapper: ({ children }) => <Form form={result.current}>{children}</Form>,
         });
@@ -286,7 +287,7 @@ describe('useBuyForm', () => {
 
     it('should clear fiatValue when user edits cryptoValue', async () => {
         const store = await getInitializedStore();
-        const { result } = await renderUseTradingBuyForm(store);
+        const { result } = await renderUseBuyForm(store);
         const { result: fieldResult } = renderHook(() => useField({ name: 'cryptoValue' }), {
             wrapper: ({ children }) => <Form form={result.current}>{children}</Form>,
         });
@@ -303,7 +304,7 @@ describe('useBuyForm', () => {
 
     it('should set amountInCrypto to true when user edits cryptoValue', async () => {
         const store = await getInitializedStore();
-        const { result } = await renderUseTradingBuyForm(store);
+        const { result } = await renderUseBuyForm(store);
         const { result: fieldResult } = renderHook(() => useField({ name: 'cryptoValue' }), {
             wrapper: ({ children }) => <Form form={result.current}>{children}</Form>,
         });
@@ -318,7 +319,7 @@ describe('useBuyForm', () => {
 
     it('should set amountInCrypto to false when user edits fiatValue', async () => {
         const store = await getInitializedStore();
-        const { result } = await renderUseTradingBuyForm(store);
+        const { result } = await renderUseBuyForm(store);
         const { result: fieldResult } = renderHook(() => useField({ name: 'fiatValue' }), {
             wrapper: ({ children }) => <Form form={result.current}>{children}</Form>,
         });
@@ -335,7 +336,7 @@ describe('useBuyForm', () => {
     describe('on quotes change', () => {
         it('if no quote is selected should select 1st quote with creditCard payment method', async () => {
             const store = await getInitializedStore();
-            const { result } = await renderUseTradingBuyForm(store);
+            const { result } = await renderUseBuyForm(store);
 
             initFormAndQuotes(result.current, store);
 
@@ -349,7 +350,7 @@ describe('useBuyForm', () => {
 
         it('if no quote is selected and creditCard method is not available should select 1st quote', async () => {
             const store = await getInitializedStore();
-            const { result } = await renderUseTradingBuyForm(store);
+            const { result } = await renderUseBuyForm(store);
 
             act(() => {
                 result.current.setValue('fiatValue', '10');
@@ -367,7 +368,7 @@ describe('useBuyForm', () => {
 
         it('should set quote to undefined when no quotes are available', async () => {
             const store = await getInitializedStore();
-            const { result } = await renderUseTradingBuyForm(store);
+            const { result } = await renderUseBuyForm(store);
 
             // this will load quotes and selects one
             initFormAndQuotes(result.current, store);
@@ -381,7 +382,7 @@ describe('useBuyForm', () => {
 
         it('should clear cryptoValue when no quotes are available', async () => {
             const store = await getInitializedStore();
-            const { result } = await renderUseTradingBuyForm(store);
+            const { result } = await renderUseBuyForm(store);
 
             // this will load quotes and selects one
             initFormAndQuotes(result.current, store);
@@ -396,7 +397,7 @@ describe('useBuyForm', () => {
 
         it('should clear fiatValue when no quotes are available and user inserted cryptoValue', async () => {
             const store = await getInitializedStore();
-            const { result } = await renderUseTradingBuyForm(store);
+            const { result } = await renderUseBuyForm(store);
 
             // this will load quotes and selects one
             act(() => {
@@ -416,7 +417,7 @@ describe('useBuyForm', () => {
 
         it('should update cryptoValue when selected quote is changed and truncate it to 9 decimals', async () => {
             const store = await getInitializedStore();
-            const { result } = await renderUseTradingBuyForm(store);
+            const { result } = await renderUseBuyForm(store);
 
             initFormAndQuotes(result.current, store);
 
@@ -430,7 +431,7 @@ describe('useBuyForm', () => {
 
         it('should update fiatAmount when selected quote is changed and user inserted cryptoAmount and truncate it to 3 decimals', async () => {
             const store = await getInitializedStore();
-            const { result } = await renderUseTradingBuyForm(store);
+            const { result } = await renderUseBuyForm(store);
 
             act(() => {
                 result.current.setValue('asset', btcAsset);
@@ -450,11 +451,11 @@ describe('useBuyForm', () => {
 
         describe('when quote is selected and new quotes are fetched', () => {
             let store: EnhancedStore;
-            let form: TradingBuyForm;
+            let form: BuyForm;
 
             beforeEach(async () => {
                 store = await getInitializedStore();
-                const { result } = await renderUseTradingBuyForm(store);
+                const { result } = await renderUseBuyForm(store);
                 form = result.current;
 
                 act(() => {
@@ -512,7 +513,7 @@ describe('useBuyForm', () => {
 
     it('should set correct cryptoValue when using BTC and amount in sats', async () => {
         const store = await getInitializedStore(true);
-        const { result } = await renderUseTradingBuyForm(store);
+        const { result } = await renderUseBuyForm(store);
 
         initFormAndQuotes(result.current, store);
 
@@ -532,7 +533,7 @@ describe('useBuyForm', () => {
                     currency: 'USD',
                 }),
             );
-            const { result } = await renderUseTradingBuyForm(store);
+            const { result } = await renderUseBuyForm(store);
 
             act(() => {
                 result.current.setValue('fiatValue', amount);
@@ -559,7 +560,7 @@ describe('useBuyForm', () => {
                     currency: 'BTC',
                 }),
             );
-            const { result } = await renderUseTradingBuyForm(store);
+            const { result } = await renderUseBuyForm(store);
 
             act(() => {
                 result.current.setValue('amountInCrypto', true);
@@ -579,7 +580,7 @@ describe('useBuyForm', () => {
 
         it('should trigger validation once limits are loaded', async () => {
             const store = await getInitializedStore(true);
-            const { result } = await renderUseTradingBuyForm(store);
+            const { result } = await renderUseBuyForm(store);
 
             act(() => {
                 result.current.setValue('fiatValue', '1');
@@ -605,7 +606,7 @@ describe('useBuyForm', () => {
         describe('generalAlert', () => {
             it('should be undefined by default', async () => {
                 const store = await getInitializedStore(true);
-                const { result } = await renderUseTradingBuyForm(store);
+                const { result } = await renderUseBuyForm(store);
 
                 act(() => {
                     store.dispatch(tradingBuyActions.saveQuotes([] as BuyTrade[]));
@@ -617,7 +618,7 @@ describe('useBuyForm', () => {
 
             it('should be set when empty quotes are fetched and no limits are set', async () => {
                 const store = await getInitializedStore(true);
-                const { result } = await renderUseTradingBuyForm(store);
+                const { result } = await renderUseBuyForm(store);
 
                 act(() => {
                     store.dispatch(
@@ -639,7 +640,7 @@ describe('useBuyForm', () => {
 
             it('should be undefined when empty quotes are fetched and limits are set', async () => {
                 const store = await getInitializedStore(true);
-                const { result } = await renderUseTradingBuyForm(store);
+                const { result } = await renderUseBuyForm(store);
 
                 act(() => {
                     store.dispatch(
@@ -664,7 +665,7 @@ describe('useBuyForm', () => {
 
             it('should be undefined when quotes are fetched ', async () => {
                 const store = await getInitializedStore(true);
-                const { result } = await renderUseTradingBuyForm(store);
+                const { result } = await renderUseBuyForm(store);
 
                 act(() => {
                     store.dispatch(
@@ -684,7 +685,7 @@ describe('useBuyForm', () => {
 
             it('should be cleared once quotes are fetched', async () => {
                 const store = await getInitializedStore(true);
-                const { result } = await renderUseTradingBuyForm(store);
+                const { result } = await renderUseBuyForm(store);
 
                 act(() => {
                     store.dispatch(
@@ -708,10 +709,10 @@ describe('useBuyForm', () => {
         });
     });
 
-    describe('clearTradingBuyFormQuoteData', () => {
+    describe('clearBuyFormQuoteData', () => {
         it('should clear quote, fiatValue, cryptoValue and generalAlert data', async () => {
             const store = await getInitializedStore();
-            const { result } = await renderUseTradingBuyForm(store);
+            const { result } = await renderUseBuyForm(store);
 
             act(() => {
                 result.current.setValue('fiatValue', '10');
@@ -720,7 +721,7 @@ describe('useBuyForm', () => {
             });
 
             act(() => {
-                clearTradingBuyFormQuoteData(result.current);
+                clearBuyFormQuoteData(result.current);
             });
 
             expect(result.current.getValues('quote')).toBeUndefined();

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
@@ -13,7 +13,7 @@ import {
 import quotes from '../../../__fixtures__/quotes.json';
 import { bnbAsset, usdcAsset } from '../../../__fixtures__/tradeableAssets';
 import { getInitializedTradingState } from '../../../__fixtures__/tradingState';
-import { TradingBuyFormValues } from '../../../types';
+import { BuyFormValues } from '../../../types/buy';
 import { useBuyForm } from '../useBuyForm';
 import { useBuyQuotes } from '../useBuyQuotes';
 
@@ -171,7 +171,7 @@ describe('useBuyQuotes', () => {
         ['fiatValue', '1000'],
         ['country', 'CZ'],
         ['receiveAccount', { account: { key: 'btc1', descriptor: 'descriptor_btc1' } as Account }],
-    ] as [keyof TradingBuyFormValues, TradingBuyFormValues[keyof TradingBuyFormValues]][])(
+    ] as [keyof BuyFormValues, BuyFormValues[keyof BuyFormValues]][])(
         'should re-fetch quotes on %s value change',
         async (field, value) => {
             const store = await getInitializedStore();

--- a/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
@@ -22,8 +22,8 @@ import {
 } from '@suite-native/navigation';
 import { useTimer } from '@trezor/react-utils';
 
-import { clearTradingBuyFormQuoteData } from './useBuyForm';
-import { TradingBuyForm } from '../../types';
+import { clearBuyFormQuoteData } from './useBuyForm';
+import { BuyForm } from '../../types/buy';
 import {
     buildTradingUrl,
     getAnalyticsTradingBuyPayload,
@@ -58,7 +58,7 @@ const reportTradeConfirmation = () => {
     });
 };
 
-export const useBuyFlow = (form: TradingBuyForm) => {
+export const useBuyFlow = (form: BuyForm) => {
     const dispatch = useDispatch();
     const isLoading = useSelector(selectTradingBuyIsLoading);
 
@@ -149,7 +149,7 @@ export const useBuyFlow = (form: TradingBuyForm) => {
             handleWebview(response.tradeForm.form, returnUrl);
         }
 
-        clearTradingBuyFormQuoteData(form);
+        clearBuyFormQuoteData(form);
     };
 
     const confirmTrade = async (quote: BuyTrade, address: string) => {

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -25,13 +25,13 @@ import {
     selectBuySelectedReceiveAccount,
 } from '../../selectors/buySelectors';
 import { setBuySelectedReceiveAccount } from '../../tradingSlice';
-import { TradingBuyForm, TradingBuyFormValues } from '../../types';
+import { BuyForm, BuyFormValues } from '../../types/buy';
 import { buyFormValidationSchema } from '../../utils/buy/buyFormValidationSchema';
 import { truncateDecimals } from '../../utils/general/amountUtils';
 import { getSelectedSymbolFromBuyForm } from '../../utils/general/tradeableAssetUtils';
 import { getRandomAccountDescriptor } from '../../utils/general/utils';
 
-const useReceiveAccountChangeEffect = ({ getValues, setValue }: TradingBuyForm) => {
+const useReceiveAccountChangeEffect = ({ getValues, setValue }: BuyForm) => {
     const selectedReceiveAccount = useSelector(selectBuySelectedReceiveAccount);
 
     // make sure invityAPIKey is initialized with some unique string on form mount
@@ -52,7 +52,7 @@ const useReceiveAccountChangeEffect = ({ getValues, setValue }: TradingBuyForm) 
     }, [selectedReceiveAccount, getValues, setValue]);
 };
 
-const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: TradingBuyForm) => {
+const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: BuyForm) => {
     const dispatch = useDispatch();
     const prevCryptoId = useRef<CryptoId | undefined>(undefined);
     const prevFiatCurrency = useRef<FiatCurrencyCode | undefined>(getValues('fiatCurrency'));
@@ -123,7 +123,7 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: 
     }, [dispatch, setValue, watch]);
 };
 
-const useBuyQuotesChangeEffect = ({ getValues, setValue }: TradingBuyForm) => {
+const useBuyQuotesChangeEffect = ({ getValues, setValue }: BuyForm) => {
     const quotes = useSelector(selectValidTradingBuyQuotes);
 
     useEffect(() => {
@@ -163,7 +163,7 @@ const useBuyQuotesChangeEffect = ({ getValues, setValue }: TradingBuyForm) => {
     }, [quotes, getValues, setValue]);
 };
 
-const useBuyQuoteChangeEffect = (form: TradingBuyForm) => {
+const useBuyQuoteChangeEffect = (form: BuyForm) => {
     const { getValues, setValue, watch } = form;
     const quote = watch('quote');
     const symbol = getSelectedSymbolFromBuyForm(form);
@@ -200,7 +200,7 @@ const useBuyQuoteChangeEffect = (form: TradingBuyForm) => {
 };
 
 const useValidations = (
-    { trigger, setValue }: TradingBuyForm,
+    { trigger, setValue }: BuyForm,
     limits: TradingAmountLimitProps | undefined,
 ) => {
     const { translate } = useTranslate();
@@ -221,13 +221,13 @@ const useValidations = (
     }, [generalAlertMsg, setValue]);
 };
 
-export const useBuyForm = (): TradingBuyForm => {
+export const useBuyForm = (): BuyForm => {
     const { translate } = useTranslate();
     const { FiatAmountFormatter, CryptoAmountFormatter } = useFormatters();
     const defaultValues = useSelector(selectBuyFormDefaultValues);
     const limits = useSelector(selectBuyAmountLimits);
 
-    const form = useForm<TradingBuyFormValues>({
+    const form = useForm<BuyFormValues>({
         defaultValues,
         validation: buyFormValidationSchema,
         context: { ...limits, translate, FiatAmountFormatter, CryptoAmountFormatter },
@@ -242,7 +242,7 @@ export const useBuyForm = (): TradingBuyForm => {
     return form;
 };
 
-export const clearTradingBuyFormQuoteData = (form: TradingBuyForm) => {
+export const clearBuyFormQuoteData = (form: BuyForm) => {
     form.setValue('quote', undefined);
     form.setValue('fiatValue', undefined, { shouldValidate: true });
     form.setValue('cryptoValue', undefined, { shouldValidate: true });

--- a/suite-native/module-trading/src/hooks/buy/useBuyFormContext.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyFormContext.ts
@@ -1,5 +1,5 @@
 import { useFormContext } from '@suite-native/forms';
 
-import { TradingBuyFormValues } from '../../types';
+import { BuyFormValues } from '../../types/buy';
 
-export const useBuyFormContext = () => useFormContext<TradingBuyFormValues>();
+export const useBuyFormContext = () => useFormContext<BuyFormValues>();

--- a/suite-native/module-trading/src/hooks/buy/useBuyQuotes.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyQuotes.ts
@@ -19,8 +19,8 @@ import { EventType, analytics } from '@suite-native/analytics';
 import { useDebounce } from '@trezor/react-utils';
 
 import { clearBuyState, clearQuotesAndQuotesRequest } from '../../tradingSlice';
-import { TradingBuyForm } from '../../types';
-import { tradingBuyFormToTradingBuyFormProps } from '../../utils/general/quotesUtils';
+import { BuyForm } from '../../types/buy';
+import { buyFormTobuyFormProps } from '../../utils/general/quotesUtils';
 import { getSelectedSymbolFromBuyForm } from '../../utils/general/tradeableAssetUtils';
 import { useReloadTimer } from '../general/useReloadTimer';
 
@@ -42,7 +42,7 @@ type ShouldFetchBuyQuotes = {
     shouldFetchQuotes: boolean;
 };
 
-const useShouldFetchBuyQuotes = (form: TradingBuyForm): ShouldFetchBuyQuotes => {
+const useShouldFetchBuyQuotes = (form: BuyForm): ShouldFetchBuyQuotes => {
     const prevState = useRef<ShouldFetchBuyQuotesRef>({
         cryptoId: undefined,
         fiatCurrency: undefined,
@@ -145,7 +145,7 @@ const useBuyQuotesInvalidator = (
 };
 
 const useBuyQuotesThunk = (
-    form: TradingBuyForm,
+    form: BuyForm,
     timer: ReturnType<typeof useReloadTimer>['timer'],
     shouldRefetchQuotes: boolean,
     quotesPromiseRef: ReturnType<typeof useRef<PromiseType | undefined>>,
@@ -176,7 +176,7 @@ const useBuyQuotesThunk = (
 
                 const payload: HandleBuyRequestThunkProps = {
                     network,
-                    formValues: tradingBuyFormToTradingBuyFormProps(form, coinInfo),
+                    formValues: buyFormTobuyFormProps(form, coinInfo),
                     shouldSendInSats,
                     timer,
                 };
@@ -207,7 +207,7 @@ const useBuyQuotesThunk = (
     ]);
 };
 
-export const useBuyQuotes = (form: TradingBuyForm) => {
+export const useBuyQuotes = (form: BuyForm) => {
     const debounce = useDebounce();
     const promiseRef = useRef<PromiseType | undefined>(undefined);
 

--- a/suite-native/module-trading/src/hooks/general/__tests__/useFavouriteAssetsSectionList.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useFavouriteAssetsSectionList.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '@suite-native/test-utils';
 
 import { adaAsset, btcAsset, usdcAsset } from '../../../__fixtures__/tradeableAssets';
-import { TradeableAsset } from '../../../types';
+import { TradeableAsset } from '../../../types/general';
 import { useFavouriteAssetsSectionList } from '../useFavouriteAssetsSectionList';
 
 describe('useFavouriteAssetsSectionList', () => {

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTradeableAssetsFilteredData.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTradeableAssetsFilteredData.test.ts
@@ -11,7 +11,7 @@ import {
     usdtOnArbAsset,
     usdtOnBscAsset,
 } from '../../../__fixtures__/tradeableAssets';
-import { TradeableAsset } from '../../../types';
+import { TradeableAsset } from '../../../types/general';
 import { useTradeableAssetsFilteredData } from '../useTradeableAssetsFilteredData';
 
 const mockAssets: TradeableAsset[] = [

--- a/suite-native/module-trading/src/hooks/general/useFavouriteAssetsSectionList.ts
+++ b/suite-native/module-trading/src/hooks/general/useFavouriteAssetsSectionList.ts
@@ -7,7 +7,7 @@ import { useTranslate } from '@suite-native/intl';
 
 import { SectionListData } from './useSectionList';
 import { selectTradingFavouriteAssets } from '../../selectors/favouritesSelectors';
-import { TradeableAsset } from '../../types';
+import { TradeableAsset } from '../../types/general';
 
 export type ListItemExtraData = {
     isFavourite: boolean;

--- a/suite-native/module-trading/src/hooks/general/useFiatCurrencyFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/general/useFiatCurrencyFilteredData.ts
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { useListDataFilter } from './useListDataFilter';
 import { selectBuySupportedFiatCurrenciesList } from '../../selectors/buySelectors';
-import { FiatCurrencyItem } from '../../types';
+import { FiatCurrencyItem } from '../../types/general';
 
 const filterCallback = ({ label, value }: FiatCurrencyItem, filterValue: string): boolean =>
     label.toLowerCase().includes(filterValue.toLowerCase()) ||

--- a/suite-native/module-trading/src/hooks/general/useReceiveAccountsListData.ts
+++ b/suite-native/module-trading/src/hooks/general/useReceiveAccountsListData.ts
@@ -11,7 +11,7 @@ import { Account } from '@suite-common/wallet-types/';
 import { useTranslate } from '@suite-native/intl';
 
 import { SectionListData } from './useSectionList';
-import { ReceiveAccount } from '../../types';
+import { ReceiveAccount } from '../../types/general';
 
 export type ReceiveAccountsListMode = 'account' | 'address';
 

--- a/suite-native/module-trading/src/hooks/general/useSheetControls.ts
+++ b/suite-native/module-trading/src/hooks/general/useSheetControls.ts
@@ -1,15 +1,24 @@
 import { useCallback } from 'react';
 
-import { useBottomSheetControls } from './useBottomSheetControls';
-import { TradingBuyForm, TradingBuyFormValues } from '../../types';
+import type { FieldPath, FieldValues, UseFormReturn } from '@suite-native/forms';
 
-export const useSheetControls = <Key extends keyof TradingBuyFormValues>(
-    { setValue, watch }: TradingBuyForm,
+import { useBottomSheetControls } from './useBottomSheetControls';
+
+export type SheetControls<TFieldValues extends FieldValues, Key extends FieldPath<TFieldValues>> = {
+    selectedValue: TFieldValues[Key];
+    setSelectedValue: (value: TFieldValues[Key]) => void;
+} & ReturnType<typeof useBottomSheetControls>;
+
+export const useSheetControls = <
+    TFieldValues extends FieldValues,
+    Key extends FieldPath<TFieldValues>,
+>(
+    { setValue, watch }: UseFormReturn<TFieldValues>,
     key: Key,
-) => {
+): SheetControls<TFieldValues, Key> => {
     const bottomSheetControls = useBottomSheetControls();
 
-    const selectedValue = watch(key);
+    const selectedValue = watch(key as FieldPath<TFieldValues>);
 
     const setSelectedValue = useCallback(
         (value: typeof selectedValue) => setValue(key, value),

--- a/suite-native/module-trading/src/hooks/general/useTradeableAssetsFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradeableAssetsFilteredData.ts
@@ -4,7 +4,7 @@ import { cryptoIdToSymbol } from '@suite-common/trading';
 import { NetworkSymbol, getNetworkByCoingeckoId } from '@suite-common/wallet-config';
 
 import { useListDataFilter } from './useListDataFilter';
-import { TradeableAsset } from '../../types';
+import { TradeableAsset } from '../../types/general';
 
 const doesContractAddressIncludeValue = (asset: TradeableAsset, value: string) =>
     asset.contractAddress?.toLowerCase().includes(value.toLowerCase()) ?? false;

--- a/suite-native/module-trading/src/index.ts
+++ b/suite-native/module-trading/src/index.ts
@@ -1,5 +1,4 @@
 export * from './navigation/TradingStackNavigator';
 export * from './tradingSlice';
 export * from './selectors/commonSelectors';
-export * from './types';
 export * from './screens/TradingWebViewScreen';

--- a/suite-native/module-trading/src/selectors/__tests__/favouritesSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/favouritesSelectors.test.ts
@@ -4,7 +4,7 @@ import { extraDependenciesMock } from '@suite-common/test-utils';
 
 import { btcAsset } from '../../__fixtures__/tradeableAssets';
 import { TradingState, addTradeableAssetToFavourites, tradingSlice } from '../../tradingSlice';
-import { TradeableAsset } from '../../types';
+import { TradeableAsset } from '../../types/general';
 import {
     selectIsTradingFavouriteAsset,
     selectTradingFavouriteAssets,

--- a/suite-native/module-trading/src/selectors/buySelectors.ts
+++ b/suite-native/module-trading/src/selectors/buySelectors.ts
@@ -11,7 +11,8 @@ import {
 
 import { supportedFiatCurrenciesMap } from '../consts/general/supportedFiatCurrencies';
 import { TradingRootState, createMemoizedSelector } from '../tradingSlice';
-import { Country, FiatCurrencyItem, TradingBuyFormValues } from '../types';
+import { BuyFormValues } from '../types/buy';
+import { Country, FiatCurrencyItem } from '../types/general';
 import {
     coinInfoToTradeableAsset,
     tradeableAssetSortingComparator,
@@ -54,7 +55,7 @@ export const selectBuyFormDefaultValues = createMemoizedSelector(
     ],
     (buyInfo, coins) => {
         if (!buyInfo || !coins) {
-            return {} as Partial<TradingBuyFormValues>;
+            return {} as Partial<BuyFormValues>;
         }
 
         const { country, suggestedFiatCurrency } = buyInfo.buyInfo;
@@ -71,7 +72,7 @@ export const selectBuyFormDefaultValues = createMemoizedSelector(
             fiatCurrency: fiatCurrency.toLowerCase(),
             country: countryDefaultValue,
             amountInCrypto: false,
-        } as Partial<TradingBuyFormValues>;
+        } as Partial<BuyFormValues>;
     },
 );
 

--- a/suite-native/module-trading/src/selectors/favouritesSelectors.ts
+++ b/suite-native/module-trading/src/selectors/favouritesSelectors.ts
@@ -1,5 +1,5 @@
 import { TradingRootState, createMemoizedSelector } from '../tradingSlice';
-import { TradeableAsset } from '../types';
+import { TradeableAsset } from '../types/general';
 
 export const selectTradingFavouriteAssets = (state: TradingRootState) =>
     state.wallet.tradingNew.favouriteAssets;

--- a/suite-native/module-trading/src/tradingSlice.ts
+++ b/suite-native/module-trading/src/tradingSlice.ts
@@ -10,7 +10,7 @@ import {
     prepareTradingReducer,
 } from '@suite-common/trading';
 
-import { ReceiveAccount } from './types';
+import { ReceiveAccount } from './types/general';
 
 export interface TradingBuyState extends CommonTradingBuyState {
     selectedReceiveAccount: ReceiveAccount | undefined;

--- a/suite-native/module-trading/src/types/buy.ts
+++ b/suite-native/module-trading/src/types/buy.ts
@@ -1,0 +1,17 @@
+import { BuyTrade, FiatCurrencyCode } from 'invity-api';
+
+import type { UseFormReturn } from '@suite-native/forms';
+
+import { Country, FocusableFormValues, ReceiveAccount, TradeableAsset } from './general';
+
+export type BuyFormValues = {
+    quote: BuyTrade | undefined;
+    asset: TradeableAsset | undefined;
+    receiveAccount: ReceiveAccount | undefined;
+    fiatCurrency: FiatCurrencyCode;
+    amountInCrypto: boolean;
+    country: Country;
+    generalAlert: string | undefined;
+} & FocusableFormValues<'fiatValue' | 'cryptoValue'>;
+
+export type BuyForm = UseFormReturn<BuyFormValues>;

--- a/suite-native/module-trading/src/types/general.ts
+++ b/suite-native/module-trading/src/types/general.ts
@@ -1,4 +1,4 @@
-import { BuyTrade, CoinInfo, CryptoId, FiatCurrencyCode } from 'invity-api';
+import { CoinInfo, CryptoId, FiatCurrencyCode } from 'invity-api';
 
 import { Formatters } from '@suite-common/formatters';
 import { TradingAmountLimitProps } from '@suite-common/trading';
@@ -22,26 +22,17 @@ export type ReceiveAccount = {
     address?: Address;
 };
 
-export type TradingBuyFormValues = {
-    quote: BuyTrade | undefined;
-    asset: TradeableAsset | undefined;
-    receiveAccount: ReceiveAccount | undefined;
-    fiatCurrency: FiatCurrencyCode;
-    fiatValue: string | undefined;
-    cryptoValue: string | undefined;
-    amountInCrypto: boolean;
-    focusedValue: 'fiatValue' | 'cryptoValue' | undefined;
-    country: Country;
-    generalAlert: string | undefined;
-};
+export type FocusableFormValues<T extends string> = {
+    focusedValue: T | undefined;
+} & Record<Exclude<T, 'focusedValue'>, string | undefined>;
 
-export type TradingBuyFormContext = (TradingAmountLimitProps | Record<string, never>) & {
+export type GenericForm<T extends string> = UseFormReturn<FocusableFormValues<T>>;
+
+export type FormContext = (TradingAmountLimitProps | Record<string, never>) & {
     translate: ReturnType<typeof useTranslate>['translate'];
     FiatAmountFormatter: Formatters['FiatAmountFormatter'];
     CryptoAmountFormatter: Formatters['CryptoAmountFormatter'];
 };
-
-export type TradingBuyForm = UseFormReturn<TradingBuyFormValues>;
 
 export type FiatCurrencyItem = {
     value: FiatCurrencyCode;

--- a/suite-native/module-trading/src/utils/buy/buyFormValidationSchema.ts
+++ b/suite-native/module-trading/src/utils/buy/buyFormValidationSchema.ts
@@ -1,15 +1,15 @@
 import { yup } from '@suite-common/validators';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
-import { TradingBuyFormContext } from '../../types';
+import { FormContext } from '../../types/general';
 
 const getAmountLimitContext = ({ options }: yup.TestContext<unknown>) =>
-    options.context as TradingBuyFormContext;
+    options.context as FormContext;
 
 const formatCryptoAmount = (
     amount: string,
     currency: string,
-    CryptoAmountFormatter: TradingBuyFormContext['CryptoAmountFormatter'],
+    CryptoAmountFormatter: FormContext['CryptoAmountFormatter'],
 ) =>
     CryptoAmountFormatter.format(amount, {
         symbol: currency.toLowerCase() as NetworkSymbol,

--- a/suite-native/module-trading/src/utils/general/__tests__/quotesUtils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/quotesUtils.test.ts
@@ -7,19 +7,19 @@ import quotes from '../../../__fixtures__/quotes.json';
 import { btcAsset } from '../../../__fixtures__/tradeableAssets';
 import { getInitializedTradingState } from '../../../__fixtures__/tradingState';
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { TradingBuyForm } from '../../../types';
-import { getPaymentMethodFromBuyForm, tradingBuyFormToTradingBuyFormProps } from '../quotesUtils';
+import { BuyForm } from '../../../types/buy';
+import { buyFormTobuyFormProps, getPaymentMethodFromBuyForm } from '../quotesUtils';
 
 describe('quotesUtils', () => {
-    let form: TradingBuyForm;
+    let form: BuyForm;
 
-    const renderUseTradingBuyForm = () =>
+    const renderUseBuyForm = () =>
         renderHookWithStoreProviderAsync(() => useBuyForm(), {
             preloadedState: { wallet: { tradingNew: getInitializedTradingState() } },
         });
 
     beforeEach(async () => {
-        const { result } = await renderUseTradingBuyForm();
+        const { result } = await renderUseBuyForm();
         form = result.current;
     });
 
@@ -40,11 +40,9 @@ describe('quotesUtils', () => {
         });
     });
 
-    describe('tradingBuyFormToTradingBuyFormProps', () => {
+    describe('buyFormTobuyFormProps', () => {
         it('should throw when crypto value is not selected', () => {
-            expect(() => tradingBuyFormToTradingBuyFormProps(form, coins.bitcoin)).toThrow(
-                'Asset is required',
-            );
+            expect(() => buyFormTobuyFormProps(form, coins.bitcoin)).toThrow('Asset is required');
         });
 
         describe('with buy form populated', () => {
@@ -61,13 +59,13 @@ describe('quotesUtils', () => {
             });
 
             it('should throw when info is not defined', () => {
-                expect(() => tradingBuyFormToTradingBuyFormProps(form, undefined)).toThrow(
+                expect(() => buyFormTobuyFormProps(form, undefined)).toThrow(
                     'CoinInfo is required',
                 );
             });
 
             it('should return correct props', () => {
-                const props = tradingBuyFormToTradingBuyFormProps(form, coins.bitcoin);
+                const props = buyFormTobuyFormProps(form, coins.bitcoin);
                 expect(props).toEqual({
                     fiatInput: '100',
                     cryptoInput: '0.001000168',
@@ -104,7 +102,7 @@ describe('quotesUtils', () => {
                     } as unknown as BuyTrade);
                 });
 
-                const props = tradingBuyFormToTradingBuyFormProps(form, coins.bitcoin);
+                const props = buyFormTobuyFormProps(form, coins.bitcoin);
 
                 expect(props).toEqual(
                     expect.objectContaining({

--- a/suite-native/module-trading/src/utils/general/__tests__/tradeableAssetUtils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/tradeableAssetUtils.test.ts
@@ -10,7 +10,7 @@ import {
     usdcAsset,
 } from '../../../__fixtures__/tradeableAssets';
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { TradeableAsset } from '../../../types';
+import { TradeableAsset } from '../../../types/general';
 import {
     coinInfoToTradeableAsset,
     getSelectedSymbolFromBuyForm,

--- a/suite-native/module-trading/src/utils/general/quotesUtils.ts
+++ b/suite-native/module-trading/src/utils/general/quotesUtils.ts
@@ -5,10 +5,10 @@ import type { TradingBuyFormProps, TradingPaymentMethodListProps } from '@suite-
 import { toCryptoOption } from '@suite-common/trading';
 
 import { supportedFiatCurrenciesMap } from '../../consts/general/supportedFiatCurrencies';
-import { TradingBuyForm } from '../../types';
+import { BuyForm } from '../../types/buy';
 
 export const getPaymentMethodFromBuyForm = (
-    form: TradingBuyForm,
+    form: BuyForm,
 ): TradingPaymentMethodListProps | undefined => {
     const quote = form.getValues('quote');
 
@@ -22,8 +22,8 @@ export const getPaymentMethodFromBuyForm = (
     return undefined;
 };
 
-export const tradingBuyFormToTradingBuyFormProps = (
-    form: TradingBuyForm,
+export const buyFormTobuyFormProps = (
+    form: BuyForm,
     coinInfo: CoinInfo | undefined,
 ): TradingBuyFormProps => {
     const [asset, fiatCurrency, fiatValue, cryptoValue, amountInCrypto, country] = form.getValues([

--- a/suite-native/module-trading/src/utils/general/tradeableAssetUtils.ts
+++ b/suite-native/module-trading/src/utils/general/tradeableAssetUtils.ts
@@ -4,7 +4,8 @@ import { cryptoIdToSymbol, isCryptoIdForNativeToken, parseCryptoId } from '@suit
 import { NetworkSymbolExtended } from '@suite-common/wallet-config';
 import { TokenAddress } from '@suite-common/wallet-types';
 
-import { TradeableAsset, TradingBuyForm } from '../../types';
+import { BuyForm } from '../../types/buy';
+import { TradeableAsset } from '../../types/general';
 
 const FAVOURITE_NETWORKS_PRIORITY_ORDER = ['bitcoin', 'ethereum', 'litecoin', 'cardano', 'solana'];
 
@@ -43,7 +44,7 @@ export const coinInfoToTradeableAsset = (
     };
 };
 
-export const getSelectedSymbolFromBuyForm = (form: TradingBuyForm) => {
+export const getSelectedSymbolFromBuyForm = (form: BuyForm) => {
     const cryptoId = form.watch('asset')?.cryptoId;
 
     return cryptoId ? cryptoIdToSymbol(cryptoId) : undefined;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Rename types in mobile trading module to better correspond with file structure.
- Create generic amount input component.

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/mobile-trade-types&lookback=7)