### PR TITLE
fix: naming of findLabelsToBeMovedOrDeletedThunk

### DIFF
--- a/packages/suite/src/actions/wallet/moveLabelsForRbf/__tests__/moveLabelsForRbfThunk.test.ts
+++ b/packages/suite/src/actions/wallet/moveLabelsForRbf/__tests__/moveLabelsForRbfThunk.test.ts
@@ -18,7 +18,7 @@ import {
     originalTransactionSpendAccount,
     transactionSendingCoinsReplacement,
 } from '../__fixtures__/moveLabelsForRbfTransactions.fixture';
-import { findLabelsToBeMovedOrDeleted } from '../findLabelsToBeMovedOrDeletedThunk';
+import { findLabelsToBeMovedOrDeletedThunk } from '../findLabelsToBeMovedOrDeletedThunk';
 import { moveLabelsForRbfThunk } from '../moveLabelsForRbfThunk';
 
 const rootReducer = combineReducers({
@@ -68,7 +68,7 @@ describe(moveLabelsForRbfThunk.name, () => {
         });
 
         const toBeMovedOrDeletedList = store.dispatch(
-            findLabelsToBeMovedOrDeleted({
+            findLabelsToBeMovedOrDeletedThunk({
                 prevTxid: originalTransactionSpendAccount.txid,
             }),
         );

--- a/packages/suite/src/actions/wallet/moveLabelsForRbf/findLabelsToBeMovedOrDeletedThunk.ts
+++ b/packages/suite/src/actions/wallet/moveLabelsForRbf/findLabelsToBeMovedOrDeletedThunk.ts
@@ -4,12 +4,12 @@ import { findChainedTransactions, findTransactions } from '@suite-common/wallet-
 import { Dispatch, GetState } from '../../../types/suite';
 import { RbfLabelsToBeUpdated } from '../../../types/wallet/sendForm';
 
-type FindLabelsToBeMovedOrDeletedParams = {
+type FindLabelsToBeMovedOrDeletedThunkParams = {
     prevTxid: string;
 };
 
-export const findLabelsToBeMovedOrDeleted =
-    ({ prevTxid }: FindLabelsToBeMovedOrDeletedParams) =>
+export const findLabelsToBeMovedOrDeletedThunk =
+    ({ prevTxid }: FindLabelsToBeMovedOrDeletedThunkParams) =>
     (_dispatch: Dispatch, getState: GetState): RbfLabelsToBeUpdated => {
         const accountTransactions = findTransactions(
             prevTxid,

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -36,7 +36,7 @@ import { RbfLabelsToBeUpdated } from 'src/types/wallet/sendForm';
 
 import { RBF_ERROR_ALREADY_MINED } from './replaceByFeeErrorThunk';
 import { MODULE_PREFIX } from './sendThunksConsts';
-import { findLabelsToBeMovedOrDeleted } from '../moveLabelsForRbf/findLabelsToBeMovedOrDeletedThunk';
+import { findLabelsToBeMovedOrDeletedThunk } from '../moveLabelsForRbf/findLabelsToBeMovedOrDeletedThunk';
 import { moveLabelsForRbfThunk } from '../moveLabelsForRbf/moveLabelsForRbfThunk';
 
 export const saveSendFormDraftThunk = createThunk(
@@ -273,7 +273,7 @@ export const signAndPushSendFormTransactionThunk = createThunk(
         // This has to be executed prior to pushing the transaction!
         const rbfLabelsToBeEdited = isBumpFeeRbf
             ? dispatch(
-                  findLabelsToBeMovedOrDeleted({
+                  findLabelsToBeMovedOrDeletedThunk({
                       prevTxid: enhancedPrecomposedTransaction.prevTxid,
                   }),
               )


### PR DESCRIPTION
Fix naming for findLabelsToBeMovedOrDeletedThunk

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-naming-rbf-find-thunk&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-naming-rbf-find-thunk&lookback=7)