### PR TITLE
fix(e2e): Fix up suite release reporter workflow

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -105,7 +105,6 @@ runs:
         PASSPHRASE: ${{ inputs.e2e-passphrase }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
         RELEASE_BUILD: ${{ inputs.release-build }}
-        RUN_REPORTER: ${{ inputs.run-reporter }}
       run: |
         if [[ -z "${{ inputs.base-url }}" ]]; then
           BASE_URL="https://dev.suite.sldev.cz/suite-web/${{ env.branch }}/web/"
@@ -114,16 +113,27 @@ runs:
         fi
         export BASE_URL
         echo "Using BASE_URL: $BASE_URL"
+  
+        if [[ "${{ inputs.run-reporter }}" == "true" ]]; then
+          REPORTER_OPT="--reporter=./e2e/support/reporters/gitHubReporter.ts"
+        else
+          REPORTER_OPT=""
+        fi
 
         docker compose up -d ${{ inputs.containers }}
         echo "Starting Playwright project ${{ inputs.project }} for test group ${{ inputs.test-group }}"
-        yarn workspace @trezor/suite-desktop-core test:orchestrated:e2e:${{ inputs.project }} --pwc-cancel-after-failures ${{ inputs.fail-fast }} --forbid-only --grep="${{ inputs.additional-grep }}"
+        yarn workspace @trezor/suite-desktop-core test:orchestrated:e2e:${{ inputs.project }} \
+          --pwc-cancel-after-failures ${{ inputs.fail-fast }} \
+          --forbid-only \
+          $REPORTER_OPT \
+          --grep="${{ inputs.additional-grep }}"
 
     - name: Extract and Upload Logs
       if: ${{ !cancelled() }}
       uses: ./.github/actions/upload-test-logs
       with:
         test-group: ${{ inputs.test-group }}
+        project: ${{ inputs.project }}
 
     - name: Docker Compose Down
       shell: bash

--- a/.github/actions/upload-test-logs/action.yml
+++ b/.github/actions/upload-test-logs/action.yml
@@ -4,6 +4,10 @@ inputs:
   test-group:
     description: "Test group name for log file naming"
     required: true
+  project:
+    description: "Playwright project name. (web|desktop)"
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -18,7 +22,7 @@ runs:
     - name: Upload Trezor-user-env and Regtest logs
       uses: actions/upload-artifact@v4
       with:
-        name: emulator-logs-${{ inputs.test-group }}
+        name: emulator-logs-${{ inputs.project }}-${{ inputs.test-group }}
         path: |
           trezor-user-env-debugging.log
           tenv-emulator-bridge-debugging.log

--- a/.github/workflows/test-suite-desktop-e2e-release.yml
+++ b/.github/workflows/test-suite-desktop-e2e-release.yml
@@ -15,7 +15,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: desktop-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -74,7 +74,7 @@ jobs:
       - name: Run Playwright E2E Tests
         uses: ./.github/actions/run-e2e-tests
         with:
-          project: "desktop:release"
+          project: "desktop"
           containers: "trezor-user-env-unix bitcoin-regtest"
           workspace-dependencies: "@trezor/suite-desktop"
           test-group: ${{ matrix.TEST_GROUP }}

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: manual-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-suite-release-e2e-report-orchestration.yml
+++ b/.github/workflows/test-suite-release-e2e-report-orchestration.yml
@@ -5,12 +5,19 @@ name: "[Test] Release Suite Report orchestration"
 on:
   workflow_dispatch:
 
+concurrency:
+  group: orchestration-${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   call-test-suite-manual-release:
     uses: ./.github/workflows/test-suite-manual-release.yml
+    secrets: inherit
 
   call-test-suite-desktop-e2e-release:
     uses: ./.github/workflows/test-suite-desktop-e2e-release.yml
+    secrets: inherit
 
   call-test-suite-web-e2e-release:
     uses: ./.github/workflows/test-suite-web-e2e-release.yml
+    secrets: inherit

--- a/.github/workflows/test-suite-web-e2e-release.yml
+++ b/.github/workflows/test-suite-web-e2e-release.yml
@@ -15,7 +15,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: web-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 env:
@@ -67,7 +67,7 @@ jobs:
       - name: Run Playwright E2E Tests
         uses: ./.github/actions/run-e2e-tests
         with:
-          project: "web:release"
+          project: "web"
           containers: "trezor-user-env-unix bitcoin-regtest"
           test-group: ${{ matrix.TEST_GROUP }}
           fail-fast: false

--- a/packages/suite-desktop-core/e2e/playwright.config.ts
+++ b/packages/suite-desktop-core/e2e/playwright.config.ts
@@ -23,26 +23,6 @@ function getTimeout(): number {
     return process.env.GITHUB_ACTION ? CI_TIMEOUT : LOCAL_TIMEOUT;
 }
 
-function getReporter(): PlaywrightTestConfig['reporter'] {
-    // Release - Manual regression: Generate manual suite in GitHub, without currents involvement
-    if (process.env.RUN_REPORTER === 'manual') {
-        return [['./support/reporters/gitHubReporter.ts']];
-    }
-
-    // Local run
-    if (!process.env.GITHUB_ACTION) {
-        return [['list'], ['html', { open: 'never' }]];
-    }
-
-    // Release - Automated CI run: Report results both in Currents and GitHub
-    if (process.env.RUN_REPORTER === 'true') {
-        return [['@currents/playwright'], ['./support/reporters/gitHubReporter.ts']];
-    }
-
-    // Default run on CI: Report results only in Currents
-    return [['@currents/playwright']];
-}
-
 const config: PlaywrightTestConfig = defineConfig<CurrentsFixtures, CurrentsWorkerFixtures>({
     projects: [
         {
@@ -78,7 +58,10 @@ const config: PlaywrightTestConfig = defineConfig<CurrentsFixtures, CurrentsWork
         currentsFixturesEnabled: !!process.env.GITHUB_ACTION,
     },
     reportSlowTests: null,
-    reporter: getReporter(),
+    // GitHub Reporter for release is called thru CLI (workflows and package.json)
+    reporter: process.env.GITHUB_ACTION
+        ? [['@currents/playwright']] // CI run
+        : [['list'], ['html', { open: 'never' }]], // Local run
     timeout: getTimeout(),
     outputDir: path.join(__dirname, 'test-results'),
     snapshotPathTemplate: 'snapshots/{projectName}/{testFilePath}/{arg}{ext}',

--- a/packages/suite-desktop-core/e2e/support/reporters/gitHubReporter.ts
+++ b/packages/suite-desktop-core/e2e/support/reporters/gitHubReporter.ts
@@ -107,6 +107,7 @@ class GitHubReporter implements Reporter, LoggingFunctions {
     // Initializes the reporter when test run begins, creates a GitHub project if it doesn't exist
     // eslint-disable-next-line require-await
     async onBegin() {
+        this.log('GitHub reporter started. Initializing GitHub client...');
         this.initState = InitializationState.IN_PROGRESS;
         const initPromise = (async () => {
             try {

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -16,7 +16,7 @@
         "test:e2e:update-snapshots": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --grep @snapshot --update-snapshots",
         "test:orchestrated:e2e:desktop": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=desktop",
         "test:orchestrated:e2e:web": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=web",
-        "github:report:manual": "RUN_REPORTER=manual yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --project=manual",
+        "github:report:manual": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --project=manual --reporter=./e2e/support/reporters/gitHubReporter.ts",
         "github:create:project": "tsx ./e2e/support/reporters/scriptCreateProject.ts"
     },
     "dependencies": {


### PR DESCRIPTION
The orchestration was broken in my original PR. I could not know before merge since the workflow did not exist.
Here is test run - https://github.com/orgs/trezor/projects/110/views/4?sliceBy%5Bvalue%5D=fix-e2e-reporter-orchestration-4bf9d0c
Our test project contains link to the workflow for convinience.

solves inheretance issue
minor fixes
reporter definition moved back to workflow calls
solves concurrences clashes



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-reporter-orchestration&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-reporter-orchestration&lookback=7)