### PR TITLE
test(connect): fix caPubKey for T3B1, remove unused part of the config

### DIFF
--- a/docker/docker-compose.blockchain-link-test.yml
+++ b/docker/docker-compose.blockchain-link-test.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   electrum-regtest:
     image: ghcr.io/trezor/electrs:latest

--- a/docker/docker-compose.coinjoin-backend.yml
+++ b/docker/docker-compose.coinjoin-backend.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   coinjoin-backend:
     image: ghcr.io/trezor/coinjoin-backend:latest

--- a/docker/docker-compose.connect-popup-ci.yml
+++ b/docker/docker-compose.connect-popup-ci.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   trezor-user-env-unix:
     image: ghcr.io/trezor/trezor-user-env:b3b12fac7bcb069ebcb8f29135e5baae73af722d

--- a/docker/docker-compose.connect-popup-test.yml
+++ b/docker/docker-compose.connect-popup-test.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   trezor-user-env-unix:
     image: ghcr.io/trezor/trezor-user-env:b3b12fac7bcb069ebcb8f29135e5baae73af722d

--- a/docker/docker-compose.connect-test.yml
+++ b/docker/docker-compose.connect-test.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   trezor-user-env-unix:
     image: ghcr.io/trezor/trezor-user-env:b3b12fac7bcb069ebcb8f29135e5baae73af722d

--- a/docker/docker-compose.connect-webextension-test.yml
+++ b/docker/docker-compose.connect-webextension-test.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   trezor-user-env-unix:
     image: ghcr.io/trezor/trezor-user-env:b3b12fac7bcb069ebcb8f29135e5baae73af722d

--- a/docker/docker-compose.regtest-electrum.yml
+++ b/docker/docker-compose.regtest-electrum.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   electrum-regtest:
     image: ghcr.io/trezor/electrs:latest

--- a/docker/docker-compose.suite-base.yml
+++ b/docker/docker-compose.suite-base.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   suite-base:
     build:

--- a/docker/docker-compose.suite-ci-e2e.yml
+++ b/docker/docker-compose.suite-ci-e2e.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   trezor-user-env-unix:
     image: ghcr.io/trezor/trezor-user-env:b3b12fac7bcb069ebcb8f29135e5baae73af722d

--- a/docker/docker-compose.suite-desktop-ci.yml
+++ b/docker/docker-compose.suite-desktop-ci.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   trezor-user-env-unix:
     image: ghcr.io/trezor/trezor-user-env:b3b12fac7bcb069ebcb8f29135e5baae73af722d

--- a/docker/docker-compose.suite-dev.yml
+++ b/docker/docker-compose.suite-dev.yml
@@ -1,7 +1,6 @@
 # schema version '3' does not support 'extends' keyword anymore
 # https://stackoverflow.com/questions/52587643/how-to-extend-service-in-docker-compose-v3
 
-version: "3.9"
 services:
   trezor-user-env-unix:
     image: ghcr.io/trezor/trezor-user-env:b3b12fac7bcb069ebcb8f29135e5baae73af722d

--- a/docker/docker-compose.suite-native-ci.yml
+++ b/docker/docker-compose.suite-native-ci.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   trezor-user-env-unix:
     network_mode: "host"

--- a/docker/docker-compose.suite-test.yml
+++ b/docker/docker-compose.suite-test.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   trezor-user-env-unix:
     image: ghcr.io/trezor/trezor-user-env:b3b12fac7bcb069ebcb8f29135e5baae73af722d

--- a/docker/docker-compose.transport-test-ci.yml
+++ b/docker/docker-compose.transport-test-ci.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   trezor-user-env-unix:
     image: ghcr.io/trezor/trezor-user-env:b3b12fac7bcb069ebcb8f29135e5baae73af722d

--- a/docker/docker-connect-test.sh
+++ b/docker/docker-connect-test.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 
 # Ports
 # 9001  - websocket server, communication test case > user-env (setup etc...)
-# 21326 - trezord proxy. beacuse of trezord CORS check
+# 21326 - trezord proxy. because of trezord CORS check
 # 21325 - original trezord port redirected to trezor-user-env proxy
 
 ENVIRONMENT=$1

--- a/packages/connect/e2e/tests/device/authenticateDevice.test.ts
+++ b/packages/connect/e2e/tests/device/authenticateDevice.test.ts
@@ -19,39 +19,52 @@ describe('TrezorConnect.authenticateDevice', () => {
     });
 
     // NOTE: emulator uses different provisioning keys than production FW (different than ./data/deviceAuthenticityConfig)
-    const config = {
+    const config: DeviceAuthenticityConfig = {
         version: 1,
         timestamp: '2023-09-07T14:00:00+00:00',
+        T2B1: {
+            rootPubKeys: [
+                '047f77368dea2d4d61e989f474a56723c3212dacf8a808d8795595ef38441427c4389bc454f02089d7f08b873005e4c28d432468997871c0bf286fd3861e21e96a',
+            ],
+            caPubKeys: [
+                '04ba6084cb9fba7c86d5d5a86108a91d55a27056da4eabbedde88a95e1cae8bce3620889167aaf7f2db166998f950984aa195e868f96e22803c3cd991be31d39e7',
+            ],
+        },
         T3B1: {
             rootPubKeys: [
                 '047f77368dea2d4d61e989f474a56723c3212dacf8a808d8795595ef38441427c4389bc454f02089d7f08b873005e4c28d432468997871c0bf286fd3861e21e96a',
             ],
             caPubKeys: [
-                '04ba6084cb9fba7c86d5d5a86108a91d55a27056da4eabbedde88a95e1cae8bce3620889167aaf7f2db166998f950984aa195e868f96e22803c3cd991be31d39e7',
+                '0410a6bc4f9eb52fd450be2c365189ea6a523fdddd62e44566dc349a8c7f813144cde81c8c106b74bfceae9c8ca5202af635ce1a5330c41c708ebbf505e025c339',
             ],
         },
         T3T1: {
             rootPubKeys: [
-                '047f77368dea2d4d61e989f474a56723c3212dacf8a808d8795595ef38441427c4389bc454f02089d7f08b873005e4c28d432468997871c0bf286fd3861e21e96a',
+                '04e48b69cd7962068d3cca3bcc6b1747ef496c1e28b5529e34ad7295215ea161dbe8fb08ae0479568f9d2cb07630cb3e52f4af0692102da5873559e45e9fa72959',
             ],
             caPubKeys: [
-                '04ba6084cb9fba7c86d5d5a86108a91d55a27056da4eabbedde88a95e1cae8bce3620889167aaf7f2db166998f950984aa195e868f96e22803c3cd991be31d39e7',
+                '04829e8965018feb542e9236c9b2ce08f864a55ed9183d0259564f0e05345b04676a0bef36c59d21d3c24868b5601f0b1193a6bfcf6d814e1cfb79c2256a05e953',
             ],
         },
         T3W1: {
-            rootPubKeys: ['you shall not pass'],
-            caPubKeys: ['you shall not pass'],
+            rootPubKeys: [
+                '04521192e173a9da4e3023f747d836563725372681eba3079c56ff11b2fc137ab189eb4155f371127651b5594f8c332fc1e9c0f3b80d4212822668b63189706578',
+            ],
+            caPubKeys: [
+                '04a5d701fced9b5a2cd076a02d8a98e779c54946eefc7b2525fac782fa3d65b5d9e6a8c90946bd30b35dfeec34a053f1106ba130a8472037f2db8cf2c4b3b6e93a',
+            ],
         },
-    } as DeviceAuthenticityConfig;
+    };
 
     it('validation successful', async () => {
         const result = await TrezorConnect.authenticateDevice({
             config,
         });
 
-        if (result.success) {
-            expect(result.payload.valid).toEqual(true);
-        }
+        expect(result).toMatchObject({
+            success: true,
+            payload: { valid: true },
+        });
     });
 
     it('validation unsuccessful (rootPubKey not found)', async () => {
@@ -65,10 +78,10 @@ describe('TrezorConnect.authenticateDevice', () => {
             },
         });
 
-        if (result.success) {
-            expect(result.payload.valid).toEqual(false);
-            expect(result.payload.error).toEqual('ROOT_PUBKEY_NOT_FOUND');
-        }
+        expect(result).toMatchObject({
+            success: true,
+            payload: { valid: false, error: 'ROOT_PUBKEY_NOT_FOUND' },
+        });
     });
 
     it('sanity check unsuccessful (caPubkey not found)', async () => {
@@ -82,9 +95,9 @@ describe('TrezorConnect.authenticateDevice', () => {
             },
         });
 
-        if (result.success) {
-            expect(result.payload.valid).toEqual(false);
-            expect(result.payload.error).toEqual('CA_PUBKEY_NOT_FOUND');
-        }
+        expect(result).toMatchObject({
+            success: true,
+            payload: { valid: false, error: 'CA_PUBKEY_NOT_FOUND' },
+        });
     });
 });

--- a/packages/connect/e2e/tests/device/authenticateDevice.test.ts
+++ b/packages/connect/e2e/tests/device/authenticateDevice.test.ts
@@ -1,7 +1,7 @@
 import { DeviceAuthenticityConfig } from '@trezor/connect/src/data/deviceAuthenticityConfigTypes';
 
 import TrezorConnect from '../../../src';
-import { getController, initTrezorConnect, setup } from '../../common.setup';
+import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();
 
@@ -56,7 +56,7 @@ describe('TrezorConnect.authenticateDevice', () => {
         },
     };
 
-    it('validation successful', async () => {
+    conditionalTest(['!T2T1'], 'validation successful', async () => {
         const result = await TrezorConnect.authenticateDevice({
             config,
         });
@@ -67,14 +67,26 @@ describe('TrezorConnect.authenticateDevice', () => {
         });
     });
 
-    it('validation unsuccessful (rootPubKey not found)', async () => {
+    conditionalTest(['!T2T1'], 'validation unsuccessful (rootPubKey not found)', async () => {
         const result = await TrezorConnect.authenticateDevice({
             config: {
                 ...config,
-                T3B1: {
-                    ...config.T3B1,
-                    rootPubKeys: [],
-                },
+                ...Object.fromEntries(
+                    Object.entries(config)
+                        .filter(
+                            ([_, value]) =>
+                                typeof value === 'object' &&
+                                value !== null &&
+                                'rootPubKeys' in value,
+                        )
+                        .map(([key, value]) => [
+                            key,
+                            {
+                                ...value,
+                                rootPubKeys: [],
+                            },
+                        ]),
+                ),
             },
         });
 
@@ -84,14 +96,26 @@ describe('TrezorConnect.authenticateDevice', () => {
         });
     });
 
-    it('sanity check unsuccessful (caPubkey not found)', async () => {
+    conditionalTest(['!T2T1'], 'sanity check unsuccessful (caPubkey not found)', async () => {
         const result = await TrezorConnect.authenticateDevice({
             config: {
                 ...config,
-                T3B1: {
-                    ...config.T3B1,
-                    caPubKeys: [],
-                },
+                ...Object.fromEntries(
+                    Object.entries(config)
+                        .filter(
+                            ([_, value]) =>
+                                typeof value === 'object' &&
+                                value !== null &&
+                                'rootPubKeys' in value,
+                        )
+                        .map(([key, value]) => [
+                            key,
+                            {
+                                ...value,
+                                caPubKeys: [],
+                            },
+                        ]),
+                ),
             },
         });
 

--- a/packages/connect/e2e/tests/device/authenticateDevice.test.ts
+++ b/packages/connect/e2e/tests/device/authenticateDevice.test.ts
@@ -1,6 +1,8 @@
-import { DeviceAuthenticityConfig } from '@trezor/connect/src/data/deviceAuthenticityConfigTypes';
+import { DeviceModelInternal } from '@trezor/device-utils';
 
 import TrezorConnect from '../../../src';
+import { deviceAuthenticityConfig } from '../../../src/data/deviceAuthenticityConfig';
+import { DeviceAuthenticityConfig } from '../../../src/data/deviceAuthenticityConfigTypes';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();
@@ -19,42 +21,22 @@ describe('TrezorConnect.authenticateDevice', () => {
     });
 
     // NOTE: emulator uses different provisioning keys than production FW (different than ./data/deviceAuthenticityConfig)
-    const config: DeviceAuthenticityConfig = {
-        version: 1,
-        timestamp: '2023-09-07T14:00:00+00:00',
-        T2B1: {
-            rootPubKeys: [
-                '047f77368dea2d4d61e989f474a56723c3212dacf8a808d8795595ef38441427c4389bc454f02089d7f08b873005e4c28d432468997871c0bf286fd3861e21e96a',
-            ],
-            caPubKeys: [
-                '04ba6084cb9fba7c86d5d5a86108a91d55a27056da4eabbedde88a95e1cae8bce3620889167aaf7f2db166998f950984aa195e868f96e22803c3cd991be31d39e7',
-            ],
-        },
-        T3B1: {
-            rootPubKeys: [
-                '047f77368dea2d4d61e989f474a56723c3212dacf8a808d8795595ef38441427c4389bc454f02089d7f08b873005e4c28d432468997871c0bf286fd3861e21e96a',
-            ],
-            caPubKeys: [
-                '0410a6bc4f9eb52fd450be2c365189ea6a523fdddd62e44566dc349a8c7f813144cde81c8c106b74bfceae9c8ca5202af635ce1a5330c41c708ebbf505e025c339',
-            ],
-        },
-        T3T1: {
-            rootPubKeys: [
-                '04e48b69cd7962068d3cca3bcc6b1747ef496c1e28b5529e34ad7295215ea161dbe8fb08ae0479568f9d2cb07630cb3e52f4af0692102da5873559e45e9fa72959',
-            ],
-            caPubKeys: [
-                '04829e8965018feb542e9236c9b2ce08f864a55ed9183d0259564f0e05345b04676a0bef36c59d21d3c24868b5601f0b1193a6bfcf6d814e1cfb79c2256a05e953',
-            ],
-        },
-        T3W1: {
-            rootPubKeys: [
-                '04521192e173a9da4e3023f747d836563725372681eba3079c56ff11b2fc137ab189eb4155f371127651b5594f8c332fc1e9c0f3b80d4212822668b63189706578',
-            ],
-            caPubKeys: [
-                '04a5d701fced9b5a2cd076a02d8a98e779c54946eefc7b2525fac782fa3d65b5d9e6a8c90946bd30b35dfeec34a053f1106ba130a8472037f2db8cf2c4b3b6e93a',
-            ],
-        },
-    };
+    const config = {
+        ...deviceAuthenticityConfig,
+        ...Object.fromEntries(
+            Object.entries(deviceAuthenticityConfig)
+                .filter(
+                    ([_, value]) => typeof value === 'object' && value !== null && 'debug' in value,
+                )
+                .map(([key, value]: [string, any]) => [
+                    key,
+                    {
+                        rootPubKeys: value.debug.rootPubKeys,
+                        caPubKeys: value.debug.caPubKeys,
+                    },
+                ]),
+        ),
+    } as DeviceAuthenticityConfig;
 
     conditionalTest(['!T2T1'], 'validation successful', async () => {
         const result = await TrezorConnect.authenticateDevice({
@@ -73,11 +55,8 @@ describe('TrezorConnect.authenticateDevice', () => {
                 ...config,
                 ...Object.fromEntries(
                     Object.entries(config)
-                        .filter(
-                            ([_, value]) =>
-                                typeof value === 'object' &&
-                                value !== null &&
-                                'rootPubKeys' in value,
+                        .filter(([key, _]) =>
+                            Object.values(DeviceModelInternal).includes(key as DeviceModelInternal),
                         )
                         .map(([key, value]) => [
                             key,
@@ -102,11 +81,8 @@ describe('TrezorConnect.authenticateDevice', () => {
                 ...config,
                 ...Object.fromEntries(
                     Object.entries(config)
-                        .filter(
-                            ([_, value]) =>
-                                typeof value === 'object' &&
-                                value !== null &&
-                                'rootPubKeys' in value,
+                        .filter(([key, _]) =>
+                            Object.values(DeviceModelInternal).includes(key as DeviceModelInternal),
                         )
                         .map(([key, value]) => [
                             key,

--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -12,7 +12,7 @@ const groups = {
     api: {
         name: 'api',
         pattern:
-            'authorizeCoinjoin cancelCoinjoinAuthorization passphrase unlockPath setBusy checkFirmwareAuthenticity keepSession cancel.test info.test resetDevice',
+            'authorizeCoinjoin cancelCoinjoinAuthorization passphrase unlockPath setBusy authenticateDevice keepSession cancel.test info.test resetDevice',
         includeFilter: '',
     },
     // temporarily created group for flaky test - to spend less time on reruns and to make test result in CI more readable without investigating long logs


### PR DESCRIPTION
This test was not used. It seems like the file was renamed at some point and since then the runner has been omitting it. 

Also, it was broken. I made it work for all Safe devices.

I removed the `version` attribute from docker compose configs as it has been deprecated and is no longer used.

[Slack discussion](https://satoshilabs.sentry.io/discover/homepage/?dataset=errors&field=timestamp&field=message&name=All%20Errors&project=5193825&query=INVALID_DEVICE_MODEL&queryDataset=error-events&sort=-timestamp&statsPeriod=14d&widths=6&yAxis=count%28%29)

There is also this warning, which I did not resolve:
![Screenshot 2025-06-17 at 15 21 54](https://github.com/user-attachments/assets/95be7f17-0af7-45bf-9f50-c0ebbfd784e2)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=e2e/fix-ca-pub-key&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=e2e/fix-ca-pub-key&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=e2e/fix-ca-pub-key&lookback=7)