### PR TITLE
refactor(wallet-core): split updateFeeInfoThunk

### DIFF
--- a/suite-common/wallet-core/src/fees/feesThunks.ts
+++ b/suite-common/wallet-core/src/fees/feesThunks.ts
@@ -1,29 +1,18 @@
 import { createThunk } from '@suite-common/redux-utils';
-import {
-    NetworkSymbol,
-    getNetwork,
-    getNetworkOptional,
-    networksCollection,
-} from '@suite-common/wallet-config';
+import { NetworkSymbol, getNetworkOptional, networksCollection } from '@suite-common/wallet-config';
 import type { NetworksFees } from '@suite-common/wallet-types';
-import { isEip1559 } from '@suite-common/wallet-utils';
-import TrezorConnect, { FeeLevel } from '@trezor/connect';
-import { isNative } from '@trezor/env-utils';
+import TrezorConnect from '@trezor/connect';
 
 import { FEES_MODULE_PREFIX, feesActions } from './feesActions';
+import { getNewFeeInfo, sortLevels } from './feesUtils';
 import { selectNetworkBlockchainInfo } from '../blockchain/blockchainReducer';
+import { selectSelectedDevice } from '../device/deviceSelectors';
 import { selectEnabledNetworks } from '../settings/walletSettingsReducer';
 
 // Conditionally subscribe to blockchain backend
 // called after TrezorConnect.init successfully emits TRANSPORT.START event
 // checks if there are discovery processes loaded from LocalStorage
 // if so starts subscription to proper networks
-
-// sort FeeLevels in reversed order (Low > High)
-// TODO: consider to use same order in @trezor/connect to avoid double sorting
-const order: FeeLevel['label'][] = ['low', 'economy', 'normal', 'high'];
-export const sortLevels = (levels: FeeLevel[]) =>
-    levels.sort((levelA, levelB) => order.indexOf(levelA.label) - order.indexOf(levelB.label));
 
 export const preloadFeeInfoThunk = createThunk(
     `${FEES_MODULE_PREFIX}/preloadFeeInfoThunk`,
@@ -72,81 +61,20 @@ export const preloadFeeInfoThunk = createThunk(
 
 export const updateFeeInfoThunk = createThunk(
     `${FEES_MODULE_PREFIX}/updateFeeInfoThunk`,
-    async ({ networkSymbol }: { networkSymbol: NetworkSymbol }, { dispatch, getState, extra }) => {
+    async ({ networkSymbol }: { networkSymbol: NetworkSymbol }, { dispatch, getState }) => {
         const network = getNetworkOptional(networkSymbol.toLowerCase());
         if (!network) return;
         const blockchainInfo = selectNetworkBlockchainInfo(getState(), network.symbol);
+        const device = selectSelectedDevice(getState());
 
-        const device = extra.selectors.selectDevice(getState());
+        const newFeeInfo = await getNewFeeInfo({ network, device });
+        if (newFeeInfo === undefined) return;
 
-        let newFeeInfo;
-
-        if (network.networkType === 'ethereum') {
-            const result = await TrezorConnect.blockchainEstimateFee({
-                coin: network.symbol,
-                request: {
-                    blocks: [2],
-                    feeLevels: 'smart',
-                    specific: {
-                        from: '0x0000000000000000000000000000000000000000',
-                        to: '0x0000000000000000000000000000000000000000',
-                    },
-                },
-            });
-            if (result.success) {
-                const feeLevelBase = result.payload.levels[0];
-                const isEip1559ActivatedAndAvailable =
-                    getNetwork(network.symbol).features.includes('eip1559') &&
-                    isEip1559(feeLevelBase) &&
-                    !device?.unavailableCapabilities?.['eip1559'] &&
-                    !isNative(); // suite-native does not have eip1559 implementation yet #16372
-
-                if (isEip1559ActivatedAndAvailable) {
-                    newFeeInfo = result.payload;
-                } else {
-                    newFeeInfo = {
-                        ...result.payload,
-                        levels: [
-                            {
-                                ...feeLevelBase,
-                                baseFeePerGas: undefined,
-                                maxFeePerGas: undefined,
-                                maxPriorityFeePerGas: undefined,
-                                label: 'normal' as const,
-                            },
-                        ],
-                    };
-                }
-            }
-        } else {
-            const result = await TrezorConnect.blockchainEstimateFee({
-                coin: network.symbol,
-                request: {
-                    feeLevels: 'smart',
-                },
-            });
-
-            if (result.success) {
-                newFeeInfo = {
-                    ...result.payload,
-                    levels: sortLevels(
-                        result.payload.levels
-                            // hack to hide "low" fee option
-                            // (we do not want to change the connect API as it is a potentially breaking change)
-                            .filter(level => level.label !== 'low'),
-                    ),
-                };
-            }
-        }
-
-        if (newFeeInfo) {
-            const partial: Partial<NetworksFees> = {};
-            partial[network.symbol] = {
-                blockHeight: blockchainInfo.blockHeight,
-                ...newFeeInfo,
-            };
-
-            dispatch(feesActions.updateFee(partial));
-        }
+        const partialFees: Partial<NetworksFees> = {};
+        partialFees[network.symbol] = {
+            blockHeight: blockchainInfo.blockHeight,
+            ...newFeeInfo,
+        };
+        dispatch(feesActions.updateFee(partialFees));
     },
 );

--- a/suite-common/wallet-core/src/fees/feesUtils.ts
+++ b/suite-common/wallet-core/src/fees/feesUtils.ts
@@ -1,0 +1,89 @@
+import { TrezorDevice } from '@suite-common/suite-types';
+import { Network, NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { isEip1559 } from '@suite-common/wallet-utils';
+import TrezorConnect, { FeeLevel } from '@trezor/connect';
+import { BlockchainEstimatedFeeLevel } from '@trezor/connect/src/types/api/blockchainEstimateFee';
+import { isNative } from '@trezor/env-utils';
+
+// sort FeeLevels in reversed order (Low > High)
+// TODO: consider to use same order in @trezor/connect to avoid double sorting
+const order: FeeLevel['label'][] = ['low', 'economy', 'normal', 'high'];
+
+export const sortLevels = (levels: FeeLevel[]) =>
+    levels.sort((levelA, levelB) => order.indexOf(levelA.label) - order.indexOf(levelB.label));
+
+type GetEip1559AvailabilityProps = {
+    symbol: NetworkSymbol;
+    feeLevel: FeeLevel;
+    device?: TrezorDevice;
+};
+export const getEip1559Availability = ({ symbol, feeLevel, device }: GetEip1559AvailabilityProps) =>
+    getNetwork(symbol).features.includes('eip1559') &&
+    isEip1559(feeLevel) &&
+    !device?.unavailableCapabilities?.['eip1559'] &&
+    // suite-native does not have eip1559 implementation yet #16372
+    !isNative();
+
+type GetNewFeeInfoProps = { network: Network; device?: TrezorDevice };
+export const getNewFeeInfo = async ({
+    network,
+    device,
+}: GetNewFeeInfoProps): Promise<BlockchainEstimatedFeeLevel | undefined> => {
+    const { symbol } = network;
+    if (network.networkType === 'ethereum') {
+        const result = await TrezorConnect.blockchainEstimateFee({
+            coin: symbol,
+            request: {
+                blocks: [2],
+                feeLevels: 'smart',
+                specific: {
+                    from: '0x0000000000000000000000000000000000000000',
+                    to: '0x0000000000000000000000000000000000000000',
+                },
+            },
+        });
+        if (!result.success) return;
+
+        const feeLevelBase = result.payload.levels.at(0);
+        // should never occur, all coins have at least one fee level defined
+        if (feeLevelBase === undefined) return;
+        const isEip1559ActivatedAndAvailable = getEip1559Availability({
+            symbol,
+            feeLevel: feeLevelBase,
+            device,
+        });
+
+        if (isEip1559ActivatedAndAvailable) return result.payload;
+
+        return {
+            ...result.payload,
+            levels: [
+                {
+                    ...feeLevelBase,
+                    baseFeePerGas: undefined,
+                    maxFeePerGas: undefined,
+                    maxPriorityFeePerGas: undefined,
+                    label: 'normal' as const,
+                },
+            ],
+        };
+    }
+
+    const result = await TrezorConnect.blockchainEstimateFee({
+        coin: symbol,
+        request: {
+            feeLevels: 'smart',
+        },
+    });
+    if (!result.success) return;
+
+    return {
+        ...result.payload,
+        levels: sortLevels(
+            result.payload.levels
+                // hack to hide "low" fee option
+                // (we do not want to change the connect API as it is a potentially breaking change)
+                .filter(level => level.label !== 'low'),
+        ),
+    };
+};

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -27,6 +27,7 @@ export * from './discovery/passphraseUtils';
 export * from './fees/feesActions';
 export * from './fees/feesReducer';
 export * from './fees/feesThunks';
+export * from './fees/feesUtils';
 export * from './fiat-rates/fiatRatesMiddleware';
 export * from './fiat-rates/fiatRatesReducer';
 export * from './fiat-rates/fiatRatesSelectors';


### PR DESCRIPTION
## Description
Small refactoring extracted from #19577 to make `updateFeeInfoThunk` nicer:

no functional changes, only inverted conditions and changed if-else to early returns, so that the logical tree is better readable

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/code-cleanup-updateFeeInfoThunk&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/code-cleanup-updateFeeInfoThunk&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/code-cleanup-updateFeeInfoThunk&lookback=7)