### PR TITLE
fix(suite-native): Mobile Trade: Receive address is not fully visible

### DIFF
--- a/suite-native/module-trading/src/components/general/AccountList/AccountListBaseItem.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListBaseItem.tsx
@@ -52,15 +52,7 @@ const AccountListLabel = ({ label, flex }: { label: ReactNode; flex: number }) =
     const { applyStyle } = useNativeStyles();
 
     return (
-        <Text
-            variant="body"
-            numberOfLines={1}
-            ellipsizeMode="tail"
-            style={applyStyle(labelTextStyle, {
-                textColor: 'textDefault',
-                flex,
-            })}
-        >
+        <Text variant="body" style={applyStyle(labelTextStyle, { textColor: 'textDefault', flex })}>
             {label}
         </Text>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Receive address was not fully visible when selecting address in Trade Buy section.

## Related Issue

Resolve #19424

## Screenshots:
### Before
![image](https://github.com/user-attachments/assets/f1e6dcf7-ef31-4216-9dd9-674014a190bf)

### After
![Screen Shot 2025-06-09 at 08 15 18 AM](https://github.com/user-attachments/assets/45908b02-5e47-44d2-9af9-99e8d50061d6)


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19424-Trading-Buy-address-is-not-fully-visible&lookback=7)