### PR TITLE
feat(suite): separate route for connect

### DIFF
--- a/packages/components/src/components/Modal/ModalBackdrop.tsx
+++ b/packages/components/src/components/Modal/ModalBackdrop.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 
 import { ZIndexValues, spacings, zIndices } from '@trezor/theme';
 
-import { useModalTarget } from './ModalProvider';
+import { useModalTarget, useNoBackdrop } from './ModalProvider';
 import { ModalAlignment } from './types';
 import { mapAlignmentToAlignItems, mapAlignmentToJustifyContent } from './utils';
 import { Padding } from '../../utils/frameProps';
@@ -39,8 +39,11 @@ export const ModalBackdrop = ({
     zIndex = zIndices.modal,
 }: ModalBackdropProps) => {
     const modalTarget = useModalTarget();
+    const noBackdrop = useNoBackdrop();
 
-    const backdrop = (
+    const backdrop = noBackdrop ? (
+        children
+    ) : (
         // eslint-disable-next-line jsx-a11y/no-autofocus
         <FocusLock autoFocus={false}>
             <Box position={{ type: 'absolute', inset: 0 }} zIndex={zIndex}>

--- a/packages/components/src/components/Modal/ModalProvider.tsx
+++ b/packages/components/src/components/Modal/ModalProvider.tsx
@@ -10,22 +10,30 @@ import {
 
 type ModalContextData = {
     isDisabled: boolean;
+    noBackdrop?: boolean;
     modalTarget: RefObject<HTMLDivElement> | null;
 };
 
 const ModalContext = createContext<ModalContextData>({
     isDisabled: false,
+    noBackdrop: false,
     modalTarget: null,
 });
 
 export const useModalTarget = () => useContext(ModalContext).modalTarget?.current ?? null;
+export const useNoBackdrop = () => useContext(ModalContext).noBackdrop ?? false;
 
 type ModalProviderProps = {
     isDisabled?: boolean;
+    noBackdrop?: boolean;
     children: ReactNode;
 };
 
-export const ModalProvider = ({ isDisabled = false, children }: ModalProviderProps) => {
+export const ModalProvider = ({
+    isDisabled = false,
+    noBackdrop = false,
+    children,
+}: ModalProviderProps) => {
     const disabled = useContext(ModalContext).isDisabled ?? isDisabled;
     const [modalTarget, setModalTarget] = useState<RefObject<HTMLDivElement> | null>(null);
     const target = useRef<HTMLDivElement>(null);
@@ -38,6 +46,7 @@ export const ModalProvider = ({ isDisabled = false, children }: ModalProviderPro
         <ModalContext.Provider
             value={{
                 modalTarget: !disabled ? modalTarget : null,
+                noBackdrop,
                 isDisabled: disabled,
             }}
         >

--- a/packages/suite/src/actions/suite/routerActions.ts
+++ b/packages/suite/src/actions/suite/routerActions.ts
@@ -7,6 +7,7 @@ import { ROUTER } from 'src/actions/suite/constants';
 import * as suiteActions from 'src/actions/suite/suiteActions';
 import type { AnchorType } from 'src/constants/suite/anchors';
 import { RouterAppWithParams, SettingsBackRoute } from 'src/constants/suite/routes';
+import { selectRouterApp } from 'src/reducers/suite/routerReducer';
 import { selectIsRouterLocked, selectIsRouterOrUiLocked } from 'src/reducers/suite/suiteReducer';
 import history from 'src/support/history';
 import { Dispatch, GetState } from 'src/types/suite';
@@ -43,6 +44,9 @@ export type RouterAction =
 export const onBeforePopState = () => (_dispatch: Dispatch, getState: GetState) => {
     const isLocked = selectIsRouterOrUiLocked(getState());
     const hasActionModal = getState().modal.context !== '@modal/context-none';
+    // unlock connect app
+    const routerApp = selectRouterApp(getState());
+    if (routerApp === 'connect') return true;
 
     return !isLocked && !hasActionModal;
 };

--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -20,6 +20,7 @@ import {
     selectSuiteFlags,
 } from 'src/reducers/suite/suiteReducer';
 import type { AppState } from 'src/types/suite';
+import { Connect } from 'src/views/connect';
 import { Onboarding } from 'src/views/onboarding';
 import { SuiteStart } from 'src/views/start/SuiteStart';
 import { ErrorPage } from 'src/views/suite/ErrorPage';
@@ -49,6 +50,8 @@ const getFullscreenApp = (route: AppState['router']['route']): FC | undefined =>
             return SuiteStart;
         case 'onboarding':
             return Onboarding;
+        case 'connect':
+            return Connect;
         default:
             return undefined;
     }

--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -1,6 +1,7 @@
 import { FC, PropsWithChildren, useEffect } from 'react';
 
 import { selectIsAnalyticsConfirmed } from '@suite-common/analytics';
+import { selectConnectPopupCall } from '@suite-common/connect-popup';
 import {
     selectIsFirmwareAuthenticityCheckDismissed,
     selectSelectedDevice,
@@ -33,6 +34,7 @@ import { AnalyticsConsentScreen } from '../../../views/start/AnalyticsConsentScr
 import { PrerequisitesGuide } from '../PrerequisitesGuide/PrerequisitesGuide';
 import { DeviceCompromised } from '../SecurityCheck/DeviceCompromised';
 import { useReportDeviceCompromised } from '../SecurityCheck/useReportDeviceCompromised';
+import { ConnectLayout } from '../layouts/ConnectLayout/ConnectLayout';
 import { LoggedOutLayout } from '../layouts/LoggedOutLayout';
 import { SuiteLayout } from '../layouts/SuiteLayout/SuiteLayout';
 import { WelcomeLayout } from '../layouts/WelcomeLayout/WelcomeLayout';
@@ -76,6 +78,7 @@ export const Preloader = ({ children }: PropsWithChildren) => {
     // Entropy check won't be performed if disabled but we must also check it here to avoid showing the UI when the failed state is stored in database.
     const isEntropyCheckEnabledAndFailed = useSelector(selectIsEntropyCheckEnabledAndFailed);
     const isAnalyticsConsentConfirmed = useSelector(selectIsAnalyticsConfirmed);
+    const popupCall = useSelector(selectConnectPopupCall);
 
     // report firmware authenticity failures even when the UI is disabled
     useReportDeviceCompromised();
@@ -145,6 +148,9 @@ export const Preloader = ({ children }: PropsWithChildren) => {
     }
 
     if (router.route?.isForegroundApp) {
+        if (popupCall && popupCall?.state !== 'finished')
+            return <ConnectLayout>{children}</ConnectLayout>;
+
         return <SuiteLayout>{children}</SuiteLayout>;
     }
 

--- a/packages/suite/src/components/suite/layouts/ConnectLayout/ConnectLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/ConnectLayout/ConnectLayout.tsx
@@ -1,0 +1,101 @@
+import { ReactNode } from 'react';
+
+import styled from 'styled-components';
+
+import { selectBannerMessage } from '@suite-common/message-system';
+import {
+    Column,
+    ElevationDown,
+    ElevationUp,
+    Modal,
+    Row,
+    useElevation,
+    variables,
+} from '@trezor/components';
+import { Elevation, spacings, spacingsPx } from '@trezor/theme';
+
+// importing directly, otherwise unit tests fail, seems to be a styled-components issue
+import { MessageSystemBanner } from 'src/components/suite/banners';
+import { useSelector } from 'src/hooks/suite';
+
+import { LoggedOutSidebar } from '../LoggedOutSidebar';
+import { DebugLegend } from '../SuiteLayout/DebugLegend';
+
+const Content = styled.div<{ $elevation: Elevation }>`
+    display: flex;
+    flex-direction: column;
+    flex: 3;
+    padding: ${spacingsPx.lg};
+    align-items: center;
+    height: 100%;
+
+    @media (max-width: ${variables.SCREEN_SIZE.SM}) {
+        padding: ${spacingsPx.sm};
+    }
+`;
+
+const ChildrenWrapper = styled.div`
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+`;
+
+export type ConnectLayoutProps = {
+    children: ReactNode;
+    hideSidebar?: boolean;
+};
+
+const Right = ({ bannerSlot, children }: { bannerSlot?: ReactNode; children: ReactNode }) => {
+    const { elevation } = useElevation();
+
+    return (
+        <Content $elevation={elevation}>
+            {bannerSlot ?? null}
+            <ChildrenWrapper>
+                <ElevationUp>{children}</ElevationUp>
+            </ChildrenWrapper>
+        </Content>
+    );
+};
+
+export const ConnectLayout = ({ children, hideSidebar }: ConnectLayoutProps) => {
+    const bannerMessage = useSelector(selectBannerMessage);
+    const theme = useSelector(state => state.suite.settings.theme);
+
+    return (
+        <ElevationDown>
+            <Column height="100%" width="100%">
+                <Row
+                    height="100%"
+                    width="100%"
+                    data-testid="@connect-layout/body"
+                    alignItems="normal"
+                >
+                    {!hideSidebar ? (
+                        <ElevationDown>
+                            <LoggedOutSidebar />
+                        </ElevationDown>
+                    ) : null}
+
+                    <Right
+                        bannerSlot={
+                            bannerMessage && (
+                                <MessageSystemBanner
+                                    message={bannerMessage}
+                                    margin={spacings.xs}
+                                    width="100%"
+                                />
+                            )
+                        }
+                    >
+                        <Modal.Provider noBackdrop={true}>{children}</Modal.Provider>
+                    </Right>
+                </Row>
+            </Column>
+            {theme.variant === 'debug' && <DebugLegend />}
+        </ElevationDown>
+    );
+};

--- a/packages/suite/src/components/suite/layouts/ConnectLayout/ConnectLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/ConnectLayout/ConnectLayout.tsx
@@ -18,8 +18,9 @@ import { Elevation, spacings, spacingsPx } from '@trezor/theme';
 import { MessageSystemBanner } from 'src/components/suite/banners';
 import { useSelector } from 'src/hooks/suite';
 
-import { LoggedOutSidebar } from '../LoggedOutSidebar';
+import { ConnectSidebar } from './ConnectSidebar';
 import { DebugLegend } from '../SuiteLayout/DebugLegend';
+import { PassphraseFlow } from '../SuiteLayout/PassphraseFlow';
 
 const Content = styled.div<{ $elevation: Elevation }>`
     display: flex;
@@ -41,6 +42,7 @@ const ChildrenWrapper = styled.div`
     align-items: center;
     justify-content: center;
     width: 100%;
+    position: relative;
 `;
 
 export type ConnectLayoutProps = {
@@ -76,7 +78,7 @@ export const ConnectLayout = ({ children, hideSidebar }: ConnectLayoutProps) => 
                 >
                     {!hideSidebar ? (
                         <ElevationDown>
-                            <LoggedOutSidebar />
+                            <ConnectSidebar />
                         </ElevationDown>
                     ) : null}
 
@@ -91,6 +93,9 @@ export const ConnectLayout = ({ children, hideSidebar }: ConnectLayoutProps) => 
                             )
                         }
                     >
+                        <Modal.Provider>
+                            <PassphraseFlow />
+                        </Modal.Provider>
                         <Modal.Provider noBackdrop={true}>{children}</Modal.Provider>
                     </Right>
                 </Row>

--- a/packages/suite/src/components/suite/layouts/ConnectLayout/ConnectSidebar.tsx
+++ b/packages/suite/src/components/suite/layouts/ConnectLayout/ConnectSidebar.tsx
@@ -1,0 +1,62 @@
+import styled from 'styled-components';
+
+import { Route } from '@suite-common/suite-types';
+import { Column, ElevationUp, useElevation } from '@trezor/components';
+import { Elevation, mapElevationToBackground, mapElevationToBorder } from '@trezor/theme';
+
+import { TrafficLightOffset } from 'src/components/suite/TrafficLightOffset';
+import { useSelector } from 'src/hooks/suite';
+import { selectIsInitialRun } from 'src/reducers/suite/suiteReducer';
+
+import { Nav, SETTINGS_ROUTES } from '../SuiteLayout/Sidebar/Navigation';
+import { NavItem } from '../SuiteLayout/Sidebar/NavigationItem';
+import { QuickActions } from '../SuiteLayout/Sidebar/QuickActions/QuickActions';
+import { SIDEBAR_MIN_WIDTH } from '../SuiteLayout/Sidebar/Sidebar';
+
+const SidebarWrapper = styled.div<{ $elevation: Elevation }>`
+    background-color: ${mapElevationToBackground};
+    height: 100%;
+`;
+
+const SidebarNavColumn = styled.div<{ $elevation: Elevation; $minWidth: number }>`
+    border-right: solid 1px ${mapElevationToBorder};
+    min-width: ${({ $minWidth }) => $minWidth}px;
+    height: 100%;
+`;
+
+export const ConnectSidebar = () => {
+    const { elevation } = useElevation();
+
+    const isInitialRun = useSelector(selectIsInitialRun);
+    const startRoute: Route['name'] = isInitialRun ? 'suite-start' : 'suite-index';
+
+    return (
+        <SidebarWrapper $elevation={elevation}>
+            <ElevationUp>
+                <SidebarNavColumn $elevation={elevation} $minWidth={SIDEBAR_MIN_WIDTH}>
+                    <TrafficLightOffset>
+                        <Column justifyContent="space-between" height="100%">
+                            <Nav $isSidebarCollapsed>
+                                <NavItem
+                                    nameId="TR_START"
+                                    icon="trezorLogo"
+                                    goToRoute={startRoute}
+                                    routes={[startRoute]}
+                                    data-testid="@suite/menu/suite-start"
+                                />
+                                <NavItem
+                                    nameId="TR_SETTINGS"
+                                    icon="gearSix"
+                                    goToRoute="settings-index"
+                                    routes={SETTINGS_ROUTES}
+                                    data-testid="@suite/menu/settings"
+                                />
+                            </Nav>
+                            <QuickActions hideDeviceUpdateStatusBar isSidebarCollapsed />
+                        </Column>
+                    </TrafficLightOffset>
+                </SidebarNavColumn>
+            </ElevationUp>
+        </SidebarWrapper>
+    );
+};

--- a/packages/suite/src/hooks/suite/usePreferredModal.ts
+++ b/packages/suite/src/hooks/suite/usePreferredModal.ts
@@ -27,7 +27,7 @@ const hasPriority = (route: ForegroundAppRoute) => {
         recovery: true,
 
         // Backup, SwitchDevice - always get beaten by redux modals
-        'switch-device': false,
+        'switch-device': true, // WIP
         backup: false,
     };
 

--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -13,8 +13,10 @@ import { desktopApi } from '@trezor/suite-desktop-api';
 import { SUITE } from 'src/actions/suite/constants';
 import { CONTEXT_NONE, CONTEXT_USER } from 'src/actions/suite/constants/modalConstants';
 import { onCancel as cancelModal, openModal } from 'src/actions/suite/modalActions';
+import { goto } from 'src/actions/suite/routerActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectModalType } from 'src/reducers/suite/modalReducer';
+import { selectRouterApp } from 'src/reducers/suite/routerReducer';
 
 export const useConnectPopupDesktop = () => {
     const dispatch = useDispatch();
@@ -119,6 +121,7 @@ export const useConnectPopupDesktop = () => {
     // Modal opening control
     const modalContext = useSelector(state => state.modal.context);
     const modalType = useSelector(selectModalType);
+    const routerApp = useSelector(selectRouterApp);
     useEffect(() => {
         const isConnectModal =
             modalContext === CONTEXT_USER &&
@@ -137,6 +140,10 @@ export const useConnectPopupDesktop = () => {
                 | 'connect-address-confirmation'
                 | 'connect-error',
         ) => {
+            // Router
+            if (routerApp !== 'connect') {
+                dispatch(goto('connect-index'));
+            }
             // Prevent duplicate opening of the same modal
             // And also prevent opening connect modals if different modal is already open
             if (modalType !== type && (modalContext === CONTEXT_NONE || isConnectModal)) {
@@ -166,10 +173,11 @@ export const useConnectPopupDesktop = () => {
             default: {
                 if (isConnectModal) {
                     dispatch(cancelModal());
+                    dispatch(goto('suite-index'));
                 }
 
                 return;
             }
         }
-    }, [popupCall?.state, modalType, modalContext, dispatch]);
+    }, [popupCall?.state, modalType, modalContext, dispatch, routerApp]);
 };

--- a/packages/suite/src/views/connect/index.tsx
+++ b/packages/suite/src/views/connect/index.tsx
@@ -1,8 +1,23 @@
+import styled from 'styled-components';
+
+import { spacingsPx } from '@trezor/theme';
+
 import { ConnectLayout } from 'src/components/suite/layouts/ConnectLayout/ConnectLayout';
+import { DeviceSelector } from 'src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector';
 import { ModalSwitcher } from 'src/components/suite/modals/ModalSwitcher/ModalSwitcher';
+
+const DeviceSelectorContainer = styled.div`
+    position: absolute;
+    top: ${spacingsPx.xs};
+    left: 0;
+`;
 
 export const Connect = () => (
     <ConnectLayout>
+        <DeviceSelectorContainer>
+            <DeviceSelector />
+        </DeviceSelectorContainer>
+
         <ModalSwitcher />
     </ConnectLayout>
 );

--- a/packages/suite/src/views/connect/index.tsx
+++ b/packages/suite/src/views/connect/index.tsx
@@ -1,0 +1,8 @@
+import { ConnectLayout } from 'src/components/suite/layouts/ConnectLayout/ConnectLayout';
+import { ModalSwitcher } from 'src/components/suite/modals/ModalSwitcher/ModalSwitcher';
+
+export const Connect = () => (
+    <ConnectLayout>
+        <ModalSwitcher />
+    </ConnectLayout>
+);

--- a/suite-common/suite-config/src/routes.ts
+++ b/suite-common/suite-config/src/routes.ts
@@ -314,4 +314,11 @@ export const routes = [
         pattern: '/notifications',
         app: 'notifications',
     },
+    {
+        name: 'connect-index',
+        pattern: '/connect',
+        app: 'connect',
+        isForegroundApp: true,
+        isFullscreenApp: true,
+    },
 ] as const;


### PR DESCRIPTION
## Description

Separate the route for Connect popup in Suite. 
Re-uses existing Modal components, but without backdrop. 

TODO: 
- Allow navigating away during call (cancel)
- Handle device switching -> technical difficulties due to different foreground app

## Screenshots:

<img width="1440" alt="Screenshot 2025-06-16 at 16 57 51" src="https://github.com/user-attachments/assets/24bdbbdb-636f-4ba8-92d5-0ab5bf2b4c3d" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-separate-connect-path&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-separate-connect-path&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/suite-separate-connect-path&lookback=7)