### PR TITLE
Introduce eslint rule which forbids imports from /libDev/src

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,17 @@ export default [
                     ],
                 },
             ],
+            'no-restricted-imports': [
+                'error',
+                {
+                    patterns: [
+                        {
+                            regex: '/libDev/src',
+                            message: 'Importing from "*/libDev/src" path is not allowed.',
+                        },
+                    ],
+                },
+            ],
         },
     },
 ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Introduces eslint rule that raises an error when one tries to import from `*/libDev/src` path.

## Screenshots:

![Screenshot 2025-05-30 at 12 09 09](https://github.com/user-attachments/assets/c9e3f4d7-9b6b-409d-be3c-5f24f6b60c9f)



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=forbid-libdev-src-imports&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=forbid-libdev-src-imports&lookback=7)