### PR TITLE
chore(suite, suite-build): serve guide markdown as static assets and load via fetch

### DIFF
--- a/packages/suite-build/configs/desktop.webpack.config.ts
+++ b/packages/suite-build/configs/desktop.webpack.config.ts
@@ -31,7 +31,7 @@ const config: webpack.Configuration = {
     },
     plugins: [
         new CopyWebpackPlugin({
-            patterns: ['bin', 'fonts', 'images', 'videos', 'guide/assets']
+            patterns: ['bin', 'fonts', 'images', 'videos', 'guide']
                 .map(dir => ({
                     from: path.join(__dirname, '..', '..', 'suite-data', 'files', dir),
                     to: path.join(baseDir, 'build', 'static', dir),

--- a/packages/suite-build/configs/web.webpack.config.ts
+++ b/packages/suite-build/configs/web.webpack.config.ts
@@ -21,7 +21,7 @@ const config: webpack.Configuration = {
     },
     plugins: [
         new CopyWebpackPlugin({
-            patterns: ['browser-detection', 'fonts', 'images', 'oauth', 'videos', 'guide/assets']
+            patterns: ['browser-detection', 'fonts', 'images', 'oauth', 'videos', 'guide']
                 .map(dir => ({
                     from: path.join(__dirname, '..', '..', 'suite-data', 'files', dir),
                     to: path.join(baseDir, 'build', 'static', dir),

--- a/packages/suite/src/hooks/guide/useGuideLoadArticle.ts
+++ b/packages/suite/src/hooks/guide/useGuideLoadArticle.ts
@@ -4,12 +4,15 @@ import type { GuideNode } from '@suite-common/suite-types';
 
 import type { Locale } from 'src/config/suite/languages';
 
-export const loadPageMarkdownFile = async (id: string, language = 'en'): Promise<string> => {
-    const file = await import(/* @vite-ignore */ `@trezor/suite-data/files/guide/${language}${id}`);
-    const md = await file.default;
+export async function loadPageMarkdownFile(id: string, language = 'en'): Promise<string> {
+    const res = await fetch(`/static/guide/${language}${id}`);
 
-    return md;
-};
+    if (!res.ok) {
+        throw new Error(`[${res.status}] Failed to fetch article "${id}" for "${language}"`);
+    }
+
+    return res.text();
+}
 
 export const useGuideLoadArticle = (currentNode: GuideNode | null, language: Locale = 'en') => {
     const [markdown, setMarkdown] = useState<string>();

--- a/packages/suite/src/hooks/guide/useGuideLoadArticle.ts
+++ b/packages/suite/src/hooks/guide/useGuideLoadArticle.ts
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 
 import type { GuideNode } from '@suite-common/suite-types';
+import { resolveStaticPath } from '@suite-common/suite-utils';
 
 import type { Locale } from 'src/config/suite/languages';
 
 export async function loadPageMarkdownFile(id: string, language = 'en'): Promise<string> {
-    const res = await fetch(`/static/guide/${language}${id}`);
+    const res = await fetch(resolveStaticPath(`/guide/${language}${id}`));
 
     if (!res.ok) {
         throw new Error(`[${res.status}] Failed to fetch article "${id}" for "${language}"`);


### PR DESCRIPTION
## Description

This is a duplicate of [this](https://github.com/trezor/trezor-suite/pull/19204) PR. I'll close the previous one as it's created from the `trezor-suite` fork.

Guide files are now loaded with `fetch()` instead of a dynamic `import()`, which makes it work across different build tools.

The only build config tweak is to mark the entire `guide/` directory as static so the Markdown files are included. This doesn’t increase the bundle size; in fact, it’s now slightly smaller.

An alternative is `import.meta.glob` (with runtime checks to distinguish Vite from Webpack), but that adds tool-specific complexity unrelated to the feature itself.

**suite-build**

- Updated `CopyWebpackPlugin` to copy the `suite-data/files/guide` directory into `build/static/guide` (instead of only `guide/assets`).

**suite**

- Switched `useGuideLoadArticle` to load guide files via `fetch('/static/guide/${language}${id}')` instead of dynamic `import()`.

## Related Issue

Resolve [#18075](https://github.com/trezor/trezor-suite/issues/18075)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/fetch-guide-files&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/fetch-guide-files&lookback=7)