### PR TITLE
Feat: display more FW update ButtonRequests

### DIFF
--- a/packages/connect/src/api/firmware/uploadFirmware.ts
+++ b/packages/connect/src/api/firmware/uploadFirmware.ts
@@ -6,14 +6,16 @@ import { ERRORS, PROTO } from '../../constants';
 import type { Device } from '../../device/Device';
 import type { TypedCall } from '../../device/DeviceCommands';
 import { CoreEventMessage, DEVICE, UI, createUiMessage } from '../../events';
+import { FirmwareUpdateFlowType } from '../../types';
 
-// firmware does not send button message but user still must press button to continue
-// with fw update.
-const postConfirmationMessage = (device: Device) => {
-    // only if firmware is already installed. fresh device does not require button confirmation
-    if (device.features.firmware_present) {
-        device.emit(DEVICE.BUTTON, { device, payload: { code: 'ButtonRequest_FirmwareUpdate' } });
-    }
+// Each FW update flow starts with confirmation to restart into bootloader, and in some cases a confirmation for the FW
+// update itself. But device sends no ButtonRequest at that point, so create a synthethic ButtonRequest.
+const postConfirmationMessage = (device: Device, updateFlowType: FirmwareUpdateFlowType) => {
+    // Device does not require confirmation if fresh install, or if the flow is 'reboot_and_upgrade'.
+    const freshInstall = device.features.firmware_present === false;
+    if (freshInstall || updateFlowType === 'reboot_and_upgrade') return;
+
+    device.emit(DEVICE.BUTTON, { device, payload: { code: 'ButtonRequest_FirmwareUpdate' } });
 };
 
 const postProgressMessage = (
@@ -32,14 +34,23 @@ const postProgressMessage = (
 
 const FIRMWARE_ERASE_TIMEOUT_MILLISECONDS = 15_000;
 
-export const uploadFirmware = async (
-    typedCall: TypedCall,
-    postMessage: (message: CoreEventMessage) => void,
-    device: Device,
-    { payload }: PROTO.FirmwareUpload,
-) => {
+type UploadFirmwareProps = {
+    typedCall: TypedCall;
+    postMessage: (message: CoreEventMessage) => void;
+    device: Device;
+    firmwareUploadRequest: PROTO.FirmwareUpload;
+    updateFlowType: FirmwareUpdateFlowType;
+};
+
+export const uploadFirmware = async ({
+    typedCall,
+    postMessage,
+    device,
+    firmwareUploadRequest: { payload },
+    updateFlowType,
+}: UploadFirmwareProps) => {
     if (device.features.major_version === 1) {
-        postConfirmationMessage(device);
+        postConfirmationMessage(device, updateFlowType);
 
         // If FirmwareErase takes too long, it can be simply because we're waiting for the user pressing the confirm button,
         // but it may also indicate that something is wrong with the device, so inform Suite which can then display warning.
@@ -70,7 +81,7 @@ export const uploadFirmware = async (
     }
 
     if (device.features.major_version === 2) {
-        postConfirmationMessage(device);
+        postConfirmationMessage(device, updateFlowType);
         const length = payload.byteLength;
         let progress = 0;
         let response = await typedCall('FirmwareErase', ['FirmwareRequest', 'Success'], { length });

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -13,7 +13,13 @@ import { getFirmwareLocation, getReleaseByVersion } from '../data/firmwareInfo';
 import type { Device } from '../device/Device';
 import { DeviceList } from '../device/DeviceList';
 import { CoreEventMessage, UI, createUiMessage } from '../events';
-import { BinaryInfo, CommonParams, DeviceUniquePath, FirmwareType } from '../types';
+import {
+    BinaryInfo,
+    CommonParams,
+    DeviceUniquePath,
+    FirmwareType,
+    FirmwareUpdateFlowType,
+} from '../types';
 import { FirmwareUpdateResponse } from '../types/api/firmwareUpdate';
 import type { Log } from '../utils/debug';
 
@@ -165,11 +171,18 @@ const getInstallationParams = (device: Device, params: Params) => {
             device.atLeast('2.6.3') && isUpdatingToNewerVersion && isUpdatingToEqualFirmwareType;
         const manual = !device.atLeast(['1.10.0', '2.6.0']) && !upgrade;
 
+        const getUpdateFlowType = (): FirmwareUpdateFlowType => {
+            if (manual) return 'manual';
+
+            return upgrade ? 'reboot_and_upgrade' : 'reboot_and_wait';
+        };
+
         return {
             /** RebootToBootloader is not supported */
             manual,
-            /** RebootToBootloader (REBOOT_AND_UPGRADE) is supported  */
+            /** RebootToBootloader (reboot_and_upgrade) is supported  */
             upgrade,
+            updateFlowType: getUpdateFlowType(),
             btcOnly,
         };
     } else {
@@ -179,6 +192,7 @@ const getInstallationParams = (device: Device, params: Params) => {
         return {
             manual: false,
             upgrade: false,
+            updateFlowType: 'unknown_flow' as const,
             btcOnly,
         };
     }
@@ -295,10 +309,11 @@ export const onCallFirmwareUpdate = async ({
 
     registerEvents(device);
 
-    const { manual, upgrade, btcOnly } = getInstallationParams(device, params);
+    const { manual, upgrade, updateFlowType, btcOnly } = getInstallationParams(device, params);
     log.debug('onCallFirmwareUpdate', 'installation params', {
         manual,
         upgrade,
+        updateFlowType,
         btcOnly,
     });
 
@@ -425,17 +440,15 @@ export const onCallFirmwareUpdate = async ({
     // Might not be installed, but needed for calculateFirmwareHash anyway
     let stripped = stripFwHeaders(firstBinaryInfo.binary);
 
-    await uploadFirmware(
-        reconnectedDevice.getCommands().typedCall,
+    const payload =
+        !intermediary && shouldStripFwHeaders(device.features) ? stripped : firstBinaryInfo.binary;
+    await uploadFirmware({
+        typedCall: reconnectedDevice.getCommands().typedCall,
         postMessage,
-        reconnectedDevice,
-        {
-            payload:
-                !intermediary && shouldStripFwHeaders(device.features)
-                    ? stripped
-                    : firstBinaryInfo.binary,
-        },
-    );
+        device: reconnectedDevice,
+        firmwareUploadRequest: { payload },
+        updateFlowType,
+    });
 
     log.info('onCallFirmwareUpdate', 'firmware uploaded');
 
@@ -451,12 +464,13 @@ export const onCallFirmwareUpdate = async ({
         // note: fw major_version 1 requires calling initialize before calling FirmwareErase. Without it device would not respond
         await reconnectedDevice.initialize(false);
 
-        await uploadFirmware(
-            reconnectedDevice.getCommands().typedCall,
+        await uploadFirmware({
+            typedCall: reconnectedDevice.getCommands().typedCall,
             postMessage,
-            reconnectedDevice,
-            { payload: stripped },
-        );
+            device: reconnectedDevice,
+            firmwareUploadRequest: { payload: stripped },
+            updateFlowType,
+        });
     }
 
     reconnectedDevice = await waitForReconnectedDevice(

--- a/packages/connect/src/types/firmware.ts
+++ b/packages/connect/src/types/firmware.ts
@@ -31,3 +31,19 @@ export type FirmwareReleaseConfigInfo = {
     isNewer: boolean | null;
     translations?: Record<string, string>;
 };
+
+/**
+ * 'reboot_and_upgrade': after confirming reboot to bootloader, FW updates automatically.
+ *      Case: 2.x.x when upgrading FW version.
+ * 'reboot_and_wait': after confirming reboot to bootloader, device needs user confirmation before the update itself.
+ *      Case: the usual case for 1.x.x, or 2.x.x manual reinstall / downgrade / switch BTC-only.
+ * 'manual': user needs to manually reconnect device during the update flow when prompted.
+ *      Case: firmware version less than 1.10.0, 2.6.0 (corresponds to bootloader versions 1.10.0, 2.1.0).
+ * 'unknown_flow': when device starts in bootloader, the flow type cannot be reliably determined (can't tell FW version).
+ *      Case: fresh device with no FW (most usual case).
+ */
+export type FirmwareUpdateFlowType =
+    | 'reboot_and_wait'
+    | 'reboot_and_upgrade'
+    | 'manual'
+    | 'unknown_flow';

--- a/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
+++ b/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
@@ -7,7 +7,7 @@ import {
     firmwareUpdate as firmwareUpdateThunk,
     selectFirmware,
 } from '@suite-common/firmware';
-import { FirmwareStatus, TrezorDevice } from '@suite-common/suite-types';
+import { ButtonRequest, FirmwareStatus, TrezorDevice } from '@suite-common/suite-types';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { DEVICE, FirmwareType, UI } from '@trezor/connect';
 import {
@@ -56,6 +56,19 @@ export type FirmwareOperationStatus = {
     progress: number;
 };
 
+// T1 emits ButtonRequest_ProtectCall (before bootloader) and ButtonRequest_FirmwareUpdate (in bootloader to confirm the installation) in reboot_and_wait flow:
+const expectedButtonRequestsForT1: ButtonRequest[] = [
+    'ButtonRequest_ProtectCall',
+    'ButtonRequest_FirmwareUpdate',
+];
+
+// T2,T3 devices emit ButtonRequest_Other (before bootloader & also in bootloader before starting the installation)
+// and ButtonRequest_FirmwareUpdate (to confirm the installation) in reboot_and_wait and reboot_and_upgrade flows:
+const expectedButtonRequestsForT2andT3: ButtonRequest[] = [
+    'ButtonRequest_Other',
+    'ButtonRequest_FirmwareUpdate',
+];
+
 export const useFirmwareInstallation = (
     { shouldSwitchFirmwareType }: UseFirmwareInstallationParams = {
         shouldSwitchFirmwareType: false,
@@ -89,14 +102,16 @@ export const useFirmwareInstallation = (
     // and UI.FIRMWARE_RECONNECT is emitted after the device disconnects.
     const showManualReconnectPrompt = reconnectEvent?.method === 'manual';
 
+    const expectedButtonRequests =
+        originalDevice?.features?.major_version === 1
+            ? expectedButtonRequestsForT1
+            : expectedButtonRequestsForT2andT3;
+
     const showReconnectPrompt =
         // For some magic reason, the `ButtonRequest_Other` is present in FW after THP pairing;
         // This causes the UI to show the reconnect prompt, despite we are already done.
         firmware.status !== 'done' &&
-        // T1 emits ButtonRequest_ProtectCall in reboot_and_wait flow,
-        // T2 devices emit ButtonRequest_Other in reboot_and_wait and reboot_and_upgrade flows:
-        ((buttonEvent?.code &&
-            ['ButtonRequest_ProtectCall', 'ButtonRequest_Other'].includes(buttonEvent.code)) ||
+        ((buttonEvent?.code && expectedButtonRequests.includes(buttonEvent.code)) ||
             showManualReconnectPrompt);
 
     const deviceWillBeWiped = determineIfDeviceWillBeWiped(


### PR DESCRIPTION
## Description

- ~deviceReducer: add mechanism to assign ButtonRequests to a bootloader device, as currently they are all dropped~
  - already done by @martykan in e620c4c0 :heavy_check_mark: 
- Suite UI: during FW installation in `reboot_and_wait` flow , display "Confirm on device" prompt when `ButtonRequest_FirmwareUpdate` comes up in bootloader
- Connect: fix erroneously emitting `ButtonRequest_FirmwareUpdate` in `reboot_and_upgrade` flow 
  - while I was doing that, I properly documented the flows in Connect, make it as descriptive as possible

## Related Issue

Resolve #19669

## Screenshots:

In order to see the screen alongside Suite, I recorded videos with my phone in hand :upside_down_face: :clown_face:  
_Google drive links, access SL only_

[T2T1 fresh](https://drive.google.com/file/d/1p0nsajeQqLmj_zJJDKnHbTYgiJRJeHe-/view?usp=drive_link)
[T2T1 reboot_and_wait](https://drive.google.com/file/d/1_FUwVwSCO4iCgGGKKs7J9E8dhWtjEGhV/view?usp=drive_link) _(note: switch to BTC-only is also this flow, and behaves the same)_
[T2T1 reboot_and_upgrade](https://drive.google.com/file/d/1LYS1J8iMsNwg1IlqfJuO2T3Xz66pbsip/view?usp=drive_link)

[T1B1 fresh](https://drive.google.com/file/d/1Epe3nM8saq10MAmIXaFk3JJLq1dM2IWY/view?usp=drive_link)
[T1B1 reboot_and_wait upgrade](https://drive.google.com/file/d/1b3Emwc4vh0-as3Dl4sDY-aRmofyH06ll/view?usp=drive_link)
[T1B1 reboot_and_wait reinstall](https://drive.google.com/file/d/1AEajs6Bve5xOeMnrzGtvpj1skQz5UrEZ/view?usp=drive_link)

I retested all of these at 14.8.2025 :heavy_check_mark: 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/handle-more-T1B1-fw-ui-actions&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/handle-more-T1B1-fw-ui-actions&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/handle-more-T1B1-fw-ui-actions&lookback=7)