### PR TITLE
fix(transport-bridge): compatibility with trezorctl (and electrum) when using bundled node-bridge version

### DIFF
--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -84,8 +84,8 @@ const validateProtocolMessageBody =
     };
 
 export class TrezordNode {
-    /** versioning, baked in by webpack */
     version = '3.1.0';
+    bundledVersion?: string;
     serviceName = 'trezord-node';
     /** last known descriptors state */
     descriptors: Descriptor[];
@@ -121,9 +121,7 @@ export class TrezordNode {
         this.port = port || defaults.port;
         this.logger = logger;
         this.descriptors = [];
-        if (bundledVersion) {
-            this.version = `${this.version}-bundled.${bundledVersion}`;
-        }
+        this.bundledVersion = bundledVersion;
 
         this.listenSubscriptions = [];
 
@@ -454,6 +452,7 @@ export class TrezordNode {
                     const props = {
                         intro: `To download full logs go to http://127.0.0.1:${this.port}/logs`,
                         version: this.version,
+                        bundledVersion: this.bundledVersion,
                         devices: this.descriptors,
                         logs: this.logger.getLog(),
                     };

--- a/packages/transport-bridge/src/ui/pages/Status.tsx
+++ b/packages/transport-bridge/src/ui/pages/Status.tsx
@@ -11,6 +11,7 @@ import { Translation } from '../components/Translation';
 export type StatusProps = LogsProps &
     DevicesProps & {
         version: string;
+        bundledVersion?: string;
     };
 
 export const Status = () => {
@@ -26,7 +27,7 @@ export const Status = () => {
 
     if (!data) return null;
 
-    const { version, devices, logs } = data;
+    const { version, bundledVersion, devices, logs } = data;
 
     return (
         <div>
@@ -35,7 +36,8 @@ export const Status = () => {
             </H1>
             <Card>
                 <div>
-                    <Translation id="version" />: {version}
+                    <Translation id="version" />: {version}{' '}
+                    {bundledVersion && `(bundled in Trezor Suite ${bundledVersion})`}
                 </div>
                 <Translation id="bridge.description" />
             </Card>


### PR DESCRIPTION

<img width="996" alt="image" src="https://github.com/user-attachments/assets/9acb758f-6b26-409c-b63e-e4839e420bd4" />


Resolve #19253



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-node-bridge-bundled-compatibility&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-node-bridge-bundled-compatibility&lookback=7)