### PR TITLE
ci(suite-native): add possibility to create adhoc native build from any branch

### DIFF
--- a/.github/workflows/build-suite-native-adhoc.yml
+++ b/.github/workflows/build-suite-native-adhoc.yml
@@ -1,0 +1,47 @@
+name: "[Build] suite-native adhoc"
+
+on:
+  workflow_dispatch:
+    inputs:
+      PLATFORM:
+        type: choice
+        options:
+          - all
+          - android
+          - ios
+        description: Select platform to run build
+        required: true
+
+jobs:
+  adhoc-build:
+    if: github.repository == 'trezor/trezor-suite' || github.repository == 'trezor/trezor-suite-private'
+    name: EAS adhoc build
+    runs-on: ubuntu-latest
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      EXPO_PUBLIC_ENVIRONMENT: preview
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: write
+    steps:
+      - name: Print selected platform
+        run: |
+          echo "Selected platform: ${{ github.event.inputs.PLATFORM }}"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: yarn
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN_DEVELOP }}
+      - name: Install libs
+        run: |
+          yarn workspaces focus @suite-native/app
+          npx patch-package # Apply global patches.
+      - name: Trigger adhoc build
+        run: |
+          yarn native:adhoc -p ${{ github.event.inputs.PLATFORM  }} --non-interactive --message ${{ github.sha }}


### PR DESCRIPTION

## Description

So far only triggered manually and the build link has to be found in the output of the workflow, but we can improve the workflow later.

## Related Issue 

Resolve https://github.com/trezor/trezor-suite/issues/19100




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/adhoc-build-gh-workflow&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/adhoc-build-gh-workflow&lookback=7)