### PR TITLE
chore(connect): replace deprecated NodeRequire with NodeJS.Require

### DIFF
--- a/packages/connect/src/utils/assetUtils.ts
+++ b/packages/connect/src/utils/assetUtils.ts
@@ -4,8 +4,8 @@ import { isArrayMember } from '@trezor/utils';
 const isDeviceModel = (model: string): model is DeviceModelInternal =>
     isArrayMember(model, Object.values(DeviceModelInternal));
 
-export const firmwareAssets: Record<DeviceModelInternal, NodeRequire> = {
-    [DeviceModelInternal.UNKNOWN]: {} as NodeRequire,
+export const firmwareAssets: Record<DeviceModelInternal, NodeJS.Require> = {
+    [DeviceModelInternal.UNKNOWN]: {} as NodeJS.Require,
     [DeviceModelInternal.T1B1]: require('@trezor/connect-common/files/firmware/t1b1/releases.json'),
     [DeviceModelInternal.T2T1]: require('@trezor/connect-common/files/firmware/t2t1/releases.json'),
     [DeviceModelInternal.T2B1]: require('@trezor/connect-common/files/firmware/t2b1/releases.json'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Replace deprecated NodeRequire with NodeJS.Require

## Related Issue
Related https://github.com/trezor/trezor-suite/issues/19763


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/replace-deprecated-NodeRequire&lookback=7)