### PR TITLE
fix(suite): try to fix UX issue of flicking discovery loader after pa…

### DIFF
--- a/packages/product-components/src/components/PassphraseTypeCard/PassphraseTypeCard.tsx
+++ b/packages/product-components/src/components/PassphraseTypeCard/PassphraseTypeCard.tsx
@@ -61,6 +61,7 @@ export type PassphraseTypeCardProps = {
     description?: ReactNode;
     deviceLoading?: boolean;
     submitLabel: ReactNode;
+    submitting?: boolean;
     type: WalletType;
     offerPassphraseOnDevice?: boolean;
     singleColModal?: boolean;
@@ -99,9 +100,11 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardProps) => {
     } = props;
     const submit = useCallback(
         (value2: string, passphraseOnDevice?: boolean) => {
-            onSubmit(value2, passphraseOnDevice);
+            if (!props.submitting) {
+                onSubmit(value2, passphraseOnDevice);
+            }
         },
-        [onSubmit],
+        [onSubmit, props.submitting],
     );
 
     const isBip39 = deviceBackup === 'Bip39';
@@ -159,6 +162,7 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardProps) => {
                 <PassphraseTypeCardContent
                     deviceLoading={deviceLoading}
                     submitLabel={submitLabel}
+                    submitting={props.submitting}
                     submitVariant={nonAsciiChars && !isBip39 ? 'warning' : 'primary'}
                     value={value}
                     setValue={setValue}

--- a/packages/product-components/src/components/PassphraseTypeCard/PassphraseTypeCardContent.tsx
+++ b/packages/product-components/src/components/PassphraseTypeCard/PassphraseTypeCardContent.tsx
@@ -49,6 +49,7 @@ const Description = styled.div`
 
 type PassphraseTypeCardContentProps = {
     submitLabel: ReactNode;
+    submitting?: boolean;
     submitVariant?: ButtonVariant;
     type: WalletType;
     deviceLoading?: boolean;
@@ -78,6 +79,7 @@ export const PassphraseTypeCardContent = ({
     value,
     setValue,
     submitLabel,
+    submitting,
     submitVariant = 'primary',
     showAsciiBanner,
     showPassword,
@@ -209,6 +211,7 @@ export const PassphraseTypeCardContent = ({
                                             isPassphraseTooLong ||
                                             deviceLoading
                                         }
+                                        isLoading={submitting}
                                         variant={submitVariant}
                                         onClick={() => submit(value)}
                                         isFullWidth

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
@@ -1,9 +1,6 @@
 import { useIntl } from 'react-intl';
 
-import {
-    selectIsDiscoveryAuthConfirmationRequired,
-    selectSelectedDevice,
-} from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import TrezorConnect, { UI } from '@trezor/connect';
 
 import { MODAL } from 'src/actions/suite/constants';
@@ -12,7 +9,6 @@ import {
     ConfirmAddressModal,
     ConfirmFingerprintModal,
     ConfirmXpubModal,
-    PassphraseModal,
     PassphraseOnDeviceModal,
     PinModal,
     TransactionReviewModal,
@@ -33,16 +29,8 @@ export const DeviceContextModal = ({
     const intl = useIntl();
     const selectedAccount = useSelector(selectSelectedAccount);
 
-    const confirmEmptyPassphrase = useSelector(state =>
-        selectIsDiscoveryAuthConfirmationRequired(state, device?.path),
-    );
-
     if (!device) return null;
     const abort = () => TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
-
-    if (confirmEmptyPassphrase) {
-        return <PassphraseModal device={device} />;
-    }
 
     switch (windowType) {
         // T1B1 firmware

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/EnterPassphrase.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/EnterPassphrase.tsx
@@ -16,6 +16,7 @@ type EnterPassphraseProps = {
     onDeviceOffer: boolean;
     device: TrezorDevice;
     deviceLoading?: boolean;
+    submitting?: boolean;
     onBack: () => void;
     onCancel: () => void;
     onSubmit: (value: string, passphraseOnDevice?: boolean) => void;
@@ -25,6 +26,7 @@ export const EnterPassphrase = ({
     device,
     deviceLoading,
     onDeviceOffer,
+    submitting,
     onBack,
     onCancel,
     onSubmit,
@@ -71,6 +73,7 @@ export const EnterPassphrase = ({
                     <PassphraseTypeCard
                         deviceLoading={deviceLoading}
                         submitLabel={<Translation id="TR_ACCESS_HIDDEN_WALLET" />}
+                        submitting={submitting}
                         type="hidden"
                         singleColModal
                         offerPassphraseOnDevice={onDeviceOffer}

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
@@ -128,6 +128,7 @@ export const PassphraseModal = ({ device }: { device: TrezorDevice }) => {
                 loading={Boolean(passphraseState.loading)}
                 deviceOffer={deviceOffer}
                 authConfirmation={authConfirmation}
+                submittingPassphrase={Boolean(passphraseState.isSubmitting)}
                 onSubmit={onSubmit}
             />
         );
@@ -138,6 +139,7 @@ export const PassphraseModal = ({ device }: { device: TrezorDevice }) => {
             passphraseState={passphraseState.screen}
             loading={Boolean(passphraseState.loading)}
             deviceOffer={deviceOffer}
+            submittingPassphrase={Boolean(passphraseState.isSubmitting)}
             onSubmit={onSubmit}
         />
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletExistsFlow.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletExistsFlow.tsx
@@ -17,6 +17,7 @@ type PassphraseWalletExistsFlowProps = {
     deviceOffer: boolean;
     authConfirmation?: boolean;
     passphraseState: string;
+    submittingPassphrase: boolean;
     loading: boolean;
     onSubmit: (value: string, passphraseOnDevice?: boolean) => void;
 };
@@ -26,6 +27,7 @@ export const PassphraseWalletExistsFlow = ({
     device,
     deviceOffer,
     passphraseState,
+    submittingPassphrase,
     loading,
     onSubmit,
 }: PassphraseWalletExistsFlowProps) => {
@@ -99,6 +101,7 @@ export const PassphraseWalletExistsFlow = ({
         <EnterPassphrase
             deviceLoading={loading}
             device={device}
+            submitting={submittingPassphrase}
             onDeviceOffer={deviceOffer}
             onBack={onCancel}
             onCancel={onCancel}

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletIsNotExistFlow.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletIsNotExistFlow.tsx
@@ -12,6 +12,7 @@ type PassphraseWalletIsNotExistFlowProps = {
     passphraseState: string;
     loading: boolean;
     onSubmit: (value: string, passphraseOnDevice?: boolean) => void;
+    submittingPassphrase?: boolean;
 };
 
 export const PassphraseWalletIsNotExistFlow = ({
@@ -20,6 +21,7 @@ export const PassphraseWalletIsNotExistFlow = ({
     passphraseState,
     loading,
     onSubmit,
+    submittingPassphrase,
 }: PassphraseWalletIsNotExistFlowProps) => {
     const dispatch = useDispatch();
 
@@ -44,6 +46,7 @@ export const PassphraseWalletIsNotExistFlow = ({
             <EnterPassphrase
                 deviceLoading={loading}
                 device={device}
+                submitting={submittingPassphrase}
                 onDeviceOffer={deviceOffer}
                 onBack={() => {
                     dispatch(cancelDiscoveryThunk(device));

--- a/suite-common/wallet-core/src/discovery/__tests__/discoveryReducer.test.ts
+++ b/suite-common/wallet-core/src/discovery/__tests__/discoveryReducer.test.ts
@@ -1,0 +1,372 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { configureMockStore, extraDependenciesMock } from '@suite-common/test-utils';
+import { DeviceUniquePath } from '@trezor/connect';
+
+import { discoveryActions } from '../discoveryActions';
+import { DiscoveryRootState, prepareDiscoveryReducer } from '../discoveryReducer';
+
+const discoveryReducer = prepareDiscoveryReducer(extraDependenciesMock);
+
+type InitStoreArgs = {
+    preloadedState?: DiscoveryRootState;
+};
+
+const initStore = ({ preloadedState }: InitStoreArgs = {}) => {
+    const store = configureMockStore({
+        reducer: { wallet: combineReducers({ discovery: discoveryReducer }) },
+        preloadedState,
+    });
+
+    return store;
+};
+
+const TEST_DEVICE_PATH = 'device-id:1' as DeviceUniquePath;
+const TEST_DEVICE_PATH_2 = 'device-id:2' as DeviceUniquePath;
+
+describe('Discovery Reducer', () => {
+    it('should have initial state', () => {
+        const store = initStore();
+        expect(store.getState().wallet.discovery).toEqual({});
+    });
+
+    it('should handle startDiscovery action', () => {
+        const store = initStore();
+        const timestamp = Date.now();
+        jest.spyOn(Date, 'now').mockImplementation(() => timestamp);
+
+        store.dispatch(discoveryActions.startDiscovery(TEST_DEVICE_PATH));
+
+        expect(store.getState().wallet.discovery).toEqual({
+            [TEST_DEVICE_PATH]: {
+                status: 'starting',
+                isAddingHiddenWallet: undefined,
+                isAddingExistingWallet: undefined,
+                startTimestamp: timestamp,
+            },
+        });
+
+        // Cleanup mock
+        jest.restoreAllMocks();
+    });
+
+    it('should handle startDiscovery action with additional flags', () => {
+        const store = initStore();
+        const timestamp = Date.now();
+        jest.spyOn(Date, 'now').mockImplementation(() => timestamp);
+
+        store.dispatch(discoveryActions.startDiscovery(TEST_DEVICE_PATH, true, true));
+
+        expect(store.getState().wallet.discovery).toEqual({
+            [TEST_DEVICE_PATH]: {
+                status: 'starting',
+                isAddingHiddenWallet: true,
+                isAddingExistingWallet: true,
+                startTimestamp: timestamp,
+            },
+        });
+
+        // Cleanup mock
+        jest.restoreAllMocks();
+    });
+
+    it('should handle updateDiscovery action', () => {
+        // Initialize store with existing discovery
+        const store = initStore({
+            preloadedState: {
+                wallet: {
+                    discovery: {
+                        [TEST_DEVICE_PATH]: {
+                            status: 'starting',
+                            startTimestamp: 1000,
+                        },
+                    },
+                },
+            },
+        });
+
+        // Update to enter-passphrase status
+        store.dispatch(
+            discoveryActions.updateDiscovery(
+                {
+                    status: 'enter-passphrase',
+                },
+                TEST_DEVICE_PATH,
+            ),
+        );
+
+        expect(store.getState().wallet.discovery[TEST_DEVICE_PATH]).toEqual({
+            status: 'enter-passphrase',
+            startTimestamp: 1000,
+            hasLoadedAnyNonEmptyAccount: undefined,
+            passphraseSubmitted: undefined,
+        });
+    });
+
+    it('should handle updateDiscovery action with progress status', () => {
+        // Initialize store with existing discovery
+        const store = initStore({
+            preloadedState: {
+                wallet: {
+                    discovery: {
+                        [TEST_DEVICE_PATH]: {
+                            status: 'starting',
+                            startTimestamp: 1000,
+                        },
+                    },
+                },
+            },
+        });
+
+        // Update to progress status
+        store.dispatch(
+            discoveryActions.updateDiscovery(
+                {
+                    status: 'progress',
+                    total: 10,
+                    progress: 5,
+                    hasLoadedAnyNonEmptyAccount: true,
+                },
+                TEST_DEVICE_PATH,
+            ),
+        );
+
+        expect(store.getState().wallet.discovery[TEST_DEVICE_PATH]).toEqual({
+            status: 'progress',
+            startTimestamp: 1000,
+            total: 10,
+            progress: 5,
+            hasLoadedAnyNonEmptyAccount: true,
+            passphraseSubmitted: undefined,
+        });
+    });
+
+    it('should not set "hasLoadedAnyNonEmptyAccount" when status is not "progress"', () => {
+        // Initialize store with existing discovery
+        const store = initStore({
+            preloadedState: {
+                wallet: {
+                    discovery: {
+                        [TEST_DEVICE_PATH]: {
+                            status: 'starting',
+                            startTimestamp: 1000,
+                        },
+                    },
+                },
+            },
+        });
+
+        // Update to progress status
+        store.dispatch(
+            discoveryActions.updateDiscovery(
+                {
+                    status: 'enter-passphrase',
+                    // @ts-expect-error: this is not possible type-wise but in runtime, who know
+                    hasLoadedAnyNonEmptyAccount: true,
+                    total: 10,
+                    progress: 5,
+                },
+                TEST_DEVICE_PATH,
+            ),
+        );
+
+        expect(store.getState().wallet.discovery[TEST_DEVICE_PATH]).toEqual({
+            status: 'enter-passphrase',
+            startTimestamp: 1000,
+            hasLoadedAnyNonEmptyAccount: undefined,
+            passphraseSubmitted: undefined,
+            total: 10,
+            progress: 5,
+        });
+    });
+
+    it('should handle updateDiscovery action with passphraseSubmitted flag', () => {
+        // Initialize store with existing discovery
+        const store = initStore({
+            preloadedState: {
+                wallet: {
+                    discovery: {
+                        [TEST_DEVICE_PATH]: {
+                            status: 'enter-passphrase',
+                            startTimestamp: 1000,
+                        },
+                    },
+                },
+            },
+        });
+
+        // Update with passphraseSubmitted flag
+        store.dispatch(
+            discoveryActions.updateDiscovery(
+                {
+                    status: 'enter-passphrase',
+                    passphraseSubmitted: true,
+                },
+                TEST_DEVICE_PATH,
+            ),
+        );
+
+        expect(store.getState().wallet.discovery[TEST_DEVICE_PATH]).toEqual({
+            status: 'enter-passphrase',
+            startTimestamp: 1000,
+            hasLoadedAnyNonEmptyAccount: undefined,
+            passphraseSubmitted: true,
+        });
+    });
+
+    it('should handle updateDiscovery action with status change and passphraseSubmitted flag', () => {
+        // Initialize store with existing discovery
+        const store = initStore({
+            preloadedState: {
+                wallet: {
+                    discovery: {
+                        [TEST_DEVICE_PATH]: {
+                            status: 'enter-passphrase',
+                            passphraseSubmitted: true,
+                            startTimestamp: 1000,
+                        },
+                    },
+                },
+            },
+        });
+
+        // Update with status change and passphraseSubmitted flag
+        store.dispatch(
+            discoveryActions.updateDiscovery(
+                {
+                    status: 'progress',
+                    total: 10,
+                    progress: 0,
+                    passphraseSubmitted: true,
+                },
+                TEST_DEVICE_PATH,
+            ),
+        );
+
+        // When status changes, passphraseSubmitted should be set to the new value
+        expect(store.getState().wallet.discovery[TEST_DEVICE_PATH]).toEqual({
+            status: 'progress',
+            startTimestamp: 1000,
+            total: 10,
+            progress: 0,
+            hasLoadedAnyNonEmptyAccount: undefined,
+            passphraseSubmitted: undefined,
+        });
+    });
+
+    it('should not update non-existent discovery', () => {
+        const store = initStore();
+
+        // Try to update non-existent discovery
+        store.dispatch(
+            discoveryActions.updateDiscovery(
+                {
+                    status: 'enter-passphrase',
+                },
+                TEST_DEVICE_PATH,
+            ),
+        );
+
+        // State should remain unchanged
+        expect(store.getState().wallet.discovery).toEqual({});
+    });
+
+    it('should handle deleteDiscovery action', () => {
+        // Initialize store with multiple discoveries
+        const store = initStore({
+            preloadedState: {
+                wallet: {
+                    discovery: {
+                        [TEST_DEVICE_PATH]: {
+                            status: 'complete',
+                            startTimestamp: 1000,
+                        },
+                        [TEST_DEVICE_PATH_2]: {
+                            status: 'starting',
+                            startTimestamp: 2000,
+                        },
+                    },
+                },
+            },
+        });
+
+        // Delete one discovery
+        store.dispatch(discoveryActions.deleteDiscovery(TEST_DEVICE_PATH));
+
+        // Only the specified discovery should be deleted
+        expect(store.getState().wallet.discovery).toEqual({
+            [TEST_DEVICE_PATH_2]: {
+                status: 'starting',
+                startTimestamp: 2000,
+            },
+        });
+    });
+
+    it('should handle deleteDiscovery action for non-existent path', () => {
+        // Initialize store with one discovery
+        const store = initStore({
+            preloadedState: {
+                wallet: {
+                    discovery: {
+                        [TEST_DEVICE_PATH]: {
+                            status: 'complete',
+                            startTimestamp: 1000,
+                        },
+                    },
+                },
+            },
+        });
+
+        // Try to delete non-existent discovery
+        store.dispatch(discoveryActions.deleteDiscovery('non-existent-path' as DeviceUniquePath));
+
+        // State should remain unchanged
+        expect(store.getState().wallet.discovery).toEqual({
+            [TEST_DEVICE_PATH]: {
+                status: 'complete',
+                startTimestamp: 1000,
+            },
+        });
+    });
+
+    it('should handle updateDiscovery action with failed status', () => {
+        // Initialize store with existing discovery
+        const store = initStore({
+            preloadedState: {
+                wallet: {
+                    discovery: {
+                        [TEST_DEVICE_PATH]: {
+                            status: 'progress',
+                            total: 10,
+                            progress: 5,
+                            startTimestamp: 1000,
+                        },
+                    },
+                },
+            },
+        });
+
+        // Update to failed status with error
+        store.dispatch(
+            discoveryActions.updateDiscovery(
+                {
+                    status: 'failed',
+                    error: 'Connection error',
+                    errorCode: 'Method_InvalidParameter',
+                },
+                TEST_DEVICE_PATH,
+            ),
+        );
+
+        expect(store.getState().wallet.discovery[TEST_DEVICE_PATH]).toEqual({
+            status: 'failed',
+            error: 'Connection error',
+            errorCode: 'Method_InvalidParameter',
+            startTimestamp: 1000,
+            progress: 5,
+            total: 10,
+            hasLoadedAnyNonEmptyAccount: undefined,
+            passphraseSubmitted: undefined,
+        });
+    });
+});

--- a/suite-common/wallet-core/src/discovery/discoveryReducer.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryReducer.ts
@@ -23,10 +23,19 @@ const update = (draft: Discovery, payload: { status: DiscoveryStatus; path: Devi
         (payload.status.status === 'progress' && payload.status.hasLoadedAnyNonEmptyAccount) ||
         undefined;
 
+    const statusChanged = payload.status.status && currentStatus.status !== payload.status.status;
+
     draft[payload.path] = {
         ...currentStatus,
         ...payload.status,
         ...{ hasLoadedAnyNonEmptyAccount },
+        ...{
+            passphraseSubmitted:
+                payload.status.passphraseSubmitted ?? currentStatus.passphraseSubmitted,
+        },
+        // NOTE: this flag is used for just one status, so whene status is changed, make it undefined
+        // eg. submitting "first" passphrase and then confirming the passphrase, then we want submitted false again
+        ...(statusChanged ? { passphraseSubmitted: undefined } : {}),
     };
 };
 

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -500,6 +500,18 @@ export const runDiscoveryThunk = createThunk(
                 console.warn('No networks to discover, todo: stop discovery');
             }
 
+            // NOTE: sync set discovery status to progress to make sure that there aren't some hanging states
+            // before asnyc onBundleProgress is called which sets progress
+            dispatch(
+                discoveryActions.updateDiscovery(
+                    {
+                        status: 'progress',
+                        total: Infinity,
+                        progress: 0,
+                    },
+                    device.path,
+                ),
+            );
             const result = await TrezorConnect.discoverAccounts({
                 device: {
                     instance,
@@ -792,19 +804,22 @@ export const submitPassphrase = createThunk(
             passphrase: string;
             passphraseOnDevice?: boolean;
         },
-        { dispatch },
+        { dispatch, getState },
     ) => {
-        dispatch(
-            discoveryActions.updateDiscovery(
-                {
-                    status: 'progress',
-                    progress: 0, // dummy value, otherwise it comes in progress event from trezor-connect
-                    total: 100,
-                    passphraseOnDevice,
-                },
-                device.path,
-            ),
-        );
+        const currentDiscovery = selectDiscoveryByDevicePath(getState(), device.path);
+
+        if (currentDiscovery) {
+            dispatch(
+                discoveryActions.updateDiscovery(
+                    {
+                        ...currentDiscovery,
+                        passphraseSubmitted: true,
+                        passphraseOnDevice,
+                    },
+                    device.path,
+                ),
+            );
+        }
 
         TrezorConnect.uiResponse({
             type: UI.RECEIVE_PASSPHRASE,

--- a/suite-common/wallet-core/src/discovery/passphraseUtils.ts
+++ b/suite-common/wallet-core/src/discovery/passphraseUtils.ts
@@ -44,6 +44,7 @@ export const determinePassphraseFlowState = (
                 screen: 'exists-enter-passphrase',
                 discovery,
                 loading: isLoading,
+                isSubmitting: Boolean(discovery.passphraseSubmitted),
             } as const;
         }
 
@@ -79,6 +80,7 @@ export const determinePassphraseFlowState = (
             screen: 'not-exist-enter-passphrase',
             discovery,
             loading: isLoading,
+            isSubmitting: Boolean(discovery.passphraseSubmitted),
         } as const;
     }
 

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -18,6 +18,7 @@ type CommonDiscoveryStatus = {
     failed?: FailedAccount[];
     passphraseOnDevice?: boolean;
     startTimestamp?: number;
+    passphraseSubmitted?: boolean;
 };
 
 export type DiscoveryStatus = CommonDiscoveryStatus &


### PR DESCRIPTION
…ssphrase is submitted

<!--- Provide a general summary of your changes in the Title above -->

## Description

Problem: after clicking `Submit passphrase` the progress was immediatly displayed. Which was bad UX.

Solution: make a state for the enter passphrase step with loading button instead of progress.
For confirmation passphrase screen, do the same.

Also, fix that confirmation passphrase screen hangs and is rendered instead of "device modals"

## Related Issue

https://github.com/trezor/trezor-suite/issues/19446

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=19446-passphrase-submitting-loading&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=19446-passphrase-submitting-loading&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19446-passphrase-submitting-loading&lookback=7)