### PR TITLE
feat(message-system): blacklist trading for GB

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,8 +1,56 @@
 {
     "version": 1,
-    "timestamp": "2025-06-16T00:00:00+00:00",
-    "sequence": 91,
+    "timestamp": "2025-07-01T18:08:10+00:00",
+    "sequence": 92,
     "actions": [
+        {
+            "conditions": [
+                {
+                    "environment": {
+                        "desktop": "!",
+                        "mobile": ">=25.6.1",
+                        "web": "!"
+                    },
+                    "os": {
+                        "macos": "!",
+                        "linux": "!",
+                        "windows": "!",
+                        "android": "!",
+                        "ios": "*",
+                        "chromeos": "!"
+                    },
+                    "countryCodes": ["GB"]
+                }
+            ],
+            "message": {
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "priority": 91,
+                "dismissible": false,
+                "variant": "info",
+                "category": "feature",
+                "content": {
+                    "en-GB": "Trading is not available in your country yet.",
+                    "en": "Trading is not available in your country yet.",
+                    "es": "Trading is not available in your country yet.",
+                    "cs": "Trading is not available in your country yet.",
+                    "de": "Trading is not available in your country yet.",
+                    "fr": "Trading is not available in your country yet.",
+                    "it": "Trading is not available in your country yet.",
+                    "pt": "Trading is not available in your country yet.",
+                    "tr": "Trading is not available in your country yet.",
+                    "ru": "Trading is not available in your country yet.",
+                    "ja": "Trading is not available in your country yet.",
+                    "uk": "Trading is not available in your country yet.",
+                    "hu": "Trading is not available in your country yet."
+                },
+                "feature": [
+                    {
+                        "domain": "trading.restrictions.blacklist",
+                        "flag": true
+                    }
+                ]
+            }
+        },
         {
             "conditions": [
                 {


### PR DESCRIPTION
**Do not merge before testing on develop**

Disables trading on iOS for Great Britain

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/message-system/blacklist-trading-in-gb&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/message-system/blacklist-trading-in-gb&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/message-system/blacklist-trading-in-gb&lookback=7)