### PR TITLE
feat(suite-native): keep firmware screen awake

### DIFF
--- a/scripts/list-outdated-dependencies/mobile-dependencies.txt
+++ b/scripts/list-outdated-dependencies/mobile-dependencies.txt
@@ -37,6 +37,7 @@ expo-device
 expo-haptics
 expo-image
 expo-image-picker
+expo-keep-awake
 expo-linear-gradient
 expo-linking
 expo-local-authentication

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -103,6 +103,7 @@
         "expo-haptics": "14.0.1",
         "expo-image": "2.0.7",
         "expo-image-picker": "16.0.6",
+        "expo-keep-awake": "14.0.3",
         "expo-linear-gradient": "14.0.2",
         "expo-linking": "^7.0.5",
         "expo-secure-store": "14.0.1",

--- a/suite-native/firmware/package.json
+++ b/suite-native/firmware/package.json
@@ -21,6 +21,7 @@
         "@trezor/connect": "workspace:*",
         "@trezor/react-native-usb": "workspace:*",
         "@trezor/styles": "workspace:*",
+        "expo-keep-awake": "14.0.3",
         "react": "18.2.0",
         "react-native": "0.76.9",
         "react-native-reanimated": "^3.16.7",

--- a/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
+++ b/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
@@ -9,6 +9,7 @@ import Animated, {
 import { useDispatch } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
+import { useKeepAwake } from 'expo-keep-awake';
 
 import { Badge, Box, Button, IconButton, Text, VStack } from '@suite-native/atoms';
 import { ConfirmOnTrezorImage, setTemporaryRememberedDeviceThunk } from '@suite-native/device';
@@ -56,6 +57,8 @@ export const FirmwareInstallationScreenContent = ({
     isTemporaryRememeberAllowed = true,
     navigationLocation,
 }: FirmwareInstallationScreenContentProps) => {
+    useKeepAwake(); // Prevents screen from sleeping while installing firmware (might take few minutes).
+
     const dispatch = useDispatch();
     const { applyStyle } = useNativeStyles();
     const navigation = useNavigation();

--- a/yarn.lock
+++ b/yarn.lock
@@ -9931,6 +9931,7 @@ __metadata:
     expo-haptics: "npm:14.0.1"
     expo-image: "npm:2.0.7"
     expo-image-picker: "npm:16.0.6"
+    expo-keep-awake: "npm:14.0.3"
     expo-linear-gradient: "npm:14.0.2"
     expo-linking: "npm:^7.0.5"
     expo-secure-store: "npm:14.0.1"
@@ -10288,6 +10289,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/react-native-usb": "workspace:*"
     "@trezor/styles": "workspace:*"
+    expo-keep-awake: "npm:14.0.3"
     react: "npm:18.2.0"
     react-native: "npm:0.76.9"
     react-native-reanimated: "npm:^3.16.7"
@@ -22748,7 +22750,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-keep-awake@npm:~14.0.3":
+"expo-keep-awake@npm:14.0.3, expo-keep-awake@npm:~14.0.3":
   version: 14.0.3
   resolution: "expo-keep-awake@npm:14.0.3"
   peerDependencies:


### PR DESCRIPTION
## Description
- screen is kept awake while is the firmware installation screen focused
## Related issue

Resolve #19216



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/keep-firmware-screen-awake&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/keep-firmware-screen-awake&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/keep-firmware-screen-awake&lookback=7)