### PR TITLE
fix(suite): remove exhaustive typing for error handler

### DIFF
--- a/packages/suite/src/actions/suite/metadataProviderActions.ts
+++ b/packages/suite/src/actions/suite/metadataProviderActions.ts
@@ -203,8 +203,9 @@ export const handleProviderError =
                 case 'NOT_FOUND_ERROR':
                     break;
 
+                // intentionally not exhaustive: although we expect a typed Error, any Error can in fact happen
                 default:
-                    exhaustive(error.code);
+                    console.error(error);
             }
         }
     };


### PR DESCRIPTION
:thought_balloon:  I believe that switch-cases should not be exhaustive when dealing with typed caught error.
Any error can be thrown at any time.
Typing a caught error is an expectation that helps us handle _some known cases_, but we cannot consider it exhaustive.

## Related Issue

Resolve #19223

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/not-exhaustive-error-handler&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/not-exhaustive-error-handler&lookback=7)