### PR TITLE
fix(suite-common): remove incorrect filtering in prepareSelectAllDevices

### DIFF
--- a/suite-common/bluetooth/src/bluetoothSelectors.ts
+++ b/suite-common/bluetooth/src/bluetoothSelectors.ts
@@ -1,7 +1,7 @@
 import { createWeakMapSelector } from '@suite-common/redux-utils';
 
 import { BluetoothState } from './bluetoothReducer';
-import { BluetoothDeviceCommon, BluetoothFilterPolicy } from './types';
+import { BluetoothDeviceCommon } from './types';
 
 export type WithBluetoothState<T extends BluetoothDeviceCommon> = {
     bluetooth: BluetoothState<T>;
@@ -46,9 +46,7 @@ export const prepareSelectAllDevices = <T extends BluetoothDeviceCommon>() =>
 
             knownDevices.forEach(knownDevice => map.set(knownDevice.id, knownDevice));
 
-            const nearbyDevicesCopy = (nearbyDevices ?? []).filter(
-                d => d.manufacturerData.filterPolicy === BluetoothFilterPolicy.UNFILTERED,
-            );
+            const nearbyDevicesCopy = [...(nearbyDevices ?? [])];
             nearbyDevicesCopy.forEach(nearbyDevice => {
                 map.delete(nearbyDevice.id); // Delete and re-add to change the order, replace would keep original order
                 map.set(nearbyDevice.id, nearbyDevice);


### PR DESCRIPTION
Filtering leads to UI glitches in Bluetooth connection dialog on macOS.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/common/bluetooth-all-devices&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/common/bluetooth-all-devices&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/common/bluetooth-all-devices&lookback=7)