### PR TITLE
feat(suite): implement trade feedback form

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/guidePanel.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/guidePanel.ts
@@ -1,6 +1,6 @@
 import { Locator, Page, expect } from '@playwright/test';
 
-import { FeedbackCategory } from '@suite-common/suite-types';
+import { FeedbackCategory } from '@suite-common/feedback';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import { step } from '../common';

--- a/packages/suite-desktop-core/e2e/tests/suite/bug-report-form.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/bug-report-form.test.ts
@@ -1,4 +1,4 @@
-import { FeedbackCategory } from '@suite-common/suite-types';
+import { FeedbackCategory } from '@suite-common/feedback';
 
 import { TestCategory, TestPriority } from '../../support/enums/testAnnotations';
 import { expect, test } from '../../support/fixtures';

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -33,6 +33,7 @@
         "@suite-common/connect-init": "workspace:*",
         "@suite-common/connect-popup": "workspace:*",
         "@suite-common/device-authenticity": "workspace:*",
+        "@suite-common/feedback": "workspace:*",
         "@suite-common/fiat-services": "workspace:*",
         "@suite-common/firmware": "workspace:*",
         "@suite-common/formatters": "workspace:*",

--- a/packages/suite/src/actions/suite/guideActions.ts
+++ b/packages/suite/src/actions/suite/guideActions.ts
@@ -1,12 +1,4 @@
-import type {
-    ActiveView,
-    Feedback,
-    FeedbackType,
-    GuideCategory,
-    GuideNode,
-} from '@suite-common/suite-types';
-import { notificationsActions } from '@suite-common/toast-notifications';
-import { isCodesignBuild } from '@trezor/env-utils';
+import type { ActiveView, GuideCategory, GuideNode } from '@suite-common/suite-types';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { Dispatch } from 'src/types/suite';
@@ -59,30 +51,3 @@ export const openNode = (payload: GuideNode) => (dispatch: Dispatch) => {
         payload,
     });
 };
-
-const getUrl = (feedbackType: FeedbackType) => {
-    const typeUri = feedbackType === 'BUG' ? 'bugs' : 'feedback';
-    const base = `https://data.trezor.io/suite/${typeUri}`;
-
-    if (isCodesignBuild()) {
-        return `${base}/stable.log`;
-    }
-
-    return `${base}/develop.log`;
-};
-
-export const sendFeedback =
-    ({ type, payload }: Feedback) =>
-    async (dispatch: Dispatch) => {
-        const url = getUrl(type);
-        const params = new URLSearchParams({ ...payload });
-        try {
-            await fetch(`${url}?${params.toString()}`, {
-                method: 'GET',
-            });
-            dispatch(notificationsActions.addToast({ type: 'user-feedback-send-success' }));
-        } catch (err) {
-            dispatch(notificationsActions.addToast({ type: 'user-feedback-send-error' }));
-            console.error('failed to send user feedback', err);
-        }
-    };

--- a/packages/suite/src/components/guide/Feedback.tsx
+++ b/packages/suite/src/components/guide/Feedback.tsx
@@ -1,26 +1,24 @@
 import { ChangeEvent, ReactNode, useCallback, useState } from 'react';
 
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
-import { FeedbackCategory, FeedbackType, Rating, UserData } from '@suite-common/suite-types';
-import { Button, CollapsibleBox, Select, Textarea, variables } from '@trezor/components';
-import { getFirmwareVersion } from '@trezor/device-utils';
 import {
-    getCommitHash,
-    getEnvironment,
-    getOsName,
-    getSuiteVersion,
-    getUserAgent,
-    getWindowHeight,
-    getWindowWidth,
-} from '@trezor/env-utils';
+    FeedbackCategory,
+    FeedbackType,
+    Rating,
+    buildUserFeedbackData,
+    sendFeedback,
+} from '@suite-common/feedback';
+import { Button, CollapsibleBox, Select, Textarea, variables } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacingsPx } from '@trezor/theme';
 
-import { sendFeedback, setView } from 'src/actions/suite/guideActions';
+import { setView } from 'src/actions/suite/guideActions';
 import { GuideContent, GuideHeader, GuideViewWrapper } from 'src/components/guide';
 import { Translation } from 'src/components/suite';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
+
+import { EmojiRatingSelector } from '../suite/EmojiRatingSelector';
 
 const Headline = styled.div`
     font-size: ${variables.FONT_SIZE.TINY};
@@ -41,37 +39,6 @@ const SelectWrapper = styled.div`
     padding: 0 0 20px;
 `;
 
-const RatingWrapper = styled.div`
-    display: flex;
-    justify-content: space-between;
-    padding: 0 0 20px;
-`;
-
-const RatingItem = styled.button<{ $selected?: boolean }>`
-    width: 48px;
-    height: 47px;
-    padding-top: 1px;
-    border-radius: 50%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    border: 1px solid ${({ theme }) => theme.legacy.STROKE_GREY};
-    cursor: pointer;
-    font-size: 30px;
-    background-color: inherit;
-
-    ${({ $selected, theme }) =>
-        $selected &&
-        css`
-            background: ${theme.legacy.BG_GREEN};
-            border: 1px solid ${theme.legacy.BG_GREEN};
-
-            &:hover {
-                background: ${theme.legacy.BG_GREEN};
-            }
-        `};
-`;
-
 const AnonymousDataList = styled.ul`
     margin-left: 20px;
 `;
@@ -88,34 +55,7 @@ const StyledTextarea = styled(Textarea)`
     margin-bottom: ${spacingsPx.md};
 `;
 
-type RatingItem = {
-    id: Rating;
-    value: ReactNode;
-};
-
 const MESSAGE_CHARACTER_LIMIT = 1000;
-const ratingOptions: RatingItem[] = [
-    {
-        id: '1',
-        value: <>&#128545;</>,
-    },
-    {
-        id: '2',
-        value: <>&#128533;</>,
-    },
-    {
-        id: '3',
-        value: <>&#128529;</>,
-    },
-    {
-        id: '4',
-        value: <>&#128522;</>,
-    },
-    {
-        id: '5',
-        value: <>&#128525;</>,
-    },
-];
 
 /** A format compatible with React Select component. */
 type FeedbackCategoryOption = {
@@ -132,7 +72,7 @@ export const Feedback = ({ type }: FeedbackProps) => {
     const dispatch = useDispatch();
     const router = useSelector(state => state.router);
     const [description, setDescription] = useState('');
-    const [rating, setRating] = useState<RatingItem>();
+    const [rating, setRating] = useState<Rating | undefined>();
 
     const feedbackCategories: { [key in FeedbackCategory]: ReactNode } = {
         dashboard: <Translation id="TR_FEEDBACK_CATEGORY_DASHBOARD" />,
@@ -179,18 +119,8 @@ export const Feedback = ({ type }: FeedbackProps) => {
 
     const goBack = () => dispatch(setView('SUPPORT_FEEDBACK_SELECTION'));
     const onSubmit = useCallback(() => {
-        const userData: UserData = {
-            platform: getEnvironment(),
-            os: getOsName(),
-            user_agent: getUserAgent(),
-            suite_version: getSuiteVersion(),
-            suite_revision: getCommitHash(),
-            window_dimensions: `${getWindowWidth()}x${getWindowHeight()}`,
-            device_model: device?.features?.internal_model,
-            firmware_version: device?.features ? getFirmwareVersion(device) : '',
-            firmware_revision: device?.features?.revision || '',
-            firmware_type: device?.firmwareType || '',
-        };
+        const userData = buildUserFeedbackData(device);
+
         if (type === 'BUG') {
             dispatch(
                 sendFeedback({
@@ -210,7 +140,7 @@ export const Feedback = ({ type }: FeedbackProps) => {
                     type: 'SUGGESTION',
                     payload: {
                         description,
-                        rating: rating?.id,
+                        rating,
                         ...userData,
                     },
                 }),
@@ -221,7 +151,7 @@ export const Feedback = ({ type }: FeedbackProps) => {
             type: EventType.GuideFeedbackSubmit,
             payload: { type: type === 'BUG' ? 'bug' : 'suggestion' },
         });
-    }, [device, dispatch, type, description, category, rating?.id]);
+    }, [device, dispatch, type, description, category, rating]);
 
     return (
         <GuideViewWrapper>
@@ -264,18 +194,11 @@ export const Feedback = ({ type }: FeedbackProps) => {
                         <Headline>
                             <Translation id="TR_GUIDE_FEEDBACK_RATING_HEADLINE" />
                         </Headline>
-                        <RatingWrapper>
-                            {ratingOptions.map(item => (
-                                <RatingItem
-                                    key={item.id}
-                                    $selected={rating?.id === item.id}
-                                    onClick={() => setRating(item)}
-                                    data-testid={`@guide/feedback/suggestion/${item.id}`}
-                                >
-                                    {item.value}
-                                </RatingItem>
-                            ))}
-                        </RatingWrapper>
+                        <EmojiRatingSelector
+                            value={rating}
+                            onChange={setRating}
+                            data-testid="@guide/feedback/suggestion"
+                        />
                     </>
                 )}
                 {type === 'BUG' && (

--- a/packages/suite/src/components/suite/EmojiRatingSelector.tsx
+++ b/packages/suite/src/components/suite/EmojiRatingSelector.tsx
@@ -1,0 +1,53 @@
+import styled from 'styled-components';
+
+import { Rating, ratingOptions } from '@suite-common/feedback';
+import { Row } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
+const Item = styled.button<{ $selected?: boolean }>`
+    width: 48px;
+    height: 47px;
+    border-radius: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    font-size: 30px;
+    padding: 1px 4px;
+    border: 1px solid
+        ${({ $selected, theme }) => ($selected ? theme.legacy.BG_GREEN : theme.legacy.STROKE_GREY)};
+
+    background: ${({ $selected, theme }) =>
+        $selected ? theme.legacy.BG_GREEN : theme.legacy.BG_GREY};
+
+    &:hover {
+        background: ${({ $selected, theme }) =>
+            $selected ? theme.legacy.BG_GREEN : theme.legacy.BG_GREY};
+    }
+`;
+
+export interface EmojiRatingSelectorProps {
+    value: Rating | undefined;
+    onChange: (rating: Rating) => void;
+    'data-testid'?: string;
+}
+
+export const EmojiRatingSelector = ({
+    value,
+    onChange,
+    'data-testid': dataTestId,
+}: EmojiRatingSelectorProps) => (
+    <Row gap={spacings.xs} data-testid={dataTestId}>
+        {ratingOptions.map(({ id, emoji }) => (
+            <Item
+                key={id}
+                $selected={value === id}
+                data-testid={`${dataTestId}/${id}`}
+                onClick={() => onChange(id)}
+                type="button"
+            >
+                {emoji}
+            </Item>
+        ))}
+    </Row>
+);

--- a/packages/suite/src/components/suite/Experiment/ExperimentWrapper.tsx
+++ b/packages/suite/src/components/suite/Experiment/ExperimentWrapper.tsx
@@ -1,9 +1,9 @@
 import { ReactElement } from 'react';
 
-import { ExperimentId, useExperiment } from '@suite-common/message-system';
+import { ExperimentKey, useExperiment } from '@suite-common/message-system';
 
 interface ExperimentWrapperProps {
-    id: ExperimentId;
+    id: ExperimentKey;
     components: Array<{
         variant: string;
         element: ReactElement;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -10529,4 +10529,25 @@ export default defineMessages({
         id: 'TR_SIMULATION_NO_ASSETS',
         defaultMessage: 'No asset changes detected',
     },
+    TR_EXCHANGE_DETAIL_FEEDBACK_TITLE: {
+        id: 'TR_EXCHANGE_DETAIL_FEEDBACK_TITLE',
+        defaultMessage: 'How was your trading experience with Trezor Suite?',
+    },
+    TR_EXCHANGE_DETAIL_FEEDBACK_DESCRIPTION: {
+        id: 'TR_EXCHANGE_DETAIL_FEEDBACK_DESCRIPTION',
+        defaultMessage:
+            'Can you tell us more about your experience? Any details help make it better.',
+    },
+    TR_EXCHANGE_DETAIL_FEEDBACK_INPUT_BUTTON: {
+        id: 'TR_EXCHANGE_DETAIL_FEEDBACK_INPUT_BUTTON',
+        defaultMessage: 'Send feedback',
+    },
+    TR_EXCHANGE_DETAIL_FEEDBACK_SUCCESS_TITLE: {
+        id: 'TR_EXCHANGE_DETAIL_FEEDBACK_SUCCESS_TITLE',
+        defaultMessage: 'Thanks!',
+    },
+    TR_EXCHANGE_DETAIL_FEEDBACK_SUCCESS_DESCRIPTION: {
+        id: 'TR_EXCHANGE_DETAIL_FEEDBACK_SUCCESS_DESCRIPTION',
+        defaultMessage: 'We value your feedback.',
+    },
 } as const);

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuy.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuy.tsx
@@ -6,8 +6,9 @@ import styled from 'styled-components';
 
 import type { TradingBuyType } from '@suite-common/trading';
 import { selectAccounts } from '@suite-common/wallet-core';
-import { Card } from '@trezor/components';
+import { Card, Column } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
+import { spacings } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -17,6 +18,7 @@ import { TradingDetailBuyPaymentFailed } from 'src/views/wallet/trading/common/T
 import { TradingDetailBuyPaymentProcessing } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuyPaymentProcessing';
 import { TradingDetailBuyPaymentPaymentSuccessful } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuyPaymentSuccessful';
 import { TradingDetailBuyPaymentWaitingForUser } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuyPaymentWaitingForUser';
+import { TradingDetailFeedback } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback';
 import { TradingSelectedOfferInfo } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo';
 import { TradingWrapper } from 'src/views/wallet/trading/common/TradingWrapper';
 
@@ -100,22 +102,31 @@ export const TradingDetailBuy = () => {
 
     return (
         <Wrapper data-testid="@trading/transaction/detail">
-            <Card data-testid="@trading/transaction/detail/status-card">
-                {tradeStatusStep === 'error' && (
-                    <TradingDetailBuyPaymentFailed account={account} supportUrl={supportUrl} />
-                )}
-                {tradeStatusStep === 'processing' && <TradingDetailBuyPaymentProcessing />}
-                {tradeStatusStep === 'waiting' && (
-                    <TradingDetailBuyPaymentWaitingForUser
-                        trade={trade.data}
-                        account={account}
-                        providerName={provider?.brandName || provider?.companyName}
-                    />
-                )}
-                {tradeStatusStep === 'success' && (
-                    <TradingDetailBuyPaymentPaymentSuccessful account={account} />
-                )}
-            </Card>
+            <Column gap={spacings.lg}>
+                <Card data-testid="@trading/transaction/detail/status-card">
+                    {tradeStatusStep === 'error' && (
+                        <TradingDetailBuyPaymentFailed account={account} supportUrl={supportUrl} />
+                    )}
+                    {tradeStatusStep === 'processing' && <TradingDetailBuyPaymentProcessing />}
+                    {tradeStatusStep === 'waiting' && (
+                        <TradingDetailBuyPaymentWaitingForUser
+                            trade={trade.data}
+                            account={account}
+                            providerName={provider?.brandName || provider?.companyName}
+                        />
+                    )}
+                    {tradeStatusStep === 'success' && (
+                        <TradingDetailBuyPaymentPaymentSuccessful account={account} />
+                    )}
+                </Card>
+                <TradingDetailFeedback
+                    status={tradeStatus}
+                    type={trade.tradeType}
+                    provider={provider?.name}
+                    id={trade.data.id}
+                    quoteAmounts={quoteAmounts}
+                />
+            </Column>
             <Card>
                 <TradingSelectedOfferInfo
                     account={account}

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
@@ -7,8 +7,9 @@ import styled from 'styled-components';
 import { type TradingExchangeType, cryptoIdToNetwork } from '@suite-common/trading';
 import { getExplorerUrl } from '@suite-common/wallet-config';
 import { selectAccounts, selectExplorer } from '@suite-common/wallet-core';
-import { Card, InfoItem } from '@trezor/components';
+import { Card, Column, InfoItem } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
+import { spacings } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite';
@@ -22,6 +23,7 @@ import { TradingDetailExchangePaymentFailed } from 'src/views/wallet/trading/com
 import { TradingDetailExchangePaymentKYC } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentKYC';
 import { TradingDetailExchangePaymentSending } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentSending';
 import { TradingDetailExchangePaymentSuccessful } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentSuccessful';
+import { TradingDetailFeedback } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback';
 import { TradingSelectedOfferInfo } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo';
 import { TradingWrapper } from 'src/views/wallet/trading/common/TradingWrapper';
 
@@ -111,41 +113,49 @@ export const TradingDetailExchange = () => {
 
     return (
         <Wrapper>
-            <Card>
-                {trade.data.receiveTxHash && (
-                    <InfoItem label={<Translation id="TR_TXID" />}>
-                        <TxAddress
-                            txAddress={trade.data.receiveTxHash}
-                            explorerUrl={getExplorerUrl(explorer, 'tx')}
-                            explorerUrlQueryString={explorer?.queryString}
+            <Column gap={spacings.lg}>
+                <Card>
+                    {trade.data.receiveTxHash && (
+                        <InfoItem label={<Translation id="TR_TXID" />}>
+                            <TxAddress
+                                txAddress={trade.data.receiveTxHash}
+                                explorerUrl={getExplorerUrl(explorer, 'tx')}
+                                explorerUrlQueryString={explorer?.queryString}
+                            />
+                        </InfoItem>
+                    )}
+                    {tradeStatusStep === 'success' && (
+                        <TradingDetailExchangePaymentSuccessful account={account} />
+                    )}
+                    {tradeStatusStep === 'kyc' && (
+                        <TradingDetailExchangePaymentKYC
+                            account={account}
+                            provider={provider}
+                            supportUrl={supportUrl}
                         />
-                    </InfoItem>
-                )}
-
-                {tradeStatusStep === 'success' && (
-                    <TradingDetailExchangePaymentSuccessful account={account} />
-                )}
-                {tradeStatusStep === 'kyc' && (
-                    <TradingDetailExchangePaymentKYC
-                        account={account}
-                        provider={provider}
-                        supportUrl={supportUrl}
-                    />
-                )}
-                {tradeStatusStep === 'error' && (
-                    <TradingDetailExchangePaymentFailed
-                        account={account}
-                        transactionId={trade.key}
-                        supportUrl={supportUrl}
-                    />
-                )}
-                {tradeStatusStep === 'converting' && (
-                    <TradingDetailExchangePaymentConverting supportUrl={supportUrl} />
-                )}
-                {tradeStatusStep === 'sending' && (
-                    <TradingDetailExchangePaymentSending supportUrl={supportUrl} />
-                )}
-            </Card>
+                    )}
+                    {tradeStatusStep === 'error' && (
+                        <TradingDetailExchangePaymentFailed
+                            account={account}
+                            transactionId={trade.key}
+                            supportUrl={supportUrl}
+                        />
+                    )}
+                    {tradeStatusStep === 'converting' && (
+                        <TradingDetailExchangePaymentConverting supportUrl={supportUrl} />
+                    )}
+                    {tradeStatusStep === 'sending' && (
+                        <TradingDetailExchangePaymentSending supportUrl={supportUrl} />
+                    )}
+                </Card>
+                <TradingDetailFeedback
+                    status={tradeStatus}
+                    type={trade.tradeType}
+                    provider={provider?.name}
+                    id={trade.data.id}
+                    quoteAmounts={quoteAmounts}
+                />
+            </Column>
             <Card>
                 <TradingSelectedOfferInfo
                     account={sendAccount}

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+
+import {
+    BuyTradeStatus,
+    ExchangeProviderInfo,
+    ExchangeTradeStatus,
+    SellTradeStatus,
+} from 'invity-api';
+
+import { Rating, buildUserFeedbackData, sendFeedback } from '@suite-common/feedback';
+import { TradingType } from '@suite-common/trading';
+import { Button, Card, Column, IconCircle, Row, Text, Textarea } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
+import { Translation } from 'src/components/suite';
+import { EmojiRatingSelector } from 'src/components/suite/EmojiRatingSelector';
+import { ExperimentWrapper } from 'src/components/suite/Experiment/ExperimentWrapper';
+import { useDevice, useDispatch } from 'src/hooks/suite';
+import { TradingGetCryptoQuoteAmountProps } from 'src/types/trading/trading';
+
+interface TradingDetailFeedbackProps {
+    status: ExchangeTradeStatus | SellTradeStatus | BuyTradeStatus | undefined;
+    type: TradingType;
+    provider?: ExchangeProviderInfo['name'];
+    id?: string;
+    quoteAmounts: TradingGetCryptoQuoteAmountProps;
+}
+
+export const TradingDetailFeedback = ({
+    status,
+    type,
+    provider,
+    id,
+    quoteAmounts: { sendCurrency, receiveCurrency },
+}: TradingDetailFeedbackProps) => {
+    const [rating, setRating] = useState<Rating | undefined>();
+    const [description, setDescription] = useState<string>('');
+    const [view, setView] = useState<'form' | 'success'>('form');
+
+    const { device } = useDevice();
+    const dispatch = useDispatch();
+
+    const submitFeedback = () => {
+        if (!rating) return;
+
+        const userData = buildUserFeedbackData(device);
+
+        dispatch(
+            sendFeedback({
+                type: 'SUGGESTION',
+                payload: {
+                    category: 'trade',
+                    description,
+                    rating,
+                    status,
+                    provider,
+                    id,
+                    type,
+                    sendCurrency,
+                    receiveCurrency,
+                    ...userData,
+                },
+            }),
+        );
+
+        setView('success');
+        setRating(undefined);
+        setDescription('');
+    };
+
+    const isFormValid = rating !== undefined && description.trim().length > 0;
+
+    const Success = (
+        <Row gap={spacings.lg} margin={{ vertical: spacings.xs }}>
+            <IconCircle name="check" size={64} />
+            <Column gap={spacings.xs}>
+                <Text typographyStyle="titleSmall">
+                    <Translation id="TR_EXCHANGE_DETAIL_FEEDBACK_SUCCESS_TITLE" />
+                </Text>
+                <Text typographyStyle="hint">
+                    <Translation id="TR_EXCHANGE_DETAIL_FEEDBACK_SUCCESS_DESCRIPTION" />
+                </Text>
+            </Column>
+        </Row>
+    );
+
+    const Form = (
+        <>
+            <Text typographyStyle="titleSmall">
+                <Translation id="TR_EXCHANGE_DETAIL_FEEDBACK_TITLE" />
+            </Text>
+
+            <EmojiRatingSelector value={rating} onChange={setRating} />
+
+            <Text typographyStyle="hint">
+                <Translation id="TR_EXCHANGE_DETAIL_FEEDBACK_DESCRIPTION" />
+            </Text>
+
+            <Textarea
+                rows={3}
+                value={description}
+                onChange={e => setDescription(e.target.value)}
+                characterCount
+                data-testid="@trading/feedback/textarea"
+                maxLength={1000}
+            />
+
+            <Button
+                isDisabled={!isFormValid}
+                variant="primary"
+                type="button"
+                size="small"
+                onClick={submitFeedback}
+            >
+                <Translation id="TR_EXCHANGE_DETAIL_FEEDBACK_INPUT_BUTTON" />
+            </Button>
+        </>
+    );
+
+    return (
+        <ExperimentWrapper
+            id="tradingFeedbackForm"
+            components={[
+                { variant: 'A', element: <></> },
+                {
+                    variant: 'B',
+                    element: (
+                        <Card>
+                            <Column
+                                gap={spacings.md}
+                                alignItems="start"
+                                margin={{ vertical: spacings.xs }}
+                            >
+                                {view === 'form' ? Form : Success}
+                            </Column>
+                        </Card>
+                    ),
+                },
+            ]}
+        />
+    );
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSell.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSell.tsx
@@ -6,14 +6,16 @@ import styled from 'styled-components';
 
 import type { TradingSellType } from '@suite-common/trading';
 import { selectAccounts } from '@suite-common/wallet-core';
-import { Card } from '@trezor/components';
+import { Card, Column } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
+import { spacings } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingDetailContext } from 'src/hooks/wallet/trading/useTradingDetail';
 import { tradeFinalStatuses } from 'src/hooks/wallet/trading/useTradingWatchTrade';
 import { TradingGetCryptoQuoteAmountProps } from 'src/types/trading/trading';
+import { TradingDetailFeedback } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback';
 import { TradingDetailSellPaymentFailed } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSellPaymentFailed';
 import { TradingDetailSellPaymentPending } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSellPaymentPending';
 import { TradingDetailSellPaymentSuccessful } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSellPaymentSuccessful';
@@ -93,21 +95,30 @@ export const TradingDetailSell = () => {
 
     return (
         <Wrapper>
-            <Card>
-                {tradeStatusStep === 'success' && (
-                    <TradingDetailSellPaymentSuccessful account={account} />
-                )}
-                {tradeStatusStep === 'error' && (
-                    <TradingDetailSellPaymentFailed
-                        account={account}
-                        transactionId={trade.key}
-                        supportUrl={supportUrl}
-                    />
-                )}
-                {tradeStatusStep === 'pending' && (
-                    <TradingDetailSellPaymentPending supportUrl={supportUrl} />
-                )}
-            </Card>
+            <Column gap={spacings.lg}>
+                <Card>
+                    {tradeStatusStep === 'success' && (
+                        <TradingDetailSellPaymentSuccessful account={account} />
+                    )}
+                    {tradeStatusStep === 'error' && (
+                        <TradingDetailSellPaymentFailed
+                            account={account}
+                            transactionId={trade.key}
+                            supportUrl={supportUrl}
+                        />
+                    )}
+                    {tradeStatusStep === 'pending' && (
+                        <TradingDetailSellPaymentPending supportUrl={supportUrl} />
+                    )}
+                </Card>
+                <TradingDetailFeedback
+                    status={tradeStatus}
+                    type={trade.tradeType}
+                    provider={provider?.name}
+                    id={trade.data.id}
+                    quoteAmounts={quoteAmounts}
+                />
+            </Column>
             <Card>
                 <TradingSelectedOfferInfo
                     account={account}

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -28,6 +28,7 @@
         {
             "path": "../../suite-common/device-authenticity"
         },
+        { "path": "../../suite-common/feedback" },
         {
             "path": "../../suite-common/fiat-services"
         },

--- a/suite-common/feedback/jest.config.js
+++ b/suite-common/feedback/jest.config.js
@@ -1,0 +1,11 @@
+/**
+ * Jest configuration for web packages.
+ * Keeping this file next to the package.json file instead of providing configuration
+ * with `-c ../../jest.config.base` option in package.json scripts
+ * allows us to run jest tests directly from IDEs.
+ */
+const { ...baseConfig } = require('../../jest.config.base');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-common/feedback/package.json
+++ b/suite-common/feedback/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "@suite-common/feedback",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "yarn g:jest",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@suite-common/redux-utils": "workspace:*",
+        "@suite-common/suite-types": "workspace:*",
+        "@trezor/device-utils": "workspace:*",
+        "@trezor/env-utils": "workspace:*"
+    }
+}

--- a/suite-common/feedback/src/constants.ts
+++ b/suite-common/feedback/src/constants.ts
@@ -1,0 +1,26 @@
+import { FeedbackEmoji, RatingItem } from './types';
+
+export const FEEDBACK_ENDPOINT = 'https://data.trezor.io/suite';
+
+export const ratingOptions: RatingItem[] = [
+    {
+        id: '1',
+        emoji: FeedbackEmoji.ANGRY,
+    },
+    {
+        id: '2',
+        emoji: FeedbackEmoji.SAD,
+    },
+    {
+        id: '3',
+        emoji: FeedbackEmoji.NEUTRAL,
+    },
+    {
+        id: '4',
+        emoji: FeedbackEmoji.HAPPY,
+    },
+    {
+        id: '5',
+        emoji: FeedbackEmoji.LOVE,
+    },
+];

--- a/suite-common/feedback/src/feedbackActions.ts
+++ b/suite-common/feedback/src/feedbackActions.ts
@@ -1,0 +1,31 @@
+import { createThunk } from '@suite-common/redux-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
+
+import { getFeedbackUrl } from './feedbackUtils';
+import { Feedback } from './types';
+
+const FEEDBACK_MODULE_PREFIX = '@suite/feedback';
+
+export const sendFeedback = createThunk<void, Feedback>(
+    `${FEEDBACK_MODULE_PREFIX}/sendFeedback`,
+    async ({ type, payload }, { dispatch, rejectWithValue }) => {
+        const url = getFeedbackUrl(type);
+        const params = new URLSearchParams(
+            Object.entries(payload)
+                .filter(([, v]) => v != null)
+                .map(([k, v]) => [k, String(v)]),
+        );
+
+        try {
+            await fetch(`${url}?${params.toString()}`, {
+                method: 'GET',
+            });
+            dispatch(notificationsActions.addToast({ type: 'user-feedback-send-success' }));
+        } catch (err) {
+            dispatch(notificationsActions.addToast({ type: 'user-feedback-send-error' }));
+            console.error('failed to send user feedback', err);
+
+            return rejectWithValue('Failed to send feedback');
+        }
+    },
+);

--- a/suite-common/feedback/src/feedbackUtils.ts
+++ b/suite-common/feedback/src/feedbackUtils.ts
@@ -1,0 +1,39 @@
+import { TrezorDevice } from '@suite-common/suite-types';
+import { getFirmwareVersion } from '@trezor/device-utils';
+import {
+    getCommitHash,
+    getEnvironment,
+    getOsName,
+    getSuiteVersion,
+    getUserAgent,
+    getWindowHeight,
+    getWindowWidth,
+    isCodesignBuild,
+} from '@trezor/env-utils';
+
+import { FEEDBACK_ENDPOINT } from './constants';
+import { FeedbackType, UserData } from './types';
+
+export const buildUserFeedbackData = (device?: TrezorDevice): UserData => ({
+    platform: getEnvironment(),
+    os: getOsName(),
+    user_agent: getUserAgent(),
+    suite_version: getSuiteVersion(),
+    suite_revision: getCommitHash(),
+    window_dimensions: `${getWindowWidth()}x${getWindowHeight()}`,
+    device_model: device?.features?.internal_model,
+    firmware_version: device?.features ? getFirmwareVersion(device) : '',
+    firmware_revision: device?.features?.revision || '',
+    firmware_type: device?.firmwareType || '',
+});
+
+export const getFeedbackUrl = (type: FeedbackType) => {
+    const typeUri = type === 'BUG' ? 'bugs' : 'feedback';
+    const base = `${FEEDBACK_ENDPOINT}/${typeUri}`;
+
+    if (isCodesignBuild()) {
+        return `${base}/stable.log`;
+    }
+
+    return `${base}/develop.log`;
+};

--- a/suite-common/feedback/src/index.ts
+++ b/suite-common/feedback/src/index.ts
@@ -1,0 +1,4 @@
+export * from './feedbackActions';
+export * from './feedbackUtils';
+export * from './types';
+export * from './constants';

--- a/suite-common/feedback/src/types.ts
+++ b/suite-common/feedback/src/types.ts
@@ -1,0 +1,70 @@
+import { DeviceModelInternal } from '@trezor/device-utils';
+import { Environment } from '@trezor/env-utils';
+
+import { ratingOptions } from './constants';
+
+type RatingId = (typeof ratingOptions)[number]['id'];
+type RatingEmoji = (typeof ratingOptions)[number]['emoji'];
+
+export type RatingOption = {
+    id: RatingId;
+    emoji: RatingEmoji;
+};
+
+export type FeedbackType = 'BUG' | 'SUGGESTION';
+
+export type FeedbackCategory =
+    | 'dashboard'
+    | 'account'
+    | 'settings'
+    | 'send'
+    | 'receive'
+    | 'trade'
+    | 'other';
+
+export enum FeedbackEmoji {
+    ANGRY = '😡',
+    SAD = '😞',
+    NEUTRAL = '😐',
+    HAPPY = '🙂',
+    LOVE = '😍',
+}
+
+export type RatingItem = {
+    id: Rating;
+    emoji: FeedbackEmoji;
+};
+
+export type Rating = '1' | '2' | '3' | '4' | '5'; // 1 = worst, 5 = best. Portrayed as Emojis in the UI to minimize the comprehension barrier
+
+export interface UserData {
+    platform: Environment;
+    os: string;
+    user_agent: string;
+    suite_version: string;
+    suite_revision: string;
+    window_dimensions: string;
+    device_model?: DeviceModelInternal;
+    firmware_version: string;
+    firmware_revision: string;
+    firmware_type: string;
+}
+
+type FeedbackExtras = Record<string, string | number | boolean | undefined>;
+
+interface BasePayload extends UserData, FeedbackExtras {
+    description: string;
+}
+
+export interface BugPayload extends BasePayload {
+    category: FeedbackCategory;
+}
+
+export interface SuggestionPayload extends BasePayload {
+    rating?: Rating;
+    category?: FeedbackCategory;
+}
+
+export type Feedback =
+    | { type: 'BUG'; payload: BugPayload }
+    | { type: 'SUGGESTION'; payload: SuggestionPayload };

--- a/suite-common/feedback/tests/feedbackUtils.test.ts
+++ b/suite-common/feedback/tests/feedbackUtils.test.ts
@@ -1,0 +1,61 @@
+import { testMocks } from '@suite-common/test-utils';
+import { getFirmwareVersion } from '@trezor/device-utils';
+import * as helpers from '@trezor/env-utils';
+
+import { FeedbackType, buildUserFeedbackData, getFeedbackUrl } from '../src';
+import { FEEDBACK_ENDPOINT } from '../src/constants';
+
+describe('getFeedbackUrl', () => {
+    it.each([
+        ['BUG', true, `${FEEDBACK_ENDPOINT}/bugs/stable.log`],
+        ['BUG', false, `${FEEDBACK_ENDPOINT}/bugs/develop.log`],
+        ['SUGGESTION', true, `${FEEDBACK_ENDPOINT}/feedback/stable.log`],
+        ['SUGGESTION', false, `${FEEDBACK_ENDPOINT}/feedback/develop.log`],
+    ] as Array<[FeedbackType, boolean, string]>)(
+        '(%s, codesign=%s) → %s',
+        (type, isCodesignBuild, expected) => {
+            jest.spyOn(helpers, 'isCodesignBuild').mockReturnValue(isCodesignBuild);
+            expect(getFeedbackUrl(type)).toBe(expected);
+        },
+    );
+});
+
+describe('buildUserFeedbackData', () => {
+    beforeEach(() => {
+        jest.spyOn(helpers, 'getEnvironment').mockReturnValue('desktop');
+        jest.spyOn(helpers, 'getOsName').mockReturnValue('linux');
+        jest.spyOn(helpers, 'getUserAgent').mockReturnValue('user-agent');
+        jest.spyOn(helpers, 'getSuiteVersion').mockReturnValue('25.7.0');
+        jest.spyOn(helpers, 'getCommitHash').mockReturnValue('commit-hash');
+        jest.spyOn(helpers, 'getWindowWidth').mockReturnValue(1920);
+        jest.spyOn(helpers, 'getWindowHeight').mockReturnValue(1080);
+    });
+
+    it('returns full payload when device is connected', () => {
+        const device = testMocks.getSuiteDevice();
+
+        const data = buildUserFeedbackData(device);
+
+        expect(data).toEqual({
+            platform: 'desktop',
+            os: 'linux',
+            user_agent: 'user-agent',
+            suite_version: '25.7.0',
+            suite_revision: 'commit-hash',
+            window_dimensions: '1920x1080',
+            device_model: device?.features?.internal_model,
+            firmware_version: device?.features ? getFirmwareVersion(device) : '',
+            firmware_revision: device?.features?.revision || '',
+            firmware_type: device?.firmwareType || '',
+        });
+    });
+
+    it('omits device info when no device is connected', () => {
+        const data = buildUserFeedbackData(undefined);
+
+        expect(data.device_model).toBeUndefined();
+        expect(data.firmware_version).toBe('');
+        expect(data.firmware_revision).toBe('');
+        expect(data.firmware_type).toBe('');
+    });
+});

--- a/suite-common/feedback/tsconfig.json
+++ b/suite-common/feedback/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        { "path": "../redux-utils" },
+        { "path": "../suite-types" },
+        { "path": "../../packages/device-utils" },
+        { "path": "../../packages/env-utils" }
+    ]
+}

--- a/suite-common/message-system/src/messageSystemSelectors.ts
+++ b/suite-common/message-system/src/messageSystemSelectors.ts
@@ -4,6 +4,8 @@ import { Category, Message } from '@suite-common/suite-types';
 
 import {
     ContextDomain,
+    Experiment,
+    ExperimentKey,
     ExperimentsItemType,
     FeatureDomain,
     MessageSystemRootState,
@@ -175,5 +177,12 @@ export const selectExperimentById = (id: ExperimentId) =>
     createMemoizedSelector([selectAllValidExperiments], allValidExperiments =>
         allValidExperiments.find(
             (experiment): experiment is ExperimentsItemType => experiment.id === id,
+        ),
+    );
+
+export const selectExperimentByKey = (key: ExperimentKey) =>
+    createMemoizedSelector([selectAllValidExperiments], allValidExperiments =>
+        allValidExperiments.find(
+            (experiment): experiment is ExperimentsItemType => experiment.id === Experiment[key],
         ),
     );

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -124,9 +124,10 @@ type FunctionContextReturnValues = {
 export type ContextDomain = FunctionContextReturnValues;
 
 export const Experiment = {
-    // e.g. orangeSendButton: 'fb0eb1bc-8ec3-44d4-98eb-53301d73d981',
+    tradingFeedbackForm: '092db279-98dc-418e-bbfa-ef70716fb211',
 } as const;
 
-export type ExperimentId = (typeof Experiment)[keyof typeof Experiment];
+export type ExperimentKey = keyof typeof Experiment;
+export type ExperimentId = (typeof Experiment)[ExperimentKey];
 
 export type ExperimentsItemType = Omit<ExperimentsItem, 'id'> & { id: ExperimentId };

--- a/suite-common/message-system/src/useExperiment.ts
+++ b/suite-common/message-system/src/useExperiment.ts
@@ -4,12 +4,12 @@ import { useSelector } from 'react-redux';
 import { selectAnalyticsInstanceId } from '@suite-common/analytics';
 
 import { selectActiveExperimentGroup } from './experimentUtils';
-import { selectExperimentById } from './messageSystemSelectors';
-import { ExperimentId } from './messageSystemTypes';
+import { selectExperimentByKey } from './messageSystemSelectors';
+import { ExperimentKey } from './messageSystemTypes';
 
-export const useExperiment = (experimentId: ExperimentId) => {
+export const useExperiment = (experimentKey: ExperimentKey) => {
     const instanceId = useSelector(selectAnalyticsInstanceId);
-    const experiment = useSelector(selectExperimentById(experimentId));
+    const experiment = useSelector(selectExperimentByKey(experimentKey));
     const activeExperimentVariant = useMemo(
         () => selectActiveExperimentGroup({ instanceId, experiment }),
         [instanceId, experiment],

--- a/suite-common/suite-types/package.json
+++ b/suite-common/suite-types/package.json
@@ -15,7 +15,6 @@
         "@suite-common/suite-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/connect": "workspace:*",
-        "@trezor/env-utils": "workspace:*",
         "@trezor/protocol": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*"

--- a/suite-common/suite-types/src/guide.ts
+++ b/suite-common/suite-types/src/guide.ts
@@ -1,6 +1,3 @@
-import { DeviceModelInternal } from '@trezor/device-utils';
-import { Environment } from '@trezor/env-utils';
-
 /**
  * A group of Guide content.
  * Can contain other Pages or Categories.
@@ -34,55 +31,6 @@ export interface GuideArticle {
 export type GuideNode = GuideCategory | GuideArticle;
 
 export type GuideView = 'GUIDE_DEFAULT' | 'GUIDE_CATEGORY' | 'GUIDE_ARTICLE';
-
 export type FeedbackView = 'SUPPORT_FEEDBACK_SELECTION' | 'FEEDBACK_BUG' | 'FEEDBACK_SUGGESTION';
 
 export type ActiveView = GuideView | FeedbackView;
-
-export type FeedbackCategory =
-    | 'dashboard'
-    | 'account'
-    | 'settings'
-    | 'send'
-    | 'receive'
-    | 'trade'
-    | 'other';
-
-export type Rating = '1' | '2' | '3' | '4' | '5'; // 1 = worst, 5 = best. Portrayed as Emojis in the UI to minimize the comprehension barrier
-
-export type FeedbackType = 'BUG' | 'SUGGESTION';
-
-export interface UserData {
-    platform: Environment;
-    os: string;
-    user_agent: string;
-    suite_version: string;
-    suite_revision: string;
-    window_dimensions: string;
-    device_model?: DeviceModelInternal;
-    firmware_version: string;
-    firmware_revision: string;
-    firmware_type: string;
-}
-
-export interface PayloadBug extends UserData {
-    description: string;
-    category: FeedbackCategory;
-}
-
-export interface PayloadSuggestion extends UserData {
-    description: string;
-    rating?: Rating;
-}
-
-export type FeedbackBug = {
-    type: 'BUG';
-    payload: PayloadBug;
-};
-
-export type FeedbackSuggestion = {
-    type: 'SUGGESTION';
-    payload: PayloadSuggestion;
-};
-
-export type Feedback = FeedbackBug | FeedbackSuggestion;

--- a/suite-common/suite-types/tsconfig.json
+++ b/suite-common/suite-types/tsconfig.json
@@ -6,7 +6,6 @@
         { "path": "../suite-config" },
         { "path": "../wallet-types" },
         { "path": "../../packages/connect" },
-        { "path": "../../packages/env-utils" },
         { "path": "../../packages/protocol" },
         { "path": "../../packages/type-utils" },
         { "path": "../../packages/utils" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9418,6 +9418,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite-common/feedback@workspace:*, @suite-common/feedback@workspace:suite-common/feedback":
+  version: 0.0.0-use.local
+  resolution: "@suite-common/feedback@workspace:suite-common/feedback"
+  dependencies:
+    "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/suite-types": "workspace:*"
+    "@trezor/device-utils": "workspace:*"
+    "@trezor/env-utils": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
 "@suite-common/fiat-services@workspace:*, @suite-common/fiat-services@workspace:suite-common/fiat-services":
   version: 0.0.0-use.local
   resolution: "@suite-common/fiat-services@workspace:suite-common/fiat-services"
@@ -9633,7 +9644,6 @@ __metadata:
     "@suite-common/suite-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/connect": "workspace:*"
-    "@trezor/env-utils": "workspace:*"
     "@trezor/protocol": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
@@ -12667,6 +12677,7 @@ __metadata:
     "@suite-common/connect-init": "workspace:*"
     "@suite-common/connect-popup": "workspace:*"
     "@suite-common/device-authenticity": "workspace:*"
+    "@suite-common/feedback": "workspace:*"
     "@suite-common/fiat-services": "workspace:*"
     "@suite-common/firmware": "workspace:*"
     "@suite-common/formatters": "workspace:*"


### PR DESCRIPTION
## Description

This PR implements the feedback form visible after the swap is submitted.

- Form is connected to the A/B testing infrastructure and is _**not shown**_ by default. In case you want to test it, you'll have to update `config.v1.json` in `message-system` package with this:
```json
    "experiments": [
        {
            "conditions": [
                {
                    "environment": {
                        "desktop": "*",
                        "mobile": "*",
                        "web": "*"
                    }
                }
            ],
            "experiment": {
                "id": "092db279-98dc-418e-bbfa-ef70716fb211",
                "groups": [
                    {
                        "variant": "A",
                        "percentage": 0
                    },
                    {
                        "variant": "B",
                        "percentage": 100
                    }
                ]
            }
        }
    ]

```
- Form follows the same API calls as feedback form in Guide section, it's just sending some extra parameters like `category` and `tradeStatus`

There is also one small change implemented. Instead of using experiment `id` with `ExperimentWrapper`, we're using its `key` defined in `message-system/messageSystemTypes.ts` in `Experiment` constant so we can use it in a more friendly way without knowing the ids.

So instead of:
```ts
<ExperimentWrapper
    id="092db279-98dc-418e-bbfa-ef70716fb211"
/>
```
we just do:
```ts
<ExperimentWrapper
    id="tradingFeedbackForm"
/>
```

@adderpositive please let me know if that's what you meant with this change 🙏 

---

Also, there's a new component introduced, `EmojiPickerSelector` with simple `value` and `onChange` props used by both forms (guide and trading section)
![image](https://github.com/user-attachments/assets/a3b1ccb1-3c38-44d7-9831-0344652285d0)


## Related Issue

Resolve #19290 

## Screenshots:


### Before

| Desktop | Mobile |
|--------|-------|
|![Screenshot 2025-06-30 at 10 13 12](https://github.com/user-attachments/assets/f17e470d-f52a-4ff4-9e08-f92f591490ed)|![Screenshot 2025-06-30 at 10 13 22](https://github.com/user-attachments/assets/7e0f5337-897f-47ed-b132-a28771324faa)|

### After

| Desktop | Mobile |
|--------|-------|
|![Screenshot 2025-06-30 at 10 06 10](https://github.com/user-attachments/assets/f26d05f5-2b15-4fac-9c2e-28ea8f17c61a)|![Screenshot 2025-06-30 at 10 06 22](https://github.com/user-attachments/assets/968f2e4f-a942-4850-82a3-6e467ad74796)|
|![Screenshot 2025-06-30 at 10 02 09](https://github.com/user-attachments/assets/b1bd839d-2679-4165-abbc-1fd94ec42f79)|![Screenshot 2025-06-30 at 10 02 53](https://github.com/user-attachments/assets/4b436467-2399-4871-813c-74c993dc40fe)|
|![Screenshot 2025-06-30 at 14 42 27](https://github.com/user-attachments/assets/9adb59b4-e134-4bf3-9a86-5ee192ca106d)|![Screenshot 2025-06-30 at 14 43 03](https://github.com/user-attachments/assets/805d5ec9-3d46-46c9-98b9-9dd34c18d4a6)|




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feature/trading-feedback-form&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feature/trading-feedback-form&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feature/trading-feedback-form&lookback=7)