### PR TITLE
chore(suite): Move react deps from engagement to mobile

### DIFF
--- a/scripts/list-outdated-dependencies/engagement-dependencies.txt
+++ b/scripts/list-outdated-dependencies/engagement-dependencies.txt
@@ -10,7 +10,6 @@
 @storybook/react-webpack5
 @types/pako
 @types/pdfmake
-@types/react
 @types/react-date-range
 @types/react-dom
 @types/react-qr-reader
@@ -30,10 +29,8 @@ polished
 postcss-loader
 postcss-styled-syntax
 qrcode.react
-react
 react-error-boundary
 react-date-range
-react-dom
 react-focus-lock
 react-helmet-async
 react-intl

--- a/scripts/list-outdated-dependencies/engagement-dependencies.txt
+++ b/scripts/list-outdated-dependencies/engagement-dependencies.txt
@@ -23,14 +23,16 @@ csstype
 date-fns
 framer-motion
 lottie-react
+node-loader
 pako
+passport-desktop
 pdfmake
 polished
 postcss-loader
 postcss-styled-syntax
 qrcode.react
-react-error-boundary
 react-date-range
+react-error-boundary
 react-focus-lock
 react-helmet-async
 react-intl
@@ -41,8 +43,8 @@ react-select
 react-svg
 react-toastify
 recharts
-simple-git
 sharp
+simple-git
 storybook
 style-loader
 styled-components
@@ -58,5 +60,3 @@ vite
 vite-plugin-wasm
 vm-browserify
 zxcvbn
-passport-desktop
-node-loader

--- a/scripts/list-outdated-dependencies/mobile-dependencies.txt
+++ b/scripts/list-outdated-dependencies/mobile-dependencies.txt
@@ -1,5 +1,6 @@
 @babel/plugin-transform-export-namespace-from
 @config-plugins/detox
+@expo/config-plugins
 @gorhom/bottom-sheet
 @mobily/ts-belt
 @react-native-async-storage/async-storage
@@ -19,7 +20,6 @@
 @types/jest
 @types/node
 @types/react
-@expo/config-plugins
 @whatwg-node/events
 abortcontroller-polyfill
 babel-plugin-transform-inline-environment-variables
@@ -70,10 +70,10 @@ metro
 node-gyp
 node-libs-browser
 react
+react-dom
 react-fela
 react-native
 react-native-ble-plx
-react-dom
 react-native-edge-to-edge
 react-native-gesture-handler
 react-native-keyboard-controller

--- a/scripts/list-outdated-dependencies/mobile-dependencies.txt
+++ b/scripts/list-outdated-dependencies/mobile-dependencies.txt
@@ -18,6 +18,7 @@
 @types/fast-text-encoding
 @types/jest
 @types/node
+@types/react
 @expo/config-plugins
 @whatwg-node/events
 abortcontroller-polyfill
@@ -68,9 +69,11 @@ lottie-react-native
 metro
 node-gyp
 node-libs-browser
+react
 react-fela
 react-native
 react-native-ble-plx
+react-dom
 react-native-edge-to-edge
 react-native-gesture-handler
 react-native-keyboard-controller


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It makes sense to move `react` dependency to mobile, because we can't update it without updating `expo`. Already discussed with @matejkriz 

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=move-react-deps-from-engagement-to-mobile&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=move-react-deps-from-engagement-to-mobile&lookback=7)