### PR TITLE
fix(e2e): Solve interaction between regtest tests

### DIFF
--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -1,4 +1,4 @@
-import test, { TestInfo } from '@playwright/test';
+import test, { Locator, TestInfo } from '@playwright/test';
 import { isEqual, omit } from 'lodash';
 import { readdirSync } from 'node:fs';
 import path from 'node:path';
@@ -6,7 +6,7 @@ import path from 'node:path';
 import { regional } from '@suite-common/trading';
 import { getAccountDecimals, localizeNumber } from '@suite-common/wallet-utils';
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
-import { splitStringEveryNCharacters } from '@trezor/utils';
+import { BigNumber, splitStringEveryNCharacters } from '@trezor/utils';
 
 import releases from '../../../../submodules/trezor-common/releases.json';
 import { PlaywrightProjects } from '../playwright.config';
@@ -132,4 +132,20 @@ export const countDecimalPlaces = (value: string | number) => {
     }
 
     return value.toString().split('.')[1].length || 0;
+};
+
+export const getBigNumberFromBalance = async (locator: Locator) => {
+    let originalBalanceText = await locator.textContent();
+    if (!originalBalanceText) {
+        throw new Error('Balance text content is empty');
+    }
+
+    const hasEllipsis = originalBalanceText?.endsWith('…');
+    if (hasEllipsis) {
+        originalBalanceText = originalBalanceText.slice(0, -1);
+    }
+
+    const originalBalance = BigNumber(originalBalanceText);
+
+    return { originalBalance, hasEllipsis };
 };

--- a/packages/suite-desktop-core/e2e/support/testExtends/customMatchers.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/customMatchers.ts
@@ -18,7 +18,8 @@ const compareTextAndNumber = async (
 ) => {
     await baseExpect(locator).toBeVisible();
     const text = await locator.textContent();
-    const numericValue = Number(text);
+    const textWithoutEllipsis = text?.endsWith('…') ? text.slice(0, -1) : text;
+    const numericValue = Number(textWithoutEllipsis);
     const isNumber = Number.isFinite(numericValue);
 
     return {

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase.test.ts
@@ -124,12 +124,30 @@ test.describe('Passphrase', { tag: ['@group=passphrase'] }, () => {
             await page.getByTestId('@passphrase-confirmation/step2-button').click();
         });
 
-        // confirm - input wrong passphrase
-        await dashboardPage.passphraseInput.fill('cba');
+        await test.step('Confirm wrong passphrase', async () => {
+            await dashboardPage.passphraseInput.fill('cba');
 
-        await dashboardPage.passphraseSubmitButton.click();
-        await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
-        await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
+            await test.step('Toggle passphrase visibility', async () => {
+                await expect(dashboardPage.passphraseInput).toHaveCSS(
+                    '-webkit-text-security',
+                    'disc',
+                );
+                await dashboardPage.passphraseShowButton.click();
+                await expect(dashboardPage.passphraseInput).not.toHaveCSS(
+                    '-webkit-text-security',
+                    'disc',
+                );
+                await dashboardPage.passphraseShowButton.click();
+                await expect(dashboardPage.passphraseInput).toHaveCSS(
+                    '-webkit-text-security',
+                    'disc',
+                );
+            });
+
+            await dashboardPage.passphraseSubmitButton.click();
+            await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
+            await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
+        });
 
         await test.step('Retry passphrase confirmation', async () => {
             await page.getByTestId('@passphrase-mismatch/start-over').click();
@@ -137,19 +155,21 @@ test.describe('Passphrase', { tag: ['@group=passphrase'] }, () => {
             await dashboardPage.passphraseSubmitButton.click();
             await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
             await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
+            await page
+                .getByTestId('@passphrase-confirmation/step1-open-unused-wallet-button')
+                .click();
+            await page.getByTestId('@passphrase-confirmation/step2-button').click();
         });
 
-        await page.getByTestId('@passphrase-confirmation/step1-open-unused-wallet-button').click();
-        await page.getByTestId('@passphrase-confirmation/step2-button').click();
+        await test.step('Confirm correct passphrase', async () => {
+            await dashboardPage.passphraseInput.fill('abc');
+            await dashboardPage.passphraseSubmitButton.click();
+            await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
+            await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
 
-        // confirm - input wrong passphrase
-        await dashboardPage.passphraseInput.fill('abc');
-        await dashboardPage.passphraseSubmitButton.click();
-        await devicePrompt.waitForPromptAndConfirm(); // Confirm next screen shows your passphrase
-        await devicePrompt.waitForPromptAndConfirm(); // Confirm passphrase
-
-        await dashboardPage.modal.waitFor({ state: 'detached' });
-        await dashboardPage.openDeviceSwitcher();
-        await expect(dashboardPage.walletAtIndex(1)).toContainText('Passphrase wallet #1');
+            await dashboardPage.modal.waitFor({ state: 'detached' });
+            await dashboardPage.openDeviceSwitcher();
+            await expect(dashboardPage.walletAtIndex(1)).toContainText('Passphrase wallet #1');
+        });
     });
 });

--- a/packages/suite-desktop-core/e2e/tests/wallet/coin-balance.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/coin-balance.test.ts
@@ -1,6 +1,6 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
-import { BigNumber } from '@trezor/utils';
 
+import { getBigNumberFromBalance } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 test.describe('Coin balance', { tag: ['@group=wallet'] }, () => {
@@ -16,6 +16,7 @@ test.describe('Coin balance', { tag: ['@group=wallet'] }, () => {
         settingsPage,
         walletPage,
     }) => {
+        const firstAccountBalanceLocator = walletPage.balanceOfAccount('regtest').first();
         await trezorUserEnvLink.sendToAddressAndMineBlock({ address, btc_amount: 1 });
         await test.step('Regtest discovered with non zero value', async () => {
             await settingsPage.changeNetworks({ enableNetworks: ['regtest'] });
@@ -23,21 +24,19 @@ test.describe('Coin balance', { tag: ['@group=wallet'] }, () => {
             await expect(walletPage.accountLabel({ symbol: 'regtest' })).toHaveText(
                 'Bitcoin Regtest #1',
             );
-            await expect(walletPage.balanceOfAccount('regtest')).toHaveTextGreaterThan(0);
+            await expect(firstAccountBalanceLocator).toHaveTextGreaterThan(0);
         });
 
         await test.step('Balance is increased after sending another BTC', async () => {
-            const originalBalanceText = await walletPage.balanceOfAccount('regtest').textContent();
-            if (!originalBalanceText) {
-                throw new Error('Balance text content is empty');
-            }
-            const originalBalance = BigNumber(originalBalanceText);
-            const rawIncreasedBalance = originalBalance.plus(1).toString();
-            const expectedIncreasedBalance = localizeNumber(rawIncreasedBalance, 'en', 0, 8);
-            await trezorUserEnvLink.sendToAddressAndMineBlock({ address, btc_amount: 1 });
-            await expect(walletPage.balanceOfAccount('regtest')).toHaveText(
-                expectedIncreasedBalance,
+            const { originalBalance, hasEllipsis } = await getBigNumberFromBalance(
+                firstAccountBalanceLocator,
             );
+            const rawIncreasedBalance = originalBalance.plus(1).toString();
+            const expectedIncreasedBalance =
+                localizeNumber(rawIncreasedBalance, 'en', 0, 8) + (hasEllipsis ? '…' : '');
+
+            await trezorUserEnvLink.sendToAddressAndMineBlock({ address, btc_amount: 1 });
+            await expect(firstAccountBalanceLocator).toHaveText(expectedIncreasedBalance);
         });
     });
 });


### PR DESCRIPTION
One test is causing regtest env to have 3 accounts and our balance test was not expecting that.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-coin-balance-flaky&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-coin-balance-flaky&lookback=7)