### PR TITLE
chore(suite): bump node bridge rollout threshold to 20 percent

### DIFF
--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -101,7 +101,7 @@ const shouldUseLegacyBridge = (store: Dependencies['store']) => {
         store.setBridgeSettings({ ...store.getBridgeSettings(), newBridgeRollout });
     }
     const newBridgeRollout = store.getBridgeSettings().newBridgeRollout || 0;
-    const NEW_BRIDGE_ROLLOUT_THRESHOLD = 0.1;
+    const NEW_BRIDGE_ROLLOUT_THRESHOLD = 0.2;
     const legacyBridgeReasonRollout = newBridgeRollout >= NEW_BRIDGE_ROLLOUT_THRESHOLD;
 
     return legacyBridgeReasonRollout;


### PR DESCRIPTION
## Description

We are bumping node bridge rollout percentage to 20%.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bump-node-bridge-rollout-20&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bump-node-bridge-rollout-20&lookback=7)