### PR TITLE
fix(wallet-core): new passphrase wallet should not have view-only on by default (yet)

### DIFF
--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -129,6 +129,7 @@ const applyDeviceStatesThunk = createThunk(
                             metadata: {},
                             instance: getNewInstanceNumber(selectDevices(getState()), device),
                             useEmptyPassphrase: !isAddingHiddenWallet,
+                            remember: false,
                             state: newDeviceState,
                         },
                     }),

--- a/suite-native/module-home/package.json
+++ b/suite-native/module-home/package.json
@@ -19,7 +19,6 @@
         "@suite-native/analytics": "workspace:*",
         "@suite-native/assets": "workspace:*",
         "@suite-native/atoms": "workspace:*",
-        "@suite-native/biometrics": "workspace:*",
         "@suite-native/blockchain": "workspace:*",
         "@suite-native/device": "workspace:*",
         "@suite-native/device-manager": "workspace:*",

--- a/suite-native/module-home/src/screens/HomeScreen/useShowViewOnlyAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/useShowViewOnlyAlert.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
@@ -11,7 +11,6 @@ import {
 import { useAlert } from '@suite-native/alerts';
 import { EventType, analytics } from '@suite-native/analytics';
 import { CenteredTitleHeader, LottieAnimation, VStack } from '@suite-native/atoms';
-import { getIsBiometricsFeatureAvailable } from '@suite-native/biometrics';
 import { selectIsDeviceReadyToUseAndAuthorized } from '@suite-native/device';
 import { selectIsCreatingNewPassphraseWallet } from '@suite-native/device-authorization';
 import { Translation } from '@suite-native/intl';
@@ -38,16 +37,6 @@ export const useShowViewOnlyAlert = () => {
     const isDeviceRemembered = useSelector(selectIsDeviceRemembered);
     const hasDiscovery = useSelector(selectHasRunningDiscovery);
     const isCreatingNewPassphraseWallet = useSelector(selectIsCreatingNewPassphraseWallet);
-    const [isAvailableBiometrics, setIsAvailableBiometrics] = useState(false);
-
-    useEffect(() => {
-        const fetchBiometricsAvailability = async () => {
-            const isAvailable = await getIsBiometricsFeatureAvailable();
-            setIsAvailableBiometrics(isAvailable);
-        };
-
-        fetchBiometricsAvailability();
-    }, []);
 
     const handleEnable = useCallback(() => {
         if (device) {
@@ -123,7 +112,6 @@ export const useShowViewOnlyAlert = () => {
         };
     }, [
         hasDiscovery,
-        isAvailableBiometrics,
         isDeviceReadyToUseAndAuthorized,
         isDeviceRemembered,
         isPortfolioTrackerDevice,

--- a/suite-native/module-home/src/screens/HomeScreen/useShowViewOnlyAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/useShowViewOnlyAlert.tsx
@@ -12,7 +12,6 @@ import { useAlert } from '@suite-native/alerts';
 import { EventType, analytics } from '@suite-native/analytics';
 import { CenteredTitleHeader, LottieAnimation, VStack } from '@suite-native/atoms';
 import { selectIsDeviceReadyToUseAndAuthorized } from '@suite-native/device';
-import { selectIsCreatingNewPassphraseWallet } from '@suite-native/device-authorization';
 import { Translation } from '@suite-native/intl';
 import {
     selectViewOnlyCancelationTimestamp,
@@ -36,7 +35,6 @@ export const useShowViewOnlyAlert = () => {
     const viewOnlyCancelationTimestamp = useSelector(selectViewOnlyCancelationTimestamp);
     const isDeviceRemembered = useSelector(selectIsDeviceRemembered);
     const hasDiscovery = useSelector(selectHasRunningDiscovery);
-    const isCreatingNewPassphraseWallet = useSelector(selectIsCreatingNewPassphraseWallet);
 
     const handleEnable = useCallback(() => {
         if (device) {
@@ -94,8 +92,7 @@ export const useShowViewOnlyAlert = () => {
             isDeviceReadyToUseAndAuthorized &&
             !isPortfolioTrackerDevice &&
             !hasDiscovery &&
-            !viewOnlyCancelationTimestamp &&
-            !isCreatingNewPassphraseWallet;
+            !viewOnlyCancelationTimestamp;
 
         //show after a delay
         if (canBeShowed) {
@@ -117,6 +114,5 @@ export const useShowViewOnlyAlert = () => {
         isPortfolioTrackerDevice,
         showViewOnlyAlert,
         viewOnlyCancelationTimestamp,
-        isCreatingNewPassphraseWallet,
     ]);
 };

--- a/suite-native/module-home/tsconfig.json
+++ b/suite-native/module-home/tsconfig.json
@@ -9,7 +9,6 @@
         { "path": "../analytics" },
         { "path": "../assets" },
         { "path": "../atoms" },
-        { "path": "../biometrics" },
         { "path": "../blockchain" },
         { "path": "../device" },
         { "path": "../device-manager" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10819,7 +10819,6 @@ __metadata:
     "@suite-native/analytics": "workspace:*"
     "@suite-native/assets": "workspace:*"
     "@suite-native/atoms": "workspace:*"
-    "@suite-native/biometrics": "workspace:*"
     "@suite-native/blockchain": "workspace:*"
     "@suite-native/device": "workspace:*"
     "@suite-native/device-manager": "workspace:*"


### PR DESCRIPTION

## Description

So far, a new passphrase wallet shouldn’t have view-only mode enabled until the user turns it on. 

- On desktop, the user has to go to the wallet switcher and enable it manually. 
- On mobile, a bottom sheet prompting the user to enable it should appear once discovery is finished (unless the user skipped it earlier).

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19450


## Screenshot

https://github.com/user-attachments/assets/3981ef93-d651-415c-ac0c-3a72e0889680




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/discovery-passhprase-remember-false-by-default&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/discovery-passhprase-remember-false-by-default&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/discovery-passhprase-remember-false-by-default&lookback=7)