### PR TITLE
fix(suite): adjust release notes for 25.6x

### DIFF
--- a/packages/suite-desktop/releaseNotes/release-notes.md
+++ b/packages/suite-desktop/releaseNotes/release-notes.md
@@ -6,7 +6,6 @@
 
 ### 🎨 Improvements
 
-- Bitcoin send form now refreshes fee rates every 60 seconds and includes a manual refresh option to avoid using outdated fees.
 - Fonts for addresses and public keys in Suite now match those on Trezor devices to reduce visual discrepancies.
 - The transactions export menu has been improved with clarified filters and support for .csv, .pdf, and .json formats.
 


### PR DESCRIPTION
We will be reverting https://github.com/trezor/trezor-suite/pull/19242 , thus editing the release notes accordingly 