### PR TITLE
fix(suite-desktop): windows build missing electron-main runtime deps

### DIFF
--- a/packages/suite-desktop-core/webpack/core.webpack.config.ts
+++ b/packages/suite-desktop-core/webpack/core.webpack.config.ts
@@ -52,10 +52,17 @@ const threads = sync(`${threadPath}/**/*.ts`).map(globMatch => {
     return path.join(`threads`, relPath.replace('.ts', ''));
 });
 
-/* **** EXTERNALS **** */
+/* **** RUNTIME REQUIRE DEPENDENCIES ****
+ a.k.a. externals
+ Any package that needs a runtime require() call in electron-main or electron-preload
+ must be listed in suite-desktop/package.json "dependencies"
 
+ But how do I tell?
+ 1. Run `yarn workspace @trezor/suite-desktop build:app`
+ 2. find any occurrences of your local trezor-suite repo path in dist/**.js
+    (if any, Suite will likely crash when executed on another computer).
+*/
 const dependencies = Object.keys(pkg.dependencies);
-const devDependencies = Object.keys(pkg.devDependencies);
 
 /* **** CONFIG **** */
 
@@ -85,7 +92,6 @@ const config: webpack.Configuration = {
     },
     externals: [
         ...dependencies,
-        ...devDependencies,
         'bufferutil', // optional dependency of ws lib
         'memcpy', // optional depencency of bytebuffer lib
         'utf-8-validate', // optional dependency of ws lib

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -19,10 +19,12 @@
         "build:app:electron": "yarn workspace @trezor/suite-desktop-core run build:scripts && yarn electron-builder --config electron-builder-config.js",
         "build:linux": "yarn clean && yarn build:ui && yarn build:app && yarn build:app:electron --publish never --linux --x64 --arm64",
         "build:mac": "yarn clean && yarn build:ui && yarn build:app && yarn build:app:electron --publish never --mac --x64 --arm64",
-        "build:win": "yarn clean && yarn build:ui && yarn build:app && yarn build:app:electron --publish never --win --x64"
+        "build:win": "yarn clean && yarn build:ui && yarn build:app && yarn build:app:electron --publish never --win --x64",
+        "_______ DO NOT REMOVE DEPENDENCIES unless you are sure of consequences! _______": "In this package they have special meaning, see core.webpack.config"
     },
     "dependencies": {
         "blake-hash": "^2.0.0",
+        "openpgp": "^6.1.1",
         "passport-desktop": "^0.1.2",
         "usb": "^2.15.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12583,6 +12583,7 @@ __metadata:
     blake-hash: "npm:^2.0.0"
     electron: "npm:35.1.2"
     electron-builder: "npm:26.0.3"
+    openpgp: "npm:^6.1.1"
     passport-desktop: "npm:^0.1.2"
     usb: "npm:^2.15.0"
   languageName: unknown


### PR DESCRIPTION
## Description

- Return dependencies that need a runtime `require()` in electron-main or electron-preload.
- Add commentarry to make it clear

## Related Issue

Resolve #19699

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/windows-desktop-electron-main&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/windows-desktop-electron-main&lookback=7)