### PR TITLE
chore(env-utils): cleanup unused or duplicated env utils

### DIFF
--- a/packages/env-utils/src/envUtils.native.ts
+++ b/packages/env-utils/src/envUtils.native.ts
@@ -26,7 +26,6 @@ const getDeviceType = () => '';
 
 // no need for async fn on native; only for the sake of consistency with Web/Desktop
 const getOsVersion = () => Promise.resolve(`${Platform.Version}`);
-const getDeprecatedOsVersion = () => `${Platform.Version}`;
 
 const getCpuArch = () => Promise.resolve('');
 
@@ -95,7 +94,6 @@ export const envUtils: EnvUtils = {
     getCommitHash,
     getDeviceType,
     getOsVersion,
-    getDeprecatedOsVersion,
     getCpuArch,
     getSuiteVersion,
     isFirefox,

--- a/packages/env-utils/src/envUtils.ts
+++ b/packages/env-utils/src/envUtils.ts
@@ -47,8 +47,6 @@ const getOsVersion = async () => {
 
     return version ?? '';
 };
-/** @deprecated: Use the async getOsVersion instead. */
-const getDeprecatedOsVersion = () => getUserAgentParser().getOS().version || '';
 
 /**
  * Similar to `getOsVersion`. Here, the sync fn works everywhere but macOS, hence we use async.
@@ -127,6 +125,7 @@ const getOsName = () => {
     return '';
 };
 
+// generally works the same as `getOsName`, just with different information source, but does not work in some specific iOS cases
 const getOsNameWeb = () => getUserAgentParser().getOS().name?.replaceAll(' ', '');
 
 const getOsFamily = () => {
@@ -161,7 +160,6 @@ export const envUtils: EnvUtils = {
     isAndroid,
     isChromeOs,
     getOsVersion,
-    getDeprecatedOsVersion,
     getCpuArch,
     getBrowserName,
     getBrowserVersion,

--- a/packages/env-utils/src/index.ts
+++ b/packages/env-utils/src/index.ts
@@ -15,7 +15,6 @@ export const {
     getCommitHash,
     getDeviceType,
     getOsVersion,
-    getDeprecatedOsVersion,
     getCpuArch,
     getSuiteVersion,
     isFirefox,

--- a/packages/env-utils/src/types.ts
+++ b/packages/env-utils/src/types.ts
@@ -15,7 +15,6 @@ export interface EnvUtils {
     getCommitHash: () => string;
     getDeviceType: () => string | undefined;
     getOsVersion: () => Promise<string>;
-    getDeprecatedOsVersion: () => string;
     getCpuArch: () => Promise<string>;
     getSuiteVersion: () => string;
     isFirefox: () => boolean;


### PR DESCRIPTION
## Description

Remove a deprecated env-util

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/cleanup-env-utils&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/cleanup-env-utils&lookback=7)