### PR TITLE
fix(suite): take wallet type loading settings into account

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PassphraseFlow.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PassphraseFlow.tsx
@@ -47,15 +47,28 @@ export const ReduxModal = (modal: ReduxModalProps) => {
 type ForegroundAppModalProps = {
     app: ForegroundAppRoute['app'];
     cancelable: boolean;
+    isAddingHiddenWalletWithRespectToSettings?: boolean;
 };
 
-const ForegroundAppModal = ({ app, cancelable }: ForegroundAppModalProps) => {
+const ForegroundAppModal = ({
+    app,
+    isAddingHiddenWalletWithRespectToSettings,
+    cancelable,
+}: ForegroundAppModalProps) => {
     const dispatch = useDispatch();
 
     const onCancel = () => dispatch(closeModalApp());
 
     if (app === 'switch-device') {
-        return <SwitchDevice cancelable={cancelable} onCancel={onCancel} />;
+        return (
+            <SwitchDevice
+                cancelable={cancelable}
+                isAddingHiddenWalletWithRespectToSettings={
+                    isAddingHiddenWalletWithRespectToSettings
+                }
+                onCancel={onCancel}
+            />
+        );
     }
 };
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/EnterPassphrase.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/EnterPassphrase.tsx
@@ -20,6 +20,7 @@ import { Translation, TranslationKey } from '../../../Translation';
 
 type EnterPassphraseProps = {
     onDeviceOffer: boolean;
+    cancelDisabled?: boolean;
     device: TrezorDevice;
     deviceLoading?: boolean;
     submitting?: boolean;
@@ -31,6 +32,7 @@ type EnterPassphraseProps = {
 
 export const EnterPassphrase = ({
     device,
+    cancelDisabled,
     deviceLoading,
     onDeviceOffer,
     isExistingWallet = false,
@@ -47,6 +49,7 @@ export const EnterPassphrase = ({
     return (
         <SwitchDeviceModal isAnimationEnabled onCancel={onCancel}>
             <CardWithDevice
+                cancelDisabled={cancelDisabled}
                 onCancel={onCancel}
                 device={device}
                 onBackButtonClick={onBack}

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
@@ -9,8 +9,10 @@ import {
     selectIsDiscoveryAuthConfirmationRequired,
     submitPassphrase,
 } from '@suite-common/wallet-core';
+import { UI } from '@trezor/connect';
 
 import { CONTEXT_DEVICE } from 'src/actions/suite/constants/modalConstants';
+import { goto } from 'src/actions/suite/routerActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { PassphraseWalletBestPractices } from './PassphraseWalletBestPractices';
@@ -19,8 +21,6 @@ import { PassphraseWalletIsNotExistFlow } from './PassphraseWalletIsNotExistFlow
 import { DiscoveryLoader } from '../../ModalSwitcher/DiscoveryLoader';
 import { PassphraseDuplicateModal } from '../UserContextModal/PassphraseDuplicateModal';
 import { PassphraseMismatchModal } from '../UserContextModal/PassphraseMismatchModal';
-
-// Using the shared determinePassphraseFlowState function from suite-common/wallet-core
 
 export const PassphraseModal = ({ device }: { device: TrezorDevice }) => {
     const discovery = useSelector(state => selectDiscoveryByDevicePath(state, device?.path));
@@ -54,10 +54,26 @@ export const PassphraseModal = ({ device }: { device: TrezorDevice }) => {
         selectIsDiscoveryAuthConfirmationRequired(state, device?.path),
     );
 
-    const cancel = useCallback(() => {
-        if (!passphraseState?.discovery) return;
+    const onBackToInitial = () => {
         dispatch(cancelDiscoveryThunk(device));
-    }, [device, dispatch, passphraseState?.discovery]);
+        dispatch({ type: UI.CLOSE_UI_WINDOW });
+        if (passphraseState?.isAddingHiddenWalletWithRespectToSettings) {
+            dispatch(
+                goto('suite-switch-device', {
+                    params: {
+                        cancelable: false,
+                        isAddingHiddenWalletWithRespectToSettings: true,
+                    },
+                }),
+            );
+        }
+    };
+
+    const onCancel = () => {
+        if (!passphraseState?.isAddingHiddenWalletWithRespectToSettings) {
+            dispatch(cancelDiscoveryThunk(device));
+        }
+    };
 
     const onSubmit = useCallback(
         (value: string, passphraseOnDevice?: boolean) => {
@@ -111,9 +127,10 @@ export const PassphraseModal = ({ device }: { device: TrezorDevice }) => {
         case 'not-exist-best-practices':
             return (
                 <PassphraseWalletBestPractices
+                    cancelDisabled={passphraseState.isAddingHiddenWalletWithRespectToSettings}
                     device={device}
-                    onBack={cancel}
-                    onCancel={cancel}
+                    onBack={onBackToInitial}
+                    onCancel={onCancel}
                     onNext={() => dispatch(runDiscoveryThunk(device))}
                 />
             );
@@ -125,10 +142,15 @@ export const PassphraseModal = ({ device }: { device: TrezorDevice }) => {
                 discovery={passphraseState.discovery}
                 device={device}
                 passphraseState={passphraseState.screen}
+                isAddingHiddenWalletWithRespectToSettings={
+                    passphraseState.isAddingHiddenWalletWithRespectToSettings
+                }
                 loading={Boolean(passphraseState.loading)}
                 deviceOffer={deviceOffer}
                 authConfirmation={authConfirmation}
                 submittingPassphrase={Boolean(passphraseState.isSubmitting)}
+                onBackToInitial={onBackToInitial}
+                onCancel={onCancel}
                 onSubmit={onSubmit}
             />
         );
@@ -137,10 +159,14 @@ export const PassphraseModal = ({ device }: { device: TrezorDevice }) => {
     return (
         <PassphraseWalletIsNotExistFlow
             device={device}
+            isAddingHiddenWalletWithRespectToSettings={
+                passphraseState.isAddingHiddenWalletWithRespectToSettings
+            }
             passphraseState={passphraseState.screen}
             loading={Boolean(passphraseState.loading)}
             deviceOffer={deviceOffer}
             submittingPassphrase={Boolean(passphraseState.isSubmitting)}
+            onCancel={onCancel}
             onSubmit={onSubmit}
         />
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletBestPractices.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletBestPractices.tsx
@@ -7,6 +7,7 @@ import { SwitchDeviceModal } from '../../../../../views/suite/SwitchDevice/Switc
 import { Translation } from '../../../Translation';
 
 type PassphraseWalletBestPracticesProps = {
+    cancelDisabled?: boolean;
     onCancel: () => void;
     onNext: () => void;
     onBack: () => void;
@@ -55,6 +56,7 @@ const PassphraseWalletBestPracticesContent = ({
 );
 
 export const PassphraseWalletBestPractices = ({
+    cancelDisabled,
     onCancel,
     onNext,
     onBack,
@@ -63,6 +65,7 @@ export const PassphraseWalletBestPractices = ({
     <SwitchDeviceModal onCancel={onCancel}>
         <CardWithDevice
             onCancel={onCancel}
+            cancelDisabled={cancelDisabled}
             device={device}
             onBackButtonClick={onBack}
             isFullHeaderVisible

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletExistsFlow.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletExistsFlow.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { cancelDiscoveryThunk, startDiscoveryThunk } from '@suite-common/wallet-core';
 import { DiscoveryStatus } from '@suite-common/wallet-types';
-import { UI } from '@trezor/connect-web';
 
 import { useDispatch } from 'src/hooks/suite';
 
@@ -19,8 +18,11 @@ type PassphraseWalletExistsFlowProps = {
     authConfirmation?: boolean;
     passphraseState: string;
     submittingPassphrase: boolean;
+    isAddingHiddenWalletWithRespectToSettings: boolean;
     loading: boolean;
+    onCancel: () => void;
     onSubmit: (value: string, passphraseOnDevice?: boolean) => void;
+    onBackToInitial: () => void;
 };
 
 export const PassphraseWalletExistsFlow = ({
@@ -29,19 +31,16 @@ export const PassphraseWalletExistsFlow = ({
     deviceOffer,
     passphraseState,
     submittingPassphrase,
+    isAddingHiddenWalletWithRespectToSettings,
     loading,
+    onCancel,
     onSubmit,
+    onBackToInitial,
 }: PassphraseWalletExistsFlowProps) => {
     const dispatch = useDispatch();
     const [confirmPassphraseFlowState, setConfirmPassphraseFlowState] = useState<
         'exists-empty-wallet' | 'exists-best-practices' | 'exists-confirm-passphrase'
     >('exists-empty-wallet');
-
-    const onCancel = () => {
-        // To close any dangling modals in the passphrase flow
-        dispatch({ type: UI.CLOSE_UI_WINDOW });
-        dispatch(cancelDiscoveryThunk(device));
-    };
 
     const toExistEnterPassphrase = () => {
         dispatch(cancelDiscoveryThunk(device));
@@ -100,11 +99,12 @@ export const PassphraseWalletExistsFlow = ({
     return (
         <EnterPassphrase
             isExistingWallet={true}
+            cancelDisabled={isAddingHiddenWalletWithRespectToSettings}
             deviceLoading={loading}
             device={device}
             submitting={submittingPassphrase}
             onDeviceOffer={deviceOffer}
-            onBack={onCancel}
+            onBack={onBackToInitial}
             onCancel={onCancel}
             onSubmit={onSubmit}
         />

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletIsNotExistFlow.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletIsNotExistFlow.tsx
@@ -1,6 +1,5 @@
 import { TrezorDevice } from '@suite-common/suite-types';
 import { cancelDiscoveryThunk, startDiscoveryThunk } from '@suite-common/wallet-core';
-import { UI } from '@trezor/connect-web';
 
 import { useDispatch } from 'src/hooks/suite';
 
@@ -12,8 +11,10 @@ type PassphraseWalletIsNotExistFlowProps = {
     deviceOffer: boolean;
     passphraseState: string;
     loading: boolean;
+    onCancel: () => void;
     onSubmit: (value: string, passphraseOnDevice?: boolean) => void;
     submittingPassphrase?: boolean;
+    isAddingHiddenWalletWithRespectToSettings?: boolean;
 };
 
 export const PassphraseWalletIsNotExistFlow = ({
@@ -22,15 +23,11 @@ export const PassphraseWalletIsNotExistFlow = ({
     passphraseState,
     loading,
     onSubmit,
+    onCancel,
     submittingPassphrase,
+    isAddingHiddenWalletWithRespectToSettings,
 }: PassphraseWalletIsNotExistFlowProps) => {
     const dispatch = useDispatch();
-
-    const onCancel = () => {
-        // To close any dangling modals in the passphrase flow
-        dispatch({ type: UI.CLOSE_UI_WINDOW });
-        dispatch(cancelDiscoveryThunk(device));
-    };
 
     if (passphraseState === 'not-exist-confirm-passphrase') {
         return (
@@ -47,6 +44,7 @@ export const PassphraseWalletIsNotExistFlow = ({
     if (passphraseState === 'not-exist-enter-passphrase') {
         return (
             <EnterPassphrase
+                cancelDisabled={isAddingHiddenWalletWithRespectToSettings}
                 deviceLoading={loading}
                 device={device}
                 submitting={submittingPassphrase}
@@ -58,6 +56,7 @@ export const PassphraseWalletIsNotExistFlow = ({
                             device,
                             isAddingHiddenWallet: true,
                             isAddingExistingWallet: false,
+                            isAddingHiddenWalletWithRespectToSettings,
                         }),
                     );
                 }}

--- a/packages/suite/src/hooks/suite/usePreferredModal.ts
+++ b/packages/suite/src/hooks/suite/usePreferredModal.ts
@@ -38,6 +38,7 @@ const getForegroundAppAction = (route: ForegroundAppRoute, params: Partial<Modal
     ({
         type: 'foreground-app',
         payload: {
+            ...params,
             app: route.app,
             // params are undefined when the user goes directly to the URL
             cancelable: !!params?.cancelable,

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -7,7 +7,7 @@ import {
     deviceActions,
     runAdditionalDiscoveryThunk,
     selectSelectedDevice,
-    startDiscoveryThunk,
+    startInitialDiscovery,
 } from '@suite-common/wallet-core';
 
 import { SUITE } from 'src/actions/suite/constants';
@@ -55,7 +55,11 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         ) {
             if (device && device.connected && isDeviceAcquired(device) && !isDeviceLocked) {
                 if (!device?.state) {
-                    dispatch(startDiscoveryThunk({ device }));
+                    dispatch(
+                        startInitialDiscovery({
+                            device,
+                        }),
+                    );
                 } else if (device.state.staticSessionId) {
                     dispatch(runAdditionalDiscoveryThunk(device.state.staticSessionId));
                 }

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -132,6 +132,7 @@ export type ForegroundAppRoute = Extract<
 export type ForegroundAppProps = {
     cancelable: boolean;
     onCancel: (preserveParams?: boolean) => void;
+    isAddingHiddenWalletWithRespectToSettings?: boolean;
 };
 
 export type ToastNotificationVariant = 'success' | 'info' | 'warning' | 'error' | 'transparent';

--- a/packages/suite/src/utils/suite/router.ts
+++ b/packages/suite/src/utils/suite/router.ts
@@ -68,15 +68,38 @@ const validateWalletParams = (url: string): CommonWalletParams => {
     };
 };
 
-const validateModalAppParams = (url: string) => {
+const parseParamValue = <T>(value: string, defaultValue?: T) => {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+
+    return value ?? defaultValue;
+};
+
+export type ModalAppParams = {
+    cancelable: boolean;
+    isAddingHiddenWalletWithRespectToSettings?: boolean;
+    variant?: string;
+};
+
+const validateModalAppParams = (url: string, params?: Route['params']): ModalAppParams | null => {
     const [, hash] = stripPrefixedURL(url).split('#');
-    if (!hash) return;
-    const [cancelable] = hash.split('/').filter(p => p.length > 0);
-    if (cancelable !== 'true') return;
+    if (!hash) return null;
+    const splitted = hash.split('/').filter(p => p.length > 0);
+    if (splitted.length === 0) return null;
+
+    const defaults: ModalAppParams = { cancelable: true };
+
+    if (params === undefined) return defaults;
 
     return {
-        cancelable: true,
-    };
+        ...defaults,
+        ...Object.fromEntries(
+            params.map((param, index) => [
+                param,
+                parseParamValue(splitted[index], defaults[param as keyof ModalAppParams]),
+            ]),
+        ),
+    } as ModalAppParams;
 };
 
 // Used in routerReducer
@@ -102,7 +125,7 @@ export const getAppWithParams = (url: string): RouterAppWithParams => {
     if (route.params) {
         return {
             app: route.app,
-            params: validateModalAppParams(url),
+            params: validateModalAppParams(url, route.params),
             route,
         } as RouterAppWithParams;
     }
@@ -115,8 +138,9 @@ export const getAppWithParams = (url: string): RouterAppWithParams => {
 };
 
 export type WalletParams = CommonWalletParams;
-export type ModalAppParams = NonNullable<ReturnType<typeof validateModalAppParams>>;
-export type RouteParams = WalletParams | ModalAppParams;
+export type RouteParams = (WalletParams | ModalAppParams) & {
+    isAddingHiddenWalletWithRespectToSettings?: boolean;
+};
 
 export const getRoute = (name: Route['name'], params?: RouteParams) => {
     const route = findRouteByName(name);

--- a/packages/suite/src/views/suite/SwitchDevice/CardWithDevice.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/CardWithDevice.tsx
@@ -13,6 +13,7 @@ import { NeedsAttentionBanner } from './NeedsAttentionBanner';
 
 type CardWithDeviceProps = {
     children: ReactNode;
+    cancelDisabled?: boolean;
     onCancel?: ForegroundAppProps['onCancel'];
     device: TrezorDevice;
     isFullHeaderVisible?: boolean;
@@ -22,6 +23,7 @@ type CardWithDeviceProps = {
 
 export const CardWithDevice = ({
     children,
+    cancelDisabled,
     onCancel,
     device,
     isFullHeaderVisible = false,
@@ -38,6 +40,7 @@ export const CardWithDevice = ({
             <Column gap={spacings.md} margin={spacings.xs}>
                 <DeviceHeader
                     isFindTrezorVisible={isFindTrezorVisible}
+                    cancelDisabled={cancelDisabled}
                     onCancel={onCancel}
                     device={device}
                     isFullHeaderVisible={isFullHeaderVisible}

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
@@ -18,6 +18,7 @@ import {
 import { CardButton } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
+import { closeModalApp } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { selectIsDeviceOrUiLocked } from 'src/reducers/suite/suiteReducer';
@@ -27,9 +28,15 @@ interface AddWalletButtonProps {
     device: TrezorDevice;
     instances: AcquiredDevice[];
     onCancel: ForegroundAppProps['onCancel'];
+    isAddingHiddenWalletWithRespectToSettings?: boolean;
 }
 
-export const AddWalletButton = ({ device, instances, onCancel }: AddWalletButtonProps) => {
+export const AddWalletButton = ({
+    device,
+    instances,
+    onCancel,
+    isAddingHiddenWalletWithRespectToSettings, // NOTE: This is passed from to opening goto() that's called from the passphrase modals
+}: AddWalletButtonProps) => {
     // Find a "standard wallet" among user's wallet instances. If no such wallet is found, the variable is undefined.
     const emptyPassphraseWalletExists = instances.find(d => d.useEmptyPassphrase && d.state);
     const isDeviceOrUiLocked = useSelector(selectIsDeviceOrUiLocked);
@@ -47,11 +54,19 @@ export const AddWalletButton = ({ device, instances, onCancel }: AddWalletButton
     }) => {
         onCancel(false);
         dispatch(selectDeviceThunk({ device }));
+        dispatch(closeModalApp());
         dispatch(
+            // NOTE: this prop drilling of isAddingHiddenWalletWithRespectToSettings is "needed"
+            // becuase this infor comes from when the APP IS STARTED an initial discovery receives this flag
+            // from the settings. However! Only "first" discovery must get this flag, no other following,
+            // but if the first discovery is cancelled the switch-device is opened with this flag in "router params"
+            // and in this case, we want to make device switch uncancelable and pass this prop to another discovery
+            // as required first passphrase wallet hasn't been yet opened
             startDiscoveryThunk({
                 device,
                 isAddingHiddenWallet: walletType === WalletType.PASSPHRASE,
                 isAddingExistingWallet: isExisting,
+                isAddingHiddenWalletWithRespectToSettings,
             }),
         );
     };

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceHeader.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceHeader.tsx
@@ -21,6 +21,7 @@ const Container = styled.div<{ $isFullHeaderVisible: boolean }>`
 
 type DeviceHeaderProps = {
     device: TrezorDevice;
+    cancelDisabled?: boolean;
     onCancel?: ForegroundAppProps['onCancel'];
     isFullHeaderVisible: boolean;
     onBackButtonClick?: () => void;
@@ -30,6 +31,7 @@ type DeviceHeaderProps = {
 
 export const DeviceHeader = ({
     onCancel,
+    cancelDisabled,
     device,
     isFullHeaderVisible,
     onBackButtonClick,
@@ -42,7 +44,7 @@ export const DeviceHeader = ({
     const deviceModelInternal = getDeviceInternalModel(device);
 
     const onHeaderClick = () => {
-        if (isFullHeaderVisible && onCancel) {
+        if (isFullHeaderVisible && onCancel && !cancelDisabled) {
             onCancel();
         }
     };
@@ -78,7 +80,7 @@ export const DeviceHeader = ({
                     ) : (
                         <WebUsbButton variant="primary" size="tiny" />
                     ))}
-                {isFullHeaderVisible && (
+                {isFullHeaderVisible && !cancelDisabled && (
                     <Tooltip delayShow={TOOLTIP_DELAY_LONG} content={<Translation id="TR_CLOSE" />}>
                         <IconButton
                             icon="x"

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
@@ -23,14 +23,18 @@ const WalletsWrapper = styled.div<{ $enabled: boolean }>`
 `;
 
 interface DeviceItemProps {
+    cancelable: boolean;
     device: TrezorDevice;
+    isAddingHiddenWalletWithRespectToSettings?: boolean;
     instances: AcquiredDevice[];
     onCancel: ForegroundAppProps['onCancel'];
     isFullHeaderVisible?: boolean;
 }
 
 export const DeviceItem = ({
+    cancelable,
     device,
+    isAddingHiddenWalletWithRespectToSettings,
     instances,
     onCancel,
     isFullHeaderVisible,
@@ -42,6 +46,7 @@ export const DeviceItem = ({
     return (
         <CardWithDevice
             isFindTrezorVisible
+            cancelDisabled={!cancelable}
             onCancel={onCancel}
             device={device}
             isFullHeaderVisible={isFullHeaderVisible}
@@ -65,7 +70,14 @@ export const DeviceItem = ({
                             ))}
                         </Column>
                     )}
-                    <AddWalletButton device={device} instances={instances} onCancel={onCancel} />
+                    <AddWalletButton
+                        device={device}
+                        instances={instances}
+                        onCancel={onCancel}
+                        isAddingHiddenWalletWithRespectToSettings={
+                            isAddingHiddenWalletWithRespectToSettings
+                        }
+                    />
                 </Column>
             </WalletsWrapper>
         </CardWithDevice>

--- a/packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import * as deviceUtils from '@suite-common/suite-utils';
 import { selectDevices } from '@suite-common/wallet-core';
 import { Button, Column, Icon, Row, Text } from '@trezor/components';
@@ -13,7 +15,11 @@ import { selectIsBluetoothListOpen } from '../../../actions/bluetooth/desktopBlu
 import { BluetoothConnect } from '../../../components/suite/bluetooth/BluetoothConnect';
 import { selectSuiteFlags } from '../../../reducers/suite/suiteReducer';
 
-export const SwitchDevice = ({ onCancel }: ForegroundAppProps) => {
+export const SwitchDevice = ({
+    cancelable,
+    isAddingHiddenWalletWithRespectToSettings,
+    onCancel,
+}: ForegroundAppProps) => {
     const { isBluetoothEnabled } = useSelector(selectSuiteFlags);
     const isBluetoothMode = useSelector(selectIsBluetoothListOpen);
     const dispatch = useDispatch();
@@ -30,8 +36,14 @@ export const SwitchDevice = ({ onCancel }: ForegroundAppProps) => {
         dispatch(setBluetoothListOpen({ isOpen: true }));
     };
 
+    const handleCancel = useCallback(() => {
+        if (cancelable) {
+            onCancel();
+        }
+    }, [cancelable, onCancel]);
+
     return (
-        <SwitchDeviceModal isAnimationEnabled onCancel={onCancel}>
+        <SwitchDeviceModal isAnimationEnabled onCancel={handleCancel}>
             {isBluetoothMode ? (
                 <BluetoothConnect uiMode="card" />
             ) : (
@@ -39,9 +51,13 @@ export const SwitchDevice = ({ onCancel }: ForegroundAppProps) => {
                     {sortedDevices.map((device, index) => (
                         <DeviceItem
                             key={`${device.id}-${device.instance}`}
+                            cancelable={cancelable}
                             device={device}
+                            isAddingHiddenWalletWithRespectToSettings={
+                                isAddingHiddenWalletWithRespectToSettings
+                            }
                             instances={deviceUtils.getDeviceInstances(device, devices)}
-                            onCancel={onCancel}
+                            onCancel={handleCancel}
                             isFullHeaderVisible={index === 0}
                         />
                     ))}

--- a/suite-common/suite-config/src/routes.ts
+++ b/suite-common/suite-config/src/routes.ts
@@ -5,7 +5,11 @@
 // 4. add params types to RouteParamsTypes (@suite-constants/routes)
 
 const walletParams = ['symbol', 'accountIndex', 'accountType'] as const;
-const modalAppParams = ['cancelable', 'variant'] as const;
+const modalAppParams = [
+    'isAddingHiddenWalletWithRespectToSettings',
+    'cancelable',
+    'variant',
+] as const;
 
 export const routes = [
     {

--- a/suite-common/wallet-core/src/discovery/__tests__/discoveryReducer.test.ts
+++ b/suite-common/wallet-core/src/discovery/__tests__/discoveryReducer.test.ts
@@ -55,7 +55,12 @@ describe('Discovery Reducer', () => {
         const timestamp = Date.now();
         jest.spyOn(Date, 'now').mockImplementation(() => timestamp);
 
-        store.dispatch(discoveryActions.startDiscovery(TEST_DEVICE_PATH, true, true));
+        store.dispatch(
+            discoveryActions.startDiscovery(TEST_DEVICE_PATH, {
+                isAddingHiddenWallet: true,
+                isAddingExistingWallet: true,
+            }),
+        );
 
         expect(store.getState().wallet.discovery).toEqual({
             [TEST_DEVICE_PATH]: {

--- a/suite-common/wallet-core/src/discovery/discoveryActions.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryActions.ts
@@ -26,11 +26,23 @@ export const deleteDiscovery = createAction(
 
 export const startDiscovery = createAction(
     `${DISCOVERY_MODULE_PREFIX}/start`,
-    (path: DeviceUniquePath, isAddingHiddenWallet?: boolean, isAddingExistingWallet?: boolean) => ({
+    (
+        path: DeviceUniquePath,
+        {
+            isAddingHiddenWallet,
+            isAddingExistingWallet,
+            isAddingHiddenWalletWithRespectToSettings,
+        }: {
+            isAddingHiddenWallet?: boolean;
+            isAddingExistingWallet?: boolean;
+            isAddingHiddenWalletWithRespectToSettings?: boolean;
+        } = {},
+    ) => ({
         payload: {
             path,
             isAddingHiddenWallet,
             isAddingExistingWallet,
+            isAddingHiddenWalletWithRespectToSettings,
         },
     }),
 );

--- a/suite-common/wallet-core/src/discovery/discoveryReducer.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryReducer.ts
@@ -47,6 +47,8 @@ export const prepareDiscoveryReducer = createReducerWithExtraDeps(
                 status: 'starting',
                 isAddingHiddenWallet: payload.isAddingHiddenWallet,
                 isAddingExistingWallet: payload.isAddingExistingWallet,
+                isAddingHiddenWalletWithRespectToSettings:
+                    payload.isAddingHiddenWalletWithRespectToSettings,
                 startTimestamp: Date.now() as Timestamp,
             };
         });

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -668,16 +668,17 @@ export const startDiscoveryThunk = createThunk(
         {
             device,
             isAddingHiddenWallet,
+            isAddingHiddenWalletWithRespectToSettings,
             isAddingExistingWallet,
         }: {
             device?: TrezorDevice;
             isAddingHiddenWallet?: boolean;
+            isAddingHiddenWalletWithRespectToSettings?: boolean;
             isAddingExistingWallet?: boolean;
         },
         { dispatch, getState },
     ): void => {
         const selectedDevice = selectSelectedDevice(getState());
-
         const actualDevice = device ?? selectedDevice;
 
         if (!actualDevice) {
@@ -697,20 +698,43 @@ export const startDiscoveryThunk = createThunk(
         }
 
         dispatch(
-            discoveryActions.startDiscovery(
-                actualDevice.path,
+            discoveryActions.startDiscovery(actualDevice.path, {
                 isAddingHiddenWallet,
                 isAddingExistingWallet,
-            ),
+                isAddingHiddenWalletWithRespectToSettings,
+            }),
         );
 
         // NOTE: run the discovery only if
         // - we are adding a standard wallet,
         // - or adding an existing hidden wallet,
-        // -
-        if (!isAddingHiddenWallet || (isAddingHiddenWallet && isAddingExistingWallet)) {
+        // - or adding initially a hidden wallet set by settings
+        if (
+            !isAddingHiddenWallet ||
+            ((isAddingHiddenWalletWithRespectToSettings || isAddingHiddenWallet) &&
+                isAddingExistingWallet)
+        ) {
             dispatch(runDiscoveryThunk(actualDevice));
         }
+    },
+);
+
+export const startInitialDiscovery = createThunk(
+    `${DISCOVERY_MODULE_PREFIX}/startInitial`,
+    ({ device }: { device: TrezorDevice }, { dispatch, getState, extra }) => {
+        // note: currently this is only used in Suite. If a Suite Lite implementation is needed,
+        // refactor this to a parameter because suiteSettings is a suite-only reducer.
+        const isAddingHiddenWalletWithRespectToSettings =
+            extra.selectors.selectSuiteSettings(getState()).defaultWalletLoading === 'passphrase';
+
+        dispatch(
+            startDiscoveryThunk({
+                device,
+                isAddingHiddenWalletWithRespectToSettings,
+                isAddingExistingWallet: true,
+                isAddingHiddenWallet: isAddingHiddenWalletWithRespectToSettings,
+            }),
+        );
     },
 );
 
@@ -739,7 +763,13 @@ export const runAdditionalDiscoveryThunk = createThunk(
 
             return;
         }
-        dispatch(discoveryActions.startDiscovery(device.path, false, false));
+        dispatch(
+            discoveryActions.startDiscovery(device.path, {
+                isAddingHiddenWallet: false,
+                isAddingExistingWallet: false,
+                isAddingHiddenWalletWithRespectToSettings: false,
+            }),
+        );
 
         const onBundleProgress = createOnBundleProgressHandler(
             device.path,

--- a/suite-common/wallet-core/src/discovery/passphraseUtils.ts
+++ b/suite-common/wallet-core/src/discovery/passphraseUtils.ts
@@ -17,6 +17,10 @@ export const determinePassphraseFlowState = (
         (!modalState.modalContextDevice || modalState.context === modalState.modalContextDevice) &&
         modalState.windowType === UI.REQUEST_PASSPHRASE
     );
+
+    const isAddingHiddenWalletWithRespectToSettings =
+        discovery.isAddingHiddenWalletWithRespectToSettings === true;
+
     if (!discovery.isAddingHiddenWallet) {
         return null;
     }
@@ -25,6 +29,7 @@ export const determinePassphraseFlowState = (
         return {
             isExisting: discovery.isAddingExistingWallet,
             screen: 'discovery-loader',
+            isAddingHiddenWalletWithRespectToSettings,
             discovery,
         } as const;
     }
@@ -33,6 +38,7 @@ export const determinePassphraseFlowState = (
         return {
             isExisting: discovery.isAddingExistingWallet,
             screen: 'passphrase-enable-on-device',
+            isAddingHiddenWalletWithRespectToSettings,
             discovery,
         } as const;
     }
@@ -42,6 +48,7 @@ export const determinePassphraseFlowState = (
             return {
                 isExisting: true,
                 screen: 'exists-enter-passphrase',
+                isAddingHiddenWalletWithRespectToSettings,
                 discovery,
                 loading: isLoading,
                 isSubmitting: Boolean(discovery.passphraseSubmitted),
@@ -52,6 +59,7 @@ export const determinePassphraseFlowState = (
             return {
                 isExisting: true,
                 screen: 'exists-confirm-passphrase',
+                isAddingHiddenWalletWithRespectToSettings,
                 discovery,
                 loading: isLoading,
             } as const;
@@ -78,6 +86,7 @@ export const determinePassphraseFlowState = (
         return {
             isExisting: false,
             screen: 'not-exist-enter-passphrase',
+            isAddingHiddenWalletWithRespectToSettings,
             discovery,
             loading: isLoading,
             isSubmitting: Boolean(discovery.passphraseSubmitted),
@@ -88,6 +97,7 @@ export const determinePassphraseFlowState = (
         return {
             isExisting: false,
             screen: 'not-exist-confirm-passphrase',
+            isAddingHiddenWalletWithRespectToSettings,
             discovery,
             loading: isLoading,
         } as const;
@@ -97,6 +107,7 @@ export const determinePassphraseFlowState = (
         return {
             isExisting: false,
             screen: 'passphrase-duplicate',
+            isAddingHiddenWalletWithRespectToSettings,
             discovery,
         } as const;
     }
@@ -105,6 +116,7 @@ export const determinePassphraseFlowState = (
         return {
             isExisting: false,
             screen: 'not-exist-passphrase-mismatch-warning',
+            isAddingHiddenWalletWithRespectToSettings,
             discovery,
         } as const;
     }
@@ -112,6 +124,7 @@ export const determinePassphraseFlowState = (
     return {
         isExisting: false,
         screen: 'not-exist-best-practices',
+        isAddingHiddenWalletWithRespectToSettings,
         discovery,
     } as const;
 };

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -14,6 +14,7 @@ export type FailedAccount = {
 type CommonDiscoveryStatus = {
     isAddingHiddenWallet?: boolean; // to control visibility of special loader
     isAddingExistingWallet?: boolean; // to control visibility of special loader
+    isAddingHiddenWalletWithRespectToSettings?: boolean;
     emptyWallet?: boolean;
     failed?: FailedAccount[];
     passphraseOnDevice?: boolean;


### PR DESCRIPTION
I'm contemplating #19426, but I don't know if this is a good solution from a UX perspective. I guess @vojtatranta should take over this 

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=discovery-wallet-loading-settings&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=discovery-wallet-loading-settings&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=discovery-wallet-loading-settings&lookback=7)