### PR TITLE
Geolocation countries blacklist

### DIFF
--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -48,6 +48,9 @@ export const Feature = {
         buy: 'trading.buy',
         sell: 'trading.sell',
         exchange: 'trading.exchange',
+        restrictions: {
+            blacklist: 'trading.restrictions.blacklist',
+        },
     },
 
     // device onboarding (MOBILE ONLY!!!).

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -2007,6 +2007,7 @@ export const en = {
             btcOnlyFirmwareTitle: 'Bitcoin-only firmware',
             btcOnlyFirmwareDescription:
                 'Swapping is unavailable with Bitcoin-only firmware. To enable, switch to universal firmware.',
+            notAvailableInCountryTitle: 'Trading is not yet available in your country',
         },
         defaultSearchLabel: 'Search',
         notSelected: 'Not selected',

--- a/suite-native/module-trading/src/components/general/Error/NotAvailableInCountry.tsx
+++ b/suite-native/module-trading/src/components/general/Error/NotAvailableInCountry.tsx
@@ -1,0 +1,7 @@
+import { Translation } from '@suite-native/intl';
+
+import { WarningCard } from './WarningCard';
+
+export const NotAvailableInCountry = () => (
+    <WarningCard title={<Translation id="moduleTrading.error.notAvailableInCountryTitle" />} />
+);

--- a/suite-native/module-trading/src/components/general/TradingTabContent.tsx
+++ b/suite-native/module-trading/src/components/general/TradingTabContent.tsx
@@ -1,0 +1,25 @@
+import { useSelector } from 'react-redux';
+
+import { useNetInfo } from '@react-native-community/netinfo';
+
+import { ActiveTab } from './ActiveTab';
+import { DeviceOffline } from './Error/DeviceOffline';
+import { NotAvailableInCountry } from './Error/NotAvailableInCountry';
+import { useGeolocationCountryCode } from '../../hooks/general/useGeolocationCountryCode';
+import { selectIsTradingBlacklisted } from '../../selectors/commonSelectors';
+
+export const TradingTabContent = () => {
+    const { isInternetReachable } = useNetInfo();
+    const isTradingBlacklisted = useSelector(selectIsTradingBlacklisted);
+    useGeolocationCountryCode();
+
+    if (isTradingBlacklisted) {
+        return <NotAvailableInCountry />;
+    }
+
+    if (isInternetReachable === false) {
+        return <DeviceOffline />;
+    }
+
+    return <ActiveTab />;
+};

--- a/suite-native/module-trading/src/components/general/__tests__/TradingTabContent.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingTabContent.comp.test.tsx
@@ -1,0 +1,105 @@
+import { renderWithStoreProviderAsync, screen } from '@suite-native/test-utils';
+
+import { initialState } from '../../../tradingSlice';
+import { TradingTabContent } from '../TradingTabContent';
+
+let mockIsInternetReachable: boolean | null = true;
+
+jest.mock('@react-native-community/netinfo', () => ({
+    useNetInfo: () => ({
+        isInternetReachable: mockIsInternetReachable,
+    }),
+}));
+
+jest.mock('../../../hooks/buy/useBuyData', () => ({
+    useBuyData: () => ({
+        isLoading: false,
+        lastLoadedTimestamp: 1,
+        isFullyLoaded: true,
+    }),
+}));
+
+describe('TradingTabContent', () => {
+    const renderTradingTabContent = (isBlacklisted: boolean = false) =>
+        renderWithStoreProviderAsync(<TradingTabContent />, {
+            preloadedState: {
+                wallet: {
+                    tradingNew: {
+                        ...initialState,
+                        activeTradingType: 'buy',
+                    },
+                },
+                messageSystem: {
+                    validMessages: {
+                        feature: ['actionId'],
+                        banner: [],
+                        context: [],
+                        modal: [],
+                    },
+                    dismissedMessages: {},
+                    config: {
+                        actions: [
+                            {
+                                message: {
+                                    id: 'actionId',
+                                    category: ['feature'],
+                                    feature: [
+                                        {
+                                            domain: 'trading.restrictions.blacklist',
+                                            flag: isBlacklisted,
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        });
+
+    const expectDeviceOffline = () => {
+        expect(screen.getByText('Trading is not available offline')).toBeOnTheScreen();
+    };
+
+    const expectTradingNotAllowedInCountry = () => {
+        expect(screen.getByText('Trading is not yet available in your country')).toBeOnTheScreen();
+    };
+
+    const expectBuyForm = () => {
+        expect(screen.getByText('You pay')).toBeOnTheScreen();
+    };
+
+    beforeEach(() => {
+        mockIsInternetReachable = true;
+    });
+
+    it('should render error screen when isInternetReachable is false', async () => {
+        mockIsInternetReachable = false;
+
+        await renderTradingTabContent();
+
+        expectDeviceOffline();
+    });
+
+    it('should render trading not allowed in your country warning when ff is set up', async () => {
+        await renderTradingTabContent(true);
+
+        expectTradingNotAllowedInCountry();
+    });
+
+    it('trading not allowed should have priority over offline notice', async () => {
+        mockIsInternetReachable = false;
+
+        await renderTradingTabContent(true);
+
+        expectTradingNotAllowedInCountry();
+    });
+
+    it('should render form even when isInternetReachable is null', async () => {
+        mockIsInternetReachable = null;
+
+        await renderTradingTabContent();
+
+        expectBuyForm();
+    });
+});

--- a/suite-native/module-trading/src/screens/TradingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingScreen.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
-import { useNetInfo } from '@react-native-community/netinfo';
 import { useNavigation } from '@react-navigation/native';
 
 import { EventType, analytics } from '@suite-native/analytics';
@@ -9,15 +8,13 @@ import { VStack } from '@suite-native/atoms';
 import { DeviceManagerScreenHeader } from '@suite-native/device-manager';
 import { Screen, TradingStackRoutes } from '@suite-native/navigation';
 
-import { ActiveTab } from '../components/general/ActiveTab';
-import { DeviceOffline } from '../components/general/Error/DeviceOffline';
 import { Footer } from '../components/general/Footer';
 import { Header } from '../components/general/Header/Header';
 import { HistoryButton, NavigationProps } from '../components/general/HistoryButton';
 import { LegalGatewayContextMessage } from '../components/general/LegalGatewayContextMessage';
+import { TradingTabContent } from '../components/general/TradingTabContent';
 import { TradingTypeAwareContextMessage } from '../components/general/TradingTypeAwareContextMessage';
 import { useActiveTradingTypeReaction } from '../hooks/general/useActiveTradingTypeReaction';
-import { useGeolocationCountryCode } from '../hooks/general/useGeolocationCountryCode';
 import { useMountedRecentlyFlag } from '../hooks/general/useMountedRecentlyFlag';
 import {
     selectActiveTradingType,
@@ -26,13 +23,11 @@ import {
 } from '../selectors/commonSelectors';
 
 const TradingScreenContent = () => {
-    const { isInternetReachable } = useNetInfo();
     const tradeToBeOpened = useSelector(selectTradeToBeOpened);
     const activeTradingType = useSelector(selectActiveTradingType);
     const navigation = useNavigation<NavigationProps>();
     const isScreenMountedRecently = useMountedRecentlyFlag(activeTradingType);
     useActiveTradingTypeReaction();
-    useGeolocationCountryCode();
 
     useEffect(() => {
         if (tradeToBeOpened) {
@@ -51,7 +46,7 @@ const TradingScreenContent = () => {
     return (
         <VStack spacing="sp16">
             <Header isFormMountedRecently={isScreenMountedRecently} />
-            {isInternetReachable === false ? <DeviceOffline /> : <ActiveTab />}
+            <TradingTabContent />
             <Footer isFormMountedRecently={isScreenMountedRecently} />
             <HistoryButton isFormMountedRecently={isScreenMountedRecently} />
         </VStack>

--- a/suite-native/module-trading/src/screens/__tests__/TradingScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingScreen.comp.test.tsx
@@ -3,8 +3,6 @@ import { PreloadedState, renderWithStoreProviderAsync, screen } from '@suite-nat
 
 import { TradingScreen } from '../TradingScreen';
 
-let mockIsInternetReachable: boolean | null = true;
-
 jest.mock('@react-navigation/native', () => ({
     ...jest.requireActual('@react-navigation/native'),
     useRoute: () => ({ name: 'TradingScreen' }),
@@ -23,12 +21,6 @@ jest.mock('../../hooks/exchange/useExchangeData', () => ({
         isLoading: false,
         lastLoadedTimestamp: 1,
         isFullyLoaded: true,
-    }),
-}));
-
-jest.mock('@react-native-community/netinfo', () => ({
-    useNetInfo: () => ({
-        isInternetReachable: mockIsInternetReachable,
     }),
 }));
 
@@ -71,34 +63,12 @@ const stateWithDisabledTrading = {
     },
 } as unknown as PreloadedState;
 
-const stateWithEnabledExchange = {
-    ...stateWithDisabledTrading,
-    featureFlags: {
-        ...featureFlagsInitialState,
-        [FeatureFlag.IsTradingBuyEnabled]: false,
-        [FeatureFlag.IsTradingExchangeEnabled]: true,
-    },
-};
-
 describe('TradingScreen', () => {
-    beforeEach(() => {
-        mockIsInternetReachable = true;
-    });
-
     const renderTradingScreen = (preloadedState?: PreloadedState) =>
         renderWithStoreProviderAsync(<TradingScreen />, { preloadedState });
 
     const expectBuyForm = () => {
         expect(screen.getByText('You pay')).toBeOnTheScreen();
-    };
-
-    const expectExchangeForm = () => {
-        expect(screen.getByText('You pay')).toBeOnTheScreen();
-        expect(screen.getByText('You get')).toBeOnTheScreen();
-    };
-
-    const expectDeviceOffline = () => {
-        expect(screen.getByText('Trading is not available offline')).toBeOnTheScreen();
     };
 
     it('should render nothing when trading feature flag is not enabled', async () => {
@@ -107,29 +77,7 @@ describe('TradingScreen', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should render error screen when isInternetReachable is false', async () => {
-        mockIsInternetReachable = false;
-
-        await renderTradingScreen(stateWithEnabledBuy);
-
-        expectDeviceOffline();
-    });
-
     it('should render Buy form by default', async () => {
-        await renderTradingScreen(stateWithEnabledBuy);
-
-        expectBuyForm();
-    });
-
-    it('should render exchange form when only exchange feature flag is enabled', async () => {
-        await renderTradingScreen(stateWithEnabledExchange);
-
-        expectExchangeForm();
-    });
-
-    it('should render form even when isInternetReachable is null', async () => {
-        mockIsInternetReachable = null;
-
         await renderTradingScreen(stateWithEnabledBuy);
 
         expectBuyForm();

--- a/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
@@ -7,6 +7,7 @@ import {
     selectActiveTradingType,
     selectEnabledTradingTypes,
     selectIsAmountInputActive,
+    selectIsTradingBlacklisted,
     selectIsTradingBuyEnabled,
     selectIsTradingEnabled,
     selectIsTradingExchangeEnabled,
@@ -22,10 +23,12 @@ const getPreloadedState = ({
     buy,
     sell,
     exchange,
+    blacklist,
 }: {
     buy?: boolean;
     sell?: boolean;
     exchange?: boolean;
+    blacklist?: boolean;
 }) => {
     const features: Feature[] = [];
     if (buy !== undefined) {
@@ -44,6 +47,12 @@ const getPreloadedState = ({
         features.push({
             domain: 'trading.exchange',
             flag: exchange,
+        });
+    }
+    if (blacklist !== undefined) {
+        features.push({
+            domain: 'trading.restrictions.blacklist',
+            flag: blacklist,
         });
     }
 
@@ -226,6 +235,23 @@ describe('commonSelectors', () => {
             const firstCall = selectEnabledTradingTypes(getPreloadedState(flags));
             const secondCall = selectEnabledTradingTypes(getPreloadedState(flags));
             expect(firstCall).toBe(secondCall);
+        });
+    });
+
+    describe('selectIsTradingBlacklisted', () => {
+        it('should return true if trading.restrictions.blacklist feature is enabled', () => {
+            const state = getPreloadedState({ blacklist: true });
+            expect(selectIsTradingBlacklisted(state)).toBe(true);
+        });
+
+        it('should return false if trading.restrictions.blacklist feature is disabled', () => {
+            const state = getPreloadedState({ blacklist: false });
+            expect(selectIsTradingBlacklisted(state)).toBe(false);
+        });
+
+        it('should return false if trading.restrictions.blacklist feature is not set', () => {
+            const state = getPreloadedState({});
+            expect(selectIsTradingBlacklisted(state)).toBe(false);
         });
     });
 });

--- a/suite-native/module-trading/src/selectors/commonSelectors.ts
+++ b/suite-native/module-trading/src/selectors/commonSelectors.ts
@@ -58,6 +58,9 @@ export const selectEnabledTradingTypes = createFeatureFlagsMemoizedSelector(
     },
 );
 
+export const selectIsTradingBlacklisted = (state: MessageSystemRootState) =>
+    selectIsFeatureEnabled(state, Feature.trading.restrictions.blacklist, false);
+
 // trade for opening in detail
 export const selectTradeToBeOpened = (state: TradingRootState) => {
     const orderId = state.wallet.tradingNew.tradeOrderIdToBeOpened;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Do not display trading in GB. But still allows to displaye already executed trades.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
![Simulator Screenshot - iPhone 16 Plus - 2025-06-26 at 13 42 51](https://github.com/user-attachments/assets/2fa39dc5-4793-4d8a-9269-215500b02f1a)


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=geolocation-countries-blacklist&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=geolocation-countries-blacklist&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=geolocation-countries-blacklist&lookback=7)