### PR TITLE
fix(suite): Portfolio header skeleton for 0.00 wallet

### DIFF
--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
@@ -17,7 +17,6 @@ export type PortfolioCardHeaderProps = {
     isWalletLoading: boolean;
     isWalletError: boolean;
     isDiscoveryRunning?: boolean;
-    isMissingFiatRate?: boolean;
     showGraphControls: boolean;
     receiveClickHandler: () => void;
 };
@@ -30,7 +29,6 @@ export const PortfolioCardHeader = ({
     isWalletLoading,
     isWalletError,
     isDiscoveryRunning,
-    isMissingFiatRate,
     showGraphControls,
     receiveClickHandler,
 }: PortfolioCardHeaderProps) => {
@@ -65,8 +63,7 @@ export const PortfolioCardHeader = ({
         }
     }
 
-    const valueLoading =
-        isDiscoveryRunning || isMissingFiatRate || (!discovery && !Number(fiatAmount));
+    const valueLoading = isDiscoveryRunning || (!discovery && isNaN(Number(fiatAmount)));
 
     return (
         <Row justifyContent="space-between">


### PR DESCRIPTION
## Description

Do not show skeleton for remembered device when balance is 0.00

## Related Issue

Resolve #19572

## Screenshots:

**Before:** See issue

**After:** Remembered `all` seed standard wallet:

![image](https://github.com/user-attachments/assets/db5f860d-a5d3-43d4-a88b-e130f2e5d30c)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/portfolio-skeleton-when-0.00&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/portfolio-skeleton-when-0.00&lookback=7)