### PR TITLE
Unreadable devices

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -126,7 +126,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     public readonly transportPath;
     public readonly bluetoothProps;
     private thp: protocolThp.ThpState | undefined;
-    private readonly transportDescriptorType;
+    private readonly possibleHIDdevice;
     private sessionAcquired: Session | null;
 
     // protocol related
@@ -221,7 +221,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         this.uniquePath = id;
         this.transport = transport;
         this.transportPath = descriptor.path;
-        this.transportDescriptorType = descriptor.type;
+        this.possibleHIDdevice = [0, 2].includes(descriptor.type);
         this.bluetoothProps = descriptor.id ? { id: descriptor.id } : undefined;
 
         this.sessionAcquired = null;
@@ -356,6 +356,17 @@ export class Device extends TypedEmitter<DeviceEvents> {
                     ) {
                         // disconnected, do nothing
                     } else if (
+                        // if unable to open device and it's HID -> device is unreadable
+                        (this.possibleHIDdevice &&
+                            error.message === TRANSPORT_ERROR.INTERFACE_UNABLE_TO_OPEN_DEVICE) ||
+                        // catch LIBUSB_ERROR_ACCESS -> missing udev rules usually
+                        error.message === TRANSPORT_ERROR.LIBUSB_ERROR_ACCESS
+                    ) {
+                        this.unreadableError = error.message;
+                        this.emitLifecycle(DEVICE.CONNECT_UNACQUIRED);
+                    } else if (
+                        // device was claimed by another application on transport api layer (claimInterface in usb nomenclature) but never released (releaseInterface in usb nomenclature)
+                        error.message === TRANSPORT_ERROR.INTERFACE_UNABLE_TO_OPEN_DEVICE ||
                         // we don't know what really happened
                         error.message === TRANSPORT_ERROR.UNEXPECTED_ERROR ||
                         // someone else took the device at the same time
@@ -365,15 +376,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
                         // TODO: is this needed? can't I just use transport error?
                         error.code === 'Device_InitializeFailed'
                     ) {
-                        this.emitLifecycle(DEVICE.CONNECT_UNACQUIRED);
-                    } else if (
-                        // device was claimed by another application on transport api layer (claimInterface in usb nomenclature) but never released (releaseInterface in usb nomenclature)
-                        // the only remedy for this is to reconnect device manually
-                        error.message === TRANSPORT_ERROR.INTERFACE_UNABLE_TO_OPEN_DEVICE ||
-                        // catch one of trezord LIBUSB_ERRORs
-                        error.message === TRANSPORT_ERROR.LIBUSB_ERROR_ACCESS
-                    ) {
-                        this.unreadableError = error?.message;
                         this.emitLifecycle(DEVICE.CONNECT_UNACQUIRED);
                     } else {
                         await resolveAfter(501);
@@ -520,10 +522,8 @@ export class Device extends TypedEmitter<DeviceEvents> {
                     //         the 'use device here' button and here you go. Yet I didn't want to burden every TrezorConnect method call with this but we may reconsider this.
                     // note 5: ad note 4. it is not so problematic anymore since cleanup on dispose has been improved in https://github.com/trezor/trezor-suite/pull/16930
                     // note 6: T1 with older bootloader (1.8.0) doesn't respond to Cancel message, so we better ignore those
-                    if (
-                        ['v1', 'bridge'].includes(this.protocol.name) &&
-                        ![0, 2].includes(this.transportDescriptorType) // ignore model 1 hid or webusb bootloader mode
-                    ) {
+                    if (['v1', 'bridge'].includes(this.protocol.name) && !this.possibleHIDdevice) {
+                        // ignore model 1 hid or webusb bootloader mode
                         _log.debug(
                             'sending a preventive cancel on the first encounter with the device',
                         );
@@ -1132,7 +1132,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 type: 'unreadable',
                 error: this.unreadableError, // provide error details
                 label: 'Unreadable device',
-                transportDescriptorType: this.transportDescriptorType,
+                hid: this.possibleHIDdevice,
             };
         }
         if (this.isUnacquired()) {

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -371,7 +371,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
                         // the only remedy for this is to reconnect device manually
                         error.message === TRANSPORT_ERROR.INTERFACE_UNABLE_TO_OPEN_DEVICE ||
                         // catch one of trezord LIBUSB_ERRORs
-                        error.message?.indexOf(ERRORS.LIBUSB_ERROR_MESSAGE) >= 0
+                        error.message === TRANSPORT_ERROR.LIBUSB_ERROR_ACCESS
                     ) {
                         this.unreadableError = error?.message;
                         this.emitLifecycle(DEVICE.CONNECT_UNACQUIRED);

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -1,6 +1,5 @@
 import { FeaturesNarrowing, FirmwareType } from '@trezor/device-utils';
 import type { ThpStateSerialized } from '@trezor/protocol';
-import { Descriptor } from '@trezor/transport';
 
 import type { PROTO } from '../constants';
 import type { ReleaseInfo } from './firmware';
@@ -107,7 +106,7 @@ export type KnownDevice = BaseDevice & {
         // Maybe add AuthenticityCheck result here?
     };
     transportSessionOwner?: undefined;
-    transportDescriptorType?: typeof undefined;
+    hid?: undefined;
     bluetoothProps?: BluetoothDeviceProps;
 };
 
@@ -130,7 +129,7 @@ export type UnknownDevice = BaseDevice & {
     unavailableCapabilities?: typeof undefined;
     availableTranslations?: typeof undefined;
     transportSessionOwner?: string;
-    transportDescriptorType?: typeof undefined;
+    hid?: undefined;
     bluetoothProps?: BluetoothDeviceProps;
 };
 
@@ -153,7 +152,7 @@ export type UnreadableDevice = BaseDevice & {
     unavailableCapabilities?: typeof undefined;
     availableTranslations?: typeof undefined;
     transportSessionOwner?: undefined;
-    transportDescriptorType: Descriptor['type'];
+    hid: boolean;
     bluetoothProps?: BluetoothDeviceProps;
 };
 

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -289,7 +289,7 @@ describe('Preloader component', () => {
             selectedDevice: {
                 type: 'unreadable',
                 error: 'unable to open device',
-                transportDescriptorType: 0,
+                hid: true,
             },
         };
 

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
@@ -36,12 +36,7 @@ export const DeviceUnreadable = ({ device }: DeviceUnreadableProps) => {
     }
 
     // only for unreadable HID devices
-    if (
-        // model 1 hid normal mode
-        selectedDevice?.transportDescriptorType === 0 ||
-        // model 1 webusb or hid bootloader mode
-        selectedDevice?.transportDescriptorType === 2
-    ) {
+    if (selectedDevice?.hid) {
         // If even this did not work, go to support or knowledge base
         // 'If the last time you updated your device firmware was in 2019 and earlier please follow instructions in <a>the knowledge base</a>',
         items.push(TROUBLESHOOTING_TIP_UNREADABLE_HID);

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -163,7 +163,7 @@ const getConnectDevice = (dev?: Partial<StringPath<Device>>, feat?: Partial<Feat
             label: 'Unreadable device',
             name: 'name of unreadable device',
             error: 'unreadable device',
-            transportDescriptorType: 0,
+            hid: true,
         };
     }
 


### PR DESCRIPTION
## Description

Trying to improve the situation with unreadable devices (`Device connected` warning) a bit. Now the only reasons for unreadability could be `LIBUSB_ERROR_ACCESS` (probably missing udev) and `Unable to open device` **only** for HID devices, because in other cases it could mean a lot of things and it's better to show the retry button than not.

The `LIBUSB_ERROR_ACCESS` equality comparison instead of `LIBUSB_ERROR` matching is there because I strongly believe that no other error like this should ever happen during handshake (I may be wrong tho).



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/unreadable-devices&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/unreadable-devices&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/unreadable-devices&lookback=7)