### PR TITLE
fix(suite-native): replace selectConfiguration in native USB transport with NOOP

### DIFF
--- a/packages/react-native-usb/android/src/main/java/io/trezor/rnusb/ReactNativeUsbModule.kt
+++ b/packages/react-native-usb/android/src/main/java/io/trezor/rnusb/ReactNativeUsbModule.kt
@@ -80,10 +80,6 @@ class ReactNativeUsbModule : Module() {
             return@AsyncFunction closeDevice(deviceName)
         }
 
-        AsyncFunction("selectConfiguration") { deviceName: String, configurationIndex: Int ->
-            return@AsyncFunction selectConfiguration(deviceName, configurationIndex)
-        }
-
         AsyncFunction("claimInterface") { deviceName: String, interfaceNumber: Int ->
             return@AsyncFunction claimInterface(deviceName, interfaceNumber)
         }
@@ -272,21 +268,6 @@ class ReactNativeUsbModule : Module() {
         pendingRequests.clear()
         openedConnections.values.forEach { it.close() }
         openedConnections.clear()
-    }
-
-    private fun selectConfiguration(deviceName: String, configurationIndex: Int) {
-        Log.d(LOG_TAG, "Selecting configuration $configurationIndex for device $deviceName")
-        val device = getDeviceByName(deviceName)
-        val configurationValue = device.getConfiguration(configurationIndex)
-        if (configurationValue == null) {
-            Log.e(
-                LOG_TAG,
-                "Failed to get configuration $configurationIndex for device ${device.deviceName}"
-            )
-            throw Exception("Failed to get configuration $configurationIndex for device ${device.deviceName}")
-        }
-        val usbConnection = getOpenedConnection(deviceName)
-        usbConnection.setConfiguration(configurationValue)
     }
 
     private fun claimInterface(deviceName: String, interfaceNumber: Int) {

--- a/packages/react-native-usb/src/ReactNativeUsbModule.ts
+++ b/packages/react-native-usb/src/ReactNativeUsbModule.ts
@@ -14,7 +14,6 @@ declare class ReactNativeUsbModuleDeclaration extends NativeModule<DeviceEvents>
     close: (deviceName: string) => Promise<void>;
     claimInterface: (deviceName: string, interfaceNumber: number) => Promise<void>;
     releaseInterface: (deviceName: string, interfaceNumber: number) => Promise<void>;
-    selectConfiguration: (deviceName: string, configurationValue: number) => Promise<void>;
     transferIn: (deviceName: string, endpointNumber: number, length: number) => Promise<number[]>;
     transferOut: (deviceName: string, endpointNumber: number, data: string) => Promise<void>;
     setPriorityMode: (isInPriorityMode: boolean) => void;

--- a/packages/react-native-usb/src/index.ts
+++ b/packages/react-native-usb/src/index.ts
@@ -27,9 +27,6 @@ const claimInterface = (deviceName: string, interfaceNumber: number) =>
 const releaseInterface = (deviceName: string, interfaceNumber: number) =>
     ReactNativeUsbModule.releaseInterface(deviceName, interfaceNumber);
 
-const selectConfiguration = (deviceName: string, configurationValue: number) =>
-    ReactNativeUsbModule.selectConfiguration(deviceName, configurationValue);
-
 const transferIn = async (deviceName: string, endpointNumber: number, length: number) => {
     const perf = performance.now();
     const data = await ReactNativeUsbModule.transferIn(deviceName, endpointNumber, length)
@@ -78,8 +75,7 @@ const createWebUSBDevice = (device: NativeDevice): WebUSBDevice => ({
     reset: () => reset(device.deviceName),
     close: () => close(device.deviceName),
     forget: createNoop('forget'),
-    selectConfiguration: (configurationValue: number) =>
-        selectConfiguration(device.deviceName, configurationValue),
+    selectConfiguration: createNoop('selectConfiguration'),
     claimInterface: (interfaceNumber: number) => claimInterface(device.deviceName, interfaceNumber),
     releaseInterface: (interfaceNumber: number) =>
         releaseInterface(device.deviceName, interfaceNumber),


### PR DESCRIPTION
Make sure to initialize `NativeUsbTransport` with `logger: console` for testing.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18743
