### PR TITLE
Random WalletConnect fixes

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { selectVisibleSortedDeviceAccounts } from '@suite-common/wallet-core';
+import { selectAllAccountsToList } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import {
     selectPendingProposal,
@@ -50,7 +50,7 @@ interface WalletConnectProposalModalProps {
 export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalModalProps) => {
     const dispatch = useDispatch();
     const pendingProposal = useSelector(selectPendingProposal);
-    const accounts = useSelector(selectVisibleSortedDeviceAccounts);
+    const accounts = useSelector(selectAllAccountsToList);
     const accountLabels = useSelector(selectAccountLabels);
     const selectableAccounts = useMemo<Account[]>(
         () =>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { selectVisibleSortedDeviceAccounts } from '@suite-common/wallet-core';
+import { selectAllAccountsToList } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import {
     getSessionNetworks,
@@ -29,7 +29,7 @@ export const WalletConnectSwitchAccountModal = ({
     const dispatch = useDispatch();
     const sessions = useSelector(selectSessions);
     const session = sessions.find(s => s.topic === sessionTopic);
-    const accounts = useSelector(selectVisibleSortedDeviceAccounts);
+    const accounts = useSelector(selectAllAccountsToList);
     const accountLabels = useSelector(selectAccountLabels);
     const selectableAccounts = useMemo<Account[]>(
         () =>

--- a/packages/suite/src/views/settings/SettingsConnectedApps/SettingsConnectedApps.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/SettingsConnectedApps.tsx
@@ -26,18 +26,18 @@ export const SettingsConnectedApps = () => {
 
     const tabs = [
         {
-            id: 'trezor-connect',
-            icon: 'trezorLogo' as const,
-            title: <Translation id="TR_TREZOR_CONNECT" />,
-            component: <ConnectPermissions />,
-            isEnabled: connectFeatureFlag,
-        },
-        {
             id: 'walletconnect',
             icon: 'walletConnect' as const,
             title: <Translation id="TR_WALLETCONNECT" />,
             component: <WalletConnectList />,
             isEnabled: wcEnabled,
+        },
+        {
+            id: 'trezor-connect',
+            icon: 'trezorLogo' as const,
+            title: <Translation id="TR_TREZOR_CONNECT" />,
+            component: <ConnectPermissions />,
+            isEnabled: connectFeatureFlag,
         },
     ].filter(tab => tab.isEnabled);
     const [activeItemdId, setActiveItemId] = useState(tabs[0]?.id ?? 0);

--- a/suite-common/wallet-core/src/accounts/accountsSelectors.ts
+++ b/suite-common/wallet-core/src/accounts/accountsSelectors.ts
@@ -58,16 +58,6 @@ export const selectVisibleDeviceAccounts = createMemoizedSelector(
         ),
 );
 
-export const selectVisibleSortedDeviceAccounts = createMemoizedSelector(
-    [selectVisibleDeviceAccounts],
-    accounts =>
-        pipe(
-            accounts,
-            A.sortBy(a => a.index),
-            returnStableArrayIfEmpty,
-        ),
-);
-
 export const selectDeviceAccountsForNetworkSymbolAndAccountType = createMemoizedSelector(
     [
         selectDeviceAccounts,

--- a/suite-common/walletconnect/src/adapters/ethereum.ts
+++ b/suite-common/walletconnect/src/adapters/ethereum.ts
@@ -82,7 +82,7 @@ const ethereumRequestThunk = createThunk<
                 throw new Error('personal_sign error');
             }
 
-            return response.payload.signature;
+            return `0x${response.payload.signature}`;
         }
         case 'eth_signTypedData_v4': {
             const [address, data] = event.params.request.params;
@@ -103,7 +103,7 @@ const ethereumRequestThunk = createThunk<
                 throw new Error('eth_signTypedData_v4 error');
             }
 
-            return response.payload.signature;
+            return `0x${response.payload.signature}`;
         }
         case 'eth_sendTransaction': {
             const chainId = Number(event.params.chainId.replace('eip155:', ''));

--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -185,9 +185,18 @@ export const switchSelectedAccountThunk = createThunk<
         if (!session) {
             return console.warn(`Session with topic ${sessionTopic} not found`);
         }
+        const approvedNamespaces = buildApprovedNamespaces({
+            // @ts-expect-error originally only takes proposal, but this works
+            proposal: {
+                requiredNamespaces: session.requiredNamespaces,
+                optionalNamespaces: session.optionalNamespaces,
+            },
+            supportedNamespaces: updatedNamespaces,
+        });
+
         await walletKit.updateSession({
             topic: sessionTopic,
-            namespaces: updatedNamespaces,
+            namespaces: approvedNamespaces,
         });
         const namespace = account.networkType === 'solana' ? 'solana' : 'eip155';
         const { chains } = session.namespaces[namespace];

--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -12,7 +12,7 @@ import { EventType, analytics } from '@suite-common/analytics';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getNetwork } from '@suite-common/wallet-config';
-import { selectSelectedDevice, selectVisibleSortedDeviceAccounts } from '@suite-common/wallet-core';
+import { selectAllAccountsToList, selectSelectedDevice } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import TrezorConnect from '@trezor/connect';
 
@@ -33,7 +33,7 @@ export const sessionAuthenticateThunk = createThunk<
     // Support for Sign-In with Ethereum (SIWE) message, enhanced by ReCaps (ReCap Capabilities)
     try {
         const device = selectSelectedDevice(getState());
-        const accounts = selectVisibleSortedDeviceAccounts(getState());
+        const accounts = selectAllAccountsToList(getState());
         const supportedNamespaces = getNamespaces(accounts);
         const authPayload = populateAuthPayload({
             authPayload: event.params.authPayload,
@@ -91,7 +91,7 @@ export const sessionProposalThunk = createThunk<
     }
 >(`${WALLETCONNECT_MODULE}/sessionProposalThunk`, ({ event }, { dispatch, getState }) => {
     // Check supported networks
-    const accounts = selectVisibleSortedDeviceAccounts(getState());
+    const accounts = selectAllAccountsToList(getState());
     const networks: PendingConnectionProposalNetwork[] = [];
     processNamespaces(accounts, networks, event.params.requiredNamespaces, true);
     processNamespaces(accounts, networks, event.params.optionalNamespaces, false);
@@ -174,7 +174,7 @@ export const switchSelectedAccountThunk = createThunk<
 >(
     `${WALLETCONNECT_MODULE}/switchSelectedAccountThunk`,
     async ({ account, sessionTopic }, { getState }) => {
-        const accounts = selectVisibleSortedDeviceAccounts(getState());
+        const accounts = selectAllAccountsToList(getState());
         const updatedNamespaces = getNamespaces([account, ...accounts]);
         const network = getNetwork(account.symbol);
         if (!network) {
@@ -246,7 +246,7 @@ export const sessionProposalApproveThunk = createThunk<
                 throw new Error('Proposal not found');
             }
 
-            const accounts = selectVisibleSortedDeviceAccounts(getState());
+            const accounts = selectAllAccountsToList(getState());
             const supportedNamespaces = getNamespaces([
                 ...(selectedDefaultAccount ? [selectedDefaultAccount] : []),
                 ...accounts,

--- a/suite-native/module-connect-popup/src/screens/WalletConnectSessionPopupScreen.tsx
+++ b/suite-native/module-connect-popup/src/screens/WalletConnectSessionPopupScreen.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { selectVisibleSortedDeviceAccounts } from '@suite-common/wallet-core';
+import { selectAllAccountsToList } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import {
     selectPendingProposal,
@@ -45,7 +45,7 @@ export const WalletConnectSessionPopupScreen = () => {
 
     const dispatch = useDispatch();
     const pendingProposal = useSelector(selectPendingProposal);
-    const accounts = useSelector(selectVisibleSortedDeviceAccounts);
+    const accounts = useSelector(selectAllAccountsToList);
     const selectableAccounts = useMemo<Account[]>(
         () =>
             pendingProposal?.networks

--- a/suite-native/module-connect-popup/src/screens/WalletConnectSwitchAccountScreen.tsx
+++ b/suite-native/module-connect-popup/src/screens/WalletConnectSwitchAccountScreen.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { selectVisibleSortedDeviceAccounts } from '@suite-common/wallet-core';
+import { selectAllAccountsToList } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import {
     getSessionNetworks,
@@ -31,7 +31,7 @@ export const WalletConnectSwitchAccountScreen = ({ route }: NavigationProps) => 
     const { sessionTopic } = route.params;
     const sessions = useSelector(selectSessions);
     const session = sessions.find(s => s.topic === sessionTopic);
-    const accounts = useSelector(selectVisibleSortedDeviceAccounts);
+    const accounts = useSelector(selectAllAccountsToList);
     const selectableAccounts = useMemo<Account[]>(
         () =>
             session


### PR DESCRIPTION
## Description

1. Check namespaces when switching account. Before this fix, we were sending all namespaces, which was causing issues - for example sending empty Solana namespace even when not using Solana.

2. Fix to signature response format, adding 0x prefix.

3. Order normal accounts first in select.

4. Put "WalletConnect" tab first in Settings

---

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/walletconnect-switchaccount-namespace&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/walletconnect-switchaccount-namespace&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/walletconnect-switchaccount-namespace&lookback=7)