### PR TITLE
refactor(suite-e2e): Improve testcase naming

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/analytics/events.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/analytics/events.test.ts
@@ -10,7 +10,7 @@ test.describe('Analytics Events', { tag: ['@group=suite', '@webOnly'] }, () => {
         await onboardingPage.disableNecessaryFirmwareChecks();
     });
 
-    test('reports transport-type, suite-ready and device-connect/device-disconnect events when analytics is initialized and enabled', async ({
+    test('Analytics captures important events when started enabled', async ({
         page,
         analytics,
         onboardingPage,
@@ -21,9 +21,7 @@ test.describe('Analytics Events', { tag: ['@group=suite', '@webOnly'] }, () => {
 
         const firmwareVersion = findLatestVersionForModel('T3T1');
         await trezorUserEnvLink.startEmu({ wipe: true, model: 'T3T1', version: firmwareVersion });
-        await trezorUserEnvLink.setupEmu({
-            passphrase_protection: true,
-        });
+        await trezorUserEnvLink.setupEmu({ passphrase_protection: true });
 
         // reload to activate bridge and start testing app with enabled analytics
         await trezorUserEnvLink.startBridge();
@@ -92,7 +90,7 @@ test.describe('Analytics Events', { tag: ['@group=suite', '@webOnly'] }, () => {
         expect(analytics.findLatestRequestByType(EventType.DeviceDisconnect)).toBeDefined();
     });
 
-    test('reports suite-ready after enabling analytics on app initial run', async ({
+    test('Analytics capture suite-ready after getting enabled', async ({
         analytics,
         page,
         analyticsSection,

--- a/packages/suite-desktop-core/e2e/tests/metadata/dropbox-api-errors.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/dropbox-api-errors.test.ts
@@ -1,6 +1,7 @@
 import { AccountLabelId } from '../../support/enums/accountLabelId';
 import { expect, test } from '../../support/fixtures';
 import { MetadataProvider } from '../../support/mocks/metadataMock';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('Dropbox API errors', { tag: ['@group=metadata', '@webOnly'] }, () => {
     test.use({
@@ -10,143 +11,148 @@ test.describe('Dropbox API errors', { tag: ['@group=metadata', '@webOnly'] }, ()
     test.beforeEach(async ({ metadataMock }) => {
         await metadataMock.start(MetadataProvider.DROPBOX);
     });
-    test('Malformed token', async ({
-        page,
-        onboardingPage,
-        settingsPage,
-        metadataPage,
-        walletPage,
-        metadataMock,
-    }) => {
-        await metadataMock.setFileContent(
-            '/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
-            metadataMock.defaultFileContent,
-            metadataMock.defaultAesKey,
-        );
+    test(
+        'Malformed token',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Suite labeling handles malformed token error from Dropbox',
+            }),
+        },
+        async ({ page, onboardingPage, settingsPage, metadataPage, walletPage, metadataMock }) => {
+            await metadataMock.setFileContent(
+                '/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
+                metadataMock.defaultFileContent,
+                metadataMock.defaultAesKey,
+            );
 
-        await onboardingPage.completeOnboarding();
+            await onboardingPage.completeOnboarding();
 
-        await settingsPage.navigateTo('application');
-        await settingsPage.metadataSwitch.click();
+            await settingsPage.navigateTo('application');
+            await settingsPage.metadataSwitch.click();
 
-        await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
+            await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
 
-        await walletPage.openAccount();
+            await walletPage.openAccount();
 
-        await metadataPage.account.accountLabel(AccountLabelId.BitcoinDefault1).click();
-        await metadataPage.account.editLabelButton(AccountLabelId.BitcoinDefault1).click();
+            await metadataPage.account.accountLabel(AccountLabelId.BitcoinDefault1).click();
+            await metadataPage.account.editLabelButton(AccountLabelId.BitcoinDefault1).click();
 
-        // Simulated API responses for retries with malformed token must be supplied exactly at this point in the flow
-        for (let i = 0; i < 4; i++) {
+            // Simulated API responses for retries with malformed token must be supplied exactly at this point in the flow
+            for (let i = 0; i < 4; i++) {
+                metadataMock.setNextResponse({
+                    status: 400,
+                    body: 'Error in call to API function "files/upload": The given OAuth 2 access token is malformed.',
+                    headers: {
+                        'Content-Type': 'text/plain; charset=utf-8',
+                    },
+                });
+            }
+
+            await metadataPage.account.metadataInput.fill('Kvooo');
+            await page.keyboard.press('Enter');
+
+            // Validate the error message in the toast notification
+            await expect(page.getByTestId('@toast/error')).toHaveText(
+                'Error: Failed to save labeling data: Error in call to API function "files/upload": The given OAuth 2 access token is malformed.',
+            );
+
+            await expect(
+                metadataPage.account.accountLabel(AccountLabelId.BitcoinDefault1),
+            ).toContainText('Bitcoin #1');
+        },
+    );
+
+    //TODO: #17855 Fix unstable test
+    test.skip(
+        'Success after retrying GET request',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Suite labeling handles GET retries from Dropbox',
+            }),
+        },
+        async ({ onboardingPage, settingsPage, metadataPage, walletPage, metadataMock }) => {
+            await metadataMock.setFileContent(
+                '/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
+                metadataMock.defaultFileContent,
+                metadataMock.defaultAesKey,
+            );
+
+            await onboardingPage.completeOnboarding();
+
+            await settingsPage.navigateTo('application');
+            await settingsPage.metadataSwitch.click();
+
+            await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
+
             metadataMock.setNextResponse({
-                status: 400,
-                body: 'Error in call to API function "files/upload": The given OAuth 2 access token is malformed.',
+                status: 200,
+                body: {
+                    name: {
+                        given_name: 'dog',
+                        surname: 'cat',
+                        familiar_name: 'kitty-dog',
+                        display_name: 'dog-cat',
+                        abbreviated_name: 'DC',
+                    },
+                    email: 'some@mail.com',
+                    email_verified: true,
+                    profile_photo_url: 'foo',
+                    disabled: false,
+                    country: 'CZ',
+                    locale: 'en',
+                    referral_link: 'foo',
+                    is_paired: false,
+                },
+            });
+
+            metadataMock.setNextResponse({
+                status: 429,
+                body: 'Rate limited!',
                 headers: {
                     'Content-Type': 'text/plain; charset=utf-8',
                 },
             });
-        }
 
-        await metadataPage.account.metadataInput.fill('Kvooo');
-        await page.keyboard.press('Enter');
+            await walletPage.openAccount();
+            await metadataPage.account.editLabel(AccountLabelId.BitcoinDefault1, 'Kvooo');
+            await expect(
+                metadataPage.account.accountLabel(AccountLabelId.BitcoinDefault1),
+            ).toContainText('Kvooo');
+        },
+    );
 
-        // Validate the error message in the toast notification
-        await expect(page.getByTestId('@toast/error')).toHaveText(
-            'Error: Failed to save labeling data: Error in call to API function "files/upload": The given OAuth 2 access token is malformed.',
-        );
-
-        await expect(
-            metadataPage.account.accountLabel(AccountLabelId.BitcoinDefault1),
-        ).toContainText('Bitcoin #1');
-    });
-
-    //TODO: #17855 Fix unstable test
-    test.skip('Success after retrying GET request', async ({
-        onboardingPage,
-        settingsPage,
-        metadataPage,
-        walletPage,
-        metadataMock,
-    }) => {
-        await metadataMock.setFileContent(
-            '/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
-            metadataMock.defaultFileContent,
-            metadataMock.defaultAesKey,
-        );
-
-        await onboardingPage.completeOnboarding();
-
-        await settingsPage.navigateTo('application');
-        await settingsPage.metadataSwitch.click();
-
-        await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
-
-        metadataMock.setNextResponse({
-            status: 200,
-            body: {
-                name: {
-                    given_name: 'dog',
-                    surname: 'cat',
-                    familiar_name: 'kitty-dog',
-                    display_name: 'dog-cat',
-                    abbreviated_name: 'DC',
+    test(
+        'Incomplete data returned from provider',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Suite labeling handles incomplete data from Dropbox',
+            }),
+        },
+        async ({ onboardingPage, settingsPage, metadataPage, walletPage, metadataMock }) => {
+            await metadataMock.setFileContent(
+                '/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
+                {
+                    version: '1.0.0',
+                    accountLabel: 'already existing label',
+                    // note: outputLabels and addressLabels are missing. this can happen in 2 situations:
+                    // 1] user manually changed the files (very unlikely);
+                    // 2] we screwed app data saving or reading
                 },
-                email: 'some@mail.com',
-                email_verified: true,
-                profile_photo_url: 'foo',
-                disabled: false,
-                country: 'CZ',
-                locale: 'en',
-                referral_link: 'foo',
-                is_paired: false,
-            },
-        });
+                metadataMock.defaultAesKey,
+            );
 
-        metadataMock.setNextResponse({
-            status: 429,
-            body: 'Rate limited!',
-            headers: {
-                'Content-Type': 'text/plain; charset=utf-8',
-            },
-        });
+            await onboardingPage.completeOnboarding();
 
-        await walletPage.openAccount();
-        await metadataPage.account.editLabel(AccountLabelId.BitcoinDefault1, 'Kvooo');
-        await expect(
-            metadataPage.account.accountLabel(AccountLabelId.BitcoinDefault1),
-        ).toContainText('Kvooo');
-    });
+            await settingsPage.navigateTo('application');
+            await settingsPage.metadataSwitch.click();
 
-    test('Incomplete data returned from provider', async ({
-        onboardingPage,
-        settingsPage,
-        metadataPage,
-        walletPage,
-        metadataMock,
-    }) => {
-        await metadataMock.setFileContent(
-            '/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
-            {
-                version: '1.0.0',
-                accountLabel: 'already existing label',
-                // note: outputLabels and addressLabels are missing. this can happen in 2 situations:
-                // 1] user manually changed the files (very unlikely);
-                // 2] we screwed app data saving or reading
-            },
-            metadataMock.defaultAesKey,
-        );
+            await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
 
-        await onboardingPage.completeOnboarding();
-
-        await settingsPage.navigateTo('application');
-        await settingsPage.metadataSwitch.click();
-
-        await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
-
-        await walletPage.openAccount();
-        // just enter some label, this indicates that app did not crash
-        await metadataPage.account.editLabel(AccountLabelId.BitcoinDefault1, 'Kvooo');
-    });
+            await walletPage.openAccount();
+            // just enter some label, this indicates that app did not crash
+            await metadataPage.account.editLabel(AccountLabelId.BitcoinDefault1, 'Kvooo');
+        },
+    );
 
     // TODO: Add tests for more possible errors
 });

--- a/packages/suite-desktop-core/e2e/tests/metadata/google-api-errors.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/google-api-errors.test.ts
@@ -1,6 +1,7 @@
 import { AccountLabelId } from '../../support/enums/accountLabelId';
 import { expect, test } from '../../support/fixtures';
 import { MetadataProvider } from '../../support/mocks/metadataMock';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('Google API errors', { tag: ['@group=metadata', '@webOnly'] }, () => {
     test.use({
@@ -10,52 +11,54 @@ test.describe('Google API errors', { tag: ['@group=metadata', '@webOnly'] }, () 
     test.beforeEach(async ({ metadataMock }) => {
         await metadataMock.start(MetadataProvider.GOOGLE);
     });
-    test('Malformed token', async ({
-        page,
-        onboardingPage,
-        metadataPage,
-        walletPage,
-        metadataMock,
-    }) => {
-        // Simulate API responses for retries with malformed token
-        for (let i = 0; i < 4; i++) {
-            metadataMock.setNextResponse({
-                status: 401,
-                body: {
-                    error: {
-                        errors: [
-                            {
-                                domain: 'global',
-                                reason: 'authError',
-                                message: 'Invalid Credentials',
-                                locationType: 'header',
-                                location: 'Authorization',
-                            },
-                        ],
-                        code: 401,
-                        message: 'Invalid Credentials',
+    test(
+        'Malformed token',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Suite labeling handles malformed token from Google',
+            }),
+        },
+        async ({ page, onboardingPage, metadataPage, walletPage, metadataMock }) => {
+            // Simulate API responses for retries with malformed token
+            for (let i = 0; i < 4; i++) {
+                metadataMock.setNextResponse({
+                    status: 401,
+                    body: {
+                        error: {
+                            errors: [
+                                {
+                                    domain: 'global',
+                                    reason: 'authError',
+                                    message: 'Invalid Credentials',
+                                    locationType: 'header',
+                                    location: 'Authorization',
+                                },
+                            ],
+                            code: 401,
+                            message: 'Invalid Credentials',
+                        },
                     },
-                },
-                headers: {
-                    'Content-Type': 'application/json; charset=UTF-8',
-                },
+                    headers: {
+                        'Content-Type': 'application/json; charset=UTF-8',
+                    },
+                });
+            }
+
+            await onboardingPage.completeOnboarding();
+
+            await walletPage.openAccount();
+            await metadataPage.account.clickAddLabelButton(AccountLabelId.BitcoinDefault1);
+
+            await metadataPage.passThroughInitMetadata(MetadataProvider.GOOGLE, {
+                skipVerification: true,
             });
-        }
 
-        await onboardingPage.completeOnboarding();
-
-        await walletPage.openAccount();
-        await metadataPage.account.clickAddLabelButton(AccountLabelId.BitcoinDefault1);
-
-        await metadataPage.passThroughInitMetadata(MetadataProvider.GOOGLE, {
-            skipVerification: true,
-        });
-
-        // Validate the error message in the toast notification
-        await expect(page.getByTestId('@toast/error')).toHaveText(
-            'Error: Failed to connect to labeling provider: Invalid Credentials',
-        );
-    });
+            // Validate the error message in the toast notification
+            await expect(page.getByTestId('@toast/error')).toHaveText(
+                'Error: Failed to connect to labeling provider: Invalid Credentials',
+            );
+        },
+    );
 
     // TODO: Add tests for more possible errors
     // Reference: https://developers.google.com/drive/api/v3/handle-errors

--- a/packages/suite-desktop-core/e2e/tests/metadata/switching-providers.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/switching-providers.test.ts
@@ -1,6 +1,7 @@
 import { AccountLabelId } from '../../support/enums/accountLabelId';
 import { expect, test } from '../../support/fixtures';
 import { MetadataProvider } from '../../support/mocks/metadataMock';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe(
     'Metadata - switching between cloud providers',
@@ -10,67 +11,75 @@ test.describe(
         const googleLabel = 'google label';
         const defaultLabel = 'Bitcoin #1';
 
-        test('Start with one and switch to another', async ({
-            page,
-            onboardingPage,
-            metadataPage,
-            settingsPage,
-            metadataMock,
-            walletPage,
-        }) => {
-            await onboardingPage.completeOnboarding();
+        test(
+            'Start with one and switch to another',
+            {
+                annotation: createTestAnnotation({
+                    testCase: 'Suite labeling support switching from provider to another',
+                }),
+            },
+            async ({
+                page,
+                onboardingPage,
+                metadataPage,
+                settingsPage,
+                metadataMock,
+                walletPage,
+            }) => {
+                await onboardingPage.completeOnboarding();
 
-            // Navigate to account and verify initial state
-            await walletPage.openAccount();
-            await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
-                defaultLabel,
-            );
+                // Navigate to account and verify initial state
+                await walletPage.openAccount();
+                await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
+                    defaultLabel,
+                );
 
-            await metadataMock.start(MetadataProvider.DROPBOX);
+                await metadataMock.start(MetadataProvider.DROPBOX);
 
-            // Add a label using Dropbox
-            await metadataPage.account.clickAddLabelButton(AccountLabelId.BitcoinDefault1);
-            await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
+                // Add a label using Dropbox
+                await metadataPage.account.clickAddLabelButton(AccountLabelId.BitcoinDefault1);
+                await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
 
-            await metadataPage.account.metadataInput.fill(dropboxLabel);
-            await page.keyboard.press('Enter');
-            await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
-                dropboxLabel,
-            );
+                await metadataPage.account.metadataInput.fill(dropboxLabel);
+                await page.keyboard.press('Enter');
+                await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
+                    dropboxLabel,
+                );
 
-            // Disconnect Dropbox
-            await settingsPage.navigateTo('application');
-            await page.getByTestId('@settings/metadata/disconnect-provider-button').click();
-            await expect(
-                page.getByTestId('@settings/metadata/connect-provider-button'),
-            ).toBeVisible();
+                // Disconnect Dropbox
+                await settingsPage.navigateTo('application');
+                await page.getByTestId('@settings/metadata/disconnect-provider-button').click();
+                await expect(
+                    page.getByTestId('@settings/metadata/connect-provider-button'),
+                ).toBeVisible();
 
-            await metadataMock.stop();
+                await metadataMock.stop();
 
-            // Verify that labels are removed after disconnect
-            await walletPage.openAccount();
-            await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toBeVisible();
-            await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
-                defaultLabel,
-            );
+                // Verify that labels are removed after disconnect
+                await walletPage.openAccount();
+                await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toBeVisible();
+                await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
+                    defaultLabel,
+                );
 
-            await metadataMock.start(MetadataProvider.GOOGLE);
+                await metadataMock.start(MetadataProvider.GOOGLE);
 
-            // Connect to Google and add a label
-            await metadataPage.account.clickAddLabelButton(AccountLabelId.BitcoinDefault1);
-            await expect(page.getByTestId('@modal/metadata-provider')).toBeVisible();
-            await expect(
-                page.getByTestId('@modal/metadata-provider/file-system-button'),
-            ).toBeHidden();
-            await page.getByTestId('@modal/metadata-provider/google-button').click();
-            await expect(page.getByTestId('@modal/metadata-provider')).toBeHidden();
+                // Connect to Google and add a label
+                await metadataPage.account.clickAddLabelButton(AccountLabelId.BitcoinDefault1);
+                await expect(page.getByTestId('@modal/metadata-provider')).toBeVisible();
+                await expect(
+                    page.getByTestId('@modal/metadata-provider/file-system-button'),
+                ).toBeHidden();
+                await page.getByTestId('@modal/metadata-provider/google-button').click();
+                await expect(page.getByTestId('@modal/metadata-provider')).toBeHidden();
 
-            await metadataPage.account.metadataInput.fill(googleLabel);
-            await page.keyboard.press('Enter');
-            await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
-                googleLabel,
-            );
-        });
+                await metadataPage.account.metadataInput.fill(googleLabel);
+                await page.keyboard.press('Enter');
+                await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toHaveText(
+                    googleLabel,
+                );
+            },
+        );
 
         test.afterEach(async ({ metadataMock }) => {
             await metadataMock.stop();

--- a/packages/suite-desktop-core/e2e/tests/settings/autodetect.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/autodetect.test.ts
@@ -2,6 +2,7 @@ import { colorVariants } from '@trezor/theme';
 import { hexToRgba } from '@trezor/utils';
 
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 enum ColorScheme {
     Light = 'light',
@@ -36,14 +37,22 @@ test.use({ startEmulator: false });
 testCases.forEach(({ testName, userPreferences, text, textColor, bodyBackgroundColor }) => {
     test.describe.serial('Language and theme detection', { tag: ['@group=settings'] }, () => {
         test.use(userPreferences);
-        test(testName, async ({ onboardingPage, analyticsSection }) => {
-            await onboardingPage.optionallyDismissFwHashCheckError();
-            await expect(analyticsSection.heading).toHaveText(text);
-            await expect(analyticsSection.heading).toHaveCSS('color', hexToRgba(textColor));
-            await expect(onboardingPage.page.locator('body')).toHaveCSS(
-                'background-color',
-                hexToRgba(bodyBackgroundColor),
-            );
-        });
+        test(
+            testName,
+            {
+                annotation: createTestAnnotation({
+                    testCase: `Suite adopts preferences of the browser: ${testName}`,
+                }),
+            },
+            async ({ onboardingPage, analyticsSection }) => {
+                await onboardingPage.optionallyDismissFwHashCheckError();
+                await expect(analyticsSection.heading).toHaveText(text);
+                await expect(analyticsSection.heading).toHaveCSS('color', hexToRgba(textColor));
+                await expect(onboardingPage.page.locator('body')).toHaveCSS(
+                    'background-color',
+                    hexToRgba(bodyBackgroundColor),
+                );
+            },
+        );
     });
 });

--- a/packages/suite-desktop-core/e2e/tests/settings/safety-checks.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/safety-checks.test.ts
@@ -13,7 +13,7 @@ test.describe('Safety Checks Settings', { tag: ['@group=settings'] }, () => {
         await expect(page.getByTestId('@safety-checks-apply')).toBeVisible();
     });
 
-    test('Only one level is selected at a time', async ({ page }) => {
+    test('Only one level of Safety Checks is selected at a time', async ({ page }) => {
         // Open the safety checks modal.
         await page.getByTestId('@settings/device/safety-checks-button').click();
 
@@ -36,7 +36,7 @@ test.describe('Safety Checks Settings', { tag: ['@group=settings'] }, () => {
         ).toHaveCount(1);
     });
 
-    test('Apply button is enabled only when value is changed', async ({ page }) => {
+    test('Apply button is enabled only when Safety Checks value is changed', async ({ page }) => {
         // Open the safety checks modal.
         await page.getByTestId('@settings/device/safety-checks-button').click();
 

--- a/packages/suite-desktop-core/e2e/tests/suite/version-page.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/version-page.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '../../support/fixtures';
 
 test.describe('Hidden version page', { tag: ['@group=suite', '@webOnly'] }, () => {
     test.use({ startEmulator: false });
-    test('is accessible via route', async ({ url, page, analyticsSection }) => {
+    test('Version page is accessible on URL', async ({ url, page, analyticsSection }) => {
         await analyticsSection.continueButton.click();
 
         await page.goto(url + 'version');

--- a/packages/suite-desktop-core/e2e/tests/trading/navigation.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/navigation.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('Trading - Navigation', { tag: ['@group=trading'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
@@ -13,72 +14,80 @@ test.describe('Trading - Navigation', { tag: ['@group=trading'] }, () => {
         await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
     });
 
-    test('Navigate to', async ({ page, dashboardPage, tradingPage, walletPage }) => {
-        // BUY
-        await test.step('Buy from dashboard asset card', async () => {
-            await dashboardPage.navigateTo();
-            await page.getByTestId('@dashboard/asset/btc/buy-button').click();
-            await tradingPage.verifyBuyFormOpened('BTC');
-            await page.getByTestId(`@account-menu/filter-accounts`).click();
-            await walletPage.walletFilter('btc').click();
-        });
+    test(
+        'Navigate to',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies navigation to all Trading Forms.',
+            }),
+        },
+        async ({ page, dashboardPage, tradingPage, walletPage }) => {
+            // BUY
+            await test.step('Buy from dashboard asset card', async () => {
+                await dashboardPage.navigateTo();
+                await page.getByTestId('@dashboard/asset/btc/buy-button').click();
+                await tradingPage.verifyBuyFormOpened('BTC');
+                await page.getByTestId(`@account-menu/filter-accounts`).click();
+                await walletPage.walletFilter('btc').click();
+            });
 
-        await test.step('Buy from account trade section', async () => {
-            await walletPage.openAccount({ symbol: 'btc' });
-            await page.getByTestId('@trading/menu/wallet-trading-buy').click();
-            await tradingPage.verifyBuyFormOpened('BTC');
-        });
+            await test.step('Buy from account trade section', async () => {
+                await walletPage.openAccount({ symbol: 'btc' });
+                await page.getByTestId('@trading/menu/wallet-trading-buy').click();
+                await tradingPage.verifyBuyFormOpened('BTC');
+            });
 
-        await test.step('Buy from global header', async () => {
-            await dashboardPage.navigateTo();
-            await walletPage.openTradingGlobalButton.click();
-            await tradingPage.verifyBuyFormOpened('BTC');
-        });
+            await test.step('Buy from global header', async () => {
+                await dashboardPage.navigateTo();
+                await walletPage.openTradingGlobalButton.click();
+                await tradingPage.verifyBuyFormOpened('BTC');
+            });
 
-        await test.step('Buy from empty account', async () => {
-            await walletPage.openAccount({ symbol: 'ltc' });
-            await page.getByTestId('@accounts/empty-account/buy').click();
-            await tradingPage.verifyBuyFormOpened('LTC');
-        });
+            await test.step('Buy from empty account', async () => {
+                await walletPage.openAccount({ symbol: 'ltc' });
+                await page.getByTestId('@accounts/empty-account/buy').click();
+                await tradingPage.verifyBuyFormOpened('LTC');
+            });
 
-        await test.step('Buy from token', async () => {
-            await walletPage.openBuyTradingOfToken('eth', 'TrueUSD');
-            await tradingPage.verifyBuyFormOpened('TrueUSD');
-        });
+            await test.step('Buy from token', async () => {
+                await walletPage.openBuyTradingOfToken('eth', 'TrueUSD');
+                await tradingPage.verifyBuyFormOpened('TrueUSD');
+            });
 
-        // SELL
-        // We don't test cases where navigation goes first thru buy form
-        await test.step('Sell from account trade section', async () => {
-            await walletPage.openAccount({ symbol: 'btc' });
-            await page.getByTestId('@trading/menu/wallet-trading-sell').click();
-            await tradingPage.verifySellFormOpened('BTC');
-        });
+            // SELL
+            // We don't test cases where navigation goes first thru buy form
+            await test.step('Sell from account trade section', async () => {
+                await walletPage.openAccount({ symbol: 'btc' });
+                await page.getByTestId('@trading/menu/wallet-trading-sell').click();
+                await tradingPage.verifySellFormOpened('BTC');
+            });
 
-        await test.step('Sell from token', async () => {
-            // There is instability in test, sell form has Ethereum instead of USD Coin
-            // We cannot reproduce it manually, so we are using retry workaround to stabilize automation
-            await expect(async () => {
-                await walletPage.openSellTradingOfToken('eth', 'USD Coin');
-                await tradingPage.verifySellFormOpened('USD Coin');
-            }).toPass({ timeout: 15_000 });
-        });
+            await test.step('Sell from token', async () => {
+                // There is instability in test, sell form has Ethereum instead of USD Coin
+                // We cannot reproduce it manually, so we are using retry workaround to stabilize automation
+                await expect(async () => {
+                    await walletPage.openSellTradingOfToken('eth', 'USD Coin');
+                    await tradingPage.verifySellFormOpened('USD Coin');
+                }).toPass({ timeout: 15_000 });
+            });
 
-        // SWAP
-        await test.step('Swap from Global header', async () => {
-            await dashboardPage.navigateTo();
-            await walletPage.openSwapGlobalButton.click();
-            await tradingPage.verifySwapFormOpened('BTC');
-        });
+            // SWAP
+            await test.step('Swap from Global header', async () => {
+                await dashboardPage.navigateTo();
+                await walletPage.openSwapGlobalButton.click();
+                await tradingPage.verifySwapFormOpened('BTC');
+            });
 
-        await test.step('Swap from account trade section', async () => {
-            await walletPage.openAccount({ symbol: 'btc' });
-            await page.getByTestId('@trading/menu/wallet-trading-exchange').click();
-            await tradingPage.verifySwapFormOpened('BTC');
-        });
+            await test.step('Swap from account trade section', async () => {
+                await walletPage.openAccount({ symbol: 'btc' });
+                await page.getByTestId('@trading/menu/wallet-trading-exchange').click();
+                await tradingPage.verifySwapFormOpened('BTC');
+            });
 
-        await test.step('Swap from token', async () => {
-            await walletPage.openSwapTradingOfToken('eth', 'USD Coin');
-            await tradingPage.verifySwapFormOpened('USD Coin');
-        });
-    });
+            await test.step('Swap from token', async () => {
+                await walletPage.openSwapTradingOfToken('eth', 'USD Coin');
+                await tradingPage.verifySwapFormOpened('USD Coin');
+            });
+        },
+    );
 });

--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/error.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/error.test.ts
@@ -1,6 +1,7 @@
 import TrezorConnect from '@trezor/connect-web';
 
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('TrezorConnect', { tag: ['@group=connect', '@desktopOnly'] }, () => {
     test.use({ electronConf: { exposeConnectWs: true } });
@@ -19,9 +20,17 @@ test.describe('TrezorConnect', { tag: ['@group=connect', '@desktopOnly'] }, () =
         });
     });
 
-    test('Error screen', async ({ page }) => {
-        TrezorConnect.ethereumGetAddress({ path: 'foo bar' });
-        const modalErrorMessage = page.getByTestId('@connect-popup-error/message');
-        await expect(modalErrorMessage).toHaveText('Not a valid path');
-    });
+    test(
+        'Error screen',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Suite Connect correctly displays invalid path error screen',
+            }),
+        },
+        async ({ page }) => {
+            TrezorConnect.ethereumGetAddress({ path: 'foo bar' });
+            const modalErrorMessage = page.getByTestId('@connect-popup-error/message');
+            await expect(modalErrorMessage).toHaveText('Not a valid path');
+        },
+    );
 });

--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/permissions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/permissions.test.ts
@@ -1,6 +1,7 @@
 import TrezorConnect from '@trezor/connect-web';
 
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('TrezorConnect', { tag: ['@group=connect', '@desktopOnly'] }, () => {
     test.use({ electronConf: { exposeConnectWs: true } });
@@ -19,46 +20,50 @@ test.describe('TrezorConnect', { tag: ['@group=connect', '@desktopOnly'] }, () =
         });
     });
 
-    test('Permissions - add and forget', async ({
-        settingsPage,
-        connectPermissionsModal,
-        page,
-    }) => {
-        await settingsPage.navigateTo('connect');
+    test(
+        'Permissions - add and forget',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Suite Connect: Add and forget permissions.',
+            }),
+        },
+        async ({ settingsPage, connectPermissionsModal, page }) => {
+            await settingsPage.navigateTo('connect');
 
-        await page.getByTestId('@settings/connect-apps/no-apps').waitFor({ state: 'visible' });
+            await page.getByTestId('@settings/connect-apps/no-apps').waitFor({ state: 'visible' });
 
-        TrezorConnect.getAddress({
-            path: "m/44'/0'/0'/0/0",
-            coin: 'btc',
-        });
+            TrezorConnect.getAddress({
+                path: "m/44'/0'/0'/0/0",
+                coin: 'btc',
+            });
 
-        await expect(connectPermissionsModal.processParagraph).toHaveText('node');
-        await expect(connectPermissionsModal.rememberCheckbox).toHaveText(
-            'Always allow for this app',
-        );
-        await connectPermissionsModal.rememberCheckbox.click();
-        await connectPermissionsModal.confirmButton.click();
-        await page.getByTestId('@connect-address-confirmation/close-button').click();
+            await expect(connectPermissionsModal.processParagraph).toHaveText('node');
+            await expect(connectPermissionsModal.rememberCheckbox).toHaveText(
+                'Always allow for this app',
+            );
+            await connectPermissionsModal.rememberCheckbox.click();
+            await connectPermissionsModal.confirmButton.click();
+            await page.getByTestId('@connect-address-confirmation/close-button').click();
 
-        // permission is already saved, user won't be prompted again for this app
-        TrezorConnect.getAddress({
-            path: "m/44'/0'/0'/0/0",
-            coin: 'btc',
-        });
-        await page.getByTestId('@connect-address-confirmation/close-button').click();
-        await page.getByTestId(`@settings/connect-apps/0`).waitFor({ state: 'visible' });
-        await page.getByTestId(`@settings/connect-apps/0/dropdown`).click();
+            // permission is already saved, user won't be prompted again for this app
+            TrezorConnect.getAddress({
+                path: "m/44'/0'/0'/0/0",
+                coin: 'btc',
+            });
+            await page.getByTestId('@connect-address-confirmation/close-button').click();
+            await page.getByTestId(`@settings/connect-apps/0`).waitFor({ state: 'visible' });
+            await page.getByTestId(`@settings/connect-apps/0/dropdown`).click();
 
-        // todo: it looks like data-test is not passed down to list items in dropdown
-        await page.getByText('Forget').click();
-        await page.getByTestId('@settings/connect-apps/no-apps').waitFor({ state: 'visible' });
+            // todo: it looks like data-test is not passed down to list items in dropdown
+            await page.getByText('Forget').click();
+            await page.getByTestId('@settings/connect-apps/no-apps').waitFor({ state: 'visible' });
 
-        // permissions modal appears again
-        TrezorConnect.getAddress({
-            path: "m/44'/0'/0'/0/0",
-            coin: 'btc',
-        });
-        await expect(connectPermissionsModal.processParagraph).toHaveText('node');
-    });
+            // permissions modal appears again
+            TrezorConnect.getAddress({
+                path: "m/44'/0'/0'/0/0",
+                coin: 'btc',
+            });
+            await expect(connectPermissionsModal.processParagraph).toHaveText('node');
+        },
+    );
 });

--- a/packages/suite-desktop-core/e2e/tests/wallet/coin-balance.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/coin-balance.test.ts
@@ -2,6 +2,7 @@ import { localizeNumber } from '@suite-common/wallet-utils';
 
 import { getBigNumberFromBalance } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('Coin balance', { tag: ['@group=wallet'] }, () => {
     const address = 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v';
@@ -10,33 +11,36 @@ test.describe('Coin balance', { tag: ['@group=wallet'] }, () => {
         await onboardingPage.completeOnboarding();
     });
 
-    test('Account balance is increased', async ({
-        trezorUserEnvLink,
-        dashboardPage,
-        settingsPage,
-        walletPage,
-    }) => {
-        const firstAccountBalanceLocator = walletPage.balanceOfAccount('regtest').first();
-        await trezorUserEnvLink.sendToAddressAndMineBlock({ address, btc_amount: 1 });
-        await test.step('Regtest discovered with non zero value', async () => {
-            await settingsPage.changeNetworks({ enableNetworks: ['regtest'] });
-            await dashboardPage.navigateTo();
-            await expect(walletPage.accountLabel({ symbol: 'regtest' })).toHaveText(
-                'Bitcoin Regtest #1',
-            );
-            await expect(firstAccountBalanceLocator).toHaveTextGreaterThan(0);
-        });
-
-        await test.step('Balance is increased after sending another BTC', async () => {
-            const { originalBalance, hasEllipsis } = await getBigNumberFromBalance(
-                firstAccountBalanceLocator,
-            );
-            const rawIncreasedBalance = originalBalance.plus(1).toString();
-            const expectedIncreasedBalance =
-                localizeNumber(rawIncreasedBalance, 'en', 0, 8) + (hasEllipsis ? '…' : '');
-
+    test(
+        'Account balance is increased',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that the account balance is increased after receiving BTC.',
+            }),
+        },
+        async ({ trezorUserEnvLink, dashboardPage, settingsPage, walletPage }) => {
+            const firstAccountBalanceLocator = walletPage.balanceOfAccount('regtest').first();
             await trezorUserEnvLink.sendToAddressAndMineBlock({ address, btc_amount: 1 });
-            await expect(firstAccountBalanceLocator).toHaveText(expectedIncreasedBalance);
-        });
-    });
+            await test.step('Regtest discovered with non zero value', async () => {
+                await settingsPage.changeNetworks({ enableNetworks: ['regtest'] });
+                await dashboardPage.navigateTo();
+                await expect(walletPage.accountLabel({ symbol: 'regtest' })).toHaveText(
+                    'Bitcoin Regtest #1',
+                );
+                await expect(firstAccountBalanceLocator).toHaveTextGreaterThan(0);
+            });
+
+            await test.step('Balance is increased after sending another BTC', async () => {
+                const { originalBalance, hasEllipsis } = await getBigNumberFromBalance(
+                    firstAccountBalanceLocator,
+                );
+                const rawIncreasedBalance = originalBalance.plus(1).toString();
+                const expectedIncreasedBalance =
+                    localizeNumber(rawIncreasedBalance, 'en', 0, 8) + (hasEllipsis ? '…' : '');
+
+                await trezorUserEnvLink.sendToAddressAndMineBlock({ address, btc_amount: 1 });
+                await expect(firstAccountBalanceLocator).toHaveText(expectedIncreasedBalance);
+            });
+        },
+    );
 });

--- a/packages/suite-desktop-core/e2e/tests/wallet/sign-and-verify-eth.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/sign-and-verify-eth.test.ts
@@ -20,7 +20,7 @@ test.describe('Sign and verify ETH', { tag: ['@group=wallet'] }, () => {
      * 5. Fill out fields and sign message.
      * 6. Check that notification was rendered and correct message was generated
      */
-    test('Sign ETH', async ({ page, devicePrompt, walletPage }) => {
+    test('Signs message with Ethereum', async ({ page, devicePrompt, walletPage }) => {
         await walletPage.openAccount({ symbol: 'eth', type: 'normal', atIndex: 0 });
         await walletPage.walletExtraDropDown.click();
         await walletPage.signAndVerifyButton.click();
@@ -42,7 +42,7 @@ test.describe('Sign and verify ETH', { tag: ['@group=wallet'] }, () => {
      * 6. Fill out fields and sign message.
      * 7. Check that notification was rendered and correct message was generated
      */
-    test('Verify ETH', async ({ page, devicePrompt, walletPage }) => {
+    test('Verify message signed with Ethereum', async ({ page, devicePrompt, walletPage }) => {
         await walletPage.openAccount({ symbol: 'eth', type: 'normal', atIndex: 0 });
         await walletPage.walletExtraDropDown.click();
         await walletPage.signAndVerifyButton.click();

--- a/packages/suite-desktop-core/e2e/tests/wallet/sign-and-verify.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/sign-and-verify.test.ts
@@ -7,6 +7,7 @@ const SIGNATURE =
     'JxpInbBQH8LYgBBnRt4/QCV+HBW3hL1o1Yg85biWX1DdBTbfN96pyLL7tLQdYn+VtjvuZWJhEYbUCasjZLmih6w=';
 const ELECTRUM_SIGNATURE =
     'HxpInbBQH8LYgBBnRt4/QCV+HBW3hL1o1Yg85biWX1DdBTbfN96pyLL7tLQdYn+VtjvuZWJhEYbUCasjZLmih6w=';
+
 test.describe('Sign and verify', { tag: ['@group=wallet'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_all' } });
     test.beforeEach(async ({ page, walletPage, onboardingPage }) => {
@@ -27,7 +28,7 @@ test.describe('Sign and verify', { tag: ['@group=wallet'] }, () => {
      * 7. Compare signature with expected value
      */
 
-    test('Sign', async ({ page, devicePrompt }) => {
+    test('Signs message with standard Bitcoin signature format', async ({ page, devicePrompt }) => {
         await page.getByTestId('@sign-verify/message').fill(MESSAGE);
         await page.getByTestId('@sign-verify/sign-address/input').click();
         await page.getByTestId(`@sign-verify/sign-address/option/${PATH}`).click();
@@ -40,7 +41,10 @@ test.describe('Sign and verify', { tag: ['@group=wallet'] }, () => {
         await expect(page.getByTestId('@sign-verify/signature')).toHaveValue(SIGNATURE);
     });
 
-    test('Sign Electrum', async ({ page, devicePrompt }) => {
+    test('Signs message with Electrum-compatible signature format', async ({
+        page,
+        devicePrompt,
+    }) => {
         await page.getByTestId('@sign-verify/message').fill(MESSAGE);
         await page.getByTestId('@sign-verify/sign-address/input').click();
         await page.getByTestId(`@sign-verify/sign-address/option/${PATH}`).click();
@@ -53,7 +57,10 @@ test.describe('Sign and verify', { tag: ['@group=wallet'] }, () => {
         await expect(page.getByTestId('@sign-verify/signature')).toHaveValue(ELECTRUM_SIGNATURE);
     });
 
-    test('Verify', async ({ page, devicePrompt }) => {
+    test('Verify message signed with standard Bitcoin signature format', async ({
+        page,
+        devicePrompt,
+    }) => {
         await page.getByTestId('@sign-verify/navigation/verify').click();
         await page.getByTestId('@sign-verify/message').fill(MESSAGE);
         await page.getByTestId('@sign-verify/select-address').fill(ADDRESS);


### PR DESCRIPTION
Prompted by Boso. Some of the tests didnt have clear naming. In code it is obvious what they do but in our release project not. So we identify problematic ones and I improved those. either by annotation or just straight rename (which unfortunately breaks the history in currents, so i tried to minimized that.)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-e2e-automation-testcase-naming&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-e2e-automation-testcase-naming&lookback=7)