### PR TITLE
Feat/transport thp modules

### DIFF
--- a/packages/protocol/src/protocol-thp/ThpState.ts
+++ b/packages/protocol/src/protocol-thp/ThpState.ts
@@ -81,6 +81,29 @@ export class ThpState {
         }
     }
 
+    sync(type: 'send' | 'recv', messageType: string) {
+        // check if syncBit should be updated
+        const updateSyncBit = !['ThpCreateChannelRequest', 'ThpCreateChannelResponse'].includes(
+            messageType,
+        );
+        if (updateSyncBit) {
+            this.updateSyncBit(type);
+        }
+
+        // check if nonce should be updated
+        const updateNonce =
+            updateSyncBit &&
+            ![
+                'ThpHandshakeInitRequest',
+                'ThpHandshakeInitResponse',
+                'ThpHandshakeCompletionRequest',
+                'ThpHandshakeCompletionResponse',
+            ].includes(messageType);
+        if (updateNonce) {
+            this.updateNonce(type);
+        }
+    }
+
     serialize(): ThpStateSerialized {
         return {
             properties: this._properties,
@@ -89,8 +112,8 @@ export class ThpState {
             recvBit: this.recvBit,
             sendNonce: this.sendNonce,
             recvNonce: this.recvNonce,
-            expectedResponses: this._expectedResponses,
-            credentials: this._pairingCredentials,
+            expectedResponses: this._expectedResponses.slice(0),
+            credentials: this._pairingCredentials.slice(0),
         };
     }
 

--- a/packages/protocol/src/protocol-thp/utils.ts
+++ b/packages/protocol/src/protocol-thp/utils.ts
@@ -1,9 +1,16 @@
 import type { ThpState } from './ThpState';
 import {
     THP_CONTINUATION_PACKET,
+    THP_CONTROL_BYTE_DECRYPTED,
+    THP_CONTROL_BYTE_ENCRYPTED,
     THP_CREATE_CHANNEL_REQUEST,
     THP_CREATE_CHANNEL_RESPONSE,
     THP_ERROR_HEADER_BYTE,
+    THP_HANDSHAKE_COMPLETION_REQUEST,
+    THP_HANDSHAKE_COMPLETION_RESPONSE,
+    THP_HANDSHAKE_INIT_REQUEST,
+    THP_HANDSHAKE_INIT_RESPONSE,
+    THP_READ_ACK_HEADER_BYTE,
 } from './constants';
 import type { ThpMessageSyncBit } from './messages';
 
@@ -69,9 +76,40 @@ export const getExpectedResponses = (bytes: Buffer) => {
     if (magic === THP_CREATE_CHANNEL_REQUEST) {
         return [THP_CREATE_CHANNEL_RESPONSE];
     }
+    if (magic === THP_HANDSHAKE_INIT_REQUEST) {
+        return [THP_HANDSHAKE_INIT_RESPONSE, THP_CONTINUATION_PACKET];
+    }
+    if (magic === THP_HANDSHAKE_COMPLETION_REQUEST) {
+        return [THP_HANDSHAKE_COMPLETION_RESPONSE, THP_CONTINUATION_PACKET];
+    }
+    if (magic === THP_CONTROL_BYTE_ENCRYPTED) {
+        return [THP_CONTROL_BYTE_ENCRYPTED, THP_CONTINUATION_PACKET];
+    }
+    if (magic === THP_CONTROL_BYTE_DECRYPTED) {
+        return [THP_CONTROL_BYTE_DECRYPTED, THP_CONTINUATION_PACKET];
+    }
 
     return [];
 };
+
+// get expected responses from ThpState (stored as numbers)
+// and join them with the channel to receive 3 bytes header
+export const getExpectedHeaders = (state: ThpState): Buffer[] =>
+    state.expectedResponses.map(resp => {
+        let magic;
+        switch (resp) {
+            case THP_CONTINUATION_PACKET:
+                magic = Buffer.from([resp]); // THP_CONTINUATION_PACKET is not masked with sequence bit
+                break;
+            case THP_READ_ACK_HEADER_BYTE:
+                magic = addAckBit(resp, state.sendBit);
+                break;
+            default:
+                magic = addSequenceBit(resp, state.recvBit);
+        }
+
+        return Buffer.concat([magic, state.channel]);
+    });
 
 export const isExpectedResponse = (bytes: Buffer, state: ThpState) => {
     if (bytes.length < 3) {

--- a/packages/protocol/src/protocol-v2/encode.ts
+++ b/packages/protocol/src/protocol-v2/encode.ts
@@ -1,5 +1,6 @@
 import * as ERRORS from '../errors';
 import { HEADER_SIZE, MESSAGE_LEN_SIZE, MESSAGE_TYPE } from './constants';
+import { THP_CONTINUATION_PACKET } from '../protocol-thp/constants';
 import { TransportProtocol } from '../types';
 
 const getChunkHeader = (data: Buffer) => {
@@ -9,7 +10,7 @@ const getChunkHeader = (data: Buffer) => {
     }
 
     const channel = data.subarray(1, HEADER_SIZE);
-    const header = Buffer.concat([Buffer.from([0x80]), channel]); // THP_CONTINUATION_PACKET
+    const header = Buffer.concat([Buffer.from([THP_CONTINUATION_PACKET]), channel]);
 
     return header;
 };

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -3,6 +3,7 @@ import { WebUSB, usb } from 'usb';
 import {
     TransportProtocol,
     bridge as protocolBridge,
+    thp as protocolThp,
     v1 as protocolV1,
     v2 as protocolV2,
 } from '@trezor/protocol';
@@ -11,11 +12,12 @@ import { UdpApi } from '@trezor/transport/src/api/udp';
 import { UsbApi } from '@trezor/transport/src/api/usb';
 import { SessionsBackground } from '@trezor/transport/src/sessions/background';
 import { SessionsClient } from '@trezor/transport/src/sessions/client';
+import { callThpMessage, receiveThpMessage, sendThpMessage } from '@trezor/transport/src/thp';
 import { AcquireInput, ReleaseInput } from '@trezor/transport/src/transports/abstract';
 import { BridgeProtocolMessage, PathInternal, Session } from '@trezor/transport/src/types';
 import { createProtocolMessage } from '@trezor/transport/src/utils/bridgeProtocolMessage';
 import { receive as receiveUtil } from '@trezor/transport/src/utils/receive';
-import { success, unknownError } from '@trezor/transport/src/utils/result';
+import { error, success, unknownError } from '@trezor/transport/src/utils/result';
 import { createChunks, sendChunks } from '@trezor/transport/src/utils/send';
 import { Log } from '@trezor/utils';
 
@@ -211,6 +213,7 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         data,
         protocol: protocolName,
         signal,
+        thpState,
     }: BridgeProtocolMessage & {
         session: Session;
         signal: AbortSignal;
@@ -230,6 +233,45 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
 
         return api.runInIsolation({ lock: { read: true, write: true }, path }, async () => {
             logger?.debug('core: call: writeUtil');
+
+            if (protocol.name === 'v2') {
+                if (!thpState) {
+                    return error({ error: 'ThpStateMissing' });
+                }
+
+                const state = new protocolThp.ThpState();
+                state.deserialize(thpState);
+
+                const bytes = Buffer.from(data, 'hex');
+                const [, chunkHeader] = protocol.getHeaders(bytes);
+                const chunks = createChunks(bytes, chunkHeader, api.chunkSize);
+
+                const apiWrite = (chunk: Buffer, attemptSignal?: AbortSignal) =>
+                    api.write(path, chunk, attemptSignal || signal);
+
+                const message = await callThpMessage({
+                    thpState: state,
+                    chunks,
+                    apiWrite,
+                    apiRead: attemptSignal => api.read(path, attemptSignal || signal),
+                    signal,
+                    logger,
+                });
+                if (!message.success) {
+                    return message;
+                }
+
+                return createProtocolMessageResponse(
+                    {
+                        success: true,
+                        payload: protocol
+                            .encode(message.payload.payload, message.payload)
+                            .toString('hex'),
+                    },
+                    protocol.name,
+                );
+            }
+
             const writeResult = await writeUtil({ path, data, signal, protocol });
             if (!writeResult.success) {
                 logger?.error(`core: call: writeUtil ${writeResult.error}`);
@@ -248,6 +290,7 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         data,
         protocol: protocolName,
         signal,
+        thpState,
     }: BridgeProtocolMessage & {
         session: Session;
         signal: AbortSignal;
@@ -261,6 +304,34 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         }
         const protocol = getProtocol(protocolName);
         const { path } = sessionsResult.payload;
+        if (protocol.name === 'v2') {
+            if (!thpState) {
+                return error({ error: 'ThpStateMissing' });
+            }
+
+            const state = new protocolThp.ThpState();
+            state.deserialize(thpState);
+
+            const bytes = Buffer.from(data, 'hex');
+            const [, chunkHeader] = protocol.getHeaders(bytes);
+            const chunks = createChunks(bytes, chunkHeader, api.chunkSize);
+
+            const writeResult = await sendThpMessage({
+                thpState: state,
+                chunks,
+                apiWrite: (chunk, attemptSignal) => api.write(path, chunk, attemptSignal || signal),
+                apiRead: attemptSignal => api.read(path, attemptSignal || signal),
+                signal,
+                logger,
+                skipAck: true,
+            });
+
+            if (!writeResult.success) {
+                return writeResult;
+            }
+
+            return createProtocolMessageResponse(writeResult, protocolName);
+        }
 
         const writeResult = await writeUtil({ path, data, signal, protocol });
 
@@ -271,6 +342,7 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         session,
         protocol: protocolName,
         signal,
+        thpState,
     }: BridgeProtocolMessage & {
         session: Session;
         signal: AbortSignal;
@@ -286,6 +358,38 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         const { path } = sessionsResult.payload;
 
         return api.runInIsolation({ lock: { read: true, write: false }, path }, async () => {
+            if (protocol.name === 'v2') {
+                if (!thpState) {
+                    return error({ error: 'ThpStateMissing' });
+                }
+
+                const state = new protocolThp.ThpState();
+                state.deserialize(thpState);
+
+                const message = await receiveThpMessage({
+                    thpState: state,
+                    apiWrite: (chunk, attemptSignal) =>
+                        api.write(path, chunk, attemptSignal || signal),
+                    apiRead: attemptSignal => api.read(path, attemptSignal || signal),
+                    signal,
+                    logger,
+                    skipAck: true,
+                });
+                if (!message.success) {
+                    return message;
+                }
+
+                return createProtocolMessageResponse(
+                    {
+                        success: true,
+                        payload: protocol
+                            .encode(message.payload.payload, message.payload)
+                            .toString('hex'),
+                    },
+                    protocolName,
+                );
+            }
+
             const readResult = await readUtil({ path, signal, protocol });
 
             return createProtocolMessageResponse(readResult, protocolName);

--- a/packages/transport/src/errors.ts
+++ b/packages/transport/src/errors.ts
@@ -94,3 +94,7 @@ export const ABORTED_BY_TIMEOUT = 'Aborted by timeout' as const;
  * missing udev rules on linux
  */
 export const LIBUSB_ERROR_ACCESS = 'LIBUSB_ERROR_ACCESS' as const;
+/**
+ * missing THP state
+ */
+export const THP_STATE_MISSING = 'ThpStateMissing' as const;

--- a/packages/transport/src/thp/call.ts
+++ b/packages/transport/src/thp/call.ts
@@ -1,0 +1,35 @@
+import { receiveThpMessage } from './receive';
+import { SendThpMessageProps, sendThpMessage } from './send';
+
+export const callThpMessage = async ({
+    thpState,
+    chunks,
+    apiWrite,
+    apiRead,
+    signal,
+    logger,
+}: SendThpMessageProps) => {
+    // send and wait for ThpAck
+    const sendResult = await sendThpMessage({
+        chunks,
+        thpState,
+        apiWrite,
+        apiRead,
+        signal,
+        logger,
+    });
+    if (!sendResult.success) {
+        return sendResult;
+    }
+
+    // read and send ThpAck
+    const receiveResult = await receiveThpMessage({
+        thpState,
+        apiWrite,
+        apiRead,
+        signal,
+        logger,
+    });
+
+    return receiveResult;
+};

--- a/packages/transport/src/thp/index.ts
+++ b/packages/transport/src/thp/index.ts
@@ -1,0 +1,3 @@
+export { receiveThpMessage, parseThpMessage } from './receive';
+export { sendThpMessage } from './send';
+export { callThpMessage } from './call';

--- a/packages/transport/src/thp/receive.ts
+++ b/packages/transport/src/thp/receive.ts
@@ -1,0 +1,82 @@
+// receive with ThpAck
+
+import { decodeMessage } from '@trezor/protobuf';
+import { thp as protocolThp, v2 as protocolV2 } from '@trezor/protocol';
+
+import type { AbstractApi } from '../api/abstract';
+import { Logger } from '../types';
+import { readWithExpectedHeaders } from '../utils/readWithExpectedHeaders';
+import { receive } from '../utils/receive';
+import { error } from '../utils/result';
+
+export type ReceiveThpMessageProps = {
+    apiWrite: (chunk: Buffer, signal?: AbortSignal) => ReturnType<AbstractApi['write']>;
+    apiRead: (signal?: AbortSignal) => ReturnType<AbstractApi['read']>;
+    thpState?: protocolThp.ThpState;
+    skipAck?: boolean;
+    signal?: AbortSignal;
+    logger?: Logger;
+};
+
+export const receiveThpMessage = async ({
+    thpState,
+    skipAck,
+    apiRead,
+    apiWrite,
+    signal,
+    logger,
+}: ReceiveThpMessageProps) => {
+    if (!thpState) {
+        return error({ error: 'ThpStateMissing' });
+    }
+
+    logger?.debug(`receiveThpMessage start ${thpState.expectedResponses}`);
+
+    try {
+        const apiReadWithExpectedHeaders = readWithExpectedHeaders(apiRead, { signal, logger });
+        const expectedHeaders = protocolThp.getExpectedHeaders(thpState);
+        const message = await receive(
+            () => apiReadWithExpectedHeaders(expectedHeaders),
+            protocolV2,
+        );
+        if (!message.success) {
+            return message;
+        }
+
+        const isAckExpected = protocolThp.isAckExpected(thpState.expectedResponses || []);
+        if (!skipAck && isAckExpected) {
+            const chunk = protocolThp.encodeAck(message.payload.header);
+
+            logger?.debug(`receiveThpMessage send ThpAck`);
+
+            const ackResult = await apiWrite(chunk, signal);
+            if (!ackResult.success) {
+                return ackResult;
+            }
+        }
+
+        logger?.debug(`receiveThpMessage done`);
+
+        return message;
+    } catch (err) {
+        logger?.error(`receiveThpMessage error ${err.message}`);
+
+        return error({ error: err.code, message: err.message });
+    }
+};
+
+export type ParseThpMessageProps = {
+    messages: Parameters<typeof decodeMessage>[0];
+    decoded: Extract<Awaited<ReturnType<typeof receive>>, { success: true }>['payload'];
+    thpState?: protocolThp.ThpState;
+};
+
+export const parseThpMessage = ({ decoded, messages, thpState }: ParseThpMessageProps) => {
+    const message = protocolThp.decode(
+        decoded,
+        (messageType, data) => decodeMessage(messages, messageType, data),
+        thpState,
+    );
+
+    return message;
+};

--- a/packages/transport/src/thp/send.ts
+++ b/packages/transport/src/thp/send.ts
@@ -1,0 +1,113 @@
+import { thp as protocolThp, v2 as protocolV2 } from '@trezor/protocol';
+import { scheduleAction } from '@trezor/utils';
+
+import type { ReceiveThpMessageProps } from './receive';
+import { readWithExpectedHeaders } from '../utils/readWithExpectedHeaders';
+import { error, success } from '../utils/result';
+import { sendChunks } from '../utils/send';
+
+export type SendThpMessageProps = Omit<ReceiveThpMessageProps, 'apiChunkSize'> & {
+    chunks: Buffer[];
+};
+
+const ATTEMPTS_LIMIT = 10;
+const THP_ACK_DEADLINE = 3000;
+
+export const sendThpMessage = async ({
+    thpState,
+    skipAck,
+    chunks,
+    apiWrite,
+    apiRead,
+    signal,
+    logger,
+}: SendThpMessageProps) => {
+    if (!thpState) {
+        return error({ error: 'ThpStateMissing' });
+    }
+
+    const expectedResponses = protocolThp.getExpectedResponses(chunks[0]);
+    const isAckExpected = protocolThp.isAckExpected(chunks[0]);
+    // ThpAck is not expected. just set expectedResponses and continue
+    if (skipAck || !isAckExpected || expectedResponses.length === 0) {
+        const sendResult = await sendChunks(chunks, apiWrite);
+        if (!sendResult.success) {
+            return sendResult;
+        }
+        thpState.setExpectedResponses(expectedResponses);
+
+        return sendResult;
+    }
+
+    // ThpAck is expected.
+    // set expectedResponses to ThpAck
+    thpState.setExpectedResponses([0x20]); // THP_READ_ACK_HEADER_BYTE
+
+    let attempt = 0;
+
+    const apiReadWithExpectedHeaders = readWithExpectedHeaders(apiRead, { signal });
+
+    // create sequence of scheduled actions controlled by one AbortSignal (from Transport call/send)
+    // 1. send message
+    // 2. try to read ThpAck/ThpError with deadline/timeout
+    // if ThpAck is not received try to send and read again
+    try {
+        const result = await scheduleAction(
+            async attemptSignal => {
+                logger?.debug(`sendThpMessage attempt ${attempt} start`);
+                const sendResult = await sendChunks(chunks, apiWrite);
+                logger?.debug(`sendThpMessage success: ${sendResult.success}`);
+                if (!sendResult.success) {
+                    return sendResult;
+                }
+                logger?.debug(`sendThpMessage read ThpAck`);
+
+                // read until ThpAck or ThpError
+                return scheduleAction(
+                    () => apiReadWithExpectedHeaders(protocolThp.getExpectedHeaders(thpState)),
+                    {
+                        signal: attemptSignal,
+                        deadline: Date.now() + THP_ACK_DEADLINE,
+                    },
+                );
+            },
+            {
+                signal,
+                attempts: ATTEMPTS_LIMIT,
+                attemptFailureHandler: error => {
+                    if (error.message !== 'Aborted by deadline') {
+                        logger?.error(`sendThpMessage error ${error.message}`);
+
+                        // break attempts on unexpected errors
+                        return error;
+                    }
+                    attempt++;
+                    logger?.debug(`sendThpMessage retransmission ${attempt} start`);
+                },
+            },
+        );
+
+        if (!result.success) {
+            return result;
+        }
+
+        // parse and check the result
+        const decodedResult = protocolThp.decodeSendAck(protocolV2.decode(result.payload));
+        // fail on ThpError
+        if (decodedResult.type === 'ThpError') {
+            const { code, message } = decodedResult.message;
+
+            return error({ error: code, message });
+        }
+
+        logger?.debug('sendThpMessage done');
+        // set expectedResponses as they will be used in receiveThpMessage
+        thpState.setExpectedResponses(expectedResponses);
+
+        return success(undefined);
+    } catch (err) {
+        logger?.error(`sendThpMessage error ${err.message}`);
+
+        return error({ error: err.code, message: err.message });
+    }
+};

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -70,7 +70,8 @@ export type ReadWriteError =
     | typeof ERRORS.WRONG_ENVIRONMENT
     | typeof ERRORS.DEVICE_NOT_FOUND
     | typeof ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE
-    | typeof ERRORS.INTERFACE_DATA_TRANSFER;
+    | typeof ERRORS.INTERFACE_DATA_TRANSFER
+    | typeof ERRORS.THP_STATE_MISSING;
 
 type TransportEvents = {
     [TRANSPORT.DEVICE_CONNECTED]: Descriptor;

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -11,6 +11,7 @@ import * as ERRORS from '../errors';
 import { SessionsBackground } from '../sessions/background';
 import { SessionsClient } from '../sessions/client';
 import { SessionsBackgroundInterface } from '../sessions/types';
+import { callThpMessage, parseThpMessage, receiveThpMessage, sendThpMessage } from '../thp';
 import { Session } from '../types';
 import { receiveAndParse } from '../utils/receive';
 import { buildMessage, createChunks, sendChunks } from '../utils/send';
@@ -205,7 +206,36 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 });
                 const [, chunkHeader] = protocol.getHeaders(bytes);
                 const chunks = createChunks(bytes, chunkHeader, this.api.chunkSize);
-                const apiWrite = (chunk: Buffer) => this.api.write(path, chunk, signal);
+                const apiWrite = (chunk: Buffer, attemptSignal?: AbortSignal) =>
+                    this.api.write(path, chunk, attemptSignal || signal);
+                const apiRead = (attemptSignal?: AbortSignal) =>
+                    this.api.read(path, attemptSignal || signal);
+
+                if (protocol.name === 'v2') {
+                    const callResult = await callThpMessage({
+                        thpState,
+                        chunks,
+                        apiWrite,
+                        apiRead,
+                        signal,
+                        logger: this.logger,
+                    });
+                    if (!callResult.success) {
+                        handleError(callResult.error);
+
+                        return callResult;
+                    }
+
+                    thpState?.sync('send', name);
+                    const message = parseThpMessage({
+                        messages: this.messages,
+                        decoded: callResult.payload,
+                        thpState,
+                    });
+                    thpState?.sync('recv', message.type);
+
+                    return this.success(message);
+                }
                 const sendResult = await sendChunks(chunks, apiWrite);
 
                 if (!sendResult.success) {
@@ -214,11 +244,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     return sendResult;
                 }
 
-                const readResult = await receiveAndParse(
-                    this.messages,
-                    () => this.api.read(path, signal),
-                    protocol,
-                );
+                const readResult = await receiveAndParse(this.messages, apiRead, protocol);
 
                 if (!readResult.success) {
                     handleError(readResult.error);
@@ -262,7 +288,20 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
                 const chunks = createChunks(bytes, chunkHeader, this.api.chunkSize);
                 const apiWrite = (chunk: Buffer) => this.api.write(path, chunk, signal);
-                const sendResult = await sendChunks(chunks, apiWrite);
+                let sendResult;
+                if (protocol.name === 'v2') {
+                    sendResult = await sendThpMessage({
+                        thpState,
+                        skipAck: true,
+                        chunks,
+                        apiWrite,
+                        apiRead: attemptSignal => this.api.read(path, attemptSignal || signal),
+                        signal,
+                        logger: this.logger,
+                    });
+                } else {
+                    sendResult = await sendChunks(chunks, apiWrite);
+                }
 
                 if (!sendResult.success) {
                     if (sendResult.error === ERRORS.DEVICE_DISCONNECTED_DURING_ACTION) {
@@ -292,13 +331,34 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 }
                 const { path } = getPathBySessionResponse.payload;
 
+                const apiRead = (attemptSignal?: AbortSignal) =>
+                    this.api.read(path, attemptSignal || signal);
+
                 const protocol = customProtocol || v1Protocol;
-                const message = await receiveAndParse(
-                    this.messages,
-                    () => this.api.read(path, signal),
-                    protocol,
-                    thpState,
-                );
+                if (protocol.name === 'v2') {
+                    const decoded = await receiveThpMessage({
+                        thpState,
+                        skipAck: true,
+                        apiWrite: (chunk, attemptSignal) =>
+                            this.api.write(path, chunk, attemptSignal || signal),
+                        apiRead,
+                        signal,
+                    });
+
+                    if (!decoded.success) {
+                        return decoded;
+                    }
+
+                    const message = parseThpMessage({
+                        messages: this.messages,
+                        decoded: decoded.payload,
+                        thpState,
+                    });
+
+                    return this.success(message);
+                }
+
+                const message = await receiveAndParse(this.messages, apiRead, protocol);
 
                 if (!message.success) {
                     console.log(message.error);

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -14,6 +14,7 @@ import {
 } from './abstract';
 import { TRANSPORT } from '../constants';
 import * as ERRORS from '../errors';
+import { parseThpMessage } from '../thp/receive';
 import {
     AnyError,
     AsyncResultWithTypedError,
@@ -242,20 +243,35 @@ export class BridgeTransport extends AbstractTransport {
                     protocol,
                     thpState,
                 });
+
                 const response = await this.post(`/call`, {
                     params: session,
                     body: this.getRequestBody(bytes, protocol, thpState),
                     signal,
                 });
+
                 if (!response.success) {
                     return response;
                 }
 
+                const respBytes = Buffer.from(response.payload.data, 'hex');
+                if (protocol.name === 'v2') {
+                    // see callThpMessage in @trezor/transport-bridge
+                    thpState?.sync('send', name);
+                    const message = parseThpMessage({
+                        decoded: protocol.decode(respBytes),
+                        messages: this.messages,
+                        thpState,
+                    });
+                    thpState?.sync('recv', message.type);
+
+                    return this.success(message);
+                }
+
                 return receiveAndParse(
                     this.messages,
-                    () => Promise.resolve(this.success(Buffer.from(response.payload.data, 'hex'))),
+                    () => Promise.resolve(this.success(respBytes)),
                     protocol,
-                    thpState,
                 );
             },
             { signal, timeout },
@@ -280,6 +296,7 @@ export class BridgeTransport extends AbstractTransport {
                     protocol,
                     thpState,
                 });
+                // see sendThpMessage in @trezor/transport-bridge
                 const response = await this.post('/post', {
                     params: session,
                     body: this.getRequestBody(bytes, protocol, thpState),
@@ -287,6 +304,9 @@ export class BridgeTransport extends AbstractTransport {
                 });
                 if (!response.success) {
                     return response;
+                }
+                if (protocol.name === 'v2') {
+                    thpState?.sync('send', name);
                 }
 
                 return this.success(undefined);
@@ -314,11 +334,23 @@ export class BridgeTransport extends AbstractTransport {
                     return response;
                 }
 
+                const respBytes = Buffer.from(response.payload.data, 'hex');
+                if (protocol.name === 'v2') {
+                    // see readThpMessage in @trezor/transport-bridge
+                    const message = parseThpMessage({
+                        decoded: protocol.decode(respBytes),
+                        messages: this.messages,
+                        thpState,
+                    });
+                    thpState?.sync('recv', message.type);
+
+                    return this.success(message);
+                }
+
                 return receiveAndParse(
                     this.messages,
-                    () => Promise.resolve(this.success(Buffer.from(response.payload.data, 'hex'))),
+                    () => Promise.resolve(this.success(respBytes)),
                     protocol,
-                    thpState,
                 );
             },
             { signal, timeout: undefined },

--- a/packages/transport/src/utils/readWithExpectedHeaders.ts
+++ b/packages/transport/src/utils/readWithExpectedHeaders.ts
@@ -1,0 +1,87 @@
+import { scheduleAction } from '@trezor/utils';
+
+import { success } from './result';
+import { AbstractApi } from '../api/abstract';
+import { Logger } from '../types';
+
+type Receiver = (attemptSignal?: AbortSignal) => ReturnType<AbstractApi['read']>;
+
+type Options = {
+    signal?: AbortSignal;
+    attempts?: number;
+    timeout?: number;
+    logger?: Logger;
+};
+
+const ATTEMPT_ERROR = 'Unexpected chunk';
+
+async function readAndAssert<T extends Receiver>(
+    receiver: T,
+    expectedHeaders?: Buffer[],
+    { signal, logger }: Options = {},
+): ReturnType<AbstractApi['read']> {
+    logger?.debug('readAndAssert start');
+    // try to read one packet
+    const chunk = await receiver(signal);
+    if (!chunk.success) {
+        return chunk;
+    }
+
+    // if there are no expectedHeaders are set then each chunk is expected
+    if (!expectedHeaders || expectedHeaders.length === 0) {
+        logger?.debug('readAndAssert skip');
+
+        return chunk;
+    }
+
+    const bytes = chunk.payload;
+    const expected = expectedHeaders.find(header => {
+        if (bytes.length < header.length) {
+            return false;
+        }
+
+        return bytes.subarray(0, header.length).compare(header) === 0 ? true : false;
+    });
+
+    if (expected) {
+        logger?.debug('readAndAssert done');
+
+        return success(chunk.payload);
+    }
+
+    logger?.warn(`readAndAssert unexpected header`);
+    // for detailed debugging purposes
+    // logger?.warn(
+    //     bytes.subarray(0, 3).toString('hex'),
+    //     'not match',
+    //     expectedHeaders.map(b => b.toString('hex')).join(','),
+    // );
+
+    // throw error to break scheduleAction attempt
+    // and handle it in scheduleAction attemptFailureHandler below
+    throw new Error(ATTEMPT_ERROR);
+}
+
+// AbstractApi['read'] wrapper
+// returns function: (expectedHeaders: Buffer[]) => ReturnType<AbstractApi['read']>
+// read until received chunk contains expected header and ignore other chunks
+export function readWithExpectedHeaders<T extends Receiver>(receiver: T, options: Options = {}) {
+    return (expectedHeaders?: Buffer[]) =>
+        scheduleAction(
+            attemptSignal =>
+                readAndAssert(receiver, expectedHeaders, { ...options, signal: attemptSignal }),
+            {
+                signal: options?.signal,
+                attempts: options?.attempts || Infinity,
+                timeout: options?.timeout,
+                attemptFailureHandler: error => {
+                    if (error.message !== ATTEMPT_ERROR) {
+                        options.logger?.debug(`readAndAssert attempt error ${error.message}`);
+
+                        // stop scheduleAction attempts on any other error
+                        return error;
+                    }
+                },
+            },
+        );
+}

--- a/packages/transport/src/utils/receive.ts
+++ b/packages/transport/src/utils/receive.ts
@@ -1,19 +1,18 @@
 import { decodeMessage } from '@trezor/protobuf';
-import { ThpState, TransportProtocol } from '@trezor/protocol';
+import { TransportProtocol } from '@trezor/protocol';
 
 import { success } from './result';
 import { AbstractApi } from '../api/abstract';
 
-export async function receive<T extends () => ReturnType<AbstractApi['read']>>(
-    receiver: T,
-    protocol: TransportProtocol,
-) {
+type Receiver = () => ReturnType<AbstractApi['read']>;
+
+export async function receive<T extends Receiver>(receiver: T, protocol: TransportProtocol) {
     const readResult = await receiver();
     if (!readResult.success) {
         return readResult;
     }
     const data = readResult.payload;
-    const { length, messageType, payload } = protocol.decode(data);
+    const { length, messageType, payload, header } = protocol.decode(data);
     const result = Buffer.alloc(length);
     const [, chunkHeader] = protocol.getHeaders(Buffer.from(data));
 
@@ -27,19 +26,22 @@ export async function receive<T extends () => ReturnType<AbstractApi['read']>>(
             return readResult;
         }
         const data = readResult.payload;
+        const dataChunkHeader = data.subarray(0, chunkHeader.length);
+        if (dataChunkHeader.compare(chunkHeader) !== 0) {
+            throw new Error(`Unexpected chunkHeader ${dataChunkHeader.toString('hex')}`);
+        }
 
         Buffer.from(data).copy(result, offset, chunkHeader.byteLength);
         offset += data.byteLength - chunkHeader.byteLength;
     }
 
-    return success({ messageType, payload: result, length });
+    return success({ messageType, payload: result, header, length });
 }
 
-export async function receiveAndParse<T extends () => ReturnType<AbstractApi['read']>>(
+export async function receiveAndParse<T extends Receiver>(
     messages: Parameters<typeof decodeMessage>[0],
     receiver: T,
     protocol: TransportProtocol,
-    _thpState?: ThpState,
 ) {
     const readResult = await receive(receiver, protocol);
     if (!readResult.success) return readResult;

--- a/packages/transport/src/utils/send.ts
+++ b/packages/transport/src/utils/send.ts
@@ -1,5 +1,5 @@
 import { encodeMessage } from '@trezor/protobuf';
-import { ThpState, TransportProtocol } from '@trezor/protocol';
+import { ThpState, TransportProtocol, thp as protocolThp } from '@trezor/protocol';
 
 import { AsyncResultWithTypedError } from '../types';
 
@@ -34,10 +34,25 @@ interface BuildMessageProps {
     thpState?: ThpState;
 }
 
-export const buildMessage = ({ messages, name, data, protocol }: BuildMessageProps) => {
-    const { messageType, message } = encodeMessage(messages, name, data);
+// common protobufEncoder for protocol v1 and v2 (THP)
+export const buildMessage = ({ messages, name, data, protocol, thpState }: BuildMessageProps) => {
+    const protobufEncoder = (messageName: string, data: Record<string, unknown>) => {
+        const { messageType, message } = encodeMessage(messages, messageName, data);
 
-    return protocol.encode(message, { messageType });
+        return protocol.encode(message, { messageType });
+    };
+
+    if (protocol.name === 'v2') {
+        // THP encoding requires more data than regular protocol.encode
+        return protocolThp.encode({
+            messageName: name,
+            data,
+            thpState,
+            protobufEncoder: (messageName, data) => encodeMessage(messages, messageName, data),
+        });
+    }
+
+    return protobufEncoder(name, data);
 };
 
 export const sendChunks = async <T, E>(

--- a/packages/transport/tests/readWithExpectedHeaders.test.ts
+++ b/packages/transport/tests/readWithExpectedHeaders.test.ts
@@ -1,0 +1,133 @@
+import { thp as protocolThp, v1 as protocolV1 } from '@trezor/protocol';
+
+import { readWithExpectedHeaders } from '../src/utils/readWithExpectedHeaders';
+
+describe('readWithExpectedHeaders', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    // common AbstractApi['read'] mock
+    const SUCCESS = Buffer.from('3f23230002000000060a046d656f77', 'hex'); // proto Success
+    const apiRead = jest.fn(
+        signal =>
+            new Promise<any>((resolve, reject) => {
+                const listener = () => {
+                    signal.removeEventListener('abort', listener);
+                    reject(new Error('Aborted'));
+                };
+                signal?.addEventListener('abort', listener);
+
+                setTimeout(() => {
+                    signal.removeEventListener('abort', listener);
+                    resolve({
+                        success: true,
+                        payload: SUCCESS,
+                    });
+                }, 10);
+            }),
+    );
+
+    it('read aborted', async () => {
+        const abortController = new AbortController();
+        const read = readWithExpectedHeaders(apiRead, {
+            signal: abortController.signal,
+        });
+
+        const resultPromise = read([Buffer.alloc(3)]);
+
+        abortController.abort();
+        // error thrown from scheduleAction
+        await expect(() => resultPromise).rejects.toThrow('Aborted by signal');
+    });
+
+    it('read timeout', async () => {
+        const read = readWithExpectedHeaders(apiRead, {
+            timeout: 7, // see default apiRead timeout
+        });
+
+        const resultPromise = read([Buffer.alloc(3)]);
+
+        // error thrown from scheduleAction
+        await expect(() => resultPromise).rejects.toThrow('Aborted by timeout');
+    });
+
+    it('api.read failed', async () => {
+        const read = readWithExpectedHeaders(() =>
+            Promise.resolve({ success: false, error: 'unexpected error' }),
+        );
+
+        const result = await read();
+        expect(result).toMatchObject({ success: false, error: 'unexpected error' });
+    });
+
+    it('attempts limit reached', async () => {
+        const apiRead = jest.fn(() =>
+            Promise.resolve({ success: true, payload: Buffer.alloc(64) } as const),
+        );
+        const expectedHeaders = protocolV1.getHeaders(SUCCESS);
+        const read = readWithExpectedHeaders(apiRead, { attempts: 7 });
+        // error thrown from scheduleAction
+        await expect(() => read(expectedHeaders)).rejects.toThrow('Unexpected chunk');
+        expect(apiRead).toHaveBeenCalledTimes(7);
+    });
+
+    it('success with expectedHeaders', async () => {
+        const expectedHeaders = protocolV1.getHeaders(SUCCESS);
+
+        const result = await readWithExpectedHeaders(apiRead)(expectedHeaders);
+        expect(result).toMatchObject({ success: true });
+    });
+
+    it('success. expectedHeaders not set', async () => {
+        const result = await readWithExpectedHeaders(apiRead)();
+        expect(result).toMatchObject({ success: true });
+    });
+
+    it('success. received at 5th attempt', async () => {
+        const expectedHeaders = protocolV1.getHeaders(SUCCESS);
+
+        let attempt = 0;
+        const apiRead = jest.fn(
+            () =>
+                new Promise<any>(resolve => {
+                    if (++attempt < 5) {
+                        resolve({ success: true, payload: Buffer.alloc(32) });
+                    } else {
+                        resolve({ success: true, payload: SUCCESS });
+                    }
+                }),
+        );
+
+        const result = await readWithExpectedHeaders(apiRead)(expectedHeaders);
+
+        expect(apiRead).toHaveBeenCalledTimes(5);
+        expect(result).toMatchObject({ success: true });
+    });
+
+    it('success with THP', async () => {
+        const readResult = Buffer.from('2833da0004527eb068', 'hex');
+
+        let attempt = 0;
+        const apiRead = jest.fn(
+            () =>
+                new Promise<any>(resolve => {
+                    if (++attempt < 5) {
+                        resolve({ success: true, payload: Buffer.alloc(32) });
+                    } else {
+                        resolve({ success: true, payload: readResult });
+                    }
+                }),
+        );
+
+        const thpState = new protocolThp.ThpState();
+        thpState.setChannel(readResult.subarray(1, 3));
+        thpState.setExpectedResponses([0x20]); // expect ThpAck
+        thpState.updateSyncBit('send'); // ThpAck is masked, data will start with "28" instead of "20"
+
+        const result = await readWithExpectedHeaders(apiRead)(
+            protocolThp.getExpectedHeaders(thpState),
+        );
+        expect(result).toMatchObject({ success: true });
+    });
+});

--- a/packages/transport/tests/thp.test.ts
+++ b/packages/transport/tests/thp.test.ts
@@ -1,0 +1,338 @@
+import { parseConfigure } from '@trezor/protobuf';
+import { thp as protocolThp, v2 } from '@trezor/protocol';
+
+import { parseThpMessage, receiveThpMessage, sendThpMessage } from '../src/thp';
+
+describe('thp', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const apiChunkSize = 64;
+    const thpState = new protocolThp.ThpState();
+    const apiRead = jest.fn(
+        signal =>
+            new Promise<any>((resolve, reject) => {
+                const listener = () => {
+                    signal.removeEventListener('abort', listener);
+                    reject(new Error('Aborted'));
+                };
+                signal?.addEventListener('abort', listener);
+
+                setTimeout(() => {
+                    signal.removeEventListener('abort', listener);
+                    resolve({ success: true, payload: Buffer.alloc(apiChunkSize) });
+                }, 100);
+            }),
+    );
+
+    const apiWrite = jest.fn(() => Promise.resolve({ success: true } as any));
+
+    describe('receiveThpMessage', () => {
+        it('aborted', async () => {
+            const abortController = new AbortController();
+            let attempt = 0;
+            const apiRead = jest.fn(
+                () =>
+                    new Promise<any>(resolve => {
+                        if (++attempt < 5) {
+                            resolve({ success: true, payload: Buffer.alloc(32) });
+                        } else {
+                            abortController.abort();
+                        }
+                    }),
+            );
+
+            thpState.setExpectedResponses([0x20]);
+
+            const result = await receiveThpMessage({
+                thpState,
+                apiRead,
+                apiWrite,
+                signal: abortController.signal,
+            });
+
+            expect(apiRead).toHaveBeenCalledTimes(5);
+            expect(result).toMatchObject({ success: false, message: 'Aborted by signal' });
+        });
+
+        it('api write failed', async () => {
+            const readResult = Buffer.from('200c22000471913136', 'hex');
+            thpState.setChannel(readResult.subarray(1, 3));
+            thpState.setExpectedResponses([0x20]);
+
+            const result = await receiveThpMessage({
+                thpState,
+                apiRead: () => Promise.resolve({ success: true, payload: readResult }),
+                apiWrite: () => Promise.resolve({ success: false, error: 'unexpected error' }),
+            });
+
+            expect(result).toMatchObject({ success: false, error: 'unexpected error' });
+        });
+
+        it('success', async () => {
+            const readResult = Buffer.from('200c22000471913136', 'hex');
+            thpState.setChannel(readResult.subarray(1, 3));
+            thpState.setExpectedResponses([0x20]);
+
+            const result = await receiveThpMessage({
+                thpState,
+                apiRead: () => Promise.resolve({ success: true, payload: readResult }),
+                apiWrite,
+            });
+
+            expect(apiWrite).toHaveBeenCalledTimes(1);
+            expect(result).toMatchObject({ success: true });
+        });
+
+        it('success. Expected chunk received at 5th attempt', async () => {
+            const readResult = Buffer.from('200c22000471913136', 'hex');
+            thpState.setChannel(readResult.subarray(1, 3));
+            thpState.setExpectedResponses([0x20]);
+
+            let attempt = 0;
+            const apiRead = jest.fn(
+                () =>
+                    new Promise<any>(resolve => {
+                        if (++attempt < 5) {
+                            resolve({ success: true, payload: Buffer.alloc(32) });
+                        } else {
+                            resolve({ success: true, payload: readResult });
+                        }
+                    }),
+            );
+
+            const result = await receiveThpMessage({
+                thpState,
+                apiRead,
+                apiWrite,
+            });
+
+            expect(apiRead).toHaveBeenCalledTimes(5);
+            expect(apiWrite).toHaveBeenCalledTimes(1);
+            expect(result).toMatchObject({ success: true });
+        });
+
+        it('success. ThpAck not required', async () => {
+            const readResult = Buffer.from(
+                '41ffff0022cb263fc1c42de1ac12340a045432543110001800200228022803280428017d8ccd6b',
+                'hex',
+            );
+            thpState.setChannel(readResult.subarray(1, 3));
+            thpState.setExpectedResponses([0x41]); // ThpCreateChannelResponse
+
+            const result = await receiveThpMessage({
+                thpState,
+                apiRead: () => Promise.resolve({ success: true, payload: readResult }),
+                apiWrite,
+            });
+
+            expect(apiWrite).toHaveBeenCalledTimes(0);
+            expect(result).toMatchObject({ success: true });
+        });
+    });
+
+    describe('sendThpMessage', () => {
+        it('retransmission attempts limit reached', async () => {
+            jest.useFakeTimers();
+
+            const sendPromise = sendThpMessage({
+                thpState,
+                chunks: [
+                    Buffer.from(
+                        '00123700245123076b080f174d3a5e7e8906d4282f577b28f46135618cf10c00b4eeb08c62ea514194',
+                        'hex',
+                    ),
+                ],
+                apiWrite,
+                apiRead,
+            });
+
+            await jest.advanceTimersByTimeAsync(11 * 3000); // (ATTEMPTS_LIMIT + 1) * THP_ACK_DEADLINE
+            const result = await sendPromise;
+
+            expect(result).toMatchObject({ success: false, message: 'Aborted by deadline' });
+            expect(apiWrite).toHaveBeenCalledTimes(10);
+        });
+
+        it('ThpAck never received', async () => {
+            jest.useFakeTimers();
+
+            const apiRead = jest.fn(
+                signal =>
+                    new Promise<any>((_resolve, reject) => {
+                        const listener = () => {
+                            signal.removeEventListener('abort', listener);
+                            reject(new Error('Aborted by signal inside API'));
+                        };
+                        signal?.addEventListener('abort', listener);
+                    }),
+            );
+
+            const sendPromise = sendThpMessage({
+                thpState,
+                chunks: [
+                    Buffer.from(
+                        '00123700245123076b080f174d3a5e7e8906d4282f577b28f46135618cf10c00b4eeb08c62ea514194',
+                        'hex',
+                    ),
+                ],
+                apiWrite,
+                apiRead,
+            });
+
+            await jest.advanceTimersByTimeAsync(20 * 3000); // (ATTEMPTS_LIMIT + 1) * THP_ACK_DEADLINE
+            const result = await sendPromise;
+
+            expect(result).toMatchObject({ success: false, message: 'Aborted by deadline' });
+            expect(apiWrite).toHaveBeenCalledTimes(10);
+        });
+
+        it('api read failed', async () => {
+            jest.useFakeTimers();
+
+            const apiRead = jest.fn(
+                () =>
+                    new Promise<any>(resolve => {
+                        resolve({ success: false, message: 'API read error' });
+                    }),
+            );
+
+            const sendPromise = sendThpMessage({
+                thpState,
+                chunks: [
+                    Buffer.from(
+                        '00123700245123076b080f174d3a5e7e8906d4282f577b28f46135618cf10c00b4eeb08c62ea514194',
+                        'hex',
+                    ),
+                ],
+                apiWrite,
+                apiRead,
+            });
+
+            await jest.advanceTimersByTimeAsync(10000);
+            const result = await sendPromise;
+
+            expect(result).toMatchObject({ success: false });
+            expect(apiWrite).toHaveBeenCalledTimes(1);
+            expect(apiRead).toHaveBeenCalledTimes(1);
+        });
+
+        it('api write failed', async () => {
+            const apiWrite = jest.fn(
+                () =>
+                    new Promise<any>(resolve => {
+                        resolve({ success: false, error: 'unexpected error' });
+                    }),
+            );
+
+            const result = await sendThpMessage({
+                thpState,
+                chunks: [
+                    Buffer.from(
+                        '00123700245123076b080f174d3a5e7e8906d4282f577b28f46135618cf10c00b4eeb08c62ea514194',
+                        'hex',
+                    ),
+                ],
+                apiWrite,
+                apiRead,
+            });
+
+            expect(result).toMatchObject({ success: false, error: 'unexpected error' });
+            expect(apiRead).toHaveBeenCalledTimes(0);
+        });
+
+        it('aborted', async () => {
+            jest.useFakeTimers();
+            const abortController = new AbortController();
+            const sendPromise = sendThpMessage({
+                thpState,
+                chunks: [
+                    Buffer.from(
+                        '00123700245123076b080f174d3a5e7e8906d4282f577b28f46135618cf10c00b4eeb08c62ea514194',
+                        'hex',
+                    ),
+                ],
+                apiWrite,
+                apiRead,
+                signal: abortController.signal,
+            });
+
+            await jest.advanceTimersByTimeAsync(4000);
+            expect(apiWrite).toHaveBeenCalledTimes(2); // there was 1 retransmission
+
+            abortController.abort();
+
+            const result = await sendPromise;
+            expect(result).toMatchObject({ success: false, message: 'Aborted by signal' });
+        });
+
+        it('success. ThpAck not required', async () => {
+            const result = await sendThpMessage({
+                thpState,
+                chunks: [Buffer.from([0x40, 0, 0])],
+                apiWrite,
+                apiRead,
+            });
+
+            expect(apiWrite).toHaveBeenCalledTimes(1);
+            expect(apiRead).toHaveBeenCalledTimes(0);
+            expect(result).toMatchObject({ success: true });
+        });
+
+        it('success. ThpAck received', async () => {
+            const readResult = Buffer.from('200c22000471913136', 'hex');
+            thpState.setChannel(readResult.subarray(1, 3));
+            thpState.setExpectedResponses([0x20]);
+
+            const result = await sendThpMessage({
+                thpState,
+                chunks: [Buffer.from([0x04, 0, 0])],
+                apiWrite,
+                apiRead: () => Promise.resolve({ success: true, payload: readResult }),
+            });
+
+            expect(result).toMatchObject({ success: true });
+        });
+    });
+
+    describe('parseThpMessage', () => {
+        it('success decrypted', async () => {
+            const readResult = Buffer.from(
+                '41ffff0020b06fe019f6f7e1a333d60a0454335731180220002802280328042801ab2d478b',
+                'hex',
+            );
+
+            const protobufRoot = parseConfigure({
+                nested: protocolThp.getProtobufDefinitions(),
+            });
+
+            const result = await parseThpMessage({
+                messages: protobufRoot,
+                decoded: v2.decode(readResult),
+                thpState,
+            });
+
+            expect(result.type).toEqual('ThpCreateChannelResponse');
+        });
+
+        it('success encrypted', async () => {
+            const readResult = Buffer.from(
+                '41ffff0020b06fe019f6f7e1a333d60a0454335731180220002802280328042801ab2d478b',
+                'hex',
+            );
+
+            const protobufRoot = parseConfigure({
+                nested: protocolThp.getProtobufDefinitions(),
+            });
+
+            const result = await parseThpMessage({
+                messages: protobufRoot,
+                decoded: v2.decode(readResult),
+                thpState,
+            });
+
+            expect(result.type).toEqual('ThpCreateChannelResponse');
+        });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

protocol v2 `THP` in `@trezor/transport`

1. add ThpState.sync function used in transport after call/send/receive.
    update ThpState synchronization bits and nonces basing on thpCall/typedCall message name
1. add `getExpectedHeaders` function used in `readWithExpectedHeaders` utility (description below)
1. add thp modules: `callThpMessage` `sendThpMessage` and `receiveThpMessage` as reflection of `@trezor/transport/utils/send` and `utils/receive`
1. implementation of THP modules in `AbstractApiTransport`, `BridgeTransport` and `@trezor/transport-bridge`
  
  
  sending and receiving THP messages is well covered by the docs (Synchronization layer)
  https://www.notion.so/satoshilabs/THP-Specification-2-1-203dc5260606804192aecaa58fb961ca
  
  TLDR: 
  1. after each **api.write** additionally reads `ThpAck` back from the device (confirmation that message was delivered)  and if not received in some meaningful time send the message again, repeat the process few times then die.
  2. after each **api.read** sends `ThpAck` to the device (confirmation that the message was received)
  3. each **api.read** is using `readWithExpectedHeaders` utility and reads until receive expected message. also described in this PR https://github.com/trezor/trezor-suite/pull/19278 which i will close later

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/transport-thp-modules&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/transport-thp-modules&lookback=7)