### PR TITLE
fix(e2e): Resolve deprecated punycode

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -112,7 +112,6 @@
         "karma-jasmine-async": "^0.0.1",
         "karma-sourcemap-loader": "^0.4.0",
         "karma-webpack": "^5.0.1",
-        "node-fetch": "^2.6.4",
         "node-libs-browser": "^2.2.1",
         "ts-node": "^10.9.2",
         "tsx": "^4.19.3",

--- a/packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts
+++ b/packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts
@@ -1,5 +1,3 @@
-import { FetchError } from 'node-fetch';
-
 import { DeviceModelInternal, FirmwareRelease } from '@trezor/device-utils';
 
 import { FirmwareRevisionCheckResult } from '../../exports';
@@ -90,11 +88,17 @@ describe.each(DeviceNames)(`${checkFirmwareRevision.name} for device %s`, intern
         {
             it: 'fails with a specific error message when the check cannot be performed because the revision is not found locally and the user is offline',
             httpRequestMock: () => {
-                throw new FetchError('You are offline!', 'network', {
-                    code: 'ENOTFOUND',
-                    name: 'FetchError',
-                    message: 'You are offline!',
+                // Create a new TypeError that mimics a network error from cross-fetch
+                const error = new TypeError('Failed to fetch');
+                // Add properties that cross-fetch's FetchError would have
+                Object.defineProperties(error, {
+                    type: { value: 'system' },
+                    code: { value: 'ENOTFOUND' },
+                    errno: { value: 'ENOTFOUND' },
+                    name: { value: 'FetchError' },
+                    message: { value: 'You are offline!' },
                 });
+                throw error;
             },
             params: createDeviceParams({
                 expectedRevision: undefined, // firmware not known by local releases.json file

--- a/packages/suite-data/package.json
+++ b/packages/suite-data/package.json
@@ -29,6 +29,7 @@
         "@mobily/ts-belt": "^3.13.1",
         "@trezor/eslint": "workspace:*",
         "@types/fs-extra": "^11.0.4",
+        "@types/tr46": "^5",
         "autoprefixer": "^10.4.21",
         "babel-loader": "^10.0.0",
         "css-loader": "^6.10.0",
@@ -40,6 +41,7 @@
         "postcss-modules-values": "^4.0.0",
         "simple-git": "^3.27.0",
         "style-loader": "^4.0.0",
+        "tr46": "^5.1.1",
         "tsx": "^4.19.3",
         "webpack": "5.99.9",
         "webpack-cli": "^6.0.1"

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -14,9 +14,9 @@
         "test:e2e:desktop": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --project=desktop",
         "test:e2e:web": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --project=web",
         "test:e2e:update-snapshots": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --grep @snapshot --update-snapshots",
-        "test:orchestrated:e2e:desktop": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=desktop",
-        "test:orchestrated:e2e:web": "yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=web",
-        "github:report:manual": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --project=manual --reporter=./e2e/support/reporters/gitHubReporter.ts",
+        "test:orchestrated:e2e:desktop": "NODE_OPTIONS='--no-warnings=DEP0040' yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=desktop",
+        "test:orchestrated:e2e:web": "NODE_OPTIONS='--no-warnings=DEP0040' yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=web",
+        "github:report:manual": "NODE_OPTIONS='--no-warnings=DEP0040' yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --project=manual --reporter=./e2e/support/reporters/gitHubReporter.ts",
         "github:create:project": "tsx ./e2e/support/reporters/scriptCreateProject.ts"
     },
     "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12054,7 +12054,6 @@ __metadata:
     karma-jasmine-async: "npm:^0.0.1"
     karma-sourcemap-loader: "npm:^0.4.0"
     karma-webpack: "npm:^5.0.1"
-    node-fetch: "npm:^2.6.4"
     node-libs-browser: "npm:^2.2.1"
     ts-node: "npm:^10.9.2"
     tsx: "npm:^4.19.3"
@@ -12389,6 +12388,7 @@ __metadata:
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/fs-extra": "npm:^11.0.4"
+    "@types/tr46": "npm:^5"
     autoprefixer: "npm:^10.4.21"
     babel-loader: "npm:^10.0.0"
     css-loader: "npm:^6.10.0"
@@ -12401,6 +12401,7 @@ __metadata:
     semver: "npm:^7.7.1"
     simple-git: "npm:^3.27.0"
     style-loader: "npm:^4.0.0"
+    tr46: "npm:^5.1.1"
     tsx: "npm:^4.19.3"
     webpack: "npm:5.99.9"
     webpack-cli: "npm:^6.0.1"
@@ -14150,6 +14151,13 @@ __metadata:
   version: 4.0.2
   resolution: "@types/tough-cookie@npm:4.0.2"
   checksum: 10/8682b4062959c15c0521361825839e10d374344fa84166ee0b731b815ac7b79a942f6e9192fad6383d69df2251021678c86c46748ff69c61609934a3e27472f2
+  languageName: node
+  linkType: hard
+
+"@types/tr46@npm:^5":
+  version: 5.0.1
+  resolution: "@types/tr46@npm:5.0.1"
+  checksum: 10/f232969ca629793dd3bbb50fa9e0a7f3143017ac63cdffc004a764e53c126454c079b52117ccde23040106391243f4a6ca27f80999d51c48cc36e41ab83794d7
   languageName: node
   linkType: hard
 
@@ -34718,7 +34726,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^2.1.0, punycode@npm:^2.1.1":
+"punycode@npm:^2.1.0, punycode@npm:^2.1.1, punycode@npm:^2.3.1":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
   checksum: 10/febdc4362bead22f9e2608ff0171713230b57aff9dddc1c273aa2a651fbd366f94b7d6a71d78342a7c0819906750351ca7f2edd26ea41b626d87d6a13d1bd059
@@ -39786,6 +39794,15 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.1"
   checksum: 10/b09a15886cbfaee419a3469081223489051ce9dca3374dd9500d2378adedbee84a3c73f83bfdd6bb13d53657753fc0d4e20a46bfcd3f1b9057ef528426ad7ce4
+  languageName: node
+  linkType: hard
+
+"tr46@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "tr46@npm:5.1.1"
+  dependencies:
+    punycode: "npm:^2.3.1"
+  checksum: 10/833a0e1044574da5790148fd17866d4ddaea89e022de50279967bcd6b28b4ce0d30d59eb3acf9702b60918975b3bad481400337e3a2e6326cffa5c77b874753d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Due to test importing methods and objects from suite-connect, we had for a while these warning on both CI and local runs. I have tried to solve it by removing node-fetch dependency from suite-connect based on @tomasklim 
recommendation. But there are other packages that do import the deprecated punycode. So I have resolved to workaround of suppressing the warnings on CI runs.

```
(node:5145) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

Here's the path of dependencies:

tests import from @trezor/connect
Which uses node-fetch
Which depends on whatwg-url
Which depends on tr46
Which uses the deprecated punycode module

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-solve-deprecated-punycode&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-e2e-solve-deprecated-punycode&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-solve-deprecated-punycode&lookback=7)