### PR TITLE
fix(suite-native): remove bluetoothIpc dep from common

### DIFF
--- a/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
@@ -1,27 +1,22 @@
 import { BLUETOOTH_PREFIX, bluetoothActions } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
-import { TrezorDevice } from '@suite-common/suite-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
-import { Dispatch } from '../../types/suite';
-
 type UnpairCurrentBondParams = {
     bluetoothId: string;
-    device: TrezorDevice;
-    dispatch: Dispatch;
 };
 
-const unpairCurrentBond = async ({ bluetoothId, device, dispatch }: UnpairCurrentBondParams) => {
-    const result = await TrezorConnect.bleUnpair({ device, all: false });
-    if (
-        result.success ||
-        result.payload.code === 'Device_Disconnected' // This is an expected success
-    ) {
-        dispatch(bluetoothActions.removeKnownDeviceAction({ id: bluetoothId }));
+export const forgetBluetoothDevice = createThunk(
+    `${BLUETOOTH_PREFIX}/forgetBluetoothDevice`,
+    async (_, { getState, dispatch }) => {
+        const device = selectSelectedDevice(getState());
 
-        const resultForget = await bluetoothIpc.forgetDevice(bluetoothId);
+        if (!device || !device.bluetoothProps) return;
+
+        const resultForget = await bluetoothIpc.forgetDevice(device.bluetoothProps.id);
         if (!resultForget.success) {
             dispatch(
                 bluetoothActions.setBluetoothDeviceNeedsManualOsRemoval({
@@ -29,26 +24,41 @@ const unpairCurrentBond = async ({ bluetoothId, device, dispatch }: UnpairCurren
                 }),
             );
         }
-    } else {
-        dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
-    }
-};
+    },
+);
 
-type BluetoothEraseBondsThunkParams = {
-    device: TrezorDevice;
-};
+const unpairCurrentBond = createThunk<void, UnpairCurrentBondParams, void>(
+    `${BLUETOOTH_PREFIX}/unpairCurrentBond`,
+    async ({ bluetoothId }, { dispatch, getState }) => {
+        const device = selectSelectedDevice(getState());
 
-export const bluetoothEraseBondsThunk = createThunk<void, BluetoothEraseBondsThunkParams, void>(
+        if (!device) return;
+
+        const result = await TrezorConnect.bleUnpair({ device, all: false });
+        if (
+            result.success ||
+            result.payload.code === 'Device_Disconnected' // This is an expected success
+        ) {
+            dispatch(bluetoothActions.removeKnownDeviceAction({ id: bluetoothId }));
+            dispatch(forgetBluetoothDevice());
+        } else {
+            dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
+        }
+    },
+);
+
+export const bluetoothEraseBondsThunk = createThunk(
     `${BLUETOOTH_PREFIX}/bluetoothEraseBondsThunk`,
-    async ({ device }, { dispatch }) => {
-        if (!device.features?.capabilities.includes('Capability_BLE')) {
+    async (_, { dispatch, getState }) => {
+        const device = selectSelectedDevice(getState());
+        if (!device || !device.features?.capabilities.includes('Capability_BLE')) {
             return;
         }
 
         const bluetoothId = device.bluetoothProps?.id;
 
         if (bluetoothId !== undefined) {
-            await unpairCurrentBond({ bluetoothId, device, dispatch });
+            await dispatch(unpairCurrentBond({ bluetoothId }));
         }
     },
 );

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -36,6 +36,7 @@ import { reportCheckFail } from 'src/components/suite/SecurityCheck/useReportDev
 import { selectIsWindowVisible } from 'src/reducers/suite/windowReducer';
 import { fixLoadedCoinjoinAccount } from 'src/utils/wallet/coinjoinUtils';
 
+import { forgetBluetoothDevice } from '../actions/bluetooth/bluetoothEraseBondsThunk';
 import { METADATA, STORAGE } from '../actions/suite/constants';
 import * as suiteActions from '../actions/suite/suiteActions';
 import { selectSuiteSettings } from '../reducers/suite/suiteReducer';
@@ -69,6 +70,7 @@ export const extraDependencies: ExtraDependencies = {
         findLabelsToBeMovedOrDeleted,
         moveLabelsForRbfAction,
         openSwitchDeviceDialog,
+        forgetBluetoothDevice,
     },
     selectors: {
         selectDevices: (state: AppState) => state.device.devices,

--- a/packages/suite/src/views/settings/SettingsDevice/BluetoothEraseBonds.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/BluetoothEraseBonds.tsx
@@ -25,7 +25,7 @@ export const BluetoothEraseBonds = ({ isDeviceLocked }: BluetoothEraseBondsProps
 
     const onEraseClick = async () => {
         setInProgress(true);
-        await dispatch(bluetoothEraseBondsThunk({ device }));
+        await dispatch(bluetoothEraseBondsThunk());
         setInProgress(false);
     };
 

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -54,6 +54,7 @@ export type ExtraDependencies = {
             >;
         }>;
         openSwitchDeviceDialog: SuiteCompatibleThunk<void>;
+        forgetBluetoothDevice: SuiteCompatibleThunk<void>;
     };
     selectors: {
         selectDevices: SuiteCompatibleSelector<TrezorDevice[]>;

--- a/suite-common/test-utils/src/extraDependenciesMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesMock.ts
@@ -65,6 +65,7 @@ export const extraDependenciesMock: ExtraDependencies = {
         findLabelsToBeMovedOrDeleted: mockThunk('findLabelsToBeMovedOrDeleted'),
         moveLabelsForRbfAction: mockThunk('moveLabelsForRbfAction'),
         openSwitchDeviceDialog: mockThunk('openSwitchDeviceDialog'),
+        forgetBluetoothDevice: mockThunk('forgetBluetoothDevice'),
     },
     selectors: {
         selectDevices: mockSelector('selectDevices', []),

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -32,7 +32,6 @@
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
-        "@trezor/transport-bluetooth": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "date-fns": "^4.1.0",

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -27,7 +27,6 @@ import TrezorConnect, {
     UI,
 } from '@trezor/connect';
 import { getEnvironment } from '@trezor/env-utils';
-import { bluetoothIpc } from '@trezor/transport-bluetooth';
 import { exhaustive } from '@trezor/type-utils';
 import { isChanged } from '@trezor/utils';
 
@@ -553,15 +552,7 @@ export const wipeDeviceThunk = createThunk(
                 dispatch(
                     bluetoothActions.removeKnownDeviceAction({ id: device.bluetoothProps.id }),
                 );
-
-                const resultForget = await bluetoothIpc.forgetDevice(device.bluetoothProps.id);
-                if (!resultForget.success) {
-                    dispatch(
-                        bluetoothActions.setBluetoothDeviceNeedsManualOsRemoval({
-                            needsManualRemoval: true,
-                        }),
-                    );
-                }
+                dispatch(extra.thunks.forgetBluetoothDevice());
             }
             const newDevice = selectSelectedDevice(getState());
             const newDevices = selectDevices(getState());

--- a/suite-common/wallet-core/tsconfig.json
+++ b/suite-common/wallet-core/tsconfig.json
@@ -25,9 +25,6 @@
         { "path": "../../packages/connect" },
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/env-utils" },
-        {
-            "path": "../../packages/transport-bluetooth"
-        },
         { "path": "../../packages/type-utils" },
         { "path": "../../packages/utils" }
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -9693,7 +9693,6 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"
-    "@trezor/transport-bluetooth": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     date-fns: "npm:^4.1.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- having `@trezor/transport-bluetooth` in suite-common was a mistake since it's purely desktop implementation of bluetooth transport. This PR will remove the dependency and move parts of the code that are desktop specific to suite package while keeping calls that could be useful for both platforms in suite-common.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/remove-bluetoothipc-dep&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/remove-bluetoothipc-dep&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/remove-bluetoothipc-dep&lookback=7)