### PR TITLE
feat(suite-native): keep screen awake while interacting with device

### DIFF
--- a/suite-native/device-mutex/package.json
+++ b/suite-native/device-mutex/package.json
@@ -6,11 +6,13 @@
     "private": true,
     "sideEffects": false,
     "dependencies": {
-        "@mobily/ts-belt": "^3.13.1"
+        "@mobily/ts-belt": "^3.13.1",
+        "expo-keep-awake": "14.0.3",
+        "uuid": "^11.1.0"
     },
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
-        "test:unit": "yarn g:jest -c ../../jest.config.base.js"
+        "test:unit": "yarn g:jest -c ../../jest.config.native.js"
     }
 }

--- a/suite-native/device-mutex/src/requestDeviceAccess.ts
+++ b/suite-native/device-mutex/src/requestDeviceAccess.ts
@@ -1,3 +1,6 @@
+import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
+import { v4 as uuidv4 } from 'uuid';
+
 import { deviceAccessMutex } from './DeviceAccessMutex';
 import { DEVICE_ACCESS_ERROR } from './constants';
 import { DeviceAccessResponse } from './types';
@@ -19,7 +22,10 @@ export const requestDeviceAccess = async <TParams extends unknown[], TReturnType
         : deviceAccessMutex.lock());
     if (!wasLockSuccessful) return DEVICE_ACCESS_ERROR;
 
+    const keepAwakeTag = uuidv4();
+
     try {
+        activateKeepAwakeAsync(keepAwakeTag); // Prevents screen from sleeping while app interacts with device.
         const response = await deviceCallback(...callbackParams);
         deviceAccessMutex.unlock();
 
@@ -28,6 +34,8 @@ export const requestDeviceAccess = async <TParams extends unknown[], TReturnType
         deviceAccessMutex.unlock();
 
         return { success: false, error };
+    } finally {
+        deactivateKeepAwake(keepAwakeTag);
     }
 };
 

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -8,6 +8,7 @@ import {
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { WalletBackupType, reportCheckFail } from '@suite-native/device';
+import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import TrezorConnect, { PROTO } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { exhaustive } from '@trezor/type-utils';
@@ -97,22 +98,39 @@ export const createAndBackupWalletThunk = createThunk(
                       }
                     : {};
 
-            return await TrezorConnect.backupDevice({
-                ...backupParams,
-                device: {
-                    path: device.path,
-                },
+            const deviceResponse = await requestPrioritizedDeviceAccess({
+                deviceCallback: () =>
+                    TrezorConnect.backupDevice({
+                        ...backupParams,
+                        device: {
+                            path: device.path,
+                        },
+                    }),
             });
+
+            if (!deviceResponse.success) {
+                throw new Error(deviceResponse.error);
+            }
+
+            return deviceResponse.payload;
         }
 
-        const result = await TrezorConnect.resetDevice({
-            device: { path: devicePath },
-            skip_backup: false,
-            ...getResetDeviceConfig(walletBackupType),
-            //Entropy check can be toggled via message system config so it should be always last to avoid unintentional disabling.
-            entropy_check: isEntropyCheckEnabled,
+        const deviceResponse = await requestPrioritizedDeviceAccess({
+            deviceCallback: () =>
+                TrezorConnect.resetDevice({
+                    device: { path: devicePath },
+                    skip_backup: false,
+                    ...getResetDeviceConfig(walletBackupType),
+                    //Entropy check can be toggled via message system config so it should be always last to avoid unintentional disabling.
+                    entropy_check: isEntropyCheckEnabled,
+                }),
         });
 
+        if (!deviceResponse.success) {
+            throw new Error(deviceResponse.error);
+        }
+
+        const result = deviceResponse.payload;
         if (!result.success && result.payload.code === 'Failure_EntropyCheck') {
             const contextData = {
                 model: device?.features?.internal_model,
@@ -133,9 +151,17 @@ export const createAndBackupWalletThunk = createThunk(
 
 export const recoverWalletThunk = createThunk(
     `${NATIVE_DEVICE_MODULE_PREFIX}/recoverWalletThunk`,
-    (_, { getState }) => {
+    async (_, { getState }) => {
         const devicePath = selectDevicePath(getState());
 
-        return TrezorConnect.recoveryDevice({ device: { path: devicePath } });
+        const deviceResponse = await requestPrioritizedDeviceAccess({
+            deviceCallback: () => TrezorConnect.recoveryDevice({ device: { path: devicePath } }),
+        });
+
+        if (!deviceResponse.success) {
+            throw new Error(deviceResponse.error);
+        }
+
+        return deviceResponse.payload;
     },
 );

--- a/suite-native/module-device-onboarding/src/screens/DeviceTutorialScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/DeviceTutorialScreen.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { ContinueOnTrezorScreenContent } from '@suite-native/device';
+import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import {
     DeviceOnboardingStackParamList,
     DeviceOnboardingStackRoutes,
@@ -18,11 +19,10 @@ export const DeviceTutorialScreen = ({
     const device = useSelector(selectSelectedDevice);
     useEffect(() => {
         const showTutorial = async () => {
-            const { success, payload } = await TrezorConnect.showDeviceTutorial({ device });
-
-            if (success || payload.code === 'Failure_ActionCancelled') {
-                navigation.navigate(DeviceOnboardingStackRoutes.CreateOrRecoverCrossroads);
-            }
+            await requestPrioritizedDeviceAccess({
+                deviceCallback: () => TrezorConnect.showDeviceTutorial({ device }),
+            });
+            navigation.navigate(DeviceOnboardingStackRoutes.CreateOrRecoverCrossroads);
         };
         showTutorial();
 
@@ -32,7 +32,6 @@ export const DeviceTutorialScreen = ({
 
     const handleSkipTutorial = () => {
         TrezorConnect.cancel();
-        navigation.navigate(DeviceOnboardingStackRoutes.CreateOrRecoverCrossroads);
     };
 
     return (

--- a/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
+import { isFulfilled } from '@reduxjs/toolkit';
+
 import { createAndBackupWalletThunk } from '@suite-native/device';
 import {
     DeviceOnboardingStackParamList,
@@ -28,14 +30,23 @@ export const WalletCreationScreen = ({
     const dispatch = useDispatch();
 
     const handleCreateAndBackupWallet = useCallback(async () => {
-        const response = await dispatch(createAndBackupWalletThunk({ walletBackupType })).unwrap();
+        const response = await dispatch(createAndBackupWalletThunk({ walletBackupType }));
 
-        if (response.success) {
-            return navigation.navigate(DeviceOnboardingStackRoutes.WalletCreatedSuccess, {
-                flowType: 'create',
-            });
+        if (isFulfilled(response)) {
+            const responsePayload = response.payload;
+
+            if (responsePayload.success) {
+                return navigation.navigate(DeviceOnboardingStackRoutes.WalletCreatedSuccess, {
+                    flowType: 'create',
+                });
+            }
+            if (
+                responsePayload.payload.code &&
+                DEFINITIVE_ERRORS.includes(responsePayload.payload.code)
+            ) {
+                return;
+            }
         }
-        if (response.payload.code && DEFINITIVE_ERRORS.includes(response.payload.code)) return;
 
         handleCreateAndBackupWallet();
     }, [dispatch, walletBackupType, navigation]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10346,6 +10346,8 @@ __metadata:
   resolution: "@suite-native/device-mutex@workspace:suite-native/device-mutex"
   dependencies:
     "@mobily/ts-belt": "npm:^3.13.1"
+    expo-keep-awake: "npm:14.0.3"
+    uuid: "npm:^11.1.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description
- The device mutex has been improved, ensuring that if there are any devices waiting for a response from the phone, the phone screen remains awake. This prevents the phone from going to sleep and disrupting communication with the devices.


## Related Issue

Resolve #19554 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/keep-awake-while-calling-device&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/keep-awake-while-calling-device&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/keep-awake-while-calling-device&lookback=7)

Adhoc build link (commit 14590bc, last fixup excluded) https://expo.dev/accounts/trezorcompany-develop/projects/trezor-suite-preview/builds/518970e2-16c6-4680-a84e-a39f7cbad6d6