### PR TITLE
fix(suite): update t1b1 eth staking flow

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -15,17 +15,11 @@ import {
     selectSendFormReviewButtonRequestsCount,
     selectStakePrecomposedForm,
 } from '@suite-common/wallet-core';
-import {
-    FormState,
-    RbfTransactionType,
-    ReviewOutput,
-    StakeFormState,
-    StakeType,
-} from '@suite-common/wallet-types';
+import { FormState, RbfTransactionType, ReviewOutput, StakeType } from '@suite-common/wallet-types';
 import {
     constructTransactionReviewOutputs,
     findAccountsByAddress,
-    getTxStakeNameByDataHex,
+    getStakeType,
     isRbfBumpFeeTransaction,
     isRbfCancelTransaction,
     isRbfTransaction,
@@ -91,9 +85,6 @@ const shouldShowTxValidityTimer = (
 };
 
 const isStakeState = (state: SendState | StakeState): state is StakeState => 'data' in state;
-
-const isStakeForm = (form: FormState | StakeFormState): form is StakeFormState =>
-    'stakeType' in form;
 
 const getTxType = (txInfoState: SendState | StakeState, precomposedForm: FormState) => {
     const stakeType = isStakeState(txInfoState) ? 'stake' : undefined;
@@ -202,12 +193,7 @@ export const TransactionReviewModalContent = ({
     });
 
     // for bump fee we have to analyze tx data which are in outputs[0], for legacy in outputs[1]
-    const stakeType = isStakeForm(precomposedForm)
-        ? precomposedForm.stakeType
-        : outputs
-              .filter(output => output.type === 'data')
-              .map(output => getTxStakeNameByDataHex(output?.value))
-              .find(type => type) || null;
+    const stakeType = getStakeType(precomposedForm, outputs);
 
     const onCancel = () => {
         dispatch(modalActions.onCancel());

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -75,13 +75,13 @@ const getOutputTitle = (
         case 'contract':
             return <Translation id={networkType === 'solana' ? 'TR_TOKEN' : 'TR_CONTRACT'} />;
         case 'address':
+        case 'regular_legacy':
             return (
                 <Translation
                     id={stakeType ? displayModeStringsMap[stakeType].label : 'TR_RECIPIENT_ADDRESS'}
                 />
             );
-        case 'regular_legacy':
-            return <Translation id="TR_RECIPIENT_ADDRESS" />;
+
         case 'amount':
             return <Translation id="TR_AMOUNT_SENT" />;
         case 'destination-tag':
@@ -168,6 +168,7 @@ const getOutputLines = (
             ];
         case 'address':
         case 'data':
+        case 'regular_legacy':
             if (stakeType) {
                 return [
                     {
@@ -183,25 +184,7 @@ const getOutputLines = (
             return [
                 {
                     id: type,
-                    type,
-                    value,
-                },
-            ];
-        case 'regular_legacy':
-            if (stakeType) {
-                return [
-                    {
-                        id: 'data',
-                        type: 'default',
-                        value,
-                    },
-                ];
-            }
-
-            return [
-                {
-                    id: type,
-                    type: 'address',
+                    type: type === 'regular_legacy' ? 'address' : type,
                     value,
                 },
             ];
@@ -310,7 +293,8 @@ export const TransactionReviewOutput = ({
     });
 
     // prevents double label when bumping stake type txs
-    if (type === 'address' && isRbf && stakeType) {
+    const ignoredRbfTypes = ['address', 'regular_legacy'];
+    if (isRbf && stakeType && ignoredRbfTypes.includes(type)) {
         return null;
     }
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
@@ -26,10 +26,11 @@ const getLines = (
     stakeType?: StakeType,
 ): OutputElementLine[] => {
     const isUpdatedSendFlow = getIsUpdatedSendFlow(device);
-    const isUpdatedEthereumSendFlow = getIsUpdatedEthereumSendFlow(device, networkType);
+    const isUpdatedEthereumSendFlow = getIsUpdatedEthereumSendFlow(device, networkType, stakeType);
     const isEthereum = networkType === 'ethereum';
     const isSolana = networkType === 'solana';
     const showAmountWithoutFee = isEthereum || isSolana;
+
     const feeLabelId = ((network: NetworkType) => {
         switch (network) {
             case 'ethereum':
@@ -48,7 +49,7 @@ const getLines = (
         .toString();
 
     if (isUpdatedEthereumSendFlow) {
-        const isUnknownStakingClaimValue = isRbfAction && stakeType === 'claim';
+        const isUnknownStakingValue = isRbfAction && stakeType !== 'stake';
 
         const amountLine: OutputElementLine = {
             id: 'amount', // In updated ethereum send flow there is no total amount shown, only amount without fee
@@ -64,7 +65,7 @@ const getLines = (
             type: 'amount',
         };
 
-        return isUnknownStakingClaimValue ? [feeLine] : [amountLine, feeLine];
+        return isUnknownStakingValue ? [feeLine] : [amountLine, feeLine];
     }
     if (isUpdatedSendFlow) {
         const amount = showAmountWithoutFee ? amountWithoutFee : precomposedTx.totalSpent;

--- a/suite-common/wallet-utils/src/ethereumStakingUtils.ts
+++ b/suite-common/wallet-utils/src/ethereumStakingUtils.ts
@@ -3,6 +3,9 @@ import { fromWei, hexToNumberString } from 'web3-utils';
 import { NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
 import {
     Account,
+    FormState,
+    ReviewOutput,
+    StakeFormState,
     StakeType,
     StakingPoolExtended,
     SupportedEthereumNetworkSymbol,
@@ -133,3 +136,14 @@ export const getUnstakeAmountByEthereumDataHex = (dataHex?: string) => {
 
     return hexToNumberString(`0x${dataBuffer.subarray(4, 36).toString('hex')}`);
 };
+
+export const isStakeForm = (form: FormState | StakeFormState): form is StakeFormState =>
+    'stakeType' in form;
+
+export const getStakeType = (precomposedForm: FormState, outputs: ReviewOutput[]) =>
+    isStakeForm(precomposedForm)
+        ? precomposedForm.stakeType
+        : outputs
+              .filter(output => output.type === 'data')
+              .map(output => getTxStakeNameByDataHex(output?.value))
+              .find(type => type) || null;

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -8,12 +8,14 @@ import {
     ReviewOutput,
     ReviewOutputState,
     StakeFormState,
+    StakeType,
 } from '@suite-common/wallet-types';
 import { CardanoOutput } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { versionUtils } from '@trezor/utils';
 
 import { getShortFingerprint, isCardanoTx } from './cardanoUtils';
+import { getStakeType } from './ethereumStakingUtils';
 import { isRbfBumpFeeTransaction } from './transactionUtils';
 
 export const getTransactionReviewOutputState = (
@@ -35,13 +37,15 @@ export const getIsUpdatedSendFlow = (device: TrezorDevice) => {
 export const getIsUpdatedEthereumSendFlow = (
     device: TrezorDevice,
     network: Account['networkType'],
+    stakeType?: StakeType,
 ) => {
     if (network !== 'ethereum') return false;
 
     const firmwareVersion = getFirmwareVersion(device);
 
     // publicly introduced in 2.6.3, versions 2.6.1 and 2.6.2 were internal
-    return versionUtils.isNewer(firmwareVersion, '2.6.0');
+    // staking uses new flow on T1B1
+    return versionUtils.isNewer(firmwareVersion, '2.6.0') || !!stakeType;
 };
 
 const getCardanoTokenBundle = (account: Account, output: CardanoOutput) => {
@@ -209,6 +213,10 @@ const constructOldFlow = ({
         outputs.push({ type: 'data', value: precomposedForm.ethereumDataHex });
     }
 
+    // For bump fee we have to analyze tx data,
+    // so outputs must already include type 'data' beforehand
+    const stakeType = getStakeType(precomposedForm, outputs);
+
     if (networkType === 'ripple') {
         // ripple displays requests on device in different order:
         // 1. destination tag
@@ -221,7 +229,7 @@ const constructOldFlow = ({
                 value: precomposedForm.destinationTag,
             });
         }
-    } else if (!isBumpFeeRbf || !precomposedTx.useNativeRbf) {
+    } else if ((!isBumpFeeRbf || !precomposedTx.useNativeRbf) && !stakeType) {
         outputs.push({ type: 'fee', value: precomposedTx.fee });
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Aligns Ethereum Stake/Unstake/Claim flow with the updated T1B1 behavior in Trezor Suite.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18707

## Screenshots:



Regular:
![image](https://github.com/user-attachments/assets/ad43e484-306c-4580-9e1d-dca0705dd30b)
![image](https://github.com/user-attachments/assets/e280d1fc-b858-4216-a51b-c92a2b730bd3)
![image](https://github.com/user-attachments/assets/a0164f5c-137b-496f-95ea-1669d2db6405)


RBF:
![image](https://github.com/user-attachments/assets/c5f51c81-95bf-4936-9290-12eadc446268)
![image](https://github.com/user-attachments/assets/ca0b00e9-4330-45ee-84a3-94a6273905a4)
![image](https://github.com/user-attachments/assets/23bae532-21aa-4606-945d-dd3c2e4b2b46)





