### PR TITLE
ci: include connect mobile in release process

### DIFF
--- a/.github/actions/release-connect-npm/action.yml
+++ b/.github/actions/release-connect-npm/action.yml
@@ -34,6 +34,7 @@ inputs:
       - connect
       - connect-web
       - connect-webextension
+      - connect-mobile
 
 runs:
   using: "composite"

--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -121,7 +121,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: ["connect", "connect-web", "connect-webextension"]
+        package: ["connect", "connect-web", "connect-webextension", "connect-mobile"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/packages/connect-explorer/src/pages/readme/[name].mdx
+++ b/packages/connect-explorer/src/pages/readme/[name].mdx
@@ -3,13 +3,8 @@ import { RemoteContent } from 'nextra/data';
 import { buildDynamicMDX, buildDynamicMeta } from 'nextra/remote';
 import remarkGemoji from 'remark-gemoji';
 
-import { isBetaOnly } from '../../components/BetaOnly';
-
 export const getStaticPaths = () => {
-    const packages = ["connect", "connect-web", "connect-webextension"];
-    if(isBetaOnly) {
-        packages.push("connect-mobile");
-    }
+    const packages = ["connect", "connect-web", "connect-webextension", "connect-mobile"];
 
     const paths = packages.map((name) => ({
         params: {

--- a/scripts/ci/connect-bump-versions.ts
+++ b/scripts/ci/connect-bump-versions.ts
@@ -93,10 +93,9 @@ const updateConnectChangelog = async (
                 canary,
             },
             {
-                // TODO: we keep @trezor/connect-mobile hardcoded until we make it stable release.
                 package: 'npm @trezor/connect-mobile',
-                stable: '-',
-                canary: '0.0.1-beta.1',
+                stable,
+                canary,
             },
         ];
 

--- a/scripts/ci/get-connect-dependencies-to-release.ts
+++ b/scripts/ci/get-connect-dependencies-to-release.ts
@@ -60,6 +60,7 @@ const getConnectDependenciesToRelease = async () => {
     // and remote greatest version is lower than the local one.
     await checkNonReleasedDependencies('connect');
     await checkNonReleasedDependencies('connect-web');
+    await checkNonReleasedDependencies('connect-mobile');
     await checkNonReleasedDependencies('connect-webextension');
     await checkNonReleasedDependencies('connect-plugin-stellar');
     await checkNonReleasedDependencies('connect-plugin-ethereum');
@@ -67,7 +68,7 @@ const getConnectDependenciesToRelease = async () => {
     // We do not want to include `connect`, `connect-web` and `connect-webextension` since we want
     // to release those separately and we always want to release them.
     const onlyDependenciesToRelease = nonReleaseDependencies.filter(item => {
-        return !['connect', 'connect-web', 'connect-webextension'].includes(item);
+        return !['connect', 'connect-web', 'connect-webextension', 'connect-mobile'].includes(item);
     });
 
     // We use `onlyDependenciesToRelease` to trigger NPM releases


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Including package `@trezor/connect-mobile` in NPM release process. 

This will allow us to release `@trezor/connect-mobile` every time we release connect with same connect versioning.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/include-connect-mobile-in-release-process&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/include-connect-mobile-in-release-process&lookback=7)