### PR TITLE
fix(suite): inappropriate AccountMenu rediscovery prompt

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
@@ -47,11 +47,13 @@ const animationConfig: MotionProps = {
 export const RefreshAfterDiscoveryNeeded = () => {
     const dispatch = useDispatch();
     const selectedDevice = useSelector(selectSelectedDevice);
-    const isDiscoveryButtonVisible = useSelector(state =>
+    const isRediscoverNeeded = useSelector(state =>
         selectIsRediscoverNeeded(state, selectedDevice?.state?.staticSessionId),
     );
     const isSidebarCollapsed = useIsSidebarCollapsed();
     const isDiscoveryInProgress = useSelector(selectHasRunningDiscovery);
+    const isDiscoveryButtonVisible = isRediscoverNeeded && !isDiscoveryInProgress;
+
     if (!selectedDevice?.connected) {
         return null;
     }


### PR DESCRIPTION
## Description

Do not display "Don't see an account after activating a coin?" when discovery is still running.

On develop it briefly shows when discovery starts and no networks are discovered yet.

Now it should be visible in the sidebar only when you goto settings, activate a new coin but not "Activate" yet.

## Related Issue

Resolve #19414

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/inappropriate-rediscover-prompt&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/inappropriate-rediscover-prompt&lookback=7)