### PR TITLE
chore(connect): log error when trying to call device which was not …

### DIFF
--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -21,6 +21,19 @@ const blacklist: Record<string, string[] | true> = {
     Features: true,
 };
 
+const allowedCallsBeforeInitialize: Messages.MessageKey[] = [
+    // Preventive Cancel
+    'Cancel',
+    // At the beginning of each call either Initialize or GetFeatures is called.
+    'Initialize',
+    'GetFeatures',
+    // After one of the two above there might be optionally some of these
+    'GetFirmwareHash',
+    'ChangeLanguage',
+    'DataChunkAck',
+    // There are other, which are allowed by firmware (ApplySettings,...) but we do not use them this way in connect.
+];
+
 const filterForLog = (type: string, msg: any) =>
     blacklist[type] === true
         ? '(redacted...)'
@@ -89,6 +102,12 @@ export class DeviceCurrentSession implements TypedCallProvider {
         expectedType: Messages.MessageKey | Messages.MessageKey[],
         msg: Messages.MessagePayload = {},
     ) {
+        if (!allowedCallsBeforeInitialize.includes(type) && !this.device?.features?.session_id) {
+            console.error(
+                'Runtime',
+                `typedCall: Device not initialized when calling ${type}. call Initialize first`,
+            );
+        }
         // Assert message type
         // msg is allowed to be undefined for some calls, in that case the schema is an empty object
         Assert(Messages.MessageType.properties[type], msg);


### PR DESCRIPTION
…Initialized

There are occasional [occurrences](https://satoshilabs.sentry.io/issues/6620590564/events/?environment=production&project=5193825&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20entropy&referrer=issue-stream&stream_index=0) of `Invalid session` error in Sentry. [Most likely](https://github.dev/trezor/trezor-firmware/blob/0081788d48af58daad600054ef65b1b53bf79c16/legacy/firmware/config.c#L581) because we send a call which requires calling Initialize first without calling it. 

Here I am adding console.error, which should (is it right? @Lemonexe) be propagated to Sentry to get some more intel on this. Later we might turn console.error to hard error if we are sure there are no false positives. 

cc @marekrjpolak for post-merge review some day later

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=meditation-over-entropy-check-false-positives&lookback=7)