### PR TITLE
fix(e2e): Enable skipped passphrase tests

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/devicePrompt.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/devicePrompt.ts
@@ -6,6 +6,7 @@ export class DevicePrompt {
     readonly confirmOnDevicePrompt: Locator;
     readonly connectDevicePrompt: Locator;
     readonly modal: Locator;
+    readonly modalCloseButton: Locator;
     private readonly paginatedText: Locator;
     private readonly paginatedTextSeparator: Locator;
     readonly chunkedText: Locator;
@@ -35,6 +36,7 @@ export class DevicePrompt {
     constructor(private page: Page) {
         this.confirmOnDevicePrompt = page.getByTestId('@prompts/confirm-on-device');
         this.connectDevicePrompt = page.getByTestId('@connect-device-prompt');
+        this.modalCloseButton = page.getByTestId('@modal/close-button');
         this.modal = page.getByTestId('@modal');
         this.paginatedText = page.locator("[data-testid-alt='@device-display/paginated-text']");
         this.paginatedTextSeparator = page.getByTestId('@device-display/paginated-text/separator');
@@ -182,5 +184,11 @@ export class DevicePrompt {
         }
 
         return lines[lines.length - 1];
+    }
+
+    @step()
+    async closeModal() {
+        await this.modalCloseButton.click();
+        await expect(this.modal).toBeHidden();
     }
 }

--- a/packages/suite-desktop-core/e2e/tests/metadata/metadata-lifecycle.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/metadata-lifecycle.test.ts
@@ -62,7 +62,7 @@ test.describe(
             await trezorUserEnvLink.pressYes();
 
             // Close connect to data provider modal
-            await page.getByTestId('@modal/close-button').click();
+            await devicePrompt.closeModal();
 
             // Forget device and reload
             await page.getByTestId('@menu/switch-device').click();

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-cardano.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-cardano.test.ts
@@ -61,7 +61,7 @@ test.describe('Passphrase with cardano', { tag: ['@group=passphrase'] }, () => {
         await trezorUserEnvLink.pressYes(); // Confirm receive address
 
         await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
-        await page.getByTestId('@modal/close-button').click();
+        await devicePrompt.closeModal();
         await expect(walletPage.revealAddressButton).toBeVisible();
 
         // restart device again

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-cardano.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-cardano.test.ts
@@ -21,59 +21,65 @@ test.describe('Passphrase with cardano', { tag: ['@group=passphrase'] }, () => {
         emulatorStartConf,
     }) => {
         async function restartEmulator() {
-            await trezorUserEnvLink.stopEmu();
-            await expect(page.getByTestId('@deviceStatus-disconnected')).toBeVisible();
-            await trezorUserEnvLink.startEmu({ model: emulatorStartConf.model, wipe: false });
-            await expect(page.getByTestId('@deviceStatus-connected')).toBeVisible();
+            await test.step('Restart emulator', async () => {
+                await trezorUserEnvLink.stopEmu();
+                await expect(page.getByTestId('@deviceStatus-disconnected')).toBeVisible();
+                await trezorUserEnvLink.startEmu({ model: emulatorStartConf.model, wipe: false });
+                await expect(page.getByTestId('@deviceStatus-connected')).toBeVisible();
+            });
         }
 
-        await settingsPage.changeNetworks({ enableNetworks: ['ada'] });
-        // starting discovery triggers passphrase dialogue
-        await dashboardPage.openDeviceSwitcher();
-        await dashboardPage.addUnusedHiddenWallet(passphrase);
-
-        // turn on view-only on the hidden wallet
-        await dashboardPage.openDeviceSwitcher();
-        await dashboardPage.setViewOnlyForWallet(1, 'enabled');
-        await dashboardPage.deviceSwitchingCloseButton.click();
-
-        // restart device
-        await restartEmulator();
-
-        // reveal cardano address
-        await walletPage.openAccount({ symbol: 'ada', type: 'normal', atIndex: 0 });
-        await walletPage.receiveButton.click();
-        await walletPage.revealAddressButton.click();
-        // device after reset asks for passphrase again, enter correct passphrase associated with this account
-        await dashboardPage.passphraseInput.fill(passphrase);
-        await dashboardPage.passphraseSubmitButton.click();
-        await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
-        await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
-
-        await expect(page.getByTestId('@modal/output-value')).toHaveText(
-            formatAddress(correctPassphraseAddr),
-        );
-
-        await devicePrompt.confirmOnDevicePromptIsShown();
-        await expect(devicePrompt).toDisplayReceiveAddress(correctPassphraseAddr, {
-            lineFormat: 'fullLine',
+        await test.step('Starting discovery triggers passphrase dialogue', async () => {
+            await settingsPage.changeNetworks({ enableNetworks: ['ada'] });
+            await dashboardPage.openDeviceSwitcher();
+            await dashboardPage.addUnusedHiddenWallet(passphrase);
         });
-        await trezorUserEnvLink.pressYes(); // Confirm receive address
 
-        await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
-        await devicePrompt.closeModal();
-        await expect(walletPage.revealAddressButton).toBeVisible();
+        await test.step('Turn on view-only on the hidden wallet', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await dashboardPage.setViewOnlyForWallet(1, 'enabled');
+            await dashboardPage.deviceSwitchingCloseButton.click();
+        });
 
-        // restart device again
         await restartEmulator();
 
-        // reveal cardano address, now enter wrong passphrase
-        await walletPage.revealAddressButton.click();
-        await dashboardPage.passphraseInput.fill('wrong passphrase');
-        await dashboardPage.passphraseSubmitButton.click();
-        await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
-        await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
+        await test.step('Reveal cardano address', async () => {
+            await walletPage.openAccount({ symbol: 'ada', type: 'normal', atIndex: 0 });
+            await walletPage.receiveButton.click();
+            await walletPage.revealAddressButton.click();
+        });
 
-        await expect(page.getByTestId('@toast/verify-address-error')).toBeVisible();
+        await test.step('Enter correct passphrase when device asks for passphrase after reset', async () => {
+            await dashboardPage.passphraseInput.fill(passphrase);
+            await dashboardPage.passphraseSubmitButton.click();
+            await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
+            await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
+
+            await expect(page.getByTestId('@modal/output-value')).toHaveText(
+                formatAddress(correctPassphraseAddr),
+            );
+
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await expect(devicePrompt).toDisplayReceiveAddress(correctPassphraseAddr, {
+                lineFormat: 'fullLine',
+            });
+            await trezorUserEnvLink.pressYes(); // Confirm receive address
+
+            await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
+            await devicePrompt.closeModal();
+            await expect(walletPage.revealAddressButton).toBeVisible();
+        });
+
+        await restartEmulator();
+
+        await test.step('Reveal cardano address, now enter wrong passphrase', async () => {
+            await walletPage.revealAddressButton.click();
+            await dashboardPage.passphraseInput.fill('wrong passphrase');
+            await dashboardPage.passphraseSubmitButton.click();
+            await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
+            await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
+
+            await expect(page.getByTestId('@toast/verify-address-error')).toBeVisible();
+        });
     });
 });

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-duplicate.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-duplicate.test.ts
@@ -1,3 +1,5 @@
+import messages from '@trezor/suite/src/support/messages';
+
 import { expect, test } from '../../support/fixtures';
 
 test.describe('Passphrase duplicate', { tag: ['@group=passphrase'] }, () => {
@@ -7,22 +9,27 @@ test.describe('Passphrase duplicate', { tag: ['@group=passphrase'] }, () => {
         await onboardingPage.completeOnboarding();
     });
 
-    //TODO: #17161 Fix instable test
-    test.skip('attempt to add the same hidden wallet twice results in warning', async ({
+    test('attempt to add the same hidden wallet twice results in warning', async ({
         page,
         dashboardPage,
     }) => {
         const passphraseToType = 'taxation is theft';
 
-        // enter passphrase A for the first time
-        await dashboardPage.openDeviceSwitcher();
-        await dashboardPage.addUnusedHiddenWallet(passphraseToType);
+        await test.step('Add first passphrase wallet', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await dashboardPage.addUnusedHiddenWallet(passphraseToType);
+        });
 
-        // try to add another wallet with the same passphrase
-        await dashboardPage.openDeviceSwitcher();
-        await dashboardPage.addHiddenWallet(passphraseToType, { skipDiscovery: true });
-
-        // duplicate passphrase modal appears;
-        await expect(page.getByTestId('@passphrase-duplicate-header')).toBeVisible();
+        await test.step('Attempt to add another wallet with the same passphrase', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await dashboardPage.addHiddenWallet(passphraseToType, { skipDiscovery: true });
+            await expect(page.getByTestId('@passphrase-duplicate-header')).toBeVisible();
+            await expect(page.getByTestId('@passphrase-duplicate-header')).toHaveText(
+                messages['TR_WALLET_DUPLICATE_TITLE'].defaultMessage,
+            );
+            await expect(page.getByTestId('@passphrase-duplicate-description')).toHaveText(
+                messages['TR_WALLET_DUPLICATE_DESC'].defaultMessage,
+            );
+        });
     });
 });

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-input.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-input.test.ts
@@ -7,66 +7,71 @@ test.describe('Passphrase input', { tag: ['@group=passphrase'] }, () => {
     });
 
     test('just test passphrase input', async ({ dashboardPage, page }) => {
-        // start adding hidden wallet
-        dashboardPage.openDeviceSwitcher();
-        dashboardPage.addHiddenWalletButton.click();
-        await page.getByTestId('@switch-device/add-existing-hidden-wallet-button').click();
+        await test.step('Add passphrase wallet', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await dashboardPage.addHiddenWalletButton.click();
+            await page.getByTestId('@switch-device/add-existing-hidden-wallet-button').click();
+        });
 
-        // select whole text and delete it
-        await dashboardPage.passphraseInput.pressSequentially('123456');
-        await dashboardPage.passphraseInput.clear();
-        await dashboardPage.passphraseInput.pressSequentially('1');
-        await dashboardPage.passphraseInput.press('Backspace');
-        await expect(dashboardPage.passphraseInput).toHaveValue('');
+        await test.step('test clear input and backspace functionality', async () => {
+            await dashboardPage.passphraseInput.pressSequentially('123456');
+            await dashboardPage.passphraseInput.clear();
+            await dashboardPage.passphraseInput.pressSequentially('1');
+            await dashboardPage.passphraseInput.press('Backspace');
+            await expect(dashboardPage.passphraseInput).toHaveValue('');
+        });
 
-        // leftarrow sets caret to correct position
-        await dashboardPage.passphraseInput.pressSequentially('abcdef');
-        await dashboardPage.passphraseInput.press('ArrowLeft');
-        await dashboardPage.passphraseInput.press('ArrowLeft');
-        await dashboardPage.passphraseInput.pressSequentially('12');
-        await dashboardPage.passphraseShowButton.click();
-        await expect(dashboardPage.passphraseInput).toHaveValue('abcd12ef');
-        await dashboardPage.passphraseShowButton.click();
-        await dashboardPage.passphraseInput.press('ArrowLeft');
-        await dashboardPage.passphraseInput.press('ArrowLeft');
-        await dashboardPage.passphraseInput.press('Backspace');
-        await dashboardPage.passphraseInput.press('Backspace');
-        await dashboardPage.passphraseShowButton.click();
-        await expect(dashboardPage.passphraseInput).toHaveValue('ab12ef');
+        await test.step('test leftarrow sets caret to correct position', async () => {
+            await dashboardPage.passphraseInput.pressSequentially('abcdef');
+            await dashboardPage.passphraseInput.press('ArrowLeft');
+            await dashboardPage.passphraseInput.press('ArrowLeft');
+            await dashboardPage.passphraseInput.pressSequentially('12');
+            await dashboardPage.passphraseShowButton.click();
+            await expect(dashboardPage.passphraseInput).toHaveValue('abcd12ef');
+            await dashboardPage.passphraseShowButton.click();
+            await dashboardPage.passphraseInput.press('ArrowLeft');
+            await dashboardPage.passphraseInput.press('ArrowLeft');
+            await dashboardPage.passphraseInput.press('Backspace');
+            await dashboardPage.passphraseInput.press('Backspace');
+            await dashboardPage.passphraseShowButton.click();
+            await expect(dashboardPage.passphraseInput).toHaveValue('ab12ef');
+        });
 
-        // toggle hidden/visible keeps caret position
-        await dashboardPage.passphraseInput.click();
-        await dashboardPage.passphraseInput.clear();
-        await expect(dashboardPage.passphraseInput).toBeEmpty();
-        await dashboardPage.passphraseInput.pressSequentially('1');
-        await dashboardPage.passphraseInput.press('Backspace');
-        await dashboardPage.passphraseInput.pressSequentially('123');
-        await dashboardPage.passphraseInput.press('ArrowLeft');
-        await dashboardPage.passphraseShowButton.click();
-        await dashboardPage.passphraseInput.pressSequentially('abc');
-        await dashboardPage.passphraseShowButton.click();
-        await expect(dashboardPage.passphraseInput).toHaveValue('12abc3');
-        await dashboardPage.passphraseShowButton.click();
-        await dashboardPage.passphraseInput.press('ArrowRight');
-        await dashboardPage.passphraseInput.pressSequentially('xyz');
-        await dashboardPage.passphraseShowButton.click();
-        await expect(dashboardPage.passphraseInput).toHaveValue('12abc3xyz');
+        await test.step('toggle hidden/visible keeps caret position', async () => {
+            await dashboardPage.passphraseInput.click();
+            await dashboardPage.passphraseInput.clear();
+            await expect(dashboardPage.passphraseInput).toBeEmpty();
+            await dashboardPage.passphraseInput.pressSequentially('1');
+            await dashboardPage.passphraseInput.press('Backspace');
+            await dashboardPage.passphraseInput.pressSequentially('123');
+            await dashboardPage.passphraseInput.press('ArrowLeft');
+            await dashboardPage.passphraseShowButton.click();
+            await dashboardPage.passphraseInput.pressSequentially('abc');
+            await dashboardPage.passphraseShowButton.click();
+            await expect(dashboardPage.passphraseInput).toHaveValue('12abc3');
+            await dashboardPage.passphraseShowButton.click();
+            await dashboardPage.passphraseInput.press('ArrowRight');
+            await dashboardPage.passphraseInput.pressSequentially('xyz');
+            await dashboardPage.passphraseShowButton.click();
+            await expect(dashboardPage.passphraseInput).toHaveValue('12abc3xyz');
+        });
 
-        // when selectionStart===0 (looking at you nullish coalescing)
-        await dashboardPage.passphraseInput.clear();
-        await dashboardPage.passphraseInput.pressSequentially('123');
-        await dashboardPage.passphraseInput.press('ArrowLeft');
-        await dashboardPage.passphraseInput.press('ArrowLeft');
-        await dashboardPage.passphraseInput.press('ArrowLeft');
-        await dashboardPage.passphraseInput.pressSequentially('abc');
-        await expect(dashboardPage.passphraseInput).toHaveValue('abc123');
-        await dashboardPage.passphraseInput.clear();
-        await dashboardPage.passphraseInput.pressSequentially('123');
-        await dashboardPage.passphraseInput.press('ArrowLeft');
-        await dashboardPage.passphraseInput.press('ArrowLeft');
-        await dashboardPage.passphraseInput.press('ArrowLeft');
-        await dashboardPage.passphraseInput.press('Backspace');
-        await dashboardPage.passphraseInput.press('Delete');
-        await expect(dashboardPage.passphraseInput).toHaveValue('23');
+        await test.step('test when selectionStart===0 (nullish coalescing case)', async () => {
+            await dashboardPage.passphraseInput.clear();
+            await dashboardPage.passphraseInput.pressSequentially('123');
+            await dashboardPage.passphraseInput.press('ArrowLeft');
+            await dashboardPage.passphraseInput.press('ArrowLeft');
+            await dashboardPage.passphraseInput.press('ArrowLeft');
+            await dashboardPage.passphraseInput.pressSequentially('abc');
+            await expect(dashboardPage.passphraseInput).toHaveValue('abc123');
+            await dashboardPage.passphraseInput.clear();
+            await dashboardPage.passphraseInput.pressSequentially('123');
+            await dashboardPage.passphraseInput.press('ArrowLeft');
+            await dashboardPage.passphraseInput.press('ArrowLeft');
+            await dashboardPage.passphraseInput.press('ArrowLeft');
+            await dashboardPage.passphraseInput.press('Backspace');
+            await dashboardPage.passphraseInput.press('Delete');
+            await expect(dashboardPage.passphraseInput).toHaveValue('23');
+        });
     });
 });

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-numbering.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-numbering.test.ts
@@ -11,32 +11,36 @@ test.describe('Passphrase numbering', { tag: ['@group=passphrase'] }, () => {
         const passphraseTwo = 'Second passphrase';
         const passphraseThree = 'Third passphrase';
 
-        // Add two hidden wallets
-        await dashboardPage.openDeviceSwitcher();
-        await dashboardPage.addUnusedHiddenWallet(passphraseOne);
+        await test.step('Add two passphrase wallets', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await dashboardPage.addUnusedHiddenWallet(passphraseOne);
+            await dashboardPage.openDeviceSwitcher();
+            await dashboardPage.addUnusedHiddenWallet(passphraseTwo);
+        });
 
-        await dashboardPage.openDeviceSwitcher();
-        await dashboardPage.addUnusedHiddenWallet(passphraseTwo);
+        await test.step('verify wallet labels are correct', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await expect(dashboardPage.walletAtIndex(0)).toContainText('Standard wallet');
+            await expect(dashboardPage.walletAtIndex(1)).toContainText('Passphrase wallet #1');
+            await expect(dashboardPage.walletAtIndex(2)).toContainText('Passphrase wallet #2');
+        });
 
-        // assert that wallet labels are correct
-        await dashboardPage.openDeviceSwitcher();
-        await expect(dashboardPage.walletAtIndex(0)).toContainText('Standard wallet');
-        await expect(dashboardPage.walletAtIndex(1)).toContainText('Passphrase wallet #1');
-        await expect(dashboardPage.walletAtIndex(2)).toContainText('Passphrase wallet #2');
+        await test.step('eject standard and the first passphrase wallet', async () => {
+            await dashboardPage.ejectWallet();
+            await dashboardPage.ejectWallet();
+        });
 
-        // eject standard and the first hidden wallet
-        await dashboardPage.ejectWallet();
-        await dashboardPage.ejectWallet();
+        await test.step('add standard and another passphrase wallet', async () => {
+            await dashboardPage.addStandardWallet();
+            await dashboardPage.openDeviceSwitcher();
+            await dashboardPage.addUnusedHiddenWallet(passphraseThree);
+        });
 
-        // add standard and another hidden wallet
-        await dashboardPage.addStandardWallet();
-        await dashboardPage.openDeviceSwitcher();
-        await dashboardPage.addUnusedHiddenWallet(passphraseThree);
-
-        // assert that wallet labels are correct
-        await dashboardPage.openDeviceSwitcher();
-        await expect(dashboardPage.walletAtIndex(0)).toContainText('Passphrase wallet #2');
-        await expect(dashboardPage.walletAtIndex(1)).toContainText('Standard wallet');
-        await expect(dashboardPage.walletAtIndex(2)).toContainText('Passphrase wallet #3');
+        await test.step('verify passphrase wallet labels are correct', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await expect(dashboardPage.walletAtIndex(0)).toContainText('Passphrase wallet #2');
+            await expect(dashboardPage.walletAtIndex(1)).toContainText('Standard wallet');
+            await expect(dashboardPage.walletAtIndex(2)).toContainText('Passphrase wallet #3');
+        });
     });
 });

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-reconnection.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-reconnection.test.ts
@@ -9,14 +9,7 @@ test.describe('Passphrase reconnection', { tag: ['@group=passphrase'] }, () => {
         await onboardingPage.completeOnboarding();
     });
 
-    // add 1st hidden wallet (abc)
-    // check 1st address
-    // disconnect device
-    // reconnect device
-    // go back to 1st hidden wallet
-    // check confirm passphrase appears.
-    // TODO: #17161 Fix unstable test
-    test.skip('after device is reconnected passphrase needs to be confirmed', async ({
+    test('after device is reconnected passphrase needs to be confirmed', async ({
         page,
         dashboardPage,
         walletPage,
@@ -24,72 +17,85 @@ test.describe('Passphrase reconnection', { tag: ['@group=passphrase'] }, () => {
         trezorUserEnvLink,
         emulatorStartConf,
     }) => {
-        // add 1st hidden wallet
-        await dashboardPage.openDeviceSwitcher();
-        await dashboardPage.addUnusedHiddenWallet('abc');
-
-        await walletPage.openAccount({
-            symbol: 'btc',
-            type: 'normal',
-            atIndex: 0,
-        });
-        await walletPage.receiveButton.click();
-        await walletPage.revealAddressButton.click();
-        await expect(page.getByTestId('@modal/output-value')).toHaveText(formatAddress(abcAddr));
-        await devicePrompt.confirmOnDevicePromptIsShown();
-        await expect(devicePrompt).toDisplayReceiveAddress(abcAddr);
-        await trezorUserEnvLink.pressYes(); // confirm address
-
-        await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
-        await expect(page.getByTestId('@metadata/copy-address-button')).not.toBeDisabled();
-
-        await devicePrompt.closeModal();
-
-        // disconnect and reconnect device
-        await trezorUserEnvLink.stopEmu();
-        await trezorUserEnvLink.startEmu({ model: emulatorStartConf.model, wipe: false });
-        await dashboardPage.deviceSwitchingOpenButton.click();
-        // Clicking on the device switcher button should either open the modal or show the "Unavailable while loading" message
-        await Promise.race([
-            expect(dashboardPage.deviceSwitcherModal).toBeVisible(),
-            expect(page.getByText('Unavailable while loading')).toBeVisible(),
-        ]);
-        const deviceSwitchUnavailable = page.getByText('Unavailable while loading').isVisible();
-        // If the device switcher is unavailable, we need to wait for discovery to finish and then open the device switcher again
-        if (await deviceSwitchUnavailable) {
-            await page.discoveryShouldFinish();
+        await test.step('Add passphrase wallet "abc"', async () => {
             await dashboardPage.openDeviceSwitcher();
-        }
+            await dashboardPage.addUnusedHiddenWallet('abc');
+        });
 
-        await expect(dashboardPage.walletAtIndex(1)).toContainText('Passphrase wallet #1');
-        await dashboardPage.walletAtIndex(1).click();
-        await walletPage.receiveButton.click();
-        await expect(page.getByTestId('@wallet/receive/used-address/0')).not.toBeVisible();
-        await expect(walletPage.revealAddressButton).not.toBeDisabled();
-        await walletPage.revealAddressButton.click();
-        await expect(page.getByText('Confirm passphrase')).toBeVisible();
-        await dashboardPage.passphraseInput.fill('abc');
-        await dashboardPage.passphraseSubmitButton.click();
-        await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
-        await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase, shows your address
-        await expect(page.getByTestId('@modal/output-value')).toHaveText(formatAddress(abcAddr));
-        await devicePrompt.confirmOnDevicePromptIsShown();
-        await expect(devicePrompt).toDisplayReceiveAddress(abcAddr);
-        await trezorUserEnvLink.pressYes(); // confirm address
-        await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
-        await expect(page.getByTestId('@metadata/copy-address-button')).not.toBeDisabled();
-        await devicePrompt.closeModal();
+        await test.step('Display receive address', async () => {
+            await walletPage.openAccount({
+                symbol: 'btc',
+                type: 'normal',
+                atIndex: 0,
+            });
+            await walletPage.receiveButton.click();
+            await walletPage.revealAddressButton.click();
+            await expect(page.getByTestId('@modal/output-value')).toHaveText(
+                formatAddress(abcAddr),
+            );
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await expect(devicePrompt).toDisplayReceiveAddress(abcAddr);
+            await trezorUserEnvLink.pressYes(); // confirm address
 
-        await page.getByTestId('@modal/close-button').click();
+            await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
+            await expect(page.getByTestId('@metadata/copy-address-button')).not.toBeDisabled();
 
-        // now should show new address without entering passphrase
-        await walletPage.revealAddressButton.click();
-        await expect(page.getByTestId('@modal/output-value')).toBeVisible();
-        await trezorUserEnvLink.pressYes(); // confirm address
+            await devicePrompt.closeModal();
+        });
 
-        await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
-        await expect(page.getByTestId('@metadata/copy-address-button')).not.toBeDisabled();
+        await test.step('Disconnect and reconnect the device', async () => {
+            await trezorUserEnvLink.stopEmu();
+            await trezorUserEnvLink.startEmu({ model: emulatorStartConf.model, wipe: false });
+        });
 
-        await page.getByTestId('@modal/close-button').click();
+        await test.step('Check passphrase wallet "abc" is still cached and connected', async () => {
+            await dashboardPage.deviceSwitchingOpenButton.click();
+            // Clicking on the device switcher button should either open the modal or show the "Unavailable while loading" message
+            await Promise.race([
+                expect(dashboardPage.deviceSwitcherModal).toBeVisible(),
+                expect(page.getByText('Unavailable while loading')).toBeVisible(),
+            ]);
+            const deviceSwitchUnavailable = page.getByText('Unavailable while loading').isVisible();
+            // If the device switcher is unavailable, we need to wait for discovery to finish and then open the device switcher again
+            if (await deviceSwitchUnavailable) {
+                await page.discoveryShouldFinish();
+                await dashboardPage.openDeviceSwitcher();
+            }
+
+            await expect(dashboardPage.walletAtIndex(1)).toContainText('Passphrase wallet #1');
+        });
+
+        await test.step('Displaying receive address should prompt for passphrase', async () => {
+            await dashboardPage.walletAtIndex(1).click();
+            await walletPage.receiveButton.click();
+            await expect(page.getByTestId('@wallet/receive/used-address/0')).not.toBeVisible();
+            await expect(walletPage.revealAddressButton).not.toBeDisabled();
+            await walletPage.revealAddressButton.click();
+            await expect(page.getByText('Confirm passphrase')).toBeVisible();
+            await dashboardPage.passphraseInput.fill('abc');
+            await dashboardPage.passphraseSubmitButton.click();
+            await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
+            await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase, shows your address
+        });
+
+        await test.step('Verify displayed receive address', async () => {
+            await expect(page.getByTestId('@modal/output-value')).toHaveText(
+                formatAddress(abcAddr),
+            );
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await expect(devicePrompt).toDisplayReceiveAddress(abcAddr);
+            await trezorUserEnvLink.pressYes(); // confirm address
+            await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
+            await expect(page.getByTestId('@metadata/copy-address-button')).not.toBeDisabled();
+            await devicePrompt.closeModal();
+        });
+
+        await test.step('Second displaying receive address after reconnect should NOT prompt for passphrase', async () => {
+            await walletPage.revealAddressButton.click();
+            await expect(page.getByTestId('@modal/output-value')).toBeVisible();
+            await trezorUserEnvLink.pressYes(); // confirm address
+            await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
+            await expect(page.getByTestId('@metadata/copy-address-button')).not.toBeDisabled();
+        });
     });
 });

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-reconnection.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-reconnection.test.ts
@@ -43,34 +43,42 @@ test.describe('Passphrase reconnection', { tag: ['@group=passphrase'] }, () => {
         await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
         await expect(page.getByTestId('@metadata/copy-address-button')).not.toBeDisabled();
 
-        await page.getByTestId('@modal/close-button').click();
+        await devicePrompt.closeModal();
 
         // disconnect and reconnect device
         await trezorUserEnvLink.stopEmu();
         await trezorUserEnvLink.startEmu({ model: emulatorStartConf.model, wipe: false });
+        await dashboardPage.deviceSwitchingOpenButton.click();
+        // Clicking on the device switcher button should either open the modal or show the "Unavailable while loading" message
+        await Promise.race([
+            expect(dashboardPage.deviceSwitcherModal).toBeVisible(),
+            expect(page.getByText('Unavailable while loading')).toBeVisible(),
+        ]);
+        const deviceSwitchUnavailable = page.getByText('Unavailable while loading').isVisible();
+        // If the device switcher is unavailable, we need to wait for discovery to finish and then open the device switcher again
+        if (await deviceSwitchUnavailable) {
+            await page.discoveryShouldFinish();
+            await dashboardPage.openDeviceSwitcher();
+        }
 
-        // Passphrase abc again. now it is cached in device
-        await dashboardPage.openDeviceSwitcher();
+        await expect(dashboardPage.walletAtIndex(1)).toContainText('Passphrase wallet #1');
         await dashboardPage.walletAtIndex(1).click();
         await walletPage.receiveButton.click();
         await expect(page.getByTestId('@wallet/receive/used-address/0')).not.toBeVisible();
         await expect(walletPage.revealAddressButton).not.toBeDisabled();
         await walletPage.revealAddressButton.click();
-
-        // re-enter passphrase
+        await expect(page.getByText('Confirm passphrase')).toBeVisible();
         await dashboardPage.passphraseInput.fill('abc');
         await dashboardPage.passphraseSubmitButton.click();
         await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
-        await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
-
-        // check address
+        await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase, shows your address
         await expect(page.getByTestId('@modal/output-value')).toHaveText(formatAddress(abcAddr));
         await devicePrompt.confirmOnDevicePromptIsShown();
         await expect(devicePrompt).toDisplayReceiveAddress(abcAddr);
         await trezorUserEnvLink.pressYes(); // confirm address
-
         await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
         await expect(page.getByTestId('@metadata/copy-address-button')).not.toBeDisabled();
+        await devicePrompt.closeModal();
 
         await page.getByTestId('@modal/close-button').click();
 

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase.test.ts
@@ -26,126 +26,133 @@ test.describe('Passphrase', { tag: ['@group=passphrase'] }, () => {
             }),
         },
         async ({ page, analytics, devicePrompt, dashboardPage, walletPage, trezorUserEnvLink }) => {
-            // add 1st hidden wallet
-            await dashboardPage.openDeviceSwitcher();
-            await dashboardPage.addUnusedHiddenWallet('abc');
+            await test.step('Add passphrase wallet #1', async () => {
+                await dashboardPage.openDeviceSwitcher();
+                await dashboardPage.addUnusedHiddenWallet('abc');
 
-            await analytics.interceptAnalytics();
-
-            await walletPage.openAccount({
-                symbol: 'btc',
-                type: 'normal',
-                atIndex: 0,
+                await analytics.interceptAnalytics();
             });
-            await walletPage.receiveButton.click();
-            await walletPage.revealAddressButton.click();
-            await expect(page.getByTestId('@modal/output-value')).toHaveText(
-                formatAddress(abcAddr),
-            );
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await expect(devicePrompt).toDisplayReceiveAddress(abcAddr);
-            await trezorUserEnvLink.pressYes(); // confirm address
 
-            await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
-            await expect(page.getByTestId('@metadata/copy-address-button')).not.toBeDisabled();
+            await test.step('Display receive address of wallet #1', async () => {
+                await walletPage.openAccount({
+                    symbol: 'btc',
+                    type: 'normal',
+                    atIndex: 0,
+                });
+                await walletPage.receiveButton.click();
+                await walletPage.revealAddressButton.click();
+                await expect(page.getByTestId('@modal/output-value')).toHaveText(
+                    formatAddress(abcAddr),
+                );
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await expect(devicePrompt).toDisplayReceiveAddress(abcAddr);
+                await trezorUserEnvLink.pressYes(); // confirm address
 
-            await devicePrompt.closeModal();
+                await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
+                await expect(page.getByTestId('@metadata/copy-address-button')).not.toBeDisabled();
 
-            // add 2nd hidden wallet
-            await dashboardPage.openDeviceSwitcher();
-            await dashboardPage.addUnusedHiddenWallet('def');
-            const element = page.getByTestId(/^@account-menu\/btc\//);
-            await element.first().click();
+                await devicePrompt.closeModal();
+            });
 
-            const selectWalletEvent = analytics.findAnalyticsEventByType<
-                ExtractByEventType<EventType.SelectWalletType>
-            >(EventType.SelectWalletType);
-            expect(selectWalletEvent.type).toEqual('hidden');
+            await test.step('Add second passphrase wallet #2', async () => {
+                await dashboardPage.openDeviceSwitcher();
+                await dashboardPage.addUnusedHiddenWallet('def');
+                const element = page.getByTestId(/^@account-menu\/btc\//);
+                await element.first().click();
 
-            // go to receive
-            await walletPage.receiveButton.click();
-            await test.step('Verify no address is yet in table', async () => {
+                const selectWalletEvent = analytics.findAnalyticsEventByType<
+                    ExtractByEventType<EventType.SelectWalletType>
+                >(EventType.SelectWalletType);
+                expect(selectWalletEvent.type).toEqual('hidden');
+            });
+
+            await test.step('Open receive address of wallet #2', async () => {
+                await walletPage.receiveButton.click();
+                await test.step('Verify no address is yet in table', async () => {
+                    await expect(
+                        page.getByTestId('@wallet/receive/used-address/0'),
+                    ).not.toBeVisible();
+                });
+
+                await expect(walletPage.revealAddressButton).not.toBeDisabled();
+                await walletPage.revealAddressButton.click();
+                await expect(page.getByTestId('@modal/output-value')).toHaveText(
+                    formatAddress(defAddr),
+                );
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await expect(devicePrompt).toDisplayReceiveAddress(defAddr);
+                await trezorUserEnvLink.pressYes(); // confirm address
+
+                await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
+                await expect(page.getByTestId('@metadata/copy-address-button')).not.toBeDisabled();
+
+                await devicePrompt.closeModal();
+            });
+
+            await test.step('Switch back to the wallet #1, which is cached in device', async () => {
+                await dashboardPage.openDeviceSwitcher();
+                await dashboardPage.walletAtIndex(1).click();
+                await walletPage.receiveButton.click();
+            });
+
+            await test.step('No address is yet in table of wallet #1', async () => {
                 await expect(page.getByTestId('@wallet/receive/used-address/0')).not.toBeVisible();
+                await expect(walletPage.revealAddressButton).not.toBeDisabled();
+
+                await walletPage.revealAddressButton.click();
+                await expect(page.getByTestId('@modal/output-value')).toHaveText(
+                    formatAddress(abcAddr),
+                );
+                await devicePrompt.confirmOnDevicePromptIsShown();
+                await expect(devicePrompt).toDisplayReceiveAddress(abcAddr);
+                await trezorUserEnvLink.pressYes(); // confirm address
+
+                await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
+                await expect(page.getByTestId('@metadata/copy-address-button')).not.toBeDisabled();
+
+                await devicePrompt.closeModal();
             });
-
-            // no address should be in table yet
-            await expect(page.getByTestId('@wallet/receive/used-address/0')).not.toBeVisible();
-            await expect(walletPage.revealAddressButton).not.toBeDisabled();
-
-            await walletPage.revealAddressButton.click();
-            await expect(page.getByTestId('@modal/output-value')).toHaveText(
-                formatAddress(defAddr),
-            );
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await expect(devicePrompt).toDisplayReceiveAddress(defAddr);
-            await trezorUserEnvLink.pressYes(); // confirm address
-
-            await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
-            await expect(page.getByTestId('@metadata/copy-address-button')).not.toBeDisabled();
-
-            await devicePrompt.closeModal();
-
-            // now go back to the 1st wallet, which is cached in device
-            await dashboardPage.openDeviceSwitcher();
-            await dashboardPage.walletAtIndex(1).click();
-            await walletPage.receiveButton.click();
-
-            // no address should be in table yet
-            await expect(page.getByTestId('@wallet/receive/used-address/0')).not.toBeVisible();
-            await expect(walletPage.revealAddressButton).not.toBeDisabled();
-
-            await walletPage.revealAddressButton.click();
-            await expect(page.getByTestId('@modal/output-value')).toHaveText(
-                formatAddress(abcAddr),
-            );
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await expect(devicePrompt).toDisplayReceiveAddress(abcAddr);
-            await trezorUserEnvLink.pressYes(); // confirm address
-
-            await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
-            await expect(page.getByTestId('@metadata/copy-address-button')).not.toBeDisabled();
-
-            await devicePrompt.closeModal();
         },
     );
 
-    // add hidden wallet (abc)
-    // fail to confirm passphrase
-    // try again from notification, succeed
     test('Fail to confirm passphrase and retry', async ({ page, dashboardPage, devicePrompt }) => {
-        // add 1st hidden wallet
-        await dashboardPage.openDeviceSwitcher();
-        await dashboardPage.addHiddenWallet('abc', { skipDiscovery: true });
+        await test.step('Initiate adding passphrase wallet', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await dashboardPage.addHiddenWallet('abc', { skipDiscovery: true });
+
+            await page
+                .getByTestId('@passphrase-confirmation/step1-open-unused-wallet-button')
+                .click();
+            await page.getByTestId('@passphrase-confirmation/step2-button').click();
+        });
+
+        await test.step('Confirm wrong passphrase', async () => {
+            await dashboardPage.passphraseInput.fill('cba');
+            await dashboardPage.passphraseSubmitButton.click();
+            await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
+            await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
+        });
+
+        await test.step('Retry passphrase confirmation', async () => {
+            await page.getByTestId('@passphrase-mismatch/start-over').click();
+            await dashboardPage.passphraseInput.fill('abc');
+            await dashboardPage.passphraseSubmitButton.click();
+            await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
+            await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
+        });
 
         await page.getByTestId('@passphrase-confirmation/step1-open-unused-wallet-button').click();
         await page.getByTestId('@passphrase-confirmation/step2-button').click();
 
-        // confirm - input wrong passphrase
-        await dashboardPage.passphraseInput.fill('cba');
-        await dashboardPage.passphraseSubmitButton.click();
-        await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
-        await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
+        await test.step('Confirm correct passphrase', async () => {
+            await dashboardPage.passphraseInput.fill('abc');
+            await dashboardPage.passphraseSubmitButton.click();
+            await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
+            await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
 
-        // retry
-        await page.getByTestId('@passphrase-mismatch/start-over').click();
-
-        // confirm again - input correct this time
-        await dashboardPage.passphraseInput.fill('abc');
-        await dashboardPage.passphraseSubmitButton.click();
-        await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
-        await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
-
-        await page.getByTestId('@passphrase-confirmation/step1-open-unused-wallet-button').click();
-        await page.getByTestId('@passphrase-confirmation/step2-button').click();
-
-        // confirm - input wrong passphrase
-        await dashboardPage.passphraseInput.fill('abc');
-        await dashboardPage.passphraseSubmitButton.click();
-        await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
-        await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
-
-        await dashboardPage.modal.waitFor({ state: 'detached' });
-        await dashboardPage.openDeviceSwitcher();
-        await expect(dashboardPage.walletAtIndex(1)).toContainText('Passphrase wallet #1');
+            await dashboardPage.modal.waitFor({ state: 'detached' });
+            await dashboardPage.openDeviceSwitcher();
+            await expect(dashboardPage.walletAtIndex(1)).toContainText('Passphrase wallet #1');
+        });
     });
 });

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase.test.ts
@@ -49,7 +49,7 @@ test.describe('Passphrase', { tag: ['@group=passphrase'] }, () => {
             await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
             await expect(page.getByTestId('@metadata/copy-address-button')).not.toBeDisabled();
 
-            await page.getByTestId('@modal/close-button').click();
+            await devicePrompt.closeModal();
 
             // add 2nd hidden wallet
             await dashboardPage.openDeviceSwitcher();
@@ -64,6 +64,9 @@ test.describe('Passphrase', { tag: ['@group=passphrase'] }, () => {
 
             // go to receive
             await walletPage.receiveButton.click();
+            await test.step('Verify no address is yet in table', async () => {
+                await expect(page.getByTestId('@wallet/receive/used-address/0')).not.toBeVisible();
+            });
 
             // no address should be in table yet
             await expect(page.getByTestId('@wallet/receive/used-address/0')).not.toBeVisible();
@@ -80,7 +83,7 @@ test.describe('Passphrase', { tag: ['@group=passphrase'] }, () => {
             await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
             await expect(page.getByTestId('@metadata/copy-address-button')).not.toBeDisabled();
 
-            await page.getByTestId('@modal/close-button').click();
+            await devicePrompt.closeModal();
 
             // now go back to the 1st wallet, which is cached in device
             await dashboardPage.openDeviceSwitcher();
@@ -102,7 +105,7 @@ test.describe('Passphrase', { tag: ['@group=passphrase'] }, () => {
             await expect(page.getByTestId('@metadata/copy-address-button')).toBeVisible();
             await expect(page.getByTestId('@metadata/copy-address-button')).not.toBeDisabled();
 
-            await page.getByTestId('@modal/close-button').click();
+            await devicePrompt.closeModal();
         },
     );
 

--- a/packages/suite-desktop-core/e2e/tests/settings/t2t1-device-settings.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/t2t1-device-settings.test.ts
@@ -21,7 +21,7 @@ test.describe('T2T1 - Device settings', { tag: ['@group=settings'] }, () => {
         async ({ page, settingsPage, devicePrompt, trezorUserEnvLink }) => {
             await test.step('Verify firmware modal', async () => {
                 await page.getByTestId('@settings/device/update-button').click();
-                await page.getByTestId('@modal/close-button').click();
+                await devicePrompt.closeModal();
             });
 
             await test.step("Change and verify device's name", async () => {

--- a/packages/suite-desktop-core/e2e/tests/suite/db-migration.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/db-migration.test.ts
@@ -25,7 +25,14 @@ test.describe('Database migration', { tag: ['@group=migrations', '@webOnly'] }, 
                 priority: TestPriority.Medium,
             }),
         },
-        async ({ page, onboardingPage, dashboardPage, walletPage, trezorUserEnvLink }) => {
+        async ({
+            page,
+            onboardingPage,
+            dashboardPage,
+            walletPage,
+            devicePrompt,
+            trezorUserEnvLink,
+        }) => {
             const discoveryBar = page.locator(
                 '[data-test="\\@wallet\\/discovery-progress-bar"] div',
             );
@@ -119,7 +126,7 @@ test.describe('Database migration', { tag: ['@group=migrations', '@webOnly'] }, 
                 await walletPage.receiveButton.click();
                 await walletPage.revealAddressButton.click();
                 await expect(page.getByTestId('@modal')).toBeVisible();
-                await page.getByTestId('@modal/close-button').click();
+                await devicePrompt.closeModal();
                 await expect(page.getByTestId('@modal')).not.toBeVisible();
             });
 

--- a/packages/suite-desktop-core/e2e/tests/wallet/pending-transactions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/pending-transactions.test.ts
@@ -94,7 +94,7 @@ test.describe(
                     }
                     transaction.txid = txid;
 
-                    await page.getByTestId('@modal/close-button').click();
+                    await devicePrompt.closeModal();
                 }
             });
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseDuplicateModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseDuplicateModal.tsx
@@ -82,7 +82,7 @@ export const PassphraseDuplicateModal = ({
                     <H3 data-testid="@passphrase-duplicate-header">
                         <Translation id="TR_WALLET_DUPLICATE_TITLE" />
                     </H3>
-                    <Text variant="tertiary">
+                    <Text data-testid="@passphrase-duplicate-description" variant="tertiary">
                         <Translation id="TR_WALLET_DUPLICATE_DESC" />
                     </Text>
                     <Column gap={spacings.xs} margin={{ top: spacings.lg }} alignItems="stretch">


### PR DESCRIPTION
minor refactoring
adds test.steps to each test

Resolves #17161 17161

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-passphrase&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-passphrase&lookback=7)