### PR TITLE
feat(transport): send message progress

### DIFF
--- a/packages/connect/src/api/firmware/uploadFirmware.ts
+++ b/packages/connect/src/api/firmware/uploadFirmware.ts
@@ -1,5 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/uploadFirmware.js
 
+import { TRANSPORT } from '@trezor/transport';
+
 import { ERRORS, PROTO } from '../../constants';
 import type { Device } from '../../device/Device';
 import type { TypedCall } from '../../device/DeviceCommands';
@@ -70,18 +72,32 @@ export const uploadFirmware = async (
     if (device.features.major_version === 2) {
         postConfirmationMessage(device);
         const length = payload.byteLength;
+        let progress = 0;
         let response = await typedCall('FirmwareErase', ['FirmwareRequest', 'Success'], { length });
         while (response.type !== 'Success') {
             // NOTE: offset and message are present in T2
-            const start = response.message.offset!;
-            const end = response.message.offset! + response.message.length!;
+            const start = response.message.offset;
+            const end = response.message.offset + response.message.length;
             const chunk = payload.slice(start, end);
+            const progressStart = Math.round((start / length) * 100);
+            const progressEnd = Math.round((end / length) * 100);
+            const progressDiff = progressEnd - progressStart;
+            device.transport.on(TRANSPORT.SEND_MESSAGE_PROGRESS, p => {
+                const newProgress = progressStart + Math.floor(progressDiff * p);
+                if (start > 0 && newProgress > progress) {
+                    progress = newProgress;
+                    postProgressMessage(device, progress, postMessage);
+                }
+            });
+
             // in this moment, device is still displaying 'update firmware dialog', no firmware process is in progress yet
             if (start > 0) {
-                postProgressMessage(device, Math.round((start / length) * 100), postMessage);
+                postProgressMessage(device, progressStart, postMessage);
             }
             response = await typedCall('FirmwareUpload', ['FirmwareRequest', 'Success'], {
                 payload: chunk,
+            }).finally(() => {
+                device.transport.removeAllListeners(TRANSPORT.SEND_MESSAGE_PROGRESS);
             });
         }
         postProgressMessage(device, 100, postMessage);

--- a/packages/transport/src/constants.ts
+++ b/packages/transport/src/constants.ts
@@ -34,6 +34,7 @@ export const TRANSPORT = {
     DEVICE_DISCONNECTED: 'transport-device_disconnected',
     DEVICE_SESSION_CHANGED: 'transport-device_session_changed',
     DEVICE_REQUEST_RELEASE: 'transport-device_request_release',
+    SEND_MESSAGE_PROGRESS: 'transport-send_message_progress',
     /* messages */
     DISABLE_WEBUSB: 'transport-disable_webusb',
     REQUEST_DEVICE: 'transport-request_device',

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -77,6 +77,7 @@ type TransportEvents = {
     [TRANSPORT.DEVICE_CONNECTED]: Descriptor;
     [TRANSPORT.ERROR]: BridgeCommonErrors | typeof ERRORS.API_DISCONNECTED; // BluetoothApi disconnected
     [TRANSPORT.STOPPED]: void;
+    [TRANSPORT.SEND_MESSAGE_PROGRESS]: number;
 };
 
 export type TransportDeviceEvent =

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -206,8 +206,16 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 });
                 const [, chunkHeader] = protocol.getHeaders(bytes);
                 const chunks = createChunks(bytes, chunkHeader, this.api.chunkSize);
-                const apiWrite = (chunk: Buffer, attemptSignal?: AbortSignal) =>
-                    this.api.write(path, chunk, attemptSignal || signal);
+                let progress = 0;
+                const apiWrite = (chunk: Buffer, attemptSignal?: AbortSignal) => {
+                    if (chunks.length > 1) {
+                        progress++;
+                        this.emit(TRANSPORT.SEND_MESSAGE_PROGRESS, progress / chunks.length);
+                    }
+
+                    return this.api.write(path, chunk, attemptSignal || signal);
+                };
+
                 const apiRead = (attemptSignal?: AbortSignal) =>
                     this.api.read(path, attemptSignal || signal);
 
@@ -288,7 +296,15 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 const [_, chunkHeader] = protocol.getHeaders(bytes);
 
                 const chunks = createChunks(bytes, chunkHeader, this.api.chunkSize);
-                const apiWrite = (chunk: Buffer) => this.api.write(path, chunk, signal);
+                let progress = 0;
+                const apiWrite = (chunk: Buffer) => {
+                    if (chunks.length > 1) {
+                        progress++;
+                        this.emit(TRANSPORT.SEND_MESSAGE_PROGRESS, progress / chunks.length);
+                    }
+
+                    return this.api.write(path, chunk, signal);
+                };
                 let sendResult;
                 if (protocol.name === 'v2') {
                     sendResult = await sendThpMessage({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

when we are streaming big messages like for example `FirmwareUpload` we want to know the progress otherwise loader in suite is jumping by 10% once in a while instead of showing actual progress of chunks sent.

this is confusing especially when uploading FW via bluetooth transport, it takes longer so the experience is that nothing happens


unfortunately it will **not work** with `BridgeTransport` as chunks are sent by the server and the process in not visible by host (suite)
but it should work with any othe variant of `AbstrtactTransport` (nodeusb, webusb, bluetooth, react-native)


OLD:
https://github.com/user-attachments/assets/53e00cd4-c6c6-43e2-8c6d-840568a6e99e

USB:
https://github.com/user-attachments/assets/43352da4-7ab5-46f0-b5ad-2ab759d639ba

BLUETOOTH:
https://github.com/user-attachments/assets/00ddb377-9702-424f-97ab-0faedc40a038



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/transport-send-message-progress&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/transport-send-message-progress&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/transport-send-message-progress&lookback=7)