### PR TITLE
feat(suite): make context message banner closable if dismissible

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ContextMessage.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ContextMessage.tsx
@@ -1,4 +1,10 @@
-import { Context, selectContextMessageContent } from '@suite-common/message-system';
+import { useMemo } from 'react';
+
+import {
+    Context,
+    messageSystemActions,
+    selectContextMessageContent,
+} from '@suite-common/message-system';
 import { Banner, Row } from '@trezor/components';
 
 import { goto } from 'src/actions/suite/routerActions';
@@ -17,36 +23,64 @@ export const ContextMessage = ({ context }: ContextMessageProps) => {
     const torOnionLinks = useSelector(state => state.suite.settings.torOnionLinks);
     const dispatch = useDispatch();
 
-    if (!message) return null;
+    const dismissalConfig = useMemo(() => {
+        if (!message?.dismissible) return undefined;
 
-    const onCallToAction = ({ action, link, anchor }: NonNullable<(typeof message)['cta']>) => {
-        switch (action) {
-            case 'internal-link':
-                // @ts-expect-error: impossible to add all href options to the message system config json schema
-                return () => dispatch(goto(link, { anchor, preserveParams: true }));
-            case 'external-link':
-                return () =>
-                    window.open(
-                        isTorEnabled && torOnionLinks ? getTorUrlIfAvailable(link) : link,
-                        '_blank',
-                    );
-        }
-    };
+        return {
+            onClick: () =>
+                dispatch(
+                    messageSystemActions.dismissMessage({ id: message.id, category: 'context' }),
+                ),
+            'data-testid': `@message-system/${message.id}/dismiss`,
+        };
+    }, [message, dispatch]);
+
+    const actionConfig = useMemo(() => {
+        if (!message?.cta) return undefined;
+
+        const { action, label, link, anchor } = message.cta;
+
+        const onClick =
+            action === 'internal-link'
+                ? // @ts-expect-error: impossible to add all href options to the message system config json schema
+                  () => dispatch(goto(link, { anchor, preserveParams: true }))
+                : () =>
+                      window.open(
+                          isTorEnabled && torOnionLinks ? getTorUrlIfAvailable(link) : link,
+                          '_blank',
+                      );
+
+        return {
+            label,
+            onClick,
+            'data-testid': `@message-system/${message.id}/cta`,
+        };
+    }, [message, dispatch, isTorEnabled, torOnionLinks]);
+
+    if (!message) return null;
 
     return (
         <Banner
             variant={message.variant === 'critical' ? 'destructive' : message.variant}
             rightContent={
-                message.cta && (
-                    <Row gap={8}>
+                <Row gap={8}>
+                    {actionConfig && (
                         <Banner.Button
-                            onClick={onCallToAction(message.cta)}
-                            data-testid={`@context-message/${context}/cta`}
+                            onClick={actionConfig?.onClick}
+                            data-testid={actionConfig['data-testid']}
                         >
-                            {message.cta.label}
+                            {actionConfig.label}
                         </Banner.Button>
-                    </Row>
-                )
+                    )}
+                    {dismissalConfig && (
+                        <Banner.IconButton
+                            icon="x"
+                            onClick={dismissalConfig.onClick}
+                            isSubtle
+                            data-testid={dismissalConfig['data-testid']}
+                        />
+                    )}
+                </Row>
             }
         >
             {message.content}


### PR DESCRIPTION
## Description

Added a close (dismiss) button to the `ContextMessage` banner.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18811

## Screenshots:

<img width="1355" alt="image" src="https://github.com/user-attachments/assets/ad30f78f-ac65-46da-85c6-7f2c34402d4d" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/context-message-dismissible&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/context-message-dismissible&lookback=7)