### PR TITLE
Mobile trade: do not filter trade history selectors by tradeType

### DIFF
--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -27,9 +27,8 @@ import {
     TradingRootState,
     selectBestBuyQuoteByPaymentMethod,
     selectBuyQuotesByPaymentMethod,
-    selectDeviceHasTradingTradesOfTradeType,
-    selectDeviceTradingTradesByTradeType,
-    selectDeviceTradingTradesByTradeTypeOrderedByDate,
+    selectDeviceHasTradingTrades,
+    selectDeviceTradingTradesOrderedByDate,
     selectTrading,
     selectTradingAccountAccordingActiveSection,
     selectTradingActiveSection,
@@ -569,43 +568,29 @@ describe('tradingSelectors', () => {
         expect(selectTradingTrades(state)).toBe(state.wallet.tradingNew.trades);
     });
 
-    it('selectDeviceTradingTradesByTradeType should return only data for relevant tradeType', () => {
-        expect(
-            selectDeviceTradingTradesByTradeType(state, 'buy').map(t => t.data.orderId),
-        ).toStrictEqual(['orderId1', 'orderId2', 'orderId3']);
-
-        expect(
-            selectDeviceTradingTradesByTradeType(state, 'exchange').map(t => t.data.orderId),
-        ).toStrictEqual(['orderId4', 'orderId5']);
-    });
-
-    describe('selectDeviceTradingTradesByTradeTypeOrderedByDate', () => {
+    describe('selectDeviceTradingTradesOrderedByDate', () => {
         it('should return trades ordered by date in descending order', () => {
-            const result = selectDeviceTradingTradesByTradeTypeOrderedByDate(state, 'buy');
+            const result = selectDeviceTradingTradesOrderedByDate(state);
 
-            expect(result).toHaveLength(3);
-            expect(result[0].data.orderId).toBe('orderId3');
-            expect(result[1].data.orderId).toBe('orderId2');
-            expect(result[2].data.orderId).toBe('orderId1');
-        });
-
-        it('should return empty array for trade type with no trades', () => {
-            const result = selectDeviceTradingTradesByTradeTypeOrderedByDate(state, 'sell');
-
-            expect(result).toHaveLength(0);
+            expect(result).toHaveLength(5);
+            expect(result[0].data.orderId).toBe('orderId4');
+            expect(result[1].data.orderId).toBe('orderId3');
+            expect(result[2].data.orderId).toBe('orderId2');
+            expect(result[3].data.orderId).toBe('orderId1');
+            expect(result[4].data.orderId).toBe('orderId5');
         });
 
         it('should be stable', () => {
-            const first = selectDeviceTradingTradesByTradeTypeOrderedByDate(state, 'buy');
-            const second = selectDeviceTradingTradesByTradeTypeOrderedByDate(state, 'buy');
+            const first = selectDeviceTradingTradesOrderedByDate(state);
+            const second = selectDeviceTradingTradesOrderedByDate(state);
 
             expect(first).toBe(second);
         });
     });
 
     it('selectDeviceHasTradingTradesOfTradeType should return correctly whether there is a trade', () => {
-        expect(selectDeviceHasTradingTradesOfTradeType(state, 'buy')).toBe(true);
-        expect(selectDeviceHasTradingTradesOfTradeType(state, 'sell')).toBe(false);
+        expect(selectDeviceHasTradingTrades(state)).toBe(true);
+        
     });
 
     it('selectTradingTradeByOrderId should find trade for correct orderId', () => {

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -590,7 +590,6 @@ describe('tradingSelectors', () => {
 
     it('selectDeviceHasTradingTradesOfTradeType should return correctly whether there is a trade', () => {
         expect(selectDeviceHasTradingTrades(state)).toBe(true);
-        
     });
 
     it('selectTradingTradeByOrderId should find trade for correct orderId', () => {

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -301,14 +301,9 @@ export const selectTradingTradesForSelectedDevice = createMemoizedSelector(
 
 export const selectDeviceTradingTrades: (
     state: TradingRootState & AccountsRootState & DeviceRootState,
-    tradeType: TradingType,
 ) => TradingTransaction[] = createMemoizedSelectorWithDeviceAndAccounts(
-    [
-        state => selectDeviceAccounts(state),
-        selectTradingTrades,
-        (_, tradeType: TradingType) => tradeType,
-    ],
-    (accounts, trades, tradeType) => {
+    [state => selectDeviceAccounts(state), selectTradingTrades],
+    (accounts, trades) => {
         const accountKeys = new Set(accounts.map(({ key }) => key));
 
         return returnStableArrayIfEmpty(
@@ -316,32 +311,22 @@ export const selectDeviceTradingTrades: (
                 const tradeKey =
                     'selectedAccountKey' in trade ? trade.selectedAccountKey : trade.sendAccountKey;
 
-                return tradeKey && accountKeys.has(tradeKey) && trade.tradeType === tradeType;
+                return tradeKey && accountKeys.has(tradeKey);
             }),
         );
     },
 );
 
-export const selectDeviceTradingTradesByTradeType: (
+export const selectDeviceTradingTradesOrderedByDate: (
     state: TradingRootState & AccountsRootState & DeviceRootState,
-    tradeType: TradingType,
 ) => TradingTransaction[] = createMemoizedSelectorWithDeviceAndAccounts(
-    [selectDeviceTradingTrades, (_, tradeType: TradingType) => tradeType],
-    (trades, tradeType) => returnStableArrayIfEmpty(trades.filter(t => t.tradeType === tradeType)),
-);
-
-export const selectDeviceTradingTradesByTradeTypeOrderedByDate: (
-    state: TradingRootState & AccountsRootState & DeviceRootState,
-    tradeType: TradingType,
-) => TradingTransaction[] = createMemoizedSelectorWithDeviceAndAccounts(
-    [selectDeviceTradingTradesByTradeType],
+    [selectDeviceTradingTrades],
     trades => trades.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()),
 );
 
-export const selectDeviceHasTradingTradesOfTradeType = (
+export const selectDeviceHasTradingTrades = (
     state: TradingRootState & AccountsRootState & DeviceRootState,
-    tradeType: TradingType,
-) => selectDeviceTradingTradesByTradeType(state, tradeType).length > 0;
+) => selectDeviceTradingTrades(state).length > 0;
 
 export const selectTradingTradeByOrderId = (state: TradingRootState, orderId: string | undefined) =>
     selectTradingTrades(state).find(t => orderId && t.data.orderId === orderId);

--- a/suite-native/module-trading/src/components/general/HistoryButton.tsx
+++ b/suite-native/module-trading/src/components/general/HistoryButton.tsx
@@ -4,11 +4,7 @@ import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import {
-    TradingRootState,
-    TradingType,
-    selectDeviceHasTradingTradesOfTradeType,
-} from '@suite-common/trading';
+import { TradingRootState, selectDeviceHasTradingTrades } from '@suite-common/trading';
 import { AccountsRootState, DeviceRootState } from '@suite-common/wallet-core';
 import { AnimatedBox, HStack, Text } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
@@ -24,7 +20,6 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles/src';
 import { selectIsAmountInputActive } from '../../selectors/commonSelectors';
 
 export type HistoryButtonProps = {
-    tradeType: TradingType;
     isFormMountedRecently?: boolean;
 };
 
@@ -48,11 +43,11 @@ const buttonStyle = prepareNativeStyle(utils => ({
     alignItems: 'center',
 }));
 
-export const HistoryButton = ({ tradeType, isFormMountedRecently }: HistoryButtonProps) => {
+export const HistoryButton = ({ isFormMountedRecently }: HistoryButtonProps) => {
     const { applyStyle } = useNativeStyles();
     const navigation = useNavigation<NavigationProps>();
     const hasTrades = useSelector((state: TradingRootState & AccountsRootState & DeviceRootState) =>
-        selectDeviceHasTradingTradesOfTradeType(state, tradeType),
+        selectDeviceHasTradingTrades(state),
     );
     const shouldHideButton = useSelector(selectIsAmountInputActive);
 
@@ -60,8 +55,7 @@ export const HistoryButton = ({ tradeType, isFormMountedRecently }: HistoryButto
         return null;
     }
 
-    const handleOnPress = () =>
-        navigation.navigate(TradingStackRoutes.TradingHistory, { tradeType });
+    const handleOnPress = () => navigation.navigate(TradingStackRoutes.TradingHistory);
 
     return (
         <AnimatedBox

--- a/suite-native/module-trading/src/components/general/__tests__/HistoryButton.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/HistoryButton.comp.test.tsx
@@ -2,13 +2,12 @@ import { PreloadedState, fireEvent, renderWithStoreProviderAsync } from '@suite-
 
 import { HistoryButton } from '../HistoryButton';
 
-let mockSelectDeviceHasTradingTradesOfTradeTypeReturn: boolean;
+let mockSelectDeviceHasTradingTradesReturn: boolean;
 let mockNavigate: jest.Mock;
 
 jest.mock('@suite-common/trading', () => ({
     ...jest.requireActual('@suite-common/trading'),
-    selectDeviceHasTradingTradesOfTradeType: () =>
-        mockSelectDeviceHasTradingTradesOfTradeTypeReturn,
+    selectDeviceHasTradingTrades: () => mockSelectDeviceHasTradingTradesReturn,
 }));
 
 jest.mock('@react-navigation/native', () => ({
@@ -20,12 +19,12 @@ jest.mock('@react-navigation/native', () => ({
 
 describe('HistoryButton', () => {
     const renderHistoryButton = (preloadedState: PreloadedState) =>
-        renderWithStoreProviderAsync(<HistoryButton tradeType="buy" />, {
+        renderWithStoreProviderAsync(<HistoryButton />, {
             preloadedState,
         });
 
     it('should render nothing where no trades are available', async () => {
-        mockSelectDeviceHasTradingTradesOfTradeTypeReturn = false;
+        mockSelectDeviceHasTradingTradesReturn = false;
         const { toJSON } = await renderHistoryButton({});
 
         expect(toJSON()).toBeNull();
@@ -33,7 +32,7 @@ describe('HistoryButton', () => {
 
     describe('with trades available', () => {
         beforeEach(() => {
-            mockSelectDeviceHasTradingTradesOfTradeTypeReturn = true;
+            mockSelectDeviceHasTradingTradesReturn = true;
             mockNavigate = jest.fn();
         });
 
@@ -60,9 +59,7 @@ describe('HistoryButton', () => {
 
             fireEvent.press(getByText('Trade history'));
 
-            expect(mockNavigate).toHaveBeenCalledWith('TradingHistory', {
-                tradeType: 'buy',
-            });
+            expect(mockNavigate).toHaveBeenCalledWith('TradingHistory');
         });
     });
 });

--- a/suite-native/module-trading/src/screens/TradingHistoryScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingHistoryScreen.tsx
@@ -2,22 +2,16 @@ import { useCallback, useEffect, useState } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { RouteProp, useRoute } from '@react-navigation/native';
 import { FlashList } from '@shopify/flash-list';
 
 import {
     TradingRootState,
     TradingTransaction,
-    selectDeviceTradingTradesByTradeTypeOrderedByDate,
+    selectDeviceTradingTradesOrderedByDate,
 } from '@suite-common/trading';
 import { AccountsRootState, DeviceRootState } from '@suite-common/wallet-core';
 import { useTranslate } from '@suite-native/intl';
-import {
-    Screen,
-    ScreenHeader,
-    TradingStackParamList,
-    TradingStackRoutes,
-} from '@suite-native/navigation';
+import { Screen, ScreenHeader } from '@suite-native/navigation';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { TradeDetailSheet } from '../components/history/TradeDetailSheet/TradeDetailSheet';
@@ -38,9 +32,6 @@ const contentContainerStyle = prepareNativeStyle<{
 const keyExtractor = (item: TradingTransaction) => `${item.key ?? ''}`;
 
 export const TradingHistoryScreen = () => {
-    const {
-        params: { tradeType },
-    } = useRoute<RouteProp<TradingStackParamList, TradingStackRoutes.TradingHistory>>();
     const { applyStyle } = useNativeStyles();
     const { translate } = useTranslate();
     const dispatch = useDispatch();
@@ -49,7 +40,7 @@ export const TradingHistoryScreen = () => {
     const [detailOrderId, setDetailOrderId] = useState<string | undefined>(undefined);
     const { isSheetVisible, showSheet, hideSheet } = useBottomSheetControls();
     const trades = useSelector((state: TradingRootState & AccountsRootState & DeviceRootState) =>
-        selectDeviceTradingTradesByTradeTypeOrderedByDate(state, tradeType),
+        selectDeviceTradingTradesOrderedByDate(state),
     );
 
     const handleSelectedTrade = useCallback(

--- a/suite-native/module-trading/src/screens/TradingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingScreen.tsx
@@ -37,9 +37,7 @@ const TradingScreenContent = () => {
                 type: EventType.TradingSuccess,
                 payload: { type: tradeToBeOpened.tradeType },
             });
-            navigation.navigate(TradingStackRoutes.TradingHistory, {
-                tradeType: tradeToBeOpened.tradeType,
-            });
+            navigation.navigate(TradingStackRoutes.TradingHistory);
         }
     }, [tradeToBeOpened, navigation]);
 
@@ -54,7 +52,7 @@ const TradingScreenContent = () => {
                 <Header isFormMountedRecently={isScreenMountedRecently} />
                 {isInternetReachable === false ? <DeviceOffline /> : <ActiveTab />}
                 <Footer isFormMountedRecently={isScreenMountedRecently} />
-                <HistoryButton tradeType="buy" isFormMountedRecently={isScreenMountedRecently} />
+                <HistoryButton isFormMountedRecently={isScreenMountedRecently} />
             </VStack>
         </>
     );

--- a/suite-native/module-trading/src/screens/__tests__/TradingHistoryScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingHistoryScreen.comp.test.tsx
@@ -1,24 +1,14 @@
 import { RouteProp } from '@react-navigation/native';
 
-import { TradingTransaction, TradingType } from '@suite-common/trading';
 import { Account } from '@suite-common/wallet-types';
 import { TradingStackParamList, TradingStackRoutes } from '@suite-native/navigation';
-import {
-    PreloadedState,
-    act,
-    fireEvent,
-    renderWithStoreProviderAsync,
-} from '@suite-native/test-utils';
+import { PreloadedState, fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 import { StaticSessionId } from '@trezor/connect';
 
 import fixturesAccounts from '../../__fixtures__/accounts.json';
-import { getBuyTrade, getExchangeTrade } from '../../__fixtures__/trades';
+import { getBuyTrade } from '../../__fixtures__/trades';
 import { getInitializedTradingState } from '../../__fixtures__/tradingState';
 import { TradingHistoryScreen } from '../TradingHistoryScreen';
-
-let mockRouteParams: {
-    tradeType: TradingType;
-} = { tradeType: 'buy' };
 
 const mockShowSheet = jest.fn();
 
@@ -26,7 +16,7 @@ jest.mock('@react-navigation/native', () => ({
     ...jest.requireActual('@react-navigation/native'),
     useRoute: () =>
         ({
-            params: { ...mockRouteParams },
+            params: undefined,
         }) as RouteProp<TradingStackParamList, TradingStackRoutes.TradingHistory>,
 }));
 
@@ -48,14 +38,11 @@ jest.mock('@suite-common/trading', () => {
     };
 });
 
-const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
-const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
-
-const getPreloadedState = (trades: TradingTransaction[]): PreloadedState => ({
+const getPreloadedState = (): PreloadedState => ({
     wallet: {
         tradingNew: {
             ...getInitializedTradingState(),
-            trades,
+            trades: [getBuyTrade({ status: 'SUBMITTED' })],
         },
         accounts: fixturesAccounts as Account[],
     },
@@ -78,33 +65,18 @@ describe('TradingHistoryScreen', () => {
         jest.clearAllMocks();
     });
 
-    it('should render list of buy trades', async () => {
-        mockRouteParams = { tradeType: 'buy' };
+    it('should render list of trades', async () => {
+        const { getByText } = await renderScreen(getPreloadedState());
 
-        const { getByText } = await renderScreen(getPreloadedState([buyTrade]));
-
-        await expect(getByText('Mercuryo')).toBeTruthy();
+        expect(getByText('Mercuryo')).toBeTruthy();
         expect(getByText('$1,234.00')).toBeTruthy();
         expect(getByText('0.462586 ETH')).toBeTruthy();
     });
 
-    it('should render list of exchange trades', async () => {
-        mockRouteParams = { tradeType: 'exchange' };
-
-        const { getByText } = await renderScreen(getPreloadedState([exchangeTrade]));
-
-        expect(getByText('Converting')).toBeTruthy();
-        expect(getByText('Trans. ID: 12ffba9e-7370-4a6e-87dc-aefd3851c735')).toBeTruthy();
-    });
-
     it('should show bottom sheet when trade item is clicked', async () => {
-        mockRouteParams = { tradeType: 'buy' };
+        const { getByText, queryAllByText } = await renderScreen(getPreloadedState());
 
-        const { getByText, queryAllByText } = await renderScreen(getPreloadedState([buyTrade]));
-
-        await act(() => {
-            fireEvent.press(getByText('Trans. ID: d3ef3451-8f68-4250-9e08-580ece5e7d12'));
-        });
+        fireEvent.press(getByText('Trans. ID: d3ef3451-8f68-4250-9e08-580ece5e7d12'));
 
         expect(mockShowSheet).toHaveBeenCalledTimes(1);
 

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -283,5 +283,5 @@ export type RootStackParamList = {
 export type TradingStackParamList = {
     [TradingStackRoutes.Trading]: { tradingType?: TradingType };
     [TradingStackRoutes.ReceiveAccounts]: { symbol: NetworkSymbol };
-    [TradingStackRoutes.TradingHistory]: { tradeType: TradingType };
+    [TradingStackRoutes.TradingHistory]: undefined;
 };


### PR DESCRIPTION
Previously trade history was filtered by current tradeType, this PR changes it to have single one with all types

## Related Issue

Resolve #19359


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=19359-mobile-swap-lets-make-history-one&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=19359-mobile-swap-lets-make-history-one&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19359-mobile-swap-lets-make-history-one&lookback=7)