### PR TITLE
Chore: filter accounts at display

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -1,26 +1,19 @@
 import { AccountType } from '@suite-common/wallet-config';
-import {
-    selectDeviceAccountsVisibleEnabledAndSupported,
-    selectSelectedDevice,
-} from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
-import { accountSearchFn, getFailedAccounts, sortByCoin } from '@suite-common/wallet-utils';
+import { accountSearchFn } from '@suite-common/wallet-utils';
 import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
-import {
-    useAccountSearch,
-    useDefaultAccountLabel,
-    useDiscovery,
-    useSelector,
-} from 'src/hooks/suite';
+import { useAccountSearch, useDefaultAccountLabel, useSelector } from 'src/hooks/suite';
 import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
 
 import { AccountGroup } from './AccountGroup';
 import { AccountItemSkeleton } from './AccountItemSkeleton';
 import { AccountSection } from './AccountSection';
 import { AccountsMenuNotice } from './AccountsMenuNotice';
+import { useAccounts } from '../../../../hooks/wallet';
 import { selectDiscoveryOverallStatus } from '../../../../utils/wallet/selectDiscoveryOverallStatus';
 import { CollapsedSidebarOnly } from '../../../suite/layouts/SuiteLayout/Sidebar/CollapsedSidebarOnly';
 import { ExpandedSidebarOnly } from '../../../suite/layouts/SuiteLayout/Sidebar/ExpandedSidebarOnly';
@@ -78,10 +71,9 @@ const Accounts = ({
 
 export const AccountsList = ({ onItemClick }: AccountListProps) => {
     const device = useSelector(selectSelectedDevice);
-    const accounts = useSelector(selectDeviceAccountsVisibleEnabledAndSupported);
+    const accounts = useAccounts();
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const coinjoinIsPreloading = useSelector(state => state.wallet.coinjoin.isPreloading);
-    const { discovery } = useDiscovery();
     const accountLabels = useSelector(selectAccountLabels);
     const { getDefaultAccountLabel } = useDefaultAccountLabel();
     const isSidebarCollapsed = useIsSidebarCollapsed();
@@ -93,13 +85,9 @@ export const AccountsList = ({ onItemClick }: AccountListProps) => {
         return null;
     }
 
-    const staticSessionId = device.state?.staticSessionId;
-    const failed = getFailedAccounts(staticSessionId, discovery);
-
-    const list = sortByCoin(accounts).concat(failed);
     const filteredAccounts =
         searchString || coinFilter
-            ? list.filter(account => {
+            ? accounts.filter(account => {
                   const { key, accountType, symbol, index } = account;
                   const accountLabel = Object.prototype.hasOwnProperty.call(accountLabels, key)
                       ? accountLabels[key]
@@ -107,7 +95,7 @@ export const AccountsList = ({ onItemClick }: AccountListProps) => {
 
                   return accountSearchFn(account, searchString, coinFilter, accountLabel);
               })
-            : list;
+            : accounts;
 
     const filterAccountsByType = (type: Account['accountType']) =>
         filteredAccounts.filter(a => a.accountType === type);

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -1,5 +1,5 @@
 import { AccountType } from '@suite-common/wallet-config';
-import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { selectAllAccountsToList, selectSelectedDevice } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import { accountSearchFn } from '@suite-common/wallet-utils';
 import { Column } from '@trezor/components';
@@ -13,7 +13,6 @@ import { AccountGroup } from './AccountGroup';
 import { AccountItemSkeleton } from './AccountItemSkeleton';
 import { AccountSection } from './AccountSection';
 import { AccountsMenuNotice } from './AccountsMenuNotice';
-import { useAccounts } from '../../../../hooks/wallet';
 import { selectDiscoveryOverallStatus } from '../../../../utils/wallet/selectDiscoveryOverallStatus';
 import { CollapsedSidebarOnly } from '../../../suite/layouts/SuiteLayout/Sidebar/CollapsedSidebarOnly';
 import { ExpandedSidebarOnly } from '../../../suite/layouts/SuiteLayout/Sidebar/ExpandedSidebarOnly';
@@ -71,7 +70,7 @@ const Accounts = ({
 
 export const AccountsList = ({ onItemClick }: AccountListProps) => {
     const device = useSelector(selectSelectedDevice);
-    const accounts = useAccounts();
+    const accounts = useSelector(selectAllAccountsToList);
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const coinjoinIsPreloading = useSelector(state => state.wallet.coinjoin.isPreloading);
     const accountLabels = useSelector(selectAccountLabels);

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -1,5 +1,8 @@
 import { AccountType } from '@suite-common/wallet-config';
-import { selectAccounts, selectSelectedDevice } from '@suite-common/wallet-core';
+import {
+    selectDeviceAccountsVisibleEnabledAndSupported,
+    selectSelectedDevice,
+} from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import { accountSearchFn, getFailedAccounts, sortByCoin } from '@suite-common/wallet-utils';
 import { Column } from '@trezor/components';
@@ -75,7 +78,7 @@ const Accounts = ({
 
 export const AccountsList = ({ onItemClick }: AccountListProps) => {
     const device = useSelector(selectSelectedDevice);
-    const accounts = useSelector(selectAccounts);
+    const accounts = useSelector(selectDeviceAccountsVisibleEnabledAndSupported);
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const coinjoinIsPreloading = useSelector(state => state.wallet.coinjoin.isPreloading);
     const { discovery } = useDiscovery();
@@ -93,7 +96,7 @@ export const AccountsList = ({ onItemClick }: AccountListProps) => {
     const staticSessionId = device.state?.staticSessionId;
     const failed = getFailedAccounts(staticSessionId, discovery);
 
-    const list = sortByCoin(accounts.filter(a => a.deviceState === staticSessionId)).concat(failed);
+    const list = sortByCoin(accounts).concat(failed);
     const filteredAccounts =
         searchString || coinFilter
             ? list.filter(account => {
@@ -107,21 +110,17 @@ export const AccountsList = ({ onItemClick }: AccountListProps) => {
             : list;
 
     const filterAccountsByType = (type: Account['accountType']) =>
-        filteredAccounts.filter(a => a.accountType === type && (!a.empty || a.visible));
+        filteredAccounts.filter(a => a.accountType === type);
 
     // always show first "normal" account even if they are empty
-    const normalAccounts = filteredAccounts.filter(
-        a => a.accountType === 'normal' && (a.index === 0 || !a.empty || a.visible),
-    );
+    const normalAccounts = filteredAccounts.filter(a => a.accountType === 'normal');
     const coinjoinAccounts = filterAccountsByType('coinjoin');
     const taprootAccounts = filterAccountsByType('taproot');
     const segwitAccounts = filterAccountsByType('segwit');
     const legacyAccounts = filterAccountsByType('legacy');
     const ledgerAccounts = filterAccountsByType('ledger');
 
-    const hasMultipleAccounts = filteredAccounts.some(
-        a => a.accountType !== 'normal' && (!a.empty || a.visible),
-    );
+    const hasMultipleAccounts = filteredAccounts.some(a => a.accountType !== 'normal');
     const { params } = selectedAccount;
 
     const keepOpen = (type: Account['accountType']) =>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { selectAllAccountsToList, selectSelectedDevice } from '@suite-common/wallet-core';
 import {
     Box,
     Column,
@@ -18,7 +18,6 @@ import { CoinsFilter } from './CoinsFilter';
 import { useAvailableNetworkSymbols } from './useAvailableNetworkSymbols';
 import { setIsCoinsFilterVisible } from '../../../../actions/suite/suiteActions';
 import { useAccountSearch, useDiscovery, useDispatch, useSelector } from '../../../../hooks/suite';
-import { useAccounts } from '../../../../hooks/wallet';
 import { Translation } from '../../../suite';
 import { CollapsedSidebarOnly } from '../../../suite/layouts/SuiteLayout/Sidebar/CollapsedSidebarOnly';
 import { ExpandedSidebarOnly } from '../../../suite/layouts/SuiteLayout/Sidebar/ExpandedSidebarOnly';
@@ -43,7 +42,7 @@ export const AccountsMenuHeader = () => {
     const { coinFilter } = useAccountSearch();
 
     const device = useSelector(selectSelectedDevice);
-    const accounts = useAccounts();
+    const accounts = useSelector(selectAllAccountsToList);
     const { discovery } = useDiscovery();
 
     const isEmpty = accounts.length === 0;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 
 import { selectSelectedDevice } from '@suite-common/wallet-core';
-import { getFailedAccounts, sortByCoin } from '@suite-common/wallet-utils';
 import {
     Box,
     Column,
@@ -19,6 +18,7 @@ import { CoinsFilter } from './CoinsFilter';
 import { useAvailableNetworkSymbols } from './useAvailableNetworkSymbols';
 import { setIsCoinsFilterVisible } from '../../../../actions/suite/suiteActions';
 import { useAccountSearch, useDiscovery, useDispatch, useSelector } from '../../../../hooks/suite';
+import { useAccounts } from '../../../../hooks/wallet';
 import { Translation } from '../../../suite';
 import { CollapsedSidebarOnly } from '../../../suite/layouts/SuiteLayout/Sidebar/CollapsedSidebarOnly';
 import { ExpandedSidebarOnly } from '../../../suite/layouts/SuiteLayout/Sidebar/ExpandedSidebarOnly';
@@ -43,13 +43,10 @@ export const AccountsMenuHeader = () => {
     const { coinFilter } = useAccountSearch();
 
     const device = useSelector(selectSelectedDevice);
-    const accounts = useSelector(state => state.wallet.accounts);
+    const accounts = useAccounts();
     const { discovery } = useDiscovery();
 
-    const staticSessionId = device?.state?.staticSessionId;
-    const failed = getFailedAccounts(staticSessionId, discovery);
-    const list = sortByCoin(accounts.filter(a => a.deviceState === staticSessionId).concat(failed));
-    const isEmpty = list.length === 0;
+    const isEmpty = accounts.length === 0;
 
     const isDiscoveryRunning = discovery?.status === 'progress';
     const isCoinsFilterVisible = useSelector(state => state.suite.settings.isCoinsFilterVisible);

--- a/packages/suite/src/hooks/wallet/index.ts
+++ b/packages/suite/src/hooks/wallet/index.ts
@@ -1,2 +1,1 @@
-export { useAccounts } from './useAccounts';
 export { useSendFormContext } from './useSendForm';

--- a/packages/suite/src/hooks/wallet/index.ts
+++ b/packages/suite/src/hooks/wallet/index.ts
@@ -1,2 +1,2 @@
-export { useAccounts, useFastAccounts } from './useAccounts';
+export { useAccounts } from './useAccounts';
 export { useSendFormContext } from './useSendForm';

--- a/packages/suite/src/hooks/wallet/useAccounts.ts
+++ b/packages/suite/src/hooks/wallet/useAccounts.ts
@@ -1,30 +1,8 @@
 import { useMemo } from 'react';
 
-import {
-    selectDeviceAccountsVisibleEnabledAndSupported,
-    selectDiscoveryForSelectedDevice,
-    selectSelectedDevice,
-} from '@suite-common/wallet-core';
-import { getFailedAccounts, sortByCoin } from '@suite-common/wallet-utils';
 import type { AccountAddress } from '@trezor/connect';
 
-import { useSelector } from 'src/hooks/suite';
 import type { Account } from 'src/types/wallet';
-
-export const useAccounts = () => {
-    const accounts = useSelector(selectDeviceAccountsVisibleEnabledAndSupported);
-    const device = useSelector(selectSelectedDevice);
-    const staticSessionId = device?.state?.staticSessionId;
-    const discovery = useSelector(selectDiscoveryForSelectedDevice);
-
-    return useMemo(() => {
-        const failed = getFailedAccounts(staticSessionId, discovery);
-        const allAccounts = [...accounts, ...failed];
-        const sortedAccounts = sortByCoin(allAccounts);
-
-        return sortedAccounts;
-    }, [staticSessionId, discovery, accounts]);
-};
 
 export const useAccountAddressDictionary = (account: Account | undefined) =>
     useMemo(() => {

--- a/packages/suite/src/hooks/wallet/useAccounts.ts
+++ b/packages/suite/src/hooks/wallet/useAccounts.ts
@@ -1,34 +1,29 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
-import { selectSelectedDevice } from '@suite-common/wallet-core';
-import { DiscoveryStatus } from '@suite-common/wallet-types';
-import * as accountUtils from '@suite-common/wallet-utils';
+import {
+    selectDeviceAccountsVisibleEnabledAndSupported,
+    selectDiscoveryForSelectedDevice,
+    selectSelectedDevice,
+} from '@suite-common/wallet-core';
+import { getAllAccounts, getFailedAccounts, sortByCoin } from '@suite-common/wallet-utils';
 import type { AccountAddress } from '@trezor/connect';
 
 import { useSelector } from 'src/hooks/suite';
 import type { Account } from 'src/types/wallet';
 
-export const useAccounts = (discovery?: DiscoveryStatus) => {
-    const [accounts, setAccounts] = useState<Account[]>([]);
-
+export const useAccounts = () => {
+    const accounts = useSelector(selectDeviceAccountsVisibleEnabledAndSupported);
     const device = useSelector(selectSelectedDevice);
-    const accountsState = useSelector(state => state.wallet.accounts);
+    const staticSessionId = device?.state?.staticSessionId;
+    const discovery = useSelector(selectDiscoveryForSelectedDevice);
 
-    useEffect(() => {
-        if (device) {
-            const deviceAccounts = accountUtils.getAllAccounts(device.state, accountsState);
-            const failedAccounts = accountUtils.getFailedAccounts(
-                device?.state?.staticSessionId,
-                discovery,
-            );
-            const sortedAccounts = accountUtils.sortByCoin(deviceAccounts.concat(failedAccounts));
-            setAccounts(sortedAccounts);
-        }
-    }, [device, discovery, accountsState]);
+    return useMemo(() => {
+        const failed = getFailedAccounts(staticSessionId, discovery);
+        const allAccounts = [...accounts, ...failed];
+        const sortedAccounts = sortByCoin(allAccounts);
 
-    return {
-        accounts,
-    };
+        return sortedAccounts;
+    }, [staticSessionId, discovery, accounts]);
 };
 
 export const useFastAccounts = () => {
@@ -36,7 +31,7 @@ export const useFastAccounts = () => {
     const accounts = useSelector(state => state.wallet.accounts);
 
     const deviceAccounts = useMemo(
-        () => (device ? accountUtils.getAllAccounts(device.state, accounts) : []),
+        () => (device ? getAllAccounts(device.state, accounts) : []),
         [accounts, device],
     );
 

--- a/packages/suite/src/hooks/wallet/useAccounts.ts
+++ b/packages/suite/src/hooks/wallet/useAccounts.ts
@@ -5,7 +5,7 @@ import {
     selectDiscoveryForSelectedDevice,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
-import { getAllAccounts, getFailedAccounts, sortByCoin } from '@suite-common/wallet-utils';
+import { getFailedAccounts, sortByCoin } from '@suite-common/wallet-utils';
 import type { AccountAddress } from '@trezor/connect';
 
 import { useSelector } from 'src/hooks/suite';
@@ -24,18 +24,6 @@ export const useAccounts = () => {
 
         return sortedAccounts;
     }, [staticSessionId, discovery, accounts]);
-};
-
-export const useFastAccounts = () => {
-    const device = useSelector(selectSelectedDevice);
-    const accounts = useSelector(state => state.wallet.accounts);
-
-    const deviceAccounts = useMemo(
-        () => (device ? getAllAccounts(device.state, accounts) : []),
-        [accounts, device],
-    );
-
-    return deviceAccounts;
 };
 
 export const useAccountAddressDictionary = (account: Account | undefined) =>

--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -10,6 +10,7 @@ import {
     isNetworkSymbol,
 } from '@suite-common/wallet-config';
 import {
+    selectAllAccountsToList,
     selectCurrentFiatRates,
     selectEnabledNetworks,
     selectLocalCurrency,
@@ -33,7 +34,6 @@ import { DashboardSection } from 'src/components/dashboard';
 import { Translation } from 'src/components/suite';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { useDiscovery, useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
-import { useAccounts } from 'src/hooks/wallet';
 import { Account } from 'src/types/wallet';
 import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOverallStatus';
 
@@ -93,7 +93,7 @@ export const AssetsView = () => {
     const dispatch = useDispatch();
     const { isDiscoveryRunning } = useDiscovery();
     const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
-    const accounts = useAccounts();
+    const accounts = useSelector(selectAllAccountsToList);
     const { supportedMainnets } = useNetworkSupport();
     const { isBelowTablet } = useLayoutSize();
 

--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -91,9 +91,9 @@ export const AssetsView = () => {
 
     const theme = useTheme();
     const dispatch = useDispatch();
-    const { discovery, isDiscoveryRunning } = useDiscovery();
+    const { isDiscoveryRunning } = useDiscovery();
     const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
-    const { accounts } = useAccounts(discovery);
+    const accounts = useAccounts();
     const { supportedMainnets } = useNetworkSupport();
     const { isBelowTablet } = useLayoutSize();
 

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -10,7 +10,7 @@ import { setFlag } from 'src/actions/suite/suiteActions';
 import { DashboardSection } from 'src/components/dashboard';
 import { GraphScaleDropdownItem, GraphSkeleton, Translation } from 'src/components/suite';
 import { useDevice, useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
-import { useFastAccounts } from 'src/hooks/wallet';
+import { useAccounts } from 'src/hooks/wallet';
 import { useTotalFiatBalance } from 'src/hooks/wallet/useTotalFiatBalance';
 import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOverallStatus';
 
@@ -24,7 +24,7 @@ export const PortfolioCard = memo(() => {
     const localCurrency = useSelector(selectLocalCurrency);
     const { discovery, isDiscoveryRunning } = useDiscovery();
     const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
-    const accounts = useFastAccounts();
+    const accounts = useAccounts();
     const { dashboardGraphHidden } = useSelector(s => s.suite.flags);
     const dispatch = useDispatch();
     const { device } = useDevice();

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -1,6 +1,10 @@
 import { memo, useMemo } from 'react';
 
-import { selectCurrentFiatRates, selectLocalCurrency } from '@suite-common/wallet-core';
+import {
+    selectAllAccountsToList,
+    selectCurrentFiatRates,
+    selectLocalCurrency,
+} from '@suite-common/wallet-core';
 import { Card, Column, Dropdown, Switch, Tooltip } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { spacings } from '@trezor/theme';
@@ -10,7 +14,6 @@ import { setFlag } from 'src/actions/suite/suiteActions';
 import { DashboardSection } from 'src/components/dashboard';
 import { GraphScaleDropdownItem, GraphSkeleton, Translation } from 'src/components/suite';
 import { useDevice, useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
-import { useAccounts } from 'src/hooks/wallet';
 import { useTotalFiatBalance } from 'src/hooks/wallet/useTotalFiatBalance';
 import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOverallStatus';
 
@@ -24,7 +27,7 @@ export const PortfolioCard = memo(() => {
     const localCurrency = useSelector(selectLocalCurrency);
     const { discovery, isDiscoveryRunning } = useDiscovery();
     const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
-    const accounts = useAccounts();
+    const accounts = useSelector(selectAllAccountsToList);
     const { dashboardGraphHidden } = useSelector(s => s.suite.flags);
     const dispatch = useDispatch();
     const { device } = useDevice();

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
@@ -1,11 +1,12 @@
 import { useCallback } from 'react';
 
+import { selectAllAccountsToList } from '@suite-common/wallet-core';
 import { Button, Row, SkeletonRectangle } from '@trezor/components';
 
 import { updateGraphData } from 'src/actions/wallet/graphActions';
 import { GraphRangeSelector, Translation } from 'src/components/suite';
 import { FiatHeader } from 'src/components/wallet/FiatHeader';
-import { useAccounts } from 'src/hooks/wallet';
+import { useSelector } from 'src/hooks/suite';
 import { Discovery } from 'src/types/wallet';
 import { GraphRange } from 'src/types/wallet/graph';
 
@@ -34,7 +35,7 @@ export const PortfolioCardHeader = ({
     showGraphControls,
     receiveClickHandler,
 }: PortfolioCardHeaderProps) => {
-    const accounts = useAccounts();
+    const accounts = useSelector(selectAllAccountsToList);
 
     const onSelectedRange = useCallback(
         (_range: GraphRange) => {

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
@@ -5,7 +5,7 @@ import { Button, Row, SkeletonRectangle } from '@trezor/components';
 import { updateGraphData } from 'src/actions/wallet/graphActions';
 import { GraphRangeSelector, Translation } from 'src/components/suite';
 import { FiatHeader } from 'src/components/wallet/FiatHeader';
-import { useFastAccounts } from 'src/hooks/wallet';
+import { useAccounts } from 'src/hooks/wallet';
 import { Discovery } from 'src/types/wallet';
 import { GraphRange } from 'src/types/wallet/graph';
 
@@ -34,7 +34,7 @@ export const PortfolioCardHeader = ({
     showGraphControls,
     receiveClickHandler,
 }: PortfolioCardHeaderProps) => {
-    const accounts = useFastAccounts();
+    const accounts = useAccounts();
 
     const onSelectedRange = useCallback(
         (_range: GraphRange) => {

--- a/packages/suite/src/views/dashboard/StakeEthCard/StakeEthCard.tsx
+++ b/packages/suite/src/views/dashboard/StakeEthCard/StakeEthCard.tsx
@@ -2,7 +2,11 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { MIN_ETH_BALANCE_FOR_STAKING } from '@suite-common/wallet-constants';
-import { selectEnabledNetworks, selectPoolStatsApyData } from '@suite-common/wallet-core';
+import {
+    selectAllAccountsToList,
+    selectEnabledNetworks,
+    selectPoolStatsApyData,
+} from '@suite-common/wallet-core';
 import { Card, Column, Divider, Grid, H3, IconName, Paragraph, Tooltip } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { spacings } from '@trezor/theme';
@@ -11,7 +15,6 @@ import { setFlag } from 'src/actions/suite/suiteActions';
 import { DashboardSection } from 'src/components/dashboard';
 import { StakingFeature, Translation } from 'src/components/suite';
 import { useDevice, useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
-import { useAccounts } from 'src/hooks/wallet';
 import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
 
 import { StakeEthCardFooter } from './StakeEthCardFooter/StakeEthCardFooter';
@@ -37,7 +40,7 @@ export const StakeEthCard = () => {
 
     const apy = useSelector(state => selectPoolStatsApyData(state, bannerSymbol));
 
-    const accounts = useAccounts();
+    const accounts = useSelector(selectAllAccountsToList);
     const ethAccountWithSufficientBalanceForStaking = accounts.find(
         ({ symbol, formattedBalance }) =>
             symbol === bannerSymbol &&

--- a/packages/suite/src/views/dashboard/StakeEthCard/StakeEthCard.tsx
+++ b/packages/suite/src/views/dashboard/StakeEthCard/StakeEthCard.tsx
@@ -10,7 +10,7 @@ import { spacings } from '@trezor/theme';
 import { setFlag } from 'src/actions/suite/suiteActions';
 import { DashboardSection } from 'src/components/dashboard';
 import { StakingFeature, Translation } from 'src/components/suite';
-import { useDevice, useDiscovery, useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
+import { useDevice, useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
 import { useAccounts } from 'src/hooks/wallet';
 import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
 
@@ -37,8 +37,7 @@ export const StakeEthCard = () => {
 
     const apy = useSelector(state => selectPoolStatsApyData(state, bannerSymbol));
 
-    const { discovery } = useDiscovery();
-    const { accounts } = useAccounts(discovery);
+    const accounts = useAccounts();
     const ethAccountWithSufficientBalanceForStaking = accounts.find(
         ({ symbol, formattedBalance }) =>
             symbol === bannerSymbol &&

--- a/suite-common/wallet-core/src/accounts/accountsSelectors.ts
+++ b/suite-common/wallet-core/src/accounts/accountsSelectors.ts
@@ -52,6 +52,7 @@ export const selectVisibleDeviceAccounts = createMemoizedSelector(
     accounts =>
         pipe(
             accounts,
+            // all non-empty accounts are also made visible by discoveryThunks, so need to filter by !account.empty
             A.filter(account => account.visible),
             returnStableArrayIfEmpty,
         ),

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -1,6 +1,6 @@
-import { createWeakMapSelector } from '@suite-common/redux-utils';
+import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { networksCollection } from '@suite-common/wallet-config';
-import { getFailedAccounts } from '@suite-common/wallet-utils';
+import { getFailedAccounts, sortByCoin } from '@suite-common/wallet-utils';
 import { StaticSessionId } from '@trezor/connect';
 
 import { AccountsRootState } from './accounts/accountsReducer';
@@ -19,6 +19,7 @@ import {
 import { DiscoveryRootState } from './discovery/discoveryReducer';
 import {
     selectDiscoveryByDevicePath,
+    selectDiscoveryForSelectedDevice,
     selectHasRunningDiscovery,
 } from './discovery/discoverySelectors';
 import { WalletSettingsRootState, selectEnabledNetworks } from './settings/walletSettingsReducer';
@@ -40,6 +41,22 @@ export const selectDeviceAccountsVisibleEnabledAndSupported = createMemoizedSele
         return accounts.filter(
             ({ symbol }) => enabledNetworks.includes(symbol) && deviceNetworks.includes(symbol),
         );
+    },
+);
+
+export const selectAllAccountsToList = createMemoizedSelector(
+    [
+        selectDeviceAccountsVisibleEnabledAndSupported,
+        selectSelectedDevice,
+        selectDiscoveryForSelectedDevice,
+    ],
+    (okAccounts, device, discovery) => {
+        const staticSessionId = device?.state?.staticSessionId;
+        const failedAccounts = getFailedAccounts(staticSessionId, discovery);
+        const allAccounts = [...okAccounts, ...failedAccounts];
+        const sortedAccounts = sortByCoin(allAccounts);
+
+        return returnStableArrayIfEmpty(sortedAccounts);
     },
 );
 

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -8,9 +8,14 @@ import {
     selectAccounts,
     selectAccountsByDeviceState,
     selectIsDeviceAccountless,
+    selectVisibleDeviceAccounts,
 } from './accounts/accountsSelectors';
 import { DeviceRootState } from './device/deviceReducer';
-import { selectHasOnlyPortfolioDevice, selectSelectedDevice } from './device/deviceSelectors';
+import {
+    selectHasOnlyPortfolioDevice,
+    selectSelectedDevice,
+    selectSupportedNetworkByDevice,
+} from './device/deviceSelectors';
 import { DiscoveryRootState } from './discovery/discoveryReducer';
 import {
     selectDiscoveryByDevicePath,
@@ -24,8 +29,19 @@ to prevent circular dependencies between reducers
 */
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<
-    AccountsRootState & DeviceRootState & DiscoveryRootState
+    AccountsRootState & DeviceRootState & DiscoveryRootState & WalletSettingsRootState
 >();
+
+export const selectDeviceAccountsVisibleEnabledAndSupported = createMemoizedSelector(
+    [selectVisibleDeviceAccounts, selectSelectedDevice, selectEnabledNetworks],
+    (accounts, device, enabledNetworks) => {
+        const deviceNetworks = selectSupportedNetworkByDevice(device);
+
+        return accounts.filter(
+            ({ symbol }) => enabledNetworks.includes(symbol) && deviceNetworks.includes(symbol),
+        );
+    },
+);
 
 export const selectNetworksToDiscover = (
     state: DiscoveryRootState & DeviceRootState & AccountsRootState & WalletSettingsRootState,


### PR DESCRIPTION
## Description

See the issue, we were trying to find out how !enabled or !supported networks end up being displayed.
We tried to fix it on input (do not save these accounts into redux), which is tricky because two sources are mixed: remembered wallet from store & running discovery, which is async (things happen in the meantime).

Thanks to @Hermez-cz thinking outside of the box, let's fix on the output instead – don't display !enabled or !supported, even if the accounts linger in redux somehow.

Commits:
- 1st commit create a new selector for Suite accounts list
  - to centralize the following often-repeated logic: get accounts for selected device, only visible, only enabled, only device-supported, append failed accounts from discovery if any, and sort by coin
- but in Suite, there are still problems with Assets and Portfolio, so do a lot of Suite cleanup:
- 2nd commit centralize the logic of putting together ok accounts + failed accounts, and use the new selector for that
- 3rd commit afuera Fast accounts, whatever that was supposed to mean?
- 4th commit aaand ofc `useAccounts` can actually be refactored into a new selector and afuera too 

## Related Issue

Resolve #19473 (this will solve it for good!)

## Screenshots:

universal FW, altcoins enabled & discovered → remember wallet → at different Suite, install BTC-only → reconnect
It's the edgiest of edgy edge cases, not rly important, but it's useful to reproduce the issue! (and fix reliably)

Videos:
[Before](https://github.com/user-attachments/assets/bf53decc-3314-44f2-bba2-ffe891a242bd)
[After](https://github.com/user-attachments/assets/862f38f1-fd53-4617-80b2-838ca84f37f3)



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/filter-accounts-at-display&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/filter-accounts-at-display&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/filter-accounts-at-display&lookback=7)