### PR TITLE
Revert "feat(connect): allow temporarily outdated t1b1 firmwares"

### DIFF
--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -323,7 +323,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
             (device.firmwareStatus === 'required' ||
                 !versionUtils.isNewerOrEqual(version, range.min))
         ) {
-            // return UI.FIRMWARE_OLD;
+            return UI.FIRMWARE_OLD;
         }
 
         if (range.max !== '0' && versionUtils.isNewer(version, range.max)) {


### PR DESCRIPTION
This reverts commit b38d473dfdeffaf0c27f01992a30bcc427ac4323 since it was not intended to get into develop.


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/revert-495b9acd8d120c8ddc363b4401b51d780bc3b7f1&lookback=7)