### PR TITLE
fix(connect): allow FW update calls when uninitialized

### DIFF
--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -31,6 +31,9 @@ const allowedCallsBeforeInitialize: Messages.MessageKey[] = [
     'GetFirmwareHash',
     'ChangeLanguage',
     'DataChunkAck',
+    // During firmware update, we can call these messages
+    'FirmwareErase',
+    'FirmwareUpload',
     // There are other, which are allowed by firmware (ApplySettings,...) but we do not use them this way in connect.
 ];
 


### PR DESCRIPTION
## Description

Allow FW update calls when device is uninitialized. Followup to [#19292](https://github.com/trezor/trezor-suite/pull/19292)

Note: in suite lite any console.error renders a toast message 

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/allow-fw-update-calls-when-uninitialized&lookback=7)