### PR TITLE
chore(suite-common): update XRPL network name

### DIFF
--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -316,7 +316,7 @@ export const networks = {
     xrp: {
         symbol: 'xrp',
         displaySymbol: 'XRP',
-        name: 'XRP',
+        name: 'XRP Ledger',
         networkType: 'ripple',
         bip43Path: "m/44'/144'/i'/0/0",
         decimals: 6,


### PR DESCRIPTION
## Description

- renamed `name` "XRP" to "XRP Ledger" in `networksConfig.ts`


## Related Issue

Resolve #18846 

## Screenshots:

### Before

![Screenshot 2025-06-30 at 18 17 23](https://github.com/user-attachments/assets/37846ea1-ac65-4a39-90b8-2b82f7d14b7e)

### After

![Screenshot 2025-06-30 at 18 15 59](https://github.com/user-attachments/assets/03321573-80be-4874-8aa3-e762458dd0a9)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/ripple-name-update&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/ripple-name-update&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/ripple-name-update&lookback=7)