### PR TITLE
fix(suite-native): fix yarn error in EAS

### DIFF
--- a/suite-native/app/eas.json
+++ b/suite-native/app/eas.json
@@ -5,7 +5,13 @@
         "promptToConfigurePushNotifications": false
     },
     "build": {
+        "base": {
+            "env": {
+                "EAS_NO_FROZEN_LOCKFILE": "1"
+            }
+        },
         "develop": {
+            "extends": "base",
             "env": {
                 "EXPO_PUBLIC_ENVIRONMENT": "develop",
                 "EXPO_PUBLIC_BLUETOOTH_ENABLED": "true"
@@ -21,6 +27,7 @@
             }
         },
         "preview": {
+            "extends": "base",
             "env": {
                 "EXPO_PUBLIC_ENVIRONMENT": "preview",
                 "EXPO_PUBLIC_BLUETOOTH_ENABLED": "true"
@@ -36,6 +43,7 @@
             "developmentClient": false
         },
         "production": {
+            "extends": "base",
             "env": {
                 "EXPO_PUBLIC_ENVIRONMENT": "production",
                 "EXPO_PUBLIC_CODESIGN_BUILD": "true",
@@ -51,6 +59,7 @@
             }
         },
         "productionAPK": {
+            "extends": "base",
             "env": {
                 "EXPO_PUBLIC_ENVIRONMENT": "production",
                 "EXPO_PUBLIC_CODESIGN_BUILD": "true"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hotfix by opting out of using frozen lockfiles.



## Related Issue

Issue probably caused by https://expo.dev/changelog/sdk-53#expo-application-services-eas 

```
EAS Build now uses frozen lockfiles by default for SDK 53+ projects. Depending on the package manager that you use, the appropriate command/flag will be use when installing Node modules — npm ci, yarn install --frozen-lockfile (and modern equivalents), pnpm install --frozen-lockfile, etc. You can opt out of using frozen lockfiles by setting EAS_NO_FROZEN_LOCKFILE=1 in your project [environment variables](https://docs.expo.dev/eas/environment-variables/).
```

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/yarn-issue&lookback=7)