### PR TITLE
fix(suite): Hide wallet switcher init animations

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmPassphraseBeforeAction.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmPassphraseBeforeAction.tsx
@@ -47,7 +47,7 @@ export const ConfirmPassphraseBeforeAction = () => {
     const onDeviceOffer = !!device?.features?.capabilities?.includes('Capability_PassphraseEntry');
 
     return (
-        <SwitchDeviceModal isAnimationEnabled onCancel={onEnterPassphraseDialogCancel}>
+        <SwitchDeviceModal onCancel={onEnterPassphraseDialogCancel}>
             <CardWithDevice
                 onCancel={onEnterPassphraseDialogCancel}
                 device={device}

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/EnterPassphrase.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/EnterPassphrase.tsx
@@ -47,7 +47,7 @@ export const EnterPassphrase = ({
     const isUsingNonAsciiCharacters = getNonAsciiChars(value) !== null;
 
     return (
-        <SwitchDeviceModal isAnimationEnabled onCancel={onCancel}>
+        <SwitchDeviceModal onCancel={onCancel}>
             <CardWithDevice
                 cancelDisabled={cancelDisabled}
                 onCancel={onCancel}

--- a/packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx
@@ -43,7 +43,7 @@ export const SwitchDevice = ({
     }, [cancelable, onCancel]);
 
     return (
-        <SwitchDeviceModal isAnimationEnabled onCancel={handleCancel}>
+        <SwitchDeviceModal onCancel={handleCancel}>
             {isBluetoothMode ? (
                 <BluetoothConnect uiMode="card" />
             ) : (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=hide-wallet-switcher-animations&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=hide-wallet-switcher-animations&lookback=7)