### PR TITLE
test(suite-desktop): assing custom @group=connect

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/error.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/error.test.ts
@@ -2,7 +2,7 @@ import TrezorConnect from '@trezor/connect-web';
 
 import { expect, test } from '../../support/fixtures';
 
-test.describe('TrezorConnect', { tag: ['@group=suite', '@desktopOnly'] }, () => {
+test.describe('TrezorConnect', { tag: ['@group=connect', '@desktopOnly'] }, () => {
     test.use({ electronConf: { exposeConnectWs: true } });
     test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();

--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/ethereumSignMessage.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/ethereumSignMessage.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from '../../support/fixtures';
 
 test.describe(
     'TrezorConnect.ethereumSignMessage',
-    { tag: ['@group=suite', '@desktopOnly'] },
+    { tag: ['@group=connect', '@desktopOnly'] },
     () => {
         test.use({ electronConf: { exposeConnectWs: true } });
         test.beforeEach(async ({ onboardingPage }) => {

--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from '../../support/fixtures';
 
 test.describe(
     'TrezorConnect.ethereumSignTransaction',
-    { tag: ['@group=suite', '@desktopOnly'] },
+    { tag: ['@group=connect', '@desktopOnly'] },
     () => {
         test.use({ electronConf: { exposeConnectWs: true } });
         test.beforeEach(async ({ onboardingPage }) => {

--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/getAccountInfo.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/getAccountInfo.test.ts
@@ -2,7 +2,7 @@ import TrezorConnect from '@trezor/connect-web';
 
 import { expect, test } from '../../support/fixtures';
 
-test.describe('TrezorConnect.getAccountInfo', { tag: ['@group=suite', '@desktopOnly'] }, () => {
+test.describe('TrezorConnect.getAccountInfo', { tag: ['@group=connect', '@desktopOnly'] }, () => {
     test.use({ electronConf: { exposeConnectWs: true } });
     test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();

--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/getAddress.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/getAddress.test.ts
@@ -2,7 +2,7 @@ import TrezorConnect from '@trezor/connect-web';
 
 import { expect, test } from '../../support/fixtures';
 
-test.describe('TrezorConnect.getAddress', { tag: ['@group=suite', '@desktopOnly'] }, () => {
+test.describe('TrezorConnect.getAddress', { tag: ['@group=connect', '@desktopOnly'] }, () => {
     test.use({ electronConf: { exposeConnectWs: true } });
     test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();

--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/permissions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/permissions.test.ts
@@ -2,7 +2,7 @@ import TrezorConnect from '@trezor/connect-web';
 
 import { expect, test } from '../../support/fixtures';
 
-test.describe('TrezorConnect', { tag: ['@group=suite', '@desktopOnly'] }, () => {
+test.describe('TrezorConnect', { tag: ['@group=connect', '@desktopOnly'] }, () => {
     test.use({ electronConf: { exposeConnectWs: true } });
     test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();

--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/signTransaction.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/signTransaction.test.ts
@@ -2,7 +2,7 @@ import TrezorConnect from '@trezor/connect-web';
 
 import { test } from '../../support/fixtures';
 
-test.describe('TrezorConnect.signTransaction', { tag: ['@group=suite', '@desktopOnly'] }, () => {
+test.describe('TrezorConnect.signTransaction', { tag: ['@group=connect', '@desktopOnly'] }, () => {
     test.use({ electronConf: { exposeConnectWs: true } });
     test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();


### PR DESCRIPTION
makes sense to have @group=connect? 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-popup-tests-custom-grup&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-popup-tests-custom-grup&lookback=7)