### PR TITLE
chore(suite-native): remove bluetooth build configuration flag

### DIFF
--- a/suite-native/app/.env.development
+++ b/suite-native/app/.env.development
@@ -1,5 +1,4 @@
 EXPO_PUBLIC_ENVIRONMENT=debug
-EXPO_PUBLIC_BLUETOOTH_ENABLED=true
 
 ### Create .env.development.local files and copy there what you want to override for you locally
 

--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -157,17 +157,14 @@ const getPlugins = (): ExpoPlugins => {
             },
         ],
         ['expo-secure-store'],
-    ];
-
-    if (process.env.EXPO_PUBLIC_BLUETOOTH_ENABLED) {
-        plugins.push(['react-native-ble-plx', {}]);
-        plugins.push([
+        ['react-native-ble-plx', {}],
+        [
             'react-native-permissions',
             {
                 iosPermissions: ['Bluetooth'],
             },
-        ]);
-    }
+        ],
+    ];
 
     return [
         ...plugins,
@@ -191,7 +188,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         slug: appSlugs[buildType],
         owner: appOwners[buildType],
         version: suiteNativeVersion,
-        runtimeVersion: '33',
+        runtimeVersion: '34',
         ...(buildType === 'production'
             ? {}
             : {

--- a/suite-native/app/eas.json
+++ b/suite-native/app/eas.json
@@ -13,8 +13,7 @@
         "develop": {
             "extends": "base",
             "env": {
-                "EXPO_PUBLIC_ENVIRONMENT": "develop",
-                "EXPO_PUBLIC_BLUETOOTH_ENABLED": "true"
+                "EXPO_PUBLIC_ENVIRONMENT": "develop"
             },
             "channel": "develop",
             "autoIncrement": true,
@@ -29,8 +28,7 @@
         "preview": {
             "extends": "base",
             "env": {
-                "EXPO_PUBLIC_ENVIRONMENT": "preview",
-                "EXPO_PUBLIC_BLUETOOTH_ENABLED": "true"
+                "EXPO_PUBLIC_ENVIRONMENT": "preview"
             },
             "channel": "preview",
             "autoIncrement": true,
@@ -46,8 +44,7 @@
             "extends": "base",
             "env": {
                 "EXPO_PUBLIC_ENVIRONMENT": "production",
-                "EXPO_PUBLIC_CODESIGN_BUILD": "true",
-                "EXPO_PUBLIC_BLUETOOTH_ENABLED": "false"
+                "EXPO_PUBLIC_CODESIGN_BUILD": "true"
             },
             "autoIncrement": true,
             "android": {

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -11,15 +11,12 @@ import { NativeBluetoothTransport } from '@trezor/transport-native-bluetooth';
 import { NativeUsbTransport } from '@trezor/transport-native-usb';
 import { mergeDeepObject } from '@trezor/utils';
 
-const isBluetoothBuild = process.env.EXPO_PUBLIC_BLUETOOTH_ENABLED === 'true';
 const deviceType = Device.isDevice ? 'device' : 'emulator';
 
 const transportsPerDeviceType = {
     device: Platform.select({
-        ios: isBluetoothBuild ? ['BridgeTransport', NativeBluetoothTransport] : ['BridgeTransport'],
-        android: isBluetoothBuild
-            ? [NativeUsbTransport, NativeBluetoothTransport]
-            : [NativeUsbTransport],
+        ios: ['BridgeTransport', NativeBluetoothTransport],
+        android: [NativeUsbTransport, NativeBluetoothTransport],
     }),
     emulator: ['BridgeTransport'],
 } as const;


### PR DESCRIPTION
Bluetooth logic to be available in all builds behind a feature flag.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/remove-bluetooth-build-flag&lookback=7)