### PR TITLE
refactor(suite-native): test-utils as dev dependency only

### DIFF
--- a/suite-native/module-accounts-import/package.json
+++ b/suite-native/module-accounts-import/package.json
@@ -38,7 +38,6 @@
         "@suite-native/intl": "workspace:*",
         "@suite-native/navigation": "workspace:*",
         "@suite-native/qr-code": "workspace:*",
-        "@suite-native/test-utils": "workspace:*",
         "@suite-native/video-assets": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/styles": "workspace:*",
@@ -49,5 +48,8 @@
         "react-native": "0.76.9",
         "react-native-reanimated": "^3.16.7",
         "react-redux": "9.2.0"
+    },
+    "devDependencies": {
+        "@suite-native/test-utils": "workspace:*"
     }
 }

--- a/suite-native/module-accounts-import/tsconfig.json
+++ b/suite-native/module-accounts-import/tsconfig.json
@@ -38,12 +38,12 @@
         { "path": "../intl" },
         { "path": "../navigation" },
         { "path": "../qr-code" },
-        { "path": "../test-utils" },
         { "path": "../video-assets" },
         { "path": "../../packages/connect" },
         { "path": "../../packages/styles" },
         { "path": "../../packages/utils" },
-        { "path": "../../packages/utxo-lib" }
+        { "path": "../../packages/utxo-lib" },
+        { "path": "../test-utils" }
     ],
     "include": [".", "**/*.json"]
 }

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -20,7 +20,6 @@
         "@suite-common/trading": "workspace:*",
         "@suite-native/analytics": "workspace:*",
         "@suite-native/navigation": "workspace:*",
-        "@suite-native/test-utils": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/utils": "workspace:*",
@@ -33,5 +32,8 @@
         "react-native-safe-area-context": "^4.14.0",
         "react-native-webview": "13.12.5",
         "react-redux": "9.2.0"
+    },
+    "devDependencies": {
+        "@suite-native/test-utils": "workspace:*"
     }
 }

--- a/suite-native/module-trading/tsconfig.json
+++ b/suite-native/module-trading/tsconfig.json
@@ -5,12 +5,12 @@
         { "path": "../../suite-common/trading" },
         { "path": "../analytics" },
         { "path": "../navigation" },
-        { "path": "../test-utils" },
         {
             "path": "../../packages/blockchain-link-types"
         },
         { "path": "../../packages/connect" },
-        { "path": "../../packages/utils" }
+        { "path": "../../packages/utils" },
+        { "path": "../test-utils" }
     ],
     "include": [".", "**/*.json"]
 }


### PR DESCRIPTION
`@suite-native/test-utils` package was imported as main dependency at some places even though that it should be `devDependency` only (it is necessary only for tests). This PR fixes that.

Thanks for the edu session BTW ;)
 


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/test-utils-as-dev-dependency&lookback=7)