### PR TITLE
fix(suite): walletconnect reject proposal

### DIFF
--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -311,19 +311,23 @@ export const sessionProposalRejectThunk = createThunk<
     {
         eventId: number;
     }
->(`${WALLETCONNECT_MODULE}/sessionProposalRejectThunk`, async ({ eventId }) => {
-    await walletKit.rejectSession({
-        id: eventId,
-        reason: getSdkError('USER_REJECTED'),
-    });
-    /* const pendingProposal = selectPendingProposal(getState());
-    analytics.report({
-        type: EventType.WalletConnectProposalRejected,
-        payload: {
-            origin: pendingProposal?.origin,
-        },
-    });*/
-});
+>(
+    `${WALLETCONNECT_MODULE}/sessionProposalRejectThunk`,
+    async ({ eventId }, { getState, dispatch }) => {
+        await walletKit.rejectSession({
+            id: eventId,
+            reason: getSdkError('USER_REJECTED'),
+        });
+        const pendingProposal = selectPendingProposal(getState());
+        dispatch(walletConnectActions.clearSessionProposal());
+        analytics.report({
+            type: EventType.WalletConnectProposalRejected,
+            payload: {
+                origin: pendingProposal?.origin,
+            },
+        });
+    },
+);
 
 export const walletConnectInitThunk = createThunk(
     `${WALLETCONNECT_MODULE}/walletConnectInitThunk`,


### PR DESCRIPTION
## Description

Minor fix to WalletConnect `sessionProposalRejectThunk`

- Re-enable analytics that were previously commented out
- Dispatch `clearSessionProposal`

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/walletconnect-reject-proposal&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/walletconnect-reject-proposal&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/walletconnect-reject-proposal&lookback=7)