### PR TITLE
feat(suite-native) hide zero balance tokens

### DIFF
--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -180,12 +180,13 @@ export const getAccountListSections = (
     }
 
     if (hasAnyKnownTokens) {
-        tokens.forEach((token, index) => {
+        const tokensWithBalance = tokens.filter(token => parseFloat(token?.balance ?? '0') > 0);
+        tokensWithBalance.forEach((token, index) => {
             sections.push({
                 type: 'token',
                 account,
                 token: token as TokenInfoBranded,
-                isLast: index === tokens.length - 1,
+                isLast: index === tokensWithBalance.length - 1,
             });
         });
     }

--- a/suite-native/accounts/src/tests/selectors.test.ts
+++ b/suite-native/accounts/src/tests/selectors.test.ts
@@ -1,11 +1,18 @@
-import { Account } from '@suite-common/wallet-types';
+import { Account, TokenInfoBranded } from '@suite-common/wallet-types';
 
-import { selectFreshAccountAddress } from '../selectors';
+import { getAccountListSections, selectFreshAccountAddress } from '../selectors';
 import {
     groupAccountsByNetworkAccountType,
     isFilterValueMatchingAccount,
     sortAccountsByNetworksAndAccountTypes,
 } from '../utils';
+
+let mockStakingBalance = '0';
+
+jest.mock('@suite-common/wallet-utils', () => ({
+    ...jest.requireActual('@suite-common/wallet-utils'),
+    getAccountTotalStakingBalance: (_: Account) => mockStakingBalance,
+}));
 
 describe('isFilterValueMatchingAccountLabelOrNetworkName', () => {
     const account = {
@@ -250,5 +257,124 @@ describe('selectFreshAccountAddress', () => {
 
         expect(result1).toEqual(result2);
         expect(result1).toBe(result2);
+    });
+});
+
+describe('getAccountListSections', () => {
+    const mockAccount = {
+        symbol: 'eth',
+        accountType: 'normal',
+        balance: '100',
+        availableBalance: '100',
+        formattedBalance: '100',
+        tokens: [
+            {
+                name: 'Token1',
+                balance: '100',
+                contract: '0x1',
+                type: 'ERC20',
+                standard: 'ERC20',
+                decimals: 18,
+            },
+            {
+                name: 'Token2',
+                balance: '0',
+                contract: '0x2',
+                type: 'ERC20',
+                standard: 'ERC20',
+                decimals: 18,
+            },
+            {
+                name: 'Token3',
+                balance: '50',
+                contract: '0x3',
+                type: 'ERC20',
+                standard: 'ERC20',
+                decimals: 18,
+            },
+        ] as TokenInfoBranded[],
+        networkType: 'ethereum',
+    } as any as Account;
+
+    const mockTokenDefinitions = ['0x1', '0x2', '0x3'];
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should include only tokens with positive balance', () => {
+        mockStakingBalance = '0';
+
+        const sections = getAccountListSections(mockAccount, mockTokenDefinitions);
+
+        // Should have section title, account section, and two token sections (for Token1 and Token3)
+        expect(sections).toHaveLength(4);
+
+        // Verify token sections only include tokens with positive balance
+        const tokenSections = sections.filter(section => section.type === 'token');
+        expect(tokenSections).toHaveLength(2);
+
+        const tokenNames = tokenSections.map(section => section.token.name);
+        expect(tokenNames).toEqual(['Token1', 'Token3']);
+    });
+
+    it('should handle account with no tokens', () => {
+        const accountWithoutTokens: Account = {
+            ...mockAccount,
+            tokens: [],
+        };
+
+        const sections = getAccountListSections(accountWithoutTokens, mockTokenDefinitions);
+
+        // Should only have section title and account section
+        expect(sections).toHaveLength(2);
+        expect(sections[0].type).toBe('sectionTitle');
+        expect(sections[1].type).toBe('account');
+    });
+
+    it('should handle account with only zero balance tokens', () => {
+        mockStakingBalance = '0';
+
+        const accountWithZeroBalanceTokens: Account = {
+            ...mockAccount,
+            tokens: [
+                {
+                    name: 'Token1',
+                    balance: '0',
+                    contract: '0x1',
+                    type: 'ERC20',
+                    standard: 'ERC20',
+                    decimals: 18,
+                },
+                {
+                    name: 'Token2',
+                    balance: '0',
+                    contract: '0x2',
+                    type: 'ERC20',
+                    standard: 'ERC20',
+                    decimals: 18,
+                },
+            ] as TokenInfoBranded[],
+        };
+
+        const sections = getAccountListSections(accountWithZeroBalanceTokens, mockTokenDefinitions);
+
+        // Should only have section title and account section
+        expect(sections).toHaveLength(2);
+        expect(sections[0].type).toBe('sectionTitle');
+        expect(sections[1].type).toBe('account');
+    });
+
+    it('should handle account with staking balance', () => {
+        mockStakingBalance = '100';
+
+        const sections = getAccountListSections(mockAccount, mockTokenDefinitions);
+
+        // Should have section title, account section, staking section, and two token sections
+        expect(sections).toHaveLength(5);
+        expect(sections[0].type).toBe('sectionTitle');
+        expect(sections[1].type).toBe('account');
+        expect(sections[2].type).toBe('staking');
+        expect(sections[3].type).toBe('token');
+        expect(sections[4].type).toBe('token');
     });
 });

--- a/suite-native/module-accounts-import/src/components/AccountImportConfirmFormScreen.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportConfirmFormScreen.tsx
@@ -63,6 +63,7 @@ export const AccountImportConfirmFormScreen = ({
         selectAccountsByNetworkAndDeviceState(state, PORTFOLIO_TRACKER_DEVICE_STATE, symbol),
     );
 
+    const nonEmptyTokens = knownTokens.filter(info => parseFloat(info.balance ?? '0') > 0);
     const defaultAccountLabel = `${getNetwork(symbol).name} #${deviceNetworkAccounts.length + 1}`;
 
     const form = useAccountLabelForm(defaultAccountLabel);
@@ -85,8 +86,8 @@ export const AccountImportConfirmFormScreen = ({
                 type: EventType.AssetsSync,
                 payload: {
                     assetSymbol: symbol,
-                    tokenSymbols: knownTokens.map(token => token.symbol as TokenSymbol),
-                    tokenAddresses: knownTokens.map(token => token.contract as TokenAddress),
+                    tokenSymbols: nonEmptyTokens.map(token => token.symbol as TokenSymbol),
+                    tokenAddresses: nonEmptyTokens.map(token => token.contract as TokenAddress),
                 },
             });
 
@@ -132,9 +133,9 @@ export const AccountImportConfirmFormScreen = ({
                     symbol={symbol}
                     formControl={form.control}
                 />
-                {knownTokens.length > 0 && (
+                {nonEmptyTokens.length > 0 && (
                     <FlashList
-                        data={knownTokens}
+                        data={nonEmptyTokens}
                         renderItem={renderItem}
                         ListEmptyComponent={null}
                         ListHeaderComponent={


### PR DESCRIPTION
Tokens are filtered to show only tokens with positive balance

## Related Issue

Resolve #18454




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=18454-hide-zero-balance-tokens-like-in-the-desktop-app&lookback=7)