### PR TITLE
fix: RBF form crashed by a mistakenly repeated unit conversion

### DIFF
--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -7,7 +7,7 @@ import {
     DEFAULT_VALUES,
     ETH_SPEED_UP_TX_MULTIPLIER,
 } from '@suite-common/wallet-constants';
-import { DEFAULT_FEE_INFO, selectNetworkFeeInfo } from '@suite-common/wallet-core';
+import { DEFAULT_FEE_INFO } from '@suite-common/wallet-core';
 import {
     ChainedTransactions,
     FeeInfo,
@@ -120,7 +120,7 @@ const getRbfFeeInfo = (info: FeeInfo, rbfParams: RbfTransactionParams) => {
 const useRbfState = ({ selectedAccount, rbfParams, chainedTxs }: UseRbfProps) => {
     const { account, network } = selectedAccount;
 
-    const networkFees = useSelector(state => selectNetworkFeeInfo(state, account.symbol));
+    const networkFees = useSelector(state => state.wallet.fees[account.symbol]?.data);
     const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
     const coinjoinRegisteredUtxos = useCoinjoinRegisteredUtxos({ account });
 


### PR DESCRIPTION
## Description

Remove selector that was added in #19721 which does unit conversion – revert to raw data.
Otherwise the same number passes through the same unit conversion twice which does not make sense: and web3 utils library throws because it expects much larger number (an integer).

I checked that there are no other cases of this mistake, idk why I did this in RBF form :shrug: 

## Related Issue

Resolve #19805

## Screenshots

RBF form opens properly for the same TX referenced in the issue

![image](https://github.com/user-attachments/assets/91951d55-f6ba-4155-85de-cbce44bf1d9f)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/selectNetworkFeeInfo&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/selectNetworkFeeInfo&lookback=7)