### PR TITLE
feat(suite): display icons for Connect and WalletConnect

### DIFF
--- a/packages/connect-explorer/src/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/actions/trezorConnectActions.ts
@@ -152,6 +152,7 @@ export const init =
                 email: 'info@trezor.io',
                 appUrl: '@trezor/connect-explorer',
                 appName: 'Trezor Connect Explorer',
+                appIcon: 'https://trezor.io/favicon/apple-touch-icon.png',
             },
             trustedHost: false,
             connectSrc: window.__TREZOR_CONNECT_SRC,

--- a/packages/suite/src/components/suite/ConnectAppIcon.tsx
+++ b/packages/suite/src/components/suite/ConnectAppIcon.tsx
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+
+import { IconCircle } from '@trezor/components';
+import { SpacingValues, spacings } from '@trezor/theme';
+
+import { useProxyImage } from 'src/hooks/suite/useProxyImage';
+
+const AppIconImage = styled.img<{ size: SpacingValues }>`
+    width: ${({ size }) => size}px;
+    height: ${({ size }) => size}px;
+    border-radius: ${({ size }) => size / 2}px;
+    background: ${({ theme }) => theme.backgroundNeutralSubtleOnElevation1};
+`;
+
+export const ConnectAppIcon = ({
+    src,
+    type,
+    size = spacings.xxl,
+}: {
+    src?: string;
+    type?: 'walletConnect' | 'trezorConnect';
+    size?: SpacingValues;
+}) => {
+    const { loading, error, imageBlob } = useProxyImage(src);
+
+    if (loading || error || !src || !imageBlob) {
+        return (
+            <IconCircle
+                name={type === 'walletConnect' ? 'walletConnect' : 'plugs'}
+                size={size}
+                paddingType={size > spacings.xxl ? 'large' : 'small'}
+                variant="tertiary"
+                hasBorder={false}
+            />
+        );
+    }
+
+    return <AppIconImage src={imageBlob} alt="App Icon" size={size} />;
+};

--- a/packages/suite/src/components/suite/ConnectCallSource.tsx
+++ b/packages/suite/src/components/suite/ConnectCallSource.tsx
@@ -1,8 +1,11 @@
 import { selectConnectPopupCall } from '@suite-common/connect-popup';
-import { Note, Text } from '@trezor/components';
+import { CALL_SOURCE_WALLETCONNECT } from '@suite-common/connect-popup/src/connectPopupTypes';
+import { Row, Text } from '@trezor/components';
+import { spacings } from '@trezor/theme';
 
 import { useSelector } from 'src/hooks/suite';
 
+import { ConnectAppIcon } from './ConnectAppIcon';
 import { Translation } from './Translation';
 
 export const ConnectCallSource = () => {
@@ -11,12 +14,23 @@ export const ConnectCallSource = () => {
         return null;
 
     return (
-        <Note iconName="plug">
-            <Translation id="TR_CONNECTED_TO" />
-            {': '}
-            <Text variant="primary">
-                {connectPopupCall.source?.manifest?.appName || connectPopupCall.source?.origin}
+        <Row gap={spacings.xs} alignItems="center">
+            <ConnectAppIcon
+                src={connectPopupCall.source?.manifest?.appIcon}
+                size={spacings.lg}
+                type={
+                    connectPopupCall.source?.type === CALL_SOURCE_WALLETCONNECT
+                        ? 'walletConnect'
+                        : 'trezorConnect'
+                }
+            />
+            <Text typographyStyle="hint" variant="tertiary">
+                <Translation id="TR_CONNECTED_TO" />
+                {': '}
+                <Text variant="primary">
+                    {connectPopupCall.source?.manifest?.appName || connectPopupCall.source?.origin}
+                </Text>
             </Text>
-        </Note>
+        </Row>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
@@ -2,22 +2,13 @@ import { useState } from 'react';
 
 import { connectPopupActions, selectConnectPopupCall } from '@suite-common/connect-popup';
 import { CALL_SOURCE_WALLETCONNECT } from '@suite-common/connect-popup/src/connectPopupTypes';
-import {
-    Card,
-    Checkbox,
-    Column,
-    Icon,
-    IconCircle,
-    List,
-    Modal,
-    Row,
-    Text,
-} from '@trezor/components';
+import { Card, Checkbox, Column, Icon, List, Modal, Row, Text } from '@trezor/components';
 import { ERRORS } from '@trezor/connect';
 import { EventTypeShared, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
+import { ConnectAppIcon } from 'src/components/suite/ConnectAppIcon';
 import { ConnectProcessLabel } from 'src/components/suite/ConnectProcessLabel';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { getPermissionText } from 'src/views/settings/SettingsConnectedApps/ConnectPermissions';
@@ -94,16 +85,14 @@ export const ConnectPermissionsModal = () => {
 
                 <Card>
                     <Row gap={spacings.md}>
-                        <IconCircle
-                            name={
+                        <ConnectAppIcon
+                            src={source.manifest?.appIcon}
+                            size={spacings.xxxxl}
+                            type={
                                 source.type === CALL_SOURCE_WALLETCONNECT
                                     ? 'walletConnect'
-                                    : 'plugs'
+                                    : 'trezorConnect'
                             }
-                            size={spacings.xxxxl}
-                            paddingType="large"
-                            variant="tertiary"
-                            hasBorder={false}
                         />
 
                         <Column gap={spacings.xxs}>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
@@ -16,7 +16,6 @@ import {
     Card,
     Column,
     ElevationUp,
-    IconCircle,
     Modal,
     Option,
     Row,
@@ -32,6 +31,7 @@ import { onCancel } from 'src/actions/suite/modalActions';
 import { goto } from 'src/actions/suite/routerActions';
 import { AccountLabel, Translation } from 'src/components/suite';
 import { AccountTypeBadge } from 'src/components/suite/AccountTypeBadge';
+import { ConnectAppIcon } from 'src/components/suite/ConnectAppIcon';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
 
@@ -133,12 +133,10 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                 </Text>
                 <Card>
                     <Row gap={spacings.md}>
-                        <IconCircle
-                            name="walletConnect"
+                        <ConnectAppIcon
+                            src={pendingProposal.params.proposer.metadata.icons[0]}
                             size={spacings.xxxxl}
-                            paddingType="large"
-                            variant="tertiary"
-                            hasBorder={false}
+                            type="walletConnect"
                         />
 
                         <Column gap={spacings.xxs}>

--- a/packages/suite/src/hooks/suite/useProxyImage.ts
+++ b/packages/suite/src/hooks/suite/useProxyImage.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+
+import { IMAGE_PROXY_API_AUTH_BEARER, IMAGE_PROXY_API_URL } from '@trezor/urls';
+
+/**
+ * Load a remote image using proxy to preserve privacy of our users.
+ * Display loadingComponent while the image is being fetched
+ * Display fallbackComponent if the image fails to load
+ */
+export const useProxyImage = (src?: string) => {
+    const [imageBlob, setImageBlob] = useState<string | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(false);
+
+    useEffect(() => {
+        let isCancelled = false;
+        setLoading(true);
+        setError(false);
+        setImageBlob(null);
+
+        if (!src) {
+            setLoading(false);
+            setError(true);
+
+            return;
+        }
+
+        fetch(`${IMAGE_PROXY_API_URL}?url=${encodeURIComponent(src)}`, {
+            headers: {
+                Authorization: `Bearer ${IMAGE_PROXY_API_AUTH_BEARER}`,
+            },
+        })
+            .then(res => {
+                if (!res.ok) throw new Error('Image fetch failed');
+
+                return res.blob();
+            })
+            .then(blob => {
+                if (!isCancelled) {
+                    const objectUrl = URL.createObjectURL(blob);
+                    setImageBlob(objectUrl);
+                }
+            })
+            .catch(() => {
+                if (!isCancelled) setError(true);
+            })
+            .finally(() => {
+                if (!isCancelled) setLoading(false);
+            });
+
+        return () => {
+            isCancelled = true;
+        };
+    }, [src]);
+
+    return {
+        imageBlob,
+        loading,
+        error,
+    };
+};

--- a/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
@@ -1,10 +1,11 @@
 import styled from 'styled-components';
 
 import { connectPopupActions, selectConnectAppPermissions } from '@suite-common/connect-popup';
-import { Card, Column, Dropdown, H3, IconCircle, Row, Text } from '@trezor/components';
+import { Card, Column, Dropdown, H3, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
+import { ConnectAppIcon } from 'src/components/suite/ConnectAppIcon';
 import { ConnectProcessLabel } from 'src/components/suite/ConnectProcessLabel';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
@@ -61,13 +62,7 @@ export const ConnectPermissions = () => {
                         padding={spacings.md}
                         data-testid={`@settings/connect-apps/${index}`}
                     >
-                        <IconCircle
-                            name="plugs"
-                            size={spacings.xxl}
-                            paddingType="small"
-                            variant="tertiary"
-                            hasBorder={false}
-                        />
+                        <ConnectAppIcon src={app.manifest?.appIcon} />
 
                         <Column flex="1">
                             <Row columnGap={spacings.sm} rowGap={spacings.xxxs} flexWrap="wrap">

--- a/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectList.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectList.tsx
@@ -1,31 +1,19 @@
-import { useState } from 'react';
-
-import styled from 'styled-components';
-
 import {
     getSessionNetworks,
     selectSessions,
     walletConnectDisconnectThunk,
 } from '@suite-common/walletconnect';
-import { Badge, Card, Column, Dropdown, H3, IconCircle, Row, Text } from '@trezor/components';
-import { spacings, spacingsPx } from '@trezor/theme';
+import { Badge, Card, Column, Dropdown, H3, Row, Text } from '@trezor/components';
+import { spacings } from '@trezor/theme';
 
 import * as modalActions from 'src/actions/suite/modalActions';
 import { Translation } from 'src/components/suite';
+import { ConnectAppIcon } from 'src/components/suite/ConnectAppIcon';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-
-const AppIconImage = styled.img`
-    width: ${spacingsPx.xxl};
-    height: ${spacingsPx.xxl};
-    border-radius: ${spacingsPx.md};
-    background: ${({ theme }) => theme.backgroundNeutralSubtleOnElevation1};
-`;
 
 export const WalletConnectList = () => {
     const dispatch = useDispatch();
     const sessions = useSelector(selectSessions);
-    // TODO: we need some sort of proxy to load images from 3rd parties securely
-    const [fallbackIcon, setFallbackIcon] = useState(true);
 
     if (sessions.length === 0) {
         return (
@@ -50,20 +38,7 @@ export const WalletConnectList = () => {
                         padding={spacings.md}
                         data-testid={`@settings/walletconnect-apps/${index}`}
                     >
-                        {fallbackIcon ? (
-                            <IconCircle
-                                name="walletConnect"
-                                size={spacings.xxl}
-                                paddingType="small"
-                                variant="tertiary"
-                                hasBorder={false}
-                            />
-                        ) : (
-                            <AppIconImage
-                                src={session.peer.metadata.icons[0]}
-                                onError={() => setFallbackIcon(true)}
-                            />
-                        )}
+                        <ConnectAppIcon src={session.peer.metadata.icons[0]} type="walletConnect" />
                         <Column flex="1">
                             <Row columnGap={spacings.sm} rowGap={spacings.xxxs} flexWrap="wrap">
                                 <Text>{session.peer.metadata.name}</Text>

--- a/packages/urls/src/index.ts
+++ b/packages/urls/src/index.ts
@@ -5,6 +5,7 @@ export * from './urls';
 export * from './github';
 export * from './tor';
 export * from './deeplinks';
+export * from './keys';
 
 type AllUrls = typeof Urls & typeof GithubUrls;
 export type Url = AllUrls[keyof AllUrls];

--- a/packages/urls/src/keys.ts
+++ b/packages/urls/src/keys.ts
@@ -1,0 +1,3 @@
+// This is not a secret token, but it is used to prevent unauthorized access to the image proxy API.
+// Eg. phishing links that display harmful content though the image proxy.
+export const IMAGE_PROXY_API_AUTH_BEARER = 'X4kceZjHiyKQie63RnJ9G5u2';

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -175,3 +175,4 @@ export const TRADING_DOWNLOAD_INVITY_APP_URL: Url = 'https://get.invity.io';
 export const UNINSTALL_BRIDGE_URL: Url = 'https://trezor.io/learn/a/what-is-trezor-bridge';
 
 export const GEOLOCATION_API_URL = 'https://services.trezor.io/get-country/';
+export const IMAGE_PROXY_API_URL = 'https://services.trezor.io/image-proxy/';


### PR DESCRIPTION
## Description

Display icons for Connect and WalletConnect, using a new image proxy service that we host to protect our users from directly loading from 3rd party servers.

## Screenshots:

<img width="1238" alt="Screenshot 2025-06-05 at 16 05 25" src="https://github.com/user-attachments/assets/a9cfc983-9c2c-47c0-a950-bf5726c8e5ae" />

<img width="725" alt="Screenshot 2025-06-05 at 16 05 05" src="https://github.com/user-attachments/assets/95280742-37b8-4f70-b041-9ddaeea6f8ca" />

<img width="725" alt="Screenshot 2025-06-05 at 16 05 16" src="https://github.com/user-attachments/assets/3a0e44ae-1d48-411d-80fd-57684f0a3808" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-app-icons&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connect-app-icons&lookback=7)