### PR TITLE
fix(suite): update Address component to use the same font as device

### DIFF
--- a/packages/components/src/components/Card/utils.tsx
+++ b/packages/components/src/components/Card/utils.tsx
@@ -26,7 +26,7 @@ export const mapPaddingTypeToPadding = ({ paddingType }: PaddingMapArgs): Paddin
     const paddingMap: Record<PaddingType, Padding | undefined> = {
         none: undefined,
         tiny: { vertical: spacings.xxxs, horizontal: spacings.xxs },
-        small: { vertical: spacings.xs, horizontal: spacings.sm },
+        small: { vertical: spacings.sm, horizontal: spacings.md },
         normal: { vertical: spacings.md, horizontal: spacings.lg },
         large: { vertical: spacings.lg, horizontal: spacings.xl },
     };

--- a/packages/components/src/components/form/styles.ts
+++ b/packages/components/src/components/form/styles.ts
@@ -66,7 +66,10 @@ export const baseInputStyle = css<BaseInputProps>`
     ${typography.body}
     transition: border-color 0.1s;
     outline: none;
-    font-variant-numeric: slashed-zero tabular-nums;
+    font-feature-settings:
+        'tnum' 1,
+        'zero' 1,
+        'ss03' 1;
 
     &::placeholder {
         color: ${({ theme }) => theme.textSubdued};

--- a/packages/suite/src/components/suite/Address.tsx
+++ b/packages/suite/src/components/suite/Address.tsx
@@ -1,15 +1,39 @@
-import styled from 'styled-components';
+import styled, { RuleSet, css } from 'styled-components';
+
+import { DEFAULT_FLAGSHIP_MODEL } from '@suite-common/suite-constants';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { useSelector } from 'src/hooks/suite';
 import { selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
 
 const TRUNCATION_PLACEHOLDER = ' ... ';
 
-const AddressWrapper = styled.p`
+const mapDeviceModelToFontStyle = (deviceModelInternal: DeviceModelInternal): RuleSet<object> => {
+    switch (deviceModelInternal) {
+        case DeviceModelInternal.T1B1:
+        case DeviceModelInternal.T2B1:
+        case DeviceModelInternal.T3B1:
+            return css`
+                font-family: 'PixelOperatorMono8', monospace;
+                font-size: 0.75em;
+            `;
+        case DeviceModelInternal.T2T1:
+        case DeviceModelInternal.T3T1:
+        case DeviceModelInternal.T3W1:
+        default:
+            return css`
+                font-family: RobotoMono, monospace;
+            `;
+    }
+};
+
+const AddressWrapper = styled.p<{ $device: DeviceModelInternal; $isChunked: boolean }>`
     text-wrap: balance;
-    font-variant-numeric: tabular-nums;
     letter-spacing: 0;
-    word-break: break-all;
+    word-break: ${({ $isChunked }) => ($isChunked ? 'normal' : 'break-all')};
+
+    ${({ $device }) => mapDeviceModelToFontStyle($device)}
 `;
 
 const addSpacing = (value: string) => value.match(/.{1,4}/g)?.join(' ') || value;
@@ -27,6 +51,8 @@ export const Address = ({
     isChunked,
     'data-testid': dataTestId,
 }: AddressProps) => {
+    const selectedDevice = useSelector(selectSelectedDevice);
+    const deviceModelInternal = selectedDevice?.features?.internal_model || DEFAULT_FLAGSHIP_MODEL;
     const isChunkedSettings = useSelector(selectAddressDisplayType);
     const isAddressChunked = isChunked ?? isChunkedSettings === 'chunked';
     const placeholder = isAddressChunked ? TRUNCATION_PLACEHOLDER : TRUNCATION_PLACEHOLDER.trim();
@@ -48,7 +74,12 @@ export const Address = ({
     };
 
     return (
-        <AddressWrapper onCopy={handleCopy} data-testid={dataTestId}>
+        <AddressWrapper
+            onCopy={handleCopy}
+            data-testid={dataTestId}
+            $device={deviceModelInternal}
+            $isChunked={isAddressChunked}
+        >
             {formattedValue ?? value}
         </AddressWrapper>
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -188,6 +188,7 @@ export const TransactionReviewOutputElement = ({
                                             </Text>
                                         }
                                         direction="row"
+                                        verticalAlignment="start"
                                     >
                                         <Text
                                             as="div"


### PR DESCRIPTION
<img width="660" alt="Screenshot 2025-06-02 at 15 05 52" src="https://github.com/user-attachments/assets/c471ac62-46a6-495a-aae9-a7bfe6b2da72" />
<img width="657" alt="Screenshot 2025-06-02 at 15 24 10" src="https://github.com/user-attachments/assets/7143c1db-9086-4f79-84cd-5838d0eca191" />
<img width="787" alt="Screenshot 2025-06-02 at 15 24 32" src="https://github.com/user-attachments/assets/7b9b12b2-bd5b-4bd2-8a33-38341b656477" />
<img width="969" alt="Screenshot 2025-06-02 at 15 07 28" src="https://github.com/user-attachments/assets/148b7010-df68-44c1-ad5f-87dd66283016" />
<img width="1005" alt="Screenshot 2025-06-02 at 15 07 51" src="https://github.com/user-attachments/assets/34544dc2-f9ac-41b8-9815-35c6d8c623be" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/improve-address-fonts-in-suite-to-avoid-large-differences-from-on-device-fonts&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/improve-address-fonts-in-suite-to-avoid-large-differences-from-on-device-fonts&lookback=7)