### PR TITLE
feat(suite): moved tx size from standard to custom

### DIFF
--- a/packages/suite/src/components/wallet/Fees/CustomFee/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CustomFee.tsx
@@ -69,12 +69,12 @@ export const CustomFee = <TFieldValues extends FormState>({
 }: CustomFeeProps<TFieldValues>) => {
     const { translationString } = useTranslation();
     const [cachedNetworkAmount, setCachedNetworkAmount] = useState<string | undefined>(undefined);
-    const [cachedBytes, setCachedBytes] = useState<number | undefined>(undefined);
+    const cachedBytes =
+        transactionInfo && transactionInfo.type !== 'error' && transactionInfo.bytes;
 
     useEffect(() => {
         if (transactionInfo && transactionInfo.type !== 'error' && transactionInfo.fee) {
             setCachedNetworkAmount(formatNetworkAmount(transactionInfo.fee, symbol));
-            if (transactionInfo.bytes) setCachedBytes(transactionInfo.bytes);
         }
     }, [symbol, transactionInfo]);
 
@@ -155,7 +155,7 @@ export const CustomFee = <TFieldValues extends FormState>({
                     </Row>
                 </Column>
             )}
-            {cachedBytes && (
+            {cachedBytes !== undefined && cachedBytes !== false && (
                 <Row alignItems="baseline" justifyContent="space-between">
                     <Text variant="tertiary" typographyStyle="hint">
                         <Translation id="TR_SIZE" />:

--- a/packages/suite/src/components/wallet/Fees/CustomFee/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CustomFee.tsx
@@ -69,10 +69,12 @@ export const CustomFee = <TFieldValues extends FormState>({
 }: CustomFeeProps<TFieldValues>) => {
     const { translationString } = useTranslation();
     const [cachedNetworkAmount, setCachedNetworkAmount] = useState<string | undefined>(undefined);
+    const [cachedBytes, setCachedBytes] = useState<number | undefined>(undefined);
 
     useEffect(() => {
         if (transactionInfo && transactionInfo.type !== 'error' && transactionInfo.fee) {
             setCachedNetworkAmount(formatNetworkAmount(transactionInfo.fee, symbol));
+            if (transactionInfo.bytes) setCachedBytes(transactionInfo.bytes);
         }
     }, [symbol, transactionInfo]);
 
@@ -152,6 +154,16 @@ export const CustomFee = <TFieldValues extends FormState>({
                         </Row>
                     </Row>
                 </Column>
+            )}
+            {cachedBytes && (
+                <Row alignItems="baseline" justifyContent="space-between">
+                    <Text variant="tertiary" typographyStyle="hint">
+                        <Translation id="TR_SIZE" />:
+                    </Text>
+                    <Text variant="default" typographyStyle="hint">
+                        {cachedBytes} <Translation id="TR_BYTES" />
+                    </Text>
+                </Row>
             )}
         </>
     );

--- a/packages/suite/src/components/wallet/Fees/StandardFee/BitcoinFeeCards.tsx
+++ b/packages/suite/src/components/wallet/Fees/StandardFee/BitcoinFeeCards.tsx
@@ -1,8 +1,5 @@
-import { useEffect, useState } from 'react';
-
 import { formatDurationStrict } from '@suite-common/suite-utils';
 import { getFeeUnits } from '@suite-common/wallet-utils';
-import { Row, Text } from '@trezor/components';
 import { FeeRate } from '@trezor/product-components';
 
 import { Translation } from 'src/components/suite';
@@ -22,21 +19,9 @@ export const BitcoinFeeCards = ({
     selectedLevel,
     changeFeeLevel,
     symbol,
-    isDirty,
     getValues,
 }: StandardFeeProps) => {
     const locale = useLocales();
-
-    const [cachedBytes, setCachedBytes] = useState<number | undefined>(undefined);
-
-    useEffect(() => {
-        if (transactionInfo && transactionInfo.type !== 'error' && transactionInfo.bytes) {
-            setCachedBytes(transactionInfo.bytes);
-        }
-        if (!isDirty) {
-            setCachedBytes(undefined);
-        }
-    }, [transactionInfo, isDirty]);
 
     if (!feeOptions.length) {
         return null;
@@ -96,16 +81,6 @@ export const BitcoinFeeCards = ({
                 baseFee={getValues('baseFee')}
                 feeUnits={getFeeUnits(networkType)}
             />
-            {cachedBytes && (
-                <Row alignItems="baseline" justifyContent="space-between">
-                    <Text variant="tertiary" typographyStyle="hint">
-                        <Translation id="TR_SIZE" />:
-                    </Text>
-                    <Text variant="default" typographyStyle="hint">
-                        {cachedBytes} <Translation id="TR_BYTES" />
-                    </Text>
-                </Row>
-            )}
         </>
     );
 };


### PR DESCRIPTION
Moved tx size from standard to custom fee option.

## Description
- moved the tx size from standard to custom fee view
- tx size now shows for any network which fee is based of tx size (specifically, if `transactionInfo` contains `bytes`)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18855

## Screenshots:
Before
![442609539-f456eb55-10b1-4b37-9803-c2b6d6550190](https://github.com/user-attachments/assets/01958cf3-6430-4c97-80d7-c68d04dfe6cc)
After
<img width="754" alt="Screenshot 2025-06-09 at 13 44 08" src="https://github.com/user-attachments/assets/22ddba95-a29d-4c54-8e78-ac69dd8de869" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/move-tx-size-from-standard-to-fdvanced-fees&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/move-tx-size-from-standard-to-fdvanced-fees&lookback=7)