### PR TITLE
Data Analytics: add events for send transaction process

### DIFF
--- a/packages/suite-analytics/src/constants.ts
+++ b/packages/suite-analytics/src/constants.ts
@@ -32,6 +32,10 @@ export enum EventType {
     CreateReceiveAddressCopyAddress = 'create-receive-address/copy-address',
     CreateReceiveAddressConfirmOnTrezor = 'create-receive-address/confirm-on-trezor',
 
+    SendInitialised = 'send/initialised',
+    SendConfirmerOnDevice = 'send/confirmed-on-device',
+    SendDetailOpened = 'send/detail-opened',
+
     AccountsStatus = 'accounts/status',
     AccountsTokensStatus = 'accounts/tokens-status',
     AccountsNonZeroBalance = 'accounts/non-zero-balance',

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -157,6 +157,24 @@ export type SuiteAnalyticsEvent =
           };
       }
     | {
+          type: EventType.SendInitialised;
+          payload: {
+              assetSymbol: NetworkSymbol;
+          };
+      }
+    | {
+          type: EventType.SendConfirmerOnDevice;
+          payload: {
+              assetSymbol: NetworkSymbol;
+          };
+      }
+    | {
+          type: EventType.SendDetailOpened;
+          payload: {
+              assetSymbol: NetworkSymbol;
+          };
+      }
+    | {
           type: EventType.AccountsStatus;
           payload: {
               [key: string]: number;

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -21,6 +21,7 @@ import {
     PrecomposedTransactionFinalBumpFeeRbf,
 } from '@suite-common/wallet-types';
 import { isCardanoTx, isRbfBumpFeeTransaction } from '@suite-common/wallet-utils';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { getSynchronize } from '@trezor/utils';
 
 import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
@@ -218,6 +219,13 @@ export const signAndPushSendFormTransactionThunk = createThunk(
         // this action is blocked by modalActions.preserve()
         dispatch(modalActions.preserve());
 
+        analytics.report({
+            type: EventType.SendInitialised,
+            payload: {
+                assetSymbol: selectedAccount.symbol,
+            },
+        });
+
         const signResponse = await dispatch(
             signTransactionThunk({
                 formState,
@@ -225,6 +233,13 @@ export const signAndPushSendFormTransactionThunk = createThunk(
                 selectedAccount,
             }),
         );
+
+        analytics.report({
+            type: EventType.SendConfirmerOnDevice,
+            payload: {
+                assetSymbol: selectedAccount.symbol,
+            },
+        });
 
         if (isRejected(signResponse)) {
             // Do not close the modal, as we need that modal to display the error state.

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -315,6 +315,21 @@ export const TransactionReviewModalContent = ({
         });
     };
 
+    const handleDetailsClick = () => {
+        setAreDetailsVisible(areVisible => {
+            if (!areVisible) {
+                analytics.report({
+                    type: EventType.SendDetailOpened,
+                    payload: {
+                        assetSymbol: symbol,
+                    },
+                });
+            }
+
+            return !areVisible;
+        });
+    };
+
     const BottomContent = () => {
         if (isRbfConfirmedError) {
             return (
@@ -439,9 +454,7 @@ export const TransactionReviewModalContent = ({
                                 tx={precomposedTx}
                                 account={account}
                                 broadcast={isBroadcastEnabled}
-                                onDetailsClick={() => {
-                                    setAreDetailsVisible(!areDetailsVisible);
-                                }}
+                                onDetailsClick={handleDetailsClick}
                                 stakeType={stakeType}
                             />
                             {showTxValidityTimer && (


### PR DESCRIPTION
## Description

Improves analytics tracking of the send transaction process by adding the following events:

- `send/initialised` - triggered when the transaction is initialised
- `send/confirmed-on-device` - triggered when the user confirms the transaction on their device
- `send/detail-opened` - triggered when the transaction detail info screen is opened

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17310

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/analytics-send-form&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/analytics-send-form&lookback=7)