### PR TITLE
feat(suite-native): connect UI update and permission settings

### DIFF
--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -178,9 +178,19 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies<Connect
     }
 
     private buildUrl(method: string, params: any, callback: string) {
-        return `${this._settings.deeplinkUrl}?method=${method}&params=${encodeURIComponent(
-            JSON.stringify(params),
-        )}&callback=${encodeURIComponent(callback)}`;
+        let url =
+            `${this._settings.deeplinkUrl}` +
+            `?method=${method}` +
+            `&params=${encodeURIComponent(JSON.stringify(params))}` +
+            `&callback=${encodeURIComponent(callback)}`;
+        if (this._settings.manifest?.appName) {
+            url += `&appName=${encodeURIComponent(this._settings.manifest.appName)}`;
+        }
+        if (this._settings.manifest?.appIcon) {
+            url += `&appIcon=${encodeURIComponent(this._settings.manifest.appIcon)}`;
+        }
+
+        return url;
     }
 
     private buildCallbackUrl(url: string, params: Record<string, string | number>) {

--- a/suite-common/connect-popup/src/connectPopupReducer.ts
+++ b/suite-common/connect-popup/src/connectPopupReducer.ts
@@ -76,7 +76,8 @@ export const prepareConnectPopupReducer = createReducerWithExtraDeps(
             .addCase(connectPopupActions.confirmAddresses, (state, { payload }) => {
                 if (
                     state.activeCall?.state === 'ongoing' ||
-                    state.activeCall?.state === 'address-confirmation'
+                    state.activeCall?.state === 'address-confirmation' ||
+                    state.activeCall?.state === 'deeplink-callback'
                 ) {
                     state.activeCall = {
                         ...state.activeCall,
@@ -97,7 +98,10 @@ export const prepareConnectPopupReducer = createReducerWithExtraDeps(
                 if (state.activeCall) state.activeCall.state = 'finished';
             })
             .addCase(connectPopupActions.deeplinkCallback, (state, { payload }) => {
-                if (state.activeCall?.state === 'finished')
+                if (
+                    state.activeCall?.state === 'finished' ||
+                    state.activeCall?.state === 'address-confirmation'
+                )
                     state.activeCall = {
                         ...state.activeCall,
                         state: 'deeplink-callback',

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -242,6 +242,10 @@ export const connectPopupDeeplinkThunk = createThunk<void, { url: string }>(
                 source: {
                     type: 'deeplink',
                     origin: `${callbackUrl.protocol}//${callbackUrl.host}`,
+                    manifest: {
+                        appName: queryParams.appName,
+                        appIcon: queryParams.appIcon,
+                    },
                 },
                 method: method as keyof typeof TrezorConnect,
                 payload,

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -294,6 +294,7 @@ export const connectPopupVerifyAddressThunk = createThunk<void, { index: number 
                 chunked: false,
             });
             const validatedStatus = res.success ? 'valid' : 'failed';
+            dispatch(deviceActions.removeButtonRequests({ device }));
             dispatch(
                 connectPopupActions.confirmAddresses({
                     addresses: call.addresses.map((address, i) => ({

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -34,7 +34,7 @@ export type ConnectCallSource = {
     | {
           type: typeof CALL_SOURCE_DEEPLINK;
           process?: undefined;
-          manifest?: undefined;
+          manifest: ManifestPartial;
       }
 );
 

--- a/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
+++ b/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
@@ -51,14 +51,10 @@ const preCallHook = <M extends keyof typeof TrezorConnect>({
 
 export function postCallHook<M extends keyof typeof TrezorConnect>({
     method,
-    source,
     originalPayload,
     response,
     dispatch,
 }: PostCallHookParams<M>) {
-    // Skip on deeplink for now
-    if (source.type === 'deeplink') return false;
-
     if (methods.includes(method) && response.success) {
         const bundledResponse = (
             Array.isArray(response.payload) ? response.payload : [response.payload]

--- a/suite-native/app/src/navigation/RootStackNavigator.tsx
+++ b/suite-native/app/src/navigation/RootStackNavigator.tsx
@@ -12,6 +12,7 @@ import { AddCoinAccountStackNavigator } from '@suite-native/module-add-accounts'
 import { DeviceCompromisedModalScreen } from '@suite-native/module-authenticity-checks';
 import { AuthorizeDeviceStackNavigator } from '@suite-native/module-authorize-device';
 import {
+    ConnectPermissionsScreen,
     ConnectPopupScreen,
     WalletConnectPairScreen,
     WalletConnectSessionPopupScreen,
@@ -101,6 +102,10 @@ export const RootStackNavigator = () => {
             <RootStack.Screen
                 name={RootStackRoutes.WalletConnectPair}
                 component={WalletConnectPairScreen}
+            />
+            <RootStack.Screen
+                name={RootStackRoutes.ConnectPermissions}
+                component={ConnectPermissionsScreen}
             />
             <RootStack.Screen
                 name={RootStackRoutes.SettingsScreenStack}

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -410,6 +410,10 @@ export const en = {
         },
         optional: 'Optional',
         alwaysAllow: 'Always allow for this app',
+        confirmAddress: {
+            title: 'Confirm address',
+            message: 'Please compare the address on your Trezor with the third-party app.',
+        },
         connectionStatus: {
             loading: 'Loading...',
             discoveryRunning: 'Discovery running, please wait...',

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -388,11 +388,28 @@ export const en = {
         },
     },
     moduleConnectPopup: {
-        title: 'Trezor Connect Mobile',
         callback: 'Callback',
         confirm: 'Confirm',
         cancel: 'Cancel',
         areYouSureMessage: 'Are you sure you want to continue?\nMake sure you trust the source.',
+        noConnectedApps: 'No connected apps',
+        noConnectedAppsDescription:
+            'Use your Trezor with third-party apps and wallets to manage your assets.',
+        grantPermission: {
+            title: 'Grant permissions',
+            message:
+                'This app wants to connect with Trezor Suite and needs the following permissions.',
+        },
+        permissions: {
+            title: 'Permissions',
+            // Matches MethodPermission enum
+            read: 'Access public keys from your Trezor device',
+            write: 'Permit transaction and data signing on Trezor',
+            management: 'Modify device settings',
+            push_tx: 'Broadcast transactions to the blockchain',
+        },
+        optional: 'Optional',
+        alwaysAllow: 'Always allow for this app',
         connectionStatus: {
             loading: 'Loading...',
             discoveryRunning: 'Discovery running, please wait...',
@@ -407,6 +424,10 @@ export const en = {
         bottomSheets: {
             confirmOnDeviceMessage: 'Go to your device and verify the details of the operation.',
         },
+        trezorConnect: {
+            title: 'Trezor Connect',
+            forget: 'Forget',
+        },
         walletConnect: {
             title: 'WalletConnect',
             message:
@@ -420,9 +441,6 @@ export const en = {
             scanQR: 'Scan WalletConnect QR',
             addConnection: 'Add connection',
             activeConnections: 'Active connections',
-            noConnectedApps: 'No connected apps',
-            noConnectedAppsDescription:
-                'Use your Trezor with third-party apps and wallets to manage your assets.',
             disconnect: 'Disconnect',
             switchAccount: 'Switch account',
             app: 'App',
@@ -708,9 +726,13 @@ export const en = {
             },
             connections: {
                 title: 'Connections',
+                trezorConnect: {
+                    title: 'Trezor Connect',
+                    subtitle: 'Use supported wallets and apps with your Trezor',
+                },
                 walletConnect: {
                     title: 'WalletConnect',
-                    subtitle: 'Use external apps using the WalletConnect protocol',
+                    subtitle: 'Connect external apps using the WalletConnect protocol',
                     add: 'Add WalletConnect connection',
                 },
             },

--- a/suite-native/module-connect-popup/package.json
+++ b/suite-native/module-connect-popup/package.json
@@ -12,7 +12,6 @@
     "dependencies": {
         "@react-navigation/native": "6.1.18",
         "@reduxjs/toolkit": "2.8.2",
-        "@suite-common/suite-types": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/walletconnect": "workspace:*",
         "@suite-native/atoms": "workspace:*",

--- a/suite-native/module-connect-popup/src/components/ButtonRequestsOverlay.tsx
+++ b/suite-native/module-connect-popup/src/components/ButtonRequestsOverlay.tsx
@@ -1,34 +1,32 @@
 import { useSelector } from 'react-redux';
 
-import { ButtonRequest } from '@suite-common/suite-types';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
-import { Box, Text, VStack } from '@suite-native/atoms';
+import { VStack } from '@suite-native/atoms';
 import { ConfirmOnTrezorImage } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+const overlayStyle = prepareNativeStyle(() => ({
+    position: 'absolute',
+    bottom: 0,
+    width: '100%',
+}));
 
 export const ButtonRequestsOverlay = () => {
+    const { applyStyle } = useNativeStyles();
     const selectedDevice = useSelector(selectSelectedDevice);
 
     if (!selectedDevice?.buttonRequests || selectedDevice.buttonRequests.length === 0) {
         return null;
     }
 
-    const getButtonRequestComponent = (request: ButtonRequest) => {
-        if (request.code === 'ButtonRequest_Address') {
-            return (
-                <Box paddingBottom="sp32" key={request.code}>
-                    <Text variant="body">{(request as any).data.address}</Text>
-                </Box>
-            );
-        }
-
-        return null;
-    };
-
     return (
-        <VStack spacing="sp24" alignItems="center" justifyContent="center" flex={1} padding="sp8">
-            {selectedDevice.buttonRequests.map(request => getButtonRequestComponent(request))}
-
+        <VStack
+            alignItems="center"
+            justifyContent="center"
+            flex={1}
+            style={applyStyle(overlayStyle)}
+        >
             <ConfirmOnTrezorImage
                 bottomSheetText={
                     <Translation id="moduleConnectPopup.bottomSheets.confirmOnDeviceMessage" />

--- a/suite-native/module-connect-popup/src/components/ConnectAppIcon.tsx
+++ b/suite-native/module-connect-popup/src/components/ConnectAppIcon.tsx
@@ -6,7 +6,7 @@ import { IMAGE_PROXY_API_AUTH_BEARER, IMAGE_PROXY_API_URL } from '@trezor/urls';
 
 const sizeMapping = {
     medium: 48,
-    large: 64,
+    large: 60,
 };
 const fallbackIconSizeMapping = {
     medium: 'mediumLarge' as const,

--- a/suite-native/module-connect-popup/src/index.ts
+++ b/suite-native/module-connect-popup/src/index.ts
@@ -1,5 +1,6 @@
 export * from './components/WalletConnectPairBottomSheet';
 export * from './screens/ConnectPopupScreen';
+export * from './screens/ConnectPermissionsScreen';
 export * from './screens/WalletConnectSessionPopupScreen';
 export * from './screens/WalletConnectSwitchAccountScreen';
 export * from './screens/WalletConnectPairScreen';

--- a/suite-native/module-connect-popup/src/screens/ConnectPermissionsScreen.tsx
+++ b/suite-native/module-connect-popup/src/screens/ConnectPermissionsScreen.tsx
@@ -1,0 +1,104 @@
+import { TouchableOpacity } from 'react-native';
+import { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { connectPopupActions, selectConnectAppPermissions } from '@suite-common/connect-popup';
+import { AppRememberedPermission } from '@suite-common/connect-popup/src/connectPopupTypes';
+import { AnimatedBox, Button, Card, CardDivider, HStack, Text, VStack } from '@suite-native/atoms';
+import { AccordionContent } from '@suite-native/atoms/src/Accordion/AccordionContent';
+import { Icon } from '@suite-native/icons';
+import { Translation } from '@suite-native/intl';
+import { Screen, ScreenHeader } from '@suite-native/navigation';
+
+import { ConnectAppIcon } from '../components/ConnectAppIcon';
+
+const PermissionDetailCard = ({ app }: { app: AppRememberedPermission }) => {
+    const dispatch = useDispatch();
+    const handleDisconnect = () => {
+        dispatch(connectPopupActions.forgetAppPermissions(app));
+    };
+    const isExpanded = useSharedValue(false);
+    const animatedChevronStyle = useAnimatedStyle(() => ({
+        transform: [
+            {
+                rotate: withTiming(`${isExpanded.value ? -180 : 0}deg`, {
+                    duration: 200,
+                }),
+            },
+        ],
+    }));
+
+    return (
+        <Card>
+            <VStack spacing={0}>
+                <TouchableOpacity onPress={() => (isExpanded.value = !isExpanded.value)}>
+                    <HStack spacing="sp12" alignItems="center">
+                        <ConnectAppIcon
+                            src={app.manifest?.appIcon}
+                            type="trezorConnect"
+                            size="medium"
+                        />
+                        <VStack flex={1} spacing="sp1">
+                            <Text numberOfLines={1}>{app.manifest?.appName ?? app.origin}</Text>
+                            {app.manifest?.appName && (
+                                <Text color="textSubdued" numberOfLines={1}>
+                                    {app.origin}
+                                </Text>
+                            )}
+                        </VStack>
+                        <AnimatedBox style={animatedChevronStyle}>
+                            <Icon name="caretDown" size="mediumLarge" />
+                        </AnimatedBox>
+                    </HStack>
+                </TouchableOpacity>
+                <AccordionContent isOpened={isExpanded}>
+                    <VStack spacing="sp16" paddingTop="sp16">
+                        <CardDivider />
+                        <Button onPress={handleDisconnect} colorScheme="tertiaryElevation0">
+                            <Translation id="moduleConnectPopup.trezorConnect.forget" />
+                        </Button>
+                    </VStack>
+                </AccordionContent>
+            </VStack>
+        </Card>
+    );
+};
+
+export const ConnectPermissionsScreen = () => {
+    const apps = useSelector(selectConnectAppPermissions);
+
+    return (
+        <Screen
+            header={
+                <ScreenHeader
+                    closeActionType="close"
+                    content={
+                        <Text>
+                            <Translation id="moduleConnectPopup.trezorConnect.title" />
+                        </Text>
+                    }
+                />
+            }
+        >
+            <VStack
+                spacing="sp24"
+                justifyContent={apps.length === 0 ? 'center' : 'flex-start'}
+                flex={1}
+            >
+                {apps.map(app => (
+                    <PermissionDetailCard key={app.origin} app={app} />
+                ))}
+                {apps.length === 0 && (
+                    <>
+                        <Text textAlign="center" variant="titleSmall">
+                            <Translation id="moduleConnectPopup.noConnectedApps" />
+                        </Text>
+                        <Text textAlign="center" color="textSubdued">
+                            <Translation id="moduleConnectPopup.noConnectedAppsDescription" />
+                        </Text>
+                    </>
+                )}
+            </VStack>
+        </Screen>
+    );
+};

--- a/suite-native/module-connect-popup/src/screens/ConnectPopupScreen.tsx
+++ b/suite-native/module-connect-popup/src/screens/ConnectPopupScreen.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { TouchableOpacity } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
@@ -9,13 +10,26 @@ import {
     selectIsDeviceConnectedAndAuthorized,
     selectIsPortfolioTrackerDevice,
 } from '@suite-common/wallet-core';
-import { Box, Button, ErrorMessage, IconButton, Loader, Text, VStack } from '@suite-native/atoms';
-import { isDevelopOrDebugEnv } from '@suite-native/config';
+import {
+    Box,
+    Button,
+    Card,
+    CheckBox,
+    ErrorMessage,
+    HStack,
+    Loader,
+    Text,
+    TextDivider,
+    TitleHeader,
+    VStack,
+} from '@suite-native/atoms';
 import { DeviceManager } from '@suite-native/device-manager';
+import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import { Screen, ScreenHeader } from '@suite-native/navigation';
+import { Screen } from '@suite-native/navigation';
 
 import { ButtonRequestsOverlay } from '../components/ButtonRequestsOverlay';
+import { ConnectAppIcon } from '../components/ConnectAppIcon';
 
 export const ConnectPopupScreen = () => {
     const navigation = useNavigation();
@@ -26,7 +40,7 @@ export const ConnectPopupScreen = () => {
     const validDevice = deviceConnectedAndAuthorized && !isPortfolioTrackerDevice;
     const discoveryActive = useSelector(selectHasRunningDiscovery);
     const popupCall = useSelector(selectConnectPopupCall);
-    const [showDebug, setShowDebug] = useState<boolean>(false);
+    const [isRemembered, setIsRemembered] = useState(false);
 
     useEffect(() => {
         if (popupCall?.state == 'finished' && navigation.canGoBack()) {
@@ -35,8 +49,6 @@ export const ConnectPopupScreen = () => {
     }, [popupCall, navigation]);
 
     const mainView = useMemo(() => {
-        const onConfirm = () => dispatch(connectPopupActions.approvePermissions());
-
         if (!popupCall) {
             return (
                 <Loader
@@ -69,28 +81,85 @@ export const ConnectPopupScreen = () => {
                     );
                 }
 
-                return (
-                    <VStack testID="@popup/deeplink-info" spacing="sp8" alignItems="center">
-                        <Text variant="titleSmall">{popupCall.methodInfo.methodTitle}</Text>
-                        <Text>
-                            <Translation id="moduleConnectPopup.callback" />
-                            {': '}
-                            <Text color="textAlertBlue">{popupCall.source.origin}</Text>
-                        </Text>
+                const onConfirm = () => {
+                    if (isRemembered) {
+                        dispatch(
+                            connectPopupActions.rememberAppPermissions({
+                                types: popupCall.methodInfo.permissionTypes,
+                                ...popupCall.source,
+                            }),
+                        );
+                    }
+                    dispatch(connectPopupActions.approvePermissions());
+                };
 
-                        <Text
-                            style={{
-                                textAlign: 'center',
-                                padding: 20,
-                            }}
-                            color="textSubdued"
-                        >
-                            <Translation id="moduleConnectPopup.areYouSureMessage" />
-                        </Text>
+                return (
+                    <VStack testID="@popup/deeplink-info" spacing="sp16" flex={1}>
+                        <TitleHeader
+                            title={<Translation id="moduleConnectPopup.grantPermission.title" />}
+                            subtitle={
+                                <Translation id="moduleConnectPopup.grantPermission.message" />
+                            }
+                        />
+
+                        <Card>
+                            <HStack alignItems="center" spacing="sp16">
+                                <ConnectAppIcon
+                                    src={popupCall.source.manifest?.appIcon}
+                                    type="trezorConnect"
+                                    size="large"
+                                />
+                                <VStack flex={1} spacing="sp4">
+                                    <Text>
+                                        {popupCall.source.manifest?.appName ??
+                                            popupCall.source.origin}
+                                    </Text>
+                                    {popupCall.source.manifest?.appName && (
+                                        <Text color="textSubdued">{popupCall.source.origin}</Text>
+                                    )}
+                                </VStack>
+                            </HStack>
+
+                            <TextDivider title="moduleConnectPopup.permissions.title" />
+
+                            <VStack spacing="sp8" padding="sp8">
+                                {popupCall.methodInfo.permissionTypes.map(permission => (
+                                    <HStack key={permission} alignItems="center" spacing="sp8">
+                                        <Icon name="checkCircle" color="iconPrimaryDefault" />
+                                        <Text color="textSubdued" variant="hint">
+                                            <Translation
+                                                id={`moduleConnectPopup.permissions.${permission}`}
+                                            />
+                                        </Text>
+                                    </HStack>
+                                ))}
+                            </VStack>
+
+                            <TextDivider title="moduleConnectPopup.optional" />
+
+                            <TouchableOpacity onPress={() => setIsRemembered(!isRemembered)}>
+                                <HStack spacing="sp16" padding="sp8" alignItems="center">
+                                    <CheckBox
+                                        isChecked={isRemembered}
+                                        onChange={() => setIsRemembered(!isRemembered)}
+                                    />
+                                    <Text color="textSubdued" variant="hint">
+                                        <Translation id="moduleConnectPopup.alwaysAllow" />
+                                    </Text>
+                                </HStack>
+                            </TouchableOpacity>
+                        </Card>
+
                         <Button testID="@popup/call-device" onPress={onConfirm}>
                             {popupCall.methodInfo.confirmLabel || (
                                 <Translation id="moduleConnectPopup.confirm" />
                             )}
+                        </Button>
+                        <Button
+                            colorScheme="tertiaryElevation0"
+                            onPress={() => navigation.goBack()}
+                        >
+                            <Translation id="generic.buttons.close" />
                         </Button>
                     </VStack>
                 );
@@ -127,36 +196,21 @@ export const ConnectPopupScreen = () => {
                 />
             );
         }
-    }, [validDevice, popupCall, discoveryActive, dispatch]);
+    }, [validDevice, popupCall, discoveryActive, isRemembered, dispatch, navigation]);
 
     return (
-        <Screen
-            header={
-                <ScreenHeader
-                    closeActionType="close"
-                    content={
-                        <Text>
-                            <Translation id="moduleConnectPopup.title" />
-                        </Text>
-                    }
-                    rightIcon={
-                        isDevelopOrDebugEnv() ? (
-                            <IconButton
-                                iconName="bugBeetle"
-                                onPress={() => setShowDebug(!showDebug)}
-                                colorScheme="tertiaryElevation0"
-                                size="medium"
-                            />
-                        ) : null
-                    }
-                />
-            }
-        >
+        <Screen>
             <Box>
                 <DeviceManager />
             </Box>
 
-            <Box alignItems="center" justifyContent="center" flex={1}>
+            <Box
+                padding="sp8"
+                paddingTop="sp16"
+                flex={1}
+                justifyContent="center"
+                alignItems="center"
+            >
                 {mainView}
             </Box>
 

--- a/suite-native/module-connect-popup/src/screens/ConnectPopupScreen.tsx
+++ b/suite-native/module-connect-popup/src/screens/ConnectPopupScreen.tsx
@@ -4,7 +4,12 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { connectPopupActions, selectConnectPopupCall } from '@suite-common/connect-popup';
+import {
+    connectPopupActions,
+    connectPopupVerifyAddressThunk,
+    selectConnectPopupCall,
+} from '@suite-common/connect-popup';
+import { ConnectPopupCall } from '@suite-common/connect-popup/src/connectPopupTypes';
 import {
     selectHasRunningDiscovery,
     selectIsDeviceConnectedAndAuthorized,
@@ -17,6 +22,7 @@ import {
     CheckBox,
     ErrorMessage,
     HStack,
+    IconButton,
     Loader,
     Text,
     TextDivider,
@@ -41,12 +47,26 @@ export const ConnectPopupScreen = () => {
     const discoveryActive = useSelector(selectHasRunningDiscovery);
     const popupCall = useSelector(selectConnectPopupCall);
     const [isRemembered, setIsRemembered] = useState(false);
+    const [addressConfirmation, setAddressConfirmation] = useState<
+        (ConnectPopupCall & { state: 'address-confirmation' }) | null
+    >();
 
     useEffect(() => {
+        // Reset the popup call when the screen is mounted
+        // Hold and restore address confirmation state during deep link callback
+        if (popupCall?.state == 'address-confirmation') {
+            setAddressConfirmation(popupCall);
+        }
+        if (popupCall?.state == 'deeplink-callback' && addressConfirmation) {
+            dispatch(connectPopupActions.confirmAddresses(addressConfirmation));
+            setAddressConfirmation(null);
+        }
+        // If the popup call is finished we can exit the screen
         if (popupCall?.state == 'finished' && navigation.canGoBack()) {
+            setAddressConfirmation(null);
             navigation.goBack();
         }
-    }, [popupCall, navigation]);
+    }, [popupCall, navigation, addressConfirmation, dispatch]);
 
     const mainView = useMemo(() => {
         if (!popupCall) {
@@ -160,6 +180,58 @@ export const ConnectPopupScreen = () => {
                             onPress={() => navigation.goBack()}
                         >
                             <Translation id="generic.buttons.close" />
+                        </Button>
+                    </VStack>
+                );
+            }
+
+            if (popupCall.state === 'address-confirmation') {
+                const onFinish = () => {
+                    dispatch(connectPopupActions.finishCall());
+                };
+                const onVerify = (index: number) => {
+                    dispatch(connectPopupVerifyAddressThunk({ index }));
+                };
+
+                return (
+                    <VStack testID="@popup/address-confirmation" spacing="sp16" flex={1}>
+                        <TitleHeader
+                            title={<Translation id="moduleConnectPopup.confirmAddress.title" />}
+                            subtitle={
+                                <Translation id="moduleConnectPopup.confirmAddress.message" />
+                            }
+                        />
+                        <Card>
+                            <VStack>
+                                {popupCall.addresses.map((item, index) => (
+                                    <HStack
+                                        key={index}
+                                        alignItems="center"
+                                        justifyContent="space-between"
+                                        padding="sp8"
+                                    >
+                                        <Text variant="hint">{item.address}</Text>
+                                        <IconButton
+                                            size="small"
+                                            colorScheme={
+                                                item.validated === 'valid'
+                                                    ? 'primary'
+                                                    : 'tertiaryElevation0'
+                                            }
+                                            iconName={
+                                                item.validated === 'valid'
+                                                    ? 'checkCircle'
+                                                    : 'trezorDevices'
+                                            }
+                                            onPress={() => onVerify(index)}
+                                        />
+                                    </HStack>
+                                ))}
+                            </VStack>
+                        </Card>
+
+                        <Button testID="@popup/confirm-addresses" onPress={onFinish}>
+                            <Translation id="moduleConnectPopup.confirm" />
                         </Button>
                     </VStack>
                 );

--- a/suite-native/module-connect-popup/src/screens/WalletConnectPairScreen.tsx
+++ b/suite-native/module-connect-popup/src/screens/WalletConnectPairScreen.tsx
@@ -132,10 +132,10 @@ export const WalletConnectPairScreen = () => {
                 {sessions.length === 0 && (
                     <>
                         <Text textAlign="center" variant="titleSmall">
-                            <Translation id="moduleConnectPopup.walletConnect.noConnectedApps" />
+                            <Translation id="moduleConnectPopup.noConnectedApps" />
                         </Text>
                         <Text textAlign="center" color="textSubdued">
-                            <Translation id="moduleConnectPopup.walletConnect.noConnectedAppsDescription" />
+                            <Translation id="moduleConnectPopup.noConnectedAppsDescription" />
                         </Text>
                     </>
                 )}

--- a/suite-native/module-connect-popup/tsconfig.json
+++ b/suite-native/module-connect-popup/tsconfig.json
@@ -3,9 +3,6 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
-            "path": "../../suite-common/suite-types"
-        },
-        {
             "path": "../../suite-common/wallet-core"
         },
         {

--- a/suite-native/module-settings/src/components/ConnectionSettings.tsx
+++ b/suite-native/module-settings/src/components/ConnectionSettings.tsx
@@ -57,6 +57,19 @@ export const ConnectionSettings = () => {
                     <CardDivider />
                 </>
             )}
+            {isConnectPopupEnabled && (
+                <SettingsSectionItem
+                    iconName="trezorLogo"
+                    title={
+                        <Translation id="moduleSettings.items.connections.trezorConnect.title" />
+                    }
+                    subtitle={
+                        <Translation id="moduleSettings.items.connections.trezorConnect.subtitle" />
+                    }
+                    onPress={() => navigation.navigate(RootStackRoutes.ConnectPermissions)}
+                    testID="@settings/connect-permissions"
+                />
+            )}
             {isWalletConnectEnabled && (
                 <SettingsSectionItem
                     iconName="walletConnect"

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -266,6 +266,7 @@ export type RootStackParamList = {
     [RootStackRoutes.SendStack]: NavigatorScreenParams<SendStackParamList>;
     [RootStackRoutes.CoinEnablingInit]: undefined;
     [RootStackRoutes.ConnectPopup]: undefined;
+    [RootStackRoutes.ConnectPermissions]: undefined;
     [RootStackRoutes.WalletConnectSessionPopup]: undefined;
     [RootStackRoutes.WalletConnectSwitchAccount]: {
         sessionTopic: string;

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -16,6 +16,7 @@ export enum RootStackRoutes {
     AddCoinAccountStack = 'AddCoinAccountStack',
     CoinEnablingInit = 'CoinEnablingInit',
     ConnectPopup = 'ConnectPopup',
+    ConnectPermissions = 'ConnectPermissions',
     WalletConnectSessionPopup = 'WalletConnectSessionPopup',
     WalletConnectSwitchAccount = 'WalletConnectSwitchAccount',
     WalletConnectPair = 'WalletConnectPair',

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -235,6 +235,13 @@ export const prepareRootReducers = async () => {
         transforms: [bluetoothPersistTransform],
     });
 
+    const connectPopupPersistedReducer = await preparePersistReducer({
+        reducer: connectPopupReducer,
+        persistedKeys: ['permissions'],
+        key: 'connectPopup',
+        version: 1,
+    });
+
     const rootReducer = await preparePersistReducer({
         reducer: combineReducers({
             app: appReducer,
@@ -252,7 +259,7 @@ export const prepareRootReducers = async () => {
             notifications: notificationsReducer,
             messageSystem: messageSystemPersistedReducer,
             tokenDefinitions: tokenDefinitionsReducer,
-            connectPopup: connectPopupReducer,
+            connectPopup: connectPopupPersistedReducer,
             walletConnect: walletConnectReducer,
             bluetooth: bluetoothPersistedReducer,
             geolocation: geolocationReducer,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10694,7 +10694,6 @@ __metadata:
   dependencies:
     "@react-navigation/native": "npm:6.1.18"
     "@reduxjs/toolkit": "npm:2.8.2"
-    "@suite-common/suite-types": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/walletconnect": "workspace:*"
     "@suite-native/atoms": "workspace:*"


### PR DESCRIPTION
## Description

Updated UI and flow for Connect in mobile. Now we also pass appName and appIcon via deeplink. 
Permissions can be saved, same way as desktop.

## Screenshots:

<img src="https://github.com/user-attachments/assets/d3ff27b0-36f1-4898-99c8-7c47be310de3" width="300" />

<img src="https://github.com/user-attachments/assets/0d3ec46d-413e-4b1e-bf64-f49e933d8564" width="300" />

<img src="https://github.com/user-attachments/assets/b5fcd1e8-f76a-4633-b24d-399af16e61de" width="300" />




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-mobile2&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connect-mobile2&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-mobile2&lookback=7)