### PR TITLE
chore(suite): device.useEmptyPassphrase revamp

### DIFF
--- a/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
+++ b/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
@@ -3,12 +3,7 @@ import assert from 'assert';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { testMocks } from '@suite-common/test-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import {
-    ConnectDeviceSettings,
-    deviceActions,
-    prepareDeviceReducer,
-    wipeDeviceThunk,
-} from '@suite-common/wallet-core';
+import { deviceActions, prepareDeviceReducer, wipeDeviceThunk } from '@suite-common/wallet-core';
 import { Response } from '@trezor/connect';
 
 import suiteReducer from 'src/reducers/suite/suiteReducer';
@@ -39,10 +34,6 @@ type Feature = {
     };
 };
 
-const SUITE_SETTINGS: ConnectDeviceSettings = {
-    defaultWalletLoading: 'standard',
-};
-
 const fixture: Feature[] = [
     {
         description: 'Wipe device',
@@ -69,7 +60,6 @@ const fixture: Feature[] = [
                             available: false,
                             features: { ...deviceChange.features, device_id: 'device-id' },
                         },
-                        settings: SUITE_SETTINGS,
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
                 {
@@ -82,7 +72,6 @@ const fixture: Feature[] = [
                             available: true,
                             features: { ...deviceChange.features, device_id: 'new-device-id' },
                         },
-                        settings: SUITE_SETTINGS,
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
                 {
@@ -144,7 +133,6 @@ const fixture: Feature[] = [
                             available: false,
                             features: { ...deviceChange.features, device_id: 'device-id' },
                         },
-                        settings: SUITE_SETTINGS,
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
                 {
@@ -159,7 +147,6 @@ const fixture: Feature[] = [
                             state: { staticSessionId: '1stTestnetAddress@device_1_id:0' },
                             features: { ...deviceChange.features, device_id: 'device-id' },
                         },
-                        settings: SUITE_SETTINGS,
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
                 {
@@ -174,7 +161,6 @@ const fixture: Feature[] = [
                             state: { staticSessionId: '1stTestnetAddress@device_2_id:0' },
                             features: { ...deviceChange.features, device_id: 'device-id' },
                         },
-                        settings: SUITE_SETTINGS,
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
                 {
@@ -187,7 +173,6 @@ const fixture: Feature[] = [
                             available: true,
                             features: { ...deviceChange.features, device_id: 'new-device-id' },
                         },
-                        settings: SUITE_SETTINGS,
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
                 {
@@ -202,7 +187,6 @@ const fixture: Feature[] = [
                             state: { staticSessionId: '1stTestnetAddress@device_1_id:0' },
                             features: { ...deviceChange.features, device_id: 'new-device-id' },
                         },
-                        settings: SUITE_SETTINGS,
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
                 {
@@ -217,7 +201,6 @@ const fixture: Feature[] = [
                             state: { staticSessionId: '1stTestnetAddress@device_2_id:0' },
                             features: { ...deviceChange.features, device_id: 'new-device-id' },
                         },
-                        settings: SUITE_SETTINGS,
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
                 {

--- a/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
@@ -4,7 +4,6 @@ import { connectInitThunk } from '@suite-common/connect-init';
 import { prepareFirmwareReducer } from '@suite-common/firmware';
 import { testMocks } from '@suite-common/test-utils';
 import {
-    ConnectDeviceSettings,
     acquireDevice,
     deviceActions,
     forgetDisconnectedDevices,
@@ -109,10 +108,6 @@ const initStore = (state: State) => {
     });
 
     return store;
-};
-
-const SUITE_SETTINGS: ConnectDeviceSettings = {
-    defaultWalletLoading: 'standard',
 };
 
 describe('Suite Actions', () => {
@@ -238,9 +233,7 @@ describe('Suite Actions', () => {
     // just for coverage
     it('misc', () => {
         const SUITE_DEVICE = getSuiteDevice({ path: '1' });
-        expect(
-            deviceActions.forgetDevice({ device: SUITE_DEVICE, settings: SUITE_SETTINGS }),
-        ).toMatchObject({
+        expect(deviceActions.forgetDevice({ device: SUITE_DEVICE })).toMatchObject({
             type: deviceActions.forgetDevice.type,
         });
         expect(suiteActions.setDebugMode({ showDebugMenu: true })).toMatchObject({

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -23,7 +23,6 @@ import { serializeCoinjoinAccount, serializeDevice } from 'src/utils/suite/stora
 import { deviceGraphDataFilterFn } from 'src/utils/wallet/graph';
 
 import { STORAGE } from './constants';
-import { selectSuiteSettings } from '../../reducers/suite/suiteReducer';
 import { DesktopBluetoothDevice } from '../bluetooth/DesktopBluetoothDevice';
 
 export type StorageAction = NonNullable<PreloadStoreAction>;
@@ -537,12 +536,11 @@ export const removeDatabase = () => async (dispatch: Dispatch, getState: GetStat
     if (!(await db.isAccessible())) return;
 
     const devices = selectDevices(getState());
-    const settings = selectSuiteSettings(getState());
 
     const rememberedDevices = devices.filter(d => d.remember);
     // forget all remembered devices
     rememberedDevices.forEach(d => {
-        dispatch(deviceActions.forgetDevice({ device: d, settings }));
+        dispatch(deviceActions.forgetDevice({ device: d }));
     });
     await db.removeDatabase();
     dispatch(

--- a/packages/suite/src/actions/wallet/signVerifyActions.ts
+++ b/packages/suite/src/actions/wallet/signVerifyActions.ts
@@ -35,7 +35,7 @@ const getStateParams = (getState: GetState): Promise<StateParams> => {
         : Promise.resolve({
               device,
               account,
-              useEmptyPassphrase: device.useEmptyPassphrase,
+              useEmptyPassphrase: device.useEmptyPassphrase!,
               coin: account.symbol,
               chunkify: addressDisplayType === AddressDisplayOptions.CHUNKED,
           });

--- a/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
@@ -87,7 +87,6 @@ describe('redirectMiddleware', () => {
                 type: DEVICE.CONNECT,
                 payload: {
                     device: getConnectDevice({ mode: 'initialize' }),
-                    settings: { defaultWalletLoading: 'standard' },
                 },
             };
 
@@ -102,7 +101,6 @@ describe('redirectMiddleware', () => {
                 type: DEVICE.CONNECT,
                 payload: {
                     device: getConnectDevice({ mode: 'normal', firmware: 'required' }),
-                    settings: { defaultWalletLoading: 'standard' },
                 },
             };
 

--- a/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
@@ -1,6 +1,6 @@
 import { TrezorDevice } from '@suite-common/suite-types';
 import { testMocks } from '@suite-common/test-utils';
-import { ConnectDeviceSettings, deviceActions } from '@suite-common/wallet-core';
+import { deviceActions } from '@suite-common/wallet-core';
 import { DEVICE } from '@trezor/connect';
 import { DeepPartial } from '@trezor/type-utils';
 
@@ -17,10 +17,6 @@ type Fixture<TAction> = {
     result: DeepPartial<TrezorDevice>[];
 };
 
-const SUITE_SETTINGS: ConnectDeviceSettings = {
-    defaultWalletLoading: 'standard',
-};
-
 const connect: Fixture<
     | ReturnType<typeof deviceActions.connectDevice>
     | ReturnType<typeof deviceActions.connectUnacquiredDevice>
@@ -35,9 +31,6 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
-                    settings: {
-                        defaultWalletLoading: 'standard',
-                    },
                 },
             },
         ],
@@ -64,9 +57,6 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
-                    settings: {
-                        defaultWalletLoading: 'standard',
-                    },
                 },
             },
         ],
@@ -99,9 +89,6 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
-                    settings: {
-                        defaultWalletLoading: 'standard',
-                    },
                 },
             },
         ],
@@ -129,9 +116,6 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
-                    settings: {
-                        defaultWalletLoading: 'standard',
-                    },
                 },
             },
         ],
@@ -165,9 +149,6 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
-                    settings: {
-                        defaultWalletLoading: 'standard',
-                    },
                 },
             },
         ],
@@ -204,9 +185,6 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
-                    settings: {
-                        defaultWalletLoading: 'standard',
-                    },
                 },
             },
         ],
@@ -241,9 +219,6 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
-                    settings: {
-                        defaultWalletLoading: 'standard',
-                    },
                 },
             },
         ],
@@ -281,9 +256,6 @@ const connect: Fixture<
                         type: 'unacquired',
                         path: '1',
                     }),
-                    settings: {
-                        defaultWalletLoading: 'standard',
-                    },
                 },
             },
         ],
@@ -312,9 +284,6 @@ const connect: Fixture<
                         type: 'unacquired',
                         path: '1',
                     }),
-                    settings: {
-                        defaultWalletLoading: 'standard',
-                    },
                 },
             },
         ],
@@ -949,18 +918,16 @@ const forget: Fixture<ReturnType<typeof deviceActions.forgetDevice>>[] = [
                 type: deviceActions.forgetDevice.type,
                 payload: {
                     device: getSuiteDevice({ instance: 1 }),
-                    settings: SUITE_SETTINGS,
                 },
             },
             {
                 type: deviceActions.forgetDevice.type,
-                payload: { device: SUITE_DEVICE, settings: SUITE_SETTINGS },
+                payload: { device: SUITE_DEVICE },
             },
             {
                 type: deviceActions.forgetDevice.type,
                 payload: {
                     device: getSuiteDevice({ connected: true, instance: 3 }),
-                    settings: SUITE_SETTINGS,
                 },
             },
         ],
@@ -1005,7 +972,7 @@ const forget: Fixture<ReturnType<typeof deviceActions.forgetDevice>>[] = [
         actions: [
             {
                 type: deviceActions.forgetDevice.type,
-                payload: { device: getSuiteDevice({ instance: 3 }), settings: SUITE_SETTINGS },
+                payload: { device: getSuiteDevice({ instance: 3 }) },
             },
             {
                 type: deviceActions.forgetDevice.type,
@@ -1013,12 +980,11 @@ const forget: Fixture<ReturnType<typeof deviceActions.forgetDevice>>[] = [
                     device: getSuiteDevice(undefined, {
                         device_id: 'ignored-device-id',
                     }),
-                    settings: SUITE_SETTINGS,
                 },
             },
             {
                 type: deviceActions.forgetDevice.type,
-                payload: { device: SUITE_DEVICE, settings: SUITE_SETTINGS },
+                payload: { device: SUITE_DEVICE },
             },
         ],
         result: [
@@ -1046,7 +1012,6 @@ const forget: Fixture<ReturnType<typeof deviceActions.forgetDevice>>[] = [
                     device: getSuiteDevice({
                         type: 'unacquired',
                     }),
-                    settings: SUITE_SETTINGS,
                 },
             },
         ],
@@ -1062,7 +1027,7 @@ const forget: Fixture<ReturnType<typeof deviceActions.forgetDevice>>[] = [
         actions: [
             {
                 type: deviceActions.forgetDevice.type,
-                payload: { device: SUITE_DEVICE, settings: SUITE_SETTINGS },
+                payload: { device: SUITE_DEVICE },
             },
         ],
         result: [],

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectConfirmation.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectConfirmation.tsx
@@ -9,9 +9,7 @@ import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
-import { useDispatch, useSelector } from 'src/hooks/suite';
-
-import { selectSuiteSettings } from '../../../../reducers/suite/suiteReducer';
+import { useDispatch } from 'src/hooks/suite';
 
 const Container = styled.div`
     cursor: auto;
@@ -39,10 +37,8 @@ const EjectConfirmationContainer = ({
 }: EjectConfirmationContainerProps) => {
     const dispatch = useDispatch();
 
-    const settings = useSelector(selectSuiteSettings);
-
     const handleEject = () => {
-        dispatch(deviceActions.forgetDevice({ device: instance, settings }));
+        dispatch(deviceActions.forgetDevice({ device: instance }));
 
         analytics.report({
             type: EventType.SwitchDeviceEject,

--- a/suite-common/bluetooth/tests/bluetoothReducer.test.ts
+++ b/suite-common/bluetooth/tests/bluetoothReducer.test.ts
@@ -151,7 +151,6 @@ describe('bluetoothReducer', () => {
         store.dispatch(
             deviceActions.connectDevice({
                 device: trezorDevice as Device,
-                settings: { defaultWalletLoading: 'passphrase' },
             }),
         );
         expect(store.getState().bluetooth.knownDevices).toEqual([nearbyDevice]);

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -27,7 +27,7 @@ export type ButtonRequest = Omit<DeviceEvent['payload'], 'device' | 'code'> & {
 };
 
 export interface ExtendedDevice {
-    useEmptyPassphrase: boolean;
+    useEmptyPassphrase?: boolean;
     passphraseOnDevice?: boolean;
     remember?: boolean; // device should be remembered
     forceRemember?: true; // device was forced to be remembered
@@ -57,13 +57,15 @@ export type UnknownDevice = UnknownDeviceBase & ExtendedDevice;
 
 export type UnreadableDevice = UnreadableDeviceBase & ExtendedDevice;
 
-export type TrezorDevice = AcquiredDevice | UnknownDevice | UnreadableDevice;
-
 export type AuthorizedDevice = AcquiredDevice & {
     state: Required<DeviceState>;
+    // todo: these fields should be removed from other device types (they are optional now) for better type safety
     instance: number;
     walletNumber: number;
+    useEmptyPassphrase: boolean;
 };
+
+export type TrezorDevice = AcquiredDevice | AuthorizedDevice | UnknownDevice | UnreadableDevice;
 
 /**
  * used when saving device to storage

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -10,7 +10,7 @@ export type ConnectDeviceSettings = {
     defaultWalletLoading: WalletType;
 };
 
-export type DeviceConnectActionPayload = { device: Device; settings: ConnectDeviceSettings };
+export type DeviceConnectActionPayload = { device: Device };
 
 const connectDevice = createAction(DEVICE.CONNECT, (payload: DeviceConnectActionPayload) => ({
     payload,
@@ -71,7 +71,7 @@ const setTemporaryRememberedDevice = createAction(
 
 const forgetDevice = createAction(
     `${DEVICE_MODULE_PREFIX}/forgetDevice`,
-    (payload: { device: TrezorDevice; settings: ConnectDeviceSettings }) => ({
+    (payload: { device: TrezorDevice }) => ({
         payload,
     }),
 );

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -9,9 +9,8 @@ import { AcquiredDevice, ButtonRequest, TrezorDevice } from '@suite-common/suite
 import * as deviceUtils from '@suite-common/suite-utils';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { Device, DeviceState, Features, KnownDevice, StaticSessionId, UI } from '@trezor/connect';
-import { isNative } from '@trezor/env-utils';
 
-import { ConnectDeviceSettings, deviceActions } from './deviceActions';
+import { deviceActions } from './deviceActions';
 import { PORTFOLIO_TRACKER_DEVICE_ID } from './deviceConstants';
 
 export type DeviceReducerState = {
@@ -94,32 +93,30 @@ const merge = (
     },
 });
 
-const getShouldUseEmptyPassphrase = (
-    device: Device | TrezorDevice,
-    deviceInstance: number | undefined,
-    settings: ConnectDeviceSettings,
-): boolean => {
-    if (!device.features) return false;
+// todo: maybe should be moved to discoverThunks
+// const getShouldUseEmptyPassphrase = (
+//     device: Device | TrezorDevice,
+//     deviceInstance: number | undefined,
+//     settings: ConnectDeviceSettings,
+// ): boolean => {
+//     if (!device.features) return false;
 
-    if (isNative() && (!deviceInstance || deviceInstance === 1)) {
-        // On mobile, if device has instance === 1, we always want to use empty passphrase since we
-        // connect & authorize standard wallet by default. Other instances will have `usePassphraseProtection` set same way as web/desktop app.
-        return true;
-    }
+//     if (isNative() && (!deviceInstance || deviceInstance === 1)) {
+//         // On mobile, if device has instance === 1, we always want to use empty passphrase since we
+//         // connect & authorize standard wallet by default. Other instances will have `usePassphraseProtection` set same way as web/desktop app.
+//         return true;
+//     }
 
-    return !device.features.passphrase_protection || settings.defaultWalletLoading === 'standard';
-};
+//     return !device.features.passphrase_protection || settings.defaultWalletLoading === 'standard';
+// };
+
 /**
  * Action handler: DEVICE.CONNECT + DEVICE.CONNECT_UNACQUIRED
  * @param {DeviceReducerState} draft
  * @param {Device} device
  * @returns
  */
-const connectDevice = (
-    draft: DeviceReducerState,
-    device: Device,
-    settings: ConnectDeviceSettings,
-) => {
+const connectDevice = (draft: DeviceReducerState, device: Device) => {
     const currentTime = new Date().getTime();
 
     const deviceCommonFields = {
@@ -146,7 +143,6 @@ const connectDevice = (
             ...device,
             ...deviceCommonFields,
             available: false,
-            useEmptyPassphrase: true,
         });
 
         return;
@@ -176,13 +172,10 @@ const connectDevice = (
         ? deviceUtils.getNewInstanceNumber(draft.devices, device) || 1
         : undefined;
 
-    const useEmptyPassphrase = getShouldUseEmptyPassphrase(device, deviceInstance, settings);
-
     const newDevice: TrezorDevice = {
         ...device,
         ...deviceCommonFields,
         state: device._state,
-        useEmptyPassphrase,
         remember: false,
         temporaryRemember: false,
         available: true,
@@ -299,7 +292,6 @@ const changeDevice = (
                     ...device,
                     ...extended,
                     available: true,
-                    useEmptyPassphrase: true, // device with disabled passphrase_protection can have only standard wallet
                 });
             }
 
@@ -524,11 +516,7 @@ const setTemporaryRememberedDevice = (
  * @param {TrezorDevice} device
  * @returns
  */
-const forget = (
-    draft: DeviceReducerState,
-    device: TrezorDevice,
-    settings: ConnectDeviceSettings,
-) => {
+const forget = (draft: DeviceReducerState, device: TrezorDevice) => {
     // only acquired devices
     if (!device || !device.features) return;
     const index = deviceUtils.findInstanceIndex(draft.devices, device);
@@ -540,11 +528,7 @@ const forget = (
         draft.devices[index].state = undefined;
         draft.devices[index].walletNumber = undefined;
 
-        draft.devices[index].useEmptyPassphrase = getShouldUseEmptyPassphrase(
-            device,
-            undefined,
-            settings,
-        );
+        draft.devices[index].useEmptyPassphrase = true;
 
         draft.devices[index].passphraseOnDevice = false;
         // set remember to false to make it disappear after device is disconnected
@@ -641,7 +625,7 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
             setTemporaryRememberedDevice(state, payload.device, payload.temporaryRemember);
         })
         .addCase(deviceActions.forgetDevice, (state, { payload }) => {
-            forget(state, payload.device, payload.settings);
+            forget(state, payload.device);
         })
         .addCase(deviceActions.addButtonRequest, (state, { payload }) => {
             addButtonRequest(state, payload.device, payload.buttonRequest);
@@ -688,8 +672,8 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
         })
         .addMatcher(
             isAnyOf(deviceActions.connectDevice, deviceActions.connectUnacquiredDevice),
-            (state, { payload: { device, settings } }) => {
-                connectDevice(state, device, settings);
+            (state, { payload: { device } }) => {
+                connectDevice(state, device);
             },
         );
 });

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -172,15 +172,13 @@ export const handleDeviceDisconnect = createThunk(
  */
 export const forgetDisconnectedDevices = createThunk(
     `${DEVICE_MODULE_PREFIX}/forgetDisconnectedDevices`,
-    (device: Device | TrezorDevice, { dispatch, getState, extra }) => {
+    (device: Device | TrezorDevice, { dispatch, getState }) => {
         const devices = selectDevices(getState());
         const deviceInstances = devices.filter(d => d.id === device.id);
 
-        const settings = extra.selectors.selectSuiteSettings(getState());
-
         deviceInstances.forEach(d => {
             if (d.features && !d.remember) {
-                dispatch(deviceActions.forgetDevice({ device: d, settings }));
+                dispatch(deviceActions.forgetDevice({ device: d }));
             }
         });
     },
@@ -464,16 +462,14 @@ type DeviceConnectThunksParams = {
 
 export const deviceConnectThunks = createThunk<void, DeviceConnectThunksParams, void>(
     `${DEVICE_MODULE_PREFIX}/deviceConnectThunk`,
-    ({ type, device }, { dispatch, getState, extra }) => {
-        const settings = extra.selectors.selectSuiteSettings(getState());
-
+    ({ type, device }, { dispatch }) => {
         switch (type) {
             case DEVICE.CONNECT:
-                dispatch(deviceActions.connectDevice({ device, settings }));
+                dispatch(deviceActions.connectDevice({ device }));
                 dispatch(connectThpDeviceThunk({ device }));
                 break;
             case DEVICE.CONNECT_UNACQUIRED:
-                dispatch(deviceActions.connectUnacquiredDevice({ device, settings }));
+                dispatch(deviceActions.connectUnacquiredDevice({ device }));
                 dispatch(autoInitThpAfterDeviceConnectionThunk({ device }));
                 break;
             default:
@@ -519,11 +515,10 @@ export const wipeDeviceThunk = createThunk(
             }
             const newDevice = selectSelectedDevice(getState());
             const newDevices = selectDevices(getState());
-            const settings = extra.selectors.selectSuiteSettings(getState());
 
             deviceInstances.push(...getDeviceInstances(newDevice!, newDevices));
             deviceInstances.forEach(d => {
-                dispatch(deviceActions.forgetDevice({ device: d, settings }));
+                dispatch(deviceActions.forgetDevice({ device: d }));
             });
             dispatch(notificationsActions.addToast({ type: 'device-wiped' }));
 

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -1,7 +1,6 @@
 import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
 import { createThunk } from '@suite-common/redux-utils';
 import {
-    ConnectDeviceSettings,
     deviceActions,
     selectDevicePath,
     selectIsDeviceInitialized,
@@ -34,11 +33,7 @@ export const setTemporaryRememberedDeviceThunk = createThunk(
 
         // if the device is not connected and it was remembered only temporarily, we need to forget it
         if (!device.connected && device.temporaryRemember && !temporaryRemember) {
-            const settings: ConnectDeviceSettings = {
-                defaultWalletLoading: 'standard',
-            };
-
-            dispatch(deviceActions.forgetDevice({ device, settings }));
+            dispatch(deviceActions.forgetDevice({ device }));
         }
 
         return;

--- a/suite-native/module-settings/src/components/ViewOnly/WalletRow.tsx
+++ b/suite-native/module-settings/src/components/ViewOnly/WalletRow.tsx
@@ -2,7 +2,6 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { TrezorDevice } from '@suite-common/suite-types';
 import {
-    ConnectDeviceSettings,
     DeviceRootState,
     deviceActions,
     selectDeviceLabelOrNameById,
@@ -69,12 +68,8 @@ export const WalletRow = ({ device }: WalletRowProps) => {
         }
 
         if (!device.connected && device.remember) {
-            const settings: ConnectDeviceSettings = {
-                defaultWalletLoading: 'standard',
-            };
-
             // disconnected device, view-only is being disabled so it can be forgotten
-            dispatch(deviceActions.forgetDevice({ device, settings }));
+            dispatch(deviceActions.forgetDevice({ device }));
         } else {
             // device is connected or become remembered
             dispatch(deviceActions.rememberDevice({ device, remember: !device.remember }));


### PR DESCRIPTION
not finished. I believe that device.useEmptyPassphrase should be also set as a result of passphrase flow authorization

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=discovery-nitpicks-11&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=discovery-nitpicks-11&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=discovery-nitpicks-11&lookback=7)