### PR TITLE
Add release notes for 25.7.x release

### DIFF
--- a/packages/suite-desktop/releaseNotes/release-notes.md
+++ b/packages/suite-desktop/releaseNotes/release-notes.md
@@ -1,14 +1,16 @@
 ### 🚀 New features
 
-- Added support for Stellar (XLM) network, which can be accessed via Experimental features.
-- WalletConnect integration is now available via Experimental features, allowing you to connect Suite to popular dApps.
-- You can now connect Trezor to third-party apps via TrezorConnect within Suite, a safe environment.
+- **Stellar (XLM) network now generally available:** Stellar (XLM) has moved from experimental features and can now be accessed by all Suite users via the Coins menu.
+- **Firmware Installation check:** new safety check added to ensure device firmware is correctly installed and up to date.
 
 ### 🎨 Improvements
 
-- Fonts for addresses and public keys in Suite now match those on Trezor devices to reduce visual discrepancies.
-- The transactions export menu has been improved with clarified filters and support for .csv, .pdf, and .json formats.
+- **Enhanced Passphrase wallet flow:** improved guidance when accessing passphrase wallets, making it clearer whether reopening an existing passphrase wallet or creating a new one.
+- **Faster wallet discovery:** wallets now load up to 50% faster, delivering a smoother and more responsive experience.
+- **Improved transaction history navigation:** pagination and navigation in transaction history have been refined for easier browsing.
+- **Trading interface enhancements:** modal headers have been updated for greater clarity, and DEX approvals have been moved to the start of the swap flow for a more intuitive experience.
+- **More accurate Bitcoin fee rates:** Bitcoin network fee rates now update every minute for improved accuracy when sending transactions.
 
 ### 🔧 Bug fixes
 
-- Fixed minor bugs, improved usability, and optimized performance for a smoother experience.
+- Fixed minor bugs, improved usability, and optimized overall performance for a smoother experience.


### PR DESCRIPTION
Adding release notes for upcoming Suite 25.7.x release

<img width="726" alt="image" src="https://github.com/user-attachments/assets/0037d85b-d6c1-4256-83c5-952a1f5cf4f3" />