### PR TITLE
fix(suite): make sure that when switching to empty account we go rath…

### DIFF
--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -84,7 +84,11 @@ export const WalletInstance = ({
                 account =>
                     account.symbol === selectedAccount.params?.symbol &&
                     account.index === selectedAccount.params?.accountIndex &&
-                    account.accountType === selectedAccount.params?.accountType,
+                    account.accountType === selectedAccount.params?.accountType &&
+                    // NOTE: do not switch to empty accounts, but only if the current account is first or all accounts are empty
+                    (!account.empty ||
+                        (selectedAccount.params.accountIndex === 0 &&
+                            nextDeviceAccounts.every(account => account.empty))),
             );
 
             dispatch(selectDeviceThunk({ device: instance }));


### PR DESCRIPTION
…er to dashboard

<!--- Provide a general summary of your changes in the Title above -->

## Description

The problem was that the account of this type was present but was empty

## Related Issue

https://github.com/trezor/trezor-suite/issues/4465

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=4465-fix-case-switch-empty&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=4465-fix-case-switch-empty&lookback=7)