### PR TITLE
chore(connect): add missing capabilities to config

### DIFF
--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -222,7 +222,16 @@ export const config = {
             min: { T1B1: '1.12.1', T2T1: '2.5.3' },
         },
         {
-            methods: ['showDeviceTutorial', 'authenticateDevice'],
+            capabilities: ['tutorial'],
+            methods: ['showDeviceTutorial'],
+            min: {
+                T1B1: '0',
+                T2T1: '0',
+                T3T1: '2.8.0',
+            },
+        },
+        {
+            methods: ['authenticateDevice'],
             min: {
                 T1B1: '0',
                 T2T1: '0',

--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -172,6 +172,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 chunkify: 'no-support',
                 evmApproval: 'no-support',
                 slip24: 'no-support',
+                tutorial: 'no-support',
                 ...T1B1_UPDATE_REQUIRED,
             });
         });
@@ -196,6 +197,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 chunkify: 'update-required',
                 evmApproval: 'update-required',
                 slip24: 'update-required',
+                tutorial: 'no-support',
                 ...T1B1_UPDATE_REQUIRED,
             });
         });
@@ -308,6 +310,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 chunkify: 'update-required',
                 evmApproval: 'update-required',
                 slip24: 'update-required',
+                tutorial: 'no-support',
                 ...T1B1_UPDATE_REQUIRED,
             });
         });
@@ -334,6 +337,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 chunkify: 'no-support',
                 evmApproval: 'no-support',
                 slip24: 'no-support',
+                tutorial: 'no-support',
                 ...T1B1_UPDATE_REQUIRED,
             });
         });
@@ -361,6 +365,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 chunkify: 'no-support',
                 evmApproval: 'no-support',
                 slip24: 'no-support',
+                tutorial: 'no-support',
                 ...T1B1_UPDATE_REQUIRED,
             });
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

cc @komret 

i've noticed [this feature request](https://github.com/trezor/trezor-firmware/issues/3966) (better late than never) and we also need it for T3W1.
this is how it should be done in connect, the info is accessible from suite `device.unavailableCapabilities.tutorial` - if set to true then its not supported.

feel free to fill out the rest of missing capabilities and models basing on this example

NOTE: this may require some suite db migration as stored data (saved device) may not be present until next device update event

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/connect-missing-capabilities&lookback=7)