### PR TITLE
feat(suite): human readable eip712 message in modal

### DIFF
--- a/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
@@ -119,7 +119,7 @@ export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignT
     }
 
     getButtonRequestData(code: string) {
-        if (code === 'ButtonRequest_Other') {
+        if (code === 'ButtonRequest_Other' || code === 'ButtonRequest_SignTx') {
             return {
                 type: 'message' as const,
                 coin: this.params.network?.shortcut ?? 'ETH',

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
@@ -44,6 +44,8 @@ export const DeviceContextModal = ({
         case 'ButtonRequest_ConfirmOutput':
         case 'ButtonRequest_FeeOverThreshold':
         case 'ButtonRequest_SignTx': {
+            if (data?.type === 'message') return <SignMessageModal device={device} {...data} />;
+
             return <TransactionReviewModal type="sign-transaction" />;
         }
         case 'ButtonRequest_Other': {

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/SignMessageModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/SignMessageModal.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 
-import { selectConnectPopupCall } from '@suite-common/connect-popup';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { selectDeviceAccounts } from '@suite-common/wallet-core';
@@ -14,8 +13,6 @@ import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
 import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
-
-import { ConfirmActionModal } from './ConfirmActionModal';
 
 const MessageText = styled.pre`
     font-family: monospace;
@@ -31,18 +28,22 @@ interface SignMessageModalProps {
     serializedPath?: string;
 }
 
+export const simplifyJSON = (object: any) =>
+    JSON.stringify(object, null, 2)
+        .replace(/[{}",[\]]/g, '')
+        .replace(/^\s{2}/gm, '')
+        .replace(/\n\s*\n/gm, '\n')
+        .trim();
+
 export const SignMessageModal = ({
     device,
     message,
     coin,
     serializedPath,
 }: SignMessageModalProps) => {
-    const popupCall = useSelector(selectConnectPopupCall);
     const accounts = useSelector(selectDeviceAccounts);
     const accountLabels = useSelector(selectAccountLabels);
     const deviceModelInternal = device.features?.internal_model;
-
-    if (!popupCall || popupCall?.state !== 'ongoing') return <ConfirmActionModal device={device} />;
 
     const onCancel = () => {
         TrezorConnect.cancel();
@@ -52,6 +53,15 @@ export const SignMessageModal = ({
     const networkSymbol = coin?.toLowerCase() as NetworkSymbol;
     const network = networkSymbol ? getNetwork(networkSymbol) : undefined;
     const account = accounts.find(a => a.symbol === networkSymbol && a.path === serializedPath);
+    const eip712parsed = () => {
+        try {
+            return JSON.parse(message);
+        } catch {
+            return undefined;
+        }
+    };
+    const isEip712 =
+        eip712parsed()?.primaryType && eip712parsed()?.domain && eip712parsed()?.message;
 
     return (
         <Modal.Backdrop>
@@ -65,7 +75,7 @@ export const SignMessageModal = ({
             <Modal.ModalBase
                 size="small"
                 heading={
-                    popupCall.method === 'ethereumSignTypedData' ? (
+                    isEip712 ? (
                         <Translation id="TR_SIGN_EIP712_TYPED_DATA" />
                     ) : (
                         <Translation id="TR_SIGN_MESSAGE" />
@@ -100,10 +110,46 @@ export const SignMessageModal = ({
                 }
             >
                 <Column gap={spacings.xs}>
+                    {account && (
+                        <Card
+                            header={
+                                <Row gap={spacings.sm}>
+                                    <DotIndicator isActive={device.buttonRequests.length === 1} />
+                                    <H4 margin={{ left: spacings.xxs }} typographyStyle="callout">
+                                        <Translation id="TR_ADDRESS" />
+                                    </H4>
+                                </Row>
+                            }
+                            paddingType="small"
+                        >
+                            <MessageText data-testid="@sign-message-modal/address">
+                                {account.descriptor}
+                            </MessageText>
+                        </Card>
+                    )}
+                    {isEip712 && (
+                        <Card
+                            header={
+                                <Row gap={spacings.sm}>
+                                    <DotIndicator isActive={device.buttonRequests.length === 2} />
+                                    <H4 margin={{ left: spacings.xxs }} typographyStyle="callout">
+                                        <Translation id="TR_DOMAIN" />
+                                    </H4>
+                                </Row>
+                            }
+                            paddingType="small"
+                        >
+                            <MessageText data-testid="@sign-message-modal/domain">
+                                {simplifyJSON(eip712parsed()?.domain)}
+                            </MessageText>
+                        </Card>
+                    )}
                     <Card
                         header={
                             <Row gap={spacings.sm}>
-                                <DotIndicator isActive={true} />
+                                <DotIndicator
+                                    isActive={device.buttonRequests.length === (isEip712 ? 3 : 2)}
+                                />
                                 <H4 margin={{ left: spacings.xxs }} typographyStyle="callout">
                                     <Translation id="TR_MESSAGE" />
                                 </H4>
@@ -112,7 +158,7 @@ export const SignMessageModal = ({
                         paddingType="small"
                     >
                         <MessageText data-testid="@sign-message-modal/message">
-                            {message}
+                            {isEip712 ? simplifyJSON(eip712parsed()?.message) : message}
                         </MessageText>
                     </Card>
                 </Column>

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -10458,4 +10458,8 @@ export default defineMessages({
         id: 'TR_DEFAULT_ACCOUNT',
         defaultMessage: 'Default account',
     },
+    TR_DOMAIN: {
+        id: 'TR_DOMAIN',
+        defaultMessage: 'Domain',
+    },
 } as const);


### PR DESCRIPTION
## Description

Make EIP-712 messages more readable in Connect flow in Suite. 
Instead of the actual JSON we use lighter formatting without control characters. We also don't show the type definitions

## Screenshots:

Before

<img width="660" alt="Screenshot 2025-06-30 at 14 50 06" src="https://github.com/user-attachments/assets/c5953fc2-3efd-4c8a-be1d-c82c1fbb1b75" />

After

<img width="660" alt="Screenshot 2025-06-30 at 14 48 22" src="https://github.com/user-attachments/assets/cc610318-47cd-4f88-941d-a2340a5437c7" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/eip712-modal-readability&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/eip712-modal-readability&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/eip712-modal-readability&lookback=7)