### PR TITLE
chore(suite-native): send address review copy adjustment

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -1674,10 +1674,10 @@ export const en = {
                 sendTxnFailed: 'Failed to send transaction',
             },
             address: {
-                title: 'Check the address on your Trezor against the original to make sure it’s correct.',
+                title: 'Before you confirm on your Trezor',
                 step1: 'Go to the app or place where you originally got the address.',
-                step2: 'Compare that address with what’s on your Trezor and confirm.',
-                step3: 'Come back to Trezor Suite Lite',
+                step2: 'Compare the original address with what’s on your Trezor.',
+                step3: 'If they match exactly, confirm on your Trezor.',
 
                 originBottomSheet: {
                     title: 'What’s the place of origin?',

--- a/suite-native/module-send/src/components/AddressReviewStepList.tsx
+++ b/suite-native/module-send/src/components/AddressReviewStepList.tsx
@@ -29,7 +29,7 @@ import {
 } from '../selectors';
 
 const NUMBER_OF_STEPS = 3;
-const OVERLAY_INITIAL_POSITION = 170;
+const OVERLAY_INITIAL_POSITION = 120;
 const LIST_VERTICAL_SPACING = nativeSpacings.sp16;
 
 type RouteProps = StackProps<SendStackParamList, SendStackRoutes.SendAddressReview>['route'];

--- a/suite-native/module-send/src/components/ReviewOutputItem.tsx
+++ b/suite-native/module-send/src/components/ReviewOutputItem.tsx
@@ -28,7 +28,8 @@ const isTranslationDefined = (
 ): type is keyof typeof outputLabelTranslationMap => type in outputLabelTranslationMap;
 
 export const ReviewOutputItem = ({ reviewOutput, onLayout }: ReviewOutputItemProps) => {
-    const { state, type, value } = reviewOutput;
+    const { state = 'success', type, value } = reviewOutput;
+
     const { translate } = useTranslate();
 
     const titleTxKey = isTranslationDefined(type) ? outputLabelTranslationMap[type] : null;

--- a/suite-native/module-send/src/screens/SendAddressReviewScreen.tsx
+++ b/suite-native/module-send/src/screens/SendAddressReviewScreen.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { AccountsRootState, DeviceRootState, SendRootState } from '@suite-common/wallet-core';
 import { Box, Text, VStack } from '@suite-native/atoms';
-import { Translation, useTranslate } from '@suite-native/intl';
+import { Translation } from '@suite-native/intl';
 import {
     Screen,
     ScreenHeader,
@@ -24,7 +24,6 @@ export const SendAddressReviewScreen = ({
     navigation,
 }: StackProps<SendStackParamList, SendStackRoutes.SendAddressReview>) => {
     const { accountKey, tokenContract } = route.params;
-    const { translate } = useTranslate();
 
     const isAddressConfirmed = useSelector(
         (state: AccountsRootState & DeviceRootState & SendRootState) =>
@@ -45,16 +44,13 @@ export const SendAddressReviewScreen = ({
     return (
         <Screen
             header={
-                <ScreenHeader
-                    content={translate('moduleSend.review.outputs.title')}
-                    closeActionType={isTransactionReviewInProgress ? 'close' : 'back'}
-                />
+                <ScreenHeader closeActionType={isTransactionReviewInProgress ? 'close' : 'back'} />
             }
             // TODO: improve the illustration: https://github.com/trezor/trezor-suite/issues/13965
             footer={isTransactionReviewInProgress && <SendConfirmOnDeviceImage />}
         >
             <Box flex={1} justifyContent="space-between" marginTop="sp16">
-                <VStack justifyContent="center" alignItems="center" spacing="sp24">
+                <VStack justifyContent="center" spacing="sp24">
                     <Text variant="titleSmall">
                         <Translation id="moduleSend.review.address.title" />
                     </Text>


### PR DESCRIPTION
## Description
- changes copy of outputs review screen
- success state is correctly displayed in send outputs review screen
## Related Issue

Resolves #18865



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/send-minor-fixes&lookback=7)