### PR TITLE
fix(suite-native): prevent navigating to Connecting screen over Coin enabling

### DIFF
--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -27,7 +27,10 @@ import {
     StackToStackCompositeNavigationProps,
     useNavigationRouteMatch,
 } from '@suite-native/navigation';
-import { selectIsOnboardingFinished } from '@suite-native/settings';
+import {
+    selectIsCoinEnablingInitFinished,
+    selectIsOnboardingFinished,
+} from '@suite-native/settings';
 
 import {
     isOnboardingDeviceDisconnectedAlertDisplayedAtom,
@@ -59,6 +62,7 @@ export const useHandleDeviceConnection = () => {
     const isDeviceUsingPassphrase = useSelector(selectIsDeviceUsingPassphrase);
     const isFirmwareInstallationRunning = useSelector(selectIsFirmwareInstallationRunning);
     const isDeviceSetupSupported = useSelector(selectIsDeviceSetupSupported);
+    const isCoinEnablingInitFinished = useSelector(selectIsCoinEnablingInitFinished);
 
     const { isBiometricsOverlayVisible } = useIsBiometricsOverlayVisible();
     const isOnboardingDeviceDisconnectedAlertDisplayed = useAtomValue(
@@ -148,14 +152,16 @@ export const useHandleDeviceConnection = () => {
             !isDeviceConnectedAndAuthorized &&
             !isBiometricsOverlayVisible &&
             !shouldNavigateToDeviceCompromisedModal &&
-            !isDeviceOnboardingStackFocused
+            !isDeviceOnboardingStackFocused &&
+            !isDeviceUsingPassphrase &&
+            !shouldBlockSendReviewRedirect
         ) {
-            // Note: Passphrase protected device (excluding empty passphrase, e. g. standard wallet with passphrase protection on device),
-            // post auth navigation is handled in @suite-native/module-passphrase for custom UX flow.
-            if (!isDeviceUsingPassphrase && !shouldBlockSendReviewRedirect) {
+            if (isCoinEnablingInitFinished) {
                 navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
                     screen: AuthorizeDeviceStackRoutes.ConnectingDevice,
                 });
+            } else {
+                navigation.navigate(RootStackRoutes.CoinEnablingInit);
             }
         }
         if (shouldNavigateToDeviceCompromisedModal) {
@@ -163,6 +169,7 @@ export const useHandleDeviceConnection = () => {
         }
     }, [
         failedCheck,
+        isCoinEnablingInitFinished,
         isDeviceConnected,
         isDeviceOnboardingStackFocused,
         isOnboardingFinished,

--- a/suite-native/module-authorize-device/src/hooks/useOnDeviceReadyNavigation.ts
+++ b/suite-native/module-authorize-device/src/hooks/useOnDeviceReadyNavigation.ts
@@ -57,6 +57,8 @@ export const useOnDeviceReadyNavigation = () => {
         if (isFirmwareInstallationRunning) return;
 
         if (!isCoinEnablingInitFinished && isTimeoutFinished) {
+            // TODO: This should not be needed anymore, let's remove it.
+            // User should not be redirected to this screen without coin enabling finished.
             navigation.navigate(RootStackRoutes.CoinEnablingInit);
 
             return;


### PR DESCRIPTION
## Description

Prevent navigating to Connecting screen over Coin enabling screen. 



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-native/connecting-screen-over-coin-enabling&lookback=7)