### PR TITLE
chore: add exactOptionalPropertyTypes: true

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,14 +20,18 @@
         "resolveJsonModule": true,
         "forceConsistentCasingInFileNames": true,
         "isolatedModules": true,
-        "types": ["jest", "node"],
+        "types": [
+            "jest",
+            "node"
+        ],
         "esModuleInterop": true,
         "composite": true,
         "declaration": true,
         "declarationMap": true,
         "incremental": true,
         "noEmitOnError": true,
-        "emitDeclarationOnly": true
+        "emitDeclarationOnly": true,
+        "exactOptionalPropertyTypes": true
     },
     "exclude": [
         "**/node_modules",


### PR DESCRIPTION
1. It is needed by Evolu.
2. It seems to me as a good practice anyway. 

See: https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=add_exactOptionalPropertyTypes&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=add_exactOptionalPropertyTypes&lookback=7)