### PR TITLE
feat(suite-native): Mobile Trade: Gateway 21 footer

### DIFF
--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -83,6 +83,9 @@ const getTradingContext = (type: TradingType) => `trading.${type}` as const;
 export type SettingsCategory = 'general' | 'device' | 'networks' | 'debug';
 const getSettingsContext = (category: SettingsCategory) => `settings.${category}` as const;
 
+export type LegalContextKey = 'gateway';
+const getLegalContext = (key: LegalContextKey) => `legal.${key}` as const;
+
 /**
  * Factory object for generating typed context keys used by the Message System.
  *
@@ -104,6 +107,7 @@ export const Context = {
     getStaking: getStakingContext,
     getTrading: getTradingContext,
     getSettings: getSettingsContext,
+    getLegal: getLegalContext,
 } as const;
 
 type FunctionKeysOf<T> = {

--- a/suite-native/module-trading/src/components/general/LegalGatewayContextMessage.tsx
+++ b/suite-native/module-trading/src/components/general/LegalGatewayContextMessage.tsx
@@ -1,0 +1,8 @@
+import { Context } from '@suite-common/message-system';
+import { ContextMessage, ContextMessageProps } from '@suite-native/message-system';
+
+export type LegalGatewayContextMessageProps = Omit<ContextMessageProps, 'context'>;
+
+export const LegalGatewayContextMessage = (props: LegalGatewayContextMessageProps) => (
+    <ContextMessage context={Context.getLegal('gateway')} {...props} />
+);

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.tsx
@@ -4,6 +4,7 @@ import { TradingProviderInfo, TradingTradeType } from '@suite-common/trading';
 import { BottomSheetFlashList } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 
+import { LegalGatewayContextMessage } from '../LegalGatewayContextMessage';
 import { SimpleSheetHeader } from '../SimpleSheetHeader';
 import { PROVIDER_LIST_ITEM_ESTIMATED_HEIGHT, ProviderListItem } from './ProviderListItem';
 import { TradingTypeAwareContextMessage } from '../TradingTypeAwareContextMessage';
@@ -70,6 +71,7 @@ export const ProviderSheet = <T extends TradingTradeType>({
                     <TradingTypeAwareContextMessage marginHorizontal="sp16" marginBottom="sp4" />
                 </>
             )}
+            ListFooterComponent={<LegalGatewayContextMessage marginVertical="sp12" />}
             data={quotes}
             estimatedListHeight={screenHeight}
             estimatedItemSize={PROVIDER_LIST_ITEM_ESTIMATED_HEIGHT}

--- a/suite-native/module-trading/src/components/general/__tests__/LegalGatewayContextMessage.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/LegalGatewayContextMessage.comp.test.tsx
@@ -1,0 +1,25 @@
+import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { LegalGatewayContextMessage } from '../LegalGatewayContextMessage';
+
+jest.mock('@suite-common/message-system', () => {
+    const messages: Record<string, unknown> = {
+        'legal.gateway': { content: { en: 'Legal gateway message' } },
+    };
+
+    return {
+        ...jest.requireActual('@suite-common/message-system'),
+        selectContextMessage: (_: unknown, context: string) => messages[context],
+    };
+});
+
+describe('LegalGatewayContextMessage', () => {
+    const renderLegalGatewayContextMessage = () =>
+        renderWithStoreProviderAsync(<LegalGatewayContextMessage />);
+
+    it('should render legal.gateway context message', async () => {
+        const { getByText } = await renderLegalGatewayContextMessage();
+
+        expect(getByText('Legal gateway message')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/screens/TradingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingScreen.tsx
@@ -14,6 +14,7 @@ import { DeviceOffline } from '../components/general/Error/DeviceOffline';
 import { Footer } from '../components/general/Footer';
 import { Header } from '../components/general/Header/Header';
 import { HistoryButton, NavigationProps } from '../components/general/HistoryButton';
+import { LegalGatewayContextMessage } from '../components/general/LegalGatewayContextMessage';
 import { TradingTypeAwareContextMessage } from '../components/general/TradingTypeAwareContextMessage';
 import { useActiveTradingTypeReaction } from '../hooks/general/useActiveTradingTypeReaction';
 import { useGeolocationCountryCode } from '../hooks/general/useGeolocationCountryCode';
@@ -74,6 +75,7 @@ export const TradingScreen = () => {
             }
         >
             <TradingScreenContent />
+            <LegalGatewayContextMessage marginVertical="sp16" />
         </Screen>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Introduce new message system context types for trading footers.
- Displays footer on Trading and Providers screens.

## Related Issue

Resolve #19738

## Screenshots:

https://github.com/user-attachments/assets/f6e002d9-a3f8-4b7b-b709-f19cdc7501ab




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=19738-Mobile-Trade-Gateway-21-mobile&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=19738-Mobile-Trade-Gateway-21-mobile&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19738-Mobile-Trade-Gateway-21-mobile&lookback=7)