### PR TITLE
attempt to fixed way-long loading when adding a non-empty passph…

### DIFF
--- a/packages/suite/src/components/suite/modals/ModalSwitcher/ModalSwitcher.tsx
+++ b/packages/suite/src/components/suite/modals/ModalSwitcher/ModalSwitcher.tsx
@@ -1,6 +1,5 @@
 import { usePreferredModal } from 'src/hooks/suite/usePreferredModal';
 
-import { DiscoveryLoader } from './DiscoveryLoader';
 import { ForegroundAppModal } from './ForegroundAppModal';
 import { UnpairedBluetoothDeviceNeedsManualOsRemovalModal } from '../../bluetooth/UnpairedBluetoothDeviceNeedsManualOsRemovalModal';
 import { ReduxModal } from '../ReduxModal/ReduxModal';
@@ -11,8 +10,6 @@ const Inner = ({ modal }: { modal: ModalParams }) => {
     switch (modal.type) {
         case 'redux-modal':
             return <ReduxModal {...modal.payload} />;
-        case 'discovery-loading':
-            return <DiscoveryLoader />;
         default:
             return null;
     }

--- a/packages/suite/src/hooks/suite/usePreferredModal.ts
+++ b/packages/suite/src/hooks/suite/usePreferredModal.ts
@@ -1,11 +1,11 @@
 import { Route } from '@suite-common/suite-types';
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { UI } from '@trezor/connect';
 
 import { MODAL } from 'src/actions/suite/constants';
 import { useDiscovery, useSelector } from 'src/hooks/suite';
 import type { ForegroundAppRoute } from 'src/types/suite';
 import { ModalAppParams } from 'src/utils/suite/router';
-import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOverallStatus';
 
 const isForegroundApp = (route: Route): route is ForegroundAppRoute =>
     !route.isFullscreenApp && !!route.isForegroundApp;
@@ -46,15 +46,17 @@ const getForegroundAppAction = (route: ForegroundAppRoute, params: Partial<Modal
 
 export const usePreferredModal = () => {
     const { discovery: discoveryForSelectedDevice } = useDiscovery();
-    const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
     const route = useSelector(state => state.router.route);
     const params = useSelector(state => state.router.params as Partial<ModalAppParams>);
     const modal = useSelector(state => state.modal);
+    const discoveryInProgress = useSelector(selectHasRunningDiscovery);
     const isPassphraseFlow =
         Boolean(discoveryForSelectedDevice?.isAddingHiddenWallet) &&
-        discoveryForSelectedDevice?.status !== 'cancelled' &&
-        discoveryForSelectedDevice?.status !== 'complete' &&
-        discoveryForSelectedDevice?.status !== 'failed';
+        discoveryInProgress &&
+        !(
+            discoveryForSelectedDevice?.status === 'progress' &&
+            discoveryForSelectedDevice.hasLoadedAnyNonEmptyAccount
+        );
 
     if (route && isForegroundApp(route) && hasPriority(route)) {
         return getForegroundAppAction(route, params);
@@ -90,15 +92,6 @@ export const usePreferredModal = () => {
     if (isPassphraseFlow && discoveryForSelectedDevice) {
         return {
             type: 'passphrase-flow',
-        } as const;
-    }
-
-    // account discovery in progress and didn't find any used account yet.
-    // display Loader wrapped in modal above requested route to keep "modal" flow continuity.
-    // or display "Action modal" (like: pin/passphrase request)
-    if (discoveryStatus?.type === 'auth-confirm') {
-        return {
-            type: 'discovery-loading',
         } as const;
     }
 

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -34,7 +34,7 @@ export type { Discovery } from '@suite-common/wallet-types';
 export type DiscoveryStatusType =
     | {
           status: 'loading';
-          type: 'waiting-for-device' | 'auth' | 'auth-confirm' | 'discovery';
+          type: 'waiting-for-device' | 'auth' | 'discovery';
       }
     | {
           status: 'exception';

--- a/packages/suite/src/utils/wallet/selectDiscoveryOverallStatus.ts
+++ b/packages/suite/src/utils/wallet/selectDiscoveryOverallStatus.ts
@@ -33,19 +33,6 @@ const getDiscoveryStatus = ({
     }
 
     if (discovery) {
-        if (discovery.status === 'progress' && discovery.isAddingHiddenWallet)
-            return {
-                status: 'loading',
-                // type: 'discovery',
-                type: 'auth-confirm',
-            };
-
-        if (discovery.status === 'confirm-empty-passphrase')
-            return {
-                status: 'loading',
-                type: 'auth-confirm',
-            };
-
         if (walletSettings.enabledNetworks.length === 0)
             return {
                 status: 'exception',

--- a/suite-common/wallet-core/src/discovery/discoveryReducer.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryReducer.ts
@@ -16,9 +16,17 @@ const update = (draft: Discovery, payload: { status: DiscoveryStatus; path: Devi
     if (!draft[payload.path]) {
         return;
     }
+
+    const currentStatus = draft[payload.path];
+    const hasLoadedAnyNonEmptyAccount: true | undefined =
+        (currentStatus.status === 'progress' && currentStatus.hasLoadedAnyNonEmptyAccount) ||
+        (payload.status.status === 'progress' && payload.status.hasLoadedAnyNonEmptyAccount) ||
+        undefined;
+
     draft[payload.path] = {
-        ...draft[payload.path],
+        ...currentStatus,
         ...payload.status,
+        ...{ hasLoadedAnyNonEmptyAccount },
     };
 };
 

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -97,6 +97,18 @@ const applyDeviceStatesThunk = createThunk(
             const devices = selectDevices(getState());
             const devicesByPath = devices.filter(d => d.path === devicePath);
 
+            const currentDeviceByStaticSessionId = newDeviceState.staticSessionId
+                ? selectDeviceByStaticSessionId(getState(), newDeviceState.staticSessionId)
+                : null;
+
+            if (currentDeviceByStaticSessionId && isAddingHiddenWallet) {
+                console.warn(
+                    'applyDeviceStatesThunk: applying state to a device with static session id',
+                );
+
+                return;
+            }
+
             // sanity check that there is no 2 devices sharing the same path. this shouldn't happen, the only way that comes to my mind
             // is when you would create a copy of device and store it in redux before authorizing it (this is actually the old way of doing things)
             // todo: this sanity check could be moved somewhere higher.
@@ -455,9 +467,6 @@ export const runDiscoveryThunk = createThunk(
                 return;
             }
 
-            // NOTE: this should be true anytime the applyDeviceStatesThunk() is called
-            let deviceStateApplied = false;
-
             const onBundleProgress = createOnBundleProgressHandler(
                 device.path,
                 deviceStateResponse.payload._state.staticSessionId,
@@ -466,7 +475,6 @@ export const runDiscoveryThunk = createThunk(
                 {
                     onNonFirstNonEmptyAccountDiscovered: () => {
                         if (isAddingHiddenWallet) {
-                            deviceStateApplied = true;
                             dispatch(
                                 applyDeviceStatesThunk({
                                     newDeviceState: deviceStateResponse.payload._state,
@@ -547,16 +555,13 @@ export const runDiscoveryThunk = createThunk(
             const allAccountsEmpty = result.payload.nonempty === 0;
             // there is at least one account with balance - passphrase is not empty
             if (!allAccountsEmpty) {
-                if (!deviceStateApplied) {
-                    deviceStateApplied = true;
-                    await dispatch(
-                        applyDeviceStatesThunk({
-                            newDeviceState: deviceStateResponse.payload._state,
-                            isAddingHiddenWallet,
-                            devicePath: device.path,
-                        }),
-                    );
-                }
+                await dispatch(
+                    applyDeviceStatesThunk({
+                        newDeviceState: deviceStateResponse.payload._state,
+                        isAddingHiddenWallet,
+                        devicePath: device.path,
+                    }),
+                );
 
                 dispatch(
                     completeDiscoveryThunk({
@@ -621,16 +626,13 @@ export const runDiscoveryThunk = createThunk(
                 return;
             }
 
-            if (!deviceStateApplied) {
-                deviceStateApplied = true;
-                await dispatch(
-                    applyDeviceStatesThunk({
-                        newDeviceState: deviceStateResponse.payload._state,
-                        isAddingHiddenWallet,
-                        devicePath: passedDevice.path,
-                    }),
-                );
-            }
+            await dispatch(
+                applyDeviceStatesThunk({
+                    newDeviceState: deviceStateResponse.payload._state,
+                    isAddingHiddenWallet,
+                    devicePath: passedDevice.path,
+                }),
+            );
 
             dispatch(
                 completeDiscoveryThunk({

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -455,6 +455,9 @@ export const runDiscoveryThunk = createThunk(
                 return;
             }
 
+            // NOTE: this should be true anytime the applyDeviceStatesThunk() is called
+            let deviceStateApplied = false;
+
             const onBundleProgress = createOnBundleProgressHandler(
                 device.path,
                 deviceStateResponse.payload._state.staticSessionId,
@@ -463,6 +466,7 @@ export const runDiscoveryThunk = createThunk(
                 {
                     onNonFirstNonEmptyAccountDiscovered: () => {
                         if (isAddingHiddenWallet) {
+                            deviceStateApplied = true;
                             dispatch(
                                 applyDeviceStatesThunk({
                                     newDeviceState: deviceStateResponse.payload._state,
@@ -543,13 +547,16 @@ export const runDiscoveryThunk = createThunk(
             const allAccountsEmpty = result.payload.nonempty === 0;
             // there is at least one account with balance - passphrase is not empty
             if (!allAccountsEmpty) {
-                await dispatch(
-                    applyDeviceStatesThunk({
-                        newDeviceState: deviceStateResponse.payload._state,
-                        isAddingHiddenWallet,
-                        devicePath: device.path,
-                    }),
-                );
+                if (!deviceStateApplied) {
+                    deviceStateApplied = true;
+                    await dispatch(
+                        applyDeviceStatesThunk({
+                            newDeviceState: deviceStateResponse.payload._state,
+                            isAddingHiddenWallet,
+                            devicePath: device.path,
+                        }),
+                    );
+                }
 
                 dispatch(
                     completeDiscoveryThunk({
@@ -614,13 +621,16 @@ export const runDiscoveryThunk = createThunk(
                 return;
             }
 
-            await dispatch(
-                applyDeviceStatesThunk({
-                    newDeviceState: deviceStateResponse.payload._state,
-                    isAddingHiddenWallet,
-                    devicePath: passedDevice.path,
-                }),
-            );
+            if (!deviceStateApplied) {
+                deviceStateApplied = true;
+                await dispatch(
+                    applyDeviceStatesThunk({
+                        newDeviceState: deviceStateResponse.payload._state,
+                        isAddingHiddenWallet,
+                        devicePath: passedDevice.path,
+                    }),
+                );
+            }
 
             dispatch(
                 completeDiscoveryThunk({

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -431,6 +431,30 @@ export const runDiscoveryThunk = createThunk(
             assertDeviceIsAcquired(device);
 
             assertStaticSessionId(deviceStateResponse.payload._state);
+
+            const duplicate = selectDevices(getState())
+                .filter(d => d.state?.staticSessionId)
+                .find(
+                    d =>
+                        d.state!.staticSessionId!.split(':')[0] ===
+                        deviceStateResponse.payload._state.staticSessionId!.split(':')[0],
+                );
+
+            if (isAddingHiddenWallet && duplicate) {
+                dispatch(
+                    discoveryActions.updateDiscovery(
+                        {
+                            status: 'passphrase-duplicate',
+                            duplicateDeviceStaticSessionId:
+                                deviceStateResponse.payload._state.staticSessionId,
+                        },
+                        device.path,
+                    ),
+                );
+
+                return;
+            }
+
             const onBundleProgress = createOnBundleProgressHandler(
                 device.path,
                 deviceStateResponse.payload._state.staticSessionId,
@@ -509,29 +533,6 @@ export const runDiscoveryThunk = createThunk(
 
             if (!deviceStateResponse.payload._state.staticSessionId) {
                 console.error('Discovery: staticSessionId missing in device state response');
-
-                return;
-            }
-
-            const duplicate = selectDevices(getState())
-                .filter(d => d.state?.staticSessionId)
-                .find(
-                    d =>
-                        d.state!.staticSessionId!.split(':')[0] ===
-                        deviceStateResponse.payload._state.staticSessionId!.split(':')[0],
-                );
-
-            if (duplicate) {
-                dispatch(
-                    discoveryActions.updateDiscovery(
-                        {
-                            status: 'passphrase-duplicate',
-                            duplicateDeviceStaticSessionId:
-                                deviceStateResponse.payload._state.staticSessionId,
-                        },
-                        device.path,
-                    ),
-                );
 
                 return;
             }

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -155,6 +155,9 @@ const createOnBundleProgressHandler = (
     deviceStaticSessionId: StaticSessionId,
     dispatch: any,
     getState: any,
+    progressHooks: {
+        onNonFirstNonEmptyAccountDiscovered?: () => void;
+    } = {},
 ) => {
     let encounteredNonEmptyAccount = false;
     // we do not create empty accounts right away, but store the progress events for later
@@ -189,16 +192,30 @@ const createOnBundleProgressHandler = (
             return;
         }
 
+        const hasLoadedAnyNonEmptyAccount =
+            'balance' in event.response &&
+            !isNaN(Number(event.response.balance)) &&
+            Number(event.response.balance) > 0;
+
         dispatch(
             discoveryActions.updateDiscovery(
                 {
                     status: 'progress',
                     total: event.total,
                     progress: event.progress,
+                    hasLoadedAnyNonEmptyAccount,
                 },
                 devicePath,
             ),
         );
+
+        if (
+            discovery.status === 'progress' &&
+            !discovery.hasLoadedAnyNonEmptyAccount &&
+            hasLoadedAnyNonEmptyAccount
+        ) {
+            progressHooks.onNonFirstNonEmptyAccountDiscovered?.();
+        }
 
         if (isProgressEventOk(event)) {
             // all encountered accounts were empty, so create all of the delayed empty accounts (and also the latest event)
@@ -419,6 +436,19 @@ export const runDiscoveryThunk = createThunk(
                 deviceStateResponse.payload._state.staticSessionId,
                 dispatch,
                 getState,
+                {
+                    onNonFirstNonEmptyAccountDiscovered: () => {
+                        if (isAddingHiddenWallet) {
+                            dispatch(
+                                applyDeviceStatesThunk({
+                                    newDeviceState: deviceStateResponse.payload._state,
+                                    isAddingHiddenWallet,
+                                    devicePath: passedDevice.path,
+                                }),
+                            );
+                        }
+                    },
+                },
             );
 
             TrezorConnect.on<DiscoverAccountsProgress>(UI.BUNDLE_PROGRESS, onBundleProgress);

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -45,6 +45,7 @@ export type DiscoveryStatus = CommonDiscoveryStatus &
               status: 'progress';
               total: BundleProgress<any>['payload']['total'];
               progress: BundleProgress<any>['payload']['progress'];
+              hasLoadedAnyNonEmptyAccount?: boolean; // NOTE: used to indicate the the disocovery started loading actual accounts
           }
         | {
               status: 'confirm-empty-passphrase';

--- a/suite-native/device-authorization/src/deviceAuthorizationSlice.ts
+++ b/suite-native/device-authorization/src/deviceAuthorizationSlice.ts
@@ -176,14 +176,17 @@ export const selectPassphraseDeviceNotEmpty = (state: DiscoveryRootState & Devic
     }
 };
 
-export const selectDiscoveryCompleted = (state: DiscoveryRootState & DeviceRootState) => {
+export const selectPassphraseDiscoveryCompleted = (state: DiscoveryRootState & DeviceRootState) => {
     const discovery = selectDiscoveryByDevicePath(state, state.device.selectedDevice?.path);
 
     if (!discovery || !discovery.isAddingHiddenWallet) {
         return null;
     }
 
-    return discovery.status === 'complete';
+    return (
+        discovery.status === 'complete' ||
+        (discovery.status === 'progress' && discovery.hasLoadedAnyNonEmptyAccount)
+    );
 };
 
 export const { setCheckPassphraseOnDevice, setInputPassphraseOnDevice } =

--- a/suite-native/module-authorize-device/src/useRedirectOnPassphraseCompletion.ts
+++ b/suite-native/module-authorize-device/src/useRedirectOnPassphraseCompletion.ts
@@ -11,8 +11,8 @@ import {
 } from '@suite-common/wallet-core';
 import { EventType, analytics } from '@suite-native/analytics';
 import {
-    selectDiscoveryCompleted,
     selectHasVerificationCancelledError,
+    selectPassphraseDiscoveryCompleted,
     selectPassphraseError,
 } from '@suite-native/device-authorization';
 import { useNavigateToInitialScreen } from '@suite-native/navigation';
@@ -20,7 +20,7 @@ import { useNavigateToInitialScreen } from '@suite-native/navigation';
 export const useRedirectOnPassphraseCompletion = () => {
     const device = useSelector(selectSelectedDevice);
 
-    const passphraseDiscoveryCompleted = useSelector(selectDiscoveryCompleted);
+    const passphraseDiscoveryCompleted = useSelector(selectPassphraseDiscoveryCompleted);
     const hasPassphraseError = useSelector(selectPassphraseError);
     const hasVerificationCancelledError = useSelector(selectHasVerificationCancelledError);
 


### PR DESCRIPTION
…rase wallet

<!--- Provide a general summary of your changes in the Title above -->

## Description

Bug: When the discovery is in state when it is known that the passphrase wallet ISNT empty, so that wallet can be opened nad user can interact with the app while the accounts are being loaded, the app is still in "loading state" with a discovery loading modal on

The solution:
- we don't want to wait for the discovery to completely finish to "hide" the discovery loader in the passphrase flow context
- create a "hook" to the discovery progress handler, which will trigger only once to select the added wallet
- add a flag to the discovery to be able to trigger said hook and to if-out the "passphrase flow" modals, so their are hidden

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-stucked-progress-passphrase&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-stucked-progress-passphrase&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-stucked-progress-passphrase&lookback=7)