### PR TITLE
fix(suite-native): device onboarding e2e test firmware skip

### DIFF
--- a/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
@@ -96,8 +96,14 @@ class DeviceOnboardingActions {
 
     async skipFirmwareUpdate() {
         const testId = '@firmware/skip-button';
-        await waitForElementByIdToBeVisible(testId, 20000);
-        await element(by.id(testId)).tap();
+        try {
+            await waitForElementByIdToBeVisible(testId, 10000);
+            await element(by.id(testId)).tap();
+        } catch {
+            console.warn(
+                'SKIPPING FIRMWARE UPDATE: Firmware update was not displayed, it is already latest version.',
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Description
- optionally skip the firmware update screen in device onboarding test if the firmware version is already latest (in that case the screen is not displayed in the flow)
  - this test was failing recently in CI because trezor-user-env was updated and the emulators used the latest firmware by default 



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/onboarding-test-fw-install&lookback=7)