### PR TITLE
Feat: image border-radius

### DIFF
--- a/packages/components/src/components/Box/Box.stories.tsx
+++ b/packages/components/src/components/Box/Box.stories.tsx
@@ -32,10 +32,6 @@ export const Box: StoryObj<typeof BoxComponent> = {
         hasBackground: {
             control: 'boolean',
         },
-        borderRadius: {
-            control: 'select',
-            options: ['undefined', ...Object.values(borders.radii)],
-        },
         borderWidth: {
             control: 'select',
             options: ['undefined', ...Object.values(borders.widths)],

--- a/packages/components/src/components/Box/Box.tsx
+++ b/packages/components/src/components/Box/Box.tsx
@@ -1,7 +1,6 @@
 import styled, { css } from 'styled-components';
 
 import {
-    BorderRadii,
     BorderWidths,
     Elevation,
     mapElevationToBackground,
@@ -22,6 +21,7 @@ export const allowedBoxFrameProps = [
     'padding',
     'width',
     'overflow',
+    'borderRadius',
     'minWidth',
     'maxWidth',
     'height',
@@ -39,7 +39,6 @@ type AllowedFrameProps = Pick<FrameProps, (typeof allowedBoxFrameProps)[number]>
 
 const Container = styled.div<
     TransientProps<AllowedFrameProps> & {
-        $borderRadius?: BorderRadii;
         $borderWidth?: BorderWidth;
         $elevation: Elevation;
         $hasBackground?: boolean;
@@ -89,7 +88,6 @@ type BorderWidth =
 
 export type BoxProps = AllowedFrameProps & {
     children: React.ReactNode;
-    borderRadius?: BorderRadii;
     borderWidth?: BorderWidth;
     hasBackground?: boolean;
     'data-testid'?: string;
@@ -102,7 +100,6 @@ export type BoxProps = AllowedFrameProps & {
 
 export const Box = ({
     children,
-    borderRadius,
     borderWidth,
     hasBackground,
     'data-testid': dataTestId,
@@ -121,7 +118,6 @@ export const Box = ({
             as={as}
             data-testid={dataTestId}
             aria-hidden={ariaHidden}
-            $borderRadius={borderRadius}
             $borderWidth={borderWidth}
             $hasBackground={hasBackground}
             $elevation={elevation}

--- a/packages/components/src/components/Image/Image.tsx
+++ b/packages/components/src/components/Image/Image.tsx
@@ -16,6 +16,7 @@ export const allowedImageFrameProps = [
     'margin',
     'width',
     'height',
+    'borderRadius',
     'maxWidth',
     'maxHeight',
     'flex',

--- a/packages/components/src/utils/frameProps.tsx
+++ b/packages/components/src/utils/frameProps.tsx
@@ -1,6 +1,6 @@
 import { css } from 'styled-components';
 
-import { SpacingValues } from '@trezor/theme';
+import { BorderRadii, SpacingValues, borders } from '@trezor/theme';
 
 import { TransientProps, makePropsTransient } from './transientProps';
 import type { Flex } from '../components/Flex/Flex';
@@ -74,6 +74,7 @@ export type FrameProps = {
     minHeight?: string | number;
     maxHeight?: string | number;
     overflow?: Overflow;
+    borderRadius?: BorderRadii;
     pointerEvents?: PointerEvent;
     flex?: Flex;
     position?: Position;
@@ -117,6 +118,7 @@ export const withFrameProps = ({
     $minHeight,
     $maxHeight,
     $overflow,
+    $borderRadius,
     $pointerEvents,
     $flex,
     $position,
@@ -175,6 +177,10 @@ export const withFrameProps = ({
     ${$overflow &&
     css`
         overflow: ${$overflow};
+    `};
+    ${$borderRadius &&
+    css`
+        border-radius: ${$borderRadius};
     `};
     ${$pointerEvents &&
     css`
@@ -240,6 +246,13 @@ const getStorybookType = (key: FramePropsKeys) => {
         case 'overflow':
             return {
                 options: overflows,
+                control: {
+                    type: 'select',
+                },
+            };
+        case 'borderRadius':
+            return {
+                options: borders.radii,
                 control: {
                     type: 'select',
                 },
@@ -337,6 +350,7 @@ export const getFramePropsStory = (allowedFrameProps: Array<FramePropsKeys>) => 
             ...(allowedFrameProps.includes('maxWidth') ? { maxWidth: undefined } : {}),
             ...(allowedFrameProps.includes('maxHeight') ? { maxHeight: undefined } : {}),
             ...(allowedFrameProps.includes('overflow') ? { overflow: undefined } : {}),
+            ...(allowedFrameProps.includes('borderRadius') ? { borderRadius: undefined } : {}),
             ...(allowedFrameProps.includes('flex') ? { flex: undefined } : {}),
             ...(allowedFrameProps.includes('pointerEvents') ? { pointerEvents: undefined } : {}),
             ...(allowedFrameProps.includes('cursor') ? { cursor: undefined } : {}),


### PR DESCRIPTION
## Description

- Add `borderRadius` as a frame prop 
- Add `borderRadius` frame prop to `Image`, required by [private#140](https://github.com/trezor/trezor-suite-private/issues/140) 
  - can't verify if it works in storybook, because Image stories are broken on develop :x:
  - but I verified by using it in Suite :heavy_check_mark: 
- Replace `Box` own implementation of `borderRadius` by the frame prop 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/image-border-radius&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/image-border-radius&lookback=7)