### PR TITLE
Feat/connect handshake cancel

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -53,6 +53,7 @@ import {
     UnavailableCapabilities,
     VersionArray,
 } from '../types';
+import { handshakeCancel } from './workflow/handshake';
 import { initLog } from '../utils/debug';
 import {
     ensureInternalModelFeature,
@@ -74,11 +75,6 @@ type RunOptions = {
     skipFirmwareChecks?: boolean;
     skipLanguageChecks?: boolean;
 };
-
-export const CANCEL_TIMEOUT = 1_000;
-export const GET_FEATURES_TIMEOUT = 3_000;
-// Due to performance issues in suite-native during app start, original timeout is not sufficient.
-export const GET_FEATURES_TIMEOUT_REACT_NATIVE = 20_000;
 
 type Result<T> = { success: true; payload: T } | { success: false; error: Error };
 
@@ -504,34 +500,11 @@ export class Device extends TypedEmitter<DeviceEvents> {
         if (acquireNeeded || !staticSessionId || (!deriveCardano && options.useCardanoDerivation)) {
             // update features
             try {
+                await handshakeCancel({ device: this, logger: _log, signal: abortSignal });
+
                 if (fn) {
                     await this.initialize(!!options.useCardanoDerivation);
                 } else {
-                    const isNative = DataManager.getSettings('env') === 'react-native';
-                    const cancelTimeout = isNative
-                        ? GET_FEATURES_TIMEOUT_REACT_NATIVE
-                        : CANCEL_TIMEOUT;
-
-                    // note 1: clear communication with the device using Cancel message. This causes any remaining messages in its transport stack to get flushed.
-                    //         this case may happen when communication with the device was abruptly interrupted by unloading connect unexpectedly (example window reload)
-                    // note 2: this problem should not occur for the upcoming trezor host protocol, so we limit this to v1 and bridge protocols
-                    // note 3: in 99% of cases we send this message unnecessarily. as @Szymon pointed out, it might be better to catch this call and repeat it.
-                    // note 4: this case can happen also in the 'if' branch. 1] reload app, 2], browser doesn't fire release in time, 3] you get unacquired device, 4] you click
-                    //         the 'use device here' button and here you go. Yet I didn't want to burden every TrezorConnect method call with this but we may reconsider this.
-                    // note 5: ad note 4. it is not so problematic anymore since cleanup on dispose has been improved in https://github.com/trezor/trezor-suite/pull/16930
-                    // note 6: T1 with older bootloader (1.8.0) doesn't respond to Cancel message, so we better ignore those
-                    if (['v1', 'bridge'].includes(this.protocol.name) && !this.possibleHIDdevice) {
-                        // ignore model 1 hid or webusb bootloader mode
-                        _log.debug(
-                            'sending a preventive cancel on the first encounter with the device',
-                        );
-
-                        await Promise.race([
-                            this.getCurrentSession().cancelCall(),
-                            new Promise((_, reject) => setTimeout(reject, cancelTimeout)),
-                        ]).catch(() => this.acquire());
-                    }
-
                     await this.getFeatures();
                 }
             } catch (error) {

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -21,6 +21,11 @@ const blacklist: Record<string, string[] | true> = {
     Features: true,
 };
 
+type AbortableOptions = {
+    timeout?: number;
+    signal?: AbortSignal;
+};
+
 const allowedCallsBeforeInitialize: Messages.MessageKey[] = [
     // Preventive Cancel
     'Cancel',
@@ -68,6 +73,9 @@ export interface TypedCallProvider {
     typedCall: Messages.TypedCall;
     cancelCall: DeviceCurrentSession['cancelCall'];
     isDisposed: () => boolean;
+    call: DeviceCurrentSession['call'];
+    send: DeviceCurrentSession['send'];
+    receive: DeviceCurrentSession['receive'];
 }
 
 export class DeviceCurrentSession implements TypedCallProvider {
@@ -183,7 +191,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
             // next time device should be called together with "Initialize" (calling "acquireDevice" from the UI)
             const timeout = name === 'GetFeatures' ? getFeaturesTimeout() : undefined;
 
-            const callPromise = this.call(name, data, timeout);
+            const callPromise = this.call(name, data, { timeout });
 
             const [abortedDuringCall, response] = await Promise.race([
                 callPromise.then(res => [false, res] as const),
@@ -321,10 +329,10 @@ export class DeviceCurrentSession implements TypedCallProvider {
         }
     }
 
-    private async call<T extends Messages.MessageKey>(
+    async call<T extends Messages.MessageKey>(
         name: T,
         data: Messages.MessagePayload<T>,
-        timeout?: number,
+        options: AbortableOptions = {},
     ) {
         if (this.disposed) return Promise.resolve(error(this.disposed));
 
@@ -336,7 +344,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
             session: this.session,
             protocol: this.device.protocol,
             thpState: this.device.getThpState(),
-            timeout,
+            ...options,
         });
 
         if (result.success) {
@@ -347,7 +355,39 @@ export class DeviceCurrentSession implements TypedCallProvider {
             logger.warn('Received transport error', result.error, result.message);
         }
 
-        return result.success ? success(result.payload) : fail(result.error);
+        return result.success ? success(result.payload) : fail(result.message || result.error);
+    }
+
+    async send<T extends Messages.MessageKey>(
+        name: T,
+        data: Messages.MessagePayload<T>,
+        options: AbortableOptions = {},
+    ) {
+        if (this.disposed) return Promise.resolve(error(this.disposed));
+
+        const result = await this.transport.send({
+            name,
+            data,
+            session: this.session,
+            protocol: this.device.protocol,
+            thpState: this.device.getThpState(),
+            ...options,
+        });
+
+        return result.success ? success(result.payload) : fail(result.message || result.error);
+    }
+
+    async receive(options: AbortableOptions = {}) {
+        if (this.disposed) return Promise.resolve(error(this.disposed));
+
+        const result = await this.transport.receive({
+            session: this.session,
+            protocol: this.device.protocol,
+            thpState: this.device.getThpState(),
+            ...options,
+        });
+
+        return result.success ? success(result.payload) : fail(result.message || result.error);
     }
 
     cancelCall() {

--- a/packages/connect/src/device/__tests__/handshakeWorkflow.test.ts
+++ b/packages/connect/src/device/__tests__/handshakeWorkflow.test.ts
@@ -1,0 +1,233 @@
+import { DataManager } from '../../data/DataManager';
+import { parseConnectSettings } from '../../data/connectSettings';
+import { Device } from '../Device';
+import { handshakeCancel } from '../workflow/handshake';
+
+const { createTestTransport } = global.JestMocks;
+
+const getAcquiredDevice = async (apiMethods: any = {}) => {
+    let emitTransportEvent: (d: any[]) => void = () => {};
+    const transport = createTestTransport({
+        openDevice: () => {
+            setTimeout(() => emitTransportEvent([{ path: '1', session: '1' }]), 100);
+
+            return { success: true, payload: true };
+        },
+        on: (name: string, fn: typeof emitTransportEvent) => {
+            if (name === 'transport-interface-change') {
+                fn([{ path: '1', session: null }]);
+                emitTransportEvent = fn;
+            }
+        },
+        ...apiMethods,
+    });
+    transport.updateMessages(DataManager.getProtobufMessages());
+
+    await transport.init();
+    await transport.enumerate();
+    await transport.listen();
+
+    const device = new Device({
+        id: 'ABCD' as any, // any = DeviceUniquePath
+        transport,
+        descriptor: { path: '1' as any, type: 3, session: null }, // any = PathPublic
+        listener: () => {},
+    });
+    await device.acquire();
+
+    const abortController = new AbortController();
+
+    return { transport, device, abortController };
+};
+
+const fastForward = (time: number) => jest.advanceTimersByTimeAsync(time);
+
+describe('workflow/handshake', () => {
+    beforeAll(() => {
+        // todo: I don't get it. If we pass empty messages: {} (see getDeviceListParams), tests behave differently.
+        DataManager.load(
+            {
+                ...parseConnectSettings({}),
+            },
+            true,
+        );
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        jest.useRealTimers();
+    });
+
+    it('success at N-th read', async () => {
+        let readAttempt = 0;
+        const readMock = jest.fn(
+            () =>
+                new Promise(resolve => {
+                    if (readAttempt >= 3) {
+                        resolve({
+                            success: true,
+                            payload: Buffer.from('3f23230002000000060a046d656f77', 'hex'),
+                        }); // Success
+                    } else {
+                        resolve({ success: true, payload: Buffer.alloc(readAttempt) });
+                        readAttempt++;
+                    }
+                }),
+        );
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const { device, abortController } = await getAcquiredDevice({ read: readMock });
+        await handshakeCancel({ device, signal: abortController.signal });
+
+        expect(console.error).toHaveBeenCalledTimes(1); // empty buffer received at 1st read, console.error was called
+        expect(readMock).toHaveBeenCalledTimes(4); // respond at 4th attempt
+    });
+
+    it('read timeout at N-th attempt', async () => {
+        jest.useFakeTimers();
+
+        let readAttempt = 0;
+        const abortSpy = jest.fn();
+        const readMock = jest.fn(
+            (_, signal) =>
+                new Promise(resolve => {
+                    const timeout = setTimeout(
+                        () => resolve({ success: true, payload: Buffer.alloc(readAttempt) }),
+                        500 * readAttempt, // increase respond time on each attempt, should timeout on 3rd
+                    );
+                    signal.addEventListener('abort', () => {
+                        abortSpy();
+                        clearTimeout(timeout);
+                        resolve({ success: false });
+                    });
+                    readAttempt++;
+                }),
+        );
+
+        const { device, abortController } = await getAcquiredDevice({ read: readMock });
+        const promise = handshakeCancel({ device, signal: abortController.signal });
+
+        await fastForward(2000);
+        await promise;
+
+        expect(readMock).toHaveBeenCalledTimes(3);
+        expect(abortSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('read aborted', async () => {
+        jest.useFakeTimers();
+
+        const abortSpy = jest.fn();
+        const readMock = jest.fn(
+            (_, signal) =>
+                new Promise(resolve => {
+                    const timeout = setTimeout(() => resolve({ success: false }), 2000);
+                    signal.addEventListener('abort', () => {
+                        abortSpy();
+                        clearTimeout(timeout);
+                        resolve({ success: false });
+                    });
+                }),
+        );
+
+        const { device, abortController } = await getAcquiredDevice({ read: readMock });
+        const promise = handshakeCancel({ device, signal: abortController.signal });
+
+        await fastForward(500);
+        abortController.abort();
+        await promise;
+
+        expect(abortSpy).toHaveBeenCalledTimes(1);
+        expect(readMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('read attempts limit reached', async () => {
+        const readMock = jest.fn(() => ({ success: true, payload: Buffer.alloc(10) }));
+
+        const { device, abortController } = await getAcquiredDevice({ read: readMock });
+        await handshakeCancel({ device, signal: abortController.signal });
+
+        expect(readMock).toHaveBeenCalledTimes(10);
+    });
+
+    it('skipped. Device with features', async () => {
+        const { device, abortController, transport } = await getAcquiredDevice();
+        await device.getFeatures();
+
+        const sendSpy = jest.spyOn(transport, 'send');
+        await handshakeCancel({ device, signal: abortController.signal });
+
+        expect(sendSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it('skipped. Device with protocol v2', async () => {
+        const { device, abortController, transport } = await getAcquiredDevice();
+        await device.getFeatures();
+
+        const sendSpy = jest.spyOn(transport, 'send');
+        await handshakeCancel({ device, signal: abortController.signal });
+
+        expect(sendSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it('send timeout', async () => {
+        jest.useFakeTimers();
+
+        const abortSpy = jest.fn();
+        const writeMock = jest.fn(
+            (_a, _b, signal) =>
+                new Promise(resolve => {
+                    const timeout = setTimeout(() => resolve({ success: false }), 2000);
+                    signal.addEventListener('abort', () => {
+                        abortSpy();
+                        clearTimeout(timeout);
+                        resolve({ success: false });
+                    });
+                }),
+        );
+        const readMock = jest.fn();
+
+        const { device, abortController } = await getAcquiredDevice({
+            write: writeMock,
+            read: readMock,
+        });
+        const promise = handshakeCancel({ device, signal: abortController.signal });
+
+        await fastForward(2000);
+        await promise;
+
+        expect(writeMock).toHaveBeenCalledTimes(1);
+        expect(abortSpy).toHaveBeenCalledTimes(1);
+        expect(readMock).toHaveBeenCalledTimes(0);
+    });
+
+    it('send aborted', async () => {
+        jest.useFakeTimers();
+
+        const abortSpy = jest.fn();
+        const writeMock = jest.fn(
+            (_a, _b, signal) =>
+                new Promise(resolve => {
+                    const timeout = setTimeout(() => resolve({ success: false }), 2000);
+                    signal.addEventListener('abort', () => {
+                        abortSpy();
+                        clearTimeout(timeout);
+                        resolve({ success: false });
+                    });
+                }),
+        );
+        const readMock = jest.fn();
+
+        const { device } = await getAcquiredDevice({ write: writeMock, read: readMock });
+        const abortController = new AbortController();
+        const promise = handshakeCancel({ device, signal: abortController.signal });
+
+        await fastForward(500);
+        abortController.abort();
+        await promise;
+
+        expect(writeMock).toHaveBeenCalledTimes(1);
+        expect(abortSpy).toHaveBeenCalledTimes(1);
+        expect(readMock).toHaveBeenCalledTimes(0);
+    });
+});

--- a/packages/connect/src/device/workflow/handshake.ts
+++ b/packages/connect/src/device/workflow/handshake.ts
@@ -1,0 +1,83 @@
+import { PROTOCOL_MALFORMED } from '@trezor/protocol';
+
+import { DataManager } from '../../data/DataManager';
+import { WorkflowContext } from '../../types/workflow';
+import { Log } from '../../utils/debug';
+
+const CANCEL_TIMEOUT = 1_000;
+// Due to performance issues in suite-native during app start, original timeout is not sufficient.
+const CANCEL_TIMEOUT_REACT_NATIVE = 20_000;
+const ATTEMPTS_LIMIT = 10;
+
+type Context = {
+    device: WorkflowContext['device'];
+    signal: AbortSignal;
+    logger?: Log;
+};
+
+// note 1: clear communication with the device using Cancel message. This causes any remaining messages in its transport stack to get flushed.
+//         this case may happen when communication with the device was abruptly interrupted by unloading connect unexpectedly (example window reload)
+// note 2: this problem should not occur for the upcoming trezor host protocol, so we limit this to v1 and bridge protocols
+// note 3: in 99% of cases we send this message unnecessarily. as @Szymon pointed out, it might be better to catch this call and repeat it.
+// note 4: this case can happen also in the 'if' branch. 1] reload app, 2], browser doesn't fire release in time, 3] you get unacquired device, 4] you click
+//         the 'use device here' button and here you go. Yet I didn't want to burden every TrezorConnect method call with this but we may reconsider this.
+// note 5: ad note 4. it is not so problematic anymore since cleanup on dispose has been improved in https://github.com/trezor/trezor-suite/pull/16930
+// note 6: T1 with older bootloader (1.8.0) doesn't respond to Cancel message, so we better ignore those
+export const handshakeCancel = async ({ device, logger, signal }: Context) => {
+    // device handshake already done
+    if (device.features) {
+        return;
+    }
+
+    const isNative = DataManager.getSettings('env') === 'react-native';
+    const cancelTimeout = isNative ? CANCEL_TIMEOUT_REACT_NATIVE : CANCEL_TIMEOUT;
+
+    logger?.debug('handshake Cancel start');
+
+    // send could fail on T1 bootloader when device has erase/wipe button request displayed
+    const send = await device
+        .getCurrentSession()
+        .send('Cancel', {}, { signal, timeout: cancelTimeout });
+
+    if (!send.success) {
+        logger?.debug(`handshake Cancel send error ${send.error}`);
+
+        return;
+    }
+
+    logger?.debug('handshake Cancel sent');
+
+    // try to read until receive some meaningful decoded message, timeout or attempts limit reached
+    for (let attempt = 0; attempt < ATTEMPTS_LIMIT; ++attempt) {
+        logger?.debug(`handshake Cancel read attempt ${attempt}`);
+
+        const result = await device.getCurrentSession().receive({
+            signal,
+            timeout: cancelTimeout,
+        });
+
+        // Malformed protocol is thrown if received chunk:
+        // 1. is empty message (empty buffer)
+        // 2. has invalid protocol header
+        // 3. it is a continuation packet
+        // 4. message could not be encoded for some other reason (for example: missing definitions)
+        if (!result.success && result.error.message !== PROTOCOL_MALFORMED) {
+            logger?.debug(`handshake Cancel read error: ${result.error}`);
+
+            // in any other case stop reading
+            return;
+        } else if (result.success) {
+            logger?.debug(`handshake Cancel read success: ${result.payload.type}`);
+            if (
+                result.payload.type === 'Failure' &&
+                result.payload.message.code === 'Failure_InvalidProtocol'
+            ) {
+                logger?.debug(`handshake Cancel protocol v2 detected`);
+            }
+
+            return;
+        }
+    }
+
+    logger?.debug(`handshake Cancel attempts limit reached`);
+};

--- a/packages/connect/src/device/workflow/handshake.ts
+++ b/packages/connect/src/device/workflow/handshake.ts
@@ -1,4 +1,6 @@
 import { PROTOCOL_MALFORMED } from '@trezor/protocol';
+import { TRANSPORT_ERROR } from '@trezor/transport';
+import { resolveAfter, versionUtils } from '@trezor/utils';
 
 import { DataManager } from '../../data/DataManager';
 import { WorkflowContext } from '../../types/workflow';
@@ -14,6 +16,10 @@ type Context = {
     signal: AbortSignal;
     logger?: Log;
 };
+
+const isLegacyBridge = (transport: Context['device']['transport']) =>
+    transport.name === 'BridgeTransport' &&
+    !versionUtils.isNewerOrEqual(transport.version, '3.0.0');
 
 // note 1: clear communication with the device using Cancel message. This causes any remaining messages in its transport stack to get flushed.
 //         this case may happen when communication with the device was abruptly interrupted by unloading connect unexpectedly (example window reload)
@@ -55,6 +61,16 @@ export const handshakeCancel = async ({ device, logger, signal }: Context) => {
             signal,
             timeout: cancelTimeout,
         });
+
+        // Older T1 don't respond to Cancel message which seems to be recoverable only by reacquiring
+        if (!result.success && result.error.message === TRANSPORT_ERROR.ABORTED_BY_TIMEOUT) {
+            // On trezord, session is lost when request is aborted from outside, so we should wait
+            // for the session change before we reacquire
+            if (isLegacyBridge(device.transport)) {
+                await resolveAfter(501);
+            }
+            await device.acquire();
+        }
 
         // Malformed protocol is thrown if received chunk:
         // 1. is empty message (empty buffer)

--- a/packages/protocol/src/protocol-bridge/decode.ts
+++ b/packages/protocol/src/protocol-bridge/decode.ts
@@ -1,4 +1,5 @@
 import { HEADER_SIZE } from './constants';
+import { PROTOCOL_MALFORMED } from '../errors';
 import { TransportProtocolDecode } from '../types';
 
 /**
@@ -14,6 +15,10 @@ const readHeader = (buffer: Buffer) => {
 };
 
 export const decode: TransportProtocolDecode = bytes => {
+    if (bytes.byteLength < HEADER_SIZE) {
+        throw new Error(PROTOCOL_MALFORMED);
+    }
+
     const { messageType, length } = readHeader(bytes);
 
     return {

--- a/packages/protocol/src/protocol-v1/decode.ts
+++ b/packages/protocol/src/protocol-v1/decode.ts
@@ -1,4 +1,4 @@
-import * as ERRORS from '../errors';
+import { PROTOCOL_MALFORMED } from '../errors';
 import { HEADER_SIZE, MESSAGE_HEADER_BYTE, MESSAGE_MAGIC_HEADER_BYTE } from './constants';
 import { TransportProtocolDecode } from '../types';
 
@@ -28,6 +28,10 @@ export const decode: TransportProtocolDecode = bytes => {
         console.error('protocol-v1: decode: received empty buffer');
     }
 
+    if (bytes.byteLength < HEADER_SIZE) {
+        throw new Error(PROTOCOL_MALFORMED);
+    }
+
     const { magic, sharp1, sharp2, messageType, length } = readHeaderChunked(bytes);
 
     if (
@@ -36,7 +40,7 @@ export const decode: TransportProtocolDecode = bytes => {
         sharp2 !== MESSAGE_HEADER_BYTE
     ) {
         // read-write is out of sync
-        throw new Error(ERRORS.PROTOCOL_MALFORMED);
+        throw new Error(PROTOCOL_MALFORMED);
     }
 
     return {

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -239,6 +239,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
         protocol: customProtocol,
         thpState,
         signal,
+        timeout,
     }: AbstractTransportMethodParams<'send'>) {
         return this.scheduleAction(
             async signal => {
@@ -272,7 +273,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
                 return sendResult;
             },
-            { signal, timeout: undefined },
+            { signal, timeout },
         );
     }
 
@@ -281,6 +282,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
         protocol: customProtocol,
         thpState,
         signal,
+        timeout,
     }: AbstractTransportMethodParams<'receive'>) {
         return this.scheduleAction(
             async signal => {
@@ -301,7 +303,6 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 );
 
                 if (!message.success) {
-                    console.log(message.error);
                     if (message.error === ERRORS.DEVICE_DISCONNECTED_DURING_ACTION) {
                         this.enumerate();
                     }
@@ -309,7 +310,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
                 return message;
             },
-            { signal, timeout: undefined },
+            { signal, timeout },
         );
     }
 

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -269,6 +269,7 @@ export class BridgeTransport extends AbstractTransport {
         protocol: customProtocol,
         thpState,
         signal,
+        timeout,
     }: AbstractTransportMethodParams<'send'>) {
         return this.scheduleAction(
             async signal => {
@@ -291,7 +292,7 @@ export class BridgeTransport extends AbstractTransport {
 
                 return this.success(undefined);
             },
-            { signal },
+            { signal, timeout },
         );
     }
 
@@ -300,6 +301,7 @@ export class BridgeTransport extends AbstractTransport {
         protocol: customProtocol,
         thpState,
         signal,
+        timeout,
     }: AbstractTransportMethodParams<'receive'>) {
         return this.scheduleAction(
             async signal => {
@@ -321,7 +323,7 @@ export class BridgeTransport extends AbstractTransport {
                     thpState,
                 );
             },
-            { signal, timeout: undefined },
+            { signal, timeout },
         );
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Cleaning up in handshake Cancel aka preventive cancel, moving code to standalone module (workflow)

1. Cancel is called **always** as first message even before Initialize (currently ii is done only before GetFeatures)
2. not using Transport.call anymore, instead of call workflow is using send + receive loop until: receive meaningful response or timeout or attempt limit reached.
3. both send and receive are using timeout and abort signal
4. Cancel response can detect protocol v2/thp 

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-handshake-cancel&lookback=7)