### PR TITLE
fix(suite): disable trading button when balance is insufficient

### DIFF
--- a/packages/suite/src/utils/suite/validation.ts
+++ b/packages/suite/src/utils/suite/validation.ts
@@ -3,9 +3,8 @@ import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { getDisplaySymbol, isNetworkSymbol } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 import {
-    findToken,
-    formatNetworkAmount,
     fromFiatCurrency,
+    getAmountValidationResult,
     isDecimalsValid,
     isInteger,
     networkAmountToSmallestUnit,
@@ -184,40 +183,32 @@ export const validateMin =
 interface ValidateReserveOrBalanceOptions {
     account: Account;
     areSatsUsed?: boolean;
-    tokenAddress?: string | null;
+    contractAddress?: string | null;
 }
 
 export const validateReserveOrBalance =
     (
         translationString: TranslationFunction,
-        { account, areSatsUsed, tokenAddress }: ValidateReserveOrBalanceOptions,
+        { account, areSatsUsed, contractAddress }: ValidateReserveOrBalanceOptions,
     ) =>
     (value: string) => {
-        const token = findToken(account.tokens, tokenAddress);
-        let formattedAvailableBalance: string;
+        const result = getAmountValidationResult({
+            amount: value,
+            account,
+            areSatsUsed,
+            contractAddress,
+        });
 
-        if (token) {
-            formattedAvailableBalance = token.balance || '0';
-        } else {
-            formattedAvailableBalance = areSatsUsed
-                ? account.availableBalance
-                : formatNetworkAmount(account.availableBalance, account.symbol);
+        if (result.type === 'reserve') {
+            return translationString('AMOUNT_IS_MORE_THAN_RESERVE', {
+                reserve: result.reserve,
+                displaySymbol: getDisplaySymbol(account.symbol),
+            });
         }
 
-        const amountBig = new BigNumber(value);
-        if (amountBig.gt(formattedAvailableBalance)) {
-            const reserve =
-                account.networkType === 'ripple' || account.networkType === 'stellar'
-                    ? formatNetworkAmount(account.misc.reserve, account.symbol)
-                    : undefined;
-
-            if (reserve && amountBig.lt(formatNetworkAmount(account.balance, account.symbol))) {
-                return translationString('AMOUNT_IS_MORE_THAN_RESERVE', {
-                    reserve,
-                    displaySymbol: getDisplaySymbol(account.symbol),
-                });
-            }
-
+        if (result.type === 'not_enough') {
             return translationString('AMOUNT_IS_NOT_ENOUGH');
         }
+
+        return undefined;
     };

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
@@ -122,7 +122,7 @@ export const Amount = ({ output, outputId }: AmountProps) => {
             reserveOrBalance: validateReserveOrBalance(translationString, {
                 account,
                 areSatsUsed: !!shouldSendInSats,
-                tokenAddress: tokenValue,
+                contractAddress: tokenValue,
             }),
         },
     };

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputCryptoAmount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputCryptoAmount.tsx
@@ -105,7 +105,7 @@ export const TradingFormInputCryptoAmount = <TFieldValues extends TradingAllForm
                       reserveOrBalance: validateReserveOrBalance(translationString, {
                           account,
                           areSatsUsed: !!shouldSendInSats,
-                          tokenAddress: (getValues() as FormState).outputs?.[0]?.token,
+                          contractAddress: (getValues() as FormState).outputs?.[0]?.token,
                       }),
                   }
                 : {}),

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -10,6 +10,8 @@ import {
     parseCryptoId,
     useTradingInfo,
 } from '@suite-common/trading';
+import { TokenAddress } from '@suite-common/wallet-types';
+import { isAmountTooHigh } from '@suite-common/wallet-utils';
 import { Button, Column, Paragraph, Row, TextButton, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
@@ -55,6 +57,7 @@ export const TradingFormOffer = () => {
     const [isCompareLoading, setIsCompareLoading] = useState<boolean>(false);
     const context = useTradingFormContext();
     const {
+        account,
         type,
         quotes,
         goToOffers,
@@ -104,6 +107,30 @@ export const TradingFormOffer = () => {
         setIsCompareLoading(true);
         await goToOffers();
     };
+
+    let amount: string = '0';
+    let tokenAddress: TokenAddress | undefined;
+    let areSatsUsed = false;
+
+    if (isTradingSellContext(context) || isTradingExchangeContext(context)) {
+        const { shouldSendInSats, getValues } = context;
+        const { outputs } = getValues();
+
+        const output = outputs[0];
+        amount = output.amount;
+        tokenAddress = (output.token ?? undefined) as TokenAddress | undefined;
+        areSatsUsed = !!shouldSendInSats;
+    }
+
+    const amountTooHigh = isAmountTooHigh({
+        amount,
+        contractAddress: tokenAddress,
+        account,
+        areSatsUsed,
+    });
+
+    const isButtonDisabled =
+        tradingDeviceDisconnected || state.isLoadingOrInvalid || !quote || amountTooHigh;
 
     return (
         <Column gap={spacings.lg}>
@@ -197,7 +224,7 @@ export const TradingFormOffer = () => {
                     top: spacings.md,
                 }}
                 isFullWidth
-                isDisabled={tradingDeviceDisconnected || state.isLoadingOrInvalid || !quote}
+                isDisabled={isButtonDisabled}
                 data-testid={`@trading/form/${type}-button`}
             >
                 <Translation id={tradingGetSectionActionLabel(type)} />

--- a/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
@@ -29,7 +29,7 @@ export const composeCardanoTransactionFeeLevelsThunk = createThunk<
     ComposeTransactionThunkArguments,
     { rejectValue: ComposeFeeLevelsError }
 >(
-    `${SEND_MODULE_PREFIX}/composeBitcoinTransactionFeeLevelsThunk`,
+    `${SEND_MODULE_PREFIX}/composeCardanoTransactionFeeLevelsThunk`,
     async ({ formState, composeContext }, { dispatch, rejectWithValue }) => {
         const { account, feeInfo } = composeContext;
         const changeAddress = getUnusedChangeAddress(account);

--- a/suite-common/wallet-utils/src/__tests__/sendFormUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/sendFormUtils.test.ts
@@ -8,6 +8,7 @@ import {
     calculateTotal,
     calculateTotalGasCost,
     findComposeErrors,
+    getAmountValidationResult,
     getBitcoinComposeOutputs,
     getExcludedUtxos,
     getExternalComposeOutput,
@@ -405,5 +406,122 @@ describe('sendForm utils', () => {
         expect(excludedUtxos[getUtxoOutpoint(lowAnonymityDustUtxo)]).toBe('dust');
         expect(excludedUtxos[getUtxoOutpoint(lowAnonymityUtxo)]).toBe('low-anonymity');
         expect(excludedUtxos[getUtxoOutpoint(spendableUtxo)]).toBe(undefined);
+    });
+
+    describe('getAmountValidationResult', () => {
+        describe('should test bitcoin without tokens', () => {
+            const btcAccount = getWalletAccount({
+                networkType: 'bitcoin',
+                symbol: 'btc',
+                tokens: undefined,
+                balance: '1000000000', // 10 BTC
+                availableBalance: '10000000', // 0.1 BTC
+            });
+
+            it('returns ok when amount is within available balance', () => {
+                expect(getAmountValidationResult({ amount: '0.05', account: btcAccount })).toEqual({
+                    type: 'ok',
+                });
+
+                expect(getAmountValidationResult({ amount: '0.1', account: btcAccount })).toEqual({
+                    type: 'ok',
+                });
+            });
+
+            it('returns not_enough when amount exceeds available balance', () => {
+                expect(getAmountValidationResult({ amount: '0.11', account: btcAccount })).toEqual({
+                    type: 'not_enough',
+                });
+            });
+        });
+
+        describe('should test ripple (with reserve)', () => {
+            const rippleAccount = getWalletAccount({
+                networkType: 'ripple',
+                symbol: 'xrp',
+                tokens: undefined,
+                balance: '10000000', // 10 XRP
+                availableBalance: '9000000', // 9 XRP
+                misc: { reserve: '1000000', sequence: 0 },
+            });
+
+            it('returns reserve when amount is above available but below total balance', () => {
+                expect(
+                    getAmountValidationResult({ amount: '9.9', account: rippleAccount }),
+                ).toEqual({
+                    type: 'reserve',
+                    reserve: '1',
+                });
+            });
+
+            it('returns not_enough when amount exceeds total balance', () => {
+                expect(getAmountValidationResult({ amount: '10', account: rippleAccount })).toEqual(
+                    { type: 'not_enough' },
+                );
+            });
+        });
+
+        describe('should test stellar (with reserve)', () => {
+            const stellarAccount = getWalletAccount({
+                networkType: 'stellar',
+                symbol: 'xlm',
+                balance: '100000000', // 10 XLM
+                availableBalance: '95000000', // 9.5 XLM
+                misc: { reserve: '5000000', stellarSequence: '0' },
+            });
+
+            it('returns reserve when amount exceeds available but below total', () => {
+                expect(
+                    getAmountValidationResult({ amount: '9.9', account: stellarAccount }),
+                ).toEqual({
+                    type: 'reserve',
+                    reserve: '0.5',
+                });
+            });
+
+            it('returns not_enough when amount exceeds total balance', () => {
+                expect(
+                    getAmountValidationResult({ amount: '10', account: stellarAccount }),
+                ).toEqual({ type: 'not_enough' });
+            });
+        });
+
+        describe('should test token balances', () => {
+            const tokenAccount = getWalletAccount({
+                networkType: 'ethereum',
+                symbol: 'eth',
+                balance: '0',
+                availableBalance: '0',
+                tokens: [
+                    {
+                        contract: '0xabc',
+                        balance: '200',
+                        decimals: 18,
+                        type: 'ERC20',
+                        standard: 'ERC20',
+                    },
+                ],
+            });
+
+            it('returns ok when amount is within token balance', () => {
+                expect(
+                    getAmountValidationResult({
+                        amount: '150',
+                        account: tokenAccount,
+                        contractAddress: '0xabc',
+                    }),
+                ).toEqual({ type: 'ok' });
+            });
+
+            it('returns not_enough when amount exceeds token balance', () => {
+                expect(
+                    getAmountValidationResult({
+                        amount: '250',
+                        account: tokenAccount,
+                        contractAddress: '0xabc',
+                    }),
+                ).toEqual({ type: 'not_enough' });
+            });
+        });
     });
 });

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -41,7 +41,12 @@ import {
 } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { amountToSmallestUnit, getUtxoOutpoint, networkAmountToSmallestUnit } from './accountUtils';
+import {
+    amountToSmallestUnit,
+    formatNetworkAmount,
+    getUtxoOutpoint,
+    networkAmountToSmallestUnit,
+} from './accountUtils';
 import { isEip1559, sanitizeHex } from './ethUtils';
 
 export const calculateTotal = (amount: string, fee: string): string => {
@@ -535,3 +540,53 @@ export const getSendFormDraftKey = (
     accountKey: AccountKey,
     tokenAddress?: TokenAddress,
 ): SendFormDraftKey => (tokenAddress ? `${accountKey}-${tokenAddress}` : accountKey);
+
+type AmountValidationResult =
+    | { type: 'ok' }
+    | { type: 'not_enough' }
+    | { type: 'reserve'; reserve: string };
+
+interface GetAmountValidationResultParams {
+    amount: string | undefined;
+    contractAddress?: string | null;
+    account: Account;
+    areSatsUsed?: boolean;
+}
+
+export const getAmountValidationResult = ({
+    amount,
+    contractAddress,
+    account,
+    areSatsUsed,
+}: GetAmountValidationResultParams): AmountValidationResult => {
+    const token = findToken(account.tokens, contractAddress);
+    let formattedAvailableBalance: string;
+
+    if (token) {
+        formattedAvailableBalance = token.balance || '0';
+    } else {
+        formattedAvailableBalance = areSatsUsed
+            ? account.availableBalance
+            : formatNetworkAmount(account.availableBalance, account.symbol);
+    }
+
+    const amountBig = new BigNumber(amount ?? '0');
+
+    if (amountBig.gt(formattedAvailableBalance)) {
+        const reserve =
+            account.networkType === 'ripple' || account.networkType === 'stellar'
+                ? formatNetworkAmount(account.misc.reserve, account.symbol)
+                : undefined;
+
+        if (reserve && amountBig.lt(formatNetworkAmount(account.balance, account.symbol))) {
+            return { type: 'reserve', reserve };
+        }
+
+        return { type: 'not_enough' };
+    }
+
+    return { type: 'ok' };
+};
+
+export const isAmountTooHigh = (params: GetAmountValidationResultParams): boolean =>
+    getAmountValidationResult(params).type !== 'ok';


### PR DESCRIPTION
## Description

Added a balance check to properly disable the trade button when the account has insufficient funds.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/14927
Resolve https://github.com/trezor/trezor-suite/issues/14928

## Video:

https://github.com/user-attachments/assets/ef387f27-fef0-47ad-8615-2646bbd2f078

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-form-disabled-button-validation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-form-disabled-button-validation&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading-form-disabled-button-validation&lookback=7)