### PR TITLE
feat(trading): update amount for paymentRequest and tx preview modal

### DIFF
--- a/suite-common/trading/src/thunks/common/__tests__/createPaymentRequestsThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/createPaymentRequestsThunk.test.ts
@@ -259,6 +259,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'exchange',
                     account: mockAccount,
                     composedLevels: mockComposedTransaction,
+                    formattedMaxAmount: mockExchangeQuote.sendStringAmount,
                 }),
             );
 
@@ -281,6 +282,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'exchange',
                     account: mockAccount,
                     composedLevels: mockComposedTransaction,
+                    formattedMaxAmount: mockExchangeQuote.sendStringAmount,
                 }),
             );
 
@@ -305,6 +307,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'exchange',
                     account: mockAccount,
                     composedLevels: mockComposedTransaction,
+                    formattedMaxAmount: mockExchangeQuote.sendStringAmount,
                 }),
             );
 
@@ -331,6 +334,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'exchange',
                     account: mockAccount,
                     composedLevels: mockComposedTransaction,
+                    formattedMaxAmount: mockExchangeQuote.sendStringAmount,
                 }),
             );
 
@@ -363,6 +367,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'exchange',
                     account: mockAccount,
                     composedLevels: mockComposedTransaction,
+                    formattedMaxAmount: mockExchangeQuote.sendStringAmount,
                 }),
             );
 
@@ -413,6 +418,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'sell',
                     account: mockAccount,
                     composedLevels: mockComposedTransaction,
+                    formattedMaxAmount: mockSellQuote.cryptoStringAmount,
                 }),
             );
 
@@ -434,6 +440,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'sell',
                     account: mockAccount,
                     composedLevels: mockComposedTransaction,
+                    formattedMaxAmount: mockSellQuote.cryptoStringAmount,
                 }),
             );
 
@@ -464,6 +471,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'sell',
                     account: mockAccount,
                     composedLevels: mockComposedTransaction,
+                    formattedMaxAmount: mockSellQuote.cryptoStringAmount,
                 }),
             );
 
@@ -491,6 +499,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'exchange',
                     account: mockAccount,
                     composedLevels: invalidTransaction as any,
+                    formattedMaxAmount: mockSellQuote.cryptoStringAmount,
                 }),
             );
 
@@ -539,6 +548,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'sell',
                     account: mockAccount,
                     composedLevels: transactionWithOnlyDirectOutputs,
+                    formattedMaxAmount: mockSellQuote.cryptoStringAmount,
                 }),
             );
 
@@ -572,6 +582,7 @@ describe('createPaymentRequestsThunk', () => {
                     type: 'exchange',
                     account: mockAccount,
                     composedLevels: mockComposedTransaction,
+                    formattedMaxAmount: mockSellQuote.cryptoStringAmount,
                 }),
             );
 

--- a/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
@@ -230,7 +230,7 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { fulfillWithValue }) => fulfillWithValue(levels),
             ),
         );
@@ -266,7 +266,7 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { fulfillWithValue }) =>
                     fulfillWithValue({
                         type: 'final',
@@ -300,7 +300,7 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { rejectWithValue }) => rejectWithValue({ error: 'fee-levels-compose-failed' }),
             ),
         );
@@ -336,7 +336,7 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { fulfillWithValue }) =>
                     fulfillWithValue({
                         type: 'final',
@@ -370,7 +370,7 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { fulfillWithValue }) =>
                     fulfillWithValue({
                         type: 'nonfinal',
@@ -404,7 +404,7 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { fulfillWithValue }) =>
                     fulfillWithValue({
                         normal: {
@@ -467,12 +467,16 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { fulfillWithValue }) =>
                     fulfillWithValue({
                         normal: {
                             type: 'final',
-                            data: {},
+                            outputs: [
+                                {
+                                    amount: '10000000',
+                                },
+                            ],
                         },
                     }),
             ),
@@ -519,15 +523,25 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementation(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { fulfillWithValue }) =>
                     fulfillWithValue({
                         normal: {
                             type: 'final',
                             feeLimit: '1111',
+                            outputs: [
+                                {
+                                    amount: '10000000',
+                                },
+                            ],
                         },
                         custom: {
                             type: 'final',
+                            outputs: [
+                                {
+                                    amount: '10000000',
+                                },
+                            ],
                         },
                     }),
             ),
@@ -588,12 +602,16 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { fulfillWithValue }) =>
                     fulfillWithValue({
                         normal: {
                             type: 'final',
-                            data: {},
+                            outputs: [
+                                {
+                                    amount: '10000000',
+                                },
+                            ],
                         },
                     }),
             ),
@@ -628,6 +646,7 @@ describe('recomposeAndSignTxThunk', () => {
             composedLevels: expect.objectContaining({
                 type: 'final',
             }),
+            formattedMaxAmount: '0.1',
         });
         expect(mockSignAndPushSendFormTransaction).toHaveBeenCalledWith({
             formState: expect.any(Object),
@@ -654,12 +673,16 @@ describe('recomposeAndSignTxThunk', () => {
 
         (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
             createThunk(
-                '@common/wallet-core/send/composeSendFormTransactionThunk',
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
                 (_, { fulfillWithValue }) =>
                     fulfillWithValue({
                         normal: {
                             type: 'final',
-                            data: {},
+                            outputs: [
+                                {
+                                    amount: '10000000',
+                                },
+                            ],
                         },
                     }),
             ),

--- a/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
+++ b/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
@@ -34,6 +34,7 @@ type CreateSignatureThunkProps = {
     type: TradingTradeSellExchangeType;
     account: Account;
     composedLevels: GeneralPrecomposedTransaction;
+    formattedMaxAmount: string | undefined;
 };
 
 export const createPaymentRequestsThunk = createThunk<
@@ -45,13 +46,11 @@ export const createPaymentRequestsThunk = createThunk<
 >(
     `${TRADING_THUNK_PREFIX}/createPaymentRequests`,
     async (
-        { type, account, composedLevels },
+        { type, account, composedLevels, formattedMaxAmount },
         { dispatch, getState, fulfillWithValue, rejectWithValue },
     ) => {
         const { mac: macRefund } = await dispatch(getRefundAddress({ account })).unwrap();
         const nonce = await dispatch(getNonce()).unwrap();
-
-        // const { composed } = selectTradingComposedTransactionInfo(getState()); // TODO: slip24 - use after update fees during swaps/sells
 
         if (!('outputs' in composedLevels)) {
             return rejectWithValue({
@@ -134,7 +133,10 @@ export const createPaymentRequestsThunk = createThunk<
                 }
 
                 const paymentRequest = tradingExchangeCreatePaymentRequest({
-                    trade,
+                    trade: {
+                        ...trade,
+                        sendStringAmount: formattedMaxAmount ?? trade.sendStringAmount,
+                    },
                     provider,
                     macPurchase: verifiedAddress.mac,
                     macRefund,
@@ -199,7 +201,10 @@ export const createPaymentRequestsThunk = createThunk<
                 }
 
                 const paymentRequest = tradingSellCreatePaymentRequest({
-                    trade,
+                    trade: {
+                        ...trade,
+                        cryptoStringAmount: formattedMaxAmount ?? trade.cryptoStringAmount,
+                    },
                     provider,
                     macRefund,
                     nonce,

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -9,6 +9,7 @@ import {
     selectNetworkFeeInfo,
 } from '@suite-common/wallet-core';
 import { Account, FormOptions, FormState, FormStateTrading } from '@suite-common/wallet-types';
+import { formatAmount } from '@suite-common/wallet-utils';
 import { Success, Unsuccessful } from '@trezor/connect';
 
 import { tradingThunks } from '../';
@@ -49,6 +50,16 @@ export type RecomposeAndSignTxThunkProps = {
         paymentRequests,
     }: TradingSignAndPushSendFormTransactionProps) => Promise<FulfillValue>;
 };
+
+const getTradingFormStateAccordingRestriction = (
+    tradingFormState: FormStateTrading,
+    isPaymentRequestsAllowed: boolean,
+): FormStateTrading =>
+    isPaymentRequestsAllowed
+        ? tradingFormState
+        : {
+              activeSection: tradingFormState.activeSection,
+          };
 
 /**
  * This thunk is particularly useful for scenarios where transaction details (e.g., fees, outputs) need to be recalculated
@@ -106,6 +117,10 @@ export const recomposeAndSignTxThunk = createThunk<
             });
         }
 
+        const restrictedTradingFormState = getTradingFormStateAccordingRestriction(
+            tradingFormState,
+            isPaymentRequestsAllowed,
+        );
         // prepare the fee levels, set custom values from composed
         // WORKAROUND: sendFormEthereumActions and sendFormRippleActions use form outputs instead of composed transaction data
         const formState: FormState = {
@@ -131,11 +146,7 @@ export const recomposeAndSignTxThunk = createThunk<
             ethereumDataHex,
             ethereumAdjustGasLimit,
             selectedUtxos: [],
-            trading: isPaymentRequestsAllowed
-                ? tradingFormState
-                : {
-                      activeSection: tradingFormState.activeSection,
-                  },
+            trading: restrictedTradingFormState,
         };
 
         // prepare form state for composeAction
@@ -212,18 +223,48 @@ export const recomposeAndSignTxThunk = createThunk<
             });
         }
 
+        /*
+            SLIP-24 to achieve the consistent trade data
+            --- 
+            If the transaction is a trade of whole balance, we need to set the amount to 
+            the formState (displayed in the UI) and for the payment requests to
+            ensure that the payment requests are created with the correct amount.
+        */
+        const { decimals } = getNetwork(account.symbol);
+        const isTradedWholeBalance = precomposedToSign.outputs.length === 1; // sending whole balance
+        const sendAmount = isTradedWholeBalance
+            ? precomposedToSign.outputs[0].amount.toString()
+            : undefined;
+        const formattedMaxAmount = sendAmount ? formatAmount(sendAmount, decimals) : undefined;
+
+        const formStateUpdated: FormState = {
+            ...formState,
+            trading: {
+                ...restrictedTradingFormState,
+                ...('send' in restrictedTradingFormState
+                    ? {
+                          send: {
+                              ...restrictedTradingFormState.send,
+                              amount: formattedMaxAmount ?? restrictedTradingFormState.send.amount,
+                          },
+                      }
+                    : {}),
+            },
+        };
+
         const paymentRequests = isPaymentRequestsAllowed
             ? await dispatch(
                   tradingThunks.createPaymentRequestsThunk({
-                      type: tradingFormState.activeSection,
+                      type: restrictedTradingFormState.activeSection,
                       account,
                       composedLevels: precomposedToSign,
+                      formattedMaxAmount,
                   }),
               ).unwrap()
             : [];
 
         const resultOfSignedTransaction = await signAndPushSendFormTransaction({
-            formState,
+            formState: formStateUpdated,
             precomposedTransaction: precomposedToSign,
             selectedAccount: account,
             paymentRequests,


### PR DESCRIPTION
## Description
- update the amount for the payment requests and the tx preview modal according to outputs

### Note
Initially, there was an idea to make fees persistent during Swap and Sell operations. However, this approach runs into issues due to the variable transaction size on Bitcoin-like networks:
1. Initial fee estimation is based on the assumption that a legacy address will be used, which results in calculating the maximum possible transaction size, because we do not know the address of the provider.
2. The actual recipient address (which could be SegWit or Native SegWit) is only known after the trade is confirmed. This affects the transaction size, as SegWit addresses typically result in smaller transactions.
3. This discrepancy leads to a mismatch between the expected trade amount (calculated at the beginning) and the final payment request, particularly for SLIP-24 compliance.

There is also the possibility to pad some additional bytes to balance the bytes between the initial fees and the sending transaction fees.


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19506


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/update-trading-fees&lookback=7)