### PR TITLE
fix(components): add workaround for problem with scrolling to selected option

### DIFF
--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -287,6 +287,8 @@ export type SelectProps = KeyPressScrollProps &
         isLoading?: boolean;
         /** @deprecated: workaround for issues with modal (GH #19376) */
         isRenderedInModal?: boolean;
+        /** @deprecated: workaround for issues with scroll */
+        isScrollToSelectedEnabled?: boolean;
         onChange?: (value: Option, ref?: SelectInstance<Option, boolean> | null) => void;
         'data-testid'?: string;
     };
@@ -305,6 +307,7 @@ export const Select = ({
     placeholder,
     isLoading = false,
     isRenderedInModal = false,
+    isScrollToSelectedEnabled = true,
     'data-testid': dataTest,
     ...rest
 }: SelectProps) => {
@@ -356,12 +359,16 @@ export const Select = ({
                 <Control {...controlProps} data-testid={dataTest} />
             ),
             Option: (optionProps: OptionComponentProps) => (
-                <Option {...optionProps} data-testid={dataTest} selectedOption={selectedOption} />
+                <Option
+                    {...optionProps}
+                    data-testid={dataTest}
+                    selectedOption={isScrollToSelectedEnabled ? selectedOption : undefined}
+                />
             ),
             GroupHeading,
             ...components,
         }),
-        [components, dataTest, selectedOption],
+        [components, dataTest, selectedOption, isScrollToSelectedEnabled],
     );
 
     return (

--- a/packages/connect-explorer-theme/src/components/menu.tsx
+++ b/packages/connect-explorer-theme/src/components/menu.tsx
@@ -186,6 +186,7 @@ export function Menu({
                     menuPortalTarget={typeof document !== 'undefined' ? document.body : undefined}
                     menuShouldScrollIntoView={false}
                     maxMenuHeight={400}
+                    isScrollToSelectedEnabled={false}
                     data-testid="@select-coin"
                 />
             </SelectWrapper>


### PR DESCRIPTION
## Description

Unfortunately #18993 broke the coins menu in Connect Explorer, where it would scroll to the bottom of the page and only then open:

https://github.com/user-attachments/assets/54788c59-4abe-4fac-af59-a0b9352259de

I added a prop to disable the scrolling, before someone refactors the component properly. 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-explorer-select&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-explorer-select&lookback=7)