### PR TITLE
fix(ci): build windows app with BT binary

### DIFF
--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -127,7 +127,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          yarn workspace @trezor/suite-desktop build:${{env.platform}}
+          BLUETOOTH=${{ github.event.inputs.bluetooth }} yarn workspace @trezor/suite-desktop build:${{env.platform}}
           bash packages/suite-desktop-core/scripts/gnupg-sign.sh
           mv packages/suite-desktop/build-electron/* .
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

windows build does not includes bt binary,
fixing this commit: https://github.com/trezor/trezor-suite/commit/dd3d60d09f25f6f92558b3efc00b78dc146fb9b4
