### PR TITLE
chore(suite-web): display meaningful error when navigating to /bridge…

### DIFF
--- a/packages/suite/src/views/suite/bridge-requested/index.tsx
+++ b/packages/suite/src/views/suite/bridge-requested/index.tsx
@@ -10,6 +10,8 @@ import { Metadata, Translation } from 'src/components/suite';
 import { useDispatch, useLayout } from 'src/hooks/suite';
 import { AutoStart } from 'src/views/settings/SettingsGeneral/AutoStart';
 
+import { ErrorPage } from '../ErrorPage';
+
 /**
  * This component renders only in desktop version - as an explanation why suite-desktop app was opened using a deeplink from suite-web
  */
@@ -30,7 +32,11 @@ export const BridgeRequested = () => {
 
     if (!isDesktop()) {
         // this component doesn't make sense for web.
-        return null;
+        return (
+            <Modal>
+                <ErrorPage />
+            </Modal>
+        );
     }
 
     if (confirmGoToWallet) {


### PR DESCRIPTION
this is a nitpick. instead of displaying nothing, use standard 404 error page 

<img width="861" alt="image" src="https://github.com/user-attachments/assets/6b2b252b-e1f8-40a8-84c6-d2962c633125" />

related #18146

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=bridge-requested-web-error&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=bridge-requested-web-error&lookback=7)