### PR TITLE
chore(suite-native): bump suite-native version to 25.6.2

### DIFF
--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@suite-native/app",
     "version": "1.0.0",
-    "suiteNativeVersion": "25.6.1",
+    "suiteNativeVersion": "25.6.2",
     "main": "index.js",
     "scripts": {
         "android": "expo run:android",


### PR DESCRIPTION
Bumping beta version after freeze


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/bump-app-version-to-25.6.2&lookback=7)