### PR TITLE
fix(suite): use blacklist in connect-init patch

### DIFF
--- a/suite-common/connect-init/src/blacklist.ts
+++ b/suite-common/connect-init/src/blacklist.ts
@@ -1,0 +1,29 @@
+import { ConnectKey } from './types';
+
+// List of methods that don't work with device, so they don't need to be patched
+export const blacklist: ConnectKey[] = [
+    'manifest',
+    'init',
+    'setTransports',
+    'getSettings',
+    'on',
+    'off',
+    'removeAllListeners',
+    'uiResponse',
+    'blockchainGetAccountBalanceHistory',
+    'blockchainGetInfo',
+    'blockchainGetCurrentFiatRates',
+    'blockchainGetFiatRatesForTimestamps',
+    'blockchainDisconnect',
+    'blockchainEstimateFee',
+    'blockchainGetTransactions',
+    'blockchainSetCustomBackend',
+    'blockchainSubscribe',
+    'blockchainSubscribeFiatRates',
+    'blockchainUnsubscribe',
+    'blockchainUnsubscribeFiatRates',
+    'requestLogin',
+    'getCoinInfo',
+    'dispose',
+    'cancel',
+];

--- a/suite-common/connect-init/src/cardanoConnectPatch.ts
+++ b/suite-common/connect-init/src/cardanoConnectPatch.ts
@@ -1,36 +1,7 @@
 import TrezorConnect from '@trezor/connect';
 
-type ConnectKey = keyof typeof TrezorConnect;
-
-// List of methods that doesn't work with additional `useCardanoDerivation` param
-// (eg. because they don't accept options object as a param)
-// or they don't trigger seed derivation on a device so there is no need to pass it.
-const blacklist: ConnectKey[] = [
-    'manifest',
-    'init',
-    'setTransports',
-    'getSettings',
-    'on',
-    'off',
-    'removeAllListeners',
-    'uiResponse',
-    'blockchainGetAccountBalanceHistory',
-    'blockchainGetInfo',
-    'blockchainGetCurrentFiatRates',
-    'blockchainGetFiatRatesForTimestamps',
-    'blockchainDisconnect',
-    'blockchainEstimateFee',
-    'blockchainGetTransactions',
-    'blockchainSetCustomBackend',
-    'blockchainSubscribe',
-    'blockchainSubscribeFiatRates',
-    'blockchainUnsubscribe',
-    'blockchainUnsubscribeFiatRates',
-    'requestLogin',
-    'getCoinInfo',
-    'dispose',
-    'cancel',
-];
+import { blacklist } from './blacklist';
+import { ConnectKey } from './types';
 
 export const cardanoConnectPatch = (getEnabledNetworks: () => string[]) => {
     // Pass additional parameter `useCardanoDerivation` to Trezor Connect methods

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -22,7 +22,9 @@ import { isDesktop } from '@trezor/env-utils';
 import { DATA_URL } from '@trezor/urls';
 import { getSynchronize } from '@trezor/utils';
 
+import { blacklist } from './blacklist';
 import { cardanoConnectPatch } from './cardanoConnectPatch';
+import { ConnectKey } from './types';
 
 const CONNECT_INIT_MODULE = '@common/connect-init';
 
@@ -143,59 +145,28 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
 
         const synchronize = getSynchronize();
 
-        const wrappedMethods: Array<keyof typeof TrezorConnect> = [
-            'applySettings',
-            'authenticateDevice',
-            'authorizeCoinjoin',
-            'backupDevice',
-            'cancelCoinjoinAuthorization',
-            'cardanoGetAddress',
-            'cardanoGetPublicKey',
-            'cardanoSignTransaction',
-            'changePin',
-            'cipherKeyValue',
-            'discoverAccounts',
-            'ethereumGetAddress',
-            'ethereumSignTransaction',
-            'getAddress',
-            'getDeviceState',
-            'getFeatures',
-            'getOwnershipProof',
-            'getPublicKey',
-            'pushTransaction',
-            'recoveryDevice',
-            'resetDevice',
-            'rippleGetAddress',
-            'rippleSignTransaction',
-            'setBusy',
-            'showDeviceTutorial',
-            'signTransaction',
-            'solanaGetAddress',
-            'solanaSignTransaction',
-            'unlockPath',
-            'wipeDevice',
-        ] as const;
+        Object.keys(TrezorConnect)
+            .filter(k => !blacklist.includes(k as ConnectKey))
+            .forEach(key => {
+                // typescript complains about params and return type, need to be "any"
+                const original: any = TrezorConnect[key as ConnectKey];
+                if (!original) return;
+                (TrezorConnect[key as ConnectKey] as any) = async (params: any) => {
+                    dispatch(lockDevice(true));
+                    const result = await synchronize(() => original(params));
 
-        wrappedMethods.forEach(key => {
-            // typescript complains about params and return type, need to be "any"
-            const original: any = TrezorConnect[key];
-            if (!original) return;
-            (TrezorConnect[key] as any) = async (params: any) => {
-                dispatch(lockDevice(true));
-                const result = await synchronize(() => original(params));
+                    dispatch(lockDevice(false));
+                    dispatch(
+                        deviceActions.removeButtonRequests({
+                            // todo: device not 'thread safe' - meaning that device to which button requests have been added to might not
+                            // be the same re-selected device from this line. We should reuse device from params.
+                            device: selectSelectedDevice(getState()),
+                        }),
+                    );
 
-                dispatch(lockDevice(false));
-                dispatch(
-                    deviceActions.removeButtonRequests({
-                        // todo: device not 'thread safe' - meaning that device to which button requests have been added to might not
-                        // be the same re-selected device from this line. We should reuse device from params.
-                        device: selectSelectedDevice(getState()),
-                    }),
-                );
-
-                return result;
-            };
-        });
+                    return result;
+                };
+            });
 
         cardanoConnectPatch(getEnabledNetworks);
 

--- a/suite-common/connect-init/src/types.ts
+++ b/suite-common/connect-init/src/types.ts
@@ -1,0 +1,3 @@
+import TrezorConnect from '@trezor/connect';
+
+export type ConnectKey = keyof typeof TrezorConnect;


### PR DESCRIPTION
## Description

The list of wrapped methods in `suite-common/connect-init` does not accurately cover everything used in Suite. For example sign message methods are missing. 
Since #19533 it has become a bit more important, so I propose switching from a whitelist to a blacklist, which is already used for `cardanoConnectPatch`

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-init-use-blacklist&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-init-use-blacklist&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-init-use-blacklist&lookback=7)