### PR TITLE
fix(components): revert increase depth in useDetectPortalTarget

### DIFF
--- a/packages/components/src/components/form/Select/useDetectPortalTarget.ts
+++ b/packages/components/src/components/form/Select/useDetectPortalTarget.ts
@@ -10,9 +10,6 @@ export const useDetectPortalTarget = (selectRef: RefObject<SelectInstance<Option
     // The inputRef is deeply nested so we iterate with while loop until wee reach the parentElement or max depth.
     // The depth has a limit so that it does not iterate over the entire DOM.
     // The depth limit has a buffer of 2 iterations in case the select is wrapped. (Minimum depth is 4.)
-
-    // UPDATE (2025-06-02): There is a lot more wrapping now, just in the modal itself there's 4 layers of wrapping.
-    // So I increased the depth limit to 15 iterations.
     useEffect(() => {
         let parent = selectRef.current?.inputRef?.parentElement;
         let count = 0;
@@ -21,7 +18,7 @@ export const useDetectPortalTarget = (selectRef: RefObject<SelectInstance<Option
                 setMenuPortalTarget(document.body);
                 break;
             }
-            if (count > 15) {
+            if (count > 5) {
                 break;
             }
             parent = parent.parentElement;


### PR DESCRIPTION
## Description

Turns out the fix for Select in Modal from #19277 broke something else. Reverting for now. 
AFAIK the logic in `useDetectPortalTarget` is still technically wrong, but at least it's stable. 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/select-issue&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/select-issue&lookback=7)