### PR TITLE
fix(suite): get rid of repeated passphrase requests for saved devices

### DIFF
--- a/packages/suite/src/actions/settings/__tests__/deviceSettingsActions.test.ts
+++ b/packages/suite/src/actions/settings/__tests__/deviceSettingsActions.test.ts
@@ -52,7 +52,8 @@ describe('DeviceSettings Actions', () => {
             // this action have influence on reducers and forget device process
             const mock = () => {
                 if (f.deviceChange) {
-                    store.dispatch(deviceActions.deviceChanged(f.deviceChange));
+                    // @ts-expect-error
+                    store.dispatch(deviceActions.deviceChanged({ device: f.deviceChange }));
                     store.dispatch(deviceActions.updateSelectedDevice(f.deviceChange));
                 }
 

--- a/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
@@ -521,15 +521,17 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
         actions: [
             {
                 type: DEVICE.CHANGED,
-                payload: getConnectDevice(
-                    {
-                        path: '1',
-                        status: 'occupied',
-                    },
-                    {
-                        device_id: 'different-device-id',
-                    },
-                ),
+                payload: {
+                    device: getConnectDevice(
+                        {
+                            path: '1',
+                            status: 'occupied',
+                        },
+                        {
+                            device_id: 'different-device-id',
+                        },
+                    ),
+                },
             },
         ],
         result: [
@@ -547,10 +549,12 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
         actions: [
             {
                 type: DEVICE.CHANGED,
-                payload: getConnectDevice({
-                    type: 'unacquired',
-                    path: '1',
-                }),
+                payload: {
+                    device: getConnectDevice({
+                        type: 'unacquired',
+                        path: '1',
+                    }),
+                },
             },
         ],
         result: [],
@@ -568,9 +572,11 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
         actions: [
             {
                 type: DEVICE.CHANGED,
-                payload: getConnectDevice({
-                    status: 'occupied',
-                }),
+                payload: {
+                    device: getConnectDevice({
+                        status: 'occupied',
+                    }),
+                },
             },
         ],
         result: [
@@ -594,14 +600,16 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
         actions: [
             {
                 type: DEVICE.CHANGED,
-                payload: getConnectDevice(
-                    {
-                        status: 'occupied',
-                    },
-                    {
-                        passphrase_protection: true,
-                    },
-                ),
+                payload: {
+                    device: getConnectDevice(
+                        {
+                            status: 'occupied',
+                        },
+                        {
+                            passphrase_protection: true,
+                        },
+                    ),
+                },
             },
         ],
         result: [
@@ -619,7 +627,9 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
         actions: [
             {
                 type: DEVICE.CHANGED,
-                payload: CONNECT_DEVICE,
+                payload: {
+                    device: CONNECT_DEVICE,
+                },
             },
         ],
         result: [],
@@ -639,10 +649,12 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
         actions: [
             {
                 type: DEVICE.CHANGED,
-                payload: getConnectDevice(undefined, {
-                    unlocked: false,
-                    safety_checks: null,
-                }),
+                payload: {
+                    device: getConnectDevice(undefined, {
+                        unlocked: false,
+                        safety_checks: null,
+                    }),
+                },
             },
         ],
         result: [

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -3,9 +3,9 @@ import { TrezorDevice } from '@suite-common/suite-types';
 import {
     deviceActions,
     deviceConnectThunks,
+    selectDeviceByStaticSessionId,
     selectDevices,
     selectEnabledNetworks,
-    selectHasRunningDiscovery,
     selectIsPendingTransportEvent,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
@@ -63,12 +63,17 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
                 // this is not nice - during passphrase/discovery refactor, I made a decision that we are not going to update device.state in reducer
                 // in any other case than as a result of device authorization (passphrase+discovery). But later we realized that we need to update device.state.sessionId
                 // for saved devices too https://github.com/trezor/trezor-suite/issues/19411 so I am adding this as a quick fix that should work until we come up with a better solution.
-                const isDiscoveryInProgress = selectHasRunningDiscovery(getState());
+                const staticSessionId = eventData.payload?.state;
+                const device = staticSessionId
+                    ? selectDeviceByStaticSessionId(getState(), staticSessionId)
+                    : undefined;
+                const shouldUpdateState = !!device && device.remember && !device.useEmptyPassphrase;
+
                 dispatch({
                     type: eventData.type,
                     payload: {
                         device: eventData.payload,
-                        shouldUpdateState: !isDiscoveryInProgress,
+                        shouldUpdateState,
                     },
                 });
             }

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -5,6 +5,7 @@ import {
     deviceConnectThunks,
     selectDevices,
     selectEnabledNetworks,
+    selectHasRunningDiscovery,
     selectIsPendingTransportEvent,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
@@ -58,8 +59,21 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
                 if (connectInitHooks && eventData.type in connectInitHooks) {
                     connectInitHooks[eventData.type]?.(eventData.payload, connectedDevices);
                 }
-            } else {
-                // dispatch event as action
+            } else if (eventData.type === DEVICE.CHANGED) {
+                // this is not nice - during passphrase/discovery refactor, I made a decision that we are not going to update device.state in reducer
+                // in any other case than as a result of device authorization (passphrase+discovery). But later we realized that we need to update device.state.sessionId
+                // for saved devices too https://github.com/trezor/trezor-suite/issues/19411 so I am adding this as a quick fix that should work until we come up with a better solution.
+                const isDiscoveryInProgress = selectHasRunningDiscovery(getState());
+                dispatch({
+                    type: eventData.type,
+                    payload: {
+                        device: eventData.payload,
+                        shouldUpdateState: !isDiscoveryInProgress,
+                    },
+                });
+            }
+            // dispatch event as action
+            else {
                 dispatch({ type: eventData.type, payload: eventData.payload });
             }
         });

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -26,9 +26,12 @@ const connectUnacquiredDevice = createAction(
     (payload: DeviceConnectActionPayload) => ({ payload }),
 );
 
-const deviceChanged = createAction(DEVICE.CHANGED, (payload: Device | TrezorDevice) => ({
-    payload,
-}));
+const deviceChanged = createAction(
+    DEVICE.CHANGED,
+    (payload: { device: Device; shouldUpdateState?: boolean }) => ({
+        payload,
+    }),
+);
 
 const setDeviceState = createAction(
     `${DEVICE_MODULE_PREFIX}/set-device-state`,

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -233,15 +233,18 @@ const addAuthorizedDevice = (draft: DeviceReducerState, device: TrezorDevice) =>
 const changeDevice = (
     draft: DeviceReducerState,
     device: Device | TrezorDevice,
-    extended?: Partial<AcquiredDevice>,
+    extended: Partial<AcquiredDevice>,
+    shouldUpdateState = false,
 ) => {
     // change only acquired devices
     if (!device.features) return;
 
-    // ignore device state updates. we set device state explicitly using addAuthorizedDevice or setDeviceState
-    delete device.state;
-    // @ts-expect-error - connect feeds this but we don't work with it
-    delete device._state;
+    if (!shouldUpdateState) {
+        // ignore device state updates. we set device state explicitly using addAuthorizedDevice or setDeviceState
+        delete device.state;
+        // @ts-expect-error - connect feeds this but we don't work with it
+        delete device._state;
+    }
 
     // find devices with the same "device_id"
     const affectedDevices = draft.devices.filter(
@@ -592,7 +595,8 @@ export const setDeviceAuthenticity = (
 export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (builder, extra) => {
     builder
         .addCase(deviceActions.deviceChanged, (state, { payload }) => {
-            changeDevice(state, payload, { connected: true, available: true });
+            const { device, shouldUpdateState } = payload;
+            changeDevice(state, device, { connected: true, available: true }, shouldUpdateState);
         })
         .addCase(deviceActions.setDeviceState, (state, { payload }) => {
             setDeviceState(state, payload.device, payload.state, payload.useEmptyPassphrase);


### PR DESCRIPTION


## Description

What about - as an ugly hotfix - updating state on every device change if the device is remembered and using passphrase? 

It seems to work fine on mobile. Don't know if extra device state change can break something 🤔 


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/discovery-nitpicks-12-hotfix&lookback=7)