### PR TITLE
Feat/remove trailing slashes utils

### DIFF
--- a/packages/connect/src/api/firmware/getBinary.ts
+++ b/packages/connect/src/api/firmware/getBinary.ts
@@ -1,8 +1,7 @@
 import type { FirmwareRelease } from '@trezor/device-utils';
+import { removeTrailingSlashes } from '@trezor/utils';
 
 import { httpRequest } from '../../utils/assets';
-
-const ALL_SLASHES_AT_THE_END_REGEX = /\/+$/;
 
 interface GetBinaryProps {
     baseUrl: string;
@@ -12,7 +11,7 @@ interface GetBinaryProps {
 
 export const getBinary = ({ baseUrl, btcOnly, release }: GetBinaryProps) => {
     const fwUrl = release[btcOnly ? 'url_bitcoinonly' : 'url'];
-    const sanitizedBaseUrl = baseUrl.replace(ALL_SLASHES_AT_THE_END_REGEX, '');
+    const sanitizedBaseUrl = removeTrailingSlashes(baseUrl);
     const url = `${sanitizedBaseUrl}/${fwUrl}`;
 
     return httpRequest(url, 'binary');

--- a/packages/suite-desktop-core/src/libs/update-checker.ts
+++ b/packages/suite-desktop-core/src/libs/update-checker.ts
@@ -2,6 +2,8 @@ import fs from 'fs';
 import { createMessage, readKey, readSignature, verify } from 'openpgp';
 import path from 'path';
 
+import { removeTrailingSlashes } from '@trezor/utils';
+
 const signingKey = process.env.APP_PUBKEY;
 
 // This will prevent the auto-updater from loading if the pubkey is not defined
@@ -15,7 +17,7 @@ const getSignatureFile = async ({ filename, feedURL }: GetSignatureFileProps) =>
     /**
      * Signature files are available next to installation files.
      */
-    const signatureFileURL = `${feedURL.replace(/\/+$/, '')}/${filename}.asc`;
+    const signatureFileURL = `${removeTrailingSlashes(feedURL)}/${filename}.asc`;
 
     const signatureFile = await fetch(signatureFileURL);
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -57,3 +57,4 @@ export * from './typedEventEmitter';
 export * from './typedObjectKeys';
 export * from './urlToOnion';
 export * from './zip';
+export * from './removeTrailingSlashes';

--- a/packages/utils/src/removeTrailingSlashes.ts
+++ b/packages/utils/src/removeTrailingSlashes.ts
@@ -1,0 +1,19 @@
+/**
+ * Removes all trailing slashes from a given string.
+ *
+ * * We could use regex `/\/+$/` but it might run slow on strings with many repetitions of '/' so in order
+ * to avoid potential DoS from input we use the Loop instead.
+ */
+export const removeTrailingSlashes = (input: string | null | undefined): string => {
+    if (!input) {
+        return input || '';
+    }
+
+    let i = input.length;
+    // Iterate backwards until we find something else than slash
+    while (i > 0 && input[i - 1] === '/') {
+        i--;
+    }
+
+    return input.substring(0, i);
+};

--- a/packages/utils/tests/removeTrailingSlashes.test.ts
+++ b/packages/utils/tests/removeTrailingSlashes.test.ts
@@ -1,0 +1,36 @@
+import { removeTrailingSlashes } from '../src/removeTrailingSlashes'; // Adjust path as needed
+
+describe('removeTrailingSlashes', () => {
+    it('should remove multiple trailing slashes', () => {
+        expect(removeTrailingSlashes('path/to/something///')).toEqual('path/to/something');
+    });
+
+    it('should return the same string if there are no trailing slashes', () => {
+        expect(removeTrailingSlashes('path/to/something')).toEqual('path/to/something');
+    });
+
+    it('should return an empty string for an already empty string input', () => {
+        expect(removeTrailingSlashes('')).toEqual('');
+    });
+
+    it('should return an empty string for a null or undefined input', () => {
+        expect(removeTrailingSlashes(null)).toEqual('');
+        expect(removeTrailingSlashes(undefined)).toEqual('');
+    });
+
+    it('should not remove slashes from the middle of the string', () => {
+        expect(removeTrailingSlashes('path/to//something')).toEqual('path/to//something');
+    });
+
+    it('should handle a url-like string with trailing slashes', () => {
+        expect(removeTrailingSlashes('http://example.com/api/v1//')).toEqual(
+            'http://example.com/api/v1',
+        );
+    });
+
+    it('should handle a url-like string without trailing slashes', () => {
+        expect(removeTrailingSlashes('http://example.com/api/v1')).toEqual(
+            'http://example.com/api/v1',
+        );
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
New utility function `removeTrailingSlashes` to avoid duplicated regex.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/removeTrailingSlashes-utils&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/removeTrailingSlashes-utils&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/removeTrailingSlashes-utils&lookback=7)