### PR TITLE
feat: follow-up fimware update for mobile

### DIFF
--- a/packages/connect/src/data/__tests__/getReleaseInfo.bootloader.test.ts
+++ b/packages/connect/src/data/__tests__/getReleaseInfo.bootloader.test.ts
@@ -20,7 +20,7 @@ const fixtures = [
         }),
         release: getReleaseData(),
         conditions: {
-            environment: { min_suite_version: '25.2.1' },
+            environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
         },
         isBitcoinOnlyAvailable: true,
@@ -28,7 +28,7 @@ const fixtures = [
         intermediary: undefined,
         result: {
             releaseConditions: {
-                environment: { min_suite_version: '25.2.1' },
+                environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },
@@ -49,7 +49,7 @@ const fixtures = [
         }),
         release: getReleaseData(),
         conditions: {
-            environment: { min_suite_version: '25.2.1' },
+            environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
         },
         isBitcoinOnlyAvailable: true,
@@ -63,7 +63,7 @@ const fixtures = [
         },
         result: {
             releaseConditions: {
-                environment: { min_suite_version: '25.2.1' },
+                environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },
@@ -94,7 +94,7 @@ const fixtures = [
         }),
         release: getReleaseData(),
         conditions: {
-            environment: { min_suite_version: '25.2.1' },
+            environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
         },
         isBitcoinOnlyAvailable: true,
@@ -102,7 +102,7 @@ const fixtures = [
         intermediary: undefined,
         result: {
             releaseConditions: {
-                environment: { min_suite_version: '25.2.1' },
+                environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },
@@ -124,7 +124,7 @@ const fixtures = [
         }),
         release: getReleaseData(),
         conditions: {
-            environment: { min_suite_version: '25.2.1' },
+            environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
         },
         isBitcoinOnlyAvailable: true,
@@ -138,7 +138,7 @@ const fixtures = [
         },
         result: {
             releaseConditions: {
-                environment: { min_suite_version: '25.2.1' },
+                environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },

--- a/packages/connect/src/data/__tests__/getReleaseInfo.firmware.test.ts
+++ b/packages/connect/src/data/__tests__/getReleaseInfo.firmware.test.ts
@@ -15,14 +15,14 @@ const fixtures = [
         }),
         release: getReleaseData(),
         conditions: {
-            environment: { min_suite_version: '25.2.1' },
+            environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
         },
         isBitcoinOnlyAvailable: true,
         firmwareType: FirmwareType.Universal,
         result: {
             releaseConditions: {
-                environment: { min_suite_version: '25.2.1' },
+                environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },
@@ -43,14 +43,14 @@ const fixtures = [
         }),
         release: getReleaseData(),
         conditions: {
-            environment: { min_suite_version: '25.2.1' },
+            environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 0,
         },
         isBitcoinOnlyAvailable: true,
         firmwareType: FirmwareType.Universal,
         result: {
             releaseConditions: {
-                environment: { min_suite_version: '25.2.1' },
+                environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
                 rollout_probability: 0,
                 shouldBeOffered: false,
             },
@@ -71,14 +71,14 @@ const fixtures = [
         }),
         release: getReleaseData(),
         conditions: {
-            environment: { min_suite_version: '25.2.1' },
+            environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
         },
         isBitcoinOnlyAvailable: true,
         firmwareType: FirmwareType.Universal,
         result: {
             releaseConditions: {
-                environment: { min_suite_version: '25.2.1' },
+                environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },
@@ -99,7 +99,7 @@ const fixtures = [
         }),
         release: getReleaseData(),
         conditions: {
-            environment: { min_suite_version: '25.2.1' },
+            environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
         },
         intermediary: {
@@ -113,7 +113,7 @@ const fixtures = [
         firmwareType: FirmwareType.Universal,
         result: {
             releaseConditions: {
-                environment: { min_suite_version: '25.2.1' },
+                environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },

--- a/packages/connect/src/data/__tests__/getReleaseInfo.fresh.test.ts
+++ b/packages/connect/src/data/__tests__/getReleaseInfo.fresh.test.ts
@@ -22,7 +22,7 @@ const fixtures = [
         }),
         release: getReleaseData(),
         conditions: {
-            environment: { min_suite_version: '25.2.1' },
+            environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
         },
         isBitcoinOnlyAvailable: true,
@@ -36,7 +36,7 @@ const fixtures = [
         },
         result: {
             releaseConditions: {
-                environment: { min_suite_version: '25.2.1' },
+                environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },

--- a/packages/connect/src/data/__tests__/getReleaseInfo.required.test.ts
+++ b/packages/connect/src/data/__tests__/getReleaseInfo.required.test.ts
@@ -15,14 +15,14 @@ const fixtures = [
         }),
         release: getReleaseData(),
         conditions: {
-            environment: { min_suite_version: '25.2.1' },
+            environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
         },
         isBitcoinOnlyAvailable: true,
         firmwareType: FirmwareType.Universal,
         result: {
             releaseConditions: {
-                environment: { min_suite_version: '25.2.1' },
+                environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },
@@ -43,14 +43,14 @@ const fixtures = [
         }),
         release: getReleaseData(),
         conditions: {
-            environment: { min_suite_version: '25.2.1' },
+            environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 0,
         },
         isBitcoinOnlyAvailable: true,
         firmwareType: FirmwareType.Universal,
         result: {
             releaseConditions: {
-                environment: { min_suite_version: '25.2.1' },
+                environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
                 rollout_probability: 0,
                 shouldBeOffered: false,
             },
@@ -71,14 +71,14 @@ const fixtures = [
         }),
         release: getReleaseData(),
         conditions: {
-            environment: { min_suite_version: '25.2.1' },
+            environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
         },
         isBitcoinOnlyAvailable: true,
         firmwareType: FirmwareType.Universal,
         result: {
             releaseConditions: {
-                environment: { min_suite_version: '25.2.1' },
+                environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },
@@ -99,7 +99,7 @@ const fixtures = [
         }),
         release: getReleaseData(),
         conditions: {
-            environment: { min_suite_version: '25.2.1' },
+            environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
             rollout_probability: 100,
         },
         intermediary: {
@@ -113,7 +113,7 @@ const fixtures = [
         firmwareType: FirmwareType.Universal,
         result: {
             releaseConditions: {
-                environment: { min_suite_version: '25.2.1' },
+                environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
                 rollout_probability: 100,
                 shouldBeOffered: true,
             },

--- a/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
+++ b/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
@@ -82,7 +82,8 @@ const verifyFirmwareRelease = (
 
     const JWSPublicKey = getJWSPublicKey(
         'firmware-release',
-        ['test-signed', 'production'].includes(env),
+        // When using local we always want to use CodeSignKey.
+        ['test-signed', 'production'].includes(env) || !isRemote,
     );
     if (!JWSPublicKey) {
         throw new Error('JWS public key is not defined!');

--- a/packages/device-utils/src/types.ts
+++ b/packages/device-utils/src/types.ts
@@ -107,6 +107,7 @@ export interface ConditionalRelease {
     conditions: {
         environment: {
             min_suite_version: string;
+            min_suite_native_version: string;
         };
         rollout_probability: number;
     };

--- a/packages/suite/src/actions/backup/__tests__/backupActions.test.ts
+++ b/packages/suite/src/actions/backup/__tests__/backupActions.test.ts
@@ -35,6 +35,7 @@ const getInitialState = (override: any) => {
             },
         },
         messageSystem: messageSystemInitialState,
+        firmware: { firmwareUpdateSource: 'production' },
     };
     if (override) {
         return mergeDeepObject(defaults, override);

--- a/packages/suite/src/actions/suite/__tests__/initAction.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/initAction.test.ts
@@ -66,6 +66,7 @@ const getInitialState = (initialRun?: boolean) => ({
     messageSystem: messageSystemReducer(undefined, EMPTY_ACTION),
     device: deviceReducer(undefined, EMPTY_ACTION),
     metadata: metadataReducer(undefined, EMPTY_ACTION),
+    firmware: { firmwareUpdateSource: 'production' },
 });
 
 type Fixture = {

--- a/packages/suite/src/actions/suite/__tests__/trezorConnectActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/trezorConnectActions.test.ts
@@ -25,6 +25,7 @@ const getInitialState = (suite?: Partial<SuiteState>, device?: Partial<DevicesSt
         },
     },
     messageSystem: messageSystemInitialState,
+    firmware: { firmwareUpdateSource: 'production' },
 });
 
 type State = ReturnType<typeof getInitialState>;

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -540,6 +540,20 @@ export const saveConnectSettings = () => async (_dispatch: Dispatch, getState: G
     );
 };
 
+export const saveFirmwareSettings = () => async (_dispatch: Dispatch, getState: GetState) => {
+    if (!(await db.isAccessible())) return;
+    const { firmware } = getState();
+
+    db.addItem(
+        'firmware',
+        {
+            firmwareUpdateSource: firmware.firmwareUpdateSource,
+        },
+        'firmware',
+        true,
+    );
+};
+
 export const removeDatabase = () => async (dispatch: Dispatch, getState: GetState) => {
     if (!(await db.isAccessible())) return;
 

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -362,18 +362,6 @@ export const setDebugMode = (payload: Partial<DebugModeOptions>): SuiteAction =>
 });
 
 /**
- * Triggered by user action in:
- * - Debug Settings
- * Set `firmwareUpdateSource` field in suite reducer
- * @param {FirmwareUpdateSource} payload
- * @returns {SuiteAction}
- */
-export const setFirmwareUpdateSource = (payload: FirmwareUpdateSource): SuiteAction => ({
-    type: SUITE.SET_FIRMWARE_UPDATE_SOURCE,
-    payload,
-});
-
-/**
  * Called from multiple places before and after TrezorConnect call
  * Prevent from mad clicking
  * Set `lock` field in suite reducer

--- a/packages/suite/src/actions/wallet/__tests__/publicKeyActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/publicKeyActions.test.ts
@@ -78,6 +78,7 @@ const rootReducer = combineReducers({
         () => ({}),
     ),
     messageSystem: createReducer(messageSystemInitialState, () => ({})),
+    firmware: createReducer([{ firmwareUpdateSource: 'production' }], () => ({})),
 });
 
 interface StateOverrides {

--- a/packages/suite/src/actions/wallet/__tests__/receiveActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/receiveActions.test.ts
@@ -116,6 +116,7 @@ const getInitialState = (state: Partial<InitialState> | undefined) => ({
         ...state?.device,
     },
     messageSystem: messageSystemInitialState,
+    firmware: { firmwareUpdateSource: 'production' },
 });
 
 type State = ReturnType<typeof getInitialState>;

--- a/packages/suite/src/middlewares/suite/__tests__/buttonRequestMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/buttonRequestMiddleware.test.ts
@@ -32,6 +32,7 @@ const getInitialState = () => ({
         selectedDevice: device,
     },
     messageSystem: messageSystemInitialState,
+    firmware: { firmwareUpdateSource: 'production' },
 });
 
 type State = ReturnType<typeof getInitialState>;

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -4,6 +4,7 @@ import { MiddlewareAPI } from 'redux';
 import { analyticsActions } from '@suite-common/analytics';
 import { bluetoothActions } from '@suite-common/bluetooth';
 import { connectPopupActions } from '@suite-common/connect-popup';
+import { firmwareActions } from '@suite-common/firmware';
 import { messageSystemActions } from '@suite-common/message-system';
 import { isDeviceRemembered } from '@suite-common/suite-utils';
 import { thpActions } from '@suite-common/thp';
@@ -233,6 +234,10 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 )(action)
             ) {
                 api.dispatch(storageActions.saveConnectSettings());
+            }
+
+            if (firmwareActions.setFirmwareUpdateSource.match(action)) {
+                api.dispatch(storageActions.saveFirmwareSettings());
             }
 
             if (

--- a/packages/suite/src/storage/definitions.ts
+++ b/packages/suite/src/storage/definitions.ts
@@ -20,6 +20,7 @@ import type {
     RatesByTimestamps,
     WalletSettings,
 } from '@suite-common/wallet-types';
+import { FirmwareUpdateSource } from '@trezor/connect/src/data/firmwareInfo';
 
 import type { BioAuthState } from 'src/reducers/bioAuth';
 import type { SuiteState } from 'src/reducers/suite/suiteReducer';
@@ -154,7 +155,7 @@ export interface SuiteDBSchema extends DBSchema {
     firmware: {
         key: 'firmware';
         value: {
-            firmwareHashInvalid: string[];
+            firmwareUpdateSource: FirmwareUpdateSource;
         };
     };
     security: {

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -86,7 +86,6 @@ export const extraDependencies: ExtraDependencies = {
             staticKey: state.thp?.staticKey,
             knownCredentials: state.thp?.credentials,
         }),
-        selectFirmwareUpdateSource: (state: AppState) => state.suite.settings.firmwareUpdateSource,
     },
     actions: {
         setAccountAddMetadata: metadataActions.setAccountAdd,

--- a/packages/suite/src/support/suite/preloadStore.ts
+++ b/packages/suite/src/support/suite/preloadStore.ts
@@ -49,6 +49,7 @@ export const preloadStore = async () => {
         connect,
         explorer,
         bioAuth,
+        firmware,
     ] = await Promise.all([
         db.getItemByPK('suiteSettings', 'suite'),
         db.getItemsExtended('devices'),
@@ -73,6 +74,7 @@ export const preloadStore = async () => {
         db.getItemByPK('connect', 'connect'),
         db.getItemsExtended('explorer'),
         db.getItemByPK('bioAuth', 'bioAuth'),
+        db.getItemByPK('firmware', 'firmware'),
     ]);
 
     return {
@@ -101,6 +103,7 @@ export const preloadStore = async () => {
             bioAuth,
             connect,
             explorer,
+            firmware,
         },
     } as const;
 };

--- a/packages/suite/src/views/settings/SettingsDebug/FirmwareUpdate.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/FirmwareUpdate.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
+import { firmwareActions, selectFirmwareUpdateSource } from '@suite-common/firmware';
 import { FirmwareUpdateSource } from '@trezor/connect/src/data/firmwareInfo';
 
-import { setFirmwareUpdateSource } from 'src/actions/suite/suiteActions';
 import { ActionColumn, ActionSelect, SectionItem, TextColumn } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
@@ -11,7 +11,7 @@ const StyledActionSelect = styled(ActionSelect)`
 `;
 
 export const FirmwareUpdate = () => {
-    const firmwareUpdateSource = useSelector(state => state.suite.settings.firmwareUpdateSource);
+    const firmwareUpdateSource = useSelector(selectFirmwareUpdateSource);
     const dispatch = useDispatch();
 
     const options: { label: string; value: FirmwareUpdateSource }[] = [
@@ -25,8 +25,7 @@ export const FirmwareUpdate = () => {
         options.find(option => option.value === firmwareUpdateSource) || options[0];
 
     const handleChange = (item: { value: FirmwareUpdateSource }) => {
-        console.log('handleChange');
-        dispatch(setFirmwareUpdateSource(item.value));
+        dispatch(firmwareActions.setFirmwareUpdateSource(item.value));
     };
 
     return (

--- a/suite-common/connect-init/src/__tests__/connectInitThunks.test.ts
+++ b/suite-common/connect-init/src/__tests__/connectInitThunks.test.ts
@@ -12,6 +12,7 @@ describe('TrezorConnect Actions', () => {
             preloadedState: {
                 wallet: { settings: { enabledNetworks: [] } },
                 device: { selectedDevice: undefined, devices: [] },
+                firmware: { firmwareUpdateSource: 'production' },
                 messageSystem: messageSystemInitialState,
             },
         });

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -1,3 +1,4 @@
+import { selectFirmwareUpdateSource } from '@suite-common/firmware/src/firmwareReducer';
 import {
     Feature,
     parseTimeoutThresholdsPerModel,
@@ -48,7 +49,7 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
     `${CONNECT_INIT_MODULE}/initThunk`,
     async (connectInitHooks, { dispatch, getState, extra }) => {
         const {
-            selectors: { selectDebugSettings, selectThpSettings, selectFirmwareUpdateSource },
+            selectors: { selectDebugSettings, selectThpSettings },
             actions: { lockDevice },
             utils: { connectInitSettings },
         } = extra;

--- a/suite-common/firmware/src/firmwareActions.ts
+++ b/suite-common/firmware/src/firmwareActions.ts
@@ -2,6 +2,7 @@ import { createAction } from '@reduxjs/toolkit';
 
 import { FirmwareStatus, TrezorDevice } from '@suite-common/suite-types';
 import { FirmwareType } from '@trezor/connect';
+import { FirmwareUpdateSource } from '@trezor/connect/src/data/firmwareInfo';
 
 export const FIRMWARE_MODULE_PREFIX = '@common/wallet-core/firmware';
 
@@ -47,6 +48,13 @@ const cacheDevice = createAction(
     }),
 );
 
+const setFirmwareUpdateSource = createAction(
+    `${FIRMWARE_MODULE_PREFIX}/set-firmware-update-source`,
+    (payload: FirmwareUpdateSource) => ({
+        payload,
+    }),
+);
+
 export const firmwareActions = {
     setStatus,
     setFirmwareUpdateError,
@@ -55,4 +63,5 @@ export const firmwareActions = {
     resetReducer,
     toggleUseDevkit,
     cacheDevice,
+    setFirmwareUpdateSource,
 };

--- a/suite-common/firmware/src/firmwareReducer.ts
+++ b/suite-common/firmware/src/firmwareReducer.ts
@@ -1,3 +1,5 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { FirmwareStatus, TrezorDevice } from '@suite-common/suite-types';
 import {
@@ -9,6 +11,7 @@ import {
     FirmwareType,
     UI,
 } from '@trezor/connect';
+import { FirmwareUpdateSource } from '@trezor/connect/src/data/firmwareInfo';
 
 import { firmwareActions } from './firmwareActions';
 
@@ -24,6 +27,7 @@ type FirmwareUpdateCommon = {
     targetType?: FirmwareType;
     useDevkit: boolean;
     uiEvent?: FirmwwareUpdateUiEvent;
+    firmwareUpdateSource: FirmwareUpdateSource;
 };
 
 export type FirmwareUpdateState =
@@ -43,14 +47,28 @@ const initialState: FirmwareUpdateState = {
     targetType: undefined,
     useDevkit: false,
     uiEvent: undefined,
+    firmwareUpdateSource: 'production',
 };
 
 type RootState = {
     firmware: typeof initialState;
 };
 
-export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, builder => {
+type StorageActionPayload = {
+    firmware: {
+        firmwareUpdateSource: FirmwareUpdateSource;
+    };
+};
+
+export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, (builder, extra) => {
     builder
+        .addCase(
+            extra.actionTypes.storageLoad,
+            (state, { payload }: PayloadAction<StorageActionPayload>) => {
+                if (payload.firmware)
+                    state.firmwareUpdateSource = payload.firmware.firmwareUpdateSource;
+            },
+        )
         .addCase(firmwareActions.setStatus, (state, { payload }) => {
             state.status = payload;
         })
@@ -74,6 +92,9 @@ export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, b
         .addCase(firmwareActions.cacheDevice, (state, { payload }) => {
             state.cachedDevice = payload;
         })
+        .addCase(firmwareActions.setFirmwareUpdateSource, (state, { payload }) => {
+            state.firmwareUpdateSource = payload;
+        })
         .addMatcher<FirmwwareUpdateUiEvent>(
             (action: FirmwwareUpdateUiEvent) =>
                 action.type === UI.FIRMWARE_RECONNECT ||
@@ -92,3 +113,4 @@ export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, b
 
 export const selectFirmware = (state: RootState) => state.firmware;
 export const selectUseDevkit = (state: RootState) => state.firmware.useDevkit;
+export const selectFirmwareUpdateSource = (state: RootState) => state.firmware.firmwareUpdateSource;

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -19,7 +19,6 @@ import {
     WalletType,
 } from '@suite-common/wallet-types';
 import { BlockchainBlock, ConnectSettings, Manifest, StaticSessionId } from '@trezor/connect';
-import { FirmwareUpdateSource } from '@trezor/connect/src/data/firmwareInfo';
 
 import { ActionType, SuiteCompatibleSelector, SuiteCompatibleThunk } from './types';
 
@@ -71,7 +70,6 @@ export type ExtraDependencies = {
         >;
         selectIsViewOnlyByDefaultEnabled: SuiteCompatibleSelector<boolean>;
         selectThpSettings: SuiteCompatibleSelector<NonNullable<ConnectSettings['thp']>>;
-        selectFirmwareUpdateSource: SuiteCompatibleSelector<FirmwareUpdateSource>;
     };
     // You should only use ActionCreatorWithPayload from redux-toolkit!
     // That means you will need to convert actual action creators in packages/suite to use createAction from redux-toolkit,

--- a/suite-common/test-utils/src/extraDependenciesMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesMock.ts
@@ -98,7 +98,6 @@ export const extraDependenciesMock: ExtraDependencies = {
         selectTradingEnvironment: mockSelector('selectTradingEnvironment', 'localhost'),
         selectIsViewOnlyByDefaultEnabled: mockSelector('selectIsViewOnlyByDefaultEnabled', true),
         selectThpSettings: mockSelector('selectThpSettings', { pairingMethods: ['CodeEntry'] }),
-        selectFirmwareUpdateSource: mockSelector('selectFirmwareUpdateSource', 'production'),
     },
     actions: {
         setAccountAddMetadata: mockAction('setAccountAddMetadata'),

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -70,7 +70,7 @@ const getFirmwareReleaseConfigInfo = (): NonNullable<Device['firmwareReleaseConf
     isBitcoinOnlyAvailable: true,
     intermediary: undefined,
     releaseConditions: {
-        environment: { min_suite_version: '25.2.1' },
+        environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
         rollout_probability: 100,
         shouldBeOffered: true,
     },

--- a/suite-common/thp/tests/autoInitThpAfterDeviceConnectionThunk.test.ts
+++ b/suite-common/thp/tests/autoInitThpAfterDeviceConnectionThunk.test.ts
@@ -31,6 +31,7 @@ const initialFirmwareState: FirmwareUpdateState = {
     targetType: undefined,
     uiEvent: undefined,
     useDevkit: false,
+    firmwareUpdateSource: 'production',
 };
 
 const testCases: {

--- a/suite-common/thp/tests/connectThpDeviceThunk.test.ts
+++ b/suite-common/thp/tests/connectThpDeviceThunk.test.ts
@@ -38,6 +38,7 @@ const initialFirmwareState: FirmwareUpdateState = {
     targetType: undefined,
     uiEvent: undefined,
     useDevkit: false,
+    firmwareUpdateSource: 'production',
 };
 
 const device: Pick<Device, 'thp'> = {

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -440,10 +440,9 @@ export const selectShouldOfferUpdateFirmware = createMemoizedSelector(
         if (!firmwareReleaseConfig) return false;
         const { releaseConditions } = firmwareReleaseConfig;
         const { environment } = releaseConditions;
-        const isValidSuiteNativeVersion = environment?.min_suite_native_version ? versionUtils.isNewerOrEqual(
-            getSuiteVersion(),
-            environment?.min_suite_native_version,
-        ) : false;
+        const isValidSuiteNativeVersion = environment?.min_suite_native_version
+            ? versionUtils.isNewerOrEqual(getSuiteVersion(), environment?.min_suite_native_version)
+            : false;
 
         return (
             firmwareReleaseConfig?.isNewer &&

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -12,6 +12,8 @@ import {
     getFirmwareVersionArray,
     hasBitcoinOnlyFirmware,
 } from '@trezor/device-utils';
+import { getSuiteVersion } from '@trezor/env-utils';
+import { versionUtils } from '@trezor/utils';
 
 import { PORTFOLIO_TRACKER_DEVICE_ID } from './deviceConstants';
 import { DeviceRootState } from './deviceReducer';
@@ -303,13 +305,13 @@ export const selectDeviceModel = createMemoizedSelector(
     selectedDevice => selectedDevice?.features?.internal_model ?? null,
 );
 
-export const selectDeviceReleaseInfo = createMemoizedSelector(
+export const selectFirmwareReleaseConfig = createMemoizedSelector(
     [selectSelectedDevice],
     device => device?.firmwareReleaseConfigInfo ?? null,
 );
 
 export const selectIsFirmwareUpgradable = createMemoizedSelector(
-    [selectDeviceReleaseInfo],
+    [selectFirmwareReleaseConfig],
     deviceReleaseInfo => deviceReleaseInfo?.isNewer ?? false,
 );
 
@@ -430,6 +432,25 @@ export const selectInstacelessUnselectedDevices = createMemoizedSelector(
 
 export const selectHasBitcoinOnlyFirmware = createMemoizedSelector([selectSelectedDevice], device =>
     hasBitcoinOnlyFirmware(device),
+);
+
+export const selectShouldOfferUpdateFirmware = createMemoizedSelector(
+    [selectFirmwareReleaseConfig],
+    firmwareReleaseConfig => {
+        if (!firmwareReleaseConfig) return false;
+        const { releaseConditions } = firmwareReleaseConfig;
+        const { environment } = releaseConditions;
+        const isValidSuiteNativeVersion = environment?.min_suite_native_version ? versionUtils.isNewerOrEqual(
+            getSuiteVersion(),
+            environment?.min_suite_native_version,
+        ) : false;
+
+        return (
+            firmwareReleaseConfig?.isNewer &&
+            isValidSuiteNativeVersion &&
+            releaseConditions.shouldBeOffered
+        );
+    },
 );
 
 export const selectDeviceUpdateFirmwareVersion = (state: DeviceRootState) => {

--- a/suite-native/module-dev-utils/src/components/FirmwareUpdateEnvironmentSelect.tsx
+++ b/suite-native/module-dev-utils/src/components/FirmwareUpdateEnvironmentSelect.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { firmwareActions, selectFirmwareUpdateSource } from '@suite-common/firmware';
+import { Select, SelectItemType } from '@suite-native/atoms';
+import { FirmwareUpdateSource } from '@trezor/connect/src/data/firmwareInfo';
+
+const options: SelectItemType<FirmwareUpdateSource>[] = [
+    { label: 'Production', value: 'production' },
+    { label: 'Test Unsigned', value: 'test-unsigned' },
+    { label: 'Test Signed', value: 'test-signed' },
+];
+
+export const FirmwareUpdateEnvironmentSelect = () => {
+    const selectedFirmwareUpdateSource: FirmwareUpdateSource = useSelector(
+        selectFirmwareUpdateSource,
+    );
+    const dispatch = useDispatch();
+
+    const handleSelectEnvironment = (environment: FirmwareUpdateSource) => {
+        dispatch(firmwareActions.setFirmwareUpdateSource(environment));
+    };
+
+    return (
+        <Select<FirmwareUpdateSource>
+            items={options}
+            selectLabel="Environment"
+            selectValue={selectedFirmwareUpdateSource}
+            onSelectItem={handleSelectEnvironment}
+        />
+    );
+};

--- a/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
@@ -20,6 +20,7 @@ import { getCommitHash, getSuiteVersion } from '@trezor/env-utils';
 
 import { DevicePassphraseSwitch } from '../components/DevicePassphraseSwitch';
 import { FeatureFlags } from '../components/FeatureFlags';
+import { FirmwareUpdateEnvironmentSelect } from '../components/FirmwareUpdateEnvironmentSelect';
 import { MessageSystemInfo } from '../components/MessageSystemInfo';
 import { RenderingUtils } from '../components/RenderingUtils';
 import { TestnetsToggle } from '../components/TestnetsToggle';
@@ -97,6 +98,12 @@ export const DevUtilsScreen = () => {
                     </VStack>
                 </Card>
                 <MessageSystemInfo />
+                <Card>
+                    <VStack>
+                        <Text variant="highlight">Firmware Source</Text>
+                        <FirmwareUpdateEnvironmentSelect />
+                    </VStack>
+                </Card>
             </VStack>
         </Screen>
     );

--- a/suite-native/module-device-onboarding/src/screens/ConfirmFirmwareUpdateScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ConfirmFirmwareUpdateScreen.tsx
@@ -26,6 +26,7 @@ export const ConfirmFirmwareUpdateScreen = ({
 >) => {
     const hasDeviceFirmwareInstalled = useSelector(selectHasDeviceFirmwareInstalled);
     const isDeviceFirmwareSupported = useSelector(selectIsDeviceFirmwareSupported);
+
     const updateOnboardingAnalytics = useSetAtom(updateOnboardingAnalyticsAtom);
 
     const { navigateToNextScreenAfterFirmwareInstallation } =

--- a/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
@@ -7,7 +7,7 @@ import { useSetAtom } from 'jotai';
 import {
     selectDeviceModel,
     selectHasDeviceFirmwareInstalled,
-    selectIsLatestFirmwareInstalled,
+    selectShouldOfferUpdateFirmware,
 } from '@suite-common/wallet-core';
 import { EventType, analytics } from '@suite-native/analytics';
 import { Box, Button, Image, Text, TextButton, TitleHeader, VStack } from '@suite-native/atoms';
@@ -89,7 +89,7 @@ export const UninitializedDeviceLandingScreen = ({
     DeviceOnboardingStackRoutes.UninitializedDeviceLanding
 >) => {
     const hasDeviceFirmwareInstalled = useSelector(selectHasDeviceFirmwareInstalled);
-    const isLatestFirmwareInstalled = useSelector(selectIsLatestFirmwareInstalled);
+    const shouldOfferUpdateFirmware = useSelector(selectShouldOfferUpdateFirmware);
     const deviceModel = useSelector(selectDeviceModel);
     const resetOnboardingAnalytics = useSetAtom(resetOnboardingAnalyticsAtom);
     const updateOnboardingAnalytics = useSetAtom(updateOnboardingAnalyticsAtom);
@@ -97,15 +97,15 @@ export const UninitializedDeviceLandingScreen = ({
         useNavigateToNextScreenAfterFirmwareInstallation();
     const handleConfirmButtonPress = () => {
         if (hasDeviceFirmwareInstalled) {
-            if (isLatestFirmwareInstalled) {
+            if (shouldOfferUpdateFirmware) {
+                navigation.navigate(DeviceOnboardingStackRoutes.ConfirmFirmwareUpdate);
+            } else {
                 // If user already has the latest firmware installed, skip this update screen and navigate to device auth-check directly.
                 updateOnboardingAnalytics({
                     firmware: 'up-to-date',
                 });
 
                 navigateToNextScreenAfterFirmwareInstallation();
-            } else {
-                navigation.navigate(DeviceOnboardingStackRoutes.ConfirmFirmwareUpdate);
             }
         } else {
             // Security check is relevant for brand new devices without FW only.

--- a/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
@@ -5,7 +5,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import {
     selectDeviceModel,
-    selectDeviceReleaseInfo,
+    selectFirmwareReleaseConfig,
     selectHasRunningDiscovery,
     selectIsDeviceBackedUp,
     selectIsFirmwareUpgradable,
@@ -33,7 +33,7 @@ type NavigationProp = StackNavigationProps<
 export const DeviceFirmwareCard = () => {
     const device = useSelector(selectSelectedDevice);
     const deviceModel = useSelector(selectDeviceModel);
-    const deviceReleaseInfo = useSelector(selectDeviceReleaseInfo);
+    const deviceReleaseInfo = useSelector(selectFirmwareReleaseConfig);
     const isDeviceBackedUp = useSelector(selectIsDeviceBackedUp);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
     const isFirmwareUpgradable = useSelector(selectIsFirmwareUpgradable);

--- a/suite-native/module-home/src/screens/HomeScreen/components/FirmwareUpdateAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/FirmwareUpdateAlert.tsx
@@ -13,6 +13,7 @@ import {
     selectIsDeviceConnected,
     selectIsFirmwareUpgradable,
     selectIsPortfolioTrackerDevice,
+    selectShouldOfferUpdateFirmware,
 } from '@suite-common/wallet-core';
 import { Box, Button, HStack, Text, VStack } from '@suite-native/atoms';
 import { useIsFirmwareUpdateFeatureEnabled } from '@suite-native/firmware';
@@ -52,6 +53,7 @@ const closeStateAtom = atom<CloseStateItem[]>([]);
 export const FirmwareUpdateAlert = () => {
     const { applyStyle } = useNativeStyles();
     const updateFirmwareVersion = useSelector(selectDeviceUpdateFirmwareVersion);
+    const shouldOfferUpdateFirmware = useSelector(selectShouldOfferUpdateFirmware);
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const deviceId = useSelector(selectDeviceId);
     const isConnected = useSelector(selectIsDeviceConnected);
@@ -97,6 +99,7 @@ export const FirmwareUpdateAlert = () => {
 
     if (
         !isFirmwareUpgradable ||
+        !shouldOfferUpdateFirmware ||
         isPortfolioTrackerDevice ||
         isDiscoveryRunning ||
         !isConnected ||

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -242,6 +242,13 @@ export const prepareRootReducers = async () => {
         version: 1,
     });
 
+    const firmwarePersistedReducer = await preparePersistReducer({
+        reducer: firmwareReducer,
+        key: 'firmware',
+        version: 1,
+        persistedKeys: ['firmwareUpdateSource'],
+    });
+
     const rootReducer = await preparePersistReducer({
         reducer: combineReducers({
             app: appReducer,
@@ -253,7 +260,7 @@ export const prepareRootReducers = async () => {
             graph: graphReducer,
             device: devicePersistedReducer,
             deviceAuthorization: deviceAuthorizationReducer,
-            firmware: firmwareReducer,
+            firmware: firmwarePersistedReducer,
             nativeFirmware: nativeFirmwareReducer,
             logs: logsSlice.reducer,
             notifications: notificationsReducer,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a follow-up of firmware update flow https://github.com/trezor/trezor-suite/pull/18821  for Suite mobile app.
* It makes mobile app to use the conditional firmware updates
* Add new dev setting in mobile app to select the firmware source "production" | "test-unsigned" | "test-signed"
* It refactors the way firmwareUpdateSource is stored in Suite web and desktop as well so it can play better with mobile.

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/19763

## Screenshots:

<img width="757" height="1414" alt="image" src="https://github.com/user-attachments/assets/56bab495-c4f4-467b-81dc-905f9bdc114b" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/firmware-update-wit-mobile&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/firmware-update-wit-mobile&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/firmware-update-wit-mobile&lookback=7)