### PR TITLE
Test: Allow 0 gas price for BSC

### DIFF
--- a/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeEthereum.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeEthereum.tsx
@@ -89,9 +89,9 @@ export const CustomFeeEthereum = <TFieldValues extends FormState>({
             range: (value: string) => {
                 const customFee = new BigNumber(value);
 
-                if (customFee.isGreaterThan(maxFee) || customFee.isLessThan(minFee)) {
+                if (customFee.isGreaterThan(maxFee) || customFee.isLessThan(0)) {
                     return translationString('CUSTOM_FEE_NOT_IN_RANGE', {
-                        minFee: new BigNumber(minFee).toString(),
+                        minFee: new BigNumber(0).toString(),
                         maxFee: new BigNumber(maxFee).toString(),
                     });
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- to test free swaps on https://blockbook-dev2.corp.sldev.cz:9165/
- just set gas price to `0` in `Advanced fee`

![Screenshot 2025-06-23 at 14 39 37](https://github.com/user-attachments/assets/11275296-00d1-44e6-9337-c320b8a6aa5e)

**Approve**
https://bscscan.com/tx/0xa934d73df764ba1082128f82706d9448d71ea101bf3bbb979d779702ab86735a
**Swap**
https://bscscan.com/tx/0x65a920ed45ac505dfec65f660a13a44c44d10ae752abe39dd38a69eddea5e9a2

![Screenshot 2025-06-23 at 14 36 59](https://github.com/user-attachments/assets/7d8b6963-c266-4150-be30-77f75b4777d7)