### PR TITLE
Refactor buy/exchange to use tradingAccountKey and receiveAccountKey

### DIFF
--- a/suite-native/module-trading/src/__fixtures__/account.ts
+++ b/suite-native/module-trading/src/__fixtures__/account.ts
@@ -1,10 +1,12 @@
 import { Account } from '@suite-common/wallet-types';
 
-export const getBtcAccount = () =>
+export const getBtcAccount = (key = 'btc-account-1') =>
     ({
+        key,
         symbol: 'btc',
         accountType: 'normal',
         accountLabel: 'BTC Account #1',
+        descriptor: 'descriptor-' + key,
         balance: '1000000',
         availableBalance: '1000000',
         formattedBalance: '0.01',

--- a/suite-native/module-trading/src/__tests__/tradingSlice.test.ts
+++ b/suite-native/module-trading/src/__tests__/tradingSlice.test.ts
@@ -2,10 +2,10 @@ import { BuyTrade, CryptoId } from 'invity-api';
 
 import { TrezorDevice } from '@suite-common/suite-types';
 import { extraDependenciesMock } from '@suite-common/test-utils';
-import { tradingBuyActions } from '@suite-common/trading';
+import { tradingBuyActions, tradingExchangeActions } from '@suite-common/trading';
 import { deviceActions } from '@suite-common/wallet-core';
+import { Address } from '@trezor/blockchain-link-types';
 
-import { getBtcAccount } from '../__fixtures__/account';
 import quotes from '../__fixtures__/quotes.json';
 import { adaAsset, btcAsset, usdcAsset } from '../__fixtures__/tradeableAssets';
 import { TradingState, initialState, tradingActions, tradingSlice } from '../tradingSlice';
@@ -38,107 +38,97 @@ describe('tradingSlice', () => {
         });
     });
 
-    describe('buy', () => {
-        it('setBuySelectedReceiveAccount should set selectedReceiveAccount', () => {
-            const receiveAccount = { account: getBtcAccount(), address: undefined };
-            const state = tradingReducer(
-                undefined,
-                tradingActions.setBuySelectedReceiveAccount({
-                    selectedReceiveAccount: receiveAccount,
-                }),
-            );
-
-            expect(state.buy.selectedReceiveAccount).toBe(receiveAccount);
-        });
-
-        it('setBuySelectedReceiveAccount should set and clear selectedReceiveAccount', () => {
+    describe('favouriteAssets', () => {
+        it('addTradeableAssetToFavourites should add asset to favourites', () => {
             const actions = [
-                tradingActions.setBuySelectedReceiveAccount({
-                    selectedReceiveAccount: { account: getBtcAccount(), address: undefined },
-                }),
-                tradingActions.setBuySelectedReceiveAccount({
-                    selectedReceiveAccount: undefined,
-                }),
+                tradingActions.addTradeableAssetToFavourites(btcAsset.cryptoId),
+                tradingActions.addTradeableAssetToFavourites(usdcAsset.cryptoId),
+                tradingActions.addTradeableAssetToFavourites(adaAsset.cryptoId),
             ];
             const state = actions.reduce(tradingReducer, undefined) as TradingState;
 
-            expect(state.buy.selectedReceiveAccount).toBeUndefined();
+            expect(state.favouriteAssets).toEqual({
+                bitcoin: true,
+                cardano: true,
+                'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': true,
+            });
         });
 
-        describe('favouriteAssets', () => {
-            it('addTradeableAssetToFavourites should add asset to favourites', () => {
-                const actions = [
+        describe('given state with one favourite asset', () => {
+            let prevState: TradingState;
+
+            beforeEach(() => {
+                prevState = tradingReducer(
+                    undefined,
                     tradingActions.addTradeableAssetToFavourites(btcAsset.cryptoId),
-                    tradingActions.addTradeableAssetToFavourites(usdcAsset.cryptoId),
-                    tradingActions.addTradeableAssetToFavourites(adaAsset.cryptoId),
-                ];
-                const state = actions.reduce(tradingReducer, undefined) as TradingState;
+                );
+            });
+
+            it('addTradeableAssetToFavourites should not add same asset twice', () => {
+                const state = tradingReducer(
+                    prevState,
+                    tradingActions.addTradeableAssetToFavourites(btcAsset.cryptoId),
+                );
 
                 expect(state.favouriteAssets).toEqual({
                     bitcoin: true,
-                    cardano: true,
-                    'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': true,
                 });
             });
 
-            describe('given state with one favourite asset', () => {
-                let prevState: TradingState;
+            it('removeTradeableAssetFromFavourites should remove asset from favourites', () => {
+                const state = tradingReducer(
+                    prevState,
+                    tradingActions.removeTradeableAssetFromFavourites(btcAsset.cryptoId),
+                );
 
-                beforeEach(() => {
-                    prevState = tradingReducer(
-                        undefined,
-                        tradingActions.addTradeableAssetToFavourites(btcAsset.cryptoId),
-                    );
-                });
+                expect(state.favouriteAssets).toEqual({});
+            });
+        });
+    });
 
-                it('addTradeableAssetToFavourites should not add same asset twice', () => {
-                    const state = tradingReducer(
-                        prevState,
-                        tradingActions.addTradeableAssetToFavourites(btcAsset.cryptoId),
-                    );
+    describe('buy', () => {
+        describe('setBuyReceiveAddress', () => {
+            it('should set buy receive address', () => {
+                const address = { address: 'bc1qxyz' } as Address;
+                const state = tradingReducer(
+                    undefined,
+                    tradingActions.setBuyReceiveAddress(address),
+                );
 
-                    expect(state.favouriteAssets).toEqual({
-                        bitcoin: true,
-                    });
-                });
+                expect(state.buy.receiveAddress).toEqual(address);
+            });
 
-                it('removeTradeableAssetFromFavourites should remove asset from favourites', () => {
-                    const state = tradingReducer(
-                        prevState,
-                        tradingActions.removeTradeableAssetFromFavourites(btcAsset.cryptoId),
-                    );
+            it('should set buy receive address to undefined', () => {
+                const state = tradingReducer(
+                    undefined,
+                    tradingActions.setBuyReceiveAddress(undefined),
+                );
 
-                    expect(state.favouriteAssets).toEqual({});
-                });
+                expect(state.buy.receiveAddress).toBeUndefined();
             });
         });
     });
 
     describe('exchange', () => {
-        it('setExchangeSelectedReceiveAccount should set selectedReceiveAccount', () => {
-            const receiveAccount = { account: getBtcAccount(), address: undefined };
-            const state = tradingReducer(
-                undefined,
-                tradingActions.setExchangeSelectedReceiveAccount({
-                    selectedReceiveAccount: receiveAccount,
-                }),
-            );
+        describe('setExchangeReceiveAddress', () => {
+            it('should set exchange receive address', () => {
+                const address = { address: 'bc1qxyz' } as Address;
+                const state = tradingReducer(
+                    undefined,
+                    tradingActions.setExchangeReceiveAddress(address),
+                );
 
-            expect(state.exchange.selectedReceiveAccount).toBe(receiveAccount);
-        });
+                expect(state.exchange.receiveAddress).toEqual(address);
+            });
 
-        it('setExchangeSelectedReceiveAccount should set and clear selectedReceiveAccount', () => {
-            const actions = [
-                tradingActions.setExchangeSelectedReceiveAccount({
-                    selectedReceiveAccount: { account: getBtcAccount(), address: undefined },
-                }),
-                tradingActions.setExchangeSelectedReceiveAccount({
-                    selectedReceiveAccount: undefined,
-                }),
-            ];
-            const state = actions.reduce(tradingReducer, undefined) as TradingState;
+            it('should set exchange receive address to undefined', () => {
+                const state = tradingReducer(
+                    undefined,
+                    tradingActions.setExchangeReceiveAddress(undefined),
+                );
 
-            expect(state.exchange.selectedReceiveAccount).toBeUndefined();
+                expect(state.exchange.receiveAddress).toBeUndefined();
+            });
         });
     });
 
@@ -154,11 +144,7 @@ describe('tradingSlice', () => {
 
             expect(state.tradingEnvironment).toBe('dev');
             expect(state.buy).toEqual({
-                selectedReceiveAccount: undefined,
-                quotesRequest: undefined,
                 quotes: [],
-                selectedQuote: undefined,
-                amountLimits: undefined,
                 isFromRedirect: false,
                 isLoading: false,
             });
@@ -171,7 +157,10 @@ describe('tradingSlice', () => {
                 ...initialState,
                 buy: {
                     ...initialState.buy,
-                    selectedReceiveAccount: { account: getBtcAccount(), address: undefined },
+                    tradingAccountKey: 'account-key',
+                    receiveAddress: {
+                        address: 'bc1qxyz',
+                    } as Address,
                     quotesRequest: {
                         wantCrypto: true,
                         receiveCurrency: 'btc' as CryptoId,
@@ -190,7 +179,8 @@ describe('tradingSlice', () => {
             const state = tradingReducer(tradingInitialState, tradingSlice.actions.clearBuyState());
 
             expect(state.buy).toEqual({
-                selectedReceiveAccount: undefined,
+                receiveAddress: undefined,
+                tradingAccountKey: undefined,
                 quotesRequest: undefined,
                 quotes: [],
                 selectedQuote: undefined,
@@ -207,7 +197,10 @@ describe('tradingSlice', () => {
                 ...initialState,
                 buy: {
                     ...initialState.buy,
-                    selectedReceiveAccount: { account: getBtcAccount(), address: undefined },
+                    tradingAccountKey: 'account-key',
+                    receiveAddress: {
+                        address: 'address',
+                    } as Address,
                     quotesRequest: {
                         wantCrypto: true,
                         receiveCurrency: 'btc' as CryptoId,
@@ -226,7 +219,7 @@ describe('tradingSlice', () => {
 
             expect(state.buy).toEqual({
                 ...tradingInitialState.buy,
-                selectedReceiveAccount: expect.any(Object),
+                receiveAddress: expect.any(Object),
                 quotesRequest: undefined,
                 quotes: [],
                 selectedQuote: expect.any(Object),
@@ -265,36 +258,56 @@ describe('tradingSlice', () => {
     });
 
     describe('@suite/device/selectDevice', () => {
-        it('should clear selectedReceiveAccount', () => {
+        it('should clear receiveAddress', () => {
             const actions = [
-                tradingActions.setBuySelectedReceiveAccount({
-                    selectedReceiveAccount: { account: getBtcAccount(), address: undefined },
-                }),
-                tradingActions.setExchangeSelectedReceiveAccount({
-                    selectedReceiveAccount: { account: getBtcAccount(), address: undefined },
-                }),
+                tradingActions.setBuyReceiveAddress({
+                    address: 'address',
+                } as Address),
+                tradingActions.setExchangeReceiveAddress({
+                    address: 'address',
+                } as Address),
                 deviceActions.selectDevice({ name: 'TEST_DEVICE' } as TrezorDevice),
             ];
 
             const state = actions.reduce(tradingReducer, undefined) as TradingState;
 
-            expect(state.buy.selectedReceiveAccount).toBeUndefined();
-            expect(state.exchange.selectedReceiveAccount).toBeUndefined();
+            expect(state.buy.receiveAddress).toBeUndefined();
+            expect(state.exchange.receiveAddress).toBeUndefined();
+        });
+
+        it('should clear buy.tradingAccountKey', () => {
+            const actions = [
+                tradingBuyActions.setTradingAccountKey('account-key'),
+                deviceActions.selectDevice({ name: 'TEST_DEVICE' } as TrezorDevice),
+            ];
+
+            const state = actions.reduce(tradingReducer, undefined) as TradingState;
+            expect(state.buy.tradingAccountKey).toBeUndefined();
+        });
+
+        it('should clear exchange.receiveAccountKey', () => {
+            const actions = [
+                tradingExchangeActions.setReceiveAccountKey('account-key'),
+                deviceActions.selectDevice({ name: 'TEST_DEVICE' } as TrezorDevice),
+            ];
+
+            const state = actions.reduce(tradingReducer, undefined) as TradingState;
+            expect(state.exchange.receiveAccountKey).toBeUndefined();
         });
     });
 
     describe('buyAssetChanged', () => {
-        it('should clear selectedReceiveAccount', () => {
+        it('should clear tradingAccountKey and receiveAddress', () => {
             const actions = [
-                tradingActions.setBuySelectedReceiveAccount({
-                    selectedReceiveAccount: { account: getBtcAccount(), address: undefined },
-                }),
+                tradingBuyActions.setTradingAccountKey('account-key'),
+                tradingActions.setBuyReceiveAddress({ address: 'address' } as Address),
                 tradingActions.buyAssetChanged(),
             ];
 
             const state = actions.reduce(tradingReducer, undefined) as TradingState;
 
-            expect(state.buy.selectedReceiveAccount).toBeUndefined();
+            expect(state.buy.tradingAccountKey).toBeUndefined();
+            expect(state.buy.receiveAddress).toBeUndefined();
         });
 
         it('should clear buy amountLimits', () => {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountPicker.comp.test.tsx
@@ -10,6 +10,7 @@ import {
 import { getBtcAccount } from '../../../__fixtures__/account';
 import { btcAsset } from '../../../__fixtures__/tradeableAssets';
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
+import { initialState } from '../../../tradingSlice';
 import { BuyFormType } from '../../../types/buy';
 import { ReceiveAccount, TradeableAsset } from '../../../types/general';
 import { BuyReceiveAccountPicker } from '../BuyReceiveAccountPicker';
@@ -25,13 +26,17 @@ jest.mock('@react-navigation/native', () => ({
     }),
 }));
 
-const getBuyState = (selectedReceiveAccount: ReceiveAccount | undefined) => ({
+const getTradingState = (selectedReceiveAccount: ReceiveAccount | undefined) => ({
     wallet: {
         tradingNew: {
+            ...initialState,
             buy: {
-                selectedReceiveAccount,
+                ...initialState.buy,
+                receiveAddress: selectedReceiveAccount?.address,
+                tradingAccountKey: selectedReceiveAccount?.account.key,
             },
         },
+        accounts: [getBtcAccount()],
     },
 });
 
@@ -78,7 +83,7 @@ describe('BuyReceiveAccountPicker', () => {
         setSelectedAsset(btcAsset);
         const btcAccount = getBtcAccount();
         const { getByText } = await renderPicker({
-            preloadedState: getBuyState({
+            preloadedState: getTradingState({
                 account: btcAccount,
                 address: btcAccount.addresses?.used[0],
             }),
@@ -92,7 +97,7 @@ describe('BuyReceiveAccountPicker', () => {
         setSelectedAsset(btcAsset);
         const btcAccount = getBtcAccount();
         const { getByText } = await renderPicker({
-            preloadedState: getBuyState({
+            preloadedState: getTradingState({
                 account: btcAccount,
                 address: btcAccount.addresses?.used[0],
             }),

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountPicker.comp.test.tsx
@@ -10,6 +10,7 @@ import {
 import { getBtcAccount } from '../../../../__fixtures__/account';
 import { btcAsset } from '../../../../__fixtures__/tradeableAssets';
 import { useExchangeForm } from '../../../../hooks/exchange/useExchangeForm';
+import { initialState } from '../../../../tradingSlice';
 import { ExchangeFormType } from '../../../../types/exchange';
 import { ReceiveAccount, TradeableAsset } from '../../../../types/general';
 import { ExchangeReceiveAccountPicker } from '../ExchangeReceiveAccountPicker';
@@ -28,10 +29,14 @@ jest.mock('@react-navigation/native', () => ({
 const getExchangeState = (selectedReceiveAccount: ReceiveAccount | undefined) => ({
     wallet: {
         tradingNew: {
+            ...initialState,
             exchange: {
-                selectedReceiveAccount,
+                ...initialState.exchange,
+                receiveAddress: selectedReceiveAccount?.address,
+                receiveAccountKey: selectedReceiveAccount?.account.key,
             },
         },
+        accounts: [getBtcAccount()],
     },
 });
 

--- a/suite-native/module-trading/src/components/general/AccountList/AccountList.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountList.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import { FlashList } from '@shopify/flash-list';
 
-import { TradingType } from '@suite-common/trading';
+import { TradingType, tradingBuyActions, tradingExchangeActions } from '@suite-common/trading';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { selectIsDeviceInViewOnlyMode } from '@suite-common/wallet-core';
 import {
@@ -82,12 +82,16 @@ export const AccountList = ({
         }) ?? [];
 
     const onItemSelect = (receiveAccount: ReceiveAccount) => {
-        const payload = { selectedReceiveAccount: receiveAccount };
-        const action =
+        const accountAction =
             tradingType === 'buy'
-                ? tradingActions.setBuySelectedReceiveAccount(payload)
-                : tradingActions.setExchangeSelectedReceiveAccount(payload);
-        dispatch(action);
+                ? tradingBuyActions.setTradingAccountKey(receiveAccount.account.key)
+                : tradingExchangeActions.setReceiveAccountKey(receiveAccount.account.key);
+        const addressAction =
+            tradingType === 'buy'
+                ? tradingActions.setBuyReceiveAddress(receiveAccount.address)
+                : tradingActions.setExchangeReceiveAddress(receiveAccount.address);
+        dispatch(accountAction);
+        dispatch(addressAction);
         const hasAddresses = receiveAccount.account.addresses;
         if (receiveAccount.account && hasAddresses) {
             onSetPickerMode('address');

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountList.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountList.comp.test.tsx
@@ -13,6 +13,7 @@ import { StaticSessionId } from '@trezor/connect';
 import fixturesAccounts from '../../../../__fixtures__/accounts.json';
 import { selectBuySelectedReceiveAccount } from '../../../../selectors/buySelectors';
 import { selectExchangeSelectedReceiveAccount } from '../../../../selectors/exchangeSelectors';
+import { initialState } from '../../../../tradingSlice';
 import { ReceiveAccount } from '../../../../types/general';
 import { AccountList, AccountsListProps, keyExtractor } from '../AccountList';
 
@@ -36,8 +37,11 @@ const getStateMockupBuy = (selectedAccount: ReceiveAccount) => ({
     wallet: {
         accounts: defaultPreloadedState.wallet.accounts,
         tradingNew: {
+            ...initialState,
             buy: {
-                selectedReceiveAccount: selectedAccount,
+                ...initialState.buy,
+                receiveAddress: selectedAccount?.address,
+                tradingAccountKey: selectedAccount.account.key,
             },
         },
     },
@@ -48,8 +52,11 @@ const getStateMockupExchange = (selectedAccount: ReceiveAccount) => ({
     wallet: {
         accounts: defaultPreloadedState.wallet.accounts,
         tradingNew: {
+            ...initialState,
             exchange: {
-                selectedReceiveAccount: selectedAccount,
+                ...initialState.exchange,
+                receiveAddress: selectedAccount?.address,
+                receiveAccountKey: selectedAccount.account.key,
             },
         },
     },

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
@@ -4,7 +4,6 @@ import { EnhancedStore } from '@reduxjs/toolkit';
 import type { BuyTrade, CryptoId } from 'invity-api';
 
 import { invityAPI, tradingBuyActions } from '@suite-common/trading';
-import { Account } from '@suite-common/wallet-types';
 import { Form, useField } from '@suite-native/forms';
 import {
     PreloadedState,
@@ -14,9 +13,9 @@ import {
     renderHook,
     renderHookWithStoreProviderAsync,
 } from '@suite-native/test-utils';
-import { Address } from '@trezor/blockchain-link-types';
 import { PROTO } from '@trezor/connect';
 
+import { getBtcAccount } from '../../../__fixtures__/account';
 import quotes from '../../../__fixtures__/quotes.json';
 import { btcAsset, usdcAsset } from '../../../__fixtures__/tradeableAssets';
 import { getInitializedTradingState } from '../../../__fixtures__/tradingState';
@@ -43,11 +42,14 @@ describe('useBuyForm', () => {
                         ? PROTO.AmountUnit.SATOSHI
                         : PROTO.AmountUnit.BITCOIN,
                 },
+                accounts: [
+                    getBtcAccount('btc-account-1'),
+                    getBtcAccount('btc-account-2'),
+                    { ...getBtcAccount('btc-account-3'), descriptor: '' },
+                ],
             },
         };
-        preloadedState.wallet!.tradingNew!.buy!.selectedReceiveAccount = {
-            account: { key: 'btc1' } as Account,
-        };
+        preloadedState.wallet!.tradingNew!.buy!.tradingAccountKey = 'btc-account-1';
 
         return await initStore(preloadedState);
     };
@@ -72,14 +74,12 @@ describe('useBuyForm', () => {
         const { result } = await renderUseTradingBuyForm(store);
 
         act(() => {
-            store.dispatch(
-                tradingActions.setBuySelectedReceiveAccount({
-                    selectedReceiveAccount: { account: { key: 'btc2' } as Account },
-                }),
-            );
+            store.dispatch(tradingBuyActions.setTradingAccountKey('btc-account-2'));
         });
 
-        expect(result.current.getValues('receiveAccount')).toEqual({ account: { key: 'btc2' } });
+        expect(result.current.getValues('receiveAccount')).toEqual({
+            account: expect.objectContaining({ key: 'btc-account-2' }),
+        });
     });
 
     describe('createInvityAPIKey', () => {
@@ -99,16 +99,10 @@ describe('useBuyForm', () => {
             invityAPISpy.mockClear();
 
             act(() => {
-                store.dispatch(
-                    tradingActions.setBuySelectedReceiveAccount({
-                        selectedReceiveAccount: {
-                            account: { key: 'btc2', descriptor: 'descriptor_btc2' } as Account,
-                        },
-                    }),
-                );
+                store.dispatch(tradingBuyActions.setTradingAccountKey('btc-account-2'));
             });
 
-            expect(invityAPISpy).toHaveBeenCalledWith('descriptor_btc2');
+            expect(invityAPISpy).toHaveBeenCalledWith('descriptor-btc-account-2');
         });
 
         it('should not call createInvityAPIKey when descriptor is not changed', async () => {
@@ -118,24 +112,11 @@ describe('useBuyForm', () => {
             invityAPISpy.mockClear();
 
             act(() => {
-                store.dispatch(
-                    tradingActions.setBuySelectedReceiveAccount({
-                        selectedReceiveAccount: {
-                            account: { key: 'btc1', descriptor: 'descriptor_btc1' } as Account,
-                        },
-                    }),
-                );
+                store.dispatch(tradingBuyActions.setTradingAccountKey('btc-account-2'));
             });
 
             act(() => {
-                store.dispatch(
-                    tradingActions.setBuySelectedReceiveAccount({
-                        selectedReceiveAccount: {
-                            account: { key: 'btc1', descriptor: 'descriptor_btc1' } as Account,
-                            address: { address: 'TEST_BTC_ADDRESS' } as Address,
-                        },
-                    }),
-                );
+                store.dispatch(tradingBuyActions.setTradingAccountKey('btc-account-2'));
             });
 
             expect(invityAPISpy).toHaveBeenCalledTimes(1);
@@ -148,13 +129,7 @@ describe('useBuyForm', () => {
             invityAPISpy.mockClear();
 
             act(() => {
-                store.dispatch(
-                    tradingActions.setBuySelectedReceiveAccount({
-                        selectedReceiveAccount: {
-                            account: { key: 'btc1', descriptor: '' } as Account,
-                        },
-                    }),
-                );
+                store.dispatch(tradingBuyActions.setTradingAccountKey('btc-account-3'));
             });
 
             expect(invityAPISpy).toHaveBeenCalledTimes(1);
@@ -168,34 +143,10 @@ describe('useBuyForm', () => {
             invityAPISpy.mockClear();
 
             act(() => {
-                store.dispatch(
-                    tradingActions.setBuySelectedReceiveAccount({
-                        selectedReceiveAccount: {
-                            account: { key: 'btc1', descriptor: 'descriptor_btc1' } as Account,
-                        },
-                    }),
-                );
+                store.dispatch(tradingBuyActions.setTradingAccountKey(undefined));
             });
 
-            act(() => {
-                store.dispatch(
-                    tradingActions.setBuySelectedReceiveAccount({
-                        selectedReceiveAccount: {
-                            account: { key: 'btc1' } as Account,
-                        },
-                    }),
-                );
-            });
-
-            act(() => {
-                store.dispatch(
-                    tradingActions.setBuySelectedReceiveAccount({
-                        selectedReceiveAccount: undefined,
-                    }),
-                );
-            });
-
-            expect(invityAPISpy).toHaveBeenCalledTimes(2);
+            expect(invityAPISpy).toHaveBeenCalledTimes(1);
             expect(invityAPISpy).toHaveBeenLastCalledWith('random_string');
         });
     });
@@ -218,15 +169,13 @@ describe('useBuyForm', () => {
         const { result } = await renderUseTradingBuyForm(store);
 
         act(() => {
-            store.dispatch(
-                tradingActions.setBuySelectedReceiveAccount({
-                    selectedReceiveAccount: { account: { key: 'btc2' } as Account },
-                }),
-            );
+            store.dispatch(tradingBuyActions.setTradingAccountKey('btc-account-1'));
             result.current.setValue('asset', undefined as unknown as TradeableAsset);
         });
 
-        expect(result.current.getValues('receiveAccount')).toEqual({ account: { key: 'btc2' } });
+        expect(result.current.getValues('receiveAccount')).toEqual({
+            account: expect.objectContaining({ key: 'btc-account-1' }),
+        });
     });
 
     it('should clear crypto amount on coin change', async () => {

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
@@ -10,6 +10,7 @@ import {
     renderHookWithStoreProviderAsync,
 } from '@suite-native/test-utils';
 
+import { getBtcAccount } from '../../../__fixtures__/account';
 import quotes from '../../../__fixtures__/quotes.json';
 import { bnbAsset, usdcAsset } from '../../../__fixtures__/tradeableAssets';
 import { getInitializedTradingState } from '../../../__fixtures__/tradingState';
@@ -45,11 +46,9 @@ jest.mock('@suite-common/trading', () => ({
 describe('useBuyQuotes', () => {
     const getInitializedStore = async () => {
         const preloadedState: PreloadedState = {
-            wallet: { tradingNew: getInitializedTradingState() },
+            wallet: { tradingNew: getInitializedTradingState(), accounts: [getBtcAccount()] },
         };
-        preloadedState.wallet!.tradingNew!.buy!.selectedReceiveAccount = {
-            account: { key: 'btc1' } as Account,
-        };
+        preloadedState.wallet!.tradingNew!.buy!.tradingAccountKey = 'btc-account-1';
 
         return await initStore(preloadedState);
     };
@@ -261,17 +260,13 @@ describe('useBuyQuotes', () => {
             store.dispatch(tradingBuyActions.saveQuotes(quotes as BuyTrade[]));
         });
 
+        dispatchSpy.mockClear();
         // clear some value to make form invalid
         act(() => {
             result.current.setValue('fiatValue', undefined);
         });
 
-        // 1st call - trading/buyAssetChanged
-        // 2nd call - trading/buyFiatCurrencyChanged
-        // 3rd call - initial handleRequestThunkMock
-        // 4th call - manual saveQuotes
-        // 5th call - clearQuotesAndQuotesRequest
-        expect(dispatchSpy).toHaveBeenCalledTimes(5);
+        expect(dispatchSpy).toHaveBeenCalledTimes(1);
         expect(dispatchSpy).toHaveBeenLastCalledWith({
             payload: undefined,
             type: 'trading/clearQuotesAndQuotesRequest',

--- a/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
@@ -10,11 +10,13 @@ import { Platform } from 'react-native';
 import { BuyTrade, CryptoId } from 'invity-api';
 
 import { extraDependenciesMock } from '@suite-common/test-utils';
+import { TradingRootState as CommonTradingRootState } from '@suite-common/trading';
+import { Account } from '@suite-common/wallet-types';
 
 import { getBtcAccount } from '../../__fixtures__/account';
 import quotes from '../../__fixtures__/quotes.json';
 import { getInitializedTradingState } from '../../__fixtures__/tradingState';
-import { TradingState, tradingSlice } from '../../tradingSlice';
+import { TradingRootState, TradingState, tradingSlice } from '../../tradingSlice';
 import {
     selectBuyAmountLimits,
     selectBuyBestQuotesForAvailablePaymentMethods,
@@ -41,13 +43,54 @@ describe('buySelectors', () => {
         expect(selectTradingBuy({ wallet: { tradingNew: prevState } })).toEqual(prevState.buy);
     });
 
-    it('selectBuySelectedReceiveAccount should select receiveAccount', () => {
-        const receiveAccount = { account: getBtcAccount(), address: undefined };
-        prevState.buy.selectedReceiveAccount = receiveAccount;
+    describe('selectBuySelectedReceiveAccount', () => {
+        let account: Account;
 
-        expect(selectBuySelectedReceiveAccount({ wallet: { tradingNew: prevState } })).toEqual(
-            receiveAccount,
-        );
+        beforeEach(() => {
+            account = getBtcAccount();
+            prevState.buy.tradingAccountKey = account.key;
+            prevState.buy.receiveAddress = account.addresses?.used[0];
+        });
+
+        it('should be undefined when no tradingAccountKey is defined', () => {
+            prevState.buy.tradingAccountKey = undefined;
+            const state = {
+                wallet: { tradingNew: prevState, accounts: [account] },
+            } as unknown as CommonTradingRootState & TradingRootState;
+
+            expect(selectBuySelectedReceiveAccount(state)).toBeUndefined();
+        });
+
+        it('should select receiveAccount and receiveAddress', () => {
+            const state = {
+                wallet: { tradingNew: prevState, accounts: [account] },
+            } as unknown as CommonTradingRootState & TradingRootState;
+
+            expect(selectBuySelectedReceiveAccount(state)).toEqual({
+                account,
+                address: account.addresses?.used[0],
+            });
+        });
+
+        it('should be stable', () => {
+            const state = {
+                wallet: { tradingNew: prevState, accounts: [account] },
+            } as unknown as CommonTradingRootState & TradingRootState;
+            expect(selectBuySelectedReceiveAccount(state)).toBe(
+                selectBuySelectedReceiveAccount(state),
+            );
+        });
+
+        it('should throw when no account with given key exists', () => {
+            prevState.buy.tradingAccountKey = 'unknown_account_key';
+            const state = {
+                wallet: { tradingNew: prevState, accounts: [account] },
+            } as unknown as CommonTradingRootState & TradingRootState;
+
+            expect(() => selectBuySelectedReceiveAccount(state)).toThrow(
+                'Unknown tradingAccountKey: [unknown_account_key]',
+            );
+        });
     });
 
     describe('selectBuyTradeableAssetsSorted', () => {

--- a/suite-native/module-trading/src/selectors/__tests__/exchangeSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/exchangeSelectors.test.ts
@@ -1,10 +1,12 @@
 import { CryptoId } from 'invity-api';
 
 import { extraDependenciesMock } from '@suite-common/test-utils';
+import { TradingRootState as CommonTradingRootState } from '@suite-common/trading';
+import { Account } from '@suite-common/wallet-types';
 
 import { getBtcAccount } from '../../__fixtures__/account';
 import { getInitializedTradingState } from '../../__fixtures__/tradingState';
-import { TradingState, tradingSlice } from '../../tradingSlice';
+import { TradingRootState, TradingState, tradingSlice } from '../../tradingSlice';
 import {
     selectExchangeSelectedReceiveAccount,
     selectExchangeTradeableAssetsSorted,
@@ -26,13 +28,53 @@ describe('exchangeSelectors', () => {
         );
     });
 
-    it('selectExchangeSelectedReceiveAccount should select receiveAccount', () => {
-        const receiveAccount = { account: getBtcAccount(), address: undefined };
-        prevState.exchange.selectedReceiveAccount = receiveAccount;
+    describe('selectExchangeSelectedReceiveAccount', () => {
+        let account: Account;
 
-        expect(selectExchangeSelectedReceiveAccount({ wallet: { tradingNew: prevState } })).toEqual(
-            receiveAccount,
-        );
+        beforeEach(() => {
+            account = getBtcAccount();
+            prevState.exchange.receiveAccountKey = account.key;
+            prevState.exchange.receiveAddress = account.addresses?.used[0];
+        });
+
+        it('should be undefined when no receiveAccountKey is defined', () => {
+            prevState.exchange.receiveAccountKey = undefined;
+            const state = {
+                wallet: { tradingNew: prevState, accounts: [account] },
+            } as unknown as CommonTradingRootState & TradingRootState;
+
+            expect(selectExchangeSelectedReceiveAccount(state)).toBeUndefined();
+        });
+
+        it('should select receiveAccount and receiveAddress', () => {
+            const state = {
+                wallet: { tradingNew: prevState, accounts: [account] },
+            } as unknown as CommonTradingRootState & TradingRootState;
+            expect(selectExchangeSelectedReceiveAccount(state)).toEqual({
+                account,
+                address: account.addresses?.used[0],
+            });
+        });
+
+        it('should be stable', () => {
+            const state = {
+                wallet: { tradingNew: prevState, accounts: [account] },
+            } as unknown as CommonTradingRootState & TradingRootState;
+            expect(selectExchangeSelectedReceiveAccount(state)).toBe(
+                selectExchangeSelectedReceiveAccount(state),
+            );
+        });
+
+        it('should throw when no account with given key exists', () => {
+            prevState.exchange.receiveAccountKey = 'unknown_account_key';
+            const state = {
+                wallet: { tradingNew: prevState, accounts: [account] },
+            } as unknown as CommonTradingRootState & TradingRootState;
+
+            expect(() => selectExchangeSelectedReceiveAccount(state)).toThrow(
+                'Unknown receiveAccountKey: [unknown_account_key]',
+            );
+        });
     });
 
     describe('selectExchangeTradeableAssetsSorted', () => {

--- a/suite-native/module-trading/src/selectors/buySelectors.ts
+++ b/suite-native/module-trading/src/selectors/buySelectors.ts
@@ -3,6 +3,7 @@ import { Platform } from 'react-native';
 import { BuyCryptoPaymentMethod, BuyTrade, FiatCurrencyCode } from 'invity-api';
 
 import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
+import { invariant } from '@suite-common/suite-utils';
 import {
     TradingPaymentMethodProps,
     getBestRatedQuote,
@@ -12,11 +13,16 @@ import {
     selectTradingBuySupportedCryptoIds,
     selectValidTradingBuyQuotes,
 } from '@suite-common/trading';
+import { selectAccountByKey } from '@suite-common/wallet-core';
 
 import { supportedFiatCurrenciesMap } from '../consts/general/supportedFiatCurrencies';
-import { TradingRootState, createMemoizedSelector } from '../tradingSlice';
+import {
+    TradingRootState,
+    createMemoizedSelector,
+    createMemoizedSelectorWithAccounts,
+} from '../tradingSlice';
 import { BuyFormValues } from '../types/buy';
-import { Country, FiatCurrencyItem } from '../types/general';
+import { Country, FiatCurrencyItem, ReceiveAccount } from '../types/general';
 import {
     coinInfoToTradeableAsset,
     tradeableAssetSortingComparator,
@@ -26,8 +32,19 @@ const DEFAULT_FIAT_CURRENCY_FALLBACK = 'USD';
 
 export const selectTradingBuy = (state: TradingRootState) => state.wallet.tradingNew.buy;
 
-export const selectBuySelectedReceiveAccount = (state: TradingRootState) =>
-    selectTradingBuy(state).selectedReceiveAccount;
+export const selectBuySelectedReceiveAccount = createMemoizedSelectorWithAccounts(
+    [state => state, selectTradingBuy],
+    (state, { receiveAddress: address, tradingAccountKey }) => {
+        if (!tradingAccountKey) {
+            return undefined;
+        }
+
+        const account = selectAccountByKey(state, tradingAccountKey);
+        invariant(account, `Unknown tradingAccountKey: [${tradingAccountKey}]`);
+
+        return { account, address } as ReceiveAccount;
+    },
+);
 
 export const selectBuySupportedFiatCurrencies = (state: TradingRootState) =>
     returnStableArrayIfEmpty(selectTradingBuy(state).buyInfo?.supportedFiatCurrencies);

--- a/suite-native/module-trading/src/selectors/exchangeSelectors.ts
+++ b/suite-native/module-trading/src/selectors/exchangeSelectors.ts
@@ -1,6 +1,13 @@
+import { invariant } from '@suite-common/suite-utils';
 import { selectTradingExchangeBuyCryptoIds } from '@suite-common/trading';
+import { selectAccountByKey } from '@suite-common/wallet-core';
 
-import { TradingRootState, createMemoizedSelector } from '../tradingSlice';
+import {
+    TradingRootState,
+    createMemoizedSelector,
+    createMemoizedSelectorWithAccounts,
+} from '../tradingSlice';
+import { ReceiveAccount } from '../types/general';
 import {
     coinInfoToTradeableAsset,
     tradeableAssetSortingComparator,
@@ -8,8 +15,20 @@ import {
 
 export const selectTradingExchange = (state: TradingRootState) => state.wallet.tradingNew.exchange;
 
-export const selectExchangeSelectedReceiveAccount = (state: TradingRootState) =>
-    selectTradingExchange(state).selectedReceiveAccount;
+export const selectExchangeSelectedReceiveAccount = createMemoizedSelectorWithAccounts(
+    [state => state, selectTradingExchange],
+    (state, { receiveAddress: address, receiveAccountKey }) => {
+        if (!receiveAccountKey) {
+            return undefined;
+        }
+
+        const account = selectAccountByKey(state, receiveAccountKey);
+
+        invariant(account, `Unknown receiveAccountKey: [${receiveAccountKey}]`);
+
+        return { account, address } as ReceiveAccount;
+    },
+);
 
 export const selectExchangeTradeableAssetsSorted = createMemoizedSelector(
     [

--- a/suite-native/module-trading/src/tradingSlice.ts
+++ b/suite-native/module-trading/src/tradingSlice.ts
@@ -11,16 +11,15 @@ import {
     initialState as commonInitialState,
     prepareTradingReducer,
 } from '@suite-common/trading';
-import { deviceActions } from '@suite-common/wallet-core';
-
-import { ReceiveAccount } from './types/general';
+import { AccountsRootState, deviceActions } from '@suite-common/wallet-core';
+import { Address } from '@trezor/blockchain-link-types';
 
 export interface TradingBuyState extends CommonTradingBuyState {
-    selectedReceiveAccount: ReceiveAccount | undefined;
+    receiveAddress: Address | undefined;
 }
 
 export interface TradingExchangeState extends CommonTradingExchangeState {
-    selectedReceiveAccount: ReceiveAccount | undefined;
+    receiveAddress: Address | undefined;
 }
 
 export interface TradingState extends CommonTradingState {
@@ -41,8 +40,8 @@ export type TradingRootState = {
 
 export const initialState: TradingState = {
     ...commonInitialState,
-    buy: { ...commonInitialState.buy, selectedReceiveAccount: undefined },
-    exchange: { ...commonInitialState.exchange, selectedReceiveAccount: undefined },
+    buy: { ...commonInitialState.buy, receiveAddress: undefined },
+    exchange: { ...commonInitialState.exchange, receiveAddress: undefined },
     favouriteAssets: {},
     tradingEnvironment: 'production',
     tradeOrderIdToBeOpened: undefined,
@@ -54,11 +53,11 @@ export const tradingSlice = createSliceWithExtraDeps({
     name: 'trading',
     initialState,
     reducers: {
-        setBuySelectedReceiveAccount: (
-            state,
-            { payload }: PayloadAction<{ selectedReceiveAccount: ReceiveAccount | undefined }>,
-        ) => {
-            state.buy.selectedReceiveAccount = payload.selectedReceiveAccount;
+        setBuyReceiveAddress: (state, { payload }: PayloadAction<Address | undefined>) => {
+            state.buy.receiveAddress = payload;
+        },
+        setExchangeReceiveAddress: (state, { payload }: PayloadAction<Address | undefined>) => {
+            state.exchange.receiveAddress = payload;
         },
         addTradeableAssetToFavourites: (state, { payload }: PayloadAction<CryptoId>) => {
             state.favouriteAssets[payload] = true;
@@ -69,7 +68,8 @@ export const tradingSlice = createSliceWithExtraDeps({
         setTradingEnvironment: (state, { payload }: PayloadAction<InvityServerEnvironment>) => {
             state.tradingEnvironment = payload;
             // clear buy state so everything is fetched for new environment
-            state.buy.selectedReceiveAccount = undefined;
+            state.buy.tradingAccountKey = undefined;
+            state.buy.receiveAddress = undefined;
             state.buy.quotesRequest = undefined;
             state.buy.quotes = [];
             state.buy.selectedQuote = undefined;
@@ -77,7 +77,8 @@ export const tradingSlice = createSliceWithExtraDeps({
             state.tradeOrderIdToBeOpened = undefined;
         },
         clearBuyState: state => {
-            state.buy.selectedReceiveAccount = undefined;
+            state.buy.tradingAccountKey = undefined;
+            state.buy.receiveAddress = undefined;
             state.buy.quotesRequest = undefined;
             state.buy.quotes = [];
             state.buy.selectedQuote = undefined;
@@ -95,7 +96,8 @@ export const tradingSlice = createSliceWithExtraDeps({
             state.tradeOrderIdToBeOpened = undefined;
         },
         buyAssetChanged: state => {
-            state.buy.selectedReceiveAccount = undefined;
+            state.buy.tradingAccountKey = undefined;
+            state.buy.receiveAddress = undefined;
             state.buy.amountLimits = undefined;
             state.buy.quotesRequest = undefined;
         },
@@ -112,19 +114,15 @@ export const tradingSlice = createSliceWithExtraDeps({
         clearActiveTradingType: state => {
             state.activeTradingType = undefined;
         },
-        setExchangeSelectedReceiveAccount: (
-            state,
-            { payload }: PayloadAction<{ selectedReceiveAccount: ReceiveAccount | undefined }>,
-        ) => {
-            state.exchange.selectedReceiveAccount = payload.selectedReceiveAccount;
-        },
     },
     extraReducers: (builder, extra) => {
         const commonTradingFormReducer = prepareTradingReducer(extra);
         builder
             .addCase(deviceActions.selectDevice, state => {
-                state.buy.selectedReceiveAccount = undefined;
-                state.exchange.selectedReceiveAccount = undefined;
+                state.buy.tradingAccountKey = undefined;
+                state.buy.receiveAddress = undefined;
+                state.exchange.receiveAccountKey = undefined;
+                state.exchange.receiveAddress = undefined;
             })
             // In case that this reducer does not match the action, try to handle it by suite-common tradingReducer.
             .addDefaultCase((state, action) => {
@@ -136,3 +134,6 @@ export const tradingSlice = createSliceWithExtraDeps({
 export const tradingActions = tradingSlice.actions;
 
 export const createMemoizedSelector = createWeakMapSelector.withTypes<TradingRootState>();
+export const createMemoizedSelectorWithAccounts = createWeakMapSelector.withTypes<
+    TradingRootState & AccountsRootState
+>();


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- refactor buy logic to also use `buy.tradingAccountKey` from common instead of `buy.selectedReceiveAccount`
- refactor swap logic to also use `exchange.receiveAccountKey` from common instead of `exchange.selectedReceiveAccount`

## Related Issue

Resolve #19610

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19610-mobile-trade-use-trading-account-key&lookback=7)