### PR TITLE
Discovery nitpicks 4

### DIFF
--- a/packages/suite/src/components/suite/PinMatrix/PinMatrix.tsx
+++ b/packages/suite/src/components/suite/PinMatrix/PinMatrix.tsx
@@ -24,16 +24,9 @@ type PinMatrixProps = {
     setPin: (pin: string) => void;
     onSubmit: () => void;
     showExplanation?: boolean;
-    showLabel?: boolean;
 };
 
-export const PinMatrix = ({
-    showExplanation,
-    showLabel,
-    pin,
-    setPin,
-    onSubmit,
-}: PinMatrixProps) => {
+export const PinMatrix = ({ showExplanation, pin, setPin, onSubmit }: PinMatrixProps) => {
     const learnMoreUrl = useExternalLink(HELP_CENTER_PIN_URL);
 
     const onPinBackspace = useCallback(() => {
@@ -131,7 +124,7 @@ export const PinMatrix = ({
                     </Paragraph>
                 </Banner>
             )}
-            <Card label={showLabel ? <Translation id="TR_ENTER_PIN" /> : undefined}>
+            <Card>
                 <Column gap={spacings.xl} padding={spacings.md} data-testid="@pin">
                     <Grid columns={3} gap={spacings.lg} width="100%">
                         {

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -43,7 +43,7 @@ export const TREZOR_SUPPORT_DIFFERENT_PACKAGING: Url =
     'https://trezor.io/support/a/why-is-my-box-different-from-what-is-shown-on-the-website';
 
 export const HELP_CENTER_PIN_URL: Url =
-    'https://trezor.io/learn/a/pin-protection-on-trezor-devices';
+    'https://trezor.io/guides/trezor-devices/pin-protection-on-trezor-devices#trezor-model-one';
 export const HELP_CENTER_DRY_RUN_T1B1_URL: Url =
     'https://trezor.io/learn/a/test-recovery-seed-on-trezor-model-one';
 export const HELP_CENTER_DRY_RUN_T2T1_URL: Url =


### PR DESCRIPTION
cherrypicked from #19421

- removed unused prop 
- add link anchor to model one section to HELP_CENTER_PIN_URL as this URL is shown only in component that is rendered only for model one devices.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=discovery-nitpicks-4&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=discovery-nitpicks-4&lookback=7)