### PR TITLE
chore(suite): remove systeminformation lib

### DIFF
--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -50,7 +50,6 @@
         "electron-updater": "6.6.4",
         "openpgp": "^6.1.1",
         "passport-desktop": "^0.1.2",
-        "systeminformation": "^5.25.11",
         "ws": "^8.18.0"
     },
     "devDependencies": {

--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -206,7 +206,7 @@ const init = async () => {
     const buildInfo = getBuildInfo();
     logger.info('build', buildInfo);
 
-    const computerInfo = await getComputerInfo();
+    const computerInfo = getComputerInfo();
     logger.debug('computer', computerInfo);
 
     const widthArg = parseInt(app.commandLine.getSwitchValue('width'), 10);

--- a/packages/suite-desktop-core/src/libs/info.ts
+++ b/packages/suite-desktop-core/src/libs/info.ts
@@ -1,10 +1,25 @@
 import { app } from 'electron';
-import si from 'systeminformation';
+import os from 'os';
 
 import { isDevEnv } from '@suite-common/suite-utils';
 import { bytesToHumanReadable } from '@trezor/utils';
 
 import { b2t } from './utils';
+
+const getCPUInfo = () => {
+    const cpus = os.cpus();
+    const cores = cpus.length;
+    const model = cpus[0]?.model.trim() ?? 'Unknown CPU';
+
+    const maxSpeedMHz = Math.max(...cpus.map(cpu => cpu.speed));
+    const speedGHz = isNaN(maxSpeedMHz) ? 'Unknown CPU speed' : (maxSpeedMHz / 1000).toFixed(2);
+
+    return {
+        model,
+        cores,
+        speedGHz,
+    };
+};
 
 export const getBuildInfo = () => [
     'Info:',
@@ -17,25 +32,21 @@ export const getBuildInfo = () => [
     `- CWD: ${process.cwd()}`,
 ];
 
-export const getComputerInfo = async () => {
-    const { system, cpu, mem, osInfo } = await si.get({
-        system: 'manufacturer, model, virtual',
-        cpu: 'manufacturer, brand, processors, physicalCores, cores, speed',
-        mem: 'total',
-        osInfo: 'platform, arch, distro, release',
-    });
+/**
+ * This information is currently used *only* in Debug mode, goes to stdout and local files, see logger.ts.
+ * It is neither sent to analytics (but a similar info is queried in the renderer process for consistency with Web),
+ * nor offered in the UI "Application logs" section (those are redux logs, nothing from nodeJS process).
+ */
+export const getComputerInfo = () => {
+    const cpu = getCPUInfo();
 
     return [
         'Info:',
-        `- Platform: ${osInfo.platform} ${osInfo.arch}`,
-        `- OS: ${osInfo.distro} ${osInfo.release}`,
-        `- Manufacturer: ${system.manufacturer}`,
-        `- Model: ${system.model}`,
-        `- Virtual: ${b2t(system.virtual)}`,
-        `- CPU: ${cpu.manufacturer} ${cpu.brand}`,
-        `- Cores: ${cpu.processors}x${cpu.physicalCores}(+${cpu.cores - cpu.physicalCores}) @ ${
-            cpu.speed
-        }GHz`,
-        `- RAM: ${bytesToHumanReadable(mem.total)}`,
+        `- Platform: ${os.platform()} ${os.arch()}`,
+        `- OS release: ${os.release()}`,
+        `- OS version: ${os.version()}`,
+        `- CPU: ${cpu.model}`,
+        `- Cores: ${cpu.cores} @ ${cpu.speedGHz} GHz`,
+        `- RAM: ${bytesToHumanReadable(os.totalmem())}`,
     ];
 };

--- a/packages/suite-desktop-core/src/libs/logger.ts
+++ b/packages/suite-desktop-core/src/libs/logger.ts
@@ -105,11 +105,11 @@ export class Logger implements ILogger {
         this.exit();
     }
 
-    private async logBasicInfo() {
+    private logBasicInfo() {
         const buildInfo = getBuildInfo();
         this.info('build', buildInfo);
 
-        const computerInfo = await getComputerInfo();
+        const computerInfo = getComputerInfo();
         this.debug('computer', computerInfo);
     }
 

--- a/packages/suite-desktop-core/webpack/core.webpack.config.ts
+++ b/packages/suite-desktop-core/webpack/core.webpack.config.ts
@@ -95,7 +95,6 @@ const config: webpack.Configuration = {
         'bufferutil', // optional dependency of ws lib
         'memcpy', // optional depencency of bytebuffer lib
         'utf-8-validate', // optional dependency of ws lib
-        'osx-temperature-sensor', // optional dependency of systeminformation lib
     ],
     module: {
         rules: [

--- a/scripts/list-outdated-dependencies/foundation-dependencies.txt
+++ b/scripts/list-outdated-dependencies/foundation-dependencies.txt
@@ -62,7 +62,6 @@ react-router
 react-router-dom
 rimraf
 sort-package-json
-systeminformation
 tar
 tiny-secp256k1
 typeforce

--- a/yarn.lock
+++ b/yarn.lock
@@ -12557,7 +12557,6 @@ __metadata:
     lodash: "npm:^4.17.21"
     openpgp: "npm:^6.1.1"
     passport-desktop: "npm:^0.1.2"
-    systeminformation: "npm:^5.25.11"
     terser-webpack-plugin: "npm:^5.3.14"
     tsx: "npm:^4.20.3"
     webpack: "npm:5.99.9"
@@ -39266,16 +39265,6 @@ __metadata:
   version: 0.1.0
   resolution: "system-architecture@npm:0.1.0"
   checksum: 10/ca0dd793c45c354ab57dd7fc8ce7dc9923a6e07382bd3b22eb5b08f55ddb0217c390d00767549c5155fd4ce7ef23ffdd8cfb33dd4344cbbd37837d085a50f6f0
-  languageName: node
-  linkType: hard
-
-"systeminformation@npm:^5.25.11":
-  version: 5.25.11
-  resolution: "systeminformation@npm:5.25.11"
-  bin:
-    systeminformation: lib/cli.js
-  checksum: 10/9a43bb8991ac07a0bcf3f9002c32e9f36a1100b2f620049c4c3dc24f74556c681b1e4552dc27581af32a842540cd42c1bb085e842b0c325273fb558b51c7159f
-  conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Remove `systeminformation` lib from Suite Desktop electron-main, because it is unnecessarily complex, and it does automatically many queries that we don't need.

I am partially replacing it with nodeJS api.

Please note these logs **are only generated [in debug mode](https://github.com/trezor/trezor-suite/blob/a188538e948d2a9e5a8a3e45de4e224c55b76736/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/SettingsName.tsx#L37-L46)** and this data **are not sent anywhere**.
Yeah, they are not even sent with the Suite logs generated by the UI (which are mostly redux logs).
These nodeJS logs stay in `suite app data/logs/*.txt` if you have debug mode on.

## Related Issue

Resolve #19787

## Logs

**Before**
```
Platform: linux x64
OS: Ubuntu 24.04.2 LTS
Manufacturer: Dell Inc.
Model: Latitude 5440
Virtual: No
CPU: Intel Gen Intel® Core™ i7-1365U
Cores: 1x10(+2) @ 2.23GHz
RAM: 38.8 GB
```

**After**
```
Platform: linux x64
CPU: 13th Gen Intel(R) Core(TM) i7-1365U
Cores: 12 @ 3.30 GHz
RAM: 38.8 GB
```

Missing:
- physical vs virtual cores, this only displays virtual cores
- manufacturer, model
- virtualization

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/remove-systeminformation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/remove-systeminformation&lookback=7)