### PR TITLE
fix(suite-web): set crowdin in-context translations for dev build only

### DIFF
--- a/packages/suite-build/configs/web.webpack.config.ts
+++ b/packages/suite-build/configs/web.webpack.config.ts
@@ -62,6 +62,7 @@ const config: webpack.Configuration = {
                     templateParameters: {
                         assetPrefix,
                         isOnionLocation: FLAGS.ONION_LOCATION_META,
+                        isCrowdinEnabled: FLAGS.CROWDIN_IN_ENABLED,
                     },
                     inject: 'body' as const,
                     scriptLoading: 'blocking' as const,

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -6,8 +6,8 @@
         "type-check": "yarn g:tsc --build tsconfig.json",
         "type-check:watch": "yarn type-check -- --watch",
         "lint:styles": "npx stylelint './src/**/*{.ts,.tsx}' --cache --config ../../.stylelintrc",
-        "dev": "yarn rimraf ./build && yarn workspace @trezor/suite-build run dev:web",
-        "dev:vite": "PROJECT=web yarn rimraf ./build && yarn workspace @trezor/suite-build run dev:web:vite",
+        "dev": "CROWDIN_IN_ENABLED=true yarn rimraf ./build && yarn workspace @trezor/suite-build run dev:web",
+        "dev:vite": "CROWDIN_IN_ENABLED=true PROJECT=web yarn rimraf ./build && yarn workspace @trezor/suite-build run dev:web:vite",
         "analyze": "ANALYZE=true yarn build",
         "build": "yarn rimraf ./build && yarn workspace @trezor/suite-build run build:web"
     },

--- a/packages/suite-web/src/static/index.html
+++ b/packages/suite-web/src/static/index.html
@@ -13,7 +13,7 @@
             http-equiv="onion-location"
             content="http://suite.trezoriovpjcahpzkrewelclulmszwbqpzmzgub37gbcjlvluxtruqad.onion/web"
         />
-        <% } %>
+        <% } %> <% if(isCrowdinEnabled) { %>
         <script type="text/javascript">
             if (localStorage.getItem('translation_mode') === 'true') {
                 console.warn('INJECTING CROWDIN IN-CONTEXT');
@@ -30,7 +30,9 @@
                 script.setAttribute('src', '//cdn.crowdin.com/jipt/jipt.js');
                 document.head.prepend(script);
             }
-
+        </script>
+        <% } %>
+        <script type="text/javascript">
             // set favicon according to current system theme
             function si(event) {
                 var isDM = event.matches; // isDarkMode

--- a/suite-common/suite-config/src/features.ts
+++ b/suite-common/suite-config/src/features.ts
@@ -8,6 +8,7 @@ export const FLAGS = {
     FILE_SYSTEM_SYNC: false, // File system sync (used for labeling)
     ONION_LOCATION_META: true, // Show TOR onion-location meta tag in page head
     DESKTOP_AUTO_UPDATER: true, // Runs auto updater code on desktop
+    CROWDIN_IN_ENABLED: false, // Inject Crowdin in-context script for translation ui
 } as const;
 
 // Web specific flags


### PR DESCRIPTION
This change sets CrowdIn In-Context translation to be injected into the web suite via a feature flag so that it is included in the dev builds only and is not in production builds.

This relates to https://github.com/trezor/trezor-suite/issues/19303

### Feature Addition: Crowdin In-Context Translation

* [`suite-common/suite-config/src/features.ts`](diffhunk://#diff-6c9f6a439ac55fa6175dbf4fee663b4451aeaac42397838004af87c6e56f08baR11): Added a new feature flag `CROWDIN_IN_ENABLED` to control the injection of Crowdin's in-context translation script.

### Configuration Updates

* [`packages/suite-build/configs/web.webpack.config.ts`](diffhunk://#diff-85acacca7aee6e1ed3be74bd564086f492af04cf0e44983bdd473314df4bb1aaR65): Updated the `templateParameters` object to include the `isCrowdinEnabled` parameter, which is derived from the new feature flag.
* [`packages/suite-web/package.json`](diffhunk://#diff-33b34ea81a11d3c1ef649d535faa3f83cbda58941c313a752f1cc0bbf3b35285L9-R10): Modified `dev` and `dev:vite` scripts to set `CROWDIN_IN_ENABLED=true`, enabling Crowdin during development.

### HTML Injection for Crowdin Script

* [`packages/suite-web/src/static/index.html`](diffhunk://#diff-236515809fcf1a7c3199c21e0d445568f00498708e636dea257597b54ef984f1R17): Added conditional logic to inject Crowdin's in-context translation script into the web application if the `isCrowdinEnabled` flag is set to `true`. [[1]](diffhunk://#diff-236515809fcf1a7c3199c21e0d445568f00498708e636dea257597b54ef984f1R17) [[2]](diffhunk://#diff-236515809fcf1a7c3199c21e0d445568f00498708e636dea257597b54ef984f1L33-R36)