### PR TITLE
fix(suite-native): submit coin enabling changes on button or leaving the screen

### DIFF
--- a/suite-native/coin-enabling/package.json
+++ b/suite-native/coin-enabling/package.json
@@ -10,7 +10,6 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@mobily/ts-belt": "^3.13.1",
         "@react-navigation/native": "6.1.18",
         "@reduxjs/toolkit": "2.8.2",
         "@suite-common/wallet-config": "workspace:*",

--- a/suite-native/coin-enabling/src/coinEnablingSchema.ts
+++ b/suite-native/coin-enabling/src/coinEnablingSchema.ts
@@ -1,0 +1,10 @@
+import { yup } from '@suite-common/validators';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+
+export type CoinEnablingFormValues = {
+    enabledCoins: NetworkSymbol[];
+};
+
+export const coinEnablingFormValidationSchema = yup.object({
+    enabledCoins: yup.array().of(yup.string().required()).min(1),
+});

--- a/suite-native/coin-enabling/src/components/CoinEnablingForm.tsx
+++ b/suite-native/coin-enabling/src/components/CoinEnablingForm.tsx
@@ -1,0 +1,86 @@
+import { useCallback, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { changeCoinVisibility } from '@suite-common/wallet-core';
+import { useAlert } from '@suite-native/alerts';
+import { EventType, analytics } from '@suite-native/analytics';
+import {
+    selectDeviceEnabledDiscoveryNetworkSymbols,
+    selectDiscoveryNetworkSymbols,
+} from '@suite-native/discovery';
+import { Form, useForm } from '@suite-native/forms';
+import { Translation } from '@suite-native/intl';
+
+import { DiscoveryCoinsFilter } from './DiscoveryCoinsFilter';
+import { CoinEnablingFormValues, coinEnablingFormValidationSchema } from '../coinEnablingSchema';
+
+export const CoinEnablingForm = () => {
+    const dispatch = useDispatch();
+    const navigation = useNavigation();
+
+    const enabledNetworkSymbols = useSelector(selectDeviceEnabledDiscoveryNetworkSymbols);
+    const networkSymbols = useSelector(selectDiscoveryNetworkSymbols);
+
+    const { showAlert } = useAlert();
+
+    const showLastNetworkAlert = useCallback(
+        () =>
+            showAlert({
+                title: <Translation id="moduleSettings.coinEnabling.oneNetworkSymbolAlert.title" />,
+                description: (
+                    <Translation id="moduleSettings.coinEnabling.oneNetworkSymbolAlert.description" />
+                ),
+                primaryButtonTitle: <Translation id="generic.buttons.gotIt" />,
+                primaryButtonVariant: 'redBold',
+            }),
+        [showAlert],
+    );
+
+    const form = useForm<CoinEnablingFormValues>({
+        defaultValues: {
+            enabledCoins: enabledNetworkSymbols,
+        },
+        validation: coinEnablingFormValidationSchema,
+    });
+
+    const handleSubmit = form.handleSubmit(values => {
+        const changedCoins = networkSymbols.filter(
+            symbol =>
+                enabledNetworkSymbols.includes(symbol) !== values.enabledCoins.includes(symbol),
+        );
+
+        if (changedCoins.length === 0) return;
+
+        changedCoins.forEach(symbol => {
+            const isEnabled = values.enabledCoins.includes(symbol);
+            dispatch(changeCoinVisibility({ symbol, shouldBeVisible: isEnabled }));
+
+            analytics.report({
+                type: EventType.SettingsChangeCoinEnabled,
+                payload: {
+                    symbol,
+                    value: isEnabled,
+                },
+            });
+        });
+    });
+
+    useEffect(
+        () =>
+            navigation.addListener('beforeRemove', () => {
+                handleSubmit();
+            }),
+        [navigation, handleSubmit],
+    );
+
+    return (
+        <Form form={form}>
+            <DiscoveryCoinsFilter
+                networkSymbols={networkSymbols}
+                onDisablingLastCoin={showLastNetworkAlert}
+            />
+        </Form>
+    );
+};

--- a/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
+++ b/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
@@ -1,38 +1,70 @@
 import { useSelector } from 'react-redux';
 
+import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { selectIsDeviceConnected } from '@suite-common/wallet-core';
 import { Text, VStack } from '@suite-native/atoms';
-import {
-    selectDeviceEnabledDiscoveryNetworkSymbols,
-    selectDiscoverySupportedNetworks,
-} from '@suite-native/discovery';
+import { useFormContext } from '@suite-native/forms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
+import { useToast } from '@suite-native/toasts';
 
 import { NetworkSymbolSwitchItem } from './NetworkSymbolSwitchItem';
 
 type DiscoveryCoinsFilterProps = {
-    allowDeselectLastCoin?: boolean; // If true, the last coin can be deselected
-    allowChangeAnalytics?: boolean; // If true, analytics will be sent
+    networkSymbols: NetworkSymbol[];
+    onDisablingLastCoin?: () => void;
 };
 
 export const DiscoveryCoinsFilter = ({
-    allowDeselectLastCoin = false,
-    allowChangeAnalytics = true,
+    networkSymbols,
+    onDisablingLastCoin,
 }: DiscoveryCoinsFilterProps) => {
-    const enabledNetworkSymbols = useSelector(selectDeviceEnabledDiscoveryNetworkSymbols);
-    const availableNetworks = useSelector(selectDiscoverySupportedNetworks);
+    const isDeviceConnected = useSelector(selectIsDeviceConnected);
+    const { showToast } = useToast();
 
-    const uniqueNetworkSymbols = [...new Set(availableNetworks.map(n => n.symbol))];
+    const { setValue, watch } = useFormContext();
+    const enabledSymbols: NetworkSymbol[] = watch('enabledCoins');
+
+    const handleToggle = (symbol: NetworkSymbol, isEnabled: boolean) => {
+        if (
+            !isEnabled &&
+            onDisablingLastCoin &&
+            enabledSymbols.length === 1 &&
+            enabledSymbols.includes(symbol)
+        ) {
+            onDisablingLastCoin();
+
+            return;
+        }
+
+        if (!isDeviceConnected && isEnabled) {
+            const { name } = getNetwork(symbol);
+            showToast({
+                variant: 'default',
+                message: (
+                    <Translation
+                        id="moduleSettings.coinEnabling.toasts.coinEnabled"
+                        values={{ coin: name }}
+                    />
+                ),
+            });
+        }
+
+        const newEnabledSymbols = isEnabled
+            ? [...enabledSymbols, symbol]
+            : enabledSymbols.filter(s => s !== symbol);
+
+        setValue('enabledCoins', newEnabledSymbols, { shouldDirty: true, shouldValidate: true });
+    };
 
     return (
         <VStack spacing="sp12">
-            {uniqueNetworkSymbols.map(symbol => (
+            {networkSymbols.map(symbol => (
                 <NetworkSymbolSwitchItem
                     key={symbol}
                     symbol={symbol}
-                    isEnabled={enabledNetworkSymbols.includes(symbol)}
-                    allowDeselectLastCoin={allowDeselectLastCoin}
-                    allowChangeAnalytics={allowChangeAnalytics}
+                    isEnabled={enabledSymbols?.includes(symbol)}
+                    onToggle={isEnabled => handleToggle(symbol, isEnabled)}
                 />
             ))}
             <VStack paddingVertical="sp8" alignItems="center">

--- a/suite-native/coin-enabling/src/components/NetworkSymbolSwitchItem.tsx
+++ b/suite-native/coin-enabling/src/components/NetworkSymbolSwitchItem.tsx
@@ -1,23 +1,16 @@
 import { TouchableOpacity, View } from 'react-native';
-import { useDispatch, useSelector } from 'react-redux';
 
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
-import { changeCoinVisibility, selectIsDeviceConnected } from '@suite-common/wallet-core';
-import { useAlert } from '@suite-native/alerts';
-import { EventType, analytics } from '@suite-native/analytics';
 import { Card, HStack, Switch, Text, VStack } from '@suite-native/atoms';
-import { selectDeviceEnabledDiscoveryNetworkSymbols } from '@suite-native/discovery';
 import { CryptoIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import { useToast } from '@suite-native/toasts';
 import { isCoinWithTokens } from '@suite-native/tokens';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type NetworkSymbolSwitchItemProps = {
     symbol: NetworkSymbol;
     isEnabled: boolean;
-    allowDeselectLastCoin: boolean;
-    allowChangeAnalytics?: boolean;
+    onToggle: (isEnabled: boolean) => void;
 };
 
 const cardStyle = prepareNativeStyle<{ isEnabled: boolean }>((utils, { isEnabled }) => ({
@@ -49,72 +42,15 @@ const iconWrapperStyle = prepareNativeStyle(utils => ({
 export const NetworkSymbolSwitchItem = ({
     symbol,
     isEnabled,
-    allowDeselectLastCoin,
-    allowChangeAnalytics,
+    onToggle,
 }: NetworkSymbolSwitchItemProps) => {
-    const dispatch = useDispatch();
-    const isDeviceConnected = useSelector(selectIsDeviceConnected);
-    const enabledNetworkSymbols = useSelector(selectDeviceEnabledDiscoveryNetworkSymbols);
     const { applyStyle } = useNativeStyles();
-    const { showToast } = useToast();
-    const { showAlert } = useAlert();
     const { name } = getNetwork(symbol);
-
-    const showOneNetworkSymbolAlert = () =>
-        showAlert({
-            title: <Translation id="moduleSettings.coinEnabling.oneNetworkSymbolAlert.title" />,
-            description: (
-                <Translation id="moduleSettings.coinEnabling.oneNetworkSymbolAlert.description" />
-            ),
-            primaryButtonTitle: <Translation id="generic.buttons.gotIt" />,
-            primaryButtonVariant: 'redBold',
-        });
-
-    const handleEnabledChange = (isChecked: boolean) => {
-        if (
-            !isChecked &&
-            !allowDeselectLastCoin &&
-            enabledNetworkSymbols.length === 1 &&
-            enabledNetworkSymbols.includes(symbol)
-        ) {
-            showOneNetworkSymbolAlert();
-
-            return;
-        }
-
-        if (!isDeviceConnected) {
-            showToast({
-                variant: 'default',
-                message: isChecked ? (
-                    <Translation
-                        id="moduleSettings.coinEnabling.toasts.coinEnabled"
-                        values={{ coin: name }}
-                    />
-                ) : (
-                    <Translation
-                        id="moduleSettings.coinEnabling.toasts.coinDisabled"
-                        values={{ coin: name }}
-                    />
-                ),
-            });
-        }
-        dispatch(changeCoinVisibility({ symbol, shouldBeVisible: isChecked }));
-
-        if (allowChangeAnalytics) {
-            analytics.report({
-                type: EventType.SettingsChangeCoinEnabled,
-                payload: {
-                    symbol,
-                    value: isChecked,
-                },
-            });
-        }
-    };
 
     return (
         <Card style={applyStyle(cardStyle, { isEnabled })}>
             <TouchableOpacity
-                onPress={_ => handleEnabledChange(!isEnabled)}
+                onPress={() => onToggle(!isEnabled)}
                 accessibilityRole="togglebutton"
                 activeOpacity={0.6}
                 testID={`@coin-enabling/toggle-${symbol}`}
@@ -138,7 +74,7 @@ export const NetworkSymbolSwitchItem = ({
                             )}
                         </VStack>
 
-                        <Switch onChange={handleEnabledChange} isChecked={isEnabled} />
+                        <Switch onChange={onToggle} isChecked={isEnabled} />
                     </HStack>
                 </HStack>
             </TouchableOpacity>

--- a/suite-native/coin-enabling/src/index.ts
+++ b/suite-native/coin-enabling/src/index.ts
@@ -1,3 +1,4 @@
-export * from './components/DiscoveryCoinsFilter';
 export * from './components/BtcOnlyCoinEnablingContent';
+export * from './components/CoinEnablingForm';
+export * from './components/DiscoveryCoinsFilter';
 export * from './screens/CoinEnablingInitScreen';

--- a/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
+++ b/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
@@ -1,12 +1,13 @@
 import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { A } from '@mobily/ts-belt';
 import { useNavigation } from '@react-navigation/native';
 
+import { changeCoinVisibility } from '@suite-common/wallet-core';
 import { EventType, analytics } from '@suite-native/analytics';
 import { Box, Button, Text, VStack } from '@suite-native/atoms';
-import { selectDeviceEnabledDiscoveryNetworkSymbols } from '@suite-native/discovery';
+import { selectDiscoveryNetworkSymbols } from '@suite-native/discovery';
+import { Form, useForm } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 import {
     AppTabsRoutes,
@@ -20,6 +21,7 @@ import {
 } from '@suite-native/navigation';
 import { setIsCoinEnablingInitFinished } from '@suite-native/settings';
 
+import { CoinEnablingFormValues, coinEnablingFormValidationSchema } from '../coinEnablingSchema';
 import { DiscoveryCoinsFilter } from '../components/DiscoveryCoinsFilter';
 
 type NavigationProps = StackNavigationProps<RootStackParamList, RootStackRoutes.CoinEnablingInit>;
@@ -29,28 +31,37 @@ export const CoinEnablingInitScreen = () => {
     const navigation = useNavigation<NavigationProps>();
     useHandleHardwareBackNavigation();
 
-    const enabledNetworkSymbols = useSelector(selectDeviceEnabledDiscoveryNetworkSymbols);
+    const networkSymbols = useSelector(selectDiscoveryNetworkSymbols);
 
-    const handleSave = () => {
+    const form = useForm<CoinEnablingFormValues>({
+        defaultValues: {
+            enabledCoins: [],
+        },
+        validation: coinEnablingFormValidationSchema,
+    });
+    const {
+        formState: { isValid },
+    } = form;
+
+    const handleSubmit = form.handleSubmit(values => {
+        values.enabledCoins.forEach(symbol => {
+            dispatch(changeCoinVisibility({ symbol, shouldBeVisible: true }));
+        });
+
         dispatch(setIsCoinEnablingInitFinished(true));
-        if (enabledNetworkSymbols.length > 0) {
-            analytics.report({
-                type: EventType.CoinEnablingInitState,
-                payload: { enabledNetworks: enabledNetworkSymbols },
-            });
 
-            // TODO: COSMETIC IMPROVEMENT: redirect to home after 2.5 seconds timeout so user can see some assets already there.
-            // until then change button state to `loading`.
-            navigation.navigate(RootStackRoutes.AppTabs, {
-                screen: AppTabsRoutes.HomeStack,
-                params: {
-                    screen: HomeStackRoutes.Home,
-                },
-            });
-        }
-    };
+        analytics.report({
+            type: EventType.CoinEnablingInitState,
+            payload: { enabledNetworks: values.enabledCoins },
+        });
 
-    const canBeSaved = A.isNotEmpty(enabledNetworkSymbols);
+        navigation.navigate(RootStackRoutes.AppTabs, {
+            screen: AppTabsRoutes.HomeStack,
+            params: {
+                screen: HomeStackRoutes.Home,
+            },
+        });
+    });
 
     return (
         <Screen
@@ -65,11 +76,11 @@ export const CoinEnablingInitScreen = () => {
                 </VStack>
             }
             footer={
-                canBeSaved && (
+                isValid && (
                     <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
                         <ScreenFooterGradient />
                         <Box marginHorizontal="sp16" marginBottom="sp16">
-                            <Button onPress={handleSave} testID="@coin-enabling/button-save">
+                            <Button onPress={handleSubmit} testID="@coin-enabling/button-save">
                                 <Translation id="moduleSettings.coinEnabling.initialSetup.button" />
                             </Button>
                         </Box>
@@ -77,9 +88,11 @@ export const CoinEnablingInitScreen = () => {
                 )
             }
         >
-            <Box>
-                <DiscoveryCoinsFilter allowDeselectLastCoin={true} allowChangeAnalytics={false} />
-            </Box>
+            <Form form={form}>
+                <Box>
+                    <DiscoveryCoinsFilter networkSymbols={networkSymbols} />
+                </Box>
+            </Form>
         </Screen>
     );
 };

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -855,7 +855,6 @@ export const en = {
                 'Didn’t find what you’re looking for? Check if it’s not a token running one of the listed coin’s network.',
             toasts: {
                 coinEnabled: '{coin} will load once you connect Trezor.',
-                coinDisabled: '{coin} disabled',
             },
             btcOnly: {
                 title: 'Your Trezor is BTC only.',

--- a/suite-native/module-settings/package.json
+++ b/suite-native/module-settings/package.json
@@ -27,7 +27,6 @@
         "@suite-native/biometrics": "workspace:*",
         "@suite-native/coin-enabling": "workspace:*",
         "@suite-native/config": "workspace:*",
-        "@suite-native/device": "workspace:*",
         "@suite-native/device-manager": "workspace:*",
         "@suite-native/discovery": "workspace:*",
         "@suite-native/feature-flags": "workspace:*",

--- a/suite-native/module-settings/src/screens/SettingsCoinEnablingScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsCoinEnablingScreen.tsx
@@ -3,13 +3,8 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import {
-    changeNetworks,
-    selectEnabledNetworks,
-    selectHasBitcoinOnlyFirmware,
-} from '@suite-common/wallet-core';
-import { BtcOnlyCoinEnablingContent, DiscoveryCoinsFilter } from '@suite-native/coin-enabling';
-import { selectViewOnlyDevicesAccountsNetworkSymbols } from '@suite-native/device';
+import { selectEnabledNetworks, selectHasBitcoinOnlyFirmware } from '@suite-common/wallet-core';
+import { BtcOnlyCoinEnablingContent, CoinEnablingForm } from '@suite-native/coin-enabling';
 import { selectDiscoveryNetworkSymbols } from '@suite-native/discovery';
 import { useTranslate } from '@suite-native/intl';
 import { Screen, ScreenHeader } from '@suite-native/navigation';
@@ -23,20 +18,9 @@ export const SettingsCoinEnablingScreen = () => {
     const enabledNetworkSymbols = useSelector(selectEnabledNetworks);
     const availableNetworkSymbols = useSelector(selectDiscoveryNetworkSymbols);
     const hasBitcoinOnlyFirmware = useSelector(selectHasBitcoinOnlyFirmware);
-    const viewOnlyDevicesAccountsNetworkSymbols = useSelector(
-        selectViewOnlyDevicesAccountsNetworkSymbols,
-    );
 
     //testnets can be enabled and we want to show networks that case
     const showNetworks = availableNetworkSymbols.length > 1 || !hasBitcoinOnlyFirmware;
-
-    useEffect(() => {
-        // in case the user has view only devices and gets to the settings
-        // before the Coin Enabling has been initialized, we need to set the networks
-        if (enabledNetworkSymbols.length === 0) {
-            dispatch(changeNetworks(viewOnlyDevicesAccountsNetworkSymbols));
-        }
-    }, [enabledNetworkSymbols.length, dispatch, viewOnlyDevicesAccountsNetworkSymbols]);
 
     useEffect(() => {
         const unsubscribe = navigation.addListener('blur', () => {
@@ -54,7 +38,7 @@ export const SettingsCoinEnablingScreen = () => {
                 <ScreenHeader content={translate('moduleSettings.coinEnabling.settings.title')} />
             }
         >
-            {showNetworks ? <DiscoveryCoinsFilter /> : <BtcOnlyCoinEnablingContent />}
+            {showNetworks ? <CoinEnablingForm /> : <BtcOnlyCoinEnablingContent />}
         </Screen>
     );
 };

--- a/suite-native/module-settings/tsconfig.json
+++ b/suite-native/module-settings/tsconfig.json
@@ -23,7 +23,6 @@
         { "path": "../biometrics" },
         { "path": "../coin-enabling" },
         { "path": "../config" },
-        { "path": "../device" },
         { "path": "../device-manager" },
         { "path": "../discovery" },
         { "path": "../feature-flags" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10515,7 +10515,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/coin-enabling@workspace:suite-native/coin-enabling"
   dependencies:
-    "@mobily/ts-belt": "npm:^3.13.1"
     "@react-navigation/native": "npm:6.1.18"
     "@reduxjs/toolkit": "npm:2.8.2"
     "@suite-common/wallet-config": "workspace:*"
@@ -11287,7 +11286,6 @@ __metadata:
     "@suite-native/biometrics": "workspace:*"
     "@suite-native/coin-enabling": "workspace:*"
     "@suite-native/config": "workspace:*"
-    "@suite-native/device": "workspace:*"
     "@suite-native/device-manager": "workspace:*"
     "@suite-native/discovery": "workspace:*"
     "@suite-native/feature-flags": "workspace:*"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- If we change enabled networks directly by clicking the toggle, the app can became easily unresponsive (new discovery is triggered) and toggle states are lagging.
- But the reason for this change was remembered passhrase wallet - it's not nice to ask user for passhprase at the moment he click the coin toggle.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19628
Resolve https://github.com/trezor/trezor-suite/issues/19471



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/coin-enabling-form&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/coin-enabling-form&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/coin-enabling-form&lookback=7)