### PR TITLE
feat(connect): included bundled releases and improve types in DataManager

### DIFF
--- a/packages/connect/src/data/DataManager.ts
+++ b/packages/connect/src/data/DataManager.ts
@@ -2,7 +2,7 @@
 
 import coinsEth from '@trezor/connect-common/files/coins-eth.json';
 import coins from '@trezor/connect-common/files/coins.json';
-import { DeviceModelInternal } from '@trezor/device-utils';
+import { DeviceModelInternal, FirmwareRelease } from '@trezor/device-utils';
 import messages from '@trezor/protobuf/messages.json';
 
 import { parseCoinsJson } from './coinInfo';
@@ -10,7 +10,10 @@ import { parseFirmwareReleases } from './firmwareInfo';
 import type { ConnectSettings, LocalFirmwares } from '../types/settings';
 import { firmwareAssets } from '../utils/assetUtils'; // Adjust the path as necessary
 
-type AssetCollection = { [key: string]: Record<string, any> };
+type AssetKeys = `firmware-${string}` | 'coins' | 'coinsEth';
+type AssetCollection = {
+    [K in AssetKeys]?: Record<string, any>;
+};
 
 export class DataManager {
     static assets: AssetCollection = {};
@@ -28,10 +31,12 @@ export class DataManager {
             coins,
             coinsEth,
             ...Object.fromEntries(
-                Object.entries(firmwareAssets).map(([key, value]) => [
-                    `firmware-${key.toLowerCase()}`,
-                    value,
-                ]),
+                Object.entries(firmwareAssets).map(([key, value]) => {
+                    // For `unknown` firmware we get `{}` so we use `[]` to have always same type.
+                    const release = Array.isArray(value) ? value : [];
+
+                    return [`firmware-${key.toLowerCase()}`, release];
+                }),
             ),
         };
         Object.assign(this.assets, assetsMap);
@@ -44,11 +49,12 @@ export class DataManager {
 
         // parse firmware definitions
         for (const model in DeviceModelInternal) {
-            const firmwareKey = `firmware-${model.toLowerCase()}`;
+            const firmwareKey: `firmware-${string}` = `firmware-${model.toLowerCase()}`;
             const modelType = DeviceModelInternal[model as keyof typeof DeviceModelInternal];
+            const modelReleases = this.assets[firmwareKey] as FirmwareRelease[];
             // Check if the firmware data exists for this model
-            if (this.assets[firmwareKey]) {
-                parseFirmwareReleases(this.assets[firmwareKey], modelType);
+            if (modelReleases) {
+                parseFirmwareReleases(modelReleases, modelType);
             }
         }
     }

--- a/packages/connect/src/data/__tests__/firmwareInfo.test.ts
+++ b/packages/connect/src/data/__tests__/firmwareInfo.test.ts
@@ -1,16 +1,16 @@
-import * as releases2 from '@trezor/connect-common/files/firmware/t2t1/releases.json';
-import { DeviceModelInternal } from '@trezor/device-utils';
+import releases from '@trezor/connect-common/files/firmware/t2t1/releases.json';
+import { DeviceModelInternal, FirmwareRelease } from '@trezor/device-utils';
 
 import { getFirmwareStatus, getReleases, parseFirmwareReleases } from '../firmwareInfo';
 
 describe('data/firmwareInfo', () => {
     beforeEach(() => {
-        parseFirmwareReleases(releases2, DeviceModelInternal.T2T1);
+        parseFirmwareReleases(releases as FirmwareRelease[], DeviceModelInternal.T2T1);
     });
 
     test('getReleases', () => {
         expect(getReleases(DeviceModelInternal.T2T1)[0]).toMatchObject({
-            ...releases2[0],
+            ...releases[0],
             url: expect.any(String),
             url_bitcoinonly: expect.any(String),
         });

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -17,10 +17,17 @@ const releases = Object.values(DeviceModelInternal).reduce(
     (acc, key) => ({ ...acc, [key]: [] }),
     {} as Record<keyof typeof DeviceModelInternal, FirmwareRelease[] | undefined>,
 );
+// We use `bundledReleases` to know what are the binaries that are bundled so we do not need to download them if they are needed.
+const bundledReleases: Record<keyof typeof DeviceModelInternal, FirmwareRelease | undefined> =
+    {} as Record<keyof typeof DeviceModelInternal, FirmwareRelease>;
 
-export const parseFirmwareReleases = (json: any, deviceModel: DeviceModelInternal) => {
-    Object.keys(json).forEach(key => {
-        const release = json[key];
+export const parseFirmwareReleases = (
+    modelReleases: FirmwareRelease[],
+    deviceModel: DeviceModelInternal,
+) => {
+    const [latestRelease] = modelReleases;
+    bundledReleases[deviceModel] = latestRelease;
+    modelReleases.forEach(release => {
         releases[deviceModel]?.push({
             ...release,
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR is a little extraction to facilitate reviewing where we type better releases and include `bundledReleases` as new concept that later will be used to know if a binary is bundled with the app so we know we can use it from bundled instead of fetching it.

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/19763



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/type-releases-and-include-bundled-releases-in-firmwareInfo&lookback=7)