### PR TITLE
DRAFT: chore(suite): allow DeepSerializable types in state

### DIFF
--- a/suite-common/bluetooth/src/bluetoothReducer.ts
+++ b/suite-common/bluetooth/src/bluetoothReducer.ts
@@ -1,13 +1,13 @@
 import { AnyAction, Draft } from '@reduxjs/toolkit';
 
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import { DeepSerializable , createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { DeviceConnectActionPayload, deviceActions } from '@suite-common/wallet-core';
 
 import { bluetoothActions } from './bluetoothActions';
 import { deserializeBluetoothDeviceSerialization } from './deserializeBluetoothDeviceSerialization';
 import { BluetoothAdapterStatus, BluetoothDeviceCommon, BluetoothScanStatus } from './types';
 
-export type BluetoothState<T extends BluetoothDeviceCommon> = {
+export type BluetoothState<T extends DeepSerializable<BluetoothDeviceCommon>> = {
     isBluetoothListOpen: boolean;
     adapterStatus: BluetoothAdapterStatus;
     scanStatus: BluetoothScanStatus;
@@ -31,7 +31,7 @@ export type BluetoothState<T extends BluetoothDeviceCommon> = {
     connectingDeviceIds: string[];
 };
 
-export const prepareInitialState = <T extends BluetoothDeviceCommon>(): BluetoothState<T> => ({
+export const prepareInitialState = <T extends DeepSerializable<BluetoothDeviceCommon>>(): BluetoothState<T> => ({
     isBluetoothListOpen: false,
     adapterStatus: 'unknown',
     scanStatus: 'idle',
@@ -41,8 +41,8 @@ export const prepareInitialState = <T extends BluetoothDeviceCommon>(): Bluetoot
     connectingDeviceIds: [],
 });
 
-export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>() =>
-    createReducerWithExtraDeps<BluetoothState<T>>(prepareInitialState<T>(), (builder, extra) =>
+export const prepareBluetoothReducerCreator = <T extends DeepSerializable<BluetoothDeviceCommon>>() =>
+    createReducerWithExtraDeps<BluetoothState<T>>(prepareInitialState<T>() as BluetoothState<DeepSerializable<T>>, (builder, extra) =>
         builder
             .addCase(bluetoothActions.adapterEventAction, (state, { payload: { status } }) => {
                 state.adapterStatus = status;
@@ -54,6 +54,7 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
             .addCase(
                 bluetoothActions.nearbyDevicesUpdateAction,
                 (state, { payload: { nearbyDevices } }) => {
+                    // @ts-expect-error
                     state.nearbyDevices = nearbyDevices
                         // Devices with 'pairing-error' status should NOT be displayed in the list, as it
                         // won't be possible to connect to them ever again. User has to start pairing again,
@@ -67,11 +68,13 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
                 bluetoothActions.updateDeviceConnectionStatus,
                 (state, { payload: { deviceId, connectionStatus } }) => {
                     if (state.nearbyDevices !== null) {
+                        // @ts-expect-error
                         state.nearbyDevices = state.nearbyDevices.map(it =>
                             it.id === deviceId ? { ...it, connectionStatus } : it,
                         ) as Draft<T>[];
                     }
 
+                    // @ts-expect-error
                     state.knownDevices = state.knownDevices.map(it =>
                         it.id === deviceId ? { ...it, connectionStatus } : it,
                     ) as Draft<T>[];
@@ -79,11 +82,12 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
             )
             .addCase(bluetoothActions.deviceUpdateAction, (state, { payload: { device } }) => {
                 if (state.nearbyDevices !== null) {
+                    // @ts-expect-error
                     state.nearbyDevices = state.nearbyDevices.map(it =>
                         it.id === device.id ? device : it,
                     ) as Draft<T>[];
                 }
-
+                // @ts-expect-error
                 state.knownDevices = state.knownDevices.map(it =>
                     it.id === device.id ? device : it,
                 ) as Draft<T>[];
@@ -91,6 +95,7 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
             .addCase(
                 bluetoothActions.knownDevicesUpdateAction,
                 (state, { payload: { knownDevices } }) => {
+                    // @ts-expect-error
                     state.knownDevices = knownDevices as Draft<T>[];
                 },
             )
@@ -170,6 +175,7 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
                     const loadedKnownDevices = (action.payload?.bluetooth?.knownDevices ??
                         []) as T[];
 
+                    // @ts-expect-error
                     state.knownDevices = loadedKnownDevices.map(
                         deserializeBluetoothDeviceSerialization,
                     ) as Draft<T>[];

--- a/suite-common/connect-popup/src/connectPopupReducer.ts
+++ b/suite-common/connect-popup/src/connectPopupReducer.ts
@@ -55,6 +55,7 @@ export const prepareConnectPopupReducer = createReducerWithExtraDeps(
             })
             .addCase(connectPopupActions.approvePermissions, state => {
                 if (state.activeCall?.state === 'permission-request') {
+                    // @ts-expect-error
                     state.activeCall.permissionDecision?.resolve();
                     state.activeCall = {
                         ...state.activeCall,
@@ -65,6 +66,7 @@ export const prepareConnectPopupReducer = createReducerWithExtraDeps(
             })
             .addCase(connectPopupActions.rejectPermissions, (state, { payload }) => {
                 if (state.activeCall?.state === 'permission-request') {
+                    // @ts-expect-error
                     state.activeCall.permissionDecision?.reject(payload);
                     state.activeCall = {
                         ...state.activeCall,

--- a/suite-common/firmware/src/firmwareReducer.ts
+++ b/suite-common/firmware/src/firmwareReducer.ts
@@ -43,6 +43,7 @@ type RootState = {
     firmware: typeof initialState;
 };
 
+// @ts-expect-error
 export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, builder => {
     builder
         .addCase(firmwareActions.setStatus, (state, { payload }) => {
@@ -58,6 +59,7 @@ export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, b
         .addCase(firmwareActions.setTargetType, (state, { payload }) => {
             state.targetType = payload;
         })
+        // @ts-expect-error
         .addCase(firmwareActions.resetReducer, state => ({
             ...initialState,
             useDevkit: state.useDevkit,
@@ -66,6 +68,7 @@ export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, b
             state.useDevkit = payload;
         })
         .addCase(firmwareActions.cacheDevice, (state, { payload }) => {
+            // @ts-expect-error
             state.cachedDevice = payload;
         })
         .addMatcher<FirmwareProgress | FirmwareReconnect | DeviceButtonRequest>(
@@ -77,6 +80,7 @@ export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, b
                 // DEVICE.BUTTON can be dispatched outside of the firmware update flow and that should not change the uiEvent,
                 // otherwise it could result in confirmation pill being displayed unintentionally.
                 if (!(action.type === DEVICE.BUTTON && state.status === 'initial'))
+                    // @ts-expect-error
                     state.uiEvent = action;
             },
         );

--- a/suite-common/message-system/src/messageSystemReducer.ts
+++ b/suite-common/message-system/src/messageSystemReducer.ts
@@ -41,6 +41,7 @@ const getMessageStateById = (draft: MessageSystemState, id: string): MessageStat
 };
 
 export const prepareMessageSystemReducer = createReducerWithExtraDeps(
+    // @ts-expect-error
     initialState,
     (builder, extra) => {
         builder
@@ -51,6 +52,7 @@ export const prepareMessageSystemReducer = createReducerWithExtraDeps(
             .addCase(messageSystemActions.fetchSuccessUpdate, (state, { payload }) => {
                 const { timestamp, config } = payload;
                 state.timestamp = timestamp;
+                // @ts-expect-error
                 state.config = config;
                 state.currentSequence = config.sequence;
             })

--- a/suite-common/redux-utils/src/createReducerWithExtraDeps.ts
+++ b/suite-common/redux-utils/src/createReducerWithExtraDeps.ts
@@ -1,15 +1,13 @@
 import { ActionReducerMapBuilder, createReducer } from '@reduxjs/toolkit';
 
 import { ExtraDependenciesForReducer } from './extraDependenciesType';
-
-// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-type NotFunction<T> = T extends Function ? never : T;
+import { DeepSerializable } from './types';
 
 export const createReducerWithExtraDeps =
-    <S extends NotFunction<any>>(
-        initialState: S | (() => S),
+    <S>(
+        initialState: DeepSerializable<S> | (() => DeepSerializable<S>),
         builderCallback: (
-            builder: ActionReducerMapBuilder<S>,
+            builder: ActionReducerMapBuilder<DeepSerializable<S>>,
             extra: ExtraDependenciesForReducer,
         ) => void,
     ) =>
@@ -21,3 +19,5 @@ export const createReducerWithExtraDeps =
                 reducers: extraDeps.reducers,
             }),
         );
+
+

--- a/suite-common/redux-utils/src/types.ts
+++ b/suite-common/redux-utils/src/types.ts
@@ -38,3 +38,13 @@ export type ActionsFromAsyncThunk<T extends AnyAsyncThunk> =
     | ActionFromMatcher<T['pending']>
     | ActionFromMatcher<T['fulfilled']>
     | ActionFromMatcher<T['rejected']>;
+
+// because of nested objects, we need to use a recursive type
+export type DeepSerializable<T> =
+    T extends string | number | boolean | null | undefined
+        ? T
+        : T extends Array<infer U>
+        ? DeepSerializable<U>[]
+        : T extends object
+        ? { [K in keyof T]: DeepSerializable<T[K]> }
+        : never;

--- a/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
@@ -217,24 +217,28 @@ export const prepareBlockchainReducer = createReducerWithExtraDeps(
             .addMatcher(
                 action => action.type === TREZOR_CONNECT_BLOCKCHAIN_ACTIONS.CONNECT,
                 (state, { payload }: PayloadAction<BlockchainInfo>) => {
+                    // @ts-expect-error
                     connect(state, payload);
                 },
             )
             .addMatcher(
                 action => action.type === TREZOR_CONNECT_BLOCKCHAIN_ACTIONS.ERROR,
                 (state, { payload }: PayloadAction<BlockchainError>) => {
+                    // @ts-expect-error
                     error(state, payload);
                 },
             )
             .addMatcher(
                 action => action.type === TREZOR_CONNECT_BLOCKCHAIN_ACTIONS.RECONNECTING,
                 (state, { payload }: PayloadAction<BlockchainReconnecting>) => {
+                    // @ts-expect-error
                     reconnecting(state, payload);
                 },
             )
             .addMatcher(
                 action => action.type === TREZOR_CONNECT_BLOCKCHAIN_ACTIONS.BLOCK,
                 (state, { payload }: PayloadAction<BlockchainBlock>) => {
+                    // @ts-expect-error
                     update(state, payload);
                 },
             );

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -594,40 +594,52 @@ export const setDeviceAuthenticity = (
     };
 };
 
+// @ts-expect-error
 export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (builder, extra) => {
     builder
         .addCase(deviceActions.deviceChanged, (state, { payload }) => {
+            // @ts-expect-error
             changeDevice(state, payload, { connected: true, available: true });
         })
         .addCase(deviceActions.setDeviceState, (state, { payload }) => {
+            // @ts-expect-error
             setDeviceState(state, payload.device, payload.state, payload.useEmptyPassphrase);
         })
         .addCase(deviceActions.addAuthorizedDevice, (state, { payload }) => {
+            // @ts-expect-error
             addAuthorizedDevice(state, payload.device);
         })
 
         .addCase(deviceActions.deviceDisconnect, (state, { payload }) => {
+            // @ts-expect-error
             disconnectDevice(state, payload);
         })
         .addCase(deviceActions.updatePassphraseMode, (state, { payload }) => {
+            // @ts-expect-error
             changePassphraseMode(state, payload.device, payload.hidden, payload.alwaysOnDevice);
         })
         .addCase(UI.REQUEST_PIN, state => {
+            // @ts-expect-error
             resetAuthFailed(state);
         })
         .addCase(deviceActions.rememberDevice, (state, { payload }) => {
+            // @ts-expect-error
             remember(state, payload.device, payload.remember, payload.forceRemember);
         })
         .addCase(deviceActions.setTemporaryRememberedDevice, (state, { payload }) => {
+            // @ts-expect-error
             setTemporaryRememberedDevice(state, payload.device, payload.temporaryRemember);
         })
         .addCase(deviceActions.forgetDevice, (state, { payload }) => {
+            // @ts-expect-error
             forget(state, payload.device, payload.settings);
         })
         .addCase(deviceActions.addButtonRequest, (state, { payload }) => {
+            // @ts-expect-error
             addButtonRequest(state, payload.device, payload.buttonRequest);
         })
         .addCase(deviceActions.removeButtonRequests, (state, { payload }) => {
+            // @ts-expect-error
             removeButtonRequests(state, payload.device, payload.buttonRequestCode);
         })
         .addCase(deviceActions.requestDeviceReconnect, state => {
@@ -636,13 +648,17 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
             }
         })
         .addCase(deviceActions.selectDevice, (state, { payload }) => {
+            // @ts-expect-error
             updateTimestamp(state, payload);
+            // @ts-expect-error
             state.selectedDevice = payload;
         })
         .addCase(deviceActions.updateSelectedDevice, (state, { payload }) => {
+            // @ts-expect-error
             state.selectedDevice = payload;
         })
         .addCase(deviceAuthenticityActions.result, (state, { payload }) => {
+            // @ts-expect-error
             setDeviceAuthenticity(state, payload.device, payload.result);
         })
         .addCase(deviceActions.dismissFirmwareAuthenticityCheck, (state, { payload }) => {
@@ -667,11 +683,13 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
             state.devicesWithFailedEntropyCheck.push(payload);
         })
         .addCase(deviceActions.createDeviceInstance, (state, { payload }) => {
+            // @ts-expect-error
             createInstance(state, payload.device);
         })
         .addMatcher(
             isAnyOf(deviceActions.connectDevice, deviceActions.connectUnacquiredDevice),
             (state, { payload: { device, settings } }) => {
+                // @ts-expect-error
                 connectDevice(state, device, settings);
             },
         );

--- a/suite-common/walletconnect/src/walletConnectReducer.ts
+++ b/suite-common/walletconnect/src/walletConnectReducer.ts
@@ -5,6 +5,7 @@ import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { walletConnectActions } from './walletConnectActions';
 import { PendingConnectionProposal, WalletConnectSession } from './walletConnectTypes';
 
+
 export type WalletConnectState = {
     sessions: WalletConnectSession[];
     pendingProposal: PendingConnectionProposal | undefined;
@@ -26,6 +27,7 @@ const walletConnectInitialState: WalletConnectState = {
 };
 
 export const prepareWalletConnectReducer = createReducerWithExtraDeps(
+    // @ts-expect-error
     walletConnectInitialState,
     (builder, extra) => {
         builder
@@ -52,6 +54,7 @@ export const prepareWalletConnectReducer = createReducerWithExtraDeps(
                 state.sessions = state.sessions.filter(session => session.topic !== topic);
             })
             .addCase(walletConnectActions.createSessionProposal, (state, { payload }) => {
+                // @ts-expect-error
                 state.pendingProposal = payload;
             })
             .addCase(walletConnectActions.clearSessionProposal, state => {

--- a/suite-native/message-system/src/components/__tests__/ContextMessage.comp.test.tsx
+++ b/suite-native/message-system/src/components/__tests__/ContextMessage.comp.test.tsx
@@ -77,6 +77,7 @@ describe('ContextMessage', () => {
     it('should render content when there is message of given context', async () => {
         const { queryByText } = await render({
             context: Context.tradingBuy,
+            // @ts-expect-error
             preloadedState: stateWithTradeContextMessage,
         });
         expect(queryByText(contentText)).toBeTruthy();
@@ -92,6 +93,7 @@ describe('ContextMessage', () => {
     it('should return null when there is message of different context', async () => {
         const { queryByHintText } = await render({
             context: Context.coinjoin,
+            // @ts-expect-error
             preloadedState: stateWithTradeContextMessage,
         });
         expect(queryByHintText(contextActionId)).toBeNull();


### PR DESCRIPTION
it felt easier, lol

description TBD

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19251

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/ban-non-serializable-values-in-redux&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/ban-non-serializable-values-in-redux&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/ban-non-serializable-values-in-redux&lookback=7)