### PR TITLE
chore(suite): remove unused bridge-dev-restart notification

### DIFF
--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -136,12 +136,6 @@ export const NotificationRenderer = ({
             return success(render, notification, 'TR_DEVICE_AUTHENTICITY_SUCCESS');
         case 'device-authenticity-error':
             return error(render, notification, 'TR_DEVICE_AUTHENTICITY_ERROR');
-        case 'bridge-dev-restart':
-            return info(
-                render,
-                notification,
-                notification.devMode ? 'TR_BRIDGE_DEV_MODE_START' : 'TR_BRIDGE_DEV_MODE_STOP',
-            );
         case 'metadata-not-found-error':
             return error(render, notification, 'METADATA_PROVIDER_NOT_FOUND_ERROR');
         case 'metadata-auth-error':

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5666,14 +5666,6 @@ export default defineMessages({
         id: 'TR_ADD_TOKEN_TOAST_ERROR',
         defaultMessage: 'Action failed: {error}',
     },
-    TR_BRIDGE_DEV_MODE_START: {
-        id: 'TR_BRIDGE_DEV_MODE_START',
-        defaultMessage: 'Starting Trezor Bridge on port 21324',
-    },
-    TR_BRIDGE_DEV_MODE_STOP: {
-        id: 'TR_BRIDGE_DEV_MODE_STOP',
-        defaultMessage: 'Starting Trezor Bridge on default port',
-    },
     TR_TO_ADD_NEW_ACCOUNT_WAIT_FOR_DISCOVERY: {
         id: 'TR_TO_ADD_NEW_ACCOUNT_WAIT_FOR_DISCOVERY',
         defaultMessage: 'Loading accounts. Wait before adding another one.',

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -82,10 +82,6 @@ export type ToastPayload = (
           txid: string;
       }
     | {
-          type: 'bridge-dev-restart';
-          devMode: boolean;
-      }
-    | {
           type:
               | 'error'
               | 'auth-failed'


### PR DESCRIPTION
it doesn't seem to be used anywhere

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=cleanup&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=cleanup&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=cleanup&lookback=7)