### PR TITLE
refactor(e2e): Revert optionallyDismissFwHashCheckError

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -92,13 +92,10 @@ export class OnboardingPage {
     async optionallyDismissFwHashCheckError() {
         await this.verifySuiteIsLoaded();
         // dismisses the error modal only if it appears (handle it async in parallel, not necessary to block the rest of the flow)
-        // eslint-disable-next-line playwright/no-wait-for-selector
-        void this.page
-            .waitForSelector('[data-testid="@device-compromised/dismiss-button"]', {
-                timeout: 10_000,
-            })
-            .then(async button => await button.click())
-            .catch(() => {}); // Intentionally ignore timeout errors - means the modal was not shown
+        // eslint-disable-next-line playwright/no-element-handle
+        this.page
+            .$('[data-testid="@device-compromised/dismiss-button"]')
+            .then(dismissFwHashCheckButton => dismissFwHashCheckButton?.click());
     }
 
     @step()

--- a/packages/suite-desktop-core/e2e/tests/suite/initial-run.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/initial-run.test.ts
@@ -1,4 +1,17 @@
+import { Page } from '@playwright/test';
+
 import { expect, test } from '../../support/fixtures';
+
+const optionallyDismissFwHashCheckError = (page: Page) => {
+    // dismisses the error modal only if it appears (handle it async in parallel, not necessary to block the rest of the flow)
+    // eslint-disable-next-line playwright/no-wait-for-selector
+    void page
+        .waitForSelector('[data-testid="@device-compromised/dismiss-button"]', {
+            timeout: 10_000,
+        })
+        .then(async button => await button.click())
+        .catch(() => {}); // Intentionally ignore timeout errors - means the modal was not shown
+};
 
 test.describe('Suite initial run', { tag: ['@group=suite'] }, () => {
     test('Until user passed through initial run, it will be there after reload', async ({
@@ -6,19 +19,21 @@ test.describe('Suite initial run', { tag: ['@group=suite'] }, () => {
         analyticsSection,
         onboardingPage,
     }) => {
-        await onboardingPage.disableNecessaryFirmwareChecks();
-        await onboardingPage.optionallyDismissFwHashCheckError();
+        await onboardingPage.verifySuiteIsLoaded();
+        optionallyDismissFwHashCheckError(page);
         await expect(analyticsSection.toggleSwitch).toBeVisible();
 
         await page.reload();
-        await onboardingPage.optionallyDismissFwHashCheckError();
+        await onboardingPage.verifySuiteIsLoaded();
+        optionallyDismissFwHashCheckError(page);
         // analytics screen is there until user confirms his choice
         await expect(analyticsSection.toggleSwitch).toBeVisible();
         await analyticsSection.continueButton.click();
         await expect(page.getByTestId('@onboarding/exit-app-button')).toBeVisible();
 
         await page.reload();
-        await onboardingPage.optionallyDismissFwHashCheckError();
+        await onboardingPage.verifySuiteIsLoaded();
+        optionallyDismissFwHashCheckError(page);
         await expect(analyticsSection.toggleSwitch).toBeHidden();
         await expect(onboardingPage.onboardingContinueButton).toBeVisible();
     });


### PR DESCRIPTION
while working, the new version had confusing sideeffect in logs. It showed steps expanded with the waitFor red as it timedout. So I am fallbacking to original solution. And using the new on only on the one specific tests where the original solution did not work.

![image](https://github.com/user-attachments/assets/2f84db9f-435e-41f4-992b-ae293b517f32)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-e2e-dismiiss-fwhashcheck&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-e2e-dismiiss-fwhashcheck&lookback=7)