### PR TITLE
fix(e2e): Stabilize flaky tests

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/suite/initial-run.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/initial-run.test.ts
@@ -1,15 +1,13 @@
 import { expect, test } from '../../support/fixtures';
 
 test.describe('Suite initial run', { tag: ['@group=suite'] }, () => {
-    test.beforeEach(async ({ onboardingPage }) => {
-        await onboardingPage.disableNecessaryFirmwareChecks();
-    });
-
     test('Until user passed through initial run, it will be there after reload', async ({
         page,
         analyticsSection,
         onboardingPage,
     }) => {
+        await onboardingPage.disableNecessaryFirmwareChecks();
+        await onboardingPage.optionallyDismissFwHashCheckError();
         await expect(analyticsSection.toggleSwitch).toBeVisible();
         await page.reload();
         // analytics screen is there until user confirms his choice

--- a/packages/suite-desktop-core/e2e/tests/wallet/coin-balance.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/coin-balance.test.ts
@@ -1,4 +1,5 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
 
 import { expect, test } from '../../support/fixtures';
 
@@ -26,11 +27,17 @@ test.describe('Coin balance', { tag: ['@group=wallet'] }, () => {
         });
 
         await test.step('Balance is increased after sending another BTC', async () => {
-            const originalValue = await walletPage.balanceOfAccount('regtest').textContent();
-            const rawIncreasedValue = (Number(originalValue) + 1).toString();
-            const expectedIncreasedValue = localizeNumber(rawIncreasedValue, 'en', 0, 7);
+            const originalBalanceText = await walletPage.balanceOfAccount('regtest').textContent();
+            if (!originalBalanceText) {
+                throw new Error('Balance text content is empty');
+            }
+            const originalBalance = BigNumber(originalBalanceText);
+            const rawIncreasedBalance = originalBalance.plus(1).toString();
+            const expectedIncreasedBalance = localizeNumber(rawIncreasedBalance, 'en', 0, 8);
             await trezorUserEnvLink.sendToAddressAndMineBlock({ address, btc_amount: 1 });
-            await expect(walletPage.balanceOfAccount('regtest')).toHaveText(expectedIncreasedValue);
+            await expect(walletPage.balanceOfAccount('regtest')).toHaveText(
+                expectedIncreasedBalance,
+            );
         });
     });
 });


### PR DESCRIPTION
Stabilizes two flaky tests

Nightly run for WEB which contains all tests - [LINK](https://github.com/trezor/trezor-suite/actions/runs/15752863146)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-unstable-tests&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-unstable-tests&lookback=7)