### PR TITLE
feat(suite-native): device settings structure

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -544,8 +544,11 @@ export const en = {
         confirmOnDeviceSheetTitle: 'Confirm on Trezor',
     },
     moduleDeviceSettings: {
-        title: 'Device settings',
-        dangerZoneDivider: 'DANGER ZONE',
+        sectionTitles: {
+            general: 'General',
+            checks: 'Checks',
+            dangerZone: 'Danger Zone',
+        },
         pinProtection: {
             title: 'PIN protection',
             content: 'PIN protects your device against physical attack.',

--- a/suite-native/module-device-settings/src/components/DeviceSettingsSection.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceSettingsSection.tsx
@@ -1,0 +1,28 @@
+import { Children, ReactNode } from 'react';
+
+import { A, G } from '@mobily/ts-belt';
+
+import { Text, VStack } from '@suite-native/atoms';
+
+type DeviceSettingsSectionProps = {
+    title: ReactNode;
+    children: ReactNode;
+};
+
+export const DeviceSettingsSection = ({ title, children }: DeviceSettingsSectionProps) => {
+    // If children elements are conditionally rendered and section would end up being empty, avoid rendering the whole section.
+    const validChildren = Children.toArray(children).filter(child => G.isNotNullable(child));
+
+    if (A.isEmpty(validChildren)) {
+        return null;
+    }
+
+    return (
+        <VStack spacing="sp16">
+            <Text variant="titleSmall" color="textOnTertiary">
+                {title}
+            </Text>
+            {children}
+        </VStack>
+    );
+};

--- a/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
@@ -6,21 +6,21 @@ import {
     selectDeviceName,
     selectIsDeviceConnectedViaBluetooth,
 } from '@suite-common/wallet-core';
-import { Text, TextDivider, VStack } from '@suite-native/atoms';
+import { Text, VStack } from '@suite-native/atoms';
 import { DeviceImage } from '@suite-native/device';
-import { useTranslate } from '@suite-native/intl';
+import { Translation } from '@suite-native/intl';
 import { Screen, ScreenHeader } from '@suite-native/navigation';
 
 import { DeviceAuthenticityCard } from '../components/DeviceAuthenticityCard';
 import { DeviceBluetoothCard } from '../components/DeviceBluetoothCard';
 import { DeviceFirmwareCard } from '../components/DeviceFirmwareCard';
 import { DevicePinProtectionCard } from '../components/DevicePinProtectionCard';
+import { DeviceSettingsSection } from '../components/DeviceSettingsSection';
 import { WipeDeviceCard } from '../components/WipeDeviceCard';
 import { useDeviceChangedCheck } from '../hooks/useDeviceChangedCheck';
 
 export const DeviceSettingsModalScreen = () => {
     useDeviceChangedCheck();
-    const { translate } = useTranslate();
 
     const deviceModel = useSelector(selectDeviceModel);
     const deviceName = useSelector(selectDeviceName);
@@ -31,25 +31,29 @@ export const DeviceSettingsModalScreen = () => {
     }
 
     return (
-        <Screen
-            header={
-                <ScreenHeader
-                    content={translate('moduleDeviceSettings.title')}
-                    closeActionType="close"
-                />
-            }
-        >
-            <VStack marginVertical="sp32" spacing="sp24" alignItems="center">
-                <DeviceImage deviceModel={deviceModel} />
-                <Text variant="titleMedium">{deviceName}</Text>
-            </VStack>
-            <VStack spacing="sp16">
-                <DeviceFirmwareCard />
-                <DevicePinProtectionCard />
-                {SUPPORTS_DEVICE_AUTHENTICITY_CHECK[deviceModel] && <DeviceAuthenticityCard />}
+        <Screen header={<ScreenHeader closeActionType="close" />}>
+            <VStack spacing="sp40">
+                <VStack marginTop="sp24" spacing="sp24" alignItems="center">
+                    <DeviceImage deviceModel={deviceModel} />
+                    <Text variant="titleMedium">{deviceName}</Text>
+                </VStack>
+                <DeviceSettingsSection
+                    title={<Translation id="moduleDeviceSettings.sectionTitles.general" />}
+                >
+                    <DeviceFirmwareCard />
+                    <DevicePinProtectionCard />
+                </DeviceSettingsSection>
+                <DeviceSettingsSection
+                    title={<Translation id="moduleDeviceSettings.sectionTitles.checks" />}
+                >
+                    {SUPPORTS_DEVICE_AUTHENTICITY_CHECK[deviceModel] && <DeviceAuthenticityCard />}
+                </DeviceSettingsSection>
                 {isDeviceConnectedViaBluetooth && <DeviceBluetoothCard />}
-                <TextDivider title="moduleDeviceSettings.dangerZoneDivider" />
-                <WipeDeviceCard />
+                <DeviceSettingsSection
+                    title={<Translation id="moduleDeviceSettings.sectionTitles.dangerZone" />}
+                >
+                    <WipeDeviceCard />
+                </DeviceSettingsSection>
             </VStack>
         </Screen>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Super small and simple PR for restructuring the device settings modal screen. Please note that only the structure and layout changes are implemented in this PR and the individual cards will be done separately. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19612

## Screenshots:
![image](https://github.com/user-attachments/assets/7f52bec1-f0f7-43b6-a7af-172755ef786a)


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/device-settings-cards-and-structure&lookback=7)