### PR TITLE
fix(walletconnect): don't send empty namespace

### DIFF
--- a/suite-common/walletconnect/src/adapters/ethereum.ts
+++ b/suite-common/walletconnect/src/adapters/ethereum.ts
@@ -210,7 +210,7 @@ const ethereumRequestThunk = createThunk<
 
 export const getChainId = (network: Network) => [`eip155:${network.chainId}`];
 
-export const getNamespace = (accounts: Account[]) => {
+export const getNamespace = (accounts: Account[]): Record<string, WalletConnectNamespace> => {
     const eip155 = {
         chains: [],
         accounts: [],
@@ -235,6 +235,10 @@ export const getNamespace = (accounts: Account[]) => {
             }
         }
     });
+
+    if (eip155.chains.length === 0) {
+        return {};
+    }
 
     return { eip155 };
 };

--- a/suite-common/walletconnect/src/adapters/solana.ts
+++ b/suite-common/walletconnect/src/adapters/solana.ts
@@ -167,7 +167,7 @@ export const getChainId = (network: Network) =>
         ? [SolanaChainIds.TESTNET]
         : [SolanaChainIds.MAINNET, SolanaChainIds.MAINNET_LEGACY];
 
-export const getNamespace = (accounts: Account[]) => {
+export const getNamespace = (accounts: Account[]): Record<string, WalletConnectNamespace> => {
     const solana = {
         chains: [],
         accounts: [],
@@ -189,6 +189,10 @@ export const getNamespace = (accounts: Account[]) => {
             solana.accounts.push(`${walletConnectChainId}:${account.descriptor}`);
         }
     });
+
+    if (solana.chains.length === 0) {
+        return {};
+    }
 
     return { solana };
 };


### PR DESCRIPTION
## Description

Followup to #19626

Found one more case where the DApp supports Solana namespace, but the user doesn't have any accounts with it, this results in the empty namespace problem.
With this PR it only creates the namespace if they contain accounts.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/walletconnect-empty-namespace&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/walletconnect-empty-namespace&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/walletconnect-empty-namespace&lookback=7)