### PR TITLE
fix(suite): missing evm internal txs

### DIFF
--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -8,6 +8,7 @@
 - added `explorer` store for custom explorer configuration
 - created `thp` and `bluetooth` object store
 - remove saved solana txs to force refetch
+- remove saved evm txs to force refetch due to bug in migration v52
 
 ## 54
 
@@ -20,7 +21,7 @@
 ## 52
 
 - Deprecated Vertcoin (VTC), Bitcoin Gold (BTG), Namecoin (NMC), DigiByte (DGB), and Dash (DASH) networks. Removed related transactions, accounts, and settings.
-- saved ripple network type txs are removed to be fetched again and obtain internal transfers and token transfer contract and standard
+- saved ripple network type txs are removed to be fetched again
 - added `security.devicesWithFailedEntropyCheck`
 
 ## 51

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -1247,7 +1247,6 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
             if (accountsToUpdate.includes(tx.tx.symbol)) {
                 return null;
             }
-            tx.tx.internalTransfers = [];
 
             return tx;
         });

--- a/packages/suite/src/storage/migrations/versions/migrateToV56.ts
+++ b/packages/suite/src/storage/migrations/versions/migrateToV56.ts
@@ -70,7 +70,7 @@ const findAccountForTrade = (
 
 export const migrateToV56: OnUpgradeFunc<SuiteDBSchema> = async (
     db,
-    _oldVersion,
+    oldVersion,
     _newVersion,
     transaction,
 ) => {
@@ -191,6 +191,11 @@ export const migrateToV56: OnUpgradeFunc<SuiteDBSchema> = async (
 
     // 6. refetch solana txs
     const accountsToUpdate = ['sol', 'dsol'];
+
+    // refetch also evm txs for version 52+
+    if (oldVersion >= 52) {
+        accountsToUpdate.push(...['eth', 'pol', 'bsc', 'base', 'arb', 'op', 'thol', 'tsep']);
+    }
 
     await updateAll<'txs', DBWalletAccountTransactionCompatible>(transaction, 'txs', tx => {
         if (accountsToUpdate.includes(tx.tx.symbol)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- force refetch internal txs for evms when user is migrating db from version 52+

## Related Issue

Resolve #19284

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/missing-internal-txs&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/missing-internal-txs&lookback=7)