### PR TITLE
ci(suite-native): redact UDIDs from the build output

### DIFF
--- a/.github/workflows/build-suite-native-adhoc.yml
+++ b/.github/workflows/build-suite-native-adhoc.yml
@@ -44,4 +44,10 @@ jobs:
           npx patch-package # Apply global patches.
       - name: Trigger adhoc build
         run: |
-          yarn native:adhoc -p ${{ github.event.inputs.PLATFORM  }} --non-interactive --no-wait --freeze-credentials --message ${{ github.sha }}
+          yarn native:adhoc \
+            -p ${{ github.event.inputs.PLATFORM }} \
+            --non-interactive \
+            --no-wait \
+            --freeze-credentials \
+            --message ${{ github.sha }} \
+            2>&1 | sed -E 's/UDID: [A-Za-z0-9-]+/UDID: [REDACTED]/g' # remove UDIDs from output


### PR DESCRIPTION


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/ci-redact-udids-from-adhoc-build-output&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/ci-redact-udids-from-adhoc-build-output&lookback=7)