### PR TITLE
chore(nix-flake): update playwright-web-flake to version 1.52.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -86,16 +86,16 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1741354899,
-        "narHash": "sha256-CkfoVCQQoRosUT/SqgbW3gGn8TWnKwsVozI7Egk8qwA=",
+        "lastModified": 1744969290,
+        "narHash": "sha256-8pMFEdOT83u4VAIbnGOfnHvv5jNfRqZOnYjtQJaXkTs=",
         "owner": "pietdevries94",
         "repo": "playwright-web-flake",
-        "rev": "e41a037c2a658bdb1af6dfb38f7ac3832f0a3770",
+        "rev": "ceda34e26f2d0a939346c5d456afe69c9cf5250f",
         "type": "github"
       },
       "original": {
         "owner": "pietdevries94",
-        "ref": "1.51.0",
+        "ref": "1.52.0",
         "repo": "playwright-web-flake",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable"; 
     flake-utils.url = "github:numtide/flake-utils";
-    playwright-web-flake.url = "github:pietdevries94/playwright-web-flake/1.51.0";
+    playwright-web-flake.url = "github:pietdevries94/playwright-web-flake/1.52.0";
     old-gcc-nixpkgs.url = "github:NixOS/nixpkgs/a78ed5cbdd5427c30ca02a47ce6cccc9b7d17de4";  # For GCC 10.2.0
   };
 


### PR DESCRIPTION
update playwright-web-flake to version 1.52.0


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=update-PW&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=update-PW&lookback=7)