### PR TITLE
feat(suite-native): add kyc warning to buy

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -1816,6 +1816,8 @@ export const en = {
                 sell: 'Sell',
                 exchange: 'Swap',
             },
+            kycWarning: 'This provider requires to know your identity.',
+            warning: 'Warning',
         },
         selectFiat: {
             title: 'You pay',

--- a/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
@@ -110,6 +110,9 @@ export const BuyProviderPicker = () => {
                 onPress={handleProviderPress}
                 testID={PROVIDER_PICKER_TEST_ID}
                 noCaret={isLoading}
+                warning={
+                    isLoading ? undefined : translate('moduleTrading.tradingScreen.kycWarning')
+                }
             >
                 <BuyProviderPickerRight
                     isLoading={isLoading}

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.comp.test.tsx
@@ -95,6 +95,20 @@ describe('BuyProviderPicker', () => {
             expect(getByText('Mercuryo')).toBeOnTheScreen();
         });
 
+        it('should display kyc warning when not loading', async () => {
+            const { getByText } = await renderTradingProviderPicker(preloadedState);
+
+            expect(getByText('This provider requires to know your identity.')).toBeOnTheScreen();
+        });
+
+        it('should not display kyc warning when loading', async () => {
+            preloadedState!.wallet!.tradingNew!.buy!.isLoading = true;
+            const { queryByText } = await renderTradingProviderPicker(preloadedState);
+            expect(
+                queryByText('This provider requires to know your identity.'),
+            ).not.toBeOnTheScreen();
+        });
+
         describe('analytics', () => {
             const analyticsSpy = jest.spyOn(analytics, 'report');
 

--- a/suite-native/module-trading/src/components/general/OverviewRow.tsx
+++ b/suite-native/module-trading/src/components/general/OverviewRow.tsx
@@ -1,8 +1,9 @@
 import { ReactNode } from 'react';
 import { Pressable } from 'react-native';
 
-import { Box, HStack, Text } from '@suite-native/atoms';
+import { Box, HStack, InlineAlertBox, Text, VStack } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
+import { useTranslate } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 export type TradeOverviewOptionProps = {
@@ -12,6 +13,7 @@ export type TradeOverviewOptionProps = {
     noBottomBorder?: boolean;
     noCaret?: boolean;
     testID?: string;
+    warning?: string;
 };
 
 const pressableStyle = prepareNativeStyle<{ noBottomBorder: boolean }>(
@@ -35,8 +37,10 @@ export const OverviewRow = ({
     noBottomBorder = false,
     noCaret = false,
     testID,
+    warning,
 }: TradeOverviewOptionProps) => {
     const { applyStyle } = useNativeStyles();
+    const { translate } = useTranslate();
 
     return (
         <Pressable
@@ -47,23 +51,34 @@ export const OverviewRow = ({
             style={applyStyle(pressableStyle, { noBottomBorder })}
             testID={testID}
         >
-            <HStack paddingHorizontal="sp12" justifyContent="space-between">
-                <Box paddingVertical="sp20" paddingHorizontal="sp8" flex={0}>
-                    <Text color="textDefault" variant="body">
-                        {title}
-                    </Text>
-                </Box>
-                <HStack flex={1} justifyContent="flex-end" alignItems="center">
-                    <Box flex={1} justifyContent="flex-end" alignItems="flex-end">
-                        {children}
+            <VStack spacing={0}>
+                <HStack paddingHorizontal="sp12" justifyContent="space-between">
+                    <Box paddingVertical="sp20" paddingHorizontal="sp8" flex={0}>
+                        <Text color="textDefault" variant="body">
+                            {title}
+                        </Text>
                     </Box>
-                    {!noCaret && (
-                        <Box flex={0}>
-                            <Icon name="caretDown" size="medium" color="textSubdued" />
+                    <HStack flex={1} justifyContent="flex-end" alignItems="center">
+                        <Box flex={1} justifyContent="flex-end" alignItems="flex-end">
+                            {children}
                         </Box>
-                    )}
+                        {!noCaret && (
+                            <Box flex={0}>
+                                <Icon name="caretDown" size="medium" color="textSubdued" />
+                            </Box>
+                        )}
+                    </HStack>
                 </HStack>
-            </HStack>
+                {warning && (
+                    <Box paddingHorizontal="sp16" paddingBottom="sp12">
+                        <InlineAlertBox
+                            variant="warning"
+                            title={warning}
+                            accessibilityHint={translate('moduleTrading.tradingScreen.warning')}
+                        />
+                    </Box>
+                )}
+            </VStack>
         </Pressable>
     );
 };

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.tsx
@@ -5,6 +5,7 @@ import { Card, HStack, Radio, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
+import { isBuyTrade } from '../../../utils/general/utils';
 import { ProviderLogo } from '../ProviderLogo';
 import { InfoLineItem } from './InfoLineItem';
 import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
@@ -50,6 +51,8 @@ export const ProviderListItem = <T extends TradingTradeType>({
 
         isAnonymous = kycPolicy === 'noKYC' || isDex;
         requiresKyc = ['KYC-required', 'KYC-norefund', 'KYC-yesrefund'].includes(kycPolicy);
+    } else if (isBuyTrade(quote)) {
+        requiresKyc = true;
     }
 
     return (

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.comp.test.tsx
@@ -101,4 +101,18 @@ describe('ProviderListItem', () => {
 
         expect(queryByText('TestProvider')).toBeNull();
     });
+
+    it('should render KYC warning for buy quote', async () => {
+        const preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
+        const quote = preloadedState.wallet.tradingNew.buy.quotes[0];
+
+        const { queryByText } = await renderProviderListItem(quote, preloadedState, {
+            provider: {
+                companyName: 'TestProvider',
+                logo: '',
+            } as TradingProviderInfo,
+        });
+
+        expect(queryByText('This provider requires to verify identity.')).toBeTruthy();
+    });
 });

--- a/suite-native/module-trading/src/components/general/__tests__/OverviewRow.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/OverviewRow.comp.test.tsx
@@ -27,4 +27,24 @@ describe('OverviewRow', () => {
 
         expect(onPress).toHaveBeenCalledWith();
     });
+
+    it('should render warning when added', () => {
+        const { queryByHintText } = renderWithBasicProvider(
+            <OverviewRow title="Title" warning="Warning message">
+                <Text>Child</Text>
+            </OverviewRow>,
+        );
+
+        expect(queryByHintText('Warning')).toHaveTextContent(/^.Warning message$/);
+    });
+
+    it('should not render warning when not added', () => {
+        const { queryByHintText } = renderWithBasicProvider(
+            <OverviewRow title="Title">
+                <Text>Child</Text>
+            </OverviewRow>,
+        );
+
+        expect(queryByHintText('Warning')).not.toBeOnTheScreen();
+    });
 });


### PR DESCRIPTION
- enable to add warning to OverviewRow and add kyc warning to buy provider row
- add kyc warning to buy providers list
- prerequisity for #19531

## Screenshots:


https://github.com/user-attachments/assets/b7983d26-307d-4e3c-9b89-1f9ef03123ad

also adding to provider list for buy:
<img width=300 src="https://github.com/user-attachments/assets/f45763c2-992f-4a7c-a09f-993fb2959ec8" />




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19531-mobile-swap-add-kyc-warning-to-provider-row&lookback=7)