### PR TITLE
fix(wallet-utils): accidental account dedupe for the same wallet at two devices

### DIFF
--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -1193,9 +1193,13 @@ export const isNftMatchesSearch = (token: TokenInfo, search: string) =>
 
 export const isAccountInCollection = (account: Account, accounts: Account[]) =>
     accounts.some(
-        ({ descriptor, symbol, accountType, index }) =>
+        ({ deviceState, descriptor, symbol, accountType, index }) =>
+            // most of the time, descriptor is unique for a given (symbol, accountType, index)
             descriptor === account.descriptor &&
+            // but not for EVM networks (intentionally sharing same eth address), so let's compare them too
             symbol === account.symbol &&
             accountType === account.accountType &&
-            index === account.index,
+            index === account.index &&
+            // do not mark as duplicate if two different devices discover the same wallet
+            deviceState === account.deviceState,
     );


### PR DESCRIPTION
## Description

Don't dedupe accounts with distinct device state

## Related Issue

Partially resolve #19350

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/accounts-dedupe-two-devices&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/accounts-dedupe-two-devices&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/accounts-dedupe-two-devices&lookback=7)