### PR TITLE
fix(suite): race condition crashing Advanced Fee tab

### DIFF
--- a/packages/suite/src/components/wallet/Fees/Fees.tsx
+++ b/packages/suite/src/components/wallet/Fees/Fees.tsx
@@ -154,6 +154,9 @@ export const Fees = <TFieldValues extends FormState>({
 
     const feeOptions = buildFeeOptions(feeInfo.levels, networkType, symbol, composedLevels);
 
+    // when fees are loading, feeInfo.levels = [], but CustomFee requires at least the 'normal' level to have some default
+    const hasNormalFeeLevel = feeInfo.levels.some(level => level.label === 'normal');
+
     const supportsCustomFee = networkType !== 'solana';
 
     useFetchFeesOnce({ networkSymbol: symbol });
@@ -205,6 +208,7 @@ export const Fees = <TFieldValues extends FormState>({
                 </Tooltip>
                 {supportsCustomFee && (
                     <SelectBar
+                        isDisabled={!hasNormalFeeLevel}
                         orientation="horizontal"
                         selectedOption={isCustomFee ? 'custom' : 'normal'}
                         size="small"


### PR DESCRIPTION
## Description

Clicking on Advanced fee tab (any screen: send, stake, sell, etc.) crashes with unhandled error when fees are not loaded yet, and they are not preloaded either.
There is a brief time window where clicking Advanced tab crashes → so disable the Normal/Advanced Select bar when loading.

:information_source: [this line](https://github.com/trezor/trezor-suite/blob/2b6bf21bb28d2dc24899c21a764459e7a1e9258c/packages/suite/src/hooks/wallet/form/useFees.ts#L126-L128) finds `undefined` despite the `!` ( gasp :open_mouth: ) and then unhandled error `undefined.feePerUnit` 

:information_source: All coins that are turned on when you start Suite, will be preloaded, but coins that you just turned are not preloaded. 

This was discovered thanks to [sell eth test](https://github.com/trezor/trezor-suite/blob/f74c96b30506b327e153c3191297a148f9850468/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum.test.ts) – the issue likely existed for a long time, but only this newly developed test crashed to this race condition.

You can very easily reproduce locally if you put long delay in `updateFeeInfoThunk`.
e.g. `await getArtificialDelayPromise(5000);` [here](https://github.com/trezor/trezor-suite/blob/ee4dda956233b1eb86e018421bf33038b744e64e/suite-common/wallet-core/src/fees/feesThunks.ts#L92)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/Fees-race-condition&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/Fees-race-condition&lookback=7)