### PR TITLE
feat(walletconnect): new account switching flow

### DIFF
--- a/packages/components/src/components/form/Select/useDetectPortalTarget.ts
+++ b/packages/components/src/components/form/Select/useDetectPortalTarget.ts
@@ -10,6 +10,9 @@ export const useDetectPortalTarget = (selectRef: RefObject<SelectInstance<Option
     // The inputRef is deeply nested so we iterate with while loop until wee reach the parentElement or max depth.
     // The depth has a limit so that it does not iterate over the entire DOM.
     // The depth limit has a buffer of 2 iterations in case the select is wrapped. (Minimum depth is 4.)
+
+    // UPDATE (2025-06-02): There is a lot more wrapping now, just in the modal itself there's 4 layers of wrapping.
+    // So I increased the depth limit to 15 iterations.
     useEffect(() => {
         let parent = selectRef.current?.inputRef?.parentElement;
         let count = 0;
@@ -18,7 +21,7 @@ export const useDetectPortalTarget = (selectRef: RefObject<SelectInstance<Option
                 setMenuPortalTarget(document.body);
                 break;
             }
-            if (count > 5) {
+            if (count > 15) {
                 break;
             }
             parent = parent.parentElement;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -58,6 +58,7 @@ import { ConnectLoadingModal } from './ConnectLoadingModal';
 import { TradingDCAModal } from './TradingDCAModal';
 import { EverstakeModal } from './UnstakeModal/EverstakeModal';
 import { WalletConnectProposalModal } from './WalletConnectProposalModal';
+import { WalletConnectSwitchAccountModal } from './WalletConnectSwitchAccountModal';
 
 /** Modals opened as a result of user action */
 export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL.CONTEXT_USER>) => {
@@ -218,6 +219,8 @@ export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL.CONTE
             return <ConnectPermissionsModal />;
         case 'walletconnect-proposal':
             return <WalletConnectProposalModal eventId={payload.eventId} />;
+        case 'walletconnect-switch-account':
+            return <WalletConnectSwitchAccountModal sessionTopic={payload.sessionTopic} />;
         case 'trading-dca':
             return <TradingDCAModal device={payload.device} onCancel={onCancel} />;
         case 'connect-address-confirmation':

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
@@ -1,11 +1,8 @@
-import { useEffect, useMemo, useState } from 'react';
-import { GroupBase } from 'react-select';
+import { useMemo, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { TrezorDevice } from '@suite-common/suite-types';
-import { AccountType, NetworkType } from '@suite-common/wallet-config';
-import { selectAccounts, selectDevices } from '@suite-common/wallet-core';
+import { selectVisibleSortedDeviceAccounts } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import {
     selectPendingProposal,
@@ -18,6 +15,7 @@ import {
     Banner,
     Card,
     Column,
+    ElevationUp,
     IconCircle,
     Modal,
     Option,
@@ -32,7 +30,7 @@ import { spacings, spacingsPx } from '@trezor/theme';
 
 import { onCancel } from 'src/actions/suite/modalActions';
 import { goto } from 'src/actions/suite/routerActions';
-import { AccountLabel, Translation, WalletLabeling } from 'src/components/suite';
+import { AccountLabel, Translation } from 'src/components/suite';
 import { AccountTypeBadge } from 'src/components/suite/AccountTypeBadge';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
@@ -49,24 +47,31 @@ interface WalletConnectProposalModalProps {
     eventId: number;
 }
 
-interface AccountGroup extends GroupBase<Account> {
-    options: Account[];
-    label: string;
-    device: TrezorDevice;
-    accountType: AccountType;
-    networkType: NetworkType;
-}
-
 export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalModalProps) => {
     const dispatch = useDispatch();
     const pendingProposal = useSelector(selectPendingProposal);
-    const accounts = useSelector(selectAccounts);
+    const accounts = useSelector(selectVisibleSortedDeviceAccounts);
     const accountLabels = useSelector(selectAccountLabels);
-    const devices = useSelector(selectDevices);
-    const [selectedDefaultAccounts, setSelectedDefaultAccounts] = useState<Account[]>([]);
+    const selectableAccounts = useMemo<Account[]>(
+        () =>
+            pendingProposal?.networks
+                .filter(network => network.status === 'active')
+                .flatMap(network =>
+                    accounts.filter(account => account.symbol === network.symbol),
+                ) ?? [],
+        [accounts, pendingProposal?.networks],
+    );
+    const [selectedDefaultAccount, setSelectedDefaultAccount] = useState<Account | null>(
+        selectableAccounts[0] || null,
+    );
 
     const handleAccept = () => {
-        dispatch(sessionProposalApproveThunk({ eventId, selectedDefaultAccounts }));
+        dispatch(
+            sessionProposalApproveThunk({
+                eventId,
+                selectedDefaultAccount,
+            }),
+        );
         dispatch(onCancel());
     };
     const handleReject = () => {
@@ -76,70 +81,6 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
     const handleGoToCoinSettings = async () => {
         await dispatch(onCancel());
         dispatch(goto('settings-coins'));
-    };
-    const handleSelectAccount = (account: Account) => {
-        setSelectedDefaultAccounts(prev => {
-            const newAccounts = prev.filter(prevAccount => prevAccount.symbol !== account.symbol);
-
-            return [...newAccounts, account];
-        });
-    };
-
-    const orderedAccounts = useMemo(
-        () =>
-            [...accounts]
-                .filter(account => account.visible)
-                .map(account => ({
-                    ...account,
-                    accountLabel: accountLabels[account.key],
-                }))
-                .sort((a, b) => {
-                    if (a.deviceState !== b.deviceState) {
-                        return a.deviceState.localeCompare(b.deviceState);
-                    }
-                    if (a.accountType !== b.accountType) {
-                        // normal first
-                        if (a.accountType === 'normal' && b.accountType !== 'normal') return -1;
-                        if (a.accountType !== 'normal' && b.accountType === 'normal') return 1;
-
-                        return a.accountType.localeCompare(b.accountType);
-                    }
-
-                    return a.index - b.index;
-                }),
-        [accounts, accountLabels],
-    );
-    useEffect(() => {
-        const newDefaultAccounts = pendingProposal?.networks
-            .filter(network => network.status === 'active')
-            .map(network => orderedAccounts.find(account => account.symbol === network.symbol))
-            .filter(Boolean) as Account[];
-        setSelectedDefaultAccounts(newDefaultAccounts);
-    }, [orderedAccounts, pendingProposal?.networks]);
-
-    const buildAccountOptionGroups = (network: PendingConnectionProposalNetwork) => {
-        const groups: AccountGroup[] = [];
-        orderedAccounts
-            .filter(account => account.symbol === network.symbol)
-            .forEach(account => {
-                const device = devices.find(d => d.state?.staticSessionId === account.deviceState);
-                if (!device) return;
-                const label = `${account.deviceState}-${account.accountType}`;
-                const group = groups.find(g => g.label === label);
-                if (group) {
-                    group.options.push(account);
-                } else {
-                    groups.push({
-                        label,
-                        device,
-                        accountType: account.accountType,
-                        networkType: account.networkType,
-                        options: [account],
-                    });
-                }
-            });
-
-        return groups;
     };
 
     const getTooltipContent = (network: PendingConnectionProposalNetwork) => {
@@ -251,63 +192,55 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                                                 size={24}
                                             />
                                         )}
-                                        {network.status === 'active' &&
-                                        network.namespaceId.startsWith('solana') ? (
-                                            <Select
-                                                isSearchable={false}
-                                                isClearable={false}
-                                                isClean
-                                                menuFitContent
-                                                size="small"
-                                                value={selectedDefaultAccounts.find(
-                                                    account => account.symbol === network.symbol,
-                                                )}
-                                                options={buildAccountOptionGroups(network)}
-                                                formatGroupLabel={(data: GroupBase<Account>) => (
-                                                    <Row gap={spacings.xs}>
-                                                        <WalletLabeling
-                                                            device={(data as AccountGroup).device}
-                                                            shouldUseDeviceLabel
-                                                        />
-                                                        <AccountTypeBadge
-                                                            accountType={
-                                                                (data as AccountGroup).accountType
-                                                            }
-                                                            networkType={
-                                                                (data as AccountGroup).networkType
-                                                            }
-                                                            size="small"
-                                                            onElevation
-                                                        />
-                                                    </Row>
-                                                )}
-                                                formatOptionLabel={(account: Account) => (
-                                                    <AccountLabel
-                                                        key={account.descriptor}
-                                                        accountLabel={account.accountLabel}
-                                                        accountType={account.accountType}
-                                                        networkType={account.networkType}
-                                                        symbol={account.symbol}
-                                                        index={account.index}
-                                                        path={account.path}
-                                                    />
-                                                )}
-                                                onChange={(option: Option) =>
-                                                    handleSelectAccount(option)
-                                                }
-                                            />
-                                        ) : (
-                                            <Text>
-                                                {network.name}
-                                                {network.required && (
-                                                    <Text variant="destructive">*</Text>
-                                                )}
-                                            </Text>
-                                        )}
+                                        <Text>
+                                            {network.name}
+                                            {network.required && (
+                                                <Text variant="destructive">*</Text>
+                                            )}
+                                        </Text>
                                     </NetworkItemWrapper>
                                 </Tooltip>
                             ))}
                     </Row>
+                </Card>
+
+                <Text>
+                    <Translation id="TR_DEFAULT_ACCOUNT" />
+                </Text>
+                <Card paddingType="none">
+                    {/* Wrapped to keep consistent styling */}
+                    <ElevationUp>
+                        <Select
+                            isSearchable={false}
+                            isClearable={false}
+                            size="large"
+                            value={selectedDefaultAccount}
+                            options={selectableAccounts}
+                            formatOptionLabel={(account: Account) => (
+                                <Row gap={spacings.xs}>
+                                    {account.symbol && (
+                                        <CoinLogo type="token" symbol={account.symbol} size={24} />
+                                    )}
+                                    <AccountLabel
+                                        key={account.descriptor}
+                                        accountLabel={accountLabels[account.key]}
+                                        accountType={account.accountType}
+                                        networkType={account.networkType}
+                                        symbol={account.symbol}
+                                        index={account.index}
+                                        path={account.path}
+                                    />
+                                    <AccountTypeBadge
+                                        accountType={account.accountType}
+                                        networkType={account.networkType}
+                                        size="small"
+                                        onElevation
+                                    />
+                                </Row>
+                            )}
+                            onChange={(option: Option) => setSelectedDefaultAccount(option)}
+                        />
+                    </ElevationUp>
                 </Card>
 
                 {(requiredNetworksNotActivated || noNetworksActivated) && (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx
@@ -1,0 +1,111 @@
+import { useMemo, useState } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { selectVisibleSortedDeviceAccounts } from '@suite-common/wallet-core';
+import { Account } from '@suite-common/wallet-types';
+import {
+    getSessionNetworks,
+    selectSessions,
+    switchSelectedAccountThunk,
+    walletConnectActions,
+} from '@suite-common/walletconnect';
+import { Column, Modal, Option, Row, Select } from '@trezor/components';
+import { CoinLogo } from '@trezor/product-components';
+import { spacings } from '@trezor/theme';
+
+import * as modalActions from 'src/actions/suite/modalActions';
+import { AccountLabel, Translation } from 'src/components/suite';
+import { AccountTypeBadge } from 'src/components/suite/AccountTypeBadge';
+import { useSelector } from 'src/hooks/suite';
+import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
+
+interface WalletConnectSwitchAccountModalProps {
+    sessionTopic: string;
+}
+
+export const WalletConnectSwitchAccountModal = ({
+    sessionTopic,
+}: WalletConnectSwitchAccountModalProps) => {
+    const dispatch = useDispatch();
+    const sessions = useSelector(selectSessions);
+    const session = sessions.find(s => s.topic === sessionTopic);
+    const accounts = useSelector(selectVisibleSortedDeviceAccounts);
+    const accountLabels = useSelector(selectAccountLabels);
+    const selectableAccounts = useMemo<Account[]>(
+        () =>
+            session
+                ? getSessionNetworks(session)
+                      .filter(network => network.status === 'active')
+                      .flatMap(network =>
+                          accounts.filter(account => account.symbol === network.symbol),
+                      )
+                : [],
+        [accounts, session],
+    );
+    const [selectedDefaultAccount, setSelectedDefaultAccount] = useState<Account | null>(
+        session?.lastAccount || selectableAccounts[0] || null,
+    );
+
+    const handleSwitch = () => {
+        if (selectedDefaultAccount && session) {
+            dispatch(switchSelectedAccountThunk({ account: selectedDefaultAccount, sessionTopic }));
+            dispatch(
+                walletConnectActions.saveSession({
+                    ...session,
+                    lastAccount: selectedDefaultAccount,
+                }),
+            );
+        }
+        dispatch(modalActions.onCancel());
+    };
+    const handleCancel = () => {
+        dispatch(modalActions.onCancel());
+    };
+
+    return (
+        <Modal
+            bottomContent={
+                <>
+                    <Modal.Button variant="primary" onClick={handleSwitch}>
+                        <Translation id="TR_CONFIRM" />
+                    </Modal.Button>
+                </>
+            }
+            heading={<Translation id="TR_SWITCH_ACCOUNT" />}
+            onCancel={handleCancel}
+        >
+            <Column gap={spacings.xs}>
+                <Select
+                    isSearchable={false}
+                    isClearable={false}
+                    size="large"
+                    value={selectedDefaultAccount}
+                    options={selectableAccounts}
+                    formatOptionLabel={(account: Account) => (
+                        <Row gap={spacings.xs}>
+                            {account.symbol && (
+                                <CoinLogo type="token" symbol={account.symbol} size={24} />
+                            )}
+                            <AccountLabel
+                                key={account.descriptor}
+                                accountLabel={accountLabels[account.key]}
+                                accountType={account.accountType}
+                                networkType={account.networkType}
+                                symbol={account.symbol}
+                                index={account.index}
+                                path={account.path}
+                            />
+                            <AccountTypeBadge
+                                accountType={account.accountType}
+                                networkType={account.networkType}
+                                size="small"
+                                onElevation
+                            />
+                        </Row>
+                    )}
+                    onChange={(option: Option) => setSelectedDefaultAccount(option)}
+                />
+            </Column>
+        </Modal>
+    );
+};

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -10024,4 +10024,12 @@ export default defineMessages({
         id: 'TR_EXPERIMENTAL_WALLETCONNECT_DESCRIPTION',
         defaultMessage: 'Use WalletConnect to connect your Trezor to Ethereum dApps.',
     },
+    TR_SWITCH_ACCOUNT: {
+        id: 'TR_SWITCH_ACCOUNT',
+        defaultMessage: 'Switch account',
+    },
+    TR_DEFAULT_ACCOUNT: {
+        id: 'TR_DEFAULT_ACCOUNT',
+        defaultMessage: 'Default account',
+    },
 } as const);

--- a/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectButton.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectButton.tsx
@@ -14,11 +14,14 @@ export const WalletConnectButton = ({ handleOpened }: WalletConnectButtonProps) 
     const dispatch = useDispatch();
     const [connectionUrl, setConnectionUrl] = useState('');
     const [modalOpened, setModalOpened] = useState(false);
+    const [isLoading, setLoading] = useState(false);
     const { translationString } = useTranslation();
 
-    const handleConnect = () => {
-        dispatch(walletConnectPairThunk({ uri: connectionUrl }));
+    const handleConnect = async () => {
+        setLoading(true);
         setConnectionUrl(''); // Clear input after attempt
+        await dispatch(walletConnectPairThunk({ uri: connectionUrl }));
+        setLoading(false);
         setModalOpened(false);
     };
     const handleOpen = () => {
@@ -38,7 +41,11 @@ export const WalletConnectButton = ({ handleOpened }: WalletConnectButtonProps) 
                         size="small"
                         bottomContent={
                             <>
-                                <Modal.Button onClick={handleConnect} isDisabled={!connectionUrl}>
+                                <Modal.Button
+                                    onClick={handleConnect}
+                                    isDisabled={!connectionUrl}
+                                    isLoading={isLoading}
+                                >
                                     <Translation id="TR_CONNECT" />
                                 </Modal.Button>
                                 <Modal.Button variant="tertiary" onClick={onCancel}>

--- a/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectList.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectList.tsx
@@ -2,15 +2,15 @@ import { useState } from 'react';
 
 import styled from 'styled-components';
 
-import { networksCollection } from '@suite-common/wallet-config';
-import { selectSessions, walletConnectDisconnectThunk } from '@suite-common/walletconnect';
 import {
-    PendingConnectionProposalNetwork,
-    WalletConnectSession,
-} from '@suite-common/walletconnect/src/walletConnectTypes';
+    getSessionNetworks,
+    selectSessions,
+    walletConnectDisconnectThunk,
+} from '@suite-common/walletconnect';
 import { Badge, Card, Column, Dropdown, H3, IconCircle, Row, Text } from '@trezor/components';
 import { spacings, spacingsPx } from '@trezor/theme';
 
+import * as modalActions from 'src/actions/suite/modalActions';
 import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
@@ -39,32 +39,6 @@ export const WalletConnectList = () => {
             </Column>
         );
     }
-
-    const getNetworks = (session: WalletConnectSession) => {
-        const networks: Pick<PendingConnectionProposalNetwork, 'symbol' | 'name'>[] = [];
-        // EVMs
-        session.namespaces.eip155?.chains?.forEach(chain => {
-            const supported = networksCollection.find(nc => chain === `eip155:${nc.chainId}`);
-            if (supported) {
-                networks.push({
-                    symbol: supported?.symbol,
-                    name: supported?.name ?? `Unknown (${chain})`,
-                });
-            }
-        });
-        // Solana
-        if (session.namespaces.solana?.chains?.length) {
-            const supported = networksCollection.find(nc => nc.symbol === 'sol');
-            if (supported) {
-                networks.push({
-                    symbol: supported.symbol,
-                    name: supported.name,
-                });
-            }
-        }
-
-        return networks;
-    };
 
     return (
         <Card paddingType="none">
@@ -112,7 +86,7 @@ export const WalletConnectList = () => {
                             </Row>
 
                             <Text variant="tertiary">
-                                {getNetworks(session)
+                                {getSessionNetworks(session)
                                     .map(network => network.name)
                                     .join(', ')}
                             </Text>
@@ -128,6 +102,18 @@ export const WalletConnectList = () => {
                                         dispatch(
                                             walletConnectDisconnectThunk({
                                                 topic: session.topic,
+                                            }),
+                                        );
+                                    },
+                                },
+                                {
+                                    icon: 'arrowsClockwise',
+                                    label: <Translation id="TR_SWITCH_ACCOUNT" />,
+                                    onClick: () => {
+                                        dispatch(
+                                            modalActions.openModal({
+                                                type: 'walletconnect-switch-account',
+                                                sessionTopic: session.topic,
                                             }),
                                         );
                                     },

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -198,6 +198,10 @@ export type UserContextPayload =
           eventId: number;
       }
     | {
+          type: 'walletconnect-switch-account';
+          sessionTopic: string;
+      }
+    | {
           type: 'trading-dca';
           device: TrezorDevice;
       }

--- a/suite-common/walletconnect/src/adapters/index.ts
+++ b/suite-common/walletconnect/src/adapters/index.ts
@@ -20,14 +20,26 @@ export const getAdapterByNetwork = (networkType: string) =>
 
 export const getAllMethods = () => adapters.flatMap(adapter => adapter.methods);
 
-export const getNamespaces = (accounts: Account[]) =>
-    adapters
-        .map(adapter => adapter.getNamespace(accounts))
+export const getNamespaces = (accounts: Account[]) => {
+    const accountsDeduped: Account[] = [];
+    accounts.forEach(account => {
+        if (
+            !accountsDeduped.some(
+                a => a.descriptor === account.descriptor && a.symbol === account.symbol,
+            )
+        ) {
+            accountsDeduped.push(account);
+        }
+    });
+
+    return adapters
+        .map(adapter => adapter.getNamespace(accountsDeduped))
         .reduce((acc, val) => {
             Object.assign(acc, val);
 
             return acc;
         }, {});
+};
 
 export const processNamespaces = (
     accounts: Account[],

--- a/suite-common/walletconnect/src/index.ts
+++ b/suite-common/walletconnect/src/index.ts
@@ -2,3 +2,4 @@ export * from './walletConnectActions';
 export * from './walletConnectThunks';
 export * from './walletConnectMiddleware';
 export * from './walletConnectReducer';
+export * from './walletConnectUtils';

--- a/suite-common/walletconnect/src/walletConnectMiddleware.ts
+++ b/suite-common/walletconnect/src/walletConnectMiddleware.ts
@@ -1,5 +1,4 @@
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
-import { accountsActions, deviceActions } from '@suite-common/wallet-core';
 
 import { walletConnectActions } from './walletConnectActions';
 import * as walletConnectThunks from './walletConnectThunks';
@@ -7,22 +6,6 @@ import * as walletConnectThunks from './walletConnectThunks';
 export const prepareWalletConnectMiddleware = createMiddlewareWithExtraDeps(
     async (action, { dispatch, next, extra }) => {
         await next(action);
-
-        if (accountsActions.updateSelectedAccount.match(action) && action.payload.account) {
-            dispatch(
-                walletConnectThunks.switchSelectedAccountThunk({
-                    account: action.payload.account,
-                }),
-            );
-        }
-
-        if (
-            deviceActions.selectDevice.match(action) ||
-            accountsActions.createAccount.match(action) ||
-            accountsActions.removeAccount.match(action)
-        ) {
-            dispatch(walletConnectThunks.updateAccountsThunk());
-        }
 
         if (walletConnectActions.createSessionProposal.match(action)) {
             dispatch(

--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -16,12 +16,7 @@ import { selectSelectedDevice, selectVisibleSortedDeviceAccounts } from '@suite-
 import { Account } from '@suite-common/wallet-types';
 import TrezorConnect from '@trezor/connect';
 
-import {
-    getAdapterByMethod,
-    getAdapterByNetwork,
-    getNamespaces,
-    processNamespaces,
-} from './adapters';
+import { getAdapterByMethod, getNamespaces, processNamespaces } from './adapters';
 import { walletConnectActions } from './walletConnectActions';
 import { PROJECT_ID, WALLETCONNECT_METADATA, WALLETCONNECT_MODULE } from './walletConnectConstants';
 import { selectPendingProposal } from './walletConnectReducer';
@@ -172,15 +167,66 @@ export const sessionRequestThunk = createThunk<
     }
 });
 
+// Selected Account was switched in Suite
+export const switchSelectedAccountThunk = createThunk<
+    void,
+    { account: Account; sessionTopic: string }
+>(
+    `${WALLETCONNECT_MODULE}/switchSelectedAccountThunk`,
+    async ({ account, sessionTopic }, { getState }) => {
+        const accounts = selectVisibleSortedDeviceAccounts(getState());
+        const updatedNamespaces = getNamespaces([account, ...accounts]);
+        const network = getNetwork(account.symbol);
+        if (!network) {
+            return console.warn(`No network found for account symbol ${account.symbol}`);
+        }
+        const sessions = await walletKit.getActiveSessions();
+        const session = sessions[sessionTopic];
+        if (!session) {
+            return console.warn(`Session with topic ${sessionTopic} not found`);
+        }
+        await walletKit.updateSession({
+            topic: sessionTopic,
+            namespaces: updatedNamespaces,
+        });
+        const namespace = account.networkType === 'solana' ? 'solana' : 'eip155';
+        const { chains } = session.namespaces[namespace];
+        if (!chains) {
+            return console.warn(`No chains found for namespace ${namespace}`);
+        }
+
+        for (const chainId of chains) {
+            if (network.chainId) {
+                await walletKit.emitSessionEvent({
+                    topic: sessionTopic,
+                    event: {
+                        name: 'chainChanged',
+                        data: network.chainId,
+                    },
+                    chainId,
+                });
+            }
+            await walletKit.emitSessionEvent({
+                topic: sessionTopic,
+                event: {
+                    name: 'accountsChanged',
+                    data: [...updatedNamespaces[namespace].accounts],
+                },
+                chainId,
+            });
+        }
+    },
+);
+
 export const sessionProposalApproveThunk = createThunk<
     void,
     {
         eventId: number;
-        selectedDefaultAccounts?: Account[];
+        selectedDefaultAccount?: Account | null;
     }
 >(
     `${WALLETCONNECT_MODULE}/sessionProposalApproveThunk`,
-    async ({ eventId, selectedDefaultAccounts }, { dispatch, getState }) => {
+    async ({ eventId, selectedDefaultAccount }, { dispatch, getState }) => {
         try {
             const pendingProposal = selectPendingProposal(getState());
             if (
@@ -192,17 +238,10 @@ export const sessionProposalApproveThunk = createThunk<
             }
 
             const accounts = selectVisibleSortedDeviceAccounts(getState());
-            const accountsInPreferentialOrder = [...(selectedDefaultAccounts || [])];
-            accounts.forEach(account => {
-                if (
-                    !accountsInPreferentialOrder.some(
-                        a => a.descriptor === account.descriptor && a.symbol === account.symbol,
-                    )
-                ) {
-                    accountsInPreferentialOrder.push(account);
-                }
-            });
-            const supportedNamespaces = getNamespaces(accountsInPreferentialOrder);
+            const supportedNamespaces = getNamespaces([
+                ...(selectedDefaultAccount ? [selectedDefaultAccount] : []),
+                ...accounts,
+            ]);
             const approvedNamespaces = buildApprovedNamespaces({
                 proposal: pendingProposal.params,
                 supportedNamespaces,
@@ -224,12 +263,28 @@ export const sessionProposalApproveThunk = createThunk<
                 namespaces: approvedNamespaces,
             });
 
-            dispatch(
-                walletConnectActions.saveSession({
-                    ...session,
-                    validation: pendingProposal.validation,
-                }),
-            );
+            if (selectedDefaultAccount) {
+                dispatch(
+                    switchSelectedAccountThunk({
+                        account: selectedDefaultAccount,
+                        sessionTopic: session.topic,
+                    }),
+                );
+                dispatch(
+                    walletConnectActions.saveSession({
+                        ...session,
+                        validation: pendingProposal.validation,
+                        lastAccount: selectedDefaultAccount,
+                    }),
+                );
+            } else {
+                dispatch(
+                    walletConnectActions.saveSession({
+                        ...session,
+                        validation: pendingProposal.validation,
+                    }),
+                );
+            }
             analytics.report({
                 type: EventType.WalletConnectProposalApproved,
                 payload: {
@@ -269,73 +324,6 @@ export const sessionProposalRejectThunk = createThunk<
         },
     });*/
 });
-
-// Selected Account was switched in Suite
-export const switchSelectedAccountThunk = createThunk<void, { account: Account }>(
-    `${WALLETCONNECT_MODULE}/switchSelectedAccountThunk`,
-    async ({ account }, { getState }) => {
-        const accounts = selectVisibleSortedDeviceAccounts(getState());
-        const network = getNetwork(account.symbol);
-        if (!network) return;
-        const sessions = await walletKit.getActiveSessions();
-        const updatedNamespaces = getNamespaces([account, ...accounts]);
-        const chainId = getAdapterByNetwork(network.networkType)?.getChainId(network)?.[0];
-        if (!chainId) return;
-
-        for (const topic in sessions) {
-            const session = sessions[topic];
-            for (const namespace in session.namespaces) {
-                if (namespace === 'eip155' && network.chainId) {
-                    walletKit.emitSessionEvent({
-                        topic,
-                        event: {
-                            name: 'chainChanged',
-                            data: network.chainId,
-                        },
-                        chainId,
-                    });
-                }
-                walletKit.emitSessionEvent({
-                    topic,
-                    event: {
-                        name: 'accountsChanged',
-                        data: [...updatedNamespaces[namespace].accounts],
-                    },
-                    chainId,
-                });
-            }
-        }
-    },
-);
-
-// Account was created or removed in Suite
-export const updateAccountsThunk = createThunk(
-    `${WALLETCONNECT_MODULE}/updateAccountsThunk`,
-    async (_, { getState }) => {
-        const accounts = selectVisibleSortedDeviceAccounts(getState());
-        const sessions = await walletKit.getActiveSessions();
-        const updatedNamespaces = getNamespaces(accounts);
-        for (const topic in sessions) {
-            const { namespaces: oldNamespaces } = sessions[topic];
-            const namespaces = Object.keys(oldNamespaces).reduce(
-                (acc, key) => {
-                    acc[key] = {
-                        ...oldNamespaces[key],
-                        accounts: updatedNamespaces[key as any]?.accounts ?? [],
-                        chains: updatedNamespaces[key as any]?.chains ?? [],
-                    };
-
-                    return acc;
-                },
-                { ...oldNamespaces },
-            );
-            await walletKit.updateSession({
-                topic,
-                namespaces,
-            });
-        }
-    },
-);
 
 export const walletConnectInitThunk = createThunk(
     `${WALLETCONNECT_MODULE}/walletConnectInitThunk`,

--- a/suite-common/walletconnect/src/walletConnectTypes.ts
+++ b/suite-common/walletconnect/src/walletConnectTypes.ts
@@ -48,6 +48,7 @@ export interface WalletConnectSession {
             verifyUrl?: string;
         };
     };
+    lastAccount?: Account;
 }
 
 export interface PendingConnectionProposalNetwork {

--- a/suite-common/walletconnect/src/walletConnectUtils.tsx
+++ b/suite-common/walletconnect/src/walletConnectUtils.tsx
@@ -1,0 +1,35 @@
+import { networksCollection } from '@suite-common/wallet-config';
+
+import { PendingConnectionProposalNetwork, WalletConnectSession } from './walletConnectTypes';
+
+export const getSessionNetworks = (session: WalletConnectSession) => {
+    const networks: PendingConnectionProposalNetwork[] = [];
+    // EVMs
+    session.namespaces.eip155?.chains?.forEach(chain => {
+        const supported = networksCollection.find(nc => chain === `eip155:${nc.chainId}`);
+        if (supported) {
+            networks.push({
+                namespaceId: 'eip155',
+                symbol: supported?.symbol,
+                name: supported?.name ?? `Unknown (${chain})`,
+                status: 'active',
+                required: false,
+            });
+        }
+    });
+    // Solana
+    if (session.namespaces.solana?.chains?.length) {
+        const supported = networksCollection.find(nc => nc.symbol === 'sol');
+        if (supported) {
+            networks.push({
+                namespaceId: 'solana',
+                symbol: supported.symbol,
+                name: supported.name,
+                status: 'active',
+                required: false,
+            });
+        }
+    }
+
+    return networks;
+};


### PR DESCRIPTION
## Description

Previously switching accounts in WalletConnect was connected to accounts in Suite. 
This was bad UX and bad for performance. 
With this PR, we add a modal that allows to explicitly switch accounts for each connection. 
Also it's possible to select a default account initially. 

## Screenshots:
<img width="726" alt="Screenshot 2025-06-02 at 16 32 59" src="https://github.com/user-attachments/assets/de59c706-0df8-454e-9750-53b0945b41a4" />
<img width="250" alt="Screenshot 2025-06-02 at 16 33 28" src="https://github.com/user-attachments/assets/7a7efb27-c81a-4421-b2d2-451d5f3c2423" />
<img width="726" alt="Screenshot 2025-06-02 at 16 33 19" src="https://github.com/user-attachments/assets/17781a2b-e903-426a-a925-c92fdcefb4c3" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/walletconnect-switch-account&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/walletconnect-switch-account&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/walletconnect-switch-account&lookback=7)