### PR TITLE
fix(suite-desktop-core): clear storage with autostart

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -147,6 +147,7 @@ const init = async () => {
 
     ipcMain.on('app/restart', () => {
         logger.info('main', 'App restart requested');
+        mainThreadEmitter.emit('app/fully-quit');
         restartApp();
     });
 

--- a/packages/suite/src/views/settings/SettingsGeneral/ClearStorage.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/ClearStorage.tsx
@@ -16,6 +16,7 @@ export const ClearStorage = () => {
         dispatch(removeDatabase());
         if (desktopApi.available) {
             // Reset the desktop-specific store.
+            desktopApi.appAutoStart(false);
             desktopApi.clearStore();
         } else {
             // redirect to / and reload the web


### PR DESCRIPTION
## Description

When clearing storage also disable autostart, since that's what most users expect

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/wipe-suite-autorestart&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/wipe-suite-autorestart&lookback=7)