### PR TITLE
chore(suite): remove unneeded device.change event augmentation

### DIFF
--- a/packages/suite/src/actions/settings/__tests__/deviceSettingsActions.test.ts
+++ b/packages/suite/src/actions/settings/__tests__/deviceSettingsActions.test.ts
@@ -53,7 +53,7 @@ describe('DeviceSettings Actions', () => {
             const mock = () => {
                 if (f.deviceChange) {
                     // @ts-expect-error
-                    store.dispatch(deviceActions.deviceChanged({ device: f.deviceChange }));
+                    store.dispatch(deviceActions.deviceChanged(f.deviceChange));
                     store.dispatch(deviceActions.updateSelectedDevice(f.deviceChange));
                 }
 

--- a/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
@@ -521,17 +521,15 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
         actions: [
             {
                 type: DEVICE.CHANGED,
-                payload: {
-                    device: getConnectDevice(
-                        {
-                            path: '1',
-                            status: 'occupied',
-                        },
-                        {
-                            device_id: 'different-device-id',
-                        },
-                    ),
-                },
+                payload: getConnectDevice(
+                    {
+                        path: '1',
+                        status: 'occupied',
+                    },
+                    {
+                        device_id: 'different-device-id',
+                    },
+                ),
             },
         ],
         result: [
@@ -549,12 +547,10 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
         actions: [
             {
                 type: DEVICE.CHANGED,
-                payload: {
-                    device: getConnectDevice({
-                        type: 'unacquired',
-                        path: '1',
-                    }),
-                },
+                payload: getConnectDevice({
+                    type: 'unacquired',
+                    path: '1',
+                }),
             },
         ],
         result: [],
@@ -572,11 +568,9 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
         actions: [
             {
                 type: DEVICE.CHANGED,
-                payload: {
-                    device: getConnectDevice({
-                        status: 'occupied',
-                    }),
-                },
+                payload: getConnectDevice({
+                    status: 'occupied',
+                }),
             },
         ],
         result: [
@@ -600,16 +594,14 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
         actions: [
             {
                 type: DEVICE.CHANGED,
-                payload: {
-                    device: getConnectDevice(
-                        {
-                            status: 'occupied',
-                        },
-                        {
-                            passphrase_protection: true,
-                        },
-                    ),
-                },
+                payload: getConnectDevice(
+                    {
+                        status: 'occupied',
+                    },
+                    {
+                        passphrase_protection: true,
+                    },
+                ),
             },
         ],
         result: [
@@ -627,9 +619,7 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
         actions: [
             {
                 type: DEVICE.CHANGED,
-                payload: {
-                    device: CONNECT_DEVICE,
-                },
+                payload: CONNECT_DEVICE,
             },
         ],
         result: [],
@@ -649,12 +639,10 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
         actions: [
             {
                 type: DEVICE.CHANGED,
-                payload: {
-                    device: getConnectDevice(undefined, {
-                        unlocked: false,
-                        safety_checks: null,
-                    }),
-                },
+                payload: getConnectDevice(undefined, {
+                    unlocked: false,
+                    safety_checks: null,
+                }),
             },
         ],
         result: [

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -3,7 +3,6 @@ import { TrezorDevice } from '@suite-common/suite-types';
 import {
     deviceActions,
     deviceConnectThunks,
-    selectDeviceByStaticSessionId,
     selectDevices,
     selectEnabledNetworks,
     selectIsPendingTransportEvent,
@@ -59,23 +58,6 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
                 if (connectInitHooks && eventData.type in connectInitHooks) {
                     connectInitHooks[eventData.type]?.(eventData.payload, connectedDevices);
                 }
-            } else if (eventData.type === DEVICE.CHANGED) {
-                // this is not nice - during passphrase/discovery refactor, I made a decision that we are not going to update device.state in reducer
-                // in any other case than as a result of device authorization (passphrase+discovery). But later we realized that we need to update device.state.sessionId
-                // for saved devices too https://github.com/trezor/trezor-suite/issues/19411 so I am adding this as a quick fix that should work until we come up with a better solution.
-                const staticSessionId = eventData.payload?.state;
-                const device = staticSessionId
-                    ? selectDeviceByStaticSessionId(getState(), staticSessionId)
-                    : undefined;
-                const shouldUpdateState = !!device && device.remember && !device.useEmptyPassphrase;
-
-                dispatch({
-                    type: eventData.type,
-                    payload: {
-                        device: eventData.payload,
-                        shouldUpdateState,
-                    },
-                });
             }
             // dispatch event as action
             else {

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -26,12 +26,9 @@ const connectUnacquiredDevice = createAction(
     (payload: DeviceConnectActionPayload) => ({ payload }),
 );
 
-const deviceChanged = createAction(
-    DEVICE.CHANGED,
-    (payload: { device: Device; shouldUpdateState?: boolean }) => ({
-        payload,
-    }),
-);
+const deviceChanged = createAction(DEVICE.CHANGED, (payload: Device) => ({
+    payload,
+}));
 
 const setDeviceState = createAction(
     `${DEVICE_MODULE_PREFIX}/set-device-state`,

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -234,10 +234,21 @@ const changeDevice = (
     draft: DeviceReducerState,
     device: Device | TrezorDevice,
     extended: Partial<AcquiredDevice>,
-    shouldUpdateState = false,
 ) => {
     // change only acquired devices
     if (!device.features) return;
+
+    // this is not nice - during passphrase/discovery refactor, I made a decision that we are not going to update device.state in reducer
+    // in any other case than as a result of device authorization (passphrase+discovery). But later we realized that we need to update device.state.sessionId
+    // for saved devices too https://github.com/trezor/trezor-suite/issues/19411 so I am adding this as a quick fix that should work until we come up with a better solution.
+    const staticSessionId = device?.state;
+    const deviceBeforeUpdate = staticSessionId
+        ? draft.devices.find(d => d.state?.staticSessionId === staticSessionId)
+        : undefined;
+    const shouldUpdateState =
+        !!deviceBeforeUpdate &&
+        deviceBeforeUpdate.remember &&
+        !deviceBeforeUpdate.useEmptyPassphrase;
 
     if (!shouldUpdateState) {
         // ignore device state updates. we set device state explicitly using addAuthorizedDevice or setDeviceState
@@ -605,8 +616,7 @@ const requestDeviceReconnect = (draft: DeviceReducerState) => {
 export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (builder, extra) => {
     builder
         .addCase(deviceActions.deviceChanged, (state, { payload }) => {
-            const { device, shouldUpdateState } = payload;
-            changeDevice(state, device, { connected: true, available: true }, shouldUpdateState);
+            changeDevice(state, payload, { connected: true, available: true });
         })
         .addCase(deviceActions.setDeviceState, (state, { payload }) => {
             setDeviceState(state, payload.device, payload.state, payload.useEmptyPassphrase);


### PR DESCRIPTION
followup after 62b0bbc244dd6382838b150c9a65d2c09553b7bb (#19588)

basically just moving the nasty code to one single place to make it smell less. It should be refactored way more later..

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=discovery-nitpicks-12&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=discovery-nitpicks-12&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=discovery-nitpicks-12&lookback=7)