### PR TITLE
chore(suite-native): bump target android sdk to 35

### DIFF
--- a/suite-native/app/plugins/minSdkProjectGradlePatch.js
+++ b/suite-native/app/plugins/minSdkProjectGradlePatch.js
@@ -4,10 +4,7 @@ const generateCode = require('@expo/config-plugins/build/utils/generateCode');
 // https://github.com/expo/expo/issues/36461#issuecomment-2846152663
 const minSdkPatchCode = `
   ext {
-    buildToolsVersion = findProperty('android.buildToolsVersion') ?: '35.0.0'
     minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '24')
-    compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '35')
-    targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '34')
     kotlinVersion = findProperty('android.kotlinVersion') ?: '2.0.21'
   }
 `;


### PR DESCRIPTION

## Description
- Google Play demands the target build SDK to be 35, this PR fixes that
![Screenshot 2025-07-01 at 9 14 11 PM](https://github.com/user-attachments/assets/706a21e2-2001-446f-bf79-8f668ab3d785)


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/bump-target-android-sdk-to-35&lookback=7)