### PR TITLE
feat(connect-common): temporarily add 1.13.0 FW

### DIFF
--- a/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.13.0-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.13.0-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:370122a4ecc2d7a900585944b2c1ecf216dd39367e49ffc09f0debc228e0ec69
+size 404204

--- a/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.13.0.bin
+++ b/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.13.0.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5f51f64c0ad8dac888ed5a1c5e6b64271b382b6ed73cfe6a569cfb874cd4545
+size 504172


### PR DESCRIPTION
## Description

Temporarily add T1B1 FW versions 1.13.0 for FW checks.

To be removed when no longer needed.

## QA instructions

Connect trezor-user-env T1B1 1.13.0 on suite desktop.
See that FW hash check fails.