### PR TITLE
fix(suite-native): Mobile Trade: Fix account list item balance alignment

### DIFF
--- a/suite-native/module-trading/src/components/general/AccountList/AccountListBaseItem.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListBaseItem.tsx
@@ -103,7 +103,8 @@ export const AccountListBaseItem = ({
                 )}
                 <VStack flex={info ? 1 : 0} spacing={0}>
                     <HStack alignItems="center" justifyContent="space-between">
-                        {info && <AccountListLabel label={label} flex={1} />}
+                        {/* If no info is provided, display empty Box to maintain layout consistency */}
+                        {info ? <AccountListLabel label={label} flex={1} /> : <Box />}
                         {shouldDisplayBalance && (
                             <CryptoAmountFormatter
                                 value={cryptoValue}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes visual inconsistency on account list in trading. 



## Screenshots:

### Before
<img width="387" alt="Screenshot 2025-06-09 at 8 58 28" src="https://github.com/user-attachments/assets/af8f64cf-8a89-4461-82c5-263d1284c08b" />

### After
<img width="384" alt="Screenshot 2025-06-09 at 9 16 17" src="https://github.com/user-attachments/assets/da46d743-6231-45a9-b46c-154cc8bde18a" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mobile-trade-account-list-aligning&lookback=7)