### PR TITLE
feat(suite-native): fetch country code on trade visit

### DIFF
--- a/suite-native/app/src/navigation/AppTabNavigator.tsx
+++ b/suite-native/app/src/navigation/AppTabNavigator.tsx
@@ -1,8 +1,7 @@
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import { BottomTabBarProps, createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
-import { fetchCountryCodeThunk, selectCountryCode } from '@suite-common/geolocation';
 import { EventType, analytics } from '@suite-native/analytics';
 import { useHandleDeviceRequestsPassphrase } from '@suite-native/device-authorization';
 import { AccountsStackNavigator } from '@suite-native/module-accounts-management';
@@ -46,8 +45,6 @@ export const AppTabNavigator = () => {
     const isTradingBuyEnabled = useSelector(selectIsTradingBuyEnabled);
     const isTradingExchangeEnabled = useSelector(selectIsTradingExchangeEnabled);
     const isTradingSellEnabled = useSelector(selectIsTradingSellEnabled);
-    const countryCode = useSelector(selectCountryCode);
-    const dispatch = useDispatch();
 
     const handleTradeTabPress = () => {
         const tradingType = getTradingAnalyticsType(
@@ -55,6 +52,7 @@ export const AppTabNavigator = () => {
             isTradingExchangeEnabled,
             isTradingSellEnabled,
         );
+
         if (!tradingType) return;
 
         analytics.report({
@@ -65,12 +63,6 @@ export const AppTabNavigator = () => {
                 from: 'trade',
             },
         });
-
-        if (!countryCode) {
-            // fetch country code to show context message
-            // it is not fetched on mount because it is not needed for other tabs
-            dispatch(fetchCountryCodeThunk());
-        }
     };
 
     return (

--- a/suite-native/app/src/navigation/AppTabNavigator.tsx
+++ b/suite-native/app/src/navigation/AppTabNavigator.tsx
@@ -1,7 +1,8 @@
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { BottomTabBarProps, createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
+import { fetchCountryCodeThunk, selectCountryCode } from '@suite-common/geolocation';
 import { EventType, analytics } from '@suite-native/analytics';
 import { useHandleDeviceRequestsPassphrase } from '@suite-native/device-authorization';
 import { AccountsStackNavigator } from '@suite-native/module-accounts-management';
@@ -45,6 +46,32 @@ export const AppTabNavigator = () => {
     const isTradingBuyEnabled = useSelector(selectIsTradingBuyEnabled);
     const isTradingExchangeEnabled = useSelector(selectIsTradingExchangeEnabled);
     const isTradingSellEnabled = useSelector(selectIsTradingSellEnabled);
+    const countryCode = useSelector(selectCountryCode);
+    const dispatch = useDispatch();
+
+    const handleTradeTabPress = () => {
+        const tradingType = getTradingAnalyticsType(
+            isTradingBuyEnabled,
+            isTradingExchangeEnabled,
+            isTradingSellEnabled,
+        );
+        if (!tradingType) return;
+
+        analytics.report({
+            type: EventType.TradingNavigate,
+            payload: {
+                action: 'navigate',
+                type: tradingType,
+                from: 'trade',
+            },
+        });
+
+        if (!countryCode) {
+            // fetch country code to show context message
+            // it is not fetched on mount because it is not needed for other tabs
+            dispatch(fetchCountryCodeThunk());
+        }
+    };
 
     return (
         <Tab.Navigator
@@ -64,23 +91,7 @@ export const AppTabNavigator = () => {
                     name={AppTabsRoutes.TradeStack}
                     component={TradingStackNavigator}
                     listeners={{
-                        tabPress: () => {
-                            const tradingType = getTradingAnalyticsType(
-                                isTradingBuyEnabled,
-                                isTradingExchangeEnabled,
-                                isTradingSellEnabled,
-                            );
-                            if (!tradingType) return;
-
-                            analytics.report({
-                                type: EventType.TradingNavigate,
-                                payload: {
-                                    action: 'navigate',
-                                    type: tradingType,
-                                    from: 'trade',
-                                },
-                            });
-                        },
+                        tabPress: handleTradeTabPress,
                     }}
                 />
             )}

--- a/suite-native/atoms/src/InlineAlertBox/InlineAlertBox.tsx
+++ b/suite-native/atoms/src/InlineAlertBox/InlineAlertBox.tsx
@@ -1,9 +1,9 @@
 import { ReactNode } from 'react';
-import { AccessibilityProps } from 'react-native';
 
 import { Icon, IconName } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
+import { BoxProps } from '../Box';
 import { Text } from '../Text';
 import {
     InlineAlertBoxStyles,
@@ -32,7 +32,7 @@ const textStyle = prepareNativeStyle(utils => ({
     paddingTop: utils.spacings.sp2,
 }));
 
-export type InlineAlertBoxProps = AccessibilityProps & {
+export type InlineAlertBoxProps = Omit<BoxProps, 'style'> & {
     title: Exclude<ReactNode, null | undefined>;
     variant?: InlineAlertBoxVariant;
     buttonLabel?: ReactNode;

--- a/suite-native/message-system/src/components/ContextMessage.tsx
+++ b/suite-native/message-system/src/components/ContextMessage.tsx
@@ -5,7 +5,8 @@ import {
     MessageSystemRootState,
     selectContextMessage,
 } from '@suite-common/message-system';
-import { InlineAlertBox, InlineAlertBoxProps } from '@suite-native/atoms';
+import { InlineAlertBox, InlineAlertBoxProps, Text } from '@suite-native/atoms';
+import { Link } from '@suite-native/link';
 
 import { useHandleMessageLink } from '../hooks/useHandleMessageLink';
 
@@ -24,19 +25,36 @@ export const ContextMessage = ({ context, ...rest }: ContextMessageProps) => {
         selectContextMessage(state, context),
     );
 
-    const { linkLabel, handleLinkPress } = useHandleMessageLink({
+    const { linkLabel } = useHandleMessageLink({
         messageCTA: message?.cta,
         language,
     });
 
     if (!message) return null;
 
+    const msgText = message.content[language];
+    const link = message?.cta?.link;
+    const shouldDisplayLink = !!(link && linkLabel);
+
     return (
         <InlineAlertBox
             variant={message.variant}
-            title={message.content[language]}
-            buttonLabel={linkLabel}
-            onButtonPress={handleLinkPress}
+            title={
+                <Text variant="label">
+                    {msgText}
+                    {msgText && shouldDisplayLink && ' '}
+                    {shouldDisplayLink && (
+                        <Link
+                            label={linkLabel}
+                            textVariant="label"
+                            href={link}
+                            isUnderlined
+                            textColor="textDefault"
+                            textPressedColor="textSubdued"
+                        />
+                    )}
+                </Text>
+            }
             {...rest}
         />
     );

--- a/suite-native/message-system/src/components/ContextMessage.tsx
+++ b/suite-native/message-system/src/components/ContextMessage.tsx
@@ -1,4 +1,3 @@
-import { AccessibilityProps } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import {
@@ -6,11 +5,14 @@ import {
     MessageSystemRootState,
     selectContextMessage,
 } from '@suite-common/message-system';
-import { InlineAlertBox } from '@suite-native/atoms';
+import { InlineAlertBox, InlineAlertBoxProps } from '@suite-native/atoms';
 
 import { useHandleMessageLink } from '../hooks/useHandleMessageLink';
 
-type ContextMessageProps = AccessibilityProps & {
+export type ContextMessageProps = Omit<
+    InlineAlertBoxProps,
+    'variant' | 'title' | 'buttonLabel' | 'onButtonPress'
+> & {
     context: (typeof Context)[keyof typeof Context];
 };
 

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.tsx
@@ -1,7 +1,7 @@
 import { Dimensions } from 'react-native';
 
 import { TradingProviderInfo, TradingTradeType } from '@suite-common/trading';
-import { BottomSheetFlashList, Box } from '@suite-native/atoms';
+import { BottomSheetFlashList } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 
 import { SimpleSheetHeader } from '../SimpleSheetHeader';
@@ -67,10 +67,7 @@ export const ProviderSheet = <T extends TradingTradeType>({
                         onClose={onClose}
                         title={translate('moduleTrading.tradingScreen.provider')}
                     />
-                    {/* context message cant scroll for some use cases (UK banner) so it cant be in items */}
-                    <Box paddingHorizontal="sp16" paddingVertical="sp4">
-                        <TradingTypeAwareContextMessage />
-                    </Box>
+                    <TradingTypeAwareContextMessage marginHorizontal="sp16" marginBottom="sp4" />
                 </>
             )}
             data={quotes}

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.tsx
@@ -1,9 +1,12 @@
+import { Dimensions } from 'react-native';
+
 import { TradingProviderInfo, TradingTradeType } from '@suite-common/trading';
-import { BottomSheetFlashList } from '@suite-native/atoms';
+import { BottomSheetFlashList, Box } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 
-import { ESTIMATED_HEADER_HEIGHT, SimpleSheetHeader } from '../SimpleSheetHeader';
+import { SimpleSheetHeader } from '../SimpleSheetHeader';
 import { PROVIDER_LIST_ITEM_ESTIMATED_HEIGHT, ProviderListItem } from './ProviderListItem';
+import { TradingTypeAwareContextMessage } from '../TradingTypeAwareContextMessage';
 
 export type ProvidersSheetProps<T extends TradingTradeType> = {
     quotes: T[];
@@ -14,11 +17,7 @@ export type ProvidersSheetProps<T extends TradingTradeType> = {
     providerInfos: { [name: string]: TradingProviderInfo };
 };
 
-const EXTRA_LIST_PADDING = 20;
-
 const keyExtractor = <T extends TradingTradeType>(item: T) => item.orderId ?? '';
-const getEstimatedListHeight = (itemsCount: number) =>
-    itemsCount * PROVIDER_LIST_ITEM_ESTIMATED_HEIGHT + ESTIMATED_HEADER_HEIGHT + EXTRA_LIST_PADDING;
 
 const getProviderInfo = (
     id: string | undefined,
@@ -38,6 +37,9 @@ export const ProviderSheet = <T extends TradingTradeType>({
     providerInfos,
 }: ProvidersSheetProps<T>) => {
     const { translate } = useTranslate();
+
+    const screenHeight = Dimensions.get('screen').height;
+
     const onQuoteSelectCallback = (quote: T) => {
         onQuoteSelect(quote);
         onClose();
@@ -60,13 +62,19 @@ export const ProviderSheet = <T extends TradingTradeType>({
                 );
             }}
             handleComponent={() => (
-                <SimpleSheetHeader
-                    onClose={onClose}
-                    title={translate('moduleTrading.tradingScreen.provider')}
-                />
+                <>
+                    <SimpleSheetHeader
+                        onClose={onClose}
+                        title={translate('moduleTrading.tradingScreen.provider')}
+                    />
+                    {/* context message cant scroll for some use cases (UK banner) so it cant be in items */}
+                    <Box paddingHorizontal="sp16" paddingVertical="sp4">
+                        <TradingTypeAwareContextMessage />
+                    </Box>
+                </>
             )}
             data={quotes}
-            estimatedListHeight={getEstimatedListHeight(quotes.length)}
+            estimatedListHeight={screenHeight}
             estimatedItemSize={PROVIDER_LIST_ITEM_ESTIMATED_HEIGHT}
             keyExtractor={keyExtractor}
             extraData={selectedQuote?.orderId}

--- a/suite-native/module-trading/src/components/general/TradingTypeAwareContextMessage.tsx
+++ b/suite-native/module-trading/src/components/general/TradingTypeAwareContextMessage.tsx
@@ -1,10 +1,12 @@
 import { useSelector } from 'react-redux';
 
 import { Context, ContextDomain } from '@suite-common/message-system';
-import { ContextMessage } from '@suite-native/message-system';
+import { ContextMessage, ContextMessageProps } from '@suite-native/message-system';
 import { exhaustive } from '@trezor/type-utils';
 
 import { selectActiveTradingType } from '../../selectors/commonSelectors';
+
+export type TradingTypeAwareContextMessageProps = Omit<ContextMessageProps, 'context'>;
 
 const useTradingTypeAwareContext = (): ContextDomain | undefined => {
     const activeType = useSelector(selectActiveTradingType);
@@ -27,12 +29,12 @@ const useTradingTypeAwareContext = (): ContextDomain | undefined => {
     }
 };
 
-export const TradingTypeAwareContextMessage = () => {
+export const TradingTypeAwareContextMessage = (props: TradingTypeAwareContextMessageProps) => {
     const context = useTradingTypeAwareContext();
 
     if (!context) {
         return null;
     }
 
-    return <ContextMessage context={context} />;
+    return <ContextMessage context={context} {...props} />;
 };

--- a/suite-native/module-trading/src/hooks/general/__tests__/useGeolocationCountryCode.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useGeolocationCountryCode.test.ts
@@ -1,0 +1,37 @@
+import { geolocationActions, selectCountryCode } from '@suite-common/geolocation';
+import { TestStore, initStore, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { useGeolocationCountryCode } from '../useGeolocationCountryCode';
+
+jest.mock('@suite-common/geolocation', () => {
+    const actual = jest.requireActual('@suite-common/geolocation');
+
+    return {
+        ...actual,
+        fetchCountryCodeThunk: jest
+            .fn()
+            .mockImplementation(() => actual.geolocationActions.setCountryCode('US')),
+    };
+});
+
+describe('useGeolocationCountryCode', () => {
+    const renderUseGeolocationCountryCode = (store: TestStore) =>
+        renderHookWithStoreProviderAsync(() => useGeolocationCountryCode(), { store });
+
+    it('should call geolocation thunk on mount', async () => {
+        const store = await initStore();
+
+        await renderUseGeolocationCountryCode(store);
+
+        expect(selectCountryCode(store.getState())).toBe('US');
+    });
+
+    it('should not call geolocation thunk if country code is already known', async () => {
+        const store = await initStore();
+        store.dispatch(geolocationActions.setCountryCode('CZ'));
+
+        await renderUseGeolocationCountryCode(store);
+
+        expect(selectCountryCode(store.getState())).toBe('CZ');
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/useGeolocationCountryCode.ts
+++ b/suite-native/module-trading/src/hooks/general/useGeolocationCountryCode.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { fetchCountryCodeThunk, selectCountryCode } from '@suite-common/geolocation';
+
+export const useGeolocationCountryCode = () => {
+    const dispatch = useDispatch();
+    const countryCode = useSelector(selectCountryCode);
+
+    useEffect(() => {
+        if (!countryCode) {
+            dispatch(fetchCountryCodeThunk());
+        }
+    }, [countryCode, dispatch]);
+};

--- a/suite-native/module-trading/src/screens/TradingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingScreen.tsx
@@ -16,6 +16,7 @@ import { Header } from '../components/general/Header/Header';
 import { HistoryButton, NavigationProps } from '../components/general/HistoryButton';
 import { TradingTypeAwareContextMessage } from '../components/general/TradingTypeAwareContextMessage';
 import { useActiveTradingTypeReaction } from '../hooks/general/useActiveTradingTypeReaction';
+import { useGeolocationCountryCode } from '../hooks/general/useGeolocationCountryCode';
 import { useMountedRecentlyFlag } from '../hooks/general/useMountedRecentlyFlag';
 import {
     selectActiveTradingType,
@@ -30,6 +31,7 @@ const TradingScreenContent = () => {
     const navigation = useNavigation<NavigationProps>();
     const isScreenMountedRecently = useMountedRecentlyFlag(activeTradingType);
     useActiveTradingTypeReaction();
+    useGeolocationCountryCode();
 
     useEffect(() => {
         if (tradeToBeOpened) {

--- a/suite-native/module-trading/src/screens/TradingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingScreen.tsx
@@ -5,7 +5,7 @@ import { useNetInfo } from '@react-native-community/netinfo';
 import { useNavigation } from '@react-navigation/native';
 
 import { EventType, analytics } from '@suite-native/analytics';
-import { VStack } from '@suite-native/atoms';
+import { Box, VStack } from '@suite-native/atoms';
 import { DeviceManagerScreenHeader } from '@suite-native/device-manager';
 import { Screen, TradingStackRoutes } from '@suite-native/navigation';
 
@@ -46,15 +46,12 @@ const TradingScreenContent = () => {
     }
 
     return (
-        <>
-            <TradingTypeAwareContextMessage />
-            <VStack spacing="sp16">
-                <Header isFormMountedRecently={isScreenMountedRecently} />
-                {isInternetReachable === false ? <DeviceOffline /> : <ActiveTab />}
-                <Footer isFormMountedRecently={isScreenMountedRecently} />
-                <HistoryButton isFormMountedRecently={isScreenMountedRecently} />
-            </VStack>
-        </>
+        <VStack spacing="sp16">
+            <Header isFormMountedRecently={isScreenMountedRecently} />
+            {isInternetReachable === false ? <DeviceOffline /> : <ActiveTab />}
+            <Footer isFormMountedRecently={isScreenMountedRecently} />
+            <HistoryButton isFormMountedRecently={isScreenMountedRecently} />
+        </VStack>
     );
 };
 
@@ -66,7 +63,17 @@ export const TradingScreen = () => {
     }
 
     return (
-        <Screen header={<DeviceManagerScreenHeader />}>
+        <Screen
+            header={
+                <>
+                    <DeviceManagerScreenHeader />
+                    {/* context message cant scroll for some use cases (UK banner) so it cant be in the children */}
+                    <Box paddingHorizontal="sp16" paddingVertical="sp4">
+                        <TradingTypeAwareContextMessage />
+                    </Box>
+                </>
+            }
+        >
             <TradingScreenContent />
         </Screen>
     );

--- a/suite-native/module-trading/src/screens/TradingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingScreen.tsx
@@ -5,7 +5,7 @@ import { useNetInfo } from '@react-native-community/netinfo';
 import { useNavigation } from '@react-navigation/native';
 
 import { EventType, analytics } from '@suite-native/analytics';
-import { Box, VStack } from '@suite-native/atoms';
+import { VStack } from '@suite-native/atoms';
 import { DeviceManagerScreenHeader } from '@suite-native/device-manager';
 import { Screen, TradingStackRoutes } from '@suite-native/navigation';
 
@@ -67,10 +67,7 @@ export const TradingScreen = () => {
             header={
                 <>
                     <DeviceManagerScreenHeader />
-                    {/* context message cant scroll for some use cases (UK banner) so it cant be in the children */}
-                    <Box paddingHorizontal="sp16" paddingVertical="sp4">
-                        <TradingTypeAwareContextMessage />
-                    </Box>
+                    <TradingTypeAwareContextMessage marginHorizontal="sp16" marginBottom="sp16" />
                 </>
             }
         >


### PR DESCRIPTION
- On visiting trade, fetch country code, so message related to the country can be shown.
- show context banner in trading and in provider sheet non scrollable

## Screenshots:
<img width=250 src="https://github.com/user-attachments/assets/a1c0250c-554e-4531-8861-6484108e1031" />
<img width=250 src="https://github.com/user-attachments/assets/fc0d6d46-af98-4f02-b3d2-379e8e5caab6" />
<img width=250 src="https://github.com/user-attachments/assets/d334d2a1-c9b3-45d9-9dd4-e9ea3b129bb6" />
<img width=250 src="https://github.com/user-attachments/assets/ceb2a4db-0805-4ce8-bc82-95e0c9c22675" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/country-code-fetch&lookback=7)