### PR TITLE
`discoverAccounts` followup

### DIFF
--- a/packages/connect/src/api/discoverAccounts.ts
+++ b/packages/connect/src/api/discoverAccounts.ts
@@ -51,6 +51,9 @@ const isEvmLedger = (account: AccountTypeItem, coinInfo: CoinInfo) =>
 
 const getAccountTypeKey = ({ symbol, type }: AccountTypeKey) => `${symbol}-${type}` as const;
 
+// TODO use substituteBip43Path from wallet-utils somehow
+const substituteBip43Path = (path: string, index: number) => path.replace('i', String(index));
+
 export default class DiscoverAccounts extends AbstractMethod<'discoverAccounts', Request[]> {
     disposed = false;
 
@@ -63,7 +66,7 @@ export default class DiscoverAccounts extends AbstractMethod<'discoverAccounts',
         const { payload } = this;
 
         // validate bundle type
-        validateParams(payload, [{ name: 'accounts', type: 'array' }]);
+        validateParams(payload, [{ name: 'accounts', type: 'array', allowEmpty: true }]);
 
         this.params = payload.accounts.flatMap(item => {
             // validate incoming parameters
@@ -112,26 +115,26 @@ export default class DiscoverAccounts extends AbstractMethod<'discoverAccounts',
         this.progress[key] = progress;
     }
 
-    private sendProgress(account: DiscoverAccountsProgress) {
+    private sendProgress(response: DiscoverAccountsProgress) {
         const progress =
             Object.values(this.progress).reduce((sum, typeProgress) => sum + typeProgress, 0) /
             // if no items in progress, divide by 1 instead of 0 as the numerator will be 0 anyway
             (Object.keys(this.progress).length || 1);
 
         this.postMessage(
-            createUiMessage(UI.BUNDLE_PROGRESS, {
-                total: 100,
-                progress: 100 * progress,
-                response: account,
-            }),
+            createUiMessage(UI.BUNDLE_PROGRESS, { total: 100, progress: 100 * progress, response }),
         );
     }
 
     async run() {
         const [unsupported, supported] = this.filterUnsupportedAccounts(this.params);
 
-        unsupported.forEach(({ account: { path, ...rest }, error }) =>
-            this.sendProgress({ ...rest, index: 0, error }),
+        unsupported.forEach(
+            ({ account: { path: bip43, ...rest }, error, coinInfo, skip, offset }) => {
+                const path = substituteBip43Path(bip43, skip + offset);
+                const backendType = coinInfo.blockchainLink?.type;
+                this.sendProgress({ ...rest, index: skip, failed: true, error, path, backendType });
+            },
         );
 
         const [cardanoAccounts, otherAccounts] = arrayPartition(supported, isCardanoRequest);
@@ -206,7 +209,7 @@ export default class DiscoverAccounts extends AbstractMethod<'discoverAccounts',
         derivationType: CardanoDerivation | undefined,
         index: number,
     ) {
-        const path = bip43PathTemplate.replace('i', String(index)); // TODO use substituteBip43Path from wallet-utils somehow
+        const path = substituteBip43Path(bip43PathTemplate, index);
 
         const { address_n: _, ...descriptorRest } = await this.descriptorLock(async () => {
             const key = `${path}-${derivationType}`;
@@ -228,25 +231,28 @@ export default class DiscoverAccounts extends AbstractMethod<'discoverAccounts',
 
     private async discoverAccount(request: Request): Promise<{ nonempty: number; error?: string }> {
         const { details, identity, pageSize, coinInfo, derivation, offset, skip } = request;
-        const { path, ...accountKey } = request.account;
+        const { path: bip43, ...accountKey } = request.account;
+        const backendType = coinInfo.blockchainLink?.type;
         const utxoRequired = isUtxoBased(coinInfo) && details && details !== 'basic';
         let index = skip;
 
         let blockchain;
         try {
             blockchain = await initBlockchain(coinInfo, this.postMessage, identity);
-        } catch (error) {
+        } catch (err) {
+            const path = substituteBip43Path(bip43, offset + index);
             this.updateProgress(accountKey, index + 1, true);
-            this.sendProgress({ ...accountKey, index, error: error.message });
+            const error = err.message;
+            this.sendProgress({ ...accountKey, index, failed: true, error, path, backendType });
 
-            return { nonempty: 0, error: error.message };
+            return { nonempty: 0, error };
         }
 
-        let descPromise = this.getDescriptor(coinInfo, path, derivation, offset + index);
+        let descPromise = this.getDescriptor(coinInfo, bip43, derivation, offset + index);
         while (true) {
             try {
                 const { descriptor, ...descRest } = await descPromise;
-                descPromise = this.getDescriptor(coinInfo, path, derivation, offset + index + 1);
+                descPromise = this.getDescriptor(coinInfo, bip43, derivation, offset + index + 1);
 
                 const info = await blockchain.getAccountInfo({ descriptor, details, pageSize });
 
@@ -265,7 +271,8 @@ export default class DiscoverAccounts extends AbstractMethod<'discoverAccounts',
                     utxo,
                     ...accountKey,
                     index,
-                    backendType: request.coinInfo.blockchainLink?.type,
+                    backendType,
+                    failed: false,
                 });
 
                 if (info.empty) {
@@ -273,10 +280,13 @@ export default class DiscoverAccounts extends AbstractMethod<'discoverAccounts',
 
                     return { nonempty: index - skip };
                 }
-            } catch (error) {
+            } catch (err) {
                 descPromise.catch(() => {});
+                const path = substituteBip43Path(bip43, offset + index);
+                const { message: error, code } = err;
+                const failed = true;
                 this.updateProgress(accountKey, index + 1, true);
-                this.sendProgress({ ...accountKey, index, error: error.message, code: error.code });
+                this.sendProgress({ ...accountKey, index, failed, error, code, path, backendType });
 
                 return { nonempty: index - skip, error };
             }

--- a/packages/connect/src/types/api/discoverAccounts.ts
+++ b/packages/connect/src/types/api/discoverAccounts.ts
@@ -88,10 +88,10 @@ type DiscoverAccountsParams = {
     accounts: (TypedAccountParam | UntypedAccountParam)[];
 };
 
-type ProgressBaseType = AccountTypeKey & { index: number };
-export type DiscoverAccountsProgressOk = ProgressBaseType &
-    AccountInfo & { path: string; backendType?: string };
-export type DiscoverAccountsProgressError = ProgressBaseType & { error: string; code?: string };
+type ProgressBaseType = AccountTypeKey & { index: number; path: string; backendType?: string };
+type DiscoveryError = { failed: true; error: string; code?: string };
+export type DiscoverAccountsProgressOk = ProgressBaseType & AccountInfo & { failed: false };
+export type DiscoverAccountsProgressError = ProgressBaseType & DiscoveryError;
 export type DiscoverAccountsProgress = DiscoverAccountsProgressOk | DiscoverAccountsProgressError;
 
 type DiscoverAccountsResult = {

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -8,9 +8,13 @@ import type { TradingTransaction } from '@suite-common/trading';
 import type { Explorer, NetworkSymbol } from '@suite-common/wallet-config';
 import { FormDraftPrefixKeyValues } from '@suite-common/wallet-constants';
 import { deviceActions, selectDevices } from '@suite-common/wallet-core';
-import type { FormState, RatesByTimestamps } from '@suite-common/wallet-types';
+import type { FormState, RatesByTimestamps, SuccessfulAccount } from '@suite-common/wallet-types';
 import { FormDraftKeyPrefix } from '@suite-common/wallet-types';
-import { getFormDraftKey, selectHistoricRatesByTransactions } from '@suite-common/wallet-utils';
+import {
+    getFormDraftKey,
+    isAccountSuccessful,
+    selectHistoricRatesByTransactions,
+} from '@suite-common/wallet-utils';
 import { cloneObject } from '@trezor/utils';
 
 import { selectCoinjoinAccountByKey } from 'src/reducers/wallet/coinjoinReducer';
@@ -250,7 +254,7 @@ export const forgetDevice = (device: TrezorDevice) => async (_: Dispatch, getSta
     ]);
 };
 
-export const saveAccounts = async (accounts: Account[]) => {
+export const saveAccounts = async (accounts: SuccessfulAccount[]) => {
     if (!(await db.isAccessible())) return;
 
     return db.addItems('accounts', accounts, true);
@@ -305,9 +309,10 @@ export const rememberDevice =
         }
 
         const { wallet } = getState();
-        const accounts = wallet.accounts.filter(
-            a => a.deviceState === device.state?.staticSessionId,
-        );
+        const accounts = wallet.accounts
+            .filter(isAccountSuccessful)
+            .filter(a => a.deviceState === device.state?.staticSessionId);
+
         const graphData = wallet.graph.data.filter(d =>
             deviceGraphDataFilterFn(d, device.state?.staticSessionId),
         );

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -80,15 +80,14 @@ const getAccountState = (state: AppState): SelectedAccountStatus => {
         };
     }
 
-    // waiting for discovery
-    const discovery = selectDiscoveryForSelectedDevice(state);
-
-    const matchedFailed = (discovery?.failed ?? []).find(
+    const matchedFailed = accounts.find(
         f =>
+            f.failed &&
             f.symbol === network.symbol &&
             f.index === params.accountIndex &&
             f.accountType === params.accountType,
     );
+
     // discovery for requested network failed
     if (matchedFailed) {
         return {
@@ -130,6 +129,8 @@ const getAccountState = (state: AppState): SelectedAccountStatus => {
             params,
         };
     }
+
+    const discovery = selectDiscoveryForSelectedDevice(state);
 
     // account doesn't exist (yet?) checking why...
     // discovery is still running

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import {
     restartDiscoveryThunk,
     selectSelectedDevice,
-    selectShowRediscoverButton,
+    selectShouldRediscoverNetworks,
 } from '@suite-common/wallet-core';
 import { Button, IconButton, Row, Tooltip, motionEasing } from '@trezor/components';
 import { spacings, spacingsPx, typography } from '@trezor/theme';
@@ -48,7 +48,7 @@ export const RefreshAfterDiscoveryNeeded = () => {
     const selectedDevice = useSelector(selectSelectedDevice);
     const isSidebarCollapsed = useIsSidebarCollapsed();
     const isDiscoveryButtonVisible = useSelector(state =>
-        selectShowRediscoverButton(state, selectedDevice?.state?.staticSessionId),
+        selectShouldRediscoverNetworks(state, selectedDevice?.state?.staticSessionId),
     );
 
     if (!selectedDevice?.connected) {

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -2,7 +2,7 @@ import { combineReducers, createReducer } from '@reduxjs/toolkit';
 
 import { testMocks } from '@suite-common/test-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { getNetwork } from '@suite-common/wallet-config';
+import { Network, getNetwork } from '@suite-common/wallet-config';
 import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants';
 import { SendState, accountsActions, prepareSendFormReducer } from '@suite-common/wallet-core';
 import { FeesState, SelectedAccountStatus } from '@suite-common/wallet-types';
@@ -54,7 +54,8 @@ const UTXO = {
     }),
 };
 
-export const BTC_ACCOUNT: DeepPartial<SelectedAccountStatus> = {
+// The type was needed because of error TS7056: The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed.
+export const BTC_ACCOUNT: Omit<SelectedAccountStatus, 'network'> & { network: Partial<Network> } = {
     status: 'loaded',
     account: testMocks.getWalletAccount({
         symbol: 'btc',

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -76,7 +76,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
                         device.state.staticSessionId,
                     );
 
-                    if (networksToDiscover.length) {
+                    if (networksToDiscover.undiscovered.length) {
                         dispatch(runAdditionalDiscoveryThunk(device.state.staticSessionId));
                     }
                 }

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -6,8 +6,8 @@ import {
     changeNetworks,
     deviceActions,
     runAdditionalDiscoveryThunk,
-    selectNetworksToDiscover,
     selectSelectedDevice,
+    selectShouldRediscoverNetworks,
     startDiscoveryThunk,
 } from '@suite-common/wallet-core';
 
@@ -71,12 +71,12 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
                         }),
                     );
                 } else if (device.state.staticSessionId) {
-                    const networksToDiscover = selectNetworksToDiscover(
+                    const shouldRediscover = selectShouldRediscoverNetworks(
                         getState(),
                         device.state.staticSessionId,
                     );
 
-                    if (networksToDiscover.undiscovered.length) {
+                    if (shouldRediscover) {
                         dispatch(runAdditionalDiscoveryThunk(device.state.staticSessionId));
                     }
                 }

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -8,7 +8,7 @@ import {
     runAdditionalDiscoveryThunk,
     selectNetworksToDiscover,
     selectSelectedDevice,
-    startInitialDiscovery,
+    startDiscoveryThunk,
 } from '@suite-common/wallet-core';
 
 import { SUITE } from 'src/actions/suite/constants';
@@ -16,7 +16,7 @@ import { selectIsDeviceLocked } from 'src/reducers/suite/suiteReducer';
 
 // todo: this is crazy. needs some consideration
 export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
-    async (action, { dispatch, next, getState }) => {
+    async (action, { dispatch, next, getState, extra }) => {
         const prevState = getState();
 
         // Pass action to next middleware, meaning that the code below runs *only after* the action has been completely processed in Redux.
@@ -56,9 +56,18 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         ) {
             if (device && device.connected && isDeviceAcquired(device) && !isDeviceLocked) {
                 if (!device?.state) {
+                    // note: currently this is only used in Suite. If a Suite Lite implementation is needed,
+                    // refactor this to a parameter because suiteSettings is a suite-only reducer.
+                    const isAddingHiddenWalletWithRespectToSettings =
+                        extra.selectors.selectSuiteSettings(getState()).defaultWalletLoading ===
+                        'passphrase';
+
                     dispatch(
-                        startInitialDiscovery({
+                        startDiscoveryThunk({
                             device,
+                            isAddingHiddenWalletWithRespectToSettings,
+                            isAddingExistingWallet: true,
+                            isAddingHiddenWallet: isAddingHiddenWalletWithRespectToSettings,
                         }),
                     );
                 } else if (device.state.staticSessionId) {

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -27,7 +27,7 @@ import {
     transactionsActions,
     updateTxsFiatRatesThunk,
 } from '@suite-common/wallet-core';
-import { findAccountDevice } from '@suite-common/wallet-utils';
+import { findAccountDevice, isAccountSuccessful } from '@suite-common/wallet-utils';
 import { walletConnectActions } from '@suite-common/walletconnect';
 
 import { METADATA, STORAGE, SUITE } from 'src/actions/suite/constants';
@@ -58,7 +58,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 const { payload } = action;
                 const device = findAccountDevice(payload, selectDevices(api.getState()));
                 // update only transactions for remembered device
-                if (isDeviceRemembered(device)) {
+                if (isDeviceRemembered(device) && isAccountSuccessful(payload)) {
                     storageActions.saveAccounts([payload]);
                     api.dispatch(storageActions.saveCoinjoinAccount(payload.key));
                 }
@@ -71,7 +71,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
             if (isAnyOf(metadataActions.setAccountAdd)(action)) {
                 const device = findAccountDevice(action.payload, selectDevices(api.getState()));
                 // if device is remembered, and there is a change in account.metadata (metadataActions.setAccountLoaded), update database
-                if (isDeviceRemembered(device)) {
+                if (isDeviceRemembered(device) && isAccountSuccessful(action.payload)) {
                     storageActions.saveAccounts([action.payload]);
                 }
             }

--- a/packages/suite/src/utils/wallet/selectDiscoveryOverallStatus.ts
+++ b/packages/suite/src/utils/wallet/selectDiscoveryOverallStatus.ts
@@ -1,7 +1,11 @@
 import { TrezorDevice } from '@suite-common/suite-types';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { selectDiscoveryByDevicePath, selectSelectedDevice } from '@suite-common/wallet-core';
-import { DiscoveryStatus } from '@suite-common/wallet-types';
+import {
+    selectAccountsByDeviceState,
+    selectDiscoveryByDevicePath,
+    selectSelectedDevice,
+} from '@suite-common/wallet-core';
+import { Account, DiscoveryStatus } from '@suite-common/wallet-types';
 
 import { AppState } from 'src/types/suite';
 
@@ -10,6 +14,7 @@ import { DiscoveryStatusType } from '../../types/wallet';
 type GetDiscoveryStatusParams = {
     device: TrezorDevice | undefined;
     discovery: DiscoveryStatus | undefined;
+    accounts: Account[] | undefined;
     walletSettings: {
         enabledNetworks: NetworkSymbol[];
     };
@@ -18,6 +23,7 @@ type GetDiscoveryStatusParams = {
 const getDiscoveryStatus = ({
     device,
     discovery,
+    accounts,
     walletSettings,
 }: GetDiscoveryStatusParams): DiscoveryStatusType | undefined => {
     if (!device) {
@@ -47,7 +53,7 @@ const getDiscoveryStatus = ({
 
     if (
         (discovery?.status === 'failed' && discovery.error) ||
-        (discovery?.failed ?? []).length > 0
+        (accounts ?? []).find(a => a.failed)
     ) {
         return {
             status: 'exception',
@@ -76,8 +82,9 @@ const getDiscoveryStatus = ({
 // TODO move this selector somewhere more sensible
 export const selectDiscoveryOverallStatus = (state: AppState) => {
     const device = selectSelectedDevice(state);
+    const accounts = device?.state && selectAccountsByDeviceState(state, device.state);
     const discovery = selectDiscoveryByDevicePath(state, device?.path);
     const walletSettings = state.wallet.settings;
 
-    return getDiscoveryStatus({ device, discovery, walletSettings });
+    return getDiscoveryStatus({ device, discovery, accounts, walletSettings });
 };

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -5,6 +5,7 @@ import {
     selectCurrentFiatRates,
     selectLocalCurrency,
 } from '@suite-common/wallet-core';
+import { isAccountFailed } from '@suite-common/wallet-utils';
 import { Card, Column, Dropdown, Switch, Tooltip } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { spacings } from '@trezor/theme';
@@ -33,6 +34,7 @@ export const PortfolioCard = memo(() => {
     const { device } = useDevice();
 
     const isDeviceEmpty = useMemo(() => accounts.every(a => a.empty), [accounts]);
+    const failedAccounts = useMemo(() => accounts.filter(isAccountFailed), [accounts]);
     const walletBalance = useTotalFiatBalance(accounts, localCurrency, currentFiatRates);
 
     // TODO: DashboardGraph will get mounted twice (thus triggering data processing twice)
@@ -42,7 +44,13 @@ export const PortfolioCard = memo(() => {
 
     let body = null;
     if (discoveryStatus && discoveryStatus.status === 'exception') {
-        body = <PortfolioCardException exception={discoveryStatus} discovery={discovery} />;
+        body = (
+            <PortfolioCardException
+                exception={discoveryStatus}
+                discovery={discovery}
+                failed={failedAccounts}
+            />
+        );
     } else if (discoveryStatus && discoveryStatus.status === 'loading') {
         body = dashboardGraphHidden ? null : (
             <Column height={320}>

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
@@ -2,7 +2,7 @@ import { ComponentProps, JSX } from 'react';
 
 import { NetworkType, getNetwork } from '@suite-common/wallet-config';
 import { restartDiscoveryThunk } from '@suite-common/wallet-core';
-import { DiscoveryStatus } from '@suite-common/wallet-types';
+import { DiscoveryStatus, FailedAccount } from '@suite-common/wallet-types';
 import { Button, Column, H3, IconCircle, IconName, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -77,14 +77,17 @@ const getAccountError = (accountError: string, networkType: NetworkType) => {
     return accountError;
 };
 
-const discoveryFailedMessage = (discovery?: DiscoveryStatus) => {
+const discoveryFailedMessage = (
+    discovery: DiscoveryStatus | undefined,
+    failed: FailedAccount[],
+) => {
     if (!discovery || discovery.status !== 'failed') return '';
     if (discovery.error) return <div>{discovery.error}</div>;
 
     // Group all failed networks into array of errors.
     const networkError: string[] = [];
 
-    const details = (discovery.failed ?? []).reduce((value, account) => {
+    const details = failed.reduce((value, account) => {
         const network = getNetwork(account.symbol);
         if (networkError.includes(account.symbol)) return value;
         networkError.push(account.symbol);
@@ -106,9 +109,14 @@ const discoveryFailedMessage = (discovery?: DiscoveryStatus) => {
 type PortfolioCardExceptionProps = {
     exception: Extract<DiscoveryStatusType, { status: 'exception' }>;
     discovery?: DiscoveryStatus;
+    failed: FailedAccount[];
 };
 
-export const PortfolioCardException = ({ exception, discovery }: PortfolioCardExceptionProps) => {
+export const PortfolioCardException = ({
+    exception,
+    discovery,
+    failed,
+}: PortfolioCardExceptionProps) => {
     const dispatch = useDispatch();
 
     switch (exception.type) {
@@ -134,7 +142,7 @@ export const PortfolioCardException = ({ exception, discovery }: PortfolioCardEx
                     description={
                         <Translation
                             id="TR_DASHBOARD_DISCOVERY_ERROR_PARTIAL_DESC"
-                            values={{ details: discoveryFailedMessage(discovery) }}
+                            values={{ details: discoveryFailedMessage(discovery, failed) }}
                         />
                     }
                     cta={{ action: () => dispatch(restartDiscoveryThunk()), icon: 'repeat' }}
@@ -148,7 +156,7 @@ export const PortfolioCardException = ({ exception, discovery }: PortfolioCardEx
                     description={
                         <Translation
                             id="TR_ACCOUNT_PASSPHRASE_DISABLED"
-                            values={{ details: discoveryFailedMessage(discovery) }}
+                            values={{ details: discoveryFailedMessage(discovery, failed) }}
                         />
                     }
                     cta={{

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -6,7 +6,7 @@ import {
     restartDiscoveryThunk,
     selectDeviceSupportedNetworks,
     selectEnabledNetworks,
-    selectShowRediscoverButton,
+    selectShouldRediscoverNetworks,
 } from '@suite-common/wallet-core';
 import { Button, Tooltip, motionEasing } from '@trezor/components';
 import { hasBitcoinOnlyFirmware, isBitcoinOnlyDevice } from '@trezor/device-utils';
@@ -85,7 +85,7 @@ export const SettingsCoins = () => {
     const { isDiscoveryRunning } = useDiscovery();
     const staticSessionId = device?.state?.staticSessionId;
     const isDiscoveryButtonVisible = useSelector(state =>
-        selectShowRediscoverButton(state, staticSessionId),
+        selectShouldRediscoverNetworks(state, staticSessionId),
     );
 
     const supportedEnabledNetworks = enabledNetworks.filter(enabledNetwork =>

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -37,6 +37,7 @@ export type CreateAccountActionProps = {
     accountInfo: AccountInfo;
     imported?: boolean;
     accountLabel?: string;
+    error?: string;
     visible: boolean;
 };
 
@@ -47,6 +48,7 @@ const composeCreateAccountActionPayload = ({
     imported,
     accountLabel,
     visible,
+    error,
 }: CreateAccountActionProps): Account => {
     try {
         const { chainId } = getNetwork(discoveryItem.coin);
@@ -61,6 +63,7 @@ const composeCreateAccountActionPayload = ({
             deviceState,
             accountLabel,
             imported,
+            ...(error !== undefined ? { error, failed: true } : { failed: undefined }),
             index: discoveryItem.index,
             path: discoveryItem.path,
             unlockPath: discoveryItem.unlockPath,
@@ -119,6 +122,7 @@ const createAccount = createAction(
         imported,
         accountLabel,
         visible,
+        error,
     }: CreateAccountActionProps): { payload: Account } => ({
         payload: composeCreateAccountActionPayload({
             deviceState,
@@ -127,6 +131,7 @@ const createAccount = createAction(
             imported,
             accountLabel,
             visible,
+            error,
         }),
     }),
 );

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -65,31 +65,20 @@ export const prepareAccountsReducer = createReducerWithExtraDeps(
                 remove(state, action.payload);
             })
             .addCase(accountsActions.createAccount, (state, action) => {
-                const { deviceState, symbol, accountType } = action.payload;
-                const matchingNetworkAndTypeAccounts = state.filter(
-                    account =>
-                        account.deviceState === deviceState &&
-                        account.symbol === symbol &&
-                        account.accountType === accountType,
-                );
-
-                const indexOfPreviousAccount = matchingNetworkAndTypeAccounts.length;
+                const { symbol, index } = action.payload;
                 const networkName = networks[symbol].name;
-                const accountLabel =
-                    action.payload.accountLabel ?? `${networkName} #${indexOfPreviousAccount + 1}`;
+                const accountLabel = action.payload.accountLabel ?? `${networkName} #${index + 1}`;
+                // remove "transactions" field, they are stored in "transactionReducer"
+                const history = enhanceHistory(action.payload.history);
 
-                const account = {
-                    ...action.payload,
-                    accountLabel,
-                    // remove "transactions" field, they are stored in "transactionReducer"
-                    history: enhanceHistory(action.payload.history),
-                };
+                const account = { ...action.payload, accountLabel, history };
+
                 if (state.some(accountEqualTo(account))) {
-                    console.warn('Prevented duplicate account in accountsReducer: ', account);
-
-                    return;
+                    console.warn('Duplicated account found, updating instead: ', account);
+                    update(state, account);
+                } else {
+                    state.push(account);
                 }
-                state.push(account);
             })
             .addCase(accountsActions.updateAccount, (state, action) => {
                 update(state, action.payload);

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -3,7 +3,7 @@ import { isAnyOf } from '@reduxjs/toolkit';
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { networks } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
-import { enhanceHistory, isAccountInCollection } from '@suite-common/wallet-utils';
+import { accountEqualTo, enhanceHistory } from '@suite-common/wallet-utils';
 
 import { accountsActions } from './accountsActions';
 import { deviceActions } from '../device/deviceActions';
@@ -22,9 +22,6 @@ const findCoinjoinAccount =
     (key: string) =>
     (account: Account): account is Extract<Account, { backendType: 'coinjoin' }> =>
         account.key === key && account.backendType === 'coinjoin';
-
-const accountEqualTo = (b: Account) => (a: Account) =>
-    a.deviceState === b.deviceState && a.descriptor === b.descriptor && a.symbol === b.symbol;
 
 const update = (state: Account[], account: Account) => {
     const accountIndex = state.findIndex(accountEqualTo(account));
@@ -87,7 +84,7 @@ export const prepareAccountsReducer = createReducerWithExtraDeps(
                     // remove "transactions" field, they are stored in "transactionReducer"
                     history: enhanceHistory(action.payload.history),
                 };
-                if (isAccountInCollection(account, state)) {
+                if (state.some(accountEqualTo(account))) {
                     console.warn('Prevented duplicate account in accountsReducer: ', account);
 
                     return;

--- a/suite-common/wallet-core/src/discovery/__tests__/discoveryReducer.test.ts
+++ b/suite-common/wallet-core/src/discovery/__tests__/discoveryReducer.test.ts
@@ -146,45 +146,6 @@ describe('Discovery Reducer', () => {
         });
     });
 
-    it('should not set "hasLoadedAnyNonEmptyAccount" when status is not "progress"', () => {
-        // Initialize store with existing discovery
-        const store = initStore({
-            preloadedState: {
-                wallet: {
-                    discovery: {
-                        [TEST_DEVICE_PATH]: {
-                            status: 'starting',
-                            startTimestamp: 1000,
-                        },
-                    },
-                },
-            },
-        });
-
-        // Update to progress status
-        store.dispatch(
-            discoveryActions.updateDiscovery(
-                {
-                    status: 'enter-passphrase',
-                    // @ts-expect-error: this is not possible type-wise but in runtime, who know
-                    hasLoadedAnyNonEmptyAccount: true,
-                    total: 10,
-                    progress: 5,
-                },
-                TEST_DEVICE_PATH,
-            ),
-        );
-
-        expect(store.getState().wallet.discovery[TEST_DEVICE_PATH]).toEqual({
-            status: 'enter-passphrase',
-            startTimestamp: 1000,
-            hasLoadedAnyNonEmptyAccount: undefined,
-            passphraseSubmitted: undefined,
-            total: 10,
-            progress: 5,
-        });
-    });
-
     it('should handle updateDiscovery action with passphraseSubmitted flag', () => {
         // Initialize store with existing discovery
         const store = initStore({

--- a/suite-common/wallet-core/src/discovery/discoveryReducer.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryReducer.ts
@@ -18,17 +18,15 @@ const update = (draft: Discovery, payload: { status: DiscoveryStatus; path: Devi
     }
 
     const currentStatus = draft[payload.path];
-    const hasLoadedAnyNonEmptyAccount: true | undefined =
-        (currentStatus.status === 'progress' && currentStatus.hasLoadedAnyNonEmptyAccount) ||
-        (payload.status.status === 'progress' && payload.status.hasLoadedAnyNonEmptyAccount) ||
-        undefined;
+    const hasLoadedAnyNonEmptyAccount =
+        currentStatus.hasLoadedAnyNonEmptyAccount || payload.status.hasLoadedAnyNonEmptyAccount;
 
     const statusChanged = payload.status.status && currentStatus.status !== payload.status.status;
 
     draft[payload.path] = {
         ...currentStatus,
         ...payload.status,
-        ...{ hasLoadedAnyNonEmptyAccount },
+        hasLoadedAnyNonEmptyAccount,
         ...{
             passphraseSubmitted:
                 payload.status.passphraseSubmitted ?? currentStatus.passphraseSubmitted,

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -35,11 +35,9 @@ const USER_UI_CANCEL_CODE = 'USER_UI_CANCEL';
 const DEVICE_CANCELLATION_CODES = ['Method_Cancel', 'Failure_ActionCancelled'];
 
 type ProgressEvent = BundleProgress<DiscoverAccountsProgress>['payload'];
-type ProgressOkEvent = BundleProgress<DiscoverAccountsProgressOk>['payload'];
+
 const isProgressOk = (progress: DiscoverAccountsProgress): progress is DiscoverAccountsProgressOk =>
     Object.prototype.hasOwnProperty.call(progress, 'path');
-const isProgressEventOk = (progressEvent: ProgressEvent): progressEvent is ProgressOkEvent =>
-    isProgressOk(progressEvent.response);
 
 function assertDeviceIsAuthorized(device?: TrezorDevice): asserts device is AuthorizedDevice {
     if (!device?.state?.staticSessionId) {
@@ -159,27 +157,13 @@ const applyDeviceStatesThunk = createThunk(
     },
 );
 
-const createOnBundleProgressHandler = (
-    devicePath: DeviceUniquePath,
-    deviceStaticSessionId: StaticSessionId,
-    dispatch: any,
-    getState: any,
-    progressHooks: {
-        onNonFirstNonEmptyAccountDiscovered?: () => void;
-    } = {},
-) => {
-    let encounteredNonEmptyAccount = false;
-    // we do not create empty accounts right away, but store the progress events for later
-    const emptyProgressEvents: ProgressOkEvent[] = [];
-
-    const progressEventToCreateAccountPayload = (
-        event: ProgressOkEvent,
-    ): CreateAccountActionProps => {
-        const { response } = event;
+const progressEventToCreateAccountPayload =
+    (deviceState: StaticSessionId) =>
+    (response: DiscoverAccountsProgressOk): CreateAccountActionProps => {
         const backendType = response.backendType as TrezorConnectBackendType | undefined;
 
         return {
-            deviceState: deviceStaticSessionId,
+            deviceState,
             discoveryItem: {
                 path: response.path as Bip43Path,
                 coin: response.symbol,
@@ -193,8 +177,24 @@ const createOnBundleProgressHandler = (
         };
     };
 
+const createOnBundleProgressHandler = (
+    devicePath: DeviceUniquePath,
+    deviceStaticSessionId: StaticSessionId,
+    dispatch: any,
+    getState: any,
+    progressHooks: {
+        onNonFirstNonEmptyAccountDiscovered?: () => void;
+    } = {},
+) => {
+    // we do not create empty accounts right away, but store the progress events for later
+    const accountQueue: ReturnType<typeof accountsActions.createAccount>[] = [];
+    const getCreateAccountPayload = progressEventToCreateAccountPayload(deviceStaticSessionId);
+
+    let encounteredNonEmptyAccount = false;
+
     return (event: ProgressEvent) => {
         const discovery = selectDiscoveryByDevicePath(getState(), devicePath);
+
         if (!discovery) {
             console.error('bundle progress handler: no discovery found');
 
@@ -226,65 +226,44 @@ const createOnBundleProgressHandler = (
             progressHooks.onNonFirstNonEmptyAccountDiscovered?.();
         }
 
-        if (isProgressEventOk(event)) {
-            // all encountered accounts were empty, so create all of the delayed empty accounts (and also the latest event)
-            if (event.progress === 100 && !encounteredNonEmptyAccount) {
-                [...emptyProgressEvents, event].forEach(delayedEvent => {
-                    dispatch(
-                        accountsActions.createAccount(
-                            progressEventToCreateAccountPayload(delayedEvent),
-                        ),
-                    );
-                });
-
-                return;
-            }
-
-            if (encounteredNonEmptyAccount) {
-                dispatch(accountsActions.createAccount(progressEventToCreateAccountPayload(event)));
-
-                return;
-            } else {
-                emptyProgressEvents.push(event);
-            }
-
-            // on first non-empty one, create all of the delayed empty accounts
-            if (!encounteredNonEmptyAccount && event.response.empty === false) {
-                encounteredNonEmptyAccount = true;
-
-                emptyProgressEvents.forEach(delayedEvent => {
-                    dispatch(
-                        accountsActions.createAccount(
-                            progressEventToCreateAccountPayload(delayedEvent),
-                        ),
-                    );
-                });
-            }
-
-            return;
-        }
-
         const { response } = event;
+
         if (isProgressOk(response)) {
-            console.error('Cannot happen per TS; event.response cannot be OK if event is not OK');
+            const accountAction = accountsActions.createAccount(getCreateAccountPayload(response));
 
-            return;
+            const prevEncountered = encounteredNonEmptyAccount;
+            encounteredNonEmptyAccount ||= !response.empty || event.progress === 100;
+
+            // no non-empty account encountered, enqueue account for postponed creation
+            if (!encounteredNonEmptyAccount) {
+                accountQueue.push(accountAction);
+            } else {
+                // first non-empty account encountered right now, create all enqueued accounts first
+                if (!prevEncountered) {
+                    accountQueue.forEach(action => dispatch(action));
+                    accountQueue.splice(0, accountQueue.length);
+                }
+                dispatch(accountAction);
+            }
+        } else {
+            const currentFailedAccounts = discovery.failed ?? [];
+            const newFailedAccount: FailedAccount = { accountType: response.type, ...response };
+
+            const { symbol, accountType, index } = newFailedAccount;
+
+            const isDuplicate = currentFailedAccounts.some(
+                f => f.symbol === symbol && f.accountType === accountType && f.index === index,
+            );
+            if (isDuplicate) return; // only defensive programming
+
+            dispatch(
+                // TODO this repeatedly rewrites last status with the previous one!
+                discoveryActions.updateDiscovery(
+                    { ...discovery, failed: [...currentFailedAccounts, newFailedAccount] },
+                    devicePath,
+                ),
+            );
         }
-        const currentFailedAccounts = discovery.failed ?? [];
-        const newFailedAccount: FailedAccount = { accountType: response.type, ...response };
-
-        const { symbol, accountType, index } = newFailedAccount;
-        const isDuplicate = currentFailedAccounts.some(
-            f => f.symbol === symbol && f.accountType === accountType && f.index === index,
-        );
-        if (isDuplicate) return; // only defensive programming
-
-        dispatch(
-            discoveryActions.updateDiscovery(
-                { ...discovery, failed: [...currentFailedAccounts, newFailedAccount] },
-                devicePath,
-            ),
-        );
     };
 };
 

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -716,25 +716,6 @@ export const startDiscoveryThunk = createThunk(
     },
 );
 
-export const startInitialDiscovery = createThunk(
-    `${DISCOVERY_MODULE_PREFIX}/startInitial`,
-    ({ device }: { device: TrezorDevice }, { dispatch, getState, extra }) => {
-        // note: currently this is only used in Suite. If a Suite Lite implementation is needed,
-        // refactor this to a parameter because suiteSettings is a suite-only reducer.
-        const isAddingHiddenWalletWithRespectToSettings =
-            extra.selectors.selectSuiteSettings(getState()).defaultWalletLoading === 'passphrase';
-
-        dispatch(
-            startDiscoveryThunk({
-                device,
-                isAddingHiddenWalletWithRespectToSettings,
-                isAddingExistingWallet: true,
-                isAddingHiddenWallet: isAddingHiddenWalletWithRespectToSettings,
-            }),
-        );
-    },
-);
-
 export const runAdditionalDiscoveryThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/runAdditional`,
     async (staticSessionId: StaticSessionId, { dispatch, getState }): Promise<void> => {

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -706,11 +706,7 @@ export const startDiscoveryThunk = createThunk(
         // - we are adding a standard wallet,
         // - or adding an existing hidden wallet,
         // - or adding initially a hidden wallet set by settings
-        if (
-            !isAddingHiddenWallet ||
-            ((isAddingHiddenWalletWithRespectToSettings || isAddingHiddenWallet) &&
-                isAddingExistingWallet)
-        ) {
+        if (!isAddingHiddenWallet || isAddingExistingWallet) {
             dispatch(runDiscoveryThunk(actualDevice));
         }
     },

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -744,7 +744,7 @@ export const runAdditionalDiscoveryThunk = createThunk(
 
         const networksToDiscover = selectNetworksToDiscover(getState(), staticSessionId);
 
-        if (!networksToDiscover.length) {
+        if (!networksToDiscover.undiscovered.length && !networksToDiscover.failed.length) {
             console.warn('no networks to discover');
 
             return;
@@ -755,7 +755,7 @@ export const runAdditionalDiscoveryThunk = createThunk(
         const result = await TrezorConnect.discoverAccounts({
             device,
             useEmptyPassphrase: device.useEmptyPassphrase,
-            accounts: networksToDiscover.map(n => ({
+            accounts: [...networksToDiscover.undiscovered, ...networksToDiscover.failed].map(n => ({
                 symbol: n,
             })),
         });

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -190,8 +190,6 @@ const createOnBundleProgressHandler = (
     const accountQueue: ReturnType<typeof accountsActions.createAccount>[] = [];
     const getCreateAccountPayload = progressEventToCreateAccountPayload(deviceStaticSessionId);
 
-    let encounteredNonEmptyAccount = false;
-
     return (event: ProgressEvent) => {
         const discovery = selectDiscoveryByDevicePath(getState(), devicePath);
 
@@ -201,50 +199,39 @@ const createOnBundleProgressHandler = (
             return;
         }
 
-        const hasLoadedAnyNonEmptyAccount =
-            'balance' in event.response &&
-            !isNaN(Number(event.response.balance)) &&
-            Number(event.response.balance) > 0;
-
-        dispatch(
-            discoveryActions.updateDiscovery(
-                {
-                    status: 'progress',
-                    total: event.total,
-                    progress: event.progress,
-                    hasLoadedAnyNonEmptyAccount,
-                },
-                devicePath,
-            ),
-        );
-
-        if (
-            discovery.status === 'progress' &&
-            !discovery.hasLoadedAnyNonEmptyAccount &&
-            hasLoadedAnyNonEmptyAccount
-        ) {
-            progressHooks.onNonFirstNonEmptyAccountDiscovered?.();
-        }
-
         const { response } = event;
 
         if (isProgressOk(response)) {
             const accountAction = accountsActions.createAccount(getCreateAccountPayload(response));
 
-            const prevEncountered = encounteredNonEmptyAccount;
-            encounteredNonEmptyAccount ||= !response.empty || event.progress === 100;
+            const hasLoadedAnyNonEmptyAccount =
+                discovery.hasLoadedAnyNonEmptyAccount || !response.empty;
 
-            // no non-empty account encountered, enqueue account for postponed creation
-            if (!encounteredNonEmptyAccount) {
+            // no non-empty account encountered and not the last event, enqueue account for postponed creation
+            if (!hasLoadedAnyNonEmptyAccount && event.progress !== 100) {
                 accountQueue.push(accountAction);
             } else {
                 // first non-empty account encountered right now, create all enqueued accounts first
-                if (!prevEncountered) {
+                if (!discovery.hasLoadedAnyNonEmptyAccount) {
+                    progressHooks.onNonFirstNonEmptyAccountDiscovered?.();
+
                     accountQueue.forEach(action => dispatch(action));
                     accountQueue.splice(0, accountQueue.length);
                 }
                 dispatch(accountAction);
             }
+
+            dispatch(
+                discoveryActions.updateDiscovery(
+                    {
+                        status: 'progress',
+                        total: event.total,
+                        progress: event.progress,
+                        hasLoadedAnyNonEmptyAccount,
+                    },
+                    devicePath,
+                ),
+            );
         } else {
             const currentFailedAccounts = discovery.failed ?? [];
             const newFailedAccount: FailedAccount = { accountType: response.type, ...response };
@@ -257,9 +244,13 @@ const createOnBundleProgressHandler = (
             if (isDuplicate) return; // only defensive programming
 
             dispatch(
-                // TODO this repeatedly rewrites last status with the previous one!
                 discoveryActions.updateDiscovery(
-                    { ...discovery, failed: [...currentFailedAccounts, newFailedAccount] },
+                    {
+                        status: 'progress',
+                        total: event.total,
+                        progress: event.progress,
+                        failed: [...currentFailedAccounts, newFailedAccount],
+                    },
                     devicePath,
                 ),
             );

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -1,8 +1,8 @@
 import { createThunk } from '@suite-common/redux-utils';
 import { AcquiredDevice, AuthorizedDevice, TrezorDevice } from '@suite-common/suite-types';
 import { getNewInstanceNumber } from '@suite-common/suite-utils';
-import { Bip43Path, TrezorConnectBackendType } from '@suite-common/wallet-config';
-import { FailedAccount } from '@suite-common/wallet-types';
+import { Bip43Path, TrezorConnectBackendType, networks } from '@suite-common/wallet-config';
+import { substituteBip43Path } from '@suite-common/wallet-utils';
 import TrezorConnect, {
     BundleProgress,
     DeviceState,
@@ -12,6 +12,7 @@ import TrezorConnect, {
 } from '@trezor/connect';
 import {
     DiscoverAccountsProgress,
+    DiscoverAccountsProgressError,
     DiscoverAccountsProgressOk,
 } from '@trezor/connect/src/types/api/discoverAccounts';
 import { isNative } from '@trezor/env-utils';
@@ -159,23 +160,44 @@ const applyDeviceStatesThunk = createThunk(
 
 const progressEventToCreateAccountPayload =
     (deviceState: StaticSessionId) =>
-    (response: DiscoverAccountsProgressOk): CreateAccountActionProps => {
-        const backendType = response.backendType as TrezorConnectBackendType | undefined;
+    (response: DiscoverAccountsProgressOk): CreateAccountActionProps => ({
+        deviceState,
+        discoveryItem: {
+            path: response.path as Bip43Path,
+            coin: response.symbol,
+            index: response.index,
+            accountType: response.type,
+            backendType: response.backendType as TrezorConnectBackendType | undefined,
+        },
+        accountInfo: response,
+        // first normal account is always visible on web & desktop
+        visible: (response.type === 'normal' && response.index === 0) || !response.empty,
+    });
 
-        return {
-            deviceState,
-            discoveryItem: {
-                path: response.path as Bip43Path,
-                coin: response.symbol,
-                index: response.index,
-                accountType: response.type,
-                backendType,
-            },
-            accountInfo: response,
-            // first normal account is always visible on web & desktop
-            visible: (response.type === 'normal' && response.index === 0) || !response.empty,
-        };
-    };
+const getFailedAccountPayload = (
+    { symbol, index, error, type }: DiscoverAccountsProgressError,
+    deviceState: StaticSessionId,
+): CreateAccountActionProps => ({
+    deviceState,
+    discoveryItem: {
+        path: substituteBip43Path(networks[symbol].bip43Path),
+        coin: symbol,
+        index,
+        accountType: type,
+    },
+    accountInfo: {
+        descriptor: `failed:${index}:${symbol}:${type}`,
+        balance: '0',
+        availableBalance: '0',
+        empty: true,
+        history: {
+            total: 0,
+            unconfirmed: 0,
+        },
+    },
+    visible: true,
+    error,
+});
 
 const createOnBundleProgressHandler = (
     devicePath: DeviceUniquePath,
@@ -233,15 +255,9 @@ const createOnBundleProgressHandler = (
                 ),
             );
         } else {
-            const currentFailedAccounts = discovery.failed ?? [];
-            const newFailedAccount: FailedAccount = { accountType: response.type, ...response };
+            const payload = getFailedAccountPayload(response, deviceStaticSessionId);
 
-            const { symbol, accountType, index } = newFailedAccount;
-
-            const isDuplicate = currentFailedAccounts.some(
-                f => f.symbol === symbol && f.accountType === accountType && f.index === index,
-            );
-            if (isDuplicate) return; // only defensive programming
+            dispatch(accountsActions.createAccount(payload));
 
             dispatch(
                 discoveryActions.updateDiscovery(
@@ -249,7 +265,6 @@ const createOnBundleProgressHandler = (
                         status: 'progress',
                         total: event.total,
                         progress: event.progress,
-                        failed: [...currentFailedAccounts, newFailedAccount],
                     },
                     devicePath,
                 ),
@@ -310,7 +325,6 @@ export const applyDeviceStateErrorThunk = createThunk(
             discoveryActions.updateDiscovery(
                 {
                     status: 'failed',
-                    failed: [], // no failed accounts yet,
                     error,
                     errorCode: code,
                 },

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -26,11 +26,9 @@ import {
     selectDevices,
     selectPhysicalDevices,
     selectSelectedDevice,
-    selectSupportedNetworkByDevice,
 } from '../device/deviceSelectors';
 import { selectDeviceThunk } from '../device/deviceThunks';
-import { selectAccountsToBeForgotten, selectNetworksToDiscover } from '../selectors';
-import { selectEnabledNetworks } from '../settings/walletSettingsReducer';
+import { selectAccountsToBeForgotten, selectDiscoveryAccountsParam } from '../selectors';
 
 const USER_UI_CANCEL_CODE = 'USER_UI_CANCEL';
 const DEVICE_CANCELLATION_CODES = ['Method_Cancel', 'Failure_ActionCancelled'];
@@ -447,6 +445,17 @@ export const runDiscoveryThunk = createThunk(
                 return;
             }
 
+            const accountsParam = selectDiscoveryAccountsParam(
+                getState(),
+                deviceStateResponse.payload._state.staticSessionId,
+            );
+
+            // no networks to discover, complete discovery
+            if (!accountsParam.length) {
+                // TODO: find out how to early return discovery; calling completeDiscoveryThunk does not work
+                console.warn('No networks to discover, todo: stop discovery');
+            }
+
             const onBundleProgress = createOnBundleProgressHandler(
                 device.path,
                 deviceStateResponse.payload._state.staticSessionId,
@@ -469,18 +478,6 @@ export const runDiscoveryThunk = createThunk(
 
             TrezorConnect.on<DiscoverAccountsProgress>(UI.BUNDLE_PROGRESS, onBundleProgress);
 
-            const deviceNetworks = selectSupportedNetworkByDevice(device);
-            const enabledNetworks = selectEnabledNetworks(getState()).filter(symbol =>
-                deviceNetworks.includes(symbol),
-            );
-            const discoveryAccountsPayload = enabledNetworks.map(n => ({ symbol: n }));
-
-            // no networks to discover, complete discovery
-            if (!discoveryAccountsPayload.length) {
-                // TODO: find out how to early return discovery; calling completeDiscoveryThunk does not work
-                console.warn('No networks to discover, todo: stop discovery');
-            }
-
             // NOTE: sync set discovery status to progress to make sure that there aren't some hanging states
             // before asnyc onBundleProgress is called which sets progress
             dispatch(
@@ -501,7 +498,7 @@ export const runDiscoveryThunk = createThunk(
                     },
                 },
                 useEmptyPassphrase: !isAddingHiddenWallet,
-                accounts: discoveryAccountsPayload,
+                accounts: accountsParam,
             });
 
             TrezorConnect.off(UI.BUNDLE_PROGRESS, onBundleProgress);
@@ -711,6 +708,14 @@ export const runAdditionalDiscoveryThunk = createThunk(
             dispatch(accountsActions.removeAccount(accountsToRemove));
         }
 
+        const accountsParam = selectDiscoveryAccountsParam(getState(), staticSessionId);
+
+        if (!accountsParam.length) {
+            console.warn('no rediscovery needed');
+
+            return;
+        }
+
         dispatch(
             discoveryActions.startDiscovery(device.path, {
                 isAddingHiddenWallet: false,
@@ -726,22 +731,12 @@ export const runAdditionalDiscoveryThunk = createThunk(
             getState,
         );
 
-        const networksToDiscover = selectNetworksToDiscover(getState(), staticSessionId);
-
-        if (!networksToDiscover.undiscovered.length && !networksToDiscover.failed.length) {
-            console.warn('no networks to discover');
-
-            return;
-        }
-
         TrezorConnect.on<DiscoverAccountsProgress>(UI.BUNDLE_PROGRESS, onBundleProgress);
 
         const result = await TrezorConnect.discoverAccounts({
             device,
             useEmptyPassphrase: device.useEmptyPassphrase,
-            accounts: [...networksToDiscover.undiscovered, ...networksToDiscover.failed].map(n => ({
-                symbol: n,
-            })),
+            accounts: accountsParam,
         });
 
         console.warn('runAdditionalDiscovery: TrezorConnect.getAccountInfo, result: ', result);

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -1,20 +1,17 @@
 import { createThunk } from '@suite-common/redux-utils';
 import { AcquiredDevice, AuthorizedDevice, TrezorDevice } from '@suite-common/suite-types';
 import { getNewInstanceNumber } from '@suite-common/suite-utils';
-import { Bip43Path, TrezorConnectBackendType, networks } from '@suite-common/wallet-config';
-import { substituteBip43Path } from '@suite-common/wallet-utils';
+import { Bip43Path, TrezorConnectBackendType } from '@suite-common/wallet-config';
+import { DiscoveryItem, DiscoveryStatus } from '@suite-common/wallet-types';
 import TrezorConnect, {
+    AccountInfo,
     BundleProgress,
     DeviceState,
     DeviceUniquePath,
     StaticSessionId,
     UI,
 } from '@trezor/connect';
-import {
-    DiscoverAccountsProgress,
-    DiscoverAccountsProgressError,
-    DiscoverAccountsProgressOk,
-} from '@trezor/connect/src/types/api/discoverAccounts';
+import { DiscoverAccountsProgress } from '@trezor/connect/src/types/api/discoverAccounts';
 import { isNative } from '@trezor/env-utils';
 
 import { DISCOVERY_MODULE_PREFIX, discoveryActions } from './discoveryActions';
@@ -34,9 +31,6 @@ const USER_UI_CANCEL_CODE = 'USER_UI_CANCEL';
 const DEVICE_CANCELLATION_CODES = ['Method_Cancel', 'Failure_ActionCancelled'];
 
 type ProgressEvent = BundleProgress<DiscoverAccountsProgress>['payload'];
-
-const isProgressOk = (progress: DiscoverAccountsProgress): progress is DiscoverAccountsProgressOk =>
-    Object.prototype.hasOwnProperty.call(progress, 'path');
 
 function assertDeviceIsAuthorized(device?: TrezorDevice): asserts device is AuthorizedDevice {
     if (!device?.state?.staticSessionId) {
@@ -156,119 +150,48 @@ const applyDeviceStatesThunk = createThunk(
     },
 );
 
-const progressEventToCreateAccountPayload =
-    (deviceState: StaticSessionId) =>
-    (response: DiscoverAccountsProgressOk): CreateAccountActionProps => ({
-        deviceState,
-        discoveryItem: {
-            path: response.path as Bip43Path,
-            coin: response.symbol,
-            index: response.index,
-            accountType: response.type,
-            backendType: response.backendType as TrezorConnectBackendType | undefined,
-        },
-        accountInfo: response,
-        // first normal account is always visible on web & desktop
-        visible: (response.type === 'normal' && response.index === 0) || !response.empty,
-    });
-
-const getFailedAccountPayload = (
-    { symbol, index, error, type }: DiscoverAccountsProgressError,
+const transformProgressEventData = (
+    { response, progress, total }: ProgressEvent,
     deviceState: StaticSessionId,
-): CreateAccountActionProps => ({
-    deviceState,
-    discoveryItem: {
-        path: substituteBip43Path(networks[symbol].bip43Path),
-        coin: symbol,
-        index,
-        accountType: type,
-    },
-    accountInfo: {
-        descriptor: `failed:${index}:${symbol}:${type}`,
-        balance: '0',
-        availableBalance: '0',
-        empty: true,
-        history: {
-            total: 0,
-            unconfirmed: 0,
-        },
-    },
-    visible: true,
-    error,
-});
-
-const createOnBundleProgressHandler = (
-    devicePath: DeviceUniquePath,
-    deviceStaticSessionId: StaticSessionId,
-    dispatch: any,
-    getState: any,
-    progressHooks: {
-        onNonFirstNonEmptyAccountDiscovered?: () => void;
-    } = {},
+    discovery: DiscoveryStatus,
 ) => {
-    // we do not create empty accounts right away, but store the progress events for later
-    const accountQueue: ReturnType<typeof accountsActions.createAccount>[] = [];
-    const getCreateAccountPayload = progressEventToCreateAccountPayload(deviceStaticSessionId);
+    const { index, symbol: coin, type: accountType, path, backendType } = response;
 
-    return (event: ProgressEvent) => {
-        const discovery = selectDiscoveryByDevicePath(getState(), devicePath);
-
-        if (!discovery) {
-            console.error('bundle progress handler: no discovery found');
-
-            return;
-        }
-
-        const { response } = event;
-
-        if (isProgressOk(response)) {
-            const accountAction = accountsActions.createAccount(getCreateAccountPayload(response));
-
-            const hasLoadedAnyNonEmptyAccount =
-                discovery.hasLoadedAnyNonEmptyAccount || !response.empty;
-
-            // no non-empty account encountered and not the last event, enqueue account for postponed creation
-            if (!hasLoadedAnyNonEmptyAccount && event.progress !== 100) {
-                accountQueue.push(accountAction);
-            } else {
-                // first non-empty account encountered right now, create all enqueued accounts first
-                if (!discovery.hasLoadedAnyNonEmptyAccount) {
-                    progressHooks.onNonFirstNonEmptyAccountDiscovered?.();
-
-                    accountQueue.forEach(action => dispatch(action));
-                    accountQueue.splice(0, accountQueue.length);
-                }
-                dispatch(accountAction);
-            }
-
-            dispatch(
-                discoveryActions.updateDiscovery(
-                    {
-                        status: 'progress',
-                        total: event.total,
-                        progress: event.progress,
-                        hasLoadedAnyNonEmptyAccount,
-                    },
-                    devicePath,
-                ),
-            );
-        } else {
-            const payload = getFailedAccountPayload(response, deviceStaticSessionId);
-
-            dispatch(accountsActions.createAccount(payload));
-
-            dispatch(
-                discoveryActions.updateDiscovery(
-                    {
-                        status: 'progress',
-                        total: event.total,
-                        progress: event.progress,
-                    },
-                    devicePath,
-                ),
-            );
-        }
+    const discoveryItem: DiscoveryItem = {
+        coin,
+        index,
+        accountType,
+        path: path as Bip43Path,
+        backendType: backendType as TrezorConnectBackendType | undefined,
     };
+
+    const accountInfo: AccountInfo = !response.failed
+        ? response
+        : {
+              descriptor: `failed:${index}:${coin}:${accountType}`,
+              balance: '0',
+              availableBalance: '0',
+              empty: true,
+              history: { total: 0, unconfirmed: 0 },
+          };
+
+    const accountPayload: CreateAccountActionProps = {
+        deviceState,
+        discoveryItem,
+        accountInfo,
+        // first normal account is always visible on web & desktop
+        visible: response.failed || !response.empty || (accountType === 'normal' && index === 0),
+        error: response.failed ? response.error : undefined,
+    };
+
+    const discoveryPayload: DiscoveryStatus = {
+        status: 'progress' as const,
+        progress,
+        total,
+        hasLoadedAnyNonEmptyAccount: discovery.hasLoadedAnyNonEmptyAccount || !accountInfo.empty,
+    };
+
+    return { accountPayload, discoveryPayload };
 };
 
 const completeDiscoveryThunk = createThunk(
@@ -336,7 +259,14 @@ export const runDiscoveryThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/run`,
     async (passedDevice: TrezorDevice, { dispatch, getState }): Promise<void> => {
         try {
-            let device: TrezorDevice | undefined = passedDevice;
+            let device: TrezorDevice = passedDevice;
+
+            const reselectDevice = () => {
+                const selectedDevice = selectSelectedDevice(getState());
+                assertDeviceIsAcquired(selectedDevice);
+
+                return selectedDevice;
+            };
 
             const discovery = selectDiscoveryByDevicePath(getState(), device.path);
 
@@ -417,8 +347,7 @@ export const runDiscoveryThunk = createThunk(
                 );
             }
 
-            device = selectSelectedDevice(getState());
-            assertDeviceIsAcquired(device);
+            device = reselectDevice();
 
             assertStaticSessionId(deviceStateResponse.payload._state);
 
@@ -456,25 +385,47 @@ export const runDiscoveryThunk = createThunk(
                 console.warn('No networks to discover, todo: stop discovery');
             }
 
-            const onBundleProgress = createOnBundleProgressHandler(
-                device.path,
-                deviceStateResponse.payload._state.staticSessionId,
-                dispatch,
-                getState,
-                {
-                    onNonFirstNonEmptyAccountDiscovered: () => {
-                        if (isAddingHiddenWallet) {
+            // we do not create empty accounts right away, but store the progress events for later
+            const accountQueue: CreateAccountActionProps[] = [];
+            const deviceState = deviceStateResponse.payload._state;
+            const onBundleProgress = (event: ProgressEvent) => {
+                const currentDiscovery = selectDiscoveryByDevicePath(getState(), device.path);
+                if (!currentDiscovery) {
+                    return console.error('bundle progress handler: no discovery found');
+                }
+
+                const { accountPayload, discoveryPayload } = transformProgressEventData(
+                    event,
+                    deviceState.staticSessionId,
+                    currentDiscovery,
+                );
+
+                // no non-empty account encountered and not the last event, enqueue account for postponed creation
+                if (!discoveryPayload.hasLoadedAnyNonEmptyAccount && event.progress !== 100) {
+                    accountQueue.push(accountPayload);
+                } else {
+                    // first non-empty account encountered right now or the last event, create all enqueued accounts first
+                    if (!currentDiscovery.hasLoadedAnyNonEmptyAccount) {
+                        if (isAddingHiddenWallet && discoveryPayload.hasLoadedAnyNonEmptyAccount) {
                             dispatch(
                                 applyDeviceStatesThunk({
-                                    newDeviceState: deviceStateResponse.payload._state,
+                                    newDeviceState: deviceState,
                                     isAddingHiddenWallet,
                                     devicePath: passedDevice.path,
                                 }),
                             );
                         }
-                    },
-                },
-            );
+
+                        accountQueue.forEach(account =>
+                            dispatch(accountsActions.createAccount(account)),
+                        );
+                        accountQueue.splice(0, accountQueue.length);
+                    }
+                    dispatch(accountsActions.createAccount(accountPayload));
+                }
+
+                dispatch(discoveryActions.updateDiscovery(discoveryPayload, device.path));
+            };
 
             TrezorConnect.on<DiscoverAccountsProgress>(UI.BUNDLE_PROGRESS, onBundleProgress);
 
@@ -490,6 +441,7 @@ export const runDiscoveryThunk = createThunk(
                     device.path,
                 ),
             );
+
             const result = await TrezorConnect.discoverAccounts({
                 device: {
                     instance,
@@ -541,8 +493,7 @@ export const runDiscoveryThunk = createThunk(
                 return;
             }
 
-            device = selectSelectedDevice(getState());
-            assertDeviceIsAcquired(device);
+            device = reselectDevice();
 
             const allAccountsEmpty = result.payload.nonempty === 0;
             // there is at least one account with balance - passphrase is not empty
@@ -724,12 +675,21 @@ export const runAdditionalDiscoveryThunk = createThunk(
             }),
         );
 
-        const onBundleProgress = createOnBundleProgressHandler(
-            device.path,
-            device.state.staticSessionId,
-            dispatch,
-            getState,
-        );
+        const onBundleProgress = (event: ProgressEvent) => {
+            const discovery = selectDiscoveryByDevicePath(getState(), device.path);
+            if (!discovery) {
+                return console.error('bundle progress handler: no discovery found');
+            }
+
+            const { accountPayload, discoveryPayload } = transformProgressEventData(
+                event,
+                device.state.staticSessionId,
+                discovery,
+            );
+
+            dispatch(accountsActions.createAccount(accountPayload));
+            dispatch(discoveryActions.updateDiscovery(discoveryPayload, device.path));
+        };
 
         TrezorConnect.on<DiscoverAccountsProgress>(UI.BUNDLE_PROGRESS, onBundleProgress);
 

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -1,7 +1,7 @@
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { NetworkSymbol, networksCollection } from '@suite-common/wallet-config';
 import { ReviewOutput } from '@suite-common/wallet-types';
-import { findAccountsByAddress, getFailedAccounts, sortByCoin } from '@suite-common/wallet-utils';
+import { findAccountsByAddress, sortByCoin } from '@suite-common/wallet-utils';
 import { StaticSessionId } from '@trezor/connect';
 
 import { AccountsRootState } from './accounts/accountsReducer';
@@ -19,11 +19,7 @@ import {
     selectSupportedNetworkByDevice,
 } from './device/deviceSelectors';
 import { DiscoveryRootState } from './discovery/discoveryReducer';
-import {
-    selectDiscoveryByDevicePath,
-    selectDiscoveryForSelectedDevice,
-    selectHasRunningDiscovery,
-} from './discovery/discoverySelectors';
+import { selectHasRunningDiscovery } from './discovery/discoverySelectors';
 import { WalletSettingsRootState, selectEnabledNetworks } from './settings/walletSettingsReducer';
 
 /*
@@ -38,31 +34,15 @@ type CompoundRootState = AccountsRootState &
 const createMemoizedSelector = createWeakMapSelector.withTypes<CompoundRootState>();
 
 /**
- * This means "all potentially visible accounts", because for accounts that failed to be discovered
- * we don't know if they would have been visible or not (depends on discovery account.empty result).
- */
-export const selectVisibleAccountsWithFailed = createMemoizedSelector(
-    [selectVisibleDeviceAccounts, selectSelectedDevice, selectDiscoveryForSelectedDevice],
-    (okAccounts, device, discovery) => {
-        const staticSessionId = device?.state?.staticSessionId;
-        const failedAccounts = getFailedAccounts(staticSessionId, discovery);
-
-        const allAccounts = [...okAccounts, ...failedAccounts];
-
-        return returnStableArrayIfEmpty(allAccounts);
-    },
-);
-
-/**
  * Listable accounts are visible, enabled in settings, supported by the device and conventionally sorted.
  * Edge cases: accounts failed to be discovered, or remembered accounts no longer supported by the device.
  */
 export const selectAllAccountsToList = createMemoizedSelector(
-    [selectVisibleAccountsWithFailed, selectSelectedDevice, selectEnabledNetworks],
-    (allAccounts, device, enabledNetworks) => {
+    [selectVisibleDeviceAccounts, selectSelectedDevice, selectEnabledNetworks],
+    (accounts, device, enabledNetworks) => {
         const deviceNetworks = selectSupportedNetworkByDevice(device);
 
-        const filteredAccounts = allAccounts.filter(
+        const filteredAccounts = accounts.filter(
             ({ symbol }) => enabledNetworks.includes(symbol) && deviceNetworks.includes(symbol),
         );
         const sortedAccounts = sortByCoin(filteredAccounts);
@@ -79,13 +59,11 @@ export const selectNetworksToDiscover = (
     const device = selectSelectedDevice(state);
     const deviceNetworks = selectSupportedNetworkByDevice(device);
     const networks = enabledNetworks.filter(network => deviceNetworks.includes(network));
-    const discovery = selectDiscoveryByDevicePath(state, device?.path);
-    const okAccounts = selectAccountsByDeviceState(state, staticSessionId);
-    const failedAccounts = getFailedAccounts(staticSessionId, discovery);
+    const accounts = selectAccountsByDeviceState(state, staticSessionId);
 
     const networkSet = new Set(networks);
-    const allSet = new Set([...okAccounts, ...failedAccounts].map(a => a.symbol));
-    const failedSet = new Set(failedAccounts.map(a => a.symbol));
+    const allSet = new Set(accounts.map(a => a.symbol));
+    const failedSet = new Set(accounts.filter(a => a.failed).map(a => a.symbol));
 
     return {
         failed: [...failedSet].filter(s => networkSet.has(s)),

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -78,19 +78,19 @@ export const selectNetworksToDiscover = (
     const enabledNetworks = selectEnabledNetworks(state);
     const device = selectSelectedDevice(state);
     const deviceNetworks = selectSupportedNetworkByDevice(device);
-    const enabledSupportedNetworks = enabledNetworks.filter(network =>
-        deviceNetworks.includes(network),
-    );
-
+    const networks = enabledNetworks.filter(network => deviceNetworks.includes(network));
     const discovery = selectDiscoveryByDevicePath(state, device?.path);
     const okAccounts = selectAccountsByDeviceState(state, staticSessionId);
     const failedAccounts = getFailedAccounts(staticSessionId, discovery);
 
-    const discoveredNetworks = [
-        ...new Set([...okAccounts, ...failedAccounts].map(account => account.symbol)),
-    ];
+    const networkSet = new Set(networks);
+    const allSet = new Set([...okAccounts, ...failedAccounts].map(a => a.symbol));
+    const failedSet = new Set(failedAccounts.map(a => a.symbol));
 
-    return enabledSupportedNetworks.filter(network => !discoveredNetworks.includes(network));
+    return {
+        failed: [...failedSet].filter(s => networkSet.has(s)),
+        undiscovered: [...networkSet].filter(s => !allSet.has(s)),
+    };
 };
 
 export const selectShowRediscoverButton = (
@@ -98,7 +98,7 @@ export const selectShowRediscoverButton = (
     staticSessionId?: StaticSessionId,
 ) =>
     staticSessionId &&
-    selectNetworksToDiscover(state, staticSessionId).length > 0 &&
+    selectNetworksToDiscover(state, staticSessionId).undiscovered.length > 0 &&
     !selectHasRunningDiscovery(state);
 
 export const selectAccountsToBeForgotten = (

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -2,7 +2,8 @@ import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/r
 import { NetworkSymbol, networksCollection } from '@suite-common/wallet-config';
 import { ReviewOutput } from '@suite-common/wallet-types';
 import { findAccountsByAddress, sortByCoin } from '@suite-common/wallet-utils';
-import { StaticSessionId } from '@trezor/connect';
+import { StaticSessionId, type TrezorConnect } from '@trezor/connect';
+import { arrayToDictionary } from '@trezor/utils';
 
 import { AccountsRootState } from './accounts/accountsReducer';
 import {
@@ -33,51 +34,78 @@ type CompoundRootState = AccountsRootState &
     WalletSettingsRootState;
 const createMemoizedSelector = createWeakMapSelector.withTypes<CompoundRootState>();
 
+const selectEnabledSupportedNetworks = (state: CompoundRootState) => {
+    const enabledNetworks = selectEnabledNetworks(state);
+    const device = selectSelectedDevice(state);
+    const deviceNetworks = selectSupportedNetworkByDevice(device);
+
+    return enabledNetworks.filter(network => deviceNetworks.includes(network));
+};
+
 /**
  * Listable accounts are visible, enabled in settings, supported by the device and conventionally sorted.
  * Edge cases: accounts failed to be discovered, or remembered accounts no longer supported by the device.
  */
 export const selectAllAccountsToList = createMemoizedSelector(
-    [selectVisibleDeviceAccounts, selectSelectedDevice, selectEnabledNetworks],
-    (accounts, device, enabledNetworks) => {
-        const deviceNetworks = selectSupportedNetworkByDevice(device);
-
-        const filteredAccounts = accounts.filter(
-            ({ symbol }) => enabledNetworks.includes(symbol) && deviceNetworks.includes(symbol),
+    [selectVisibleDeviceAccounts, selectEnabledSupportedNetworks],
+    (accounts, enabledSupportedNetworks) => {
+        const filteredAccounts = accounts.filter(({ symbol }) =>
+            enabledSupportedNetworks.includes(symbol),
         );
+
         const sortedAccounts = sortByCoin(filteredAccounts);
 
         return returnStableArrayIfEmpty(sortedAccounts);
     },
 );
 
-export const selectNetworksToDiscover = (
-    state: DiscoveryRootState & DeviceRootState & AccountsRootState & WalletSettingsRootState,
+export const selectDiscoveryAccountsParam = (
+    state: CompoundRootState,
     staticSessionId: StaticSessionId,
-) => {
-    const enabledNetworks = selectEnabledNetworks(state);
-    const device = selectSelectedDevice(state);
-    const deviceNetworks = selectSupportedNetworkByDevice(device);
-    const networks = enabledNetworks.filter(network => deviceNetworks.includes(network));
+): Parameters<TrezorConnect['discoverAccounts']>[0]['accounts'] => {
+    const networks = selectEnabledSupportedNetworks(state);
     const accounts = selectAccountsByDeviceState(state, staticSessionId);
 
-    const networkSet = new Set(networks);
-    const allSet = new Set(accounts.map(a => a.symbol));
-    const failedSet = new Set(accounts.filter(a => a.failed).map(a => a.symbol));
+    const symbolMap = arrayToDictionary(accounts, acc => acc.symbol, true);
 
-    return {
-        failed: [...failedSet].filter(s => networkSet.has(s)),
-        undiscovered: [...networkSet].filter(s => !allSet.has(s)),
-    };
+    return networks.flatMap(symbol => {
+        const symbolAccounts = symbolMap[symbol];
+
+        // undiscovered network; discover as a whole
+        if (!symbolAccounts) return [{ symbol }];
+
+        // discovered network; separate by account type
+        const typeMap = arrayToDictionary(symbolAccounts, acc => acc.accountType, true);
+
+        return Object.entries(typeMap).flatMap(([type, accs]) => {
+            // account with the highest index
+            const lastAccount = accs.reduce((last, current) =>
+                current.index > last.index ? current : last,
+            );
+
+            // last account is a failed one; try to discover it again
+            if (lastAccount.failed) return [{ symbol, type, skip: lastAccount.index }];
+            // last account is a used one; skip it and try to discover next one
+            else if (!lastAccount.empty) return [{ symbol, type, skip: lastAccount.index + 1 }];
+            // last account is an empty one; no need to discover
+            else return [];
+        });
+    });
 };
 
-export const selectShowRediscoverButton = (
-    state: DiscoveryRootState & DeviceRootState & AccountsRootState & WalletSettingsRootState,
+export const selectShouldRediscoverNetworks = (
+    state: CompoundRootState,
     staticSessionId?: StaticSessionId,
-) =>
-    staticSessionId &&
-    selectNetworksToDiscover(state, staticSessionId).undiscovered.length > 0 &&
-    !selectHasRunningDiscovery(state);
+) => {
+    if (!staticSessionId) return false;
+    if (selectHasRunningDiscovery(state)) return false;
+
+    const networks = selectEnabledSupportedNetworks(state);
+    const accounts = selectAccountsByDeviceState(state, staticSessionId);
+    const discoveredNetworks = new Set(accounts.map(account => account.symbol));
+
+    return networks.some(network => !discoveredNetworks.has(network));
+};
 
 export const selectAccountsToBeForgotten = (
     state: DiscoveryRootState & AccountsRootState & WalletSettingsRootState,

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -102,6 +102,8 @@ export type AccountBackendSpecific =
           syncing?: boolean;
       };
 
+type AccountFailureSpecific = { failed: true; error: string } | { failed?: false };
+
 export type AccountKey = string; // <AccountDescriptor>-<NetworkSymbol>-<DeviceStaticSessionId>
 export type AccountDescriptor = string & Branded<'AccountDescriptor'>; // Descriptor or xpub/zpub/..
 
@@ -118,7 +120,6 @@ export type Account = {
     empty: boolean;
     visible: boolean;
     imported?: boolean;
-    failed?: boolean;
     balance: string;
     availableBalance: string;
     formattedBalance: string;
@@ -134,7 +135,11 @@ export type Account = {
     accountLabel?: string;
     ts: number;
 } & AccountBackendSpecific &
-    AccountNetworkSpecific;
+    AccountNetworkSpecific &
+    AccountFailureSpecific;
+
+export type FailedAccount = Extract<Account, { failed: true }>;
+export type SuccessfulAccount = Extract<Account, { failed?: false }>;
 
 export type UppercaseAccountType = Uppercase<AccountType>;
 

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -1,23 +1,15 @@
-import { AccountType, Bip43Path, NetworkSymbol } from '@suite-common/wallet-config';
+import { Bip43Path } from '@suite-common/wallet-config';
 import type { DeviceUniquePath } from '@trezor/connect';
 import { BundleProgress, StaticSessionId } from '@trezor/connect';
 
 import { Account, AccountBackendSpecific } from './account';
 
-export type FailedAccount = {
-    symbol: NetworkSymbol;
-    index: number;
-    accountType: NonNullable<AccountType>;
-    error: string;
-    fwException?: string;
-};
 type CommonDiscoveryStatus = {
     isAddingHiddenWallet?: boolean; // to control visibility of special loader
     isAddingExistingWallet?: boolean; // to control visibility of special loader
     isAddingHiddenWalletWithRespectToSettings?: boolean;
     hasLoadedAnyNonEmptyAccount?: boolean; // NOTE: used to indicate the the disocovery started loading actual accounts
     emptyWallet?: boolean;
-    failed?: FailedAccount[];
     passphraseOnDevice?: boolean;
     startTimestamp?: number;
     passphraseSubmitted?: boolean;

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -15,6 +15,7 @@ type CommonDiscoveryStatus = {
     isAddingHiddenWallet?: boolean; // to control visibility of special loader
     isAddingExistingWallet?: boolean; // to control visibility of special loader
     isAddingHiddenWalletWithRespectToSettings?: boolean;
+    hasLoadedAnyNonEmptyAccount?: boolean; // NOTE: used to indicate the the disocovery started loading actual accounts
     emptyWallet?: boolean;
     failed?: FailedAccount[];
     passphraseOnDevice?: boolean;
@@ -47,7 +48,6 @@ export type DiscoveryStatus = CommonDiscoveryStatus &
               status: 'progress';
               total: BundleProgress<any>['payload']['total'];
               progress: BundleProgress<any>['payload']['progress'];
-              hasLoadedAnyNonEmptyAccount?: boolean; // NOTE: used to indicate the the disocovery started loading actual accounts
           }
         | {
               status: 'confirm-empty-passphrase';

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -16,11 +16,12 @@ import {
     Account,
     AccountDescriptor,
     AccountKey,
-    DiscoveryStatus,
+    FailedAccount,
     GeneralPrecomposedTransactionFinal,
     PrecomposedTransactionFinal,
     RatesByKey,
     ReceiveInfo,
+    SuccessfulAccount,
     TokenAddress,
 } from '@suite-common/wallet-types';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
@@ -55,6 +56,11 @@ import { isRbfBumpFeeTransaction } from './transactionUtils';
 
 export const isUtxoBased = (account: Account) =>
     account.networkType === 'bitcoin' || account.networkType === 'cardano';
+
+export const isAccountSuccessful = (account: Account): account is SuccessfulAccount =>
+    !account.failed;
+
+export const isAccountFailed = (account: Account): account is FailedAccount => !!account.failed;
 
 export const getFirstFreshAddress = (
     account: Account,
@@ -896,48 +902,6 @@ export const getAccountSpecific = (accountInfo: Partial<AccountInfo>, networkTyp
         stellarCursor: undefined,
         page: accountInfo.page,
     };
-};
-
-// Used in wallet/Menu and Dashboard
-export const getFailedAccounts = (
-    staticSessionId?: StaticSessionId,
-    discovery?: DiscoveryStatus,
-): Account[] => {
-    if (staticSessionId === undefined || discovery?.failed === undefined) return [];
-
-    return discovery.failed.map(f => {
-        const descriptor = `failed:${f.index}:${f.symbol}:${f.accountType}`;
-        const network = networks[f.symbol];
-
-        return {
-            failed: true,
-            deviceState: staticSessionId,
-            index: f.index,
-            path: substituteBip43Path(network.bip43Path), // placeholder - not relevant for failed, but required by TS to be an actual Bip43Path
-            descriptor,
-            key: descriptor,
-            accountType: f.accountType,
-            symbol: f.symbol,
-            empty: true,
-            // first normal account is always visible on web & desktop
-            visible: f.accountType === 'normal' && f.index === 0,
-            balance: '0',
-            availableBalance: '0',
-            formattedBalance: '0',
-            tokens: [],
-            addresses: undefined,
-            utxo: undefined,
-            history: {
-                total: 0,
-                unconfirmed: 0,
-            },
-            metadata: {
-                key: descriptor,
-            },
-            ts: 0,
-            ...getAccountSpecific({}, network.networkType),
-        };
-    });
 };
 
 export const getAccountIdentifier = (account: Account) => ({

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -1188,18 +1188,27 @@ export const isNftMatchesSearch = (token: TokenInfo, search: string) =>
     token.name?.toLowerCase().includes(search) ||
     token.contract?.toLowerCase().includes(search);
 
-export const isAccountInCollection = (account: Account, accounts: Account[]) =>
-    accounts.some(
-        ({ deviceState, descriptor, symbol, accountType, index }) =>
-            // most of the time, descriptor is unique for a given (symbol, accountType, index)
-            descriptor === account.descriptor &&
-            // but not for EVM networks (intentionally sharing same eth address), so let's compare them too
-            symbol === account.symbol &&
-            accountType === account.accountType &&
-            index === account.index &&
-            // do not mark as duplicate if two different devices discover the same wallet
-            deviceState === account.deviceState,
-    );
+export const accountEqualTo = (a: Account) => (b: Account) =>
+    a.deviceState === b.deviceState &&
+    a.symbol === b.symbol &&
+    a.accountType === b.accountType &&
+    a.index === b.index &&
+    // TODO just to be sure; delete later
+    (() => {
+        // if the accounts seem equal but the descriptors are different
+        if (a.descriptor !== b.descriptor) {
+            const { deviceState, symbol, accountType, index } = a;
+            console.warn('Potentially equal accounts with different descriptors!', {
+                deviceState,
+                symbol,
+                accountType,
+                index,
+                descriptors: [a.descriptor, b.descriptor],
+            });
+        }
+
+        return true;
+    })();
 
 export const parseAccountKey = (accountKey: AccountKey) => {
     const [accountDescriptor, networkSymbol, deviceStaticSessionId] = accountKey.split('-');

--- a/suite-native/discovery/src/discoveryMiddleware.ts
+++ b/suite-native/discovery/src/discoveryMiddleware.ts
@@ -8,8 +8,8 @@ import {
     deviceActions,
     discoveryActions,
     restartDiscoveryThunk,
-    selectNetworksToDiscover,
     selectSelectedDevice,
+    selectShouldRediscoverNetworks,
     startDiscoveryThunk,
 } from '@suite-common/wallet-core';
 import {
@@ -75,12 +75,12 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
                 if (!device?.state) {
                     dispatch(startDiscoveryThunk({}));
                 } else if (device.state.staticSessionId) {
-                    const networksToDiscover = selectNetworksToDiscover(
+                    const shouldRediscover = selectShouldRediscoverNetworks(
                         getState(),
                         device.state.staticSessionId,
                     );
 
-                    if (networksToDiscover.undiscovered.length) {
+                    if (shouldRediscover) {
                         dispatch(restartDiscoveryThunk());
                     }
                 }

--- a/suite-native/discovery/src/discoveryMiddleware.ts
+++ b/suite-native/discovery/src/discoveryMiddleware.ts
@@ -80,7 +80,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
                         device.state.staticSessionId,
                     );
 
-                    if (networksToDiscover.length) {
+                    if (networksToDiscover.undiscovered.length) {
                         dispatch(restartDiscoveryThunk());
                     }
                 }

--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -16,7 +16,6 @@ import {
     DeviceRootState,
     accountsActions,
     selectDeviceAccounts,
-    selectDiscoveryForSelectedDevice,
     selectIsDeviceInViewOnlyMode,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
@@ -92,7 +91,6 @@ export const useAddCoinAccount = () => {
     const device = useSelector(selectSelectedDevice);
     const isDeviceInViewOnlyMode = useSelector(selectIsDeviceInViewOnlyMode);
     const enabledDiscoveryNetworkSymbols = useSelector(selectDeviceEnabledDiscoveryNetworkSymbols);
-    const discovery = useSelector(selectDiscoveryForSelectedDevice);
 
     const navigation = useNavigation<AddCoinAccountNavigationProps>();
 
@@ -325,7 +323,7 @@ export const useAddCoinAccount = () => {
         }
 
         // the account should already exist, but be invisible, so make it visible
-        if (firstHiddenEmptyAccount) {
+        if (firstHiddenEmptyAccount && !firstHiddenEmptyAccount.failed) {
             dispatch(accountsActions.changeAccountVisibility(firstHiddenEmptyAccount));
             navigateToSuccessorScreen({
                 flowType,
@@ -338,15 +336,8 @@ export const useAddCoinAccount = () => {
         }
 
         // or the account discovery might have failed
-        const nextAccountIndex = accounts.length;
-        const failedAccount = discovery?.failed?.find(
-            f =>
-                f.symbol === symbol &&
-                f.accountType === accountType &&
-                f.index === nextAccountIndex,
-        );
-        if (failedAccount !== undefined) {
-            navigateToFailureScreen({ flowType, errorString: failedAccount.error });
+        if (firstHiddenEmptyAccount?.failed) {
+            navigateToFailureScreen({ flowType, errorString: firstHiddenEmptyAccount.error });
         }
     };
 


### PR DESCRIPTION
## Description

I tried to make the suite-side discovery refactor cleaner, better readable and hopefully more effective while fixing some issues I encountered.

- https://github.com/trezor/trezor-suite/pull/19886/commits/70c48dc7ef868be65ed5c66cff405b9fcd0e904a - dissolve `startInitialDiscovery` thunk in `discoveryMiddleware` as it was the only place where it's used. (Hopefully it's the prerequisite for creating single thunk which can handle both discovery start and additional discovery?)
- https://github.com/trezor/trezor-suite/pull/19886/commits/5b6c384526255dfa01fcfc3d235098a9870b00a1 - minor condition improvement (part of it was useless)
- https://github.com/trezor/trezor-suite/pull/19886/commits/92459fa26ac231ba9b17a2aa2430d1e08a8284ac - `selectNetworksToDiscover` selector now separates failed coins and undiscovered coins, so it's possible to rerun discovery by changing app route only when there are undiscovered coins, but making the rediscovery itself even when there's a failed one.
- https://github.com/trezor/trezor-suite/pull/19886/commits/ca2f36f5e63d264a697f2770c6e14635c55b27ee - improving the discovery progress handler so it's a bit shorter, nothing important should change tho
- https://github.com/trezor/trezor-suite/pull/19886/commits/2f71a1e4c028279e790ee076a51ac727fa27cab2 - some real changes inside the handler:
  - `hadLoadedAnyNonEmptyAccount` flag in discovery reducer and local variable `encounteredNonEmptyAccount` were merged as I believe they should do the same stuff
  - `hasLoadedAnyNonEmptyAccount` now stays in discovery reducer instead of being switched on/off based on the status
  - `hasLoadedAnyNonEmptyAccount` now means that there's tx history, not that there's positive balance (which didn't make sense imo)
  - discovery status is now not updated twice in case of failed account (moreover, the second update always switched the `'progress'` status back to `'starting'`, which was a bug I believe)
- https://github.com/trezor/trezor-suite/pull/19886/commits/3c35a67694a036d0943bb87a845933b35c4b2279 - for some reason, failed accounts were stored in different shape in discovery reducer, so I moved them between ordinary accounts with corresponding `failed`/`error` fields. It can bring some unexpected changes, but it allows much simpler code so I believe it's the right thing to do.
- https://github.com/trezor/trezor-suite/pull/19886/commits/fdde6d4c3bd2b81ee630af54ea1edde550051628 - `discoverAccounts` api was extended a bit, so a) `path` and `backendType` is returned even for failed accounts which makes creating them Suite-side a bit easier, b) account failure can be identified by `failed` field and c) it's allowed to pass empty `accounts` param, which does nothing but at least doesn't throw
- https://github.com/trezor/trezor-suite/pull/19886/commits/6044be1da6122e7a8de6cd076506575ae7431162 - `selectNetworksToDiscover` changed, again, to `selectDiscoveryAccountsParam` which properly utilizes `discoverAccounts` features (mostly `skip` param to rediscover coins only from the first failed or empty account)
- https://github.com/trezor/trezor-suite/pull/19886/commits/dda4103c35cb198b86227fb21205dfd5822b4297 - discovery progress handler polished once again:
  - failed/success progress events are now handler together by `transformProgressEventData` function which creates `updateDiscovery`/`createAccount` payloads from them
  - postponing account creation is now used only in `runDiscoveryThunk` as I believe it's not necessary in `runAdditionalDiscoveryThunk` (I may be wrong ofc)
- https://github.com/trezor/trezor-suite/pull/19886/commits/414fa783f5d3d863d0a485a75594a272749deebf - as failed accounts are now subset of all the accounts, conditions were added not to store them in IndexedDB
- https://github.com/trezor/trezor-suite/pull/19886/commits/8c7cbfe2e49b82b610ed7f003e91dcb4afc18c63 - account equality is now not defined by `deviceState + symbol + descriptor` but by `deviceState + symbol + accountType + index` so even failed accounts with placeholder descriptors can be later paired with their successful counterparts. It can be a bit risky (e.g. when there are some plus one errors in indices or incorrectly set account types) so I've left a warning whenever there are some _equal_ accounts with different descriptors (but it doesn't cover all the possible faults)
- https://github.com/trezor/trezor-suite/pull/19886/commits/cfb7fe8259dc6aa2cf0c717ea120da1d04b324b2 - based on previous commit, when creating already existing account, it's updated instead. Also, I've changed `accountLabel` creation so it works with account index instead of existing accounts counts. It may break something (in native e.g.) but I believe it should be safer (unless some accounts are skipped? We should ask native guys).
- https://github.com/trezor/trezor-suite/pull/19886/commits/310a012a33c7c3838c953bf3aff38be4b0bd3de8 - unit tests adjustment
  - it was needed to type `BTC_ACCOUNT` fixture more precisely as inference was already too hard for Typescript
  - I've removed a unit test which sense I wasn't able to figure out and it was failing because of my changes

## TODO
- ask native guys about account labels and indices
- check that all the new passphrase flows still work as expected (or better!)
- resolve `accountType: coinjoin` which may break additional discovery flow

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/rediscovery&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/rediscovery&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/rediscovery&lookback=7)