### PR TITLE
Erase BT bonds settings & Modal to notify user to remove BT device from OS settings

### DIFF
--- a/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
@@ -1,0 +1,54 @@
+import { BLUETOOTH_PREFIX, bluetoothActions } from '@suite-common/bluetooth';
+import { createThunk } from '@suite-common/redux-utils';
+import { TrezorDevice } from '@suite-common/suite-types';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import TrezorConnect from '@trezor/connect';
+import { bluetoothIpc } from '@trezor/transport-bluetooth';
+
+import { Dispatch } from '../../types/suite';
+
+type UnpairCurrentBondParams = {
+    bluetoothId: string;
+    device: TrezorDevice;
+    dispatch: Dispatch;
+};
+
+const unpairCurrentBond = async ({ bluetoothId, device, dispatch }: UnpairCurrentBondParams) => {
+    const result = await TrezorConnect.bleUnpair({ device, all: false });
+    if (
+        result.success ||
+        result.payload.code === 'Device_Disconnected' // This is an expected success
+    ) {
+        dispatch(bluetoothActions.removeKnownDeviceAction({ id: bluetoothId }));
+
+        const resultForget = await bluetoothIpc.forgetDevice(bluetoothId);
+        if (!resultForget.success) {
+            dispatch(
+                bluetoothActions.setBluetoothDeviceNeedsManualOsRemoval({
+                    needsManualRemoval: true,
+                }),
+            );
+        }
+    } else {
+        dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
+    }
+};
+
+type BluetoothEraseBondsThunkParams = {
+    device: TrezorDevice;
+};
+
+export const bluetoothEraseBondsThunk = createThunk<void, BluetoothEraseBondsThunkParams, void>(
+    `${BLUETOOTH_PREFIX}/bluetoothEraseBondsThunk`,
+    async ({ device }, { dispatch }) => {
+        if (!device.features?.capabilities.includes('Capability_BLE')) {
+            return;
+        }
+
+        const bluetoothId = device.bluetoothProps?.id;
+
+        if (bluetoothId !== undefined) {
+            await unpairCurrentBond({ bluetoothId, device, dispatch });
+        }
+    },
+);

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -1,3 +1,4 @@
+import { bluetoothActions } from '@suite-common/bluetooth';
 import { FIRMWARE_MODULE_PREFIX } from '@suite-common/firmware';
 import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
 import { createThunk } from '@suite-common/redux-utils';
@@ -7,6 +8,7 @@ import { deviceActions, selectDevices, selectSelectedDevice } from '@suite-commo
 import TrezorConnect, { ERRORS } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { EventType, analytics } from '@trezor/suite-analytics';
+import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
 import * as modalActions from 'src/actions/suite/modalActions';
 import * as routerActions from 'src/actions/suite/routerActions';
@@ -101,7 +103,7 @@ export const changeWipeCode =
 export const wipeDevice = () => async (dispatch: Dispatch, getState: GetState) => {
     const device = selectSelectedDevice(getState());
     if (!device) return;
-    const bootloaderMode = device.mode === 'bootloader';
+    const isBootloaderMode = device.mode === 'bootloader';
     const devices = selectDevices(getState());
     // collect devices with old "device.id" to be removed (see description below)
     const deviceInstances = deviceUtils.getDeviceInstances(device, devices);
@@ -111,14 +113,30 @@ export const wipeDevice = () => async (dispatch: Dispatch, getState: GetState) =
             path: device.path,
         },
         // In bootloader mode we need the skip the final reload, otherwise we never get the resolution
-        skipFinalReload: bootloaderMode,
+        skipFinalReload: isBootloaderMode,
     });
 
-    if (result.success) {
+    if (
+        result.success ||
+        // This is an expected success for Bluetooth-connected devices
+        (device.bluetoothProps !== undefined && result.payload.code === 'Device_Disconnected')
+    ) {
         // Wiping a device triggers device.id change, and this change is propagated to device reducer via @trezor/connect DEVICE.CHANGE event.
         // Accounts data are related to the old device.id; to properly clear reducers and indexed db,
         // we need to retrieve device objects BEFORE and AFTER the wipe process.
         // And call SUITE.FORGET_DEVICE on ALL devices (with old and new device.id)
+        if (device.bluetoothProps !== undefined) {
+            dispatch(bluetoothActions.removeKnownDeviceAction({ id: device.bluetoothProps.id }));
+
+            const resultForget = await bluetoothIpc.forgetDevice(device.bluetoothProps.id);
+            if (!resultForget.success) {
+                dispatch(
+                    bluetoothActions.setBluetoothDeviceNeedsManualOsRemoval({
+                        needsManualRemoval: true,
+                    }),
+                );
+            }
+        }
         const state = getState();
         const newDevice = selectSelectedDevice(getState());
         const newDevices = selectDevices(getState());

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -65,6 +65,9 @@ const getInitialState = ({ suite, router, device }: any = {}) => ({
         devices: [],
         ...device,
     },
+    bluetooth: {
+        unpairedDeviceNeedsManualOsRemoval: false,
+    },
     window: {
         size: 'LARGE',
     },

--- a/packages/suite/src/components/suite/bluetooth/UnpairedBluetoothDeviceNeedsManualOsRemovalModal.tsx
+++ b/packages/suite/src/components/suite/bluetooth/UnpairedBluetoothDeviceNeedsManualOsRemovalModal.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+
+import {
+    bluetoothActions,
+    selectUnpairedDeviceNeedsManualOsRemoval,
+} from '@suite-common/bluetooth';
+import { Banner, H3, Modal, Paragraph } from '@trezor/components';
+import { desktopApi } from '@trezor/suite-desktop-api';
+import { spacings } from '@trezor/theme';
+
+import { Translation } from 'src/components/suite';
+
+import { useDispatch, useSelector } from '../../../hooks/suite';
+
+export const UnpairedBluetoothDeviceNeedsManualOsRemovalModal = () => {
+    const dispatch = useDispatch();
+    const wasBluetoothDeviceWiped = useSelector(selectUnpairedDeviceNeedsManualOsRemoval);
+
+    const [hasDeeplinkFailed, setHasDeeplinkFailed] = useState(false);
+
+    const handleOpenBluetoothSettings = async () => {
+        const opened = await desktopApi.openSystemSettings('bluetooth');
+
+        if (!opened.success) {
+            setHasDeeplinkFailed(true);
+        }
+    };
+
+    const onCancel = () => {
+        dispatch(
+            bluetoothActions.setBluetoothDeviceNeedsManualOsRemoval({ needsManualRemoval: false }),
+        );
+    };
+
+    if (!wasBluetoothDeviceWiped) {
+        return null;
+    }
+
+    return (
+        <Modal
+            onCancel={onCancel}
+            variant="info"
+            iconName="info"
+            bottomContent={
+                <>
+                    <Modal.Button
+                        onClick={handleOpenBluetoothSettings}
+                        data-testid="@wipe/open-bluetooth-settings"
+                    >
+                        <Translation id="TR_BLUETOOTH_OPEN_BLUETOOTH_SETTINGS" />
+                    </Modal.Button>
+                    <Modal.Button variant="tertiary" onClick={onCancel}>
+                        <Translation id="TR_CANCEL" />
+                    </Modal.Button>
+                </>
+            }
+        >
+            <H3>
+                <Translation id="TR_BLUETOOTH_REMOVE_FROM_BLUETOOTH_SETTINGS" />
+            </H3>
+            <Paragraph variant="tertiary" margin={{ top: spacings.xs }}>
+                <Translation id="TR_BLUETOOTH_REMOVE_FROM_BLUETOOTH_SETTINGS_DESCRIPTION" />
+            </Paragraph>
+            {hasDeeplinkFailed && (
+                <Banner variant="warning">
+                    <Translation id="TR_BLUETOOTH_CANNOT_OPEN_BLUETOOTH_SETTINGS" />
+                </Banner>
+            )}
+        </Modal>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ModalSwitcher/ModalSwitcher.tsx
+++ b/packages/suite/src/components/suite/modals/ModalSwitcher/ModalSwitcher.tsx
@@ -8,14 +8,23 @@ import { ReduxModal } from '../ReduxModal/ReduxModal';
 export const ModalSwitcher = () => {
     const modal = usePreferredModal();
 
-    switch (modal.type) {
-        case 'foreground-app':
-            return <ForegroundAppModal {...modal.payload} />;
-        case 'redux-modal':
-            return <ReduxModal {...modal.payload} />;
-        case 'discovery-loading':
-            return <DiscoveryLoader />;
-        default:
-            return null;
+    // For foreground apps, we have to NOT render the other modals.
+    // There may be conflicts: for example, Firmware Install / Upgrade flow
+    // handles the THP separately.
+    if (modal.type === 'foreground-app') {
+        return <ForegroundAppModal {...modal.payload} />;
     }
+
+    const Inner = () => {
+        switch (modal.type) {
+            case 'redux-modal':
+                return <ReduxModal {...modal.payload} />;
+            case 'discovery-loading':
+                return <DiscoveryLoader />;
+            default:
+                return null;
+        }
+    };
+
+    return <Inner />;
 };

--- a/packages/suite/src/components/suite/modals/ModalSwitcher/ModalSwitcher.tsx
+++ b/packages/suite/src/components/suite/modals/ModalSwitcher/ModalSwitcher.tsx
@@ -5,6 +5,19 @@ import { ForegroundAppModal } from './ForegroundAppModal';
 import { UnpairedBluetoothDeviceNeedsManualOsRemovalModal } from '../../bluetooth/UnpairedBluetoothDeviceNeedsManualOsRemovalModal';
 import { ReduxModal } from '../ReduxModal/ReduxModal';
 
+type ModalParams = ReturnType<typeof usePreferredModal>;
+
+const Inner = ({ modal }: { modal: ModalParams }) => {
+    switch (modal.type) {
+        case 'redux-modal':
+            return <ReduxModal {...modal.payload} />;
+        case 'discovery-loading':
+            return <DiscoveryLoader />;
+        default:
+            return null;
+    }
+};
+
 /** Displays whichever redux modal or foreground app should be displayed */
 export const ModalSwitcher = () => {
     const modal = usePreferredModal();
@@ -16,21 +29,10 @@ export const ModalSwitcher = () => {
         return <ForegroundAppModal {...modal.payload} />;
     }
 
-    const Inner = () => {
-        switch (modal.type) {
-            case 'redux-modal':
-                return <ReduxModal {...modal.payload} />;
-            case 'discovery-loading':
-                return <DiscoveryLoader />;
-            default:
-                return null;
-        }
-    };
-
     return (
         <>
             <UnpairedBluetoothDeviceNeedsManualOsRemovalModal />
-            <Inner />
+            <Inner modal={modal} />
         </>
     );
 };

--- a/packages/suite/src/components/suite/modals/ModalSwitcher/ModalSwitcher.tsx
+++ b/packages/suite/src/components/suite/modals/ModalSwitcher/ModalSwitcher.tsx
@@ -2,6 +2,7 @@ import { usePreferredModal } from 'src/hooks/suite/usePreferredModal';
 
 import { DiscoveryLoader } from './DiscoveryLoader';
 import { ForegroundAppModal } from './ForegroundAppModal';
+import { UnpairedBluetoothDeviceNeedsManualOsRemovalModal } from '../../bluetooth/UnpairedBluetoothDeviceNeedsManualOsRemovalModal';
 import { ReduxModal } from '../ReduxModal/ReduxModal';
 
 /** Displays whichever redux modal or foreground app should be displayed */
@@ -26,5 +27,10 @@ export const ModalSwitcher = () => {
         }
     };
 
-    return <Inner />;
+    return (
+        <>
+            <UnpairedBluetoothDeviceNeedsManualOsRemovalModal />
+            <Inner />
+        </>
+    );
 };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9861,6 +9861,18 @@ export default defineMessages({
         defaultMessage:
             "To unpair completely, make sure you remove your Trezor from your computer's Bluetooth settings. If not, your Trezor won't appear in Trezor Suite when you try to pair it again.",
     },
+    TR_BLUETOOTH_ERASE_BONDS_SETTINGS: {
+        defaultMessage: 'Manage Bluetooth pairing',
+        id: 'TR_BLUETOOTH_ERASE_BONDS_SETTINGS',
+    },
+    TR_BLUETOOTH_ERASE_BONDS_SETTINGS_DESCRIPTION: {
+        defaultMessage: '{deviceName} is paired via Bluetooth',
+        id: 'TR_BLUETOOTH_ERASE_BONDS_SETTINGS_DESCRIPTION',
+    },
+    TR_BLUETOOTH_ERASE_BONDS_SETTINGS_UNPAIR: {
+        defaultMessage: 'Unpair',
+        id: 'TR_BLUETOOTH_ERASE_BONDS_SETTINGS_UNPAIR',
+    },
     TR_YOUR_BRIDGE_VERSION_WILL_SOON_BE_DEPRECATED: {
         id: 'TR_YOUR_BRIDGE_VERSION_WILL_SOON_BE_DEPRECATED',
         defaultMessage: 'Trezor Bridge will soon no longer be supported.',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9844,6 +9844,23 @@ export default defineMessages({
         id: 'TR_TREZOR_SAFE_7',
         defaultMessage: 'Trezor Safe 7',
     },
+    TR_BLUETOOTH_OPEN_BLUETOOTH_SETTINGS: {
+        id: 'TR_BLUETOOTH_OPEN_BLUETOOTH_SETTINGS',
+        defaultMessage: 'Open Bluetooth Settings',
+    },
+    TR_BLUETOOTH_CANNOT_OPEN_BLUETOOTH_SETTINGS: {
+        id: 'TR_BLUETOOTH_CANNOT_OPEN_BLUETOOTH_SETTINGS',
+        defaultMessage: 'Cannot open bluetooth settings. Please enable bluetooth manually.',
+    },
+    TR_BLUETOOTH_REMOVE_FROM_BLUETOOTH_SETTINGS: {
+        id: 'TR_BLUETOOTH_REMOVE_FROM_BLUETOOTH_SETTINGS',
+        defaultMessage: 'Remove Trezor from Bluetooth settings',
+    },
+    TR_BLUETOOTH_REMOVE_FROM_BLUETOOTH_SETTINGS_DESCRIPTION: {
+        id: 'TR_BLUETOOTH_REMOVE_FROM_BLUETOOTH_SETTINGS_DESCRIPTION',
+        defaultMessage:
+            "To unpair completely, make sure you remove your Trezor from your computer's Bluetooth settings. If not, your Trezor won't appear in Trezor Suite when you try to pair it again.",
+    },
     TR_YOUR_BRIDGE_VERSION_WILL_SOON_BE_DEPRECATED: {
         id: 'TR_YOUR_BRIDGE_VERSION_WILL_SOON_BE_DEPRECATED',
         defaultMessage: 'Trezor Bridge will soon no longer be supported.',

--- a/packages/suite/src/views/settings/SettingsDevice/BluetoothEraseBonds.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/BluetoothEraseBonds.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+
+import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
+import { Button } from '@trezor/components';
+
+import { ActionColumn, SectionItem, TextColumn, Translation } from 'src/components/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+import { bluetoothEraseBondsThunk } from '../../../actions/bluetooth/bluetoothEraseBondsThunk';
+
+type BluetoothEraseBondsProps = {
+    isDeviceLocked: boolean;
+};
+
+export const BluetoothEraseBonds = ({ isDeviceLocked }: BluetoothEraseBondsProps) => {
+    const dispatch = useDispatch();
+    const device = useSelector(state => state.device.selectedDevice);
+    const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
+
+    const [inProgress, setInProgress] = useState(false);
+
+    if (!device) {
+        return null;
+    }
+
+    const onEraseClick = async () => {
+        setInProgress(true);
+        await dispatch(bluetoothEraseBondsThunk({ device }));
+        setInProgress(false);
+    };
+
+    return (
+        <SectionItem data-test="@settings/debug/bluetooth-erase">
+            <TextColumn
+                title={<Translation id="TR_BLUETOOTH_ERASE_BONDS_SETTINGS" />}
+                description={
+                    <Translation
+                        id="TR_BLUETOOTH_ERASE_BONDS_SETTINGS_DESCRIPTION"
+                        values={{ deviceName: deviceLabel }}
+                    />
+                }
+            />
+            <ActionColumn>
+                <Button
+                    onClick={onEraseClick}
+                    isLoading={inProgress}
+                    isDisabled={inProgress || isDeviceLocked}
+                >
+                    <Translation id="TR_BLUETOOTH_ERASE_BONDS_SETTINGS_UNPAIR" />
+                </Button>
+            </ActionColumn>
+        </SectionItem>
+    );
+};

--- a/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
@@ -5,7 +5,7 @@ import { isBitcoinOnlyDevice } from '@trezor/device-utils';
 import { DeviceBanner, SettingsLayout, SettingsSection } from 'src/components/settings';
 import { Translation } from 'src/components/suite';
 import { useDevice, useSelector } from 'src/hooks/suite';
-import { selectHasActiveTransport } from 'src/reducers/suite/suiteReducer';
+import { selectHasActiveTransport, selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
 import type { TrezorDevice } from 'src/types/suite';
 import { isRecoveryInProgress } from 'src/utils/device/isRecoveryInProgress';
 
@@ -13,6 +13,7 @@ import { AuthenticateDevice } from './AuthenticateDevice';
 import { AutoLock } from './AutoLock';
 import { BackupFailed } from './BackupFailed';
 import { BackupRecoverySeed } from './BackupRecoverySeed';
+import { BluetoothEraseBonds } from './BluetoothEraseBonds';
 import { Brightness } from './Brightness';
 import { ChangeLanguage } from './ChangeLanguage';
 import { ChangePin } from './ChangePin';
@@ -55,6 +56,7 @@ export const SettingsDevice = () => {
     const deviceRemembered = isDeviceRemembered(device) && !device?.connected;
     const bitcoinOnlyDevice = isBitcoinOnlyDevice(device);
     const isPassphraseProtectionOn = Boolean(device?.features?.passphrase_protection);
+    const flags = useSelector(selectSuiteFlags);
 
     if (noTransportAvailable || deviceSettingsUnavailable(device)) {
         return (
@@ -88,6 +90,9 @@ export const SettingsDevice = () => {
     const deviceModelInternal = device.features.internal_model;
 
     const supportsDeviceAuthentication = SUPPORTS_DEVICE_AUTHENTICITY_CHECK[deviceModelInternal];
+
+    const isBluetoothDevice = device.features?.capabilities.includes('Capability_BLE');
+    const isBluetoothConnectedDevice = device?.bluetoothProps?.id !== undefined;
 
     return (
         <SettingsLayout>
@@ -176,6 +181,12 @@ export const SettingsDevice = () => {
                 {supportsDeviceAuthentication && <DeviceAuthenticityOptOut />}
                 <FirmwareAuthenticityChecks />
             </SettingsSection>
+
+            {flags.isBluetoothEnabled && isBluetoothDevice && isBluetoothConnectedDevice && (
+                <SettingsSection title={<Translation id="TR_BLUETOOTH" />}>
+                    <BluetoothEraseBonds isDeviceLocked={isDeviceLocked} />
+                </SettingsSection>
+            )}
         </SettingsLayout>
     );
 };

--- a/suite-common/bluetooth/src/bluetoothReducer.ts
+++ b/suite-common/bluetooth/src/bluetoothReducer.ts
@@ -134,6 +134,13 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
             .addCase(bluetoothActions.setBluetoothListOpen, (state, { payload: { isOpen } }) => {
                 state.isBluetoothListOpen = isOpen;
             })
+
+            .addCase(
+                bluetoothActions.setBluetoothDeviceNeedsManualOsRemoval,
+                (state, { payload: { needsManualRemoval } }) => {
+                    state.unpairedDeviceNeedsManualOsRemoval = needsManualRemoval;
+                },
+            )
             .addMatcher(
                 action =>
                     action.type === deviceActions.connectDevice.type ||

--- a/suite-common/bluetooth/src/bluetoothReducer.ts
+++ b/suite-common/bluetooth/src/bluetoothReducer.ts
@@ -134,13 +134,6 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
             .addCase(bluetoothActions.setBluetoothListOpen, (state, { payload: { isOpen } }) => {
                 state.isBluetoothListOpen = isOpen;
             })
-
-            .addCase(
-                bluetoothActions.setBluetoothDeviceNeedsManualOsRemoval,
-                (state, { payload: { needsManualRemoval } }) => {
-                    state.unpairedDeviceNeedsManualOsRemoval = needsManualRemoval;
-                },
-            )
             .addMatcher(
                 action =>
                     action.type === deviceActions.connectDevice.type ||


### PR DESCRIPTION
- Adds BT erase bonds functionality
- Adds a modal for notifying the user to remvoe the BT device from the OS in case we cannot do it automatically (MacOS, Linux)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bt-thp-cherrypicks&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bt-thp-cherrypicks&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/bt-thp-cherrypicks&lookback=7)