### PR TITLE
fix(suite): custom backends modal

### DIFF
--- a/packages/components/src/components/typography/Text/Text.tsx
+++ b/packages/components/src/components/typography/Text/Text.tsx
@@ -47,10 +47,10 @@ export type TextVariant = (typeof textVariants)[number];
 type ExclusiveColorOrVariant =
     | { variant?: TextVariant; color?: undefined }
     | {
-          variant?: undefined;
-          /** @deprecated Use only is case of absolute desperation. Prefer using `variant`. */
-          color?: string;
-      };
+        variant?: undefined;
+        /** @deprecated Use only is case of absolute desperation. Prefer using `variant`. */
+        color?: string;
+    };
 
 const variantColorMap: Record<TextVariant, Color> = {
     default: 'textDefault',
@@ -79,6 +79,7 @@ const getColorForTextVariant = ({ $variant, theme, $color }: ColorProps): CSSCol
 type StyledTextProps = ExclusiveColorOrVariant & {
     $isMonospaced?: boolean;
     $isHighlighted?: boolean;
+    $isUrl?: boolean;
 } & TransientProps<AllowedFrameProps & AllowedTextTextProps>;
 
 const StyledText = styled.span<StyledTextProps>`
@@ -100,6 +101,13 @@ const StyledText = styled.span<StyledTextProps>`
             box-decoration-break: clone;
         `}
 
+    ${({ $isUrl }) =>
+        $isUrl &&
+        css`
+            work-break: break-all;
+            overflow-wrap: anywhere;
+        `}
+
     ${withTextProps}
     ${withFrameProps}
 `;
@@ -109,6 +117,7 @@ export type TextProps = {
     className?: string;
     isMonospaced?: boolean;
     isHighlighted?: boolean;
+    isUrl?: boolean;
     as?: string;
     onClick?: () => void;
     'data-testid'?: string;
@@ -127,6 +136,7 @@ export const Text = ({
     onClick,
     isMonospaced,
     isHighlighted,
+    isUrl,
     role,
     ...rest
 }: TextProps) => {
@@ -142,6 +152,7 @@ export const Text = ({
             data-testid={dataTest}
             $isMonospaced={isMonospaced}
             $isHighlighted={isHighlighted}
+            $isUrl={isUrl}
             role={role}
             {...textProps}
             {...frameProps}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
@@ -177,6 +177,7 @@ export const AdvancedCoinSettingsModal = ({ symbol, onCancel }: AdvancedCoinSett
                                     inputState={backendsForm.input.error ? 'error' : undefined}
                                     bottomText={backendsForm.input.error?.message || null}
                                     innerRef={inputRef}
+                                    maxLength={backendsForm.maxUrlLength}
                                     innerAddon={
                                         <Button
                                             variant="primary"

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
@@ -145,6 +145,7 @@ export const AdvancedCoinSettingsModal = ({ symbol, onCancel }: AdvancedCoinSett
                                     >
                                         <Row gap={spacings.sm}>
                                             <Text
+                                                isUrl={true}
                                                 variant={
                                                     url === blockchain[symbol]?.url
                                                         ? 'default'

--- a/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
+++ b/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
@@ -156,6 +156,7 @@ export const useBackendsForm = (symbol: NetworkSymbol) => {
     };
 
     return {
+        maxUrlLength: 2048,
         type: currentValues.type,
         urls: currentValues.urls,
         input,


### PR DESCRIPTION
When adding a custom backend URL, you could end up with a very long URL that does not break to a new line. This results in the inability to remove it, as the remove button goes outside the view.

Additionally, adding a very long URL freezes the app.

**Solution**:
- extended Text.tsx with `isUrl` flag that enables break anywhere in the string
- adding maxUrlLength 2048

<!--- Describe your changes in detail -->

## Related Issue

Resolves https://github.com/trezor/trezor-suite/issues/17763

## Screenshots:
**Before**
<img width="662" alt="Screenshot 2025-06-05 at 9 54 50" src="https://github.com/user-attachments/assets/742a631a-4cc4-4de4-b664-ad216be1cc4b" />
**After**
<img width="685" alt="Screenshot 2025-06-05 at 10 38 48" src="https://github.com/user-attachments/assets/354cea82-2c6f-450b-9a46-a719dcdc6d98" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix(suite)/custom-backends-modal&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix(suite)/custom-backends-modal&lookback=7)