### PR TITLE
Fix: sell ethereum test

### DIFF
--- a/packages/components/src/components/form/SelectBar/SelectBar.tsx
+++ b/packages/components/src/components/form/SelectBar/SelectBar.tsx
@@ -213,6 +213,8 @@ export const SelectBar = <V extends ValueTypes>({
                                     <Option
                                         onClick={handleOptionClick(option)}
                                         $isDisabled={!!isDisabled}
+                                        // @ts-expect-error
+                                        disabled={!!isDisabled}
                                         $isSelected={isSelected}
                                         data-testid={`select-bar/${String(option.value)}`}
                                     >

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum.test.ts
@@ -23,7 +23,7 @@ const formattedAddress = formatAddress(sellWatchEthereum.destinationAddress);
 const gasLimit = '26000';
 const maxFeePerGas = '2.67674454';
 const maxPriorityFeePerGas = '1.375641927';
-/*TODO: Uncomment once bug #19186 is resolved 
+/*TODO: Uncomment once bug #19186 is resolved
 + import BigNumber from '@trezor/utils' and localizeNumber from '@suite-common/wallet-utils'
 const maxFeePerGasRounded = new BigNumber(maxFeePerGas).decimalPlaces(2, BigNumber.ROUND_UP);
 const maxPriorityFeePerGasRounded = new BigNumber(maxPriorityFeePerGas).decimalPlaces(
@@ -65,8 +65,12 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=trading', '@webOnly'] }
         },
     );
 
-    test('Sell Ethereum', async ({ tradingPage, devicePrompt }) => {
+    test('Sell Ethereum', async ({ page, tradingPage, devicePrompt }) => {
         await test.step('Fill in a sell request', async () => {
+            await expect(tradingPage.fees.switchModeButton('custom')).toBeVisible();
+            await expect(tradingPage.fees.switchModeButton('custom')).toBeEnabled();
+            // TODO: toBeEnabled() is not working, it immediately resolves despite disabled attribute being present
+            await page.waitForTimeout(1000);
             await tradingPage.fees.switchModeButton('custom').click();
             await tradingPage.fees.ethereumFeeLimit.fill(gasLimit);
             await tradingPage.fees.ethereumMaxFeePerGas.fill(maxFeePerGas);
@@ -126,7 +130,7 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=trading', '@webOnly'] }
                 ],
                 footer: 'Tap to continue',
             });
-           
+
             await expect(
                 devicePrompt.cryptoAmountWithSymbolOf('fee'),
                 errorMessageMaxCalculation,

--- a/packages/suite/src/components/wallet/Fees/Fees.tsx
+++ b/packages/suite/src/components/wallet/Fees/Fees.tsx
@@ -154,6 +154,9 @@ export const Fees = <TFieldValues extends FormState>({
 
     const feeOptions = buildFeeOptions(feeInfo.levels, networkType, symbol, composedLevels);
 
+    // when fees are loading, feeInfo.levels = [], but CustomFee requires at least the 'normal' level to have some default
+    const hasNormalFeeLevel = feeInfo.levels.some(level => level.label === 'normal');
+
     const supportsCustomFee = networkType !== 'solana';
 
     useFetchFeesOnce({ networkSymbol: symbol });
@@ -205,6 +208,7 @@ export const Fees = <TFieldValues extends FormState>({
                 </Tooltip>
                 {supportsCustomFee && (
                     <SelectBar
+                        isDisabled={!hasNormalFeeLevel}
                         orientation="horizontal"
                         selectedOption={isCustomFee ? 'custom' : 'normal'}
                         size="small"


### PR DESCRIPTION
WIP followp to https://github.com/trezor/trezor-suite/pull/19909, after which the Normal/Advanced fee `SelectBar` is properly disabled, but the `sell-ethereum-test` does not know it yet, so it tries clicking on it right away.

- `disabled` attribute is missing on the `SelectBar` component, so add it
- in the test, await the option to be enabled, but that's not working yet :confused: 
