### PR TITLE
chore(suite-desktop-core): more info for buy-post error in http-receiver

### DIFF
--- a/packages/suite-desktop-core/src/libs/http-receiver.ts
+++ b/packages/suite-desktop-core/src/libs/http-receiver.ts
@@ -146,7 +146,7 @@ export const createHttpReceiver = () => {
             } catch (error) {
                 const template = applyTemplate('Error');
                 response.end(template);
-                throw new Error(`Could not handle buy post request: ${error}`);
+                throw new Error(`Could not handle buy post request at ${request.url} : ${error}`);
             }
         },
     ]);


### PR DESCRIPTION
## Description

Provide more debug info – what was the url that crashed validation?

## Related issue

Related to #19672 but it only provide more context, the issue is that buy form allows some invalid URLs.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/buy-post-http-receiver-error-debug&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/buy-post-http-receiver-error-debug&lookback=7)