### PR TITLE
fix(suite-native): use different callbacks for btcdirect and invity

### DIFF
--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailWaitingAlert.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailWaitingAlert.tsx
@@ -49,6 +49,7 @@ export const TradeDetailWaitingAlert = ({
                           actionType: 'trade',
                           tradeType: trade.tradeType,
                           orderId,
+                          exchange: trade.data.partnerData,
                       }),
                       source: { uri: trade.data.partnerData },
                   });

--- a/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
@@ -161,6 +161,7 @@ export const useBuyFlow = (form: TradingBuyForm) => {
             actionType: 'trade',
             tradeType: 'buy',
             orderId: quote.orderId,
+            exchange: quote.exchange,
         });
 
         await dispatch(
@@ -209,6 +210,7 @@ export const useBuyFlow = (form: TradingBuyForm) => {
             actionType: 'quote',
             tradeType: 'buy',
             orderId: candidateQuote.orderId,
+            exchange: candidateQuote.exchange,
         });
 
         await dispatch(

--- a/suite-native/module-trading/src/utils/general/__tests__/formUtils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/formUtils.test.ts
@@ -184,13 +184,27 @@ describe('getRequestFormSource', () => {
 });
 
 describe('buildTradingUrl', () => {
-    it('should return correct url format', () => {
+    it('should return correct url format without https', () => {
         expect(
             buildTradingUrl({
                 actionType: 'quote',
                 tradeType: 'buy',
                 orderId: '1234',
+                exchange: 'paybis',
             }),
         ).toBe('trezorsuitelite://trading?action=quote&tradeType=buy&orderId=1234');
+    });
+
+    it('should return correct url format with https', () => {
+        expect(
+            buildTradingUrl({
+                actionType: 'quote',
+                tradeType: 'buy',
+                orderId: '1234',
+                exchange: 'invity',
+            }),
+        ).toBe(
+            'https://suite.trezor.io/web/accounts/coinmarket/buy?action=quote&tradeType=buy&orderId=1234',
+        );
     });
 });

--- a/suite-native/module-trading/src/utils/general/__tests__/utils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/utils.test.ts
@@ -5,7 +5,7 @@ import { useTranslate } from '@suite-native/intl';
 import { renderHookWithBasicProvider } from '@suite-native/test-utils';
 
 import { getBuyTrade, getExchangeTrade, getSellTrade } from '../../../__fixtures__/trades';
-import { TRADING_URL_DEFAULT_BACK } from '../formUtils';
+import { INVITY_CALLBACK_TREZOR_BUY_URL, TRADING_URL_DEFAULT_BACK } from '../formUtils';
 import {
     doesUrlContainCloseCallbackUrl,
     getRandomAccountDescriptor,
@@ -146,6 +146,11 @@ describe('utils', () => {
 
         it('should return true when URL contains TRADING_URL_DEFAULT_BACK', () => {
             const url = `${TRADING_URL_DEFAULT_BACK}?action=trade&tradeType=buy&orderId=123`;
+            expect(doesUrlContainCloseCallbackUrl(url, closeCallbackUrl)).toBe(true);
+        });
+
+        it('should return true when URL contains INVITY_CALLBACK_TREZOR_BUY_URL', () => {
+            const url = `${INVITY_CALLBACK_TREZOR_BUY_URL}?action=trade&tradeType=buy&orderId=123`;
             expect(doesUrlContainCloseCallbackUrl(url, closeCallbackUrl)).toBe(true);
         });
 

--- a/suite-native/module-trading/src/utils/general/formUtils.ts
+++ b/suite-native/module-trading/src/utils/general/formUtils.ts
@@ -21,6 +21,7 @@ export type BuildTradingUrlProps = {
     actionType: 'quote' | 'trade';
     tradeType: TradingType;
     orderId: string | undefined;
+    exchange: string | undefined;
 };
 
 export type GetAnalyticsTradingBuyPayloadProps = {
@@ -30,6 +31,9 @@ export type GetAnalyticsTradingBuyPayloadProps = {
 
 export const TRADING_URL_BASE = 'trezorsuitelite://trading';
 export const TRADING_URL_DEFAULT_BACK = `${TRADING_URL_BASE}/back`;
+export const INVITY_CALLBACK_TREZOR_BUY_URL = 'https://suite.trezor.io/web/accounts/coinmarket/buy';
+
+const exchangesWithHttps = ['invity', 'btcdirect-sandbox', 'btcdirect'];
 
 export const applyHtmlTemplate = (
     content = 'You may now close this window.',
@@ -125,8 +129,14 @@ export const getSourceForForm = (form: FormResponse['form'] | undefined, backUrl
     return null;
 };
 
-export const buildTradingUrl = ({ actionType, tradeType, orderId }: BuildTradingUrlProps) => {
-    const url = new URL(TRADING_URL_BASE);
+export const buildTradingUrl = ({
+    actionType,
+    tradeType,
+    orderId,
+    exchange,
+}: BuildTradingUrlProps) => {
+    const useHttpsVersion = exchangesWithHttps.includes(exchange ?? '');
+    const url = new URL(useHttpsVersion ? INVITY_CALLBACK_TREZOR_BUY_URL : TRADING_URL_BASE);
     const { searchParams } = url;
     searchParams.set('action', actionType);
     searchParams.set('tradeType', tradeType);

--- a/suite-native/module-trading/src/utils/general/utils.ts
+++ b/suite-native/module-trading/src/utils/general/utils.ts
@@ -13,7 +13,7 @@ import { useTranslate } from '@suite-native/intl';
 import { exhaustive } from '@trezor/type-utils';
 import { getWeakRandomId } from '@trezor/utils';
 
-import { TRADING_URL_DEFAULT_BACK } from './formUtils';
+import { INVITY_CALLBACK_TREZOR_BUY_URL, TRADING_URL_DEFAULT_BACK } from './formUtils';
 
 export const tradeFinalStatuses: Record<TradingType, TradingTradeStatusType[]> = {
     buy: ['SUCCESS', 'ERROR', 'BLOCKED'] satisfies BuyTradeFinalStatus[],
@@ -157,7 +157,9 @@ export const getTradeStatusStep = (trade: TradingTransaction | undefined) => {
 };
 
 export const doesUrlContainCloseCallbackUrl = (url: string, closeCallbackUrl: string) =>
-    url.includes(closeCallbackUrl) || url.includes(TRADING_URL_DEFAULT_BACK);
+    url.includes(closeCallbackUrl) ||
+    url.includes(TRADING_URL_DEFAULT_BACK) ||
+    url.includes(INVITY_CALLBACK_TREZOR_BUY_URL);
 
 export const getRandomAccountDescriptor = () => getWeakRandomId(20);
 


### PR DESCRIPTION
Do buy even for BTCDirect and Invity by using https scheme for url callback

## Related Issue

Resolve #19149

## Screenshots:
<img width=300 src="https://github.com/user-attachments/assets/3608239a-06b2-49a0-91ae-b8d34d544e5e" />
<img width=300 src="https://github.com/user-attachments/assets/4b6e79e5-657a-41e9-96eb-5f005e512e8b" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/buy-callbacks&lookback=7)