### PR TITLE
chore(suite-desktop): node-bridge rollout set to 10000%

### DIFF
--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -101,7 +101,7 @@ const shouldUseLegacyBridge = (store: Dependencies['store']) => {
         store.setBridgeSettings({ ...store.getBridgeSettings(), newBridgeRollout });
     }
     const newBridgeRollout = store.getBridgeSettings().newBridgeRollout || 0;
-    const NEW_BRIDGE_ROLLOUT_THRESHOLD = 0.1;
+    const NEW_BRIDGE_ROLLOUT_THRESHOLD = 1;
     const legacyBridgeReasonRollout = newBridgeRollout >= NEW_BRIDGE_ROLLOUT_THRESHOLD;
 
     return legacyBridgeReasonRollout;


### PR DESCRIPTION
This pull request includes an update to the `shouldUseLegacyBridge` function in the `bridge.ts` module, adjusting the threshold for determining the use of the legacy bridge.

Key change:

* Increased the `NEW_BRIDGE_ROLLOUT_THRESHOLD` from `0.1` to `1` in the `shouldUseLegacyBridge` function, which alters the conditions under which the legacy bridge is used. (`[packages/suite-desktop-core/src/modules/bridge.tsL104-R104](diffhunk://#diff-61c77116eb9034a1ad27d45399eb99e8abfdbdbb86d31ce0e9573e363cca542dL104-R104)`)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/node-bridge-25&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/node-bridge-25&lookback=7)