### PR TITLE
fix(walletconnect): use eip1559 gas estimate

### DIFF
--- a/suite-common/walletconnect/src/adapters/ethereum.ts
+++ b/suite-common/walletconnect/src/adapters/ethereum.ts
@@ -112,7 +112,10 @@ const ethereumRequestThunk = createThunk<
             if (account.networkType !== 'ethereum') {
                 throw new Error('Account is not Ethereum');
             }
-            if (!transaction.gasPrice && !transaction.maxFeePerGas) {
+            if (
+                !transaction.gasPrice &&
+                (!transaction.maxFeePerGas || !transaction.maxPriorityFeePerGas)
+            ) {
                 // Fee not provided, estimate it
                 const feeLevels = await TrezorConnect.blockchainEstimateFee({
                     coin: account.symbol,
@@ -127,7 +130,10 @@ const ethereumRequestThunk = createThunk<
                 if (!feeLevels.success) {
                     throw new Error('eth_sendTransaction cannot estimate fee');
                 }
-                transaction.gasPrice = feeLevels.payload.levels[0]?.feePerUnit;
+                transaction.maxFeePerGas =
+                    feeLevels.payload.levels[0]?.eip1559?.medium?.maxFeePerGas;
+                transaction.maxPriorityFeePerGas =
+                    feeLevels.payload.levels[0]?.eip1559?.medium?.maxPriorityFeePerGas;
             }
             if (!transaction.gas) {
                 const estimatedFee = await TrezorConnect.blockchainEstimateFee({


### PR DESCRIPTION
## Description

Use EIP-1559 fee levels in WalletConnect if not provided from the DApp

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/walletconnect-estimate-eip1559&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/walletconnect-estimate-eip1559&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/walletconnect-estimate-eip1559&lookback=7)