### PR TITLE
test(connect): remove 1ms flaky override test

### DIFF
--- a/packages/connect/e2e/tests/device/override.test.ts
+++ b/packages/connect/e2e/tests/device/override.test.ts
@@ -16,7 +16,10 @@ describe('TrezorConnect override param', () => {
         TrezorConnect.dispose();
     });
 
-    [1, 10, 100, 300, 500, 1000, 1500].forEach(delay => {
+    [
+        // 1, this is flaky and only @marekrjpolak has the power to solve it
+        10, 100, 300, 500, 1000, 1500,
+    ].forEach(delay => {
         it(`override previous call after ${delay}ms`, async () => {
             TrezorConnect.removeAllListeners();
 


### PR DESCRIPTION
lets turn it off now. It is flaky but unlikely to happen in the wild at the same time..

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=connect-flaky-test-afuera&lookback=7)