### PR TITLE
Feat/transport read with attempts

### DIFF
--- a/packages/connect/setupJest.ts
+++ b/packages/connect/setupJest.ts
@@ -11,8 +11,15 @@ class TestTransport extends AbstractApiTransport {
 }
 
 // mock of navigator.usb
-const createTransportApi = (override = {}) =>
-    ({
+const createTransportApi = (override = {}) => {
+    const read = () =>
+        Promise.resolve({
+            success: true,
+            payload: Buffer.from('3f232300110000000c1002180020006000aa010154', 'hex'), // partial proto.Features
+            // payload: Buffer.from('3f23230002000000060a046d656f77', 'hex'), // proto.Success
+        });
+
+    return {
         chunkSize: 0,
         enumerate: () => Promise.resolve({ success: true, payload: [{ path: '1' }] }),
         on: () => {},
@@ -20,16 +27,13 @@ const createTransportApi = (override = {}) =>
         openDevice: (path: string) => Promise.resolve({ success: true, payload: [{ path }] }),
         closeDevice: () => Promise.resolve({ success: true }),
         write: () => Promise.resolve({ success: true }),
-        read: () =>
-            Promise.resolve({
-                success: true,
-                payload: Buffer.from('3f232300110000000c1002180020006000aa010154', 'hex'), // partial proto.Features
-                // payload: Buffer.from('3f23230002000000060a046d656f77', 'hex'), // proto.Success
-            }),
+        read,
+        readWithAttempts: () => () => read(),
         listen: () => {},
         dispose: () => {},
         ...override,
-    }) as unknown as UsbApi;
+    } as unknown as UsbApi;
+};
 
 export const createTestTransport = (apiMethods = {}) =>
     new TestTransport({

--- a/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
+++ b/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
@@ -42,6 +42,30 @@ const transportApiMock = (fixtures: ResponseFixture[]) => {
 
     const success = '3f23230002000000060a046d656f77';
 
+    const read = () => {
+        const index = fixtures.findIndex(f => f.id === request);
+        if (index >= 0) {
+            const { data } = fixtures[index];
+            fixtures.splice(index, 1);
+
+            return response(data);
+        }
+
+        if (request === '0057' || request === '0006') {
+            // RebootToBootloader (57) > Success
+            // FirmwareErase (06) > Success
+            eventChangeListener([]); // dispatch disconnected device event
+
+            return response(success);
+        } else if (request === '0058') {
+            // GetFirmwareHash > FirmwareHash
+            return response('3f23230059000000160a14' + LATEST_RELEASE.firmware_revision);
+        }
+
+        // Success
+        return response(success);
+    };
+
     return {
         on: (evt: string, listener: any) => {
             if (evt === 'transport-interface-change') {
@@ -59,29 +83,8 @@ const transportApiMock = (fixtures: ResponseFixture[]) => {
 
             return Promise.resolve({ success: true });
         },
-        read: () => {
-            const index = fixtures.findIndex(f => f.id === request);
-            if (index >= 0) {
-                const { data } = fixtures[index];
-                fixtures.splice(index, 1);
-
-                return response(data);
-            }
-
-            if (request === '0057' || request === '0006') {
-                // RebootToBootloader (57) > Success
-                // FirmwareErase (06) > Success
-                eventChangeListener([]); // dispatch disconnected device event
-
-                return response(success);
-            } else if (request === '0058') {
-                // GetFirmwareHash > FirmwareHash
-                return response('3f23230059000000160a14' + LATEST_RELEASE.firmware_revision);
-            }
-
-            // Success
-            return response(success);
-        },
+        read,
+        readWithAttempts: () => () => read(),
     };
 };
 

--- a/packages/connect/src/device/__tests__/DeviceList.test.ts
+++ b/packages/connect/src/device/__tests__/DeviceList.test.ts
@@ -152,7 +152,7 @@ describe('DeviceList', () => {
 
     it('.init() with pendingTransportEvent (unreadable device)', async () => {
         const transport = createTestTransport({
-            read: () =>
+            readWithAttempts: () =>
                 Promise.resolve({
                     success: true,
                     payload: Buffer.from('3f23230002000000060a046d656f77', 'hex'), // proto.Success
@@ -277,7 +277,7 @@ describe('DeviceList', () => {
     it('FIRMWARE_VERSION_CHANGED event', async () => {
         let readCount = 0;
         const transport = createTestTransport({
-            read: () => {
+            readWithAttempts: () => () => {
                 let res = '';
                 if (readCount === 0) {
                     // cancel response

--- a/packages/protocol/src/protocol-thp/utils.ts
+++ b/packages/protocol/src/protocol-thp/utils.ts
@@ -4,6 +4,7 @@ import {
     THP_CREATE_CHANNEL_REQUEST,
     THP_CREATE_CHANNEL_RESPONSE,
     THP_ERROR_HEADER_BYTE,
+    THP_READ_ACK_HEADER_BYTE,
 } from './constants';
 import type { ThpMessageSyncBit } from './messages';
 
@@ -72,6 +73,25 @@ export const getExpectedResponses = (bytes: Buffer) => {
 
     return [];
 };
+
+// get expected responses from ThpState (stored as numbers)
+// and join them with the channel to receive 3 bytes header
+export const getExpectedHeaders = (state: ThpState): Buffer[] =>
+    state.expectedResponses.map(resp => {
+        let magic;
+        switch (resp) {
+            case THP_CONTINUATION_PACKET:
+                magic = Buffer.from([resp]); // THP_CONTINUATION_PACKET is not masked with sequence bit
+                break;
+            case THP_READ_ACK_HEADER_BYTE:
+                magic = addAckBit(resp, state.sendBit);
+                break;
+            default:
+                magic = addSequenceBit(resp, state.recvBit);
+        }
+
+        return Buffer.concat([magic, state.channel]);
+    });
 
 export const isExpectedResponse = (bytes: Buffer, state: ThpState) => {
     if (bytes.length < 3) {

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -97,7 +97,11 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         logger?.debug(`core: readUtil protocol ${protocol.name}`);
         try {
             const receiveProtocol = protocol.name === 'bridge' ? protocolV1 : protocol;
-            const res = await receiveUtil(() => api.read(path, signal), receiveProtocol);
+            const apiRead = api.readWithAttempts(path, { signal });
+
+            // generate default headers
+            const expectedHeaders = receiveProtocol.getHeaders(Buffer.alloc(api.chunkSize));
+            const res = await receiveUtil(() => apiRead(expectedHeaders), receiveProtocol);
             if (!res.success) return res;
             const { messageType, payload } = res.payload;
             logger?.debug(

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -9,6 +9,7 @@ import type {
     PathInternal,
     Success,
 } from '../types';
+import { readWithAttempts } from '../utils/readWithAttempts';
 import { error, success, unknownError } from '../utils/result';
 
 export interface AbstractApiConstructorParams {
@@ -82,6 +83,20 @@ export abstract class AbstractApi extends TypedEmitter<{
         | typeof ERRORS.ABORTED_BY_TIMEOUT
         | typeof ERRORS.ABORTED_BY_SIGNAL
     >;
+
+    readWithAttempts(
+        path: PathInternal,
+        options: {
+            signal?: AbortSignal;
+            attempts?: number;
+            timeout?: number;
+        },
+    ) {
+        return readWithAttempts(
+            (attemptSignal?: AbortSignal) => this.read(path, attemptSignal || options.signal),
+            options,
+        );
+    }
 
     /**
      * write to device on path

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -203,9 +203,11 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     protocol,
                     thpState,
                 });
-                const [, chunkHeader] = protocol.getHeaders(bytes);
+                const [header, chunkHeader] = protocol.getHeaders(bytes);
                 const chunks = createChunks(bytes, chunkHeader, this.api.chunkSize);
                 const apiWrite = (chunk: Buffer) => this.api.write(path, chunk, signal);
+                const apiRead = this.api.readWithAttempts(path, { signal });
+
                 const sendResult = await sendChunks(chunks, apiWrite);
 
                 if (!sendResult.success) {
@@ -216,7 +218,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
                 const readResult = await receiveAndParse(
                     this.messages,
-                    () => this.api.read(path, signal),
+                    () => apiRead([header, chunkHeader]),
                     protocol,
                 );
 
@@ -293,9 +295,13 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 const { path } = getPathBySessionResponse.payload;
 
                 const protocol = customProtocol || v1Protocol;
+                const apiRead = this.api.readWithAttempts(path, { signal });
+
+                // generate default headers
+                const expectedHeaders = protocol.getHeaders(Buffer.alloc(this.api.chunkSize));
                 const message = await receiveAndParse(
                     this.messages,
-                    () => this.api.read(path, signal),
+                    () => apiRead(expectedHeaders),
                     protocol,
                     thpState,
                 );

--- a/packages/transport/src/utils/readWithAttempts.ts
+++ b/packages/transport/src/utils/readWithAttempts.ts
@@ -1,0 +1,67 @@
+import { scheduleAction } from '@trezor/utils';
+
+import { success } from './result';
+import { AbstractApi } from '../api/abstract';
+
+type Receiver = (attemptSignal?: AbortSignal) => ReturnType<AbstractApi['read']>;
+
+const ATTEMPT_ERROR = 'Unexpected chunk';
+
+async function readAndAssert<T extends Receiver>(
+    receiver: T,
+    expectedHeaders?: Buffer[],
+    attemptSignal?: AbortSignal,
+): ReturnType<AbstractApi['read']> {
+    // read one packet
+    const chunk = await receiver(attemptSignal);
+    if (!chunk.success) {
+        return chunk;
+    }
+
+    // if no expectedHeaders are set then each chunk is expected
+    if (!expectedHeaders) {
+        return chunk;
+    }
+
+    const bytes = chunk.payload;
+    const expected = expectedHeaders.find(header => {
+        if (bytes.length < header.length) {
+            return false;
+        }
+
+        return bytes.subarray(0, header.length).compare(header) === 0 ? true : false;
+    });
+
+    if (expected) {
+        return success(chunk.payload);
+    }
+
+    // throw error to break scheduleAction attempt
+    // and handle it in scheduleAction attemptFailureHandler below
+    throw new Error(ATTEMPT_ERROR);
+}
+
+// AbstractApi['read'] wrapper
+// returns: (expectedHeaders: Buffer[]) => ReturnType<AbstractApi['read']>
+// read until received chunk contains expected header and ignore other chunks
+export function readWithAttempts<T extends Receiver>(
+    receiver: T,
+    options?: {
+        signal?: AbortSignal;
+        attempts?: number;
+        timeout?: number;
+    },
+) {
+    return (expectedHeaders?: Buffer[]) =>
+        scheduleAction(attemptSignal => readAndAssert(receiver, expectedHeaders, attemptSignal), {
+            signal: options?.signal,
+            attempts: options?.attempts || Infinity,
+            timeout: options?.timeout,
+            attemptFailureHandler: e => {
+                if (e.message !== ATTEMPT_ERROR) {
+                    // stop scheduleAction attempts on any other error
+                    return e;
+                }
+            },
+        });
+}

--- a/packages/transport/tests/readWithAttempts.test.ts
+++ b/packages/transport/tests/readWithAttempts.test.ts
@@ -1,0 +1,131 @@
+import { thp as protocolThp, v1 as protocolV1 } from '@trezor/protocol';
+
+import { readWithAttempts } from '../src/utils/readWithAttempts';
+
+describe('readWithAttempts', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    // common AbstractApi['read'] mock
+    const SUCCESS = Buffer.from('3f23230002000000060a046d656f77', 'hex'); // proto Success
+    const apiRead = jest.fn(
+        signal =>
+            new Promise<any>((resolve, reject) => {
+                const listener = () => {
+                    signal.removeEventListener('abort', listener);
+                    reject(new Error('Aborted'));
+                };
+                signal?.addEventListener('abort', listener);
+
+                setTimeout(() => {
+                    signal.removeEventListener('abort', listener);
+                    resolve({
+                        success: true,
+                        payload: SUCCESS,
+                    });
+                }, 10);
+            }),
+    );
+
+    it('read aborted', async () => {
+        const abortController = new AbortController();
+        const read = readWithAttempts(apiRead, {
+            signal: abortController.signal,
+        });
+
+        const resultPromise = read([Buffer.alloc(3)]);
+
+        abortController.abort();
+        // error thrown from scheduleAction
+        await expect(() => resultPromise).rejects.toThrow('Aborted by signal');
+    });
+
+    it('read timeout', async () => {
+        const read = readWithAttempts(apiRead, {
+            timeout: 7, // see default apiRead timeout
+        });
+
+        const resultPromise = read([Buffer.alloc(3)]);
+
+        // error thrown from scheduleAction
+        await expect(() => resultPromise).rejects.toThrow('Aborted by timeout');
+    });
+
+    it('api.read failed', async () => {
+        const read = readWithAttempts(() =>
+            Promise.resolve({ success: false, error: 'unexpected error' }),
+        );
+
+        const result = await read();
+        expect(result).toMatchObject({ success: false, error: 'unexpected error' });
+    });
+
+    it('attempts limit reached', async () => {
+        const apiRead = jest.fn(() =>
+            Promise.resolve({ success: true, payload: Buffer.alloc(64) } as const),
+        );
+        const expectedHeaders = protocolV1.getHeaders(SUCCESS);
+        const read = readWithAttempts(apiRead, { attempts: 7 });
+        // error thrown from scheduleAction
+        await expect(() => read(expectedHeaders)).rejects.toThrow('Unexpected chunk');
+        expect(apiRead).toHaveBeenCalledTimes(7);
+    });
+
+    it('success with expectedHeaders', async () => {
+        const expectedHeaders = protocolV1.getHeaders(SUCCESS);
+
+        const result = await readWithAttempts(apiRead)(expectedHeaders);
+        expect(result).toMatchObject({ success: true });
+    });
+
+    it('success. expectedHeaders not set', async () => {
+        const result = await readWithAttempts(apiRead)();
+        expect(result).toMatchObject({ success: true });
+    });
+
+    it('success. received at 5th attempt', async () => {
+        const expectedHeaders = protocolV1.getHeaders(SUCCESS);
+
+        let attempt = 0;
+        const apiRead = jest.fn(
+            () =>
+                new Promise<any>(resolve => {
+                    if (++attempt < 5) {
+                        resolve({ success: true, payload: Buffer.alloc(32) });
+                    } else {
+                        resolve({ success: true, payload: SUCCESS });
+                    }
+                }),
+        );
+
+        const result = await readWithAttempts(apiRead)(expectedHeaders);
+
+        expect(apiRead).toHaveBeenCalledTimes(5);
+        expect(result).toMatchObject({ success: true });
+    });
+
+    it('success with THP', async () => {
+        const readResult = Buffer.from('2833da0004527eb068', 'hex');
+
+        let attempt = 0;
+        const apiRead = jest.fn(
+            () =>
+                new Promise<any>(resolve => {
+                    if (++attempt < 5) {
+                        resolve({ success: true, payload: Buffer.alloc(32) });
+                    } else {
+                        resolve({ success: true, payload: readResult });
+                    }
+                }),
+        );
+
+        const thpState = new protocolThp.ThpState();
+        thpState.setChannel(readResult.subarray(1, 3));
+        thpState.setExpectedResponses([0x20]); // expect ThpAck
+        thpState.updateSyncBit('send'); // ThpAck is masked, data will start with "28" instead of "20"
+
+        const result = await readWithAttempts(apiRead)(protocolThp.getExpectedHeaders(thpState));
+        expect(result).toMatchObject({ success: true });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

introduce read with expected headers:
   read from the device endlessly until expected data is received and ignore unexpected chunks.  
   this is important part for handling THP retransmission properly.
   
   
example: protocol-v1 message is sent expected headers are set to ['3f2323', '3f']
   
 ```
  read() => "3f2323......." (OK, first chunk)
  read() => "3f......." (OK, continuation chunk)
  read() => "1234" (NOK, unexpected message, retry attempt)
  read() => "" (NOK, unexpected message, retry attempt)
```

in case of unexpected packet/chunk device.read is called repetitively until success, timeout or attempt limit reached (default limit = **Infinity**)


   

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/transport-read-with-attempts&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/transport-read-with-attempts&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/transport-read-with-attempts&lookback=7)