### PR TITLE
fix(connect-init): add getAccountInfo to wrapping blacklist

### DIFF
--- a/suite-common/connect-init/src/blacklist.ts
+++ b/suite-common/connect-init/src/blacklist.ts
@@ -26,4 +26,8 @@ export const blacklist: ConnectKey[] = [
     'getCoinInfo',
     'dispose',
     'cancel',
+    // this API may use device or not, depending on parameters. The flow that doesn't use device is called very often,
+    // so locking device must be avoided (blocks a lot of Suite features needlessly)
+    // TODO find a better solution to wrap this method only when device is used
+    'getAccountInfo',
 ];


### PR DESCRIPTION
## Description

Do not wrap `getAccountInfo` which was introduced in #19833 because it is often called in a way that does not require device, and locks the suite excessively.

Neither is entirely correct, because some flows of `getAccountInfo` do use device, and some don't.
:thought_balloon:  It'd be best to wrap it only when Suite knows that device will be used, but that'd require to duplicate the Connect code in `connectInitThunks`.
Does anyone have a better idea? If so, please make a PR instead of this one, but this is at least a hotfix that restores original behavior for today's freeze :slightly_smiling_face:  

## Related Issue

Resolve #19590

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/lock-device-too-often&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/lock-device-too-often&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/lock-device-too-often&lookback=7)