### PR TITLE
Show sign tx modal when doing approve with 2.9.0 fw version

### DIFF
--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -83,6 +83,18 @@ const buttonRequest =
 
                 return action;
             }
+
+            if (
+                action.type === UI.REQUEST_BUTTON &&
+                action.payload.name === 'confirm_ethereum_approve'
+            ) {
+                api.dispatch({
+                    ...action,
+                    payload: { ...action.payload, code: 'ButtonRequest_SignTx' },
+                });
+
+                return action;
+            }
         }
 
         if (action.type === UI.REQUEST_BUTTON && action.payload.code === 'ButtonRequest_Address') {


### PR DESCRIPTION
## Description

EVM Approval transaction now use `TransactionReviewModal` instead of `ConfirmActionModal`.

`ButtonRequest_Other` with `confirm_ethereum_approve` name is being intercepted in `buttonRequestMiddleware` and changed to `ButtonRequest_SignTx`. This solution is just a hotfix for the release.


## Related Issue

Related #19830
 
## Screenshots:

https://github.com/user-attachments/assets/492874eb-d3ca-4cfa-b5ce-3cf5aadb9fbc

