### PR TITLE
Refactoring: Bluetooth common code moved to slices

### DIFF
--- a/packages/suite/src/actions/bluetooth/__tests__/desktopBluetoothReducer.test.ts
+++ b/packages/suite/src/actions/bluetooth/__tests__/desktopBluetoothReducer.test.ts
@@ -1,0 +1,62 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { BluetoothManufacturerData } from '@suite-common/bluetooth';
+import { configureMockStore, extraDependenciesMock } from '@suite-common/test-utils';
+import { DeviceModelInternal } from '@trezor/device-utils';
+
+import { DesktopBluetoothDevice } from '../DesktopBluetoothDevice';
+import {
+    DesktopBluetoothState,
+    bluetoothSlice,
+    startConnectingBluetoothDevice,
+    stopConnectingBluetoothDevice,
+} from '../desktopBluetoothReducer';
+
+const manufacturerData: BluetoothManufacturerData = {
+    deviceModel: DeviceModelInternal.T3W1,
+    deviceColor: 0,
+    filterPolicy: null,
+};
+
+const bluetoothReducer = bluetoothSlice.prepareReducer(extraDependenciesMock);
+
+const initialState: DesktopBluetoothState = {
+    isBluetoothListOpen: false,
+    adapterStatus: 'unknown',
+    scanStatus: 'idle',
+    nearbyDevices: [] as DesktopBluetoothDevice[],
+    knownDevices: [] as DesktopBluetoothDevice[],
+    unpairedDeviceNeedsManualOsRemoval: false,
+    connectingDeviceIds: [],
+};
+
+const disconnectedDeviceB: DesktopBluetoothDevice = {
+    connected: false,
+    macAddress: '',
+    id: 'B',
+    manufacturerData,
+    name: 'Trezor B',
+    lastUpdatedTimestamp: 2,
+    connectionStatus: { type: 'disconnected' },
+};
+
+describe('desktopBluetoothReducer', () => {
+    it('starts and stops the auto-connection of the device', () => {
+        const store = configureMockStore({
+            extra: {},
+            reducer: combineReducers({ bluetooth: bluetoothReducer }),
+            preloadedState: {
+                bluetooth: { ...initialState, knownDevices: [disconnectedDeviceB] },
+            },
+        });
+
+        store.dispatch(startConnectingBluetoothDevice({ deviceId: disconnectedDeviceB.id }));
+        expect(store.getState().bluetooth.connectingDeviceIds).toEqual([disconnectedDeviceB.id]);
+
+        store.dispatch(stopConnectingBluetoothDevice({ deviceId: 'non-existing-device' }));
+        expect(store.getState().bluetooth.connectingDeviceIds).toEqual([disconnectedDeviceB.id]);
+
+        store.dispatch(stopConnectingBluetoothDevice({ deviceId: disconnectedDeviceB.id }));
+        expect(store.getState().bluetooth.connectingDeviceIds).toEqual([]);
+    });
+});

--- a/packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts
@@ -1,8 +1,14 @@
-import { BLUETOOTH_PREFIX, bluetoothActions } from '@suite-common/bluetooth';
+import { BLUETOOTH_PREFIX } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import TrezorConnect, { Device } from '@trezor/connect';
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
+
+import {
+    setBluetoothListOpen,
+    startConnectingBluetoothDevice,
+    stopConnectingBluetoothDevice,
+} from './desktopBluetoothReducer';
 
 type BluetoothConnectDeviceThunkResult = {
     success: boolean;
@@ -15,7 +21,7 @@ export const bluetoothConnectDeviceThunk = createThunk<
 >(
     `${BLUETOOTH_PREFIX}/bluetoothConnectDeviceThunk`,
     async ({ deviceId }, { fulfillWithValue, dispatch }) => {
-        dispatch(bluetoothActions.startConnectingBluetoothDevice({ deviceId }));
+        dispatch(startConnectingBluetoothDevice({ deviceId }));
 
         const result = await bluetoothIpc.connectDevice(deviceId);
 
@@ -30,7 +36,7 @@ export const bluetoothConnectDeviceThunk = createThunk<
                 }),
             );
 
-            dispatch(bluetoothActions.stopConnectingBluetoothDevice({ deviceId }));
+            dispatch(stopConnectingBluetoothDevice({ deviceId }));
 
             return fulfillWithValue({ success: result.success });
         }
@@ -54,8 +60,8 @@ export const bluetoothConnectDeviceThunk = createThunk<
             TrezorConnect.on('device-disconnect', closeViewAfterConnection);
         });
 
-        dispatch(bluetoothActions.stopConnectingBluetoothDevice({ deviceId }));
-        dispatch(bluetoothActions.setBluetoothListOpen({ isOpen: false }));
+        dispatch(stopConnectingBluetoothDevice({ deviceId }));
+        dispatch(setBluetoothListOpen({ isOpen: false }));
 
         return fulfillWithValue({ success: result.success });
     },

--- a/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
@@ -5,6 +5,8 @@ import { selectSelectedDevice } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
+import { setBluetoothDeviceNeedsManualOsRemoval } from './desktopBluetoothReducer';
+
 type UnpairCurrentBondParams = {
     bluetoothId: string;
 };
@@ -19,7 +21,7 @@ export const forgetBluetoothDevice = createThunk(
         const resultForget = await bluetoothIpc.forgetDevice(device.bluetoothProps.id);
         if (!resultForget.success) {
             dispatch(
-                bluetoothActions.setBluetoothDeviceNeedsManualOsRemoval({
+                setBluetoothDeviceNeedsManualOsRemoval({
                     needsManualRemoval: true,
                 }),
             );

--- a/packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts
+++ b/packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts
@@ -1,0 +1,66 @@
+import {
+    BluetoothState,
+    prepareBluetoothReducerCreator,
+    prepareInitialState,
+} from '@suite-common/bluetooth';
+import { AnyAction, createSliceWithExtraDeps } from '@suite-common/redux-utils';
+
+import { DesktopBluetoothDevice } from './DesktopBluetoothDevice';
+
+export type DesktopBluetoothState = BluetoothState<DesktopBluetoothDevice> & {
+    isBluetoothListOpen: boolean;
+    // Flag to display some extra info (Modal) to instruct the user to remove
+    // the device from the OS settings manually
+    unpairedDeviceNeedsManualOsRemoval: boolean;
+
+    // When we get an update that KnownDevice appeared, we start auto-connecting to it.
+    // But there may be other updates before the connection is done, and we want to skip them
+    // during the connection process.
+    //
+    // This indicates that suite initiated connection to the device. In contrast with:
+    // { type: 'connecting' } in the DeviceBluetoothConnectionStatus which indicates
+    // the state of the Bluetooth connection itself.
+    connectingDeviceIds: string[];
+};
+
+export type WithBluetoothRootState = {
+    bluetooth: DesktopBluetoothState;
+};
+
+export const bluetoothSlice = createSliceWithExtraDeps({
+    name: 'bluetooth',
+    initialState: {
+        ...prepareInitialState<DesktopBluetoothDevice>(),
+        isBluetoothListOpen: false,
+        unpairedDeviceNeedsManualOsRemoval: false,
+        connectingDeviceIds: [] as string[],
+    } satisfies DesktopBluetoothState,
+    reducers: {
+        setBluetoothDeviceNeedsManualOsRemoval: (state, { payload: { needsManualRemoval } }) => {
+            state.unpairedDeviceNeedsManualOsRemoval = needsManualRemoval;
+        },
+        startConnectingBluetoothDevice: (state, { payload: { deviceId } }) => {
+            state.connectingDeviceIds.push(deviceId);
+        },
+        stopConnectingBluetoothDevice: (state, { payload: { deviceId } }) => {
+            state.connectingDeviceIds = state.connectingDeviceIds.filter(id => id !== deviceId);
+        },
+        setBluetoothListOpen: (state, { payload: { isOpen } }) => {
+            state.isBluetoothListOpen = isOpen;
+        },
+    },
+    extraReducers: (builder, extra) => {
+        const commonReducer = prepareBluetoothReducerCreator<DesktopBluetoothDevice>()(extra);
+
+        builder.addDefaultCase((state, action) => {
+            commonReducer(state, action as AnyAction);
+        });
+    },
+});
+
+export const {
+    setBluetoothDeviceNeedsManualOsRemoval,
+    startConnectingBluetoothDevice,
+    stopConnectingBluetoothDevice,
+    setBluetoothListOpen,
+} = bluetoothSlice.actions;

--- a/packages/suite/src/actions/bluetooth/desktopBluetoothSelectors.ts
+++ b/packages/suite/src/actions/bluetooth/desktopBluetoothSelectors.ts
@@ -1,0 +1,10 @@
+import { WithBluetoothRootState } from './desktopBluetoothReducer';
+
+export const selectConnectingDevices = (state: WithBluetoothRootState) =>
+    state.bluetooth.connectingDeviceIds;
+
+export const selectUnpairedDeviceNeedsManualOsRemoval = (state: WithBluetoothRootState) =>
+    state.bluetooth.unpairedDeviceNeedsManualOsRemoval;
+
+export const selectIsBluetoothListOpen = (state: WithBluetoothRootState) =>
+    state.bluetooth.isBluetoothListOpen;

--- a/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
+++ b/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
@@ -1,9 +1,4 @@
-import {
-    BLUETOOTH_PREFIX,
-    bluetoothActions,
-    selectConnectingDevices,
-    selectKnownDevices,
-} from '@suite-common/bluetooth';
+import { BLUETOOTH_PREFIX, bluetoothActions, selectKnownDevices } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils/';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { BluetoothDevice, bluetoothIpc } from '@trezor/transport-bluetooth';
@@ -15,6 +10,7 @@ import {
 } from './DesktopBluetoothDevice';
 import { bluetoothConnectDeviceThunk } from './bluetoothConnectDeviceThunk';
 import { bluetoothStartScanningThunk } from './bluetoothStartScanningThunk';
+import { selectConnectingDevices } from './desktopBluetoothSelectors';
 import { remapKnownDevicesForLinux } from './remapKnownDevicesForLinux';
 import { selectSuiteFlags } from '../../reducers/suite/suiteReducer';
 
@@ -51,8 +47,7 @@ export const initBluetoothThunk = createThunk<void, void, void>(
 
         const attemptDeviceConnect = async ({ device }: { device: DesktopBluetoothDevice }) => {
             const knownDevices = selectKnownDevices<DesktopBluetoothDevice>(getState());
-            const autoConnectingDevices =
-                selectConnectingDevices<DesktopBluetoothDevice>(getState());
+            const autoConnectingDevices = selectConnectingDevices(getState());
 
             if (
                 !device.connected &&

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -9,8 +9,9 @@ import { getFirmwareVersion } from '@trezor/device-utils';
 import * as modalActions from 'src/actions/suite/modalActions';
 import { reportCheckFail } from 'src/components/suite/SecurityCheck/useReportDeviceCompromised';
 import * as DEVICE from 'src/constants/suite/device';
-import { selectIsEntropyCheckEnabled } from 'src/reducers/suite/suiteReducer';
 import { Dispatch, GetState } from 'src/types/suite';
+
+import { selectIsEntropyCheckEnabled } from '../../reducers/suite/suiteReducer';
 
 export const applySettings =
     (params: Parameters<typeof TrezorConnect.applySettings>[0]) =>

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceConnect.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceConnect.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from 'react';
 
-import { selectConnectingDevices } from '@suite-common/bluetooth';
 import { Button } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
 
@@ -15,6 +14,7 @@ import {
     TROUBLESHOOTING_TIP_USB,
 } from 'src/components/suite/troubleshooting/tips';
 
+import { selectConnectingDevices } from '../../../actions/bluetooth/desktopBluetoothSelectors';
 import { useSelector } from '../../../hooks/suite';
 import { selectHasTransportOfType, selectSuiteFlags } from '../../../reducers/suite/suiteReducer';
 import {

--- a/packages/suite/src/components/suite/PrerequisitesGuide/PrerequisitesGuide.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/PrerequisitesGuide.tsx
@@ -3,7 +3,6 @@ import { PropsWithChildren, useMemo } from 'react';
 import { motion } from 'framer-motion';
 import styled from 'styled-components';
 
-import { bluetoothActions, selectIsBluetoothListOpen } from '@suite-common/bluetooth';
 import {
     deviceNeedsAttention,
     getStatus,
@@ -40,6 +39,8 @@ import { DeviceUpdateRequired } from './DeviceUpdateRequired';
 import { DeviceUsedElsewhere } from './DeviceUsedElsewhere';
 import { MultiShareBackupInProgress } from './MultiShareBackupInProgress';
 import { Transport } from './Transport';
+import { setBluetoothListOpen } from '../../../actions/bluetooth/desktopBluetoothReducer';
+import { selectIsBluetoothListOpen } from '../../../actions/bluetooth/desktopBluetoothSelectors';
 import { BluetoothConnect } from '../bluetooth/BluetoothConnect';
 
 const Wrapper = styled.div`
@@ -161,7 +162,7 @@ export const PrerequisitesGuide = ({ allowSwitchDevice }: PrerequisitesGuideProp
     const dispatch = useDispatch();
 
     const setIsBluetoothConnectOpen = () => {
-        dispatch(bluetoothActions.setBluetoothListOpen({ isOpen: true }));
+        dispatch(setBluetoothListOpen({ isOpen: true }));
     };
 
     return (

--- a/packages/suite/src/components/suite/bluetooth/BluetoothConnect.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothConnect.tsx
@@ -22,6 +22,7 @@ import { bluetoothConnectDeviceThunk } from '../../../actions/bluetooth/bluetoot
 import { bluetoothDisconnectDeviceThunk } from '../../../actions/bluetooth/bluetoothDisconnectDeviceThunk';
 import { bluetoothStartScanningThunk } from '../../../actions/bluetooth/bluetoothStartScanningThunk';
 import { bluetoothStopScanningThunk } from '../../../actions/bluetooth/bluetoothStopScanningThunk';
+import { setBluetoothListOpen } from '../../../actions/bluetooth/desktopBluetoothReducer';
 import { closeModalApp } from '../../../actions/suite/routerActions';
 import { useDispatch, useSelector } from '../../../hooks/suite';
 
@@ -113,7 +114,7 @@ export const BluetoothConnect = ({ uiMode }: BluetoothConnectProps) => {
     }, [setWaitingForFirstUpdate]);
 
     const onClose = () => {
-        dispatch(bluetoothActions.setBluetoothListOpen({ isOpen: false }));
+        dispatch(setBluetoothListOpen({ isOpen: false }));
     };
 
     const onReScanClick = () => {

--- a/packages/suite/src/components/suite/bluetooth/BluetoothDeviceListItem.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDeviceListItem.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import {
     DeviceBluetoothConnectionStatusType,
     bluetoothActions,
-    selectConnectingDevices,
     selectKnownDevices,
     selectNearbyDevices,
 } from '@suite-common/bluetooth';
@@ -12,6 +11,7 @@ import { spacings } from '@trezor/theme';
 
 import { BluetoothDeviceComponent } from './BluetoothDeviceComponent';
 import { DesktopBluetoothDevice } from '../../../actions/bluetooth/DesktopBluetoothDevice';
+import { selectConnectingDevices } from '../../../actions/bluetooth/desktopBluetoothSelectors';
 import { useDispatch, useSelector } from '../../../hooks/suite';
 import { Translation, TranslationKey } from '../Translation';
 

--- a/packages/suite/src/components/suite/bluetooth/UnpairedBluetoothDeviceNeedsManualOsRemovalModal.tsx
+++ b/packages/suite/src/components/suite/bluetooth/UnpairedBluetoothDeviceNeedsManualOsRemovalModal.tsx
@@ -1,15 +1,13 @@
 import { useState } from 'react';
 
-import {
-    bluetoothActions,
-    selectUnpairedDeviceNeedsManualOsRemoval,
-} from '@suite-common/bluetooth';
 import { Banner, H3, Modal, Paragraph } from '@trezor/components';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
 
+import { setBluetoothDeviceNeedsManualOsRemoval } from '../../../actions/bluetooth/desktopBluetoothReducer';
+import { selectUnpairedDeviceNeedsManualOsRemoval } from '../../../actions/bluetooth/desktopBluetoothSelectors';
 import { useDispatch, useSelector } from '../../../hooks/suite';
 
 export const UnpairedBluetoothDeviceNeedsManualOsRemovalModal = () => {
@@ -27,9 +25,7 @@ export const UnpairedBluetoothDeviceNeedsManualOsRemovalModal = () => {
     };
 
     const onCancel = () => {
-        dispatch(
-            bluetoothActions.setBluetoothDeviceNeedsManualOsRemoval({ needsManualRemoval: false }),
-        );
+        dispatch(setBluetoothDeviceNeedsManualOsRemoval({ needsManualRemoval: false }));
     };
 
     if (!wasBluetoothDeviceWiped) {

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -15,7 +15,6 @@ import { isCodesignBuild } from '@trezor/env-utils';
 import { mergeDeepObject } from '@trezor/utils';
 import { prepareTokenDefinitionsReducer } from '@suite-common/token-definitions';
 import { prepareFirmwareReducer } from '@suite-common/firmware';
-import { prepareBluetoothReducerCreator } from '@suite-common/bluetooth';
 import { prepareThpReducer } from '@suite-common/thp';
 import { accountsActions } from '@suite-common/wallet-core';
 
@@ -35,14 +34,13 @@ import toastMiddleware from 'src/middlewares/suite/toastMiddleware';
 import type { PreloadStoreAction } from 'src/support/suite/preloadStore';
 import { desktopReducer } from './desktop';
 import { extraDependencies } from '../support/extraDependencies';
-import { DesktopBluetoothDevice } from '../actions/bluetooth/DesktopBluetoothDevice';
 import { OPEN_USER_CONTEXT } from 'src/actions/suite/constants/modalConstants';
 import { geolocationReducer } from '@suite-common/geolocation';
+import { bluetoothSlice } from '../actions/bluetooth/desktopBluetoothReducer';
 
 const firmwareReducer = prepareFirmwareReducer(extraDependencies);
 const tokenDefinitionsReducer = prepareTokenDefinitionsReducer(extraDependencies);
-const bluetoothReducer =
-    prepareBluetoothReducerCreator<DesktopBluetoothDevice>()(extraDependencies);
+const bluetoothReducer = bluetoothSlice.prepareReducer(extraDependencies);
 const thpReducer = prepareThpReducer(extraDependencies);
 
 const rootReducer = combineReducers({

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -30,6 +30,8 @@ import type { WindowAction } from 'src/actions/suite/windowActions';
 import type { AppState } from 'src/reducers/store';
 import type { WalletAction } from 'src/types/wallet';
 
+import { bluetoothSlice } from '../../actions/bluetooth/desktopBluetoothReducer';
+
 // reexport
 export type { ExtendedMessageDescriptor } from 'src/components/suite/Translation';
 export type { AppState } from 'src/reducers/store';
@@ -71,6 +73,9 @@ type DeviceAuthenticityAction = ReturnType<
     (typeof deviceAuthenticityActions)[keyof typeof deviceAuthenticityActions]
 >;
 type BluetoothAction = ReturnType<(typeof bluetoothActions)[keyof typeof bluetoothActions]>;
+type BluetoothActionDesktop = ReturnType<
+    (typeof bluetoothSlice.actions)[keyof typeof bluetoothSlice.actions]
+>;
 type ThpAction = ReturnType<(typeof thpActions)[keyof typeof thpActions]>;
 type GeolocationAction = ReturnType<(typeof geolocationActions)[keyof typeof geolocationActions]>;
 
@@ -100,6 +105,7 @@ export type Action =
     | DeviceAuthenticityAction
     | ReturnType<typeof addLog>
     | BluetoothAction
+    | BluetoothActionDesktop
     | ThpAction
     | GeolocationAction;
 

--- a/packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx
@@ -1,4 +1,3 @@
-import { bluetoothActions, selectIsBluetoothListOpen } from '@suite-common/bluetooth';
 import * as deviceUtils from '@suite-common/suite-utils';
 import { selectDevices } from '@suite-common/wallet-core';
 import { Button, Column, Icon, Row, Text } from '@trezor/components';
@@ -9,6 +8,8 @@ import { ForegroundAppProps } from 'src/types/suite';
 
 import { DeviceItem } from './DeviceItem/DeviceItem';
 import { SwitchDeviceModal } from './SwitchDeviceModal';
+import { setBluetoothListOpen } from '../../../actions/bluetooth/desktopBluetoothReducer';
+import { selectIsBluetoothListOpen } from '../../../actions/bluetooth/desktopBluetoothSelectors';
 import { BluetoothConnect } from '../../../components/suite/bluetooth/BluetoothConnect';
 import { selectSuiteFlags } from '../../../reducers/suite/suiteReducer';
 
@@ -26,7 +27,7 @@ export const SwitchDevice = ({ onCancel }: ForegroundAppProps) => {
     });
 
     const openBluetoothList = () => {
-        dispatch(bluetoothActions.setBluetoothListOpen({ isOpen: true }));
+        dispatch(setBluetoothListOpen({ isOpen: true }));
     };
 
     return (

--- a/suite-common/bluetooth/src/bluetoothActions.ts
+++ b/suite-common/bluetooth/src/bluetoothActions.ts
@@ -68,34 +68,6 @@ const scanStatusAction = createAction(
     ({ status }: { status: BluetoothScanStatus }) => ({ payload: { status } }),
 );
 
-const setBluetoothDeviceNeedsManualOsRemoval = createAction(
-    `${BLUETOOTH_PREFIX}/set-bluetooth-device-needs-manual-os-removal`,
-    ({ needsManualRemoval }: { needsManualRemoval: boolean }) => ({
-        payload: { needsManualRemoval },
-    }),
-);
-
-const startConnectingBluetoothDevice = createAction(
-    `${BLUETOOTH_PREFIX}/start-connecting-bluetooth-device`,
-    ({ deviceId }: { deviceId: string }) => ({
-        payload: { deviceId },
-    }),
-);
-
-const stopConnectingBluetoothDevice = createAction(
-    `${BLUETOOTH_PREFIX}/stop-connecting-bluetooth-device`,
-    ({ deviceId }: { deviceId: string }) => ({
-        payload: { deviceId },
-    }),
-);
-
-const setBluetoothListOpen = createAction(
-    `${BLUETOOTH_PREFIX}/set-bluetooth-list-open`,
-    ({ isOpen }: { isOpen: boolean }) => ({
-        payload: { isOpen },
-    }),
-);
-
 export const bluetoothActions = {
     adapterEventAction,
     nearbyDevicesUpdateAction,
@@ -104,8 +76,4 @@ export const bluetoothActions = {
     knownDevicesUpdateAction,
     removeKnownDeviceAction,
     updateDeviceConnectionStatus,
-    setBluetoothDeviceNeedsManualOsRemoval,
-    startConnectingBluetoothDevice,
-    stopConnectingBluetoothDevice,
-    setBluetoothListOpen,
 };

--- a/suite-common/bluetooth/src/bluetoothReducer.ts
+++ b/suite-common/bluetooth/src/bluetoothReducer.ts
@@ -8,7 +8,6 @@ import { deserializeBluetoothDeviceSerialization } from './deserializeBluetoothD
 import { BluetoothAdapterStatus, BluetoothDeviceCommon, BluetoothScanStatus } from './types';
 
 export type BluetoothState<T extends BluetoothDeviceCommon> = {
-    isBluetoothListOpen: boolean;
     adapterStatus: BluetoothAdapterStatus;
     scanStatus: BluetoothScanStatus;
     nearbyDevices: null | T[]; // Must be sorted, the newest last. Null = we haven't received first update yet
@@ -16,29 +15,13 @@ export type BluetoothState<T extends BluetoothDeviceCommon> = {
     // This will be persisted. Those are devices we believed that are paired
     // (because we already successfully paired them in the Suite) in the Operating System
     knownDevices: T[];
-
-    // Flag to display some extra info (Modal) to instruct the user to remove
-    // the device from the OS settings manually
-    unpairedDeviceNeedsManualOsRemoval: boolean;
-
-    // When we get an update that KnownDevice appeared, we start auto-connecting to it.
-    // But there may be other updates before the connection is done, and we want to skip them
-    // during the connection process.
-    //
-    // This indicates that suite initiated connection to the device. In contrast with:
-    // { type: 'connecting' } in the DeviceBluetoothConnectionStatus which indicates
-    // the state of the Bluetooth connection itself.
-    connectingDeviceIds: string[];
 };
 
 export const prepareInitialState = <T extends BluetoothDeviceCommon>(): BluetoothState<T> => ({
-    isBluetoothListOpen: false,
     adapterStatus: 'unknown',
     scanStatus: 'idle',
     nearbyDevices: null,
     knownDevices: [] as T[],
-    unpairedDeviceNeedsManualOsRemoval: false,
-    connectingDeviceIds: [],
 });
 
 export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>() =>
@@ -111,29 +94,7 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
                     }
                 }
             })
-            .addCase(
-                bluetoothActions.setBluetoothDeviceNeedsManualOsRemoval,
-                (state, { payload: { needsManualRemoval } }) => {
-                    state.unpairedDeviceNeedsManualOsRemoval = needsManualRemoval;
-                },
-            )
-            .addCase(
-                bluetoothActions.startConnectingBluetoothDevice,
-                (state, { payload: { deviceId } }) => {
-                    state.connectingDeviceIds.push(deviceId);
-                },
-            )
-            .addCase(
-                bluetoothActions.stopConnectingBluetoothDevice,
-                (state, { payload: { deviceId } }) => {
-                    state.connectingDeviceIds = state.connectingDeviceIds.filter(
-                        id => id !== deviceId,
-                    );
-                },
-            )
-            .addCase(bluetoothActions.setBluetoothListOpen, (state, { payload: { isOpen } }) => {
-                state.isBluetoothListOpen = isOpen;
-            })
+
             .addMatcher(
                 action =>
                     action.type === deviceActions.connectDevice.type ||

--- a/suite-common/bluetooth/src/bluetoothSelectors.ts
+++ b/suite-common/bluetooth/src/bluetoothSelectors.ts
@@ -14,21 +14,9 @@ export const selectAdapterStatus = <T extends BluetoothDeviceCommon>(
 export const selectKnownDevices = <T extends BluetoothDeviceCommon>(state: WithBluetoothState<T>) =>
     state.bluetooth.knownDevices;
 
-export const selectConnectingDevices = <T extends BluetoothDeviceCommon>(
-    state: WithBluetoothState<T>,
-) => state.bluetooth.connectingDeviceIds;
-
 export const selectNearbyDevices = <T extends BluetoothDeviceCommon>(
     state: WithBluetoothState<T>,
 ) => state.bluetooth.nearbyDevices;
-
-export const selectUnpairedDeviceNeedsManualOsRemoval = <T extends BluetoothDeviceCommon>(
-    state: WithBluetoothState<T>,
-) => state.bluetooth.unpairedDeviceNeedsManualOsRemoval;
-
-export const selectIsBluetoothListOpen = <T extends BluetoothDeviceCommon>(
-    state: WithBluetoothState<T>,
-) => state.bluetooth.isBluetoothListOpen;
 
 /**
  * We need to have generic `createWeakMapSelector.withTypes` so we need to wrap it into Higher Order Function,

--- a/suite-common/bluetooth/src/index.ts
+++ b/suite-common/bluetooth/src/index.ts
@@ -15,9 +15,6 @@ export {
     selectAdapterStatus,
     selectScanStatus,
     selectNearbyDevices,
-    selectUnpairedDeviceNeedsManualOsRemoval,
-    selectConnectingDevices,
-    selectIsBluetoothListOpen,
 } from './bluetoothSelectors';
 
 export { parseManufacturerData, serializeManufacturerData } from './manufacturerDataUtils';

--- a/suite-common/bluetooth/tests/bluetoothReducer.test.ts
+++ b/suite-common/bluetooth/tests/bluetoothReducer.test.ts
@@ -24,13 +24,10 @@ const bluetoothReducer =
     prepareBluetoothReducerCreator<BluetoothDeviceCommon>()(extraDependenciesMock);
 
 const initialState: BluetoothState<BluetoothDeviceCommon> = {
-    isBluetoothListOpen: false,
     adapterStatus: 'unknown',
     scanStatus: 'idle',
     nearbyDevices: [] as BluetoothDeviceCommon[],
     knownDevices: [] as BluetoothDeviceCommon[],
-    unpairedDeviceNeedsManualOsRemoval: false,
-    connectingDeviceIds: [],
 };
 
 const pairingDeviceA: BluetoothDeviceCommon = {
@@ -171,36 +168,5 @@ describe('bluetoothReducer', () => {
 
         store.dispatch(bluetoothActions.nearbyDevicesUpdateAction({ nearbyDevices }));
         expect(store.getState().bluetooth.nearbyDevices).toEqual([pairingDeviceA]);
-    });
-
-    it('starts and stops the auto-connection of the device', () => {
-        const store = configureMockStore({
-            extra: {},
-            reducer: combineReducers({ bluetooth: bluetoothReducer }),
-            preloadedState: {
-                bluetooth: { ...initialState, knownDevices: [disconnectedDeviceB] },
-            },
-        });
-
-        store.dispatch(
-            bluetoothActions.startConnectingBluetoothDevice({
-                deviceId: disconnectedDeviceB.id,
-            }),
-        );
-        expect(store.getState().bluetooth.connectingDeviceIds).toEqual([disconnectedDeviceB.id]);
-
-        store.dispatch(
-            bluetoothActions.stopConnectingBluetoothDevice({
-                deviceId: 'non-existing-device',
-            }),
-        );
-        expect(store.getState().bluetooth.connectingDeviceIds).toEqual([disconnectedDeviceB.id]);
-
-        store.dispatch(
-            bluetoothActions.stopConnectingBluetoothDevice({
-                deviceId: disconnectedDeviceB.id,
-            }),
-        );
-        expect(store.getState().bluetooth.connectingDeviceIds).toEqual([]);
     });
 });

--- a/suite-common/bluetooth/tests/bluetoothSelectors.test.ts
+++ b/suite-common/bluetooth/tests/bluetoothSelectors.test.ts
@@ -12,13 +12,10 @@ const manufacturerData: BluetoothManufacturerData = {
 };
 
 const initialState: BluetoothState<BluetoothDeviceCommon> = {
-    isBluetoothListOpen: false,
     adapterStatus: 'unknown',
     scanStatus: 'idle',
     nearbyDevices: [],
     knownDevices: [],
-    unpairedDeviceNeedsManualOsRemoval: false,
-    connectingDeviceIds: [],
 };
 
 const pairingDeviceStateA: BluetoothDeviceCommon = {


### PR DESCRIPTION
Needs to be merged after: https://github.com/trezor/trezor-suite/pull/19373

(Only last commit)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=bluetooth_to_sluces&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=bluetooth_to_sluces&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=bluetooth_to_sluces&lookback=7)