### PR TITLE
Pagination - added ellipses for numerous pages

### DIFF
--- a/packages/suite/src/components/wallet/Pagination.tsx
+++ b/packages/suite/src/components/wallet/Pagination.tsx
@@ -1,14 +1,18 @@
-import { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
 
 import styled, { css } from 'styled-components';
 
-import { Button } from '@trezor/components';
-import { borders, spacingsPx, typography } from '@trezor/theme';
+import { Button, Row } from '@trezor/components';
+import { NumberInput } from '@trezor/product-components';
+import { borders, spacings, spacingsPx, typography } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
+import { selectLanguage } from 'src/reducers/suite/suiteReducer';
 
 const Wrapper = styled.div<{ $hasPages?: boolean }>`
     display: flex;
+    align-items: center;
     justify-content: center;
     flex-wrap: wrap;
     gap: ${$hasPages => ($hasPages ? spacingsPx.xs : spacingsPx.xxxs)};
@@ -42,13 +46,43 @@ const PageItem = styled.div<{ $isActive?: boolean }>`
         `};
 `;
 
+const Ellipsis = styled(PageItem)`
+    cursor: default;
+
+    &:hover {
+        background: transparent;
+        color: inherit;
+    }
+`;
+
 const Actions = styled.div<{ $isActive: boolean }>`
     display: flex;
     visibility: ${props => (props.$isActive ? 'auto' : 'hidden')};
     ${typography.callout};
 `;
 
-const LIMITED_NUMBER_OF_NEXT_VISIBLE_PAGES = 2;
+export interface GetPagesProps {
+    currentPage: number;
+    totalPages: number;
+}
+
+export type Page = number | '...';
+
+export const getPages = ({ currentPage: page, totalPages: total }: GetPagesProps): Page[] => {
+    if (total <= 7) {
+        return [...Array(total)].map((_, i) => i + 1);
+    }
+
+    if (page <= 4) {
+        return [1, 2, 3, 4, 5, '...', total];
+    }
+
+    if (page >= total - 3) {
+        return [1, '...', total - 4, total - 3, total - 2, total - 1, total];
+    }
+
+    return [1, '...', page - 1, page, page + 1, '...', total];
+};
 
 interface PaginationProps {
     currentPage: number;
@@ -56,7 +90,7 @@ interface PaginationProps {
     hasPages?: boolean;
     perPage: number;
     totalItems: number;
-    isPageListLimited?: boolean;
+    explicitNavigation?: boolean;
     onPageSelected: (page: number) => void;
 }
 
@@ -67,21 +101,38 @@ export const Pagination = ({
     isLastPage,
     perPage,
     totalItems,
-    isPageListLimited,
+    explicitNavigation = false,
     ...rest
 }: PaginationProps) => {
+    const locale = useSelector(selectLanguage);
+
     const totalPages = Math.ceil(totalItems / perPage);
-    const showPrevious = currentPage > 1;
-    // array of int used for creating all page buttons
-    const calculatedPages = useMemo(
-        () => [...Array(totalPages)].map((_p, i) => i + 1),
-        [totalPages],
-    );
+    const showPrev = currentPage > 1;
+    const showNext = currentPage < totalPages;
+
+    const { control, watch } = useForm({
+        defaultValues: {
+            pageInput: currentPage.toString(),
+        },
+    });
+
+    const pageInput = watch('pageInput');
+
+    const isPageInputInvalid =
+        !Number.isInteger(Number(pageInput)) ||
+        Number(pageInput) < 1 ||
+        Number(pageInput) > totalPages;
+
+    const pageNumbers = getPages({ currentPage, totalPages });
+
+    const goToPage = () => {
+        onPageSelected(Number(pageInput));
+    };
 
     if (!hasPages) {
         return (
             <Wrapper $hasPages={hasPages} {...rest}>
-                <Actions $isActive={showPrevious}>
+                <Actions $isActive={showPrev}>
                     <Button
                         onClick={() => onPageSelected(currentPage - 1)}
                         icon="caretLeft"
@@ -107,56 +158,43 @@ export const Pagination = ({
 
     return (
         <Wrapper $hasPages={hasPages} {...rest}>
-            <Actions $isActive={showPrevious}>
-                {currentPage > 2 && <PageItem onClick={() => onPageSelected(1)}>«</PageItem>}
+            <Actions $isActive={showPrev}>
                 <PageItem onClick={() => onPageSelected(currentPage - 1)}>‹</PageItem>
             </Actions>
 
-            {totalPages ? (
-                calculatedPages
-                    .slice(
-                        0,
-                        isPageListLimited
-                            ? currentPage + LIMITED_NUMBER_OF_NEXT_VISIBLE_PAGES
-                            : calculatedPages.length,
-                    )
-                    .map(i => (
-                        <PageItem
-                            key={i}
-                            data-testid={`@wallet/accounts/pagination/${i}`}
-                            data-test-activated={i === currentPage}
-                            onClick={() => onPageSelected(i)}
-                            $isActive={i === currentPage}
-                        >
-                            {i}
-                        </PageItem>
-                    ))
-            ) : (
-                <>
-                    {[...Array(currentPage - 1)].map((_p, i) => (
-                        // this is fine, read "exception from the rule"
-                        // the list is never reordered/filtered, items have no ids, list/items do not change
-                        // https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318
-                        <PageItem
-                            key={i}
-                            data-testid={`@wallet/accounts/pagination/${i + 1}`}
-                            onClick={() => onPageSelected(i + 1)}
-                        >
-                            {i + 1}
-                        </PageItem>
-                    ))}
-                    <PageItem onClick={() => onPageSelected(currentPage)} $isActive>
-                        {currentPage}
+            {pageNumbers.map((page, index) =>
+                page === '...' ? (
+                    <Ellipsis key={`ellipsis-${index}`}>...</Ellipsis>
+                ) : (
+                    <PageItem
+                        key={page}
+                        data-testid={`@wallet/accounts/pagination/${page}`}
+                        data-test-activated={page === currentPage}
+                        onClick={() => (page !== currentPage ? onPageSelected(page) : {})}
+                        $isActive={page === currentPage}
+                    >
+                        {page}
                     </PageItem>
-                </>
+                ),
             )}
 
-            <Actions $isActive={currentPage < (totalPages || 1)}>
+            <Actions $isActive={showNext}>
                 <PageItem onClick={() => onPageSelected(currentPage + 1)}>›</PageItem>
-                {totalPages && totalPages > 2 && !isPageListLimited && (
-                    <PageItem onClick={() => onPageSelected(totalPages)}>»</PageItem>
-                )}
             </Actions>
+
+            {explicitNavigation && (
+                <Row alignItems="center" gap={spacings.sm} maxWidth="140px">
+                    <NumberInput name="pageInput" control={control} locale={locale} size="small" />
+                    <Button
+                        variant="tertiary"
+                        onClick={goToPage}
+                        size="small"
+                        isDisabled={isPageInputInvalid}
+                    >
+                        <Translation id="TR_PAGINATION_GO" />
+                    </Button>
+                </Row>
+            )}
         </Wrapper>
     );
 };

--- a/packages/suite/src/components/wallet/__tests__/getPages.test.ts
+++ b/packages/suite/src/components/wallet/__tests__/getPages.test.ts
@@ -1,0 +1,47 @@
+import { getPages } from '../Pagination';
+
+describe('getPages', () => {
+    it('should show all pages when there page count is less or equal to stride + 2', () => {
+        const currentPage = 1;
+
+        for (let totalPages = 1; totalPages <= 7; totalPages++) {
+            const result = getPages({ currentPage, totalPages });
+            expect(result).toEqual([...Array(totalPages)].map((_, i) => i + 1));
+        }
+    });
+
+    it('should show first pages correctly when current page is near start', () => {
+        const totalPages = 10;
+
+        for (let currentPage = 1; currentPage < 5; currentPage++) {
+            const result = getPages({ currentPage, totalPages });
+            expect(result).toEqual([1, 2, 3, 4, 5, '...', 10]);
+        }
+    });
+
+    it('should show last pages correctly when current page is near end', () => {
+        const totalPages = 10;
+
+        for (let currentPage = 7; currentPage <= totalPages; currentPage++) {
+            const result = getPages({ currentPage, totalPages });
+            expect(result).toEqual([1, '...', 6, 7, 8, 9, 10]);
+        }
+    });
+
+    it('should show middle pages correctly', () => {
+        const totalPages = 20;
+
+        for (let currentPage = 5; currentPage <= 16; currentPage++) {
+            const result = getPages({ currentPage, totalPages });
+            expect(result).toEqual([
+                1,
+                '...',
+                currentPage - 1,
+                currentPage,
+                currentPage + 1,
+                '...',
+                20,
+            ]);
+        }
+    });
+});

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6886,6 +6886,10 @@ export default defineMessages({
         id: 'TR_PAGINATION_OLDER',
         defaultMessage: 'Older',
     },
+    TR_PAGINATION_GO: {
+        id: 'TR_PAGINATION_GO',
+        defaultMessage: 'Go',
+    },
     TR_TXID: {
         id: 'TR_TXID',
         defaultMessage: 'TX ID',

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/components/Rewards/RewardsList.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/components/Rewards/RewardsList.tsx
@@ -157,6 +157,7 @@ export const RewardsList = ({ account }: RewardsListProps) => {
                     perPage={itemsPerPage}
                     totalItems={totalItems}
                     onPageSelected={onPageSelected}
+                    explicitNavigation
                 />
             )}
         </DashboardSection>

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
@@ -33,7 +33,6 @@ interface TransactionListProps {
     symbol: WalletAccountTransaction['symbol'];
     isLoading?: boolean;
     account: Account;
-    isPagingLimited?: boolean;
     customTotalItems?: number;
     customNoTransactions?: ReactNode;
     isExportable?: boolean;
@@ -47,7 +46,6 @@ export const TransactionList = ({
     isLoading,
     account,
     symbol,
-    isPagingLimited,
     customNoTransactions,
     customTotalItems,
     onPageRequested,
@@ -204,13 +202,13 @@ export const TransactionList = ({
 
             {showPagination && (
                 <Pagination
-                    isPageListLimited={Boolean(isPagingLimited)}
                     hasPages={!isRippleOrStellar}
                     currentPage={currentPage}
                     isLastPage={isLastRippleOrStellarPage}
                     perPage={perPage}
                     totalItems={totalItems}
                     onPageSelected={onPageSelected}
+                    explicitNavigation
                 />
             )}
         </DashboardSection>

--- a/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
@@ -50,7 +50,6 @@ export const WalletTransactionList = ({
             key={account.key} // NOTE: ensure that transaction list is unmounted when account key changes
             customPageFetching={fraudTransactionPossible}
             customNoTransactions={<NoVisibleTransactions />}
-            isPagingLimited={fraudTransactionPossible}
             allTransactions={result.allTransactions}
             transactions={result.visibleTransactions}
             symbol={symbol}


### PR DESCRIPTION
## Description

Added ellipses to pagination when there are more than 7 pages.

## Related Issue

Resolve #16565 

## Screenshots:

<img width="500" alt="Screenshot 2025-06-05 at 16 58 04" src="https://github.com/user-attachments/assets/c21a9d3b-7fcb-4ffa-acbb-e026f65d7b68" />

<img width="500" alt="Screenshot 2025-06-05 at 16 58 10" src="https://github.com/user-attachments/assets/b5210ed7-2622-41c6-b52a-4d8bddd4ba54" />

<img width="500" alt="Screenshot 2025-06-05 at 16 58 16" src="https://github.com/user-attachments/assets/8e982ce7-8841-4e00-8b1c-58c1cec786f5" />

<img width="500" alt="Screenshot 2025-06-05 at 16 58 28" src="https://github.com/user-attachments/assets/be0cb8ac-9a35-48ae-bf73-011fb42522f9" />

<img width="500" alt="Screenshot 2025-06-05 at 16 58 35" src="https://github.com/user-attachments/assets/7b934ff9-6edb-4b5e-abde-ec823e7fde45" />

Explicit page navigation:

<img width="500" alt="Screenshot 2025-06-06 at 12 28 31" src="https://github.com/user-attachments/assets/e82f74a0-575d-4b01-9f8f-32ea12c1a830" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/pagination&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/pagination&lookback=7)