### PR TITLE
fix(e2e): stabilize flaky suite initial run

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/suite/initial-run.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/initial-run.test.ts
@@ -11,12 +11,14 @@ test.describe('Suite initial run', { tag: ['@group=suite'] }, () => {
         await expect(analyticsSection.toggleSwitch).toBeVisible();
         await page.reload();
         // analytics screen is there until user confirms his choice
+        await onboardingPage.optionallyDismissFwHashCheckError();
         await expect(analyticsSection.toggleSwitch).toBeVisible();
         await analyticsSection.continueButton.click();
 
         await expect(page.getByTestId('@onboarding/exit-app-button')).toBeVisible();
 
         await page.reload();
+        await onboardingPage.optionallyDismissFwHashCheckError();
         await expect(analyticsSection.toggleSwitch).toBeHidden();
         await expect(onboardingPage.onboardingContinueButton).toBeVisible();
     });


### PR DESCRIPTION
adds optionallyDismissFwHashCheckError after each reload since the onboarding is not completed. There is chance the FwHashCheckError will appear after each reload.

[Link](https://app.currents.dev/instance/7uFrsWlP6Dsdnc86) to 30x runs in CI


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-suite-init&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-suite-init&lookback=7)