### PR TITLE
chore(suite-native): bump app version to 25.5.3

### DIFF
--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@suite-native/app",
     "version": "1.0.0",
-    "suiteNativeVersion": "25.5.2",
+    "suiteNativeVersion": "25.5.3",
     "main": "index.js",
     "scripts": {
         "android": "expo run:android",


### PR DESCRIPTION


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/bump-version-to-25.5.3&lookback=7)