### PR TITLE
feat(suite): add message system context banners to accounts, settings and dashboard

### DIFF
--- a/packages/suite/src/components/settings/SettingsLayout.tsx
+++ b/packages/suite/src/components/settings/SettingsLayout.tsx
@@ -16,6 +16,7 @@ import {
     selectHasExperimentalFeature,
     selectIsDebugModeActive,
 } from 'src/reducers/suite/suiteReducer';
+import { AccountHeaderProvider } from 'src/support/suite/AccountHeaderProvider';
 import { SettingsLoading } from 'src/views/settings/SettingsLoader';
 
 type SettingsLayoutProps = {
@@ -75,10 +76,10 @@ const SettingsHeader = () => {
     );
 
     return (
-        <>
+        <AccountHeaderProvider>
             <PageHeader />
             <SubpageNavigation items={settingsSubpages} />
-        </>
+        </AccountHeaderProvider>
     );
 };
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountName.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useState } from 'react';
 
 import { Account } from '@suite-common/wallet-types';
-import { spacings } from '@trezor/theme';
 
-import { ACCOUNT_INFO_HEIGHT } from 'src/components/wallet/WalletLayout/AccountTopPanel/AccountTopPanel';
+import { HEADER_HEIGHT } from 'src/constants/suite/layout';
+import { useOptionalAccountHeaderContext } from 'src/support/suite/AccountHeaderProvider';
 
 import { AccountDetails } from './AccountDetails';
-import { SCROLL_WRAPPER_ID } from '../../../SuiteLayout';
 
 interface AccountNameProps {
     selectedAccount: Account;
@@ -14,26 +13,28 @@ interface AccountNameProps {
 
 export const AccountName = ({ selectedAccount }: AccountNameProps) => {
     const [isScrolled, setIsScrolled] = useState(false);
+    const accountHeaderContext = useOptionalAccountHeaderContext();
+    const balanceSectionRef = accountHeaderContext?.balanceSectionRef;
 
     useEffect(() => {
-        const scrollContainer = document.getElementById(SCROLL_WRAPPER_ID);
+        const target = balanceSectionRef?.current;
+        if (!target) return;
 
-        if (!scrollContainer) return;
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                setIsScrolled(!entry.isIntersecting);
+            },
+            {
+                root: null,
+                threshold: 0,
+                rootMargin: `-${HEADER_HEIGHT} 0px 0px 0px`,
+            },
+        );
 
-        const handleScroll = (e: Event) => {
-            const target = e.target as HTMLElement;
-            //  ContentWrapper top padding + info height + AccountInfo bottom margin
-            const breakingPoint = spacings.lg + ACCOUNT_INFO_HEIGHT + spacings.lg;
+        observer.observe(target);
 
-            setIsScrolled(target.scrollTop > breakingPoint);
-        };
-
-        scrollContainer.addEventListener('scroll', handleScroll);
-
-        return () => {
-            scrollContainer.removeEventListener('scroll', handleScroll);
-        };
-    }, []);
+        return () => observer.disconnect();
+    }, [balanceSectionRef]);
 
     return <AccountDetails selectedAccount={selectedAccount} isBalanceShown={isScrolled} />;
 };

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useRef, useState } from 'react';
+import { ReactNode, createContext, useEffect, useRef, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -27,7 +27,10 @@ import { PassphraseFlow } from './PassphraseFlow';
 import { Sidebar } from './Sidebar/Sidebar';
 import { ModalSwitcher } from '../../modals/ModalSwitcher/ModalSwitcher';
 
-export const SCROLL_WRAPPER_ID = 'layout-scroll';
+export const ScrollContext = createContext<React.RefObject<HTMLDivElement | null>>({
+    current: null,
+});
+
 export const Wrapper = styled.div`
     display: flex;
     flex: 1;
@@ -149,59 +152,57 @@ export const SuiteLayout = ({ children }: SuiteLayoutProps) => {
     const isAccountPage = !!selectedAccount;
 
     return (
-        <ElevationContext baseElevation={-1}>
-            <Wrapper ref={wrapperRef} data-testid="@suite-layout">
-                <PageWrapper>
-                    <Modal.Provider>
-                        <Metadata title={title} />
+        <ScrollContext.Provider value={scrollRef}>
+            <ElevationContext baseElevation={-1}>
+                <Wrapper ref={wrapperRef} data-testid="@suite-layout">
+                    <PageWrapper>
+                        <Modal.Provider>
+                            <Metadata title={title} />
 
-                        <ModalSwitcher />
-                        <PassphraseFlow />
-                        <AppShortcuts />
+                            <ModalSwitcher />
+                            <PassphraseFlow />
+                            <AppShortcuts />
 
-                        {isBelowTablet && <CoinjoinBars />}
+                            {isBelowTablet && <CoinjoinBars />}
 
-                        {isBelowTablet && <MobileMenu />}
+                            {isBelowTablet && <MobileMenu />}
 
-                        <DiscoveryProgress />
+                            <DiscoveryProgress />
 
-                        <LayoutContext.Provider value={setLayoutPayload}>
-                            <Body data-testid="@suite-layout/body">
-                                <Columns>
-                                    {!isBelowTablet && (
-                                        <ElevationDown>
-                                            <Sidebar />
-                                        </ElevationDown>
-                                    )}
-                                    <MainContent>
-                                        {!isBelowTablet && <CoinjoinBars />}
-                                        <SuiteBanners />
-                                        <AppWrapper
-                                            data-testid="@app"
-                                            ref={scrollRef}
-                                            id={SCROLL_WRAPPER_ID}
-                                        >
-                                            <ElevationUp>
-                                                {isBelowTablet && isAccountPage && (
-                                                    <MobileAccountsMenu />
-                                                )}
-                                                {layoutHeader}
+                            <LayoutContext.Provider value={setLayoutPayload}>
+                                <Body data-testid="@suite-layout/body">
+                                    <Columns>
+                                        {!isBelowTablet && (
+                                            <ElevationDown>
+                                                <Sidebar />
+                                            </ElevationDown>
+                                        )}
+                                        <MainContent>
+                                            {!isBelowTablet && <CoinjoinBars />}
+                                            <SuiteBanners />
+                                            <AppWrapper data-testid="@app" ref={scrollRef}>
+                                                <ElevationUp>
+                                                    {isBelowTablet && isAccountPage && (
+                                                        <MobileAccountsMenu />
+                                                    )}
+                                                    {layoutHeader}
 
-                                                <ContentWrapper>{children}</ContentWrapper>
-                                            </ElevationUp>
-                                        </AppWrapper>
-                                    </MainContent>
-                                </Columns>
-                            </Body>
-                        </LayoutContext.Provider>
+                                                    <ContentWrapper>{children}</ContentWrapper>
+                                                </ElevationUp>
+                                            </AppWrapper>
+                                        </MainContent>
+                                    </Columns>
+                                </Body>
+                            </LayoutContext.Provider>
 
-                        {!isBelowTablet && <GuideButton />}
-                    </Modal.Provider>
-                </PageWrapper>
+                            {!isBelowTablet && <GuideButton />}
+                        </Modal.Provider>
+                    </PageWrapper>
 
-                <GuideRouter />
-            </Wrapper>
-            {theme.variant === 'debug' && <DebugLegend />}
-        </ElevationContext>
+                    <GuideRouter />
+                </Wrapper>
+                {theme.variant === 'debug' && <DebugLegend />}
+            </ElevationContext>
+        </ScrollContext.Provider>
     );
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx
@@ -30,13 +30,19 @@ export const AccountBanners = ({ account }: AccountBannersProps) => {
 
     return (
         <Column gap={spacings.sm}>
-            {account?.accountType === 'coinjoin' && <ContextMessage context={Context.coinjoin} />}
+            {account?.accountType === 'coinjoin' && (
+                <ContextMessage context={Context.getDeprecated('accounts.coinjoin')} />
+            )}
             {account?.symbol &&
                 isSupportedEthStakingNetworkSymbol(account.symbol) &&
-                route?.name === 'wallet-staking' && <ContextMessage context={Context.ethStaking} />}
+                route?.name === 'wallet-staking' && (
+                    <ContextMessage context={Context.getStaking('eth')} />
+                )}
             {account?.symbol &&
                 isSupportedSolStakingNetworkSymbol(account.symbol) &&
-                route?.name === 'wallet-staking' && <ContextMessage context={Context.solStaking} />}
+                route?.name === 'wallet-staking' && (
+                    <ContextMessage context={Context.getStaking('sol')} />
+                )}
             <BackendDisconnected />
             <DeviceUnavailable />
             <TorDisconnected />

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx
@@ -31,7 +31,7 @@ export const AccountBanners = ({ account }: AccountBannersProps) => {
     return (
         <Column gap={spacings.sm}>
             {account?.accountType === 'coinjoin' && (
-                <ContextMessage context={Context.getDeprecated('accounts.coinjoin')} />
+                <ContextMessage context={Context.getAccount('btc', 'coinjoin')} />
             )}
             {account?.symbol &&
                 isSupportedEthStakingNetworkSymbol(account.symbol) &&

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ContextMessage.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ContextMessage.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import {
-    Context,
+    ContextDomain,
     messageSystemActions,
     selectContextMessageContent,
 } from '@suite-common/message-system';
@@ -13,7 +13,7 @@ import { selectLanguage, selectTorState } from 'src/reducers/suite/suiteReducer'
 import { getTorUrlIfAvailable } from 'src/utils/suite/tor';
 
 type ContextMessageProps = {
-    context: (typeof Context)[keyof typeof Context];
+    context: ContextDomain;
 };
 
 export const ContextMessage = ({ context }: ContextMessageProps) => {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountTopPanel.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountTopPanel.tsx
@@ -2,6 +2,7 @@ import { forwardRef } from 'react';
 
 import styled from 'styled-components';
 
+import { Context } from '@suite-common/message-system';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { selectLocalCurrency } from '@suite-common/wallet-core';
 import { SkeletonCircle, SkeletonRectangle } from '@trezor/components';
@@ -11,6 +12,8 @@ import { spacingsPx, zIndices } from '@trezor/theme';
 import { AmountUnitSwitchWrapper, FormattedCryptoAmount } from 'src/components/suite';
 import { FiatHeader } from 'src/components/wallet/FiatHeader';
 import { useSelector } from 'src/hooks/suite';
+
+import { ContextMessage } from '../AccountBanners/ContextMessage';
 
 export const ACCOUNT_INFO_HEIGHT = 80;
 
@@ -68,7 +71,7 @@ export const AccountTopPanel = forwardRef<HTMLDivElement>((_, ref) => {
         );
     }
 
-    const { symbol, formattedBalance } = account;
+    const { symbol, formattedBalance, accountType } = account;
 
     return (
         <Container ref={ref}>
@@ -93,6 +96,7 @@ export const AccountTopPanel = forwardRef<HTMLDivElement>((_, ref) => {
                     />
                 </div>
             </AmountsWrapper>
+            <ContextMessage context={Context.getAccount(symbol, accountType)} />
         </Container>
     );
 });

--- a/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountTopPanel.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountTopPanel.tsx
@@ -1,5 +1,3 @@
-import { forwardRef } from 'react';
-
 import styled from 'styled-components';
 
 import { Context } from '@suite-common/message-system';
@@ -12,19 +10,16 @@ import { spacingsPx, zIndices } from '@trezor/theme';
 import { AmountUnitSwitchWrapper, FormattedCryptoAmount } from 'src/components/suite';
 import { FiatHeader } from 'src/components/wallet/FiatHeader';
 import { useSelector } from 'src/hooks/suite';
+import { useAccountHeaderContext } from 'src/support/suite/AccountHeaderProvider';
 
 import { ContextMessage } from '../AccountBanners/ContextMessage';
-
-export const ACCOUNT_INFO_HEIGHT = 80;
 
 const Container = styled.div`
     display: flex;
     flex-direction: column;
     gap: ${spacingsPx.xxs};
-    min-height: ${ACCOUNT_INFO_HEIGHT}px;
     width: 100%;
-    padding-left: ${spacingsPx.md};
-    padding-right: ${spacingsPx.md};
+    padding-inline: ${spacingsPx.md};
     margin-top: ${spacingsPx.lg};
     z-index: ${zIndices.pageSubHeader};
 `;
@@ -36,10 +31,9 @@ const AccountCryptoBalance = styled.div`
     color: ${({ theme }) => theme.textSubdued};
 `;
 
-const AmountsWrapper = styled.div`
+const BalanceSection = styled.div`
     display: flex;
-    gap: ${spacingsPx.lg};
-    flex-wrap: wrap;
+    flex-direction: column;
 `;
 
 interface AccountTopPanelSkeletonProps {
@@ -58,9 +52,10 @@ const AccountTopPanelSkeleton = ({ animate, symbol }: AccountTopPanelSkeletonPro
     </Container>
 );
 
-export const AccountTopPanel = forwardRef<HTMLDivElement>((_, ref) => {
+export const AccountTopPanel = () => {
     const { account, loader, status } = useSelector(state => state.wallet.selectedAccount);
     const localCurrency = useSelector(selectLocalCurrency);
+    const { balanceSectionRef } = useAccountHeaderContext();
 
     if (status !== 'loaded' || !account) {
         return (
@@ -74,29 +69,26 @@ export const AccountTopPanel = forwardRef<HTMLDivElement>((_, ref) => {
     const { symbol, formattedBalance, accountType } = account;
 
     return (
-        <Container ref={ref}>
-            <AmountsWrapper>
-                <div>
-                    <AmountUnitSwitchWrapper symbol={symbol}>
-                        <AccountCryptoBalance>
-                            <FormattedCryptoAmount
-                                data-testid="@wallet/account-top-panel/crypto-balance"
-                                value={formattedBalance}
-                                symbol={symbol}
-                            />
-                        </AccountCryptoBalance>
-                    </AmountUnitSwitchWrapper>
-
-                    <FiatHeader
-                        symbol={account.symbol}
-                        amount={account.formattedBalance}
-                        size="large"
-                        localCurrency={localCurrency}
-                        data-testid="@wallet/account-top-panel/fiat-amount"
-                    />
-                </div>
-            </AmountsWrapper>
+        <Container>
+            <BalanceSection ref={balanceSectionRef}>
+                <AmountUnitSwitchWrapper symbol={symbol}>
+                    <AccountCryptoBalance>
+                        <FormattedCryptoAmount
+                            data-testid="@wallet/account-top-panel/crypto-balance"
+                            value={formattedBalance}
+                            symbol={symbol}
+                        />
+                    </AccountCryptoBalance>
+                </AmountUnitSwitchWrapper>
+                <FiatHeader
+                    symbol={account.symbol}
+                    amount={account.formattedBalance}
+                    size="large"
+                    localCurrency={localCurrency}
+                    data-testid="@wallet/account-top-panel/fiat-amount"
+                />
+            </BalanceSection>
             <ContextMessage context={Context.getAccount(symbol, accountType)} />
         </Container>
     );
-});
+};

--- a/packages/suite/src/components/wallet/WalletLayout/WalletLayout.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/WalletLayout.tsx
@@ -7,6 +7,7 @@ import { PrimitiveType } from '@trezor/type-utils';
 import { TranslationKey } from 'src/components/suite/Translation';
 import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
 import { useLayout, useTranslation } from 'src/hooks/suite';
+import { AccountHeaderProvider } from 'src/support/suite/AccountHeaderProvider';
 import { AppState } from 'src/types/suite';
 
 import { AccountBanners } from './AccountBanners/AccountBanners';
@@ -20,11 +21,11 @@ type WalletPageHeaderProps = {
 };
 
 const WalletPageHeader = ({ isSubpage }: WalletPageHeaderProps) => (
-    <>
+    <AccountHeaderProvider>
         <PageHeader />
         {!isSubpage && <AccountTopPanel />}
         {!isSubpage && <AccountNavigation />}
-    </>
+    </AccountHeaderProvider>
 );
 
 type WalletLayoutProps = {

--- a/packages/suite/src/hooks/suite/useAnchor.ts
+++ b/packages/suite/src/hooks/suite/useAnchor.ts
@@ -1,18 +1,19 @@
-import { useEffect, useRef } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 
-import { SCROLL_WRAPPER_ID } from 'src/components/suite/layouts/SuiteLayout/SuiteLayout';
+import { ScrollContext } from 'src/components/suite/layouts/SuiteLayout/SuiteLayout';
 import { HEADER_HEIGHT_NUMERIC, SUBPAGE_NAV_HEIGHT_NUMERIC } from 'src/constants/suite/layout';
 import { useSelector } from 'src/hooks/suite';
 
 const OFFSET = 30;
 
 export const useAnchor = (anchorId: string) => {
+    const scrollRef = useContext(ScrollContext);
     const anchorRef = useRef<HTMLDivElement>(null);
     const anchor = useSelector(state => state.router.anchor);
 
     useEffect(() => {
         if (anchorId === anchor && anchorRef.current) {
-            const scrollContainer = document.getElementById(SCROLL_WRAPPER_ID);
+            const scrollContainer = scrollRef?.current;
             if (!scrollContainer) return;
 
             const headerHeight = HEADER_HEIGHT_NUMERIC + SUBPAGE_NAV_HEIGHT_NUMERIC + OFFSET;
@@ -29,7 +30,7 @@ export const useAnchor = (anchorId: string) => {
                 behavior: 'smooth',
             });
         }
-    }, [anchor, anchorId]);
+    }, [anchor, anchorId, scrollRef]);
 
     return {
         anchorRef,

--- a/packages/suite/src/hooks/suite/useMessageSystemStaking.ts
+++ b/packages/suite/src/hooks/suite/useMessageSystemStaking.ts
@@ -3,13 +3,12 @@ import {
     selectFeatureMessageContent,
     selectIsFeatureDisabled,
 } from '@suite-common/message-system';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkSymbol, StakingNetworkSymbol } from '@suite-common/wallet-config';
 
 import { selectLanguage } from 'src/reducers/suite/suiteReducer';
 
 import { useSelector } from './useSelector';
 
-type AvailableNetworkSymbols = Extract<NetworkSymbol, 'eth' | 'sol'>;
 const availableNetworks = [
     ...Object.keys(Feature.stake),
     ...Object.keys(Feature.unstake),
@@ -21,11 +20,11 @@ export const useMessageSystemStaking = (networkSymbol?: NetworkSymbol) => {
 
     const isAvailable = networkSymbol != null && availableNetworks.includes(networkSymbol);
 
-    const stake = isAvailable ? Feature.stake[networkSymbol as AvailableNetworkSymbols] : undefined;
+    const stake = isAvailable ? Feature.stake[networkSymbol as StakingNetworkSymbol] : undefined;
     const unstake = isAvailable
-        ? Feature.unstake[networkSymbol as AvailableNetworkSymbols]
+        ? Feature.unstake[networkSymbol as StakingNetworkSymbol]
         : undefined;
-    const claim = isAvailable ? Feature.claim[networkSymbol as AvailableNetworkSymbols] : undefined;
+    const claim = isAvailable ? Feature.claim[networkSymbol as StakingNetworkSymbol] : undefined;
 
     const isStakingDisabled = useSelector(state =>
         stake ? selectIsFeatureDisabled(state, stake) : undefined,

--- a/packages/suite/src/support/suite/AccountHeaderProvider.tsx
+++ b/packages/suite/src/support/suite/AccountHeaderProvider.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, useContext, useRef } from 'react';
+
+type AccountHeaderContextValue = {
+    balanceSectionRef: React.RefObject<HTMLDivElement | null>;
+};
+
+const AccountHeaderContext = createContext<AccountHeaderContextValue | null>(null);
+
+interface AccountHeaderProviderProps {
+    children: React.ReactNode;
+}
+
+export const AccountHeaderProvider = ({ children }: AccountHeaderProviderProps) => {
+    const balanceSectionRef = useRef<HTMLDivElement>(null);
+
+    return (
+        <AccountHeaderContext.Provider value={{ balanceSectionRef }}>
+            {children}
+        </AccountHeaderContext.Provider>
+    );
+};
+
+export const useOptionalAccountHeaderContext = () => useContext(AccountHeaderContext) ?? null;
+
+export const useAccountHeaderContext = () => {
+    const ctx = useOptionalAccountHeaderContext();
+    if (!ctx) throw new Error('Missing provider');
+
+    return ctx;
+};

--- a/packages/suite/src/views/dashboard/DashboardPassphraseBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPassphraseBanner.tsx
@@ -19,7 +19,7 @@ import { bannerAnimationConfig } from './banner-animations';
 
 const Container = styled(motion.div)`
     width: 100%;
-    margin-bottom: ${spacingsPx.xxxxl};
+    margin-bottom: ${spacingsPx.xl};
 `;
 
 export const DashboardPassphraseBanner = () => {

--- a/packages/suite/src/views/dashboard/index.tsx
+++ b/packages/suite/src/views/dashboard/index.tsx
@@ -1,7 +1,11 @@
+import styled from 'styled-components';
+
+import { Context } from '@suite-common/message-system';
 import { Column } from '@trezor/components';
-import { spacings } from '@trezor/theme';
+import { spacings, spacingsPx } from '@trezor/theme';
 
 import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
+import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useLayout } from 'src/hooks/suite';
 
 import { AssetsView } from './AssetsView/AssetsView';
@@ -11,15 +15,22 @@ import { PromoBanner } from './PromoBanner';
 import { StakeEthCard } from './StakeEthCard/StakeEthCard';
 // import { T3T1PromoBanner } from './T3T1PromoBanner/T3T1PromoBanner';
 
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: ${spacingsPx.xl};
+`;
+
 export const Dashboard = () => {
     useLayout('Home', <PageHeader />);
 
     return (
         <Column gap={spacings.xxxxl} data-testid="@dashboard/index">
-            <div>
+            <Container>
+                <ContextMessage context={Context.getGeneral('dashboard')} />
                 <DashboardPassphraseBanner />
                 <PortfolioCard />
-            </div>
+            </Container>
             {/*<T3T1PromoBanner />*/}
             <AssetsView />
             <StakeEthCard />

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence, MotionProps, motion } from 'framer-motion';
 import styled from 'styled-components';
 
+import { Context } from '@suite-common/message-system';
 import {
     restartDiscoveryThunk,
     selectDeviceSupportedNetworks,
@@ -18,6 +19,7 @@ import {
     SettingsSectionItem,
 } from 'src/components/settings';
 import { CoinGroup, Translation } from 'src/components/suite';
+import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { useDevice, useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
@@ -112,6 +114,8 @@ export const SettingsCoins = () => {
 
     return (
         <SettingsLayout>
+            <ContextMessage context={Context.getSettings('networks')} />
+
             {showDeviceBanner && (
                 <DeviceBanner
                     title={

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -1,7 +1,9 @@
+import { Context } from '@suite-common/message-system';
 import { isDesktop, isWeb } from '@trezor/env-utils';
 
 import { SettingsLayout, SettingsSection } from 'src/components/settings';
 import { Translation } from 'src/components/suite';
+import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useSelector } from 'src/hooks/suite';
 import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
 
@@ -35,6 +37,8 @@ export const SettingsDebug = () => {
 
     return (
         <SettingsLayout>
+            <ContextMessage context={Context.getSettings('debug')} />
+
             {isWeb() && (
                 <SettingsSection title="Localization">
                     <TranslationMode />

--- a/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
@@ -1,9 +1,11 @@
+import { Context } from '@suite-common/message-system';
 import { SUPPORTS_DEVICE_AUTHENTICITY_CHECK } from '@suite-common/suite-constants';
 import { isDeviceRemembered, isDeviceWithButtons } from '@suite-common/suite-utils';
 import { isBitcoinOnlyDevice } from '@trezor/device-utils';
 
 import { DeviceBanner, SettingsLayout, SettingsSection } from 'src/components/settings';
 import { Translation } from 'src/components/suite';
+import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useDevice, useSelector } from 'src/hooks/suite';
 import { selectHasActiveTransport, selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
 import type { TrezorDevice } from 'src/types/suite';
@@ -99,6 +101,8 @@ export const SettingsDevice = () => {
 
     return (
         <SettingsLayout>
+            <ContextMessage context={Context.getSettings('device')} />
+
             {bootloaderMode && (
                 <DeviceBanner
                     title={<Translation id="TR_SETTINGS_DEVICE_BANNER_TITLE_BOOTLOADER" />}

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -1,9 +1,11 @@
+import { Context } from '@suite-common/message-system';
 import { getNetwork } from '@suite-common/wallet-config';
 import { selectEnabledNetworks } from '@suite-common/wallet-core';
 import { isDesktop, isWeb } from '@trezor/env-utils';
 
 import { SettingsLayout, SettingsSection } from 'src/components/settings';
 import { Translation } from 'src/components/suite';
+import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useLayoutSize, useSelector } from 'src/hooks/suite';
 import { selectSelectedProviderForLabels } from 'src/reducers/suite/metadataReducer';
 import {
@@ -64,6 +66,8 @@ export const SettingsGeneral = () => {
 
     return (
         <SettingsLayout data-testid="@settings/index">
+            <ContextMessage context={Context.getSettings('general')} />
+
             <div>
                 {isWeb() && !isBelowTablet && shouldShowSettingsDesktopAppPromoBanner && (
                     <DesktopSuiteBanner />

--- a/packages/suite/src/views/wallet/trading/buy/TradingBuyForm.tsx
+++ b/packages/suite/src/views/wallet/trading/buy/TradingBuyForm.tsx
@@ -28,7 +28,7 @@ const TradingBuyFormWrapper = ({ selectedAccount }: UseTradingProps) => {
 
     return (
         <TradingLayout>
-            <ContextMessage context={Context.tradingBuy} />
+            <ContextMessage context={Context.getTrading(type)} />
             {isDisabled ? (
                 <TradingDisabled type={type} content={content} />
             ) : (

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeForm.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeForm.tsx
@@ -28,7 +28,7 @@ const TradingExchangeFormWrapper = ({ selectedAccount }: UseTradingProps) => {
 
     return (
         <TradingLayout>
-            <ContextMessage context={Context.tradingExchange} />
+            <ContextMessage context={Context.getTrading(type)} />
             {isDisabled ? (
                 <TradingDisabled type={type} content={content} />
             ) : (

--- a/packages/suite/src/views/wallet/trading/sell/TradingSellForm.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/TradingSellForm.tsx
@@ -28,7 +28,7 @@ const TradingSellFormWrapper = ({ selectedAccount }: UseTradingProps) => {
 
     return (
         <TradingLayout>
-            <ContextMessage context={Context.tradingSell} />
+            <ContextMessage context={Context.getTrading(type)} />
             {isDisabled ? (
                 <TradingDisabled type={type} content={content} />
             ) : (

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -917,7 +917,7 @@
                         "uk": "Дізнатись більше"
                     }
                 },
-                "context": { "domain": "accounts.coinjoin" }
+                "context": { "domain": ["accounts.coinjoin", "accounts.btc.coinjoin"] }
             }
         },
         {
@@ -1062,7 +1062,7 @@
                         "uk": "Дізнатись більше"
                     }
                 },
-                "context": { "domain": "accounts.coinjoin" }
+                "context": { "domain": ["accounts.coinjoin", "accounts.btc.coinjoin"] }
             }
         },
         {

--- a/suite-common/message-system/src/__tests__/messageSystemTypes.test.ts
+++ b/suite-common/message-system/src/__tests__/messageSystemTypes.test.ts
@@ -1,0 +1,85 @@
+import { TradingType } from '@suite-common/trading';
+import { AccountType, NetworkSymbol, StakingNetworkSymbol } from '@suite-common/wallet-config';
+
+import {
+    Context,
+    DeprecatedContextKey,
+    GeneralContextKey,
+    SettingsCategory,
+} from '../messageSystemTypes';
+
+describe('Message system types', () => {
+    describe('Context', () => {
+        describe('getGeneral', () => {
+            it.each([['dashboard', 'dashboard']] as const satisfies [GeneralContextKey, string][])(
+                'getGeneral(%s) → %s',
+                (input, expected) => {
+                    expect(Context.getGeneral(input)).toBe(expected);
+                },
+            );
+        });
+
+        describe('getAccount', () => {
+            it.each([
+                ['btc', undefined, 'accounts.btc'],
+                ['btc', 'legacy', 'accounts.btc.legacy'],
+                ['eth', undefined, 'accounts.eth'],
+                ['eth', 'ledger', 'accounts.eth.ledger'],
+                ['base', undefined, 'accounts.base'],
+            ] as const satisfies [NetworkSymbol, AccountType | undefined, string][])(
+                'getAccount(%s, %s) → %s',
+                (symbol, type, expected) => {
+                    expect(Context.getAccount(symbol, type)).toBe(expected);
+                },
+            );
+        });
+
+        describe('getStaking', () => {
+            it.each([
+                ['eth', 'accounts.eth.staking'],
+                ['sol', 'accounts.sol.staking'],
+            ] as const satisfies [StakingNetworkSymbol, string][])(
+                'getStaking(%s) → %s',
+                (symbol, expected) => {
+                    expect(Context.getStaking(symbol)).toBe(expected);
+                },
+            );
+        });
+
+        describe('getTrading', () => {
+            it.each([
+                ['buy', 'trading.buy'],
+                ['sell', 'trading.sell'],
+                ['exchange', 'trading.exchange'],
+            ] as const satisfies [TradingType, string][])(
+                'getTrading(%s) → %s',
+                (type, expected) => {
+                    expect(Context.getTrading(type)).toBe(expected);
+                },
+            );
+        });
+
+        describe('getSettings', () => {
+            it.each([
+                ['general', 'settings.general'],
+                ['device', 'settings.device'],
+                ['networks', 'settings.networks'],
+                ['debug', 'settings.debug'],
+            ] as const satisfies [SettingsCategory, string][])(
+                'getSettings(%s) → %s',
+                (category, expected) => {
+                    expect(Context.getSettings(category)).toBe(expected);
+                },
+            );
+        });
+
+        describe('getDeprecated', () => {
+            it.each([['accounts.coinjoin', 'accounts.coinjoin']] as const satisfies [
+                DeprecatedContextKey,
+                string,
+            ][])('getDeprecated(%s) → %s', (key, expected) => {
+                expect(Context.getDeprecated(key)).toBe(expected);
+            });
+        });
+    });
+});

--- a/suite-common/message-system/src/__tests__/messageSystemTypes.test.ts
+++ b/suite-common/message-system/src/__tests__/messageSystemTypes.test.ts
@@ -1,12 +1,7 @@
 import { TradingType } from '@suite-common/trading';
 import { AccountType, NetworkSymbol, StakingNetworkSymbol } from '@suite-common/wallet-config';
 
-import {
-    Context,
-    DeprecatedContextKey,
-    GeneralContextKey,
-    SettingsCategory,
-} from '../messageSystemTypes';
+import { Context, GeneralContextKey, SettingsCategory } from '../messageSystemTypes';
 
 describe('Message system types', () => {
     describe('Context', () => {
@@ -71,15 +66,6 @@ describe('Message system types', () => {
                     expect(Context.getSettings(category)).toBe(expected);
                 },
             );
-        });
-
-        describe('getDeprecated', () => {
-            it.each([['accounts.coinjoin', 'accounts.coinjoin']] as const satisfies [
-                DeprecatedContextKey,
-                string,
-            ][])('getDeprecated(%s) → %s', (key, expected) => {
-                expect(Context.getDeprecated(key)).toBe(expected);
-            });
         });
     });
 });

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -83,9 +83,6 @@ const getTradingContext = (type: TradingType) => `trading.${type}` as const;
 export type SettingsCategory = 'general' | 'device' | 'networks' | 'debug';
 const getSettingsContext = (category: SettingsCategory) => `settings.${category}` as const;
 
-export type DeprecatedContextKey = 'accounts.coinjoin';
-const getDeprecatedContext = (key: DeprecatedContextKey) => key;
-
 /**
  * Factory object for generating typed context keys used by the Message System.
  *
@@ -99,7 +96,7 @@ const getDeprecatedContext = (key: DeprecatedContextKey) => key;
  * - `getStaking('eth')` → 'accounts.eth.staking'
  * - `getTrading('buy')` → 'trading.buy'
  * - `getSettings('device')` → 'settings.device'
- * - `getDeprecated('accounts.coinjoin')` → 'accounts.coinjoin'
+
  */
 export const Context = {
     getGeneral: getGeneralContext,
@@ -107,7 +104,6 @@ export const Context = {
     getStaking: getStakingContext,
     getTrading: getTradingContext,
     getSettings: getSettingsContext,
-    getDeprecated: getDeprecatedContext,
 } as const;
 
 type FunctionKeysOf<T> = {

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -1,4 +1,6 @@
-import { Category, ExperimentsItem, MessageSystem } from '@suite-common/suite-types';
+import type { Category, ExperimentsItem, MessageSystem } from '@suite-common/suite-types';
+import type { TradingType } from '@suite-common/trading';
+import type { AccountType, NetworkSymbol, StakingNetworkSymbol } from '@suite-common/wallet-config';
 
 export type MessageState = { [key in Category]: boolean };
 
@@ -65,16 +67,58 @@ type ExtractFeatureValues<T> =
 
 export type FeatureDomain = ExtractFeatureValues<typeof Feature>;
 
+export type GeneralContextKey = 'dashboard';
+const getGeneralContext = (key: GeneralContextKey) => key;
+
+const getAccountContext = (networkSymbol: NetworkSymbol, accountType?: AccountType) =>
+    accountType
+        ? (`accounts.${networkSymbol}.${accountType}` as const)
+        : (`accounts.${networkSymbol}` as const);
+
+const getStakingContext = (networkSymbol: StakingNetworkSymbol) =>
+    `accounts.${networkSymbol}.staking` as const;
+
+const getTradingContext = (type: TradingType) => `trading.${type}` as const;
+
+export type SettingsCategory = 'general' | 'device' | 'networks' | 'debug';
+const getSettingsContext = (category: SettingsCategory) => `settings.${category}` as const;
+
+export type DeprecatedContextKey = 'accounts.coinjoin';
+const getDeprecatedContext = (key: DeprecatedContextKey) => key;
+
+/**
+ * Factory object for generating typed context keys used by the Message System.
+ *
+ * This API provides helper methods to construct string keys for different
+ * parts of the app (accounts, staking, trading, settings, etc.) in a type-safe way.
+ *
+ * Use cases:
+ * - `getGeneral('dashboard')` → 'dashboard'
+ * - `getAccounts('btc')` → 'accounts.btc'
+ * - `getAccounts('btc', 'legacy')` → 'accounts.btc.legacy'
+ * - `getStaking('eth')` → 'accounts.eth.staking'
+ * - `getTrading('buy')` → 'trading.buy'
+ * - `getSettings('device')` → 'settings.device'
+ * - `getDeprecated('accounts.coinjoin')` → 'accounts.coinjoin'
+ */
 export const Context = {
-    coinjoin: 'accounts.coinjoin',
-    ethStaking: 'accounts.eth.staking',
-    solStaking: 'accounts.sol.staking',
-    tradingBuy: 'trading.buy',
-    tradingSell: 'trading.sell',
-    tradingExchange: 'trading.exchange',
+    getGeneral: getGeneralContext,
+    getAccount: getAccountContext,
+    getStaking: getStakingContext,
+    getTrading: getTradingContext,
+    getSettings: getSettingsContext,
+    getDeprecated: getDeprecatedContext,
 } as const;
 
-export type ContextDomain = (typeof Context)[keyof typeof Context];
+type FunctionKeysOf<T> = {
+    [K in keyof T]: T[K] extends (...args: any[]) => any ? K : never;
+}[keyof T];
+
+type FunctionContextReturnValues = {
+    [K in FunctionKeysOf<typeof Context>]: ReturnType<(typeof Context)[K]>;
+}[FunctionKeysOf<typeof Context>];
+
+export type ContextDomain = FunctionContextReturnValues;
 
 export const Experiment = {
     // e.g. orangeSendButton: 'fb0eb1bc-8ec3-44d4-98eb-53301d73d981',

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -32,6 +32,8 @@ export type NetworkSymbol =
  */
 export type NetworkSymbolExtended = NetworkSymbol | (string & {});
 
+export type StakingNetworkSymbol = Extract<NetworkSymbol, 'eth' | 'sol'>;
+
 export type NetworkType = 'bitcoin' | 'ethereum' | 'ripple' | 'cardano' | 'solana' | 'stellar';
 
 type UtilityAccountType = 'normal' | 'imported' | 'placeholder'; // reserved accountTypes to stand in for a real accountType

--- a/suite-native/message-system/src/components/ContextMessage.tsx
+++ b/suite-native/message-system/src/components/ContextMessage.tsx
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import {
-    Context,
+    ContextDomain,
     MessageSystemRootState,
     selectContextMessage,
 } from '@suite-common/message-system';
@@ -14,7 +14,7 @@ export type ContextMessageProps = Omit<
     InlineAlertBoxProps,
     'variant' | 'title' | 'buttonLabel' | 'onButtonPress'
 > & {
-    context: (typeof Context)[keyof typeof Context];
+    context: ContextDomain;
 };
 
 export const ContextMessage = ({ context, ...rest }: ContextMessageProps) => {

--- a/suite-native/message-system/src/components/__tests__/ContextMessage.comp.test.tsx
+++ b/suite-native/message-system/src/components/__tests__/ContextMessage.comp.test.tsx
@@ -76,7 +76,7 @@ describe('ContextMessage', () => {
 
     it('should render content when there is message of given context', async () => {
         const { queryByText } = await render({
-            context: Context.tradingBuy,
+            context: Context.getTrading('buy'),
             preloadedState: stateWithTradeContextMessage,
         });
         expect(queryByText(contentText)).toBeTruthy();
@@ -84,14 +84,14 @@ describe('ContextMessage', () => {
 
     it('should return null when there is no message fetched', async () => {
         const { queryByHintText } = await render({
-            context: Context.tradingBuy,
+            context: Context.getTrading('buy'),
         });
         expect(queryByHintText(contextActionId)).toBeNull();
     });
 
     it('should return null when there is message of different context', async () => {
         const { queryByHintText } = await render({
-            context: Context.coinjoin,
+            context: Context.getDeprecated('accounts.coinjoin'),
             preloadedState: stateWithTradeContextMessage,
         });
         expect(queryByHintText(contextActionId)).toBeNull();

--- a/suite-native/message-system/src/components/__tests__/ContextMessage.comp.test.tsx
+++ b/suite-native/message-system/src/components/__tests__/ContextMessage.comp.test.tsx
@@ -88,12 +88,4 @@ describe('ContextMessage', () => {
         });
         expect(queryByHintText(contextActionId)).toBeNull();
     });
-
-    it('should return null when there is message of different context', async () => {
-        const { queryByHintText } = await render({
-            context: Context.getDeprecated('accounts.coinjoin'),
-            preloadedState: stateWithTradeContextMessage,
-        });
-        expect(queryByHintText(contextActionId)).toBeNull();
-    });
 });

--- a/suite-native/module-trading/src/components/general/TradingTypeAwareContextMessage.tsx
+++ b/suite-native/module-trading/src/components/general/TradingTypeAwareContextMessage.tsx
@@ -1,40 +1,18 @@
 import { useSelector } from 'react-redux';
 
-import { Context, ContextDomain } from '@suite-common/message-system';
+import { Context } from '@suite-common/message-system';
 import { ContextMessage, ContextMessageProps } from '@suite-native/message-system';
-import { exhaustive } from '@trezor/type-utils';
 
 import { selectActiveTradingType } from '../../selectors/commonSelectors';
 
 export type TradingTypeAwareContextMessageProps = Omit<ContextMessageProps, 'context'>;
 
-const useTradingTypeAwareContext = (): ContextDomain | undefined => {
+export const TradingTypeAwareContextMessage = (props: TradingTypeAwareContextMessageProps) => {
     const activeType = useSelector(selectActiveTradingType);
 
-    switch (activeType) {
-        case 'buy':
-            return Context.tradingBuy;
-
-        case 'exchange':
-            return Context.tradingExchange;
-
-        case 'sell':
-            return Context.tradingSell;
-
-        case undefined:
-            return undefined;
-
-        default:
-            return exhaustive(activeType);
-    }
-};
-
-export const TradingTypeAwareContextMessage = (props: TradingTypeAwareContextMessageProps) => {
-    const context = useTradingTypeAwareContext();
-
-    if (!context) {
+    if (!activeType) {
         return null;
     }
 
-    return <ContextMessage context={context} {...props} />;
+    return <ContextMessage context={Context.getTrading(activeType)} {...props} />;
 };


### PR DESCRIPTION
## Description

This PR extends the existing message system context banners to the remaining parts of the application:

- accounts (parameters: network type + account type)
- dashboard
- settings (all tabs)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18848

## Screenshots:

<img width="1442" alt="image" src="https://github.com/user-attachments/assets/bfccab98-a5ce-410f-a37f-0b422cc81332" />

<img width="1437" alt="Screenshot 2025-06-11 at 10 26 13" src="https://github.com/user-attachments/assets/9f5ce97a-98e2-4cca-898e-ab5008bef72e" />

<img width="1441" alt="Screenshot 2025-06-11 at 10 26 39" src="https://github.com/user-attachments/assets/8700bd66-f221-4cb0-b63c-0374a03aaeb3" />

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/message-system-context-integration&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/message-system-context-integration&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/message-system-context-integration&lookback=7)