### PR TITLE
fix(suite): copy for onboarding change device name

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2627,6 +2627,10 @@ export default defineMessages({
         defaultMessage: 'Change Homescreen',
         id: 'TR_ONBOARDING_FINAL_CHANGE_HOMESCREEN',
     },
+    TR_ONBOARDING_DEVICE_EDIT_LABEL: {
+        defaultMessage: 'Change name',
+        id: 'TR_ONBOARDING_DEVICE_EDIT_LABEL',
+    },
     TR_FIRMWARE: {
         defaultMessage: 'Firmware',
         id: 'TR_FIRMWARE',

--- a/packages/suite/src/views/onboarding/steps/Final.tsx
+++ b/packages/suite/src/views/onboarding/steps/Final.tsx
@@ -188,7 +188,7 @@ export const FinalStep = () => {
                                 onClick={() => setState('rename')}
                                 isDisabled={isWaitingForConfirm}
                             >
-                                <Translation id="TR_DEVICE_SETTINGS_DEVICE_EDIT_LABEL" />
+                                <Translation id="TR_ONBOARDING_DEVICE_EDIT_LABEL" />
                             </Button>
 
                             <Tooltip


### PR DESCRIPTION
## Description

`TR_DEVICE_SETTINGS_DEVICE_EDIT_LABEL` was changed in to "Save name" in https://github.com/trezor/trezor-suite/pull/19236, but that makes sense only for Settings, not for onboarding final screen.

In onboarding, revert it to the original "Change name".  

## Screenshots:

**Before:**
![before](https://github.com/user-attachments/assets/db0b375b-e886-42c4-a9e4-e304b5468c49)

**After**

[whole flow.webm](https://github.com/user-attachments/assets/dd04e893-5fa6-4981-a304-ddc8bc1b8aba)
