### PR TITLE
feat(connect): add thpCall module

### DIFF
--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -330,11 +330,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
         }
     }
 
-    async call<T extends Messages.MessageKey>(
-        name: T,
-        data: Messages.MessagePayload<T>,
-        options: AbortableOptions = {},
-    ) {
+    async call(name: string, data: Record<string, unknown>, options: AbortableOptions = {}) {
         if (this.disposed) return Promise.resolve(error(this.disposed));
 
         logger.debug('Sending', name, filterForLog(name, data));
@@ -359,11 +355,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
         return result.success ? success(result.payload) : fail(result.message || result.error);
     }
 
-    async send<T extends Messages.MessageKey>(
-        name: T,
-        data: Messages.MessagePayload<T>,
-        options: AbortableOptions = {},
-    ) {
+    async send(name: string, data: Record<string, unknown>, options: AbortableOptions = {}) {
         if (this.disposed) return Promise.resolve(error(this.disposed));
 
         const result = await this.transport.send({

--- a/packages/connect/src/device/thp/thpCall.ts
+++ b/packages/connect/src/device/thp/thpCall.ts
@@ -1,0 +1,83 @@
+import { thp as protocolThp } from '@trezor/protocol';
+
+import { ERRORS } from '../../constants';
+import { DEVICE } from '../../events';
+import type { Device } from '../Device';
+
+type ThpTypedCall = {
+    ThpCreateChannelRequest: 'ThpCreateChannelResponse';
+    ThpHandshakeInitRequest: 'ThpHandshakeInitResponse';
+    ThpHandshakeCompletionRequest: 'ThpHandshakeCompletionResponse';
+    ThpPairingRequest: 'ThpPairingRequestApproved';
+    ThpSelectMethod: [
+        'ThpCodeEntryCommitment',
+        'ThpEndResponse',
+        'ThpPairingRequestApproved',
+        'ThpPairingPreparationsFinished',
+    ];
+    ThpCodeEntryChallenge: ['ThpCodeEntryCpaceTrezor'];
+    ThpCodeEntryCpaceHostTag: 'ThpCodeEntrySecret';
+    ThpQrCodeTag: 'ThpQrCodeSecret';
+    ThpNfcTagHost: 'ThpNfcTagTrezor';
+    ThpCredentialRequest: 'ThpCredentialResponse';
+    ThpEndRequest: 'ThpEndResponse';
+    ThpCreateNewSession: 'Success';
+};
+
+type ThpMessage = protocolThp.ThpMessageType & { Success: {} };
+type TypedPayloadItem<K> = K extends keyof ThpMessage
+    ? {
+          type: K;
+          message: ThpMessage[K];
+      }
+    : never;
+type ExtractFromArray<A extends any[]> = {
+    [K in keyof A]: TypedPayloadItem<A[K]>;
+}[number];
+
+type MessageKey = keyof ThpTypedCall;
+type TypedPayload<T extends MessageKey> = ThpTypedCall[T] extends any[]
+    ? ExtractFromArray<ThpTypedCall[T]>
+    : TypedPayloadItem<ThpTypedCall[T]>;
+
+type ThpCallResponse = {
+    [K in keyof ThpTypedCall]: TypedPayload<K>;
+};
+
+type ThpMessagePayload<T extends MessageKey = MessageKey> = ThpMessage[T];
+
+export const thpCall = async <T extends MessageKey>(
+    device: Device,
+    name: T,
+    data: ThpMessagePayload<T>,
+): Promise<ThpCallResponse[T]> => {
+    const thpState = device.getThpState();
+    if (!thpState) {
+        throw ERRORS.TypedError('Device_ThpStateMissing');
+    }
+
+    const result = await device.getCurrentSession().call(name, data);
+    if (!result.success) {
+        throw ERRORS.serializeError({ code: result.error, message: result.error.message });
+    }
+
+    if (result.payload.type === 'ButtonRequest') {
+        if (result.payload.message.code === 'ButtonRequest_PassphraseEntry') {
+            device.emit(DEVICE.PASSPHRASE_ON_DEVICE);
+        } else {
+            device.emit(DEVICE.BUTTON, { device, payload: result.payload.message });
+        }
+
+        return thpCall(device, 'ButtonAck' as T, {} as ThpMessagePayload<T>);
+    }
+
+    if (result.payload.type === 'Failure') {
+        throw ERRORS.serializeError(result.payload.message);
+    }
+
+    if (result.payload.type === 'ThpError') {
+        throw ERRORS.serializeError(result.payload.message);
+    }
+
+    return result.payload as ThpCallResponse[T];
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

cherry picked module for communication on `THP` layer.

this is basically the same as regular `TypedCall` (same-same but different) using `THP` protobuf messages which are not a part of `@trezor/protobuf` package (TypedCall message assertion wont work)

`thpCall` will be used only in THP [handshake and pairing process](https://github.com/trezor/trezor-suite/pull/19489)


im also changing `DeviceCurrentSession` **call** and **send** argument types to match actual `@trezor/transport` call and send.
those 2 functions should not be strongly typed (associated only with @trezor/protobuf like .typedCall)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-thpcall&lookback=7)