### PR TITLE
chore(suite): remove useless condition

### DIFF
--- a/packages/suite/src/views/dashboard/DashboardPassphraseBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPassphraseBanner.tsx
@@ -34,7 +34,6 @@ export const DashboardPassphraseBanner = () => {
         isDashboardPassphraseBannerVisible === false ||
         device?.useEmptyPassphrase === true ||
         isDiscoveryRunning === true ||
-        isDiscoveryRunning === undefined ||
         selectedAddressDisplay === WalletType.PASSPHRASE
     ) {
         return null;


### PR DESCRIPTION
`isDiscoveryRunning` is typed as `boolean`

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=discovery-nitpick-13&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=discovery-nitpick-13&lookback=7)