### PR TITLE
chore(suite): add checks when creating object stores

### DIFF
--- a/packages/suite/src/storage/migrations/versions/migrateToV56.ts
+++ b/packages/suite/src/storage/migrations/versions/migrateToV56.ts
@@ -79,7 +79,7 @@ export const migrateToV56: OnUpgradeFunc<SuiteDBSchema> = async (
 
     // 1. Migration coinmarketTrades to tradingTrades
     // @ts-expect-error - old type
-    if (db.objectStoreNames.contains(oldStoreName)) {
+    if (db.objectStoreNames.contains(oldStoreName) && !db.objectStoreNames.contains(newStoreName)) {
         // @ts-expect-error - old type
         const trades = transaction.objectStore(oldStoreName);
         let tradesCursor = await trades.openCursor();
@@ -186,8 +186,12 @@ export const migrateToV56: OnUpgradeFunc<SuiteDBSchema> = async (
     }
 
     // 5. add thp and bluetooth object stores
+    if (!db.objectStoreNames.contains('thp')) {
     db.createObjectStore('thp');
+    }
+    if (!db.objectStoreNames.contains('bluetooth')) {
     db.createObjectStore('bluetooth');
+    }
 
     // 6. refetch solana txs
     const accountsToUpdate = ['sol', 'dsol'];

--- a/packages/suite/src/storage/migrations/versions/migrateToV56.ts
+++ b/packages/suite/src/storage/migrations/versions/migrateToV56.ts
@@ -165,20 +165,8 @@ export const migrateToV56: OnUpgradeFunc<SuiteDBSchema> = async (
         return trade;
     });
 
-    // 3. Update draft keys to trading
-    const formDrafts = transaction.objectStore('formDrafts');
-    const formDraftsKeys = (await formDrafts.getAllKeys()).filter(key =>
-        key.includes('coinmarket'),
-    );
-
-    formDraftsKeys.forEach(async key => {
-        const draft = await formDrafts.get(key);
-
-        if (draft) {
-            formDrafts.add(draft, key.replace('coinmarket', 'trading'));
-            formDrafts.delete(key);
-        }
-    });
+    // 3. Remove form drafts
+    transaction.objectStore('formDrafts').clear();
 
     // 4. add explorer object store, if it does not exist
     if (!db.objectStoreNames.contains('explorer')) {
@@ -187,10 +175,10 @@ export const migrateToV56: OnUpgradeFunc<SuiteDBSchema> = async (
 
     // 5. add thp and bluetooth object stores
     if (!db.objectStoreNames.contains('thp')) {
-    db.createObjectStore('thp');
+        db.createObjectStore('thp');
     }
     if (!db.objectStoreNames.contains('bluetooth')) {
-    db.createObjectStore('bluetooth');
+        db.createObjectStore('bluetooth');
     }
 
     // 6. refetch solana txs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- add conditions when creating db object stores
- wipe form drafts instead of migrating them

Affected users:
- users who inserted some values into trade form in previous versions

How to test:
1. build desktop app locally or download one from the CI
2. on mac go to `~/Library/Application Support/@trezor` and navigate to folder with suffix `-dev` for build from ci, to `-local` for build from your computer. If it is not there. First run the downloaded/built app. Then close it.
3. copy and replace `IndexedDB` and `Local Storage` from https://satoshilabs.slack.com/archives/C06DHAY5HU6/p1750505133169639?thread_ts=1750495465.008199&cid=C06DHAY5HU6 in the folder from step 2
4. open Suite
5. app should load

## Screenshots:

some people got into this state by some incorrect migrations in the past

![lalala](https://github.com/user-attachments/assets/ff283ec1-3cab-4aec-be81-ccfe91ca99fc)

this line
```           
formDrafts.add(draft, key.replace('coinmarket', 'trading'));
```

then caused duplicate of keys `Key already exists in the object store`

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/migration-56&lookback=7)