### PR TITLE
fix(suite): fixed unintentional approval refresh

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
@@ -29,7 +29,6 @@ import { TxAddress } from 'src/components/suite/copy/TxAddress';
 import { AccountLabeling } from 'src/components/suite/labeling';
 import { useDispatch } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
-import { useTradingExchangeWatchSendApproval } from 'src/hooks/wallet/trading/form/useTradingExchangeWatchSendApproval';
 import { TradingExchangeApprovalType } from 'src/types/trading/tradingForm';
 import { TradingCoinLogo } from 'src/views/wallet/trading/common/TradingCoinLogo';
 
@@ -57,18 +56,13 @@ export const ApproveModal = ({
         exchangeInfo,
         confirmTrade,
         sendTransaction,
-        watchTradeApproval,
+        preselectedQuote,
     } = useTradingFormContext<TradingExchangeType>();
 
     const { cryptoIdToSymbolAndContractAddress, cryptoIdToCoinSymbol } = useTradingInfo();
 
     const [approvalType, setApprovalType] = useState<DexApprovalType>('MINIMAL');
     const [isConfirmButtonLoading, setIsConfirmButtonLoading] = useState<boolean>(false);
-
-    useTradingExchangeWatchSendApproval({
-        selectedQuote,
-        watchTradeApproval,
-    });
 
     useEffect(() => {
         if (selectedQuote?.status !== 'APPROVAL_REQ') {
@@ -81,8 +75,9 @@ export const ApproveModal = ({
     const { exchange, dexTx } = selectedQuote;
     if (!exchange || !dexTx) return null;
 
-    const providerName =
-        exchangeInfo?.providerInfos[exchange]?.companyName || selectedQuote.exchange;
+    const quoteExchange = preselectedQuote?.exchange ?? exchange;
+
+    const providerName = exchangeInfo?.providerInfos[quoteExchange]?.companyName || quoteExchange;
 
     const isFullApproval = !(Number(selectedQuote.preapprovedStringAmount) > 0);
 

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -26,7 +26,7 @@ import {
     useTradingInfo,
 } from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';
-import { selectAccountByKey } from '@suite-common/wallet-core';
+import { fetchAndUpdateAccountThunk, selectAccountByKey } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import { toFiatCurrency } from '@suite-common/wallet-utils';
 import { EventType, analytics } from '@trezor/suite-analytics';
@@ -543,6 +543,8 @@ export const useTradingExchangeForm = ({
 
     const watchTradeApproval = useCallback(
         async (refreshCount: number) => {
+            await dispatch(fetchAndUpdateAccountThunk({ accountKey: account.key }));
+
             const commonFunctions = await getCommonFunctions(trade?.data);
 
             if (!commonFunctions) return;

--- a/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
@@ -134,11 +134,7 @@ export const confirmExchangeTradeThunk = createThunk(
 
         if (response.status === 'CONFIRM' && response.isDex) {
             dispatch(tradingExchangeActions.saveSelectedQuote(response));
-
-            // hotfix, will be fixed in https://github.com/trezor/trezor-suite/issues/19768
-            if (!approvalFlow) {
-                dispatch(tradingExchangeActions.setFormStep('SEND_TRANSACTION'));
-            }
+            dispatch(tradingExchangeActions.setFormStep('SEND_TRANSACTION'));
 
             return isConfirmationOk;
         }

--- a/suite-common/trading/src/thunks/exchange/watchTradeApprovalThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/watchTradeApprovalThunk.ts
@@ -1,7 +1,6 @@
 import { ExchangeTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { fetchAndUpdateAccountThunk } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 
 import { exchangeThunks } from '../';
@@ -56,7 +55,6 @@ export const watchTradeApprovalThunk = createThunk(
         };
 
         dispatch(tradingExchangeActions.saveSelectedQuote(updatedSelectedQuote));
-        await dispatch(fetchAndUpdateAccountThunk({ accountKey: account.key }));
 
         if (!updatedSelectedQuote.dexTx || !updatedSelectedQuote.receiveAddress) {
             return;


### PR DESCRIPTION
## Description

After approve/revoke transaction has been processed, the approval is refreshed instantly and does not cause unintentional delayed refresh which caused issues in receive address step.

## Related Issue

Resolve #19768 

## Screenshots:

https://github.com/user-attachments/assets/a0b1ab67-18a6-435f-9c58-2800aa821ad8




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/approval-refresh&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/approval-refresh&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/approval-refresh&lookback=7)