### PR TITLE
19372 stuck on device passphrase

### DIFF
--- a/suite-native/device-authorization/src/hooks/useHandleDeviceRequestsPassphrase.ts
+++ b/suite-native/device-authorization/src/hooks/useHandleDeviceRequestsPassphrase.ts
@@ -56,8 +56,11 @@ export const useHandleDeviceRequestsPassphrase = () => {
     }, [deviceRequestedPassphrase, handleRequestPassphrase]);
 
     const handleRequestPassphraseOnDevice = useCallback(() => {
+        // NOTE: if the passphrase flow IS NOT in the beginning skip these calls
+        if (discovery?.isAddingHiddenWallet) return;
+
         navigation.navigate(AuthorizeDeviceStackRoutes.PassphraseEnterOnTrezor);
-    }, [navigation]);
+    }, [discovery?.isAddingHiddenWallet, navigation]);
 
     useEffect(() => {
         if (inputPassphraseOnDevice) {

--- a/suite-native/module-authorize-device/src/useRedirectOnPassphraseCompletion.ts
+++ b/suite-native/module-authorize-device/src/useRedirectOnPassphraseCompletion.ts
@@ -53,6 +53,12 @@ export const useRedirectOnPassphraseCompletion = () => {
     ]);
 
     useEffect(() => {
+        if (hasPassphraseError) {
+            navigateToInitialScreen();
+        }
+    }, [hasPassphraseError, navigateToInitialScreen]);
+
+    useEffect(() => {
         // User has canceled the authorization process on device (authorizeDeviceThunk rejects with auth-failed error)
         if (hasVerificationCancelledError && device) {
             analytics.report({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I didnt fix the original error, but I noticed 2 other bugs that I solved here 

## Related Issue

Resolve (somewhat) https://github.com/trezor/trezor-suite/issues/19372

- whe discovery fails during addition of the passphrase wallet, you aren't stuck on empty screen
- when going to the "enter passphrase on device" you aren't redirected twice there



## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19372-stuck-on-device-passphrase&lookback=7)