### PR TITLE
fix(suite-native): initialize Connect after onboarding is finished

### DIFF
--- a/suite-native/app/src/App.tsx
+++ b/suite-native/app/src/App.tsx
@@ -15,13 +15,14 @@ import { IntlProvider } from '@suite-native/intl';
 import { KillswitchMessageScreen } from '@suite-native/message-system';
 import { NavigationContainerWithAnalytics } from '@suite-native/navigation';
 import { initSentry } from '@suite-native/sentry';
-import { StoreProvider, selectIsAppReady, selectIsConnectInitialized } from '@suite-native/state';
+import { selectIsOnboardingFinished } from '@suite-native/settings';
+import { StoreProvider, selectIsAppReady } from '@suite-native/state';
 
 import { BannersRenderer } from './BannersRenderer';
 import { ModalsRenderer } from './ModalsRenderer';
 import { StylesProvider } from './StylesProvider';
 import { useReportAppInitToAnalytics } from './hooks/useReportAppInitToAnalytics';
-import { applicationInit } from './initActions';
+import { applicationInit, postOnboardingInit } from './initActions';
 import { RootStackNavigator } from './navigation/RootStackNavigator';
 import { disableRTL } from './rtl';
 
@@ -47,25 +48,36 @@ SplashScreen.preventAutoHideAsync();
 // https://github.com/react-native-netinfo/react-native-netinfo?tab=readme-ov-file#configure
 configureNetInfo();
 
+let isApplicationInitDispatched = false;
+let isPostOnboardingInitDispatched = false;
+
 const AppComponent = () => {
     const dispatch = useDispatch();
     const formattersConfig = useFormattersConfig();
     const isAppReady = useSelector(selectIsAppReady);
-    const isConnectInitialized = useSelector(selectIsConnectInitialized);
+    const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
 
     useReportAppInitToAnalytics(APP_STARTED_TIMESTAMP);
 
     useEffect(() => {
-        if (!isConnectInitialized) {
+        if (!isApplicationInitDispatched) {
             dispatch(applicationInit());
+            isApplicationInitDispatched = true;
         }
-    }, [dispatch, isConnectInitialized]);
+    }, [dispatch]);
 
     useEffect(() => {
         if (isAppReady) {
             SplashScreen.hideAsync();
         }
     }, [isAppReady]);
+
+    useEffect(() => {
+        if (isAppReady && isOnboardingFinished && !isPostOnboardingInitDispatched) {
+            dispatch(postOnboardingInit());
+            isPostOnboardingInitDispatched = true;
+        }
+    }, [isAppReady, isOnboardingFinished, dispatch]);
 
     if (!isAppReady) return null;
 

--- a/suite-native/app/src/hooks/useReportAppInitToAnalytics.ts
+++ b/suite-native/app/src/hooks/useReportAppInitToAnalytics.ts
@@ -14,14 +14,14 @@ import { EventType, analytics } from '@suite-native/analytics';
 import { useDiscreetMode } from '@suite-native/atoms';
 import { useIsBiometricsEnabled } from '@suite-native/biometrics';
 import { selectIsOnboardingFinished } from '@suite-native/settings';
-import { selectIsConnectInitialized } from '@suite-native/state';
+import { selectIsAppReady } from '@suite-native/state';
 import { useUserColorScheme } from '@suite-native/theme';
 
 export const useReportAppInitToAnalytics = (appLaunchTimestamp: number) => {
     const [loadDuration, setLoadDuration] = useState<number | null>(null);
     const [initWasReported, setInitWasReported] = useState(false);
 
-    const isConnectInitialized = useSelector(selectIsConnectInitialized);
+    const isAppReady = useSelector(selectIsAppReady);
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
     const { userColorScheme } = useUserColorScheme();
     const { isDiscreetMode } = useDiscreetMode();
@@ -33,11 +33,11 @@ export const useReportAppInitToAnalytics = (appLaunchTimestamp: number) => {
     const enabledNetworks = useSelector(selectEnabledNetworks);
 
     useEffect(() => {
-        if (isConnectInitialized && !loadDuration) setLoadDuration(Date.now() - appLaunchTimestamp);
-    }, [isConnectInitialized, appLaunchTimestamp, loadDuration]);
+        if (isAppReady && !loadDuration) setLoadDuration(Date.now() - appLaunchTimestamp);
+    }, [isAppReady, appLaunchTimestamp, loadDuration]);
 
     useEffect(() => {
-        if (isConnectInitialized && isOnboardingFinished && loadDuration && !initWasReported) {
+        if (isAppReady && isOnboardingFinished && loadDuration && !initWasReported) {
             setInitWasReported(true);
             analytics.report({
                 type: EventType.AppReady,
@@ -63,7 +63,7 @@ export const useReportAppInitToAnalytics = (appLaunchTimestamp: number) => {
             });
         }
     }, [
-        isConnectInitialized,
+        isAppReady,
         isOnboardingFinished,
         initWasReported,
         currencyCode,

--- a/suite-native/app/src/initActions.ts
+++ b/suite-native/app/src/initActions.ts
@@ -13,36 +13,35 @@ import {
 import { walletConnectInitThunk } from '@suite-common/walletconnect';
 import { initAnalyticsThunk } from '@suite-native/analytics';
 import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-flags';
-import { setIsAppReady, setIsConnectInitialized } from '@suite-native/state/src/appSlice';
+import { setIsAppReady } from '@suite-native/state/src/appSlice';
 
-let isAlreadyInitialized = false;
+const ACTION_PREFIX = '@suite-native/app';
 
 export const applicationInit = createThunk(
-    `@app/init-actions`,
-    async (_, { dispatch, getState }) => {
-        if (isAlreadyInitialized) {
-            return;
-        }
-
+    `${ACTION_PREFIX}/applicationInit`,
+    (_, { dispatch }) => {
         dispatch(initAnalyticsThunk());
-
         dispatch(initMessageSystemThunk());
 
         // Select latest remembered device or Portfolio Tracker device.
         dispatch(initDevices());
 
+        // Tell the application to render
+        dispatch(setIsAppReady(true));
+    },
+);
+
+export const postOnboardingInit = createThunk(
+    `${ACTION_PREFIX}/postOnboardingInit`,
+    async (_, { dispatch, getState }) => {
         try {
             await dispatch(connectInitThunk()).unwrap();
         } catch (error) {
             console.error(`Connect init error: ${JSON.stringify(error)}`);
         }
 
-        dispatch(setIsConnectInitialized(true));
-
         dispatch(initBlockchainThunk());
-
         dispatch(periodicCheckTokenDefinitionsThunk());
-
         dispatch(initStakeDataThunk());
 
         dispatch(
@@ -58,9 +57,5 @@ export const applicationInit = createThunk(
         if (selectIsFeatureFlagEnabled(getState(), FeatureFlag.IsWalletConnectEnabled)) {
             dispatch(walletConnectInitThunk());
         }
-
-        // Tell the application to render
-        dispatch(setIsAppReady(true));
-        isAlreadyInitialized = true;
     },
 );

--- a/suite-native/state/src/appSlice.ts
+++ b/suite-native/state/src/appSlice.ts
@@ -1,7 +1,6 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 type AppSliceState = {
-    isConnectInitialized: boolean;
     isAppReady: boolean;
 };
 
@@ -11,16 +10,12 @@ type AppSliceRootState = {
 
 const appSliceInitialState: AppSliceState = {
     isAppReady: false,
-    isConnectInitialized: false,
 };
 
 export const appSlice = createSlice({
     name: 'app',
     initialState: appSliceInitialState,
     reducers: {
-        setIsConnectInitialized: (state, { payload }: PayloadAction<boolean>) => {
-            state.isConnectInitialized = payload;
-        },
         setIsAppReady: (state, { payload }: PayloadAction<boolean>) => {
             state.isAppReady = payload;
         },
@@ -28,8 +23,6 @@ export const appSlice = createSlice({
 });
 
 export const selectIsAppReady = (state: AppSliceRootState) => state.app.isAppReady;
-export const selectIsConnectInitialized = (state: AppSliceRootState) =>
-    state.app.isConnectInitialized;
 
-export const { setIsConnectInitialized, setIsAppReady } = appSlice.actions;
+export const { setIsAppReady } = appSlice.actions;
 export const appReducer = appSlice.reducer;


### PR DESCRIPTION
If an initialized Trezor is connected to a freshly installed Suite Lite app, Trezor Connect is initialized before onboarding is finished and thus may lead to a confusing prompt on the device. Mostly relevant to THP.

This is fixed by splitting the init code into two parts. 

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/application-init&lookback=7)