### PR TITLE
chore(suite): connectInitThunks - add fallback for useEmptyPassphrase…

### DIFF
--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -582,7 +582,6 @@ export const createCoinjoinAccount =
         const unlockPath = await TrezorConnect.unlockPath({
             path: "m/10025'",
             device,
-            useEmptyPassphrase: device?.useEmptyPassphrase,
         });
         if (!unlockPath.success) {
             dispatch(handleError(unlockPath.payload.error));
@@ -599,7 +598,6 @@ export const createCoinjoinAccount =
             path,
             unlockPath: unlockPath.payload,
             device,
-            useEmptyPassphrase: device?.useEmptyPassphrase,
             coin: network.symbol,
             suppressBackupWarning: true,
         });
@@ -703,7 +701,6 @@ const authorizeCoinjoin =
 
         const auth = await TrezorConnect.authorizeCoinjoin({
             device,
-            useEmptyPassphrase: device?.useEmptyPassphrase,
             path: account.path,
             coin: account.symbol,
             coordinator,
@@ -815,7 +812,6 @@ export const restoreCoinjoinSession =
 
         const auth = await TrezorConnect.authorizeCoinjoin({
             device,
-            useEmptyPassphrase: device?.useEmptyPassphrase,
             path: account.path,
             coin: account.symbol,
             preauthorized: true, // this parameter will check if device is already authorized

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -341,7 +341,6 @@ export const stopCoinjoinSession =
         if (shouldCancelAuthorization) {
             const result = await TrezorConnect.cancelCoinjoinAuthorization({
                 device,
-                useEmptyPassphrase: device?.useEmptyPassphrase,
             });
 
             if (!result.success) {
@@ -653,7 +652,6 @@ const signCoinjoinTx =
                         const signTx = await TrezorConnect.signTransaction({
                             version: 1, // Coinjoin requires the 1, the default is now 2, as most wallets have 2
                             device,
-                            useEmptyPassphrase: device?.useEmptyPassphrase,
                             inputs: tx.inputs,
                             outputs: tx.outputs,
                             coinjoinRequest: tx.coinjoinRequest,

--- a/packages/suite/src/actions/wallet/publicKeyActions.ts
+++ b/packages/suite/src/actions/wallet/publicKeyActions.ts
@@ -32,7 +32,6 @@ export const showXpub = () => async (dispatch: Dispatch, getState: GetState) => 
     const params = {
         device,
         path: account.path,
-        useEmptyPassphrase: device.useEmptyPassphrase,
         showOnTrezor: true,
         derivationType: getDerivationType(account.accountType),
         coin: account.symbol, // must be here to distinguish between testnet and regtest

--- a/packages/suite/src/actions/wallet/signVerifyActions.ts
+++ b/packages/suite/src/actions/wallet/signVerifyActions.ts
@@ -17,7 +17,6 @@ type StateParams = {
     device: TrezorDevice;
     account: Account;
     coin: Account['symbol'];
-    useEmptyPassphrase: boolean;
     chunkify?: boolean;
 };
 
@@ -35,7 +34,6 @@ const getStateParams = (getState: GetState): Promise<StateParams> => {
         : Promise.resolve({
               device,
               account,
-              useEmptyPassphrase: device.useEmptyPassphrase,
               coin: account.symbol,
               chunkify: addressDisplayType === AddressDisplayOptions.CHUNKED,
           });
@@ -43,13 +41,12 @@ const getStateParams = (getState: GetState): Promise<StateParams> => {
 
 const showAddressByNetwork =
     (_: Dispatch, address: string, path: string) =>
-    ({ account, device, coin, useEmptyPassphrase, chunkify }: StateParams) => {
+    ({ account, device, coin, chunkify }: StateParams) => {
         const params = {
             device,
             address,
             path,
             coin,
-            useEmptyPassphrase,
             chunkify,
         };
         switch (account.networkType) {
@@ -64,13 +61,12 @@ const showAddressByNetwork =
 
 const signByNetwork =
     (path: string | number[], message: string, hex: boolean, isElectrum: boolean) =>
-    ({ account, device, coin, useEmptyPassphrase }: StateParams) => {
+    ({ account, device, coin }: StateParams) => {
         const params = {
             device,
             path,
             coin,
             message,
-            useEmptyPassphrase,
             hex,
             no_script_type: isElectrum,
         };
@@ -87,14 +83,13 @@ const signByNetwork =
 
 const verifyByNetwork =
     (address: string, message: string, signature: string, hex: boolean) =>
-    ({ account, device, coin, useEmptyPassphrase }: StateParams) => {
+    ({ account, device, coin }: StateParams) => {
         const params = {
             device,
             address,
             coin,
             message,
             signature,
-            useEmptyPassphrase,
             hex,
         };
         switch (account.networkType) {

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -206,7 +206,6 @@ export const signTransaction =
                 instance: device.instance,
                 state: device.state,
             },
-            useEmptyPassphrase: device.useEmptyPassphrase,
             path: account.path,
             transaction: txData.tx,
             chunkify: addressDisplayType === AddressDisplayOptions.CHUNKED,

--- a/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
@@ -248,7 +248,6 @@ export const signTransaction =
                 instance: device.instance,
                 state: device.state,
             },
-            useEmptyPassphrase: device.useEmptyPassphrase,
             path: account.path,
             serializedTx: txData.tx.txShim.serializeMessage(),
             chunkify: addressDisplayType === AddressDisplayOptions.CHUNKED,

--- a/packages/suite/src/hooks/wallet/useCardanoStaking.ts
+++ b/packages/suite/src/hooks/wallet/useCardanoStaking.ts
@@ -230,7 +230,6 @@ export const useCardanoStaking = (): CardanoStaking => {
             const res = await trezorConnect.cardanoSignTransaction({
                 signingMode: PROTO.CardanoTxSigningMode.ORDINARY_TRANSACTION,
                 device,
-                useEmptyPassphrase: device?.useEmptyPassphrase,
                 inputs: txPlan.inputs,
                 outputs: txPlan.outputs,
                 unsignedTx: txPlan.unsignedTx,

--- a/packages/suite/src/utils/wallet/trading/tradingUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/tradingUtils.ts
@@ -120,7 +120,6 @@ export const getComposeAddressPlaceholder = async (
                     device,
                     coin: account.symbol,
                     path: `${substituteBip43Path(bip43Path)}/0/0`,
-                    useEmptyPassphrase: device.useEmptyPassphrase,
                     showOnTrezor: false,
                     chunkify,
                 });

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -134,6 +134,16 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
                 const original: any = TrezorConnect[key as ConnectKey];
                 if (!original) return;
                 (TrezorConnect[key as ConnectKey] as any) = async (params: any) => {
+                    // suite typically works only with the currently selected device, so we add this fallback here to safe lines elsewhere
+                    if (!params || typeof params['useEmptyPassphrase'] !== 'boolean') {
+                        const selectedDevice = selectSelectedDevice(getState());
+                        if (selectedDevice) {
+                            params = {
+                                ...params,
+                                useEmptyPassphrase: selectedDevice.useEmptyPassphrase,
+                            };
+                        }
+                    }
                     dispatch(lockDevice(true));
                     const result = await synchronize(() => original(params));
 

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -111,7 +111,6 @@ export const connectPopupCallThunkInner = createThunk<
                     instance: device.instance,
                     state: device.state,
                 },
-                useEmptyPassphrase: device.useEmptyPassphrase,
                 ...modifiedPayload,
             });
             response.id = undefined;
@@ -285,7 +284,6 @@ export const connectPopupVerifyAddressThunk = createThunk<void, { index: number 
                     instance: device.instance,
                     state: device.state,
                 },
-                useEmptyPassphrase: device.useEmptyPassphrase,
                 ...call.addresses[index].validatePayload,
                 showOnTrezor: true,
                 chunked: false,

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -373,7 +373,6 @@ export const confirmAddressOnDeviceThunk = createThunk(
             device,
             path: addressPath,
             unlockPath: account.unlockPath,
-            useEmptyPassphrase: device.useEmptyPassphrase,
             coin: account.symbol,
             chunkify,
             showOnTrezor,
@@ -390,7 +389,6 @@ export const confirmAddressOnDeviceThunk = createThunk(
             case 'cardano':
                 response = TrezorConnect.cardanoGetAddress({
                     device,
-                    useEmptyPassphrase: device.useEmptyPassphrase,
                     addressParameters: {
                         stakingPath: getStakingPath(account),
                         addressType: getAddressType(),

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -792,7 +792,6 @@ export const runAdditionalDiscoveryThunk = createThunk(
 
         const result = await TrezorConnect.discoverAccounts({
             device,
-            useEmptyPassphrase: device.useEmptyPassphrase,
             accounts: networksToDiscover.map(n => ({
                 symbol: n,
             })),

--- a/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
@@ -332,7 +332,6 @@ export const signBitcoinSendFormTransactionThunk = createThunk<
                 instance: device.instance,
                 state: device.state,
             },
-            useEmptyPassphrase: device.useEmptyPassphrase,
             inputs: precomposedTransaction.inputs,
             outputs: precomposedTransaction.outputs,
             account: {

--- a/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
@@ -162,7 +162,6 @@ export const signCardanoSendFormTransactionThunk = createThunk<
                 instance: device.instance,
                 state: device.state,
             },
-            useEmptyPassphrase: device.useEmptyPassphrase,
             inputs: precomposedTransaction.inputs,
             outputs: precomposedTransaction.outputs,
             unsignedTx: precomposedTransaction.unsignedTx,

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -352,7 +352,6 @@ export const signEthereumSendFormTransactionThunk = createThunk<
                 instance: device.instance,
                 state: device.state,
             },
-            useEmptyPassphrase: device.useEmptyPassphrase,
             path: selectedAccount.path,
             transaction,
             chunkify: addressDisplayType === AddressDisplayOptions.CHUNKED,

--- a/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
@@ -230,7 +230,6 @@ export const signRippleStellarSendFormTransactionThunk = createThunk<
                     instance: device.instance,
                     state: device.state,
                 },
-                useEmptyPassphrase: device.useEmptyPassphrase,
                 path: selectedAccount.path,
                 transaction: {
                     fee: precomposedTransaction.feePerByte,
@@ -288,7 +287,6 @@ export const signRippleStellarSendFormTransactionThunk = createThunk<
                     instance: device.instance,
                     state: device.state,
                 },
-                useEmptyPassphrase: device.useEmptyPassphrase,
                 path: selectedAccount.path,
                 networkPassphrase: transaction.networkPassphrase,
                 transaction: {

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -333,7 +333,6 @@ export const signSolanaSendFormTransactionThunk = createThunk<
                 instance: device.instance,
                 state: device.state,
             },
-            useEmptyPassphrase: device.useEmptyPassphrase,
             path: selectedAccount.path,
             serializedTx: transaction.payload.serializedTx,
             serialize: true,

--- a/suite-common/walletconnect/src/adapters/ethereum.ts
+++ b/suite-common/walletconnect/src/adapters/ethereum.ts
@@ -178,7 +178,6 @@ const ethereumRequestThunk = createThunk<
                     chainId,
                 },
                 device,
-                useEmptyPassphrase: device?.useEmptyPassphrase,
             };
             const signResponse = await dispatch(
                 trezorConnectPopupActions.connectPopupCallThunk({

--- a/suite-common/walletconnect/src/adapters/solana.ts
+++ b/suite-common/walletconnect/src/adapters/solana.ts
@@ -69,7 +69,6 @@ const solanaSignTransaction = createThunk<
                 payload: {
                     path: account.path,
                     device,
-                    useEmptyPassphrase: device?.useEmptyPassphrase,
                     serializedTx,
                     serialize: true,
                 },

--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -54,7 +54,6 @@ export const sessionAuthenticateThunk = createThunk<
             path: ethAccount.path,
             message,
             device,
-            useEmptyPassphrase: device?.useEmptyPassphrase,
         });
 
         if (signature.success === false) {


### PR DESCRIPTION
motivated by #19582 where global search for `useEmptyPassphrase` returns too many results.

Since suite typically only works with the currently selected device and since we already wrap connect methods, I'd say that it might make sense to automatically provide this kind of fallbacks. This PR automatically sets useEmptyPassphrase to selectedDevice.useEmptyPassphrase unless this value is explicitly set in connect method call.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=discovery-nitpicks-14&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=discovery-nitpicks-14&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=discovery-nitpicks-14&lookback=7)