### PR TITLE
fix(suite-native): make sure that requeesting passphrase on device fl…

### DIFF
--- a/suite-native/module-authorize-device/src/screens/passphrase/PassphraseEnterOnTrezorScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/passphrase/PassphraseEnterOnTrezorScreen.tsx
@@ -65,12 +65,12 @@ export const PassphraseEnterOnTrezorScreen = () => {
     }, [isDeviceAuthorizationDone, navigation]);
 
     const handleCancel = () => {
+        dispatch(setInputPassphraseOnDevice(false));
         if (isCreatingNewWalletInstance) {
             if (device) {
                 dispatch(cancelDiscoveryThunk(device));
             }
             navigateToInitialScreen();
-            dispatch(setInputPassphraseOnDevice(false));
         } else {
             analytics.report({
                 type: EventType.PassphraseExit,


### PR DESCRIPTION
…ag is switched off frist before discovery is cancelled due to useEffect in useHandleDeviceRequestPassprase navigation hook

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19352

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19352-cant-input-passphrase-device-after-cancel-on-device&lookback=7)