### PR TITLE
Small improvement for message signing in Connect in Suite

### DIFF
--- a/packages/connect/src/api/ethereum/api/ethereumSignMessage.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignMessage.ts
@@ -11,7 +11,7 @@ import {
     EthereumSignMessage as EthereumSignMessageSchema,
 } from '../../../types';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';
-import { messageToHex } from '../../../utils/formatUtils';
+import { hexToText, messageToHex } from '../../../utils/formatUtils';
 import { getSerializedPath, getSlip44ByPath, validatePath } from '../../../utils/pathUtils';
 import { getFirmwareRange } from '../../common/paramsValidator';
 import { getEthereumDefinitions } from '../ethereumDefinitions';
@@ -64,7 +64,7 @@ export default class EthereumSignMessage extends AbstractMethod<'ethereumSignMes
                 type: 'message' as const,
                 coin: this.params.network?.shortcut ?? 'ETH',
                 serializedPath: getSerializedPath(this.params.address_n),
-                message: this.payload.message,
+                message: this.payload.hex ? hexToText(this.payload.message) : this.payload.message,
             };
         }
     }

--- a/packages/connect/src/api/signMessage.ts
+++ b/packages/connect/src/api/signMessage.ts
@@ -8,7 +8,7 @@ import type { BitcoinNetworkInfo } from '../types';
 import { SignMessage as SignMessageSchema } from '../types';
 import { getFirmwareRange, validateCoinPath } from './common/paramsValidator';
 import { getBitcoinNetwork } from '../data/coinInfo';
-import { messageToHex } from '../utils/formatUtils';
+import { hexToText, messageToHex } from '../utils/formatUtils';
 import { getLabel, getScriptType, getSerializedPath, validatePath } from '../utils/pathUtils';
 
 export default class SignMessage extends AbstractMethod<'signMessage', PROTO.SignMessage> {
@@ -63,7 +63,7 @@ export default class SignMessage extends AbstractMethod<'signMessage', PROTO.Sig
                 type: 'message' as const,
                 serializedPath: getSerializedPath(this.params.address_n.slice(0, 4)),
                 coin: this.coinInfo?.shortcut ?? 'BTC',
-                message: this.payload.message,
+                message: this.payload.hex ? hexToText(this.payload.message) : this.payload.message,
             };
         }
     }

--- a/packages/connect/src/utils/formatUtils.ts
+++ b/packages/connect/src/utils/formatUtils.ts
@@ -65,6 +65,18 @@ export const messageToHex = (message: string) => {
     return buffer.toString('hex');
 };
 
+export const hexToText = (hex: string) => {
+    const clean = messageToHex(hex);
+
+    const text = Buffer.from(clean, 'hex').toString('utf8');
+
+    // U+FFFD is the replacement character for invalid UTF-8 sequences
+    // If we find it, return the hex original string
+    if (/[\uFFFD]/.test(text)) return hex;
+
+    return text;
+};
+
 export const deepTransform = <V>(transform: (str: string) => V) => {
     const recursion = <T>(value: T): DeepTransformed<T, V> => {
         if (typeof value === 'string') {

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/SignMessageModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/SignMessageModal.tsx
@@ -1,11 +1,13 @@
+import styled from 'styled-components';
+
 import { selectConnectPopupCall } from '@suite-common/connect-popup';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { selectDeviceAccounts } from '@suite-common/wallet-core';
-import { Card, Column, DotIndicator, H4, Modal, Row, Text } from '@trezor/components';
+import { Card, Column, DotIndicator, H4, Modal, Row } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
 import { CoinLogo, ConfirmOnDevice } from '@trezor/product-components';
-import { spacings } from '@trezor/theme';
+import { spacings, spacingsPx } from '@trezor/theme';
 
 import { AccountLabel } from 'src/components/suite/AccountLabel';
 import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
@@ -14,6 +16,13 @@ import { useSelector } from 'src/hooks/suite';
 import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
 
 import { ConfirmActionModal } from './ConfirmActionModal';
+
+const MessageText = styled.pre`
+    font-family: monospace;
+    white-space: pre-wrap;
+    word-break: break-all;
+    margin-left: ${spacingsPx.xxl};
+`;
 
 interface SignMessageModalProps {
     device: TrezorDevice;
@@ -102,14 +111,9 @@ export const SignMessageModal = ({
                         }
                         paddingType="small"
                     >
-                        <Text
-                            isMonospaced
-                            as="pre"
-                            margin={{ left: spacings.xxl }}
-                            data-testid="@sign-message-modal/message"
-                        >
+                        <MessageText data-testid="@sign-message-modal/message">
                             {message}
-                        </Text>
+                        </MessageText>
                     </Card>
                 </Column>
             </Modal.ModalBase>


### PR DESCRIPTION
## Description

Small improvement for message signing in Connect in Suite after feedback from Ambire. 

1. Decode hex messages same way that FW does
2. Wrap text that is too long in SignMessageModal


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-connect-signmessage&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-connect-signmessage&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-connect-signmessage&lookback=7)