### PR TITLE
fix(suite): add compose methods to init blacklist too

### DIFF
--- a/suite-common/connect-init/src/blacklist.ts
+++ b/suite-common/connect-init/src/blacklist.ts
@@ -30,4 +30,8 @@ export const blacklist: ConnectKey[] = [
     // so locking device must be avoided (blocks a lot of Suite features needlessly)
     // TODO find a better solution to wrap this method only when device is used
     'getAccountInfo',
+    // https://github.com/trezor/trezor-suite/issues/19876
+    'composeTransaction',
+    'cardanoComposeTransaction',
+    'solanaComposeTransaction',
 ];


### PR DESCRIPTION
might fix #19876 I did not test it personally, could you please @Ondra-Zik-SL 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=blacklist-compose&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=blacklist-compose&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=blacklist-compose&lookback=7)