### PR TITLE
feat(suite-common): add 2.9.0 fw binaries

### DIFF
--- a/packages/connect-common/files/firmware/t2b1/releases.json
+++ b/packages/connect-common/files/firmware/t2b1/releases.json
@@ -1,6 +1,21 @@
 [
     {
         "required": false,
+        "version": [2, 9, 0],
+        "min_bootloader_version": [2, 1, 1],
+        "min_firmware_version": [2, 6, 1],
+        "bootloader_version": [2, 1, 8],
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR"],
+        "url": "firmware/t2b1/trezor-t2b1-2.9.0.bin",
+        "url_bitcoinonly": "firmware/t2b1/trezor-t2b1-2.9.0-bitcoinonly.bin",
+        "fingerprint": "c64756ec723dba06527eebb00d7137371ffedf55a11cf5232f445433a0c27d15",
+        "fingerprint_bitcoinonly": "da044e4187e406351a1a06df903a678fe4a6b325ed9579ea22ce9f6984e42207",
+        "firmware_revision": "a09e6f04d4204607d821d9b742dcf7ffe9c4e2f5",
+        "changelog": "* Human readable Ethereum “approve”/”revoke” flow.\n* Changed unknown contract address warning screen.\n* Remove BNB Beacon Chain support.\n* Remove Turkish language support.\n* Fix tutorial-related translations.\n* Fix horizontal scroll of the title when setting Wipe code.\n* Known Solana tokens' don’t need to be confirmed.\n* Fix screen title when confirming installation.\n* \"Enter passphrase on host\" dialog is now not shown immediately after accessing Suite.",
+        "changelog_bitcoinonly": "* Changed unknown contract address warning screen.\n* Remove Turkish language support.\n* Fix tutorial-related translations.\n* Fix horizontal scroll of the title when setting Wipe code.\n* Fix screen title when confirming installation.\n* \"Enter passphrase on host\" dialog is now not shown immediately after accessing Suite."
+    },
+    {
+        "required": false,
         "version": [2, 8, 10],
         "min_bootloader_version": [2, 1, 1],
         "min_firmware_version": [2, 6, 1],

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.10-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.10-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2fcf27e4884efbceefd037ba47ebb603ce720575271e69ad0bb6f5b9dc565172
-size 1183744

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.10.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.10.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9cc8e38f5ca715e3764553149614310b5fc941293e4864e0f9c9db5a76218e14
-size 1467904

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.9.0-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.9.0-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5e8d18ac34116e201da9d5c89e4c6c61dc07c7672e543ba584ee312b081a1ac
+size 1199104

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.9.0.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.9.0.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51bd2d53d11d77161f9376df3603f54ec5950fd0b339b82a91cb02f83a95809e
+size 1479168

--- a/packages/connect-common/files/firmware/t2t1/releases.json
+++ b/packages/connect-common/files/firmware/t2t1/releases.json
@@ -1,6 +1,21 @@
 [
     {
         "required": false,
+        "version": [2, 9, 0],
+        "min_bootloader_version": [2, 0, 0],
+        "min_firmware_version": [2, 0, 8],
+        "bootloader_version": [2, 1, 8],
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR"],
+        "url": "firmware/t2t1/trezor-t2t1-2.9.0.bin",
+        "url_bitcoinonly": "firmware/t2t1/trezor-t2t1-2.9.0-bitcoinonly.bin",
+        "fingerprint": "135465194a0cc96291aed5ad97f2f3553cc561da31571e447ccc198e952854aa",
+        "fingerprint_bitcoinonly": "4cbaa64a0c9191745e8452245f235c00b053ccd157085e640c52ed9c27ccda19",
+        "firmware_revision": "a09e6f04d4204607d821d9b742dcf7ffe9c4e2f5",
+        "changelog": "* Human readable Ethereum “approve”/”revoke” flow.\n* Remove BNB Beacon Chain support.\n* Remove Turkish language support.\n* Don't enter/exit menu via horizontal swipe.\n* Fixed tutorial-related translations.\n* Known Solana tokens' don’t need to be confirmed.\n* \"Enter passphrase on host\" dialog is now not shown immediately after accessing Suite.",
+        "changelog_bitcoinonly": "* Remove Turkish language support.\n* Don't enter/exit menu via horizontal swipe.\n* Fixed tutorial-related translations.\n* \"Enter passphrase on host\" dialog is now not shown immediately after accessing Suite."
+    },
+    {
+        "required": false,
         "version": [2, 8, 10],
         "min_bootloader_version": [2, 0, 0],
         "min_firmware_version": [2, 0, 8],

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.10-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.10-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9b04bfb97723dbbc6db3edc2abe1daf603e2936cab6d180773645a2dd19f685c
-size 1273856

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.10.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.10.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f97b11599f68fe01f2f9414af6d876fb3dbedfc1e375e1e18486177e7523cb4d
-size 1589248

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.9.0-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.9.0-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdca5ebb672b9d9b4ffbcf52f3f589a95ed42280071649e951af32ebe76dc263
+size 1286144

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.9.0.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.9.0.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:399a86e51ebf287d6654a943e5529af7ab0b60ccdb37068c17ed3ff77a5a9b18
+size 1596416

--- a/packages/connect-common/files/firmware/t3b1/releases.json
+++ b/packages/connect-common/files/firmware/t3b1/releases.json
@@ -1,6 +1,21 @@
 [
     {
         "required": false,
+        "version": [2, 9, 0],
+        "min_bootloader_version": [2, 1, 7],
+        "min_firmware_version": [2, 8, 3],
+        "bootloader_version": [2, 1, 10],
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR"],
+        "url": "firmware/t3b1/trezor-t3b1-2.9.0.bin",
+        "url_bitcoinonly": "firmware/t3b1/trezor-t3b1-2.9.0-bitcoinonly.bin",
+        "fingerprint": "3fd121e6cd9d3179e8dd8a164523a2405fac04c734877c01f90f734c9d836883",
+        "fingerprint_bitcoinonly": "ef16d4e2529cbf4dd6a45f9b15177883873819dd886134dc5986cb5b71c5556f",
+        "firmware_revision": "a09e6f04d4204607d821d9b742dcf7ffe9c4e2f5",
+        "changelog": "* Human readable Ethereum “approve”/”revoke” flow.\n* Changed unknown contract address warning screen.\n* Remove BNB Beacon Chain support.\n* Remove Turkish language support.\n* Fix tutorial-related translations.\n* Fix horizontal scroll of the title when setting Wipe code.\n* Known Solana tokens' don’t need to be confirmed.\n* Fix screen title when confirming installation.\n* \"Enter passphrase on host\" dialog is now not shown immediately after accessing Suite.",
+        "changelog_bitcoinonly": "* Changed unknown contract address warning screen.\n* Remove Turkish language support.\n* Fix tutorial-related translations.\n* Fix horizontal scroll of the title when setting Wipe code.\n* Fix screen title when confirming installation.\n* \"Enter passphrase on host\" dialog is now not shown immediately after accessing Suite."
+    },
+    {
+        "required": false,
         "version": [2, 8, 10],
         "min_bootloader_version": [2, 1, 7],
         "min_firmware_version": [2, 8, 3],

--- a/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.10-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.10-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb64b3a6597b7bf27105cb4c303aaf4da6f6525bc78a75bdffcc5a3dd58c4303
-size 991744

--- a/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.10.bin
+++ b/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.10.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b082e2584c93ba815e3a4ca01e8906c126c87ea698c747b4a2138827fca95a7
-size 1345024

--- a/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.9.0-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.9.0-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c84ff1b35bc0f8f8ec3a2e23fd28d80481c054e02b518e98ff154c936dd22dd
+size 1008640

--- a/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.9.0.bin
+++ b/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.9.0.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f59d4adcab2b5db5ddcf96e4d4a9894872168438bf81b56c3faaf5dc19f73d56
+size 1356288

--- a/packages/connect-common/files/firmware/t3t1/releases.json
+++ b/packages/connect-common/files/firmware/t3t1/releases.json
@@ -1,6 +1,21 @@
 [
     {
         "required": false,
+        "version": [2, 9, 0],
+        "min_bootloader_version": [2, 1, 6],
+        "min_firmware_version": [2, 7, 2],
+        "bootloader_version": [2, 1, 10],
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR"],
+        "url": "firmware/t3t1/trezor-t3t1-2.9.0.bin",
+        "url_bitcoinonly": "firmware/t3t1/trezor-t3t1-2.9.0-bitcoinonly.bin",
+        "fingerprint": "9daf6fd2264cf0ef7f60ebad20cdfb72c3f8c23d5dc2e0096db2584f601489be",
+        "fingerprint_bitcoinonly": "6726de011043c01eafbe153f869725a1544f63e15ca24f5530aecadb8ecfe1be",
+        "firmware_revision": "a09e6f04d4204607d821d9b742dcf7ffe9c4e2f5",
+        "changelog": "* Human readable Ethereum “approve”/”revoke” flow.\n* Adjust warning screen when sending from multiple accounts at once.\n* Show success screen after sending address, public key or signature to host.\n* Remove BNB Beacon Chain support.\n* Remove Turkish language support.\n* Don't enter/exit menu via horizontal swipe.\n* Fix tutorial-related translations.\n* Fix issues with multishare backup creation.\n* Known Solana tokens' don’t need to be confirmed.\n* \"Enter passphrase on host\" dialog is now not shown immediately after accessing Suite.",
+        "changelog_bitcoinonly": "* Adjust warning screen when sending from multiple accounts at once.\n* Show success screen after sending address, public key or signature to host.\n* Remove Turkish language support.\n* Don't enter/exit menu via horizontal swipe.\n* Fix tutorial-related translations.\n* Fix issues with multishare backup creation.\n* \"Enter passphrase on host\" dialog is now not shown immediately after accessing Suite."
+    },
+    {
+        "required": false,
         "version": [2, 8, 10],
         "min_bootloader_version": [2, 1, 6],
         "min_firmware_version": [2, 7, 2],

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.10-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.10-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad66099c6bf2dd037c9844a9236f6dc3bd8eab200d5b6b0138aa29bcb4f35628
-size 1150464

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.10.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.10.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bd6b59f0cb501f8d372e2b8e7369195fdf1980f5915ca6fe61223fcd0601df6a
-size 1523200

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.9.0-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.9.0-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30a5842f08ec3135ab77ccaa84492acacd62edc6121299e1db9d3cc9c2468fab
+size 1174016

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.9.0.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.9.0.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2b3b3a7cf5d42327bfc91159ab3cf0250267c69614129ef911d3bb1b7098e01
+size 1541120


### PR DESCRIPTION
This pull request updates the firmware binaries in the packages/connect-common/files/firmware directory by removing outdated versions and adding new ones for various Trezor device models (t2b1, t2t1, t3b1, and t3t1). The changes ensure the inclusion of the latest firmware versions while cleaning up older files.

### Firmware Updates by Device Model:

#### `t2b1` Firmware:

- Removed version `2.8.10` (both standard and Bitcoin-only builds). [[1]](https://github.com/trezor/trezor-suite/pull/19875/files#diff-2812f0493c2b04b0586240d4285173f8da9b10c2f21eba0052237b86f0809e98) [[2]](https://github.com/trezor/trezor-suite/pull/19875/files#diff-d7759050894c26d43fd6c6d4cad5970832686924b8eda06fc065fe382743545b)
- Added version `2.9.0` (both standard and Bitcoin-only builds). [[1]](https://github.com/trezor/trezor-suite/pull/19875/files#diff-5c711b79b6711fecdf64884745f6ecc5915a8d96657b2ea2cfc01ca2e7cd4a72) [[2]](https://github.com/trezor/trezor-suite/pull/19875/files#diff-253bb4ce207d7569de7d991541d2604d584b4cde889c129dd60b18273e4e82e9)

#### `t2t1` Firmware:

- Removed version `2.8.10` (both standard and Bitcoin-only builds). [[1]](https://github.com/trezor/trezor-suite/pull/19875/files#diff-c39553071c18da11fa42ce836672e459ee66164a8eeda049035b3d924cc16702) [[2]](https://github.com/trezor/trezor-suite/pull/19875/files#diff-af5f2b860a3784ba47cce33ccfe8759b91474bb8d868cd2b8c47daa0e051697d)
- Added version `2.9.0` (both standard and Bitcoin-only builds). [[1]](https://github.com/trezor/trezor-suite/pull/19875/files#diff-5b09639d91ce48af6c371748138d08e39299c1eb692d1406b645e39a12d6cb04) [[2]](https://github.com/trezor/trezor-suite/pull/19875/files#diff-641799f03f19737de443491691e863b5322c010dbc338aa360e1197d414f48d0)

#### `t3b1` Firmware:

- Removed version `2.8.10` (both standard and Bitcoin-only builds). [[1]](https://github.com/trezor/trezor-suite/pull/19875/files#diff-c72c305f4564fc5e3fdfc1567321a5619ede226fd84c5ee8aa5c533a4d4994cc) [[2]](https://github.com/trezor/trezor-suite/pull/19875/files#diff-ba2884f3232cebf042119a65bb31673abf4f05ef0f0feffb233b9a4ed27665ad)
- Added version `2.9.0` (both standard and Bitcoin-only builds). [[1]](https://github.com/trezor/trezor-suite/pull/19875/files#diff-2d541699980c5bbafe072136527b6cba89c1ad3b28dd03acbd18e4e43c94805b) [[2]](https://github.com/trezor/trezor-suite/pull/19875/files#diff-11b8df2be43b3d82ce48e97e68bf77913846dd5a4b52ca261f4ecdce44ae0cf9)

#### `t3t1` Firmware:

- Removed version `2.8.10` (both standard and Bitcoin-only builds). [[1]](https://github.com/trezor/trezor-suite/pull/19875/files#diff-a28de5198d35acac2abe0fe23473e01daba0de5cf537ab85610a95cf0a26824b) [[2]](https://github.com/trezor/trezor-suite/pull/19875/files#diff-415794d75d674276da6c7b117cb1159b71c29afc019862d6a4cecf7cc66b8248)
- Added version `2.9.0` (both standard and Bitcoin-only builds). [[1]](https://github.com/trezor/trezor-suite/pull/19875/files#diff-2fa31179b145484c35ec6d1f52a3ca4e24daefdefa28cfe30cab4a9b342a38cf) [[2]](https://github.com/trezor/trezor-suite/pull/19875/files#diff-f224b79d67dda0bca904612dea3a11f20191b96d146c3b8094cfda2079702e77)