### PR TITLE
fix: lock auto-conneect during discovery, to prevent 'another call inprogress on device' error

### DIFF
--- a/packages/suite/src/components/thp/ThpAutoconnectInfoModal.tsx
+++ b/packages/suite/src/components/thp/ThpAutoconnectInfoModal.tsx
@@ -5,12 +5,14 @@ import { Button, Card, Column, Icon, List, Modal, Text } from '@trezor/component
 import { spacings } from '@trezor/theme';
 
 import { startThpAutoconnectThunk } from '../../actions/thp/startThpAutoconnectThunk';
-import { useDispatch } from '../../hooks/suite';
+import { useDevice, useDispatch } from '../../hooks/suite';
 import { Translation } from '../suite/Translation';
 
 export const ThpAutoconnectInfoModal = () => {
     const [isLoading, setIsLoading] = useState(false);
+    const { isLocked } = useDevice();
     const dispatch = useDispatch();
+    const isDeviceLocked = isLocked();
 
     const onTurnOn = () => {
         setIsLoading(true);
@@ -28,7 +30,7 @@ export const ThpAutoconnectInfoModal = () => {
             data-testid="@modal/thp-autoconnect-info"
             bottomContent={
                 <>
-                    <Button onClick={onTurnOn} isLoading={isLoading}>
+                    <Button onClick={onTurnOn} isLoading={isLoading || isDeviceLocked}>
                         <Translation id="TR_THP_TURN_ON_AUTO_CONNECT" />
                     </Button>
                     <Button onClick={onCancel} variant="tertiary" isDisabled={isLoading}>


### PR DESCRIPTION
- When device is doing discovery, some it may be locked, so not other calls can be performed. 
- Respect this lock for auto-connect modal.

![image](https://github.com/user-attachments/assets/885d7c87-da9d-4f50-a9f1-6edc9106f0d7)



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-lock-autoconnect&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-lock-autoconnect&lookback=7)