### PR TITLE
Approval Flow

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -81,7 +81,6 @@ export const useTradingExchangeForm = ({
         addressVerified,
         amountLimits,
         isLoading,
-        formStep,
     } = useSelector(selectTradingExchange);
     const exchangeInfo = useSelector(selectTradingExchangeInfo);
     const { selectedFee, composed } = useSelector(selectTradingComposedTransactionInfo);
@@ -627,6 +626,10 @@ export const useTradingExchangeForm = ({
     }, [isNotFormPage, quotesRequest, navigateToExchangeForm]);
 
     useEffect(() => {
+        checkQuotesTimer(handleChange);
+    }, [checkQuotesTimer, handleChange]);
+
+    useEffect(() => {
         if (isFromRedirect) {
             if (transactionId && trade) {
                 dispatch(tradingExchangeActions.saveSelectedQuote(trade.data));
@@ -634,16 +637,8 @@ export const useTradingExchangeForm = ({
             }
 
             dispatch(tradingExchangeActions.setIsFromRedirect(false));
-        } else {
-            if (pageType === 'form') {
-                dispatch(tradingExchangeActions.setFormStep('RECEIVING_ADDRESS'));
-            }
         }
-    }, [dispatch, formStep, isFromRedirect, pageType, trade, transactionId]);
-
-    useEffect(() => {
-        checkQuotesTimer(handleChange);
-    }, [checkQuotesTimer, handleChange]);
+    }, [dispatch, isFromRedirect, trade, transactionId]);
 
     return {
         type,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+
+import { CryptoId } from 'invity-api';
+
+import { cryptoIdToNetwork, getUnusedAddressFromAccount } from '@suite-common/trading';
+
+import { useSelector } from 'src/hooks/suite';
+
+import { useAccountAddressDictionary } from '../../useAccounts';
+
+interface TradingReceiveAddressProps {
+    cryptoId?: CryptoId;
+}
+
+interface TradingReceiveAddress {
+    receiveAddress?: string;
+}
+
+export const useTradingReceiveAddress = ({
+    cryptoId,
+}: TradingReceiveAddressProps): TradingReceiveAddress => {
+    const accounts = useSelector(state => state.wallet.accounts);
+
+    const account = useMemo(() => {
+        if (!cryptoId) return undefined;
+
+        const network = cryptoIdToNetwork(cryptoId);
+
+        return accounts.find(account => account.symbol === network?.symbol);
+    }, [accounts, cryptoId]);
+
+    const unusedAccountAddress = account && getUnusedAddressFromAccount(account);
+    const addressDictionary = useAccountAddressDictionary(account);
+
+    const accountAddress = unusedAccountAddress?.address
+        ? addressDictionary[unusedAccountAddress?.address]
+        : undefined;
+
+    return { receiveAddress: accountAddress?.address };
+};

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { TrezorDevice } from '@suite-common/suite-types';
@@ -127,16 +127,19 @@ const useTradingVerifyAccount = ({
     const addressDictionary = useAccountAddressDictionary(selectedAccountOption?.account);
     const accountAddress = address ? addressDictionary[address] : undefined;
 
-    const selectAccountOption = (option: TradingVerifyFormAccountOptionProps) => {
-        setSelectedAccountOption(option);
+    const selectAccountOption = useCallback(
+        (option: TradingVerifyFormAccountOptionProps) => {
+            setSelectedAccountOption(option);
 
-        if (option.account) {
-            const { address } = getUnusedAddressFromAccount(option.account);
-            methods.setValue('address', address, { shouldValidate: true });
-        } else {
-            methods.setValue('address', '', { shouldValidate: false });
-        }
-    };
+            if (option.account) {
+                const { address } = getUnusedAddressFromAccount(option.account);
+                methods.setValue('address', address, { shouldValidate: true });
+            } else {
+                methods.setValue('address', '', { shouldValidate: false });
+            }
+        },
+        [methods],
+    );
 
     const onChangeAccount = (account: TradingVerifyFormAccountOptionProps) => {
         if (account.type === 'ADD_SUITE' && device) {
@@ -160,11 +163,14 @@ const useTradingVerifyAccount = ({
 
     // preselect the account
     useEffect(() => {
-        if (preselectedAccount && preselectedAccount.type !== 'ADD_SUITE') {
+        if (
+            preselectedAccount &&
+            preselectedAccount.type !== 'ADD_SUITE' &&
+            !selectedAccountOption
+        ) {
             selectAccountOption(preselectedAccount);
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [accounts]);
+    }, [preselectedAccount, selectedAccountOption, selectAccountOption]);
 
     return {
         form: {

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -617,6 +617,10 @@ export default defineMessages({
         defaultMessage: 'Proceed to swap',
         id: 'TR_EXCHANGE_APPROVAL_TO_SWAP_BUTTON',
     },
+    TR_EXCHANGE_SWAP_ACCOUNT_TO_BE_SELECTED: {
+        defaultMessage: 'To be selected',
+        id: 'TR_EXCHANGE_SWAP_ACCOUNT_TO_BE_SELECTED',
+    },
     TR_EXCHANGE_SWAP_SEND_TO: {
         defaultMessage: '{provider} contract address',
         id: 'TR_EXCHANGE_SWAP_SEND_TO',

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -1,13 +1,15 @@
 import { useState } from 'react';
 
-import { CryptoId } from 'invity-api';
+import { CryptoId, ExchangeTrade } from 'invity-api';
 
 import {
     TRADING_EXCHANGE_FORM,
     TRADING_EXCHANGE_FORM_DEX,
     type TradingTradeType,
     type TradingType,
+    isSendingEvmNativeToken,
     parseCryptoId,
+    tradingExchangeActions,
     useTradingInfo,
 } from '@suite-common/trading';
 import { TokenAddress } from '@suite-common/wallet-types';
@@ -17,8 +19,10 @@ import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { Translation } from 'src/components/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { useTradingDeviceDisconnected } from 'src/hooks/wallet/trading/form/common/useTradingDeviceDisconnected';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { useTradingReceiveAddress } from 'src/hooks/wallet/trading/form/useTradingReceiveAddress';
 import { TradingFormContextValues } from 'src/types/trading/tradingForm';
 import {
     getCryptoQuoteAmountProps,
@@ -54,7 +58,9 @@ const getSelectedQuote = (
 };
 
 export const TradingFormOffer = () => {
+    const dispatch = useDispatch();
     const [isCompareLoading, setIsCompareLoading] = useState<boolean>(false);
+    const [isDexSwapLoading, setIsDexSwapLoading] = useState<boolean>(false);
     const context = useTradingFormContext();
     const {
         account,
@@ -95,9 +101,37 @@ export const TradingFormOffer = () => {
             new BigNumber(bestScoredQuoteAmounts.receiveAmount),
         );
 
-    const onSelectQuote = () => {
+    const { receiveAddress } = useTradingReceiveAddress({
+        cryptoId: quote && 'receive' in quote ? (quote as ExchangeTrade)?.receive : undefined,
+    });
+
+    const onSelectQuote = async () => {
         if (!quote) {
             return;
+        }
+
+        // DEX swap
+        if (isTradingExchangeContext(context) && (quote as ExchangeTrade).isDex) {
+            const { confirmTrade } = context;
+            const trade = quote as ExchangeTrade;
+
+            if (!receiveAddress) {
+                return;
+            }
+
+            setIsDexSwapLoading(true);
+            await confirmTrade({ trade, receiveAddress });
+            setIsDexSwapLoading(false);
+
+            dispatch(
+                tradingExchangeActions.setFormStep(
+                    isSendingEvmNativeToken(trade.send)
+                        ? 'RECEIVING_ADDRESS'
+                        : 'SEND_APPROVAL_TRANSACTION',
+                ),
+            );
+        } else {
+            dispatch(tradingExchangeActions.setFormStep('RECEIVING_ADDRESS'));
         }
 
         selectQuote(quote);
@@ -141,7 +175,8 @@ export const TradingFormOffer = () => {
                 ) : (
                     <TradingFormOfferCryptoAmount
                         amount={
-                            !state.isLoadingOrInvalid && bestScoredQuoteAmounts?.receiveAmount
+                            (!state.isLoadingOrInvalid || isDexSwapLoading) &&
+                            bestScoredQuoteAmounts?.receiveAmount
                                 ? bestScoredQuoteAmounts.receiveAmount
                                 : '0'
                         }
@@ -204,7 +239,7 @@ export const TradingFormOffer = () => {
                 {isTradingExchangeContext(context) ? (
                     <TradingFormOffersSwitcher
                         context={context}
-                        isFormLoading={state.isFormLoading}
+                        isFormLoading={state.isFormLoading && !isDexSwapLoading}
                         isFormInvalid={state.isFormInvalid}
                         providers={providers}
                     />
@@ -217,6 +252,7 @@ export const TradingFormOffer = () => {
                     />
                 )}
             </Column>
+
             <Button
                 onClick={onSelectQuote}
                 variant="primary"
@@ -225,10 +261,12 @@ export const TradingFormOffer = () => {
                 }}
                 isFullWidth
                 isDisabled={isButtonDisabled}
+                isLoading={isDexSwapLoading}
                 data-testid={`@trading/form/${type}-button`}
             >
                 <Translation id={tradingGetSectionActionLabel(type)} />
             </Button>
+
             {(type === 'buy' || type === 'sell') && <TradingFormOfferOTC />}
         </Column>
     );

--- a/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersItem.tsx
@@ -1,14 +1,22 @@
-import { SellFiatTrade } from 'invity-api';
+import { ExchangeTrade, SellFiatTrade } from 'invity-api';
 import styled, { useTheme } from 'styled-components';
 
-import { TradingTradeMapProps, getTagAndInfoNote, sellUtils } from '@suite-common/trading';
+import {
+    TradingTradeMapProps,
+    getTagAndInfoNote,
+    isSendingEvmNativeToken,
+    sellUtils,
+    tradingExchangeActions,
+} from '@suite-common/trading';
 import { Badge, Button, Card, Row, Text } from '@trezor/components';
 import { SCREEN_QUERY } from '@trezor/components/src/config/variables';
 import { spacings, spacingsPx } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { useTradingDeviceDisconnected } from 'src/hooks/wallet/trading/form/common/useTradingDeviceDisconnected';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { useTradingReceiveAddress } from 'src/hooks/wallet/trading/form/useTradingReceiveAddress';
 import {
     getCryptoQuoteAmountProps,
     getProvidersInfoProps,
@@ -93,6 +101,7 @@ export interface TradingOffersItemProps {
 }
 
 export const TradingOffersItem = ({ quote }: TradingOffersItemProps) => {
+    const dispatch = useDispatch();
     const theme = useTheme();
     const context = useTradingFormContext();
     const {
@@ -110,7 +119,33 @@ export const TradingOffersItem = ({ quote }: TradingOffersItemProps) => {
 
     const { tradingDeviceDisconnected } = useTradingDeviceDisconnected();
 
-    const onSelectQuote = () => {
+    const { receiveAddress } = useTradingReceiveAddress({
+        cryptoId: quote && 'receive' in quote ? (quote as ExchangeTrade)?.receive : undefined,
+    });
+
+    const onSelectQuote = async () => {
+        // DEX swap
+        if (isTradingExchangeContext(context) && (quote as ExchangeTrade).isDex) {
+            const { confirmTrade } = context;
+            const trade = quote as ExchangeTrade;
+
+            if (!receiveAddress) {
+                return;
+            }
+
+            await confirmTrade({ trade, receiveAddress });
+
+            dispatch(
+                tradingExchangeActions.setFormStep(
+                    isSendingEvmNativeToken(trade.send)
+                        ? 'RECEIVING_ADDRESS'
+                        : 'SEND_APPROVAL_TRANSACTION',
+                ),
+            );
+        } else {
+            dispatch(tradingExchangeActions.setFormStep('RECEIVING_ADDRESS'));
+        }
+
         selectQuote(quote);
     };
     const isSellVerificationRequired =

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
@@ -1,11 +1,12 @@
 import { CryptoId } from 'invity-api';
 
-import type { TradingType } from '@suite-common/trading';
+import { type TradingType, selectTradingExchangeFormStep } from '@suite-common/trading';
 import { Account } from '@suite-common/wallet-types';
 import { Column, InfoItem, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { AccountLabeling, Translation } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
 import { TradingPayGetLabelType } from 'src/types/trading/trading';
 import { TradingCoinLogo } from 'src/views/wallet/trading/common/TradingCoinLogo';
 import { TradingCryptoAmount } from 'src/views/wallet/trading/common/TradingCryptoAmount';
@@ -27,31 +28,43 @@ export const TradingInfoItem = ({
     label,
     currency,
     amount,
-}: TradingInfoItemProps) => (
-    <InfoItem label={<Translation id={label} />} direction="row">
-        {type === 'exchange' || isReceive ? (
-            <Column alignItems="flex-end" gap={spacings.xxxs}>
-                <Row gap={spacings.xs}>
-                    {currency && (
-                        <>
-                            <TradingCoinLogo cryptoId={currency} size={20} />
-                            <TradingCryptoAmount amount={amount} cryptoId={currency} />
-                        </>
+}: TradingInfoItemProps) => {
+    const formStep = useSelector(selectTradingExchangeFormStep);
+
+    const showReceiveAccount = !isReceive || formStep !== 'SEND_APPROVAL_TRANSACTION';
+
+    return (
+        <InfoItem label={<Translation id={label} />} direction="row">
+            {type === 'exchange' || isReceive ? (
+                <Column alignItems="flex-end" gap={spacings.xxxs}>
+                    <Row gap={spacings.xs}>
+                        {currency && (
+                            <>
+                                <TradingCoinLogo cryptoId={currency} size={20} />
+                                <TradingCryptoAmount amount={amount} cryptoId={currency} />
+                            </>
+                        )}
+                    </Row>
+                    {account && showReceiveAccount && (
+                        <Text variant="tertiary" typographyStyle="label" as="div">
+                            <Row gap={spacings.xxs}>
+                                <AccountLabeling account={account} />
+                                {account.accountType !== 'normal' ? `(${account.accountType})` : ''}
+                            </Row>
+                        </Text>
                     )}
+
+                    {account && !showReceiveAccount && (
+                        <Text variant="tertiary" typographyStyle="label" as="div">
+                            <Translation id="TR_EXCHANGE_SWAP_ACCOUNT_TO_BE_SELECTED" />
+                        </Text>
+                    )}
+                </Column>
+            ) : (
+                <Row data-testid="@trading/form/info/fiat-amount">
+                    <TradingFiatAmount amount={amount} currency={currency} />
                 </Row>
-                {account && (
-                    <Text variant="tertiary" typographyStyle="label" as="div">
-                        <Row gap={spacings.xxs}>
-                            <AccountLabeling account={account} />
-                            {account.accountType !== 'normal' ? `(${account.accountType})` : ''}
-                        </Row>
-                    </Text>
-                )}
-            </Column>
-        ) : (
-            <Row data-testid="@trading/form/info/fiat-amount">
-                <TradingFiatAmount amount={amount} currency={currency} />
-            </Row>
-        )}
-    </InfoItem>
-);
+            )}
+        </InfoItem>
+    );
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'react';
 
-import { selectTradingExchangeFormStep } from '@suite-common/trading';
+import { isSendingEvmNativeToken, selectTradingExchangeFormStep } from '@suite-common/trading';
 import { Card, Divider } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -32,16 +32,10 @@ export const TradingOfferExchange = ({
         nonSuiteAccount: !selectedQuote.tags?.includes('noExternalAddress'),
     });
 
+    const showApprovalStep = selectedQuote.isDex && !isSendingEvmNativeToken(selectedQuote.send);
+
     const steps: TradingSelectedOfferStepperItemProps[] = [
-        {
-            step: 'RECEIVING_ADDRESS',
-            translationId: 'TR_EXCHANGE_VERIFY_ADDRESS_STEP',
-            isActive: formStep === 'RECEIVING_ADDRESS',
-            component: cryptoId ? (
-                <TradingVerify tradingVerifyAccount={tradingVerifyAccount} cryptoId={cryptoId} />
-            ) : null,
-        },
-        ...((selectedQuote.isDex
+        ...((showApprovalStep
             ? [
                   {
                       step: 'SEND_APPROVAL_TRANSACTION',
@@ -51,6 +45,14 @@ export const TradingOfferExchange = ({
                   },
               ]
             : []) as TradingSelectedOfferStepperItemProps[]),
+        {
+            step: 'RECEIVING_ADDRESS',
+            translationId: 'TR_EXCHANGE_VERIFY_ADDRESS_STEP',
+            isActive: formStep === 'RECEIVING_ADDRESS',
+            component: cryptoId ? (
+                <TradingVerify tradingVerifyAccount={tradingVerifyAccount} cryptoId={cryptoId} />
+            ) : null,
+        },
         {
             step: 'SEND_TRANSACTION',
             translationId: 'TR_EXCHANGE_CONFIRM_SEND_STEP',

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendApproval.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { usePrevious } from 'react-use';
 
 import { DexApprovalType, ExchangeTrade } from 'invity-api';
 import styled from 'styled-components';
@@ -32,6 +33,7 @@ import { TxAddress } from 'src/components/suite/copy/TxAddress';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingExchangeWatchSendApproval } from 'src/hooks/wallet/trading/form/useTradingExchangeWatchSendApproval';
+import useTradingVerifyAccount from 'src/hooks/wallet/trading/form/useTradingVerifyAccount';
 import { useTradingNavigation } from 'src/hooks/wallet/useTradingNavigation';
 
 // add APPROVED means no approval request is necessary
@@ -63,6 +65,9 @@ export const TradingOfferExchangeSendApproval = () => {
         selectedQuote?.status === 'CONFIRM' ? selectedQuote : undefined,
     );
 
+    const currentQuoteStatus = selectedQuote?.status;
+    const previousQuoteStatus = usePrevious(currentQuoteStatus);
+
     const { navigateToExchangeForm } = useTradingNavigation(account);
 
     useTradingExchangeWatchSendApproval({
@@ -71,6 +76,70 @@ export const TradingOfferExchangeSendApproval = () => {
     });
 
     const explorers = useSelector(state => state.wallet.explorer);
+
+    const [approvalStep, setApprovalStep] = useState<
+        'REQUIRED' | 'APPROVED' | 'LOADING' | undefined
+    >();
+
+    const { accountAddress } = useTradingVerifyAccount({
+        cryptoId: selectedQuote?.receive,
+        nonSuiteAccount: !selectedQuote?.tags?.includes('noExternalAddress'),
+    });
+
+    useEffect(() => {
+        if (
+            (!previousQuoteStatus || previousQuoteStatus === 'APPROVAL_REQ') &&
+            currentQuoteStatus === 'APPROVAL_REQ'
+        ) {
+            setApprovalStep('REQUIRED');
+        }
+
+        if (
+            (!previousQuoteStatus || previousQuoteStatus === 'APPROVAL_PENDING') &&
+            currentQuoteStatus === 'APPROVAL_PENDING'
+        ) {
+            setApprovalStep('LOADING');
+        }
+
+        if (
+            (!previousQuoteStatus || previousQuoteStatus === 'CONFIRM') &&
+            currentQuoteStatus === 'CONFIRM'
+        ) {
+            setApprovalStep('APPROVED');
+        }
+
+        const forceConfirmTrade = async () => {
+            if (!accountAddress?.address) {
+                return;
+            }
+
+            await confirmTrade({
+                trade: selectedQuote,
+                receiveAddress: accountAddress?.address,
+            });
+        };
+
+        if (previousQuoteStatus === 'APPROVAL_PENDING' && currentQuoteStatus === 'CONFIRM') {
+            forceConfirmTrade();
+
+            if (approvalType === 'ZERO') {
+                setApprovalStep('REQUIRED');
+
+                return;
+            }
+
+            setApprovalStep('APPROVED');
+            dispatch(tradingExchangeActions.setFormStep('RECEIVING_ADDRESS'));
+        }
+    }, [
+        currentQuoteStatus,
+        previousQuoteStatus,
+        approvalType,
+        confirmTrade,
+        selectedQuote,
+        accountAddress,
+        dispatch,
+    ]);
 
     if (!selectedQuote) return null;
 
@@ -145,6 +214,8 @@ export const TradingOfferExchangeSendApproval = () => {
             trade: updatedSelectedQuote,
         });
 
+        dispatch(tradingExchangeActions.setFormStep('RECEIVING_ADDRESS'));
+
         analytics.report({
             type: EventType.TradingExchange,
             payload: {
@@ -157,6 +228,8 @@ export const TradingOfferExchangeSendApproval = () => {
 
     const confirmAndSend = async () => {
         const result = await sendTransaction();
+
+        dispatch(tradingExchangeActions.setFormStep('SEND_APPROVAL_TRANSACTION'));
 
         analytics.report({
             type: EventType.TradingExchange,
@@ -196,25 +269,8 @@ export const TradingOfferExchangeSendApproval = () => {
                     />
                 </InfoItem>
             )}
-            {selectedQuote.status === 'APPROVAL_PENDING' && (
-                <Column
-                    alignItems="center"
-                    justifyContent="center"
-                    margin={{ top: spacings.xxxxl, bottom: spacings.md }}
-                >
-                    <Spinner />
-                    <Paragraph typographyStyle="highlight" margin={{ top: spacings.lg }}>
-                        <Translation id="TR_EXCHANGE_APPROVAL_CONFIRMING" />
-                    </Paragraph>
-                </Column>
-            )}
-            {selectedQuote.status === 'ERROR' && (
-                <Banner variant="destructive" icon margin={{ top: spacings.xl }}>
-                    <Translation id="TR_EXCHANGE_APPROVAL_FAILED" />
-                </Banner>
-            )}
 
-            {(selectedQuote.status === 'APPROVAL_REQ' || selectedQuote.status === 'CONFIRM') && (
+            {approvalStep === 'REQUIRED' && (
                 <Card
                     label={
                         <Text typographyStyle="hint">
@@ -224,53 +280,89 @@ export const TradingOfferExchangeSendApproval = () => {
                     margin={{ top: spacings.md }}
                 >
                     <Column gap={spacings.xl} alignItems="flex-start">
-                        {selectedQuote.status === 'APPROVAL_REQ' && (
-                            <>
+                        <>
+                            <Radio
+                                isChecked={approvalType === 'MINIMAL'}
+                                onClick={() => selectApprovalValue('MINIMAL')}
+                                verticalAlignment="center"
+                                isDisabled={isFormLoading}
+                            >
+                                <Column alignItems="flex-start">
+                                    <Text typographyStyle="highlight">
+                                        <Translation
+                                            id="TR_EXCHANGE_APPROVAL_VALUE_MINIMAL"
+                                            values={translationValues}
+                                        />
+                                    </Text>
+                                    <Paragraph typographyStyle="hint">
+                                        <Translation
+                                            id="TR_EXCHANGE_APPROVAL_VALUE_MINIMAL_INFO"
+                                            values={translationValues}
+                                        />
+                                    </Paragraph>
+                                </Column>
+                            </Radio>
+                            <Radio
+                                isChecked={approvalType === 'INFINITE'}
+                                onClick={() => selectApprovalValue('INFINITE')}
+                                verticalAlignment="center"
+                                isDisabled={isFormLoading}
+                            >
+                                <Column alignItems="flex-start">
+                                    <Text typographyStyle="highlight">
+                                        <Translation
+                                            id="TR_EXCHANGE_APPROVAL_VALUE_INFINITE"
+                                            values={translationValues}
+                                        />
+                                    </Text>
+                                    <Paragraph typographyStyle="hint">
+                                        <Translation
+                                            id="TR_EXCHANGE_APPROVAL_VALUE_INFINITE_INFO"
+                                            values={translationValues}
+                                        />
+                                    </Paragraph>
+                                </Column>
+                            </Radio>
+
+                            {isToken && !isFullApproval && (
                                 <Radio
-                                    isChecked={approvalType === 'MINIMAL'}
-                                    onClick={() => selectApprovalValue('MINIMAL')}
+                                    isChecked={approvalType === 'ZERO'}
+                                    onClick={() => selectApprovalValue('ZERO')}
                                     verticalAlignment="center"
                                     isDisabled={isFormLoading}
                                 >
                                     <Column alignItems="flex-start">
                                         <Text typographyStyle="highlight">
                                             <Translation
-                                                id="TR_EXCHANGE_APPROVAL_VALUE_MINIMAL"
+                                                id="TR_EXCHANGE_APPROVAL_VALUE_ZERO"
                                                 values={translationValues}
                                             />
                                         </Text>
                                         <Paragraph typographyStyle="hint">
                                             <Translation
-                                                id="TR_EXCHANGE_APPROVAL_VALUE_MINIMAL_INFO"
+                                                id="TR_EXCHANGE_APPROVAL_VALUE_ZERO_INFO"
                                                 values={translationValues}
                                             />
                                         </Paragraph>
                                     </Column>
                                 </Radio>
-                                <Radio
-                                    isChecked={approvalType === 'INFINITE'}
-                                    onClick={() => selectApprovalValue('INFINITE')}
-                                    verticalAlignment="center"
-                                    isDisabled={isFormLoading}
-                                >
-                                    <Column alignItems="flex-start">
-                                        <Text typographyStyle="highlight">
-                                            <Translation
-                                                id="TR_EXCHANGE_APPROVAL_VALUE_INFINITE"
-                                                values={translationValues}
-                                            />
-                                        </Text>
-                                        <Paragraph typographyStyle="hint">
-                                            <Translation
-                                                id="TR_EXCHANGE_APPROVAL_VALUE_INFINITE_INFO"
-                                                values={translationValues}
-                                            />
-                                        </Paragraph>
-                                    </Column>
-                                </Radio>
-                            </>
-                        )}
-                        {selectedQuote.status !== 'APPROVAL_REQ' && (
+                            )}
+                        </>
+                    </Column>
+                </Card>
+            )}
+
+            {approvalStep === 'APPROVED' && (
+                <Card
+                    label={
+                        <Text typographyStyle="hint">
+                            <Translation id="TR_EXCHANGE_APPROVAL_VALUE" />
+                        </Text>
+                    }
+                    margin={{ top: spacings.md }}
+                >
+                    <Column gap={spacings.xl} alignItems="flex-start">
+                        <>
                             <Radio
                                 isChecked={approvalType === 'APPROVED'}
                                 onClick={() => selectApprovalValue('APPROVED')}
@@ -297,32 +389,46 @@ export const TradingOfferExchangeSendApproval = () => {
                                     </Paragraph>
                                 </Column>
                             </Radio>
-                        )}
-                        {isToken && !isFullApproval && (
-                            <Radio
-                                isChecked={approvalType === 'ZERO'}
-                                onClick={() => selectApprovalValue('ZERO')}
-                                verticalAlignment="center"
-                                isDisabled={isFormLoading}
-                            >
-                                <Column alignItems="flex-start">
-                                    <Text typographyStyle="highlight">
-                                        <Translation
-                                            id="TR_EXCHANGE_APPROVAL_VALUE_ZERO"
-                                            values={translationValues}
-                                        />
-                                    </Text>
-                                    <Paragraph typographyStyle="hint">
-                                        <Translation
-                                            id="TR_EXCHANGE_APPROVAL_VALUE_ZERO_INFO"
-                                            values={translationValues}
-                                        />
-                                    </Paragraph>
-                                </Column>
-                            </Radio>
-                        )}
+
+                            {isToken && !isFullApproval && (
+                                <Radio
+                                    isChecked={approvalType === 'ZERO'}
+                                    onClick={() => selectApprovalValue('ZERO')}
+                                    verticalAlignment="center"
+                                    isDisabled={isFormLoading}
+                                >
+                                    <Column alignItems="flex-start">
+                                        <Text typographyStyle="highlight">
+                                            <Translation
+                                                id="TR_EXCHANGE_APPROVAL_VALUE_ZERO"
+                                                values={translationValues}
+                                            />
+                                        </Text>
+                                        <Paragraph typographyStyle="hint">
+                                            <Translation
+                                                id="TR_EXCHANGE_APPROVAL_VALUE_ZERO_INFO"
+                                                values={translationValues}
+                                            />
+                                        </Paragraph>
+                                    </Column>
+                                </Radio>
+                            )}
+                        </>
                     </Column>
                 </Card>
+            )}
+
+            {approvalStep === 'LOADING' && (
+                <Column
+                    alignItems="center"
+                    justifyContent="center"
+                    margin={{ top: spacings.xxxxl, bottom: spacings.md }}
+                >
+                    <Spinner />
+                    <Paragraph typographyStyle="highlight" margin={{ top: spacings.lg }}>
+                        <Translation id="TR_EXCHANGE_APPROVAL_CONFIRMING" />
+                    </Paragraph>
+                </Column>
             )}
 
             {dexTx.data && (selectedQuote.status !== 'CONFIRM' || approvalType === 'ZERO') && (
@@ -331,10 +437,17 @@ export const TradingOfferExchangeSendApproval = () => {
                 </CollapsibleBox>
             )}
 
+            {selectedQuote.status === 'ERROR' && (
+                <Banner variant="destructive" icon margin={{ top: spacings.xl }}>
+                    <Translation id="TR_EXCHANGE_APPROVAL_FAILED" />
+                </Banner>
+            )}
+
             <Column>
                 <Divider margin={{ top: spacings.xxs, bottom: spacings.lg }} />
-                {(selectedQuote.status === 'APPROVAL_REQ' ||
-                    (selectedQuote.status === 'CONFIRM' && approvalType === 'ZERO')) && (
+
+                {(approvalStep === 'REQUIRED' ||
+                    (approvalStep === 'APPROVED' && approvalType === 'ZERO')) && (
                     <Button
                         isLoading={isFormLoading}
                         isDisabled={!device?.connected}
@@ -344,7 +457,7 @@ export const TradingOfferExchangeSendApproval = () => {
                     </Button>
                 )}
 
-                {selectedQuote.status === 'CONFIRM' && approvalType !== 'ZERO' && (
+                {approvalStep === 'APPROVED' && approvalType !== 'ZERO' && (
                     <Button
                         isLoading={isFormLoading}
                         isDisabled={isFormLoading}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerify.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerify.tsx
@@ -152,6 +152,7 @@ export const TradingVerify = ({ tradingVerifyAccount, cryptoId }: TradingVerifyP
             });
         }
 
+        dispatch(tradingExchangeActions.setFormStep('SEND_TRANSACTION'));
         confirmTrade({ receiveAddress: address, extraField });
     };
 

--- a/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
@@ -451,7 +451,7 @@ describe('confirmExchangeTradeThunk', () => {
     describe('should return true from confirmation for trade, which is in to confirm state from dex and request approval transaction', () => {
         it.each([
             [
-                'when formStep is RECEIVING_ADDRESS',
+                'when formStep is SEND_APPROVAL_TRANSACTION',
                 {
                     status: 'CONFIRM',
                     orderId: 'orderId',
@@ -498,16 +498,16 @@ describe('confirmExchangeTradeThunk', () => {
             const { exchange } = store.getState().wallet.tradingNew;
 
             expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
-            expect(store.getActions().length).toEqual(5);
+            expect(store.getActions().length).toEqual(4);
             expect(exchange.transactionId).toBeUndefined();
             expect(exchange.isLoading).toBeFalsy();
             expect(exchange.selectedQuote).toEqual(tradeResponse);
-            expect(exchange.formStep).toEqual('SEND_APPROVAL_TRANSACTION');
+            expect(exchange.formStep).toEqual('RECEIVING_ADDRESS');
             expect(response).toBeTruthy();
         });
     });
 
-    it('should return true from confirmation for trade, which is in to confirm state from dex and set next step', async () => {
+    it('should return true from confirmation for trade, which is in to confirm state from dex', async () => {
         const {
             store,
             returnUrl,
@@ -548,11 +548,10 @@ describe('confirmExchangeTradeThunk', () => {
         const { exchange } = store.getState().wallet.tradingNew;
 
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
-        expect(store.getActions().length).toEqual(5);
+        expect(store.getActions().length).toEqual(4);
         expect(exchange.transactionId).toBeUndefined();
         expect(exchange.isLoading).toBeFalsy();
         expect(exchange.selectedQuote).toEqual(tradeResponse);
-        expect(exchange.formStep).toEqual('SEND_TRANSACTION');
         expect(response).toBeTruthy();
     });
 

--- a/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
@@ -10,7 +10,6 @@ import { tradingExchangeActions } from '../../reducers/exchangeReducer';
 import { tradingActions } from '../../reducers/tradingReducer';
 import {
     selectTradingExchangeAccountKey,
-    selectTradingExchangeFormStep,
     selectTradingExchangeQuotesRequest,
     selectTradingExchangeReceiveAccountKey,
     selectTradingExchangeSelectedQuote,
@@ -50,7 +49,6 @@ export const confirmExchangeTradeThunk = createThunk(
         const quotesRequest = selectTradingExchangeQuotesRequest(getState());
         const sendAccountKey = selectTradingExchangeAccountKey(getState());
         const receiveAccountKey = selectTradingExchangeReceiveAccountKey(getState());
-        const formStep = selectTradingExchangeFormStep(getState());
         const { address: refundAddress } = getUnusedAddressFromAccount(account);
 
         let isConfirmationOk = false;
@@ -129,16 +127,7 @@ export const confirmExchangeTradeThunk = createThunk(
         }
 
         if (response.status === 'CONFIRM' && response.isDex) {
-            const isApprovalActive =
-                formStep === 'RECEIVING_ADDRESS' || trade.approvalType === 'ZERO';
-
             dispatch(tradingExchangeActions.saveSelectedQuote(response));
-
-            if (isApprovalActive) {
-                dispatch(tradingExchangeActions.setFormStep('SEND_APPROVAL_TRANSACTION'));
-            } else {
-                dispatch(tradingExchangeActions.setFormStep('SEND_TRANSACTION'));
-            }
 
             return isConfirmationOk;
         }

--- a/suite-common/trading/src/thunks/exchange/selectExchangeQuoteThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/selectExchangeQuoteThunk.ts
@@ -55,7 +55,10 @@ export const selectExchangeQuoteThunk = createThunk(
             return;
         }
 
-        dispatch(tradingExchangeActions.saveSelectedQuote(quote));
+        if (!quote.isDex) {
+            dispatch(tradingExchangeActions.saveSelectedQuote(quote));
+        }
+
         timer.stop();
         nextStep();
     },

--- a/suite-common/trading/src/utils/exchange/exchangeUtils.ts
+++ b/suite-common/trading/src/utils/exchange/exchangeUtils.ts
@@ -1,16 +1,31 @@
 import { CryptoId, ExchangeTrade, ExchangeTradeStatus } from 'invity-api';
 
 import {
+    CONTRACT_ADDRESS_FOR_NATIVE_TOKEN,
     TRADING_DEFAULT_CRYPTO_CURRENCY,
     TRADING_DEFAULT_CRYPTO_SECONDARY_CURRENCY,
     TRADING_EXCHANGE_RATE_FIXED,
 } from '../../constants';
 import { ExchangeInfo } from '../../reducers/exchangeReducer';
 import { TradingExchangeAmountLimitProps, TradingExchangeRateType } from '../../types';
+import { cryptoIdToNetwork, parseCryptoId } from '../../utils';
 
 type GetAmountLimitsProps = {
     quotes: ExchangeTrade[];
     currency: string;
+};
+
+export const isSendingEvmNativeToken = (cryptoId?: CryptoId) => {
+    if (!cryptoId) {
+        return false;
+    }
+
+    const isEvmNetwork = cryptoIdToNetwork(cryptoId)?.networkType === 'ethereum';
+    const { contractAddress } = parseCryptoId(cryptoId);
+
+    return (
+        isEvmNetwork && (!contractAddress || contractAddress === CONTRACT_ADDRESS_FOR_NATIVE_TOKEN)
+    );
 };
 
 // loop through quotes and if all quotes are either with error below minimum or over maximum, return error message

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -318,6 +318,7 @@ export const pushSendFormTransactionThunk = createThunk<
 
         if (isSuccessfullyPushedTransaction(pushTxResponse)) {
             const { txid } = pushTxResponse.payload;
+
             dispatch(
                 notificationsActions.addToast({
                     type: 'tx-sent',


### PR DESCRIPTION
## Description

New approval flow:

- approval step is now the first step, before receiving address
- for native EVM coin, approval step is not shown and is skipped

## Related Issue

Resolve #14839 
Resolve https://github.com/trezor/trezor-suite/issues/19283
Prerequisite for https://github.com/trezor/trezor-suite/issues/19012

## Screenshots

When doing a DEX swap on a token, approval step goes first:

<img width="1180" alt="Screenshot 2025-06-11 at 16 04 41" src="https://github.com/user-attachments/assets/3e7dda24-9ad3-47e7-9eb0-eee36199cd35" />

<img width="1180" alt="Screenshot 2025-06-11 at 16 05 56" src="https://github.com/user-attachments/assets/0a0a1492-a98a-41ec-acf4-2a0b4fc11f3b" />

<img width="1180" alt="Screenshot 2025-06-11 at 16 04 55" src="https://github.com/user-attachments/assets/b8afb02b-40c3-4466-a98e-8d7b7d483faa" />

\
After approval, the user is navigated to the receive address step:

<img width="1180" alt="Screenshot 2025-06-11 at 16 05 10" src="https://github.com/user-attachments/assets/101a3cca-7467-4fa2-8697-5e1d4c2d2f30" />

\
When swapping native EVM coin, approval step is skipped:

<img width="1180" alt="Screenshot 2025-06-11 at 16 06 15" src="https://github.com/user-attachments/assets/85d0a5f8-fb58-4ac3-94f5-783bb1bbf1bc" />

<img width="1180" alt="Screenshot 2025-06-11 at 16 06 24" src="https://github.com/user-attachments/assets/16234e65-3d28-438f-93da-6b5965dff728" />

\
🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/approval&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/approval&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/approval&lookback=7)