### PR TITLE
fix(suite-native): stop overriding letter spacing fix

### DIFF
--- a/suite-native/atoms/src/Text.tsx
+++ b/suite-native/atoms/src/Text.tsx
@@ -11,7 +11,12 @@ import Animated from 'react-native-reanimated';
 // @ts-expect-error This is not public RN API but it will make Text noticeable faster https://twitter.com/FernandoTheRojo/status/1707769877493121420
 import { NativeText } from 'react-native/Libraries/Text/TextNativeComponent';
 
-import { NativeStyleObject, prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import {
+    NativeStyleObject,
+    mergeNativeStyleObjects,
+    prepareNativeStyle,
+    useNativeStyles,
+} from '@trezor/styles';
 import { Color, NativeTypographyStyle } from '@trezor/theme';
 
 import { TestProps } from './types';
@@ -87,7 +92,7 @@ export const Text = React.forwardRef<RNText, TextProps>(
             variant = 'body',
             color = 'textDefault',
             textAlign = 'left',
-            style,
+            style = {},
             children,
             ...otherProps
         },
@@ -98,7 +103,10 @@ export const Text = React.forwardRef<RNText, TextProps>(
 
         return (
             <DefaultTextComponent
-                style={[applyStyle(textStyle, { variant, color, textAlign }), style]}
+                style={mergeNativeStyleObjects([
+                    applyStyle(textStyle, { variant, color, textAlign }),
+                    style,
+                ])}
                 maxFontSizeMultiplier={maxFontSizeMultiplier}
                 {...otherProps}
                 ref={ref}

--- a/suite-native/formatters/src/components/AmountText.tsx
+++ b/suite-native/formatters/src/components/AmountText.tsx
@@ -4,7 +4,7 @@ import {
     TextProps,
     resetLetterSpacingOnAndroidStyle,
 } from '@suite-native/atoms';
-import { useNativeStyles } from '@trezor/styles';
+import { mergeNativeStyleObjects, useNativeStyles } from '@trezor/styles';
 
 type AmountTextProps = {
     isDiscreetText?: boolean;
@@ -12,13 +12,21 @@ type AmountTextProps = {
     value: string | null;
 } & TextProps;
 
-export const AmountText = ({ value, isDiscreetText = true, ...otherProps }: AmountTextProps) => {
+export const AmountText = ({
+    value,
+    isDiscreetText = true,
+    style = {},
+    ...otherProps
+}: AmountTextProps) => {
     const { applyStyle } = useNativeStyles();
 
     const TextComponent = isDiscreetText ? DiscreetText : Text;
 
     return (
-        <TextComponent style={applyStyle(resetLetterSpacingOnAndroidStyle)} {...otherProps}>
+        <TextComponent
+            style={mergeNativeStyleObjects([style, applyStyle(resetLetterSpacingOnAndroidStyle)])}
+            {...otherProps}
+        >
             {value}
         </TextComponent>
     );


### PR DESCRIPTION
## Description

- The `resetLetterSpacingOnAndroidStyle` style was being overridden by the custom style passed via props. Now, the styles are merged in the correct order.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19402

## Screenshots:

| BEFORE  | AFTER |
|----------|----------|
| <img width="352" alt="image" src="https://github.com/user-attachments/assets/884a46fc-7124-454c-9735-3ed05525a226" />  | <img width="402" alt="image" src="https://github.com/user-attachments/assets/761fddb4-cced-4912-a26a-b5f719ecb510" />   |



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/letter-spacing-workaround&lookback=7)