### PR TITLE
fix(suite-native): fix switch atom border style

### DIFF
--- a/suite-native/atoms/src/Switch.tsx
+++ b/suite-native/atoms/src/Switch.tsx
@@ -34,21 +34,13 @@ const SWITCH_CIRCLE_TRACK_WIDTH =
     SWITCH_CIRCLE_MARGIN * 2 -
     SWITCH_CONTAINER_BORDER_WIDTH * 2;
 
-const switchContainerStyle = prepareNativeStyle<{ isChecked: boolean }>((utils, { isChecked }) => ({
+const switchContainerStyle = prepareNativeStyle(utils => ({
     height: SWITCH_CONTAINER_HEIGHT,
     width: SWITCH_CONTAINER_WIDTH,
     borderRadius: utils.borders.radii.round,
     flexDirection: 'row',
     borderWidth: SWITCH_CONTAINER_BORDER_WIDTH,
-    borderColor: 'transparent',
-    extend: [
-        {
-            condition: !isChecked,
-            style: {
-                borderColor: utils.colors.borderElevation0,
-            },
-        },
-    ],
+    borderColor: utils.colors.borderElevation0,
 }));
 
 const switchCircleStyle = prepareNativeStyle(utils => ({
@@ -104,12 +96,7 @@ export const Switch = ({ isChecked, onChange, isDisabled = false, testID }: Swit
 
     return (
         <Pressable onPress={handlePress} accessibilityRole="switch" testID={testID}>
-            <Animated.View
-                style={[
-                    animatedSwitchContainerStyle,
-                    applyStyle(switchContainerStyle, { isChecked }),
-                ]}
-            >
+            <Animated.View style={[animatedSwitchContainerStyle, applyStyle(switchContainerStyle)]}>
                 <Animated.View style={[animatedSwitchCircleStyle, applyStyle(switchCircleStyle)]} />
             </Animated.View>
         </Pressable>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- Switch is using transparent border in checked state and it looks less rounded because of that, and it seems like it increases in height when switched.


## Screenshots:

Check before/after videos (first, I toggle the switch three times in the original version, then I switch to the new one and toggle the switch three times again).


https://github.com/user-attachments/assets/3a44639c-a833-4699-9c94-d7ec2d2a3f1d

https://github.com/user-attachments/assets/f6e48e40-7f36-420c-85e5-52069a9fa40f




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/switch-border-nitpick&lookback=7)