### PR TITLE
feat(suite-native): firmware settings

### DIFF
--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -311,6 +311,11 @@ export const selectDeviceReleaseInfo = createMemoizedSelector(
     device => device?.firmwareRelease ?? null,
 );
 
+export const selectIsFirmwareUpgradable = createMemoizedSelector(
+    [selectDeviceReleaseInfo],
+    deviceReleaseInfo => deviceReleaseInfo?.isNewer ?? false,
+);
+
 export const selectDeviceFirmwareVersion = createMemoizedSelector([selectSelectedDevice], device =>
     getFirmwareVersionArray(device),
 );

--- a/suite-native/firmware/src/components/ConfirmFirmwareUpdateScreenContent.tsx
+++ b/suite-native/firmware/src/components/ConfirmFirmwareUpdateScreenContent.tsx
@@ -1,22 +1,87 @@
-import { Text, VStack } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+import {
+    selectDeviceFirmwareVersion,
+    selectDeviceUpdateFirmwareVersion,
+    selectHasBitcoinOnlyFirmware,
+    selectIsFirmwareUpgradable,
+} from '@suite-common/wallet-core';
+import { InlineAlertBox, Text, VStack } from '@suite-native/atoms';
+import { Translation, useTranslate } from '@suite-native/intl';
 
 import { FirmwareChangelogButton } from '../components/FirmwareChangelogButton';
-import { FirmwareUpdateVersionCard } from '../components/FirmwareVersionCard';
+import {
+    FirmwareUpdateVersionCard,
+    FirmwareVersionCard,
+    concatFirmwareVersion,
+} from '../components/FirmwareVersionCard';
 
-export const ConfirmFirmwareUpdateScreenContent = () => (
-    <VStack spacing="sp32">
-        <VStack>
-            <Text variant="titleMedium">
-                <Translation id="firmware.firmwareUpdateScreen.title" />
-            </Text>
-            <Text variant="body" color="textSubdued">
-                <Translation id="firmware.firmwareUpdateScreen.subtitle" />
-            </Text>
+const UpgradableContent = () => {
+    const updateFirmwareVersion = useSelector(selectDeviceUpdateFirmwareVersion);
+
+    return (
+        <>
+            <InlineAlertBox
+                title={
+                    <Translation
+                        id="firmware.updateCard.updateToVersionAvailable"
+                        values={{ firmwareVersion: updateFirmwareVersion }}
+                    />
+                }
+                variant="info"
+            />
+            <VStack>
+                <FirmwareUpdateVersionCard />
+                <FirmwareChangelogButton />
+            </VStack>
+        </>
+    );
+};
+
+const UpToDateContent = () => {
+    const firmwareVersion = useSelector(selectDeviceFirmwareVersion);
+    const isBtcOnly = useSelector(selectHasBitcoinOnlyFirmware);
+    const { translate } = useTranslate();
+
+    const firmwareTypeTranslationId = isBtcOnly
+        ? 'firmware.typeBitcoinOnly'
+        : 'firmware.typeUniversal';
+
+    return (
+        <>
+            <InlineAlertBox
+                title={<Translation id="firmware.updateCard.upToDate" />}
+                variant="success"
+            />
+            <FirmwareVersionCard
+                title={<Translation id="firmware.firmwareUpdateScreen.currentFirmware" />}
+                titleColor="textSubdued"
+                version={concatFirmwareVersion(firmwareVersion) ?? null}
+                fwType={translate(firmwareTypeTranslationId)}
+                backgroundColor="backgroundSurfaceElevation1"
+                isFullWidth
+            />
+        </>
+    );
+};
+
+export const ConfirmFirmwareUpdateScreenContent = () => {
+    const isFirmwareUpgradable = useSelector(selectIsFirmwareUpgradable);
+
+    return (
+        <VStack spacing="sp32">
+            <VStack>
+                <Text variant="titleMedium">
+                    <Translation id="firmware.firmwareUpdateScreen.title" />
+                </Text>
+                <Text variant="body" color="textSubdued">
+                    <Translation id="firmware.firmwareUpdateScreen.subtitle" />
+                </Text>
+            </VStack>
+            <VStack spacing="sp16">
+                {isFirmwareUpgradable ? <UpgradableContent /> : <UpToDateContent />}
+            </VStack>
         </VStack>
-        <VStack>
-            <FirmwareUpdateVersionCard />
-            <FirmwareChangelogButton />
-        </VStack>
-    </VStack>
-);
+    );
+};

--- a/suite-native/firmware/src/components/ConfirmFirmwareUpdateScreenFooter.tsx
+++ b/suite-native/firmware/src/components/ConfirmFirmwareUpdateScreenFooter.tsx
@@ -44,7 +44,7 @@ export const ConfirmFirmwareUpdateScreenFooter = ({
                 isDisabled={isDiscoveryRunning || !isFirmwareUpdateEnabled}
                 isLoading={isDiscoveryRunning}
             >
-                <Translation id="firmware.firmwareUpdateScreen.updateButton" />
+                <Translation id="firmware.firmwareUpdateScreen.updateFirmware" />
             </Button>
             {onSkipUpdate && (
                 <Button

--- a/suite-native/firmware/src/components/FirmwareVersionCard.tsx
+++ b/suite-native/firmware/src/components/FirmwareVersionCard.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { PixelRatio } from 'react-native';
 import { useSelector } from 'react-redux';
 
@@ -8,27 +9,38 @@ import {
 } from '@suite-common/wallet-core';
 import { Box, BoxProps, Text } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
-import { useTranslate } from '@suite-native/intl';
+import { Translation, useTranslate } from '@suite-native/intl';
+import { VersionArray } from '@trezor/device-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Color } from '@trezor/theme';
 
 type FirmwareVersionCardProps = {
-    title: string;
+    title: ReactNode;
     titleColor: Color;
-    version: string;
+    version: string | null;
     fwType: string;
     backgroundColor: Color;
+    isFullWidth?: boolean;
 } & BoxProps;
 
-const cardContainerStyle = prepareNativeStyle<{ backgroundColor: Color }>(
-    (utils, { backgroundColor }) => ({
+const cardContainerStyle = prepareNativeStyle<{ backgroundColor: Color; isFullWidth: boolean }>(
+    (utils, { backgroundColor, isFullWidth }) => ({
         padding: utils.spacings.sp16,
         backgroundColor: utils.colors[backgroundColor],
         borderRadius: utils.borders.radii.r12,
         width: '50%',
         justifyContent: 'center',
+        extend: {
+            condition: isFullWidth,
+            style: {
+                width: '100%',
+            },
+        },
     }),
 );
+
+export const concatFirmwareVersion = (firmwareVersion: VersionArray | null) =>
+    firmwareVersion?.join('.');
 
 export const FirmwareVersionCard = ({
     title,
@@ -37,17 +49,18 @@ export const FirmwareVersionCard = ({
     titleColor,
     backgroundColor,
     children,
+    isFullWidth = false,
     ...boxProps
 }: FirmwareVersionCardProps) => {
     const { applyStyle } = useNativeStyles();
 
     return (
-        <Box style={applyStyle(cardContainerStyle, { backgroundColor })} {...boxProps}>
+        <Box style={applyStyle(cardContainerStyle, { backgroundColor, isFullWidth })} {...boxProps}>
             <Text variant="body" color={titleColor}>
                 {title}
             </Text>
             <Text variant="highlight">
-                <Text variant="highlight">{version}</Text>
+                <Text variant="highlight">{version ?? '?.?.?'}</Text>
                 {' • '}
                 <Text variant="highlight">{fwType}</Text>
             </Text>
@@ -88,9 +101,9 @@ export const FirmwareUpdateVersionCard = (props: BoxProps) => {
     return (
         <Box flexDirection="row" justifyContent="center" alignItems="center" {...props}>
             <FirmwareVersionCard
-                title="Current firmware"
+                title={<Translation id="firmware.firmwareUpdateScreen.currentFirmware" />}
                 titleColor="textSubdued"
-                version={firmwareVersion?.join('.') ?? '?.?.?'}
+                version={concatFirmwareVersion(firmwareVersion) ?? null}
                 fwType={translate(firmwareTypeTranslationId)}
                 flex={1}
                 backgroundColor="backgroundTertiaryDefaultOnElevation0"
@@ -98,9 +111,9 @@ export const FirmwareUpdateVersionCard = (props: BoxProps) => {
             />
 
             <FirmwareVersionCard
-                title="Update firmware"
+                title={<Translation id="firmware.firmwareUpdateScreen.updateFirmware" />}
                 titleColor="textPrimaryDefault"
-                version={updateFirmwareVersion ?? '?.?.?'}
+                version={updateFirmwareVersion}
                 fwType={translate(firmwareTypeTranslationId)}
                 flex={1}
                 backgroundColor="backgroundSurfaceElevation1"

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -2035,6 +2035,7 @@ export const en = {
         version: 'Version {firmwareVersion}',
         typeUniversal: 'Universal',
         typeBitcoinOnly: 'Bitcoin-only',
+        updateNotAvailable: 'Firmware update disabled',
         seedBottomSheet: {
             title: 'Make sure you know where to find your wallet backup.',
             description:
@@ -2045,11 +2046,13 @@ export const en = {
         updateCard: {
             upToDate: 'You’re all up to date',
             newVersionAvailable: 'Update available',
+            updateToVersionAvailable: 'Update to version {firmwareVersion} available',
             updateButton: 'Update',
         },
         firmwareUpdateScreen: {
-            updateButton: 'Update firmware',
+            updateFirmware: 'Update firmware',
             skipButton: 'Skip for now',
+            currentFirmware: 'Current Firmware',
             title: 'Firmware',
             subtitle: "Firware is your Trezor's operating system",
             changelog: {

--- a/suite-native/module-device-onboarding/src/screens/ConfirmFirmwareUpdateScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ConfirmFirmwareUpdateScreen.tsx
@@ -17,6 +17,7 @@ import {
 import { updateOnboardingAnalyticsAtom } from '../../atoms';
 import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboardingScreenWithExitButton';
 import { useNavigateToNextScreenAfterFirmwareInstallation } from '../hooks/useNavigateToNextScreenAfterFirmwareInstallation';
+
 export const ConfirmFirmwareUpdateScreen = ({
     navigation,
 }: StackProps<

--- a/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
@@ -8,6 +8,7 @@ import {
     selectDeviceReleaseInfo,
     selectHasRunningDiscovery,
     selectIsDeviceBackedUp,
+    selectIsFirmwareUpgradable,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { InlineAlertBoxProps } from '@suite-native/atoms';
@@ -18,6 +19,7 @@ import {
     DeviceSettingsStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
+import { useToast } from '@suite-native/toasts';
 import { getFirmwareVersion } from '@trezor/device-utils';
 
 import { DeviceSettingsItemCard } from './DeviceSettingsItemCard';
@@ -33,6 +35,8 @@ export const DeviceFirmwareCard = () => {
     const deviceReleaseInfo = useSelector(selectDeviceReleaseInfo);
     const isDeviceBackedUp = useSelector(selectIsDeviceBackedUp);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
+    const isFirmwareUpgradable = useSelector(selectIsFirmwareUpgradable);
+    const { showToast } = useToast();
 
     const navigation = useNavigation<NavigationProp>();
     const isFirmwareUpdateEnabled = useIsFirmwareUpdateFeatureEnabled();
@@ -44,6 +48,16 @@ export const DeviceFirmwareCard = () => {
     const firmwareVersion = getFirmwareVersion(device);
 
     const handleOnPress = () => {
+        if (!isFirmwareUpdateEnabled) {
+            showToast({
+                variant: 'warning',
+                message: <Translation id="firmware.updateNotAvailable" />,
+                icon: 'warning',
+            });
+
+            return;
+        }
+
         navigation.navigate(DeviceSettingsStackRoutes.ConfirmFirmwareUpdate);
     };
 
@@ -53,13 +67,11 @@ export const DeviceFirmwareCard = () => {
         }
 
         if (G.isNotNullable(deviceReleaseInfo)) {
-            const isUpgradable = deviceReleaseInfo.isNewer ?? false;
-
-            if (isUpgradable) {
+            if (isFirmwareUpgradable) {
                 return {
                     title: <Translation id="firmware.updateCard.newVersionAvailable" />,
                     variant: 'info',
-                    buttonLabel: <Translation id="firmware.updateCard.updateButton" />,
+                    buttonLabel: <Translation id="firmware.firmwareUpdateScreen.updateFirmware" />,
                     onButtonPress: handleOnPress,
                     buttonProps: {
                         isDisabled: isDiscoveryRunning,

--- a/suite-native/module-device-settings/src/screens/ConfirmFirmwareUpdateScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/ConfirmFirmwareUpdateScreen.tsx
@@ -1,5 +1,8 @@
+import { useSelector } from 'react-redux';
+
 import { useNavigation } from '@react-navigation/native';
 
+import { selectIsFirmwareUpgradable } from '@suite-common/wallet-core';
 import { Box } from '@suite-native/atoms';
 import {
     ConfirmFirmwareUpdateScreenContent,
@@ -23,6 +26,7 @@ type NavigationProp = StackNavigationProps<
 export const ConfirmFirmwareUpdateScreen = () => {
     const navigation = useNavigation<NavigationProp>();
     const { isDeviceConnected } = useDeviceConnectionGuard();
+    const isFirmwareUpgradable = useSelector(selectIsFirmwareUpgradable);
 
     const handleUpdateConfirmation = () => {
         navigation.navigate(DeviceSettingsStackRoutes.FirmwareInstallation);
@@ -34,9 +38,11 @@ export const ConfirmFirmwareUpdateScreen = () => {
         <Screen
             header={<ScreenHeader closeActionType="close" />}
             footer={
-                <ConfirmFirmwareUpdateScreenFooter
-                    onUpdateConfirmation={handleUpdateConfirmation}
-                />
+                isFirmwareUpgradable && (
+                    <ConfirmFirmwareUpdateScreenFooter
+                        onUpdateConfirmation={handleUpdateConfirmation}
+                    />
+                )
             }
         >
             <Box flex={1} marginTop="sp16">

--- a/suite-native/module-home/src/screens/HomeScreen/components/FirmwareUpdateAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/FirmwareUpdateAlert.tsx
@@ -7,11 +7,11 @@ import { atom, useAtomValue, useSetAtom } from 'jotai';
 
 import {
     selectDeviceId,
-    selectDeviceReleaseInfo,
     selectDeviceUpdateFirmwareVersion,
     selectHasRunningDiscovery,
     selectIsDeviceBackedUp,
     selectIsDeviceConnected,
+    selectIsFirmwareUpgradable,
     selectIsPortfolioTrackerDevice,
 } from '@suite-common/wallet-core';
 import { Box, Button, HStack, Text, VStack } from '@suite-native/atoms';
@@ -51,7 +51,6 @@ const closeStateAtom = atom<CloseStateItem[]>([]);
 export const FirmwareUpdateAlert = () => {
     const { applyStyle } = useNativeStyles();
     const updateFirmwareVersion = useSelector(selectDeviceUpdateFirmwareVersion);
-    const deviceReleaseInfo = useSelector(selectDeviceReleaseInfo);
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const deviceId = useSelector(selectDeviceId);
     const isConnected = useSelector(selectIsDeviceConnected);
@@ -74,7 +73,7 @@ export const FirmwareUpdateAlert = () => {
     const isClosed = useAtomValue(isClosedAtom);
     const isFirmwareUpdateEnabled = useIsFirmwareUpdateFeatureEnabled();
 
-    const isUpgradable = deviceReleaseInfo?.isNewer;
+    const isFirmwareUpgradable = useSelector(selectIsFirmwareUpgradable);
 
     const handleUpdateFirmware = () => {
         navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
@@ -93,7 +92,7 @@ export const FirmwareUpdateAlert = () => {
     }
 
     if (
-        !isUpgradable ||
+        !isFirmwareUpgradable ||
         isPortfolioTrackerDevice ||
         isDiscoveryRunning ||
         !isConnected ||


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- add alert for up to date / upgrade states in firmware screen
- handle edge case for when firmware update is not enabled (through message system) - simple toast message and disable user from accessing firmware update screen

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19711

## Screenshots:
![Snímek obrazovky 2025-06-26 v 9 23 14](https://github.com/user-attachments/assets/e739f4e4-92a8-418c-a2ab-b1cac9041ffb)
![Snímek obrazovky 2025-06-26 v 9 23 21](https://github.com/user-attachments/assets/197e63bc-44e4-4c70-a6bf-af421eebe089)
![Snímek obrazovky 2025-06-26 v 9 24 33](https://github.com/user-attachments/assets/00a0157c-2496-4bb5-b73a-18305e264fc1)
![Snímek obrazovky 2025-06-26 v 9 24 39](https://github.com/user-attachments/assets/3c3d2c85-db06-4a07-9f2d-54435fba2b8e)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/device-settings-firmware&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/device-settings-firmware&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/device-settings-firmware&lookback=7)