### PR TITLE
chore(suite): add max priority fee into tx review summary modal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -2,7 +2,7 @@ import { selectConnectPopupCall } from '@suite-common/connect-popup';
 import { formatDurationStrict } from '@suite-common/suite-utils';
 import { NetworkType, networks } from '@suite-common/wallet-config';
 import { FeeInfo, GeneralPrecomposedTransactionFinal, StakeType } from '@suite-common/wallet-types';
-import { getFee, isEip1559 } from '@suite-common/wallet-utils';
+import { getFee, hasEip1559MaxPriorityFee, isEip1559 } from '@suite-common/wallet-utils';
 import { Box, IconButton, Note, Row, Text } from '@trezor/components';
 import { CoinLogo, FeeRate } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
@@ -98,6 +98,18 @@ export const TransactionReviewSummary = ({
                         {': '}
                         <FeeRate feeRate={fee} networkType={network.networkType} symbol={symbol} />
                     </Note>
+                    {hasEip1559MaxPriorityFee(tx) ? (
+                        <Note iconName="gasPump">
+                            <Translation id="TR_MAX_PRIORITY_FEE_PER_GAS" />
+
+                            {': '}
+                            <FeeRate
+                                feeRate={tx.maxPriorityFeePerGas}
+                                networkType={network.networkType}
+                                symbol={symbol}
+                            />
+                        </Note>
+                    ) : undefined}
                 </>
             )}
 

--- a/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeEthereum.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeEthereum.tsx
@@ -150,7 +150,7 @@ export const CustomFeeEthereum = <TFieldValues extends FormState>({
             customPriorityFeePerGas: (value: string) => {
                 const customPriorityFeePerGas = new BigNumber(value);
 
-                if (customMaxFeePerGas && customPriorityFeePerGas.gte(customMaxFeePerGas)) {
+                if (customMaxFeePerGas && customPriorityFeePerGas.gt(customMaxFeePerGas)) {
                     return translationString('CUSTOM_PRIORITY_HIGHER_THAN_MAX');
                 }
 

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -4,6 +4,10 @@ export const isEip1559 = (
     tx: Record<string, any> | null | undefined,
 ): tx is { maxFeePerGas: string } => !!tx && !!tx.maxFeePerGas;
 
+export const hasEip1559MaxPriorityFee = (
+    tx: Record<string, any> | null | undefined,
+): tx is { maxPriorityFeePerGas: string } => !!tx && !!tx.maxPriorityFeePerGas;
+
 export const decimalToHex = (dec: number): string => new BigNumber(dec).toString(16);
 
 export const padLeftEven = (hex: string): string => (hex.length % 2 !== 0 ? `0${hex}` : hex);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- adding priority fee to tx review summary modal to allow user check he is really signing the same tx Suite vs Device

## Screenshots:

![Screenshot 2025-05-23 at 10 10 19](https://github.com/user-attachments/assets/574b25d9-1d02-4afb-805e-a56df208bfec)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/priority-fee-in-tx-modal&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/priority-fee-in-tx-modal&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/priority-fee-in-tx-modal&lookback=7)