### PR TITLE
fix(wallet-core): filter failed accounts when they are not relevant

### DIFF
--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -33,28 +33,35 @@ const createMemoizedSelector = createWeakMapSelector.withTypes<
     AccountsRootState & DeviceRootState & DiscoveryRootState & WalletSettingsRootState
 >();
 
-export const selectDeviceAccountsVisibleEnabledAndSupported = createMemoizedSelector(
-    [selectVisibleDeviceAccounts, selectSelectedDevice, selectEnabledNetworks],
-    (accounts, device, enabledNetworks) => {
-        const deviceNetworks = selectSupportedNetworkByDevice(device);
-
-        return accounts.filter(
-            ({ symbol }) => enabledNetworks.includes(symbol) && deviceNetworks.includes(symbol),
-        );
-    },
-);
-
-export const selectAllAccountsToList = createMemoizedSelector(
-    [
-        selectDeviceAccountsVisibleEnabledAndSupported,
-        selectSelectedDevice,
-        selectDiscoveryForSelectedDevice,
-    ],
+/**
+ * This means "all potentially visible accounts", because for accounts that failed to be discovered
+ * we don't know if they would have been visible or not (depends on discovery account.empty result).
+ */
+export const selectVisibleAccountsWithFailed = createMemoizedSelector(
+    [selectVisibleDeviceAccounts, selectSelectedDevice, selectDiscoveryForSelectedDevice],
     (okAccounts, device, discovery) => {
         const staticSessionId = device?.state?.staticSessionId;
         const failedAccounts = getFailedAccounts(staticSessionId, discovery);
+
         const allAccounts = [...okAccounts, ...failedAccounts];
-        const sortedAccounts = sortByCoin(allAccounts);
+
+        return returnStableArrayIfEmpty(allAccounts);
+    },
+);
+
+/**
+ * Listable accounts are visible, enabled in settings, supported by the device and conventionally sorted.
+ * Edge cases: accounts failed to be discovered, or remembered accounts no longer supported by the device.
+ */
+export const selectAllAccountsToList = createMemoizedSelector(
+    [selectVisibleAccountsWithFailed, selectSelectedDevice, selectEnabledNetworks],
+    (allAccounts, device, enabledNetworks) => {
+        const deviceNetworks = selectSupportedNetworkByDevice(device);
+
+        const filteredAccounts = allAccounts.filter(
+            ({ symbol }) => enabledNetworks.includes(symbol) && deviceNetworks.includes(symbol),
+        );
+        const sortedAccounts = sortByCoin(filteredAccounts);
 
         return returnStableArrayIfEmpty(sortedAccounts);
     },


### PR DESCRIPTION
## Description

Reorder the operations in `selectAllAccountsToList`:
**first** merge failed accounts into ok accounts, **then** filter all of them and sort

Previously: filter ok accounts, merge failed (which were **not** filtered) and then sort
(failed accounts not filtered by enabled && supported)

## Related Issue

Resolve #19473 (that was 95% solved by #19571, this is like the last 5% of this issue :joy:  )

## Screenshots:

Since this is the edgiest of edgecases, I reproduced the bug only "in-vitro": discover BTC and ETH [with artifically failed ETH#3 discovery](https://github.com/user-attachments/assets/bc8e90fa-1b92-417a-8962-07952230a702) and then suddenly declare that device does not support ETH.

In the wild, outside "laboratory conditions", you'd probably have to discover with universal FW and having some of them fail, remember the wallet, disconnect, at **another** Suite switch the device to BTC-only and reconnect to the remembered wallet, but idk, for me it was only sometimes reproducible :upside_down_face:   

Before: ETH#3 remains visible
![in vitro reproduction](https://github.com/user-attachments/assets/5dd5df64-5a31-464a-b16b-d87dae24234e)

After: no ETH visible 
![in vitro fix](https://github.com/user-attachments/assets/6594f937-18f0-4035-a5b5-4b4da9f7ba44)


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/filter-failed-account-by-btc-only&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/filter-failed-account-by-btc-only&lookback=7)