### PR TITLE
chore(suite): move discovery migration to v57, edit changelog

### DIFF
--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -3,16 +3,21 @@
 ## 57 (25.7.0)
 
 - introduce new object store `bioAuth`
+- remove `discovery` object store
 
-## 56 (25.6.1)
+## 56 (25.6.3)
 
 - renamed from _coinmarketTrades_ to _tradingTrades_
-- updated from _coinmarket_ formDraft to _trading_
+- drop formDrafts instead of migration from prefix _coinmarket_ to _trading_
 - changed `tradingTrades` - add `sendAccountKey`, `receiveAccountKey`, `selectedAccountKey` to each buy, sell, and exchange trade
 - added `explorer` store for custom explorer configuration
 - created `thp` and `bluetooth` object store
 - remove saved solana txs to force refetch
 - remove saved evm txs to force refetch due to bug in migration v52
+
+## 55
+
+- migration was merged into 56 migration (2 migration versions within 1 Suite version)
 
 ## 54
 

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -1280,15 +1280,13 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
         db.createObjectStore('connect');
     }
 
-    // Note: 55 migration is merged into 56 migration
-
     if (oldVersion < 56) {
         await migrateToV56(db, oldVersion, newVersion, transaction);
-        // @ts-expect-error
-        db.deleteObjectStore('discovery');
     }
 
     if (oldVersion < 57) {
         db.createObjectStore('bioAuth');
+        // @ts-expect-error
+        db.deleteObjectStore('discovery');
     }
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- edit changelog https://github.com/trezor/trezor-suite/pull/19689
- move removing `discovery` object store to v57 (it was not part of `56`public release)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/changelog-migration&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/changelog-migration&lookback=7)