### PR TITLE
feat(suite): add timer to trading on Solana

### DIFF
--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -21,7 +21,7 @@ import {
     PrecomposedTransactionFinalBumpFeeRbf,
 } from '@suite-common/wallet-types';
 import { isCardanoTx, isRbfBumpFeeTransaction } from '@suite-common/wallet-utils';
-import { PROTO } from '@trezor/connect';
+import { PROTO, Unsuccessful } from '@trezor/connect';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { getSynchronize } from '@trezor/utils';
 
@@ -249,7 +249,7 @@ export const signAndPushSendFormTransactionThunk = createThunk(
 
             // Do not close the modal if the transaction signing timed out
             if (signResponse.payload?.error === 'sign-transaction-timeout') {
-                return;
+                return { type: signResponse.payload.error } as unknown as Unsuccessful;
             }
 
             // Close the modal manually since UI.CLOSE_UI.WINDOW was

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
@@ -1,7 +1,11 @@
 import { UserContextPayload } from '@suite-common/suite-types';
 import {
+    SendState,
+    StakeState,
     cancelSignSendFormTransactionThunk,
+    selectPrecomposedSendForm,
     selectStake,
+    selectStakePrecomposedForm,
     sendFormActions,
     stakeActions,
 } from '@suite-common/wallet-core';
@@ -15,10 +19,14 @@ import {
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { TransactionReviewModalContent } from './TransactionReviewModalContent';
+import { TransactionReviewModalExchange } from './TransactionReviewModalExchange';
+import { TransactionReviewModalSell } from './TransactionReviewModalSell';
+
+export const isStakeState = (state: SendState | StakeState): state is StakeState => 'data' in state;
 
 // This modal is opened either in Device (button request) or User (push tx) context
 // contexts are distinguished by `type` prop
-type TransactionReviewModalProps =
+export type TransactionReviewModalProps =
     | Extract<UserContextPayload, { type: 'review-transaction' }>
     | { type: 'sign-transaction'; decision?: undefined }
     | Extract<
@@ -36,6 +44,17 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa
     // Only one state should be available when the modal is open
     const txInfoState = isSend ? send : stake;
 
+    const precomposedForm = useSelector(state =>
+        isStakeState(txInfoState)
+            ? selectStakePrecomposedForm(state)
+            : selectPrecomposedSendForm(state),
+    );
+
+    const isRbfConfirmedError = type === 'review-transaction-rbf-previous-transaction-mined-error';
+    const isSelectedAccountLoaded = selectedAccount.status === 'loaded';
+    const isExchange = precomposedForm?.activeTradingSection === 'exchange';
+    const isSell = precomposedForm?.activeTradingSection === 'sell';
+
     const handleCancelSignTx = () => {
         if (isSend) {
             dispatch(cancelSignSendFormTransactionThunk());
@@ -44,26 +63,63 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa
         }
     };
 
+    const handleSendTx = async () => {
+        dispatch(sendFormActions.discardTransaction());
+
+        await dispatch(
+            signAndPushSendFormTransactionThunk({
+                formState: send.precomposedForm!,
+                precomposedTransaction: send.precomposedTx!,
+                selectedAccount: selectedAccount.account,
+            }),
+        );
+    };
+
+    const handleStakeTx = async () => {
+        dispatch(stakeActions.dispose());
+        await dispatch(
+            signTransaction(
+                stake.precomposedForm!,
+                stake.precomposedTx as PrecomposedTransactionFinal,
+            ),
+        );
+    };
+
     const handleTryAgainSignTx = async () => {
         if (send.precomposedForm && send.precomposedTx) {
-            dispatch(sendFormActions.discardTransaction());
-            await dispatch(
-                signAndPushSendFormTransactionThunk({
-                    formState: send.precomposedForm,
-                    precomposedTransaction: send.precomposedTx,
-                    selectedAccount: selectedAccount.account,
-                }),
-            );
+            await handleSendTx();
         } else if (stake.precomposedForm && stake.precomposedTx) {
-            dispatch(stakeActions.dispose());
-            await dispatch(
-                signTransaction(
-                    stake.precomposedForm,
-                    stake.precomposedTx as PrecomposedTransactionFinal,
-                ),
-            );
+            await handleStakeTx();
         }
     };
+
+    if (isSelectedAccountLoaded) {
+        if (isExchange) {
+            return (
+                <TransactionReviewModalExchange
+                    selectedAccount={selectedAccount}
+                    decision={decision}
+                    txInfoState={txInfoState}
+                    cancelSignTx={handleCancelSignTx}
+                    isRbfConfirmedError={isRbfConfirmedError}
+                    precomposedForm={precomposedForm}
+                />
+            );
+        }
+
+        if (isSell) {
+            return (
+                <TransactionReviewModalSell
+                    selectedAccount={selectedAccount}
+                    decision={decision}
+                    txInfoState={txInfoState}
+                    cancelSignTx={handleCancelSignTx}
+                    isRbfConfirmedError={isRbfConfirmedError}
+                    precomposedForm={precomposedForm}
+                />
+            );
+        }
+    }
 
     return (
         <TransactionReviewModalContent
@@ -71,7 +127,8 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa
             txInfoState={txInfoState}
             tryAgainSignTx={handleTryAgainSignTx}
             cancelSignTx={handleCancelSignTx}
-            isRbfConfirmedError={type === 'review-transaction-rbf-previous-transaction-mined-error'}
+            isRbfConfirmedError={isRbfConfirmedError}
+            precomposedForm={precomposedForm}
         />
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -10,10 +10,8 @@ import {
     SerializedTx,
     StakeState,
     selectIsTxOutputInternal,
-    selectPrecomposedSendForm,
     selectSelectedDevice,
     selectSendFormReviewButtonRequestsCount,
-    selectStakePrecomposedForm,
 } from '@suite-common/wallet-core';
 import { FormState, RbfTransactionType, StakeType } from '@suite-common/wallet-types';
 import {
@@ -40,6 +38,7 @@ import { redactRouterUrl } from 'src/utils/suite/analytics';
 import { getTransactionReviewModalActionTranslation } from 'src/utils/suite/transactionReview';
 
 import { TransactionReviewDetails } from './TransactionReviewDetails';
+import { isStakeState } from './TransactionReviewModal';
 import { TransactionReviewOutputList } from './TransactionReviewOutputList/TransactionReviewOutputList';
 import { TransactionReviewOutputTimer } from './TransactionReviewOutputList/TransactionReviewOutputTimer';
 import { TransactionReviewSummary } from './TransactionReviewSummary';
@@ -65,6 +64,7 @@ type ShouldShowTxValidityTimerProps = {
     stakeType: StakeType | null;
     shouldCheckTxTimeValidity: boolean;
     isInternalTransfer: boolean;
+    isTrading: boolean;
 };
 
 const shouldShowTxValidityTimer = ({
@@ -74,6 +74,7 @@ const shouldShowTxValidityTimer = ({
     stakeType,
     shouldCheckTxTimeValidity,
     isInternalTransfer,
+    isTrading,
 }: ShouldShowTxValidityTimerProps) => {
     if (!shouldCheckTxTimeValidity || hasTxValidityExpired(deadline)) {
         return false;
@@ -82,10 +83,8 @@ const shouldShowTxValidityTimer = ({
     const isFirstStep = buttonRequestsCount <= 1;
     const isStaking = stakeType && !serializedTx;
 
-    return isInternalTransfer || !isFirstStep || serializedTx || isStaking;
+    return isInternalTransfer || !isFirstStep || serializedTx || isStaking || isTrading;
 };
-
-const isStakeState = (state: SendState | StakeState): state is StakeState => 'data' in state;
 
 const getTxType = (txInfoState: SendState | StakeState, precomposedForm: FormState) => {
     const stakeType = isStakeState(txInfoState) ? 'stake' : undefined;
@@ -105,6 +104,7 @@ type TransactionReviewModalContentProps = {
     tryAgainSignTx: () => void;
     cancelSignTx: () => void;
     isRbfConfirmedError?: boolean;
+    precomposedForm?: FormState;
 };
 
 export const TransactionReviewModalContent = ({
@@ -113,6 +113,7 @@ export const TransactionReviewModalContent = ({
     tryAgainSignTx,
     cancelSignTx,
     isRbfConfirmedError,
+    precomposedForm,
 }: TransactionReviewModalContentProps) => {
     const dispatch = useDispatch();
     const account = useSelector(selectAccountIncludingChosenInTrading);
@@ -127,18 +128,10 @@ export const TransactionReviewModalContent = ({
 
     const router = useSelector(state => state.router);
 
-    const precomposedForm = useSelector(state =>
-        isStakeState(txInfoState)
-            ? selectStakePrecomposedForm(state)
-            : selectPrecomposedSendForm(state),
-    );
     const tradingToken = useSelector(selectTradingComposedTransactionInfo).composed?.token;
 
     const createdTxTimestamp = txInfoState?.precomposedTx?.createdTimestamp ?? 0;
-    const shouldCheckTxTimeValidity =
-        account?.networkType === 'solana' &&
-        !precomposedForm?.activeTradingSection &&
-        createdTxTimestamp !== 0;
+    const shouldCheckTxTimeValidity = account?.networkType === 'solana' && createdTxTimestamp !== 0;
     const deadline = createdTxTimestamp + getTxValidityTimeoutInMs(account?.networkType);
 
     // check if transaction is still valid
@@ -222,6 +215,7 @@ export const TransactionReviewModalContent = ({
         stakeType,
         shouldCheckTxTimeValidity,
         isInternalTransfer,
+        isTrading: !!precomposedForm.activeTradingSection,
     });
 
     const actionTranslation = getTransactionReviewModalActionTranslation({

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalExchange.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalExchange.tsx
@@ -1,0 +1,44 @@
+import { SendState, StakeState, sendFormActions } from '@suite-common/wallet-core';
+import { FormState, SelectedAccountLoaded } from '@suite-common/wallet-types';
+
+import { useDispatch } from 'src/hooks/suite';
+import { useTradingExchangeForm } from 'src/hooks/wallet/trading/form/useTradingExchangeForm';
+
+import { TransactionReviewModalProps } from './TransactionReviewModal';
+import { TransactionReviewModalContent } from './TransactionReviewModalContent';
+
+type TransactionReviewModalExchangeProps = {
+    selectedAccount: SelectedAccountLoaded;
+    txInfoState: SendState | StakeState;
+    isRbfConfirmedError: boolean;
+    cancelSignTx: () => void;
+    precomposedForm?: FormState;
+} & Pick<TransactionReviewModalProps, 'decision'>;
+
+export const TransactionReviewModalExchange = ({
+    decision,
+    selectedAccount,
+    txInfoState,
+    cancelSignTx,
+    isRbfConfirmedError,
+    precomposedForm,
+}: TransactionReviewModalExchangeProps) => {
+    const dispatch = useDispatch();
+    const tradingExchangeForm = useTradingExchangeForm({ selectedAccount, pageType: 'retry' });
+
+    const handleTryAgainSignTx = async () => {
+        dispatch(sendFormActions.discardTransaction());
+        await tradingExchangeForm.sendTransaction();
+    };
+
+    return (
+        <TransactionReviewModalContent
+            decision={decision}
+            txInfoState={txInfoState}
+            tryAgainSignTx={handleTryAgainSignTx}
+            cancelSignTx={cancelSignTx}
+            isRbfConfirmedError={isRbfConfirmedError}
+            precomposedForm={precomposedForm}
+        />
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalSell.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalSell.tsx
@@ -1,0 +1,44 @@
+import { SendState, StakeState, sendFormActions } from '@suite-common/wallet-core';
+import { FormState, SelectedAccountLoaded } from '@suite-common/wallet-types';
+
+import { useDispatch } from 'src/hooks/suite';
+import { useTradingSellForm } from 'src/hooks/wallet/trading/form/useTradingSellForm';
+
+import { TransactionReviewModalProps } from './TransactionReviewModal';
+import { TransactionReviewModalContent } from './TransactionReviewModalContent';
+
+type TransactionReviewModalSellProps = {
+    selectedAccount: SelectedAccountLoaded;
+    txInfoState: SendState | StakeState;
+    isRbfConfirmedError: boolean;
+    cancelSignTx: () => void;
+    precomposedForm?: FormState;
+} & Pick<TransactionReviewModalProps, 'decision'>;
+
+export const TransactionReviewModalSell = ({
+    decision,
+    selectedAccount,
+    txInfoState,
+    cancelSignTx,
+    isRbfConfirmedError,
+    precomposedForm,
+}: TransactionReviewModalSellProps) => {
+    const dispatch = useDispatch();
+    const tradingExchangeForm = useTradingSellForm({ selectedAccount, pageType: 'retry' });
+
+    const handleTryAgainSignTx = async () => {
+        dispatch(sendFormActions.discardTransaction());
+        await tradingExchangeForm.sendTransaction();
+    };
+
+    return (
+        <TransactionReviewModalContent
+            decision={decision}
+            txInfoState={txInfoState}
+            tryAgainSignTx={handleTryAgainSignTx}
+            cancelSignTx={cancelSignTx}
+            isRbfConfirmedError={isRbfConfirmedError}
+            precomposedForm={precomposedForm}
+        />
+    );
+};

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -307,6 +307,8 @@ export const NotificationRenderer = ({
             return error(render, notification, 'TR_COULD_NOT_PARSE');
         case 'thp-credentials-reset':
             return success(render, notification, 'TR_THP_RESET_CREDENTIALS_SUCCESS');
+        case 'sign-transaction-timeout':
+            return error(render, notification, 'TR_SIGN_TRANSACTION_TIMEOUT');
 
         default:
             return exhaustive(type);

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -237,7 +237,7 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
     // call change handler on every change of text inputs with debounce
     useDebounce(
         () => {
-            if (pageType === 'confirm') return;
+            if (pageType === 'confirm' || pageType === 'retry') return;
 
             const fiatValue = values?.outputs?.[0]?.fiat;
             const cryptoValue = values?.outputs?.[0]?.amount;
@@ -270,7 +270,7 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
     // call change handler on every change of select inputs
     // effect only for sell form
     useEffect(() => {
-        if (type !== 'sell' || pageType === 'confirm') return;
+        if (type !== 'sell' || pageType === 'confirm' || pageType === 'retry') return;
 
         if (
             isChanged(
@@ -293,7 +293,7 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
     // call change handler on every change of select inputs
     // effect only for exchange form
     useEffect(() => {
-        if (type !== 'exchange' || pageType === 'confirm') return;
+        if (type !== 'exchange' || pageType === 'confirm' || pageType === 'retry') return;
 
         if (
             isChanged(

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingInitializer.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingInitializer.ts
@@ -29,7 +29,7 @@ export const useTradingInitializer = ({
                     timer.stop();
                 }
 
-                if (pageType === 'confirm') {
+                if (pageType === 'confirm' || pageType === 'retry') {
                     timer.stop();
 
                     return;

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -480,12 +480,14 @@ export const useTradingExchangeForm = ({
         } catch (e) {
             const errorTyped = e as TradingSendRejectedProps;
 
-            dispatch(
-                notificationsActions.addToast({
-                    type: errorTyped.type,
-                    error: translationString(errorTyped.error.id, errorTyped.error.values),
-                }),
-            );
+            if (errorTyped.type !== 'sign-transaction-timeout') {
+                dispatch(
+                    notificationsActions.addToast({
+                        type: errorTyped.type,
+                        error: translationString(errorTyped.error.id, errorTyped.error.values),
+                    }),
+                );
+            }
 
             return false;
         }

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -471,12 +471,14 @@ export const useTradingSellForm = ({
         } catch (e) {
             const errorTyped = e as TradingSendRejectedProps;
 
-            dispatch(
-                notificationsActions.addToast({
-                    type: errorTyped.type,
-                    error: translationString(errorTyped.error.id, errorTyped.error.values),
-                }),
-            );
+            if (errorTyped.type !== 'sign-transaction-timeout') {
+                dispatch(
+                    notificationsActions.addToast({
+                        type: errorTyped.type,
+                        error: translationString(errorTyped.error.id, errorTyped.error.values),
+                    }),
+                );
+            }
 
             return false;
         }
@@ -563,14 +565,14 @@ export const useTradingSellForm = ({
 
     useEffect(() => {
         if (isFromRedirect) {
-            if (transactionId && trade) {
+            if (transactionId && trade && pageType !== 'retry') {
                 dispatch(tradingSellActions.saveSelectedQuote(trade.data));
                 dispatch(tradingSellActions.setFormStep('SEND_TRANSACTION'));
             }
 
             dispatch(tradingSellActions.setIsFromRedirect(false));
         }
-    }, [isFromRedirect, trade, transactionId, dispatch]);
+    }, [isFromRedirect, trade, transactionId, pageType, dispatch]);
 
     useEffect(() => {
         checkQuotesTimer(handleChange);

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3335,6 +3335,10 @@ export default defineMessages({
         defaultMessage: 'THP credentials have been reset. Reconnect your Trezor.',
         id: 'TR_THP_RESET_CREDENTIALS_SUCCESS',
     },
+    TR_SIGN_TRANSACTION_TIMEOUT: {
+        defaultMessage: 'Signing transaction timed out',
+        id: 'TR_SIGN_TRANSACTION_TIMEOUT',
+    },
     TR_THP_ENTER_ONE_TIME_CODE: {
         id: 'TR_THP_ENTER_ONE_TIME_CODE',
         defaultMessage: 'Enter one-time security code',

--- a/packages/suite/src/types/trading/trading.ts
+++ b/packages/suite/src/types/trading/trading.ts
@@ -36,7 +36,7 @@ import { Timer } from '@trezor/react-utils';
 import { GetDefaultAccountLabelParams } from 'src/hooks/suite/useDefaultAccountLabel';
 import { ExtendedMessageDescriptor, TrezorDevice } from 'src/types/suite';
 
-export type TradingPageType = 'form' | 'offers' | 'confirm';
+export type TradingPageType = 'form' | 'offers' | 'confirm' | 'retry';
 
 export type UseTradingProps = { selectedAccount: SelectedAccountLoaded };
 export type UseTradingCommonProps = UseTradingProps & {

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -74,7 +74,8 @@ export type ToastPayload = (
               | 'estimated-fee-error'
               | 'not-enough-funds-error'
               | 'could-not-parse-csv'
-              | 'thp-credentials-reset';
+              | 'thp-credentials-reset'
+              | 'sign-transaction-timeout';
       }
     | SentTransactionNotification
     | {

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -240,7 +240,7 @@ export type MinimalExchangeFormProps = {
 export type TradingExchangeStepType = 'RECEIVING_ADDRESS' | 'SEND_TRANSACTION' | 'SIGN_DATA';
 
 export type TradingSendRejectedProps = {
-    type: 'error' | 'sign-tx-error';
+    type: 'error' | 'sign-tx-error' | 'sign-transaction-timeout';
     error: {
         id: ExtendedMessageDescriptor['id'];
         values?: Record<string, PrimitiveType>;


### PR DESCRIPTION
## Description

A timer for the Solana has been added to the trading section.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19069

## Diagram

Added this diagram to clarify the flow since it’s a bit complex:

<img width="1653" alt="image" src="https://github.com/user-attachments/assets/26972c14-373d-4b80-a896-4e114aea0c9f" />

## Screenshots:

<img width="829" alt="image" src="https://github.com/user-attachments/assets/d75d1ab5-73bb-4410-9df8-36a7f5089f7c" />

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-solana-timer&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-solana-timer&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/trading-solana-timer&lookback=7)