### PR TITLE
feat(protobuf): add build script for `THP` protobuf messages

### DIFF
--- a/packages/protobuf/messages.json
+++ b/packages/protobuf/messages.json
@@ -2804,6 +2804,61 @@
                 }
             }
         },
+        "DebugLinkGetPairingInfo": {
+            "fields": {
+                "channel_id": {
+                    "type": "bytes",
+                    "id": 1
+                },
+                "handshake_hash": {
+                    "type": "bytes",
+                    "id": 2
+                },
+                "nfc_secret_host": {
+                    "type": "bytes",
+                    "id": 3
+                }
+            }
+        },
+        "DebugLinkPairingInfo": {
+            "fields": {
+                "channel_id": {
+                    "type": "bytes",
+                    "id": 1
+                },
+                "handshake_hash": {
+                    "type": "bytes",
+                    "id": 2
+                },
+                "code_entry_code": {
+                    "type": "uint32",
+                    "id": 3
+                },
+                "code_qr_code": {
+                    "type": "bytes",
+                    "id": 4
+                },
+                "nfc_secret_trezor": {
+                    "type": "bytes",
+                    "id": 5
+                }
+            }
+        },
+        "DebugLinkToggleThpPairingDialog": {
+            "fields": {
+                "channel_id": {
+                    "type": "bytes",
+                    "id": 1
+                },
+                "show_dialog": {
+                    "type": "bool",
+                    "id": 2,
+                    "options": {
+                        "default": false
+                    }
+                }
+            }
+        },
         "DebugLinkStop": {
             "fields": {}
         },
@@ -6663,6 +6718,8 @@
                 "DebugLinkOptigaSetSecMax": 9008,
                 "DebugLinkGetGcInfo": 9009,
                 "DebugLinkGcInfo": 9010,
+                "DebugLinkGetPairingInfo": 9011,
+                "DebugLinkPairingInfo": 9012,
                 "EthereumGetPublicKey": 450,
                 "EthereumPublicKey": 451,
                 "EthereumGetAddress": 56,

--- a/packages/protobuf/scripts/protobuf-build.sh
+++ b/packages/protobuf/scripts/protobuf-build.sh
@@ -44,3 +44,5 @@ yarn tsx ./protobuf-types.ts
 
 yarn workspace @trezor/protobuf g:prettier --write {messages.json,src/messages.ts} 
 yarn workspace @trezor/protobuf g:eslint --fix ./src/messages.ts
+
+yarn tsx ./protobuf-thp-definitions.ts "$REPO_PATH/common/protob"

--- a/packages/protobuf/scripts/protobuf-patches/ThpCreateNewSession.ts
+++ b/packages/protobuf/scripts/protobuf-patches/ThpCreateNewSession.ts
@@ -1,0 +1,6 @@
+// ThpCreateNewSession replacement
+// either passphrase or on_device needs to be present
+export type ThpCreateNewSession = { derive_cardano?: boolean } & (
+    | { passphrase: string; on_device?: undefined }
+    | { passphrase?: undefined; on_device: boolean }
+);

--- a/packages/protobuf/scripts/protobuf-patches/index.ts
+++ b/packages/protobuf/scripts/protobuf-patches/index.ts
@@ -122,6 +122,8 @@ export const RULE_PATCH = {
     'StellarAssetType.code': 'required',
     'StellarPathPaymentStrictReceiveOp.paths': 'optional', // its valid to be undefined according to implementation/tests
     'StellarPathPaymentStrictSendOp.paths': 'optional', // its valid to be undefined according to implementation/tests
+    'ThpHandshakeCompletionReqNoisePayload.host_pairing_credential': 'optional',
+    'ThpCredentialRequest.credential': 'optional',
 };
 
 // custom types IN to trezor
@@ -263,6 +265,7 @@ export const DEFINITION_PATCH = {
     TxInputType: () => readPatch('./TxInputType.ts'),
     TxOutputType: () => readPatch('./TxOutputType.ts'),
     TxAck: () => readPatch('./TxAck.ts'),
+    ThpCreateNewSession: () => readPatch('./ThpCreateNewSession.ts'),
 };
 
 // skip unnecessary types

--- a/packages/protobuf/scripts/protobuf-thp-definitions.ts
+++ b/packages/protobuf/scripts/protobuf-thp-definitions.ts
@@ -1,0 +1,70 @@
+/* eslint-disable no-console */
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import { buildDefinitions } from './protobuf-definitions';
+import { DISCLAIMER } from './protobuf-patches';
+import { createTypes } from './protobuf-types';
+
+const DIST = path.join(__dirname, '../../protocol/src/protocol-thp/messages');
+
+const buildThpDefinitions = (root: ReturnType<typeof buildDefinitions>) => {
+    const lines: string[] = [];
+    lines.push(DISCLAIMER, '');
+
+    const defs = JSON.stringify(root.nested);
+    lines.push(`export const getProtobufDefinitions = () => (`, defs, `);`, '');
+
+    fs.writeFileSync(`${DIST}/protobufDefinitions.ts`, lines.join('\n'));
+};
+
+const createMessageType = (types: ReturnType<typeof createTypes>) => {
+    const lines: string[] = [];
+    lines.push('export type ThpProtobufMessageType = {');
+    types
+        .flatMap(t => (t && t.type === 'message' ? t : []))
+        .forEach(t => {
+            lines.push(`    ${t.name}: ${t.name};`);
+        });
+    lines.push('};', '');
+
+    return lines;
+};
+
+const buildThpTypes = (json: ReturnType<typeof buildDefinitions>) => {
+    const types = createTypes(json, { defaultRule: 'required', fixOrder: false });
+    const lines: string[] = [];
+    lines.push(DISCLAIMER, '');
+
+    const content = lines
+        .concat(
+            types.flatMap(t => (t ? t.value : [])),
+            createMessageType(types),
+        )
+        .join('\n');
+
+    fs.writeFileSync(`${DIST}/protobufTypes.ts`, content);
+};
+
+const run = () => {
+    const [protoDir] = process.argv.slice(2);
+    const defs = buildDefinitions(protoDir, {
+        includeImports: true,
+        onlyPackages: ['', 'thp'], // empty package == messages.proto file (MessageType definitions), see buildDefinitions function
+    });
+
+    buildThpDefinitions(defs);
+    buildThpTypes(defs);
+
+    const filePath = `${DIST}/protobuf*`;
+    const cmd = `yarn workspace @trezor/protocol`;
+
+    console.log('Build successful. patching...');
+    let out = execSync(`${cmd} g:prettier --write ${filePath}`);
+    console.log('prettier result: ', out.toString('utf-8'));
+    out = execSync(`${cmd} g:eslint --fix ${filePath}`);
+    console.log('eslint result: ', out.toString('utf-8'));
+};
+
+run();

--- a/packages/protobuf/src/messages-schema.ts
+++ b/packages/protobuf/src/messages-schema.ts
@@ -1472,6 +1472,37 @@ export enum DebugWaitType {
 export type EnumDebugWaitType = Static<typeof EnumDebugWaitType>;
 export const EnumDebugWaitType = Type.Enum(DebugWaitType);
 
+export type DebugLinkGetPairingInfo = Static<typeof DebugLinkGetPairingInfo>;
+export const DebugLinkGetPairingInfo = Type.Object(
+    {
+        channel_id: Type.Optional(Type.String()),
+        handshake_hash: Type.Optional(Type.String()),
+        nfc_secret_host: Type.Optional(Type.String()),
+    },
+    { $id: 'DebugLinkGetPairingInfo' },
+);
+
+export type DebugLinkPairingInfo = Static<typeof DebugLinkPairingInfo>;
+export const DebugLinkPairingInfo = Type.Object(
+    {
+        channel_id: Type.Optional(Type.String()),
+        handshake_hash: Type.Optional(Type.String()),
+        code_entry_code: Type.Optional(Type.Number()),
+        code_qr_code: Type.Optional(Type.String()),
+        nfc_secret_trezor: Type.Optional(Type.String()),
+    },
+    { $id: 'DebugLinkPairingInfo' },
+);
+
+export type DebugLinkToggleThpPairingDialog = Static<typeof DebugLinkToggleThpPairingDialog>;
+export const DebugLinkToggleThpPairingDialog = Type.Object(
+    {
+        channel_id: Type.Optional(Type.String()),
+        show_dialog: Type.Optional(Type.Boolean()),
+    },
+    { $id: 'DebugLinkToggleThpPairingDialog' },
+);
+
 export type DebugLinkResetDebugEvents = Static<typeof DebugLinkResetDebugEvents>;
 export const DebugLinkResetDebugEvents = Type.Object({}, { $id: 'DebugLinkResetDebugEvents' });
 
@@ -3545,6 +3576,9 @@ export const MessageType = Type.Object(
         SignedIdentity,
         GetECDHSessionKey,
         ECDHSessionKey,
+        DebugLinkGetPairingInfo,
+        DebugLinkPairingInfo,
+        DebugLinkToggleThpPairingDialog,
         DebugLinkResetDebugEvents,
         DebugLinkOptigaSetSecMax,
         DebugLinkGetGcInfo,

--- a/packages/protobuf/src/messages.ts
+++ b/packages/protobuf/src/messages.ts
@@ -977,6 +977,25 @@ export enum DebugWaitType {
     CURRENT_LAYOUT = 2,
 }
 
+export type DebugLinkGetPairingInfo = {
+    channel_id?: string;
+    handshake_hash?: string;
+    nfc_secret_host?: string;
+};
+
+export type DebugLinkPairingInfo = {
+    channel_id?: string;
+    handshake_hash?: string;
+    code_entry_code?: number;
+    code_qr_code?: string;
+    nfc_secret_trezor?: string;
+};
+
+export type DebugLinkToggleThpPairingDialog = {
+    channel_id?: string;
+    show_dialog?: boolean;
+};
+
 export type DebugLinkResetDebugEvents = {};
 
 export type DebugLinkOptigaSetSecMax = {};
@@ -2332,6 +2351,9 @@ export type MessageType = {
     SignedIdentity: SignedIdentity;
     GetECDHSessionKey: GetECDHSessionKey;
     ECDHSessionKey: ECDHSessionKey;
+    DebugLinkGetPairingInfo: DebugLinkGetPairingInfo;
+    DebugLinkPairingInfo: DebugLinkPairingInfo;
+    DebugLinkToggleThpPairingDialog: DebugLinkToggleThpPairingDialog;
     DebugLinkResetDebugEvents: DebugLinkResetDebugEvents;
     DebugLinkOptigaSetSecMax: DebugLinkOptigaSetSecMax;
     DebugLinkGetGcInfo: DebugLinkGetGcInfo;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
~~currently doesnt work with trezor-firmware `main` branch~~
following:
https://github.com/trezor/trezor-firmware/pull/5191/files

could be tested with main branch:
```
suite protobuf update:protobuf
```



Result:

Creates set of protobuf definitions for `@trezor/protocol/protocol-thp`
Output files are copied to `./packages/protocol/src/protocol-thp/messages`

output in related PR: https://github.com/trezor/trezor-suite/pull/19122/commits

Definitions will be loaded dynamically from `@trezor/connect/Device` after thp protocol detection


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/protobuf-thp-build&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/protobuf-thp-build&lookback=7)