### PR TITLE
refactor(connect): split Device related code to workflow modules

### DIFF
--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -16,6 +16,7 @@ import { parseLocalFirmwares } from '../data/connectSettings';
 import type { Device, DeviceEvents } from '../device/Device';
 import { DeviceList, IDeviceList, assertDeviceListConnected } from '../device/DeviceList';
 import { WebextensionStateStorage } from '../device/StateStorage';
+import * as workflows from '../device/workflow';
 import {
     CORE_EVENT,
     CoreEventMessage,
@@ -33,12 +34,7 @@ import {
     createTransportMessage,
     createUiMessage,
 } from '../events';
-import type {
-    ConnectSettings,
-    DeviceIdentity,
-    Device as DeviceTyped,
-    StaticSessionId,
-} from '../types';
+import type { ConnectSettings, DeviceIdentity, Device as DeviceTyped } from '../types';
 import { LogWriter, enableLog, initLog, setLogWriter } from '../utils/debug';
 import { InteractionTimeout } from '../utils/interactionTimeout';
 import { createPopupPromiseManager } from '../utils/popupPromiseManager';
@@ -184,31 +180,6 @@ const initDevice = async (context: CoreContext, methodCallDevice?: DeviceIdentit
     }
 
     return device;
-};
-
-const MAX_PIN_TRIES = 3;
-
-/** Including up to 3 pin tries **/
-const getInvalidDeviceState = async (
-    { sendCoreMessage }: CoreContext,
-    device: Device,
-    preauthorized?: boolean,
-): Promise<StaticSessionId | undefined> => {
-    for (let i = 0; i < MAX_PIN_TRIES - 1; ++i) {
-        try {
-            return await device.validateState(preauthorized);
-        } catch (error) {
-            if (error.message.includes('PIN invalid')) {
-                sendCoreMessage(
-                    createUiMessage(UI.INVALID_PIN, { device: device.toMessageObject() }),
-                );
-            } else {
-                throw error;
-            }
-        }
-    }
-
-    return device.validateState(preauthorized);
 };
 
 /**
@@ -372,62 +343,14 @@ const inner = async (context: CoreContext, method: AbstractMethod<any>, device: 
         }
     }
 
+    const workflowCtx = {
+        device,
+        method,
+        signal: context.signal,
+    };
+
     // Make sure that device will display pin/passphrase
-    const isDeviceUnlocked = device.features.unlocked;
-    if (method.useDeviceState) {
-        try {
-            let invalidDeviceState = await getInvalidDeviceState(
-                context,
-                device,
-                method.preauthorized,
-            );
-            if (isUsingPopup) {
-                while (invalidDeviceState) {
-                    const uiPromise = uiPromises.create(UI.INVALID_PASSPHRASE_ACTION, device);
-                    // request action view
-                    sendCoreMessage(
-                        createUiMessage(UI.INVALID_PASSPHRASE, {
-                            device: device.toMessageObject(),
-                        }),
-                    );
-                    // wait for user response
-                    const uiResp = await uiPromise.promise;
-                    if (uiResp.payload) {
-                        // reset sessionId and try again
-                        device.setState({ sessionId: undefined });
-                        await device.initialize(method.useCardanoDerivation);
-
-                        invalidDeviceState = await getInvalidDeviceState(
-                            context,
-                            device,
-                            method.preauthorized,
-                        );
-                    } else {
-                        // set new state as requested
-                        device.setState({ staticSessionId: invalidDeviceState });
-                        break;
-                    }
-                }
-            } else if (invalidDeviceState) {
-                throw ERRORS.TypedError('Device_InvalidState');
-            }
-        } catch (error) {
-            // other error
-            // sendCoreMessage(ResponseMessage(method.responseID, false, { error }));
-            // closePopup();
-            // clear cached passphrase. it's not valid
-            device.setState({ sessionId: undefined });
-
-            // interrupt process and go to "final" block
-            return Promise.reject(error);
-        }
-    }
-
-    // emit additional CHANGE event if device becomes unlocked after authorization
-    // features were automatically updated after PinMatrixAck in DeviceCommands
-    if (!isDeviceUnlocked && device.features.unlocked) {
-        sendCoreMessage(createDeviceMessage(DEVICE.CHANGED, device.toMessageObject()));
-    }
+    await workflows.validateState(workflowCtx);
 
     if (method.useUi) {
         // make sure that popup is opened
@@ -1113,6 +1036,7 @@ export class Core extends EventEmitter {
 
     private getCoreContext() {
         return {
+            signal: this.abortController.signal,
             uiPromises: this.uiPromises,
             popupPromise: this.popupPromise,
             interactionTimeout: this.interactionTimeout,

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -50,7 +50,6 @@ import {
     FirmwareType,
     KnownDevice,
     ReleaseInfo,
-    StaticSessionId,
     UnavailableCapabilities,
     VersionArray,
 } from '../types';
@@ -61,7 +60,6 @@ import {
     parseCapabilities,
     parseRevision,
 } from '../utils/deviceFeaturesUtils';
-import { toHardened } from '../utils/pathUtils';
 
 // custom log
 const _log = initLog('Device');
@@ -640,38 +638,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
             this.state[this.instance] = newState;
             this.stateStorage?.saveState(this, newState);
-        }
-    }
-
-    async validateState(preauthorized = false) {
-        if (!this.features) return;
-
-        if (!this.features.unlocked && preauthorized) {
-            // NOTE: auto locked device accepts preauthorized methods (authorizeConjoin, getOwnershipProof, signTransaction) without pin request.
-            // in that case it's enough to check if session_id is preauthorized...
-            if (await this.getCommands().preauthorize(false)) {
-                return;
-            }
-            // ...and if it's not then unlock device and proceed to regular GetAddress flow
-        }
-
-        const expectedState = this.getState()?.staticSessionId;
-
-        const { message } = await this.getCurrentSession().typedCall('GetAddress', 'Address', {
-            address_n: [toHardened(44), toHardened(1), toHardened(0), 0, 0],
-            coin_name: 'Testnet',
-            script_type: 'SPENDADDRESS',
-        });
-
-        const uniqueState: StaticSessionId = `${message.address}@${this.features.device_id}:${this.instance}`;
-        if (this.features.session_id) {
-            this.setState({ sessionId: this.features.session_id });
-        }
-        if (expectedState && expectedState !== uniqueState) {
-            return uniqueState;
-        }
-        if (!expectedState) {
-            this.setState({ staticSessionId: uniqueState });
         }
     }
 

--- a/packages/connect/src/device/workflow/index.ts
+++ b/packages/connect/src/device/workflow/index.ts
@@ -1,0 +1,1 @@
+export { validateState } from './validateState';

--- a/packages/connect/src/device/workflow/validateState.ts
+++ b/packages/connect/src/device/workflow/validateState.ts
@@ -1,0 +1,119 @@
+import { ERRORS } from '../../constants';
+import { DataManager } from '../../data/DataManager';
+import { DEVICE, UI, createDeviceMessage, createUiMessage } from '../../events';
+import { StaticSessionId } from '../../types';
+import { WorkflowContext } from '../../types/workflow';
+import { toHardened } from '../../utils/pathUtils';
+
+const getState = async ({ device, method }: WorkflowContext) => {
+    if (!device.features) return;
+
+    if (!device.features.unlocked && method.preauthorized) {
+        // NOTE: auto locked device accepts preauthorized methods (authorizeConjoin, getOwnershipProof, signTransaction) without pin request.
+        // in that case it's enough to check if session_id is preauthorized...
+        // add-abort-signal
+        if (await device.getCommands().preauthorize(false)) {
+            return;
+        }
+        // ...and if it's not then unlock device and proceed to regular GetAddress flow
+    }
+
+    const expectedState = device.getState()?.staticSessionId;
+
+    // add-abort-signal
+    const { message } = await device.getCurrentSession().typedCall('GetAddress', 'Address', {
+        address_n: [toHardened(44), toHardened(1), toHardened(0), 0, 0],
+        coin_name: 'Testnet',
+        script_type: 'SPENDADDRESS',
+    });
+
+    const uniqueState: StaticSessionId = `${message.address}@${device.features.device_id}:${device.getInstance()}`;
+    if (device.features.session_id) {
+        device.setState({ sessionId: device.features.session_id });
+    }
+    if (expectedState && expectedState !== uniqueState) {
+        return uniqueState;
+    }
+    if (!expectedState) {
+        device.setState({ staticSessionId: uniqueState });
+    }
+};
+
+const MAX_PIN_TRIES = 3;
+
+/** Including up to 3 pin tries **/
+const getInvalidDeviceState = async (
+    context: WorkflowContext,
+): Promise<StaticSessionId | undefined> => {
+    for (let i = 0; i < MAX_PIN_TRIES - 1; ++i) {
+        try {
+            return await getState(context);
+        } catch (error) {
+            if (error.message.includes('PIN invalid')) {
+                context.method.postMessage(
+                    createUiMessage(UI.INVALID_PIN, { device: context.device.toMessageObject() }),
+                );
+            } else {
+                throw error;
+            }
+        }
+    }
+
+    return getState(context);
+};
+
+export const validateState = async (context: WorkflowContext) => {
+    const { device, method } = context;
+    if (!method.useDeviceState) {
+        return;
+    }
+
+    // Make sure that device will display pin/passphrase
+    const isDeviceUnlocked = device.features.unlocked;
+    const isUsingPopup = DataManager.getSettings('popup');
+    try {
+        let invalidDeviceState = await getInvalidDeviceState(context);
+        if (isUsingPopup) {
+            while (invalidDeviceState) {
+                const uiPromise = method.createUiPromise(UI.INVALID_PASSPHRASE_ACTION, device);
+                // request action view
+                method.postMessage(
+                    createUiMessage(UI.INVALID_PASSPHRASE, {
+                        device: device.toMessageObject(),
+                    }),
+                );
+
+                // wait for user response
+                const uiResp = await uiPromise.promise;
+                if (uiResp.payload) {
+                    // reset sessionId and try again
+                    device.setState({ sessionId: undefined });
+                    await device.initialize(method.useCardanoDerivation);
+
+                    invalidDeviceState = await getInvalidDeviceState(context);
+                } else {
+                    // set new state as requested
+                    device.setState({ staticSessionId: invalidDeviceState });
+                    break;
+                }
+            }
+        } else if (invalidDeviceState) {
+            throw ERRORS.TypedError('Device_InvalidState');
+        }
+    } catch (error) {
+        // other error
+        // sendCoreMessage(ResponseMessage(method.responseID, false, { error }));
+        // closePopup();
+        // clear cached passphrase. it's not valid
+        device.setState({ sessionId: undefined });
+
+        // interrupt process and go to "final" block
+        return Promise.reject(error);
+    }
+
+    // emit additional CHANGE event if device becomes unlocked after authorization
+    // features were automatically updated after PinMatrixAck in DeviceCommands
+    if (!isDeviceUnlocked && device.features.unlocked) {
+        method.postMessage(createDeviceMessage(DEVICE.CHANGED, device.toMessageObject()));
+    }
+};

--- a/packages/connect/src/types/workflow.ts
+++ b/packages/connect/src/types/workflow.ts
@@ -1,0 +1,8 @@
+import type { AbstractMethod } from '../core/AbstractMethod';
+import type { Device } from '../device/Device';
+
+export type WorkflowContext = {
+    device: Device;
+    method: AbstractMethod<any>;
+    signal: AbortSignal;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We need to start untightening this knot :) ~100 lines moved to a separate file

after irl discussion with @marekrjpolak  im creating `device/workflow` modules where we should move all the async code related to method (iframe-call) workflow /lifecycle like `initDevice`, `hasUnexpectedMode`, `checkPermissions`, `firmwareException` etc.

ideally each workflow should have access to some top level context and use abort signal to interrupt async actions.

i started to mark those places with `add-abort-signal` comment next to that line

im starting from the middle with `validateState` because this part will be modified with upcomming THP implementation

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-workflow&lookback=7)