### PR TITLE
chore(suite-web): don't open vite automatically in browser

### DIFF
--- a/packages/suite-build/vite.config.ts
+++ b/packages/suite-build/vite.config.ts
@@ -256,7 +256,7 @@ export default defineConfig({
     },
     server: {
         port: 8000,
-        open: true,
+        open: false,
         host: true,
     },
 });


### PR DESCRIPTION
## Description

Don't open vite automatically in browser, because developers may want to use a different browser or browser profiles for development than their default one.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/dont-open-vite-automatically&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/dont-open-vite-automatically&lookback=7)