### PR TITLE
fix(suite): refresh offers after timer finishes

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingInitializer.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingInitializer.ts
@@ -18,7 +18,7 @@ export const useTradingInitializer = ({
 
     const checkQuotesTimer = useCallback(
         (callback: () => Promise<void>) => {
-            if (!isLoading) return;
+            if (isLoading) return;
 
             if (!timer.isLoading && !timer.isStopped) {
                 if (timer.resetCount >= 40) {


### PR DESCRIPTION
## Description

Refresh offers and reset the timer after it finishes (reaches 0 seconds).

## Related Issue

Resolve #19124 

## Screenshots:

https://github.com/user-attachments/assets/2212f3ab-6f76-4301-aebc-7f117f5457d2


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/offers-refresh&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/offers-refresh&lookback=7)