### PR TITLE
fix(suite-native): Mobile Trade: do not display simplex provider

### DIFF
--- a/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
@@ -3,18 +3,15 @@ import { useSelector } from 'react-redux';
 import { BuyTrade } from 'invity-api';
 
 import { invariant } from '@suite-common/suite-utils';
-import {
-    TradingRootState,
-    selectBuyQuotesByPaymentMethod,
-    selectTradingBuyIsLoading,
-    selectTradingBuyProviders,
-} from '@suite-common/trading';
+import { selectTradingBuyIsLoading, selectTradingBuyProviders } from '@suite-common/trading';
 import { EventType, analytics } from '@suite-native/analytics';
 import { HStack, Text } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
 import { useSheetControls } from '../../hooks/general/useSheetControls';
+import { selectBuyQuotesByPaymentMethodNative } from '../../selectors/buySelectors';
+import { TradingRootState } from '../../tradingSlice';
 import { OverviewRow } from '../general/OverviewRow';
 import { OverviewValueSkeleton } from '../general/OverviewValueSkeleton';
 import { ProviderLogo } from '../general/ProviderLogo';
@@ -70,7 +67,7 @@ export const BuyProviderPicker = () => {
     const { paymentMethod } = selectedValue ?? {};
     const quotes =
         useSelector((state: TradingRootState) =>
-            selectBuyQuotesByPaymentMethod(state, paymentMethod),
+            selectBuyQuotesByPaymentMethodNative(state, paymentMethod),
         ) ?? [];
 
     const shouldShowPicker = (providers && quotes.length > 0) || isLoading;

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -9,7 +9,6 @@ import {
     getBestRatedQuote,
     invityAPI,
     selectTradingBuyQuotesRequest,
-    selectValidTradingBuyQuotes,
 } from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';
 import { WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
@@ -23,6 +22,7 @@ import {
     selectBuyAmountLimits,
     selectBuyFormDefaultValues,
     selectBuySelectedReceiveAccount,
+    selectValidTradingBuyQuotesNative,
 } from '../../selectors/buySelectors';
 import { setBuySelectedReceiveAccount } from '../../tradingSlice';
 import { TradingBuyForm, TradingBuyFormValues } from '../../types';
@@ -125,7 +125,7 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: 
 };
 
 const useBuyQuotesChangeEffect = ({ getValues, setValue }: TradingBuyForm) => {
-    const quotes = useSelector(selectValidTradingBuyQuotes);
+    const quotes = useSelector(selectValidTradingBuyQuotesNative);
 
     useEffect(() => {
         if (quotes.length === 0) {
@@ -205,7 +205,7 @@ const useValidations = (
     limits: TradingAmountLimitProps | undefined,
 ) => {
     const { translate } = useTranslate();
-    const quotes = useSelector(selectValidTradingBuyQuotes);
+    const quotes = useSelector(selectValidTradingBuyQuotesNative);
     const quoteRequest = useSelector(selectTradingBuyQuotesRequest);
 
     const generalAlertMsg =

--- a/suite-native/module-trading/src/hooks/buy/useBuyQuotes.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyQuotes.ts
@@ -11,13 +11,13 @@ import {
     buyThunks,
     cryptoIdToNetwork,
     selectTradingBuyIsLoading,
-    selectTradingBuyQuotes,
     selectTradingCoinInfoByCryptoId,
 } from '@suite-common/trading';
 import { WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { EventType, analytics } from '@suite-native/analytics';
 import { useDebounce } from '@trezor/react-utils';
 
+import { selectValidTradingBuyQuotesNative } from '../../selectors/buySelectors';
 import { clearBuyState, clearQuotesAndQuotesRequest } from '../../tradingSlice';
 import { TradingBuyForm } from '../../types';
 import { tradingBuyFormToTradingBuyFormProps } from '../../utils/general/quotesUtils';
@@ -101,7 +101,7 @@ const useBuyQuotesInvalidator = (
     debounce: ReturnType<typeof useDebounce>,
 ) => {
     const dispatch = useDispatch();
-    const quotes = useSelector(selectTradingBuyQuotes);
+    const quotes = useSelector(selectValidTradingBuyQuotesNative);
     const isLoading = useSelector(selectTradingBuyIsLoading);
 
     const shouldClearDebounceCallback = !isFormValid;

--- a/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
@@ -10,11 +10,13 @@ import {
     selectBuyAmountLimits,
     selectBuyBestQuotesForAvailablePaymentMethods,
     selectBuyFormDefaultValues,
+    selectBuyQuotesByPaymentMethodNative,
     selectBuySelectedReceiveAccount,
     selectBuySupportedFiatCurrencies,
     selectBuySupportedFiatCurrenciesList,
     selectBuyTradeableAssetsSorted,
     selectTradingBuy,
+    selectValidTradingBuyQuotesNative,
 } from '../buySelectors';
 
 describe('buySelectors', () => {
@@ -216,6 +218,33 @@ describe('buySelectors', () => {
         });
     });
 
+    describe('selectValidMobileTradingBuyQuotes', () => {
+        beforeEach(() => {
+            prevState.buy.quotes = [
+                ...quotes,
+                { ...quotes[0], exchange: 'simplex', orderId: 'order_id_4' },
+            ] as BuyTrade[];
+        });
+
+        it('should return valid quotes', () => {
+            expect(
+                selectValidTradingBuyQuotesNative({
+                    wallet: { tradingNew: prevState },
+                }),
+            ).toEqual([
+                expect.objectContaining({ orderId: 'order_id_0' }),
+                expect.objectContaining({ orderId: 'order_id_1' }),
+                expect.objectContaining({ orderId: 'order_id_3' }),
+            ]);
+        });
+
+        it('should be stable', () => {
+            expect(selectValidTradingBuyQuotesNative({ wallet: { tradingNew: prevState } })).toBe(
+                selectValidTradingBuyQuotesNative({ wallet: { tradingNew: prevState } }),
+            );
+        });
+    });
+
     describe('selectBuyBestQuotesForAvailablePaymentMethods', () => {
         beforeEach(() => {
             prevState.buy.quotes = quotes as BuyTrade[];
@@ -278,6 +307,41 @@ describe('buySelectors', () => {
                     wallet: { tradingNew: prevState },
                 }),
             ).toEqual([]);
+        });
+    });
+
+    describe('selectMobileBuyQuotesByPaymentMethod', () => {
+        beforeEach(() => {
+            prevState.buy.quotes = [
+                ...quotes,
+                { ...quotes[0], exchange: 'simplex', orderId: 'order_id_4' },
+            ] as BuyTrade[];
+        });
+
+        it('should select valid quotes', () => {
+            expect(
+                selectBuyQuotesByPaymentMethodNative(
+                    { wallet: { tradingNew: prevState } },
+                    'creditCard',
+                ),
+            ).toEqual([
+                expect.objectContaining({ orderId: 'order_id_1' }),
+                expect.objectContaining({ orderId: 'order_id_3' }),
+            ]);
+        });
+
+        it('should be stable', () => {
+            expect(
+                selectBuyQuotesByPaymentMethodNative(
+                    { wallet: { tradingNew: prevState } },
+                    'creditCard',
+                ),
+            ).toBe(
+                selectBuyQuotesByPaymentMethodNative(
+                    { wallet: { tradingNew: prevState } },
+                    'creditCard',
+                ),
+            );
         });
     });
 });

--- a/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
@@ -243,6 +243,31 @@ describe('buySelectors', () => {
                 selectValidTradingBuyQuotesNative({ wallet: { tradingNew: prevState } }),
             );
         });
+
+        describe('on android device', () => {
+            beforeAll(() => {
+                jest.mock('react-native/Libraries/Utilities/Platform', () => ({
+                    OS: 'android',
+                    select: (specifics: Record<'ios' | 'android' | 'default', unknown>) =>
+                        specifics.android ?? specifics.default,
+                }));
+            });
+
+            afterAll(() => {
+                jest.unmock('react-native/Libraries/Utilities/Platform');
+            });
+
+            it('should ignore applePay', () => {
+                expect(
+                    selectValidTradingBuyQuotesNative({
+                        wallet: { tradingNew: prevState },
+                    }),
+                ).toEqual([
+                    expect.objectContaining({ orderId: 'order_id_1' }),
+                    expect.objectContaining({ orderId: 'order_id_3' }),
+                ]);
+            });
+        });
     });
 
     describe('selectBuyBestQuotesForAvailablePaymentMethods', () => {

--- a/suite-native/module-trading/src/selectors/buySelectors.ts
+++ b/suite-native/module-trading/src/selectors/buySelectors.ts
@@ -2,11 +2,13 @@ import { BuyCryptoPaymentMethod, BuyTrade, FiatCurrencyCode } from 'invity-api';
 
 import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import {
+    TradingPaymentMethodProps,
     getBestRatedQuote,
+    getTradingQuotesByPaymentMethod,
     regional,
     selectTradingBuyInfo,
-    selectTradingBuyQuotes,
     selectTradingBuySupportedCryptoIds,
+    selectValidTradingBuyQuotes,
 } from '@suite-common/trading';
 
 import { supportedFiatCurrenciesMap } from '../consts/general/supportedFiatCurrencies';
@@ -99,12 +101,17 @@ export const selectBuySupportedFiatCurrenciesList = createMemoizedSelector(
 export const selectBuyAmountLimits = (state: TradingRootState) =>
     selectTradingBuy(state).amountLimits;
 
-export const selectBuyBestQuotesForAvailablePaymentMethods = createMemoizedSelector(
+export const selectValidTradingBuyQuotesNative = createMemoizedSelector(
     [
-        selectTradingBuyQuotes as unknown as (
+        selectValidTradingBuyQuotes as unknown as (
             state: TradingRootState,
-        ) => ReturnType<typeof selectTradingBuyQuotes>,
+        ) => ReturnType<typeof selectValidTradingBuyQuotes>,
     ],
+    quotes => quotes.filter(quote => quote.exchange !== 'simplex'),
+);
+
+export const selectBuyBestQuotesForAvailablePaymentMethods = createMemoizedSelector(
+    [selectValidTradingBuyQuotesNative],
     quotes => {
         const allQuotesByPaymentMethodMap = quotes.reduce((quotesByPaymentMethodMap, quote) => {
             const { paymentMethod, paymentMethodName } = quote;
@@ -126,4 +133,18 @@ export const selectBuyBestQuotesForAvailablePaymentMethods = createMemoizedSelec
             getBestRatedQuote(quotesForPaymentMethod, 'buy'),
         ) as BuyTrade[];
     },
+);
+
+export const selectBuyQuotesByPaymentMethodNative = createMemoizedSelector(
+    [
+        selectValidTradingBuyQuotesNative,
+        (_: TradingRootState, paymentMethod: TradingPaymentMethodProps | undefined) =>
+            paymentMethod,
+    ],
+    (quotes, paymentMethod) =>
+        paymentMethod
+            ? getTradingQuotesByPaymentMethod<'buy'>(quotes, paymentMethod)?.sort(
+                  (a, b) => (a.rate ?? 0) - (b.rate ?? 0),
+              )
+            : undefined,
 );

--- a/suite-native/module-trading/src/selectors/buySelectors.ts
+++ b/suite-native/module-trading/src/selectors/buySelectors.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import { BuyCryptoPaymentMethod, BuyTrade, FiatCurrencyCode } from 'invity-api';
 
 import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
@@ -107,7 +109,15 @@ export const selectValidTradingBuyQuotesNative = createMemoizedSelector(
             state: TradingRootState,
         ) => ReturnType<typeof selectValidTradingBuyQuotes>,
     ],
-    quotes => quotes.filter(quote => quote.exchange !== 'simplex'),
+    quotes => {
+        const isProviderAllowed = ({ exchange }: BuyTrade) => exchange !== 'simplex';
+        const isAllowedOnPlatform = Platform.select<(quote: BuyTrade) => boolean>({
+            ios: () => true,
+            default: ({ paymentMethod }) => paymentMethod !== 'applePay',
+        });
+
+        return quotes.filter(isProviderAllowed).filter(isAllowedOnPlatform);
+    },
 );
 
 export const selectBuyBestQuotesForAvailablePaymentMethods = createMemoizedSelector(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Simplex provider is not supported in mobile trading. Never display it to user
- Also filtering out apple pay on android devices

<!--- Describe your changes in detail -->

## Related Issue

Resolve #19143
Resolve #19171


## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19143-mobile-trade-no-simplex&lookback=7)