### PR TITLE
fix(connect-iframe): missing project env for web environment

### DIFF
--- a/packages/connect-iframe/webpack/base.webpack.config.ts
+++ b/packages/connect-iframe/webpack/base.webpack.config.ts
@@ -138,6 +138,7 @@ export const config: webpack.Configuration = {
         new webpack.DefinePlugin({
             'process.env.VERSION': JSON.stringify(version),
             'process.env.COMMIT_HASH': JSON.stringify(commitHash),
+            'process.env.SUITE_TYPE': JSON.stringify(project),
         }),
     ],
 

--- a/packages/env-utils/src/envUtils.ts
+++ b/packages/env-utils/src/envUtils.ts
@@ -3,7 +3,8 @@ import { UAParser } from 'ua-parser-js';
 import { firmwareConfigPublicKey, publicKey } from './jws';
 import { EnvUtils, Environment, JWSPublicKeyUse } from './types';
 
-export const isWeb = () => process.env.SUITE_TYPE === 'web';
+export const isWeb = () =>
+    process.env.SUITE_TYPE === 'web' || process.env.SUITE_TYPE === 'suite-web';
 
 export const isDesktop = () => process.env.SUITE_TYPE === 'desktop';
 


### PR DESCRIPTION
## Description

- found here https://github.com/trezor/trezor-suite/pull/18996
- maybe instead of this hack we should change the `suite-web` to `web` 