### PR TITLE
fix(mobile): do not show xpub when firmware is compromised

### DIFF
--- a/suite-native/module-accounts-management/src/components/AccountSettingsShowXpubButton.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountSettingsShowXpubButton.tsx
@@ -9,18 +9,29 @@ import {
     showXpubOnDevice,
 } from '@suite-common/wallet-core';
 import { isAddressBasedNetwork } from '@suite-common/wallet-utils';
+import { useAlert } from '@suite-native/alerts';
 import { Button, useBottomSheetModal } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
+import { selectHasFirmwareAuthenticityCheckHardFailed } from '@suite-native/device';
+import { Translation, useTranslate } from '@suite-native/intl';
+import { SUITE_LITE_SUPPORT_URL, useOpenLink } from '@suite-native/link';
 import { WalletBackupNotSetWarningBottomSheet } from '@suite-native/module-device-onboarding';
 import { XpubQRCodeBottomSheet } from '@suite-native/qr-code';
 import { convertTaprootXpub } from '@trezor/utils';
 
 export const AccountSettingsShowXpubButton = ({ accountKey }: { accountKey: string }) => {
+    const openLink = useOpenLink();
+    const { showAlert } = useAlert();
+    const { translate } = useTranslate();
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
+
     const [isXpubVisible, setIsXpubVisible] = useState(false);
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
+
+    const hasFirmwareAuthenticityCheckHardFailed = useSelector(
+        selectHasFirmwareAuthenticityCheckHardFailed,
+    );
 
     const isDeviceBackupRequired = useSelector(selectIsDeviceBackupRequired);
     const device = useSelector(selectSelectedDevice);
@@ -35,6 +46,21 @@ export const AccountSettingsShowXpubButton = ({ accountKey }: { accountKey: stri
             setIsXpubVisible(true);
         }
     }, [isDeviceBackupRequired, device, account, openModal]);
+
+    const showFirmwareAuthenticityCheckAlert = useCallback(
+        () =>
+            showAlert({
+                title: translate('generic.banners.deviceDanger.compromised.title'),
+                description: translate('generic.banners.deviceDanger.compromised.subtitle'),
+                icon: 'warning',
+                primaryButtonTitle: translate('generic.banners.deviceDanger.compromised.cta'),
+                primaryButtonVariant: 'redBold',
+                onPressPrimaryButton: () => openLink(SUITE_LITE_SUPPORT_URL),
+                secondaryButtonTitle: translate('generic.buttons.cancel'),
+                secondaryButtonVariant: 'redElevation0',
+            }),
+        [openLink, showAlert, translate],
+    );
 
     if (!account) return null;
 
@@ -70,7 +96,15 @@ export const AccountSettingsShowXpubButton = ({ accountKey }: { accountKey: stri
                     ref={bottomSheetRef}
                 />
             )}
-            <Button size="large" onPress={showXpub} colorScheme="tertiaryElevation0">
+            <Button
+                size="large"
+                onPress={
+                    hasFirmwareAuthenticityCheckHardFailed
+                        ? showFirmwareAuthenticityCheckAlert
+                        : showXpub
+                }
+                colorScheme="tertiaryElevation0"
+            >
                 {buttonTitle}
             </Button>
             <XpubQRCodeBottomSheet


### PR DESCRIPTION
Disables option to generate xpub on mobile when firmware is compromised.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19550

## Screenshots:
BEFORE
<img width="466" alt="Screenshot 2025-07-02 at 0 40 27" src="https://github.com/user-attachments/assets/48455fa8-bc61-4422-a10c-d4b41f9358f1" />
AFTER
<img width="434" alt="Screenshot 2025-07-07 at 7 02 16" src="https://github.com/user-attachments/assets/c686703f-bf8e-49bd-ad12-abebba8959f2" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/disable-xpub-generation-when-device-is-compromised-mobile&lookback=7)