### PR TITLE
fix(ipc-proxy): IPC response handling when rendered was destroyed

### DIFF
--- a/packages/ipc-proxy/src/proxy-handler.ts
+++ b/packages/ipc-proxy/src/proxy-handler.ts
@@ -102,6 +102,12 @@ export const createIpcProxyHandler = <Api extends EventEmitterApi>(
                     debug?.info(SERVICE_NAME, `Adding listener ${realEventName}`);
                     onAddListener(realEventName, (...payload: any[]) => {
                         debug?.info(SERVICE_NAME, `Emit ${realEventName} as ${ipcEventName}`);
+
+                        // prevents 'Render frame was disposed before WebFrameMain could be accessed', occurring when renderer process is closed during responding
+                        // https://github.com/electron/electron/blob/3536d49/docs/api/structures/ipc-main-event.md
+                        // https://github.com/electron/electron/blob/3536d49/docs/breaking-changes.md#behavior-changed-frame-properties-may-retrieve-detached-webframemain-instances-or-none-at-all
+                        if (ipcEvent.senderFrame === null) return;
+
                         reply(ipcEventName, payload);
                     });
                 },


### PR DESCRIPTION
https://github.com/electron/electron/blob/3536d49/docs/api/structures/ipc-main-event.md
https://github.com/electron/electron/blob/3536d49/docs/breaking-changes.md#behavior-changed-frame-properties-may-retrieve-detached-webframemain-instances-or-none-at-all

## Related Issue

Resolve #19670

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ipc-when-rendered-destroyed&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ipc-when-rendered-destroyed&lookback=7)