### PR TITLE
feat(suite-native): better UX copy for CTA if FW is already installed

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -919,6 +919,7 @@ export const en = {
                 subtitle:
                     'Firmware is already installed on this Trezor. Continue only if you have used this Trezor before.',
                 confirmButton: 'Yes, set up my Trezor',
+                button: "Yes, let's get started",
                 noButton: 'No, I have not',
             },
             lookDifferentLabel: 'My device looks different',

--- a/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
@@ -172,7 +172,11 @@ export const UninitializedDeviceLandingScreen = ({
                         onPress={handleConfirmButtonPress}
                         testID="@deviceOnboarding/UninitializedDeviceLandingScreen/confirmBtn"
                     >
-                        <Translation id="moduleDeviceOnboarding.uninitializedDeviceLandingScreen.noFirmware.button" />
+                        {hasDeviceFirmwareInstalled ? (
+                            <Translation id="moduleDeviceOnboarding.uninitializedDeviceLandingScreen.firmware.button" />
+                        ) : (
+                            <Translation id="moduleDeviceOnboarding.uninitializedDeviceLandingScreen.noFirmware.button" />
+                        )}
                     </Button>
                     {hasDeviceFirmwareInstalled && (
                         <Button


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

[Suggested here](https://www.notion.so/satoshilabs/Copy-adjustment-200dc5260606809685dbc349be1cf6e7?pvs=4)
[Discussed internally here](https://satoshilabs.slack.com/archives/C06JBT2P7DM/p1748596725418579) 

## Screenshots:

| with FW | without FW |
|----------|----------|
| <img width="373" alt="image" src="https://github.com/user-attachments/assets/498b6ca0-ccc5-4d5b-91cb-bffab6766b27" /> | <img width="372" alt="image" src="https://github.com/user-attachments/assets/f2fbd6fe-dd99-43b5-98d8-81397972162a" />  |

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/update-device-onboarding-welcome-copy&lookback=7)