### PR TITLE
fix(trading): wrong nonce after approval

### DIFF
--- a/suite-common/trading/src/thunks/exchange/watchTradeApprovalThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/watchTradeApprovalThunk.ts
@@ -1,6 +1,7 @@
 import { ExchangeTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
+import { fetchAndUpdateAccountThunk } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 
 import { exchangeThunks } from '../';
@@ -55,6 +56,7 @@ export const watchTradeApprovalThunk = createThunk(
         };
 
         dispatch(tradingExchangeActions.saveSelectedQuote(updatedSelectedQuote));
+        await dispatch(fetchAndUpdateAccountThunk({ accountKey: account.key }));
 
         if (!updatedSelectedQuote.dexTx || !updatedSelectedQuote.receiveAddress) {
             return;


### PR DESCRIPTION
## Description
- Fix the wrong nonce after approval transaction because of deprecated account information

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19302

## Screenshots:
![obrazek](https://github.com/user-attachments/assets/afbccab5-37d0-4bb9-bac6-7183b3b2d376)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/nonce-after-approval&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/nonce-after-approval&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/nonce-after-approval&lookback=7)