### PR TITLE
WalletConnect hex fixes

### DIFF
--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -65,7 +65,7 @@ const preCallHook = async <M extends keyof typeof TrezorConnect>({
                         options: ['ethereumNonce', 'ethereumData'],
                         selectedFee: 'custom',
                         ethereumDataAscii: '',
-                        ethereumDataHex: typedPayload.transaction.data?.replace(/^0x/, ''),
+                        ethereumDataHex: typedPayload.transaction.data,
                         ethereumNonce: typedPayload.transaction.nonce,
                     },
                     precomposedTransaction: txSigningPrecomposed,

--- a/suite-common/walletconnect/src/adapters/ethereum.ts
+++ b/suite-common/walletconnect/src/adapters/ethereum.ts
@@ -7,7 +7,11 @@ import { Network, getNetwork, networksCollection } from '@suite-common/wallet-co
 import { selectAccounts, selectSelectedDevice } from '@suite-common/wallet-core';
 import { ethereumGetCurrentNonceThunk } from '@suite-common/wallet-core/src/send/sendFormEthereumThunks';
 import { Account } from '@suite-common/wallet-types';
-import { getAccountIdentity, getEthereumEstimateFeeParams } from '@suite-common/wallet-utils';
+import {
+    getAccountIdentity,
+    getEthereumEstimateFeeParams,
+    sanitizeHex,
+} from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
 
 import { WALLETCONNECT_MODULE } from '../walletConnectConstants';
@@ -82,7 +86,7 @@ const ethereumRequestThunk = createThunk<
                 throw new Error('personal_sign error');
             }
 
-            return `0x${response.payload.signature}`;
+            return sanitizeHex(response.payload.signature);
         }
         case 'eth_signTypedData_v4': {
             const [address, data] = event.params.request.params;
@@ -103,7 +107,7 @@ const ethereumRequestThunk = createThunk<
                 throw new Error('eth_signTypedData_v4 error');
             }
 
-            return `0x${response.payload.signature}`;
+            return sanitizeHex(response.payload.signature);
         }
         case 'eth_sendTransaction': {
             const chainId = Number(event.params.chainId.replace('eip155:', ''));
@@ -163,11 +167,12 @@ const ethereumRequestThunk = createThunk<
             const { nonce } = await dispatch(
                 ethereumGetCurrentNonceThunk({ selectedAccount: account }),
             ).unwrap();
-            const nonceHex = `0x${parseInt(nonce).toString(16)}`;
+            const nonceHex = sanitizeHex(parseInt(nonce).toString(16));
             const payload = {
                 path: account.path,
                 transaction: {
                     ...transaction,
+                    data: sanitizeHex(transaction.data || ''),
                     gasLimit: transaction.gas,
                     nonce: nonceHex,
                     chainId,


### PR DESCRIPTION
## Description

- Use `sanitizeHex` in WalletConnect EVM signatures and data, should resolve EIP-712 issue found by @Ondra-Zik-SL 

- Keep hex prefix in form data, as mentioned [here](https://github.com/trezor/trezor-suite/pull/19629#issuecomment-2996345494) by @tomasklim 

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/walletconnect-sanitizehex&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/walletconnect-sanitizehex&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/walletconnect-sanitizehex&lookback=7)