### PR TITLE
test(coinjoin): use proper async to make tests not flaky

### DIFF
--- a/packages/coinjoin/tests/client/coordinatorRequest.test.ts
+++ b/packages/coinjoin/tests/client/coordinatorRequest.test.ts
@@ -146,21 +146,18 @@ describe('http', () => {
         ).rejects.toThrow('Aborted by signal');
     });
 
-    it('successful', () =>
-        new Promise<void>(done => {
-            coordinatorRequest('input-registration', {}, { baseUrl }).then(resp => {
-                expect(resp).toMatchObject({ AliceId: expect.any(String) });
-            });
-            // without baseUrl
-            coordinatorRequest<any>(`status`, {}, { baseUrl }).then(resp => {
-                expect(resp.RoundStates.length).toEqual(1);
-            });
-            // without json response
-            coordinatorRequest('ready-to-sign', {}, { baseUrl }).then(resp => {
-                expect(resp).toEqual('');
-                done();
-            });
-        }));
+    it('successful', async () => {
+        const resp1 = await coordinatorRequest('input-registration', {}, { baseUrl });
+        expect(resp1).toMatchObject({ AliceId: expect.any(String) });
+
+        // Without baseUrl.
+        const resp2 = await coordinatorRequest<any>('status', {}, { baseUrl });
+        expect(resp2.RoundStates.length).toEqual(1);
+
+        // Without json response
+        const resp3 = await coordinatorRequest('ready-to-sign', {}, { baseUrl });
+        expect(resp3).toEqual('');
+    });
 
     it('with identity', async () => {
         const requestListener = jest.fn(req => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This test has been flaky for some time. It is difficult to be 100% sure of what causes the issue but seams to me the async code in previous test was not properly handled so sometimes one the requests in previous test could be slower and then interfere whit test after.

https://github.com/trezor/trezor-suite/actions/runs/15336407601/job/43154460867

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/coordinatorRequest-test-async-improvement&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/coordinatorRequest-test-async-improvement&lookback=7)