### PR TITLE
fix(suite-native): change device label analytics

### DIFF
--- a/packages/suite/src/hooks/suite/useChangeDeviceLabel.ts
+++ b/packages/suite/src/hooks/suite/useChangeDeviceLabel.ts
@@ -4,7 +4,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 
 import { yup } from '@suite-common/validators';
 import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
-import { EventType, analytics } from '@trezor/suite-analytics';
+import { EventTypeShared, analytics } from '@trezor/suite-analytics';
 import { isAscii } from '@trezor/utils';
 
 import { applySettings } from 'src/actions/settings/deviceSettingsActions';
@@ -60,7 +60,7 @@ export const useChangeDeviceLabel = (): {
     const onSubmit = form.handleSubmit(({ deviceLabel }) => {
         dispatch(applySettings({ label: deviceLabel }));
         analytics.report({
-            type: EventType.SettingsDeviceChangeLabel,
+            type: EventTypeShared.SettingsDeviceChangeLabel,
         });
     });
 

--- a/suite-common/analytics/src/events/shared/constants.ts
+++ b/suite-common/analytics/src/events/shared/constants.ts
@@ -7,6 +7,8 @@ export enum EventType {
     WalletConnectSessionRequest = 'wallet-connect/session-request',
     WalletConnectError = 'wallet-connect/error',
 
+    SettingsDeviceChangeLabel = 'settings/device/change-label',
+
     ConnectPopupInit = 'connect-popup/init',
     ConnectPopupPermissions = 'connect-popup/permissions',
     ConnectPopupCall = 'connect-popup/call',

--- a/suite-common/analytics/src/events/shared/types.ts
+++ b/suite-common/analytics/src/events/shared/types.ts
@@ -41,6 +41,7 @@ export type SuiteSharedAnalyticsEvent =
               error: string;
           };
       }
+    | { type: EventType.SettingsDeviceChangeLabel }
     | {
           type: EventType.ConnectPopupInit;
       }

--- a/suite-common/analytics/src/events/suite/constants.ts
+++ b/suite-common/analytics/src/events/suite/constants.ts
@@ -88,7 +88,6 @@ export enum EventType {
     SettingsDeviceSetupWipeCode = 'settings/device/setup-wipe-code',
     SettingsDeviceChangeWipeCode = 'settings/device/change-wipe-code',
     SettingsDeviceDisableWipeCode = 'settings/device/disable-wipe-code',
-    SettingsDeviceChangeLabel = 'settings/device/change-label',
     SettingsDeviceUpdateAutoLock = 'settings/device/update-auto-lock',
     SettingsDeviceChangeOrientation = 'settings/device/change-orientation',
     SettingsDeviceChangeHapticFeedback = 'settings/device/change-haptic-feedback',

--- a/suite-common/analytics/src/events/suite/types.ts
+++ b/suite-common/analytics/src/events/suite/types.ts
@@ -492,7 +492,6 @@ export type SuiteAnalyticsEvent =
     | { type: EventType.SettingsDeviceSetupWipeCode }
     | { type: EventType.SettingsDeviceChangeWipeCode }
     | { type: EventType.SettingsDeviceDisableWipeCode }
-    | { type: EventType.SettingsDeviceChangeLabel }
     | {
           type: EventType.SettingsDeviceUpdateAutoLock;
           payload: {

--- a/suite-native/module-device-settings/src/hooks/useChangeDeviceName.ts
+++ b/suite-native/module-device-settings/src/hooks/useChangeDeviceName.ts
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
 import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { EventTypeShared, analytics } from '@suite-native/analytics';
 import { useForm } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import {
@@ -11,7 +12,6 @@ import {
     StackNavigationProps,
 } from '@suite-native/navigation';
 import TrezorConnect from '@trezor/connect';
-import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { deviceNameFormValidationSchema } from '../deviceNameFormSchema';
 
@@ -73,7 +73,7 @@ export const useChangeDeviceName = () => {
         navigation.navigate(DeviceNameStackRoutes.DeviceNameLoadingScreen);
 
         analytics.report({
-            type: EventType.SettingsDeviceChangeLabel,
+            type: EventTypeShared.SettingsDeviceChangeLabel,
         });
     });
 


### PR DESCRIPTION
## Description
- @trezor/suite-analytics was wrongly imported to suite-native code, fixed
- `EventTypeShared.SettingsDeviceChangeLabel` was moved to shared analytics
 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/change-label-analytics&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/change-label-analytics&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/change-label-analytics&lookback=7)