### PR TITLE
refactor(suite-native): move swipeable walkthrough to atoms

### DIFF
--- a/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
@@ -87,7 +87,7 @@ class DeviceOnboardingActions {
     }
 
     async pressHoldToConfirmButton() {
-        const buttonId = '@deviceOnboarding/HoldToConfirmButton';
+        const buttonId = '@holdToConfirmButton';
         await waitForElementByIdToBeVisible(buttonId);
         const holdToConfirmButton = element(by.id(buttonId));
         await holdToConfirmButton.longPress(3000);

--- a/suite-native/atoms/src/HoldToConfirmButton.tsx
+++ b/suite-native/atoms/src/HoldToConfirmButton.tsx
@@ -128,7 +128,7 @@ export const HoldToConfirmButton = ({
             <GestureDetector gesture={tapGesture}>
                 <Canvas
                     style={{ width: CANVAS_SIZE, height: CANVAS_SIZE }}
-                    testID="@deviceOnboarding/HoldToConfirmButton"
+                    testID="@holdToConfirmButton"
                 >
                     <Circle
                         cx={CIRCLE_CENTER}

--- a/suite-native/atoms/src/SwipeableWalkthrough/SwipeableWalkthrough.tsx
+++ b/suite-native/atoms/src/SwipeableWalkthrough/SwipeableWalkthrough.tsx
@@ -3,9 +3,8 @@ import { View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { SharedValue } from 'react-native-reanimated';
 
-import { AnimatedBox } from '@suite-native/atoms';
-
-import { useSwipeableWalkthroughStepHeight } from '../../hooks/useSwipeableWalkthroughStepHeight';
+import { useSwipeableWalkthroughStepHeight } from './useSwipeableWalkthroughStepHeight';
+import { AnimatedBox } from '../Box';
 
 type SwipeableWalkthroughProps = {
     children: ReactNode;

--- a/suite-native/atoms/src/SwipeableWalkthrough/SwipeableWalkthroughScreenHeader.tsx
+++ b/suite-native/atoms/src/SwipeableWalkthrough/SwipeableWalkthroughScreenHeader.tsx
@@ -1,13 +1,14 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { StatusBar } from 'react-native';
 import Animated, { SharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { useNavigation, useTheme } from '@react-navigation/native';
-
-import { Box, IconButton } from '@suite-native/atoms';
-import { ScreenHeader } from '@suite-native/navigation';
+import { ScreenHeader, useOverrideBackNavigation } from '@suite-native/navigation';
+import { useActiveColorScheme } from '@suite-native/theme';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+import { Box } from '../Box';
+import { IconButton } from '../Button/IconButton';
 
 type SwipeableWalkthroughScreenHeaderProps = {
     currentStepIndex: SharedValue<number>;
@@ -74,14 +75,9 @@ export const SwipeableWalkthroughScreenHeader = ({
     CustomBackButton,
     onPressBack,
 }: SwipeableWalkthroughScreenHeaderProps) => {
-    const { applyStyle } = useNativeStyles();
+    const { applyStyle, utils } = useNativeStyles();
     const { top: topSafeAreaInset } = useSafeAreaInsets();
-    const {
-        colors: { background },
-        dark,
-    } = useTheme();
-
-    const navigation = useNavigation();
+    const activeColorScheme = useActiveColorScheme();
 
     const BackButton = CustomBackButton || SwipeableWalkthroughBackButton;
 
@@ -93,25 +89,15 @@ export const SwipeableWalkthroughScreenHeader = ({
         }
     }, [currentStepIndex, onPressBack]);
 
-    useEffect(() => {
-        // Override default navigation GO_BACK action to align it with the UI back button behavior.
-        const unsubscribe = navigation.addListener('beforeRemove', e => {
-            if (e.data.action.type === 'GO_BACK') {
-                e.preventDefault();
-                handlePressBackButton();
-            }
-        });
-
-        return unsubscribe;
-    }, [handlePressBackButton, navigation]);
+    useOverrideBackNavigation({ onNavigateBack: handlePressBackButton });
 
     return (
         <>
             {/* Status bar can not be transparent same as on the other screens, because then is the animated content visible in in while transitioning. */}
             <Box style={applyStyle(statusBarStyle, { topSafeAreaInset })}>
                 <StatusBar
-                    backgroundColor={background}
-                    barStyle={dark ? 'light-content' : 'dark-content'}
+                    backgroundColor={utils.colors.backgroundSurfaceElevation0}
+                    barStyle={activeColorScheme === 'dark' ? 'light-content' : 'dark-content'}
                 />
             </Box>
             <Box style={applyStyle(screenHeaderContainerStyle)}>

--- a/suite-native/atoms/src/SwipeableWalkthrough/SwipeableWalkthroughStep.tsx
+++ b/suite-native/atoms/src/SwipeableWalkthrough/SwipeableWalkthroughStep.tsx
@@ -3,11 +3,13 @@ import { ScrollView } from 'react-native-gesture-handler';
 import { SharedValue, useAnimatedStyle, withSpring } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { AnimatedBox, IconButton, VStack } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
-import { useSwipeableWalkthroughStepHeight } from '../../hooks/useSwipeableWalkthroughStepHeight';
-import { OnboardingStepHeader } from '../OnboardingStepHeader';
+import { useSwipeableWalkthroughStepHeight } from './useSwipeableWalkthroughStepHeight';
+import { AnimatedBox } from '../Box';
+import { IconButton } from '../Button/IconButton';
+import { VStack } from '../Stack';
+import { SwipeableWalkthroughStepHeader } from './SwipeableWalkthroughStepHeader';
 
 export type SwipeableWalkthroughStepProps = {
     children: ReactNode;
@@ -91,7 +93,11 @@ export const SwipeableWalkthroughStep = ({
                 })}
                 testID="@deviceOnboarding/SwipeableWalkthroughStep/scrollView"
             >
-                <OnboardingStepHeader callout={callout} title={title} description={description} />
+                <SwipeableWalkthroughStepHeader
+                    callout={callout}
+                    title={title}
+                    description={description}
+                />
                 <VStack spacing="sp24" alignItems="center" flex={1}>
                     {children}
                     {continueButton ?? (

--- a/suite-native/atoms/src/SwipeableWalkthrough/SwipeableWalkthroughStepHeader.tsx
+++ b/suite-native/atoms/src/SwipeableWalkthrough/SwipeableWalkthroughStepHeader.tsx
@@ -1,9 +1,11 @@
 import { ReactNode } from 'react';
 
-import { Text, VStack } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
-type OnboardingStepHeaderProps = {
+import { VStack } from '../Stack';
+import { Text } from '../Text';
+
+type SwipeableWalkthroughStepHeaderProps = {
     callout: ReactNode;
     title: ReactNode;
     description?: ReactNode;
@@ -13,11 +15,11 @@ const titleStyle = prepareNativeStyle(() => ({
     letterSpacing: -1.4,
 }));
 
-export const OnboardingStepHeader = ({
+export const SwipeableWalkthroughStepHeader = ({
     callout,
     title,
     description,
-}: OnboardingStepHeaderProps) => {
+}: SwipeableWalkthroughStepHeaderProps) => {
     const { applyStyle } = useNativeStyles();
 
     if (!title || !callout) return;

--- a/suite-native/atoms/src/SwipeableWalkthrough/useSwipeableWalkthroughStepHeight.ts
+++ b/suite-native/atoms/src/SwipeableWalkthrough/useSwipeableWalkthroughStepHeight.ts
@@ -4,11 +4,11 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { atom, useAtomValue, useSetAtom } from 'jotai';
 
-const swipeableWalkthroughStepScrennLayoutHeightAtom = atom(0);
+const swipeableWalkthroughStepScreenLayoutHeightAtom = atom(0);
 
 export const useSwipeableWalkthroughStepHeight = () => {
-    const stepOffset = useAtomValue(swipeableWalkthroughStepScrennLayoutHeightAtom);
-    const setStepLayoutHeight = useSetAtom(swipeableWalkthroughStepScrennLayoutHeightAtom);
+    const stepOffset = useAtomValue(swipeableWalkthroughStepScreenLayoutHeightAtom);
+    const setStepLayoutHeight = useSetAtom(swipeableWalkthroughStepScreenLayoutHeightAtom);
     const { bottom, top } = useSafeAreaInsets();
 
     const swipeableWalkthroughStepHeight = useMemo(

--- a/suite-native/atoms/src/index.ts
+++ b/suite-native/atoms/src/index.ts
@@ -3,6 +3,7 @@ export * from './InlineAlertBox/InlineAlertBox';
 export * from './Text';
 export * from './Box';
 export * from './Hint';
+export * from './HoldToConfirmButton';
 export * from './Radio';
 export * from './NumPadButton';
 export * from './Image';
@@ -67,5 +68,9 @@ export * from './CircularSpinner';
 export * from './CardStepper/CardStepper';
 export * from './Sheet/BottomSheetModal';
 export * from './Sheet/hooks/useBottomSheetModal';
+export * from './SwipeableWalkthrough/SwipeableWalkthrough';
+export * from './SwipeableWalkthrough/SwipeableWalkthroughScreenHeader';
+export * from './SwipeableWalkthrough/SwipeableWalkthroughStep';
+export * from './SwipeableWalkthrough/SwipeableWalkthroughStepHeader';
 
 export { useDebugView } from './DebugView';

--- a/suite-native/atoms/src/jestSetup.jsx
+++ b/suite-native/atoms/src/jestSetup.jsx
@@ -3,3 +3,9 @@ import { View as MockView } from 'react-native';
 jest.mock('./Skeleton/BoxSkeleton', () => ({
     BoxSkeleton: props => <MockView {...props} testID="BoxSkeleton" />,
 }));
+
+// Skia.Path.Make that is used in HoldToConfirmButton is not included in the @shopify/react-native-skia mock
+// so we need to mock the whole component to not break the UI tests.
+jest.mock('./HoldToConfirmButton', () => ({
+    HoldToConfirmButton: props => <MockView {...props} testID="HoldToConfirmButton" />,
+}));

--- a/suite-native/module-device-onboarding/package.json
+++ b/suite-native/module-device-onboarding/package.json
@@ -34,7 +34,6 @@
         "lottie-react-native": "7.2.2",
         "react": "19.0.0",
         "react-native": "0.79.3",
-        "react-native-gesture-handler": "~2.24.0",
         "react-native-reanimated": "^3.18.0",
         "react-native-safe-area-context": "5.4.0",
         "react-native-svg": "15.11.2",

--- a/suite-native/module-device-onboarding/src/components/WalletBackupRecap/WalletRecapStepContent.tsx
+++ b/suite-native/module-device-onboarding/src/components/WalletBackupRecap/WalletRecapStepContent.tsx
@@ -1,9 +1,7 @@
 import { ReactNode } from 'react';
 
-import { Box } from '@suite-native/atoms';
+import { Box, SwipeableWalkthroughStepHeader } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-
-import { OnboardingStepHeader } from '../OnboardingStepHeader';
 
 type WalletRecapStepContentProps = {
     title?: ReactNode;
@@ -29,7 +27,7 @@ export const WalletRecapStepContent = ({
             justifyContent="center"
             style={applyStyle(innerContainerStyle)}
         >
-            {children || <OnboardingStepHeader callout={callout} title={title} />}
+            {children || <SwipeableWalkthroughStepHeader callout={callout} title={title} />}
         </Box>
     );
 };

--- a/suite-native/module-device-onboarding/src/components/WalletBackupRecap/create/WalletBackupRecapStep1.tsx
+++ b/suite-native/module-device-onboarding/src/components/WalletBackupRecap/create/WalletBackupRecapStep1.tsx
@@ -1,12 +1,11 @@
 import { SharedValue } from 'react-native-reanimated';
 
-import { VStack } from '@suite-native/atoms';
+import { SwipeableWalkthroughStep, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { WalletBackupRecapListItem } from './WalletBackupRecapListItem';
 import { WALLET_BACKUP_RECAP_STEPS, walletBackupSecuritySteps } from './presets';
-import { SwipeableWalkthroughStep } from '../../SwipeableWalkthrough/SwipeableWalkthroughStep';
 
 export type WalletBackupTutorialNumberedStepProps = {
     currentStepIndex: SharedValue<number>;

--- a/suite-native/module-device-onboarding/src/components/WalletBackupRecap/create/WalletBackupRecapStep2.tsx
+++ b/suite-native/module-device-onboarding/src/components/WalletBackupRecap/create/WalletBackupRecapStep2.tsx
@@ -1,6 +1,6 @@
 import { useDerivedValue } from 'react-native-reanimated';
 
-import { Box, Text, VStack } from '@suite-native/atoms';
+import { Box, SwipeableWalkthroughStep, Text, VStack } from '@suite-native/atoms';
 import { useIsMultiline } from '@suite-native/helpers';
 import { Translation } from '@suite-native/intl';
 
@@ -8,7 +8,6 @@ import { Underline } from './Underline';
 import { WalletBackupTutorialNumberedStepProps } from './WalletBackupRecapStep1';
 import { WalletRecapStepContent } from '../WalletRecapStepContent';
 import { WALLET_BACKUP_RECAP_STEPS } from './presets';
-import { SwipeableWalkthroughStep } from '../../SwipeableWalkthrough/SwipeableWalkthroughStep';
 
 const CURRENT_STEP_INDEX = 1;
 

--- a/suite-native/module-device-onboarding/src/components/WalletBackupRecap/create/WalletBackupRecapStep3.tsx
+++ b/suite-native/module-device-onboarding/src/components/WalletBackupRecap/create/WalletBackupRecapStep3.tsx
@@ -1,9 +1,9 @@
+import { SwipeableWalkthroughStep } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
 import { WalletBackupTutorialNumberedStepProps } from './WalletBackupRecapStep1';
 import { WalletRecapStepContent } from '../WalletRecapStepContent';
 import { WALLET_BACKUP_RECAP_STEPS } from './presets';
-import { SwipeableWalkthroughStep } from '../../SwipeableWalkthrough/SwipeableWalkthroughStep';
 
 export const WalletBackupRecapStep3 = ({
     currentStepIndex,

--- a/suite-native/module-device-onboarding/src/components/WalletBackupRecap/create/WalletBackupRecapStep4.tsx
+++ b/suite-native/module-device-onboarding/src/components/WalletBackupRecap/create/WalletBackupRecapStep4.tsx
@@ -1,5 +1,6 @@
 import { useNavigation } from '@react-navigation/core';
 
+import { HoldToConfirmButton, SwipeableWalkthroughStep } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceOnboardingStackParamList,
@@ -11,8 +12,6 @@ import {
 import { WalletBackupTutorialNumberedStepProps } from './WalletBackupRecapStep1';
 import { WalletRecapStepContent } from '../WalletRecapStepContent';
 import { WALLET_BACKUP_RECAP_STEPS } from './presets';
-import { HoldToConfirmButton } from '../../SwipeableWalkthrough/HoldToConfirmButton';
-import { SwipeableWalkthroughStep } from '../../SwipeableWalkthrough/SwipeableWalkthroughStep';
 
 type NavigationProps = StackToStackCompositeNavigationProps<
     DeviceOnboardingStackParamList,

--- a/suite-native/module-device-onboarding/src/components/WalletBackupRecap/recovery/WalletRecoveryRecapStep1.tsx
+++ b/suite-native/module-device-onboarding/src/components/WalletBackupRecap/recovery/WalletRecoveryRecapStep1.tsx
@@ -1,8 +1,8 @@
 import { SharedValue } from 'react-native-reanimated';
 
+import { SwipeableWalkthroughStep } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
-import { SwipeableWalkthroughStep } from '../../SwipeableWalkthrough/SwipeableWalkthroughStep';
 import { WalletRecapStepContent } from '../../WalletBackupRecap/WalletRecapStepContent';
 
 export type WalletBackupTutorialNumberedStepProps = {

--- a/suite-native/module-device-onboarding/src/components/WalletBackupRecap/recovery/WalletRecoveryRecapStep2.tsx
+++ b/suite-native/module-device-onboarding/src/components/WalletBackupRecap/recovery/WalletRecoveryRecapStep2.tsx
@@ -1,5 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 
+import { HoldToConfirmButton, SwipeableWalkthroughStep } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceOnboardingStackParamList,
@@ -11,8 +12,6 @@ import {
     WALLET_RECOVERY_RECAP_STEPS,
     WalletBackupTutorialNumberedStepProps,
 } from './WalletRecoveryRecapStep1';
-import { HoldToConfirmButton } from '../../SwipeableWalkthrough/HoldToConfirmButton';
-import { SwipeableWalkthroughStep } from '../../SwipeableWalkthrough/SwipeableWalkthroughStep';
 import { WalletRecapStepContent } from '../../WalletBackupRecap/WalletRecapStepContent';
 
 type NavigationProps = StackNavigationProps<

--- a/suite-native/module-device-onboarding/src/components/WalletBackupTutorial/WalletBackupTutorialStep.tsx
+++ b/suite-native/module-device-onboarding/src/components/WalletBackupTutorial/WalletBackupTutorialStep.tsx
@@ -1,8 +1,6 @@
+import { SwipeableWalkthroughStep, SwipeableWalkthroughStepProps } from '@suite-native/atoms';
+
 import { WALLET_BACKUP_TUTORIAL_STEPS_COUNT } from '../../constants';
-import {
-    SwipeableWalkthroughStep,
-    SwipeableWalkthroughStepProps,
-} from '../SwipeableWalkthrough/SwipeableWalkthroughStep';
 
 export type WalletBackupTutorialStepProps = Omit<SwipeableWalkthroughStepProps, 'totalSteps'>;
 

--- a/suite-native/module-device-onboarding/src/components/WalletBackupTutorial/WalletBackupTutorialStep6.tsx
+++ b/suite-native/module-device-onboarding/src/components/WalletBackupTutorial/WalletBackupTutorialStep6.tsx
@@ -3,6 +3,7 @@ import { useDerivedValue } from 'react-native-reanimated';
 import { useNavigation } from '@react-navigation/core';
 import { useSetAtom } from 'jotai';
 
+import { HoldToConfirmButton } from '@suite-native/atoms';
 import { WalletBackupType } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 import {
@@ -16,7 +17,6 @@ import { WalletBackupInstructionCards } from './WalletBackupInstructionCards';
 import { WalletBackupTutorialStep } from './WalletBackupTutorialStep';
 import { WalletBackupTutorialNumberedStepProps } from './WalletBackupTutorialStep1';
 import { updateOnboardingAnalyticsAtom } from '../../../atoms';
-import { HoldToConfirmButton } from '../SwipeableWalkthrough/HoldToConfirmButton';
 
 type WalletBackupTutorialStep6Props = WalletBackupTutorialNumberedStepProps & {
     selectedType: WalletBackupType;

--- a/suite-native/module-device-onboarding/src/screens/RecoveryInstructionsScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/RecoveryInstructionsScreen.tsx
@@ -1,6 +1,12 @@
 import { useSetAtom } from 'jotai';
 
-import { Box, Button, VStack, useBottomSheetModal } from '@suite-native/atoms';
+import {
+    Box,
+    Button,
+    SwipeableWalkthroughStepHeader,
+    VStack,
+    useBottomSheetModal,
+} from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceOnboardingStackParamList,
@@ -12,7 +18,6 @@ import {
 
 import { updateOnboardingAnalyticsAtom } from '../../atoms';
 import { RecoveryCardSvg } from '../assets/RecoveryCardSvg';
-import { OnboardingStepHeader } from '../components/OnboardingStepHeader';
 import { RecoveryInstructionsBottomSheet } from '../components/RecoveryInstructionsBottomSheet';
 
 export const RecoveryInstructionsScreen = ({
@@ -38,7 +43,7 @@ export const RecoveryInstructionsScreen = ({
     return (
         <Screen header={<ScreenHeader closeAction={handleGoBack} />}>
             <VStack paddingTop="sp16" spacing="sp32" justifyContent="space-between" flex={1}>
-                <OnboardingStepHeader
+                <SwipeableWalkthroughStepHeader
                     callout={
                         <Translation id="moduleDeviceOnboarding.recoveryInstructionsScreen.callout" />
                     }

--- a/suite-native/module-device-onboarding/src/screens/WalletBackupRecapScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletBackupRecapScreen.tsx
@@ -1,9 +1,8 @@
 import { useSharedValue } from 'react-native-reanimated';
 
+import { SwipeableWalkthrough, SwipeableWalkthroughScreenHeader } from '@suite-native/atoms';
 import { Screen } from '@suite-native/navigation';
 
-import { SwipeableWalkthrough } from '../components/SwipeableWalkthrough/SwipeableWalkthrough';
-import { SwipeableWalkthroughScreenHeader } from '../components/SwipeableWalkthrough/SwipeableWalkthroughScreenHeader';
 import { WalletBackupRecapBackButton } from '../components/WalletBackupRecap/WalletBackupRecapBackButton';
 import { WalletBackupRecapStep1 } from '../components/WalletBackupRecap/create/WalletBackupRecapStep1';
 import { WalletBackupRecapStep2 } from '../components/WalletBackupRecap/create/WalletBackupRecapStep2';

--- a/suite-native/module-device-onboarding/src/screens/WalletBackupTutorialScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletBackupTutorialScreen.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/core';
 
 import { selectDeviceDefaultBackupType } from '@suite-common/wallet-core';
+import { SwipeableWalkthrough, SwipeableWalkthroughScreenHeader } from '@suite-native/atoms';
 import { WalletBackupType } from '@suite-native/device';
 import {
     DeviceOnboardingStackParamList,
@@ -14,8 +15,6 @@ import {
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
 
-import { SwipeableWalkthrough } from '../components/SwipeableWalkthrough/SwipeableWalkthrough';
-import { SwipeableWalkthroughScreenHeader } from '../components/SwipeableWalkthrough/SwipeableWalkthroughScreenHeader';
 import { WalletBackupTutorialStep1 } from '../components/WalletBackupTutorial/WalletBackupTutorialStep1';
 import { WalletBackupTutorialStep2 } from '../components/WalletBackupTutorial/WalletBackupTutorialStep2';
 import { WalletBackupTutorialStep3 } from '../components/WalletBackupTutorial/WalletBackupTutorialStep3';

--- a/suite-native/module-device-onboarding/src/screens/WalletRecoveryRecapScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletRecoveryRecapScreen.tsx
@@ -1,9 +1,8 @@
 import { useSharedValue } from 'react-native-reanimated';
 
+import { SwipeableWalkthrough, SwipeableWalkthroughScreenHeader } from '@suite-native/atoms';
 import { Screen } from '@suite-native/navigation';
 
-import { SwipeableWalkthrough } from '../components/SwipeableWalkthrough/SwipeableWalkthrough';
-import { SwipeableWalkthroughScreenHeader } from '../components/SwipeableWalkthrough/SwipeableWalkthroughScreenHeader';
 import { WalletBackupRecapBackButton } from '../components/WalletBackupRecap/WalletBackupRecapBackButton';
 import {
     WALLET_RECOVERY_RECAP_STEPS,

--- a/suite-native/navigation/src/hooks/useOverrideBackNavigation.tsx
+++ b/suite-native/navigation/src/hooks/useOverrideBackNavigation.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+import { useNavigation } from '@react-navigation/native';
+
+export const useOverrideBackNavigation = ({ onNavigateBack }: { onNavigateBack?: () => void }) => {
+    const navigation = useNavigation();
+
+    useEffect(() => {
+        const unsubscribe = navigation.addListener('beforeRemove', e => {
+            if (e.data.action.type === 'GO_BACK') {
+                e.preventDefault();
+                onNavigateBack?.();
+            }
+        });
+
+        return unsubscribe;
+    }, [onNavigateBack, navigation]);
+};

--- a/suite-native/navigation/src/index.ts
+++ b/suite-native/navigation/src/index.ts
@@ -6,6 +6,7 @@ export * from './useHandleHardwareBackNavigation';
 export * from './useNavigateToInitialScreen';
 export * from './useScrollDivider';
 export * from './hooks/useNavigationRoute';
+export * from './hooks/useOverrideBackNavigation';
 export * from './components/TabBar';
 export * from './components/Screen';
 export * from './components/ScreenHeader';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10823,7 +10823,6 @@ __metadata:
     lottie-react-native: "npm:7.2.2"
     react: "npm:19.0.0"
     react-native: "npm:0.79.3"
-    react-native-gesture-handler: "npm:~2.24.0"
     react-native-reanimated: "npm:^3.18.0"
     react-native-safe-area-context: "npm:5.4.0"
     react-native-svg: "npm:15.11.2"


### PR DESCRIPTION
## Description
- swipeable walkthrough components moved from device onboarding to atoms so it can be reused in device settings module



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/native/move-swipeable-walkthrough-to-atoms&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/native/move-swipeable-walkthrough-to-atoms&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native/move-swipeable-walkthrough-to-atoms&lookback=7)