### PR TITLE
fix(suite): select device when starting wallet authorization

### DIFF
--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { startDiscoveryThunk } from '@suite-common/wallet-core';
+import { selectDeviceThunk, startDiscoveryThunk } from '@suite-common/wallet-core';
 import { WalletType } from '@suite-common/wallet-types';
 import {
     Button,
@@ -45,7 +45,7 @@ export const AddWalletButton = ({ device, instances, onCancel }: AddWalletButton
         isExisting?: boolean;
     }) => {
         onCancel(false);
-
+        dispatch(selectDeviceThunk({ device }));
         dispatch(
             startDiscoveryThunk({
                 device,


### PR DESCRIPTION
fix #19422

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=discovery-select-device-when-authorizing&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=discovery-select-device-when-authorizing&lookback=7)