### PR TITLE
Make AuthenticateDeviceFailModal closable

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceFailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceFailModal.tsx
@@ -1,15 +1,30 @@
-import { Card, Modal } from '@trezor/components';
+import { useDispatch } from 'react-redux';
 
+import { Button, Modal } from '@trezor/components';
+
+import { onCancel } from 'src/actions/suite/modalActions';
 import { SecurityCheckFail } from 'src/components/suite/SecurityCheck/SecurityCheckFail';
 import { AuthenticateDeviceSupportButton } from 'src/components/suite/SecurityCheck/deviceCompromisedCtas';
+import { Translation } from 'src/components/suite/Translation';
 
-export const AuthenticateDeviceFailModal = () => (
-    <Modal>
-        <Card>
+export const AuthenticateDeviceFailModal = () => {
+    const dispatch = useDispatch();
+
+    const close = () => dispatch(onCancel());
+
+    return (
+        <Modal>
             <SecurityCheckFail
-                ctaSection={<AuthenticateDeviceSupportButton />}
+                ctaSection={
+                    <>
+                        <AuthenticateDeviceSupportButton />
+                        <Button variant="tertiary" onClick={close}>
+                            <Translation id="TR_DISMISS" />
+                        </Button>
+                    </>
+                }
                 text="TR_DEVICE_COMPROMISED_DEVICE_AUTHENTICITY_TEXT"
             />
-        </Card>
-    </Modal>
-);
+        </Modal>
+    );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Makes the modal closable. You might want to do it and send your funds elsewhere if the check fails.
I also played with the layout a bit to fit the new modals.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19718

## Screenshots:
Variant A (before fixup):
![Screenshot 2025-06-26 at 14 59 01](https://github.com/user-attachments/assets/72e85ea8-f00f-4d23-812e-25cf19ecf230)
Variant B (after fixup):
![Screenshot 2025-06-26 at 17 29 10](https://github.com/user-attachments/assets/b9f86acf-aaa2-4af9-9ed6-fddaf81aaa77)



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/closable-device-authenticity-modal&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/closable-device-authenticity-modal&lookback=7)