### PR TITLE
Start discovery by clicking `Use Trezor here`

### DIFF
--- a/packages/suite/src/components/suite/AcquireDeviceButton.tsx
+++ b/packages/suite/src/components/suite/AcquireDeviceButton.tsx
@@ -20,7 +20,7 @@ export const AcquireDeviceButton = ({ className, onClick }: AcquireButtonProps) 
 
     const handleClick: MouseEventHandler = e => {
         onClick?.(e);
-        dispatch(acquireDevice({}));
+        dispatch(acquireDevice({ startDiscovery: true }));
     };
 
     return (


### PR DESCRIPTION
## Description

In #19739, discovery not starting after late acquire was fixed in one place, so I fixed it in another as well.

Note: I'm not sure this `startDiscovery: true` approach is the best way possible, but it's the current way.

![image](https://github.com/user-attachments/assets/1de1bdba-bac3-4365-b3de-3a8514baf504)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/acquire-discovery-start&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/acquire-discovery-start&lookback=7)