### PR TITLE
fix(wallet-core): deduplicate createAccount

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -3,7 +3,7 @@ import { isAnyOf } from '@reduxjs/toolkit';
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { networks } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
-import { enhanceHistory } from '@suite-common/wallet-utils';
+import { enhanceHistory, isAccountInCollection } from '@suite-common/wallet-utils';
 
 import { accountsActions } from './accountsActions';
 import { deviceActions } from '../device/deviceActions';
@@ -68,12 +68,16 @@ export const prepareAccountsReducer = createReducerWithExtraDeps(
                 remove(state, action.payload);
             })
             .addCase(accountsActions.createAccount, (state, action) => {
-                // TODO: check if account already exist, for example 2 device instances with same passphrase
                 const account = {
                     ...action.payload,
                     // remove "transactions" field, they are stored in "transactionReducer"
                     history: enhanceHistory(action.payload.history),
                 };
+                if (isAccountInCollection(account, state)) {
+                    console.warn('Prevented duplicate account in accountsReducer: ', account);
+
+                    return;
+                }
                 state.push(account);
             })
             .addCase(accountsActions.createIndexLabeledAccount, (state, action) => {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -1183,3 +1183,12 @@ export const isNftMatchesSearch = (token: TokenInfo, search: string) =>
     token.symbol?.toLowerCase().includes(search) ||
     token.name?.toLowerCase().includes(search) ||
     token.contract?.toLowerCase().includes(search);
+
+export const isAccountInCollection = (account: Account, accounts: Account[]) =>
+    accounts.some(
+        ({ descriptor, symbol, accountType, index }) =>
+            descriptor === account.descriptor &&
+            symbol === account.symbol &&
+            accountType === account.accountType &&
+            index === account.index,
+    );


### PR DESCRIPTION
## Description

Cherrypicked from #18724

Defensive programming to prevent duplicate accounts being persisted in `state.wallet.accounts`, which caused problems in the `discovery` branch but has been a potential issue in `develop` as well, as the todo indicates.

Prevents these kinds of issues:
![duplicate accounts](https://github.com/user-attachments/assets/29b0b1ef-de3f-4b1f-8f7f-34de3824afdd)
![duplicate accounts react error](https://github.com/user-attachments/assets/12b6eb66-c795-4a35-b96b-bfeaa676e763)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/dedupe-accounts&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/dedupe-accounts&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/dedupe-accounts&lookback=7)