### PR TITLE
Mobile Trade: Clear receive account after wallet change

### DIFF
--- a/suite-native/module-trading/src/__tests__/tradingSlice.test.ts
+++ b/suite-native/module-trading/src/__tests__/tradingSlice.test.ts
@@ -1,6 +1,8 @@
 import { BuyTrade, CryptoId } from 'invity-api';
 
+import { TrezorDevice } from '@suite-common/suite-types';
 import { extraDependenciesMock } from '@suite-common/test-utils';
+import { deviceActions } from '@suite-common/wallet-core';
 
 import { getBtcAccount } from '../__fixtures__/account';
 import quotes from '../__fixtures__/quotes.json';
@@ -228,6 +230,21 @@ describe('tradingSlice', () => {
             const state = actions.reduce(tradingReducer, undefined) as TradingState;
 
             expect(state.tradeOrderIdToBeOpened).toBeUndefined();
+        });
+    });
+
+    describe('@suite/device/selectDevice', () => {
+        it('should clear selectedReceiveAccount', () => {
+            const actions = [
+                setBuySelectedReceiveAccount({
+                    selectedReceiveAccount: { account: getBtcAccount(), address: undefined },
+                }),
+                deviceActions.selectDevice({ name: 'TEST_DEVICE' } as TrezorDevice),
+            ];
+
+            const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+            expect(state.buy.selectedReceiveAccount).toBeUndefined();
         });
     });
 });

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
@@ -138,7 +138,7 @@ describe('useBuyForm', () => {
             expect(invityAPISpy).toHaveBeenCalledTimes(1);
         });
 
-        it('should not call createInvityAPIKey when descriptor is empty string', async () => {
+        it('should call createInvityAPIKey with random string when descriptor is empty string', async () => {
             const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
             const store = await getInitializedStore();
             await renderUseTradingBuyForm(store);
@@ -154,10 +154,11 @@ describe('useBuyForm', () => {
                 );
             });
 
-            expect(invityAPISpy).toHaveBeenCalledTimes(0);
+            expect(invityAPISpy).toHaveBeenCalledTimes(1);
+            expect(invityAPISpy).toHaveBeenCalledWith('random_string');
         });
 
-        it('should not call createInvityAPIKey when descriptor is undefined ', async () => {
+        it('should call createInvityAPIKey with random string when descriptor is undefined ', async () => {
             const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
             const store = await getInitializedStore();
             await renderUseTradingBuyForm(store);
@@ -191,7 +192,8 @@ describe('useBuyForm', () => {
                 );
             });
 
-            expect(invityAPISpy).toHaveBeenCalledTimes(1);
+            expect(invityAPISpy).toHaveBeenCalledTimes(2);
+            expect(invityAPISpy).toHaveBeenLastCalledWith('random_string');
         });
     });
 

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -45,9 +45,9 @@ const useReceiveAccountChangeEffect = ({ getValues, setValue }: TradingBuyForm) 
 
         setValue('receiveAccount', selectedReceiveAccount);
 
-        // when user selects receive account set invityAPIKey accordingly
-        if (descriptor && descriptor !== prevReceiveAccount?.account?.descriptor) {
-            invityAPI.createInvityAPIKey(descriptor);
+        // when user changes receive account set invityAPIKey accordingly
+        if (descriptor !== prevReceiveAccount?.account?.descriptor) {
+            invityAPI.createInvityAPIKey(descriptor || getRandomAccountDescriptor());
         }
     }, [selectedReceiveAccount, getValues, setValue]);
 };

--- a/suite-native/module-trading/src/tradingSlice.ts
+++ b/suite-native/module-trading/src/tradingSlice.ts
@@ -9,6 +9,7 @@ import {
     initialState as commonInitialState,
     prepareTradingReducer,
 } from '@suite-common/trading';
+import { deviceActions } from '@suite-common/wallet-core';
 
 import { ReceiveAccount } from './types';
 
@@ -85,6 +86,9 @@ export const tradingSlice = createSliceWithExtraDeps({
     extraReducers: (builder, extra) => {
         const commonTradingFormReducer = prepareTradingReducer(extra);
         builder
+            .addCase(deviceActions.selectDevice, state => {
+                state.buy.selectedReceiveAccount = undefined;
+            })
             // In case that this reducer does not match the action, try to handle it by suite-common tradingReducer.
             .addDefaultCase((state, action) => {
                 commonTradingFormReducer(state, action);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- trading reducer now reacts to `selectDevice` action.
- Invity API key is changed even when receive account becomes unselected.

<!--- Describe your changes in detail -->

## Related Issue

Resolve #19178

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19178-mobile-trade-on-wallet-change&lookback=7)