### PR TITLE
chore: update idb version and changelog

### DIFF
--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Storage changelog
 
+## 57 (25.7.0)
+
+- introduce new object store `bioAuth`
+
 ## 56 (25.6.1)
 
 - renamed from _coinmarketTrades_ to _tradingTrades_

--- a/packages/suite/src/storage/index.ts
+++ b/packages/suite/src/storage/index.ts
@@ -5,7 +5,7 @@ import { reloadApp } from 'src/utils/suite/reload';
 import type { SuiteDBSchema } from './definitions';
 import { migrate } from './migrations';
 
-const VERSION = 58; // don't forget to add migration and CHANGELOG when changing versions!
+const VERSION = 57; // don't forget to add migration and CHANGELOG when changing versions!
 
 /**
  *  If the object stores don't already exist then creates them.

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -1288,7 +1288,7 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
         db.deleteObjectStore('discovery');
     }
 
-    if (oldVersion < 58) {
+    if (oldVersion < 57) {
         db.createObjectStore('bioAuth');
     }
 };


### PR DESCRIPTION
## Description

- Change IDB version `58` to `57` as it was skipped
- Include `v57 (25.7.0)` info in IDB changelog

## Related Issue

Resolve [#19645](https://github.com/trezor/trezor-suite/issues/19645)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/update-db-version&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/update-db-version&lookback=7)