### PR TITLE
fix(suite): always enable cardano derivation for cardano methods

### DIFF
--- a/suite-common/connect-init/src/cardanoConnectPatch.ts
+++ b/suite-common/connect-init/src/cardanoConnectPatch.ts
@@ -44,7 +44,9 @@ export const cardanoConnectPatch = (getEnabledNetworks: () => string[]) => {
             if (!original) return;
             (TrezorConnect[key as ConnectKey] as any) = async (params: any) => {
                 const enabledNetworks = getEnabledNetworks();
-                const cardanoEnabled = !!enabledNetworks.find(a => a === 'ada' || a === 'tada');
+                const isCardanoMethod = key.startsWith('cardano');
+                const cardanoEnabled =
+                    !!enabledNetworks.find(a => a === 'ada' || a === 'tada') || isCardanoMethod;
                 const result = await original({
                     ...params,
                     useCardanoDerivation: cardanoEnabled,


### PR DESCRIPTION
## Description

Always enable cardano derivation for Cardano methods. 
This ensures Cardano methods work in Connect Popup in Suite, even if Cardano is not explicitly enabled.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-suite-cardano&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-suite-cardano&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-suite-cardano&lookback=7)