### PR TITLE
Show provider-adjusted sell amount tooltip only when quote and displayed amount differ

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -12,6 +12,7 @@ import {
 } from '@suite-common/trading';
 import { Button, Column, Paragraph, Row, TextButton, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { Translation } from 'src/components/suite';
 import { useTradingDeviceDisconnected } from 'src/hooks/wallet/trading/form/common/useTradingDeviceDisconnected';
@@ -83,7 +84,13 @@ export const TradingFormOffer = () => {
     const { tradingDeviceDisconnected } = useTradingDeviceDisconnected();
 
     const showProviderAdjustedAmountTooltip =
-        isTradingSellContext(context) && bestScoredQuoteAmounts && !state.isFormLoading;
+        !state.isFormLoading &&
+        isTradingSellContext(context) &&
+        context.quotesRequest?.cryptoStringAmount &&
+        bestScoredQuoteAmounts &&
+        !new BigNumber(context.quotesRequest.cryptoStringAmount).isEqualTo(
+            new BigNumber(bestScoredQuoteAmounts.receiveAmount),
+        );
 
     const onSelectQuote = () => {
         if (!quote) {

--- a/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsPrice.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsPrice.tsx
@@ -4,10 +4,12 @@ import styled from 'styled-components';
 import { Tooltip } from '@trezor/components';
 import { FONT_SIZE, SCREEN_QUERY } from '@trezor/components/src/config/variables';
 import { spacingsPx, typography } from '@trezor/theme';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { Translation } from 'src/components/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { TradingCryptoAmountProps } from 'src/types/trading/trading';
+import { isTradingSellContext } from 'src/utils/wallet/trading/tradingTypingUtils';
 import { tradingGetAmountLabels } from 'src/utils/wallet/trading/tradingUtils';
 import { TradingCryptoAmount } from 'src/views/wallet/trading/common/TradingCryptoAmount';
 import { TradingFiatAmount } from 'src/views/wallet/trading/common/TradingFiatAmount';
@@ -43,12 +45,21 @@ export const TradingUtilsPrice = ({
     receiveAmount,
     receiveCurrency,
 }: TradingCryptoAmountProps) => {
-    const { type } = useTradingFormContext();
+    const context = useTradingFormContext();
+    const { type } = context;
+
+    const showProviderAdjustedAmountTooltip =
+        isTradingSellContext(context) &&
+        receiveAmount &&
+        context.quotesRequest?.cryptoStringAmount &&
+        !new BigNumber(receiveAmount).isEqualTo(
+            new BigNumber(context.quotesRequest?.cryptoStringAmount),
+        );
 
     return (
         <PriceWrap>
             <PriceTitle>
-                {type === 'sell' ? (
+                {showProviderAdjustedAmountTooltip ? (
                     <Tooltip
                         hasIcon
                         placement="right"


### PR DESCRIPTION
## Description

The tooltip explaining the provider-adjusted sell amount is now only shown when the `receiveAmount` differs from `cryptoStringAmount` in the quote. This avoids showing the explanation when no actual rounding or adjustment is applied.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16669

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tooltip-only-on-amount-difference&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tooltip-only-on-amount-difference&lookback=7)