### PR TITLE
ci: remove suite coverageThreshold

### DIFF
--- a/packages/suite/jest.config.js
+++ b/packages/suite/jest.config.js
@@ -52,14 +52,6 @@ module.exports = {
         '!**/__fixtures__/**',
         '!<rootDir>/src/hooks/**/useTrading*',
     ],
-    coverageThreshold: {
-        global: {
-            statements: 49,
-            branches: 35,
-            lines: 49,
-            functions: 46,
-        },
-    },
     modulePathIgnorePatterns: ['node_modules'],
     watchPathIgnorePatterns: ['<rootDir>/libDev'],
     testPathIgnorePatterns: [


### PR DESCRIPTION
## Description

This may be unpopular but I think that enforcing `coverageThreshold` in jest config does not make sense.
Not to be misunderstood: yes, more coverage is good, but this is not the way to do it

- I believe that this setting would only make sense if it was 100
- Let us state that some code makes sense to be covered, and some code just doesn't
  - Someone might disagree and strive for 100%, but that does not represent the state of trezor-suite repo
- That's why threshold is between 0 and 100, right?
- But value between 0 and 100 does not act as enforcement
- Because it punishes the innocent but allows the guilty to roam free 

For illustration:
- threshold = 50%
- current coverage = 51%
- Alice adds code that **should** have been covered → drops to 50.1% and CI lets her go
- Bob adds code that does not make sense to be covered → drops to 49.9% and CI punishes him
  - Bob's code could also be _partially_ covered and still have it blow up on him

Inspired by #19494. Hey as you can see, I'm not the Bob here, I'm Bob's advocate :laughing: 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/remove-suite-coverageThreshold&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/remove-suite-coverageThreshold&lookback=7)