### PR TITLE
feat(blockchain-link): wallet instead of token account in transaction detail

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -1,5 +1,6 @@
 import {
     AccountInfoBase,
+    Address,
     ClusterUrl,
     RpcMainnet,
     RpcSubscriptionsMainnet,
@@ -295,6 +296,21 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
         } as const;
     }
 
+    // token account's owner is the wallet
+    const getATAOwnerAddress = async (address: Address) => {
+        const { value: accountInfo } = await api.rpc
+            .getAccountInfo(address, {
+                encoding: 'jsonParsed',
+            })
+            .send();
+
+        if (!accountInfo?.data || 'parsed' in accountInfo.data === false) {
+            return address;
+        }
+
+        return (accountInfo.data.parsed?.info as { owner?: string })?.owner ?? address;
+    };
+
     const getTransactionPage = async (
         txIds: Signature[],
         tokenAccountsInfos: SolanaTokenAccountInfo[],
@@ -302,11 +318,12 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
         if (txIds.length === 0) {
             return [];
         }
+
         const transactionsPage = await fetchTransactionPage(api, txIds);
 
         const tokenMetadata = await request.getTokenMetadata();
 
-        return transactionsPage
+        const page = transactionsPage
             .filter(isValidTransaction)
             .map(tx =>
                 solanaUtils.transformTransaction(
@@ -317,6 +334,34 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
                 ),
             )
             .filter((tx): tx is Transaction => !!tx);
+
+        const transactions: Transaction[] = await Promise.all(
+            page.map(async tx => {
+                const tokens = await Promise.all(
+                    tx.tokens.map(async transfer => {
+                        // token account address is derived from the wallet address who is owner of that account
+                        const from =
+                            transfer.from !== payload.descriptor
+                                ? await getATAOwnerAddress(address(transfer.from))
+                                : transfer.from;
+                        const to =
+                            transfer.to !== payload.descriptor
+                                ? await getATAOwnerAddress(address(transfer.to))
+                                : transfer.to;
+
+                        return {
+                            ...transfer,
+                            from,
+                            to,
+                        };
+                    }),
+                );
+
+                return { ...tx, tokens };
+            }),
+        );
+
+        return transactions;
     };
 
     const getTokenAccountsForProgram = (programPublicKey: string) =>

--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -7,6 +7,7 @@
 - changed `tradingTrades` - add `sendAccountKey`, `receiveAccountKey`, `selectedAccountKey` to each buy, sell, and exchange trade
 - added `explorer` store for custom explorer configuration
 - created `thp` and `bluetooth` object store
+- remove saved solana txs to force refetch
 
 ## 54
 

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -31,7 +31,7 @@ type WalletWithBackends = {
     backends?: PartialRecord<NetworkSymbol, Omit<CustomBackend, 'coin'>>;
 };
 
-type DBWalletAccountTransactionCompatible = {
+export type DBWalletAccountTransactionCompatible = {
     order: DBWalletAccountTransaction['order'];
     tx: DBWalletAccountTransaction['tx'] & { totalSpent: string };
 };

--- a/packages/suite/src/storage/migrations/versions/migrateToV56.ts
+++ b/packages/suite/src/storage/migrations/versions/migrateToV56.ts
@@ -12,6 +12,7 @@ import {
 import { OnUpgradeFunc } from '@trezor/suite-storage';
 
 import { SuiteDBSchema } from 'src/storage/definitions';
+import { DBWalletAccountTransactionCompatible } from 'src/storage/migrations';
 
 import { updateAll } from '../utils';
 
@@ -187,4 +188,24 @@ export const migrateToV56: OnUpgradeFunc<SuiteDBSchema> = async (
     // 5. add thp and bluetooth object stores
     db.createObjectStore('thp');
     db.createObjectStore('bluetooth');
+
+    // 6. refetch solana txs
+    const accountsToUpdate = ['sol', 'dsol'];
+
+    await updateAll<'txs', DBWalletAccountTransactionCompatible>(transaction, 'txs', tx => {
+        if (accountsToUpdate.includes(tx.tx.symbol)) {
+            return null;
+        }
+
+        return tx;
+    });
+
+    // force to fetch solana network transactions again
+    await updateAll(transaction, 'accounts', account => {
+        if (accountsToUpdate.includes(account.symbol)) {
+            account.history = { total: 0, unconfirmed: 0, tokens: 0 };
+
+            return account;
+        }
+    });
 };


### PR DESCRIPTION
Info about what wallet owns solana ata might not be in the txn so we need to fetch it not to show ata address in the txn history.

## Related Issue

Resolve #10918 
Resolve #19094 

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/solana/wallet-instead-of-ata-in-transaction&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/solana/wallet-instead-of-ata-in-transaction&lookback=7)