### PR TITLE
Pin for t1 reworked

### DIFF
--- a/packages/components/src/components/buttons/PinButton/PinButton.tsx
+++ b/packages/components/src/components/buttons/PinButton/PinButton.tsx
@@ -33,10 +33,16 @@ const Button = styled.button<{ $elevation: Elevation }>`
     &:hover::before {
         background: ${({ theme }) => theme.textSecondaryHighlight};
     }
+
+    &:disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
+    }
 `;
 
 export interface PinButtonProps extends Pick<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick'> {
     'data-value': string;
+    disabled?: boolean;
 }
 
 export const PinButton = (props: PinButtonProps) => {

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -156,6 +156,7 @@ export const handleUIAffectingMessage = (message: CoreEventMessage) => {
             view.initWordView(message.payload);
             break;
         case UI_REQUEST.INVALID_PIN:
+            // todo: test
             showView('invalid-pin');
             break;
         // comes when user clicks "enter on device"

--- a/packages/connect/src/device/workflow/validateState.ts
+++ b/packages/connect/src/device/workflow/validateState.ts
@@ -59,7 +59,17 @@ const getInvalidDeviceState = async (
         }
     }
 
-    return getState(context);
+    // eslint-disable-next-line no-restricted-syntax
+    return getState(context).catch(error => {
+        if (error.message.includes('PIN invalid')) {
+            context.method.postMessage(
+                createUiMessage(UI.INVALID_PIN_ATTEMPTS_DEPLETED, {
+                    device: context.device.toMessageObject(),
+                }),
+            );
+        }
+        throw error;
+    });
 };
 
 export const validateState = async (context: WorkflowContext) => {

--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -48,6 +48,7 @@ export const UI_REQUEST = {
     REQUEST_CONFIRMATION: 'ui-request_confirmation',
     REQUEST_PIN: 'ui-request_pin',
     INVALID_PIN: 'ui-invalid_pin',
+    INVALID_PIN_ATTEMPTS_DEPLETED: 'ui-invalid_pin_attempts_depleted',
     REQUEST_PASSPHRASE: 'ui-request_passphrase',
     REQUEST_PASSPHRASE_ON_DEVICE: 'ui-request_passphrase_on_device',
     INVALID_PASSPHRASE: 'ui-invalid_passphrase',
@@ -116,6 +117,13 @@ export type UiRequestDeviceAction =
       }
     | {
           type: typeof UI_REQUEST.INVALID_PIN;
+          payload: {
+              device: Device;
+              type?: typeof undefined;
+          };
+      }
+    | {
+          type: typeof UI_REQUEST.INVALID_PIN_ATTEMPTS_DEPLETED;
           payload: {
               device: Device;
               type?: typeof undefined;

--- a/packages/suite/src/actions/suite/initAction.ts
+++ b/packages/suite/src/actions/suite/initAction.ts
@@ -10,13 +10,14 @@ import {
     updateMissingTxFiatRatesThunk,
 } from '@suite-common/wallet-core';
 import * as walletConnectActions from '@suite-common/walletconnect';
-import { DEVICE } from '@trezor/connect';
+import { DEVICE, UI } from '@trezor/connect';
 import { isDesktop } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import * as languageActions from 'src/actions/settings/languageActions';
 import * as analyticsActions from 'src/actions/suite/analyticsActions';
 import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
+import * as modalActions from 'src/actions/suite/modalActions';
 import * as routerActions from 'src/actions/suite/routerActions';
 import { selectHasExperimentalFeature } from 'src/reducers/suite/suiteReducer';
 import type { Dispatch, GetState } from 'src/types/suite';
@@ -97,6 +98,14 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
                             }),
                         );
                     }
+                },
+                [UI.INVALID_PIN_ATTEMPTS_DEPLETED]: () => {
+                    dispatch(
+                        modalActions.openModal({
+                            type: UI.INVALID_PIN_ATTEMPTS_DEPLETED,
+                        }),
+                    );
+                    dispatch(modalActions.preserve());
                 },
             }),
         ).unwrap();

--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -22,16 +22,6 @@ export const onCancel = createAction(MODAL.CLOSE);
  */
 export const preserve = createAction(MODAL.PRESERVE);
 
-/**
- * Called from <PinModal /> component
- * Sends pin to `@trezor/connect`
- * @param {string} payload
- * @returns
- */
-export const onPinSubmit = (payload: string) => () => {
-    TrezorConnect.uiResponse({ type: UI.RECEIVE_PIN, payload });
-};
-
 export const onReceiveConfirmation = (confirmation: boolean) => (dispatch: Dispatch) => {
     TrezorConnect.uiResponse({
         type: UI.RECEIVE_CONFIRMATION,

--- a/packages/suite/src/components/suite/PinMatrix/PinMatrix.tsx
+++ b/packages/suite/src/components/suite/PinMatrix/PinMatrix.tsx
@@ -25,6 +25,7 @@ type PinMatrixProps = {
     onSubmit: () => void;
     showExplanation?: boolean;
     showLabel?: boolean;
+    isDisabled?: boolean;
 };
 
 export const PinMatrix = ({
@@ -33,6 +34,7 @@ export const PinMatrix = ({
     pin,
     setPin,
     onSubmit,
+    isDisabled,
 }: PinMatrixProps) => {
     const learnMoreUrl = useExternalLink(HELP_CENTER_PIN_URL);
 
@@ -145,6 +147,7 @@ export const PinMatrix = ({
                                     data-value={value}
                                     onClick={() => onPinAdd(value)}
                                     data-testid={`@pin/input/${value}`}
+                                    disabled={isDisabled}
                                 />
                             ))
                         }
@@ -156,6 +159,7 @@ export const PinMatrix = ({
                             onClick={onPinBackspace}
                             size="small"
                             icon="caretLeft"
+                            isDisabled={isDisabled}
                         >
                             <Translation id="TR_BACKSPACE" />
                         </Button>

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
@@ -14,7 +14,6 @@ import {
     ConfirmXpubModal,
     PassphraseModal,
     PassphraseOnDeviceModal,
-    PinInvalidModal,
     PinModal,
     TransactionReviewModal,
 } from 'src/components/suite/modals';
@@ -48,11 +47,8 @@ export const DeviceContextModal = ({
     switch (windowType) {
         // T1B1 firmware
         case UI.REQUEST_PIN:
-            return <PinModal device={device} />;
-        // T1B1 firmware
         case UI.INVALID_PIN:
-            return <PinInvalidModal device={device} />;
-
+            return <PinModal device={device} />;
         // T2T1 firmware
         case UI.REQUEST_PASSPHRASE_ON_DEVICE:
         case 'ButtonRequest_PassphraseEntry':

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinInvalidModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinInvalidModal.tsx
@@ -1,35 +1,30 @@
 import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
-import { H2, Modal } from '@trezor/components';
-import { ConfirmOnDevice } from '@trezor/product-components';
-import { spacings } from '@trezor/theme';
+import { Modal } from '@trezor/components';
 
-import { DeviceConfirmImage } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
-import { TrezorDevice } from 'src/types/suite';
 
-type PinInvalidModalProps = {
-    device: TrezorDevice;
-};
-
-export const PinInvalidModal = ({ device }: PinInvalidModalProps) => {
+export const PinInvalidModal = ({ onCancel }: { onCancel: () => void }) => {
     const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
 
     return (
         <Modal.Backdrop>
-            <ConfirmOnDevice
-                title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
-                deviceModelInternal={device?.features?.internal_model}
-                deviceUnitColor={device?.features?.unit_color}
-            />
-            <Modal.ModalBase size="tiny">
-                <DeviceConfirmImage device={device} />
-                <H2
-                    align="center"
-                    margin={{ left: spacings.md, right: spacings.md, bottom: spacings.md }}
-                >
-                    <Translation id="TR_ENTERED_PIN_NOT_CORRECT" values={{ deviceLabel }} />
-                </H2>
+            <Modal.ModalBase
+                heading={<Translation id="TR_ENTERED_PIN_NOT_CORRECT" values={{ deviceLabel }} />}
+                onCancel={onCancel}
+                data-testid="@modal/pin"
+                size="tiny"
+                bottomContent={
+                    <>
+                        <Modal.Button onClick={onCancel} variant="tertiary">
+                            <Translation id="TR_CANCEL" />
+                        </Modal.Button>
+                    </>
+                }
+            >
+                Looks like you do not remember your PIN. Step away, take a deep breath and try again
+                later. You may have noticed that pin processing time doubles after each invalid
+                attempt.
             </Modal.ModalBase>
         </Modal.Backdrop>
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinModal.tsx
@@ -18,8 +18,8 @@ export const PinModal = ({ device }: PinModalProps) => {
         handlePinSubmit,
         setPin,
         pin,
+        submitted,
     } = usePin();
-
     if (!device.features) return null;
 
     const getHeading = () => {
@@ -54,7 +54,11 @@ export const PinModal = ({ device }: PinModalProps) => {
                 size="tiny"
                 bottomContent={
                     <>
-                        <Modal.Button onClick={handlePinSubmit} data-testid="@pin/submit-button">
+                        <Modal.Button
+                            onClick={handlePinSubmit}
+                            data-testid="@pin/submit-button"
+                            isDisabled={submitted}
+                        >
                             <Translation id="TR_CONFIRM" />
                         </Modal.Button>
                         <Modal.Button onClick={onCancel} variant="tertiary">
@@ -69,6 +73,7 @@ export const PinModal = ({ device }: PinModalProps) => {
                     onSubmit={handlePinSubmit}
                     // show explanation when either setting a new pin or wipe code or entering existing pin but has at least one invalid attempt
                     showExplanation={isSettingNewPin || isSettingNewWipeCode || hasInvalidAttempts}
+                    isDisabled={submitted}
                 />
             </Modal.ModalBase>
         </Modal.Backdrop>

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinModal.tsx
@@ -1,8 +1,8 @@
+import { usePin } from '@suite-common/wallet-core';
 import { Modal } from '@trezor/components';
 import { ConfirmOnDevice } from '@trezor/product-components';
 
 import { PinMatrix, Translation } from 'src/components/suite';
-import { usePin } from 'src/hooks/suite/usePinModal';
 import { TrezorDevice } from 'src/types/suite';
 
 type PinModalProps = {
@@ -19,7 +19,7 @@ export const PinModal = ({ device }: PinModalProps) => {
         setPin,
         pin,
         submitted,
-    } = usePin();
+    } = usePin(device.buttonRequests);
     if (!device.features) return null;
 
     const getHeading = () => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -1,5 +1,6 @@
 import { CryptoId } from 'invity-api';
 
+import { UI } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
 
 import { MODAL } from 'src/actions/suite/constants';
@@ -29,6 +30,7 @@ import {
     ImportTransactionModal,
     MetadataProviderModal,
     MoreRoundsNeededModal,
+    PinInvalidModal,
     PinMismatchModal,
     QrScannerModal,
     RequestEnableTorModal,
@@ -155,6 +157,8 @@ export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL.CONTE
             return <ImportTransactionModal {...payload} onCancel={onCancel} />;
         case 'pin-mismatch':
             return <PinMismatchModal />;
+        case UI.INVALID_PIN_ATTEMPTS_DEPLETED:
+            return <PinInvalidModal onCancel={onCancel} />;
         case 'application-log':
             return <ApplicationLogModal onCancel={onCancel} />;
         case 'metadata-provider':

--- a/packages/suite/src/hooks/suite/usePinModal.ts
+++ b/packages/suite/src/hooks/suite/usePinModal.ts
@@ -1,11 +1,10 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { ButtonRequest } from '@suite-common/suite-types';
 import { selectDeviceButtonRequests } from '@suite-common/wallet-core';
 import TrezorConnect, { UI } from '@trezor/connect';
 
-import { onPinSubmit } from 'src/actions/suite/modalActions';
-import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useSelector } from 'src/hooks/suite';
 
 const NEW_PIN_REQUEST_TYPES = ['PinMatrixRequestType_NewFirst', 'PinMatrixRequestType_NewSecond'];
 const NEW_WIPE_CODE_REQUEST_TYPES = [
@@ -14,9 +13,8 @@ const NEW_WIPE_CODE_REQUEST_TYPES = [
 ];
 
 const usePinWithoutSelector = (buttonRequests: Pick<ButtonRequest, 'code'>[]) => {
-    const dispatch = useDispatch();
-
     const [pin, setPin] = useState('');
+    const [submitted, setSubmitted] = useState(false);
 
     const pinRequestType = buttonRequests[buttonRequests.length - 1];
     const isSettingNewWipeCode =
@@ -24,24 +22,31 @@ const usePinWithoutSelector = (buttonRequests: Pick<ButtonRequest, 'code'>[]) =>
     const isSettingNewPin =
         pinRequestType?.code && NEW_PIN_REQUEST_TYPES.includes(pinRequestType.code);
 
-    const onCancel = () =>
-        isSettingNewWipeCode
+    const cancel = () => isSettingNewWipeCode
             ? TrezorConnect.cancel('wipe-cancelled')
             : TrezorConnect.cancel('pin-cancelled');
 
     const handlePinSubmit = () => {
-        dispatch(onPinSubmit(pin));
+        setSubmitted(true);
+        TrezorConnect.uiResponse({ type: UI.RECEIVE_PIN, payload: pin });
         setPin('');
     };
+
+    useEffect(() => {
+        setSubmitted(false);
+    }, [buttonRequests.length]);
+
+    const invalidPinAttempts = buttonRequests.filter(r => r.code === UI.INVALID_PIN).length;
 
     return {
         isSettingNewWipeCode,
         isSettingNewPin,
-        hasInvalidAttempts: buttonRequests.filter(r => r.code === UI.INVALID_PIN).length > 0,
+        hasInvalidAttempts: invalidPinAttempts > 0,
         pin,
         setPin,
         handlePinSubmit,
-        onCancel,
+        onCancel: cancel,
+        submitted,
     };
 };
 

--- a/packages/suite/src/views/onboarding/UnexpectedState/index.tsx
+++ b/packages/suite/src/views/onboarding/UnexpectedState/index.tsx
@@ -4,12 +4,12 @@ import styled from 'styled-components';
 
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Button, Column } from '@trezor/components';
+import TrezorConnect, { UI } from '@trezor/connect';
 import { spacings } from '@trezor/theme';
 
-import { onPinSubmit } from 'src/actions/suite/modalActions';
 import { OnboardingStepBox } from 'src/components/onboarding';
 import { PinMatrix, PrerequisitesGuide, Translation } from 'src/components/suite';
-import { useDispatch, useOnboarding, useSelector } from 'src/hooks/suite';
+import { useOnboarding, useSelector } from 'src/hooks/suite';
 import { selectPrerequisite } from 'src/reducers/suite/suiteReducer';
 
 import IsSameDevice from './components/IsSameDevice';
@@ -27,7 +27,6 @@ interface UnexpectedStateProps {
  */
 const UnexpectedState = ({ children }: UnexpectedStateProps) => {
     const [pin, setPin] = useState('');
-    const dispatch = useDispatch();
     const device = useSelector(selectSelectedDevice);
     const prerequisite = useSelector(selectPrerequisite);
 
@@ -63,7 +62,7 @@ const UnexpectedState = ({ children }: UnexpectedStateProps) => {
     }, [activeStep, prerequisite, isNotSameDevice]);
 
     const handlePinSubmit = () => {
-        dispatch(onPinSubmit(pin));
+        TrezorConnect.uiResponse({ type: UI.RECEIVE_PIN, payload: pin });
         setPin('');
     };
 

--- a/packages/suite/src/views/onboarding/steps/Pin.tsx
+++ b/packages/suite/src/views/onboarding/steps/Pin.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 
-
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Button, Column } from '@trezor/components';
 import TrezorConnect, { UI } from '@trezor/connect';

--- a/packages/suite/src/views/onboarding/steps/Pin.tsx
+++ b/packages/suite/src/views/onboarding/steps/Pin.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 
+
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Button, Column } from '@trezor/components';
+import TrezorConnect, { UI } from '@trezor/connect';
 import { spacings } from '@trezor/theme';
 
 import { changePin } from 'src/actions/settings/deviceSettingsActions';
-import { onPinSubmit } from 'src/actions/suite/modalActions';
 import {
     OnboardingButtonCta,
     OnboardingButtonSkip,
@@ -44,7 +45,8 @@ const SetPinStep = () => {
     };
 
     const handlePinSubmit = () => {
-        dispatch(onPinSubmit(pin));
+        TrezorConnect.uiResponse({ type: UI.RECEIVE_PIN, payload: pin });
+
         setPin('');
     };
 

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import { isDeviceAcquired } from '@suite-common/suite-utils';
+import { usePin } from '@suite-common/wallet-core';
 import { Box, H2, Image, Modal, Paragraph } from '@trezor/components';
 import TrezorConnect, { UI } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
@@ -18,7 +19,6 @@ import {
 import { MODAL } from 'src/actions/suite/constants';
 import { Loading, PinMatrix, Translation, WordInputAdvanced } from 'src/components/suite';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
-import { usePin } from 'src/hooks/suite/usePinModal';
 import messages from 'src/support/messages';
 import type { RecoveryType, WordCount } from 'src/types/recovery';
 import type { ForegroundAppProps } from 'src/types/suite';
@@ -39,7 +39,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
     const [wordCount, setWordCount] = useState<WordCount | undefined>();
     const [recoveryType, setRecoveryType] = useState<RecoveryType | undefined>();
     const intl = useIntl();
-    const { pin, setPin, handlePinSubmit } = usePin();
+    const { pin, setPin, handlePinSubmit } = usePin(device?.buttonRequests ?? []);
 
     const deviceModelInternal = device?.features?.internal_model;
     const isT1B1 = deviceModelInternal === DeviceModelInternal.T1B1;

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -28,174 +28,186 @@ const CONNECT_INIT_MODULE = '@common/connect-init';
 // If you are looking where connectInitSettings is defined, it is defined in packages/suite/src/support/extraDependencies.ts
 // or in suite-native/state/src/extraDependencies.ts depends on which platform this connectInitThunk runs.
 
-export const connectInitThunk = createThunk<
-    void,
-    | {
-          [key in typeof DEVICE.CONNECT | typeof DEVICE.CONNECT_UNACQUIRED]?: (
-              device: Device,
-              prevConnectedDevices: TrezorDevice[],
-          ) => void;
-      }
-    | void,
-    void
->(`${CONNECT_INIT_MODULE}/initThunk`, async (connectInitHooks, { dispatch, getState, extra }) => {
-    const {
-        selectors: { selectDebugSettings },
-        actions: { lockDevice },
-        utils: { connectInitSettings },
-    } = extra;
+type ConnectInitHooks = Partial<
+    Record<
+        typeof DEVICE.CONNECT | typeof DEVICE.CONNECT_UNACQUIRED,
+        (device: Device, prevConnectedDevices: TrezorDevice[]) => void
+    >
+> &
+    Partial<Record<typeof UI.INVALID_PIN_ATTEMPTS_DEPLETED, () => void>>;
 
-    const getEnabledNetworks = () => selectEnabledNetworks(getState());
+export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>(
+    `${CONNECT_INIT_MODULE}/initThunk`,
+    async (connectInitHooks, { dispatch, getState, extra }) => {
+        const {
+            selectors: { selectDebugSettings },
+            actions: { lockDevice },
+            utils: { connectInitSettings },
+        } = extra;
 
-    // set event listeners and dispatch as
-    TrezorConnect.on(DEVICE_EVENT, ({ event: _, ...eventData }) => {
-        if (eventData.type === DEVICE.CONNECT || eventData.type === DEVICE.CONNECT_UNACQUIRED) {
-            // This special case here allows us to "inject" extra data into action's payload
-            // and change the type of the action (in this case DeviceEvent type !== Redux Action type)
-            const connectedDevices = selectDevices(getState());
-            dispatch(deviceConnectThunks({ type: eventData.type, device: eventData.payload }));
+        const getEnabledNetworks = () => selectEnabledNetworks(getState());
 
-            connectInitHooks?.[eventData.type]?.(eventData.payload, connectedDevices);
-        } else {
-            // dispatch event as action
-            dispatch({ type: eventData.type, payload: eventData.payload });
-        }
-    });
+        // set event listeners and dispatch as
+        TrezorConnect.on(DEVICE_EVENT, ({ event: _, ...eventData }) => {
+            if (eventData.type === DEVICE.CONNECT || eventData.type === DEVICE.CONNECT_UNACQUIRED) {
+                // This special case here allows us to "inject" extra data into action's payload
+                // and change the type of the action (in this case DeviceEvent type !== Redux Action type)
+                const connectedDevices = selectDevices(getState());
+                dispatch(deviceConnectThunks({ type: eventData.type, device: eventData.payload }));
 
-    TrezorConnect.on(UI_EVENT, ({ event: _, ...action }) => {
-        if (action.type === 'ui-select_device') {
-            // this is why you received the ui-select_device event.
-            console.warn(
-                'Hey, it looks like you called a TrezorConnect method without providing device property.',
-            );
-        }
-
-        if (
-            action.type === 'ui-close_window'
-            // && getState().wallet.discovery[getState().device?.selectedDevice?.path]?.status ==='progress'
-        ) {
-            // return;
-        }
-
-        // dispatch event as action
-        dispatch(action);
-
-        // this switch is still one more layer of indirection to be removed. connect actions are dispatched
-        // and could be handled directly in reducers
-        switch (action.type) {
-            case UI.REQUEST_PIN:
-            case UI.INVALID_PIN:
-                dispatch(
-                    deviceActions.addButtonRequest({
-                        // todo: note that this is not 'threadsafe', currently selected device is not necessarily the device
-                        // connect call was made for
-                        device: selectSelectedDevice(getState()),
-                        buttonRequest: {
-                            code: action.payload.type ? action.payload.type : action.type,
-                        },
-                    }),
-                );
-                break;
-            case UI.REQUEST_BUTTON: {
-                const { device: _, ...request } = action.payload;
-                dispatch(
-                    deviceActions.addButtonRequest({
-                        device: selectSelectedDevice(getState()),
-                        buttonRequest: request,
-                    }),
-                );
-                break;
+                if (connectInitHooks && eventData.type in connectInitHooks) {
+                    connectInitHooks[eventData.type]?.(eventData.payload, connectedDevices);
+                }
+            } else {
+                // dispatch event as action
+                dispatch({ type: eventData.type, payload: eventData.payload });
             }
-        }
-    });
-
-    TrezorConnect.on(TRANSPORT_EVENT, ({ event: _, ...action }) => {
-        // dispatch event as action
-        dispatch(action);
-    });
-
-    TrezorConnect.on(BLOCKCHAIN_EVENT, ({ event: _, ...action }) => {
-        // dispatch event as action
-        dispatch(action);
-    });
-
-    const synchronize = getSynchronize();
-
-    const wrappedMethods: Array<keyof typeof TrezorConnect> = [
-        'applySettings',
-        'authenticateDevice',
-        'authorizeCoinjoin',
-        'backupDevice',
-        'cancelCoinjoinAuthorization',
-        'cardanoGetAddress',
-        'cardanoGetPublicKey',
-        'cardanoSignTransaction',
-        'changePin',
-        'cipherKeyValue',
-        'discoverAccounts',
-        'ethereumGetAddress',
-        'ethereumSignTransaction',
-        'getAddress',
-        'getDeviceState',
-        'getFeatures',
-        'getOwnershipProof',
-        'getPublicKey',
-        'pushTransaction',
-        'recoveryDevice',
-        'resetDevice',
-        'rippleGetAddress',
-        'rippleSignTransaction',
-        'setBusy',
-        'showDeviceTutorial',
-        'signTransaction',
-        'solanaGetAddress',
-        'solanaSignTransaction',
-        'unlockPath',
-        'wipeDevice',
-    ] as const;
-
-    wrappedMethods.forEach(key => {
-        // typescript complains about params and return type, need to be "any"
-        const original: any = TrezorConnect[key];
-        if (!original) return;
-        (TrezorConnect[key] as any) = async (params: any) => {
-            dispatch(lockDevice(true));
-            const result = await synchronize(() => original(params));
-            dispatch(lockDevice(false));
-            dispatch(
-                deviceActions.removeButtonRequests({
-                    // todo: device not 'thread safe' - meaning that device to which button requests have been added to might not
-                    // be the same re-selected device from this line. We should reuse device from params.
-                    device: selectSelectedDevice(getState()),
-                }),
-            );
-
-            return result;
-        };
-    });
-
-    cardanoConnectPatch(getEnabledNetworks);
-
-    const binFilesBaseUrl = isDesktop()
-        ? extra.selectors.selectDesktopBinDir(getState())
-        : DATA_URL;
-
-    const { transports, showConnectLogs } = selectDebugSettings(getState());
-    try {
-        await TrezorConnect.init({
-            ...connectInitSettings,
-            binFilesBaseUrl,
-            pendingTransportEvent: selectIsPendingTransportEvent(getState()),
-            transports,
-            debug: showConnectLogs,
         });
-    } catch (error) {
-        let formattedError: string;
-        if (typeof error === 'string') {
-            formattedError = error;
-        } else {
-            formattedError = error.code ? `${error.code}: ${error.message}` : error.message;
+
+        TrezorConnect.on(UI_EVENT, ({ event: _, ...action }) => {
+            if (action.type === 'ui-select_device') {
+                // this is why you received the ui-select_device event.
+                console.warn(
+                    'Hey, it looks like you called a TrezorConnect method without providing device property.',
+                );
+            }
+
+            if (
+                action.type === 'ui-close_window'
+                // && getState().wallet.discovery[getState().device?.selectedDevice?.path]?.status ==='progress'
+            ) {
+                // return;
+            }
+
+            // dispatch event as action
+            dispatch(action);
+
+            // this switch is still one more layer of indirection to be removed. connect actions are dispatched
+            // and could be handled directly in reducers
+            switch (action.type) {
+                case UI.REQUEST_PIN:
+                case UI.INVALID_PIN:
+                    dispatch(
+                        deviceActions.addButtonRequest({
+                            // todo: note that this is not 'threadsafe', currently selected device is not necessarily the device
+                            // connect call was made for
+                            device: selectSelectedDevice(getState()),
+                            buttonRequest: {
+                                code: action.payload.type ? action.payload.type : action.type,
+                            },
+                        }),
+                    );
+                    break;
+                case UI.REQUEST_BUTTON: {
+                    const { device: _, ...request } = action.payload;
+                    dispatch(
+                        deviceActions.addButtonRequest({
+                            device: selectSelectedDevice(getState()),
+                            buttonRequest: request,
+                        }),
+                    );
+                    break;
+                }
+            }
+
+            if (
+                action.type === UI.INVALID_PIN_ATTEMPTS_DEPLETED &&
+                connectInitHooks &&
+                UI.INVALID_PIN_ATTEMPTS_DEPLETED in connectInitHooks
+            ) {
+                connectInitHooks?.[UI.INVALID_PIN_ATTEMPTS_DEPLETED]?.();
+            }
+        });
+
+        TrezorConnect.on(TRANSPORT_EVENT, ({ event: _, ...action }) => {
+            // dispatch event as action
+            dispatch(action);
+        });
+
+        TrezorConnect.on(BLOCKCHAIN_EVENT, ({ event: _, ...action }) => {
+            // dispatch event as action
+            dispatch(action);
+        });
+
+        const synchronize = getSynchronize();
+
+        const wrappedMethods: Array<keyof typeof TrezorConnect> = [
+            'applySettings',
+            'authenticateDevice',
+            'authorizeCoinjoin',
+            'backupDevice',
+            'cancelCoinjoinAuthorization',
+            'cardanoGetAddress',
+            'cardanoGetPublicKey',
+            'cardanoSignTransaction',
+            'changePin',
+            'cipherKeyValue',
+            'discoverAccounts',
+            'ethereumGetAddress',
+            'ethereumSignTransaction',
+            'getAddress',
+            'getDeviceState',
+            'getFeatures',
+            'getOwnershipProof',
+            'getPublicKey',
+            'pushTransaction',
+            'recoveryDevice',
+            'resetDevice',
+            'rippleGetAddress',
+            'rippleSignTransaction',
+            'setBusy',
+            'showDeviceTutorial',
+            'signTransaction',
+            'solanaGetAddress',
+            'solanaSignTransaction',
+            'unlockPath',
+            'wipeDevice',
+        ] as const;
+
+        wrappedMethods.forEach(key => {
+            // typescript complains about params and return type, need to be "any"
+            const original: any = TrezorConnect[key];
+            if (!original) return;
+            (TrezorConnect[key] as any) = async (params: any) => {
+                dispatch(lockDevice(true));
+                const result = await synchronize(() => original(params));
+
+                dispatch(lockDevice(false));
+                dispatch(
+                    deviceActions.removeButtonRequests({
+                        // todo: device not 'thread safe' - meaning that device to which button requests have been added to might not
+                        // be the same re-selected device from this line. We should reuse device from params.
+                        device: selectSelectedDevice(getState()),
+                    }),
+                );
+
+                return result;
+            };
+        });
+
+        cardanoConnectPatch(getEnabledNetworks);
+
+        const binFilesBaseUrl = isDesktop()
+            ? extra.selectors.selectDesktopBinDir(getState())
+            : DATA_URL;
+
+        const { transports, showConnectLogs } = selectDebugSettings(getState());
+        try {
+            await TrezorConnect.init({
+                ...connectInitSettings,
+                binFilesBaseUrl,
+                pendingTransportEvent: selectIsPendingTransportEvent(getState()),
+                transports,
+                debug: showConnectLogs,
+            });
+        } catch (error) {
+            let formattedError: string;
+            if (typeof error === 'string') {
+                formattedError = error;
+            } else {
+                formattedError = error.code ? `${error.code}: ${error.message}` : error.message;
+            }
+            throw new Error(formattedError);
         }
-        throw new Error(formattedError);
-    }
-});
+    },
+);

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -1,6 +1,7 @@
 import { RequestEnableTorResponse } from '@suite-common/suite-config';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Account, AddressType } from '@suite-common/wallet-types';
+import { UI } from '@trezor/connect';
 import { Deferred } from '@trezor/utils';
 
 import { TrezorDevice } from './device';
@@ -95,6 +96,9 @@ export type UserContextPayload =
       }
     | {
           type: 'pin-mismatch';
+      }
+    | {
+          type: typeof UI.INVALID_PIN_ATTEMPTS_DEPLETED;
       }
     | {
           type: 'device-authenticity-check-opt-out';

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -36,6 +36,7 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "date-fns": "^4.1.0",
+        "react": "18.2.0",
         "react-hook-form": "^7.56.3",
         "web3-utils": "^4.3.1"
     }

--- a/suite-common/wallet-core/src/device/usePinHook.ts
+++ b/suite-common/wallet-core/src/device/usePinHook.ts
@@ -1,10 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { ButtonRequest } from '@suite-common/suite-types';
-import { selectDeviceButtonRequests } from '@suite-common/wallet-core';
 import TrezorConnect, { UI } from '@trezor/connect';
-
-import { useSelector } from 'src/hooks/suite';
 
 const NEW_PIN_REQUEST_TYPES = ['PinMatrixRequestType_NewFirst', 'PinMatrixRequestType_NewSecond'];
 const NEW_WIPE_CODE_REQUEST_TYPES = [
@@ -12,7 +9,7 @@ const NEW_WIPE_CODE_REQUEST_TYPES = [
     'PinMatrixRequestType_WipeCodeSecond',
 ];
 
-const usePinWithoutSelector = (buttonRequests: Pick<ButtonRequest, 'code'>[]) => {
+export const usePin = (buttonRequests: ButtonRequest[]) => {
     const [pin, setPin] = useState('');
     const [submitted, setSubmitted] = useState(false);
 
@@ -22,7 +19,8 @@ const usePinWithoutSelector = (buttonRequests: Pick<ButtonRequest, 'code'>[]) =>
     const isSettingNewPin =
         pinRequestType?.code && NEW_PIN_REQUEST_TYPES.includes(pinRequestType.code);
 
-    const cancel = () => isSettingNewWipeCode
+    const cancel = () =>
+        isSettingNewWipeCode
             ? TrezorConnect.cancel('wipe-cancelled')
             : TrezorConnect.cancel('pin-cancelled');
 
@@ -49,5 +47,3 @@ const usePinWithoutSelector = (buttonRequests: Pick<ButtonRequest, 'code'>[]) =>
         submitted,
     };
 };
-
-export const usePin = () => usePinWithoutSelector(useSelector(selectDeviceButtonRequests));

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -18,6 +18,7 @@ export * from './device/deviceConstants';
 export * from './device/deviceReducer';
 export * from './device/deviceSelectors';
 export * from './device/deviceThunks';
+export * from './device/usePinHook';
 export * from './discovery/discoveryActions';
 export * from './discovery/discoveryReducer';
 export * from './discovery/discoveryThunks';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10101,6 +10101,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     date-fns: "npm:^4.1.0"
+    react: "npm:18.2.0"
     react-hook-form: "npm:^7.56.3"
     web3-utils: "npm:^4.3.1"
   languageName: unknown


### PR DESCRIPTION
cherry picked from #19421 

- added visual feedback after pin is submitted
- removed flickering when invalid pin submitted. here it would be nice to add some error message too.
- added special modal with explanation what happened after 3 invalid pin attempts
- moved to suite-common - would like to reuse in native later

Notes: 
- 3 failed attempts can't be tested with bridge and emulator (device disconnected problem due to device not communicating over udp while validating pin), so i was unable to test this with mobile app. this pr shouldn't have any effect on it however.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=pin-reworked&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=pin-reworked&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=pin-reworked&lookback=7)