### PR TITLE
Feat/transport bluetooth dev UI

### DIFF
--- a/packages/transport-bluetooth/README.md
+++ b/packages/transport-bluetooth/README.md
@@ -79,3 +79,15 @@ nix-shell ./packages/transport-bluetooth/shell.nix
 yarn workspace @trezor/transport-bluetooth dev:server
 
 ```
+
+### Run dev UI:
+
+Simple html page to communicate with the server using `TrezorBluetooth` client.
+
+```
+
+yarn workspace @trezor/transport-bluetooth build:ui
+
+```
+
+and open `./packages/transport-bluetooth/build/index.html` in the browser

--- a/packages/transport-bluetooth/package.json
+++ b/packages/transport-bluetooth/package.json
@@ -21,7 +21,8 @@
         "type-check": "yarn g:tsc --build",
         "lint:rs": "cargo fmt --all -- --check",
         "dev:server": "RUST_BACKTRACE=1 RUST_LOG=debug cargo run",
-        "build:server": "./scripts/build.sh"
+        "build:server": "./scripts/build.sh",
+        "build:ui": "webpack --config ./webpack/webpack.build.js"
     },
     "dependencies": {
         "@trezor/ipc-proxy": "workspace:*",
@@ -29,5 +30,9 @@
         "@trezor/transport": "workspace:*",
         "@trezor/utils": "workspace:*",
         "@trezor/websocket-client": "workspace:*"
+    },
+    "devDependencies": {
+        "html-webpack-plugin": "^5.6.3",
+        "webpack": "5.99.9"
     }
 }

--- a/packages/transport-bluetooth/src/client/trezor-bluetooth.ts
+++ b/packages/transport-bluetooth/src/client/trezor-bluetooth.ts
@@ -49,12 +49,11 @@ export class TrezorBluetooth extends WebsocketClient<NotificationEvent> {
     send(method: 'close_device', id: string): Promise<boolean>;
     send(method: 'read', id: string): Promise<boolean>;
     send(method: 'write', args: [string, number[]]): Promise<boolean>; // args: id, data
-    public send(method: string, args?: any) {
-        const params = args || [];
+    public send(method: string, params?: any) {
         // connect_device timeout is dynamically set,
         // adjust websocket client and allow the server to respond with timeout error (timeout on the server)
         const timeout =
-            method === 'connect_device' && typeof params[1] === 'number'
+            method === 'connect_device' && Array.isArray(params) && typeof params[1] === 'number'
                 ? params[1] + 3000
                 : undefined;
 

--- a/packages/transport-bluetooth/src/ui/index.css
+++ b/packages/transport-bluetooth/src/ui/index.css
@@ -1,0 +1,54 @@
+body {
+    background-color: rgb(13, 17, 23);
+    color-scheme: dark;
+    font-size: 14px;
+    color: rgb(240, 246, 252);
+}
+
+button {
+    background-color: rgb(33, 40, 48);
+    border-radius: 4px;
+    border-color: rgb(61, 68, 77);
+    cursor: pointer;
+    line-height: 21px;
+    padding: 4px;
+    margin-right: 8px;
+}
+
+#output {
+    max-height: 500px;
+    overflow: auto;
+    padding: 10px;
+}
+
+#output p {
+    word-wrap: break-word;
+}
+
+#device-list {
+    padding: 10px;
+}
+
+.device-list-item {
+    display: flex;
+    flex-direction: row;
+}
+
+.device-list-item-details p {
+    font-size: 12px;
+    margin: 4px;
+}
+
+.device-list-item button {
+    margin-left: 12px;
+}
+
+content {
+    display: flex;
+    flex-direction: column;
+}
+
+section {
+    padding: 12px;
+    border-bottom: 1px solid black;
+}

--- a/packages/transport-bluetooth/src/ui/index.html
+++ b/packages/transport-bluetooth/src/ui/index.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <title>Bluetooth transport | Trezor</title>
+        <meta name="title" content="Bluetooth transport | Trezor" />
+        <meta name="description" content="Bluetooth transport | Trezor" />
+        <meta name="keywords" content="bluetooth transport trezor" />
+        <meta name="author" content="SatoshiLabs s.r.o." />
+        <meta name="viewport" content="width=1024, initial-scale=1" />
+    </head>
+    <body>
+        <header>
+            <h2>Trezor Bluetooth transport API</h2>
+            <div>
+                <svg
+                    fill="#000000"
+                    height="24px"
+                    width="24px"
+                    version="1.1"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                    viewBox="0 0 217.499 217.499"
+                    xml:space="preserve"
+                >
+                    <g>
+                        <path
+                            d="M123.264,108.749l45.597-44.488c1.736-1.693,2.715-4.016,2.715-6.441s-0.979-4.748-2.715-6.441l-50.038-48.82
+                    c-2.591-2.528-6.444-3.255-9.78-1.853c-3.336,1.406-5.505,4.674-5.505,8.294v80.504l-42.331-41.3
+                    c-3.558-3.471-9.255-3.402-12.727,0.156c-3.471,3.558-3.401,9.256,0.157,12.727l48.851,47.663l-48.851,47.663
+                    c-3.558,3.471-3.628,9.169-0.157,12.727s9.17,3.628,12.727,0.156l42.331-41.3v80.504c0,3.62,2.169,6.888,5.505,8.294
+                    c1.128,0.476,2.315,0.706,3.493,0.706c2.305,0,4.572-0.886,6.287-2.559l50.038-48.82c1.736-1.693,2.715-4.016,2.715-6.441
+                    s-0.979-4.748-2.715-6.441L123.264,108.749z M121.539,30.354l28.15,27.465l-28.15,27.465V30.354z M121.539,187.143v-54.93
+                    l28.15,27.465L121.539,187.143z"
+                        />
+                    </g>
+                </svg>
+            </div>
+            <button id="api_connect">API Connect</button>
+            <button id="api_disconnect">API Disconnect</button>
+        </header>
+        <content>
+            Devices
+            <div id="device-list"></div>
+            Output:
+            <div id="output"></div>
+
+            <section>
+                <button id="start_scan">Start scan</button>
+                <button id="stop_scan">Stop scan</button>
+                <button id="get_info">Get info</button>
+                <button id="enumerate">Enumerate</button>
+            </section>
+
+            <section>
+                <input type="text" id="connect_device_input" />
+                <button id="connect_device">Connect device</button>
+                <button id="open_device">Open device</button>
+                <button id="write">Write</button>
+                <button id="read">Read</button>
+                <button id="close_device">Close device</button>
+                <button id="disconnect_device">Disconnect device</button>
+                <button id="forget_device">Forget device</button>
+            </section>
+        </content>
+
+        <section>
+            <textarea id="send_message_input" rows="3"></textarea>
+            <button id="send_message">Send</button>
+        </section>
+    </body>
+</html>

--- a/packages/transport-bluetooth/src/ui/index.ts
+++ b/packages/transport-bluetooth/src/ui/index.ts
@@ -1,0 +1,278 @@
+import { TrezorBluetooth } from '../client/trezor-bluetooth';
+import { BluetoothDevice } from '../client/types';
+
+const getDeviceId = () =>
+    (document.getElementById('connect_device_input') as HTMLInputElement).value;
+
+const getElement = (id: string) => document.getElementById(id) as HTMLElement;
+
+const writeOutput = (message: unknown) => {
+    const output = document.getElementById('output') as HTMLElement;
+    const pre = document.createElement('p');
+    try {
+        const json = JSON.stringify(message);
+        pre.textContent = json;
+    } catch {
+        pre.textContent = `${message}`;
+    }
+
+    output.appendChild(pre);
+};
+
+const createDevice = (api: TrezorBluetooth, d: BluetoothDevice) => {
+    const item = document.createElement('div');
+    item.setAttribute('id', d.id);
+    item.className = 'device-list-item';
+    const details = document.createElement('div');
+    details.className = 'device-list-item-details';
+    item.appendChild(details);
+
+    const label = document.createElement('div');
+    label.textContent = d.name + ' ' + d.id;
+    details.appendChild(label);
+
+    const useBtn = document.createElement('button');
+    useBtn.onclick = () => {
+        (document.getElementById('connect_device_input') as HTMLInputElement).value = d.id;
+    };
+    useBtn.textContent = d.macAddress;
+    let p = document.createElement('p');
+    p.textContent = `${d.macAddress}`;
+    details.appendChild(useBtn);
+
+    p = document.createElement('p');
+    p.textContent = `connectionStatus: ${JSON.stringify(d.connectionStatus)}`;
+    details.appendChild(p);
+
+    p = document.createElement('p');
+    p.textContent = `Data (${d.data.length}): ${d.data}`;
+    details.appendChild(p);
+
+    p = document.createElement('p');
+    const timestamp = d.lastUpdatedTimestamp
+        ? new Date(d.lastUpdatedTimestamp * 1000).toLocaleTimeString('en-US', { hour12: false })
+        : 'Unknown';
+    p.textContent = `Last seen: ${timestamp}`;
+    details.appendChild(p);
+
+    p = document.createElement('p');
+    p.textContent = `Paired: ${d.paired}, Pairable: ${d.data[0]}, RSSI: ${d.rssi}`;
+    details.appendChild(p);
+
+    const connectBtn = document.createElement('button');
+    if (!d.paired && d.data.length === 0) {
+        connectBtn.setAttribute('disabled', 'disabled');
+    }
+    connectBtn.textContent = d.connected ? 'Disconnect' : 'Connect';
+    connectBtn.addEventListener('click', () => {
+        if (!d.connected) {
+            api.send('connect_device', [d.id, 30000])
+                .then(r => {
+                    writeOutput(r);
+                    (document.getElementById('connect_device_input') as HTMLInputElement).value =
+                        d.id;
+                })
+                .catch(e => {
+                    writeOutput({ error: e.message });
+                });
+        } else {
+            api.send('disconnect_device', d.id).catch(e => {
+                writeOutput({ error: e.message });
+            });
+        }
+    });
+    item.appendChild(connectBtn);
+
+    return item;
+};
+
+const updateDeviceList = (api: TrezorBluetooth, devices: BluetoothDevice[]) => {
+    const container = getElement('device-list');
+    container.textContent = '';
+
+    devices.forEach(d => {
+        const item = createDevice(api, d);
+        container.appendChild(item);
+    });
+};
+
+const updateDevice = (api: TrezorBluetooth, device: BluetoothDevice) => {
+    const toReplace = document.getElementById(device.id);
+    const item = createDevice(api, device);
+    if (toReplace) {
+        toReplace.innerHTML = item.innerHTML;
+    }
+};
+
+async function init() {
+    const api = new TrezorBluetooth({
+        url: `ws://localhost:21327/`,
+    });
+
+    try {
+        await api.connect();
+        writeOutput(`API connected.`);
+    } catch (e) {
+        writeOutput(`API not connected. ${e}`);
+    }
+
+    api.on('disconnected', () => {
+        writeOutput('Api disconnected');
+    });
+    api.on('adapter_state_changed', event => {
+        updateDeviceList(api, []);
+        writeOutput(`adapter_state_changed connected: ${event.state}`);
+    });
+    api.on('device_discovered', event => {
+        updateDeviceList(api, event.devices);
+    });
+    api.on('device_updated', event => {
+        updateDeviceList(api, event.devices);
+    });
+    api.on('device_connected', event => {
+        updateDeviceList(api, event.devices);
+    });
+    api.on('device_disconnected', event => {
+        updateDeviceList(api, event.devices);
+    });
+    api.on('device_connection_status', event => {
+        updateDevice(api, event);
+    });
+
+    getElement('api_connect').onclick = () => {
+        try {
+            api.connect()
+                .then(() => {
+                    writeOutput('API connected');
+                })
+                .catch(e => {
+                    writeOutput({ error: e.message });
+                });
+        } catch (e) {
+            writeOutput(`API not connected. ${e}`);
+        }
+    };
+
+    getElement('api_disconnect').onclick = () => {
+        api.disconnect();
+    };
+
+    getElement('start_scan').onclick = () => {
+        api.send('start_scan')
+            .then(devices => {
+                updateDeviceList(api, devices);
+            })
+            .catch(e => {
+                writeOutput({ error: e.message });
+            });
+    };
+
+    getElement('stop_scan').onclick = () => {
+        api.send('stop_scan')
+            .then(r => {
+                writeOutput(r);
+            })
+            .catch(e => {
+                writeOutput({ error: e.message });
+            });
+    };
+
+    getElement('get_info').onclick = () => {
+        api.send('get_info')
+            .then(r => {
+                writeOutput(r);
+            })
+            .catch(e => {
+                writeOutput({ error: e.message });
+            });
+    };
+
+    getElement('enumerate').onclick = () => {
+        api.send('enumerate')
+            .then(r => {
+                writeOutput(r);
+            })
+            .catch(e => {
+                writeOutput({ error: e.message });
+            });
+    };
+
+    getElement('connect_device').onclick = () => {
+        const id = getDeviceId();
+        api.send('connect_device', [id, 30000])
+            .then(r => {
+                writeOutput(r);
+            })
+            .catch(e => {
+                writeOutput({ error: e.message });
+            });
+    };
+
+    getElement('disconnect_device').onclick = () => {
+        const id = getDeviceId();
+        api.send('disconnect_device', id)
+            .then(r => {
+                writeOutput(r);
+            })
+            .catch(e => {
+                writeOutput({ error: e.message });
+            });
+    };
+
+    getElement('forget_device').onclick = () => {
+        const id = getDeviceId();
+        api.send('forget_device', id)
+            .then(r => {
+                writeOutput(r);
+            })
+            .catch(e => {
+                writeOutput({ error: e.message });
+            });
+    };
+
+    getElement('open_device').onclick = () => {
+        const id = getDeviceId();
+        api.send('open_device', id)
+            .then(r => {
+                writeOutput(r);
+            })
+            .catch(e => {
+                writeOutput({ error: e.message });
+            });
+    };
+
+    getElement('close_device').onclick = () => {
+        const id = getDeviceId();
+        api.send('close_device', id)
+            .then(r => {
+                writeOutput(r);
+            })
+            .catch(e => {
+                writeOutput({ error: e.message });
+            });
+    };
+
+    getElement('write').onclick = () => {
+        const id = getDeviceId();
+        api.send('write', [id, [63, 35, 35, 0, 55]]) // GetFeatures
+            .then(r => {
+                writeOutput(r);
+            })
+            .catch(e => {
+                writeOutput({ error: e.message });
+            });
+    };
+
+    getElement('read').onclick = () => {
+        const value = getDeviceId();
+        api.send('read', value)
+            .then(r => {
+                writeOutput(r);
+            })
+            .catch(e => {
+                writeOutput({ error: e.message });
+            });
+    };
+}
+
+window.addEventListener('load', init, false);

--- a/packages/transport-bluetooth/webpack/webpack.build.js
+++ b/packages/transport-bluetooth/webpack/webpack.build.js
@@ -1,0 +1,112 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const path = require('path');
+const webpack = require('webpack');
+
+const PACKAGE_ROOT = path.normalize(path.join(__dirname, '..'));
+const SRC = path.join(PACKAGE_ROOT, 'src/');
+const BUILD = path.join(PACKAGE_ROOT, 'build/');
+
+class RemoveJSFilePlugin {
+    apply(compiler) {
+        compiler.hooks.thisCompilation.tap('RemoveJSFilePlugin', compilation => {
+            compilation.hooks.processAssets.tap(
+                {
+                    name: 'RemoveJSFilePlugin',
+                    stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE,
+                },
+                assets => {
+                    // Iterate over assets and delete JavaScript files
+                    Object.keys(assets).forEach(filename => {
+                        if (filename.endsWith('.js')) {
+                            compilation.deleteAsset(filename);
+                        }
+                    });
+                },
+            );
+        });
+    }
+}
+
+module.exports = {
+    target: 'web',
+    mode: 'production',
+    entry: {
+        index: `${SRC}/ui/index.ts`,
+    },
+    output: {
+        path: BUILD,
+        clean: true,
+    },
+    module: {
+        rules: [
+            {
+                test: /\.ts$/,
+                exclude: /node_modules/,
+                use: [
+                    {
+                        loader: 'babel-loader',
+                        options: {
+                            presets: ['@babel/preset-typescript'],
+                        },
+                    },
+                ],
+            },
+        ],
+    },
+    resolve: {
+        modules: [SRC, 'node_modules'],
+        extensions: ['.ts', '.js'],
+        mainFields: ['main', 'module'], // prevent wrapping default exports by harmony export (bignumber.js in ripple issue)
+    },
+    performance: {
+        hints: false,
+    },
+    plugins: [
+        // provide fallback plugins
+        new webpack.ProvidePlugin({
+            Buffer: ['buffer', 'Buffer'],
+            process: 'process/browser',
+        }),
+        new HtmlWebpackPlugin({
+            template: `${SRC}ui/index.html`,
+            filename: 'index.html',
+            inject: false,
+            minify: {
+                collapseWhitespace: true,
+                keepClosingSlash: true,
+                removeComments: true,
+                removeRedundantAttributes: true,
+                removeScriptTypeAttributes: true,
+                removeStyleLinkTypeAttributes: true,
+                useShortDoctype: true,
+                minifyJS: true,
+            },
+            templateContent: ({ compilation }) => {
+                const jsBundleName = Object.keys(compilation.assets).find(name =>
+                    name.endsWith('.js'),
+                );
+                const jsBundleContent = compilation.assets[jsBundleName].source();
+                const cssBundleContent = compilation.inputFileSystem.readFileSync(
+                    `${SRC}ui/index.css`,
+                    'utf-8',
+                );
+                const originalTemplate = compilation.inputFileSystem.readFileSync(
+                    `${SRC}ui/index.html`,
+                    'utf-8',
+                );
+
+                return originalTemplate.replace(
+                    '</head>',
+                    `<style>${cssBundleContent}</style><script>${jsBundleContent}</script></head>`,
+                );
+            },
+        }),
+        new RemoveJSFilePlugin(),
+    ],
+    optimization: {
+        minimize: false,
+    },
+    // ignore optional modules, dependencies of "ws" lib
+    externals: ['utf-8-validate', 'bufferutil'],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -12645,6 +12645,8 @@ __metadata:
     "@trezor/transport": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@trezor/websocket-client": "workspace:*"
+    html-webpack-plugin: "npm:^5.6.3"
+    webpack: "npm:5.99.9"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
related to: #18791 and #18126

## Description

- Add simple html page to communicate with the server using `TrezorBluetooth` client.

![Screenshot from 2025-05-23 14-22-27](https://github.com/user-attachments/assets/76b87493-c52f-4bb3-9c6b-4f6243425b0f)

- Adjust `TrezorBluetooth` params. this change is required after [this review](https://github.com/trezor/trezor-suite/pull/18126#discussion_r2072728926):
> No need to use () if the enum variant does not contain any inner fields.
> pub enum WsRequestMethod {
>      GetInfo,
>      StartScan,
>      StopScan,
> }

explanation: `GetInfo()` meant `params: []` and `GetInfo` means `params: undefined`

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/transport-bluetooth-dev-ui&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/transport-bluetooth-dev-ui&lookback=7)