### PR TITLE
chore(suite-native): remove redirection with condition that should never happen

### DIFF
--- a/suite-native/module-authorize-device/src/hooks/useOnDeviceReadyNavigation.ts
+++ b/suite-native/module-authorize-device/src/hooks/useOnDeviceReadyNavigation.ts
@@ -56,14 +56,6 @@ export const useOnDeviceReadyNavigation = () => {
     useEffect(() => {
         if (isFirmwareInstallationRunning) return;
 
-        if (!isCoinEnablingInitFinished && isTimeoutFinished) {
-            // TODO: This should not be needed anymore, let's remove it.
-            // User should not be redirected to this screen without coin enabling finished.
-            navigation.navigate(RootStackRoutes.CoinEnablingInit);
-
-            return;
-        }
-
         if (
             (isDeviceReadyToUseAndAuthorized && isTimeoutFinished) ||
             (deviceEnabledDiscoveryNetworkSymbols.length === 0 && isCoinEnablingInitFinished)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description


- useOnDeviceReadyNavigation is only on ConnectingDeviceScreen, and we should never lead the user to that screen without Coin Enabling finished.

## Related Issue

Followup for https://github.com/trezor/trezor-suite/pull/19484


Notes for @trezor/qa:
- Try to break it by connecting trezor to fresh app (coin enabling not visited).
- It could make sense to test also opening app by connecting the trezor (kill app, connect trezor, open app by selecting it in system dialog)
- Test with btc-only FW too



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/remove-hopefully-redundat-redirection&lookback=7)