### PR TITLE
fix: make test not-dependant on real URLs

### DIFF
--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -6,8 +6,8 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "scripts": {
-        "test:all": "yarn g:jest --runInBand -c jest.config.js",
-        "test:unit": "yarn g:jest  --testPathIgnorePatterns e2e -c jest.config.js",
+        "test:all": "yarn g:jest -c jest.config.js",
+        "test:unit": "yarn g:jest --testPathIgnorePatterns e2e -c jest.config.js",
         "test:e2e": "yarn g:jest --runInBand --testPathIgnorePatterns tests -c jest.config..js",
         "type-check": "yarn g:tsc --build tsconfig.json",
         "test:stress": "ts-node  -O '{\"module\": \"commonjs\"}' ./e2e/identities-stress.ts"

--- a/packages/request-manager/tests/interceptor-whitelist.test.ts
+++ b/packages/request-manager/tests/interceptor-whitelist.test.ts
@@ -6,8 +6,11 @@ import WebSocket from 'ws';
 import { createInterceptor } from '../src';
 import { InterceptorOptions } from '../src/types';
 
-const WHITELISTED_DOMAIN = 'tbtc1.trezor.io';
-const NOT_WHITELISTED_DOMAIN = 'tbtc2.trezor.io';
+const WHITELISTED_DOMAIN = 'url-that-is-valid-and-white-listed-but-does-not-exists.com';
+const NOT_WHITELISTED_DOMAIN = 'not-white-listed-but-does-not-exists.com';
+
+const OK_ERROR_SHORT = `getaddrinfo ENOTFOUND ${WHITELISTED_DOMAIN}`;
+const OK_ERROR_HTTPS = new RegExp(`.*${OK_ERROR_SHORT}`);
 
 const createWebSocket = (url: string) =>
     new Promise<void>((resolve, reject) => {
@@ -66,7 +69,9 @@ describe('Interceptor', () => {
     });
 
     it('Blocks websocket connections', async () => {
-        await createWebSocket(`wss://${WHITELISTED_DOMAIN}/websocket`);
+        await expect(createWebSocket(`wss://${WHITELISTED_DOMAIN}/websocket`)).rejects.toThrow(
+            OK_ERROR_SHORT,
+        );
 
         await expect(createWebSocket(`wss://${NOT_WHITELISTED_DOMAIN}/websocket`)).rejects.toThrow(
             `Request blocked, not whitelisted domain: ${NOT_WHITELISTED_DOMAIN}`,
@@ -75,18 +80,20 @@ describe('Interceptor', () => {
 
     ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'].forEach(method => {
         it(`Blocks all not whitelisted node-fetch requests for: ${method}`, async () => {
-            await expect(
-                nodeFetch(`https://${WHITELISTED_DOMAIN}/`, { method }),
-            ).resolves.toBeDefined();
+            await expect(nodeFetch(`https://${WHITELISTED_DOMAIN}`, { method })).rejects.toThrow(
+                OK_ERROR_HTTPS,
+            );
 
             await expect(
-                nodeFetch(`https://${NOT_WHITELISTED_DOMAIN}/`, { method }),
+                nodeFetch(`https://${NOT_WHITELISTED_DOMAIN}`, { method }),
             ).rejects.toThrow(`Request blocked, not whitelisted domain: ${NOT_WHITELISTED_DOMAIN}`);
         });
     });
 
     it('Blocks the TCP connection', async () => {
-        (await openTcpSocket(WHITELISTED_DOMAIN, 80)).end();
+        await expect(async () =>
+            (await openTcpSocket(WHITELISTED_DOMAIN, 80)).end(),
+        ).rejects.toThrow(OK_ERROR_SHORT);
 
         await expect(openTcpSocket(NOT_WHITELISTED_DOMAIN, 80)).rejects.toThrow(
             `Request blocked, not whitelisted domain: ${NOT_WHITELISTED_DOMAIN}`,
@@ -94,7 +101,9 @@ describe('Interceptor', () => {
     });
 
     it('Blocks the TLS connection', async () => {
-        (await openTlsSocket(WHITELISTED_DOMAIN, 80)).end();
+        await expect(async () =>
+            (await openTlsSocket(WHITELISTED_DOMAIN, 80)).end(),
+        ).rejects.toThrow(OK_ERROR_SHORT);
 
         await expect(openTlsSocket(NOT_WHITELISTED_DOMAIN, 80)).rejects.toThrow(
             `Request blocked, not whitelisted domain: ${NOT_WHITELISTED_DOMAIN}`,
@@ -102,7 +111,9 @@ describe('Interceptor', () => {
     });
 
     it('Blocks net.Socket', async () => {
-        (await openNetSocket(WHITELISTED_DOMAIN, 80)).end();
+        await expect(async () =>
+            (await openNetSocket(WHITELISTED_DOMAIN, 80)).end(),
+        ).rejects.toThrow(OK_ERROR_SHORT);
 
         await expect(openNetSocket(NOT_WHITELISTED_DOMAIN, 80)).rejects.toThrow(
             `Request blocked, not whitelisted domain: ${NOT_WHITELISTED_DOMAIN}`,
@@ -110,7 +121,9 @@ describe('Interceptor', () => {
     });
 
     it('Blocks net.connect', async () => {
-        (await performNetConnect(WHITELISTED_DOMAIN, 80)).end();
+        await expect(async () =>
+            (await performNetConnect(WHITELISTED_DOMAIN, 80)).end(),
+        ).rejects.toThrow(OK_ERROR_SHORT);
 
         try {
             await performNetConnect(NOT_WHITELISTED_DOMAIN, 80);
@@ -123,7 +136,9 @@ describe('Interceptor', () => {
     });
 
     it('Blocks tls.connect', async () => {
-        (await performTlsConnect(WHITELISTED_DOMAIN, 80)).end();
+        await expect(async () =>
+            (await performTlsConnect(WHITELISTED_DOMAIN, 80)).end(),
+        ).rejects.toThrow(OK_ERROR_SHORT);
 
         try {
             await performTlsConnect(NOT_WHITELISTED_DOMAIN, 80);
@@ -137,9 +152,9 @@ describe('Interceptor', () => {
 
     ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'].forEach(method => {
         it(`Blocks all not whitelisted native fetch for: ${method}`, async () => {
-            await expect(
-                fetch(`https://${WHITELISTED_DOMAIN}/`, { method }),
-            ).resolves.toBeDefined();
+            await expect(fetch(`https://${WHITELISTED_DOMAIN}`, { method })).rejects.toThrow(
+                'fetch failed',
+            );
 
             try {
                 await fetch(`https://${NOT_WHITELISTED_DOMAIN}/`, { method });


### PR DESCRIPTION
resolves: https://github.com/trezor/trezor-suite/issues/19265

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix_failing_test_when_server_down&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix_failing_test_when_server_down&lookback=7)