### PR TITLE
fix(common): Trim unnecessary zeros with CryptoAmountFormatter

### DIFF
--- a/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
@@ -116,10 +116,16 @@ export const prepareCryptoAmountFormatter = (config: FormatterConfig) =>
                 ? truncateDecimals(convertedValue, maxDisplayedDecimals, isEllipsisAppended)
                 : convertedValue;
 
+            const withoutLeadingZeros = truncatedValue.replace(/^0+(\d)/, '$1');
+
+            const withTrimmedZeros = withoutLeadingZeros.match(/\.\d*$/)
+                ? withoutLeadingZeros.replace(/\.?0+$/, '')
+                : withoutLeadingZeros;
+
             const formattedValue =
                 withSymbol && symbol && isNetworkSymbol(symbol)
-                    ? appendSymbol(truncatedValue, config, symbol, smallestUnitsOverride)
-                    : truncatedValue;
+                    ? appendSymbol(withTrimmedZeros, config, symbol, smallestUnitsOverride)
+                    : withTrimmedZeros;
 
             return shouldRedactNumbers ? redactNumericalSubstring(formattedValue) : formattedValue;
         },

--- a/suite-common/formatters/src/formatters/tests/prepareCryptoAmountFormatter.test.ts
+++ b/suite-common/formatters/src/formatters/tests/prepareCryptoAmountFormatter.test.ts
@@ -37,13 +37,24 @@ describe('CryptoAmountFormatter', () => {
             ).toBe('0.000003');
         });
 
-        it('BTC balance with symbol', () => {
+        it.each([
+            ['0.3', '0.3 BTC'],
+            ['0.3000', '0.3 BTC'],
+            ['3.000', '3 BTC'],
+            ['000.3', '0.3 BTC'],
+            ['003', '3 BTC'],
+            ['0', '0 BTC'],
+            ['000', '0 BTC'],
+            ['3000', '3000 BTC'],
+            ['0033.3300', '33.33 BTC'],
+            ['0033', '33 BTC'],
+        ])('BTC balance with symbol, case %#', (inputValue, expectedValue) => {
             expect(
-                CryptoAmountFormatter.format('0.3', {
+                CryptoAmountFormatter.format(inputValue, {
                     symbol: 'btc',
                     isBalance: true,
                 }),
-            ).toBe('0.3 BTC');
+            ).toBe(expectedValue);
         });
 
         it('ETH balance with symbol + truncate decimals', () => {
@@ -62,7 +73,7 @@ describe('CryptoAmountFormatter', () => {
                     isBalance: true,
                     isEllipsisAppended: false,
                 }),
-            ).toBe('0.02063870 ETH');
+            ).toBe('0.0206387 ETH');
         });
 
         it('ETH balance with units', () => {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFormFieldErrorBadge.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFormFieldErrorBadge.comp.test.tsx
@@ -120,6 +120,22 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
+        it('should not render badge when crypto amount does not differ but contains trailing zeros', async () => {
+            act(() => {
+                tradingForm.setValue('amountInCrypto', true);
+            });
+            act(() => {
+                tradingForm.setValue('cryptoValue', '0.0005000');
+            });
+
+            const { toJSON } = await renderBuyFormFieldErrorBadge(
+                { fieldName: 'cryptoValue' },
+                tradingForm,
+            );
+
+            expect(toJSON()).toBeNull();
+        });
+
         it('should not render badge while quotes are loading', async () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
@@ -196,6 +212,19 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
+        it('should not render badge when fiat amount does not differ but contains trailing zeros', async () => {
+            act(() => {
+                tradingForm.setValue('fiatValue', '10.000');
+            });
+
+            const { toJSON } = await renderBuyFormFieldErrorBadge(
+                { fieldName: 'fiatValue' },
+                tradingForm,
+            );
+
+            expect(toJSON()).toBeNull();
+        });
+
         it('should correctly compare with amount in sats', async () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
@@ -240,6 +269,87 @@ describe('BuyFormFieldErrorBadge', () => {
             );
 
             expect(getByText('Provider offer: 50000 sat')).toBeTruthy();
+        });
+    });
+
+    describe('with quote with trailing zeros', () => {
+        beforeEach(() => {
+            act(() => {
+                tradingForm.setValue('asset', btcAsset);
+            });
+            act(() => {
+                tradingForm.setValue('quote', {
+                    fiatStringAmount: '10.0000',
+                    fiatCurrency: 'USD',
+                    receiveCurrency: 'bitcoin' as CryptoId,
+                    receiveStringAmount: '00.00050',
+                    rate: 20000,
+                    quoteId: 'test-quote-id',
+                    exchange: 'invity',
+                    paymentMethod: 'creditCard',
+                    paymentMethodName: 'Credit Card',
+                    orderId: 'order_id_1',
+                    paymentId: 'test-payment-id',
+                });
+            });
+        });
+
+        it('should not render badge when crypto amount does not differ', async () => {
+            act(() => {
+                tradingForm.setValue('amountInCrypto', true);
+            });
+            act(() => {
+                tradingForm.setValue('cryptoValue', '0.0005');
+            });
+
+            const { toJSON } = await renderBuyFormFieldErrorBadge(
+                { fieldName: 'cryptoValue' },
+                tradingForm,
+            );
+
+            expect(toJSON()).toBeNull();
+        });
+
+        it('should not render badge when crypto amount does not differ but contains trailing zeros', async () => {
+            act(() => {
+                tradingForm.setValue('amountInCrypto', true);
+            });
+            act(() => {
+                tradingForm.setValue('cryptoValue', '0.0005000');
+            });
+
+            const { toJSON } = await renderBuyFormFieldErrorBadge(
+                { fieldName: 'cryptoValue' },
+                tradingForm,
+            );
+
+            expect(toJSON()).toBeNull();
+        });
+
+        it('should not render badge when fiat amount does not differ', async () => {
+            act(() => {
+                tradingForm.setValue('fiatValue', '10.0');
+            });
+
+            const { toJSON } = await renderBuyFormFieldErrorBadge(
+                { fieldName: 'fiatValue' },
+                tradingForm,
+            );
+
+            expect(toJSON()).toBeNull();
+        });
+
+        it('should not render badge when fiat amount does not differ but contains trailing zeros', async () => {
+            act(() => {
+                tradingForm.setValue('fiatValue', '10.000');
+            });
+
+            const { toJSON } = await renderBuyFormFieldErrorBadge(
+                { fieldName: 'fiatValue' },
+                tradingForm,
+            );
+
+            expect(toJSON()).toBeNull();
         });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Trim unnecessary zeros from formatted crypto value. E.g. `0123.3210` becomes `123.321`.



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=improve-crypto-formatter-zero-formatting&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=improve-crypto-formatter-zero-formatting&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=improve-crypto-formatter-zero-formatting&lookback=7)