### PR TITLE
Switch bridge implementaion troubleshooting

### DIFF
--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceConnect.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceConnect.tsx
@@ -10,9 +10,11 @@ import {
     TROUBLESHOOTING_TIP_CABLE,
     TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER,
     TROUBLESHOOTING_TIP_SUITE_DESKTOP,
+    TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE,
     TROUBLESHOOTING_TIP_UDEV,
     TROUBLESHOOTING_TIP_USB,
 } from 'src/components/suite/troubleshooting/tips';
+import { useBridgeDesktopApi } from 'src/hooks/suite/useBridgeDesktopApi';
 
 import { selectConnectingDevices } from '../../../actions/bluetooth/desktopBluetoothSelectors';
 import { useSelector } from '../../../hooks/suite';
@@ -31,20 +33,24 @@ export const DeviceConnect = ({ setIsBluetoothConnectOpen }: DeviceConnectProps)
     const { isBluetoothEnabled } = useSelector(selectSuiteFlags);
     const autoConnectingDeviceIds = useSelector(selectConnectingDevices);
 
+    const commonCableTips = [
+        TROUBLESHOOTING_TIP_UDEV,
+        TROUBLESHOOTING_TIP_CABLE,
+        TROUBLESHOOTING_TIP_USB,
+    ];
     const cableItem: TroubleshootingTipsItem[] = isWebUsbTransport
-        ? [
-              TROUBLESHOOTING_TIP_UDEV,
-              TROUBLESHOOTING_TIP_CABLE,
-              TROUBLESHOOTING_TIP_USB,
-              TROUBLESHOOTING_TIP_SUITE_DESKTOP,
-          ]
+        ? [...commonCableTips, TROUBLESHOOTING_TIP_SUITE_DESKTOP]
         : [
               TROUBLESHOOTING_TIP_BRIDGE_STATUS,
-              TROUBLESHOOTING_TIP_UDEV,
-              TROUBLESHOOTING_TIP_CABLE,
-              TROUBLESHOOTING_TIP_USB,
+              ...commonCableTips,
               TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER,
           ];
+
+    if (useBridgeDesktopApi()?.bridgeProcess?.process) {
+        cableItem.push(TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE);
+    } else {
+        // todo: here we are going to put instruction to uninstall standalone bridge
+    }
 
     const getCallToActionButton = (): ReactNode => {
         if (isWebUsbTransport) {

--- a/packages/suite/src/components/suite/PrerequisitesGuide/Transport.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/Transport.tsx
@@ -5,6 +5,7 @@ import {
     TROUBLESHOOTING_ENABLE_IN_DEBUG,
     TROUBLESHOOTING_TIP_RESTART_COMPUTER,
     TROUBLESHOOTING_TIP_SUITE_DESKTOP,
+    TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE,
     TROUBLESHOOTING_TIP_WEBUSB_ENVIRONMENT,
 } from 'src/components/suite/troubleshooting/tips';
 
@@ -36,7 +37,7 @@ const TransportDesktop = ({ items }: { items: TroubleshootingTipsItem[] }) => {
     const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const { bridgeProcess } = useBridgeDesktopApi();
 
-    const itemsForDesktop = [...items];
+    const itemsForDesktop = [...items, TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE];
 
     if (isDebugModeActive && !bridgeProcess.process) {
         itemsForDesktop.push(TROUBLESHOOTING_ENABLE_IN_DEBUG);

--- a/packages/suite/src/components/suite/troubleshooting/tips/BridgeTip.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/BridgeTip.tsx
@@ -37,7 +37,7 @@ export const SuiteDesktopTip = () => {
 export const BridgeStatus = () => (
     <Wrapper>
         <Translation
-            id="TR_TROUBLESHOOTING_TIP_BRIDGE_STATUS_DESCRIPTION"
+            id="TR_TROUBLESHOOTING_TIP_TRANSPORT_STATUS_DESCRIPTION"
             values={{
                 a: chunks => (
                     <TrezorLink variant="underline" href="http://127.0.0.1:21325/status/">
@@ -49,8 +49,12 @@ export const BridgeStatus = () => (
     </Wrapper>
 );
 
+/**
+ * should only be rendered for desktop when built-in bridge is running
+ */
 export const BridgeToggle = () => {
-    const { changeBridgeSettings, bridgeSettings } = useBridgeDesktopApi();
+    const { changeBridgeSettings, bridgeSettings, toggleBridge, bridgeProcess } =
+        useBridgeDesktopApi();
     const bridge = useSelector(selectTransportOfType('BridgeTransport'));
 
     if (!bridgeSettings) return null;
@@ -58,9 +62,9 @@ export const BridgeToggle = () => {
     return (
         <Wrapper>
             <Translation
-                id="TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE_DESCRIPTION"
+                id="TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_ALT_DESCRIPTION"
                 values={{
-                    currentVersion: bridge?.version,
+                    currentVersion: bridge?.version || 'unknown', // unknown should not happen, if bridge process is running
                     a: chunks => (
                         <TrezorLink
                             variant="underline"
@@ -69,6 +73,16 @@ export const BridgeToggle = () => {
                                     ...bridgeSettings,
                                     legacy: !bridgeSettings?.legacy,
                                 });
+
+                                // if bridge process is not running it might make sense to toggle it on and also
+                                // try to switch between legacy and node implementation (= who knows why it didn't start?)
+                                if (!bridgeProcess.process) {
+                                    // to get some sentry insights
+                                    console.error(
+                                        'Bridge process was not running and user toggled it in troubleshooting tips',
+                                    );
+                                    toggleBridge();
+                                }
                             }}
                         >
                             {chunks}

--- a/packages/suite/src/components/suite/troubleshooting/tips/index.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/index.tsx
@@ -12,7 +12,7 @@ import { BluetoothSettingsDescription } from './BluetoothSettingsDescription';
 
 export const TROUBLESHOOTING_TIP_BRIDGE_STATUS: TroubleshootingTipsItem = {
     key: 'bridge-status',
-    heading: <Translation id="TR_TROUBLESHOOTING_TIP_BRIDGE_STATUS_TITLE" />,
+    heading: <Translation id="TR_TROUBLESHOOTING_TIP_TRANSPORT_STATUS_TITLE" />,
     description: <BridgeStatus />,
     hide: !isWeb(),
 };
@@ -51,8 +51,8 @@ export const TROUBLESHOOTING_TIP_SUITE_DESKTOP: TroubleshootingTipsItem = {
 };
 
 export const TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE: TroubleshootingTipsItem = {
-    key: 'suite-desktop',
-    heading: <Translation id="TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE_TITLE" />,
+    key: 'suite-desktop-toggle',
+    heading: <Translation id="TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_ALT_TITLE" />,
     description: <BridgeToggle />,
     hide: isWeb() || isAndroid(),
 };

--- a/packages/suite/src/hooks/suite/useBridgeDesktopApi.ts
+++ b/packages/suite/src/hooks/suite/useBridgeDesktopApi.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+import { isDesktop } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { BridgeSettings } from '@trezor/suite-desktop-api/src/messages';
 
@@ -14,6 +15,10 @@ export const useBridgeDesktopApi = () => {
     const [bridgeDesktopApiError, setBridgeDesktopApiError] = useState<string | null>(null);
 
     useEffect(() => {
+        if (!isDesktop()) {
+            return;
+        }
+
         desktopApi.getBridgeStatus().then(result => {
             if (result.success) {
                 setBridgeProcess(result.payload);

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7680,13 +7680,14 @@ export default defineMessages({
         defaultMessage: 'Try these steps to solve this issue.',
         id: 'TR_TROUBLESHOOTING_DEVICE_NOT_DETECTED',
     },
-    TR_TROUBLESHOOTING_TIP_BRIDGE_STATUS_TITLE: {
-        defaultMessage: 'Ensure the Trezor Bridge process is running',
-        id: 'TR_TROUBLESHOOTING_TIP_BRIDGE_STATUS_TITLE',
+    TR_TROUBLESHOOTING_TIP_TRANSPORT_STATUS_TITLE: {
+        defaultMessage: 'Check connection status',
+        id: 'TR_TROUBLESHOOTING_TIP_TRANSPORT_STATUS_TITLE',
     },
-    TR_TROUBLESHOOTING_TIP_BRIDGE_STATUS_DESCRIPTION: {
-        defaultMessage: 'Visit <a>Trezor Bridge status page</a>',
-        id: 'TR_TROUBLESHOOTING_TIP_BRIDGE_STATUS_DESCRIPTION',
+    TR_TROUBLESHOOTING_TIP_TRANSPORT_STATUS_DESCRIPTION: {
+        defaultMessage:
+            'You may visit <a>connection status page</a> where you can find useful information to solve your problem with Trezor Support.',
+        id: 'TR_TROUBLESHOOTING_TIP_TRANSPORT_STATUS_DESCRIPTION',
     },
     TR_TROUBLESHOOTING_TIP_BROWSER_WEBUSB_TITLE: {
         defaultMessage: 'Use a Chromium-based browser',
@@ -7714,14 +7715,14 @@ export default defineMessages({
         id: 'TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_DESCRIPTION',
         defaultMessage: 'Run the  <a>Trezor Suite</a> desktop app',
     },
-    TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE_TITLE: {
-        id: 'TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE_TITLE',
-        defaultMessage: 'Use another version of Trezor Bridge',
+    TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_ALT_TITLE: {
+        id: 'TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_ALT_TITLE',
+        defaultMessage: 'Use alternative transport',
     },
-    TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE_DESCRIPTION: {
-        id: 'TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE_DESCRIPTION',
+    TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_ALT_DESCRIPTION: {
+        id: 'TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_ALT_DESCRIPTION',
         defaultMessage:
-            '<a>Click to toggle</a> an alternative bridge implementation. Current version: ({currentVersion})',
+            '<a>Click to toggle</a> an alternative connection implementation. Current version: ({currentVersion})',
     },
     TR_TROUBLESHOOTING_TIP_UDEV_INSTALL_DESCRIPTION: {
         id: 'TR_TROUBLESHOOTING_TIP_UDEV_INSTALL_DESCRIPTION',

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -5,7 +5,6 @@ import {
     bridge as protocolBridge,
     v1 as protocolV1,
 } from '@trezor/protocol';
-import { resolveAfter } from '@trezor/utils';
 
 import {
     AbstractTransport,
@@ -135,20 +134,13 @@ export class BridgeTransport extends AbstractTransport {
 
     private async listenLoop() {
         while (!this.stopped) {
-            const listenTimestamp = Date.now();
-
             const response = await this.post('/listen', {
                 body: this.descriptors,
                 signal: this.abortController.signal,
             });
 
             if (!response.success) {
-                const time = Date.now() - listenTimestamp;
-                if (time <= 1100) {
-                    this.emit(TRANSPORT.ERROR, response.error);
-                    break;
-                }
-                await resolveAfter(1000);
+                this.emit(TRANSPORT.ERROR, response.error);
             } else {
                 this.handleDescriptorsChange(response.payload);
             }


### PR DESCRIPTION
based on #19823

- showing the "toggle bridge" troubleshooting tip not only for unreadable devices but also when no bridge is running.  I don't expect this much to happen. Even when you for example uninstall external bridge while suite-desktop is running, it should be able to detect it and turn on its onw bridge. Also I'd say that it would make sense to get rid of this screen completely and when suite-desktop can't start bridge for whatever reason, it should fallback to NodeUsbTransport. What do you think?
- <img width="746" alt="image" src="https://github.com/user-attachments/assets/faa460e6-108c-4e43-a704-eb685573b392" />

- desktop + standalone bridge running. nothing interesting here. do we want to link status page similarly to web?
- <img width="726" alt="image" src="https://github.com/user-attachments/assets/fc4f73a6-ce18-48a5-a680-0e6e6ec73c57" />

- desktop + bundled bridge running. This is a escape hatch just in case some users have problems with the node-bridge. 
- <img width="782" alt="image" src="https://github.com/user-attachments/assets/776f3999-dc33-45a9-a983-a441585f9173" />

- web, no bridge is running 
- <img width="673" alt="image" src="https://github.com/user-attachments/assets/eb7fce06-ee8d-42c0-a14e-8f2266ae9493" />

- web, bridge running. note that I changed copy in the first bullet. no trezor-bridge mentions are present anymore.
- <img width="686" alt="image" src="https://github.com/user-attachments/assets/04f303ca-5349-455a-9d62-172c1edde100" />




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=switch-bridge-implementaion-troubleshooting&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=switch-bridge-implementaion-troubleshooting&lookback=7)