### PR TITLE
fix(suite): optimize TransactionReviewModalContent

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -3,23 +3,21 @@ import { useEffect, useState } from 'react';
 import { selectConnectPopupCall } from '@suite-common/connect-popup';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { selectTradingComposedTransactionInfo } from '@suite-common/trading';
-import { NetworkSymbol, NetworkType } from '@suite-common/wallet-config';
+import { NetworkType } from '@suite-common/wallet-config';
 import {
-    AccountsState,
     DeviceRootState,
     SendState,
     SerializedTx,
     StakeState,
-    selectAccounts,
+    selectIsTxOutputInternal,
     selectPrecomposedSendForm,
     selectSelectedDevice,
     selectSendFormReviewButtonRequestsCount,
     selectStakePrecomposedForm,
 } from '@suite-common/wallet-core';
-import { FormState, RbfTransactionType, ReviewOutput, StakeType } from '@suite-common/wallet-types';
+import { FormState, RbfTransactionType, StakeType } from '@suite-common/wallet-types';
 import {
-    constructTransactionReviewOutputs,
-    findAccountsByAddress,
+    constructTransactionReviewOutputsOptional,
     getStakeType,
     isRbfBumpFeeTransaction,
     isRbfCancelTransaction,
@@ -60,24 +58,26 @@ const getTxValidityTimeoutInMs = (networkType?: NetworkType) => {
 
 const hasTxValidityExpired = (deadline: number) => deadline <= Date.now();
 
-const shouldShowTxValidityTimer = (
-    deadline: number,
-    outputs: ReviewOutput[],
-    symbol: NetworkSymbol,
-    accounts: AccountsState,
-    buttonRequestsCount: number,
-    serializedTx: SerializedTx | undefined,
-    stakeType: StakeType | null,
-    shouldCheckTxTimeValidity: boolean,
-) => {
+type ShouldShowTxValidityTimerProps = {
+    deadline: number;
+    buttonRequestsCount: number;
+    serializedTx: SerializedTx | undefined;
+    stakeType: StakeType | null;
+    shouldCheckTxTimeValidity: boolean;
+    isInternalTransfer: boolean;
+};
+
+const shouldShowTxValidityTimer = ({
+    deadline,
+    buttonRequestsCount,
+    serializedTx,
+    stakeType,
+    shouldCheckTxTimeValidity,
+    isInternalTransfer,
+}: ShouldShowTxValidityTimerProps) => {
     if (!shouldCheckTxTimeValidity || hasTxValidityExpired(deadline)) {
         return false;
     }
-
-    const firstOutput = outputs[0];
-    const isInternalTransfer =
-        firstOutput?.type === 'address' &&
-        findAccountsByAddress(symbol, firstOutput.value, accounts).length > 0;
 
     const isFirstStep = buttonRequestsCount <= 1;
     const isStaking = stakeType && !serializedTx;
@@ -116,7 +116,6 @@ export const TransactionReviewModalContent = ({
 }: TransactionReviewModalContentProps) => {
     const dispatch = useDispatch();
     const account = useSelector(selectAccountIncludingChosenInTrading);
-    const accounts = useSelector(selectAccounts);
     const device = useSelector(selectSelectedDevice);
     const isActionAbortable = useSelector(selectIsActionAbortable);
     const connectPopupCall = useSelector(selectConnectPopupCall);
@@ -175,6 +174,18 @@ export const TransactionReviewModalContent = ({
         selectSendFormReviewButtonRequestsCount(state, account?.symbol, decreaseOutputId),
     );
 
+    const outputs = constructTransactionReviewOutputsOptional({
+        account,
+        decreaseOutputId,
+        device,
+        precomposedForm,
+        precomposedTx,
+    });
+
+    const isInternalTransfer = useSelector(state =>
+        selectIsTxOutputInternal(state, account?.symbol, outputs[0]),
+    );
+
     if (!device) return null;
     if (!account || !precomposedTx || !precomposedForm) {
         // TODO: special case for Connect Popup
@@ -185,14 +196,6 @@ export const TransactionReviewModalContent = ({
     const { options, selectedFee } = precomposedForm;
 
     const txType = getTxType(txInfoState, precomposedForm);
-
-    const outputs = constructTransactionReviewOutputs({
-        account,
-        decreaseOutputId,
-        device,
-        precomposedForm,
-        precomposedTx,
-    });
 
     // for bump fee we have to analyze tx data which are in outputs[0], for legacy in outputs[1]
     const stakeType = getStakeType(precomposedForm, outputs);
@@ -210,16 +213,14 @@ export const TransactionReviewModalContent = ({
 
     const isTxExpired = hasTxValidityExpired(deadline);
 
-    const showTxValidityTimer = shouldShowTxValidityTimer(
+    const showTxValidityTimer = shouldShowTxValidityTimer({
         deadline,
-        outputs,
-        symbol,
-        accounts,
         buttonRequestsCount,
         serializedTx,
         stakeType,
         shouldCheckTxTimeValidity,
-    );
+        isInternalTransfer,
+    });
 
     const actionTranslation = getTransactionReviewModalActionTranslation({
         stakeType,

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -1,12 +1,14 @@
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
-import { networksCollection } from '@suite-common/wallet-config';
-import { getFailedAccounts, sortByCoin } from '@suite-common/wallet-utils';
+import { NetworkSymbol, networksCollection } from '@suite-common/wallet-config';
+import { ReviewOutput } from '@suite-common/wallet-types';
+import { findAccountsByAddress, getFailedAccounts, sortByCoin } from '@suite-common/wallet-utils';
 import { StaticSessionId } from '@trezor/connect';
 
 import { AccountsRootState } from './accounts/accountsReducer';
 import {
     selectAccounts,
     selectAccountsByDeviceState,
+    selectDeviceAccountsByNetworkSymbol,
     selectIsDeviceAccountless,
     selectVisibleDeviceAccounts,
 } from './accounts/accountsSelectors';
@@ -29,9 +31,11 @@ This file is for selectors that reach into more than one wallet-core reduce
 to prevent circular dependencies between reducers
 */
 
-const createMemoizedSelector = createWeakMapSelector.withTypes<
-    AccountsRootState & DeviceRootState & DiscoveryRootState & WalletSettingsRootState
->();
+type CompoundRootState = AccountsRootState &
+    DeviceRootState &
+    DiscoveryRootState &
+    WalletSettingsRootState;
+const createMemoizedSelector = createWeakMapSelector.withTypes<CompoundRootState>();
 
 /**
  * This means "all potentially visible accounts", because for accounts that failed to be discovered
@@ -130,4 +134,24 @@ export const selectIsDiscoveredDeviceAccountless = createMemoizedSelector(
 export const selectHasOnlyEmptyPortfolioTracker = createMemoizedSelector(
     [selectIsDiscoveredDeviceAccountless, selectHasOnlyPortfolioDevice],
     (isDiscoveredAccountless, hasOnlyPortfolio) => isDiscoveredAccountless && hasOnlyPortfolio,
+);
+
+/**
+ * Memoizing this selector is actually essential for performance, because every select accounts
+ * operation is a potential rerender-hell due to the fetchAndUpdateAccountThunk.
+ */
+export const selectIsTxOutputInternal = createMemoizedSelector(
+    [
+        selectDeviceAccountsByNetworkSymbol,
+        (_state: CompoundRootState, symbol?: NetworkSymbol, output?: ReviewOutput) => ({
+            symbol,
+            output,
+        }),
+    ],
+    (accounts, { symbol, output }) => {
+        if (!symbol || !output || output.type !== 'address') return false;
+        const matchingAccounts = findAccountsByAddress(symbol, output.value, accounts);
+
+        return matchingAccounts.length > 0;
+    },
 );

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -412,9 +412,9 @@ export const findAccountsByAddress = (
         .filter(a => {
             if (a.addresses) {
                 return (
-                    a.addresses.used.find(u => u.address === address) ||
-                    a.addresses.unused.find(u => u.address === address) ||
-                    a.addresses.change.find(u => u.address === address) ||
+                    a.addresses.used.some(u => u.address === address) ||
+                    a.addresses.unused.some(u => u.address === address) ||
+                    a.addresses.change.some(u => u.address === address) ||
                     a.descriptor === address
                 );
             }

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -97,7 +97,7 @@ const constructOldFlow = ({
     decreaseOutputId,
     account,
     precomposedForm,
-}: ConstructOutputsParams) => {
+}: ConstructOutputsParams): ReviewOutput[] => {
     const outputs: ReviewOutput[] = [];
 
     const isCardano = isCardanoTx(account, precomposedTx);
@@ -242,7 +242,7 @@ const constructNewFlow = ({
     account,
     precomposedForm,
     isUpdatedEthereumSendFlow,
-}: ConstructOutputsParams & { isUpdatedEthereumSendFlow: boolean }) => {
+}: ConstructOutputsParams & { isUpdatedEthereumSendFlow: boolean }): ReviewOutput[] => {
     const outputs: ReviewOutput[] = [];
 
     const isCardano = isCardanoTx(account, precomposedTx);
@@ -401,10 +401,12 @@ const constructNewFlow = ({
     return outputs;
 };
 
+type ConstructTransactionReviewOutputsProps = ConstructOutputsParams & { device: TrezorDevice };
+
 export const constructTransactionReviewOutputs = ({
     device,
     ...params
-}: ConstructOutputsParams & { device: TrezorDevice }) => {
+}: ConstructTransactionReviewOutputsProps): ReviewOutput[] => {
     const isUpdatedSendFlow = getIsUpdatedSendFlow(device); // >= 2.6.0
     const isUpdatedEthereumSendFlow = getIsUpdatedEthereumSendFlow(
         device,
@@ -416,4 +418,29 @@ export const constructTransactionReviewOutputs = ({
     }
 
     return constructNewFlow({ isUpdatedEthereumSendFlow, ...params });
+};
+
+export const constructTransactionReviewOutputsOptional = ({
+    account,
+    decreaseOutputId,
+    device,
+    precomposedForm,
+    precomposedTx,
+}: Partial<ConstructTransactionReviewOutputsProps>): ReviewOutput[] => {
+    if (
+        account === undefined ||
+        device === undefined ||
+        precomposedForm === undefined ||
+        precomposedTx === undefined
+    ) {
+        return [];
+    }
+
+    return constructTransactionReviewOutputs({
+        account,
+        decreaseOutputId,
+        device,
+        precomposedForm,
+        precomposedTx,
+    });
 };


### PR DESCRIPTION
## Description

See issue.
When a cluster of `updateAccountRefreshTimestamp` actions is dispatched, `TransactionReviewModalContent` rerenders so often that React can't cope and it temporarily breaks the Send button.
There is also a visual glitch in hover state as a visible symptom of the broken button.

:thought_balloon:  When investigating the issue, it took me a long time to realize this is actually a performance problem, not a business logic problem as I initially suspected – the `onClick` is wired just fine.
We might go through React code and find other such `selectAccounts` calls, because they might cause problems too.  

## Related Issue

Resolve #19876

## Screenshots:

Nothing to show – the visible symptom of the bug is gone, and the Send button is now calm & working :relieved: 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/optimize-TransactionReviewModalContent&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/optimize-TransactionReviewModalContent&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/optimize-TransactionReviewModalContent&lookback=7)