### PR TITLE
Warn user about sending to system derived account

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -92,7 +92,6 @@ function nonNullable<T>(value: T): value is NonNullable<T> {
 const getAllSignatures = async (
     api: SolanaAPI,
     descriptor: MessageTypes.GetAccountInfo['payload']['descriptor'],
-    fullHistory = true,
 ) => {
     let lastSignature: SignatureWithSlot | undefined;
     let keepFetching = true;
@@ -112,7 +111,7 @@ const getAllSignatures = async (
             slot: info.slot,
         }));
         lastSignature = signatures[signatures.length - 1];
-        keepFetching = signatures.length === limit && fullHistory;
+        keepFetching = signatures.length === limit;
         allSignatures = [...allSignatures, ...signatures];
     }
 
@@ -228,6 +227,10 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
 
     const publicKey = address(payload.descriptor);
 
+    const { value: accountInfo } = await api.rpc
+        .getAccountInfo(publicKey, { encoding: 'base64' })
+        .send();
+
     const getAllTxIds = async (tokenAccountPubkeys: string[]) => {
         const sortedTokenAccountPubkeys = tokenAccountPubkeys.sort();
         // limit to 100 accounts, loading too many would hit the rpc limit
@@ -236,14 +239,12 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
         const allAccounts = [payload.descriptor, ...sortedTokenAccountPubkeys];
 
         const allTxIds =
-            details === 'basic' || details === 'txs' || details === 'txids'
+            details === 'txs' || details === 'txids'
                 ? Array.from(
                       new Set(
                           (
                               await Promise.all(
-                                  allAccounts.map(account =>
-                                      getAllSignatures(api, account, details !== 'basic'),
-                                  ),
+                                  allAccounts.map(account => getAllSignatures(api, account)),
                               )
                           )
                               .flat()
@@ -419,16 +420,10 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
 
     // Not necessary for basic and tokens details
     if (!['basic', 'tokens'].includes(details)) {
-        // https://solana.stackexchange.com/a/13102
-        const { value: accountInfo } = await api.rpc
-            .getAccountInfo(publicKey, { encoding: 'base64' })
-            .send();
-
         const solEpoch = await getEpoch();
         const solStakingAccounts = await getSolanaStakingData(api?.rpc, publicKey, solEpoch);
 
         misc = {
-            owner: accountInfo?.owner,
             solStakingAccounts,
             solEpoch,
         };
@@ -465,7 +460,7 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
               }
             : undefined,
         tokens,
-        ...(misc ? { misc } : {}),
+        misc: { ...misc, owner: accountInfo?.owner },
     };
 
     // Update token accounts of account stored by the worker since new accounts

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2270,9 +2270,9 @@ export default defineMessages({
             "Address has no transaction history and isn't checksummed. Check that the address is correct.",
         id: 'TR_ETH_ADDRESS_NOT_USED_NOT_CHECKSUMMED',
     },
-    TR_ETH_ADDRESS_CANT_VERIFY_HISTORY: {
+    TR_ADDRESS_CANT_VERIFY_HISTORY: {
         defaultMessage: 'Unable to verify address history. Check that the address is correct.',
-        id: 'TR_ETH_ADDRESS_CANT_VERIFY_HISTORY',
+        id: 'TR_ADDRESS_CANT_VERIFY_HISTORY',
     },
     TR_EVM_ADDRESS_IS_CONTRACT: {
         defaultMessage: "You're sending funds to a contract address.",
@@ -5713,6 +5713,11 @@ export default defineMessages({
     TR_CONVERT_TO_CHECKSUM_ADDRESS: {
         defaultMessage: 'Convert to checksum',
         id: 'TR_CONVERT_TO_CHECKSUM_ADDRESS',
+    },
+    TR_SOL_ADDRESS_IS_ASSOCIATED_ACCOUNT: {
+        defaultMessage:
+            'You are sending funds to an associated account (e.g. token or staking account).',
+        id: 'TR_SOL_ADDRESS_IS_ASSOCIATED_ACCOUNT',
     },
     RECIPIENT_CANNOT_SEND_TO_MYSELF: {
         defaultMessage: "Can't send to myself",

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -15,6 +15,7 @@ import {
     isBitcoinCashAddressUppercase,
     isTaprootAddress,
 } from '@suite-common/wallet-utils';
+import { SYSTEM_PROGRAM_PUBLIC_KEY } from '@trezor/blockchain-link-utils/src/solana';
 import { Box, Button, Icon, IconButton, Input, Link, Row } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
 import { CoinLogo } from '@trezor/product-components';
@@ -49,7 +50,6 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
         useState<ReturnType<typeof isAddressDeprecated>>(undefined);
     const [hasAddressChecksummed, setHasAddressChecksummed] = useState<boolean | undefined>();
     const [autocorrectMessage, setAutocorrectMessage] = useState<string | undefined>();
-    const contractAddressWarningDismissed = useRef(false);
     const autocorrectTimeout = useRef<TimerId>(null);
     const dispatch = useDispatch();
     const { device } = useDevice();
@@ -65,6 +65,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
         watch,
         setDraftSaveRequest,
         trigger,
+        clearErrors,
     } = useSendFormContext();
     const { translationString } = useTranslation();
     const { descriptor, networkType, symbol } = account;
@@ -83,10 +84,12 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
     const broadcastEnabled = options.includes('broadcast');
     const isOnline = useSelector(state => state.suite.online);
 
-    const isContractAddressWarningEnabled = ['eth', 'tsep', 'thol'].includes(symbol);
+    const [isExternalAddressCheckWarningDismissed, setIsExternalAddressCheckWarningDismissed] =
+        useState(false);
+    const isExternalAddressCheckEnabled = ['eth', 'tsep', 'thol', 'sol', 'dsol'].includes(symbol);
 
     useEffect(() => {
-        contractAddressWarningDismissed.current = false;
+        setIsExternalAddressCheckWarningDismissed(false);
     }, [address]);
 
     const getInputState = () => {
@@ -172,7 +175,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                 return {
                     learnMoreUrl: addressDeprecatedUrl ? URLS[addressDeprecatedUrl] : undefined,
                 };
-            case 'evmchecks':
+            case 'evmChecks':
                 if (!checkAddressCheckSum(address)) {
                     return {
                         buttonProps: {
@@ -187,13 +190,14 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                         },
                     };
                 }
-                if (!contractAddressWarningDismissed.current) {
+                if (!isExternalAddressCheckWarningDismissed) {
                     return {
                         buttonProps: {
-                            onClick: () => {
-                                contractAddressWarningDismissed.current = true;
-                                trigger(inputName);
-                                composeTransaction(amountInputName);
+                            onClick: async () => {
+                                setIsExternalAddressCheckWarningDismissed(true);
+                                await trigger(inputName);
+                                clearErrors(inputName);
+                                composeTransaction();
                             },
                             text: translationString('TR_I_UNDERSTAND_THE_RISK'),
                         },
@@ -202,6 +206,24 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                 }
 
                 return {};
+            case 'solAssociatedAccountCheck':
+                if (!isExternalAddressCheckWarningDismissed) {
+                    return {
+                        buttonProps: {
+                            onClick: async () => {
+                                setIsExternalAddressCheckWarningDismissed(true);
+                                await trigger(inputName);
+                                clearErrors(inputName);
+                                composeTransaction();
+                            },
+                            text: translationString('TR_I_UNDERSTAND_THE_RISK'),
+                        },
+                        learnMoreUrl: URLS.HELP_CENTER_SOLANA_HELP_URL,
+                    };
+                }
+
+                return {};
+
             default:
                 return {};
         }
@@ -269,7 +291,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                     return translationString('RECIPIENT_REQUIRES_UPDATE');
                 }
             },
-            bch_missing_prefix: (value: string) => {
+            bchMissingPrefix: (value: string) => {
                 if (symbol === 'bch' && !hasBitcoinCashAddressPrefix(value)) {
                     setValue(inputName, 'bitcoincash:' + value, {
                         shouldValidate: true,
@@ -282,10 +304,10 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                     return true;
                 }
             },
-            evmchecks: async (address: string) => {
+            evmChecks: async (address: string) => {
                 if (networkType === 'ethereum') {
                     if (!isOnline) {
-                        return translationString('TR_ETH_ADDRESS_CANT_VERIFY_HISTORY');
+                        return translationString('TR_ADDRESS_CANT_VERIFY_HISTORY');
                     }
                     const params = {
                         descriptor: address,
@@ -294,7 +316,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                     const result = await TrezorConnect.getAccountInfo(params);
 
                     if (!result.success) {
-                        return translationString('TR_ETH_ADDRESS_CANT_VERIFY_HISTORY');
+                        return translationString('TR_ADDRESS_CANT_VERIFY_HISTORY');
                     }
 
                     const { payload } = result;
@@ -316,13 +338,37 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                     }
 
                     // 2. Check if address is a contract address (right now only for Eth, Holesky and Sepolia)
-                    if (
-                        !contractAddressWarningDismissed.current &&
-                        isContractAddressWarningEnabled
-                    ) {
+                    if (!isExternalAddressCheckWarningDismissed && isExternalAddressCheckEnabled) {
                         const isContract = payload.misc?.contractInfo;
                         if (isContract) {
                             return translationString('TR_EVM_ADDRESS_IS_CONTRACT');
+                        }
+                    }
+                }
+            },
+            solAssociatedAccountCheck: async (value: string) => {
+                if (networkType === 'solana') {
+                    if (!isOnline) {
+                        return translationString('TR_ADDRESS_CANT_VERIFY_HISTORY');
+                    }
+
+                    const { payload, success } = await TrezorConnect.getAccountInfo({
+                        descriptor: value,
+                        coin: symbol,
+                        details: 'basic',
+                    });
+
+                    if (!success) {
+                        return translationString('TR_ADDRESS_CANT_VERIFY_HISTORY');
+                    }
+
+                    if (!isExternalAddressCheckWarningDismissed && isExternalAddressCheckEnabled) {
+                        const isProgramDerivedAccount = !(
+                            payload?.misc?.owner === SYSTEM_PROGRAM_PUBLIC_KEY ||
+                            payload?.misc?.owner === undefined
+                        );
+                        if (isProgramDerivedAccount) {
+                            return translationString('TR_SOL_ADDRESS_IS_ASSOCIATED_ACCOUNT');
                         }
                     }
                 }

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -137,6 +137,8 @@ export const HELP_CENTER_CANCEL_TRANSACTION: Url =
 // TODO: update this link when the article is ready
 export const HELP_CENTER_SOL_SEND: Url =
     'https://trezor.io/learn/a/solana-sol-on-trezor-safe-5-trezor-safe-3-and-trezor-model-t';
+// TODO: update this link when the article is ready
+export const HELP_CENTER_SOLANA_HELP_URL: Url = 'https://trezor.io/support/a/where-is-my-solana';
 
 export const INVITY_URL: Url = 'https://invity.io/';
 export const INVITY_SCHEDULE_OF_FEES: Url = 'https://blog.invity.io/schedule-of-fees';

--- a/packages/urls/tests/urls.test.ts
+++ b/packages/urls/tests/urls.test.ts
@@ -15,6 +15,7 @@ const excluded = [
     URLS.HELP_CENTER_PACKAGING_T3W1_URL,
     URLS.HELP_CENTER_FW_DOWNGRADE_T3W1_URL,
     URLS.HELP_CENTER_XLM_URL,
+    URLS.HELP_CENTER_SOLANA_HELP_URL,
 ];
 
 describe('Test that all external links are alive', () => {

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -76,6 +76,7 @@ type AccountNetworkSpecific =
               rent?: number;
               solStakingAccounts?: SolanaStakingAccount[];
               solEpoch?: number;
+              owner?: string;
           };
           marker: undefined;
           stellarCursor: undefined;

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -807,6 +807,7 @@ export const getAccountSpecific = (accountInfo: Partial<AccountInfo>, networkTyp
                 rent: misc?.rent,
                 solStakingAccounts: misc?.solStakingAccounts,
                 solEpoch: misc?.solEpoch,
+                owner: misc?.owner,
             },
             marker: undefined,
             stellarCursor: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- introduced solana warning about sending to system derived account
- unified logic for evm and solana
- solana basic detail is now more basic

## Related Issue

Resolve #19145

## Screenshots:

![Screenshot 2025-06-03 at 13 55 52](https://github.com/user-attachments/assets/f988bd6d-0dc8-47ec-8b4a-985435f3da04)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/solana-prevent-sending-to-assosiated-acc&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/solana-prevent-sending-to-assosiated-acc&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/solana-prevent-sending-to-assosiated-acc&lookback=7)