### PR TITLE
chore: update packages to fix dependabot issues

### DIFF
--- a/packages/address-validator/package.json
+++ b/packages/address-validator/package.json
@@ -9,7 +9,7 @@
         "test:unit": "yarn g:jest -c ./jest.config.js"
     },
     "dependencies": {
-        "base-x": "^5.0.0",
+        "base-x": "^5.0.1",
         "bech32": "^2.0.0",
         "browserify-bignum": "^1.3.0-2",
         "cbor-js": "^0.1.0",

--- a/packages/suite-build/package.json
+++ b/packages/suite-build/package.json
@@ -55,7 +55,7 @@
         "@types/webpack-plugin-serve": "^1.4.6",
         "@vitejs/plugin-react": "^4.2.1",
         "react-refresh": "^0.17.0",
-        "vite": "^6.3.3",
+        "vite": "^6.3.5",
         "vite-plugin-wasm": "^3.4.1"
     }
 }

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -48,7 +48,7 @@
         "electron-localshortcut": "^3.2.1",
         "electron-store": "8.2.0",
         "electron-updater": "6.6.4",
-        "openpgp": "^6.1.0",
+        "openpgp": "^6.1.1",
         "systeminformation": "^5.25.11",
         "ws": "^8.18.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11894,7 +11894,7 @@ __metadata:
   resolution: "@trezor/address-validator@workspace:packages/address-validator"
   dependencies:
     "@trezor/eslint": "workspace:*"
-    base-x: "npm:^5.0.0"
+    base-x: "npm:^5.0.1"
     bech32: "npm:^2.0.0"
     browserify-bignum: "npm:^1.3.0-2"
     cbor-js: "npm:^0.1.0"
@@ -12760,7 +12760,7 @@ __metadata:
     stream-browserify: "npm:^3.0.0"
     style-loader: "npm:^4.0.0"
     terser-webpack-plugin: "npm:^5.3.14"
-    vite: "npm:^6.3.3"
+    vite: "npm:^6.3.5"
     vite-plugin-wasm: "npm:^3.4.1"
     vm-browserify: "npm:^1.1.2"
     webpack: "npm:5.99.9"
@@ -12861,7 +12861,7 @@ __metadata:
     glob: "npm:^11.0.2"
     jest-diff: "npm:^29.7.0"
     lodash: "npm:^4.17.21"
-    openpgp: "npm:^6.1.0"
+    openpgp: "npm:^6.1.1"
     systeminformation: "npm:^5.25.11"
     terser-webpack-plugin: "npm:^5.3.14"
     tsx: "npm:^4.19.3"
@@ -17113,10 +17113,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base-x@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "base-x@npm:5.0.0"
-  checksum: 10/fa82bc9a963f7a765a3287ba632661669fe553d06ee0d4d4e282640335bff30ec685e3c3b1714e265f697b234facd02a310f1e2465db88f4f1a448e6267fbc65
+"base-x@npm:^5.0.0, base-x@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "base-x@npm:5.0.1"
+  checksum: 10/6e4f847ef842e0a71c6b6020a6ec482a2a5e727f5a98534dbfd5d5a4e8afbc0d1bdf1fd57174b3f0455d107f10a932c3c7710bec07e2878f80178607f8f605c8
   languageName: node
   linkType: hard
 
@@ -33867,10 +33867,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openpgp@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "openpgp@npm:6.1.0"
-  checksum: 10/ee8a7f005defd7c312f9ff21ed90f03734ba5cf919952b65e84fec35266ebdf7727bc27819eb32bec77824115f16827eafa74f3ddcfd5ba09db5a6f28af3ab11
+"openpgp@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "openpgp@npm:6.1.1"
+  checksum: 10/1c575fe65b6fd2f03b81fe2ba44aff6961d7d57aa857a36e1e345fe9344e125cbb68d655b5cdec0e3118c5dfa5006e6bc5e67eafbb609dfd496436badc016241
   languageName: node
   linkType: hard
 
@@ -42696,9 +42696,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^6.3.3":
-  version: 6.3.3
-  resolution: "vite@npm:6.3.3"
+"vite@npm:^6.3.5":
+  version: 6.3.5
+  resolution: "vite@npm:6.3.5"
   dependencies:
     esbuild: "npm:^0.25.0"
     fdir: "npm:^6.4.4"
@@ -42747,7 +42747,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10/442e518d9da847db80bd19a9792d1d9a106a31d18f74bfd06574776932dd0907f7205b99e34d455ba505a7dd9e57a807354633b90acd46a11db849a15ae26ad4
+  checksum: 10/7bc3a1c5ef79413ad70daeeaf69b76cd1218d16aa18ed8ee08d74648ef17284f4a17c11f5cf42b573b6dc5e3d5f115110b67b1d23c2c699cfe404757764a634a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Only patch bumps

## Related Issue

Resolves:
https://github.com/trezor/trezor-suite/security/dependabot/338
https://github.com/trezor/trezor-suite/security/dependabot/337
Partially resolves (blocked by `bchaddrjs`):
https://github.com/trezor/trezor-suite/security/dependabot/336
https://github.com/trezor/trezor-suite/security/dependabot/335
Partially resolves (blocked by `webpack-plugin-serve`):
https://github.com/trezor/trezor-suite/security/dependabot/334
https://github.com/trezor/trezor-suite/security/dependabot/333


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/dependabot-issues-fix&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/dependabot-issues-fix&lookback=7)