### PR TITLE
chore(suite-native): remove selectHasRunningDiscovery reexport

### DIFF
--- a/suite-common/wallet-core/src/discovery/discoverySelectors.ts
+++ b/suite-common/wallet-core/src/discovery/discoverySelectors.ts
@@ -39,9 +39,6 @@ export const selectHasRunningDiscovery = (state: DiscoveryRootState & DeviceRoot
     return isDiscoveryInProgress(discovery);
 };
 
-// TODO remove reexport
-export const selectHasDeviceDiscovery = selectHasRunningDiscovery;
-
 /**
  * Helper selector called from components
  */

--- a/suite-native/accounts/src/components/AddAccountsButton.tsx
+++ b/suite-native/accounts/src/components/AddAccountsButton.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
 import {
-    selectHasDeviceDiscovery,
+    selectHasRunningDiscovery,
     selectIsDeviceInViewOnlyMode,
     selectIsPortfolioTrackerDevice,
 } from '@suite-common/wallet-core';
@@ -28,7 +28,7 @@ export const AddAccountButton = ({ flowType, testID }: AddAccountButtonProps) =>
     const navigation =
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AccountsImport>>();
 
-    const hasDeviceDiscovery = useSelector(selectHasDeviceDiscovery);
+    const hasDeviceDiscovery = useSelector(selectHasRunningDiscovery);
     const isSelectedDevicePortfolioTracker = useSelector(selectIsPortfolioTrackerDevice);
     const { showViewOnlyAddAccountAlert } = useAccountAlerts();
     const isDeviceInViewOnlyMode = useSelector(selectIsDeviceInViewOnlyMode);

--- a/suite-native/device-manager/src/components/DeviceList.tsx
+++ b/suite-native/device-manager/src/components/DeviceList.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { TrezorDevice } from '@suite-common/suite-types';
 import {
-    selectHasDeviceDiscovery,
+    selectHasRunningDiscovery,
     selectInstacelessUnselectedDevices,
     selectIsDeviceConnected,
     selectSelectedDevice,
@@ -132,7 +132,7 @@ export const DeviceList = ({ isVisible, onSelectDevice }: DeviceListProps) => {
     const { setIsDeviceManagerVisible } = useDeviceManager();
     const device = useSelector(selectSelectedDevice);
     const notSelectedInstancelessDevices = useSelector(selectInstacelessUnselectedDevices);
-    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
+    const hasDiscovery = useSelector(selectHasRunningDiscovery);
     const isDeviceConnected = useSelector(selectIsDeviceConnected);
     const opacity = useSharedValue(0);
     const height = useSharedValue(0);

--- a/suite-native/graph/src/components/GraphFiatBalance.tsx
+++ b/suite-native/graph/src/components/GraphFiatBalance.tsx
@@ -4,7 +4,7 @@ import { Atom, useAtomValue } from 'jotai';
 
 import { useFormatters } from '@suite-common/formatters';
 import { FiatGraphPoint } from '@suite-common/graph';
-import { selectHasDeviceDiscovery } from '@suite-common/wallet-core';
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Box, BoxSkeleton, DiscreetTextTrigger, HStack, Text, VStack } from '@suite-native/atoms';
 import { FiatBalanceFormatter } from '@suite-native/formatters';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -63,7 +63,7 @@ export const GraphFiatBalance = ({
     const firstGraphPoint = useAtomValue(referencePointAtom);
     const { DateTimeFormatter } = useFormatters();
 
-    const hasDeviceDiscovery = useSelector(selectHasDeviceDiscovery);
+    const hasDeviceDiscovery = useSelector(selectHasRunningDiscovery);
     const hasBalance = Number(totalFiatBalance) !== 0;
     const showLoading = isLoading || !firstGraphPoint;
     const showBalanceFallback =

--- a/suite-native/module-add-accounts/src/screens/AddCoinDiscoveryRunningScreen.tsx
+++ b/suite-native/module-add-accounts/src/screens/AddCoinDiscoveryRunningScreen.tsx
@@ -9,7 +9,7 @@ import {
     DeviceRootState,
     changeCoinVisibility,
     selectDeviceAccountsByNetworkSymbol,
-    selectHasDeviceDiscovery,
+    selectHasRunningDiscovery,
 } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import { Spinner, SpinnerLoadingState, Text, VStack } from '@suite-native/atoms';
@@ -34,7 +34,7 @@ export const AddCoinDiscoveryRunningScreen = ({
         selectDeviceAccountsByNetworkSymbol(state, networkSymbol),
     );
 
-    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
+    const hasDiscovery = useSelector(selectHasRunningDiscovery);
     const enabledNetworkSymbols = useSelector(selectDeviceEnabledDiscoveryNetworkSymbols);
     const { navigateToSuccessorScreen, clearNetworkWithTypeToBeAdded } = useAddCoinAccount();
     const [loadingResult, setLoadingResult] = useState<SpinnerLoadingState>('idle');

--- a/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreenHeader.tsx
+++ b/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreenHeader.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { selectHasDeviceDiscovery } from '@suite-common/wallet-core';
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { IconButton, ScreenHeaderWrapper } from '@suite-native/atoms';
 import {
@@ -41,7 +41,7 @@ export const ConnectDeviceScreenHeader = ({
     const navigation = useNavigation<NavigationProp>();
     const { showAlert, hideAlert } = useAlert();
 
-    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
+    const hasDiscovery = useSelector(selectHasRunningDiscovery);
     const isAddingHiddenWallet = useSelector(selectIsCreatingNewPassphraseWallet);
     const hasDeviceRequestedPin = useSelector(selectDeviceRequestedPin);
 

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { selectHasDeviceDiscovery, selectIsDeviceAuthorized } from '@suite-common/wallet-core';
+import { selectHasRunningDiscovery, selectIsDeviceAuthorized } from '@suite-common/wallet-core';
 import { selectHasDeviceAnySendAvailableAccount } from '@suite-native/accounts';
 import { Assets } from '@suite-native/assets';
 import { AnimatedVStack, Button, HStack, VStack } from '@suite-native/atoms';
@@ -25,7 +25,7 @@ export const PortfolioContent = forwardRef<PortfolioGraphRef>((_props, ref) => {
     const navigation = useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes>>();
 
     const isDeviceAuthorized = useSelector(selectIsDeviceAuthorized);
-    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
+    const hasDiscovery = useSelector(selectHasRunningDiscovery);
     const hasDeviceAnySendAvailableAccount = useSelector(selectHasDeviceAnySendAvailableAccount);
     const hasFirmwareAuthenticityCheckHardFailed = useSelector(
         selectHasFirmwareAuthenticityCheckHardFailed,

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, useImperativeHandle } from 'react';
 import { useSelector } from 'react-redux';
 
-import { selectHasDeviceDiscovery, selectLocalCurrency } from '@suite-common/wallet-core';
+import { selectHasRunningDiscovery, selectLocalCurrency } from '@suite-common/wallet-core';
 import { Box, Text, VStack } from '@suite-native/atoms';
 import { selectSelectedDeviceTotalFiatBalance } from '@suite-native/device';
 import { useIsDiscoveryDurationTooLong } from '@suite-native/discovery';
@@ -58,7 +58,7 @@ const IgnoredNetworksBanner = () => {
 export const PortfolioGraph = forwardRef<PortfolioGraphRef>((_props, ref) => {
     const fiatCurrencyCode = useSelector(selectLocalCurrency);
     const hasDeviceHistoryEnabledAccounts = useSelector(selectHasDeviceHistoryEnabledAccounts);
-    const hasDeviceDiscovery = useSelector(selectHasDeviceDiscovery);
+    const hasDeviceDiscovery = useSelector(selectHasRunningDiscovery);
     const loadingTakesLongerThanExpected = useIsDiscoveryDurationTooLong();
     const totalFiatBalance = useSelector(selectSelectedDeviceTotalFiatBalance);
 

--- a/suite-native/module-home/src/screens/HomeScreen/useShowViewOnlyAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/useShowViewOnlyAlert.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import {
     deviceActions,
-    selectHasDeviceDiscovery,
+    selectHasRunningDiscovery,
     selectIsDeviceRemembered,
     selectIsPortfolioTrackerDevice,
     selectSelectedDevice,
@@ -36,7 +36,7 @@ export const useShowViewOnlyAlert = () => {
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const viewOnlyCancelationTimestamp = useSelector(selectViewOnlyCancelationTimestamp);
     const isDeviceRemembered = useSelector(selectIsDeviceRemembered);
-    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
+    const hasDiscovery = useSelector(selectHasRunningDiscovery);
     const isCreatingNewPassphraseWallet = useSelector(selectIsCreatingNewPassphraseWallet);
     const [isAvailableBiometrics, setIsAvailableBiometrics] = useState(false);
 

--- a/suite-native/module-settings/src/components/FeaturesSettings.tsx
+++ b/suite-native/module-settings/src/components/FeaturesSettings.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/core';
 import { useAtomValue } from 'jotai';
 
-import { selectHasDeviceDiscovery } from '@suite-common/wallet-core';
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import { Translation } from '@suite-native/intl';
 import {
@@ -25,7 +25,7 @@ export const FeaturesSettings = () => {
     const navigation = useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes>>();
     const navigateTo = useSettingsNavigateTo();
 
-    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
+    const hasDiscovery = useSelector(selectHasRunningDiscovery);
 
     return (
         <SettingsSection title={<Translation id="moduleSettings.items.features.title" />}>

--- a/suite-native/module-settings/src/components/ViewOnly/WalletRow.tsx
+++ b/suite-native/module-settings/src/components/ViewOnly/WalletRow.tsx
@@ -6,7 +6,7 @@ import {
     DeviceRootState,
     deviceActions,
     selectDeviceLabelOrNameById,
-    selectHasDeviceDiscovery,
+    selectHasRunningDiscovery,
 } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { EventType, analytics } from '@suite-native/analytics';
@@ -33,7 +33,7 @@ export const WalletRow = ({ device }: WalletRowProps) => {
     const { showAlert, hideAlert } = useAlert();
     const { showToast } = useToast();
     const { applyStyle } = useNativeStyles();
-    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
+    const hasDiscovery = useSelector(selectHasRunningDiscovery);
     const deviceLabel = useSelector((state: DeviceRootState) =>
         selectDeviceLabelOrNameById(state, device?.id),
     );


### PR DESCRIPTION
## Description

Cleanup useless reexport

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-reexport-of-selectHasRunningDiscovery&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-reexport-of-selectHasRunningDiscovery&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/remove-reexport-of-selectHasRunningDiscovery&lookback=7)