### PR TITLE
fix webusb sync 

### DIFF
--- a/.github/actions/build-web/action.yml
+++ b/.github/actions/build-web/action.yml
@@ -46,6 +46,7 @@ runs:
       run: |
         yarn message-system-sign-config
         yarn workspace @trezor/suite-data build:lib
+        NODE_ENV=production yarn workspace @trezor/connect-iframe build:lib
         yarn workspace @trezor/suite-web build
 
     - name: Upload Suite Web to S3

--- a/.github/workflows/build-suite-web.yml
+++ b/.github/workflows/build-suite-web.yml
@@ -71,6 +71,7 @@ jobs:
         run: |
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
+          NODE_ENV=production yarn workspace @trezor/connect-iframe build:lib
           yarn workspace @trezor/suite-web build
       # this step should upload build result to s3 bucket dev.suite.sldev.cz using awscli
       - name: Upload suite-web to dev.suite.sldev.cz

--- a/packages/connect-explorer/src/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/actions/trezorConnectActions.ts
@@ -142,17 +142,6 @@ export const init =
         const urlParams = new URLSearchParams(window.location.search);
         const coreMode = (urlParams.get('core-mode') as ConnectOptions['coreMode']) || 'auto';
 
-        // localhost + dev server
-        let _sessionsBackgroundUrl = process.env.CONNECT_EXPLORER_FULL_URL
-            ? `${process.env.CONNECT_EXPLORER_FULL_URL}/workers/sessions-background-sharedworker.js`
-            : window.origin + '/workers/sessions-background-sharedworker.js';
-
-        // connect.trezor.io/9 || connect.trezor.io/9.x.y
-        if (window.location.origin.endsWith('connect.trezor.io')) {
-            _sessionsBackgroundUrl =
-                'https://connect.trezor.io/9/workers/sessions-background-sharedworker.js';
-        }
-
         const connectOptions = {
             coreMode,
             transportReconnect: true,
@@ -166,7 +155,6 @@ export const init =
             },
             trustedHost: false,
             connectSrc: window.__TREZOR_CONNECT_SRC,
-            _sessionsBackgroundUrl,
             ...options,
         };
 

--- a/packages/connect-iframe/webpack/base.webpack.config.ts
+++ b/packages/connect-iframe/webpack/base.webpack.config.ts
@@ -138,6 +138,7 @@ export const config: webpack.Configuration = {
         new webpack.DefinePlugin({
             'process.env.VERSION': JSON.stringify(version),
             'process.env.COMMIT_HASH': JSON.stringify(commitHash),
+            'process.env.ASSET_PREFIX': JSON.stringify(process.env.ASSET_PREFIX),
         }),
     ],
 

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -1285,7 +1285,7 @@ export class Core extends EventEmitter {
             if (localFirmwares) {
                 DataManager.setLocalFirmwares(localFirmwares);
             }
-            const { debug, priority, _sessionsBackgroundUrl, manifest } = DataManager.getSettings();
+            const { debug, priority, manifest } = DataManager.getSettings();
             const messages = DataManager.getProtobufMessages();
 
             enableLog(debug);
@@ -1299,7 +1299,6 @@ export class Core extends EventEmitter {
                 debug,
                 messages,
                 priority,
-                _sessionsBackgroundUrl,
                 manifest,
             });
             initDeviceList(this.getCoreContext());

--- a/packages/connect/src/data/connectSettings.ts
+++ b/packages/connect/src/data/connectSettings.ts
@@ -163,7 +163,7 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
         settings._extendWebextensionLifetime = input._extendWebextensionLifetime;
     }
 
-    if (typeof input._sessionsBackgroundUrl === 'string' || input._sessionsBackgroundUrl === null) {
+    if (typeof input._sessionsBackgroundUrl === 'string') {
         settings._sessionsBackgroundUrl = input._sessionsBackgroundUrl;
     }
 

--- a/packages/connect/src/data/connectSettings.ts
+++ b/packages/connect/src/data/connectSettings.ts
@@ -163,10 +163,6 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
         settings._extendWebextensionLifetime = input._extendWebextensionLifetime;
     }
 
-    if (typeof input._sessionsBackgroundUrl === 'string') {
-        settings._sessionsBackgroundUrl = input._sessionsBackgroundUrl;
-    }
-
     if (typeof input.binFilesBaseUrl === 'string') {
         settings.binFilesBaseUrl = input.binFilesBaseUrl;
     }

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -83,10 +83,7 @@ export const assertDeviceListConnected: (
     }
 };
 
-type ConstructorParams = Pick<
-    ConnectSettings,
-    'priority' | 'debug' | '_sessionsBackgroundUrl' | 'manifest'
-> & {
+type ConstructorParams = Pick<ConnectSettings, 'priority' | 'debug' | 'manifest'> & {
     messages: Record<string, any>;
 };
 type InitParams = Pick<
@@ -129,13 +126,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         return this.getConnectedTransports().map(getTransportInfo);
     }
 
-    constructor({
-        messages,
-        priority,
-        debug,
-        _sessionsBackgroundUrl,
-        manifest,
-    }: ConstructorParams) {
+    constructor({ messages, priority, debug, manifest }: ConstructorParams) {
         super();
 
         const transportLogger = initLog('@trezor/transport', debug);
@@ -145,7 +136,6 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         this.updateTransports = createTransportList({
             messages,
             logger: transportLogger,
-            sessionsBackgroundUrl: _sessionsBackgroundUrl,
             id: manifest?.appName || manifest?.appUrl || 'unknown app',
         });
     }

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -39,11 +39,6 @@ export interface ConnectSettingsPublic {
     lazyLoad?: boolean;
     interactionTimeout?: number;
     trustedHost: boolean;
-    /**
-     * for internal use only!
-     * in some exotic setups (suite-web where iframe is embedded locally), you might need to tell connect where it should search for sessions background shared-worker
-     */
-    _sessionsBackgroundUrl?: string;
     // URL for binary files such as firmware, may be local or remote
     binFilesBaseUrl?: string;
     // enable firmware hash check automatically when device connects. Requires binFilesBaseUrl to be set.

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -43,7 +43,7 @@ export interface ConnectSettingsPublic {
      * for internal use only!
      * in some exotic setups (suite-web where iframe is embedded locally), you might need to tell connect where it should search for sessions background shared-worker
      */
-    _sessionsBackgroundUrl?: null | string;
+    _sessionsBackgroundUrl?: string;
     // URL for binary files such as firmware, may be local or remote
     binFilesBaseUrl?: string;
     // enable firmware hash check automatically when device connects. Requires binFilesBaseUrl to be set.

--- a/packages/suite-build/configs/web.webpack.config.ts
+++ b/packages/suite-build/configs/web.webpack.config.ts
@@ -43,6 +43,18 @@ const config: webpack.Configuration = {
                 concurrency: 100,
             },
         }),
+        new CopyWebpackPlugin({
+            patterns: [
+                {
+                    from: path.join(
+                        __dirname,
+                        '../../',
+                        'connect-iframe/build/workers/sessions-background-sharedworker.js',
+                    ),
+                    to: path.join(baseDir, 'build/workers/sessions-background-sharedworker.js'),
+                },
+            ],
+        }),
         // Html files
         ...routes.map(
             route =>

--- a/packages/transport/src/transports/webusb.browser.ts
+++ b/packages/transport/src/transports/webusb.browser.ts
@@ -4,7 +4,10 @@ import { UsbApi } from '../api/usb';
 import { BrowserSessionsBackground } from '../sessions/background-browser';
 
 const defaultSessionsBackgroundUrl =
-    'https://connect.trezor.io/9/workers/sessions-background-sharedworker.js';
+    window.location.origin +
+    `${process.env.ASSET_PREFIX || ''}/workers/sessions-background-sharedworker.js`
+        // just in case so that whoever defines ASSET_PREFIX does not need to worry about trailing slashes
+        .replace(/\/+/g, '/');
 
 type WebUsbTransportParams = AbstractTransportParams & { sessionsBackgroundUrl?: string };
 
@@ -17,7 +20,7 @@ export class WebUsbTransport extends AbstractApiTransport {
     public name = 'WebUsbTransport' as const;
     public apiType = 'usb' as const;
 
-    private readonly sessionsBackgroundUrl: string | null = defaultSessionsBackgroundUrl;
+    private readonly sessionsBackgroundUrl;
 
     constructor({ logger, sessionsBackgroundUrl, ...rest }: WebUsbTransportParams) {
         super({
@@ -25,19 +28,10 @@ export class WebUsbTransport extends AbstractApiTransport {
             logger,
             ...rest,
         });
-        if (sessionsBackgroundUrl || sessionsBackgroundUrl === null) {
-            this.sessionsBackgroundUrl = sessionsBackgroundUrl;
-        }
+        this.sessionsBackgroundUrl = sessionsBackgroundUrl ?? defaultSessionsBackgroundUrl;
     }
 
     private async trySetSessionsBackground() {
-        if (!this.sessionsBackgroundUrl) {
-            this.logger?.log(
-                'No sessionsBackgroundUrl provided. Falling back to use local module.',
-            );
-
-            return;
-        }
         try {
             const response = await fetch(this.sessionsBackgroundUrl, { method: 'HEAD' });
             if (!response.ok) {

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -13,7 +13,7 @@ import TrezorConnect, {
     TRANSPORT_EVENT,
     UI_EVENT,
 } from '@trezor/connect';
-import { isDesktop, isNative } from '@trezor/env-utils';
+import { isDesktop } from '@trezor/env-utils';
 import { DATA_URL } from '@trezor/urls';
 import { getSynchronize } from '@trezor/utils';
 
@@ -136,38 +136,6 @@ export const connectInitThunk = createThunk<
 
     cardanoConnectPatch(getEnabledNetworks);
 
-    // suite-web                                               connect (explorer)                           webusb sync
-    // ======================================================  ====================                         ====================
-    // localhost:8000                                          localhost:8088                               NO
-    // https://dev.suite.sldev.cz/suite-web/develop/web/       https://dev.suite.sldev.cz/connect/develop/  YES - connect
-    // suite.trezor.io/web                                     connect.trezor.io/9(x.y)/                    YES - connect
-
-    let _sessionsBackgroundUrl: string | null = null;
-
-    if (typeof window !== 'undefined' && !isNative()) {
-        if (window.location.origin.includes('localhost')) {
-            _sessionsBackgroundUrl = null;
-        } else if (window.location.origin.endsWith('dev.suite.sldev.cz')) {
-            // we are expecting accompanying connect build at specified location
-            const assetPrefixArr = (process.env.ASSET_PREFIX || '').split('/').filter(Boolean);
-            const relevantSegments = assetPrefixArr
-                .map((segment, index) => {
-                    const first = index === 0;
-                    const last = index === assetPrefixArr.length - 1;
-                    if (segment === 'suite-web' && first) return 'connect';
-                    if (segment === 'web' && last) return null;
-
-                    return segment;
-                })
-                .filter(Boolean);
-
-            _sessionsBackgroundUrl = `${window.location.origin}/${relevantSegments.join('/')}/workers/sessions-background-sharedworker.js`;
-        } else {
-            _sessionsBackgroundUrl =
-                'https://connect.trezor.io/9/workers/sessions-background-sharedworker.js';
-        }
-    }
-
     const binFilesBaseUrl = isDesktop()
         ? extra.selectors.selectDesktopBinDir(getState())
         : DATA_URL;
@@ -179,7 +147,6 @@ export const connectInitThunk = createThunk<
             binFilesBaseUrl,
             pendingTransportEvent: selectIsPendingTransportEvent(getState()),
             transports,
-            _sessionsBackgroundUrl,
             debug: showConnectLogs,
         });
     } catch (error) {


### PR DESCRIPTION
## Description

This PR removes a failed attempt to make sharedworker (that is responsible for device access coordination between tabs) work across trezor.io subdomains. 

This means that we are returning to the previous state where coordination would work but only per domain, so suite.trezor.io and connect.trezor.io don't know about each other. This shouldn't be that big issue since connect.trezor.io/popup will be removed anyway.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="511" alt="image" src="https://github.com/user-attachments/assets/a1c26c74-b111-46f6-973d-950dcf621d82" />

## Test

- [x] localhost suite-web
- [X] localhost connect-explorer
- [x] sldev suite-web https://dev.suite.sldev.cz/suite-web/fix-webusb-sync-2/web
- [x] sldev connect expolorer
- [ ] staging suite-web
- [ ] staging connect-explorer
- [ ] production suite-web
- [ ] production connect-explorer

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-webusb-sync-2&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-webusb-sync-2&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-webusb-sync-2&lookback=7)