### PR TITLE
fix(ci): Fixed spam from bot comments when skipping tests

### DIFF
--- a/.github/actions/check-previous-test-runs/action.yml
+++ b/.github/actions/check-previous-test-runs/action.yml
@@ -71,8 +71,9 @@ runs:
       uses: peter-evans/find-comment@v3
       id: find-comment
       with:
+        token: ${{ inputs.github_token }}
         issue-number: ${{ github.event.pull_request.number }}
-        comment-author: "trezor-ci"
+        comment-author: "trezor-bot[bot]"
         body-includes: ✅ Previously successful run of **${{ inputs.workflow_name }}**
 
     - name: Post skipped tests comment


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It turned out to be a bug, which happened when the tokens were changed. It was no longer able to find the previous comment due to missing token and different comment author name.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-skip-tests-message&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-skip-tests-message&lookback=7)