### PR TITLE
fix(trading): do not update date of trade in watchTrade

### DIFF
--- a/suite-common/trading/src/thunks/common/watchTradeThunk.ts
+++ b/suite-common/trading/src/thunks/common/watchTradeThunk.ts
@@ -54,7 +54,6 @@ export const watchTradeThunk = createThunk(
         invityAPI.createInvityAPIKey(account.descriptor);
 
         const { tradeType } = trade;
-        const date = new Date().toISOString();
 
         switch (tradeType) {
             case 'buy': {
@@ -68,7 +67,7 @@ export const watchTradeThunk = createThunk(
                 dispatch(
                     tradingActions.saveTrade({
                         tradeType,
-                        date,
+                        date: trade.date,
                         key: data.tradeData.paymentId,
                         data: data.tradeData,
                         receiveAccountKey: trade.receiveAccountKey,
@@ -99,7 +98,7 @@ export const watchTradeThunk = createThunk(
                 dispatch(
                     tradingActions.saveTrade({
                         tradeType,
-                        date,
+                        date: trade.date,
                         key: data.tradeData.orderId,
                         data: data.tradeData,
                         sendAccountKey: trade.sendAccountKey,
@@ -124,7 +123,7 @@ export const watchTradeThunk = createThunk(
                 dispatch(
                     tradingActions.saveTrade({
                         tradeType,
-                        date,
+                        date: trade.date,
                         key: data.tradeData.orderId,
                         data: data.tradeData,
                         sendAccountKey: trade.sendAccountKey,


### PR DESCRIPTION
Do not update date of trade in watchTrade, so the trade item in transaction history won't shift. 

## Related Issue
Resolve #18268


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-trade-history&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-trade-history&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading-trade-history&lookback=7)