### PR TITLE
feat(suite): add traded coins into the sign tx modal

### DIFF
--- a/packages/components/src/components/AssetLogo/AssetLogo.tsx
+++ b/packages/components/src/components/AssetLogo/AssetLogo.tsx
@@ -40,18 +40,16 @@ const Container = styled.div<TransientProps<AllowedFrameProps> & { $size: number
     ${withFrameProps}
 `;
 
-const Logo = styled.img<{ $size: number; $isVisible: boolean; $elevation: Elevation }>`
+const Logo = styled.img<{ $size: number; $elevation: Elevation }>`
     width: ${({ $size }) => $size}px;
     height: ${({ $size }) => $size}px;
     border-radius: ${borders.radii.full};
-    visibility: ${({ $isVisible }) => ($isVisible ? 'visible' : 'hidden')};
     box-shadow: inset 0 0 0 1px ${mapElevationToBorder};
     background-color: ${mapElevationToBackground};
 `;
 
 interface LogoProps extends React.ImgHTMLAttributes<HTMLImageElement> {
     $size: number;
-    $isVisible: boolean;
 }
 
 const ElevatedLogo = (props: LogoProps) => {
@@ -93,7 +91,6 @@ export const AssetLogo = ({
     'data-testid': dataTest,
     ...rest
 }: AssetLogoProps) => {
-    const [isLoading, setIsLoading] = useState(true);
     const [isPlaceholder, setIsPlaceholder] = useState(!shouldTryToFetch);
     const { coingeckoId: coingeckoIdLogo, contractAddress: contractAddressLogo } =
         getCoingeckoIdAndContractAddressIncludesNativeTokens(coingeckoId, contractAddress);
@@ -110,9 +107,6 @@ export const AssetLogo = ({
 
     const frameProps = pickAndPrepareFrameProps(rest, allowedAssetLogoFrameProps);
 
-    const handleLoad = () => {
-        setIsLoading(false);
-    };
     const handleError = () => {
         setIsPlaceholder(true);
     };
@@ -133,12 +127,9 @@ export const AssetLogo = ({
                         src={logoUrl}
                         srcSet={`${logoUrl} 1x, ${logoUrl2x} 2x`}
                         $size={size}
-                        onLoad={handleLoad}
                         onError={handleError}
-                        $isVisible={!isLoading}
                         data-testid={dataTest}
                         alt={placeholder}
-                        loading="lazy"
                     />
                 </ElevationUp>
             )}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -89,7 +89,7 @@ const isStakeState = (state: SendState | StakeState): state is StakeState => 'da
 
 const getTxType = (txInfoState: SendState | StakeState, precomposedForm: FormState) => {
     const stakeType = isStakeState(txInfoState) ? 'stake' : undefined;
-    const tradeType = precomposedForm.activeTradingSection ? 'trade' : undefined;
+    const tradeType = precomposedForm.trading?.activeSection ? 'trade' : undefined;
 
     return stakeType ?? tradeType;
 };
@@ -136,7 +136,7 @@ export const TransactionReviewModalContent = ({
     const createdTxTimestamp = txInfoState?.precomposedTx?.createdTimestamp ?? 0;
     const shouldCheckTxTimeValidity =
         account?.networkType === 'solana' &&
-        !precomposedForm?.activeTradingSection &&
+        !precomposedForm?.trading?.activeSection &&
         createdTxTimestamp !== 0;
     const deadline = createdTxTimestamp + getTxValidityTimeoutInMs(account?.networkType);
 
@@ -412,7 +412,7 @@ export const TransactionReviewModalContent = ({
                     outputs={outputs}
                     buttonRequestsCount={buttonRequestsCount}
                     isRbfAction={isBumpFeeRbfAction}
-                    isTradingAction={!!precomposedForm.activeTradingSection}
+                    tradingFormState={precomposedForm?.trading}
                     isSending={isSending}
                     stakeType={stakeType || undefined}
                     deadline={deadline}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -10,6 +10,7 @@ import { exhaustive } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { Translation } from 'src/components/suite';
+import { TransactionReviewOutputAssets } from 'src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets';
 import { useSelector, useTranslation } from 'src/hooks/suite';
 import type { Account } from 'src/types/wallet';
 
@@ -102,6 +103,10 @@ const getOutputTitle = (
             return <Translation id="OP_RETURN" />;
         case 'timebounds':
             return <Translation id="TIME_BOUNDS" />;
+        case 'recipient_name':
+            return <Translation id="TR_TRADING_PROVIDER" />;
+        case 'traded_assets':
+            return <Translation id="TR_MY_ASSETS" />;
         default:
             return exhaustive(type);
     }
@@ -195,6 +200,7 @@ const getOutputLines = (
         case 'locktime':
         case 'timebounds':
         case 'network':
+        case 'recipient_name':
         case 'signing-with':
             return [
                 {
@@ -212,6 +218,9 @@ const getOutputLines = (
                     type: 'amount',
                 },
             ];
+        // independent component
+        case 'traded_assets':
+            return [];
         default:
             return exhaustive(type);
     }
@@ -231,6 +240,8 @@ export const TransactionReviewOutput = ({
     label,
     value,
     value2,
+    send,
+    receive,
     token,
     account,
     stakeType,
@@ -296,6 +307,17 @@ export const TransactionReviewOutput = ({
     const ignoredRbfTypes = ['address', 'regular_legacy'];
     if (isRbf && stakeType && ignoredRbfTypes.includes(type)) {
         return null;
+    }
+
+    if (type === 'traded_assets') {
+        return (
+            <TransactionReviewOutputAssets
+                title={outputTitle}
+                state={state}
+                send={send}
+                receive={receive}
+            />
+        );
     }
 
     return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx
@@ -1,0 +1,156 @@
+import { ReactNode } from 'react';
+
+import { CryptoId } from 'invity-api';
+
+import { selectTradingCoinSymbolByCryptoId, toTokenCryptoId } from '@suite-common/trading';
+import { getCoingeckoId, getNetwork } from '@suite-common/wallet-config';
+import {
+    FormStateTradingCryptoCurrency,
+    FormStateTradingFiatCurrency,
+    TokenAddress,
+} from '@suite-common/wallet-types';
+import { AssetLogo, Card, Column, Divider, H4, InfoItem, Row, Text } from '@trezor/components';
+import { mapPaddingTypeToPadding } from '@trezor/components/src/components/Card/utils';
+import { CoinLogo } from '@trezor/product-components';
+import { isCoinSymbol } from '@trezor/product-components/src/components/CoinLogo/coins';
+import { spacings } from '@trezor/theme';
+
+import { FiatValue } from 'src/components/suite/FiatValue';
+import { TransactionReviewOutputStatus } from 'src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputStatus';
+import { useSelector } from 'src/hooks/suite';
+
+export type TransactionReviewOutputAssetsProps = {
+    title: ReactNode;
+    state: 'active' | 'confirmed' | 'unconfirmed';
+    send: FormStateTradingCryptoCurrency;
+    receive: FormStateTradingCryptoCurrency | FormStateTradingFiatCurrency;
+};
+
+type TransactionReviewOutputAssetsCryptoCurrencyProps = {
+    type: 'send' | 'receive';
+    cryptoCurrency: FormStateTradingCryptoCurrency;
+};
+
+type TransactionReviewOutputAssetsToProps = {
+    receive: FormStateTradingCryptoCurrency | FormStateTradingFiatCurrency;
+};
+
+const TransactionReviewOutputAssetsCryptoCurrency = ({
+    cryptoCurrency,
+    type,
+}: TransactionReviewOutputAssetsCryptoCurrencyProps) => {
+    const { symbol, contractAddress, amount } = cryptoCurrency;
+    const network = getNetwork(symbol);
+    const isTokenAmount = !!cryptoCurrency.contractAddress;
+
+    const cryptoId = contractAddress
+        ? toTokenCryptoId(symbol, contractAddress)
+        : (getCoingeckoId(symbol) as CryptoId);
+    const displaySymbol = useSelector(state => selectTradingCoinSymbolByCryptoId(state, cryptoId));
+
+    const getCoinLogo = () =>
+        isCoinSymbol(symbol) ? (
+            <CoinLogo size={20} symbol={symbol} type="tokenWithNetwork" />
+        ) : null;
+
+    return (
+        <InfoItem
+            label={
+                <Row alignItems="center" gap={spacings.sm}>
+                    {network.coingeckoId ? (
+                        <AssetLogo
+                            size={20}
+                            coingeckoId={network.coingeckoId}
+                            contractAddress={
+                                symbol && contractAddress ? contractAddress : undefined
+                            }
+                            placeholder={displaySymbol ?? ''}
+                        />
+                    ) : (
+                        getCoinLogo()
+                    )}
+                    <Text
+                        variant={type === 'receive' ? 'primary' : 'destructive'}
+                        data-testid={`@modal/assets/${type}/crypto`}
+                    >
+                        {type === 'receive' ? ' + ' : ' - '}
+                        {amount} {displaySymbol}
+                    </Text>
+                </Row>
+            }
+            direction="row"
+            verticalAlignment="center"
+            data-testid={`@modal/assets/${type}`}
+        >
+            <Text
+                variant="tertiary"
+                typographyStyle="hint"
+                data-testid={`@modal/assets/${type}/fiat`}
+            >
+                &asymp;{' '}
+                <FiatValue
+                    amount={amount}
+                    symbol={symbol}
+                    tokenAddress={isTokenAmount ? (contractAddress as TokenAddress) : undefined}
+                    disableHiddenPlaceholder
+                />
+            </Text>
+        </InfoItem>
+    );
+};
+
+const TransactionReviewOutputAssetsTo = ({ receive }: TransactionReviewOutputAssetsToProps) => {
+    if ('fiatCurrency' in receive) {
+        return (
+            <InfoItem
+                label={
+                    <Text
+                        margin={{ left: spacings.xxl }}
+                        variant="primary"
+                        data-testid="@modal/assets/receive/label"
+                    >
+                        + {receive.amount} {receive.fiatCurrency}
+                    </Text>
+                }
+                data-testid="@modal/assets/receive"
+                direction="row"
+                verticalAlignment="start"
+            />
+        );
+    }
+
+    return <TransactionReviewOutputAssetsCryptoCurrency cryptoCurrency={receive} type="receive" />;
+};
+
+export const TransactionReviewOutputAssets = ({
+    title,
+    send,
+    receive,
+    state,
+}: TransactionReviewOutputAssetsProps) => (
+    <Card
+        paddingType="none"
+        fillType={state === 'confirmed' ? 'flat' : 'default'}
+        header={
+            <Row gap={spacings.sm} padding={mapPaddingTypeToPadding({ paddingType: 'small' })}>
+                <TransactionReviewOutputStatus state={state} />
+                <H4
+                    margin={{ left: spacings.xxs }}
+                    typographyStyle={state !== 'unconfirmed' ? 'callout' : 'hint'}
+                >
+                    {title}
+                </H4>
+            </Row>
+        }
+    >
+        <Column>
+            <Column padding={mapPaddingTypeToPadding({ paddingType: 'small' })}>
+                <TransactionReviewOutputAssetsCryptoCurrency cryptoCurrency={send} type="send" />
+            </Column>
+            <Divider margin={{}} />
+            <Column padding={mapPaddingTypeToPadding({ paddingType: 'small' })}>
+                <TransactionReviewOutputAssetsTo receive={receive} />
+            </Column>
+        </Column>
+    </Card>
+);

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -5,22 +5,13 @@ import styled from 'styled-components';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { TokenAddress } from '@suite-common/wallet-types';
 import { formatAmount, formatNetworkAmount } from '@suite-common/wallet-utils';
-import {
-    Card,
-    Column,
-    DotIndicator,
-    H4,
-    Icon,
-    InfoItem,
-    Note,
-    Row,
-    Text,
-} from '@trezor/components';
+import { Card, Column, H4, InfoItem, Note, Row, Text } from '@trezor/components';
 import { TokenInfo } from '@trezor/connect';
 import { spacings } from '@trezor/theme';
 import { exhaustive } from '@trezor/type-utils';
 
 import { Address, FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
+import { TransactionReviewOutputStatus } from 'src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputStatus';
 import { Account } from 'src/types/wallet';
 
 const getCardanoFingerprint = (
@@ -41,17 +32,6 @@ const DataWrapper = styled.p`
     font-variant-numeric: tabular-nums;
     letter-spacing: 0;
 `;
-
-const Status = ({ state }: { state: TransactionReviewOutputElementProps['state'] }) => {
-    switch (state) {
-        case 'confirmed':
-            return <Icon size={spacings.md} variant="primary" name="check" />;
-        case 'unconfirmed':
-            return <DotIndicator />;
-        default:
-            return <DotIndicator isActive={true} />;
-    }
-};
 
 type ValueProps = {
     value: string;
@@ -150,7 +130,7 @@ export const TransactionReviewOutputElement = ({
             fillType={state === 'confirmed' ? 'flat' : 'default'}
             header={
                 <Row gap={spacings.sm}>
-                    <Status state={state} />
+                    <TransactionReviewOutputStatus state={state} />
                     <H4
                         margin={{ left: spacings.xxs }}
                         typographyStyle={state !== 'unconfirmed' ? 'callout' : 'hint'}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -2,7 +2,10 @@ import { useEffect, useRef } from 'react';
 
 import styled from 'styled-components';
 
-import type { GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import type {
+    FormStateTrading,
+    GeneralPrecomposedTransactionFinal,
+} from '@suite-common/wallet-types';
 import { ReviewOutput, StakeType } from '@suite-common/wallet-types';
 import { findAccountsByAddress } from '@suite-common/wallet-utils';
 import { BulletList, Card, Column, H3, H4 } from '@trezor/components';
@@ -24,7 +27,7 @@ export type TransactionReviewOutputListProps = {
     outputs: ReviewOutput[];
     buttonRequestsCount: number;
     isRbfAction: boolean;
-    isTradingAction: boolean;
+    tradingFormState: FormStateTrading | undefined;
     isSending?: boolean;
     stakeType?: StakeType;
     deadline?: number;
@@ -73,7 +76,7 @@ export const TransactionReviewOutputList = ({
     outputs,
     buttonRequestsCount,
     isRbfAction,
-    isTradingAction,
+    tradingFormState,
     stakeType,
     deadline,
     onTryAgain,
@@ -89,6 +92,7 @@ export const TransactionReviewOutputList = ({
     const isStaking = stakeType;
     const isInternalTransfer =
         isFirstOutputAddress &&
+        typeof outputs[0]?.value === 'string' &&
         findAccountsByAddress(symbol, outputs[0]?.value, accounts).length > 0;
 
     const summaryIndex = outputs.findIndex(
@@ -108,7 +112,7 @@ export const TransactionReviewOutputList = ({
         isFirstOutputAddress &&
         isFirstStep &&
         !isStaking &&
-        !isTradingAction &&
+        !tradingFormState &&
         !isInternalTransfer &&
         !signedTx
     ) {
@@ -186,7 +190,7 @@ export const TransactionReviewOutputList = ({
                                 state={getState(index, buttonRequestsCount, !!signedTx)}
                                 account={account}
                                 isRbf={isRbfAction}
-                                isTrading={isTradingAction}
+                                isTrading={!!tradingFormState}
                                 stakeType={stakeType}
                             />
                         </Column>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -98,6 +98,8 @@ export const TransactionReviewOutputList = ({
     const summaryIndex = outputs.findIndex(
         ({ type }) => !['address', 'amount', 'opreturn'].includes(type),
     );
+    const isSLIP24Active =
+        !!tradingFormState && 'send' in tradingFormState && 'receive' in tradingFormState;
 
     useEffect(() => {
         if (buttonRequestsCount - 1 === outputs.length || signedTx) {
@@ -211,6 +213,7 @@ export const TransactionReviewOutputList = ({
                             precomposedTx={precomposedTx}
                             stakeType={stakeType}
                             isRbf={isRbfAction}
+                            isSLIP24Active={isSLIP24Active}
                         />
                     </Column>
                 </Wrapper>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputStatus.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputStatus.tsx
@@ -1,0 +1,19 @@
+import { DotIndicator, Icon } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
+import { TransactionReviewOutputElementProps } from 'src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement';
+
+type TransactionReviewOutputStatusProps = {
+    state: TransactionReviewOutputElementProps['state'];
+};
+
+export const TransactionReviewOutputStatus = ({ state }: TransactionReviewOutputStatusProps) => {
+    switch (state) {
+        case 'confirmed':
+            return <Icon size={spacings.md} variant="primary" name="check" />;
+        case 'unconfirmed':
+            return <DotIndicator />;
+        default:
+            return <DotIndicator isActive={true} />;
+    }
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
@@ -24,6 +24,7 @@ const getLines = (
     precomposedTx: GeneralPrecomposedTransactionFinal,
     isRbfAction?: boolean,
     stakeType?: StakeType,
+    isSLIP24Active?: boolean,
 ): OutputElementLine[] => {
     const isUpdatedSendFlow = getIsUpdatedSendFlow(device);
     const isUpdatedEthereumSendFlow = getIsUpdatedEthereumSendFlow(device, networkType, stakeType);
@@ -47,6 +48,17 @@ const getLines = (
     const amountWithoutFee = new BigNumber(precomposedTx.totalSpent)
         .minus(precomposedTx.fee)
         .toString();
+
+    if (isSLIP24Active) {
+        return [
+            {
+                id: 'fee',
+                label: <Translation id={feeLabelId} />,
+                value: precomposedTx.fee,
+                type: 'amount',
+            },
+        ];
+    }
 
     if (isUpdatedEthereumSendFlow) {
         const isUnknownStakingValue = isRbfAction && stakeType !== 'stake';
@@ -100,6 +112,7 @@ export type TransactionReviewTotalOutputProps = {
     state: TransactionReviewOutputElementProps['state'];
     precomposedTx: GeneralPrecomposedTransactionFinal;
     account: Account;
+    isSLIP24Active: boolean;
     isRbf: boolean;
     stakeType?: StakeType;
 };
@@ -109,6 +122,7 @@ export const TransactionReviewTotalOutput = ({
     state,
     precomposedTx,
     stakeType,
+    isSLIP24Active,
     isRbf,
 }: TransactionReviewTotalOutputProps) => {
     const device = useSelector(selectSelectedDevice);
@@ -118,11 +132,17 @@ export const TransactionReviewTotalOutput = ({
     }
 
     const { networkType, symbol } = account;
-    const lines = getLines(device, networkType, precomposedTx, isRbf, stakeType);
+    const lines = getLines(device, networkType, precomposedTx, isRbf, stakeType, isSLIP24Active);
 
     return (
         <TransactionReviewOutputElement
-            title={<Translation id="TR_TOTAL_INCLUDING_FEE" />}
+            title={
+                isSLIP24Active ? (
+                    <Translation id="TR_SUMMARY" />
+                ) : (
+                    <Translation id="TR_TOTAL_INCLUDING_FEE" />
+                )
+            }
             account={account}
             lines={lines}
             state={state}

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1633,6 +1633,10 @@ export default defineMessages({
         defaultMessage: 'Sell with {providerName}',
         id: 'TR_TRADING_OTC_LINK_SELL',
     },
+    TR_TRADING_PROVIDER: {
+        defaultMessage: 'Provider',
+        id: 'TR_TRADING_PROVIDER',
+    },
     TR_ADDRESS_MODAL_CLIPBOARD: {
         defaultMessage: 'Copy address',
         id: 'TR_ADDRESS_MODAL_CLIPBOARD',

--- a/packages/suite/src/utils/suite/transactionReview.ts
+++ b/packages/suite/src/utils/suite/transactionReview.ts
@@ -30,11 +30,11 @@ export const getTransactionReviewModalActionTranslation = ({
         // no default
     }
 
-    if (precomposedForm.activeTradingSection === 'sell') {
+    if (precomposedForm?.trading?.activeSection === 'sell') {
         return { id: 'TR_TRADING_SELL' };
     }
 
-    if (precomposedForm.activeTradingSection === 'exchange') {
+    if (precomposedForm?.trading?.activeSection === 'exchange') {
         const transactionPurpose = getEvmTransactionTextSignature(precomposedForm.ethereumDataHex);
 
         switch (transactionPurpose) {

--- a/suite-common/trading/src/__tests__/utils.test.ts
+++ b/suite-common/trading/src/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import type { CryptoId } from 'invity-api';
+import { CryptoId, ExchangeProviderInfo, ExchangeTrade, SellFiatTrade } from 'invity-api';
 
 import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import type { Account } from '@suite-common/wallet-types';
@@ -7,7 +7,11 @@ import * as BUY_FIXTURE from '../__fixtures__/buyUtils';
 import * as EXCHANGE_FIXTURE from '../__fixtures__/exchangeUtils';
 import * as SELL_FIXTURE from '../__fixtures__/sellUtils';
 import { accountBtc, accountEth } from '../__fixtures__/utils';
-import type { TradingAccountOptionsGroupOptionProps } from '../types';
+import type {
+    TradingAccountOptionsGroupOptionProps,
+    TradingExchangeType,
+    TradingSellType,
+} from '../types';
 import {
     addIdsToQuotes,
     cryptoIdToNetwork,
@@ -17,6 +21,7 @@ import {
     getBestRatedQuote,
     getDefaultCountry,
     getTagAndInfoNote,
+    getTradingFormState,
     getTradingNetworkDecimals,
     getTradingPaymentMethods,
     getTradingQuotesByPaymentMethod,
@@ -318,5 +323,405 @@ describe('getBestRatedQuote', () => {
         expect(getBestRatedQuote(EXCHANGE_FIXTURE.MIN_MAX_QUOTES_OK, 'exchange')).toStrictEqual(
             EXCHANGE_FIXTURE.MIN_MAX_QUOTES_OK[EXCHANGE_FIXTURE.MIN_MAX_QUOTES_OK.length - 1],
         );
+    });
+});
+
+describe('getTradingFormState', () => {
+    const mockProvider: ExchangeProviderInfo = {
+        name: 'test-exchange',
+        companyName: 'Test Exchange',
+        logo: 'test.svg',
+        isActive: true,
+        isFixedRate: false,
+        isDex: false,
+        buyTickers: [],
+        sellTickers: [],
+        addressFormats: {},
+        statusUrl: 'https://test.com/status',
+        supportUrl: 'https://test.com/support',
+        kycUrl: 'https://test.com/kyc',
+        kycPolicy: 'No KYC required',
+        kycPolicyType: 'noKYC',
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('sell section', () => {
+        const activeSection: TradingSellType = 'sell';
+
+        it('should return default state when required fields are missing', () => {
+            const incompleteTrade = {
+                exchange: 'test-exchange',
+                // Missing required fields
+            } as SellFiatTrade;
+
+            const providers = {
+                'test-exchange': mockProvider,
+            };
+
+            const result = getTradingFormState({
+                activeSection,
+                trade: incompleteTrade,
+                providers,
+            });
+
+            expect(result).toEqual({
+                activeSection: 'sell',
+            });
+        });
+
+        it('should return default state when provider is not found', () => {
+            const trade = {
+                exchange: 'unknown-exchange',
+                fiatStringAmount: '1000',
+                fiatCurrency: 'USD',
+                cryptoCurrency: 'bitcoin' as CryptoId,
+                cryptoStringAmount: '0.025',
+            } as SellFiatTrade;
+
+            const result = getTradingFormState({
+                activeSection,
+                trade,
+                providers: {},
+            });
+
+            expect(result).toEqual({
+                activeSection: 'sell',
+            });
+        });
+
+        it('should return default state when network is not found', () => {
+            const trade = {
+                exchange: 'test-exchange',
+                fiatStringAmount: '1000',
+                fiatCurrency: 'USD',
+                cryptoCurrency: 'unknown-crypto' as CryptoId,
+                cryptoStringAmount: '0.025',
+            } as SellFiatTrade;
+
+            const providers = {
+                'test-exchange': mockProvider,
+            };
+
+            const result = getTradingFormState({
+                activeSection,
+                trade,
+                providers,
+            });
+
+            expect(result).toEqual({
+                activeSection: 'sell',
+            });
+        });
+
+        it('should return complete form state for valid sell trade', () => {
+            const trade = {
+                exchange: 'test-exchange',
+                fiatStringAmount: '1000',
+                fiatCurrency: 'USD',
+                cryptoCurrency: 'bitcoin' as CryptoId,
+                cryptoStringAmount: '0.025',
+            } as SellFiatTrade;
+
+            const providers = {
+                'test-exchange': mockProvider,
+            };
+
+            const result = getTradingFormState({
+                activeSection,
+                trade,
+                providers,
+                isSlip24Active: true,
+            });
+
+            expect(result).toEqual({
+                activeSection: 'sell',
+                recipientName: 'Test Exchange',
+                send: {
+                    symbol: 'btc',
+                    contractAddress: undefined,
+                    amount: '0.025',
+                },
+                receive: {
+                    amount: '1000',
+                    fiatCurrency: 'USD',
+                },
+            });
+        });
+
+        it('should handle token trades with contract address', () => {
+            const trade = {
+                exchange: 'test-exchange',
+                fiatStringAmount: '500',
+                fiatCurrency: 'EUR',
+                cryptoCurrency: 'ethereum--0x123456789' as CryptoId,
+                cryptoStringAmount: '100',
+            } as SellFiatTrade;
+
+            const providers = {
+                'test-exchange': mockProvider,
+            };
+
+            const result = getTradingFormState({
+                activeSection,
+                trade,
+                providers,
+                isSlip24Active: true,
+            });
+
+            expect(result).toEqual({
+                activeSection: 'sell',
+                recipientName: 'Test Exchange',
+                send: {
+                    symbol: 'eth',
+                    contractAddress: '0x123456789',
+                    amount: '100',
+                },
+                receive: {
+                    amount: '500',
+                    fiatCurrency: 'EUR',
+                },
+            });
+        });
+    });
+
+    describe('exchange section', () => {
+        const activeSection: TradingExchangeType = 'exchange';
+
+        it('should return default state when required fields are missing', () => {
+            const incompleteTrade = {
+                exchange: 'test-exchange',
+                // Missing required fields
+            } as ExchangeTrade;
+
+            const providers = {
+                'test-exchange': mockProvider,
+            };
+
+            const result = getTradingFormState({
+                activeSection,
+                trade: incompleteTrade,
+                providers,
+                isSlip24Active: true,
+            });
+
+            expect(result).toEqual({
+                activeSection: 'exchange',
+            });
+        });
+
+        it('should return default state when provider is not found', () => {
+            const trade = {
+                exchange: 'unknown-exchange',
+                receive: 'ethereum' as CryptoId,
+                receiveStringAmount: '1',
+                send: 'bitcoin' as CryptoId,
+                sendStringAmount: '0.025',
+            } as ExchangeTrade;
+
+            const result = getTradingFormState({
+                activeSection,
+                trade,
+                providers: {},
+                isSlip24Active: true,
+            });
+
+            expect(result).toEqual({
+                activeSection: 'exchange',
+            });
+        });
+
+        it('should return default state when receive network is not found', () => {
+            const trade = {
+                exchange: 'test-exchange',
+                receive: 'unknown-crypto' as CryptoId,
+                receiveStringAmount: '1',
+                send: 'bitcoin' as CryptoId,
+                sendStringAmount: '0.025',
+            } as ExchangeTrade;
+
+            const providers = {
+                'test-exchange': mockProvider,
+            };
+
+            const result = getTradingFormState({
+                activeSection,
+                trade,
+                providers,
+                isSlip24Active: true,
+            });
+
+            expect(result).toEqual({
+                activeSection: 'exchange',
+            });
+        });
+
+        it('should return default state when send network is not found', () => {
+            const trade = {
+                exchange: 'test-exchange',
+                receive: 'ethereum' as CryptoId,
+                receiveStringAmount: '1',
+                send: 'unknown-crypto' as CryptoId,
+                sendStringAmount: '0.025',
+            } as ExchangeTrade;
+
+            const providers = {
+                'test-exchange': mockProvider,
+            };
+
+            const result = getTradingFormState({
+                activeSection,
+                trade,
+                providers,
+                isSlip24Active: true,
+            });
+
+            expect(result).toEqual({
+                activeSection: 'exchange',
+            });
+        });
+
+        it('should return complete form state for valid exchange trade', () => {
+            const trade = {
+                exchange: 'test-exchange',
+                receive: 'ethereum' as CryptoId,
+                receiveStringAmount: '1',
+                send: 'bitcoin' as CryptoId,
+                sendStringAmount: '0.025',
+            } as ExchangeTrade;
+
+            const providers = {
+                'test-exchange': mockProvider,
+            };
+
+            const result = getTradingFormState({
+                activeSection,
+                trade,
+                providers,
+                isSlip24Active: true,
+            });
+
+            expect(result).toEqual({
+                activeSection: 'exchange',
+                recipientName: 'Test Exchange',
+                send: {
+                    symbol: 'btc',
+                    contractAddress: undefined,
+                    amount: '0.025',
+                },
+                receive: {
+                    symbol: 'eth',
+                    contractAddress: undefined,
+                    amount: '1',
+                },
+            });
+        });
+
+        it('should handle token-to-token exchange with contract addresses', () => {
+            const trade = {
+                exchange: 'test-exchange',
+                receive: 'ethereum--0xreceive123' as CryptoId,
+                receiveStringAmount: '100',
+                send: 'ethereum--0xsend456' as CryptoId,
+                sendStringAmount: '50',
+            } as ExchangeTrade;
+
+            const providers = {
+                'test-exchange': mockProvider,
+            };
+
+            const result = getTradingFormState({
+                activeSection,
+                trade,
+                providers,
+                isSlip24Active: true,
+            });
+
+            expect(result).toEqual({
+                activeSection: 'exchange',
+                recipientName: 'Test Exchange',
+                send: {
+                    symbol: 'eth',
+                    contractAddress: '0xsend456',
+                    amount: '50',
+                },
+                receive: {
+                    symbol: 'eth',
+                    contractAddress: '0xreceive123',
+                    amount: '100',
+                },
+            });
+        });
+    });
+
+    describe('edge cases', () => {
+        it('should handle undefined providers', () => {
+            const trade = {
+                exchange: 'test-exchange',
+                fiatStringAmount: '1000',
+                fiatCurrency: 'USD',
+                cryptoCurrency: 'bitcoin' as CryptoId,
+                cryptoStringAmount: '0.025',
+            } as SellFiatTrade;
+
+            const result = getTradingFormState({
+                activeSection: 'sell',
+                trade,
+                providers: undefined,
+                isSlip24Active: true,
+            });
+
+            expect(result).toEqual({
+                activeSection: 'sell',
+            });
+        });
+
+        it('should handle trade without exchange property', () => {
+            const trade = {
+                // exchange property missing
+                fiatStringAmount: '1000',
+                fiatCurrency: 'USD',
+                cryptoCurrency: 'bitcoin' as CryptoId,
+                cryptoStringAmount: '0.025',
+            } as SellFiatTrade;
+
+            const result = getTradingFormState({
+                activeSection: 'sell',
+                trade,
+                providers: { 'test-exchange': mockProvider },
+                isSlip24Active: true,
+            });
+
+            expect(result).toEqual({
+                activeSection: 'sell',
+            });
+        });
+
+        it('should handle empty strings in trade amounts', () => {
+            const trade = {
+                exchange: 'test-exchange',
+                fiatStringAmount: '',
+                fiatCurrency: 'USD',
+                cryptoCurrency: 'bitcoin' as CryptoId,
+                cryptoStringAmount: '0.025',
+            } as SellFiatTrade;
+
+            const providers = {
+                'test-exchange': mockProvider,
+            };
+
+            const result = getTradingFormState({
+                activeSection: 'sell',
+                trade,
+                providers,
+                isSlip24Active: true,
+            });
+
+            expect(result).toEqual({
+                activeSection: 'sell',
+            });
+        });
     });
 });

--- a/suite-common/trading/src/thunks/common/__tests__/createPaymentRequestsThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/createPaymentRequestsThunk.test.ts
@@ -259,6 +259,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'exchange',
                     account: mockAccount,
                     composedLevels: mockComposedTransaction,
+                    formattedMaxAmount: mockExchangeQuote.sendStringAmount,
                 }),
             );
 
@@ -281,6 +282,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'exchange',
                     account: mockAccount,
                     composedLevels: mockComposedTransaction,
+                    formattedMaxAmount: mockExchangeQuote.sendStringAmount,
                 }),
             );
 
@@ -305,6 +307,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'exchange',
                     account: mockAccount,
                     composedLevels: mockComposedTransaction,
+                    formattedMaxAmount: mockExchangeQuote.sendStringAmount,
                 }),
             );
 
@@ -331,6 +334,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'exchange',
                     account: mockAccount,
                     composedLevels: mockComposedTransaction,
+                    formattedMaxAmount: mockExchangeQuote.sendStringAmount,
                 }),
             );
 
@@ -363,6 +367,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'exchange',
                     account: mockAccount,
                     composedLevels: mockComposedTransaction,
+                    formattedMaxAmount: mockExchangeQuote.sendStringAmount,
                 }),
             );
 
@@ -413,6 +418,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'sell',
                     account: mockAccount,
                     composedLevels: mockComposedTransaction,
+                    formattedMaxAmount: mockSellQuote.cryptoStringAmount,
                 }),
             );
 
@@ -434,6 +440,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'sell',
                     account: mockAccount,
                     composedLevels: mockComposedTransaction,
+                    formattedMaxAmount: mockSellQuote.cryptoStringAmount,
                 }),
             );
 
@@ -464,6 +471,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'sell',
                     account: mockAccount,
                     composedLevels: mockComposedTransaction,
+                    formattedMaxAmount: mockSellQuote.cryptoStringAmount,
                 }),
             );
 
@@ -491,6 +499,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'exchange',
                     account: mockAccount,
                     composedLevels: invalidTransaction as any,
+                    formattedMaxAmount: mockSellQuote.cryptoStringAmount,
                 }),
             );
 
@@ -539,6 +548,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'sell',
                     account: mockAccount,
                     composedLevels: transactionWithOnlyDirectOutputs,
+                    formattedMaxAmount: mockSellQuote.cryptoStringAmount,
                 }),
             );
 
@@ -572,6 +582,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'exchange',
                     account: mockAccount,
                     composedLevels: mockComposedTransaction,
+                    formattedMaxAmount: mockSellQuote.cryptoStringAmount,
                 }),
             );
 

--- a/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
@@ -230,7 +230,7 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { fulfillWithValue }) => fulfillWithValue(levels),
             ),
         );
@@ -266,7 +266,7 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { fulfillWithValue }) =>
                     fulfillWithValue({
                         type: 'final',
@@ -300,7 +300,7 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { rejectWithValue }) => rejectWithValue({ error: 'fee-levels-compose-failed' }),
             ),
         );
@@ -336,7 +336,7 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { fulfillWithValue }) =>
                     fulfillWithValue({
                         type: 'final',
@@ -370,7 +370,7 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { fulfillWithValue }) =>
                     fulfillWithValue({
                         type: 'nonfinal',
@@ -404,7 +404,7 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { fulfillWithValue }) =>
                     fulfillWithValue({
                         normal: {
@@ -467,12 +467,16 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { fulfillWithValue }) =>
                     fulfillWithValue({
                         normal: {
                             type: 'final',
-                            data: {},
+                            outputs: [
+                                {
+                                    amount: '10000000',
+                                },
+                            ],
                         },
                     }),
             ),
@@ -519,15 +523,25 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementation(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { fulfillWithValue }) =>
                     fulfillWithValue({
                         normal: {
                             type: 'final',
                             feeLimit: '1111',
+                            outputs: [
+                                {
+                                    amount: '10000000',
+                                },
+                            ],
                         },
                         custom: {
                             type: 'final',
+                            outputs: [
+                                {
+                                    amount: '10000000',
+                                },
+                            ],
                         },
                     }),
             ),
@@ -588,12 +602,16 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { fulfillWithValue }) =>
                     fulfillWithValue({
                         normal: {
                             type: 'final',
-                            data: {},
+                            outputs: [
+                                {
+                                    amount: '10000000',
+                                },
+                            ],
                         },
                     }),
             ),
@@ -628,6 +646,7 @@ describe('recomposeAndSignTxThunk', () => {
             composedLevels: expect.objectContaining({
                 type: 'final',
             }),
+            formattedMaxAmount: '0.1',
         });
         expect(mockSignAndPushSendFormTransaction).toHaveBeenCalledWith({
             formState: expect.any(Object),
@@ -654,12 +673,16 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { fulfillWithValue }) =>
                     fulfillWithValue({
                         normal: {
                             type: 'final',
-                            data: {},
+                            outputs: [
+                                {
+                                    amount: '10000000',
+                                },
+                            ],
                         },
                     }),
             ),

--- a/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
@@ -131,19 +131,23 @@ describe('recomposeAndSignTxThunk', () => {
                 device: deviceState,
             },
         });
+        const tradingFormState = {
+            activeSection: 'exchange' as const,
+        };
 
         const mockSignAndPushSendFormTransaction = jest.fn();
 
         return {
             store,
             account,
+            tradingFormState,
 
             mockSignAndPushSendFormTransaction,
         };
     };
 
     it('should return error when missing composed data', async () => {
-        const { store, account, mockSignAndPushSendFormTransaction } = getMocks({
+        const { store, account, tradingFormState, mockSignAndPushSendFormTransaction } = getMocks({
             composedTransactionInfo: {
                 ...mockComposedTransactionInfo,
                 composed: undefined,
@@ -155,6 +159,7 @@ describe('recomposeAndSignTxThunk', () => {
                 account,
                 address: 'address',
                 amount: '0.1',
+                tradingFormState,
 
                 signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
             }),
@@ -171,7 +176,7 @@ describe('recomposeAndSignTxThunk', () => {
     });
 
     it('should return error when missing feeInfo', async () => {
-        const { store, account, mockSignAndPushSendFormTransaction } = getMocks();
+        const { store, account, tradingFormState, mockSignAndPushSendFormTransaction } = getMocks();
 
         const response = await store.dispatch(
             tradingThunks.recomposeAndSignTxThunk({
@@ -181,6 +186,7 @@ describe('recomposeAndSignTxThunk', () => {
                 } as Account,
                 address: 'address',
                 amount: '0.1',
+                tradingFormState,
 
                 signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
             }),
@@ -215,7 +221,7 @@ describe('recomposeAndSignTxThunk', () => {
             'TR_ERROR',
         ],
     ])('should return error for custom fees %s', async (_, levels, errorId) => {
-        const { store, account, mockSignAndPushSendFormTransaction } = getMocks({
+        const { store, account, tradingFormState, mockSignAndPushSendFormTransaction } = getMocks({
             composedTransactionInfo: {
                 ...mockComposedTransactionInfo,
                 selectedFee: 'custom',
@@ -235,6 +241,7 @@ describe('recomposeAndSignTxThunk', () => {
                 address: 'address',
                 amount: '0.1',
                 recalculateCustomLimit: true,
+                tradingFormState,
                 signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
             }),
         );
@@ -250,7 +257,7 @@ describe('recomposeAndSignTxThunk', () => {
     });
 
     it('should return error when selectedFee is undefined', async () => {
-        const { store, account, mockSignAndPushSendFormTransaction } = getMocks({
+        const { store, account, tradingFormState, mockSignAndPushSendFormTransaction } = getMocks({
             composedTransactionInfo: {
                 ...mockComposedTransactionInfo,
                 selectedFee: undefined,
@@ -272,6 +279,7 @@ describe('recomposeAndSignTxThunk', () => {
                 account,
                 address: 'address',
                 amount: '0.1',
+                tradingFormState,
                 signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
             }),
         );
@@ -288,7 +296,7 @@ describe('recomposeAndSignTxThunk', () => {
     });
 
     it('should return error when composedLevels are undefined', async () => {
-        const { store, account, mockSignAndPushSendFormTransaction } = getMocks();
+        const { store, account, tradingFormState, mockSignAndPushSendFormTransaction } = getMocks();
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
@@ -302,6 +310,7 @@ describe('recomposeAndSignTxThunk', () => {
                 account,
                 address: 'address',
                 amount: '0.1',
+                tradingFormState,
                 signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
             }),
         );
@@ -318,7 +327,7 @@ describe('recomposeAndSignTxThunk', () => {
     });
 
     it('should return error when selectedFee is not in composedLevels', async () => {
-        const { store, account, mockSignAndPushSendFormTransaction } = getMocks({
+        const { store, account, tradingFormState, mockSignAndPushSendFormTransaction } = getMocks({
             composedTransactionInfo: {
                 ...mockComposedTransactionInfo,
                 selectedFee: 'economy',
@@ -340,6 +349,7 @@ describe('recomposeAndSignTxThunk', () => {
                 account,
                 address: 'address',
                 amount: '0.1',
+                tradingFormState,
                 signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
             }),
         );
@@ -356,7 +366,7 @@ describe('recomposeAndSignTxThunk', () => {
     });
 
     it('should return error when composedLevels type is not final', async () => {
-        const { store, account, mockSignAndPushSendFormTransaction } = getMocks();
+        const { store, account, tradingFormState, mockSignAndPushSendFormTransaction } = getMocks();
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
@@ -373,6 +383,7 @@ describe('recomposeAndSignTxThunk', () => {
                 account,
                 address: 'address',
                 amount: '0.1',
+                tradingFormState,
                 signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
             }),
         );
@@ -389,7 +400,7 @@ describe('recomposeAndSignTxThunk', () => {
     });
 
     it('should return custom error when composedLevels type is not final with passed error data', async () => {
-        const { store, account, mockSignAndPushSendFormTransaction } = getMocks();
+        const { store, account, tradingFormState, mockSignAndPushSendFormTransaction } = getMocks();
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
@@ -414,6 +425,7 @@ describe('recomposeAndSignTxThunk', () => {
                 account,
                 address: 'address',
                 amount: '0.1',
+                tradingFormState,
                 signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
             }),
         );
@@ -433,7 +445,7 @@ describe('recomposeAndSignTxThunk', () => {
     });
 
     it('should return successful recomposed and signed transaction', async () => {
-        const { store, account } = getMocks({
+        const { store, account, tradingFormState } = getMocks({
             composedTransactionInfo: {
                 ...mockComposedTransactionInfo,
                 composed: {
@@ -475,6 +487,7 @@ describe('recomposeAndSignTxThunk', () => {
                 ethereumDataHex: '0x123456',
                 ethereumAdjustGasLimit: '1',
                 setMaxOutputId: 0,
+                tradingFormState,
                 signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
             }),
         );
@@ -490,7 +503,7 @@ describe('recomposeAndSignTxThunk', () => {
     });
 
     it('should return successful recomposed and signed transaction using custom fees', async () => {
-        const { store, account } = getMocks({
+        const { store, account, tradingFormState } = getMocks({
             composedTransactionInfo: {
                 ...mockComposedTransactionInfo,
                 selectedFee: 'custom',
@@ -526,6 +539,7 @@ describe('recomposeAndSignTxThunk', () => {
                 address: 'address',
                 amount: '0.1',
                 recalculateCustomLimit: true,
+                tradingFormState,
                 signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
             }),
         );
@@ -541,7 +555,7 @@ describe('recomposeAndSignTxThunk', () => {
     });
 
     it('should create payment requests when SLIP24 is active and conditions are met', async () => {
-        const { store, account } = getMocks({
+        const { store, account, tradingFormState } = getMocks({
             composedTransactionInfo: {
                 ...mockComposedTransactionInfo,
             },
@@ -594,6 +608,7 @@ describe('recomposeAndSignTxThunk', () => {
                 address: 'address',
                 amount: '0.1',
                 isSlip24Active: true,
+                tradingFormState,
                 signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
             }),
         );
@@ -624,7 +639,7 @@ describe('recomposeAndSignTxThunk', () => {
     });
 
     it('should not create payment requests when SLIP24 is not active', async () => {
-        const { store, account } = getMocks({
+        const { store, account, tradingFormState } = getMocks({
             composedTransactionInfo: {
                 ...mockComposedTransactionInfo,
             },
@@ -659,6 +674,7 @@ describe('recomposeAndSignTxThunk', () => {
                 address: 'address',
                 amount: '0.1',
                 isSlip24Active: false,
+                tradingFormState,
                 signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
             }),
         );

--- a/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
+++ b/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
@@ -34,6 +34,7 @@ type CreateSignatureThunkProps = {
     type: TradingTradeSellExchangeType;
     account: Account;
     composedLevels: GeneralPrecomposedTransaction;
+    formattedMaxAmount: string | undefined;
 };
 
 export const createPaymentRequestsThunk = createThunk<
@@ -45,13 +46,11 @@ export const createPaymentRequestsThunk = createThunk<
 >(
     `${TRADING_THUNK_PREFIX}/createPaymentRequests`,
     async (
-        { type, account, composedLevels },
+        { type, account, composedLevels, formattedMaxAmount },
         { dispatch, getState, fulfillWithValue, rejectWithValue },
     ) => {
         const { mac: macRefund } = await dispatch(getRefundAddress({ account })).unwrap();
         const nonce = await dispatch(getNonce()).unwrap();
-
-        // const { composed } = selectTradingComposedTransactionInfo(getState()); // TODO: slip24 - use after update fees during swaps/sells
 
         if (!('outputs' in composedLevels)) {
             return rejectWithValue({
@@ -134,7 +133,10 @@ export const createPaymentRequestsThunk = createThunk<
                 }
 
                 const paymentRequest = tradingExchangeCreatePaymentRequest({
-                    trade,
+                    trade: {
+                        ...trade,
+                        sendStringAmount: formattedMaxAmount ?? trade.sendStringAmount,
+                    },
                     provider,
                     macPurchase: verifiedAddress.mac,
                     macRefund,
@@ -199,7 +201,10 @@ export const createPaymentRequestsThunk = createThunk<
                 }
 
                 const paymentRequest = tradingSellCreatePaymentRequest({
-                    trade,
+                    trade: {
+                        ...trade,
+                        cryptoStringAmount: formattedMaxAmount ?? trade.cryptoStringAmount,
+                    },
                     provider,
                     macRefund,
                     nonce,

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -9,6 +9,7 @@ import {
     selectNetworkFeeInfo,
 } from '@suite-common/wallet-core';
 import { Account, FormOptions, FormState, FormStateTrading } from '@suite-common/wallet-types';
+import { formatAmount } from '@suite-common/wallet-utils';
 import { Success, Unsuccessful } from '@trezor/connect';
 
 import { tradingThunks } from '../';
@@ -49,6 +50,16 @@ export type RecomposeAndSignTxThunkProps = {
         paymentRequests,
     }: TradingSignAndPushSendFormTransactionProps) => Promise<FulfillValue>;
 };
+
+const getTradingFormStateAccordingRestriction = (
+    tradingFormState: FormStateTrading,
+    isPaymentRequestsAllowed: boolean,
+): FormStateTrading =>
+    isPaymentRequestsAllowed
+        ? tradingFormState
+        : {
+              activeSection: tradingFormState.activeSection,
+          };
 
 /**
  * This thunk is particularly useful for scenarios where transaction details (e.g., fees, outputs) need to be recalculated
@@ -106,6 +117,10 @@ export const recomposeAndSignTxThunk = createThunk<
             });
         }
 
+        const restrictedTradingFormState = getTradingFormStateAccordingRestriction(
+            tradingFormState,
+            isPaymentRequestsAllowed,
+        );
         // prepare the fee levels, set custom values from composed
         // WORKAROUND: sendFormEthereumActions and sendFormRippleActions use form outputs instead of composed transaction data
         const formState: FormState = {
@@ -131,11 +146,7 @@ export const recomposeAndSignTxThunk = createThunk<
             ethereumDataHex,
             ethereumAdjustGasLimit,
             selectedUtxos: [],
-            trading: isPaymentRequestsAllowed
-                ? tradingFormState
-                : {
-                      activeSection: tradingFormState.activeSection,
-                  },
+            trading: restrictedTradingFormState,
         };
 
         // prepare form state for composeAction
@@ -212,18 +223,48 @@ export const recomposeAndSignTxThunk = createThunk<
             });
         }
 
+        /*
+            SLIP-24 to achieve the consistent trade data
+            --- 
+            If the transaction is a trade of whole balance, we need to set the amount to 
+            the formState (displayed in the UI) and for the payment requests to
+            ensure that the payment requests are created with the correct amount.
+        */
+        const { decimals } = getNetwork(account.symbol);
+        const isTradedWholeBalance = precomposedToSign.outputs.length === 1; // sending whole balance
+        const sendAmount = isTradedWholeBalance
+            ? precomposedToSign.outputs[0].amount.toString()
+            : undefined;
+        const formattedMaxAmount = sendAmount ? formatAmount(sendAmount, decimals) : undefined;
+
+        const formStateUpdated: FormState = {
+            ...formState,
+            trading: {
+                ...restrictedTradingFormState,
+                ...('send' in restrictedTradingFormState
+                    ? {
+                          send: {
+                              ...restrictedTradingFormState.send,
+                              amount: formattedMaxAmount ?? restrictedTradingFormState.send.amount,
+                          },
+                      }
+                    : {}),
+            },
+        };
+
         const paymentRequests = isPaymentRequestsAllowed
             ? await dispatch(
                   tradingThunks.createPaymentRequestsThunk({
-                      type: tradingFormState.activeSection,
+                      type: restrictedTradingFormState.activeSection,
                       account,
                       composedLevels: precomposedToSign,
+                      formattedMaxAmount,
                   }),
               ).unwrap()
             : [];
 
         const resultOfSignedTransaction = await signAndPushSendFormTransaction({
-            formState,
+            formState: formStateUpdated,
             precomposedTransaction: precomposedToSign,
             selectedAccount: account,
             paymentRequests,

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -8,20 +8,18 @@ import {
     composeSendFormTransactionFeeLevelsThunk,
     selectNetworkFeeInfo,
 } from '@suite-common/wallet-core';
-import { Account, FormOptions, FormState } from '@suite-common/wallet-types';
+import { Account, FormOptions, FormState, FormStateTrading } from '@suite-common/wallet-types';
 import { Success, Unsuccessful } from '@trezor/connect';
 
 import { tradingThunks } from '../';
 import { TRADING_THUNK_PREFIX } from '../../constants';
 import {
-    selectTradingActiveSection,
     selectTradingComposedTransactionInfo,
     selectTradingIsSlip24Allowed,
 } from '../../selectors/tradingSelectors';
 import type {
     TradingSendRejectedProps,
     TradingSignAndPushSendFormTransactionProps,
-    TradingTradeSellExchangeType,
 } from '../../types';
 import { cryptoIdToNetwork } from '../../utils';
 
@@ -42,6 +40,7 @@ export type RecomposeAndSignTxThunkProps = {
      * Important: should not be used for DEX trades.
      */
     isSlip24Active?: boolean;
+    tradingFormState: FormStateTrading;
 
     signAndPushSendFormTransaction: ({
         formState,
@@ -81,20 +80,22 @@ export const recomposeAndSignTxThunk = createThunk<
             ethereumAdjustGasLimit,
             setMaxOutputId,
             isSlip24Active = false,
+            tradingFormState,
             signAndPushSendFormTransaction,
         }: RecomposeAndSignTxThunkProps,
         { dispatch, getState, rejectWithValue, fulfillWithValue },
     ) => {
-        const activeSection = selectTradingActiveSection(
-            getState(),
-        ) as TradingTradeSellExchangeType; // used only in the sell and exchange sections
         const { composed, selectedFee } = selectTradingComposedTransactionInfo(getState());
         const options: FormOptions[] = ['broadcast'];
         const network = getNetwork(account.symbol);
         const feeInfo = selectNetworkFeeInfo(getState(), account.symbol);
-        const activeTradingSection = selectTradingActiveSection(
+        const receiveNetwork = receiveCryptoId && cryptoIdToNetwork(receiveCryptoId);
+        const isPaymentRequestsAllowed = selectTradingIsSlip24Allowed(
             getState(),
-        ) as TradingTradeSellExchangeType;
+            account,
+            isSlip24Active,
+            receiveNetwork,
+        );
 
         if (!composed || !feeInfo) {
             return rejectWithValue({
@@ -130,7 +131,11 @@ export const recomposeAndSignTxThunk = createThunk<
             ethereumDataHex,
             ethereumAdjustGasLimit,
             selectedUtxos: [],
-            activeTradingSection,
+            trading: isPaymentRequestsAllowed
+                ? tradingFormState
+                : {
+                      activeSection: tradingFormState.activeSection,
+                  },
         };
 
         // prepare form state for composeAction
@@ -207,18 +212,10 @@ export const recomposeAndSignTxThunk = createThunk<
             });
         }
 
-        const receiveNetwork = receiveCryptoId && cryptoIdToNetwork(receiveCryptoId);
-        const isPaymentRequestsAllowed = selectTradingIsSlip24Allowed(
-            getState(),
-            account,
-            isSlip24Active,
-            receiveNetwork,
-        );
-
         const paymentRequests = isPaymentRequestsAllowed
             ? await dispatch(
                   tradingThunks.createPaymentRequestsThunk({
-                      type: activeSection,
+                      type: tradingFormState.activeSection,
                       account,
                       composedLevels: precomposedToSign,
                   }),

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -76,6 +76,9 @@ export const sendDexTransactionThunk = createThunk<
                 ethereumAdjustGasLimit: selectedQuote.status === 'CONFIRM' ? '1.25' : undefined,
                 setMaxOutputId,
                 signAndPushSendFormTransaction,
+                tradingFormState: {
+                    activeSection: 'exchange',
+                },
             }),
         );
 

--- a/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
@@ -11,10 +11,12 @@ import { tradingExchangeActions } from '../../reducers/exchangeReducer';
 import { tradingActions } from '../../reducers/tradingReducer';
 import {
     selectTradingExchangeAccountKey,
+    selectTradingExchangeProviders,
     selectTradingExchangeReceiveAccountKey,
     selectTradingExchangeSelectedQuote,
 } from '../../selectors/tradingSelectors';
 import { TradingSendRejectedProps } from '../../types';
+import { getTradingFormState } from '../../utils';
 
 export type SendTransactionThunkProps = {
     trade: ExchangeTrade | undefined;
@@ -51,6 +53,7 @@ export const sendTransactionThunk = createThunk<
         const sendAccountKey = selectTradingExchangeAccountKey(getState());
         const receiveAccountKey = selectTradingExchangeReceiveAccountKey(getState());
         const selectedTrade = trade ?? selectedQuote;
+        const providers = selectTradingExchangeProviders(getState());
         // sendAddress may be set by useTradingWatchTrade hook to the trade object
         const sendAddress = selectedTrade?.sendAddress;
 
@@ -88,6 +91,13 @@ export const sendTransactionThunk = createThunk<
             });
         }
 
+        const tradingFormState = getTradingFormState({
+            activeSection: 'exchange',
+            providers,
+            trade: selectedTrade,
+            isSlip24Active,
+        });
+
         const sendStringAmount = shouldSendInSats
             ? amountToSmallestUnit(selectedTrade.sendStringAmount, decimals)
             : selectedTrade.sendStringAmount;
@@ -103,6 +113,7 @@ export const sendTransactionThunk = createThunk<
                 signAndPushSendFormTransaction,
                 setMaxOutputId,
                 isSlip24Active,
+                tradingFormState,
                 receiveCryptoId: selectedTrade.receive,
             }),
         );

--- a/suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts
@@ -12,9 +12,11 @@ import { tradingSellActions } from '../../reducers/sellReducer';
 import { tradingActions } from '../../reducers/tradingReducer';
 import {
     selectTradingSellInfo,
+    selectTradingSellProviders,
     selectTradingSellSelectedQuote,
 } from '../../selectors/tradingSelectors';
 import { TradingSellFormProps } from '../../types';
+import { getTradingFormState } from '../../utils';
 import { RecomposeAndSignTxThunkProps } from '../common/recomposeAndSignTxThunk';
 
 export type SendSellTransactionThunkProps = {
@@ -46,6 +48,7 @@ export const sendSellTransactionThunk = createThunk(
     ) => {
         const selectedQuote = selectTradingSellSelectedQuote(getState());
         const sellInfo = selectTradingSellInfo(getState());
+        const providers = selectTradingSellProviders(getState());
         const selectedTrade = trade ?? selectedQuote;
         // destinationAddress may be set by useTradingWatchTrade hook to the trade object
         const destinationAddress = selectedTrade?.destinationAddress ?? trade?.destinationAddress;
@@ -65,7 +68,12 @@ export const sendSellTransactionThunk = createThunk(
                 error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
             });
         }
-
+        const tradingFormState = getTradingFormState({
+            activeSection: 'sell',
+            providers,
+            trade: selectedTrade,
+            isSlip24Active,
+        });
         const cryptoStringAmount = shouldSendInSats
             ? amountToSmallestUnit(selectedTrade.cryptoStringAmount, decimals)
             : selectedTrade.cryptoStringAmount;
@@ -81,6 +89,7 @@ export const sendSellTransactionThunk = createThunk(
                 signAndPushSendFormTransaction,
                 // when lockSendAmount is true, the amount should not be recomputed based on the maximum balance.
                 setMaxOutputId: lockSendAmount ? undefined : formValues.setMaxOutputId,
+                tradingFormState,
             }),
         );
 

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -1,4 +1,11 @@
-import { BuyTrade, CryptoId, ExchangeTrade, SellFiatTrade } from 'invity-api';
+import {
+    BuyTrade,
+    CryptoId,
+    ExchangeProviderInfo,
+    ExchangeTrade,
+    SellFiatTrade,
+    SellProviderInfo,
+} from 'invity-api';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
@@ -9,16 +16,19 @@ import {
     getNetworkByCoingeckoId,
     getNetworkByTradeCryptoId,
 } from '@suite-common/wallet-config';
-import type { Account } from '@suite-common/wallet-types';
+import type { Account, FormStateTrading } from '@suite-common/wallet-types';
+import { exhaustive } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { CONTRACT_ADDRESS_FOR_NATIVE_TOKEN, CRYPTO_PLATFORM_SEPARATOR } from './constants';
 import { regional } from './regional';
 import {
     TradingAccountOptionsGroupOptionProps,
+    TradingExchangeType,
     TradingParsedCryptoIdProps,
     TradingPaymentMethodListProps,
     TradingPaymentMethodProps,
+    TradingSellType,
     TradingTradeBuySellMapProps,
     TradingTradeBuySellType,
     TradingTradeMapProps,
@@ -246,4 +256,109 @@ export const getBestRatedQuote = <T extends TradingType>(
     });
 
     return bestRatedQuotes[0];
+};
+
+type TradingGetFormStateSellProps = {
+    activeSection: TradingSellType;
+    trade: SellFiatTrade;
+};
+
+type TradingGetFormStateExchangeProps = {
+    activeSection: TradingExchangeType;
+    trade: ExchangeTrade;
+};
+
+type TradingGetFormStateProps = {
+    providers: Record<string, ExchangeProviderInfo | SellProviderInfo> | undefined;
+    isSlip24Active?: boolean;
+} & (TradingGetFormStateSellProps | TradingGetFormStateExchangeProps);
+
+export const getTradingFormState = ({
+    activeSection,
+    trade,
+    providers,
+    isSlip24Active,
+}: TradingGetFormStateProps): FormStateTrading => {
+    const provider = trade?.exchange ? providers?.[trade.exchange] : undefined;
+
+    // Support for SLIP-24
+    switch (activeSection) {
+        case 'sell': {
+            const defaultState = {
+                activeSection,
+            };
+
+            if (
+                !trade.fiatStringAmount ||
+                !trade.fiatCurrency ||
+                !trade.cryptoCurrency ||
+                !trade.cryptoStringAmount ||
+                !provider?.companyName ||
+                !isSlip24Active
+            ) {
+                return defaultState;
+            }
+
+            const networkData = cryptoIdToNetworkAndContractAddress(trade.cryptoCurrency);
+
+            if (!networkData || !networkData.network) {
+                return defaultState;
+            }
+
+            return {
+                activeSection,
+                recipientName: provider.companyName,
+                send: {
+                    symbol: networkData.network.symbol,
+                    contractAddress: networkData.contractAddress,
+                    amount: trade.cryptoStringAmount,
+                },
+                receive: {
+                    amount: trade.fiatStringAmount,
+                    fiatCurrency: trade.fiatCurrency,
+                },
+            };
+        }
+        case 'exchange': {
+            const defaultState = {
+                activeSection,
+            };
+
+            if (
+                !trade.receive ||
+                !trade.receiveStringAmount ||
+                !trade.send ||
+                !trade.sendStringAmount ||
+                !provider?.companyName ||
+                !isSlip24Active
+            ) {
+                return defaultState;
+            }
+
+            const receiveNetworkData = cryptoIdToNetworkAndContractAddress(trade.receive);
+            const sendNetworkData = cryptoIdToNetworkAndContractAddress(trade.send);
+
+            if (!receiveNetworkData?.network || !sendNetworkData?.network) {
+                return defaultState;
+            }
+
+            return {
+                activeSection,
+                recipientName: provider.companyName,
+                send: {
+                    symbol: sendNetworkData.network.symbol,
+                    contractAddress: sendNetworkData.contractAddress,
+                    amount: trade.sendStringAmount,
+                },
+                receive: {
+                    symbol: receiveNetworkData.network.symbol,
+                    contractAddress: receiveNetworkData.contractAddress,
+                    amount: trade.receiveStringAmount,
+                },
+            };
+        }
+        /* istanbul ignore next */
+        default:
+            return exhaustive(activeSection);
+    }
 };

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -1,3 +1,4 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountUtxo, FeeLevel } from '@trezor/connect';
 
 import { Output, RbfTransactionParams } from './transaction';
@@ -11,6 +12,41 @@ export type FormOptions =
     | 'destinationTag';
 
 export type UtxoSorting = 'newestFirst' | 'oldestFirst' | 'smallestFirst' | 'largestFirst';
+
+export type FormStateTradingCryptoCurrency = {
+    symbol: NetworkSymbol;
+    contractAddress?: string;
+    amount: string;
+};
+
+export type FormStateTradingFiatCurrency = {
+    amount: string;
+    fiatCurrency: string;
+};
+
+type FormStateTradingDefault = {
+    activeSection: 'sell' | 'exchange';
+};
+
+type FormStateTradingCommon = {
+    recipientName: string;
+    send: FormStateTradingCryptoCurrency;
+};
+
+type FormStateTradingSell = {
+    activeSection: 'sell';
+    receive: FormStateTradingFiatCurrency;
+} & FormStateTradingCommon;
+
+type FormStateTradingExchange = {
+    activeSection: 'exchange';
+    receive: FormStateTradingCryptoCurrency;
+} & FormStateTradingCommon;
+
+export type FormStateTrading =
+    | FormStateTradingSell
+    | FormStateTradingExchange
+    | FormStateTradingDefault;
 
 export interface FormState {
     outputs: Output[]; // output arrays, each element is corresponding with single Output item
@@ -45,5 +81,5 @@ export interface FormState {
     anonymityWarningChecked?: boolean;
     selectedUtxos: AccountUtxo[];
     utxoSorting?: UtxoSorting;
-    activeTradingSection?: 'sell' | 'exchange';
+    trading?: FormStateTrading;
 }

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -18,6 +18,7 @@ import {
 import { RequiredKey } from '@trezor/type-utils';
 
 import { Account } from './account';
+import { FormStateTradingCryptoCurrency, FormStateTradingFiatCurrency } from './sendForm';
 
 export type { PrecomposedTransactionFinalCardano } from '@trezor/connect';
 
@@ -305,11 +306,14 @@ export type ReviewOutput =
               | 'amount'
               | 'gas'
               | 'contract'
-              | 'regular_legacy';
+              | 'regular_legacy'
+              | 'recipient_name';
           label?: string;
           value: string;
           value2?: string;
           token?: TokenInfo;
+          send?: undefined;
+          receive?: undefined;
       }
     | {
           type: 'fee-replace';
@@ -317,6 +321,8 @@ export type ReviewOutput =
           value: string;
           value2: string;
           token?: undefined;
+          send?: undefined;
+          receive?: undefined;
       }
     | {
           type: 'reduce-output';
@@ -324,6 +330,17 @@ export type ReviewOutput =
           value: string;
           value2: string;
           token?: undefined;
+          send?: undefined;
+          receive?: undefined;
+      }
+    | {
+          type: 'traded_assets';
+          value: string;
+          value2: string;
+          label?: undefined;
+          token?: undefined;
+          send: FormStateTradingCryptoCurrency;
+          receive: FormStateTradingCryptoCurrency | FormStateTradingFiatCurrency;
       };
 
 export type ReviewOutputType = ReviewOutput['type'];

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -251,6 +251,7 @@ const constructNewFlow = ({
 
     const hasBitcoinLockTime = 'bitcoinLockTime' in precomposedForm;
     const hasDestinationTag = 'destinationTag' in precomposedForm;
+    const trading = precomposedForm?.trading;
 
     if (networkType === 'stellar') {
         // stellar displays requests on device:
@@ -340,6 +341,15 @@ const constructNewFlow = ({
                     });
                 }
             }
+        });
+    } else if (trading && 'send' in trading && 'receive' in trading) {
+        outputs.push({ type: 'recipient_name', value: trading.recipientName });
+        outputs.push({
+            type: 'traded_assets',
+            value: '', // placeholder
+            value2: '', // placeholder
+            send: trading.send,
+            receive: trading.receive,
         });
     } else {
         precomposedTx.outputs.forEach(o => {


### PR DESCRIPTION
## Description
- feature is supported only when SLIP-24 is active - firmware version >=2.9.1, bitcoin-like networks, CEX Swaps and Sells
- deleted `loading="lazy"` and `onLoad` from the `AssetItem` causes blinking when the parent component is re-rendered (hotfix)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19601

## Screenshots

### Before

#### Sell
![Screenshot 2025-06-19 at 9 27 57 AM](https://github.com/user-attachments/assets/d6da12c1-8a67-4f9a-8418-c0c4e4f95165)

#### Swap
![Screenshot 2025-06-19 at 9 28 50 AM](https://github.com/user-attachments/assets/d4d2ed2c-29d2-4c7d-8bac-e2b32846f050)

### After

#### Sell
![Screenshot 2025-06-19 at 9 33 38 AM](https://github.com/user-attachments/assets/01b62401-8bcb-4ad4-a3de-14e99a2e4d91)

#### Swap
![Screenshot 2025-06-19 at 9 43 38 AM](https://github.com/user-attachments/assets/dbf49d68-8bf5-4c72-b9a4-a38c900e9a6b)




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/modal-for-slip24&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/modal-for-slip24&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/modal-for-slip24&lookback=7)