### PR TITLE
Mobile Trade: fix displaying of Error badge when using sats

### DIFF
--- a/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.tsx
@@ -2,14 +2,13 @@ import { useSelector } from 'react-redux';
 
 import { useFormatters } from '@suite-common/formatters';
 import { selectTradingBuyIsLoading } from '@suite-common/trading';
-import { WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
-import { satoshiAmountToBtc } from '@suite-common/wallet-utils';
 import { Badge } from '@suite-native/atoms';
 import { useField } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 
 import { MAX_CRYPTO_DECIMALS, MAX_FIAT_DECIMALS } from '../../consts/general/consts';
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
+import { useConvertFormValueToBaseUnit } from '../../hooks/general/useConvertFormValueToBaseUnit';
 import { TradingBuyFormValues } from '../../types';
 import { truncateDecimals } from '../../utils/general/amountUtils';
 import { getSelectedSymbolFromBuyForm } from '../../utils/general/tradeableAssetUtils';
@@ -25,10 +24,7 @@ const useMismatchedAmountMessage = (fieldName: keyof TradingBuyFormValues) => {
     const { translate } = useTranslate();
     const { CryptoAmountFormatter, FiatAmountFormatter } = useFormatters();
     const symbol = getSelectedSymbolFromBuyForm(form);
-
-    const isAmountInSats = useSelector((state: WalletSettingsRootState) =>
-        selectIsAmountInSats(state, symbol),
-    );
+    const { convertStrToBaseUnit } = useConvertFormValueToBaseUnit();
 
     const [quote, amountInCrypto, value] = form.watch(['quote', 'amountInCrypto', fieldName]);
 
@@ -42,9 +38,7 @@ const useMismatchedAmountMessage = (fieldName: keyof TradingBuyFormValues) => {
 
     if (amountInCrypto && fieldName === 'cryptoValue' && receiveStringAmount && symbol) {
         const nonEmptyValue = asNonEmptyStringValue(value);
-        const convertedRequestedAmount = isAmountInSats
-            ? satoshiAmountToBtc(nonEmptyValue)
-            : nonEmptyValue;
+        const convertedRequestedAmount = convertStrToBaseUnit(nonEmptyValue, symbol) as string;
         requestedAmount = CryptoAmountFormatter.format(convertedRequestedAmount, {
             symbol,
             isBalance: true,

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
@@ -550,18 +550,18 @@ describe('useBuyForm', () => {
         });
 
         it.each([
-            ['10', false, 'Minimum is 1000 BTC'],
-            ['3000', false, 'Maximum is 2000 BTC'],
-            ['10', true, 'Minimum is 100000000000 sat'],
-            ['3000', true, 'Maximum is 200000000000 sat'],
+            ['0.01', false, 'Minimum is 0.1 BTC'],
+            ['3', false, 'Maximum is 2 BTC'],
+            ['10', true, 'Minimum is 10000000 sat'],
+            ['300000000', true, 'Maximum is 200000000 sat'],
         ])(
             'should display crypto error for amount %s',
             async (amount, amountInSats, expectedValue) => {
                 const store = await getInitializedStore(amountInSats);
                 store.dispatch(
                     tradingBuyActions.setAmountLimits({
-                        minCrypto: '1000',
-                        maxCrypto: '2000',
+                        minCrypto: '0.1',
+                        maxCrypto: '2',
                         currency: 'BTC',
                     }),
                 );

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -30,6 +30,7 @@ import { buyFormValidationSchema } from '../../utils/buy/buyFormValidationSchema
 import { truncateDecimals } from '../../utils/general/amountUtils';
 import { getSelectedSymbolFromBuyForm } from '../../utils/general/tradeableAssetUtils';
 import { getRandomAccountDescriptor } from '../../utils/general/utils';
+import { useConvertFormValueToBaseUnit } from '../general/useConvertFormValueToBaseUnit';
 
 const useReceiveAccountChangeEffect = ({ getValues, setValue }: TradingBuyForm) => {
     const selectedReceiveAccount = useSelector(selectBuySelectedReceiveAccount);
@@ -226,11 +227,18 @@ export const useBuyForm = (): TradingBuyForm => {
     const { FiatAmountFormatter, CryptoAmountFormatter } = useFormatters();
     const defaultValues = useSelector(selectBuyFormDefaultValues);
     const limits = useSelector(selectBuyAmountLimits);
+    const { convertNumberToBaseUnit } = useConvertFormValueToBaseUnit();
 
     const form = useForm<TradingBuyFormValues>({
         defaultValues,
         validation: buyFormValidationSchema,
-        context: { ...limits, translate, FiatAmountFormatter, CryptoAmountFormatter },
+        context: {
+            ...limits,
+            translate,
+            FiatAmountFormatter,
+            CryptoAmountFormatter,
+            convertNumberToBaseUnit,
+        },
     });
 
     useAmountAndCurrencyFieldsChangeEffect(form);

--- a/suite-native/module-trading/src/hooks/general/__tests__/useConvertFormValueToBaseUnit.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useConvertFormValueToBaseUnit.test.ts
@@ -1,0 +1,87 @@
+import { NetworkSymbol } from '@suite-common/wallet-config/libDev/src';
+import { renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { PROTO } from '@trezor/connect';
+
+import { useConvertFormValueToBaseUnit } from '../useConvertFormValueToBaseUnit';
+
+describe('useConvertFormValueToBaseUnit', () => {
+    const renderUseConvertApiToAppAmount = (bitcoinAmountUnit: PROTO.AmountUnit) => {
+        const preloadedState = { wallet: { settings: { bitcoinAmountUnit } } };
+
+        return renderHookWithStoreProviderAsync(() => useConvertFormValueToBaseUnit(), {
+            preloadedState,
+        });
+    };
+
+    describe('convertStrToBaseUnit', () => {
+        it('should return undefined when amount is undefined', async () => {
+            const { result } = await renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
+
+            expect(result.current.convertStrToBaseUnit(undefined, 'btc')).toEqual(undefined);
+        });
+
+        it.each<[NetworkSymbol, string, string]>([
+            ['btc', '1', '1'],
+            ['eth', '1', '1'],
+        ])(
+            'should correctly convert %s with BTC as app unit',
+            async (symbol, amountFromApi, expectedAmount) => {
+                const { result } = await renderUseConvertApiToAppAmount(PROTO.AmountUnit.BITCOIN);
+
+                expect(result.current.convertStrToBaseUnit(amountFromApi, symbol)).toEqual(
+                    expectedAmount,
+                );
+            },
+        );
+
+        it.each<[NetworkSymbol, string, string]>([
+            ['btc', '1', '0.00000001'],
+            ['eth', '1', '1'],
+        ])(
+            'should correctly convert %s with SAT as app unit',
+            async (symbol, amountFromApi, expectedAmount) => {
+                const { result } = await renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
+
+                expect(result.current.convertStrToBaseUnit(amountFromApi, symbol)).toEqual(
+                    expectedAmount,
+                );
+            },
+        );
+    });
+
+    describe('convertNumberToBaseUnit', () => {
+        it('should return undefined when amount is undefined', async () => {
+            const { result } = await renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
+
+            expect(result.current.convertNumberToBaseUnit(undefined, 'btc')).toEqual(undefined);
+        });
+
+        it.each<[NetworkSymbol, number, number]>([
+            ['btc', 1, 1],
+            ['eth', 1, 1],
+        ])(
+            'should correctly convert %s with BTC as app unit',
+            async (symbol, amountFromApi, expectedAmount) => {
+                const { result } = await renderUseConvertApiToAppAmount(PROTO.AmountUnit.BITCOIN);
+
+                expect(result.current.convertNumberToBaseUnit(amountFromApi, symbol)).toEqual(
+                    expectedAmount,
+                );
+            },
+        );
+
+        it.each<[NetworkSymbol, number, number]>([
+            ['btc', 1, 0.00000001],
+            ['eth', 1, 1],
+        ])(
+            'should correctly convert %s with SAT as app unit',
+            async (symbol, amountFromApi, expectedAmount) => {
+                const { result } = await renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
+
+                expect(result.current.convertNumberToBaseUnit(amountFromApi, symbol)).toEqual(
+                    expectedAmount,
+                );
+            },
+        );
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/useConvertFormValueToBaseUnit.ts
+++ b/suite-native/module-trading/src/hooks/general/useConvertFormValueToBaseUnit.ts
@@ -1,0 +1,39 @@
+import { useSelector } from 'react-redux';
+
+import { NetworkSymbol, NetworkSymbolExtended, getNetwork } from '@suite-common/wallet-config';
+import { selectAreSatsAmountUnit } from '@suite-common/wallet-core';
+import { satoshiAmountToBtc } from '@suite-common/wallet-utils';
+
+export const useConvertFormValueToBaseUnit = () => {
+    const areSatsAmountUnit = useSelector(selectAreSatsAmountUnit);
+
+    const getIsAmountInSats = (symbol: NetworkSymbolExtended) => {
+        // this is copy of selectIsAmountInSats logic
+        const network = getNetwork(symbol as NetworkSymbol);
+        const isAmountUnitSupported = !!network && network.features.includes('amount-unit');
+
+        return isAmountUnitSupported && areSatsAmountUnit;
+    };
+
+    return {
+        convertStrToBaseUnit: (amount: string | undefined, symbol: NetworkSymbolExtended) => {
+            if (amount === undefined) {
+                return undefined;
+            }
+
+            return getIsAmountInSats(symbol) ? satoshiAmountToBtc(amount) : amount;
+        },
+
+        convertNumberToBaseUnit: (amount: number | undefined, symbol: NetworkSymbolExtended) => {
+            if (amount === undefined) {
+                return undefined;
+            }
+
+            if (getIsAmountInSats(symbol)) {
+                return parseFloat(satoshiAmountToBtc(amount.toString()));
+            }
+
+            return amount;
+        },
+    };
+};

--- a/suite-native/module-trading/src/types.ts
+++ b/suite-native/module-trading/src/types.ts
@@ -8,6 +8,8 @@ import type { UseFormReturn } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import { Address } from '@trezor/blockchain-link-types';
 
+import { useConvertFormValueToBaseUnit } from './hooks/general/useConvertFormValueToBaseUnit';
+
 export type TradeableAsset = {
     symbol: NetworkSymbolExtended;
     contractAddress?: TokenAddress | undefined;
@@ -39,6 +41,9 @@ export type TradingBuyFormContext = (TradingAmountLimitProps | Record<string, ne
     translate: ReturnType<typeof useTranslate>['translate'];
     FiatAmountFormatter: Formatters['FiatAmountFormatter'];
     CryptoAmountFormatter: Formatters['CryptoAmountFormatter'];
+    convertNumberToBaseUnit: ReturnType<
+        typeof useConvertFormValueToBaseUnit
+    >['convertNumberToBaseUnit'];
 };
 
 export type TradingBuyForm = UseFormReturn<TradingBuyFormValues>;

--- a/suite-native/module-trading/src/utils/buy/buyFormValidationSchema.ts
+++ b/suite-native/module-trading/src/utils/buy/buyFormValidationSchema.ts
@@ -3,8 +3,14 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { TradingBuyFormContext } from '../../types';
 
-const getAmountLimitContext = ({ options }: yup.TestContext<unknown>) =>
-    options.context as TradingBuyFormContext;
+const getAmountLimitContext = ({ options }: yup.TestContext<unknown>): TradingBuyFormContext => {
+    const context = options.context as TradingBuyFormContext;
+
+    return {
+        ...context,
+        currency: context.currency ?? 'unknown',
+    };
+};
 
 const formatCryptoAmount = (
     amount: string,
@@ -24,10 +30,20 @@ export const buyFormValidationSchema = yup.object({
         .typeError('Invalid number')
         .min(0, 'Invalid value')
         .test('crypto-min', (value, testContext) => {
-            const { currency, minCrypto, translate, CryptoAmountFormatter } =
-                getAmountLimitContext(testContext);
+            const {
+                currency,
+                minCrypto,
+                translate,
+                CryptoAmountFormatter,
+                convertNumberToBaseUnit,
+            } = getAmountLimitContext(testContext);
+            const convertedValue = convertNumberToBaseUnit(value, currency.toLowerCase());
 
-            if (value === undefined || minCrypto === undefined || value >= parseFloat(minCrypto)) {
+            if (
+                convertedValue === undefined ||
+                minCrypto === undefined ||
+                convertedValue >= parseFloat(minCrypto)
+            ) {
                 return true;
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Introduces `useConvertFormValueToBaseUnit` hook that returns callback that allows to convert value from form to base unit (from sats to BTC)
- those callback are then used in yup validation schema for buy form (via context) or in `BuyFormFieldErrorBadge` component (in fact in `useMismatchedAmountMessage` hook)

## Related Issue

Resolve #19194

## Screenshots:

![Screenshot 2025-05-28 at 16 27 32](https://github.com/user-attachments/assets/4ee40c9f-b6b8-45c0-8e27-cb7c342b95e1)


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19194-mobile-trade-sats-error-badge&lookback=7)