### PR TITLE
fix(connect-common): bump bl version to 2.1.10 on t3b1

### DIFF
--- a/packages/connect-common/files/firmware/t3b1/releases.json
+++ b/packages/connect-common/files/firmware/t3b1/releases.json
@@ -4,7 +4,7 @@
         "version": [2, 8, 10],
         "min_bootloader_version": [2, 1, 7],
         "min_firmware_version": [2, 8, 3],
-        "bootloader_version": [2, 1, 8],
+        "bootloader_version": [2, 1, 10],
         "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR"],
         "url": "firmware/t3b1/trezor-t3b1-2.8.10.bin",
         "url_bitcoinonly": "firmware/t3b1/trezor-t3b1-2.8.10-bitcoinonly.bin",


### PR DESCRIPTION


To fix the issue for device.Firmware.release.not.set, I'm bumping the BL version FW 2.8.10 to 2.1.10  (T3B1). 

@trezor/qa please test properly. 


![image](https://github.com/user-attachments/assets/e8513e5b-26e5-4a5a-b796-ac8d65687adc)
![image](https://github.com/user-attachments/assets/726314ee-1942-438b-a7e7-fca2efb9efb9)


How to replicate the issue (on develop and production):
-  update T3B1 to latest FW (2.8.10), 
- wipe it and then re-install it

The installation should work properly on this PR. 