### PR TITLE
ci: increase test:unit timeout to 30 minutes

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -83,7 +83,7 @@ jobs:
     name: Unit Tests
     needs: setup-and-cache
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Increase unit test timeout to 30 minutes, because 15 is not enough as they grew over time.

We do want to keep a timeout, because with jest you can easily do an mistake that will leave the tests hanging.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=unit-test-timeout&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=unit-test-timeout&lookback=7)