### PR TITLE
Mobile Trade: Clear amount limits on asset / fiat currency change

### DIFF
--- a/suite-native/module-trading/src/__tests__/tradingSlice.test.ts
+++ b/suite-native/module-trading/src/__tests__/tradingSlice.test.ts
@@ -2,6 +2,7 @@ import { BuyTrade, CryptoId } from 'invity-api';
 
 import { TrezorDevice } from '@suite-common/suite-types';
 import { extraDependenciesMock } from '@suite-common/test-utils';
+import { tradingBuyActions } from '@suite-common/trading';
 import { deviceActions } from '@suite-common/wallet-core';
 
 import { getBtcAccount } from '../__fixtures__/account';
@@ -10,6 +11,8 @@ import { adaAsset, btcAsset, usdcAsset } from '../__fixtures__/tradeableAssets';
 import {
     TradingState,
     addTradeableAssetToFavourites,
+    buyAssetChanged,
+    buyFiatCurrencyChanged,
     clearTradeOrderIdToBeOpened,
     initialState,
     removeTradeableAssetFromFavourites,
@@ -245,6 +248,89 @@ describe('tradingSlice', () => {
             const state = actions.reduce(tradingReducer, undefined) as TradingState;
 
             expect(state.buy.selectedReceiveAccount).toBeUndefined();
+        });
+    });
+
+    describe('buyAssetChanged', () => {
+        it('should clear selectedReceiveAccount', () => {
+            const actions = [
+                setBuySelectedReceiveAccount({
+                    selectedReceiveAccount: { account: getBtcAccount(), address: undefined },
+                }),
+                buyAssetChanged(),
+            ];
+
+            const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+            expect(state.buy.selectedReceiveAccount).toBeUndefined();
+        });
+
+        it('should clear buy amountLimits', () => {
+            const actions = [
+                tradingBuyActions.setAmountLimits({
+                    currency: 'CZK',
+                    minFiat: '100',
+                    maxCrypto: '0.01',
+                    maxFiat: '1000',
+                    minCrypto: '0.0001',
+                }),
+                buyAssetChanged(),
+            ];
+
+            const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+            expect(state.buy.amountLimits).toBeUndefined();
+        });
+
+        it('should clear quotesRequest', () => {
+            const actions = [
+                tradingBuyActions.saveQuoteRequest({
+                    wantCrypto: true,
+                    receiveCurrency: 'btc' as CryptoId,
+                    fiatCurrency: 'czk',
+                    country: 'CZ',
+                }),
+                buyAssetChanged(),
+            ];
+
+            const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+            expect(state.buy.quotesRequest).toBeUndefined();
+        });
+    });
+
+    describe('buyFiatCurrencyChanged', () => {
+        it('should clear buy amountLimits', () => {
+            const actions = [
+                tradingBuyActions.setAmountLimits({
+                    currency: 'CZK',
+                    minFiat: '100',
+                    maxCrypto: '0.01',
+                    maxFiat: '1000',
+                    minCrypto: '0.0001',
+                }),
+                buyFiatCurrencyChanged(),
+            ];
+
+            const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+            expect(state.buy.amountLimits).toBeUndefined();
+        });
+
+        it('should clear quotesRequest', () => {
+            const actions = [
+                tradingBuyActions.saveQuoteRequest({
+                    wantCrypto: true,
+                    receiveCurrency: 'btc' as CryptoId,
+                    fiatCurrency: 'czk',
+                    country: 'CZ',
+                }),
+                buyAssetChanged(),
+            ];
+
+            const state = actions.reduce(tradingReducer, undefined) as TradingState;
+
+            expect(state.buy.quotesRequest).toBeUndefined();
         });
     });
 });

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
@@ -18,7 +18,11 @@ import { PROTO } from '@trezor/connect';
 import quotes from '../../../__fixtures__/quotes.json';
 import { btcAsset, usdcAsset } from '../../../__fixtures__/tradeableAssets';
 import { getInitializedTradingState } from '../../../__fixtures__/tradingState';
-import { setBuySelectedReceiveAccount } from '../../../tradingSlice';
+import {
+    buyAssetChanged,
+    buyFiatCurrencyChanged,
+    setBuySelectedReceiveAccount,
+} from '../../../tradingSlice';
 import { TradeableAsset, TradingBuyForm } from '../../../types';
 import { clearTradingBuyFormQuoteData, useBuyForm } from '../useBuyForm';
 
@@ -197,23 +201,17 @@ describe('useBuyForm', () => {
         });
     });
 
-    it('should clear selected account on asset network change', async () => {
+    it('should dispatch buyAssetChanged on asset change', async () => {
         const store = await getInitializedStore();
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
         const { result } = await renderUseTradingBuyForm(store);
-
-        act(() => {
-            store.dispatch(
-                setBuySelectedReceiveAccount({
-                    selectedReceiveAccount: { account: { key: 'btc2' } as Account },
-                }),
-            );
-        });
 
         act(() => {
             result.current.setValue('asset', usdcAsset);
         });
 
-        expect(result.current.getValues('receiveAccount')).toBeUndefined();
+        expect(dispatchSpy).toHaveBeenCalledTimes(1);
+        expect(dispatchSpy).toHaveBeenCalledWith(buyAssetChanged());
     });
 
     it('should not clear selected account when asset is set to undefined', async () => {
@@ -267,6 +265,19 @@ describe('useBuyForm', () => {
         });
 
         expect(result.current.getValues('fiatValue')).toBeUndefined();
+    });
+
+    it('should dispatch buyFiatCurrencyChanged action on fiat currency change', async () => {
+        const store = await getInitializedStore();
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+        const { result } = await renderUseTradingBuyForm(store);
+
+        act(() => {
+            result.current.setValue('fiatCurrency', 'eur');
+        });
+
+        expect(dispatchSpy).toHaveBeenCalledTimes(1);
+        expect(dispatchSpy).toHaveBeenCalledWith(buyFiatCurrencyChanged());
     });
 
     it('should clear cryptoValue when user edits fiatValue', async () => {
@@ -527,18 +538,22 @@ describe('useBuyForm', () => {
             ['3000', 'Maximum is $2,000.00'],
         ])('should display fiat error for amount %s', async (amount, expectedValue) => {
             const store = await getInitializedStore(true);
-            store.dispatch(
-                tradingBuyActions.setAmountLimits({
-                    minFiat: '1000',
-                    maxFiat: '2000',
-                    currency: 'USD',
-                }),
-            );
+
             const { result } = await renderUseTradingBuyForm(store);
 
             act(() => {
                 result.current.setValue('fiatValue', amount);
                 result.current.setValue('asset', btcAsset);
+            });
+
+            act(() => {
+                store.dispatch(
+                    tradingBuyActions.setAmountLimits({
+                        minFiat: '1000',
+                        maxFiat: '2000',
+                        currency: 'USD',
+                    }),
+                );
             });
 
             await act(() => result.current.trigger('fiatValue'));
@@ -558,18 +573,20 @@ describe('useBuyForm', () => {
             'should display crypto error for amount %s',
             async (amount, amountInSats, expectedValue) => {
                 const store = await getInitializedStore(amountInSats);
-                store.dispatch(
-                    tradingBuyActions.setAmountLimits({
-                        minCrypto: '0.1',
-                        maxCrypto: '2',
-                        currency: 'BTC',
-                    }),
-                );
                 const { result } = await renderUseTradingBuyForm(store);
 
                 act(() => {
                     result.current.setValue('amountInCrypto', true);
                     result.current.setValue('asset', btcAsset);
+                });
+                act(() => {
+                    store.dispatch(
+                        tradingBuyActions.setAmountLimits({
+                            minCrypto: '0.1',
+                            maxCrypto: '2',
+                            currency: 'BTC',
+                        }),
+                    );
                 });
                 act(() => {
                     result.current.setValue('cryptoValue', amount);

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
@@ -189,12 +189,12 @@ describe('useBuyQuotes', () => {
                 result.current.setValue(field, value);
             });
 
-            // 1st call - trading/setBuySelectedReceiveAccount
-            // 2nd call - initial handleRequestThunkMock
-            // 3rd call - re-fetch of handleRequestThunkMock
-            expect(dispatchSpy).toHaveBeenCalledTimes(3);
-            expect(dispatchSpy).toHaveBeenNthCalledWith(
-                3,
+            // 1st call - trading/buyAssetChanged
+            // 2nd call - trading/buyFiatCurrencyChanged
+            // 3rd call - initial handleRequestThunkMock
+            // 4th call - re-fetch of handleRequestThunkMock
+            expect(dispatchSpy).toHaveBeenCalledTimes(4);
+            expect(dispatchSpy).toHaveBeenLastCalledWith(
                 expect.objectContaining({
                     type: 'handleRequestThunkMock',
                 }),
@@ -214,17 +214,17 @@ describe('useBuyQuotes', () => {
             result.current.setValue('fiatValue', '100');
         });
 
-        expect(dispatchSpy).toHaveBeenCalledTimes(2);
+        expect(dispatchSpy).toHaveBeenCalledTimes(3);
 
         mockTimeSpent = INVITY_API_RELOAD_QUOTES_AFTER_SECONDS;
         rerender({});
 
-        // 1st call - trading/setBuySelectedReceiveAccount
-        // 2nd call - initial handleRequestThunkMock
-        // 3rd call - re-fetch of handleRequestThunkMock
-        expect(dispatchSpy).toHaveBeenCalledTimes(3);
-        expect(dispatchSpy).toHaveBeenNthCalledWith(
-            3,
+        // 1st call - trading/buyAssetChanged
+        // 2nd call - trading/buyFiatCurrencyChanged
+        // 3rd call - initial handleRequestThunkMock
+        // 4th call - re-fetch of handleRequestThunkMock
+        expect(dispatchSpy).toHaveBeenCalledTimes(4);
+        expect(dispatchSpy).toHaveBeenLastCalledWith(
             expect.objectContaining({
                 type: 'handleRequestThunkMock',
             }),
@@ -242,7 +242,8 @@ describe('useBuyQuotes', () => {
         mockTimeSpent = INVITY_API_RELOAD_QUOTES_AFTER_SECONDS;
         rerender({});
 
-        expect(dispatchSpy).toHaveBeenCalledTimes(0);
+        // 1st call - trading/buyAssetChanged
+        expect(dispatchSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should clear quotes when data in form becomes invalid', async () => {
@@ -265,12 +266,13 @@ describe('useBuyQuotes', () => {
             result.current.setValue('fiatValue', undefined);
         });
 
-        // 1st call - trading/setBuySelectedReceiveAccount
-        // 2nd call - initial handleRequestThunkMock
-        // 3rd call - manual saveQuotes
-        // 4th call - clearQuotesAndQuotesRequest
-        expect(dispatchSpy).toHaveBeenCalledTimes(4);
-        expect(dispatchSpy).toHaveBeenNthCalledWith(4, {
+        // 1st call - trading/buyAssetChanged
+        // 2nd call - trading/buyFiatCurrencyChanged
+        // 3rd call - initial handleRequestThunkMock
+        // 4th call - manual saveQuotes
+        // 5th call - clearQuotesAndQuotesRequest
+        expect(dispatchSpy).toHaveBeenCalledTimes(5);
+        expect(dispatchSpy).toHaveBeenLastCalledWith({
             payload: undefined,
             type: 'trading/clearQuotesAndQuotesRequest',
         });

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -24,7 +24,7 @@ import {
     selectBuyFormDefaultValues,
     selectBuySelectedReceiveAccount,
 } from '../../selectors/buySelectors';
-import { setBuySelectedReceiveAccount } from '../../tradingSlice';
+import { buyAssetChanged, buyFiatCurrencyChanged } from '../../tradingSlice';
 import { TradingBuyForm, TradingBuyFormValues } from '../../types';
 import { buyFormValidationSchema } from '../../utils/buy/buyFormValidationSchema';
 import { truncateDecimals } from '../../utils/general/amountUtils';
@@ -92,6 +92,7 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: 
                             prevFiatCurrency.current = fiatCurrency;
                             setValue('fiatValue', undefined, { shouldValidate: true });
                             setValue('cryptoValue', undefined, { shouldValidate: true });
+                            dispatch(buyFiatCurrencyChanged());
                         }
                         break;
 
@@ -106,9 +107,7 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: 
                             });
                             prevCryptoId.current = asset?.cryptoId as CryptoId | undefined;
                             setValue('cryptoValue', undefined, { shouldValidate: true });
-                            dispatch(
-                                setBuySelectedReceiveAccount({ selectedReceiveAccount: undefined }),
-                            );
+                            dispatch(buyAssetChanged());
                         }
                         break;
                     }

--- a/suite-native/module-trading/src/tradingSlice.ts
+++ b/suite-native/module-trading/src/tradingSlice.ts
@@ -82,6 +82,15 @@ export const tradingSlice = createSliceWithExtraDeps({
         clearTradeOrderIdToBeOpened: state => {
             state.tradeOrderIdToBeOpened = undefined;
         },
+        buyAssetChanged: state => {
+            state.buy.selectedReceiveAccount = undefined;
+            state.buy.amountLimits = undefined;
+            state.buy.quotesRequest = undefined;
+        },
+        buyFiatCurrencyChanged: state => {
+            state.buy.amountLimits = undefined;
+            state.buy.quotesRequest = undefined;
+        },
     },
     extraReducers: (builder, extra) => {
         const commonTradingFormReducer = prepareTradingReducer(extra);
@@ -105,6 +114,8 @@ export const {
     clearQuotesAndQuotesRequest,
     setTradeOrderIdToBeOpened,
     clearTradeOrderIdToBeOpened,
+    buyAssetChanged,
+    buyFiatCurrencyChanged,
 } = tradingSlice.actions;
 
 export const createMemoizedSelector = createWeakMapSelector.withTypes<TradingRootState>();


### PR DESCRIPTION
## Description

- Invalidates amount limits when selected fiat currency changes
- Invalidates amount limits when selected asset changes


## Related Issue

Resolve #19172



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19172-mobile-trade-errors-clear&lookback=7)