### PR TITLE
fix(suite): make sure that only accounts which is device capable of a…

### DIFF
--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -214,29 +214,31 @@ export const selectDeviceStatus = createMemoizedSelector(
     device => device && getStatus(device),
 );
 
+export const selectSupportedNetworkByDevice = (device: TrezorDevice | undefined) => {
+    const firmwareVersion = getFirmwareVersion(device);
+    const result = networkSymbolCollection.filter(symbol => {
+        const unavailableCapability = device?.unavailableCapabilities?.[symbol];
+        // if device does not have fw, do not show coins which are not supported by device in any case
+        if (!firmwareVersion && unavailableCapability === 'no-support') {
+            return false;
+        }
+        // if device has fw, do not show coins which are not supported by current fw
+        if (
+            firmwareVersion &&
+            ['no-support', 'no-capability'].includes(unavailableCapability || '')
+        ) {
+            return false;
+        }
+
+        return true;
+    });
+
+    return returnStableArrayIfEmpty(result);
+};
+
 export const selectDeviceSupportedNetworks = createMemoizedSelector(
     [selectSelectedDevice],
-    device => {
-        const firmwareVersion = getFirmwareVersion(device);
-        const result = networkSymbolCollection.filter(symbol => {
-            const unavailableCapability = device?.unavailableCapabilities?.[symbol];
-            // if device does not have fw, do not show coins which are not supported by device in any case
-            if (!firmwareVersion && unavailableCapability === 'no-support') {
-                return false;
-            }
-            // if device has fw, do not show coins which are not supported by current fw
-            if (
-                firmwareVersion &&
-                ['no-support', 'no-capability'].includes(unavailableCapability || '')
-            ) {
-                return false;
-            }
-
-            return true;
-        });
-
-        return returnStableArrayIfEmpty(result);
-    },
+    selectSupportedNetworkByDevice,
 );
 
 export const selectDeviceById = createMemoizedSelector(

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -24,6 +24,7 @@ import {
     selectDevices,
     selectPhysicalDevices,
     selectSelectedDevice,
+    selectSupportedNetworkByDevice,
 } from '../device/deviceSelectors';
 import { selectDeviceThunk } from '../device/deviceThunks';
 import {
@@ -487,7 +488,10 @@ export const runDiscoveryThunk = createThunk(
 
             TrezorConnect.on<DiscoverAccountsProgress>(UI.BUNDLE_PROGRESS, onBundleProgress);
 
-            const enabledNetworks = selectEnabledNetworks(getState());
+            const deviceNetworks = selectSupportedNetworkByDevice(device);
+            const enabledNetworks = selectEnabledNetworks(getState()).filter(symbol =>
+                deviceNetworks.includes(symbol),
+            );
             const discoveryAccountsPayload = enabledNetworks.map(n => ({ symbol: n }));
 
             // no networks to discover, complete discovery


### PR DESCRIPTION
…re discovered

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Issue: https://github.com/trezor/trezor-suite/issues/19473

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=19473-btc-only-discovery-fails&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=19473-btc-only-discovery-fails&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19473-btc-only-discovery-fails&lookback=7)