### PR TITLE
Chore/suite persistent thp statickey

### DIFF
--- a/packages/connect/src/events/device.ts
+++ b/packages/connect/src/events/device.ts
@@ -53,6 +53,7 @@ export interface DeviceThpCredentialsChanged {
     payload: {
         device: Device;
         credentials: ThpCredentials;
+        staticKey: string;
     };
 }
 

--- a/packages/connect/src/types/api/__tests__/events.ts
+++ b/packages/connect/src/types/api/__tests__/events.ts
@@ -32,6 +32,11 @@ export const events = (api: TrezorConnect) => {
         if (event.type === 'device-thp_credentials_changed') {
             const { payload } = event;
             payload.credentials.credential.toLowerCase();
+            payload.credentials.trezor_static_pubkey.toLowerCase();
+            payload.staticKey.toLowerCase();
+            if (payload.credentials.autoconnect === true) {
+                //
+            }
 
             return;
         }

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -118,8 +118,8 @@ export const saveCoinjoinDebugSettings = () => async (_dispatch: Dispatch, getSt
 
 export const saveThpCredentials = () => async (_dispatch: Dispatch, getState: GetState) => {
     if (!(await db.isAccessible())) return;
-    const { credentials } = getState().thp;
-    db.addItem('thp', { credentials }, 'value', true);
+    const { credentials, staticKey } = getState().thp;
+    db.addItem('thp', { credentials, staticKey }, 'value', true);
 };
 
 export const saveKnownDevices = () => async (_dispatch: Dispatch, getState: GetState) => {

--- a/packages/suite/src/storage/definitions.ts
+++ b/packages/suite/src/storage/definitions.ts
@@ -82,6 +82,7 @@ export interface SuiteDBSchema extends DBSchema {
     thp: {
         key: string;
         value: {
+            staticKey?: string;
             credentials: ThpSuiteCredentials[];
         };
     };

--- a/suite-common/thp/src/index.ts
+++ b/suite-common/thp/src/index.ts
@@ -1,5 +1,5 @@
 export { prepareThpReducer, THP_BUTTON_REQUESTS_NAMES } from './thpReducer';
 export type { ThpStep } from './thpReducer';
-export { selectThpStep, selectThpCredentials } from './thpSelectors';
+export { selectThpStep, selectThpCredentials, selectThpStaticKey } from './thpSelectors';
 export { thpActions } from './thpActions';
 export { connectThpDeviceThunk } from './connectThpDeviceThunk';

--- a/suite-common/thp/src/thpReducer.ts
+++ b/suite-common/thp/src/thpReducer.ts
@@ -27,6 +27,9 @@ export type ThpState = {
     step: ThpStep;
     lastThpCode?: string;
     credentials: ThpSuiteCredentials[];
+    // staticKey for the application.
+    // this value is generated at first THP pairing and should never change. will be used for all future pairings
+    staticKey?: string;
 };
 
 const initialState: ThpState = {
@@ -69,12 +72,13 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
             .addMatcher(
                 action => action.type === DEVICE.THP_CREDENTIALS_CHANGED,
                 (state, action: DeviceThpCredentialsChanged) => {
-                    const { credentials } = action.payload;
+                    const { credentials, staticKey } = action.payload;
 
                     state.credentials.push({
                         ...credentials,
                         connectionCounter: 0,
                     });
+                    state.staticKey = staticKey;
                 },
             )
             .addMatcher(
@@ -100,6 +104,7 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
                 action => action.type === extra.actionTypes.storageLoad,
                 (state, action: AnyAction) => {
                     state.credentials = action.payload.thp?.credentials ?? [];
+                    state.staticKey = action.payload.thp?.staticKey;
                 },
             ),
 );

--- a/suite-common/thp/src/thpSelectors.ts
+++ b/suite-common/thp/src/thpSelectors.ts
@@ -7,3 +7,5 @@ export type WithThpState = {
 export const selectThpStep = (state: WithThpState) => state.thp.step;
 
 export const selectThpCredentials = (state: WithThpState) => state.thp.credentials;
+
+export const selectThpStaticKey = (state: WithThpState) => state.thp.staticKey;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

add forgotten field

`staticKey` is undefined by default. it is randomly generated at first THP pairing and should never change. 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/suite-persistent-thp-statickey&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/suite-persistent-thp-statickey&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/suite-persistent-thp-statickey&lookback=7)