### PR TITLE
Fix broken FW update flow

### DIFF
--- a/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
+++ b/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
@@ -198,7 +198,7 @@ export const FirmwareInstallationScreenContent = ({
         return 'starting';
     }, [status, operation, isError]);
 
-    const showConfirmOnDevice = confirmOnDevice && !isError;
+    const showConfirmOnDevice = confirmOnDevice && !isError && !isDone;
     const isCancelButtonDisplayed = isCancellationAllowed && isError;
 
     const buttonStyle = applyStyle(bottomButtonsContainerStyle, {

--- a/suite-native/module-device-settings/src/screens/FirmwareInstallationScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/FirmwareInstallationScreen.tsx
@@ -1,5 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 
+import { Box } from '@suite-native/atoms';
 import { FirmwareInstallationScreenContent } from '@suite-native/firmware';
 import {
     DeviceSettingsStackParamList,
@@ -34,11 +35,13 @@ export const FirmwareInstallationScreen = () => {
 
     return (
         <Screen>
-            <FirmwareInstallationScreenContent
-                onFirmwareInstallationSuccess={handleFirmwareInstallationSuccess}
-                onFirmwareInstallationFailure={handleFirmwareInstallationFailure}
-                navigationLocation="settings"
-            />
+            <Box flex={1}>
+                <FirmwareInstallationScreenContent
+                    onFirmwareInstallationSuccess={handleFirmwareInstallationSuccess}
+                    onFirmwareInstallationFailure={handleFirmwareInstallationFailure}
+                    navigationLocation="settings"
+                />
+            </Box>
         </Screen>
     );
 };


### PR DESCRIPTION
## Description

Confirm On Device should not be visible when firmware installation/update is done.

Wrapping FirmwareInstallationScreenContent in a Box component fixes the bottom inset issue. It was previously handled with useSafeAreaInsets, but that was removed when the component was reused in Device Onboarding, where the Box makes it unnecessary. Using Box also turned out to be the simplest and most consistent solution for Device Settings.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19067



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/fw-instllation-flow&lookback=7)