### PR TITLE
chore(trading): prepare slip24

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedProceedModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedProceedModal.tsx
@@ -1,4 +1,4 @@
-import { tradingBuyActions } from '@suite-common/trading';
+import { tradingActions } from '@suite-common/trading';
 
 import { Dispatch } from 'src/types/suite';
 
@@ -10,7 +10,11 @@ interface ConfirmUnverifiedProceedModalProps {
 
 export const ConfirmUnverifiedProceedModal = ({ value }: ConfirmUnverifiedProceedModalProps) => {
     const proceedWithUnverifiedAddress = () => (dispatch: Dispatch) => {
-        dispatch(tradingBuyActions.verifyAddress(value));
+        dispatch(
+            tradingActions.setVerifiedAddress({
+                address: value,
+            }),
+        );
     };
 
     return (

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -16,6 +16,7 @@ import {
     getTradingQuotesByPaymentMethod,
     selectTradingBuy,
     selectTradingPaymentMethods,
+    selectTradingVerifiedAddress,
     tradingBuyActions,
     tradingThunks,
 } from '@suite-common/trading';
@@ -57,7 +58,6 @@ export const useTradingBuyForm = ({
     const isNotFormPage = pageType !== 'form';
     const dispatch = useDispatch();
     const {
-        addressVerified,
         buyInfo,
         isFromRedirect,
         quotes,
@@ -66,6 +66,7 @@ export const useTradingBuyForm = ({
         amountLimits,
         isLoading,
     } = useSelector(selectTradingBuy);
+    const verifiedAddress = useSelector(selectTradingVerifiedAddress);
     const paymentMethods = useSelector(selectTradingPaymentMethods);
     const isTradingTermsDismissed = useSelector(state =>
         selectIsTradingTermsDismissed(state, type),
@@ -322,7 +323,6 @@ export const useTradingBuyForm = ({
                     account,
                     address,
                     path,
-                    tradingAction: tradingBuyActions.verifyAddress.type,
                 }),
             );
         };
@@ -467,7 +467,7 @@ export const useTradingBuyForm = ({
         cryptoInputValue: values.cryptoInput,
         formState,
         device,
-        addressVerified,
+        verifiedAddress,
         timer,
         quotes: quotesByPaymentMethod,
         quotesRequest,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -20,10 +20,11 @@ import {
     selectTradingExchange,
     selectTradingExchangeInfo,
     selectTradingTrades,
+    selectTradingVerifiedAddress,
+    tradingExchangeActions,
     tradingThunks,
     useTradingInfo,
 } from '@suite-common/trading';
-import { tradingExchangeActions } from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';
 import { selectAccountByKey } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
@@ -78,10 +79,10 @@ export const useTradingExchangeForm = ({
         transactionId,
         tradingAccountKey,
         selectedQuote,
-        addressVerified,
         amountLimits,
         isLoading,
     } = useSelector(selectTradingExchange);
+    const verifiedAddress = useSelector(selectTradingVerifiedAddress);
     const exchangeInfo = useSelector(selectTradingExchangeInfo);
     const { selectedFee, composed } = useSelector(selectTradingComposedTransactionInfo);
 
@@ -529,7 +530,6 @@ export const useTradingExchangeForm = ({
                     account,
                     address,
                     path,
-                    tradingAction: tradingExchangeActions.verifyAddress.type,
                 }),
             );
         };
@@ -670,7 +670,7 @@ export const useTradingExchangeForm = ({
         network,
         receiveAccount,
         selectedQuote,
-        addressVerified,
+        verifiedAddress,
         shouldSendInSats,
         trade,
         setReceiveAccount,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -445,14 +445,12 @@ export const useTradingSellForm = ({
             formState,
             precomposedTransaction,
             selectedAccount,
-            paymentRequests,
         }: TradingSignAndPushSendFormTransactionProps) =>
             await dispatch(
                 signAndPushSendFormTransactionThunk({
                     formState,
                     precomposedTransaction,
                     selectedAccount,
-                    paymentRequests,
                 }),
             ).unwrap();
 

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -257,8 +257,8 @@ export const useTradingSellForm = ({
         };
     };
 
-    const doSellTrade = async (quote: SellFiatTrade) => {
-        const commonFunctions = await getCommonFunctions(quote);
+    const doSellTrade = async (trade: SellFiatTrade) => {
+        const commonFunctions = await getCommonFunctions(trade);
 
         if (!commonFunctions) return;
 
@@ -267,7 +267,7 @@ export const useTradingSellForm = ({
         await dispatch(
             sellThunks.handleTradeThunk({
                 account,
-                quote,
+                trade,
                 returnUrl,
                 processResponseData,
             }),
@@ -445,12 +445,14 @@ export const useTradingSellForm = ({
             formState,
             precomposedTransaction,
             selectedAccount,
+            paymentRequests,
         }: TradingSignAndPushSendFormTransactionProps) =>
             await dispatch(
                 signAndPushSendFormTransactionThunk({
                     formState,
                     precomposedTransaction,
                     selectedAccount,
+                    paymentRequests,
                 }),
             ).unwrap();
 

--- a/packages/suite/src/middlewares/wallet/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.ts
@@ -2,7 +2,7 @@ import { isAnyOf } from '@reduxjs/toolkit';
 import type { MiddlewareAPI } from 'redux';
 
 import { getTxsPerPage } from '@suite-common/suite-utils';
-import { tradingBuyActions } from '@suite-common/trading';
+import { tradingActions } from '@suite-common/trading';
 import {
     WALLET_SETTINGS,
     accountsActions,
@@ -100,7 +100,7 @@ const walletMiddleware =
             api.dispatch(accountsActions.disposeAccount());
             api.dispatch(sendFormActions.dispose());
             api.dispatch(receiveActions.dispose());
-            api.dispatch(tradingBuyActions.dispose());
+            api.dispatch(tradingActions.setVerifiedAddress(undefined));
             api.dispatch(stakeActions.dispose());
         }
 

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -30,6 +30,7 @@ import type {
     TradingTransactionExchange,
     TradingTransactionSell,
     TradingType,
+    TradingVerifiedAddress,
 } from '@suite-common/trading';
 import { Network } from '@suite-common/wallet-config';
 import { AccountsState } from '@suite-common/wallet-core';
@@ -124,7 +125,7 @@ export interface TradingBuyFormContextProps
     quotes: BuyTrade[];
     selectedQuote: BuyTrade | undefined;
     trade?: TradingTransactionBuy;
-    addressVerified: string | undefined;
+    verifiedAddress: TradingVerifiedAddress;
     // form - additional helpers for form
     form: {
         state: TradingFormStateProps;
@@ -198,7 +199,7 @@ export interface TradingExchangeFormContextProps
     dexQuotes: ExchangeTrade[];
     quotesRequest: ExchangeTradeQuoteRequest | undefined;
     receiveAccount?: Account;
-    addressVerified: string | undefined;
+    verifiedAddress: TradingVerifiedAddress;
     shouldSendInSats: boolean | undefined;
     setReceiveAccount: (account?: Account) => void;
     setAmountLimits: (limits?: CryptoAmountLimitProps) => void;

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerify.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerify.tsx
@@ -5,7 +5,7 @@ import { CryptoId } from 'invity-api';
 import {
     TradingTradeBuyExchangeType,
     cryptoIdToNetwork,
-    tradingBuyActions,
+    tradingActions,
     tradingExchangeActions,
     useTradingInfo,
 } from '@suite-common/trading';
@@ -50,7 +50,7 @@ export const TradingVerify = ({ tradingVerifyAccount, cryptoId }: TradingVerifyP
         },
         device,
         verifyAddress,
-        addressVerified,
+        verifiedAddress,
         confirmTrade,
     } = context;
     const exchangeQuote = isTradingExchangeContext(context) ? context.selectedQuote : null;
@@ -112,10 +112,9 @@ export const TradingVerify = ({ tradingVerifyAccount, cryptoId }: TradingVerifyP
         },
     });
 
-    // close modals and reset addressVerified on device connection change
+    // close modals and reset verifiedAddress on device connection change
     useEffect(() => {
-        dispatch(tradingBuyActions.verifyAddress(undefined));
-        dispatch(tradingExchangeActions.verifyAddress(undefined));
+        dispatch(tradingActions.setVerifiedAddress(undefined));
         dispatch(modalActions.onCancel());
     }, [device?.connected, dispatch]);
 
@@ -244,14 +243,16 @@ export const TradingVerify = ({ tradingVerifyAccount, cryptoId }: TradingVerifyP
 
                     {device?.connected &&
                         device.available &&
-                        addressVerified &&
-                        addressVerified === address && <ConfirmedOnTrezor device={device} />}
+                        verifiedAddress &&
+                        verifiedAddress.address === address && (
+                            <ConfirmedOnTrezor device={device} />
+                        )}
                 </Column>
             )}
             {selectedAccountOption && (
                 <Column>
                     <Divider margin={{ top: spacings.xs, bottom: spacings.lg }} />
-                    {(!addressVerified || addressVerified !== address) &&
+                    {(!verifiedAddress || verifiedAddress.address !== address) &&
                         selectedAccountOption.account && (
                             <Button
                                 data-testid="@trading/offer/confirm-on-trezor-button"
@@ -280,7 +281,7 @@ export const TradingVerify = ({ tradingVerifyAccount, cryptoId }: TradingVerifyP
                                 />
                             </Button>
                         )}
-                    {((addressVerified && addressVerified === address) ||
+                    {((verifiedAddress && verifiedAddress.address === address) ||
                         selectedAccountOption?.type === 'NON_SUITE') && (
                         <Button
                             data-testid="@trading/offer/continue-transaction-button"

--- a/suite-common/trading/src/reducers/__fixtures__/buyTradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/buyTradingReducer.ts
@@ -137,35 +137,6 @@ export const buyTradingFixtures = [
         },
     },
     {
-        description: 'should save verify address',
-        initialState: buyInitialState,
-        actions: [
-            {
-                type: tradingBuyActions.verifyAddress.type,
-                payload: '1abcdef',
-            },
-        ],
-        result: {
-            ...buyInitialState,
-            addressVerified: '1abcdef',
-        },
-    },
-    {
-        description: 'should dispose verified address',
-        initialState: {
-            ...buyInitialState,
-            addressVerified: '1abcdef',
-        },
-        actions: [
-            {
-                type: tradingBuyActions.dispose.type,
-            },
-        ],
-        result: {
-            ...buyInitialState,
-        },
-    },
-    {
         description: 'should save selected quote',
         initialState: buyInitialState,
         actions: [

--- a/suite-common/trading/src/reducers/__fixtures__/exchangeTradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/exchangeTradingReducer.ts
@@ -141,35 +141,6 @@ export const exchangeTradingFixtures = [
         },
     },
     {
-        description: 'should save verify address',
-        initialState: exchangeInitialState,
-        actions: [
-            {
-                type: tradingExchangeActions.verifyAddress.type,
-                payload: '1abcdef',
-            },
-        ],
-        result: {
-            ...exchangeInitialState,
-            addressVerified: '1abcdef',
-        },
-    },
-    {
-        description: 'should dispose verified address',
-        initialState: {
-            ...exchangeInitialState,
-            addressVerified: '1abcdef',
-        },
-        actions: [
-            {
-                type: tradingExchangeActions.dispose.type,
-            },
-        ],
-        result: {
-            ...exchangeInitialState,
-        },
-    },
-    {
         description: 'should set trading account key',
         initialState: exchangeInitialState,
         actions: [

--- a/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
@@ -89,6 +89,7 @@ const composedTransactionInfo: TradingComposedTransactionInfo = {
         feePerByte: '10',
         feeLimit: '100',
         fee: '1000',
+        outputs: [],
     },
 };
 

--- a/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
@@ -393,4 +393,42 @@ export const tradingFixtures = [
             },
         },
     },
+    {
+        description: 'should save verify address',
+        initialState,
+        actions: [
+            {
+                type: tradingActions.setVerifiedAddress.type,
+                payload: {
+                    address: '1abcdef',
+                    mac: 'mac123',
+                },
+            },
+        ],
+        result: {
+            ...initialState,
+            verifiedAddress: {
+                address: '1abcdef',
+                mac: 'mac123',
+            },
+        },
+    },
+    {
+        description: 'should dispose verified address',
+        initialState: {
+            ...initialState,
+            verifiedAddress: {
+                address: '1abcdef',
+                mac: 'mac123',
+            },
+        },
+        actions: [
+            {
+                type: tradingActions.setVerifiedAddress.type,
+            },
+        ],
+        result: {
+            ...initialState,
+        },
+    },
 ];

--- a/suite-common/trading/src/reducers/buyReducer.ts
+++ b/suite-common/trading/src/reducers/buyReducer.ts
@@ -25,7 +25,6 @@ export interface TradingBuyState {
     quotesRequest?: BuyTradeQuoteRequest;
     quotes: BuyTrade[];
     selectedQuote: BuyTrade | undefined;
-    addressVerified: string | undefined;
     tradingAccountKey?: AccountKey;
     isLoading: boolean;
     amountLimits: TradingAmountLimitProps | undefined;
@@ -40,7 +39,6 @@ export const buyInitialState: TradingBuyState = {
     quotesRequest: undefined,
     selectedQuote: undefined,
     quotes: [],
-    addressVerified: undefined,
     tradingAccountKey: undefined,
     isLoading: false,
     amountLimits: undefined,
@@ -70,12 +68,6 @@ const tradingBuySlice = createSlice({
         },
         clearQuotes(state) {
             state.quotes = [];
-        },
-        verifyAddress(state, action: PayloadAction<string | undefined>) {
-            state.addressVerified = action.payload;
-        },
-        dispose(state) {
-            state.addressVerified = undefined;
         },
         setIsLoading(state, action: PayloadAction<boolean>) {
             state.isLoading = action.payload;

--- a/suite-common/trading/src/reducers/exchangeReducer.ts
+++ b/suite-common/trading/src/reducers/exchangeReducer.ts
@@ -21,7 +21,6 @@ export interface TradingExchangeState {
     exchangeInfo?: ExchangeInfo;
     quotesRequest?: ExchangeTradeQuoteRequest;
     quotes: ExchangeTrade[];
-    addressVerified: string | undefined;
     // internal selected account key in trading section
     tradingAccountKey?: AccountKey;
     receiveAccountKey?: AccountKey;
@@ -39,7 +38,6 @@ export const exchangeInitialState: TradingExchangeState = {
     transactionId: undefined,
     quotesRequest: undefined,
     quotes: [],
-    addressVerified: undefined,
     tradingAccountKey: undefined,
     receiveAccountKey: undefined,
     selectedQuote: undefined,
@@ -67,12 +65,6 @@ const tradingExchangeSlice = createSlice({
         },
         clearQuotes(state) {
             state.quotes = [];
-        },
-        verifyAddress(state, action: PayloadAction<string | undefined>) {
-            state.addressVerified = action.payload;
-        },
-        dispose(state) {
-            state.addressVerified = undefined;
         },
         setTradingAccountKey(state, action: PayloadAction<AccountKey | undefined>) {
             state.tradingAccountKey = action.payload;

--- a/suite-common/trading/src/reducers/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/tradingReducer.ts
@@ -3,7 +3,7 @@ import { Coins, CryptoId, InfoResponse, Platforms } from 'invity-api';
 
 import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
 import { AccountKey, PrecomposedTransactionFinal } from '@suite-common/wallet-types';
-import { FeeLevel } from '@trezor/connect';
+import { CardanoOutput, FeeLevel, PROTO } from '@trezor/connect';
 
 import { TradingPaymentMethodListProps, TradingTransaction, TradingType } from '../types';
 import { TradingBuyState, buyInitialState, tradingBuyReducer } from './buyReducer';
@@ -16,17 +16,22 @@ import {
 } from './exchangeReducer';
 import { TradingSellState, sellInitialState, tradingSellReducer } from './sellReducer';
 
+type TradingComposedTransactionInfoOutputs = {
+    outputs?: PROTO.TxOutputType[] | CardanoOutput[];
+};
+
 export interface TradingComposedTransactionInfo {
     composed?: Pick<
         PrecomposedTransactionFinal,
-        | 'feePerByte'
-        | 'estimatedFeeLimit'
-        | 'feeLimit'
-        | 'token'
         | 'fee'
+        | 'feePerByte'
+        | 'feeLimit'
+        | 'estimatedFeeLimit'
         | 'maxFeePerGas'
         | 'maxPriorityFeePerGas'
-    >;
+        | 'token'
+    > &
+        TradingComposedTransactionInfoOutputs;
     selectedFee?: FeeLevel['label'];
 }
 

--- a/suite-common/trading/src/reducers/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/tradingReducer.ts
@@ -5,7 +5,12 @@ import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
 import { AccountKey, PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { CardanoOutput, FeeLevel, PROTO } from '@trezor/connect';
 
-import { TradingPaymentMethodListProps, TradingTransaction, TradingType } from '../types';
+import {
+    TradingPaymentMethodListProps,
+    TradingTransaction,
+    TradingType,
+    TradingVerifiedAddress,
+} from '../types';
 import { TradingBuyState, buyInitialState, tradingBuyReducer } from './buyReducer';
 import { TRADING_PREFIX } from '../constants';
 import { buyThunks, exchangeThunks, sellThunks } from '../thunks';
@@ -59,6 +64,7 @@ export interface TradingState {
     lastLoadedTimestamp: number;
     activeSection: TradingType;
     prefilledFromAccount: TradingPreffiledFromAccount;
+    verifiedAddress: TradingVerifiedAddress;
 }
 
 export const initialState: TradingState = {
@@ -81,6 +87,7 @@ export const initialState: TradingState = {
         cryptoId: undefined,
         descriptor: undefined,
     },
+    verifiedAddress: undefined,
 };
 
 type StorageActionPayload = {
@@ -134,6 +141,9 @@ export const tradingSlice = createSliceWithExtraDeps({
         ) {
             state.prefilledFromAccount.cryptoId = action.payload.cryptoId;
             state.prefilledFromAccount.descriptor = action.payload.descriptor;
+        },
+        setVerifiedAddress(state, action: PayloadAction<TradingVerifiedAddress>) {
+            state.verifiedAddress = action.payload;
         },
     },
     extraReducers: (builder, extra) => {

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -581,3 +581,12 @@ export const selectTradingSupportedSymbols = createMemoizedSelector(
         }
     },
 );
+
+export const selectTradingExchangeTransactionId = (state: TradingRootState) =>
+    state.wallet.tradingNew.exchange.transactionId;
+
+export const selectTradingSellTransactionId = (state: TradingRootState) =>
+    state.wallet.tradingNew.sell.transactionId;
+
+export const selectTradingVerifiedAddress = (state: TradingRootState) =>
+    state.wallet.tradingNew.verifiedAddress;

--- a/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
@@ -70,6 +70,7 @@ describe('recomposeAndSignTxThunk', () => {
             feeLimit: '1000',
             token: undefined,
             fee: '1000',
+            outputs: [],
         },
         selectedFee: 'normal' as const,
     };

--- a/suite-common/trading/src/thunks/common/__tests__/verifyAddressThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/verifyAddressThunk.test.ts
@@ -7,8 +7,6 @@ import { Account, AddressDisplayOptions } from '@suite-common/wallet-types';
 
 import { tradingThunks } from '../../';
 import { accounts } from '../../../reducers/__fixtures__/account';
-import { tradingBuyActions } from '../../../reducers/buyReducer';
-import { tradingExchangeActions } from '../../../reducers/exchangeReducer';
 import { initialState, prepareTradingReducer } from '../../../reducers/tradingReducer';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesMock);
@@ -32,55 +30,52 @@ describe('verifyAddressThunk', () => {
         jest.clearAllMocks();
     });
 
-    describe('should save verified address', () => {
-        it.each([
-            ['buy', tradingBuyActions.verifyAddress.type],
-            ['exchange', tradingExchangeActions.verifyAddress.type],
-        ])('when %s is active', async (type, tradingAction) => {
-            const store = configureMockStore({
-                extra: {},
-                reducer: combineReducers({
-                    wallet: combineReducers({
-                        tradingNew: tradingReducer,
-                    }),
-                    suite: mockedSuiteReducer(extraDependenciesMock),
+    it('should save verified address', async () => {
+        const store = configureMockStore({
+            extra: {},
+            reducer: combineReducers({
+                wallet: combineReducers({
+                    tradingNew: tradingReducer,
                 }),
-                preloadedState: {
-                    wallet: {
-                        tradingNew: initialState,
-                    },
+                suite: mockedSuiteReducer(extraDependenciesMock),
+            }),
+            preloadedState: {
+                wallet: {
+                    tradingNew: initialState,
                 },
-            });
-
-            const account = accounts[0];
-            const addressData = account.addresses?.unused[0];
-
-            (selectSelectedDevice as jest.Mock).mockImplementation(() => ({
-                connected: true,
-                available: true,
-                useEmptyPassphrase: true,
-            }));
-
-            (confirmAddressOnDeviceThunk as unknown as jest.Mock).mockImplementation(
-                createThunk('@suite/device/confirmAddressOnDeviceThunk', () => ({
-                    success: true,
-                })),
-            );
-
-            await store.dispatch(
-                tradingThunks.verifyAddressThunk({
-                    account,
-                    address: addressData?.address,
-                    path: addressData?.path,
-                    tradingAction,
-                }),
-            );
-
-            expect(store.getActions().length).toEqual(7);
-            expect(
-                store.getState().wallet.tradingNew[type as 'buy' | 'exchange'].addressVerified,
-            ).toEqual(addressData?.address);
+            },
         });
+
+        const account = accounts[0];
+        const addressData = account.addresses?.unused[0];
+        const verifiedAddress = {
+            address: addressData?.address,
+            mac: 'mockedMac',
+        };
+
+        (selectSelectedDevice as jest.Mock).mockImplementation(() => ({
+            connected: true,
+            available: true,
+            useEmptyPassphrase: true,
+        }));
+
+        (confirmAddressOnDeviceThunk as unknown as jest.Mock).mockImplementation(
+            createThunk('@suite/device/confirmAddressOnDeviceThunk', () => ({
+                success: true,
+                payload: verifiedAddress,
+            })),
+        );
+
+        await store.dispatch(
+            tradingThunks.verifyAddressThunk({
+                account,
+                address: addressData?.address,
+                path: addressData?.path,
+            }),
+        );
+
+        expect(store.getActions().length).toEqual(7);
+        expect(store.getState().wallet.tradingNew.verifiedAddress).toEqual(verifiedAddress);
     });
 
     it('should not update verified address device not found', async () => {
@@ -109,12 +104,11 @@ describe('verifyAddressThunk', () => {
                 account,
                 address: addressData?.address,
                 path: addressData?.path,
-                tradingAction: tradingBuyActions.verifyAddress.type,
             }),
         );
 
         expect(store.getActions().length).toEqual(2);
-        expect(store.getState().wallet.tradingNew.buy.addressVerified).toEqual(undefined);
+        expect(store.getState().wallet.tradingNew.verifiedAddress).toEqual(undefined);
     });
 
     it('should not update verified address when path or address are not defined', async () => {
@@ -152,12 +146,11 @@ describe('verifyAddressThunk', () => {
                 account,
                 address: addressData,
                 path: addressData,
-                tradingAction: tradingBuyActions.verifyAddress.type,
             }),
         );
 
         expect(store.getActions().length).toEqual(2);
-        expect(store.getState().wallet.tradingNew.buy.addressVerified).toEqual(undefined);
+        expect(store.getState().wallet.tradingNew.verifiedAddress).toEqual(undefined);
     });
 
     it('should not update verified address, but trigger toast when device is not available', async () => {
@@ -190,7 +183,6 @@ describe('verifyAddressThunk', () => {
                 account,
                 address: addressData?.address,
                 path: addressData?.path,
-                tradingAction: tradingBuyActions.verifyAddress.type,
             }),
         );
 
@@ -205,7 +197,7 @@ describe('verifyAddressThunk', () => {
                 value: addressData?.address,
             },
         });
-        expect(store.getState().wallet.tradingNew.buy.addressVerified).toEqual(undefined);
+        expect(store.getState().wallet.tradingNew.verifiedAddress).toEqual(undefined);
     });
 
     it('should not update verified address, but trigger toast when device is not connected', async () => {
@@ -238,7 +230,6 @@ describe('verifyAddressThunk', () => {
                 account,
                 address: addressData?.address,
                 path: addressData?.path,
-                tradingAction: tradingBuyActions.verifyAddress.type,
             }),
         );
 
@@ -253,7 +244,7 @@ describe('verifyAddressThunk', () => {
                 value: addressData?.address,
             },
         });
-        expect(store.getState().wallet.tradingNew.buy.addressVerified).toEqual(undefined);
+        expect(store.getState().wallet.tradingNew.verifiedAddress).toEqual(undefined);
     });
 
     it('should not update verified address when a confirmation of address on device is not successful (no permission)', async () => {
@@ -295,11 +286,10 @@ describe('verifyAddressThunk', () => {
                 account,
                 address: addressData?.address,
                 path: addressData?.path,
-                tradingAction: tradingBuyActions.verifyAddress.type,
             }),
         );
 
-        expect(store.getState().wallet.tradingNew.buy.addressVerified).toEqual(undefined);
+        expect(store.getState().wallet.tradingNew.verifiedAddress).toEqual(undefined);
     });
 
     it('should not update verified address when a confirmation of address on device is not successful', async () => {
@@ -343,7 +333,6 @@ describe('verifyAddressThunk', () => {
                 account,
                 address: addressData?.address,
                 path: addressData?.path,
-                tradingAction: tradingBuyActions.verifyAddress.type,
             }),
         );
 
@@ -355,6 +344,6 @@ describe('verifyAddressThunk', () => {
         expect(actionToast?.payload?.type).toEqual('verify-address-error');
         expect(actionToast?.payload?.error).toEqual(error);
 
-        expect(store.getState().wallet.tradingNew.buy.addressVerified).toEqual(undefined);
+        expect(store.getState().wallet.tradingNew.verifiedAddress).toEqual(undefined);
     });
 });

--- a/suite-common/trading/src/thunks/common/verifyAddressThunk.ts
+++ b/suite-common/trading/src/thunks/common/verifyAddressThunk.ts
@@ -7,41 +7,39 @@ import { TRADING_THUNK_PREFIX } from '../../constants';
 import { tradingBuyActions } from '../../reducers/buyReducer';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
 import { tradingActions } from '../../reducers/tradingReducer';
+import { selectTradingActiveSection } from '../../selectors/tradingSelectors';
 import { getUnusedAddressFromAccount } from '../../utils';
 
 export interface VerifyAddressThunk {
     account: Account;
     address: string | undefined;
     path: string | undefined;
-    tradingAction:
-        | typeof tradingBuyActions.verifyAddress.type
-        | typeof tradingExchangeActions.verifyAddress.type;
 }
 
 export const verifyAddressThunk = createThunk(
     `${TRADING_THUNK_PREFIX}/verifyAddress`,
-    async (
-        { account, address, path, tradingAction }: VerifyAddressThunk,
-        { dispatch, getState, extra },
-    ) => {
+    async ({ account, address, path }: VerifyAddressThunk, { dispatch, getState, extra }) => {
         const device = selectSelectedDevice(getState());
+        const activeSection = selectTradingActiveSection(getState());
+
         if (!device) return;
+
         const accountAddress = getUnusedAddressFromAccount(account);
         address = address ?? accountAddress.address;
         path = path ?? accountAddress.path;
+
         if (!path || !address) return;
 
         dispatch(tradingActions.setModalAccountKey(account.key));
 
-        if (tradingAction === tradingBuyActions.verifyAddress.type) {
+        if (activeSection === 'buy') {
             dispatch(tradingBuyActions.setTradingAccountKey(account.key));
         } else {
             dispatch(tradingExchangeActions.setReceiveAccountKey(account.key));
         }
 
         const addressDisplayType = extra.selectors.selectAddressDisplayType(getState());
-
-        const { useEmptyPassphrase, connected, available } = device;
+        const { connected, available } = device;
 
         // Show warning when device is not connected
         if (!connected || !available) {
@@ -55,22 +53,21 @@ export const verifyAddressThunk = createThunk(
             return;
         }
 
-        const params = {
-            device,
+        const params: Parameters<typeof confirmAddressOnDeviceThunk>[0] = {
             accountKey: account.key,
             addressPath: path,
-            useEmptyPassphrase,
-            coin: account.symbol,
             chunkify: addressDisplayType === AddressDisplayOptions.CHUNKED,
         };
 
         const response = await dispatch(confirmAddressOnDeviceThunk(params)).unwrap();
 
         if (response.success) {
-            dispatch({
-                type: tradingAction,
-                payload: address,
-            });
+            dispatch(
+                tradingActions.setVerifiedAddress({
+                    address: response.payload.address,
+                    mac: 'mac' in response.payload ? response.payload.mac : undefined,
+                }),
+            );
         } else {
             // special case: device no-backup permissions not granted
             if (response.payload.code === 'Method_PermissionsNotGranted') return;

--- a/suite-common/trading/src/thunks/sell/__tests__/handleSellTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/handleSellTradeThunk.test.ts
@@ -107,7 +107,7 @@ describe('handleSellTradeThunk', () => {
                 .dispatch(
                     handleSellTradeThunk({
                         account,
-                        quote: {
+                        trade: {
                             ...quote,
                             ...quoteData,
                         },
@@ -137,7 +137,7 @@ describe('handleSellTradeThunk', () => {
             .dispatch(
                 handleSellTradeThunk({
                     account,
-                    quote,
+                    trade: quote,
                     returnUrl,
                     processResponseData: mockProcessResponseData,
                 }),
@@ -170,7 +170,7 @@ describe('handleSellTradeThunk', () => {
             .dispatch(
                 handleSellTradeThunk({
                     account,
-                    quote,
+                    trade: quote,
                     returnUrl,
                     processResponseData: mockProcessResponseData,
                 }),
@@ -204,7 +204,7 @@ describe('handleSellTradeThunk', () => {
             .dispatch(
                 handleSellTradeThunk({
                     account,
-                    quote,
+                    trade: quote,
                     returnUrl,
                     processResponseData: mockProcessResponseData,
                 }),
@@ -235,7 +235,7 @@ describe('handleSellTradeThunk', () => {
             .dispatch(
                 handleSellTradeThunk({
                     account,
-                    quote,
+                    trade: quote,
                     returnUrl,
                     processResponseData: mockProcessResponseData,
                 }),
@@ -283,7 +283,7 @@ describe('handleSellTradeThunk', () => {
             .dispatch(
                 handleSellTradeThunk({
                     account,
-                    quote,
+                    trade: quote,
                     returnUrl,
                     processResponseData: mockProcessResponseData,
                 }),
@@ -341,7 +341,7 @@ describe('handleSellTradeThunk', () => {
             .dispatch(
                 handleSellTradeThunk({
                     account,
-                    quote: {
+                    trade: {
                         ...quote,
                         exchange: 'provider2',
                     },

--- a/suite-common/trading/src/thunks/sell/confirmSellTradeThunk.ts
+++ b/suite-common/trading/src/thunks/sell/confirmSellTradeThunk.ts
@@ -11,7 +11,7 @@ import { selectTradingSellSelectedQuote } from '../../selectors/tradingSelectors
 export type ConfirmSellTradeThunkProps = {
     bankAccount: BankAccount;
     triggerAnalyticsTradeConfirmation: () => void;
-} & Omit<HandleSellTradeThunkProps, 'quote'>;
+} & Omit<HandleSellTradeThunkProps, 'trade'>;
 
 export const confirmSellTradeThunk = createThunk(
     `${TRADING_SELL_THUNK_PREFIX}/confirmTrade`,
@@ -31,11 +31,11 @@ export const confirmSellTradeThunk = createThunk(
 
         triggerAnalyticsTradeConfirmation();
 
-        const quote = { ...selectedQuote, bankAccount };
+        const trade = { ...selectedQuote, bankAccount };
         const response = await dispatch(
             sellThunks.handleTradeThunk({
                 account,
-                quote,
+                trade,
                 returnUrl,
                 processResponseData,
             }),

--- a/suite-common/trading/src/thunks/sell/handleSellTradeThunk.ts
+++ b/suite-common/trading/src/thunks/sell/handleSellTradeThunk.ts
@@ -16,7 +16,7 @@ import { getUnusedAddressFromAccount } from '../../utils';
 
 export type HandleSellTradeThunkProps = {
     account: Account;
-    quote: SellFiatTrade;
+    trade: SellFiatTrade;
     returnUrl: string;
 
     processResponseData: (response: SellFiatTradeResponse) => void;
@@ -25,19 +25,19 @@ export type HandleSellTradeThunkProps = {
 export const handleSellTradeThunk = createThunk(
     `${TRADING_SELL_THUNK_PREFIX}/handleTrade`,
     async (
-        { account, quote, returnUrl, processResponseData }: HandleSellTradeThunkProps,
+        { account, trade, returnUrl, processResponseData }: HandleSellTradeThunkProps,
         { dispatch, getState, fulfillWithValue },
     ) => {
         const sellInfo = selectTradingSellInfo(getState());
         const quotesRequest = selectTradingSellQuotesRequest(getState());
         const provider =
-            sellInfo?.providerInfos && quote.exchange
-                ? sellInfo.providerInfos[quote.exchange]
+            sellInfo?.providerInfos && trade.exchange
+                ? sellInfo.providerInfos[trade.exchange]
                 : undefined;
         if (!quotesRequest || !provider) return;
 
         const response = await invityAPI.doSellTrade({
-            trade: { ...quote, refundAddress: getUnusedAddressFromAccount(account).address },
+            trade: { ...trade, refundAddress: getUnusedAddressFromAccount(account).address },
             returnUrl,
         });
 

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -275,3 +275,10 @@ export type HandleBuyRequestThunkProps = {
     timer: Timer;
     shouldSendInSats: boolean | undefined;
 };
+
+export type TradingVerifiedAddress =
+    | {
+          address: string;
+          mac?: string;
+      }
+    | undefined;

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -393,14 +393,17 @@ export const createImportedDeviceThunk = createThunk<
     },
 );
 
+type ConfirmAddressOnDeviceThunk = {
+    accountKey: AccountKey;
+    addressPath: string;
+    chunkify: boolean;
+    showOnTrezor?: boolean;
+};
+
 export const confirmAddressOnDeviceThunk = createThunk(
     `${DEVICE_MODULE_PREFIX}/confirmAddressOnDeviceThunk`,
     async (
-        {
-            accountKey,
-            addressPath,
-            chunkify,
-        }: { accountKey: AccountKey; addressPath: string; chunkify: boolean },
+        { accountKey, addressPath, chunkify, showOnTrezor = true }: ConfirmAddressOnDeviceThunk,
         { getState },
     ): Promise<ConnectResponse<Address | CardanoAddress>> => {
         const device = selectSelectedDevice(getState());
@@ -419,6 +422,7 @@ export const confirmAddressOnDeviceThunk = createThunk(
             useEmptyPassphrase: device.useEmptyPassphrase,
             coin: account.symbol,
             chunkify,
+            showOnTrezor,
         };
 
         let response;


### PR DESCRIPTION
## Description
- unified `verifiedAddress` and add saving `mac` property
- add `showOnTrezor` property into the `confirmAddress`
- small general cleaning

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19517


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/prepare-slip24&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/prepare-slip24&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/prepare-slip24&lookback=7)