### PR TITLE
fix(wallet-core): rediscovery for BTC-only

### DIFF
--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -76,7 +76,13 @@ export const selectNetworksToDiscover = (
     if (!staticSessionId) {
         return enabledNetworks;
     }
+
     const device = selectSelectedDevice(state);
+    const deviceNetworks = selectSupportedNetworkByDevice(device);
+    const enabledSupportedNetworks = enabledNetworks.filter(network =>
+        deviceNetworks.includes(network),
+    );
+
     const discovery = selectDiscoveryByDevicePath(state, device?.path);
     const okAccounts = selectAccountsByDeviceState(state, staticSessionId);
     const failedAccounts = getFailedAccounts(staticSessionId, discovery);
@@ -85,7 +91,7 @@ export const selectNetworksToDiscover = (
         ...new Set([...okAccounts, ...failedAccounts].map(account => account.symbol)),
     ];
 
-    return enabledNetworks.filter(network => !discoveredNetworks.includes(network));
+    return enabledSupportedNetworks.filter(network => !discoveredNetworks.includes(network));
 };
 
 export const selectIsRediscoverNeeded = (


### PR DESCRIPTION
## Description

Add condition to filter enabled networks by device support also for rediscovery.
That was missed in cea5bb36 which did it only for starting first discovery.

## Related Issue

Resolve #19473 third time's the charm? :crossed_fingers: 

## Screenshots:

Discovery for BTC-only now works even with enabled altcoins 
![image](https://github.com/user-attachments/assets/d645194e-96d4-40e8-9f79-6484477fb4ec) 

Still visible in debug settings but I stand by that.
- Coin settings are saved per Application, not per Device.
- Debug settings are for advanced users, so IMO they should display the full actual state of application, not filtered for user convenience
- So IMO debug settings should show enabled networks not supported by current device
  - they are correctly shown as not connected, because Connect had not called them in current session :heavy_check_mark: 
  - :thought_balloon:  I actually believe there should also be option to turn them on/off again, at least hidden, currently there's none
    - We are taking away transparancy, but that's a product question
    - It's a valid usecase that a user has one BTC-only device, and one universal for altcoins, so this is relevant

![image](https://github.com/user-attachments/assets/8a77ff1a-2a9d-4c61-ab9a-c8919bb0c1ff)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/19473-finally&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/19473-finally&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/19473-finally&lookback=7)