### PR TITLE
Fix: add standard wallet

### DIFF
--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -306,14 +306,19 @@ const setDeviceState = (
     if (!device.features) return;
 
     // find devices with the same "device_id"
-    const affectedDevice = draft.devices.filter(
-        d =>
-            d.features &&
-            ((d.connected &&
-                (d.id === device.id || (d.path.length > 0 && d.path === device.path))) ||
-                // update "disconnected" remembered devices if in bootloader mode
-                (d.mode === 'bootloader' && d.remember && d.id === device.id)),
-    ) as AcquiredDevice[];
+    const affectedDevice = draft.devices.filter(d => {
+        if (!d.features) return false;
+
+        const isConnectedDeviceMatch =
+            d.connected &&
+            d.instance === device.instance &&
+            (d.id === device.id || (d.path.length > 0 && d.path === device.path));
+
+        // update "disconnected" remembered devices if in bootloader mode
+        const isRememberedDeviceMatch = d.mode === 'bootloader' && d.remember && d.id === device.id;
+
+        return isConnectedDeviceMatch || isRememberedDeviceMatch;
+    });
 
     if (affectedDevice.length > 1) {
         console.error('there must be only one device with the same id and without state');
@@ -323,7 +328,6 @@ const setDeviceState = (
 
     affectedDevice[0].state = state;
     affectedDevice[0].useEmptyPassphrase = useEmptyPassphrase;
-    // affectedDevice[0].instance = Number.parseInt(state.staticSessionId?.split(':')[1]!);
     affectedDevice[0].walletNumber = deviceUtils.getNewWalletNumber(draft.devices, device);
 };
 

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -107,6 +107,7 @@ const applyDeviceStatesThunk = createThunk(
 
             assertDeviceIsAcquired(device);
             assertStaticSessionId(newDeviceState);
+            const { staticSessionId } = newDeviceState;
 
             const physicalDevices = selectPhysicalDevices(getState());
             const devicesWithoutState = physicalDevices.filter(d => !d.state?.staticSessionId);
@@ -133,16 +134,12 @@ const applyDeviceStatesThunk = createThunk(
                     }),
                 );
 
-                // todo: there is probably more efficient way to select device after it was created
-                const newlyAddedDevice = selectDeviceByStaticSessionId(
-                    getState(),
-                    newDeviceState.staticSessionId,
-                );
-                if (!newlyAddedDevice) return;
+                // select the device after deviceReducer updates it (it's a new object reference)
+                const newlyAddedDevice = selectDeviceByStaticSessionId(getState(), staticSessionId);
+                if (newlyAddedDevice === undefined) return;
                 dispatch(selectDeviceThunk({ device: newlyAddedDevice }));
             }
 
-            const { staticSessionId } = newDeviceState;
             await dispatch(initNewDeviceStateMetadataThunk(staticSessionId));
         } catch (error) {
             console.error('applyDeviceStatesThunk error', error);

--- a/suite-native/device-manager/src/components/WalletList.tsx
+++ b/suite-native/device-manager/src/components/WalletList.tsx
@@ -4,16 +4,17 @@ import { A } from '@mobily/ts-belt';
 
 import { TrezorDevice } from '@suite-common/suite-types';
 import {
-    createDeviceInstanceThunk,
     selectDeviceInstances,
     selectIsPortfolioTrackerDevice,
     selectSelectedDevice,
+    startDiscoveryThunk,
 } from '@suite-common/wallet-core';
 import { VStack } from '@suite-native/atoms';
 import { selectHasNoDeviceWithEmptyPassphrase } from '@suite-native/device';
 
 import { WalletItem } from './WalletItem';
 import { WalletItemBase } from './WalletItemBase';
+import { useDeviceManager } from '../hooks/useDeviceManager';
 
 type WalletListProps = {
     onSelectDevice: (device: TrezorDevice) => void;
@@ -26,23 +27,26 @@ export const WalletList = ({ onSelectDevice }: WalletListProps) => {
     const hasNoDeviceWithEmptyPassphrase = useSelector(selectHasNoDeviceWithEmptyPassphrase);
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const isSelectable = devices.length > 1 || hasNoDeviceWithEmptyPassphrase;
+    const { setIsDeviceManagerVisible } = useDeviceManager();
 
     // we want to show placeholder in case there are only passphrase wallets without standard and not portfolio
     const showPlaceholder =
-        hasNoDeviceWithEmptyPassphrase && A.isNotEmpty(devices) && !isPortfolioTrackerDevice;
+        hasNoDeviceWithEmptyPassphrase &&
+        A.isNotEmpty(devices) &&
+        !isPortfolioTrackerDevice &&
+        selectedDevice?.connected;
 
     // on tap of placeholder we actually create device with empty passphrase and select it
-    const handlePlaceholderPress = async () => {
-        if (selectedDevice) {
-            await dispatch(
-                createDeviceInstanceThunk({
-                    device: selectedDevice,
-                    useEmptyPassphrase: true,
-                }),
-            )
-                .unwrap()
-                .then(result => onSelectDevice(result.device));
-        }
+    const handlePlaceholderPress = () => {
+        if (selectedDevice === undefined) return;
+        setIsDeviceManagerVisible(false);
+        dispatch(
+            startDiscoveryThunk({
+                device: selectedDevice,
+                isAddingHiddenWallet: false,
+                isAddingExistingWallet: false,
+            }),
+        );
     };
 
     return (


### PR DESCRIPTION
## Description

Fix several errors that arise when adding a standard wallet on mobile (see issue incl. comments).

Note: you never have to add the standard wallet when connecting a non-remembered device,  but when you remember only a passhprase, and connect device, the passphrase gets selected & discovered, so you may add a standard one.

## Related Issue

Resolve #19408

## Screenshots:

See video, I start on a passhprase wallet w/ viewonly, disable viewonly for standard, **then I reload the app** to forget the standard and readd it. Switching back and forth works. 
[Screencast from 2025-06-09 18-04-44.webm](https://github.com/user-attachments/assets/88f73fc2-882d-4ede-9444-7795aac4b3f4)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/add-standard-wallet&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/add-standard-wallet&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/add-standard-wallet&lookback=7)