### PR TITLE
Refactor/native/compact card with icon layout

### DIFF
--- a/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
@@ -1,8 +1,6 @@
 import { ReactNode } from 'react';
 import { Pressable, PressableProps } from 'react-native';
-import { useSelector } from 'react-redux';
 
-import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Icon, IconName } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Color } from '@trezor/theme';
@@ -17,10 +15,11 @@ import { Text } from '../Text';
 const ICON_WRAPPER_SIZE = 48;
 
 type CardVariant = 'normal' | 'danger';
-type CompactCardWithIconLayoutProps = Omit<PressableProps, 'onPress'> & {
+export type CompactCardWithIconLayoutProps = Omit<PressableProps, 'onPress'> & {
     icon: IconName;
     title: ReactNode;
     subtitle: ReactNode;
+    isDisabled?: boolean;
     alertBoxProps?: Omit<InlineAlertBoxProps, 'borderRadius'>;
     onPress?: () => void;
     variant?: CardVariant;
@@ -68,14 +67,14 @@ export const CompactCardWithIconLayout = ({
     subtitle,
     alertBoxProps,
     onPress,
+    isDisabled = false,
     variant = 'normal',
     ...pressableProps
 }: CompactCardWithIconLayoutProps) => {
     const { applyStyle } = useNativeStyles();
-    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     return (
-        <Pressable onPress={onPress} disabled={isDiscoveryRunning} {...pressableProps}>
+        <Pressable onPress={onPress} disabled={isDisabled} {...pressableProps}>
             <Card borderColor="borderElevation1" noPadding>
                 <HStack padding="sp16" spacing="sp12" alignItems="center">
                     <Box style={applyStyle(iconWrapperStyle, { variant })}>
@@ -91,7 +90,7 @@ export const CompactCardWithIconLayout = ({
                             {subtitle}
                         </Text>
                     </VStack>
-                    {isDiscoveryRunning ? (
+                    {isDisabled ? (
                         <Loader />
                     ) : (
                         <Icon name="caretRight" size="mediumLarge" color="iconSubdued" />

--- a/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
@@ -17,7 +17,7 @@ import { Text } from '../Text';
 const ICON_WRAPPER_SIZE = 48;
 
 type CardVariant = 'normal' | 'danger';
-type SettingsItemCardProps = Omit<PressableProps, 'onPress'> & {
+type CompactCardWithIconLayoutProps = Omit<PressableProps, 'onPress'> & {
     icon: IconName;
     title: ReactNode;
     subtitle: ReactNode;
@@ -62,7 +62,7 @@ const iconWrapperStyle = prepareNativeStyle<{ variant: CardVariant }>((utils, { 
     borderRadius: utils.borders.radii.round,
 }));
 
-export const SettingsItemCard = ({
+export const CompactCardWithIconLayout = ({
     icon,
     title,
     subtitle,
@@ -70,7 +70,7 @@ export const SettingsItemCard = ({
     onPress,
     variant = 'normal',
     ...pressableProps
-}: SettingsItemCardProps) => {
+}: CompactCardWithIconLayoutProps) => {
     const { applyStyle } = useNativeStyles();
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 

--- a/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
@@ -15,7 +15,7 @@ import { Text } from '../Text';
 const ICON_WRAPPER_SIZE = 48;
 
 type CardVariant = 'normal' | 'danger';
-export type CompactCardWithIconLayoutProps = Omit<PressableProps, 'onPress'> & {
+export type CompactCardWithIconLayoutProps = {
     icon: IconName;
     title: ReactNode;
     subtitle: ReactNode;
@@ -23,7 +23,7 @@ export type CompactCardWithIconLayoutProps = Omit<PressableProps, 'onPress'> & {
     alertBoxProps?: Omit<InlineAlertBoxProps, 'borderRadius'>;
     onPress?: () => void;
     variant?: CardVariant;
-};
+} & PressableProps;
 
 type CardColorScheme = {
     iconWrapperBackgroundColor: Color;

--- a/suite-native/atoms/src/Card/SettingsItemCard.tsx
+++ b/suite-native/atoms/src/Card/SettingsItemCard.tsx
@@ -3,19 +3,16 @@ import { Pressable, PressableProps } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
-import {
-    Box,
-    Card,
-    HStack,
-    InlineAlertBox,
-    InlineAlertBoxProps,
-    Loader,
-    Text,
-    VStack,
-} from '@suite-native/atoms';
 import { Icon, IconName } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Color } from '@trezor/theme';
+
+import { Card } from './Card';
+import { Box } from '../Box';
+import { InlineAlertBox, InlineAlertBoxProps } from '../InlineAlertBox/InlineAlertBox';
+import { Loader } from '../Loader';
+import { HStack, VStack } from '../Stack';
+import { Text } from '../Text';
 
 const ICON_WRAPPER_SIZE = 48;
 

--- a/suite-native/atoms/src/index.ts
+++ b/suite-native/atoms/src/index.ts
@@ -37,7 +37,7 @@ export * from './Card/Card';
 export * from './Card/HeaderedCard';
 export * from './Card/CardDivider';
 export * from './Card/CardWithIconLayout';
-export * from './Card/SettingsItemCard';
+export * from './Card/CompactCardWithIconLayout';
 export * from './ScreenHeaderWrapper';
 export * from './ErrorMessage';
 export * from './Table';

--- a/suite-native/atoms/src/index.ts
+++ b/suite-native/atoms/src/index.ts
@@ -37,6 +37,7 @@ export * from './Card/Card';
 export * from './Card/HeaderedCard';
 export * from './Card/CardDivider';
 export * from './Card/CardWithIconLayout';
+export * from './Card/SettingsItemCard';
 export * from './ScreenHeaderWrapper';
 export * from './ErrorMessage';
 export * from './Table';

--- a/suite-native/module-device-settings/package.json
+++ b/suite-native/module-device-settings/package.json
@@ -18,7 +18,6 @@
         "@suite-native/alerts": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/device": "workspace:*",
-        "@suite-native/icons": "workspace:*",
         "@suite-native/intl": "workspace:*",
         "@suite-native/module-authorize-device": "workspace:*",
         "@suite-native/navigation": "workspace:*",

--- a/suite-native/module-device-settings/src/components/DeviceAuthenticityCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceAuthenticityCard.tsx
@@ -1,6 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
 
-import { CompactCardWithIconLayout } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceAuthenticityStackParamList,
@@ -9,6 +8,8 @@ import {
     DeviceSettingsStackRoutes,
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
+
+import { DeviceSettingsItemCard } from './DeviceSettingsItemCard';
 
 type NavigationProp = StackToStackCompositeNavigationProps<
     DeviceAuthenticityStackParamList,
@@ -24,7 +25,7 @@ export const DeviceAuthenticityCard = () => {
     };
 
     return (
-        <CompactCardWithIconLayout
+        <DeviceSettingsItemCard
             icon="shield"
             onPress={handleOnPress}
             title={<Translation id="moduleDeviceSettings.authenticity.title" />}

--- a/suite-native/module-device-settings/src/components/DeviceAuthenticityCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceAuthenticityCard.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 
-import { SettingsItemCard } from '@suite-native/atoms';
+import { CompactCardWithIconLayout } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceAuthenticityStackParamList,
@@ -24,7 +24,7 @@ export const DeviceAuthenticityCard = () => {
     };
 
     return (
-        <SettingsItemCard
+        <CompactCardWithIconLayout
             icon="shield"
             onPress={handleOnPress}
             title={<Translation id="moduleDeviceSettings.authenticity.title" />}

--- a/suite-native/module-device-settings/src/components/DeviceAuthenticityCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceAuthenticityCard.tsx
@@ -1,5 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 
+import { SettingsItemCard } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceAuthenticityStackParamList,
@@ -8,8 +9,6 @@ import {
     DeviceSettingsStackRoutes,
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
-
-import { SettingsItemCard } from './SettingsItemCard';
 
 type NavigationProp = StackToStackCompositeNavigationProps<
     DeviceAuthenticityStackParamList,

--- a/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
@@ -10,7 +10,7 @@ import {
     selectIsDeviceBackedUp,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
-import { InlineAlertBoxProps, SettingsItemCard } from '@suite-native/atoms';
+import { CompactCardWithIconLayout, InlineAlertBoxProps } from '@suite-native/atoms';
 import { useIsFirmwareUpdateFeatureEnabled } from '@suite-native/firmware';
 import { Translation } from '@suite-native/intl';
 import {
@@ -71,7 +71,7 @@ export const DeviceFirmwareCard = () => {
     })();
 
     return (
-        <SettingsItemCard
+        <CompactCardWithIconLayout
             icon="database"
             title={<Translation id="firmware.title" />}
             alertBoxProps={firmwareUpdateProps}

--- a/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
@@ -10,7 +10,7 @@ import {
     selectIsDeviceBackedUp,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
-import { InlineAlertBoxProps } from '@suite-native/atoms';
+import { InlineAlertBoxProps, SettingsItemCard } from '@suite-native/atoms';
 import { useIsFirmwareUpdateFeatureEnabled } from '@suite-native/firmware';
 import { Translation } from '@suite-native/intl';
 import {
@@ -19,8 +19,6 @@ import {
     StackNavigationProps,
 } from '@suite-native/navigation';
 import { getFirmwareVersion } from '@trezor/device-utils';
-
-import { SettingsItemCard } from './SettingsItemCard';
 
 type NavigationProp = StackNavigationProps<
     DeviceSettingsStackParamList,

--- a/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
@@ -10,7 +10,7 @@ import {
     selectIsDeviceBackedUp,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
-import { CompactCardWithIconLayout, InlineAlertBoxProps } from '@suite-native/atoms';
+import { InlineAlertBoxProps } from '@suite-native/atoms';
 import { useIsFirmwareUpdateFeatureEnabled } from '@suite-native/firmware';
 import { Translation } from '@suite-native/intl';
 import {
@@ -19,6 +19,8 @@ import {
     StackNavigationProps,
 } from '@suite-native/navigation';
 import { getFirmwareVersion } from '@trezor/device-utils';
+
+import { DeviceSettingsItemCard } from './DeviceSettingsItemCard';
 
 type NavigationProp = StackNavigationProps<
     DeviceSettingsStackParamList,
@@ -71,7 +73,7 @@ export const DeviceFirmwareCard = () => {
     })();
 
     return (
-        <CompactCardWithIconLayout
+        <DeviceSettingsItemCard
             icon="database"
             title={<Translation id="firmware.title" />}
             alertBoxProps={firmwareUpdateProps}

--- a/suite-native/module-device-settings/src/components/DevicePinProtectionCard.tsx
+++ b/suite-native/module-device-settings/src/components/DevicePinProtectionCard.tsx
@@ -7,13 +7,15 @@ import {
     selectIsDeviceProtectedByPin,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
-import { CompactCardWithIconLayout, InlineAlertBoxProps } from '@suite-native/atoms';
+import { InlineAlertBoxProps } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceSettingsStackParamList,
     DeviceSettingsStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
+
+import { DeviceSettingsItemCard } from './DeviceSettingsItemCard';
 
 type NavigationProp = StackNavigationProps<
     DeviceSettingsStackParamList,
@@ -58,7 +60,7 @@ export const DevicePinProtectionCard = () => {
     };
 
     return (
-        <CompactCardWithIconLayout
+        <DeviceSettingsItemCard
             icon="password"
             title={<Translation id="moduleDeviceSettings.pinProtection.title" />}
             subtitle={

--- a/suite-native/module-device-settings/src/components/DevicePinProtectionCard.tsx
+++ b/suite-native/module-device-settings/src/components/DevicePinProtectionCard.tsx
@@ -7,7 +7,7 @@ import {
     selectIsDeviceProtectedByPin,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
-import { InlineAlertBoxProps, SettingsItemCard } from '@suite-native/atoms';
+import { CompactCardWithIconLayout, InlineAlertBoxProps } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceSettingsStackParamList,
@@ -58,7 +58,7 @@ export const DevicePinProtectionCard = () => {
     };
 
     return (
-        <SettingsItemCard
+        <CompactCardWithIconLayout
             icon="password"
             title={<Translation id="moduleDeviceSettings.pinProtection.title" />}
             subtitle={

--- a/suite-native/module-device-settings/src/components/DevicePinProtectionCard.tsx
+++ b/suite-native/module-device-settings/src/components/DevicePinProtectionCard.tsx
@@ -7,15 +7,13 @@ import {
     selectIsDeviceProtectedByPin,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
-import { InlineAlertBoxProps } from '@suite-native/atoms';
+import { InlineAlertBoxProps, SettingsItemCard } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceSettingsStackParamList,
     DeviceSettingsStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
-
-import { SettingsItemCard } from './SettingsItemCard';
 
 type NavigationProp = StackNavigationProps<
     DeviceSettingsStackParamList,

--- a/suite-native/module-device-settings/src/components/DeviceSettingsItemCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceSettingsItemCard.tsx
@@ -1,0 +1,25 @@
+import { useSelector } from 'react-redux';
+
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { CompactCardWithIconLayout, CompactCardWithIconLayoutProps } from '@suite-native/atoms';
+
+export const DeviceSettingsItemCard = ({
+    icon,
+    title,
+    onPress,
+    testID,
+    subtitle,
+}: CompactCardWithIconLayoutProps) => {
+    const hasRunningDiscovery = useSelector(selectHasRunningDiscovery);
+
+    return (
+        <CompactCardWithIconLayout
+            icon={icon}
+            onPress={onPress}
+            title={title}
+            subtitle={subtitle}
+            isDisabled={hasRunningDiscovery}
+            testID={testID}
+        />
+    );
+};

--- a/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
+++ b/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
@@ -1,5 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 
+import { SettingsItemCard } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceSettingsStackParamList,
@@ -7,8 +8,6 @@ import {
     StackNavigationProps,
     WipeDeviceStackRoutes,
 } from '@suite-native/navigation';
-
-import { SettingsItemCard } from './SettingsItemCard';
 
 type NavigationProp = StackNavigationProps<
     DeviceSettingsStackParamList,

--- a/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
+++ b/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
@@ -1,6 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
 
-import { CompactCardWithIconLayout } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceSettingsStackParamList,
@@ -8,6 +7,8 @@ import {
     StackNavigationProps,
     WipeDeviceStackRoutes,
 } from '@suite-native/navigation';
+
+import { DeviceSettingsItemCard } from './DeviceSettingsItemCard';
 
 type NavigationProp = StackNavigationProps<
     DeviceSettingsStackParamList,
@@ -24,7 +25,7 @@ export const WipeDeviceCard = () => {
     };
 
     return (
-        <CompactCardWithIconLayout
+        <DeviceSettingsItemCard
             title={<Translation id="moduleDeviceSettings.wipeDevice.title" />}
             icon="warningOctagon"
             subtitle={<Translation id="moduleDeviceSettings.wipeDevice.subtitle" />}

--- a/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
+++ b/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 
-import { SettingsItemCard } from '@suite-native/atoms';
+import { CompactCardWithIconLayout } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceSettingsStackParamList,
@@ -24,7 +24,7 @@ export const WipeDeviceCard = () => {
     };
 
     return (
-        <SettingsItemCard
+        <CompactCardWithIconLayout
             title={<Translation id="moduleDeviceSettings.wipeDevice.title" />}
             icon="warningOctagon"
             subtitle={<Translation id="moduleDeviceSettings.wipeDevice.subtitle" />}

--- a/suite-native/module-device-settings/tsconfig.json
+++ b/suite-native/module-device-settings/tsconfig.json
@@ -8,7 +8,6 @@
         { "path": "../alerts" },
         { "path": "../atoms" },
         { "path": "../device" },
-        { "path": "../icons" },
         { "path": "../intl" },
         { "path": "../module-authorize-device" },
         { "path": "../navigation" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10838,7 +10838,6 @@ __metadata:
     "@suite-native/alerts": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/device": "workspace:*"
-    "@suite-native/icons": "workspace:*"
     "@suite-native/intl": "workspace:*"
     "@suite-native/module-authorize-device": "workspace:*"
     "@suite-native/navigation": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- move device settings item card to atoms so it can be reused for app settings

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native/compact-card-with-icon-layout&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/native/compact-card-with-icon-layout&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/native/compact-card-with-icon-layout&lookback=7)