### PR TITLE
chore(suite): decrease node bridge rollout threshold

### DIFF
--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -101,7 +101,7 @@ const shouldUseLegacyBridge = (store: Dependencies['store']) => {
         store.setBridgeSettings({ ...store.getBridgeSettings(), newBridgeRollout });
     }
     const newBridgeRollout = store.getBridgeSettings().newBridgeRollout || 0;
-    const NEW_BRIDGE_ROLLOUT_THRESHOLD = 1;
+    const NEW_BRIDGE_ROLLOUT_THRESHOLD = 0.1;
     const legacyBridgeReasonRollout = newBridgeRollout >= NEW_BRIDGE_ROLLOUT_THRESHOLD;
 
     return legacyBridgeReasonRollout;


### PR DESCRIPTION
## Description

We are decreasing rollout percentage as the root cause of Device Connected status has not been resolved so far. (see https://satoshilabs.slack.com/archives/C07GAHPAYK0/p1749037105751629)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/node-bridge-rollout&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/node-bridge-rollout&lookback=7)