### PR TITLE
chore: remove useless extraDependencies in favor of direct imports

### DIFF
--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -6,7 +6,6 @@ export const SET_BIO_AUTH_ENABLED = '@suite/set-bio-auth-enabled';
 export const REQUEST_BIO_AUTH_CHANGE = '@suite/request-bio-auth-change';
 export const REQUEST_BIO_AUTH_CHANGE_END = '@suite/request-bio-auth-change-end';
 export const REQUEST_BIO_AUTH_VALIDATED = '@suite/request-bio-auth-validated';
-export const REQUEST_AUTH_CONFIRM = '@suite/request-auth-confirm';
 export const BIO_AUTH_WINDOW_BLUR = '@suite/bio-auth-window-blur';
 export const BIO_AUTH_WINDOW_FOCUS = '@suite/bio-auth-window-focus';
 export const TOGGLE_BIO_AUTH_VALIDATION_REQUESTED = '@suite/toggle-bio-auth-validation-requested';

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -28,7 +28,6 @@ export type SuiteAction =
     | { type: typeof SUITE.READY }
     | { type: typeof SUITE.ERROR; error: string }
     | { type: typeof SUITE.DESKTOP_HANDSHAKE; payload: HandshakeElectron }
-    | { type: typeof requestAuthConfirm.type }
     | {
           type: typeof SUITE.SET_LANGUAGE;
           locale: Locale;
@@ -110,8 +109,6 @@ export const desktopHandshake = (payload: HandshakeElectron): SuiteAction => ({
 });
 
 // Bio auth related actions have been moved to bioAuthActions.ts
-
-export const requestAuthConfirm = createAction(SUITE.REQUEST_AUTH_CONFIRM);
 
 export const setTheme = (
     variant: AppState['suite']['settings']['theme']['variant'],

--- a/packages/suite/src/actions/wallet/__fixtures__/publicKeyActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/publicKeyActions.ts
@@ -88,6 +88,7 @@ export default [
         initialState: {
             device: {
                 selectedDevice: getSuiteDevice({ connected: false }),
+                devices: [],
             },
         },
         mocks: {},
@@ -107,6 +108,7 @@ export default [
         initialState: {
             device: {
                 selectedDevice: undefined,
+                devices: [],
             },
         },
         mocks: {},

--- a/packages/suite/src/actions/wallet/__tests__/publicKeyActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/publicKeyActions.test.ts
@@ -79,7 +79,7 @@ const rootReducer = combineReducers({
 });
 
 interface StateOverrides {
-    device?: Pick<DeviceReducerState, 'selectedDevice'>;
+    device?: Pick<DeviceReducerState, 'selectedDevice' | 'devices'>;
     networkType?: string;
 }
 

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -9,14 +9,9 @@ import {
 import { isNetworkSymbol } from '@suite-common/wallet-config';
 import {
     BlockchainState,
-    DeviceRootState,
-    DiscoveryRootState,
     ExplorerConfig,
     FiatRatesState,
     TransactionsState,
-    deviceActions,
-    selectDiscoveryByDevicePath,
-    selectIsPendingTransportEvent,
 } from '@suite-common/wallet-core';
 import { buildHistoricRatesFromStorage, getAccountKey } from '@suite-common/wallet-utils';
 import { StaticSessionId } from '@trezor/connect';
@@ -26,12 +21,7 @@ import * as metadataActions from 'src/actions/suite/metadataActions';
 import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
 import * as modalActions from 'src/actions/suite/modalActions';
 import { StorageLoadAction } from 'src/actions/suite/storageActions';
-import { openSwitchDeviceDialog } from 'src/actions/wallet/addWalletThunk';
 import * as cardanoStakingActions from 'src/actions/wallet/cardanoStakingActions';
-import {
-    findLabelsToBeMovedOrDeleted,
-    moveLabelsForRbfAction,
-} from 'src/actions/wallet/moveLabelsForRbfActions';
 import { reportCheckFail } from 'src/components/suite/SecurityCheck/useReportDeviceCompromised';
 import { selectIsWindowVisible } from 'src/reducers/suite/windowReducer';
 import { fixLoadedCoinjoinAccount } from 'src/utils/wallet/coinjoinUtils';
@@ -67,24 +57,17 @@ export const extraDependencies: ExtraDependencies = {
         initMetadata: metadataLabelingActions.init,
         fetchAndSaveMetadata: metadataLabelingActions.fetchAndSaveMetadata,
         addAccountMetadata: metadataLabelingActions.addAccountMetadata,
-        findLabelsToBeMovedOrDeleted,
-        moveLabelsForRbfAction,
-        openSwitchDeviceDialog,
         forgetBluetoothDevice,
     },
     selectors: {
-        selectDevices: (state: AppState) => state.device.devices,
         selectTokenDefinitionsEnabledNetworks: (state: AppState) =>
             state.wallet.settings.enabledNetworks,
-        selectIsPendingTransportEvent,
         selectDebugSettings: (state: AppState) => state.suite.settings.debug,
         // FW binaries on desktop are stored in "*/static/connect/data/firmware/*/*.bin" (see "connect-common" package)
         selectDesktopBinDir: (state: AppState) => state.desktop?.paths?.binDir,
         selectDevice: (state: AppState) => state.device.selectedDevice,
         selectLanguage: (state: AppState) => state.suite.settings.language,
         selectMetadata: (state: AppState) => state.metadata,
-        selectDiscoveryForSelectedDevice: (state: DiscoveryRootState & DeviceRootState) =>
-            selectDiscoveryByDevicePath(state, state.device.selectedDevice?.path),
         selectRouterApp: (state: AppState) => state.router.app,
         selectRoute: (state: AppState) => state.router.route,
         selectAddressDisplayType: (state: AppState) => state.suite.settings.addressDisplayType,
@@ -98,10 +81,6 @@ export const extraDependencies: ExtraDependencies = {
     actions: {
         setAccountAddMetadata: metadataActions.setAccountAdd,
         lockDevice: suiteActions.lockDevice,
-        appChanged: suiteActions.appChanged,
-        setSelectedDevice: deviceActions.selectDevice,
-        updateSelectedDevice: deviceActions.updateSelectedDevice,
-        requestAuthConfirm: suiteActions.requestAuthConfirm,
         onModalCancel: modalActions.onCancel,
         openModal: modalActions.openModal,
     },

--- a/suite-common/connect-init/src/__tests__/connectInitThunks.test.ts
+++ b/suite-common/connect-init/src/__tests__/connectInitThunks.test.ts
@@ -10,7 +10,7 @@ describe('TrezorConnect Actions', () => {
         store = configureMockStore({
             preloadedState: {
                 wallet: { settings: { enabledNetworks: [] } },
-                device: { selectedDevice: undefined },
+                device: { selectedDevice: undefined, devices: [] },
             },
         });
     });

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -5,6 +5,7 @@ import {
     deviceConnectThunks,
     selectDevices,
     selectEnabledNetworks,
+    selectIsPendingTransportEvent,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import TrezorConnect, {
@@ -39,7 +40,7 @@ export const connectInitThunk = createThunk<
     void
 >(`${CONNECT_INIT_MODULE}/initThunk`, async (connectInitHooks, { dispatch, getState, extra }) => {
     const {
-        selectors: { selectIsPendingTransportEvent, selectDebugSettings },
+        selectors: { selectDebugSettings },
         actions: { lockDevice },
         utils: { connectInitSettings },
     } = extra;

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -9,11 +9,8 @@ import { Route, TrezorDevice, UserContextPayload } from '@suite-common/suite-typ
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import {
     Account,
-    AccountKey,
     AddressDisplayOptions,
-    Discovery,
     SelectedAccountStatus,
-    WalletAccountTransaction,
     WalletType,
 } from '@suite-common/wallet-types';
 import { BlockchainBlock, ConnectSettings, Manifest, StaticSessionId } from '@trezor/connect';
@@ -40,37 +37,23 @@ export type ExtraDependencies = {
         addAccountMetadata: SuiteCompatibleThunk<
             Exclude<MetadataAddPayload, { type: 'walletLabel' }>
         >;
-        findLabelsToBeMovedOrDeleted: SuiteCompatibleThunk<{
-            prevTxid: string;
-        }>;
-        moveLabelsForRbfAction: SuiteCompatibleThunk<{
-            newTxid: string;
-            toBeMovedOrDeletedList: Record<
-                AccountKey,
-                {
-                    toBeMoved: WalletAccountTransaction;
-                    toBeDeleted: WalletAccountTransaction[];
-                }
-            >;
-        }>;
-        openSwitchDeviceDialog: SuiteCompatibleThunk<void>;
         forgetBluetoothDevice: SuiteCompatibleThunk<void>;
     };
     selectors: {
-        selectDevices: SuiteCompatibleSelector<TrezorDevice[]>;
+        // TODO when tokens are implemented 1:1 in both apps, delete from extras
+        // wallet-core selector is used in desktop, but suite-native has its own implementation
         selectTokenDefinitionsEnabledNetworks: SuiteCompatibleSelector<NetworkSymbol[]>;
-        selectIsPendingTransportEvent: SuiteCompatibleSelector<boolean>;
         // todo: we do not want to, so far, transfer coinjoin to @suite-common
         // but this is exactly what I need to get DebugModeOptions type instead of any
         selectDebugSettings: SuiteCompatibleSelector<any>;
         selectDesktopBinDir: SuiteCompatibleSelector<string | undefined>;
+        // a wallet-core selector that could be reused directly, but this one is used very often and would create circular deps
         selectDevice: SuiteCompatibleSelector<TrezorDevice | undefined>;
         selectLanguage: SuiteCompatibleSelector<string>;
         selectIsWindowVisible: SuiteCompatibleSelector<boolean>;
         selectRouterApp: SuiteCompatibleSelector<string>;
         selectRoute: SuiteCompatibleSelector<Route | undefined>;
         selectMetadata: SuiteCompatibleSelector<any>;
-        selectDiscoveryForSelectedDevice: SuiteCompatibleSelector<Discovery | undefined>;
         selectAddressDisplayType: SuiteCompatibleSelector<AddressDisplayOptions>;
         selectSelectedAccount: SuiteCompatibleSelector<SelectedAccountStatus>;
         selectSelectedAccountStatus: SuiteCompatibleSelector<SelectedAccountStatus['status']>;
@@ -87,10 +70,6 @@ export type ExtraDependencies = {
     actions: {
         setAccountAddMetadata: ActionCreatorWithPreparedPayload<[payload: Account], Account>;
         lockDevice: ActionCreatorWithPreparedPayload<[payload: boolean], boolean>;
-        appChanged: ActionCreatorWithPayload<any>;
-        setSelectedDevice: ActionCreatorWithPayload<TrezorDevice | undefined>;
-        updateSelectedDevice: ActionCreatorWithPayload<TrezorDevice>;
-        requestAuthConfirm: ActionCreatorWithoutPayload;
         onModalCancel: ActionCreatorWithoutPayload;
         openModal: ActionCreatorWithPayload<UserContextPayload>;
     };

--- a/suite-common/test-utils/src/extraDependenciesMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesMock.ts
@@ -62,18 +62,13 @@ export const extraDependenciesMock: ExtraDependencies = {
         fetchAndSaveMetadata: mockThunk('fetchAndSaveMetadata'),
         initMetadata: mockThunk('initMetadata'),
         addAccountMetadata: mockThunk('addAccountMetadata'),
-        findLabelsToBeMovedOrDeleted: mockThunk('findLabelsToBeMovedOrDeleted'),
-        moveLabelsForRbfAction: mockThunk('moveLabelsForRbfAction'),
-        openSwitchDeviceDialog: mockThunk('openSwitchDeviceDialog'),
         forgetBluetoothDevice: mockThunk('forgetBluetoothDevice'),
     },
     selectors: {
-        selectDevices: mockSelector('selectDevices', []),
         selectTokenDefinitionsEnabledNetworks: mockSelector(
             'selectTokenDefinitonsEnabledNetworks',
             ['eth'],
         ),
-        selectIsPendingTransportEvent: mockSelector('selectIsPendingTransportEvent', false),
         selectDebugSettings: mockSelector('selectDebugSettings', {
             checkFirmwareAuthenticity: false,
             showDebugMenu: false,
@@ -87,10 +82,6 @@ export const extraDependenciesMock: ExtraDependencies = {
             ...testMocks.getSuiteDevice(),
         }),
         selectLanguage: mockSelector('selectLanguage', 'en'),
-        selectDiscoveryForSelectedDevice: mockSelector(
-            'selectDiscoveryForSelectedDevice',
-            undefined,
-        ),
         selectAddressDisplayType: mockSelector(
             'selectAddressDisplayType',
             AddressDisplayOptions.CHUNKED,
@@ -109,10 +100,6 @@ export const extraDependenciesMock: ExtraDependencies = {
     actions: {
         setAccountAddMetadata: mockAction('setAccountAddMetadata'),
         lockDevice: mockAction('lockDevice'),
-        appChanged: mockAction('appChanged'),
-        setSelectedDevice: mockAction('setSelectedDevice'),
-        updateSelectedDevice: mockAction('updateSelectedDevice'),
-        requestAuthConfirm: mockAction('requestAuthConfirm'),
         onModalCancel: mockAction('onModalCancel'),
         openModal: mockAction('openModal'),
     },

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -20,6 +20,7 @@ import { accountsActions } from './accountsActions';
 import { ACCOUNTS_MODULE_PREFIX } from './accountsConstants';
 import { selectAccountByKey } from './accountsSelectors';
 import { selectBlockchainHeightBySymbol } from '../blockchain/blockchainReducer';
+import { selectDevices } from '../device/deviceSelectors';
 import { selectBitcoinAmountUnit } from '../settings/walletSettingsReducer';
 import { transactionsActions } from '../transactions/transactionsActions';
 import { selectTransactions } from '../transactions/transactionsSelectors';
@@ -56,10 +57,7 @@ const fetchAccountTokens = async (account: Account, payloadTokens: AccountInfo['
 // as we usually want to update all accounts for a single coin at once
 export const fetchAndUpdateAccountThunk = createThunk(
     `${ACCOUNTS_MODULE_PREFIX}/fetchAndUpdateAccountThunk`,
-    async ({ accountKey }: { accountKey: AccountKey }, { dispatch, extra, getState }) => {
-        const {
-            selectors: { selectDevices },
-        } = extra;
+    async ({ accountKey }: { accountKey: AccountKey }, { dispatch, getState }) => {
         const account = selectAccountByKey(getState(), accountKey);
 
         if (!account) return;

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -34,6 +34,7 @@ import { BLOCKCHAIN_MODULE_PREFIX, blockchainActions } from './blockchainActions
 import { selectBlockchainState, selectNetworkBlockchainInfo } from './blockchainReducer';
 import { selectAccounts } from '../accounts/accountsSelectors';
 import { fetchAndUpdateAccountThunk } from '../accounts/accountsThunks';
+import { selectDevices } from '../device/deviceSelectors';
 import { preloadFeeInfoThunk } from '../fees/feesThunks';
 import { selectBitcoinAmountUnit } from '../settings/walletSettingsReducer';
 
@@ -299,10 +300,7 @@ export const onBlockMinedThunk = createThunk(
 
 export const onBlockchainNotificationThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/onNotificationThunk`,
-    (payload: BlockchainNotification, { dispatch, getState, extra }) => {
-        const {
-            selectors: { selectDevices },
-        } = extra;
+    (payload: BlockchainNotification, { dispatch, getState }) => {
         const { descriptor, tx } = payload.notification;
         const symbol = payload.coin.shortcut.toLowerCase();
         if (!isNetworkSymbol(symbol)) {

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -4,11 +4,7 @@ import * as Device from 'expo-device';
 
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { extraDependenciesMock } from '@suite-common/test-utils/src/extraDependenciesMock'; // precise import path to avoid circular dependencies
-import {
-    selectDevices,
-    selectDiscoveryForSelectedDevice,
-    selectSelectedDevice,
-} from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { isBluetoothEnabled } from '@suite-native/bluetooth';
 import { selectTokenDefinitionsEnabledNetworks } from '@suite-native/discovery';
 import { selectTradingEnvironment } from '@suite-native/module-trading';
@@ -34,10 +30,8 @@ const transports = transportsPerDeviceType[deviceType];
 
 export const extraDependencies: ExtraDependencies = mergeDeepObject(extraDependenciesMock, {
     selectors: {
-        selectDevices,
         selectTokenDefinitionsEnabledNetworks,
         selectDevice: selectSelectedDevice,
-        selectDiscoveryForSelectedDevice,
         selectDebugSettings: () => ({
             transports,
         }),


### PR DESCRIPTION
## Description

I went through all extra dependencies to:
- removed unused
- replace with direct imports where feasible
  - wrote comments where not

Reason? Needless indirection = needless complexity. Clear import is less confusing :slightly_smiling_face:

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/cleanup-extra-selectors&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/cleanup-extra-selectors&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/cleanup-extra-selectors&lookback=7)