### PR TITLE
chore(suite): remove unused device.authConfirm

### DIFF
--- a/docs/analytics/sentry.md
+++ b/docs/analytics/sentry.md
@@ -24,7 +24,6 @@ Browser (User Agent), System and HW specifications, Suite version, instance id s
 ```
 [
   {
-    authConfirm:False,
     bundleSize: 0,
     deviceState: [redacted],
     failed: [],
@@ -42,7 +41,6 @@ Browser (User Agent), System and HW specifications, Suite version, instance id s
 
 ```
 {
-  authConfirm: False,
   available: False,
   buttonRequests: [],
   connected: False,

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseOnDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseOnDeviceModal.tsx
@@ -32,8 +32,7 @@ interface PassphraseOnDeviceModalProps {
  */
 export const PassphraseOnDeviceModal = ({ device }: PassphraseOnDeviceModalProps) => {
     const intl = useIntl();
-    const authConfirmation =
-        useSelector(selectIsDiscoveryAuthConfirmationRequired) || device.authConfirm;
+    const authConfirmation = useSelector(selectIsDiscoveryAuthConfirmationRequired);
     const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
 
     const onCancel = () => TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx
@@ -38,11 +38,7 @@ export const AddAccountButton = ({
     const isSidebarCollapsed = useIsSidebarCollapsed();
     // TODO: add more cases when adding account is not possible
     const addAccountDisabled =
-        isDiscoveryRunning ||
-        !device ||
-        !device.connected ||
-        device.authConfirm ||
-        device.authFailed;
+        isDiscoveryRunning || !device || !device.connected || device.authFailed;
 
     const tooltipMessage = getExplanationMessage(device, isDiscoveryRunning);
 

--- a/packages/suite/src/utils/wallet/selectDiscoveryOverallStatus.ts
+++ b/packages/suite/src/utils/wallet/selectDiscoveryOverallStatus.ts
@@ -36,7 +36,6 @@ const getDiscoveryStatus = ({
         if (discovery.status === 'progress' && discovery.isAddingHiddenWallet)
             return {
                 status: 'loading',
-                // type: discovery.authConfirm ? 'auth-confirm' : 'discovery',
                 // type: 'discovery',
                 type: 'auth-confirm',
             };

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -69,7 +69,7 @@ const Details = () => {
 
     const { account } = selectedAccount;
     const locked = isLocked(true);
-    const disabled = !!device.authConfirm || locked;
+    const disabled = locked;
 
     const accountTypeTech = getAccountTypeTech(account.path);
 

--- a/packages/suite/src/views/wallet/receive/Receive.tsx
+++ b/packages/suite/src/views/wallet/receive/Receive.tsx
@@ -38,7 +38,7 @@ export const Receive = () => {
         return <WalletLayout title="TR_NAV_RECEIVE" account={selectedAccount} />;
     }
 
-    const disabled = !!device.authConfirm;
+    const disabled = false; // TODO: it should be disabled based on locks probably
     const showCexWarning = account?.accountType === 'coinjoin' && !isCoinjoinReceiveWarningHidden;
 
     const isDeviceConnected = device.connected && device.available;

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -158,7 +158,7 @@ export const TokenRow = ({
         </InfoItem>
     );
 
-    const isReceiveButtonDisabled = isDeviceLocked || !!device.authConfirm;
+    const isReceiveButtonDisabled = isDeviceLocked;
 
     const contractAddress = getContractAddressForNetworkSymbol(account.symbol, token.contract);
     const tokenCryptoId = toTokenCryptoId(account.symbol, contractAddress);

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -35,7 +35,6 @@ export interface ExtendedDevice {
     connected: boolean; // device is connected
     available: boolean; // device cannot be used because of features.passphrase_protection is different then expected
 
-    authConfirm?: boolean; // device cannot be used because passphrase was not confirmed
     authFailed?: boolean; // device cannot be used because authorization process failed
 
     instance?: number;

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -229,7 +229,6 @@ const getSuiteDevice = (
             remember: false,
             connected: false,
             available: false,
-            authConfirm: false,
             instance: undefined,
             ts: 0,
             buttonRequests: [],

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -186,7 +186,6 @@ const connectDevice = (
         remember: false,
         temporaryRemember: false,
         available: true,
-        authConfirm: false,
         instance: deviceInstance,
     };
 
@@ -442,7 +441,6 @@ const createInstance = (draft: DeviceReducerState, device: TrezorDevice) => {
         // to be able to filter device accounts for portfolio tracker
         state: isPortfolioTrackerDevice ? device.state : undefined,
         walletNumber: undefined,
-        authConfirm: false,
         ts: currentTime,
         firstConnectedTimestamp: device.firstConnectedTimestamp ?? currentTime,
         buttonRequests: [],
@@ -520,7 +518,6 @@ const forget = (
     const others = deviceUtils.getDeviceInstances(device, draft.devices, true);
     if (device.connected && others.length < 1) {
         // do not forget the last instance, just reset state
-        draft.devices[index].authConfirm = false;
         delete draft.devices[index].authFailed;
         draft.devices[index].state = undefined;
         draft.devices[index].walletNumber = undefined;

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -162,11 +162,6 @@ export const selectIsDeviceAuthorized = createMemoizedSelector(
     device => !!device?.state,
 );
 
-export const selectHasDeviceAuthConfirm = createMemoizedSelector(
-    [selectSelectedDevice],
-    device => !!device?.authConfirm,
-);
-
 export const selectIsDeviceConnectedAndAuthorized = createMemoizedSelector(
     [selectIsDeviceAuthorized, selectDeviceFeatures],
     (isDeviceAuthorized, deviceFeatures) => isDeviceAuthorized && !!deviceFeatures,

--- a/suite-common/wallet-core/src/discovery/discoverySelectors.ts
+++ b/suite-common/wallet-core/src/discovery/discoverySelectors.ts
@@ -44,7 +44,6 @@ export const selectHasDeviceDiscovery = selectHasRunningDiscovery;
 
 /**
  * Helper selector called from components
- * return `true` if discovery process is running/completed and `authConfirm` is required
  */
 export const selectIsDiscoveryAuthConfirmationRequired = (
     state: DiscoveryRootState & DeviceRootState,


### PR DESCRIPTION
it doesn't seem to be used anywhere

based on #19458

Part of #19325

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=discovery-nitpicks-3&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=discovery-nitpicks-3&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=discovery-nitpicks-3&lookback=7)