### PR TITLE
fix(suite-native): Mobile Trade: Fix Sheet closing on quote fetch

### DIFF
--- a/suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.tsx
@@ -16,6 +16,45 @@ import { PaymentMethodSheet } from '../general/PaymentMethodSheet/PaymentMethodS
 
 const PAYMENT_METHOD_PICKER_TEST_ID = '@trading/buy/payment-method-picker';
 
+type BuyPaymentMethodPickerRightProps = {
+    isLoading: boolean;
+    selectedValue: BuyTrade | undefined;
+};
+
+const BuyPaymentMethodPickerRight = ({
+    isLoading,
+    selectedValue,
+}: BuyPaymentMethodPickerRightProps) => {
+    const { translate } = useTranslate();
+
+    if (isLoading) {
+        return <OverviewValueSkeleton />;
+    }
+
+    if (selectedValue) {
+        return (
+            <Text
+                color="textSubdued"
+                variant="body"
+                accessibilityLabel={translate('moduleTrading.tradingScreen.selectedPaymentMethod')}
+                testID={PAYMENT_METHOD_PICKER_TEST_ID + '/value'}
+            >
+                {selectedValue.paymentMethodName}
+            </Text>
+        );
+    }
+
+    return (
+        <Text
+            color="textDisabled"
+            variant="body"
+            accessibilityLabel={translate('moduleTrading.tradingScreen.noPaymentMethod')}
+        >
+            {translate('moduleTrading.notSelected')}
+        </Text>
+    );
+};
+
 export const BuyPaymentMethodPicker = () => {
     const { translate } = useTranslate();
     const form = useBuyFormContext();
@@ -24,17 +63,17 @@ export const BuyPaymentMethodPicker = () => {
     const { isSheetVisible, hideSheet, showSheet, setSelectedValue, selectedValue } =
         useSheetControls(form, 'quote');
 
-    if (isLoading) {
-        return (
-            <OverviewRow title={translate('moduleTrading.tradingScreen.paymentMethod')} noCaret>
-                <OverviewValueSkeleton />
-            </OverviewRow>
-        );
-    }
+    const shouldShowPicker = quotes.length > 0 || isLoading;
 
-    if (quotes.length === 0) {
+    if (!shouldShowPicker) {
         return null;
     }
+
+    const showSheetConditionally = () => {
+        if (!isLoading) {
+            showSheet();
+        }
+    };
 
     const handleQuoteSelect = (quote: BuyTrade) => {
         setSelectedValue(quote);
@@ -54,31 +93,11 @@ export const BuyPaymentMethodPicker = () => {
         <>
             <OverviewRow
                 title={translate('moduleTrading.tradingScreen.paymentMethod')}
-                onPress={showSheet}
+                onPress={showSheetConditionally}
                 testID={PAYMENT_METHOD_PICKER_TEST_ID}
+                noCaret={isLoading}
             >
-                {selectedValue ? (
-                    <Text
-                        color="textSubdued"
-                        variant="body"
-                        accessibilityLabel={translate(
-                            'moduleTrading.tradingScreen.selectedPaymentMethod',
-                        )}
-                        testID={PAYMENT_METHOD_PICKER_TEST_ID + '/value'}
-                    >
-                        {selectedValue.paymentMethodName}
-                    </Text>
-                ) : (
-                    <Text
-                        color="textDisabled"
-                        variant="body"
-                        accessibilityLabel={translate(
-                            'moduleTrading.tradingScreen.noPaymentMethod',
-                        )}
-                    >
-                        {translate('moduleTrading.notSelected')}
-                    </Text>
-                )}
+                <BuyPaymentMethodPickerRight isLoading={isLoading} selectedValue={selectedValue} />
             </OverviewRow>
             <PaymentMethodSheet
                 quotes={quotes}

--- a/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { BuyTrade } from 'invity-api';
 
+import { invariant } from '@suite-common/suite-utils';
 import {
     TradingRootState,
     selectBuyQuotesByPaymentMethod,
@@ -19,7 +20,44 @@ import { OverviewValueSkeleton } from '../general/OverviewValueSkeleton';
 import { ProviderLogo } from '../general/ProviderLogo';
 import { ProviderSheet } from '../general/ProviderSheet/ProviderSheet';
 
+type BuyProviderPickerRightProps = {
+    isLoading: boolean;
+    selectedValue: BuyTrade | undefined;
+    providers: ReturnType<typeof selectTradingBuyProviders>;
+};
+
 const PROVIDER_PICKER_TEST_ID = '@trading/buy/provider-picker';
+
+const BuyProviderPickerRight = ({
+    isLoading,
+    selectedValue,
+    providers,
+}: BuyProviderPickerRightProps) => {
+    const { translate } = useTranslate();
+
+    if (isLoading) {
+        return <OverviewValueSkeleton />;
+    }
+
+    const { exchange } = selectedValue ?? {};
+    const selectedProvider = exchange ? providers?.[exchange] : undefined;
+    invariant(selectedProvider, 'Selected provider should be defined');
+    const { companyName, logo } = selectedProvider;
+
+    return (
+        <HStack>
+            <ProviderLogo logo={logo} />
+            <Text
+                color="textSubdued"
+                variant="body"
+                accessibilityLabel={translate('moduleTrading.tradingScreen.selectedProvider')}
+                testID={PROVIDER_PICKER_TEST_ID + '/value'}
+            >
+                {companyName}
+            </Text>
+        </HStack>
+    );
+};
 
 export const BuyProviderPicker = () => {
     const { translate } = useTranslate();
@@ -29,20 +67,24 @@ export const BuyProviderPicker = () => {
 
     const { isSheetVisible, hideSheet, showSheet, setSelectedValue, selectedValue } =
         useSheetControls(form, 'quote');
-    const { paymentMethod, exchange: providerKey } = selectedValue ?? {};
+    const { paymentMethod } = selectedValue ?? {};
     const quotes =
         useSelector((state: TradingRootState) =>
             selectBuyQuotesByPaymentMethod(state, paymentMethod),
         ) ?? [];
 
+    const shouldShowPicker = (providers && quotes.length > 0) || isLoading;
+
     const handleProviderPress = () => {
+        if (isLoading) return;
+
+        showSheet();
         analytics.report({
             type: EventType.TradingCompareOffers,
             payload: {
                 type: 'buy',
             },
         });
-        showSheet();
     };
 
     const handleQuoteSelect = (quote: BuyTrade) => {
@@ -59,23 +101,9 @@ export const BuyProviderPicker = () => {
         });
     };
 
-    if (isLoading) {
-        return (
-            <OverviewRow
-                title={translate('moduleTrading.tradingScreen.provider')}
-                noBottomBorder
-                noCaret
-            >
-                <OverviewValueSkeleton />
-            </OverviewRow>
-        );
-    }
-
-    if (!providerKey || !providers || providers[providerKey] === undefined) {
+    if (!shouldShowPicker) {
         return null;
     }
-
-    const { companyName, logo } = providers[providerKey];
 
     return (
         <>
@@ -84,24 +112,17 @@ export const BuyProviderPicker = () => {
                 noBottomBorder
                 onPress={handleProviderPress}
                 testID={PROVIDER_PICKER_TEST_ID}
+                noCaret={isLoading}
             >
-                <HStack>
-                    <ProviderLogo logo={logo} />
-                    <Text
-                        color="textSubdued"
-                        variant="body"
-                        accessibilityLabel={translate(
-                            'moduleTrading.tradingScreen.selectedProvider',
-                        )}
-                        testID={PROVIDER_PICKER_TEST_ID + '/value'}
-                    >
-                        {companyName}
-                    </Text>
-                </HStack>
+                <BuyProviderPickerRight
+                    isLoading={isLoading}
+                    selectedValue={selectedValue}
+                    providers={providers}
+                />
             </OverviewRow>
             <ProviderSheet
                 quotes={quotes}
-                providerInfos={providers}
+                providerInfos={providers ?? {}}
                 isVisible={isSheetVisible}
                 onClose={hideSheet}
                 onQuoteSelect={handleQuoteSelect}

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
@@ -1,30 +1,56 @@
+import { EnhancedStore } from '@reduxjs/toolkit';
+import { BuyTrade } from 'invity-api';
+
+import { tradingBuyActions } from '@suite-common/trading';
+import { EventType, analytics } from '@suite-native/analytics';
 import { Form } from '@suite-native/forms';
 import {
     PreloadedState,
+    act,
     fireEvent,
+    initStore,
     renderHookWithStoreProviderAsync,
     renderWithStoreProviderAsync,
 } from '@suite-native/test-utils';
 
+import quotes from '../../../__fixtures__/quotes.json';
 import { getInitializedTradingStateWithQuotes } from '../../../__fixtures__/tradingState';
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
+import { TradingBuyForm } from '../../../types';
 import { BuyPaymentMethodPicker } from '../BuyPaymentMethodPicker';
 
 describe('BuyPaymentMethodPicker', () => {
-    const renderPaymentMethodPicker = async (preloadedState: PreloadedState = {}) => {
+    let form: TradingBuyForm;
+
+    const renderPaymentMethodPicker = async (
+        preloadedState: PreloadedState | undefined = {},
+        store?: EnhancedStore,
+    ) => {
         const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm());
+        form = result.current;
 
         return renderWithStoreProviderAsync(
-            <Form form={result.current}>
+            <Form form={form}>
                 <BuyPaymentMethodPicker />
             </Form>,
-            { preloadedState },
+            { preloadedState, store },
         );
     };
+
     it('should not render when there are no payment methods', async () => {
         const { toJSON } = await renderPaymentMethodPicker();
 
         expect(toJSON()).toBeNull();
+    });
+
+    it('should display loader when loading initial quotes', async () => {
+        const preloadedState: PreloadedState = {
+            wallet: { tradingNew: { buy: { isLoading: true, quotes: [] } } },
+        };
+
+        const { getByLabelText } = await renderPaymentMethodPicker(preloadedState);
+
+        expect(getByLabelText('Fetching offers...')).toBeOnTheScreen();
     });
 
     describe('with quotes loaded', () => {
@@ -52,7 +78,76 @@ describe('BuyPaymentMethodPicker', () => {
             preloadedState!.wallet!.tradingNew!.buy!.isLoading = true;
             const { getByLabelText } = await renderPaymentMethodPicker(preloadedState);
 
-            expect(getByLabelText('Fetching offers...')).toBeTruthy();
+            expect(getByLabelText('Fetching offers...')).toBeOnTheScreen();
+        });
+
+        it('should display sheet even while quotes are fetched', async () => {
+            const store = await initStore();
+            store.dispatch(tradingBuyActions.saveQuotes(quotes as BuyTrade[]));
+            const { getByText } = await renderPaymentMethodPicker(undefined, store);
+
+            fireEvent.press(getByText('Payment method'));
+            act(() => {
+                store.dispatch(tradingBuyActions.setIsLoading(true));
+            });
+
+            expect(getByText('Credit Card')).toBeOnTheScreen();
+        });
+
+        describe('analytics', () => {
+            const analyticsSpy = jest.spyOn(analytics, 'report');
+
+            beforeEach(() => {
+                analyticsSpy.mockClear();
+            });
+
+            afterAll(() => {
+                analyticsSpy.mockRestore();
+            });
+
+            it('should fire analytics event on payment method select', async () => {
+                const { getByText } = await renderPaymentMethodPicker(preloadedState);
+
+                fireEvent.press(getByText('Payment method'));
+                fireEvent.press(getByText('Credit Card'));
+
+                expect(analyticsSpy).toHaveBeenCalledWith({
+                    type: EventType.TradingParameterChanged,
+                    payload: {
+                        type: 'buy',
+                        parameter: 'paymentMethod',
+                    },
+                });
+            });
+
+            it('should fire analytics event on payment method change', async () => {
+                const { getByText } = await renderPaymentMethodPicker(preloadedState);
+
+                act(() => {
+                    // set credit card as selected payment method
+                    form.setValue('quote', quotes[1] as BuyTrade);
+                });
+
+                fireEvent.press(getByText('Payment method'));
+                fireEvent.press(getByText('Apple Pay'));
+
+                expect(analyticsSpy).toHaveBeenCalledTimes(1);
+            });
+
+            it('should not fire analytics event when same payment method is selected', async () => {
+                const { getByText, getAllByText } = await renderPaymentMethodPicker(preloadedState);
+
+                act(() => {
+                    // set credit card as selected payment method
+                    form.setValue('quote', quotes[1] as BuyTrade);
+                });
+
+                fireEvent.press(getByText('Payment method'));
+                // 1st Credit Card is the selected one, 2nd is the one in the list
+                fireEvent.press(getAllByText('Credit Card')[1]);
+
+                expect(analyticsSpy).toHaveBeenCalledTimes(0);
+            });
         });
     });
 });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.comp.test.tsx
@@ -1,13 +1,16 @@
 import { BuyTrade } from 'invity-api';
 
+import { EventType, analytics } from '@suite-native/analytics';
 import { Form } from '@suite-native/forms';
 import {
     PreloadedState,
     act,
+    fireEvent,
     renderHookWithStoreProviderAsync,
     renderWithStoreProviderAsync,
 } from '@suite-native/test-utils';
 
+import { cexdirect, invity, mercuryo } from '../../../__fixtures__/providers';
 import quotes from '../../../__fixtures__/quotes.json';
 import { getInitializedTradingStateWithQuotes } from '../../../__fixtures__/tradingState';
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
@@ -15,15 +18,18 @@ import { TradingBuyForm } from '../../../types';
 import { BuyProviderPicker } from '../BuyProviderPicker';
 
 describe('BuyProviderPicker', () => {
-    const renderUseTradingBuyForm = (preloadedState: PreloadedState = {}) =>
-        renderHookWithStoreProviderAsync(() => useBuyForm(), {
+    let form: TradingBuyForm;
+
+    const renderUseTradingBuyForm = async (preloadedState: PreloadedState = {}) => {
+        const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm(), {
             preloadedState,
         });
+        form = result.current;
 
-    const renderTradingProviderPicker = (
-        form: TradingBuyForm,
-        preloadedState: PreloadedState = {},
-    ) =>
+        return form;
+    };
+
+    const renderTradingProviderPicker = (preloadedState: PreloadedState = {}) =>
         renderWithStoreProviderAsync(
             <Form form={form}>
                 <BuyProviderPicker />
@@ -32,38 +38,130 @@ describe('BuyProviderPicker', () => {
         );
 
     it('should display nothing when in default state', async () => {
-        const { result } = await renderUseTradingBuyForm();
-        const { toJSON } = await renderTradingProviderPicker(result.current);
+        await renderUseTradingBuyForm();
+        const { toJSON } = await renderTradingProviderPicker();
+
         expect(toJSON()).toBeNull();
     });
 
-    it('should display selected provider according to quotes', async () => {
-        const preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
-        const { result } = await renderUseTradingBuyForm(preloadedState);
-        act(() => {
-            result.current.setValue('quote', quotes[2] as BuyTrade);
-        });
+    it('should display loader while quotes are fetched', async () => {
+        const preloadedState: PreloadedState = {
+            wallet: { tradingNew: { buy: { isLoading: true, quotes: [] } } },
+        };
+        await renderUseTradingBuyForm();
+        const { getByLabelText } = await renderTradingProviderPicker(preloadedState);
 
-        const { getByLabelText } = await renderTradingProviderPicker(
-            result.current,
-            preloadedState,
-        );
-
-        expect(getByLabelText('Selected provider')).toHaveTextContent('Invity Finance');
+        expect(getByLabelText('Fetching offers...')).toBeOnTheScreen();
     });
 
-    it('should display loader while quotes are fetched', async () => {
-        const preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
-        preloadedState!.wallet!.tradingNew!.buy!.isLoading = true;
-        const { result } = await renderUseTradingBuyForm(preloadedState);
-        act(() => {
-            result.current.setValue('quote', quotes[2] as BuyTrade);
-        });
-        const { getByLabelText } = await renderTradingProviderPicker(
-            result.current,
-            preloadedState,
-        );
+    describe('with quotes loaded', () => {
+        let preloadedState: PreloadedState;
 
-        expect(getByLabelText('Fetching offers...')).toBeTruthy();
+        beforeEach(() => {
+            act(() => {
+                form.setValue('quote', quotes[1] as BuyTrade);
+            });
+
+            preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
+            preloadedState.wallet!.tradingNew!.buy!.buyInfo!.providerInfos = {
+                invity,
+                mercuryo,
+                cexdirect,
+            };
+        });
+
+        it('should allow to select provider', async () => {
+            const { getByText, getByLabelText } = await renderTradingProviderPicker(preloadedState);
+
+            fireEvent.press(getByText('Provider'));
+            fireEvent.press(getByText('Mercuryo'));
+
+            expect(getByLabelText('Selected provider')).toHaveTextContent('Mercuryo');
+        });
+
+        it('should display loader while quotes are re-fetched', async () => {
+            preloadedState!.wallet!.tradingNew!.buy!.isLoading = true;
+            const { getByLabelText } = await renderTradingProviderPicker(preloadedState);
+
+            expect(getByLabelText('Fetching offers...')).toBeOnTheScreen();
+        });
+
+        it('should display sheet even while quotes are fetched', async () => {
+            preloadedState!.wallet!.tradingNew!.buy!.isLoading = true;
+            const { getByText } = await renderTradingProviderPicker(preloadedState);
+
+            fireEvent.press(getByText('Provider'));
+
+            expect(getByText('Mercuryo')).toBeOnTheScreen();
+        });
+
+        describe('analytics', () => {
+            const analyticsSpy = jest.spyOn(analytics, 'report');
+
+            beforeEach(() => {
+                analyticsSpy.mockClear();
+            });
+
+            afterAll(() => {
+                analyticsSpy.mockRestore();
+            });
+
+            it('should fire analytics event on provider select', async () => {
+                const { getByText } = await renderTradingProviderPicker(preloadedState);
+
+                fireEvent.press(getByText('Provider'));
+                fireEvent.press(getByText('Mercuryo'));
+
+                expect(analyticsSpy).toHaveBeenCalledTimes(2);
+                expect(analyticsSpy).toHaveBeenCalledWith({
+                    type: EventType.TradingCompareOffers,
+                    payload: {
+                        type: 'buy',
+                    },
+                });
+                expect(analyticsSpy).toHaveBeenCalledWith({
+                    type: EventType.TradingParameterChanged,
+                    payload: {
+                        type: 'buy',
+                        parameter: 'provider',
+                    },
+                });
+            });
+
+            it('should fire analytics event on provider change', async () => {
+                const { getByText } = await renderTradingProviderPicker(preloadedState);
+
+                fireEvent.press(getByText('Provider'));
+                fireEvent.press(getByText('Mercuryo'));
+
+                expect(analyticsSpy).toHaveBeenCalledTimes(2);
+            });
+
+            it('should not fire analytics event when same provider is selected', async () => {
+                const { getByText, getAllByText } =
+                    await renderTradingProviderPicker(preloadedState);
+
+                fireEvent.press(getByText('Provider'));
+                // 1st Credit Card is the selected one, 2nd is the one in the list
+                fireEvent.press(getAllByText('Cexdirect')[1]);
+
+                expect(analyticsSpy).toHaveBeenCalledTimes(1);
+                expect(analyticsSpy).toHaveBeenCalledWith({
+                    type: EventType.TradingCompareOffers,
+                    payload: {
+                        type: 'buy',
+                    },
+                });
+            });
+
+            it('should not call analytics when user tries to open sheet while quotes are loading', async () => {
+                preloadedState!.wallet!.tradingNew!.buy!.isLoading = true;
+                const { getByText } = await renderTradingProviderPicker(preloadedState);
+
+                fireEvent.press(getByText('Provider'));
+
+                expect(analyticsSpy).not.toHaveBeenCalled();
+            });
+        });
     });
 });


### PR DESCRIPTION


## Description

- Do not close sheets while quotes are fetched.
- Do not allow to open sheet while quotes are fetched.

## Related Issue

Resolve #19142

## Screenshots:
<img width="405" alt="Screenshot 2025-05-26 at 15 23 34" src="https://github.com/user-attachments/assets/f3bbc0ab-1354-4860-a91c-a0d6fda399e6" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19142-mobile-trade-keep-bottom-sheet-open&lookback=7)