### PR TITLE
Mobile Trade: refactor BuyReceiveAccountPicker

### DIFF
--- a/suite-native/module-trading/src/components/buy/BuyCryptoAmountInput.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyCryptoAmountInput.tsx
@@ -9,7 +9,7 @@ import { useTranslate } from '@suite-native/intl';
 import { MAX_CRYPTO_DECIMALS } from '../../consts/general/consts';
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
 import { useBuyInputFormControls } from '../../hooks/buy/useBuyInputFormControls';
-import { getSelectedSymbolFromBuyForm } from '../../utils/general/tradeableAssetUtils';
+import { getSymbolFromTradeableAsset } from '../../utils/general/tradeableAssetUtils';
 import { AmountInput } from '../general/Input/AmountInput';
 
 export type CryptoAmountInputProps = {
@@ -21,14 +21,14 @@ const CRYPTO_AMOUNT_TEST_ID = '@trading/buy/crypto-amount-input';
 export const BuyCryptoAmountInput = forwardRef<TextInput, CryptoAmountInputProps>(
     ({ showAssetsSheet }, ref) => {
         const { translate } = useTranslate();
-        const form = useBuyFormContext();
-        const symbol = getSelectedSymbolFromBuyForm(form);
+        const { watch } = useBuyFormContext();
+        const [amountInCrypto, asset] = watch(['amountInCrypto', 'asset']);
+        const symbol = getSymbolFromTradeableAsset(asset);
         const { cryptoAmountTransformer } = useAmountInputTransformers(symbol);
         const isLoading = useSelector(selectTradingBuyIsLoading);
         const inputControls = useBuyInputFormControls('cryptoValue');
 
-        const amountInCrypto = form.watch('amountInCrypto');
-        const isAssetSelected = !!form.watch('asset');
+        const isAssetSelected = !!asset;
 
         return (
             <AmountInput

--- a/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.tsx
@@ -11,7 +11,7 @@ import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
 import { useConvertFormValueToBaseUnit } from '../../hooks/general/useConvertFormValueToBaseUnit';
 import { BuyFormValues } from '../../types/buy';
 import { truncateDecimals } from '../../utils/general/amountUtils';
-import { getSelectedSymbolFromBuyForm } from '../../utils/general/tradeableAssetUtils';
+import { getSymbolFromTradeableAsset } from '../../utils/general/tradeableAssetUtils';
 
 export type BuyFormFieldErrorBadgeProps = {
     fieldName: keyof BuyFormValues;
@@ -20,13 +20,18 @@ export type BuyFormFieldErrorBadgeProps = {
 const asNonEmptyStringValue = (value: unknown): string => (value as string) ?? '0';
 
 const useMismatchedAmountMessage = (fieldName: keyof BuyFormValues) => {
-    const form = useBuyFormContext();
+    const { watch } = useBuyFormContext();
     const { translate } = useTranslate();
     const { CryptoAmountFormatter, FiatAmountFormatter } = useFormatters();
-    const symbol = getSelectedSymbolFromBuyForm(form);
     const { convertStrToBaseUnit } = useConvertFormValueToBaseUnit();
 
-    const [quote, amountInCrypto, value] = form.watch(['quote', 'amountInCrypto', fieldName]);
+    const [asset, quote, amountInCrypto, value] = watch([
+        'asset',
+        'quote',
+        'amountInCrypto',
+        fieldName,
+    ]);
+    const symbol = getSymbolFromTradeableAsset(asset);
 
     if (!quote) {
         return undefined;

--- a/suite-native/module-trading/src/components/buy/BuyReceiveAccountCryptoBalance.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyReceiveAccountCryptoBalance.tsx
@@ -1,10 +1,6 @@
-import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS, useFormatters } from '@suite-common/formatters';
-import { DiscreetTextTrigger, HStack, Text } from '@suite-native/atoms';
-import { CryptoAmountFormatter } from '@suite-native/formatters';
-import { Translation } from '@suite-native/intl';
-
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
 import { getSelectedSymbolFromBuyForm } from '../../utils/general/tradeableAssetUtils';
+import { ReceiveAccountCryptoBalance } from '../general/ReceiveAccount/ReceiveAccountCryptoBalance';
 
 export const RECEIVE_ACCOUNT_BALANCE_TEST_ID = '@trading/buy/receive-account-balance';
 
@@ -12,41 +8,12 @@ export const BuyReceiveAccountCryptoBalance = () => {
     const form = useBuyFormContext();
     const selectedSymbol = getSelectedSymbolFromBuyForm(form);
     const receiveAccount = form.watch('receiveAccount');
-    const { DisplaySymbolFormatter } = useFormatters();
-
-    const symbol = receiveAccount?.account?.symbol ?? selectedSymbol;
-    const balance = receiveAccount?.account?.balance;
-
-    if (!symbol) {
-        return null;
-    }
 
     return (
-        <HStack testID={RECEIVE_ACCOUNT_BALANCE_TEST_ID}>
-            <Text variant="hint" color="textSubdued">
-                <Translation id="moduleTrading.tradingScreen.balance" />
-            </Text>
-            {balance === undefined ? (
-                <Text
-                    variant="hint"
-                    color="textSubdued"
-                    testID={RECEIVE_ACCOUNT_BALANCE_TEST_ID + '/no-value'}
-                >
-                    - <DisplaySymbolFormatter value={symbol} />
-                </Text>
-            ) : (
-                <DiscreetTextTrigger>
-                    <CryptoAmountFormatter
-                        value={balance}
-                        symbol={symbol}
-                        variant="hint"
-                        color="textSubdued"
-                        isBalance={false}
-                        decimals={BASE_CRYPTO_MAX_DISPLAYED_DECIMALS}
-                        testID={RECEIVE_ACCOUNT_BALANCE_TEST_ID + '/value'}
-                    />
-                </DiscreetTextTrigger>
-            )}
-        </HStack>
+        <ReceiveAccountCryptoBalance
+            account={receiveAccount?.account}
+            defaultSymbol={selectedSymbol}
+            testID={RECEIVE_ACCOUNT_BALANCE_TEST_ID}
+        />
     );
 };

--- a/suite-native/module-trading/src/components/buy/BuyReceiveAccountCryptoBalance.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyReceiveAccountCryptoBalance.tsx
@@ -1,13 +1,13 @@
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
-import { getSelectedSymbolFromBuyForm } from '../../utils/general/tradeableAssetUtils';
+import { getSymbolFromTradeableAsset } from '../../utils/general/tradeableAssetUtils';
 import { ReceiveAccountCryptoBalance } from '../general/ReceiveAccount/ReceiveAccountCryptoBalance';
 
 export const RECEIVE_ACCOUNT_BALANCE_TEST_ID = '@trading/buy/receive-account-balance';
 
 export const BuyReceiveAccountCryptoBalance = () => {
-    const form = useBuyFormContext();
-    const selectedSymbol = getSelectedSymbolFromBuyForm(form);
-    const receiveAccount = form.watch('receiveAccount');
+    const { watch } = useBuyFormContext();
+    const [asset, receiveAccount] = watch(['asset', 'receiveAccount']);
+    const selectedSymbol = getSymbolFromTradeableAsset(asset);
 
     return (
         <ReceiveAccountCryptoBalance

--- a/suite-native/module-trading/src/components/buy/BuyReceiveAccountPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyReceiveAccountPicker.tsx
@@ -2,16 +2,17 @@ import { useSelector } from 'react-redux';
 
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
 import { selectBuySelectedReceiveAccount } from '../../selectors/buySelectors';
-import { getSelectedSymbolFromBuyForm } from '../../utils/general/tradeableAssetUtils';
+import { getSymbolFromTradeableAsset } from '../../utils/general/tradeableAssetUtils';
 import { ReceiveAccountPicker } from '../general/ReceiveAccount/ReceiveAccountPicker';
 
 const RECEIVE_ACCOUNT_PICKER_TEST_ID = '@trading/buy/receive-account';
 
 export const BuyReceiveAccountPicker = () => {
+    const { watch } = useBuyFormContext();
     const selectedReceiveAccount = useSelector(selectBuySelectedReceiveAccount);
-    const form = useBuyFormContext();
 
-    const selectedSymbol = getSelectedSymbolFromBuyForm(form);
+    const asset = watch('asset');
+    const selectedSymbol = getSymbolFromTradeableAsset(asset);
 
     return (
         <ReceiveAccountPicker

--- a/suite-native/module-trading/src/components/buy/BuyReceiveAccountPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyReceiveAccountPicker.tsx
@@ -1,132 +1,23 @@
-import { ReactNode } from 'react';
 import { useSelector } from 'react-redux';
-
-import { useNavigation } from '@react-navigation/native';
-
-import { Text, VStack } from '@suite-native/atoms';
-import { Translation, useTranslate } from '@suite-native/intl';
-import {
-    RootStackParamList,
-    StackToStackCompositeNavigationProps,
-    TradingStackParamList,
-    TradingStackRoutes,
-} from '@suite-native/navigation';
-import { Color } from '@trezor/theme';
 
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
 import { selectBuySelectedReceiveAccount } from '../../selectors/buySelectors';
 import { getSelectedSymbolFromBuyForm } from '../../utils/general/tradeableAssetUtils';
-import { AccountAddress } from '../general/AccountAddress';
-import { OverviewRow } from '../general/OverviewRow';
-
-type RightTextProps = {
-    children: ReactNode;
-    color: Color;
-    variant?: 'body' | 'hint';
-    testID?: string;
-};
-
-type ReceiveAccountPickerRightProps = {
-    selectedAccountLabel: string | undefined;
-    selectedAddress: string | undefined;
-};
-
-export type NavigationProps = StackToStackCompositeNavigationProps<
-    TradingStackParamList,
-    TradingStackRoutes.ReceiveAccounts,
-    RootStackParamList
->;
+import { ReceiveAccountPicker } from '../general/ReceiveAccount/ReceiveAccountPicker';
 
 const RECEIVE_ACCOUNT_PICKER_TEST_ID = '@trading/buy/receive-account';
 
-const RightText = ({ color, variant = 'body', testID, children }: RightTextProps) => (
-    <Text
-        color={color}
-        variant={variant}
-        testID={testID}
-        textAlign="right"
-        ellipsizeMode="tail"
-        numberOfLines={1}
-    >
-        {children}
-    </Text>
-);
-
-const ReceiveAccountPickerRight = ({
-    selectedAccountLabel,
-    selectedAddress,
-}: ReceiveAccountPickerRightProps) => {
-    if (!selectedAccountLabel) {
-        return (
-            <RightText color="textSubdued">
-                <Translation id="moduleTrading.notSelected" />
-            </RightText>
-        );
-    }
-
-    if (!selectedAddress) {
-        return (
-            <RightText
-                color="textSubdued"
-                testID={RECEIVE_ACCOUNT_PICKER_TEST_ID + '/selected-account'}
-            >
-                {selectedAccountLabel}
-            </RightText>
-        );
-    }
-
-    return (
-        <>
-            <RightText
-                color="textSubdued"
-                testID={RECEIVE_ACCOUNT_PICKER_TEST_ID + '/selected-account'}
-            >
-                {selectedAccountLabel}
-            </RightText>
-            <AccountAddress
-                address={selectedAddress}
-                form="short"
-                color="textSubdued"
-                variant="hint"
-                textAlign="right"
-            />
-        </>
-    );
-};
-
 export const BuyReceiveAccountPicker = () => {
-    const { translate } = useTranslate();
-    const navigation = useNavigation<NavigationProps>();
     const selectedReceiveAccount = useSelector(selectBuySelectedReceiveAccount);
     const form = useBuyFormContext();
 
     const selectedSymbol = getSelectedSymbolFromBuyForm(form);
 
-    if (!selectedSymbol) {
-        return null;
-    }
-
-    const openAccountPicker = () =>
-        navigation.navigate(TradingStackRoutes.ReceiveAccounts, { symbol: selectedSymbol });
-
-    const addressText =
-        (selectedReceiveAccount?.account.addresses
-            ? selectedReceiveAccount?.address?.address
-            : selectedReceiveAccount?.account.descriptor) ?? '';
-
     return (
-        <OverviewRow
-            title={translate('moduleTrading.tradingScreen.receiveAccount')}
-            onPress={openAccountPicker}
+        <ReceiveAccountPicker
+            symbol={selectedSymbol}
+            receiveAccount={selectedReceiveAccount}
             testID={RECEIVE_ACCOUNT_PICKER_TEST_ID}
-            noBottomBorder
-        >
-            <VStack spacing={0} paddingLeft="sp20">
-                <ReceiveAccountPickerRight
-                    selectedAccountLabel={selectedReceiveAccount?.account.accountLabel}
-                    selectedAddress={addressText}
-                />
-            </VStack>
-        </OverviewRow>
+        />
     );
 };

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountCryptoBalance.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountCryptoBalance.comp.test.tsx
@@ -22,46 +22,25 @@ describe('BuyReceiveAccountCryptoBalance', () => {
         return result.current;
     };
 
-    const renderComponent = async () =>
-        await renderWithStoreProviderAsync(
-            <Form form={buyForm}>
-                <BuyReceiveAccountCryptoBalance />
-            </Form>,
-        );
+    const renderComponent = () =>
+        renderWithStoreProviderAsync(<BuyReceiveAccountCryptoBalance />, {
+            wrapper: ({ children }) => <Form form={buyForm}>{children}</Form>,
+        });
 
     beforeEach(async () => {
         buyForm = await renderBuyForm();
     });
 
-    it('should display empty box when nor symbol nor asset is specified', async () => {
+    it('should use asset form field as default symbol', async () => {
         act(() => {
-            buyForm.setValue('receiveAccount', {
-                account: {
-                    symbol: undefined,
-                    balance: '10000',
-                } as any,
-            });
-        });
-        const { queryByTestId } = await renderComponent();
-
-        expect(queryByTestId(RECEIVE_ACCOUNT_BALANCE_TEST_ID)).toBeNull();
-    });
-
-    it('should display empty balance when balance is not specified', async () => {
-        act(() => {
-            buyForm.setValue('receiveAccount', {
-                account: {
-                    symbol: 'btc',
-                    balance: undefined,
-                } as any,
-            });
+            buyForm.setValue('asset', btcAsset);
         });
         const { getByTestId } = await renderComponent();
 
         expect(getByTestId(RECEIVE_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:- BTC');
     });
 
-    it('should display balance when symbol and balance is specified', async () => {
+    it('should use receiveAccount form field to obtain account', async () => {
         act(() => {
             buyForm.setValue('receiveAccount', {
                 account: {
@@ -73,14 +52,5 @@ describe('BuyReceiveAccountCryptoBalance', () => {
         const { getByTestId } = await renderComponent();
 
         expect(getByTestId(RECEIVE_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:0.01 BTC');
-    });
-
-    it('should display empty balance when symbol is not specified, but asset is', async () => {
-        act(() => {
-            buyForm.setValue('asset', btcAsset);
-        });
-        const { getByTestId } = await renderComponent();
-
-        expect(getByTestId(RECEIVE_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:- BTC');
     });
 });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountPicker.comp.test.tsx
@@ -2,25 +2,16 @@ import { Form } from '@suite-native/forms';
 import {
     PreloadedState,
     act,
-    fireEvent,
     renderHookWithStoreProviderAsync,
     renderWithStoreProviderAsync,
 } from '@suite-native/test-utils';
 
 import { getBtcAccount } from '../../../__fixtures__/account';
+import { btcAsset } from '../../../__fixtures__/tradeableAssets';
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
 import { BuyFormType } from '../../../types/buy';
-import { ReceiveAccount } from '../../../types/general';
+import { ReceiveAccount, TradeableAsset } from '../../../types/general';
 import { BuyReceiveAccountPicker } from '../BuyReceiveAccountPicker';
-
-let mockNavigate: jest.Mock;
-
-jest.mock('@react-navigation/native', () => ({
-    ...jest.requireActual('@react-navigation/native'),
-    useNavigation: () => ({
-        navigate: mockNavigate,
-    }),
-}));
 
 const btcAccountName1 = 'BTC Account #1';
 const btcAddressAddress = '1BTC';
@@ -38,10 +29,6 @@ const getBuyState = (selectedReceiveAccount: ReceiveAccount | undefined) => ({
 describe('BuyReceiveAccountPicker', () => {
     let buyForm: BuyFormType;
 
-    beforeEach(() => {
-        jest.resetAllMocks();
-    });
-
     const renderBuyForm = async () => {
         const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm());
 
@@ -49,23 +36,18 @@ describe('BuyReceiveAccountPicker', () => {
     };
 
     const renderPicker = ({ preloadedState }: { preloadedState?: PreloadedState } = {}) =>
-        renderWithStoreProviderAsync(
-            <Form form={buyForm}>
-                <BuyReceiveAccountPicker />
-            </Form>,
-            {
-                preloadedState,
-            },
-        );
+        renderWithStoreProviderAsync(<BuyReceiveAccountPicker />, {
+            preloadedState,
+            wrapper: ({ children }) => <Form form={buyForm}>{children}</Form>,
+        });
 
-    const setSelectedCryptoId = (cryptoId: string) => {
+    const setSelectedAsset = (asset: TradeableAsset) => {
         act(() => {
-            buyForm.setValue('asset', { cryptoId } as any);
+            buyForm.setValue('asset', asset);
         });
     };
 
     beforeEach(async () => {
-        mockNavigate = jest.fn();
         buyForm = await renderBuyForm();
     });
 
@@ -75,36 +57,15 @@ describe('BuyReceiveAccountPicker', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should display "Not selected" when selectedValue is not specified', async () => {
-        setSelectedCryptoId('bitcoin');
+    it('should display "Not selected" when asset is not specified', async () => {
+        setSelectedAsset(btcAsset);
         const { getByText } = await renderPicker();
 
         expect(getByText('Not selected')).toBeTruthy();
     });
 
-    it('should call navigate to account picker when selectedSymbol is specified and picker pressed', async () => {
-        setSelectedCryptoId('ethereum');
-        const { getByText } = await renderPicker({
-            preloadedState: getBuyState(undefined),
-        });
-
-        fireEvent.press(getByText('Receive account'));
-
-        expect(mockNavigate).toHaveBeenCalledTimes(1);
-        expect(mockNavigate).toHaveBeenCalledWith('ReceiveAccounts', expect.anything());
-    });
-
-    it('should display selected account name', async () => {
-        setSelectedCryptoId('bitcoin');
-        const { getByText } = await renderPicker({
-            preloadedState: getBuyState({ account: getBtcAccount() }),
-        });
-
-        expect(getByText(btcAccountName1)).toBeTruthy();
-    });
-
     it('should display selected account name and address', async () => {
-        setSelectedCryptoId('bitcoin');
+        setSelectedAsset(btcAsset);
         const btcAccount = getBtcAccount();
         const { getByText } = await renderPicker({
             preloadedState: getBuyState({

--- a/suite-native/module-trading/src/components/general/ReceiveAccount/ReceiveAccountCryptoBalance.tsx
+++ b/suite-native/module-trading/src/components/general/ReceiveAccount/ReceiveAccountCryptoBalance.tsx
@@ -1,0 +1,56 @@
+import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS, useFormatters } from '@suite-common/formatters';
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { Account } from '@suite-common/wallet-types';
+import { DiscreetTextTrigger, HStack, Text } from '@suite-native/atoms';
+import { CryptoAmountFormatter } from '@suite-native/formatters';
+import { Translation } from '@suite-native/intl';
+
+export type ReceiveAccountCryptoBalanceProps = {
+    account: Account | undefined;
+    defaultSymbol: NetworkSymbol | undefined;
+    testID?: string;
+};
+
+export const ReceiveAccountCryptoBalance = ({
+    account,
+    defaultSymbol,
+    testID,
+}: ReceiveAccountCryptoBalanceProps) => {
+    const { DisplaySymbolFormatter } = useFormatters();
+
+    const symbol = account?.symbol ?? defaultSymbol;
+    const balance = account?.balance;
+
+    if (!symbol) {
+        return null;
+    }
+
+    return (
+        <HStack testID={testID}>
+            <Text variant="hint" color="textSubdued">
+                <Translation id="moduleTrading.tradingScreen.balance" />
+            </Text>
+            {balance === undefined ? (
+                <Text
+                    variant="hint"
+                    color="textSubdued"
+                    testID={testID ? `${testID}/no-value` : undefined}
+                >
+                    - <DisplaySymbolFormatter value={symbol} />
+                </Text>
+            ) : (
+                <DiscreetTextTrigger>
+                    <CryptoAmountFormatter
+                        value={balance}
+                        symbol={symbol}
+                        variant="hint"
+                        color="textSubdued"
+                        isBalance={false}
+                        decimals={BASE_CRYPTO_MAX_DISPLAYED_DECIMALS}
+                        testID={testID ? `${testID}/value` : undefined}
+                    />
+                </DiscreetTextTrigger>
+            )}
+        </HStack>
+    );
+};

--- a/suite-native/module-trading/src/components/general/ReceiveAccount/ReceiveAccountPicker.tsx
+++ b/suite-native/module-trading/src/components/general/ReceiveAccount/ReceiveAccountPicker.tsx
@@ -60,7 +60,7 @@ const ReceiveAccountPickerRight = ({
     addressText,
     testID,
 }: ReceiveAccountPickerRightProps) => {
-    if (!accountLabel) {
+    if (accountLabel == null) {
         return (
             <RightText color="textSubdued" testID={testID ? `${testID}/not-selected` : undefined}>
                 <Translation id="moduleTrading.notSelected" />

--- a/suite-native/module-trading/src/components/general/ReceiveAccount/ReceiveAccountPicker.tsx
+++ b/suite-native/module-trading/src/components/general/ReceiveAccount/ReceiveAccountPicker.tsx
@@ -1,0 +1,138 @@
+import { ReactNode } from 'react';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { Text, VStack } from '@suite-native/atoms';
+import { Translation, useTranslate } from '@suite-native/intl';
+import {
+    RootStackParamList,
+    StackToStackCompositeNavigationProps,
+    TradingStackParamList,
+    TradingStackRoutes,
+} from '@suite-native/navigation';
+import { Color } from '@trezor/theme';
+
+import { ReceiveAccount } from '../../../types/general';
+import { AccountAddress } from '../AccountAddress';
+import { OverviewRow } from '../OverviewRow';
+
+export type ReceiveAccountPickerProps = {
+    symbol: NetworkSymbol | undefined;
+    receiveAccount: ReceiveAccount | undefined;
+    testID?: string;
+};
+
+type RightTextProps = {
+    children: ReactNode;
+    color: Color;
+    variant?: 'body' | 'hint';
+    testID?: string;
+};
+
+type ReceiveAccountPickerRightProps = {
+    accountLabel: string | undefined;
+    addressText: string | undefined;
+    testID?: string;
+};
+
+export type NavigationProps = StackToStackCompositeNavigationProps<
+    TradingStackParamList,
+    TradingStackRoutes.ReceiveAccounts,
+    RootStackParamList
+>;
+
+const RightText = ({ color, variant = 'body', testID, children }: RightTextProps) => (
+    <Text
+        color={color}
+        variant={variant}
+        testID={testID}
+        textAlign="right"
+        ellipsizeMode="tail"
+        numberOfLines={1}
+    >
+        {children}
+    </Text>
+);
+
+const ReceiveAccountPickerRight = ({
+    accountLabel,
+    addressText,
+    testID,
+}: ReceiveAccountPickerRightProps) => {
+    if (!accountLabel) {
+        return (
+            <RightText color="textSubdued" testID={testID ? `${testID}/not-selected` : undefined}>
+                <Translation id="moduleTrading.notSelected" />
+            </RightText>
+        );
+    }
+
+    if (!addressText) {
+        return (
+            <RightText
+                color="textSubdued"
+                testID={testID ? `${testID}/selected-account` : undefined}
+            >
+                {accountLabel}
+            </RightText>
+        );
+    }
+
+    return (
+        <>
+            <RightText
+                color="textSubdued"
+                testID={testID ? `${testID}/selected-account` : undefined}
+            >
+                {accountLabel}
+            </RightText>
+            <AccountAddress
+                address={addressText}
+                form="short"
+                color="textSubdued"
+                variant="hint"
+                textAlign="right"
+            />
+        </>
+    );
+};
+
+export const ReceiveAccountPicker = ({
+    receiveAccount,
+    symbol,
+    testID,
+}: ReceiveAccountPickerProps) => {
+    const { translate } = useTranslate();
+    const navigation = useNavigation<NavigationProps>();
+
+    if (!symbol) {
+        return null;
+    }
+
+    const openAccountPicker = () =>
+        navigation.navigate(TradingStackRoutes.ReceiveAccounts, { symbol });
+
+    const accountLabel = receiveAccount?.account.accountLabel;
+    const addressText =
+        (receiveAccount?.account.addresses
+            ? receiveAccount?.address?.address
+            : receiveAccount?.account.descriptor) ?? '';
+
+    return (
+        <OverviewRow
+            title={translate('moduleTrading.tradingScreen.receiveAccount')}
+            onPress={openAccountPicker}
+            testID={testID}
+            noBottomBorder
+        >
+            <VStack spacing={0} paddingLeft="sp20">
+                <ReceiveAccountPickerRight
+                    accountLabel={accountLabel}
+                    addressText={addressText}
+                    testID={testID}
+                />
+            </VStack>
+        </OverviewRow>
+    );
+};

--- a/suite-native/module-trading/src/components/general/ReceiveAccount/__tests__/ReceiveAccountCryptoBalance.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/ReceiveAccount/__tests__/ReceiveAccountCryptoBalance.comp.test.tsx
@@ -1,0 +1,83 @@
+import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import {
+    ReceiveAccountCryptoBalance,
+    ReceiveAccountCryptoBalanceProps,
+} from '../ReceiveAccountCryptoBalance';
+
+describe('ReceiveAccountCryptoBalance', () => {
+    const renderComponent = (props: ReceiveAccountCryptoBalanceProps) =>
+        renderWithStoreProviderAsync(<ReceiveAccountCryptoBalance testID="TEST_ID" {...props} />);
+
+    it('should display empty box when nor symbol nor defaultSymbol is specified', async () => {
+        const { queryByTestId } = await renderComponent({
+            account: {
+                symbol: undefined,
+                balance: '10000',
+            } as any,
+            defaultSymbol: undefined,
+        });
+
+        expect(queryByTestId('TEST_ID')).toBeNull();
+    });
+
+    it('should display empty balance when balance is not specified', async () => {
+        const { getByTestId } = await renderComponent({
+            account: {
+                symbol: 'btc',
+                balance: undefined,
+            } as any,
+            defaultSymbol: undefined,
+        });
+
+        expect(getByTestId('TEST_ID')).toHaveTextContent('Balance:- BTC');
+    });
+
+    it('should display balance when symbol and balance is specified', async () => {
+        const { getByTestId } = await renderComponent({
+            account: {
+                symbol: 'btc',
+                balance: '1000000',
+            } as any,
+            defaultSymbol: undefined,
+        });
+
+        expect(getByTestId('TEST_ID')).toHaveTextContent('Balance:0.01 BTC');
+    });
+
+    it('should display empty balance when defaultSymbol is specified', async () => {
+        const { getByTestId } = await renderComponent({
+            account: undefined,
+            defaultSymbol: 'btc',
+        });
+
+        expect(getByTestId('TEST_ID')).toHaveTextContent('Balance:- BTC');
+    });
+
+    describe('without testID specified', () => {
+        it('should render correctly with unknown balance', async () => {
+            const { getByText } = await renderComponent({
+                account: undefined,
+                defaultSymbol: 'btc',
+                testID: undefined,
+            });
+
+            expect(getByText('Balance:')).toBeOnTheScreen();
+            expect(getByText('- BTC')).toBeOnTheScreen();
+        });
+
+        it('should render correctly with known balance', async () => {
+            const { getByText } = await renderComponent({
+                account: {
+                    symbol: 'btc',
+                    balance: '1000000',
+                } as any,
+                defaultSymbol: undefined,
+                testID: undefined,
+            });
+
+            expect(getByText('Balance:')).toBeOnTheScreen();
+            expect(getByText('0.01 BTC')).toBeOnTheScreen();
+        });
+    });
+});

--- a/suite-native/module-trading/src/components/general/ReceiveAccount/__tests__/ReceiveAccountPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/ReceiveAccount/__tests__/ReceiveAccountPicker.comp.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+
+import { getBtcAccount } from '../../../../__fixtures__/account';
+import { ReceiveAccountPicker, ReceiveAccountPickerProps } from '../ReceiveAccountPicker';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual('@react-navigation/native'),
+    useNavigation: () => ({
+        navigate: mockNavigate,
+    }),
+}));
+
+describe('ReceiveAccountPicker', () => {
+    const renderReceiveAccountPicker = (props: Partial<ReceiveAccountPickerProps>) => {
+        const btcAccount = getBtcAccount();
+        const address = btcAccount.addresses!.used[0];
+
+        return renderWithBasicProvider(
+            <ReceiveAccountPicker
+                symbol="btc"
+                receiveAccount={{ account: btcAccount, address }}
+                {...props}
+            />,
+        );
+    };
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('should display nothing when selectedSymbol is not specified', () => {
+        const { toJSON } = renderReceiveAccountPicker({ symbol: undefined });
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should display "Not selected" when receiveAccount is not specified', () => {
+        const { getByText } = renderReceiveAccountPicker({
+            receiveAccount: undefined,
+        });
+
+        expect(getByText('Not selected')).toBeTruthy();
+    });
+
+    it('should call navigate to account picker when symbol is specified and picker pressed', () => {
+        const { getByText } = renderReceiveAccountPicker({
+            symbol: 'btc',
+            receiveAccount: undefined,
+        });
+
+        fireEvent.press(getByText('Receive account'));
+
+        expect(mockNavigate).toHaveBeenCalledTimes(1);
+        expect(mockNavigate).toHaveBeenCalledWith('ReceiveAccounts', { symbol: 'btc' });
+    });
+
+    it('should display account name', () => {
+        const { getByText } = renderReceiveAccountPicker({
+            receiveAccount: {
+                account: getBtcAccount(),
+                address: undefined,
+            },
+        });
+
+        expect(getByText('BTC Account #1')).toBeTruthy();
+    });
+
+    it('should display account name and address', () => {
+        const btcAccount = getBtcAccount();
+        const { getByText } = renderReceiveAccountPicker({
+            receiveAccount: {
+                account: btcAccount,
+                address: btcAccount.addresses!.used[0],
+            },
+        });
+
+        expect(getByText('BTC Account #1')).toBeTruthy();
+        expect(getByText('1BTC')).toBeTruthy();
+    });
+
+    describe('with testID specified', () => {
+        it('should render correctly with no receiveAccount', () => {
+            const { getByTestId } = renderReceiveAccountPicker({
+                receiveAccount: undefined,
+                testID: 'TEST_ID',
+            });
+
+            expect(getByTestId('TEST_ID/not-selected')).toHaveTextContent('Not selected');
+        });
+
+        it('should render correctly with receiveAccount but no address', () => {
+            const { getByTestId } = renderReceiveAccountPicker({
+                receiveAccount: {
+                    account: getBtcAccount(),
+                    address: undefined,
+                },
+                testID: 'TEST_ID',
+            });
+
+            expect(getByTestId('TEST_ID/selected-account')).toHaveTextContent('BTC Account #1');
+        });
+
+        it('should render correctly with receiveAccount and address', () => {
+            const btcAccount = getBtcAccount();
+            const { getByTestId } = renderReceiveAccountPicker({
+                receiveAccount: {
+                    account: btcAccount,
+                    address: btcAccount.addresses!.used[0],
+                },
+                testID: 'TEST_ID',
+            });
+
+            expect(getByTestId('TEST_ID/selected-account')).toHaveTextContent('BTC Account #1');
+        });
+    });
+});

--- a/suite-native/module-trading/src/components/general/ReceiveAccount/__tests__/ReceiveAccountPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/ReceiveAccount/__tests__/ReceiveAccountPicker.comp.test.tsx
@@ -90,6 +90,18 @@ describe('ReceiveAccountPicker', () => {
             expect(getByTestId('TEST_ID/not-selected')).toHaveTextContent('Not selected');
         });
 
+        it('should render correctly with empty string as receiveAccount label', () => {
+            const { getByTestId } = renderReceiveAccountPicker({
+                receiveAccount: {
+                    account: { ...getBtcAccount(), accountLabel: '' },
+                    address: undefined,
+                },
+                testID: 'TEST_ID',
+            });
+
+            expect(getByTestId('TEST_ID/selected-account')).toHaveTextContent('');
+        });
+
         it('should render correctly with receiveAccount but no address', () => {
             const { getByTestId } = renderReceiveAccountPicker({
                 receiveAccount: {

--- a/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
@@ -29,7 +29,7 @@ import {
     getAnalyticsTradingBuyPayload,
     getSourceForForm,
 } from '../../utils/general/formUtils';
-import { getSelectedSymbolFromBuyForm } from '../../utils/general/tradeableAssetUtils';
+import { getSymbolFromTradeableAsset } from '../../utils/general/tradeableAssetUtils';
 
 type NavigationProps = StackToStackCompositeNavigationProps<
     TradingStackParamList,
@@ -69,7 +69,11 @@ export const useBuyFlow = (form: BuyFormType) => {
 
     const [isConsentRequested, setIsConsentRequested] = useState(false);
 
-    const [candidateQuote, receiveAccount] = form.watch(['quote', 'receiveAccount']);
+    const [asset, candidateQuote, receiveAccount] = form.watch([
+        'asset',
+        'quote',
+        'receiveAccount',
+    ]);
     const coinInfo = useSelector((state: TradingRootState) =>
         selectTradingCoinInfoByCryptoId(state, candidateQuote?.receiveCurrency),
     );
@@ -82,7 +86,7 @@ export const useBuyFlow = (form: BuyFormType) => {
     });
 
     const selectReceiveAccount = () => {
-        const selectedNetworkSymbol = getSelectedSymbolFromBuyForm(form);
+        const selectedNetworkSymbol = getSymbolFromTradeableAsset(asset);
         if (selectedNetworkSymbol) {
             navigation.navigate(TradingStackRoutes.ReceiveAccounts, {
                 symbol: selectedNetworkSymbol,

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -29,7 +29,7 @@ import { tradingActions } from '../../tradingSlice';
 import { BuyFormType, BuyFormValues } from '../../types/buy';
 import { buyFormValidationSchema } from '../../utils/buy/buyFormValidationSchema';
 import { truncateDecimals } from '../../utils/general/amountUtils';
-import { getSelectedSymbolFromBuyForm } from '../../utils/general/tradeableAssetUtils';
+import { getSymbolFromTradeableAsset } from '../../utils/general/tradeableAssetUtils';
 import { getRandomAccountDescriptor } from '../../utils/general/utils';
 import { useConvertFormValueToBaseUnit } from '../general/useConvertFormValueToBaseUnit';
 
@@ -179,10 +179,9 @@ const useBuyQuotesChangeEffect = ({ getValues, setValue }: BuyFormType) => {
     }, [quotes, getValues, setValue]);
 };
 
-const useBuyQuoteChangeEffect = (form: BuyFormType) => {
-    const { getValues, setValue, watch } = form;
-    const quote = watch('quote');
-    const symbol = getSelectedSymbolFromBuyForm(form);
+const useBuyQuoteChangeEffect = ({ getValues, setValue, watch }: BuyFormType) => {
+    const [asset, quote] = watch(['asset', 'quote']);
+    const symbol = getSymbolFromTradeableAsset(asset);
 
     const isAmountInSats = useSelector((state: WalletSettingsRootState) =>
         selectIsAmountInSats(state, symbol),

--- a/suite-native/module-trading/src/hooks/buy/useBuyQuotes.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyQuotes.ts
@@ -21,7 +21,7 @@ import { selectValidTradingBuyQuotesNative } from '../../selectors/buySelectors'
 import { tradingActions } from '../../tradingSlice';
 import { BuyFormType } from '../../types/buy';
 import { tradingBuyFormToTradingBuyFormProps } from '../../utils/general/quotesUtils';
-import { getSelectedSymbolFromBuyForm } from '../../utils/general/tradeableAssetUtils';
+import { getSymbolFromTradeableAsset } from '../../utils/general/tradeableAssetUtils';
 import { useReloadTimer } from '../general/useReloadTimer';
 
 type PromiseType = {
@@ -154,7 +154,7 @@ const useBuyQuotesThunk = (
     const dispatch = useDispatch();
 
     const asset = form.watch('asset');
-    const symbol = getSelectedSymbolFromBuyForm(form);
+    const symbol = getSymbolFromTradeableAsset(asset);
     const shouldSendInSats = useSelector((state: WalletSettingsRootState) =>
         selectIsAmountInSats(state, symbol),
     );

--- a/suite-native/module-trading/src/types/general.ts
+++ b/suite-native/module-trading/src/types/general.ts
@@ -5,9 +5,6 @@ import { NetworkSymbolExtended } from '@suite-common/wallet-config';
 import { Account, TokenAddress } from '@suite-common/wallet-types';
 import { Address } from '@trezor/blockchain-link-types';
 
-import { BuyFormType } from './buy';
-import { ExchangeFormType } from './exchange';
-
 export type TradeableAsset = {
     symbol: NetworkSymbolExtended;
     contractAddress?: TokenAddress | undefined;
@@ -33,5 +30,3 @@ export type BaseFormValues<FocusedValue extends string, Quote extends TradingTra
     generalAlert: string | undefined;
     focusedValue: FocusedValue | undefined;
 } & Record<FocusedValue, string | undefined>;
-
-export type GeneralFormType = BuyFormType | ExchangeFormType;

--- a/suite-native/module-trading/src/utils/general/__tests__/tradeableAssetUtils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/tradeableAssetUtils.test.ts
@@ -1,7 +1,5 @@
 import { CoinInfo, CryptoId } from 'invity-api';
 
-import { act, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
-
 import coins from '../../../__fixtures__/coins.json';
 import {
     btcAsset,
@@ -9,11 +7,9 @@ import {
     ethOnBaseAsset,
     usdcAsset,
 } from '../../../__fixtures__/tradeableAssets';
-import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { TradeableAsset } from '../../../types/general';
 import {
     coinInfoToTradeableAsset,
-    getSelectedSymbolFromBuyForm,
+    getSymbolFromTradeableAsset,
     tradeableAssetSortingComparator,
 } from '../tradeableAssetUtils';
 
@@ -56,22 +52,13 @@ describe('tradeableAssetUtils', () => {
         });
     });
 
-    describe('getSelectedSymbolFromBuyForm', () => {
-        it('should return correct symbol', async () => {
-            const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm());
-
-            act(() =>
-                result.current.setValue('asset', {
-                    cryptoId: 'ethereum--0x07150e919b4de5fd6a63de1f9384828396f25fdc',
-                    symbol: 'base',
-                    name: 'Base Protocol',
-                    coingeckoId: 'base-protocol',
-                    contractAddress: '0x07150e919b4de5fd6a63de1f9384828396f25fdc',
-                    networkId: 'ethereum',
-                } as TradeableAsset),
-            );
-
-            expect(getSelectedSymbolFromBuyForm(result.current)).toEqual('eth');
+    describe('getSymbolFromTradeableAsset', () => {
+        it.each([
+            [undefined, undefined],
+            [btcAsset, 'btc'],
+            [usdcAsset, 'eth'],
+        ])('should return symbol based on asset.cryptoId', (asset, expectedSymbol) => {
+            expect(getSymbolFromTradeableAsset(asset)).toEqual(expectedSymbol);
         });
     });
 

--- a/suite-native/module-trading/src/utils/general/tradeableAssetUtils.ts
+++ b/suite-native/module-trading/src/utils/general/tradeableAssetUtils.ts
@@ -4,7 +4,6 @@ import { cryptoIdToSymbol, isCryptoIdForNativeToken, parseCryptoId } from '@suit
 import { NetworkSymbolExtended } from '@suite-common/wallet-config';
 import { TokenAddress } from '@suite-common/wallet-types';
 
-import { BuyFormType } from '../../types/buy';
 import { TradeableAsset } from '../../types/general';
 
 const FAVOURITE_NETWORKS_PRIORITY_ORDER = ['bitcoin', 'ethereum', 'litecoin', 'cardano', 'solana'];
@@ -44,8 +43,5 @@ export const coinInfoToTradeableAsset = (
     };
 };
 
-export const getSelectedSymbolFromBuyForm = (form: BuyFormType) => {
-    const cryptoId = form.watch('asset')?.cryptoId;
-
-    return cryptoId ? cryptoIdToSymbol(cryptoId) : undefined;
-};
+export const getSymbolFromTradeableAsset = (asset: TradeableAsset | undefined) =>
+    asset?.cryptoId ? cryptoIdToSymbol(asset.cryptoId) : undefined;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Introduce general Trading `ReceiveAccountPicker` component.
- Refactor `BuyReceiveAccountPicker` component to use general one.
- Same for `ReceiveAccountCryptoBalance`


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=18928-mobile-trade-inputs-ui&lookback=7)