### PR TITLE
  Feat: update fee rate options regularly – attempt 2

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
-import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { selectAreFeesLoading, selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { getStakingDataForNetwork } from '@suite-common/wallet-utils';
 import { Banner, Column, InfoItem, Modal, Paragraph, Tooltip } from '@trezor/components';
@@ -45,6 +45,7 @@ const ClaimModalLoaded = ({ onCancel, selectedAccount }: ClaimModalModalProps) =
         signTx,
         trigger,
     } = useClaimForm({ selectedAccount });
+    const areFeesLoading = useSelector(state => selectAreFeesLoading(state, account.symbol));
 
     const hasValues = Boolean(watch(CRYPTO_INPUT));
     // used instead of formState.isValid, which is sometimes returning false even if there are no errors
@@ -85,6 +86,8 @@ const ClaimModalLoaded = ({ onCancel, selectedAccount }: ClaimModalModalProps) =
         });
     };
 
+    const isLoading = isComposing || isSubmitting || isDiscoveryRunning || areFeesLoading;
+
     return (
         <Modal
             heading={<Translation id="TR_STAKE_CLAIM" />}
@@ -102,7 +105,7 @@ const ClaimModalLoaded = ({ onCancel, selectedAccount }: ClaimModalModalProps) =
                         <Modal.Button
                             type="submit"
                             isDisabled={isDisabled || isClaimingDisabled}
-                            isLoading={isComposing || isSubmitting || isDiscoveryRunning}
+                            isLoading={isLoading}
                             onClick={onClaimClick}
                             icon={isClaimingDisabled ? 'info' : undefined}
                         >

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeButton.tsx
@@ -1,4 +1,4 @@
-import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { selectAreFeesLoading, selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { Modal, Tooltip } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
@@ -26,6 +26,9 @@ export const StakeButton = () => {
         selectedAccount.network.symbol,
     );
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
+    const areFeesLoading = useSelector(state =>
+        selectAreFeesLoading(state, selectedAccount.network.symbol),
+    );
 
     const hasValues = Boolean(watch(FIAT_INPUT) || watch(CRYPTO_INPUT));
     // used instead of formState.isValid, which is sometimes returning false even if there are no errors
@@ -47,11 +50,13 @@ export const StakeButton = () => {
         });
     };
 
+    const isLoading = isComposing || isSubmitting || isDiscoveryRunning || areFeesLoading;
+
     return (
         <Tooltip content={stakingMessageContent}>
             <Modal.Button
                 isDisabled={isDisabled || isStakingDisabled}
-                isLoading={isComposing || isSubmitting || isDiscoveryRunning}
+                isLoading={isLoading}
                 onClick={onStakeClick}
                 icon={isStakingDisabled ? 'info' : undefined}
             >

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton.tsx
@@ -1,23 +1,27 @@
+import { selectAreFeesLoading } from '@suite-common/wallet-core';
 import { Modal } from '@trezor/components';
 
 import { Translation } from 'src/components/suite';
-import { useDevice } from 'src/hooks/suite';
+import { useDevice, useSelector } from 'src/hooks/suite';
 import { useRbfContext } from 'src/hooks/wallet/useRbfForm';
 
 export const ReplaceTxButton = () => {
     const { device, isLocked } = useDevice();
 
-    const { isLoading, signTransaction, getValues, composedLevels } = useRbfContext();
+    const { account, isLoading, signTransaction, getValues, composedLevels } = useRbfContext();
 
     const values = getValues();
     const composedTx = composedLevels ? composedLevels[values.selectedFee || 'normal'] : undefined;
     const isDisabled =
         !composedTx || composedTx.type !== 'final' || isLocked() || (device && !device.available);
 
+    const areFeesLoading = useSelector(state => selectAreFeesLoading(state, account.symbol));
+
     return (
         <Modal.Button
             data-testid="@send/replace-tx-button"
-            isDisabled={isDisabled || isLoading}
+            isDisabled={isDisabled}
+            isLoading={isLoading || areFeesLoading}
             onClick={signTransaction}
         >
             <Translation id="TR_REPLACE_TX" />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeButton.tsx
@@ -1,4 +1,4 @@
-import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { selectAreFeesLoading, selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { Button, Tooltip } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
@@ -34,6 +34,9 @@ export const UnstakeButton = () => {
     const isDisabled =
         !(formIsValid && hasValues) || isSubmitting || isLocked() || !device?.available;
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
+    const areFeesLoading = useSelector(state =>
+        selectAreFeesLoading(state, selectedAccount.network.symbol),
+    );
 
     const onUnstakeClick = () => {
         handleSubmit(signTx)();
@@ -49,12 +52,14 @@ export const UnstakeButton = () => {
         });
     };
 
+    const isLoading = isComposing || isSubmitting || isDiscoveryRunning || areFeesLoading;
+
     return (
         <Tooltip content={unstakingMessageContent}>
             <Button
                 type="submit"
                 isDisabled={isDisabled || isUnstakingDisabled}
-                isLoading={isComposing || isSubmitting || isDiscoveryRunning}
+                isLoading={isLoading}
                 onClick={onUnstakeClick}
                 icon={isUnstakingDisabled ? 'info' : undefined}
             >

--- a/packages/suite/src/components/wallet/Fees/CustomFee/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CustomFee.tsx
@@ -29,6 +29,7 @@ export const FEE_LIMIT = 'feeLimit';
 
 export type CustomFeeBasicProps<TFieldValues extends FormState> = {
     networkType: NetworkType;
+    symbol: NetworkSymbol;
     feeInfo: FeeInfo;
     errors: FieldErrors<TFieldValues>;
     register: UseFormRegister<TFieldValues>;
@@ -97,6 +98,7 @@ export const CustomFee = <TFieldValues extends FormState>({
                 {networkType === 'ethereum' ? (
                     <CustomFeeEthereum
                         {...props}
+                        symbol={symbol}
                         networkType={networkType}
                         feeInfo={feeInfo}
                         register={register}
@@ -108,6 +110,7 @@ export const CustomFee = <TFieldValues extends FormState>({
                 ) : (
                     <CustomFeeMisc
                         {...props}
+                        symbol={symbol}
                         networkType={networkType}
                         feeInfo={feeInfo}
                         register={register}

--- a/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeMisc.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeMisc.tsx
@@ -15,6 +15,7 @@ import { DustPreventionNotice } from '../DustPreventionNotice';
 
 export const CustomFeeMisc = <TFieldValues extends FormState>({
     networkType,
+    symbol,
     feeInfo,
     register,
     control,
@@ -77,6 +78,7 @@ export const CustomFeeMisc = <TFieldValues extends FormState>({
             />
             {isDustPreventionRelevant && (
                 <DustPreventionNotice
+                    symbol={symbol}
                     chosenFeePerByte={feePerUnitValue}
                     composedFeePerByte={composedFeePerByte}
                     baseFee={getValues('baseFee')}

--- a/packages/suite/src/components/wallet/Fees/DustPreventionNotice.tsx
+++ b/packages/suite/src/components/wallet/Fees/DustPreventionNotice.tsx
@@ -1,8 +1,13 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { selectAreFeesLoading } from '@suite-common/wallet-core';
 import { Note } from '@trezor/components';
+import { isApproximatelyEqual } from '@trezor/utils';
 
+import { useSelector } from '../../../hooks/suite';
 import { Translation } from '../../suite';
 
 type DustPreventionNoticeProps = {
+    symbol: NetworkSymbol;
     chosenFeePerByte: string | undefined;
     composedFeePerByte: string | undefined;
     baseFee: number | undefined;
@@ -10,15 +15,20 @@ type DustPreventionNoticeProps = {
 };
 
 export const DustPreventionNotice = ({
+    symbol,
     chosenFeePerByte,
     composedFeePerByte,
     baseFee,
     feeUnits,
 }: DustPreventionNoticeProps) => {
+    const areFeesLoading = useSelector(state => selectAreFeesLoading(state, symbol));
+
+    const relativeTolerance = 1e-3;
     const isComposedFeeRateDifferent =
+        !areFeesLoading &&
         composedFeePerByte !== undefined &&
-        composedFeePerByte !== '' &&
-        chosenFeePerByte !== composedFeePerByte;
+        chosenFeePerByte !== undefined &&
+        !isApproximatelyEqual(composedFeePerByte, chosenFeePerByte, relativeTolerance);
 
     if (!isComposedFeeRateDifferent) return null;
 

--- a/packages/suite/src/components/wallet/Fees/Fees.tsx
+++ b/packages/suite/src/components/wallet/Fees/Fees.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import {
     Control,
     FieldErrors,
@@ -13,7 +13,6 @@ import { useTheme } from 'styled-components';
 
 import { TranslationKey } from '@suite-common/intl-types';
 import { NetworkSymbol, NetworkType } from '@suite-common/wallet-config';
-import { updateFeeInfoThunk } from '@suite-common/wallet-core';
 import {
     FeeInfo,
     FormState,
@@ -27,7 +26,7 @@ import { spacings } from '@trezor/theme';
 import { HELP_CENTER_TRANSACTION_FEES_URL } from '@trezor/urls';
 
 import { Translation } from 'src/components/suite';
-import { useDispatch } from 'src/hooks/suite';
+import { useRefetchFees } from 'src/hooks/wallet/useRefetchFees';
 import { Account } from 'src/types/wallet';
 
 import { CustomFee } from './CustomFee/CustomFee';
@@ -144,7 +143,6 @@ export const Fees = <TFieldValues extends FormState>({
     // Type assertion allowing to make the component reusable, see https://stackoverflow.com/a/73624072.
     const { getValues, register, setValue, trigger } = props as unknown as UseFormReturn<FormState>;
     const theme = useTheme();
-    const dispatch = useDispatch();
 
     const selectedOption = getValues('selectedFee') || 'normal';
     const isCustomFee = selectedOption === 'custom';
@@ -158,9 +156,7 @@ export const Fees = <TFieldValues extends FormState>({
 
     const supportsCustomFee = networkType !== 'solana';
 
-    useEffect(() => {
-        dispatch(updateFeeInfoThunk({ networkSymbol: symbol }));
-    }, [dispatch, symbol]);
+    useRefetchFees({ networkSymbol: symbol });
 
     const feeLabelId = useMemo(() => {
         switch (networkType) {

--- a/packages/suite/src/components/wallet/Fees/Fees.tsx
+++ b/packages/suite/src/components/wallet/Fees/Fees.tsx
@@ -26,7 +26,7 @@ import { spacings } from '@trezor/theme';
 import { HELP_CENTER_TRANSACTION_FEES_URL } from '@trezor/urls';
 
 import { Translation } from 'src/components/suite';
-import { useRefetchFees } from 'src/hooks/wallet/useRefetchFees';
+import { useFetchFeesOnce, useRefetchFees } from 'src/hooks/wallet/useRefetchFees';
 import { Account } from 'src/types/wallet';
 
 import { CustomFee } from './CustomFee/CustomFee';
@@ -156,7 +156,10 @@ export const Fees = <TFieldValues extends FormState>({
 
     const supportsCustomFee = networkType !== 'solana';
 
-    useRefetchFees({ networkSymbol: symbol });
+    useFetchFeesOnce({ networkSymbol: symbol });
+    // this component is used under different contexts & form states, but `setMaxOutputId` will be compatible (see `FormState` type)
+    const isRefetchDisabled = getValues().setMaxOutputId !== undefined;
+    useRefetchFees({ networkSymbol: symbol, isDisabled: isRefetchDisabled });
 
     const feeLabelId = useMemo(() => {
         switch (networkType) {

--- a/packages/suite/src/components/wallet/Fees/StandardFee/BitcoinFeeCards.tsx
+++ b/packages/suite/src/components/wallet/Fees/StandardFee/BitcoinFeeCards.tsx
@@ -1,10 +1,11 @@
 import { formatDurationStrict } from '@suite-common/suite-utils';
+import { selectAreFeesLoading } from '@suite-common/wallet-core';
 import { getFeeUnits } from '@suite-common/wallet-utils';
 import { FeeRate } from '@trezor/product-components';
 
 import { Translation } from 'src/components/suite';
 import { FiatValue } from 'src/components/suite/FiatValue';
-import { useLocales } from 'src/hooks/suite';
+import { useLocales, useSelector } from 'src/hooks/suite';
 
 import { FeeCard } from './FeeCard';
 import { FeeCardsWrapper, StandardFeeProps } from './StandardFee';
@@ -22,6 +23,7 @@ export const BitcoinFeeCards = ({
     getValues,
 }: StandardFeeProps) => {
     const locale = useLocales();
+    const areFeesLoading = useSelector(state => selectAreFeesLoading(state, symbol));
 
     if (!feeOptions.length) {
         return null;
@@ -45,6 +47,7 @@ export const BitcoinFeeCards = ({
                         value={fee.value}
                         isSelected={selectedLevel.label === fee.value}
                         changeFeeLevel={changeFeeLevel}
+                        isLoading={areFeesLoading}
                         topLeftChild={
                             <span data-testid={`@fee-card/${fee.value}`}>
                                 <Translation id={getFeeLevelTranslationId(fee.value)} />
@@ -74,6 +77,7 @@ export const BitcoinFeeCards = ({
                 ))}
             </FeeCardsWrapper>
             <DustPreventionNotice
+                symbol={symbol}
                 chosenFeePerByte={selectedLevel.feePerUnit}
                 composedFeePerByte={
                     transactionInfo?.type === 'final' ? transactionInfo.feePerByte : undefined

--- a/packages/suite/src/components/wallet/Fees/StandardFee/EthereumFeeCards.tsx
+++ b/packages/suite/src/components/wallet/Fees/StandardFee/EthereumFeeCards.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { formatDurationStrict } from '@suite-common/suite-utils';
+import { selectAreFeesLoading } from '@suite-common/wallet-core';
 import { getFeeUnits, isEip1559 } from '@suite-common/wallet-utils';
 import { Badge, Grid, Row, Text } from '@trezor/components';
 import { FeeRate } from '@trezor/product-components';
@@ -26,6 +27,8 @@ export const EthereumFeeCards = ({
 }: StandardFeeProps) => {
     const locale = useLocales();
     const isDebug = useSelector(selectIsDebugModeActive);
+    const areFeesLoading = useSelector(state => selectAreFeesLoading(state, symbol));
+
     const [cachedGasLimit, setCachedGasLimit] = useState<string | undefined>(undefined);
 
     useEffect(() => {
@@ -59,6 +62,7 @@ export const EthereumFeeCards = ({
                         key={fee.value}
                         isSelected={selectedLevel.label === fee.value}
                         changeFeeLevel={changeFeeLevel}
+                        isLoading={areFeesLoading}
                         topLeftChild={
                             <span data-testid={`@fee-card/${fee.value}`}>
                                 <Translation id={getFeeLevelTranslationId(fee.value)} />

--- a/packages/suite/src/components/wallet/Fees/StandardFee/FeeCard.tsx
+++ b/packages/suite/src/components/wallet/Fees/StandardFee/FeeCard.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import { ReactNode } from 'react';
 
 import {
     Box,
     Column,
     RadioCard,
     Row,
+    SkeletonRectangle,
     TOOLTIP_DELAY_NORMAL,
     Text,
     Tooltip,
@@ -17,11 +18,12 @@ type FeeCardProps = {
     value: FeeLevel['label'];
     isSelected: boolean;
     changeFeeLevel: (level: FeeLevel['label']) => void;
-    topLeftChild: React.ReactNode;
-    topRightChild?: React.ReactNode;
-    bottomLeftChild: React.ReactNode;
-    bottomRightChild: React.ReactNode;
-    tooltipContent?: React.ReactNode;
+    topLeftChild: ReactNode;
+    topRightChild?: ReactNode;
+    bottomLeftChild: ReactNode;
+    bottomRightChild: ReactNode;
+    tooltipContent?: ReactNode;
+    isLoading?: boolean;
     'data-testid'?: string;
 };
 
@@ -34,6 +36,7 @@ export const FeeCard = ({
     bottomLeftChild,
     bottomRightChild,
     tooltipContent,
+    isLoading,
     'data-testid': dataTestId,
 }: FeeCardProps) => (
     <Box data-testid={dataTestId} minWidth={FEE_CARD_MIN_WIDTH}>
@@ -43,13 +46,15 @@ export const FeeCard = ({
                     <Row justifyContent="space-between">
                         <Text typographyStyle="highlight">{topLeftChild}</Text>
                         <Text variant="tertiary" typographyStyle="hint">
-                            {topRightChild}
+                            {isLoading ? <SkeletonRectangle animate={true} /> : topRightChild}
                         </Text>
                     </Row>
                     <Row justifyContent="space-between" height={24}>
-                        <Text>{bottomLeftChild}</Text>
+                        <Text>
+                            {isLoading ? <SkeletonRectangle animate={true} /> : bottomLeftChild}
+                        </Text>
                         <Text variant="tertiary" typographyStyle="hint">
-                            {bottomRightChild}
+                            {isLoading ? <SkeletonRectangle animate={true} /> : bottomRightChild}
                         </Text>
                     </Row>
                 </Column>

--- a/packages/suite/src/components/wallet/Fees/StandardFee/MiscFeeCards.tsx
+++ b/packages/suite/src/components/wallet/Fees/StandardFee/MiscFeeCards.tsx
@@ -1,7 +1,9 @@
+import { selectAreFeesLoading } from '@suite-common/wallet-core';
 import { getFeeUnits } from '@suite-common/wallet-utils';
 import { Text } from '@trezor/components';
 
 import { FiatValue, Translation } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
 
 import { FeeCard } from './FeeCard';
 import { FeeCardsWrapper, StandardFeeProps } from './StandardFee';
@@ -14,6 +16,7 @@ export const MiscFeeCards = ({
     symbol,
     changeFeeLevel,
 }: StandardFeeProps) => {
+    const areFeesLoading = useSelector(state => selectAreFeesLoading(state, symbol));
     if (!feeOptions.length) return null;
 
     const isSolanaNetwork = networkType === 'solana';
@@ -28,6 +31,7 @@ export const MiscFeeCards = ({
                 value={fee.value}
                 isSelected={true}
                 changeFeeLevel={changeFeeLevel}
+                isLoading={areFeesLoading}
                 topLeftChild={
                     <span data-testid={`@fee-card/${fee.value}`}>
                         <Translation id={getFeeLevelTranslationId(fee.value)} />

--- a/packages/suite/src/hooks/wallet/useRefetchFees.ts
+++ b/packages/suite/src/hooks/wallet/useRefetchFees.ts
@@ -7,8 +7,10 @@ import {
     FEE_UPDATE_DELAY_MILLISECONDS,
     updateFeeInfoThunk,
 } from '@suite-common/wallet-core';
+import { UI } from '@trezor/connect';
 
-import { useDispatch } from 'src/hooks/suite';
+import { MODAL } from 'src/actions/suite/constants';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 
 type UseRefetchFeesProps = { networkSymbol: NetworkSymbol; isDisabled?: boolean };
 
@@ -22,12 +24,28 @@ export const useFetchFeesOnce = ({ networkSymbol, isDisabled }: UseRefetchFeesPr
     }, [dispatch, networkSymbol, isDisabled]);
 };
 
+// Don't refetch when specific critical modals are open
+const excludedModalWindowTypes = [
+    UI.REQUEST_PASSPHRASE,
+    // both are TransactionReviewModal, which should be final and not be subject to sudden change!
+    'ButtonRequest_ConfirmOutput',
+    'ButtonRequest_SignTx',
+];
+
 // Refetch fees periodically, incl. loading behavior
 export const useRefetchFees = ({ networkSymbol, isDisabled }: UseRefetchFeesProps) => {
     const dispatch = useDispatch();
 
+    const modal = useSelector(state => state.modal);
+
+    const isExcludedModal =
+        modal.context === MODAL.CONTEXT_DEVICE &&
+        modal.windowType !== undefined &&
+        excludedModalWindowTypes.includes(modal.windowType);
+
     useInterval(() => {
         if (isDisabled === true) return;
+        if (isExcludedModal) return;
         dispatch(
             updateFeeInfoThunk({ networkSymbol, artificialDelay: FEE_UPDATE_DELAY_MILLISECONDS }),
         );

--- a/packages/suite/src/hooks/wallet/useRefetchFees.ts
+++ b/packages/suite/src/hooks/wallet/useRefetchFees.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+import { useInterval } from 'react-use';
+
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    FEES_UPDATE_INTERVAL_MILLISECONDS,
+    FEE_UPDATE_DELAY_MILLISECONDS,
+    updateFeeInfoThunk,
+} from '@suite-common/wallet-core';
+
+import { useDispatch } from 'src/hooks/suite';
+
+type UseRefetchFeesProps = { networkSymbol: NetworkSymbol };
+
+export const useRefetchFees = ({ networkSymbol }: UseRefetchFeesProps) => {
+    const dispatch = useDispatch();
+
+    // Initial fetch only when component mounts
+    useEffect(() => {
+        dispatch(updateFeeInfoThunk({ networkSymbol }));
+    }, [dispatch, networkSymbol]);
+
+    // Refetch fees periodically incl. loading behavior
+    useInterval(() => {
+        dispatch(
+            updateFeeInfoThunk({ networkSymbol, artificialDelay: FEE_UPDATE_DELAY_MILLISECONDS }),
+        );
+    }, FEES_UPDATE_INTERVAL_MILLISECONDS);
+};

--- a/packages/suite/src/hooks/wallet/useRefetchFees.ts
+++ b/packages/suite/src/hooks/wallet/useRefetchFees.ts
@@ -10,18 +10,24 @@ import {
 
 import { useDispatch } from 'src/hooks/suite';
 
-type UseRefetchFeesProps = { networkSymbol: NetworkSymbol };
+type UseRefetchFeesProps = { networkSymbol: NetworkSymbol; isDisabled?: boolean };
 
-export const useRefetchFees = ({ networkSymbol }: UseRefetchFeesProps) => {
+// Fetch fees only once when component mounts, or when it is enabled at a later time.
+export const useFetchFeesOnce = ({ networkSymbol, isDisabled }: UseRefetchFeesProps) => {
     const dispatch = useDispatch();
 
-    // Initial fetch only when component mounts
     useEffect(() => {
+        if (isDisabled === true) return;
         dispatch(updateFeeInfoThunk({ networkSymbol }));
-    }, [dispatch, networkSymbol]);
+    }, [dispatch, networkSymbol, isDisabled]);
+};
 
-    // Refetch fees periodically incl. loading behavior
+// Refetch fees periodically, incl. loading behavior
+export const useRefetchFees = ({ networkSymbol, isDisabled }: UseRefetchFeesProps) => {
+    const dispatch = useDispatch();
+
     useInterval(() => {
+        if (isDisabled === true) return;
         dispatch(
             updateFeeInfoThunk({ networkSymbol, artificialDelay: FEE_UPDATE_DELAY_MILLISECONDS }),
         );

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -74,7 +74,6 @@ const getStateFromProps = (props: UseSendFormProps) => {
     return {
         account,
         network,
-
         localCurrencyOption,
         online: props.online,
         metadataEnabled: props.metadataEnabled,
@@ -321,7 +320,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         state.network.decimals,
     ]);
 
-    // load draft from reducer
+    // load draft from reducer and reset current form values, this should be only called once on mount
     useEffect(() => {
         const loadDraftValues = async () => {
             const storedState = await dispatch(getSendFormDraftThunk()).unwrap();
@@ -336,7 +335,9 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
             }
         };
         loadDraftValues();
-    }, [dispatch, getLoadedValues, reset, composeDraft]);
+        // composeDraft is excluded because its reference changes with each feeInfo update.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [dispatch, getLoadedValues, reset]);
 
     // register custom form fields (without HTMLElement)
     useEffect(() => {
@@ -349,7 +350,14 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         if (!draft.current) return;
         composeDraft(draft.current);
         draft.current = undefined;
-    }, [draft, composeDraft]);
+        // composeDraft is excluded because its reference changes with each feeInfo update.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [draft]);
+
+    // update composedLevels when feeInfo changes
+    useEffect(() => {
+        composeDraft(getValues());
+    }, [composeDraft, getValues]);
 
     // handle draftSaveRequest
     useEffect(() => {

--- a/packages/suite/src/views/wallet/send/TotalSent/ReviewButton.tsx
+++ b/packages/suite/src/views/wallet/send/TotalSent/ReviewButton.tsx
@@ -2,12 +2,13 @@ import { useWatch } from 'react-hook-form';
 
 import styled from 'styled-components';
 
+import { selectAreFeesLoading } from '@suite-common/wallet-core';
 import { isLowAnonymityWarning } from '@suite-common/wallet-utils';
 import { Banner, Button, Checkbox, Tooltip, variables } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite/Translation';
-import { useDevice } from 'src/hooks/suite';
+import { useDevice, useSelector } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 
 const Container = styled.div`
@@ -64,11 +65,11 @@ const SecondLine = styled.p`
 export const ReviewButton = () => {
     const { device, isLocked } = useDevice();
     const {
-        account: { networkType },
+        account: { networkType, symbol },
         control,
         formState: { errors },
         online,
-        isLoading,
+        isLoading: isSendFormLoading,
         signTransaction,
         getValues,
         getDefaultValue,
@@ -81,6 +82,8 @@ export const ReviewButton = () => {
             toggleAnonymityWarning,
         },
     } = useSendFormContext();
+    const areFeesLoading = useSelector(state => selectAreFeesLoading(state, symbol));
+    const isLoading = isSendFormLoading || areFeesLoading;
 
     const options = useWatch({
         name: 'options',

--- a/packages/suite/src/views/wallet/send/TotalSent/TotalSent.tsx
+++ b/packages/suite/src/views/wallet/send/TotalSent/TotalSent.tsx
@@ -1,15 +1,22 @@
-import { useMemo } from 'react';
+import { PropsWithChildren, useMemo } from 'react';
 
 import styled from 'styled-components';
 
+import { selectAreFeesLoading } from '@suite-common/wallet-core';
 import { formatAmount, formatNetworkAmount } from '@suite-common/wallet-utils';
-import { Card, Column, InfoItem } from '@trezor/components';
+import { Card, Column, InfoItem, SkeletonRectangle } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 
 import { ReviewButton } from './ReviewButton';
+
+type ChildOrSkeletonProps = PropsWithChildren<{ isLoading?: boolean }>;
+
+const ChildOrSkeleton = ({ children, isLoading }: ChildOrSkeletonProps) =>
+    isLoading ? <SkeletonRectangle animate={true} /> : children;
 
 const Container = styled.div`
     position: sticky;
@@ -22,6 +29,7 @@ export const TotalSent = () => {
         composedLevels,
         getValues,
     } = useSendFormContext();
+    const areFeesLoading = useSelector(state => selectAreFeesLoading(state, symbol));
 
     const selectedFee = getValues().selectedFee || 'normal';
     const transactionInfo = composedLevels ? composedLevels[selectedFee] : undefined;
@@ -52,39 +60,49 @@ export const TotalSent = () => {
                         variant="default"
                         typographyStyle="body"
                     >
-                        {hasTransactionInfo && (
-                            <FormattedCryptoAmount
-                                disableHiddenPlaceholder
-                                value={
-                                    tokenInfo
-                                        ? formatAmount(
-                                              transactionInfo.totalSpent,
-                                              tokenInfo.decimals,
-                                          )
-                                        : formatNetworkAmount(transactionInfo.totalSpent, symbol)
-                                }
-                                symbol={tokenInfo?.symbol ?? symbol}
-                                contractAddress={tokenInfo?.contract}
-                            />
-                        )}
+                        <ChildOrSkeleton isLoading={areFeesLoading}>
+                            {hasTransactionInfo && (
+                                <FormattedCryptoAmount
+                                    disableHiddenPlaceholder
+                                    value={
+                                        tokenInfo
+                                            ? formatAmount(
+                                                  transactionInfo.totalSpent,
+                                                  tokenInfo.decimals,
+                                              )
+                                            : formatNetworkAmount(
+                                                  transactionInfo.totalSpent,
+                                                  symbol,
+                                              )
+                                    }
+                                    symbol={tokenInfo?.symbol ?? symbol}
+                                    contractAddress={tokenInfo?.contract}
+                                />
+                            )}
+                        </ChildOrSkeleton>
                     </InfoItem>
 
                     <InfoItem label={<Translation id={feeLabelId} />} direction="row">
-                        {hasTransactionInfo &&
-                            (tokenInfo ? (
-                                <FormattedCryptoAmount
-                                    disableHiddenPlaceholder
-                                    value={formatNetworkAmount(transactionInfo.fee, symbol)}
-                                    symbol={symbol}
-                                    contractAddress={tokenInfo.contract}
-                                />
-                            ) : (
-                                <FiatValue
-                                    disableHiddenPlaceholder
-                                    amount={formatNetworkAmount(transactionInfo.totalSpent, symbol)}
-                                    symbol={symbol}
-                                />
-                            ))}
+                        <ChildOrSkeleton isLoading={areFeesLoading}>
+                            {hasTransactionInfo &&
+                                (tokenInfo ? (
+                                    <FormattedCryptoAmount
+                                        disableHiddenPlaceholder
+                                        value={formatNetworkAmount(transactionInfo.fee, symbol)}
+                                        symbol={symbol}
+                                        contractAddress={tokenInfo.contract}
+                                    />
+                                ) : (
+                                    <FiatValue
+                                        disableHiddenPlaceholder
+                                        amount={formatNetworkAmount(
+                                            transactionInfo.totalSpent,
+                                            symbol,
+                                        )}
+                                        symbol={symbol}
+                                    />
+                                ))}
+                        </ChildOrSkeleton>
                     </InfoItem>
                 </Column>
                 <ReviewButton />

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -12,6 +12,7 @@ import {
     tradingExchangeActions,
     useTradingInfo,
 } from '@suite-common/trading';
+import { selectAreFeesLoading } from '@suite-common/wallet-core';
 import { TokenAddress } from '@suite-common/wallet-types';
 import { isAmountTooHigh } from '@suite-common/wallet-utils';
 import { Button, Column, Paragraph, Row, TextButton, Tooltip } from '@trezor/components';
@@ -19,7 +20,7 @@ import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { Translation } from 'src/components/suite';
-import { useDispatch } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingDeviceDisconnected } from 'src/hooks/wallet/trading/form/common/useTradingDeviceDisconnected';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { TradingFormContextValues } from 'src/types/trading/tradingForm';
@@ -60,6 +61,7 @@ export const TradingFormOffer = () => {
     const dispatch = useDispatch();
     const [isCompareLoading, setIsCompareLoading] = useState<boolean>(false);
     const [isDexSwapLoading, setIsDexSwapLoading] = useState<boolean>(false);
+
     const context = useTradingFormContext();
     const {
         account,
@@ -74,6 +76,7 @@ export const TradingFormOffer = () => {
     const bestScoredQuote = quotes?.[0];
     const quote = getSelectedQuote(context, bestScoredQuote);
     const bestScoredQuoteAmounts = getCryptoQuoteAmountProps(quote, context);
+    const areFeesLoading = useSelector(state => selectAreFeesLoading(state, account.symbol));
 
     const selectedCrypto = getSelectedCrypto(context);
     const receiveCurrency = bestScoredQuoteAmounts?.receiveCurrency;
@@ -262,7 +265,7 @@ export const TradingFormOffer = () => {
                 }}
                 isFullWidth
                 isDisabled={isButtonDisabled}
-                isLoading={isDexSwapLoading}
+                isLoading={isDexSwapLoading || areFeesLoading}
                 data-testid={`@trading/form/${type}-button`}
             >
                 <Translation id={tradingGetSectionActionLabel(type)} />

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -32,6 +32,7 @@ export * from './getWeakRandomNumberInRange';
 export * from './hasUppercaseLetter';
 export { hexToRgba } from './hexToRgba';
 export { hexToRgbaArray } from './hexToRgbaArray';
+export { isApproximatelyEqual } from './isApproximatelyEqual';
 export * from './isArrayMember';
 export * from './isFullPath';
 export * from './isHex';

--- a/packages/utils/src/isApproximatelyEqual.ts
+++ b/packages/utils/src/isApproximatelyEqual.ts
@@ -1,0 +1,24 @@
+import { BigNumber, BigNumberValue } from './bigNumber';
+
+/**
+ * Check if two BigNumber values are approximately equal based on relative difference
+ * @param value1
+ * @param value2
+ * @param relativeTolerance maximum threshold for relative difference of values to declare them approx. equal
+ */
+export const isApproximatelyEqual = (
+    value1: BigNumberValue,
+    value2: BigNumberValue,
+    relativeTolerance: BigNumberValue,
+): boolean => {
+    value1 = new BigNumber(value1);
+    value2 = new BigNumber(value2);
+    relativeTolerance = new BigNumber(relativeTolerance);
+
+    // Cannot calculate relative difference if one value is zero, but then they must be equal
+    if (value1.eq(0)) return value1.eq(value2);
+
+    const relativeDifference = value2.minus(value1).abs().dividedBy(value1);
+
+    return relativeDifference.lte(relativeTolerance);
+};

--- a/packages/utils/tests/isApproximatelyEqual.test.ts
+++ b/packages/utils/tests/isApproximatelyEqual.test.ts
@@ -1,0 +1,32 @@
+import { BigNumber } from '../src/bigNumber';
+import { isApproximatelyEqual } from '../src/isApproximatelyEqual';
+
+describe(isApproximatelyEqual.name, () => {
+    it('always returns true for equal values', () => {
+        expect(isApproximatelyEqual(100, 100, 0.001)).toBe(true);
+        expect(isApproximatelyEqual(100, '100', 0.001)).toBe(true);
+        expect(isApproximatelyEqual('100', '100', 0.001)).toBe(true);
+        expect(isApproximatelyEqual(new BigNumber(-123), '-123', 0.001)).toBe(true);
+        expect(isApproximatelyEqual('-123.001', '-123.001000', 0.001)).toBe(true);
+    });
+
+    it('handles zero values correctly', () => {
+        expect(isApproximatelyEqual(0, 0, 0.01)).toBe(true);
+        expect(isApproximatelyEqual(0, 1, 0.01)).toBe(false);
+    });
+
+    it('handles relative tolerance', () => {
+        expect(isApproximatelyEqual(100, 101, 0.005)).toBe(false);
+        expect(isApproximatelyEqual(100, 101, 0.01)).toBe(true);
+        expect(isApproximatelyEqual(100, 101, 0.02)).toBe(true);
+    });
+
+    it('handles NaN values', () => {
+        expect(isApproximatelyEqual(100, NaN, 0.01)).toBe(false);
+        expect(isApproximatelyEqual(NaN, 100, 0.01)).toBe(false);
+        expect(isApproximatelyEqual(NaN, NaN, 0.01)).toBe(false);
+        expect(isApproximatelyEqual('nonsense', '123', 0.01)).toBe(false);
+        expect(isApproximatelyEqual('123', 'nonsense', 0.01)).toBe(false);
+        expect(isApproximatelyEqual('nonsense', '', 0.01)).toBe(false);
+    });
+});

--- a/suite-common/wallet-core/src/fees/feesConstants.ts
+++ b/suite-common/wallet-core/src/fees/feesConstants.ts
@@ -1,0 +1,2 @@
+export const FEES_UPDATE_INTERVAL_MILLISECONDS = 60_000; // interval to refetch estimated fees from backend
+export const FEE_UPDATE_DELAY_MILLISECONDS = 1_000; // artificial delay before updating fees after user input

--- a/suite-common/wallet-core/src/fees/feesThunks.ts
+++ b/suite-common/wallet-core/src/fees/feesThunks.ts
@@ -65,21 +65,36 @@ export const preloadFeeInfoThunk = createThunk(
 
 type UpdateFeeInfoThunkProps = {
     networkSymbol: NetworkSymbol;
+    artificialDelay?: number;
 };
 
+const getArtificialDelayPromise = (artificialDelay?: number): Promise<void> =>
+    artificialDelay === undefined
+        ? Promise.resolve()
+        : new Promise(resolve => setTimeout(resolve, artificialDelay));
+
+/**
+ * Fetches feeInfo for a given network from backend.
+ * Can be called with an arbitrary delay [ms], in order to display loader for a bit longer,
+ * to visually draw users attention to the fees which are changing (because backend request is usually very quick).
+ */
 export const updateFeeInfoThunk = createThunk<
     FeeInfo,
     UpdateFeeInfoThunkProps,
     { rejectValue: undefined }
 >(
     `${FEES_MODULE_PREFIX}/updateFeeInfoThunk`,
-    async ({ networkSymbol }, { getState, fulfillWithValue, rejectWithValue }) => {
+    async ({ networkSymbol, artificialDelay }, { getState, fulfillWithValue, rejectWithValue }) => {
         const network = getNetwork(networkSymbol);
         const { symbol } = network;
         const blockchainInfo = selectNetworkBlockchainInfo(getState(), symbol);
         const device = selectSelectedDevice(getState());
 
-        const newFeeInfo = await getNewFeeInfo({ network, device });
+        const [newFeeInfo] = await Promise.all([
+            getNewFeeInfo({ network, device }),
+            getArtificialDelayPromise(artificialDelay),
+        ]);
+
         if (newFeeInfo === undefined) {
             // now errors just silently set status. If we want to handle them in any way, we might need more specific info
             return rejectWithValue(undefined);

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -25,6 +25,7 @@ export * from './discovery/discoveryThunks';
 export * from './discovery/discoverySelectors';
 export * from './discovery/passphraseUtils';
 export * from './fees/feesActions';
+export * from './fees/feesConstants';
 export * from './fees/feesReducer';
 export * from './fees/feesThunks';
 export * from './fees/feesUtils';


### PR DESCRIPTION
Reapply #19242 but a lot of changes were done.

Depends on #19721

:eyes: CR commit by commit recommended:

- 08cce95ca304f2f0292a6cdfb3dde94a836e188a – unchanged from [#19242](https://github.com/trezor/trezor-suite/pull/19242) except renaming [as per comment](https://github.com/trezor/trezor-suite/pull/19577#discussion_r2147494554)
- 61518189da7c2eaca491087facee2286b9c02d50 – **the main thing**, rewritten a lot, builds on [#19721](https://github.com/trezor/trezor-suite/pull/19721)
- de6b15db01eafda68deb62475d821316079eda60 – small UI tweak
- 91dafece6339fb4312dfa75bd02cad19e91250da – small UI tweak
- af9f99c05b48819318b685ec245914617465e4ec – fixes [#19282](https://github.com/trezor/trezor-suite/issues/19282)
- 7606f4d69a62e348b3a5b36d3271e7c66798a94f – fixes [#19281](https://github.com/trezor/trezor-suite/issues/19281)

## Description

Update fee rates regularly at all places where fee selection is available.
- periodicaly refetch fees every 60s
  - but not when modal is open
  - and not when send max is chosen
  - it works everywhere where the Fees levels options are displayed (not just send form)
- display skeletons when loading [as per figma](https://www.figma.com/design/qx5aOavcU7I2MW2PtnQtfz/Small-Things--DSK-?node-id=4048-978&t=MFI4WubrD2PkITeY-1)
- new `isApproxEqual` util for bignumbers

what I did different than specified in Figma:
- disabled the Review & send button consistently with the loaders around it
  - otherwise it would flick on/off, but with inconsistent timing (only as the draft is recomposed)
- the fetching is very quick, so if we displayed loaders only during the loading itself, they just blink on/off quickly.
  - that looks disruptive and it's not clear what is happening, just that _something blinked on the screen_
  - the point of the loaders is to visually signify to user that the fees are changing, so I extend the loader to at least one second. IMHO it works very well, see videos below :slightly_smiling_face:
- it also works in: Bump Fee, Stake, Unstake, Claim, Trading–sell
  - their confirm buttons are also loading with fees, consistently with Send Form (but no figma designs here)

## Related Issue

Resolve #18406 (again)
Resolve #19281
Resolve #19282


## Screenshots (new in this PR)

[Don't refetch when transaction review modal is open](https://github.com/user-attachments/assets/590a37bf-d698-43f3-93f1-746565c75104)
[Behavior in Bump Fee Modal](https://github.com/user-attachments/assets/523e3d99-f4fa-4d17-9dee-ff5f6ae33aef)
[Behavior in Sell page](https://github.com/user-attachments/assets/63bd5746-1363-48de-83d9-768716869632)
[Behavior in Stake modal](https://github.com/user-attachments/assets/47b15665-4b92-4862-89a1-2293c91af5e9)
[Behavior in Unstake modal](https://github.com/user-attachments/assets/9f866f04-1f79-4458-b18a-d670496057d2)
[Behavior in Claim modal](https://github.com/user-attachments/assets/de1e647e-5151-40bc-ab94-491678aaceeb)

## Screenshots (copied from old PR)

Video of the new behavior, when high fee value is selected and it's just changing: 

[demo.webm](https://github.com/user-attachments/assets/a0354d18-3949-464d-b0ff-0af6590d2573)

Playing around with various scenarios (it does not lose my progress, it does not reset my fee level choice, dust prevention works etc.), with update time lowered to 10 seconds

[playing around.webm](https://github.com/user-attachments/assets/ecd01cef-9a68-41eb-a82c-796b14fc5b40)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/send-form-update-fees-regularly-attempt-2&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/send-form-update-fees-regularly-attempt-2&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/send-form-update-fees-regularly-attempt-2&lookback=7)