### PR TITLE
feat(desktop): disable xpub generation for compromised device

### DIFF
--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -3,7 +3,16 @@ import { ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { getAccountTypeTech } from '@suite-common/wallet-utils';
-import { Button, Card, Column, InfoItem, Paragraph, Row, variables } from '@trezor/components';
+import {
+    Button,
+    Card,
+    Column,
+    InfoItem,
+    Paragraph,
+    Row,
+    Tooltip,
+    variables,
+} from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { HELP_CENTER_BIP32_URL, HELP_CENTER_XPUB_URL, Url } from '@trezor/urls';
 
@@ -15,6 +24,7 @@ import { TranslationKey } from 'src/components/suite/Translation';
 import { AccountTypeDescription } from 'src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription';
 import { WalletLayout } from 'src/components/wallet';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
+import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/reducers/suite/suiteReducer';
 
 import { CoinjoinLogs } from './CoinjoinLogs';
 import { CoinjoinSetup } from './CoinjoinSetup/CoinjoinSetup';
@@ -59,7 +69,14 @@ const DetailsRow = ({ title, description, learnMoreUrl, children }: DetailsRowPr
 
 const Details = () => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const isAuthenticityCheckFailed = useSelector(
+        selectIsFirmwareAuthenticityCheckEnabledAndHardFailed,
+    );
     const dispatch = useDispatch();
+
+    const tooltipContent = isAuthenticityCheckFailed ? (
+        <Translation id="TR_RECEIVE_ADDRESS_SECURITY_CHECK_FAILED" />
+    ) : null;
 
     const { device, isLocked } = useDevice();
 
@@ -69,7 +86,7 @@ const Details = () => {
 
     const { account } = selectedAccount;
     const locked = isLocked(true);
-    const disabled = locked;
+    const disabled = locked || isAuthenticityCheckFailed;
 
     const accountTypeTech = getAccountTypeTech(account.path);
 
@@ -130,17 +147,19 @@ const Details = () => {
                                 description={<Translation id="TR_ACCOUNT_DETAILS_XPUB" />}
                                 learnMoreUrl={HELP_CENTER_XPUB_URL}
                             >
-                                <Button
-                                    variant="tertiary"
-                                    data-testid="@wallets/details/show-xpub-button"
-                                    onClick={handleXpubClick}
-                                    isDisabled={disabled}
-                                    isLoading={locked}
-                                    size="small"
-                                    minWidth={140}
-                                >
-                                    <Translation id="TR_ACCOUNT_DETAILS_XPUB_BUTTON" />
-                                </Button>
+                                <Tooltip content={tooltipContent}>
+                                    <Button
+                                        variant="tertiary"
+                                        data-testid="@wallets/details/show-xpub-button"
+                                        onClick={handleXpubClick}
+                                        isDisabled={disabled}
+                                        isLoading={locked}
+                                        size="small"
+                                        minWidth={140}
+                                    >
+                                        <Translation id="TR_ACCOUNT_DETAILS_XPUB_BUTTON" />
+                                    </Button>
+                                </Tooltip>
                             </DetailsRow>
                         )
                     ) : (


### PR DESCRIPTION
Disables xpub generation when the device is compromised. 

## Description
- when the device is compromised
 - disabled button added tooltip on desktop suite app 

## Related Issue

Resolves #14941

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/disable-xpub-generation-when-device-is-compromised&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/disable-xpub-generation-when-device-is-compromised&lookback=7)

BEFORE
<img width="1789" alt="Screenshot 2025-06-12 at 15 07 11" src="https://github.com/user-attachments/assets/a2059799-a59d-4c33-aece-6c2d4735855d" />
AFTER
<img width="1309" alt="Screenshot 2025-06-12 at 15 16 44" src="https://github.com/user-attachments/assets/cf95d0e6-846d-4bc6-95e5-049ba9bfe2ca" />
