### PR TITLE
Chore/rename select network fee info

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -1,6 +1,7 @@
 import { selectConnectPopupCall } from '@suite-common/connect-popup';
 import { formatDurationStrict } from '@suite-common/suite-utils';
 import { NetworkType, networks } from '@suite-common/wallet-config';
+import { selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import { FeeInfo, GeneralPrecomposedTransactionFinal, StakeType } from '@suite-common/wallet-types';
 import { getFee, hasEip1559MaxPriorityFee, isEip1559 } from '@suite-common/wallet-utils';
 import { Box, IconButton, Note, Row, Text } from '@trezor/components';
@@ -49,12 +50,12 @@ export const TransactionReviewSummary = ({
     const currentAccountKey = useSelector(
         state => state.wallet.selectedAccount.account?.key,
     ) as string;
-    const fees = useSelector(state => state.wallet.fees);
+    const rawFeeInfo = useSelector(state => selectRawNetworkFeeInfo(state, account.symbol));
     const locale = useLocales();
     const { symbol, accountType, index, networkType } = account;
     const network = networks[symbol];
     const fee = getFee(account.networkType, tx);
-    const estimateTime = getEstimatedTime(networkType, fees[account.symbol]?.data, tx);
+    const estimateTime = getEstimatedTime(networkType, rawFeeInfo, tx);
     const connectPopupCall = useSelector(selectConnectPopupCall);
 
     const formFeeRate = drafts[currentAccountKey]?.feePerUnit;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
@@ -15,7 +15,7 @@ import { Network, getExplorerUrl } from '@suite-common/wallet-config';
 import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import { selectDeviceAccounts, selectExplorer } from '@suite-common/wallet-core';
 import { FormState } from '@suite-common/wallet-types';
-import { asBaseCurrencyAmount, getFeeInfo } from '@suite-common/wallet-utils';
+import { asBaseCurrencyAmount, getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 import {
     AssetLogo,
     Banner,
@@ -223,7 +223,7 @@ export const TxSimulationModal = () => {
         },
     });
     const fees = useSelector(state => state.wallet.fees);
-    const feeInfo = getFeeInfo({
+    const feeInfo = getConvertedOrDefaultFeeInfo({
         networkType: account?.networkType ?? 'ethereum',
         feeInfo: fees[account?.symbol ?? 'eth']?.data,
     });

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
@@ -9,7 +9,11 @@ import {
     tradingActions,
 } from '@suite-common/trading';
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
-import { selectAccounts, selectSelectedDevice } from '@suite-common/wallet-core';
+import {
+    selectAccounts,
+    selectRawNetworkFeeInfo,
+    selectSelectedDevice,
+} from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
 import { getFeeInfo } from '@suite-common/wallet-utils';
 
@@ -36,7 +40,6 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
     const accounts = useSelector(selectAccounts);
     const device = useSelector(selectSelectedDevice);
     const addressDisplayType = useSelector(selectAddressDisplayType);
-    const fees = useSelector(state => state.wallet.fees);
     const { translationString } = useTranslation();
 
     const { getValues, setValue, setError, clearErrors } = methods as unknown as UseFormReturn<
@@ -44,7 +47,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
     >;
     const chunkify = addressDisplayType === AddressDisplayOptions.CHUNKED;
     const { symbol, networkType } = account;
-    const rawFeeInfo = fees[symbol]?.data;
+    const rawFeeInfo = useSelector(state => selectRawNetworkFeeInfo(state, symbol));
     const feeInfo = useMemo(
         () =>
             getFeeInfo({

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
@@ -15,7 +15,7 @@ import {
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
-import { getFeeInfo } from '@suite-common/wallet-utils';
+import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { useCompose } from 'src/hooks/wallet/form/useCompose';
@@ -50,7 +50,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
     const rawFeeInfo = useSelector(state => selectRawNetworkFeeInfo(state, symbol));
     const feeInfo = useMemo(
         () =>
-            getFeeInfo({
+            getConvertedOrDefaultFeeInfo({
                 networkType,
                 feeInfo: rawFeeInfo,
             }),

--- a/packages/suite/src/hooks/wallet/useClaimForm.ts
+++ b/packages/suite/src/hooks/wallet/useClaimForm.ts
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 
-import { selectLocalCurrency } from '@suite-common/wallet-core';
+import { selectLocalCurrency, selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import { PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { getFeeInfo } from '@suite-common/wallet-utils';
 
@@ -24,7 +24,7 @@ export const useClaimForm = ({ selectedAccount }: UseStakeFormsProps): ClaimCont
     const localCurrency = useSelector(selectLocalCurrency);
 
     const { account, network } = selectedAccount;
-    const networkFees = useSelector(state => state.wallet.fees[account.symbol]?.data);
+    const networkFees = useSelector(state => selectRawNetworkFeeInfo(state, account.symbol));
 
     const defaultValues = useMemo(() => {
         const stakingContractAddress = getStakingContractAddress(account, 'claim');

--- a/packages/suite/src/hooks/wallet/useClaimForm.ts
+++ b/packages/suite/src/hooks/wallet/useClaimForm.ts
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 
 import { selectLocalCurrency, selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import { PrecomposedTransactionFinal } from '@suite-common/wallet-types';
-import { getFeeInfo } from '@suite-common/wallet-utils';
+import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 
 import { signTransaction } from 'src/actions/wallet/stakeActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -38,7 +38,7 @@ export const useClaimForm = ({ selectedAccount }: UseStakeFormsProps): ClaimCont
     }, [account]);
 
     const state = useMemo(() => {
-        const feeInfo = getFeeInfo({
+        const feeInfo = getConvertedOrDefaultFeeInfo({
             networkType: account.networkType,
             feeInfo: networkFees,
         });
@@ -100,7 +100,7 @@ export const useClaimForm = ({ selectedAccount }: UseStakeFormsProps): ClaimCont
     }, [composeRequest, defaultValues, reset]);
 
     // sub-hook, FeeLevels handler
-    const feeInfo = getFeeInfo({
+    const feeInfo = getConvertedOrDefaultFeeInfo({
         networkType: account.networkType,
         feeInfo: networkFees,
     });

--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -7,7 +7,7 @@ import {
     DEFAULT_VALUES,
     ETH_SPEED_UP_TX_MULTIPLIER,
 } from '@suite-common/wallet-constants';
-import { DEFAULT_FEE_INFO } from '@suite-common/wallet-core';
+import { DEFAULT_FEE_INFO, selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import {
     ChainedTransactions,
     FeeInfo,
@@ -120,7 +120,7 @@ const getRbfFeeInfo = (info: FeeInfo, rbfParams: RbfTransactionParams) => {
 const useRbfState = ({ selectedAccount, rbfParams, chainedTxs }: UseRbfProps) => {
     const { account, network } = selectedAccount;
 
-    const networkFees = useSelector(state => state.wallet.fees[account.symbol]?.data);
+    const networkFees = useSelector(state => selectRawNetworkFeeInfo(state, account.symbol));
     const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
     const coinjoinRegisteredUtxos = useCoinjoinRegisteredUtxos({ account });
 

--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -20,7 +20,7 @@ import {
 } from '@suite-common/wallet-types';
 import {
     calculateChainedTransactionsFeeForRbf,
-    getFeeInfo,
+    getConvertedOrDefaultFeeInfo,
     isEip1559,
 } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
@@ -42,7 +42,7 @@ export type UseRbfProps = {
 const getBitcoinFeeInfo = (info: FeeInfo, rbfParams: RbfTransactionParamsBitcoin) => {
     const { feeRate } = rbfParams;
     // increase FeeLevels (old rate + defined rate)
-    const feeInfo = getFeeInfo({
+    const feeInfo = getConvertedOrDefaultFeeInfo({
         networkType: 'bitcoin',
         feeInfo: info,
     });
@@ -61,7 +61,7 @@ const getBitcoinFeeInfo = (info: FeeInfo, rbfParams: RbfTransactionParamsBitcoin
 const getEthereumFeeInfo = (info: FeeInfo, rbfParams: RbfTransactionParamsEthereum) => {
     // use maxFeePerGas as fallback in case backend does not return eip1559 fees
     const currentGasPrice = new BigNumber(rbfParams.gasPrice || rbfParams.maxFeePerGas);
-    const feeInfo = getFeeInfo({
+    const feeInfo = getConvertedOrDefaultFeeInfo({
         networkType: 'ethereum',
         feeInfo: info,
     });

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -15,8 +15,8 @@ import { FormState } from '@suite-common/wallet-types';
 import {
     convertAmountSubunitsToUnits,
     convertAmountUnitsToSubunits,
+    getConvertedOrDefaultFeeInfo,
     getDefaultValues,
-    getFeeInfo,
     useExcludedUtxos,
 } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
@@ -101,7 +101,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     const rawFeeInfo = props.fees[symbol]?.data;
     const feeInfo = useMemo(
         () =>
-            getFeeInfo({
+            getConvertedOrDefaultFeeInfo({
                 networkType,
                 feeInfo: rawFeeInfo,
             }),

--- a/packages/suite/src/hooks/wallet/useStakeForm.ts
+++ b/packages/suite/src/hooks/wallet/useStakeForm.ts
@@ -8,6 +8,7 @@ import {
     StakeContextValues,
     selectFiatRatesByFiatRateKey,
     selectLocalCurrency,
+    selectRawNetworkFeeInfo,
 } from '@suite-common/wallet-core';
 import { PrecomposedTransactionFinal, StakeFormState } from '@suite-common/wallet-types';
 import {
@@ -46,7 +47,7 @@ export const useStakeForm = ({ selectedAccount }: UseStakeFormsProps): StakeCont
     const { symbol } = account;
 
     const localCurrency = useSelector(selectLocalCurrency);
-    const networkFees = useSelector(state => state.wallet.fees[symbol]?.data);
+    const networkFees = useSelector(state => selectRawNetworkFeeInfo(state, account.symbol));
 
     const [currency, setCurrency] = useState<'crypto' | 'fiat' | undefined>(undefined);
 

--- a/packages/suite/src/hooks/wallet/useStakeForm.ts
+++ b/packages/suite/src/hooks/wallet/useStakeForm.ts
@@ -13,7 +13,7 @@ import {
 import { PrecomposedTransactionFinal, StakeFormState } from '@suite-common/wallet-types';
 import {
     fromFiatCurrency,
-    getFeeInfo,
+    getConvertedOrDefaultFeeInfo,
     getFiatRateKey,
     getStakingLimitsByNetwork,
     toFiatCurrency,
@@ -91,7 +91,7 @@ export const useStakeForm = ({ selectedAccount }: UseStakeFormsProps): StakeCont
     const isDraft = !!draft;
 
     const state = useMemo(() => {
-        const feeInfo = getFeeInfo({
+        const feeInfo = getConvertedOrDefaultFeeInfo({
             networkType: account.networkType,
             feeInfo: networkFees,
         });
@@ -144,7 +144,7 @@ export const useStakeForm = ({ selectedAccount }: UseStakeFormsProps): StakeCont
     });
 
     // sub-hook, FeeLevels handler
-    const feeInfo = getFeeInfo({
+    const feeInfo = getConvertedOrDefaultFeeInfo({
         networkType: account.networkType,
         feeInfo: networkFees,
     });

--- a/packages/suite/src/hooks/wallet/useUnstakeForm.ts
+++ b/packages/suite/src/hooks/wallet/useUnstakeForm.ts
@@ -8,6 +8,7 @@ import {
     UnstakeFormState,
     selectFiatRatesByFiatRateKey,
     selectLocalCurrency,
+    selectRawNetworkFeeInfo,
 } from '@suite-common/wallet-core';
 import { PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import {
@@ -56,10 +57,10 @@ export const useUnstakeForm = ({ selectedAccount }: UseStakeFormsProps): Unstake
     const { symbol } = account;
 
     const localCurrency = useSelector(selectLocalCurrency);
-    const fees = useSelector(state => state.wallet.fees);
+    const rawFeeInfo = useSelector(state => selectRawNetworkFeeInfo(state, account.symbol));
     const feeInfo = getFeeInfo({
         networkType: account.networkType,
-        feeInfo: fees[account.symbol]?.data,
+        feeInfo: rawFeeInfo,
     });
 
     const [currency, setCurrency] = useState<'crypto' | 'fiat' | undefined>(undefined);

--- a/packages/suite/src/hooks/wallet/useUnstakeForm.ts
+++ b/packages/suite/src/hooks/wallet/useUnstakeForm.ts
@@ -13,7 +13,7 @@ import {
 import { PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import {
     fromFiatCurrency,
-    getFeeInfo,
+    getConvertedOrDefaultFeeInfo,
     getFiatRateKey,
     getStakingDataForNetwork,
     toFiatCurrency,
@@ -58,7 +58,7 @@ export const useUnstakeForm = ({ selectedAccount }: UseStakeFormsProps): Unstake
 
     const localCurrency = useSelector(selectLocalCurrency);
     const rawFeeInfo = useSelector(state => selectRawNetworkFeeInfo(state, account.symbol));
-    const feeInfo = getFeeInfo({
+    const feeInfo = getConvertedOrDefaultFeeInfo({
         networkType: account.networkType,
         feeInfo: rawFeeInfo,
     });

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -5,7 +5,7 @@ import { getNetwork } from '@suite-common/wallet-config';
 import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants';
 import {
     composeSendFormTransactionFeeLevelsThunk,
-    selectNetworkFeeInfo,
+    selectConvertedNetworkFeeInfo,
 } from '@suite-common/wallet-core';
 import { Account, FormOptions, FormState } from '@suite-common/wallet-types';
 import { Success, Unsuccessful } from '@trezor/connect';
@@ -75,7 +75,7 @@ export const recomposeAndSignTxThunk = createThunk<
         const { composed, selectedFee } = selectTradingComposedTransactionInfo(getState());
         const options: FormOptions[] = ['broadcast'];
         const network = getNetwork(account.symbol);
-        const feeInfo = selectNetworkFeeInfo(getState(), account.symbol);
+        const feeInfo = selectConvertedNetworkFeeInfo(getState(), account.symbol);
         const activeTradingSection = selectTradingActiveSection(
             getState(),
         ) as TradingTradeSellExchangeType;

--- a/suite-common/wallet-core/src/fees/feesReducer.ts
+++ b/suite-common/wallet-core/src/fees/feesReducer.ts
@@ -56,7 +56,10 @@ const createMemoizedSelector = createWeakMapSelector.withTypes<FeesRootState>();
 // Base selector for fees state
 export const selectFees = (state: FeesRootState) => state.wallet.fees;
 
-export const selectNetworkFeeInfo = createMemoizedSelector(
+/**
+ * Returns feeInfo per network, cleaned up, and for Ethereum also converted from wei to Gwei.
+ */
+export const selectConvertedNetworkFeeInfo = createMemoizedSelector(
     [selectFees, (_state: FeesRootState, symbol?: NetworkSymbol) => symbol],
     (fees, symbol): FeeInfo | null => {
         if (!symbol || !fees[symbol]) return null;
@@ -73,7 +76,7 @@ export const selectNetworkFeeInfo = createMemoizedSelector(
 
 export const selectNetworkFeeLevel = createMemoizedSelector(
     [
-        selectNetworkFeeInfo,
+        selectConvertedNetworkFeeInfo,
         (_state: FeesRootState, _symbol?: NetworkSymbol, level?: FeeLevelLabel) => level,
     ],
     (networkFeeInfo, level): FeeLevel | null => {
@@ -84,8 +87,8 @@ export const selectNetworkFeeLevel = createMemoizedSelector(
     },
 );
 
-export const selectNetworkFeeLevelTimeEstimate = createMemoizedSelector(
-    [selectNetworkFeeInfo, selectNetworkFeeLevel],
+export const selectConvertedNetworkFeeLevelTimeEstimate = createMemoizedSelector(
+    [selectConvertedNetworkFeeInfo, selectNetworkFeeLevel],
     (networkFeeInfo, feeLevel): string | null => {
         if (!feeLevel || !networkFeeInfo) return null;
 
@@ -93,7 +96,7 @@ export const selectNetworkFeeLevelTimeEstimate = createMemoizedSelector(
     },
 );
 
-export const selectNetworkFeeLevelFeePerUnit = createMemoizedSelector(
+export const selectConvertedNetworkFeeLevelFeePerUnit = createMemoizedSelector(
     [selectNetworkFeeLevel],
     (feeLevel): string | null => {
         if (!feeLevel) return null;

--- a/suite-common/wallet-core/src/fees/feesReducer.ts
+++ b/suite-common/wallet-core/src/fees/feesReducer.ts
@@ -57,6 +57,14 @@ const createMemoizedSelector = createWeakMapSelector.withTypes<FeesRootState>();
 export const selectFees = (state: FeesRootState) => state.wallet.fees;
 
 /**
+ * Returns raw feeInfo per network
+ */
+export const selectRawNetworkFeeInfo = createMemoizedSelector(
+    [selectFees, (_state: FeesRootState, symbol?: NetworkSymbol) => symbol],
+    (fees, symbol): FeeInfo | undefined => (symbol !== undefined ? fees[symbol]?.data : undefined),
+);
+
+/**
  * Returns feeInfo per network, cleaned up, and for Ethereum also converted from wei to Gwei.
  */
 export const selectConvertedNetworkFeeInfo = createMemoizedSelector(

--- a/suite-common/wallet-core/src/fees/feesReducer.ts
+++ b/suite-common/wallet-core/src/fees/feesReducer.ts
@@ -4,7 +4,7 @@ import { createWeakMapSelector } from '@suite-common/redux-utils';
 import { formatDuration } from '@suite-common/suite-utils';
 import { NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
 import { FeeInfo, FeeLevelLabel, FeesState, FeesStatus } from '@suite-common/wallet-types';
-import { getFeeInfo } from '@suite-common/wallet-utils';
+import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 import { FeeLevel } from '@trezor/connect';
 
 import { feesActions } from './feesActions';
@@ -73,7 +73,7 @@ export const selectConvertedNetworkFeeInfo = createMemoizedSelector(
         if (!symbol || !fees[symbol]) return null;
 
         const networkType = getNetworkType(symbol);
-        const feeInfo = getFeeInfo({
+        const feeInfo = getConvertedOrDefaultFeeInfo({
             networkType,
             feeInfo: fees[symbol].data,
         });

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -198,12 +198,15 @@ export const prepareEthereumTransaction = (
     return result;
 };
 
-interface GetFeeInfoProps {
+type GetConvertedOrDefaultFeeLevelsProps = {
     feeInfo?: FeeInfo;
     networkType: NetworkType;
-}
+};
 
-const getFeeLevels = ({ feeInfo, networkType }: GetFeeInfoProps) => {
+const getConvertedOrDefaultFeeLevels = ({
+    feeInfo,
+    networkType,
+}: GetConvertedOrDefaultFeeLevelsProps) => {
     if (!feeInfo) return [];
 
     const levels = feeInfo.levels.concat({
@@ -236,8 +239,11 @@ const getFeeLevels = ({ feeInfo, networkType }: GetFeeInfoProps) => {
     return levels;
 };
 
-export const getFeeInfo = ({ networkType, feeInfo }: GetFeeInfoProps): FeeInfo => ({
-    levels: getFeeLevels({ networkType, feeInfo }),
+export const getConvertedOrDefaultFeeInfo = ({
+    networkType,
+    feeInfo,
+}: GetConvertedOrDefaultFeeLevelsProps): FeeInfo => ({
+    levels: getConvertedOrDefaultFeeLevels({ networkType, feeInfo }),
     blockHeight: feeInfo?.blockHeight ?? 0,
     blockTime: feeInfo?.blockTime ?? 0,
     minFee: feeInfo?.minFee ?? 0,

--- a/suite-native/module-send/src/components/CustomFeeInputs.tsx
+++ b/suite-native/module-send/src/components/CustomFeeInputs.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { G } from '@mobily/ts-belt';
 
 import { NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
-import { FeesRootState, selectNetworkFeeInfo } from '@suite-common/wallet-core';
+import { FeesRootState, selectConvertedNetworkFeeInfo } from '@suite-common/wallet-core';
 import { getFeeUnits } from '@suite-common/wallet-utils';
 import { Hint, Text, VStack } from '@suite-native/atoms';
 import { TextInputField, useFormContext } from '@suite-native/forms';
@@ -19,7 +19,9 @@ type CustomFeeInputsProps = {
 
 export const CustomFeeInputs = ({ symbol }: CustomFeeInputsProps) => {
     const { translate } = useTranslate();
-    const feeInfo = useSelector((state: FeesRootState) => selectNetworkFeeInfo(state, symbol));
+    const feeInfo = useSelector((state: FeesRootState) =>
+        selectConvertedNetworkFeeInfo(state, symbol),
+    );
     const { cryptoAmountTransformer } = useAmountInputTransformers(symbol);
     const debounce = useDebounce();
     const {

--- a/suite-native/module-send/src/components/FeeOption.tsx
+++ b/suite-native/module-send/src/components/FeeOption.tsx
@@ -11,8 +11,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { type NetworkSymbol, type NetworkType, getNetworkType } from '@suite-common/wallet-config';
 import {
     FeesRootState,
-    selectNetworkFeeLevelFeePerUnit,
-    selectNetworkFeeLevelTimeEstimate,
+    selectConvertedNetworkFeeLevelFeePerUnit,
+    selectConvertedNetworkFeeLevelTimeEstimate,
 } from '@suite-common/wallet-core';
 import {
     AccountKey,
@@ -102,11 +102,11 @@ export const FeeOption = ({
     const dispatch = useDispatch();
 
     const feeTimeEstimate = useSelector((state: FeesRootState) =>
-        selectNetworkFeeLevelTimeEstimate(state, symbol, feeKey),
+        selectConvertedNetworkFeeLevelTimeEstimate(state, symbol, feeKey),
     );
 
     const backendFeePerUnit = useSelector((state: FeesRootState) =>
-        selectNetworkFeeLevelFeePerUnit(state, symbol, feeKey),
+        selectConvertedNetworkFeeLevelFeePerUnit(state, symbol, feeKey),
     );
 
     const areFeeValuesComplete = isFinalPrecomposedTransaction(feeLevel);

--- a/suite-native/module-send/src/components/SendFeesForm.tsx
+++ b/suite-native/module-send/src/components/SendFeesForm.tsx
@@ -11,8 +11,8 @@ import {
     SendRootState,
     selectAccountByKey,
     selectAreFeesLoading,
-    selectNetworkFeeInfo,
-    selectNetworkFeeLevelFeePerUnit,
+    selectConvertedNetworkFeeInfo,
+    selectConvertedNetworkFeeLevelFeePerUnit,
     selectSendFormDraftByKey,
     useFetchFeesOnce,
     useRefetchFees,
@@ -75,7 +75,7 @@ export const SendFeesForm = ({ accountKey, tokenContract }: SendFormProps) => {
     const feeLevels = useSelector(selectFeeLevels);
 
     const networkFeeInfo = useSelector((state: FeesRootState) =>
-        selectNetworkFeeInfo(state, account?.symbol),
+        selectConvertedNetworkFeeInfo(state, account?.symbol),
     );
 
     const formDraft = useSelector((state: SendRootState) =>
@@ -116,7 +116,7 @@ export const SendFeesForm = ({ accountKey, tokenContract }: SendFormProps) => {
     ] as GeneralPrecomposedTransactionFinal;
 
     const feePerUnit = useSelector((state: FeesRootState) =>
-        selectNetworkFeeLevelFeePerUnit(state, account?.symbol, selectedFeeLevel),
+        selectConvertedNetworkFeeLevelFeePerUnit(state, account?.symbol, selectedFeeLevel),
     );
 
     useRefetchFees({

--- a/suite-native/module-send/src/hooks/useSendForm.ts
+++ b/suite-native/module-send/src/hooks/useSendForm.ts
@@ -15,9 +15,9 @@ import {
     WalletSettingsRootState,
     composeSendFormTransactionFeeLevelsThunk,
     selectAccountByKey,
+    selectConvertedNetworkFeeInfo,
     selectDeviceUnavailableCapabilities,
     selectIsAmountInSats,
-    selectNetworkFeeInfo,
     selectSendFormDraftByKey,
     sendFormActions,
     updateFeeInfoThunk,
@@ -82,7 +82,7 @@ export const useSendForm = (accountKey: string, tokenContract?: TokenAddress) =>
         selectIsAmountInSats(state, account?.symbol),
     );
     const networkFeeInfo = useSelector((state: FeesRootState) =>
-        selectNetworkFeeInfo(state, account?.symbol),
+        selectConvertedNetworkFeeInfo(state, account?.symbol),
     );
     const sendFormDraft = useSelector((state: SendRootState) =>
         selectSendFormDraftByKey(state, accountKey, tokenContract),

--- a/suite-native/module-send/src/sendFormThunks.ts
+++ b/suite-native/module-send/src/sendFormThunks.ts
@@ -10,7 +10,7 @@ import {
     deviceActions,
     enhancePrecomposedTransactionThunk,
     selectAccountByKey,
-    selectNetworkFeeInfo,
+    selectConvertedNetworkFeeInfo,
     selectSelectedDevice,
     selectSendFormDraftByKey,
     selectSendFormDrafts,
@@ -142,7 +142,7 @@ export const calculateFeeLevelsMaxAmountThunk = createThunk<
         const account = selectAccountByKey(getState(), accountKey);
         if (!account) throw new Error('Account not found.');
 
-        const networkFeeInfo = selectNetworkFeeInfo(getState(), account.symbol);
+        const networkFeeInfo = selectConvertedNetworkFeeInfo(getState(), account.symbol);
         const network = getNetwork(account.symbol);
 
         if (!networkFeeInfo) throw new Error('Network fees not found.');
@@ -231,7 +231,7 @@ export const calculateCustomFeeLevelThunk = createThunk(
         { dispatch, getState },
     ) => {
         const account = selectAccountByKey(getState(), accountKey);
-        const feeInfo = selectNetworkFeeInfo(getState(), account?.symbol);
+        const feeInfo = selectConvertedNetworkFeeInfo(getState(), account?.symbol);
 
         const draft = selectSendFormDraftByKey(getState(), accountKey, tokenContract);
 


### PR DESCRIPTION
## Description

Following #19806, rename variables and slightly move code around to make it clearer to prevent these messups.
Should not break anything :crossed_fingers: 

Send form works, RBF works..

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/rename-selectNetworkFeeInfo&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/rename-selectNetworkFeeInfo&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/rename-selectNetworkFeeInfo&lookback=7)