### PR TITLE
Feat/native/wipe device trezor confirm

### DIFF
--- a/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
+++ b/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
@@ -7,6 +7,7 @@ import {
     ConnectDeviceSettings,
     deviceActions,
     prepareDeviceReducer,
+    wipeDeviceThunk,
 } from '@suite-common/wallet-core';
 import { Response } from '@trezor/connect';
 
@@ -45,7 +46,7 @@ const SUITE_SETTINGS: ConnectDeviceSettings = {
 const fixture: Feature[] = [
     {
         description: 'Wipe device',
-        action: () => deviceSettingsActions.wipeDevice(),
+        action: () => wipeDeviceThunk(),
         mocks: { success: true, payload: { message: 'Success' } },
         deviceChange,
         result: {
@@ -120,7 +121,7 @@ const fixture: Feature[] = [
                 ],
             },
         },
-        action: () => deviceSettingsActions.wipeDevice(),
+        action: () => wipeDeviceThunk(),
         mocks: { success: true, payload: { message: 'Success' } },
         deviceChange: getSuiteDevice({ path: '1' }, { device_id: 'new-device-id' }),
         result: {
@@ -232,7 +233,7 @@ const fixture: Feature[] = [
     },
     {
         description: 'Wipe device failed',
-        action: () => deviceSettingsActions.wipeDevice(),
+        action: () => wipeDeviceThunk(),
         mocks: { success: false, payload: { error: 'fuuu' } },
         result: {
             actions: [

--- a/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
+++ b/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
@@ -246,6 +246,10 @@ const fixture: Feature[] = [
                         id: expect.any(Number),
                     },
                 } satisfies ReturnType<typeof notificationsActions.addToast>,
+                {
+                    type: wipeDeviceThunk.rejected.type,
+                    payload: 'fuuu',
+                },
             ],
         },
         initialState: {},

--- a/packages/suite/src/actions/settings/__tests__/deviceSettingsActions.test.ts
+++ b/packages/suite/src/actions/settings/__tests__/deviceSettingsActions.test.ts
@@ -3,7 +3,7 @@ import { deviceActions } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 
 import suiteReducer from 'src/reducers/suite/suiteReducer';
-import { configureStore } from 'src/support/tests/configureStore';
+import { configureStore, filterThunkActionTypes } from 'src/support/tests/configureStore';
 
 import fixtures, {
     DeviceSettingsFixtureState,
@@ -66,7 +66,9 @@ describe('DeviceSettings Actions', () => {
 
             if (f.result) {
                 if (f.result.actions) {
-                    expect(store.getActions()).toMatchObject(f.result.actions);
+                    expect(filterThunkActionTypes(store.getActions())).toMatchObject(
+                        f.result.actions,
+                    );
                 }
             }
         });

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -1,25 +1,16 @@
-import { bluetoothActions } from '@suite-common/bluetooth';
 import { FIRMWARE_MODULE_PREFIX } from '@suite-common/firmware';
 import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
 import { createThunk } from '@suite-common/redux-utils';
-import * as deviceUtils from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { deviceActions, selectDevices, selectSelectedDevice } from '@suite-common/wallet-core';
+import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
 import TrezorConnect, { ERRORS } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
-import { EventType, analytics } from '@trezor/suite-analytics';
-import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
 import * as modalActions from 'src/actions/suite/modalActions';
-import * as routerActions from 'src/actions/suite/routerActions';
 import { reportCheckFail } from 'src/components/suite/SecurityCheck/useReportDeviceCompromised';
 import * as DEVICE from 'src/constants/suite/device';
+import { selectIsEntropyCheckEnabled } from 'src/reducers/suite/suiteReducer';
 import { Dispatch, GetState } from 'src/types/suite';
-
-import {
-    selectIsEntropyCheckEnabled,
-    selectSuiteSettings,
-} from '../../reducers/suite/suiteReducer';
 
 export const applySettings =
     (params: Parameters<typeof TrezorConnect.applySettings>[0]) =>
@@ -99,74 +90,6 @@ export const changeWipeCode =
             dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
         }
     };
-
-export const wipeDevice = () => async (dispatch: Dispatch, getState: GetState) => {
-    const device = selectSelectedDevice(getState());
-    if (!device) return;
-    const isBootloaderMode = device.mode === 'bootloader';
-    const devices = selectDevices(getState());
-    // collect devices with old "device.id" to be removed (see description below)
-    const deviceInstances = deviceUtils.getDeviceInstances(device, devices);
-
-    const result = await TrezorConnect.wipeDevice({
-        device: {
-            path: device.path,
-        },
-        // In bootloader mode we need the skip the final reload, otherwise we never get the resolution
-        skipFinalReload: isBootloaderMode,
-    });
-
-    if (
-        result.success ||
-        // This is an expected success for Bluetooth-connected devices
-        (device.bluetoothProps !== undefined && result.payload.code === 'Device_Disconnected')
-    ) {
-        // Wiping a device triggers device.id change, and this change is propagated to device reducer via @trezor/connect DEVICE.CHANGE event.
-        // Accounts data are related to the old device.id; to properly clear reducers and indexed db,
-        // we need to retrieve device objects BEFORE and AFTER the wipe process.
-        // And call SUITE.FORGET_DEVICE on ALL devices (with old and new device.id)
-        if (device.bluetoothProps !== undefined) {
-            dispatch(bluetoothActions.removeKnownDeviceAction({ id: device.bluetoothProps.id }));
-
-            const resultForget = await bluetoothIpc.forgetDevice(device.bluetoothProps.id);
-            if (!resultForget.success) {
-                dispatch(
-                    bluetoothActions.setBluetoothDeviceNeedsManualOsRemoval({
-                        needsManualRemoval: true,
-                    }),
-                );
-            }
-        }
-        const state = getState();
-        const newDevice = selectSelectedDevice(getState());
-        const newDevices = selectDevices(getState());
-        const settings = selectSuiteSettings(getState());
-
-        deviceInstances.push(...deviceUtils.getDeviceInstances(newDevice!, newDevices));
-        deviceInstances.forEach(d => {
-            dispatch(deviceActions.forgetDevice({ device: d, settings }));
-        });
-        dispatch(notificationsActions.addToast({ type: 'device-wiped' }));
-        analytics.report({
-            type: EventType.SettingsDeviceWipe,
-        });
-
-        // Special case with webusb: Device after wipe changes device_id. With webusb transport, device_id is used as a path
-        // and thus as a descriptor for webusb. So, after the device is wiped, in the transport layer, the device is still paired
-        // through the old descriptor, but suite already works with a new one. It kinda works, but only until we try a new call,
-        // typically resetDevice when in onboarding - we get a device-disconnected error.
-        //
-        // Edit 1: disconnecting the device wiped from bootloader mode is also necessary.
-        // Edit 2: encountered libusb error with bridge 2.0.27. So let's enforce disconnecting for all devices.
-        dispatch(deviceActions.requestDeviceReconnect());
-        if (state.router.app === 'settings') {
-            // redirect to the index to close the settings and show initial device setup
-            dispatch(routerActions.goto('suite-index'));
-        }
-    } else {
-        dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
-    }
-};
 
 export const resetDevice =
     (params: Parameters<typeof TrezorConnect.resetDevice>[0] = {}) =>

--- a/packages/suite/src/views/settings/SettingsDevice/WipeDeviceModal.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/WipeDeviceModal.tsx
@@ -1,12 +1,17 @@
 import { useState } from 'react';
 
+import { isFulfilled } from '@reduxjs/toolkit';
+
+import { wipeDeviceThunk } from '@suite-common/wallet-core';
 import { Card, Column, H3, Modal, Paragraph } from '@trezor/components';
 import { isDeviceInBootloaderMode } from '@trezor/device-utils';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
-import { wipeDevice } from 'src/actions/settings/deviceSettingsActions';
+import * as routerActions from 'src/actions/suite/routerActions';
 import { CheckItem, Translation } from 'src/components/suite';
-import { useDevice, useDispatch } from 'src/hooks/suite';
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
+import { selectRouterApp } from 'src/reducers/suite/routerReducer';
 
 type WipeDeviceModalProps = {
     onCancel: () => void;
@@ -19,14 +24,27 @@ export const WipeDeviceModal = ({ onCancel }: WipeDeviceModalProps) => {
 
     const { device, isLocked } = useDevice();
     const dispatch = useDispatch();
+    const appRoute = useSelector(selectRouterApp);
 
     const isBootloaderMode = isDeviceInBootloaderMode(device);
 
     const handleWipeDevice = async () => {
         setIsLoading(true);
-        await dispatch(wipeDevice());
+        const response = await dispatch(wipeDeviceThunk());
+
+        if (isFulfilled(response)) {
+            analytics.report({
+                type: EventType.SettingsDeviceWipe,
+            });
+            if (appRoute === 'settings') {
+                // redirect to the index to close the settings and show initial device setup
+                dispatch(routerActions.goto('suite-index'));
+            }
+        }
+
         setIsLoading(false);
     };
+
     const handleCancel = () => {
         setIsLoading(false);
         onCancel();

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -13,6 +13,7 @@
     "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
         "@reduxjs/toolkit": "2.8.2",
+        "@suite-common/bluetooth": "workspace:*",
         "@suite-common/device-authenticity": "workspace:*",
         "@suite-common/fiat-services": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
@@ -31,6 +32,7 @@
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
+        "@trezor/transport-bluetooth": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "date-fns": "^4.1.0",

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -583,7 +583,8 @@ export const wipeDeviceThunk = createThunk(
             dispatch(deviceActions.requestDeviceReconnect());
         } else {
             dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
-            rejectWithValue(result.payload.error);
+
+            return rejectWithValue(result.payload.error);
         }
     },
 );

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -1,3 +1,4 @@
+import { bluetoothActions } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
 import { TrezorDevice } from '@suite-common/suite-types';
 import {
@@ -26,6 +27,7 @@ import TrezorConnect, {
     UI,
 } from '@trezor/connect';
 import { getEnvironment } from '@trezor/env-utils';
+import { bluetoothIpc } from '@trezor/transport-bluetooth';
 import { exhaustive } from '@trezor/type-utils';
 import { isChanged } from '@trezor/utils';
 
@@ -517,5 +519,71 @@ export const passwordMismatchResetThunk = createThunk<void, { device: TrezorDevi
         dispatch(deviceActions.forgetDevice({ device, settings }));
         const newDevice = selectSelectedDevice(getState());
         dispatch(deviceActions.selectDevice(newDevice));
+    },
+);
+
+export const wipeDeviceThunk = createThunk(
+    `${DEVICE_MODULE_PREFIX}/wipeDevice`,
+    async (_, { dispatch, getState, extra, rejectWithValue }) => {
+        const device = selectSelectedDevice(getState());
+        if (!device) return;
+        const isBootloaderMode = device.mode === 'bootloader';
+        const devices = selectDevices(getState());
+        // collect devices with old "device.id" to be removed (see description below)
+        const deviceInstances = getDeviceInstances(device, devices);
+
+        const result = await TrezorConnect.wipeDevice({
+            device: {
+                path: device.path,
+            },
+            // In bootloader mode we need the skip the final reload, otherwise we never get the resolution
+            skipFinalReload: isBootloaderMode,
+        });
+
+        if (
+            result.success ||
+            // This is an expected success for Bluetooth-connected devices
+            (device.bluetoothProps !== undefined && result.payload.code === 'Device_Disconnected')
+        ) {
+            // Wiping a device triggers device.id change, and this change is propagated to device reducer via @trezor/connect DEVICE.CHANGE event.
+            // Accounts data are related to the old device.id; to properly clear reducers and indexed db,
+            // we need to retrieve device objects BEFORE and AFTER the wipe process.
+            // And call SUITE.FORGET_DEVICE on ALL devices (with old and new device.id)
+            if (device.bluetoothProps !== undefined) {
+                dispatch(
+                    bluetoothActions.removeKnownDeviceAction({ id: device.bluetoothProps.id }),
+                );
+
+                const resultForget = await bluetoothIpc.forgetDevice(device.bluetoothProps.id);
+                if (!resultForget.success) {
+                    dispatch(
+                        bluetoothActions.setBluetoothDeviceNeedsManualOsRemoval({
+                            needsManualRemoval: true,
+                        }),
+                    );
+                }
+            }
+            const newDevice = selectSelectedDevice(getState());
+            const newDevices = selectDevices(getState());
+            const settings = extra.selectors.selectSuiteSettings(getState());
+
+            deviceInstances.push(...getDeviceInstances(newDevice!, newDevices));
+            deviceInstances.forEach(d => {
+                dispatch(deviceActions.forgetDevice({ device: d, settings }));
+            });
+            dispatch(notificationsActions.addToast({ type: 'device-wiped' }));
+
+            // Special case with webusb: Device after wipe changes device_id. With webusb transport, device_id is used as a path
+            // and thus as a descriptor for webusb. So, after the device is wiped, in the transport layer, the device is still paired
+            // through the old descriptor, but suite already works with a new one. It kinda works, but only until we try a new call,
+            // typically resetDevice when in onboarding - we get a device-disconnected error.
+            //
+            // Edit 1: disconnecting the device wiped from bootloader mode is also necessary.
+            // Edit 2: encountered libusb error with bridge 2.0.27. So let's enforce disconnecting for all devices.
+            dispatch(deviceActions.requestDeviceReconnect());
+        } else {
+            dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
+            rejectWithValue(result.payload.error);
+        }
     },
 );

--- a/suite-common/wallet-core/tsconfig.json
+++ b/suite-common/wallet-core/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../bluetooth" },
         { "path": "../device-authenticity" },
         { "path": "../fiat-services" },
         { "path": "../redux-utils" },
@@ -24,6 +25,9 @@
         { "path": "../../packages/connect" },
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/env-utils" },
+        {
+            "path": "../../packages/transport-bluetooth"
+        },
         { "path": "../../packages/type-utils" },
         { "path": "../../packages/utils" }
     ]

--- a/suite-native/device-manager/src/components/DeviceSettingsButton.tsx
+++ b/suite-native/device-manager/src/components/DeviceSettingsButton.tsx
@@ -8,7 +8,7 @@ import { HStack, Text } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import {
-    DeviceStackRoutes,
+    DeviceSettingsStackRoutes,
     RootStackParamList,
     RootStackRoutes,
     StackToStackCompositeNavigationProps,
@@ -50,7 +50,7 @@ export const DeviceSettingsButton = ({ showAsFullWidth }: DeviceInfoButtonProps)
     const handleDeviceRedirect = () => {
         setIsDeviceManagerVisible(false);
         navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
-            screen: DeviceStackRoutes.DeviceSettings,
+            screen: DeviceSettingsStackRoutes.DeviceSettings,
         });
         analytics.report({
             type: EventType.DeviceManagerClick,

--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -16,7 +16,7 @@ import {
     startDiscoveryThunk,
 } from '@suite-common/wallet-core';
 import { useIsBiometricsOverlayVisible } from '@suite-native/biometrics';
-import { selectDeviceRequestedPin, selectIsWipingDevice } from '@suite-native/device-authorization';
+import { selectDeviceRequestedPin } from '@suite-native/device-authorization';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import { selectIsFirmwareInstallationRunning } from '@suite-native/firmware';
 import {
@@ -62,7 +62,6 @@ export const useHandleDeviceConnection = () => {
     const isDeviceUsingPassphrase = useSelector(selectIsDeviceUsingPassphrase);
     const isFirmwareInstallationRunning = useSelector(selectIsFirmwareInstallationRunning);
     const isDeviceSetupSupported = useSelector(selectIsDeviceSetupSupported);
-    const isWipingDevice = useSelector(selectIsWipingDevice);
 
     const { isBiometricsOverlayVisible } = useIsBiometricsOverlayVisible();
     const isOnboardingDeviceDisconnectedAlertDisplayed = useAtomValue(
@@ -118,8 +117,7 @@ export const useHandleDeviceConnection = () => {
             !isFirmwareInstallationRunning &&
             (!isDeviceOnboardingStackFocused || isDeviceOnboardingConnectAndUnlockScreenFocused) &&
             !wasDeviceOnboardingCancelled &&
-            !shouldNavigateToDeviceCompromisedModal &&
-            !isWipingDevice // After device wipe through settings, we want to redirect to homescreen
+            !shouldNavigateToDeviceCompromisedModal
         ) {
             navigation.navigate(RootStackRoutes.DeviceOnboardingStack, {
                 screen: DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
@@ -140,7 +138,6 @@ export const useHandleDeviceConnection = () => {
         isDeviceOnboardingConnectAndUnlockScreenFocused,
         wasDeviceOnboardingCancelled,
         shouldNavigateToDeviceCompromisedModal,
-        isWipingDevice,
     ]);
 
     // At the moment when unauthorized physical device is selected,

--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -16,7 +16,7 @@ import {
     startDiscoveryThunk,
 } from '@suite-common/wallet-core';
 import { useIsBiometricsOverlayVisible } from '@suite-native/biometrics';
-import { selectDeviceRequestedPin } from '@suite-native/device-authorization';
+import { selectDeviceRequestedPin, selectIsWipingDevice } from '@suite-native/device-authorization';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import { selectIsFirmwareInstallationRunning } from '@suite-native/firmware';
 import {
@@ -62,6 +62,7 @@ export const useHandleDeviceConnection = () => {
     const isDeviceUsingPassphrase = useSelector(selectIsDeviceUsingPassphrase);
     const isFirmwareInstallationRunning = useSelector(selectIsFirmwareInstallationRunning);
     const isDeviceSetupSupported = useSelector(selectIsDeviceSetupSupported);
+    const isWipingDevice = useSelector(selectIsWipingDevice);
 
     const { isBiometricsOverlayVisible } = useIsBiometricsOverlayVisible();
     const isOnboardingDeviceDisconnectedAlertDisplayed = useAtomValue(
@@ -117,7 +118,8 @@ export const useHandleDeviceConnection = () => {
             !isFirmwareInstallationRunning &&
             (!isDeviceOnboardingStackFocused || isDeviceOnboardingConnectAndUnlockScreenFocused) &&
             !wasDeviceOnboardingCancelled &&
-            !shouldNavigateToDeviceCompromisedModal
+            !shouldNavigateToDeviceCompromisedModal &&
+            !isWipingDevice // After device wipe through settings, we want to redirect to homescreen
         ) {
             navigation.navigate(RootStackRoutes.DeviceOnboardingStack, {
                 screen: DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
@@ -138,6 +140,7 @@ export const useHandleDeviceConnection = () => {
         isDeviceOnboardingConnectAndUnlockScreenFocused,
         wasDeviceOnboardingCancelled,
         shouldNavigateToDeviceCompromisedModal,
+        isWipingDevice,
     ]);
 
     // At the moment when unauthorized physical device is selected,

--- a/suite-native/device/src/hooks/useWipeDevice.tsx
+++ b/suite-native/device/src/hooks/useWipeDevice.tsx
@@ -1,7 +1,6 @@
-import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { ParamListBase, useNavigation } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import { isFulfilled } from '@reduxjs/toolkit';
 
 import { selectSelectedDevice, wipeDeviceThunk } from '@suite-common/wallet-core';
@@ -9,22 +8,23 @@ import { setIsWipingDevice } from '@suite-native/device-authorization';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import {
     DeviceSettingsStackRoutes,
-    StackToTabCompositeProps,
+    RootStackRoutes,
     WipeDeviceStackRoutes,
 } from '@suite-native/navigation';
 
-type NavigationProp = StackToTabCompositeProps<ParamListBase, string, ParamListBase>;
-
 export const useWipeDevice = () => {
     const dispatch = useDispatch();
-    const navigation = useNavigation<NavigationProp>();
+    const navigation = useNavigation();
     const device = useSelector(selectSelectedDevice);
 
-    const wipeDevice = useCallback(async () => {
+    const wipeDevice = async () => {
         if (!device) return;
         dispatch(setIsWipingDevice(true));
-        navigation.navigate(DeviceSettingsStackRoutes.WipeDeviceStack, {
-            screen: WipeDeviceStackRoutes.ContinueOnTrezor,
+        navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
+            screen: DeviceSettingsStackRoutes.WipeDeviceStack,
+            params: {
+                screen: WipeDeviceStackRoutes.ContinueOnTrezor,
+            },
         });
 
         const response = await requestPrioritizedDeviceAccess({
@@ -32,15 +32,18 @@ export const useWipeDevice = () => {
         });
 
         if (response.success && isFulfilled(response.payload)) {
-            navigation.navigate(DeviceSettingsStackRoutes.WipeDeviceStack, {
-                screen: WipeDeviceStackRoutes.WipeDeviceLoadingScreen,
+            navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
+                screen: DeviceSettingsStackRoutes.WipeDeviceStack,
+                params: {
+                    screen: WipeDeviceStackRoutes.WipeDeviceLoadingScreen,
+                },
             });
         } else {
             if (navigation.canGoBack()) {
                 navigation.goBack();
             }
         }
-    }, [device, navigation, dispatch]);
+    };
 
     return { wipeDevice };
 };

--- a/suite-native/device/src/hooks/useWipeDevice.tsx
+++ b/suite-native/device/src/hooks/useWipeDevice.tsx
@@ -2,9 +2,9 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 import { isFulfilled } from '@reduxjs/toolkit';
+import { useSetAtom } from 'jotai';
 
 import { selectSelectedDevice, wipeDeviceThunk } from '@suite-common/wallet-core';
-import { setIsWipingDevice } from '@suite-native/device-authorization';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import {
     DeviceSettingsStackRoutes,
@@ -12,14 +12,22 @@ import {
     WipeDeviceStackRoutes,
 } from '@suite-native/navigation';
 
+import { wasDeviceOnboardingCancelledAtom } from '../deviceAtoms';
+
 export const useWipeDevice = () => {
     const dispatch = useDispatch();
     const navigation = useNavigation();
     const device = useSelector(selectSelectedDevice);
+    const setWasDeviceOnboardingCancelled = useSetAtom(wasDeviceOnboardingCancelledAtom);
 
     const wipeDevice = async () => {
         if (!device) return;
-        dispatch(setIsWipingDevice(true));
+
+        // After wipe, device gets changed and reconnected. That would trigger redirect to device onboarding which is
+        // not wanted here. We want to treat it differently since it was wiped so user goes to onboarding through homescreen.
+        setWasDeviceOnboardingCancelled(true);
+
+        // @ts-expect-error
         navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
             screen: DeviceSettingsStackRoutes.WipeDeviceStack,
             params: {
@@ -32,6 +40,7 @@ export const useWipeDevice = () => {
         });
 
         if (response.success && isFulfilled(response.payload)) {
+            // @ts-expect-error
             navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
                 screen: DeviceSettingsStackRoutes.WipeDeviceStack,
                 params: {

--- a/suite-native/device/src/hooks/useWipeDevice.tsx
+++ b/suite-native/device/src/hooks/useWipeDevice.tsx
@@ -1,47 +1,47 @@
-import { useCallback, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
+import { isFulfilled } from '@reduxjs/toolkit';
 
-import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice, wipeDeviceThunk } from '@suite-common/wallet-core';
+import { setIsWipingDevice } from '@suite-native/device-authorization';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import {
-    DeviceOnboardingStackRoutes,
     RootStackParamList,
-    RootStackRoutes,
-    StackNavigationProps,
+    StackToStackCompositeNavigationProps,
+    WipeDeviceStackParamList,
+    WipeDeviceStackRoutes,
 } from '@suite-native/navigation';
-import TrezorConnect from '@trezor/connect';
 
-type NavigationProp = StackNavigationProps<RootStackParamList, RootStackRoutes.BackupFailedModal>;
+type NavigationProp = StackToStackCompositeNavigationProps<
+    WipeDeviceStackParamList,
+    WipeDeviceStackRoutes.ContinueOnTrezor,
+    RootStackParamList
+>;
 
 export const useWipeDevice = () => {
-    const [isWipeInProgress, setIsWipeInProgress] = useState(false);
+    const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProp>();
     const device = useSelector(selectSelectedDevice);
 
     const wipeDevice = useCallback(async () => {
-        setIsWipeInProgress(true);
         if (!device) return;
+        dispatch(setIsWipingDevice(true));
+        navigation.navigate(WipeDeviceStackRoutes.ContinueOnTrezor);
 
         const response = await requestPrioritizedDeviceAccess({
-            deviceCallback: async () =>
-                await TrezorConnect.wipeDevice({
-                    device: {
-                        path: device.path,
-                    },
-                    // In bootloader mode we need the skip the final reload otherwise we never get the resolution
-                    skipFinalReload: device.mode === 'bootloader',
-                }),
+            deviceCallback: async () => await dispatch(wipeDeviceThunk()),
         });
 
-        if (response.success && response.payload.success) {
-            navigation.navigate(RootStackRoutes.DeviceOnboardingStack, {
-                screen: DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
-            });
+        if (response.success && isFulfilled(response.payload)) {
+            navigation.navigate(WipeDeviceStackRoutes.WipeDeviceLoadingScreen);
+        } else {
+            if (navigation.canGoBack()) {
+                navigation.goBack();
+            }
         }
-        setIsWipeInProgress(false);
-    }, [device, navigation]);
+    }, [device, navigation, dispatch]);
 
-    return { wipeDevice, isWipeInProgress };
+    return { wipeDevice };
 };

--- a/suite-native/device/src/hooks/useWipeDevice.tsx
+++ b/suite-native/device/src/hooks/useWipeDevice.tsx
@@ -1,22 +1,34 @@
 import { useDispatch, useSelector } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/native';
+import { CompositeNavigationProp, useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { isFulfilled } from '@reduxjs/toolkit';
 import { useSetAtom } from 'jotai';
 
 import { selectSelectedDevice, wipeDeviceThunk } from '@suite-common/wallet-core';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import {
+    DeviceSettingsStackParamList,
     DeviceSettingsStackRoutes,
+    RootStackParamList,
     RootStackRoutes,
+    WipeDeviceStackParamList,
     WipeDeviceStackRoutes,
 } from '@suite-native/navigation';
 
 import { wasDeviceOnboardingCancelledAtom } from '../deviceAtoms';
 
+type NavigationProps = CompositeNavigationProp<
+    NativeStackNavigationProp<WipeDeviceStackParamList, WipeDeviceStackRoutes.WipeDevice>,
+    CompositeNavigationProp<
+        NativeStackNavigationProp<DeviceSettingsStackParamList>,
+        NativeStackNavigationProp<RootStackParamList>
+    >
+>;
+
 export const useWipeDevice = () => {
     const dispatch = useDispatch();
-    const navigation = useNavigation();
+    const navigation = useNavigation<NavigationProps>();
     const device = useSelector(selectSelectedDevice);
     const setWasDeviceOnboardingCancelled = useSetAtom(wasDeviceOnboardingCancelledAtom);
 
@@ -27,11 +39,10 @@ export const useWipeDevice = () => {
         // not wanted here. We want to treat it differently since it was wiped so user goes to onboarding through homescreen.
         setWasDeviceOnboardingCancelled(true);
 
-        // @ts-expect-error
         navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
             screen: DeviceSettingsStackRoutes.WipeDeviceStack,
             params: {
-                screen: WipeDeviceStackRoutes.ContinueOnTrezor,
+                screen: WipeDeviceStackRoutes.WipeDevice,
             },
         });
 
@@ -40,7 +51,6 @@ export const useWipeDevice = () => {
         });
 
         if (response.success && isFulfilled(response.payload)) {
-            // @ts-expect-error
             navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
                 screen: DeviceSettingsStackRoutes.WipeDeviceStack,
                 params: {

--- a/suite-native/device/src/hooks/useWipeDevice.tsx
+++ b/suite-native/device/src/hooks/useWipeDevice.tsx
@@ -42,7 +42,7 @@ export const useWipeDevice = () => {
         navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
             screen: DeviceSettingsStackRoutes.WipeDeviceStack,
             params: {
-                screen: WipeDeviceStackRoutes.WipeDevice,
+                screen: WipeDeviceStackRoutes.ContinueOnTrezor,
             },
         });
 

--- a/suite-native/device/src/hooks/useWipeDevice.tsx
+++ b/suite-native/device/src/hooks/useWipeDevice.tsx
@@ -1,24 +1,19 @@
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/native';
+import { ParamListBase, useNavigation } from '@react-navigation/native';
 import { isFulfilled } from '@reduxjs/toolkit';
 
 import { selectSelectedDevice, wipeDeviceThunk } from '@suite-common/wallet-core';
 import { setIsWipingDevice } from '@suite-native/device-authorization';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import {
-    RootStackParamList,
-    StackToStackCompositeNavigationProps,
-    WipeDeviceStackParamList,
+    DeviceSettingsStackRoutes,
+    StackToTabCompositeProps,
     WipeDeviceStackRoutes,
 } from '@suite-native/navigation';
 
-type NavigationProp = StackToStackCompositeNavigationProps<
-    WipeDeviceStackParamList,
-    WipeDeviceStackRoutes.ContinueOnTrezor,
-    RootStackParamList
->;
+type NavigationProp = StackToTabCompositeProps<ParamListBase, string, ParamListBase>;
 
 export const useWipeDevice = () => {
     const dispatch = useDispatch();
@@ -28,14 +23,18 @@ export const useWipeDevice = () => {
     const wipeDevice = useCallback(async () => {
         if (!device) return;
         dispatch(setIsWipingDevice(true));
-        navigation.navigate(WipeDeviceStackRoutes.ContinueOnTrezor);
+        navigation.navigate(DeviceSettingsStackRoutes.WipeDeviceStack, {
+            screen: WipeDeviceStackRoutes.ContinueOnTrezor,
+        });
 
         const response = await requestPrioritizedDeviceAccess({
             deviceCallback: async () => await dispatch(wipeDeviceThunk()),
         });
 
         if (response.success && isFulfilled(response.payload)) {
-            navigation.navigate(WipeDeviceStackRoutes.WipeDeviceLoadingScreen);
+            navigation.navigate(DeviceSettingsStackRoutes.WipeDeviceStack, {
+                screen: WipeDeviceStackRoutes.WipeDeviceLoadingScreen,
+            });
         } else {
             if (navigation.canGoBack()) {
                 navigation.goBack();

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -15,7 +15,6 @@ import {
     selectIsDeviceForceRemembered,
 } from '@suite-common/wallet-core';
 import { EventType, analytics } from '@suite-native/analytics';
-import { setIsWipingDevice } from '@suite-native/device-authorization';
 import { clearAndUnlockDeviceAccessQueue } from '@suite-native/device-mutex';
 import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-flags';
 import { DEVICE } from '@trezor/connect';
@@ -82,11 +81,6 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
         switch (action.type) {
             case DEVICE.CONNECT:
             case DEVICE.CONNECT_UNACQUIRED: {
-                // When device is wiped, we set isWipingDevice to true to avoid navigating to device onboarding.
-                // This is a UX edge case which requires a special handling.
-                // That flag is reset on app restart or when new device is connected.
-                dispatch(setIsWipingDevice(false));
-
                 if (isUsbDeviceConnectFeatureEnabled) {
                     dispatch(selectDeviceThunk(action.payload));
                 }

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -15,6 +15,7 @@ import {
     selectIsDeviceForceRemembered,
 } from '@suite-common/wallet-core';
 import { EventType, analytics } from '@suite-native/analytics';
+import { setIsWipingDevice } from '@suite-native/device-authorization';
 import { clearAndUnlockDeviceAccessQueue } from '@suite-native/device-mutex';
 import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-flags';
 import { DEVICE } from '@trezor/connect';
@@ -81,6 +82,11 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
         switch (action.type) {
             case DEVICE.CONNECT:
             case DEVICE.CONNECT_UNACQUIRED: {
+                // When device is wiped, we set isWipingDevice to true to avoid navigating to device onboarding.
+                // This is a UX edge case which requires a special handling.
+                // That flag is reset on app restart or when new device is connected.
+                dispatch(setIsWipingDevice(false));
+
                 if (isUsbDeviceConnectFeatureEnabled) {
                     dispatch(selectDeviceThunk(action.payload));
                 }

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -569,6 +569,9 @@ export const en = {
                         'Make sure you have your wallet backup. You won’t be able to recover access to your assets without it.',
                 },
             },
+            loadingSuccessScreen: {
+                title: 'Device wiped',
+            },
         },
         bluetooth: {
             title: 'Bluetooth',

--- a/suite-native/module-device-onboarding/src/screens/BackupFailedModalScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/BackupFailedModalScreen.tsx
@@ -1,39 +1,21 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 
 import { useAlert } from '@suite-native/alerts';
 import { Button, IconListTextItem, TitleHeader, VStack } from '@suite-native/atoms';
-import { ContinueOnTrezorScreenContent, useWipeDevice } from '@suite-native/device';
+import { useWipeDevice } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
-import {
-    RootStackParamList,
-    RootStackRoutes,
-    Screen,
-    ScreenHeader,
-    StackProps,
-} from '@suite-native/navigation';
+import { Screen, ScreenHeader } from '@suite-native/navigation';
 
 export const BACKUP_FAILED_SUPPORT_URL =
     'https://trezor.io/support/a/trezor-recovery-issues#open-chat';
 
-export const BackupFailedModalScreen = ({
-    navigation,
-}: StackProps<RootStackParamList, RootStackRoutes.BackupFailedModal>) => {
+export const BackupFailedModalScreen = () => {
     const openLink = useOpenLink();
     const { showAlert } = useAlert();
-    const { isWipeInProgress, wipeDevice } = useWipeDevice();
+    const { wipeDevice } = useWipeDevice();
 
     const handleSecondaryButtonPress = () => openLink(BACKUP_FAILED_SUPPORT_URL);
-
-    useEffect(() => {
-        const unsubscribe = navigation.addListener('beforeRemove', e => {
-            if (isWipeInProgress && e.data.action.type === 'GO_BACK') {
-                e.preventDefault();
-            }
-        });
-
-        return unsubscribe;
-    }, [navigation, isWipeInProgress]);
 
     const showWipeDeviceAlert = useCallback(
         () =>
@@ -57,14 +39,6 @@ export const BackupFailedModalScreen = ({
             }),
         [showAlert, openLink, wipeDevice],
     );
-
-    if (isWipeInProgress) {
-        return (
-            <Screen header={<ScreenHeader leftIcon={null} />}>
-                <ContinueOnTrezorScreenContent />
-            </Screen>
-        );
-    }
 
     return (
         <Screen header={<ScreenHeader />}>

--- a/suite-native/module-device-onboarding/src/screens/WalletCreatedSuccessScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletCreatedSuccessScreen.tsx
@@ -1,16 +1,14 @@
-import { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import { useSharedValue, withTiming } from 'react-native-reanimated';
 
-import { AnimatedText, Box, Spinner, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceOnboardingStackParamList,
     DeviceOnboardingStackRoutes,
-    Screen,
+    LoadingSuccessScreen,
     StackProps,
 } from '@suite-native/navigation';
 
 const NAVIGATION_TIMEOUT = 3000;
-const ANIMATION_END_FRAME = 305;
 
 export const WalletCreatedSuccessScreen = ({
     navigation,
@@ -22,7 +20,7 @@ export const WalletCreatedSuccessScreen = ({
     const { flowType } = route.params;
     const textOpacity = useSharedValue(0);
 
-    const handleAnimationEnd = () => {
+    const handleFinish = () => {
         textOpacity.value = withTiming(1);
         setTimeout(() => {
             if (flowType === 'create') {
@@ -33,25 +31,12 @@ export const WalletCreatedSuccessScreen = ({
         }, NAVIGATION_TIMEOUT);
     };
 
-    const textStyle = useAnimatedStyle(() => ({
-        opacity: textOpacity.value,
-    }));
-
     return (
-        <Screen isScrollable={false}>
-            <Box justifyContent="center" alignItems="center" flex={1}>
-                <VStack alignItems="center" spacing="sp20">
-                    <Spinner
-                        loadingState="success"
-                        onComplete={handleAnimationEnd}
-                        endFrame={ANIMATION_END_FRAME}
-                        size={80}
-                    />
-                    <AnimatedText style={textStyle} variant="titleSmall">
-                        <Translation id="moduleDeviceOnboarding.walletCreatedSuccessScreen.successLabel" />
-                    </AnimatedText>
-                </VStack>
-            </Box>
-        </Screen>
+        <LoadingSuccessScreen
+            onFinish={handleFinish}
+            title={
+                <Translation id="moduleDeviceOnboarding.walletCreatedSuccessScreen.successLabel" />
+            }
+        />
     );
 };

--- a/suite-native/module-device-settings/package.json
+++ b/suite-native/module-device-settings/package.json
@@ -26,6 +26,7 @@
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/styles": "workspace:*",
+        "jotai": "1.9.1",
         "react": "18.2.0",
         "react-native": "0.76.9",
         "react-redux": "9.2.0"

--- a/suite-native/module-device-settings/package.json
+++ b/suite-native/module-device-settings/package.json
@@ -26,7 +26,6 @@
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/styles": "workspace:*",
-        "jotai": "1.9.1",
         "react": "18.2.0",
         "react-native": "0.76.9",
         "react-redux": "9.2.0"

--- a/suite-native/module-device-settings/src/components/DeviceAuthenticityCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceAuthenticityCard.tsx
@@ -11,7 +11,7 @@ import {
     DeviceAuthenticityStackParamList,
     DeviceAuthenticityStackRoutes,
     DeviceSettingsStackParamList,
-    DeviceStackRoutes,
+    DeviceSettingsStackRoutes,
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
 
@@ -28,7 +28,7 @@ export const DeviceAuthenticityCard = () => {
     const { showAlert } = useAlert();
 
     const navigateToDeviceAuthenticityStack = useCallback(() => {
-        navigation.navigate(DeviceStackRoutes.DeviceAuthenticityStack);
+        navigation.navigate(DeviceSettingsStackRoutes.DeviceAuthenticityStack);
     }, [navigation]);
 
     const showInfoAlert = useCallback(() => {

--- a/suite-native/module-device-settings/src/components/DeviceBluetoothCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceBluetoothCard.tsx
@@ -6,14 +6,14 @@ import { useBluetoothDevice, useBluetoothSettings } from '@suite-native/bluetoot
 import { Translation } from '@suite-native/intl';
 import {
     DeviceSettingsStackParamList,
-    DeviceStackRoutes,
+    DeviceSettingsStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
 import { useToast } from '@suite-native/toasts';
 
 type NavigationProp = StackNavigationProps<
     DeviceSettingsStackParamList,
-    DeviceStackRoutes.DeviceSettings
+    DeviceSettingsStackRoutes.DeviceSettings
 >;
 
 export const DeviceBluetoothCard = () => {
@@ -25,7 +25,7 @@ export const DeviceBluetoothCard = () => {
     const { openBluetoothSettings } = useBluetoothSettings();
 
     const unpairTrezor = async () => {
-        navigation.navigate(DeviceStackRoutes.ContinueOnTrezor);
+        navigation.navigate(DeviceSettingsStackRoutes.ContinueOnTrezor);
         await unpairBluetoothDevice({
             onSuccess: () => {
                 showToast({

--- a/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
@@ -18,7 +18,7 @@ import { deviceModelToIconName } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceSettingsStackParamList,
-    DeviceStackRoutes,
+    DeviceSettingsStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
 import { getFirmwareVersion, hasBitcoinOnlyFirmware } from '@trezor/device-utils';
@@ -48,7 +48,7 @@ const FirmwareInfo = ({ label, value }: DeviceInfoProps) => {
 
 type NavigationProp = StackNavigationProps<
     DeviceSettingsStackParamList,
-    DeviceStackRoutes.ConfirmFirmwareUpdate
+    DeviceSettingsStackRoutes.ConfirmFirmwareUpdate
 >;
 
 export const DeviceFirmwareCard = () => {
@@ -89,7 +89,7 @@ export const DeviceFirmwareCard = () => {
                     variant: 'info',
                     buttonLabel: <Translation id="firmware.updateCard.updateButton" />,
                     onButtonPress: () => {
-                        navigation.navigate(DeviceStackRoutes.ConfirmFirmwareUpdate);
+                        navigation.navigate(DeviceSettingsStackRoutes.ConfirmFirmwareUpdate);
                     },
                     buttonProps: {
                         isDisabled: isDiscoveryRunning,

--- a/suite-native/module-device-settings/src/components/DevicePinActionButton.tsx
+++ b/suite-native/module-device-settings/src/components/DevicePinActionButton.tsx
@@ -7,14 +7,14 @@ import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Button, ButtonColorScheme } from '@suite-native/atoms';
 import {
     DeviceSettingsStackParamList,
-    DeviceStackRoutes,
+    DeviceSettingsStackRoutes,
     PinActionType,
     StackNavigationProps,
 } from '@suite-native/navigation';
 
 type NavigationProp = StackNavigationProps<
     DeviceSettingsStackParamList,
-    DeviceStackRoutes.DevicePinProtectionStack
+    DeviceSettingsStackRoutes.DevicePinProtectionStack
 >;
 
 type DevicePinActionButtonProps = {
@@ -33,7 +33,7 @@ export const DevicePinActionButton = ({
     const navigation = useNavigation<NavigationProp>();
 
     const navigateToPinStack = useCallback(() => {
-        navigation.navigate(DeviceStackRoutes.DevicePinProtectionStack, {
+        navigation.navigate(DeviceSettingsStackRoutes.DevicePinProtectionStack, {
             type,
         });
     }, [navigation, type]);

--- a/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
+++ b/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
@@ -9,6 +9,7 @@ import {
     DeviceSettingsStackParamList,
     DeviceSettingsStackRoutes,
     StackNavigationProps,
+    WipeDeviceStackRoutes,
 } from '@suite-native/navigation';
 
 type NavigationProp = StackNavigationProps<
@@ -21,7 +22,9 @@ export const WipeDeviceCard = () => {
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     const handleRedirect = () => {
-        navigation.navigate(DeviceSettingsStackRoutes.WipeDeviceStack);
+        navigation.navigate(DeviceSettingsStackRoutes.WipeDeviceStack, {
+            screen: WipeDeviceStackRoutes.WipeDevice,
+        });
     };
 
     return (

--- a/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
+++ b/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
@@ -4,23 +4,20 @@ import { Box, Button, CardWithIconLayout, Text, VStack } from '@suite-native/ato
 import { Translation } from '@suite-native/intl';
 import {
     DeviceSettingsStackParamList,
-    DeviceStackRoutes,
-    StackToStackCompositeNavigationProps,
-    WipeDeviceStackParamList,
-    WipeDeviceStackRoutes,
+    DeviceSettingsStackRoutes,
+    StackNavigationProps,
 } from '@suite-native/navigation';
 
-type NavigationProp = StackToStackCompositeNavigationProps<
-    WipeDeviceStackParamList,
-    WipeDeviceStackRoutes,
-    DeviceSettingsStackParamList
+type NavigationProp = StackNavigationProps<
+    DeviceSettingsStackParamList,
+    DeviceSettingsStackRoutes.DeviceSettings
 >;
 
 export const WipeDeviceCard = () => {
     const navigation = useNavigation<NavigationProp>();
 
     const handleRedirect = () => {
-        navigation.navigate(DeviceStackRoutes.WipeDeviceStack);
+        navigation.navigate(DeviceSettingsStackRoutes.WipeDeviceStack);
     };
 
     return (

--- a/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
+++ b/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
@@ -1,5 +1,8 @@
+import { useSelector } from 'react-redux';
+
 import { useNavigation } from '@react-navigation/native';
 
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Box, Button, CardWithIconLayout, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -15,6 +18,7 @@ type NavigationProp = StackNavigationProps<
 
 export const WipeDeviceCard = () => {
     const navigation = useNavigation<NavigationProp>();
+    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     const handleRedirect = () => {
         navigation.navigate(DeviceSettingsStackRoutes.WipeDeviceStack);
@@ -30,7 +34,13 @@ export const WipeDeviceCard = () => {
                     <Translation id="moduleDeviceSettings.wipeDevice.content" />
                 </Text>
                 <Box flex={1}>
-                    <Button size="small" colorScheme="redBold" onPress={handleRedirect}>
+                    <Button
+                        size="small"
+                        colorScheme="redBold"
+                        onPress={handleRedirect}
+                        isDisabled={isDiscoveryRunning}
+                        isLoading={isDiscoveryRunning}
+                    >
                         <Translation id="moduleDeviceSettings.wipeDevice.buttonTitle" />
                     </Button>
                 </Box>

--- a/suite-native/module-device-settings/src/hooks/useDeviceChangedCheck.ts
+++ b/suite-native/module-device-settings/src/hooks/useDeviceChangedCheck.ts
@@ -4,25 +4,29 @@ import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
 import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { selectIsWipingDevice } from '@suite-native/device-authorization';
 import {
     AppTabsRoutes,
-    DeviceStackRoutes,
+    DeviceSettingsStackParamList,
+    DeviceSettingsStackRoutes,
     HomeStackRoutes,
     RootStackParamList,
     RootStackRoutes,
-    SettingsStackParamList,
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
 import TrezorConnect from '@trezor/connect';
 
 type NavigationProps = StackToStackCompositeNavigationProps<
-    SettingsStackParamList,
-    DeviceStackRoutes.DeviceSettings,
+    DeviceSettingsStackParamList,
+    DeviceSettingsStackRoutes.DeviceSettings,
     RootStackParamList
 >;
 
+// When user accesses device settings in remember mode and tries to modify the device,
+// he will be prompted to connect Trezor. This hook prevents usage of incorrect device.
 export const useDeviceChangedCheck = () => {
     const device = useSelector(selectSelectedDevice);
+    const isWipingDevice = useSelector(selectIsWipingDevice);
     const navigation = useNavigation<NavigationProps>();
     const initialDeviceIdRef = useRef<string | null>(null);
 
@@ -34,8 +38,13 @@ export const useDeviceChangedCheck = () => {
             return;
         }
 
-        // Check for device mismatch only after initial device ID is set
-        if (initialDeviceIdRef.current && device?.id && initialDeviceIdRef.current !== device.id) {
+        // When device is wiped, the device ID changes and we shouldn't trigger this.
+        if (
+            initialDeviceIdRef.current &&
+            device?.id &&
+            initialDeviceIdRef.current !== device.id &&
+            !isWipingDevice
+        ) {
             TrezorConnect.cancel();
             navigation.navigate(RootStackRoutes.AppTabs, {
                 screen: AppTabsRoutes.HomeStack,
@@ -44,5 +53,5 @@ export const useDeviceChangedCheck = () => {
                 },
             });
         }
-    }, [device?.id, navigation]);
+    }, [device?.id, navigation, isWipingDevice]);
 };

--- a/suite-native/module-device-settings/src/hooks/useDeviceChangedCheck.ts
+++ b/suite-native/module-device-settings/src/hooks/useDeviceChangedCheck.ts
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
 import { selectSelectedDevice } from '@suite-common/wallet-core';
-import { selectIsWipingDevice } from '@suite-native/device-authorization';
 import {
     AppTabsRoutes,
     DeviceSettingsStackParamList,
@@ -26,14 +25,15 @@ type NavigationProps = StackToStackCompositeNavigationProps<
 // he will be prompted to connect Trezor. This hook prevents usage of incorrect device.
 export const useDeviceChangedCheck = () => {
     const device = useSelector(selectSelectedDevice);
-    const isWipingDevice = useSelector(selectIsWipingDevice);
     const navigation = useNavigation<NavigationProps>();
     const initialDeviceIdRef = useRef<string | null>(null);
+    const hasDeviceBeenConnected = useRef<boolean>(false);
 
     useEffect(() => {
         // Store the initial device ID when the component mounts
         if (initialDeviceIdRef.current === null && device?.id) {
             initialDeviceIdRef.current = device.id;
+            hasDeviceBeenConnected.current = device.connected;
 
             return;
         }
@@ -43,7 +43,8 @@ export const useDeviceChangedCheck = () => {
             initialDeviceIdRef.current &&
             device?.id &&
             initialDeviceIdRef.current !== device.id &&
-            !isWipingDevice
+            !hasDeviceBeenConnected.current &&
+            !device.connected
         ) {
             TrezorConnect.cancel();
             navigation.navigate(RootStackRoutes.AppTabs, {
@@ -53,5 +54,5 @@ export const useDeviceChangedCheck = () => {
                 },
             });
         }
-    }, [device?.id, navigation, isWipingDevice]);
+    }, [device?.id, navigation, device?.connected]);
 };

--- a/suite-native/module-device-settings/src/hooks/useDeviceChangedCheck.ts
+++ b/suite-native/module-device-settings/src/hooks/useDeviceChangedCheck.ts
@@ -27,6 +27,8 @@ export const useDeviceChangedCheck = () => {
     const device = useSelector(selectSelectedDevice);
     const navigation = useNavigation<NavigationProps>();
     const initialDeviceIdRef = useRef<string | null>(null);
+    // Important for device wipe. Device ID changes for wiped device, but if it was connected,
+    // we know the device was wiped, thus we want to prevent the navigation call.
     const hasDeviceBeenConnected = useRef<boolean>(false);
 
     useEffect(() => {
@@ -38,13 +40,12 @@ export const useDeviceChangedCheck = () => {
             return;
         }
 
-        // When device is wiped, the device ID changes and we shouldn't trigger this.
         if (
             initialDeviceIdRef.current &&
             device?.id &&
             initialDeviceIdRef.current !== device.id &&
             !hasDeviceBeenConnected.current &&
-            !device.connected
+            device.connected
         ) {
             TrezorConnect.cancel();
             navigation.navigate(RootStackRoutes.AppTabs, {

--- a/suite-native/module-device-settings/src/hooks/useDeviceConnectionGuard.ts
+++ b/suite-native/module-device-settings/src/hooks/useDeviceConnectionGuard.ts
@@ -6,7 +6,7 @@ import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { selectIsDeviceConnected } from '@suite-common/wallet-core';
 import {
     AuthorizeDeviceStackRoutes,
-    DeviceStackRoutes,
+    DeviceSettingsStackRoutes,
     RootStackParamList,
     RootStackRoutes,
     SettingsStackParamList,
@@ -15,7 +15,7 @@ import {
 
 type NavigationProps = StackToStackCompositeNavigationProps<
     SettingsStackParamList,
-    DeviceStackRoutes.DeviceSettings,
+    DeviceSettingsStackRoutes.DeviceSettings,
     RootStackParamList
 >;
 
@@ -30,7 +30,7 @@ export const useDeviceConnectionGuard = () => {
             params: {
                 onCancelNavigationTarget: {
                     name: RootStackRoutes.DeviceSettingsStack,
-                    params: { screen: DeviceStackRoutes.DeviceSettings },
+                    params: { screen: DeviceSettingsStackRoutes.DeviceSettings },
                 },
             },
         });

--- a/suite-native/module-device-settings/src/navigation/DevicePinProtectionStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/DevicePinProtectionStackNavigator.tsx
@@ -10,7 +10,7 @@ import {
     DevicePinProtectionStackParamList,
     DevicePinProtectionStackRoutes,
     DeviceSettingsStackParamList,
-    DeviceStackRoutes,
+    DeviceSettingsStackRoutes,
     StackNavigationProps,
     stackNavigationOptionsConfig,
 } from '@suite-native/navigation';
@@ -27,7 +27,7 @@ const DevicePinProtectionStack = createNativeStackNavigator<DevicePinProtectionS
 
 type NavigationProp = StackNavigationProps<
     DeviceSettingsStackParamList,
-    DeviceStackRoutes.DevicePinProtectionStack
+    DeviceSettingsStackRoutes.DevicePinProtectionStack
 >;
 
 export const DevicePinProtectionStackNavigator = () => {
@@ -35,7 +35,10 @@ export const DevicePinProtectionStackNavigator = () => {
 
     const route =
         useRoute<
-            RouteProp<DeviceSettingsStackParamList, DeviceStackRoutes.DevicePinProtectionStack>
+            RouteProp<
+                DeviceSettingsStackParamList,
+                DeviceSettingsStackRoutes.DevicePinProtectionStack
+            >
         >();
 
     const { type } = route.params;

--- a/suite-native/module-device-settings/src/navigation/DeviceSettingsStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/DeviceSettingsStackNavigator.tsx
@@ -2,7 +2,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import {
     DeviceSettingsStackParamList,
-    DeviceStackRoutes,
+    DeviceSettingsStackRoutes,
     stackNavigationOptionsConfig,
 } from '@suite-native/navigation';
 
@@ -17,35 +17,35 @@ const DeviceSettingsStack = createNativeStackNavigator<DeviceSettingsStackParamL
 
 export const DeviceSettingsStackNavigator = () => (
     <DeviceSettingsStack.Navigator
-        initialRouteName={DeviceStackRoutes.DeviceSettings}
+        initialRouteName={DeviceSettingsStackRoutes.DeviceSettings}
         screenOptions={{ ...stackNavigationOptionsConfig, animation: 'slide_from_bottom' }}
     >
         <DeviceSettingsStack.Screen
-            name={DeviceStackRoutes.DeviceSettings}
+            name={DeviceSettingsStackRoutes.DeviceSettings}
             component={DeviceSettingsModalScreen}
         />
         <DeviceSettingsStack.Screen
-            name={DeviceStackRoutes.DevicePinProtectionStack}
+            name={DeviceSettingsStackRoutes.DevicePinProtectionStack}
             component={DevicePinProtectionStackNavigator}
         />
         <DeviceSettingsStack.Screen
-            name={DeviceStackRoutes.DeviceAuthenticityStack}
+            name={DeviceSettingsStackRoutes.DeviceAuthenticityStack}
             component={DeviceAuthenticityStackNavigator}
         />
         <DeviceSettingsStack.Screen
-            name={DeviceStackRoutes.WipeDeviceStack}
+            name={DeviceSettingsStackRoutes.WipeDeviceStack}
             component={WipeDeviceStackNavigator}
         />
         <DeviceSettingsStack.Screen
-            name={DeviceStackRoutes.ConfirmFirmwareUpdate}
+            name={DeviceSettingsStackRoutes.ConfirmFirmwareUpdate}
             component={ConfirmFirmwareUpdateScreen}
         />
         <DeviceSettingsStack.Screen
-            name={DeviceStackRoutes.ContinueOnTrezor}
+            name={DeviceSettingsStackRoutes.ContinueOnTrezor}
             component={ContinueOnTrezorScreen}
         />
         <DeviceSettingsStack.Screen
-            name={DeviceStackRoutes.FirmwareInstallation}
+            name={DeviceSettingsStackRoutes.FirmwareInstallation}
             component={FirmwareInstallationScreen}
         />
     </DeviceSettingsStack.Navigator>

--- a/suite-native/module-device-settings/src/navigation/WipeDeviceStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/WipeDeviceStackNavigator.tsx
@@ -6,6 +6,8 @@ import {
     stackNavigationOptionsConfig,
 } from '@suite-native/navigation';
 
+import { WipeDeviceContinueOnTrezorScreen } from '../screens/WipeDeviceContinueOnTrezorScreen';
+import { WipeDeviceLoadingScreen } from '../screens/WipeDeviceLoadingScreen';
 import { WipeDeviceScreen } from '../screens/WipeDeviceScreen';
 
 const WipeDeviceStack = createNativeStackNavigator<WipeDeviceStackParamList>();
@@ -18,6 +20,14 @@ export const WipeDeviceStackNavigator = () => (
         <WipeDeviceStack.Screen
             name={WipeDeviceStackRoutes.WipeDevice}
             component={WipeDeviceScreen}
+        />
+        <WipeDeviceStack.Screen
+            name={WipeDeviceStackRoutes.ContinueOnTrezor}
+            component={WipeDeviceContinueOnTrezorScreen}
+        />
+        <WipeDeviceStack.Screen
+            name={WipeDeviceStackRoutes.WipeDeviceLoadingScreen}
+            component={WipeDeviceLoadingScreen}
         />
     </WipeDeviceStack.Navigator>
 );

--- a/suite-native/module-device-settings/src/navigation/WipeDeviceStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/WipeDeviceStackNavigator.tsx
@@ -1,5 +1,8 @@
+import { useSelector } from 'react-redux';
+
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
+import { selectIsDeviceConnected } from '@suite-common/wallet-core';
 import {
     WipeDeviceStackParamList,
     WipeDeviceStackRoutes,
@@ -14,7 +17,11 @@ import { WipeDeviceScreen } from '../screens/WipeDeviceScreen';
 const WipeDeviceStack = createNativeStackNavigator<WipeDeviceStackParamList>();
 
 export const WipeDeviceStackNavigator = () => {
+    const isDeviceConnected = useSelector(selectIsDeviceConnected);
+
     useDeviceConnectionGuard();
+
+    if (!isDeviceConnected) return;
 
     return (
         <WipeDeviceStack.Navigator

--- a/suite-native/module-device-settings/src/navigation/WipeDeviceStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/WipeDeviceStackNavigator.tsx
@@ -6,28 +6,33 @@ import {
     stackNavigationOptionsConfig,
 } from '@suite-native/navigation';
 
+import { useDeviceConnectionGuard } from '../hooks/useDeviceConnectionGuard';
 import { WipeDeviceContinueOnTrezorScreen } from '../screens/WipeDeviceContinueOnTrezorScreen';
 import { WipeDeviceLoadingScreen } from '../screens/WipeDeviceLoadingScreen';
 import { WipeDeviceScreen } from '../screens/WipeDeviceScreen';
 
 const WipeDeviceStack = createNativeStackNavigator<WipeDeviceStackParamList>();
 
-export const WipeDeviceStackNavigator = () => (
-    <WipeDeviceStack.Navigator
-        initialRouteName={WipeDeviceStackRoutes.WipeDevice}
-        screenOptions={stackNavigationOptionsConfig}
-    >
-        <WipeDeviceStack.Screen
-            name={WipeDeviceStackRoutes.WipeDevice}
-            component={WipeDeviceScreen}
-        />
-        <WipeDeviceStack.Screen
-            name={WipeDeviceStackRoutes.ContinueOnTrezor}
-            component={WipeDeviceContinueOnTrezorScreen}
-        />
-        <WipeDeviceStack.Screen
-            name={WipeDeviceStackRoutes.WipeDeviceLoadingScreen}
-            component={WipeDeviceLoadingScreen}
-        />
-    </WipeDeviceStack.Navigator>
-);
+export const WipeDeviceStackNavigator = () => {
+    useDeviceConnectionGuard();
+
+    return (
+        <WipeDeviceStack.Navigator
+            initialRouteName={WipeDeviceStackRoutes.WipeDevice}
+            screenOptions={stackNavigationOptionsConfig}
+        >
+            <WipeDeviceStack.Screen
+                name={WipeDeviceStackRoutes.WipeDevice}
+                component={WipeDeviceScreen}
+            />
+            <WipeDeviceStack.Screen
+                name={WipeDeviceStackRoutes.ContinueOnTrezor}
+                component={WipeDeviceContinueOnTrezorScreen}
+            />
+            <WipeDeviceStack.Screen
+                name={WipeDeviceStackRoutes.WipeDeviceLoadingScreen}
+                component={WipeDeviceLoadingScreen}
+            />
+        </WipeDeviceStack.Navigator>
+    );
+};

--- a/suite-native/module-device-settings/src/screens/ConfirmFirmwareUpdateScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/ConfirmFirmwareUpdateScreen.tsx
@@ -7,7 +7,7 @@ import {
 } from '@suite-native/firmware';
 import {
     DeviceSettingsStackParamList,
-    DeviceStackRoutes,
+    DeviceSettingsStackRoutes,
     Screen,
     ScreenHeader,
     StackNavigationProps,
@@ -17,7 +17,7 @@ import { useDeviceConnectionGuard } from '../hooks/useDeviceConnectionGuard';
 
 type NavigationProp = StackNavigationProps<
     DeviceSettingsStackParamList,
-    DeviceStackRoutes.ConfirmFirmwareUpdate
+    DeviceSettingsStackRoutes.ConfirmFirmwareUpdate
 >;
 
 export const ConfirmFirmwareUpdateScreen = () => {
@@ -25,7 +25,7 @@ export const ConfirmFirmwareUpdateScreen = () => {
     const { isDeviceConnected } = useDeviceConnectionGuard();
 
     const handleUpdateConfirmation = () => {
-        navigation.navigate(DeviceStackRoutes.FirmwareInstallation);
+        navigation.navigate(DeviceSettingsStackRoutes.FirmwareInstallation);
     };
 
     if (!isDeviceConnected) return;

--- a/suite-native/module-device-settings/src/screens/FirmwareInstallationScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/FirmwareInstallationScreen.tsx
@@ -4,14 +4,14 @@ import { Box } from '@suite-native/atoms';
 import { FirmwareInstallationScreenContent } from '@suite-native/firmware';
 import {
     DeviceSettingsStackParamList,
-    DeviceStackRoutes,
+    DeviceSettingsStackRoutes,
     Screen,
     StackNavigationProps,
 } from '@suite-native/navigation';
 
 type NavigationProp = StackNavigationProps<
     DeviceSettingsStackParamList,
-    DeviceStackRoutes.FirmwareInstallation
+    DeviceSettingsStackRoutes.FirmwareInstallation
 >;
 
 export const FirmwareInstallationScreen = () => {
@@ -19,7 +19,7 @@ export const FirmwareInstallationScreen = () => {
 
     const handleFirmwareInstallationSuccess = () => {
         const initialRoute = navigation.getState().routes.at(0)
-            ?.name as DeviceStackRoutes.DeviceSettings;
+            ?.name as DeviceSettingsStackRoutes.DeviceSettings;
 
         if (initialRoute) {
             navigation.navigate(initialRoute);
@@ -30,7 +30,7 @@ export const FirmwareInstallationScreen = () => {
     };
 
     const handleFirmwareInstallationFailure = () => {
-        navigation.navigate(DeviceStackRoutes.ConfirmFirmwareUpdate);
+        navigation.navigate(DeviceSettingsStackRoutes.ConfirmFirmwareUpdate);
     };
 
     return (

--- a/suite-native/module-device-settings/src/screens/WipeDeviceContinueOnTrezorScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/WipeDeviceContinueOnTrezorScreen.tsx
@@ -1,27 +1,11 @@
-import { useEffect } from 'react';
-import { useSelector } from 'react-redux';
-
-import { useNavigation } from '@react-navigation/native';
-
 import { ContinueOnTrezorScreenContent } from '@suite-native/device';
-import { selectIsWipingDevice } from '@suite-native/device-authorization';
+import { useHandleHardwareBackNavigation } from '@suite-native/navigation';
+import TrezorConnect from '@trezor/connect';
 
 import { DeviceInteractionScreenWrapper } from '../components/DeviceInteractionScreenWrapper';
 
 export const WipeDeviceContinueOnTrezorScreen = () => {
-    const navigation = useNavigation();
-    const isWipeInProgress = useSelector(selectIsWipingDevice);
-
-    useEffect(() => {
-        // Prevent going back when wipe device is in progress
-        const unsubscribe = navigation.addListener('beforeRemove', e => {
-            if (isWipeInProgress && e.data.action.type === 'GO_BACK') {
-                e.preventDefault();
-            }
-        });
-
-        return unsubscribe;
-    }, [isWipeInProgress, navigation]);
+    useHandleHardwareBackNavigation(() => TrezorConnect.cancel());
 
     return (
         <DeviceInteractionScreenWrapper>

--- a/suite-native/module-device-settings/src/screens/WipeDeviceContinueOnTrezorScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/WipeDeviceContinueOnTrezorScreen.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { ContinueOnTrezorScreenContent } from '@suite-native/device';
+import { selectIsWipingDevice } from '@suite-native/device-authorization';
+
+import { DeviceInteractionScreenWrapper } from '../components/DeviceInteractionScreenWrapper';
+
+export const WipeDeviceContinueOnTrezorScreen = () => {
+    const navigation = useNavigation();
+    const isWipeInProgress = useSelector(selectIsWipingDevice);
+
+    useEffect(() => {
+        // Prevent going back when wipe device is in progress
+        const unsubscribe = navigation.addListener('beforeRemove', e => {
+            if (isWipeInProgress && e.data.action.type === 'GO_BACK') {
+                e.preventDefault();
+            }
+        });
+
+        return unsubscribe;
+    }, [isWipeInProgress, navigation]);
+
+    return (
+        <DeviceInteractionScreenWrapper>
+            <ContinueOnTrezorScreenContent />
+        </DeviceInteractionScreenWrapper>
+    );
+};

--- a/suite-native/module-device-settings/src/screens/WipeDeviceLoadingScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/WipeDeviceLoadingScreen.tsx
@@ -1,0 +1,39 @@
+import { useNavigation } from '@react-navigation/native';
+
+import { Translation } from '@suite-native/intl';
+import {
+    AppTabsRoutes,
+    DeviceSettingsStackParamList,
+    DeviceSettingsStackRoutes,
+    HomeStackRoutes,
+    LoadingSuccessScreen,
+    RootStackParamList,
+    RootStackRoutes,
+    StackToStackCompositeNavigationProps,
+} from '@suite-native/navigation';
+
+type NavigationProps = StackToStackCompositeNavigationProps<
+    DeviceSettingsStackParamList,
+    DeviceSettingsStackRoutes,
+    RootStackParamList
+>;
+
+export const WipeDeviceLoadingScreen = () => {
+    const navigation = useNavigation<NavigationProps>();
+
+    const handleFinish = () => {
+        navigation.navigate(RootStackRoutes.AppTabs, {
+            screen: AppTabsRoutes.HomeStack,
+            params: {
+                screen: HomeStackRoutes.Home,
+            },
+        });
+    };
+
+    return (
+        <LoadingSuccessScreen
+            onFinish={handleFinish}
+            title={<Translation id="moduleDeviceSettings.wipeDevice.loadingSuccessScreen.title" />}
+        />
+    );
+};

--- a/suite-native/module-device-settings/src/screens/WipeDeviceScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/WipeDeviceScreen.tsx
@@ -1,7 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 
 import { CardStepper, CardStepperMap, Text, VStack } from '@suite-native/atoms';
-import { ContinueOnTrezorScreenContent, useWipeDevice } from '@suite-native/device';
+import { useWipeDevice } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 import { Screen, ScreenHeader } from '@suite-native/navigation';
 
@@ -28,21 +28,13 @@ const cardStepperContentMap = {
 
 export const WipeDeviceScreen = () => {
     const navigation = useNavigation();
-    const { wipeDevice, isWipeInProgress } = useWipeDevice();
+    const { wipeDevice } = useWipeDevice();
 
     const handleSecondaryButtonPress = () => {
         if (navigation.canGoBack()) {
             navigation.goBack();
         }
     };
-
-    if (isWipeInProgress) {
-        return (
-            <Screen header={<ScreenHeader leftIcon={null} />}>
-                <ContinueOnTrezorScreenContent />
-            </Screen>
-        );
-    }
 
     return (
         <Screen header={<ScreenHeader closeActionType="close" />}>

--- a/suite-native/module-home/src/screens/HomeScreen/components/FirmwareUpdateAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/FirmwareUpdateAlert.tsx
@@ -19,7 +19,7 @@ import { useIsFirmwareUpdateFeatureEnabled } from '@suite-native/firmware';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import {
-    DeviceStackRoutes,
+    DeviceSettingsStackRoutes,
     RootStackParamList,
     RootStackRoutes,
     StackNavigationProps,
@@ -78,7 +78,7 @@ export const FirmwareUpdateAlert = () => {
 
     const handleUpdateFirmware = () => {
         navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
-            screen: DeviceStackRoutes.ConfirmFirmwareUpdate,
+            screen: DeviceSettingsStackRoutes.ConfirmFirmwareUpdate,
         });
     };
 

--- a/suite-native/navigation/src/components/LoadingSuccessScreen.tsx
+++ b/suite-native/navigation/src/components/LoadingSuccessScreen.tsx
@@ -1,0 +1,46 @@
+import { ReactNode } from 'react';
+import { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+
+import { AnimatedText, Box, Spinner, VStack } from '@suite-native/atoms';
+import { Screen } from '@suite-native/navigation';
+
+type LoadingSuccessScreenProps = {
+    onFinish: () => void;
+    title: ReactNode;
+};
+
+const NAVIGATION_TIMEOUT = 3000;
+const ANIMATION_END_FRAME = 305;
+
+export const LoadingSuccessScreen = ({ onFinish, title }: LoadingSuccessScreenProps) => {
+    const textOpacity = useSharedValue(0);
+
+    const handleAnimationEnd = () => {
+        textOpacity.value = withTiming(1);
+        setTimeout(() => {
+            onFinish();
+        }, NAVIGATION_TIMEOUT);
+    };
+
+    const textStyle = useAnimatedStyle(() => ({
+        opacity: textOpacity.value,
+    }));
+
+    return (
+        <Screen isScrollable={false}>
+            <Box justifyContent="center" alignItems="center" flex={1}>
+                <VStack alignItems="center" spacing="sp20">
+                    <Spinner
+                        loadingState="success"
+                        onComplete={handleAnimationEnd}
+                        endFrame={ANIMATION_END_FRAME}
+                        size={80}
+                    />
+                    <AnimatedText style={textStyle} variant="titleSmall">
+                        {title}
+                    </AnimatedText>
+                </VStack>
+            </Box>
+        </Screen>
+    );
+};

--- a/suite-native/navigation/src/index.ts
+++ b/suite-native/navigation/src/index.ts
@@ -9,6 +9,7 @@ export * from './hooks/useNavigationRoute';
 export * from './components/TabBar';
 export * from './components/Screen';
 export * from './components/ScreenHeader';
+export * from './components/LoadingSuccessScreen';
 export * from './components/ScreenFooterGradient';
 export * from './components/NavigationContainerWithAnalytics';
 export * from './components/GoBackIcon';

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -200,7 +200,7 @@ export type DeviceSettingsStackParamList = {
     [DeviceSettingsStackRoutes.ConfirmFirmwareUpdate]: undefined;
     [DeviceSettingsStackRoutes.FirmwareInstallation]: undefined;
     [DeviceSettingsStackRoutes.ContinueOnTrezor]: undefined;
-    [DeviceSettingsStackRoutes.WipeDeviceStack]: undefined;
+    [DeviceSettingsStackRoutes.WipeDeviceStack]: NavigatorScreenParams<WipeDeviceStackParamList>;
 };
 
 export type DevicePinProtectionStackParamList = {

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -21,7 +21,7 @@ import {
     DeviceAuthenticityStackRoutes,
     DeviceOnboardingStackRoutes,
     DevicePinProtectionStackRoutes,
-    DeviceStackRoutes,
+    DeviceSettingsStackRoutes,
     HomeStackRoutes,
     OnboardingStackRoutes,
     ReceiveStackRoutes,
@@ -192,15 +192,15 @@ export type AddCoinAccountStackParamList = {
 };
 
 export type DeviceSettingsStackParamList = {
-    [DeviceStackRoutes.DeviceSettings]: undefined;
-    [DeviceStackRoutes.DevicePinProtectionStack]: {
+    [DeviceSettingsStackRoutes.DeviceSettings]: undefined;
+    [DeviceSettingsStackRoutes.DevicePinProtectionStack]: {
         type: PinActionType;
     };
-    [DeviceStackRoutes.DeviceAuthenticityStack]: undefined;
-    [DeviceStackRoutes.ConfirmFirmwareUpdate]: undefined;
-    [DeviceStackRoutes.FirmwareInstallation]: undefined;
-    [DeviceStackRoutes.ContinueOnTrezor]: undefined;
-    [DeviceStackRoutes.WipeDeviceStack]: undefined;
+    [DeviceSettingsStackRoutes.DeviceAuthenticityStack]: undefined;
+    [DeviceSettingsStackRoutes.ConfirmFirmwareUpdate]: undefined;
+    [DeviceSettingsStackRoutes.FirmwareInstallation]: undefined;
+    [DeviceSettingsStackRoutes.ContinueOnTrezor]: undefined;
+    [DeviceSettingsStackRoutes.WipeDeviceStack]: undefined;
 };
 
 export type DevicePinProtectionStackParamList = {
@@ -212,6 +212,8 @@ export type DevicePinProtectionStackParamList = {
 
 export type WipeDeviceStackParamList = {
     [WipeDeviceStackRoutes.WipeDevice]: undefined;
+    [WipeDeviceStackRoutes.ContinueOnTrezor]: undefined;
+    [WipeDeviceStackRoutes.WipeDeviceLoadingScreen]: undefined;
 };
 
 export type DeviceAuthenticityStackParamList = {

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -67,7 +67,7 @@ export enum AccountsImportStackRoutes {
     AccountImportSummary = 'AccountImportSummary',
 }
 
-export enum DeviceStackRoutes {
+export enum DeviceSettingsStackRoutes {
     DeviceSettings = 'DeviceSettings',
     DevicePinProtectionStack = 'DevicePinProtectionStack',
     DeviceAuthenticityStack = 'DeviceAuthenticityStack',
@@ -91,6 +91,8 @@ export enum DeviceAuthenticityStackRoutes {
 
 export enum WipeDeviceStackRoutes {
     WipeDevice = 'WipeDevice',
+    ContinueOnTrezor = 'ContinueOnTrezor',
+    WipeDeviceLoadingScreen = 'WipeDeviceLoadingScreen',
 }
 
 export enum AuthorizeDeviceStackRoutes {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10729,6 +10729,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/styles": "workspace:*"
+    jotai: "npm:1.9.1"
     react: "npm:18.2.0"
     react-native: "npm:0.76.9"
     react-redux: "npm:9.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9674,6 +9674,7 @@ __metadata:
   dependencies:
     "@mobily/ts-belt": "npm:^3.13.1"
     "@reduxjs/toolkit": "npm:2.8.2"
+    "@suite-common/bluetooth": "workspace:*"
     "@suite-common/device-authenticity": "workspace:*"
     "@suite-common/fiat-services": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
@@ -9692,6 +9693,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"
+    "@trezor/transport-bluetooth": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     date-fns: "npm:^4.1.0"
@@ -10729,7 +10731,6 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/styles": "workspace:*"
-    jotai: "npm:1.9.1"
     react: "npm:18.2.0"
     react-native: "npm:0.76.9"
     react-redux: "npm:9.2.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- handle device wipe with success state loading screen & handle cancellation navigation
- unify wipe functionality accross mobile & desktop 
- create a reusable loading success screen component
- modify useDeviceChangedCheck to be more strict and check if device was disconnected as is now connected
- unify DeviceSettingsStack naming

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18914

## Screenshots:

https://github.com/user-attachments/assets/facf9508-72b1-4803-b632-197837048381



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/wipe-device-trezor-confirm&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/wipe-device-trezor-confirm&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/wipe-device-trezor-confirm&lookback=7)