### PR TITLE
fix(suite-native): Mobile Trade: display empty balance with unit

### DIFF
--- a/suite-native/module-trading/src/components/buy/BuyReceiveAccountCryptoBalance.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyReceiveAccountCryptoBalance.tsx
@@ -1,20 +1,23 @@
-import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS } from '@suite-common/formatters';
+import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS, useFormatters } from '@suite-common/formatters';
 import { DiscreetTextTrigger, HStack, Text } from '@suite-native/atoms';
 import { CryptoAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
 
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
+import { getSelectedSymbolFromBuyForm } from '../../utils/general/tradeableAssetUtils';
 
 export const RECEIVE_ACCOUNT_BALANCE_TEST_ID = '@trading/buy/receive-account-balance';
 
 export const BuyReceiveAccountCryptoBalance = () => {
     const form = useBuyFormContext();
+    const selectedSymbol = getSelectedSymbolFromBuyForm(form);
     const receiveAccount = form.watch('receiveAccount');
+    const { DisplaySymbolFormatter } = useFormatters();
 
-    const symbol = receiveAccount?.account?.symbol;
+    const symbol = receiveAccount?.account?.symbol ?? selectedSymbol;
     const balance = receiveAccount?.account?.balance;
 
-    if (!symbol || balance === undefined) {
+    if (!symbol) {
         return null;
     }
 
@@ -23,17 +26,27 @@ export const BuyReceiveAccountCryptoBalance = () => {
             <Text variant="hint" color="textSubdued">
                 <Translation id="moduleTrading.tradingScreen.balance" />
             </Text>
-            <DiscreetTextTrigger>
-                <CryptoAmountFormatter
-                    value={balance}
-                    symbol={symbol}
+            {balance === undefined ? (
+                <Text
                     variant="hint"
                     color="textSubdued"
-                    isBalance={false}
-                    decimals={BASE_CRYPTO_MAX_DISPLAYED_DECIMALS}
-                    testID={RECEIVE_ACCOUNT_BALANCE_TEST_ID + '/value'}
-                />
-            </DiscreetTextTrigger>
+                    testID={RECEIVE_ACCOUNT_BALANCE_TEST_ID + '/no-value'}
+                >
+                    - <DisplaySymbolFormatter value={symbol} />
+                </Text>
+            ) : (
+                <DiscreetTextTrigger>
+                    <CryptoAmountFormatter
+                        value={balance}
+                        symbol={symbol}
+                        variant="hint"
+                        color="textSubdued"
+                        isBalance={false}
+                        decimals={BASE_CRYPTO_MAX_DISPLAYED_DECIMALS}
+                        testID={RECEIVE_ACCOUNT_BALANCE_TEST_ID + '/value'}
+                    />
+                </DiscreetTextTrigger>
+            )}
         </HStack>
     );
 };

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountCryptoBalance.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountCryptoBalance.comp.test.tsx
@@ -5,6 +5,7 @@ import {
     renderWithStoreProviderAsync,
 } from '@suite-native/test-utils';
 
+import { btcAsset } from '../../../__fixtures__/tradeableAssets';
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
 import { TradingBuyForm } from '../../../types';
 import {
@@ -32,7 +33,7 @@ describe('BuyReceiveAccountCryptoBalance', () => {
         buyForm = await renderBuyForm();
     });
 
-    it('should display empty box when symbol is not specified', async () => {
+    it('should display empty box when nor symbol nor asset is specified', async () => {
         act(() => {
             buyForm.setValue('receiveAccount', {
                 account: {
@@ -46,7 +47,7 @@ describe('BuyReceiveAccountCryptoBalance', () => {
         expect(queryByTestId(RECEIVE_ACCOUNT_BALANCE_TEST_ID)).toBeNull();
     });
 
-    it('should display empty box when balance is not specified', async () => {
+    it('should display empty balance when balance is not specified', async () => {
         act(() => {
             buyForm.setValue('receiveAccount', {
                 account: {
@@ -55,9 +56,9 @@ describe('BuyReceiveAccountCryptoBalance', () => {
                 } as any,
             });
         });
-        const { queryByTestId } = await renderComponent();
+        const { getByTestId } = await renderComponent();
 
-        expect(queryByTestId(RECEIVE_ACCOUNT_BALANCE_TEST_ID)).toBeNull();
+        expect(getByTestId(RECEIVE_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:- BTC');
     });
 
     it('should display balance when symbol and balance is specified', async () => {
@@ -72,5 +73,14 @@ describe('BuyReceiveAccountCryptoBalance', () => {
         const { getByTestId } = await renderComponent();
 
         expect(getByTestId(RECEIVE_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:0.01 BTC');
+    });
+
+    it('should display empty balance when symbol is not specified, but asset is', async () => {
+        act(() => {
+            buyForm.setValue('asset', btcAsset);
+        });
+        const { getByTestId } = await renderComponent();
+
+        expect(getByTestId(RECEIVE_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:- BTC');
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Display empty balance for selected asset even when account is not selected yet.
<!--- Describe your changes in detail -->

## Related Issue

Resolve #19108


## Screenshots:

![asset-account](https://github.com/user-attachments/assets/d9d356c0-b61b-4038-89ae-37f52c34cc9d)
![asset-account-hidden](https://github.com/user-attachments/assets/1b8372cf-7455-47f1-a22c-d332da867bb9)
![asset-no-account](https://github.com/user-attachments/assets/deda7c8c-6da6-4c56-a183-c9770fb36873)
![no-asset](https://github.com/user-attachments/assets/b18bf25a-4ae6-4760-bf8e-9764d9e63721)



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19108-mobile-trade-empty-balance&lookback=7)