### PR TITLE
feat(suite-native): preselect payment method based on platform

### DIFF
--- a/suite-native/module-trading/src/__fixtures__/quotes.json
+++ b/suite-native/module-trading/src/__fixtures__/quotes.json
@@ -66,5 +66,22 @@
         "paymentMethodName": "Credit Card",
         "orderId": "order_id_3",
         "paymentId": "e709df77-ee9e-4d12-98c2-84004a19c546"
+    },
+    {
+        "fiatStringAmount": "10",
+        "fiatCurrency": "EUR",
+        "receiveCurrency": "bitcoin",
+        "receiveStringAmount": "0.0010001683607972866",
+        "rate": 9991.316675433,
+        "quoteId": "ff259797-6cbe-4fea-8330-5181353f64a0",
+        "exchange": "mercuryo",
+        "minFiat": 20,
+        "maxFiat": 1999.96,
+        "minCrypto": 0.002,
+        "maxCrypto": 0.20003,
+        "paymentMethod": "googlePay",
+        "paymentMethodName": "Google Pay",
+        "orderId": "order_id_4",
+        "paymentId": "1209df77-ee9e-4d12-98c2-84004a19c521"
     }
 ]

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import { EnhancedStore } from '@reduxjs/toolkit';
 import type { BuyTrade, CryptoId } from 'invity-api';
 
@@ -347,27 +349,41 @@ describe('useBuyForm', () => {
     });
 
     describe('on quotes change', () => {
-        it('if no quote is selected should select 1st quote with creditCard payment method', async () => {
-            const store = await getInitializedStore();
-            const { result } = await renderUseTradingBuyForm(store);
+        it.each<[string, string]>([
+            ['ios', 'applePay'],
+            ['android', 'googlePay'],
+            ['web', 'creditCard'],
+        ])(
+            'if no quote is selected should select 1st quote with %s payment method based on %s',
+            async (platform, method) => {
+                jest.spyOn(Platform, 'select').mockImplementation(
+                    (option: any) => option[platform],
+                );
 
-            initFormAndQuotes(result.current, store);
+                const store = await getInitializedStore();
+                const { result } = await renderUseTradingBuyForm(store);
 
-            expect(result.current.getValues('quote')).toEqual(
-                expect.objectContaining({
-                    paymentMethod: 'creditCard',
-                    exchange: 'cexdirect',
-                }),
-            );
-        });
+                initFormAndQuotes(result.current, store);
 
-        it('if no quote is selected and creditCard method is not available should select 1st quote', async () => {
+                expect(result.current.getValues('quote')).toEqual(
+                    expect.objectContaining({
+                        paymentMethod: method,
+                    }),
+                );
+
+                jest.restoreAllMocks();
+            },
+        );
+
+        it('if no quote is selected and preferred method is not available should select 1st quote with credit card', async () => {
+            jest.spyOn(Platform, 'select').mockImplementation((option: any) => option['ios']);
             const store = await getInitializedStore();
             const { result } = await renderUseTradingBuyForm(store);
 
             act(() => {
                 result.current.setValue('fiatValue', '10');
                 result.current.setValue('asset', btcAsset);
+                // Only provide credit card quote
                 store.dispatch(tradingBuyActions.saveQuotes([quotes[0]] as BuyTrade[]));
             });
 
@@ -377,6 +393,7 @@ describe('useBuyForm', () => {
                     exchange: 'mercuryo',
                 }),
             );
+            jest.restoreAllMocks();
         });
 
         it('should set quote to undefined when no quotes are available', async () => {
@@ -530,7 +547,7 @@ describe('useBuyForm', () => {
 
         initFormAndQuotes(result.current, store);
 
-        expect(result.current.getValues('cryptoValue')).toEqual('50000');
+        expect(result.current.getValues('cryptoValue')).toEqual('100016.8');
     });
 
     describe('validations', () => {

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -1,7 +1,8 @@
 import { useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { BuyTrade, CryptoId, FiatCurrencyCode } from 'invity-api';
+import { BuyCryptoPaymentMethod, BuyTrade, CryptoId, FiatCurrencyCode } from 'invity-api';
 
 import { useFormatters } from '@suite-common/formatters';
 import {
@@ -150,8 +151,23 @@ const useBuyQuotesChangeEffect = ({ getValues, setValue }: BuyFormType) => {
             }
         }
 
+        const preferredPaymentMethod: BuyCryptoPaymentMethod = Platform.select({
+            ios: 'applePay',
+            android: 'googlePay',
+            default: 'creditCard',
+        });
+
         if (quoteCandidates.length === 0) {
-            quoteCandidates = quotes.filter(({ paymentMethod }) => paymentMethod === 'creditCard');
+            quoteCandidates = quotes.filter(
+                ({ paymentMethod }) => paymentMethod === preferredPaymentMethod,
+            );
+        }
+
+        const defaultPaymentMethod = 'creditCard';
+        if (quoteCandidates.length === 0) {
+            quoteCandidates = quotes.filter(
+                ({ paymentMethod }) => paymentMethod === defaultPaymentMethod,
+            );
         }
 
         if (quoteCandidates.length === 0) {

--- a/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
@@ -235,6 +235,7 @@ describe('buySelectors', () => {
                 expect.objectContaining({ orderId: 'order_id_0' }),
                 expect.objectContaining({ orderId: 'order_id_1' }),
                 expect.objectContaining({ orderId: 'order_id_3' }),
+                expect.objectContaining({ orderId: 'order_id_4' }),
             ]);
         });
 
@@ -265,6 +266,7 @@ describe('buySelectors', () => {
                 ).toEqual([
                     expect.objectContaining({ orderId: 'order_id_1' }),
                     expect.objectContaining({ orderId: 'order_id_3' }),
+                    expect.objectContaining({ orderId: 'order_id_4' }),
                 ]);
             });
         });
@@ -288,6 +290,10 @@ describe('buySelectors', () => {
                 expect.objectContaining({
                     paymentMethod: 'creditCard',
                     rate: 20000,
+                }),
+                expect.objectContaining({
+                    paymentMethod: 'googlePay',
+                    rate: 9991.316675433,
                 }),
             ]);
         });


### PR DESCRIPTION
Default payment method differs for android (googlePay) and ios (applePay).

## Related Issue

Resolve #19230


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19230-trading---lets-use-os-native-payment-method-as-default&lookback=7)