### PR TITLE
feat(connect): add UI response for THP pairing tag

### DIFF
--- a/packages/connect/src/constants/errors.ts
+++ b/packages/connect/src/constants/errors.ts
@@ -43,6 +43,7 @@ export const ERROR_CODES = {
     Device_MultipleNotSupported: 'Multiple devices are not supported', // thrown by methods which require single device
     Device_MissingCapability: 'Device is missing capability', // thrown by methods which require specific capability
     Device_MissingCapabilityBtcOnly: 'Device is missing capability (BTC only)', // thrown by methods which require specific capability when using BTC only firmware
+    Device_ThpPairingTagInvalid: 'Pairing tag mismatch', // thrown by RECEIVE_THP_PAIRING_TAG handler
 
     Failure_ActionCancelled: 'Action cancelled by user',
     Failure_FirmwareError: 'Firmware installation failed',

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -880,6 +880,50 @@ const onEmptyPassphraseHandler =
         callback({ success: true, payload: { value: '' } });
     };
 
+const onThpPairingHandler =
+    (device: Device, context: CoreContext) =>
+    async ({ callback, payload }: DeviceEvents['thp_pairing']) => {
+        const { uiPromises, sendCoreMessage } = context;
+        // wait for popup handshake
+        await waitForPopup(context);
+        // create ui promise
+        const uiPromise = uiPromises.create(UI.RECEIVE_THP_PAIRING_TAG, device);
+
+        sendCoreMessage(
+            createUiMessage(UI.REQUEST_THP_PAIRING, {
+                device: device.toMessageObject(),
+                ...payload,
+            }),
+        );
+        // wait for response
+        try {
+            const uiResp = await uiPromise.promise;
+            if (uiResp.payload == null) {
+                callback({
+                    success: false,
+                    error: new Error(`${UI.RECEIVE_THP_PAIRING_TAG} missing payload`),
+                });
+            } else {
+                callback({ success: true, payload: uiResp.payload });
+            }
+        } catch (error) {
+            callback({ success: false, error });
+        }
+    };
+
+const onThpCredentialsChangedHandler =
+    (device: Device, context: CoreContext) =>
+    (payload: DeviceEvents['device-thp_credentials_changed']) => {
+        const { sendCoreMessage } = context;
+
+        sendCoreMessage(
+            createDeviceMessage(DEVICE.THP_CREDENTIALS_CHANGED, {
+                device: device.toMessageObject(),
+                ...payload,
+            }),
+        );
+    };
+
 const registerDeviceEvents =
     (context: CoreContext, method?: AbstractMethod<any>) => (device: Device) => {
         device.removeAllListeners();
@@ -903,6 +947,8 @@ const registerDeviceEvents =
         device.on(DEVICE.FIRMWARE_VERSION_CHANGED, payload => {
             context.sendCoreMessage(createDeviceMessage(DEVICE.FIRMWARE_VERSION_CHANGED, payload));
         });
+        device.on(DEVICE.THP_PAIRING, onThpPairingHandler(device, context));
+        device.on(DEVICE.THP_CREDENTIALS_CHANGED, onThpCredentialsChangedHandler(device, context));
     };
 
 /**
@@ -1138,6 +1184,7 @@ export class Core extends EventEmitter {
             case UI.RECEIVE_PIN:
             case UI.RECEIVE_PASSPHRASE:
             case UI.INVALID_PASSPHRASE_ACTION:
+            case UI.RECEIVE_THP_PAIRING_TAG:
             case UI.RECEIVE_ACCOUNT:
             case UI.RECEIVE_FEE:
             case UI.RECEIVE_WORD:

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -29,10 +29,13 @@ import { getLanguage } from '../data/getLanguage';
 import {
     DEVICE,
     DeviceButtonRequestPayload,
+    DeviceThpCredentialsChangedPayload,
+    DeviceThpPairingPayload,
     DeviceVersionChanged,
     UI,
     UiResponsePassphrase,
     UiResponsePin,
+    UiResponseThpPairingTag,
     UiResponseWord,
 } from '../events';
 import {
@@ -96,6 +99,11 @@ export interface DeviceEvents {
     [DEVICE.PASSPHRASE_ON_DEVICE]: void;
     [DEVICE.BUTTON]: { device: Device; payload: DeviceButtonRequestPayload };
     [DEVICE.FIRMWARE_VERSION_CHANGED]: DeviceVersionChanged['payload'];
+    [DEVICE.THP_PAIRING]: {
+        payload: DeviceThpPairingPayload;
+        callback: (response: Result<UiResponseThpPairingTag['payload']>) => void;
+    };
+    [DEVICE.THP_CREDENTIALS_CHANGED]: DeviceThpCredentialsChangedPayload;
 }
 
 type DeviceLifecycle =
@@ -973,10 +981,13 @@ export class Device extends TypedEmitter<DeviceEvents> {
         }
     }
 
-    prompt<T extends typeof DEVICE.PIN | typeof DEVICE.PASSPHRASE | typeof DEVICE.WORD>(
-        type: T,
-        args: Omit<DeviceEvents[T], 'callback'>,
-    ) {
+    prompt<
+        T extends
+            | typeof DEVICE.PIN
+            | typeof DEVICE.PASSPHRASE
+            | typeof DEVICE.WORD
+            | typeof DEVICE.THP_PAIRING,
+    >(type: T, args: Omit<DeviceEvents[T], 'callback'>) {
         // TODO I believe this emit/on can be changed into simple async functions
         return new Promise<Parameters<DeviceEvents[T]['callback']>[0]>(callback => {
             if (!this.listenerCount(type)) {

--- a/packages/connect/src/events/device.ts
+++ b/packages/connect/src/events/device.ts
@@ -1,5 +1,5 @@
 import type { VersionArray } from '@trezor/device-utils';
-import type { ThpCredentials } from '@trezor/protocol';
+import type { ThpCredentials, ThpPairingMethod } from '@trezor/protocol';
 
 import type { PROTO } from '../constants';
 import type { Device } from '../types/device';
@@ -48,12 +48,21 @@ export interface DeviceVersionChanged {
     };
 }
 
+export type DeviceThpCredentialsChangedPayload = {
+    credentials: ThpCredentials;
+    staticKey: string;
+};
+
+export type DeviceThpPairingPayload = {
+    availableMethods: ThpPairingMethod[];
+    selectedMethod?: ThpPairingMethod; // expected pairing response data
+    nfcData?: string; // data for NFC module, if selected_method === ThpPairingMethod.NFC
+};
+
 export interface DeviceThpCredentialsChanged {
     type: typeof DEVICE.THP_CREDENTIALS_CHANGED;
-    payload: {
+    payload: DeviceThpCredentialsChangedPayload & {
         device: Device;
-        credentials: ThpCredentials;
-        staticKey: string;
     };
 }
 

--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -3,7 +3,6 @@
  */
 import type { EventTypeDeviceSelected } from '@trezor/connect-analytics';
 import { DeviceModelInternal } from '@trezor/device-utils';
-import type { ThpPairingMethod } from '@trezor/protocol';
 
 import type { PROTO } from '../constants';
 import type {
@@ -14,7 +13,7 @@ import type {
     FirmwareType,
     SelectFeeLevel,
 } from '../types';
-import type { DeviceButtonRequest } from './device';
+import type { DeviceButtonRequest, DeviceThpPairingPayload } from './device';
 import { MethodPermission } from '../core/AbstractMethod';
 import type { DiscoveryAccount, DiscoveryAccountType } from '../types/account';
 import type { MessageFactoryFn } from '../types/utils';
@@ -159,11 +158,8 @@ export type UiRequestButtonData =
 
 export interface UiRequestThpPairing {
     type: typeof UI_REQUEST.REQUEST_THP_PAIRING;
-    payload: {
+    payload: DeviceThpPairingPayload & {
         device: Device;
-        availableMethods: ThpPairingMethod[];
-        selectedMethod?: ThpPairingMethod; // expected pairing response data
-        nfcData?: string; // data for NFC module, if selected_method === ThpPairingMethod.NFC
     };
 }
 

--- a/packages/connect/src/events/ui-response.ts
+++ b/packages/connect/src/events/ui-response.ts
@@ -14,6 +14,7 @@ export const UI_RESPONSE = {
     RECEIVE_FIRMWARE: 'ui-receive_firmware',
     RECEIVE_PIN: 'ui-receive_pin',
     RECEIVE_PASSPHRASE: 'ui-receive_passphrase',
+    RECEIVE_THP_PAIRING_TAG: 'ui-receive_thp_pairing_tag',
     RECEIVE_DEVICE: 'ui-receive_device',
     RECEIVE_ACCOUNT: 'ui-receive_account',
     RECEIVE_FEE: 'ui-receive_fee',
@@ -73,6 +74,18 @@ export interface UiResponsePassphrase {
     };
 }
 
+export interface UiResponseThpPairingTag {
+    type: typeof UI_RESPONSE.RECEIVE_THP_PAIRING_TAG;
+    payload:
+        | {
+              source: 'code-entry' | 'qr-code' | 'nfc';
+              tag: string;
+          }
+        | {
+              selectedMethod: number; // change pairing method ThpPairingMethod;
+          };
+}
+
 export interface UiResponsePassphraseAction {
     type: typeof UI_RESPONSE.INVALID_PASSPHRASE_ACTION;
     payload: boolean;
@@ -115,6 +128,7 @@ export type UiResponseEvent =
     | UiResponsePin
     | UiResponseWord
     | UiResponsePassphrase
+    | UiResponseThpPairingTag
     | UiResponsePassphraseAction
     | UiResponseAccount
     | UiResponseFee


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

add missing piece to allow suite UI to be merged, with this commit all required types should be available  

- `Device_ThpPairingTagInvalid` - new typed error, result of THP pairing
- prompt handler for `DEVICE.THP_PAIRING` event: UI.REQUEST_THP_PAIRING > UI.RECEIVE_THP_PAIRING_TAG
- event handler for `DEVICE.THP_CREDENTIALS_CHANGED` 


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-thp-pairing-response&lookback=7)