### PR TITLE
fix(e2e): improve handling of optional FwHashCheckError

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -92,10 +92,13 @@ export class OnboardingPage {
     async optionallyDismissFwHashCheckError() {
         await this.verifySuiteIsLoaded();
         // dismisses the error modal only if it appears (handle it async in parallel, not necessary to block the rest of the flow)
-        // eslint-disable-next-line playwright/no-element-handle
-        this.page
-            .$('[data-testid="@device-compromised/dismiss-button"]')
-            .then(dismissFwHashCheckButton => dismissFwHashCheckButton?.click());
+        // eslint-disable-next-line playwright/no-wait-for-selector
+        void this.page
+            .waitForSelector('[data-testid="@device-compromised/dismiss-button"]', {
+                timeout: 10_000,
+            })
+            .then(async button => await button.click())
+            .catch(() => {}); // Intentionally ignore timeout errors - means the modal was not shown
     }
 
     @step()

--- a/packages/suite-desktop-core/e2e/tests/suite/initial-run.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/initial-run.test.ts
@@ -9,12 +9,12 @@ test.describe('Suite initial run', { tag: ['@group=suite'] }, () => {
         await onboardingPage.disableNecessaryFirmwareChecks();
         await onboardingPage.optionallyDismissFwHashCheckError();
         await expect(analyticsSection.toggleSwitch).toBeVisible();
+
         await page.reload();
-        // analytics screen is there until user confirms his choice
         await onboardingPage.optionallyDismissFwHashCheckError();
+        // analytics screen is there until user confirms his choice
         await expect(analyticsSection.toggleSwitch).toBeVisible();
         await analyticsSection.continueButton.click();
-
         await expect(page.getByTestId('@onboarding/exit-app-button')).toBeVisible();
 
         await page.reload();


### PR DESCRIPTION
The original method 'optionallyDismissFwHashCheckError' did not work in initial-run.test.ts. I have re-implemented it and solved the flakiness of this test.

here is [run](https://app.currents.dev/run/9eaed466538bf88c) with 30x passes.

I still need to know whether this does not impact other tests.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-flaky-initial-run&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-flaky-initial-run&lookback=7)