### PR TITLE
chore(suite): delete useActions from useFormDraft

### DIFF
--- a/packages/suite/src/hooks/wallet/useFormDraft.ts
+++ b/packages/suite/src/hooks/wallet/useFormDraft.ts
@@ -1,13 +1,32 @@
+import { useCallback } from 'react';
 import { FieldValues } from 'react-hook-form';
 
 import { FormDraftKeyPrefix } from '@suite-common/wallet-types';
 
 import * as formDraftActions from 'src/actions/wallet/formDraftActions';
-import { useActions } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 
-export const useFormDraft = <T extends FieldValues>(keyPrefix: FormDraftKeyPrefix) =>
-    useActions({
-        getDraft: formDraftActions.getDraft<T>(keyPrefix),
-        saveDraft: formDraftActions.saveDraft<T>(keyPrefix),
-        removeDraft: formDraftActions.removeDraft(keyPrefix),
-    });
+export const useFormDraft = <T extends FieldValues>(keyPrefix: FormDraftKeyPrefix) => {
+    const dispatch = useDispatch();
+
+    const getDraft = useCallback(
+        (key: string) => dispatch(formDraftActions.getDraft<T>(keyPrefix)(key)),
+        [dispatch, keyPrefix],
+    );
+
+    const saveDraft = useCallback(
+        (key: string, data: T) => dispatch(formDraftActions.saveDraft<T>(keyPrefix)(key, data)),
+        [dispatch, keyPrefix],
+    );
+
+    const removeDraft = useCallback(
+        (key: string) => dispatch(formDraftActions.removeDraft(keyPrefix)(key)),
+        [dispatch, keyPrefix],
+    );
+
+    return {
+        getDraft,
+        saveDraft,
+        removeDraft,
+    };
+};


### PR DESCRIPTION
## Description

- deleted `useActions` from _useFormDraft_


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/update-use-form-draft&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/update-use-form-draft&lookback=7)