### PR TITLE
fix(connect-web): empty settings in init in suite-desktop mode

### DIFF
--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -86,7 +86,7 @@ export class CoreInSuiteDesktop implements ConnectFactoryDependencies<ConnectSet
         }
     }
 
-    public async init(settings: Partial<ConnectSettingsPublic> = {}): Promise<void> {
+    public async init(settings: Partial<ConnectSettingsPublic>): Promise<void> {
         const newSettings = parseConnectSettings({
             ...this._settings,
             ...settings,
@@ -106,6 +106,10 @@ export class CoreInSuiteDesktop implements ConnectFactoryDependencies<ConnectSet
         }
         this._settings = newSettings;
 
+        return await this.connect();
+    }
+
+    private async connect(): Promise<void> {
         try {
             await this.ws.connect();
         } catch (err) {
@@ -123,7 +127,7 @@ export class CoreInSuiteDesktop implements ConnectFactoryDependencies<ConnectSet
     public async call(params: CallMethodPayload): Promise<CallMethodAnyResponse> {
         try {
             if (!this.ws.isConnected()) {
-                await this.init();
+                await this.connect();
             }
             await this.handshake();
 


### PR DESCRIPTION
## Description

In suite-desktop mode, when we are trying to reconnect we call `init()` again with no params. 

This works in connect-web, but causes an issue in connect-webextension, where we extend init and expect settings to be an object. This causes the following error: 

```
Cannot read properties of undefined (reading '_extendWebextensionLifetime')"
```

This PR fixes it by separating the reconnect method from init. 

## Related Issue

Reported by Ambire https://satoshilabs.slack.com/archives/C08A0CQK8KH/p1749650228884519