### PR TITLE
chore(suite): refactor connect modal handling

### DIFF
--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -11,8 +11,10 @@ import { EventType, analytics } from '@trezor/suite-analytics';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { SUITE } from 'src/actions/suite/constants';
-import { openModal } from 'src/actions/suite/modalActions';
+import { CONTEXT_NONE, CONTEXT_USER } from 'src/actions/suite/constants/modalConstants';
+import { onCancel as cancelModal, openModal } from 'src/actions/suite/modalActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectModalType } from 'src/reducers/suite/modalReducer';
 
 export const useConnectPopupDesktop = () => {
     const dispatch = useDispatch();
@@ -113,4 +115,61 @@ export const useConnectPopupDesktop = () => {
             }
         }
     }, [popupCall, currentlyOngoing, wasVisible]);
+
+    // Modal opening control
+    const modalContext = useSelector(state => state.modal.context);
+    const modalType = useSelector(selectModalType);
+    useEffect(() => {
+        const isConnectModal =
+            modalContext === CONTEXT_USER &&
+            modalType &&
+            [
+                'connect-popup',
+                'connect-loading',
+                'connect-address-confirmation',
+                'connect-error',
+            ].includes(modalType);
+
+        const openIfNeeded = (
+            type:
+                | 'connect-popup'
+                | 'connect-loading'
+                | 'connect-address-confirmation'
+                | 'connect-error',
+        ) => {
+            // Prevent duplicate opening of the same modal
+            // And also prevent opening connect modals if different modal is already open
+            if (modalType !== type && (modalContext === CONTEXT_NONE || isConnectModal)) {
+                dispatch(openModal({ type }));
+            }
+        };
+
+        switch (popupCall?.state) {
+            case 'permission-request': {
+                return openIfNeeded('connect-popup');
+            }
+            case 'ongoing': {
+                return openIfNeeded('connect-loading');
+            }
+            case 'address-confirmation': {
+                return openIfNeeded('connect-address-confirmation');
+            }
+            case 'error':
+            case 'call-error': {
+                return openIfNeeded('connect-error');
+            }
+            case 'deeplink-callback': {
+                // Not used on desktop
+                return;
+            }
+            case 'finished':
+            default: {
+                if (isConnectModal) {
+                    dispatch(cancelModal());
+                }
+
+                return;
+            }
+        }
+    }, [popupCall?.state, modalType, modalContext, dispatch]);
 };

--- a/suite-common/connect-popup/src/connectPopupMiddleware.ts
+++ b/suite-common/connect-popup/src/connectPopupMiddleware.ts
@@ -2,33 +2,10 @@ import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { UI } from '@trezor/connect';
 
-import { connectPopupActions } from './connectPopupActions';
-
 export const prepareConnectPopupMiddleware = createMiddlewareWithExtraDeps(
-    async (action, { dispatch, next, extra }) => {
+    async (action, { dispatch, next }) => {
         await next(action);
 
-        if (connectPopupActions.requestPermissions.match(action)) {
-            dispatch(extra.actions.openModal({ type: 'connect-popup' }));
-        }
-        if (connectPopupActions.confirmAddresses.match(action)) {
-            dispatch(extra.actions.openModal({ type: 'connect-address-confirmation' }));
-        }
-        if (
-            connectPopupActions.initiateCall.match(action) ||
-            connectPopupActions.approvePermissions.match(action)
-        ) {
-            dispatch(extra.actions.openModal({ type: 'connect-loading' }));
-        }
-        if (connectPopupActions.setError.match(action)) {
-            dispatch(extra.actions.openModal({ type: 'connect-error' }));
-        }
-        if (
-            connectPopupActions.finishCall.match(action) ||
-            connectPopupActions.rejectPermissions.match(action)
-        ) {
-            dispatch(extra.actions.onModalCancel());
-        }
         if (action.type === UI.INSUFFICIENT_FUNDS) {
             dispatch(
                 notificationsActions.addToast({


### PR DESCRIPTION
## Description

Move Connect modal opening/closing from middleware to a state machine. 
This solution should be able to handle edge cases better.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-connect-handle-modal-interruption&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-connect-handle-modal-interruption&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-connect-handle-modal-interruption&lookback=7)