### PR TITLE
feat: support BIP 329 style labeling export

### DIFF
--- a/packages/suite/src/actions/suite/constants/metadataConstants.ts
+++ b/packages/suite/src/actions/suite/constants/metadataConstants.ts
@@ -10,3 +10,4 @@ export const SET_INITIATING = '@metadata/set-initiating' as const;
 export const SET_DATA = '@metadata/set-data' as const;
 export const SET_SELECTED_PROVIDER = '@metadata/set-selected-provider' as const;
 export const SET_ERROR_FOR_DEVICE = '@metadata/set-error-for-device' as const;
+export const EXPORT_METADATA_TO_BIP329_FILE = '@metadata/exportMetadataToBip329File';

--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -1,13 +1,29 @@
 import { createAction } from '@reduxjs/toolkit';
 
+import { createThunk } from '@suite-common/redux-utils';
+import {
+    selectAccountLabel,
+    selectIsSuiteSyncEnabled,
+    suiteSyncToBip329,
+} from '@suite-common/suite-sync';
+import {
+    selectAddressLabelsByAccount,
+    selectOutputLabelsByAccount,
+} from '@suite-common/suite-sync/src/labeling/labelingSelectors';
+import { triggerWebDownloadFile } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { selectDevices } from '@suite-common/wallet-core';
+import { selectDevices, selectSelectedDevice } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
+import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { StaticSessionId } from '@trezor/connect';
-import { createZip } from '@trezor/utils';
+import { createZip, sanitizeFilename } from '@trezor/utils';
 
 import { METADATA, METADATA_LABELING } from 'src/actions/suite/constants';
-import { selectSelectedProviderForLabels } from 'src/reducers/suite/metadataReducer';
+import { GetDefaultAccountLabelParams } from 'src/hooks/suite/useDefaultAccountLabel';
+import {
+    selectLabelingDataForSelectedAccount,
+    selectSelectedProviderForLabels,
+} from 'src/reducers/suite/metadataReducer';
 import { Dispatch, GetState } from 'src/types/suite';
 import {
     AccountLabels,
@@ -17,8 +33,13 @@ import {
     MetadataProvider,
     WalletLabels,
 } from 'src/types/suite/metadata';
-import type { AbstractMetadataProvider, PasswordManagerState } from 'src/types/suite/metadata';
+import type {
+    AbstractMetadataProvider,
+    Bip329Label,
+    PasswordManagerState,
+} from 'src/types/suite/metadata';
 import * as metadataUtils from 'src/utils/suite/metadata';
+import { slip15ToBip329 } from 'src/utils/suite/slip15ToBip329';
 
 import { getProviderInstance } from './metadataProviderActions';
 
@@ -64,6 +85,10 @@ export type MetadataAction =
     | {
           type: typeof METADATA.ACCOUNT_ADD;
           payload: Account;
+      }
+    | {
+          type: typeof METADATA.EXPORT_METADATA_TO_BIP329_FILE;
+          payload: void;
       };
 
 export const setAccountAdd = createAction(METADATA.ACCOUNT_ADD, (payload: Account) => ({
@@ -170,6 +195,103 @@ export const encryptAndSaveMetadata = async ({
     return providerInstance.setFileContent(fileName, encrypted);
 };
 
+export const exportMetadataToBip329File = createThunk<
+    void,
+    { getDefaultAccountLabel: (params: GetDefaultAccountLabelParams) => string },
+    void
+>(METADATA.EXPORT_METADATA_TO_BIP329_FILE, ({ getDefaultAccountLabel }, { dispatch, getState }) => {
+    const showExportErrorToast = () => {
+        dispatch(
+            notificationsActions.addToast({
+                type: 'error',
+                error: 'Exporting labels BIP 329 failed',
+            }),
+        );
+    };
+
+    try {
+        const state = getState();
+        const device = selectSelectedDevice(state);
+        const { selectedAccount } = state.wallet;
+        const isSuiteSyncEnabled = selectIsSuiteSyncEnabled(state);
+
+        const staticSessionId = device?.state?.staticSessionId;
+        if (!staticSessionId) {
+            showExportErrorToast();
+
+            return;
+        }
+
+        let finalAccountLabel = getDefaultAccountLabel({
+            accountType: selectedAccount.account.accountType,
+            symbol: selectedAccount.account.symbol,
+            index: selectedAccount.account.index,
+        });
+        let labelsToExport: Bip329Label[] = [];
+
+        if (isSuiteSyncEnabled) {
+            const owner = device?.suiteSyncOwner;
+            if (owner === undefined) {
+                showExportErrorToast();
+
+                return;
+            }
+
+            const { walletDescriptor } = parseDeviceStaticSessionId(
+                selectedAccount.account.deviceState,
+            );
+
+            const suiteSyncAccountLabel = selectAccountLabel({
+                state,
+                walletDescriptor,
+                accountKey: selectedAccount.account.key,
+            });
+            if (suiteSyncAccountLabel) {
+                finalAccountLabel = suiteSyncAccountLabel;
+            }
+
+            const suiteSyncAddressLabels = selectAddressLabelsByAccount({
+                state,
+                deviceStaticSessionId: staticSessionId,
+                accountDescriptor: selectedAccount.account.descriptor,
+                networkSymbol: selectedAccount.account.symbol,
+            });
+
+            const suiteSyncOutputLabels = selectOutputLabelsByAccount({
+                state,
+                deviceStaticSessionId: staticSessionId,
+                accountDescriptor: selectedAccount.account.descriptor,
+                networkSymbol: selectedAccount.account.symbol,
+            });
+
+            labelsToExport = suiteSyncToBip329({
+                outputLabels: suiteSyncOutputLabels,
+                addressLabels: suiteSyncAddressLabels,
+                allSpendable: true,
+            });
+        } else {
+            // Legacy non-SuiteSync export.
+            const labelForSelectedAccount = selectLabelingDataForSelectedAccount(state);
+            if (labelForSelectedAccount.accountLabel) {
+                finalAccountLabel = labelForSelectedAccount.accountLabel;
+            }
+            labelsToExport = slip15ToBip329(labelForSelectedAccount as AccountLabels);
+        }
+
+        // Maps each object to its JSON string representation
+        const jsonlString = labelsToExport.map(obj => JSON.stringify(obj)).join('\n');
+
+        const blob = new Blob([jsonlString], { type: 'application/jsonl' });
+
+        const safeLabel = sanitizeFilename(finalAccountLabel);
+        const filename = `${safeLabel || 'account_labels'}_export_bip329.jsonl`;
+
+        triggerWebDownloadFile(blob, filename);
+    } catch {
+        showExportErrorToast();
+    }
+});
+
 export const exportMetadataToLocalFile = () => async (dispatch: Dispatch, getState: GetState) => {
     const providerInstance = dispatch(
         getProviderInstance({
@@ -204,14 +326,7 @@ export const exportMetadataToLocalFile = () => async (dispatch: Dispatch, getSta
         .then(filesContent => {
             const zipBlob = createZip(filesContent);
             // Trigger download
-            const a = document.createElement('a');
-            a.href = URL.createObjectURL(zipBlob);
-            a.download = 'archive.zip';
-            a.style.display = 'none';
-            document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-            URL.revokeObjectURL(a.href);
+            triggerWebDownloadFile(zipBlob, 'archive.zip');
         })
         .catch(_err => {
             dispatch(

--- a/packages/suite/src/hooks/suite/useLabelingCombined.ts
+++ b/packages/suite/src/hooks/suite/useLabelingCombined.ts
@@ -81,6 +81,7 @@ export const useLabelingCombined = ({ deviceStaticSessionId }: UseLabelingCombin
         disableSuiteSyncIfNeeded,
 
         /** Legacy Labeling */
+        isMetadataEnabled: legacyMetadataState.enabled,
         legacyMetadataState,
         legacyEnableIfNeeded,
         legacyDisableIfNeeded,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3984,6 +3984,18 @@ export default defineMessages({
         id: 'TR_ACCOUNT_DETAILS_XPUB_HEADER',
         defaultMessage: 'Public key (XPUB)',
     },
+    TR_ACCOUNT_DETAILS_EXPORT_LABELS_HEADER: {
+        id: 'TR_ACCOUNT_DETAILS_EXPORT_LABELS_HEADER',
+        defaultMessage: 'Export Labels (BIP 329)',
+    },
+    TR_ACCOUNT_DETAILS_EXPORT_LABELS_BUTTON: {
+        id: 'TR_ACCOUNT_DETAILS_EXPORT_LABELS_BUTTON',
+        defaultMessage: 'Export',
+    },
+    TR_ACCOUNT_DETAILS_EXPORT_LABELS_DESCRIPTION: {
+        id: 'TR_ACCOUNT_DETAILS_EXPORT_LABELS_DESCRIPTION',
+        defaultMessage: 'Export label files to your computer using the standard BIP 329',
+    },
     TR_ACCOUNT_DETAILS_XPUB: {
         id: 'TR_ACCOUNT_DETAILS_XPUB',
         defaultMessage:

--- a/packages/suite/src/utils/suite/__tests__/slip12ToBip329.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/slip12ToBip329.test.ts
@@ -1,0 +1,48 @@
+import { AccountLabels } from '@suite-common/metadata-types';
+
+import { slip15ToBip329 } from '../slip15ToBip329';
+
+describe(slip15ToBip329.name, () => {
+    it('transform properly', () => {
+        const slip15Example: AccountLabels = {
+            accountLabel: 'The first segwit account from all seed',
+            outputLabels: {
+                '50e4fa9ebfca7d510feae7226a7d5d046114f54a7918cdd83e40c98d70d17e4d': {
+                    '0': 'this is expending transaction output or just tx',
+                },
+                '519e17d6f3eb87cc8c4bf450d0dc2bad83a1387713680bec609bcb5d8e53335e': {
+                    '0': 'this is receive tx label',
+                },
+            },
+            addressLabels: {
+                bc1qq46pg2kafgjvsh7me3puv0jujdl77a5829xlrs: 'This address is labeled',
+            },
+        };
+
+        const bip329Output = slip15ToBip329(slip15Example);
+
+        const expectedResult = [
+            {
+                type: 'output',
+                ref: '50e4fa9ebfca7d510feae7226a7d5d046114f54a7918cdd83e40c98d70d17e4d:0',
+                label: 'this is expending transaction output or just tx',
+            },
+            {
+                type: 'output',
+                ref: '519e17d6f3eb87cc8c4bf450d0dc2bad83a1387713680bec609bcb5d8e53335e:0',
+                label: 'this is receive tx label',
+            },
+            {
+                type: 'addr',
+                ref: 'bc1qq46pg2kafgjvsh7me3puv0jujdl77a5829xlrs',
+                label: 'This address is labeled',
+            },
+        ];
+
+        bip329Output.forEach((label, index) => {
+            expect(label.type).toEqual(expectedResult[index].type);
+            expect(label.ref).toEqual(expectedResult[index].ref);
+            expect(label.label).toEqual(expectedResult[index].label);
+        });
+    });
+});

--- a/packages/suite/src/utils/suite/slip15ToBip329.ts
+++ b/packages/suite/src/utils/suite/slip15ToBip329.ts
@@ -1,0 +1,40 @@
+import { AccountLabels, Bip329Label } from '@suite-common/metadata-types';
+
+// Transforms a custom SLIP-15 like wallet label object into an array of BIP-329 label objects.
+export const slip15ToBip329 = (inputData: AccountLabels, allSpendable = true): Bip329Label[] => {
+    const bip329Labels: Bip329Label[] = [];
+
+    // `outputLabels` -> mapped to BIP-329 'utxo' type
+    if (inputData.outputLabels) {
+        for (const txid in inputData.outputLabels) {
+            if (Object.prototype.hasOwnProperty.call(inputData.outputLabels, txid)) {
+                const outputs = inputData.outputLabels[txid];
+                for (const vout in outputs) {
+                    if (Object.prototype.hasOwnProperty.call(outputs, vout)) {
+                        bip329Labels.push({
+                            type: 'output',
+                            ref: `${txid}:${vout}`, // Output reference is 'txid:vout'
+                            label: outputs[vout],
+                            spendable: allSpendable, // Right now Trezor Suite does not allow to set sependable so all are `true`.
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // `addressLabels` -> mapped to BIP-329 'addr' type
+    if (inputData.addressLabels) {
+        for (const address in inputData.addressLabels) {
+            if (Object.prototype.hasOwnProperty.call(inputData.addressLabels, address)) {
+                bip329Labels.push({
+                    type: 'addr',
+                    ref: address,
+                    label: inputData.addressLabels[address],
+                });
+            }
+        }
+    }
+
+    return bip329Labels;
+};

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -2,18 +2,21 @@ import { ReactNode } from 'react';
 
 import styled from 'styled-components';
 
+import { selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
 import { getAccountTypeTech } from '@suite-common/wallet-utils';
 import { Button, Card, Column, InfoItem, Paragraph } from '@trezor/components';
 import { spacings, typography } from '@trezor/theme';
 import { HELP_CENTER_BIP32_URL, HELP_CENTER_XPUB_URL, Url } from '@trezor/urls';
 
+import { exportMetadataToBip329File } from 'src/actions/suite/metadataActions';
 import { showXpub } from 'src/actions/wallet/publicKeyActions';
 import { AccountTypeBadge } from 'src/components/suite/AccountTypeBadge';
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
 import { Translation, TranslationKey } from 'src/components/suite/Translation';
 import { AccountTypeDescription } from 'src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription';
 import { WalletLayout } from 'src/components/wallet';
-import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
+import { useDefaultAccountLabel, useDevice, useDispatch, useSelector } from 'src/hooks/suite';
+import { useLabelingCombined } from 'src/hooks/suite/useLabelingCombined';
 import { useReceiveDisabled } from 'src/hooks/suite/useReceiveDisabled';
 
 import { CoinjoinLogs } from './CoinjoinLogs';
@@ -65,12 +68,17 @@ const DetailsRow = ({ title, description, learnMoreUrl, children }: DetailsRowPr
 };
 
 const Details = () => {
+    const { device, isLocked } = useDevice();
+    const { getDefaultAccountLabel } = useDefaultAccountLabel();
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const isLocalFirstStorageEnabled = useSelector(selectIsSuiteSyncEnabled);
+
     const { isReceiveDisabled, ReceiveDisabledWrapper } = useReceiveDisabled();
+    const { isMetadataEnabled } = useLabelingCombined({
+        deviceStaticSessionId: device?.state?.staticSessionId,
+    });
 
     const dispatch = useDispatch();
-
-    const { device, isLocked } = useDevice();
 
     if (!device || selectedAccount.status !== 'loaded') {
         return <WalletLayout title="TR_ACCOUNT_DETAILS_HEADER" account={selectedAccount} />;
@@ -88,7 +96,13 @@ const Details = () => {
     const shouldDisplayXpubSection =
         account.networkType === 'bitcoin' || account.networkType === 'cardano';
 
+    const shouldDisplayExportBip329Labels =
+        account.networkType === 'bitcoin' && (isMetadataEnabled || isLocalFirstStorageEnabled);
+
     const handleXpubClick = () => dispatch(showXpub());
+
+    const handleExportBip329 = () =>
+        dispatch(exportMetadataToBip329File({ getDefaultAccountLabel }));
 
     return (
         <WalletLayout title="TR_ACCOUNT_DETAILS_HEADER" account={selectedAccount}>
@@ -155,6 +169,26 @@ const Details = () => {
                         )
                     ) : (
                         <RescanAccount account={account} />
+                    )}
+                    {shouldDisplayExportBip329Labels && (
+                        <DetailsRow
+                            title="TR_ACCOUNT_DETAILS_EXPORT_LABELS_HEADER"
+                            description={
+                                <Translation id="TR_ACCOUNT_DETAILS_EXPORT_LABELS_DESCRIPTION" />
+                            }
+                        >
+                            <Button
+                                intent="neutral"
+                                priority="secondary"
+                                data-testid="@wallets/details/export-label-bip329"
+                                onClick={handleExportBip329}
+                                isLoading={locked}
+                                size="small"
+                                minWidth={140}
+                            >
+                                <Translation id="TR_ACCOUNT_DETAILS_EXPORT_LABELS_BUTTON" />
+                            </Button>
+                        </DetailsRow>
                     )}
                 </Column>
             </Card>

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -61,3 +61,4 @@ export * from './safeBigIntStringify';
 export * from './union';
 export * from './isInt';
 export * from './number';
+export * from './sanitizeFilename';

--- a/packages/utils/src/sanitizeFilename.ts
+++ b/packages/utils/src/sanitizeFilename.ts
@@ -1,0 +1,31 @@
+const MAX_FILENAME_LENGTH = 250;
+
+export const sanitizeFilename = (filename: string, replacement = '_'): string | undefined => {
+    if (!filename || filename.trim().length === 0) {
+        return undefined;
+    }
+
+    // Illegal characters in filenames: < > : " / \ | ? *
+    // Control codes: \x00-\x1F
+    // https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+    // https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names
+    // eslint-disable-next-line no-control-regex, no-useless-escape
+    const illegalRe = /[<>:"\/\\|?*\x00-\x1F]/g;
+    let safeName = filename.replace(illegalRe, replacement);
+
+    // Truncate to avoid filesystem limits and potential regex DoS, just sanity check.
+    if (safeName.length > MAX_FILENAME_LENGTH) {
+        safeName = safeName.substring(0, MAX_FILENAME_LENGTH);
+    }
+
+    // Since string is now max 250 chars, this Regex is guarantee to be safe and fast.
+    safeName = safeName.replace(/[. ]+$/, '');
+
+    // Windows Reserved Names (CON, PRN, AUX, NUL, COM1-9, LPT1-9)
+    const reservedRe = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])$/i;
+    if (reservedRe.test(safeName)) {
+        safeName = `${safeName}${replacement}`;
+    }
+
+    return safeName || undefined;
+};

--- a/packages/utils/tests/sanitizeFilename.test.ts
+++ b/packages/utils/tests/sanitizeFilename.test.ts
@@ -1,0 +1,75 @@
+import { sanitizeFilename } from '../src/sanitizeFilename';
+
+describe(sanitizeFilename.name, () => {
+    it('valid wallet filenames', () => {
+        expect(sanitizeFilename('silk_road_account')).toBe('silk_road_account');
+        expect(sanitizeFilename('account last bull market')).toBe('account last bull market');
+    });
+
+    it('listings with illegal characters', () => {
+        const filename = 'Order#992:BlueDreams/HighQuality|BTC_Only?No_Escrow*';
+        const sanitized = sanitizeFilename(filename);
+
+        expect(sanitized).toBe('Order#992_BlueDreams_HighQuality_BTC_Only_No_Escrow_');
+    });
+
+    it('control characters in hidden logs', () => {
+        const filename = 'tor_circuit\nnode_entry\x00_hidden_service';
+        const sanitized = sanitizeFilename(filename);
+        expect(sanitized).toBe('tor_circuit_node_entry__hidden_service');
+    });
+
+    it('reserved device names', () => {
+        expect(sanitizeFilename('CON')).toBe('CON_');
+        expect(sanitizeFilename('PRN')).toBe('PRN_');
+        expect(sanitizeFilename('NUL')).toBe('NUL_');
+        expect(sanitizeFilename('AUX')).toBe('AUX_');
+        expect(sanitizeFilename('COM1')).toBe('COM1_');
+        expect(sanitizeFilename('con')).toBe('con_');
+    });
+
+    it('filenames that look reserved but are valid identifiers', () => {
+        expect(sanitizeFilename('control_panel_access')).toBe('control_panel_access');
+        expect(sanitizeFilename('auxiliary_keys.txt')).toBe('auxiliary_keys.txt');
+        expect(sanitizeFilename('COM0_port_sniff')).toBe('COM0_port_sniff');
+    });
+
+    it('trying to hide files with trailing dots or spaces', () => {
+        expect(sanitizeFilename('trezor_7_backup.')).toBe('trezor_7_backup');
+        expect(sanitizeFilename('private_keys ')).toBe('private_keys');
+        expect(sanitizeFilename('drop_location_coords. . ')).toBe('drop_location_coords');
+    });
+
+    it('filenames with custom separator for dates', () => {
+        const filename = 'transaction:hash:block';
+
+        expect(sanitizeFilename(filename, '-')).toBe('transaction-hash-block');
+
+        expect(sanitizeFilename(filename, '')).toBe('transactionhashblock');
+    });
+
+    it('unicode and emoji in listings', () => {
+        expect(sanitizeFilename('💊_250mg_stealth_delivery')).toBe('💊_250mg_stealth_delivery');
+        expect(sanitizeFilename('🚀_to_the_moon_earnings')).toBe('🚀_to_the_moon_earnings');
+        expect(sanitizeFilename('❄️_pure_quality')).toBe('❄️_pure_quality');
+    });
+
+    it('empty or whitespace-only inputs', () => {
+        expect(sanitizeFilename('')).toBe(undefined);
+        expect(sanitizeFilename('   ')).toBe(undefined);
+    });
+
+    it('filenames that become empty after sanitization', () => {
+        expect(sanitizeFilename('...')).toBe(undefined);
+        expect(sanitizeFilename('   .   ')).toBe(undefined);
+    });
+
+    it('truncation of massive filename', () => {
+        const tooLong = 'a'.repeat(300);
+        const sanitized = sanitizeFilename(tooLong);
+
+        expect(sanitized).toBeDefined();
+        expect(sanitized!.length).toBe(250);
+        expect(sanitized).toBe('a'.repeat(250));
+    });
+});

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -291,3 +291,10 @@ export type PasswordManagerState = {
     extVersion?: string;
     tags: Record<number, PasswordTag>;
 };
+
+export type Bip329Label = {
+    type: 'tx' | 'addr' | 'wallet' | 'xpub' | 'pubkey' | 'input' | 'output';
+    ref?: string; // The identifier for the object being labeled (e.g., txid, address, txid:vout)
+    label: string; // The label text
+    spendable?: boolean;
+};

--- a/suite-common/suite-sync/src/index.ts
+++ b/suite-common/suite-sync/src/index.ts
@@ -44,3 +44,4 @@ export { labelingActions } from './labeling/labelingActions';
 
 // Legacy
 export { processMetadataMessageThunk } from './labeling/processMetadataMessageThunk';
+export { suiteSyncToBip329 } from './labeling/suiteSyncToBip329';

--- a/suite-common/suite-sync/src/labeling/labelingSelectors.ts
+++ b/suite-common/suite-sync/src/labeling/labelingSelectors.ts
@@ -1,3 +1,4 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import type { AccountKey, WalletDescriptor } from '@suite-common/wallet-types';
 import { parseAccountKey, parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import type { StaticSessionId } from '@trezor/connect';
@@ -87,6 +88,27 @@ export const selectAddressLabels = ({
     return state.labeling.walletsLabels[walletDescriptor]?.addressLabels ?? [];
 };
 
+type SelectAddressLabelsByAccountParams = {
+    state: WithLabelingState;
+    deviceStaticSessionId: StaticSessionId;
+    accountDescriptor: string;
+    networkSymbol: NetworkSymbol;
+};
+
+export const selectAddressLabelsByAccount = ({
+    state,
+    deviceStaticSessionId,
+    accountDescriptor,
+    networkSymbol,
+}: SelectAddressLabelsByAccountParams) => {
+    const addressLabels = selectAddressLabels({ state, deviceStaticSessionId });
+
+    return addressLabels.filter(
+        label =>
+            label.accountDescriptor === accountDescriptor && label.networkSymbol === networkSymbol,
+    );
+};
+
 type SelectAddressLabelParam = {
     state: WithLabelingState;
     deviceStaticSessionId: StaticSessionId;
@@ -114,6 +136,27 @@ export const selectOutputLabels = (
     const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticSessionId);
 
     return state.labeling.walletsLabels[walletDescriptor]?.outputLabels ?? [];
+};
+
+type SelectOutputLabelsByAccountParams = {
+    state: WithLabelingState;
+    deviceStaticSessionId: StaticSessionId;
+    accountDescriptor: string;
+    networkSymbol: NetworkSymbol;
+};
+
+export const selectOutputLabelsByAccount = ({
+    state,
+    deviceStaticSessionId,
+    accountDescriptor,
+    networkSymbol,
+}: SelectOutputLabelsByAccountParams) => {
+    const outputLabels = selectOutputLabels(state, deviceStaticSessionId);
+
+    return outputLabels.filter(
+        label =>
+            label.accountDescriptor === accountDescriptor && label.networkSymbol === networkSymbol,
+    );
 };
 
 type SelectOutputLabelParams = {

--- a/suite-common/suite-sync/src/labeling/suiteSyncToBip329.ts
+++ b/suite-common/suite-sync/src/labeling/suiteSyncToBip329.ts
@@ -1,0 +1,39 @@
+import { Bip329Label } from '@suite-common/metadata-types';
+import { AddressLabel, OutputLabel } from '@suite-common/suite-sync-storage';
+
+type SuiteSyncToBip329 = {
+    outputLabels: OutputLabel[];
+    addressLabels: AddressLabel[];
+    allSpendable: boolean;
+};
+
+export const suiteSyncToBip329 = ({
+    outputLabels,
+    addressLabels,
+    allSpendable,
+}: SuiteSyncToBip329): Bip329Label[] => {
+    const bip329Labels: Bip329Label[] = [];
+
+    if (outputLabels.length > 0) {
+        for (const { txId, outputIndex, label } of outputLabels) {
+            bip329Labels.push({
+                type: 'output',
+                ref: `${txId}:${outputIndex}`,
+                label: label ?? '',
+                spendable: allSpendable, // Right now Trezor Suite does not allow to set spendable so all are `true`.
+            });
+        }
+    }
+
+    if (addressLabels.length > 0) {
+        for (const { address, label } of addressLabels) {
+            bip329Labels.push({
+                type: 'addr',
+                ref: address,
+                label: label ?? '',
+            });
+        }
+    }
+
+    return bip329Labels;
+};

--- a/suite-common/suite-sync/tests/labeling/suiteSyncToBip329.test.ts
+++ b/suite-common/suite-sync/tests/labeling/suiteSyncToBip329.test.ts
@@ -1,0 +1,63 @@
+import { AddressLabel, OutputLabel } from '@suite-common/suite-sync-storage';
+
+import { suiteSyncToBip329 } from '../../src/labeling/suiteSyncToBip329';
+
+describe(suiteSyncToBip329.name, () => {
+    it('transform properly', () => {
+        const outputLabels: OutputLabel[] = [
+            {
+                txId: '50e4fa9ebfca7d510feae7226a7d5d046114f54a7918cdd83e40c98d70d17e4d',
+                outputIndex: 0,
+                label: 'this is expending transaction output or just tx',
+                accountDescriptor: 'xpub...',
+                networkSymbol: 'btc',
+            },
+            {
+                txId: '519e17d6f3eb87cc8c4bf450d0dc2bad83a1387713680bec609bcb5d8e53335e',
+                outputIndex: 0,
+                label: 'this is receive tx label',
+                accountDescriptor: 'xpub...',
+                networkSymbol: 'btc',
+            },
+        ];
+        const addressLabels: AddressLabel[] = [
+            {
+                address: 'bc1qq46pg2kafgjvsh7me3puv0jujdl77a5829xlrs',
+                label: 'This address is labeled',
+                accountDescriptor: 'xpub...',
+                networkSymbol: 'btc',
+            },
+        ];
+        const allSpendable = true;
+
+        const bip329Output = suiteSyncToBip329({
+            outputLabels,
+            addressLabels,
+            allSpendable,
+        });
+
+        const expectedResult = [
+            {
+                type: 'output',
+                ref: '50e4fa9ebfca7d510feae7226a7d5d046114f54a7918cdd83e40c98d70d17e4d:0',
+                label: 'this is expending transaction output or just tx',
+            },
+            {
+                type: 'output',
+                ref: '519e17d6f3eb87cc8c4bf450d0dc2bad83a1387713680bec609bcb5d8e53335e:0',
+                label: 'this is receive tx label',
+            },
+            {
+                type: 'addr',
+                ref: 'bc1qq46pg2kafgjvsh7me3puv0jujdl77a5829xlrs',
+                label: 'This address is labeled',
+            },
+        ];
+
+        bip329Output.forEach((label, index) => {
+            expect(label.type).toEqual(expectedResult[index].type);
+            expect(label.ref).toEqual(expectedResult[index].ref);
+            expect(label.label).toEqual(expectedResult[index].label);
+        });
+    });
+});

--- a/suite-common/suite-utils/src/index.ts
+++ b/suite-common/suite-utils/src/index.ts
@@ -8,3 +8,4 @@ export * from './protocol';
 export * from './invariant';
 export * from './jws';
 export * from './pollingController';
+export * from './triggerWebDownloadFile';

--- a/suite-common/suite-utils/src/triggerWebDownloadFile.ts
+++ b/suite-common/suite-utils/src/triggerWebDownloadFile.ts
@@ -1,0 +1,11 @@
+// Triggers a client-side download for a given Blob or MediaSource object.
+export const triggerWebDownloadFile = (obj: Blob | MediaSource, fileName: string): void => {
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(obj);
+    a.download = fileName;
+    a.style.display = 'none';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(a.href);
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add functionality to export labels to BIP 329 format.

Adding new package `metadata-utils` that handles conversion of format from [SLIP-0015](https://github.com/satoshilabs/slips/blob/master/slip-0015.md) to [BIP 329](https://github.com/bitcoin/bips/blob/master/bip-0329.mediawiki)

It requires https://github.com/trezor/trezor-suite/issues/23161 to be completed with outputs including account descriptor and network symbol so we can query for labels in one account.

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/7406 it only solves exports, next step would be imports.

## For QA

There is a new option in the Bitcoin account details to be able to export a new files with the labels. It should provide a file with `.jsonl` extension and will contain lines of JSON like:

```json
{"type":"output","ref":"064f529a5c89b584bd1578683c21624981fb8cb7f96b7b9a307986a80feb907c:0","label":"Output in Drugs segwit 1 account","spendable":true}
{"type":"addr","ref":"bc1qq46pg2kafgjvsh7me3puv0jujdl77a5829xlrs","label":"address other in drugs segwit 1 account"}
{"type":"addr","ref":"bc1qmdza0jd33ges35lkgvgk360a28e5mglfjcqsxl","label":"address in drugs segwit 1 account"}
```

This should work with the legacy label system and the new one that is not in production yet (Suite Sync)

<img width="851" height="164" alt="image" src="https://github.com/user-attachments/assets/d5fb7d51-733a-414a-934c-d8126aa2dfc3" />

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/support-bip329&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/support-bip329&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/support-bip329&lookback=7)