### PR TITLE
fix(transport-bridge): allow read while call is running

### DIFF
--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -228,7 +228,7 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         const { path } = sessionsResult.payload;
         logger?.debug(`core: call: retrieved path ${path} for session ${session}`);
 
-        return api.runInIsolation({ lock: { read: true, write: true }, path }, async () => {
+        return api.runInIsolation({ lock: { read: true, write: false }, path }, async () => {
             logger?.debug('core: call: writeUtil');
             const writeResult = await writeUtil({ path, data, signal, protocol });
             if (!writeResult.success) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

in DeviceCurrentSession file we have this comment which in my observation is not true or maybe it was true at the time writing.
node-bridge throws exacly the same error when there is a pending call (ButtonAck) and Cancel is sent 


```
/**
*Bridge version =< 2.0.28 throws "other call in progress" error....
```



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bridge-call-in-progress&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bridge-call-in-progress&lookback=7)