### PR TITLE
Trade - on account change refresh server data

### DIFF
--- a/suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
+++ b/suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
@@ -19,11 +19,15 @@ import { TradingType } from '../../types';
 
 export interface LoadInitialDataThunkProps {
     activeSection: TradingType;
+    forcedApiKey?: string;
 }
 
 export const loadInitialDataThunk = createThunk(
     `${TRADING_THUNK_PREFIX}/loadInitialData`,
-    async ({ activeSection }: LoadInitialDataThunkProps, { dispatch, getState, extra }) => {
+    async (
+        { activeSection, forcedApiKey }: LoadInitialDataThunkProps,
+        { dispatch, getState, extra },
+    ) => {
         const selectedAccount = extra.selectors.selectSelectedAccount(getState());
         const account = selectTradingAccountAccordingActiveSection(
             getState(),
@@ -42,7 +46,7 @@ export const loadInitialDataThunk = createThunk(
 
         dispatch(tradingActions.setTradingActiveSection(activeSection));
 
-        if (account && !isLoading && (isDifferentAccount || areDataOutdated)) {
+        if ((account || forcedApiKey) && !isLoading && (isDifferentAccount || areDataOutdated)) {
             dispatch(tradingActions.setLoading({ isLoading: true }));
 
             const invityServerEnvironment = extra.selectors.selectTradingEnvironment(getState());
@@ -50,7 +54,9 @@ export const loadInitialDataThunk = createThunk(
                 invityAPI.setInvityServersEnvironment(invityServerEnvironment);
             }
 
-            invityAPI.createInvityAPIKey(account.descriptor);
+            // use account descriptor or forcedApiKey - one of these two must be provided to get here
+            const apiKey = account?.descriptor || forcedApiKey!;
+            invityAPI.createInvityAPIKey(apiKey);
 
             if (isDifferentAccount || !platforms || !coins) {
                 const info = await invityAPI.getInfo();

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyData.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyData.test.tsx
@@ -1,14 +1,44 @@
-import { tradingThunks } from '@suite-common/trading';
-import { renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { tradingBuyActions, tradingThunks } from '@suite-common/trading';
+import {
+    PreloadedState,
+    TestStore,
+    act,
+    initStore,
+    renderHookWithStoreProviderAsync,
+} from '@suite-native/test-utils';
 
+import { getBtcAccount } from '../../../__fixtures__/account';
+import { getInitializedTradingState } from '../../../__fixtures__/tradingState';
 import { useBuyData } from '../useBuyData';
 
+jest.mock('../../../utils/general/utils', () => ({
+    ...jest.requireActual('../../../utils/general/utils'),
+    getRandomAccountDescriptor: () => 'random_string',
+}));
+
 describe('useBuyData', () => {
-    const renderUseBuyData = (reloadRequestOrdinalInitialValue: number = 0) =>
+    const getInitializedStore = async (tradingAccountKey: string | undefined) => {
+        const preloadedState: PreloadedState = {
+            wallet: {
+                tradingNew: getInitializedTradingState(),
+                accounts: [
+                    getBtcAccount('btc-account-1'),
+                    getBtcAccount('btc-account-2'),
+                    { ...getBtcAccount('btc-account-3'), descriptor: '' },
+                ],
+            },
+        };
+        preloadedState.wallet!.tradingNew!.buy!.tradingAccountKey = tradingAccountKey;
+
+        return await initStore(preloadedState);
+    };
+
+    const renderUseBuyData = (reloadRequestOrdinalInitialValue: number, store: TestStore) =>
         renderHookWithStoreProviderAsync(
             ({ reloadRequestOrdinal }) => useBuyData(reloadRequestOrdinal),
             {
                 initialProps: { reloadRequestOrdinal: reloadRequestOrdinalInitialValue },
+                store,
             },
         );
 
@@ -34,14 +64,16 @@ describe('useBuyData', () => {
                     }, 100);
                 }),
         );
-        const { result } = await renderUseBuyData();
+        const store = await getInitializedStore(undefined);
+        const { result } = await renderUseBuyData(0, store);
 
         expect(result.current.isLoading).toBe(true);
         expect(result.current.lastLoadedTimestamp).toBe(0);
     });
 
     it('should settle after API queries are resolved', async () => {
-        const { result } = await renderUseBuyData();
+        const store = await getInitializedStore(undefined);
+        const { result } = await renderUseBuyData(0, store);
 
         expect(result.current.isLoading).toBe(false);
         expect(result.current.lastLoadedTimestamp).toBeGreaterThan(0);
@@ -52,7 +84,8 @@ describe('useBuyData', () => {
             .spyOn(tradingThunks, 'loadInitialDataThunk')
             .mockImplementation((() => ({ type: 'TEST_ACTION' })) as () => any);
 
-        const { rerender } = await renderUseBuyData();
+        const store = await getInitializedStore(undefined);
+        const { rerender } = await renderUseBuyData(0, store);
         rerender({ reloadRequestOrdinal: 0 });
 
         expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(1);
@@ -63,9 +96,107 @@ describe('useBuyData', () => {
             .spyOn(tradingThunks, 'loadInitialDataThunk')
             .mockImplementation((() => ({ type: 'TEST_ACTION' })) as () => any);
 
-        const { rerender } = await renderUseBuyData();
+        const store = await getInitializedStore(undefined);
+        const { rerender } = await renderUseBuyData(0, store);
         rerender({ reloadRequestOrdinal: 1 });
 
         expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(2);
+    });
+
+    describe('on receive account descriptor change', () => {
+        let initialThunkLoadActionSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            initialThunkLoadActionSpy = jest
+                .spyOn(tradingThunks, 'loadInitialDataThunk')
+                .mockImplementation((() => ({ type: 'TEST_ACTION' })) as () => any);
+        });
+
+        it('should dispatch loadInitialDataThunk when account is changed with descriptor', async () => {
+            const store = await getInitializedStore(undefined);
+            await renderUseBuyData(0, store);
+
+            // Clear the initial call
+            initialThunkLoadActionSpy.mockClear();
+
+            act(() => {
+                store.dispatch(tradingBuyActions.setTradingAccountKey('btc-account-2'));
+            });
+
+            // Wait for the effect to run
+            await act(async () => {
+                await new Promise(resolve => setTimeout(resolve, 0));
+            });
+
+            expect(initialThunkLoadActionSpy).toHaveBeenCalledWith({
+                activeSection: 'buy',
+                forcedApiKey: undefined,
+            });
+        });
+
+        it('should not dispatch loadInitialDataThunk when descriptor is not changed', async () => {
+            const store = await getInitializedStore('btc-account-2');
+            await renderUseBuyData(0, store);
+
+            // Clear the initial call
+            initialThunkLoadActionSpy.mockClear();
+
+            act(() => {
+                store.dispatch(tradingBuyActions.setTradingAccountKey('btc-account-2'));
+            });
+
+            // Wait for effects to run
+            await act(async () => {
+                await new Promise(resolve => setTimeout(resolve, 0));
+            });
+
+            expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(0);
+        });
+
+        it('should dispatch loadInitialDataThunk with random string when descriptor is empty string', async () => {
+            const store = await getInitializedStore('btc-account-1');
+            await renderUseBuyData(0, store);
+
+            // Clear the initial call
+            initialThunkLoadActionSpy.mockClear();
+
+            act(() => {
+                store.dispatch(tradingBuyActions.setTradingAccountKey('btc-account-3'));
+            });
+
+            // Wait for the effect to run
+            await act(async () => {
+                await new Promise(resolve => setTimeout(resolve, 0));
+            });
+
+            expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(1);
+            expect(initialThunkLoadActionSpy).toHaveBeenCalledWith({
+                activeSection: 'buy',
+                forcedApiKey: 'random_string',
+            });
+        });
+
+        it('should dispatch loadInitialDataThunk with random string when descriptor is undefined', async () => {
+            const store = await getInitializedStore('btc-account-1');
+            await renderUseBuyData(0, store);
+
+            // Clear the initial call
+            initialThunkLoadActionSpy.mockClear();
+
+            act(() => {
+                store.dispatch(tradingBuyActions.setTradingAccountKey(undefined));
+            });
+
+            // Wait for the effect to run
+            await act(async () => {
+                await new Promise(resolve => setTimeout(resolve, 0));
+            });
+
+            expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(1);
+            expect(initialThunkLoadActionSpy).toHaveBeenLastCalledWith({
+                activeSection: 'buy',
+                forcedApiKey: 'random_string',
+            });
+        });
     });
 });

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
@@ -3,7 +3,7 @@ import { Platform } from 'react-native';
 import { EnhancedStore } from '@reduxjs/toolkit';
 import type { BuyTrade, CryptoId } from 'invity-api';
 
-import { invityAPI, tradingBuyActions } from '@suite-common/trading';
+import { tradingBuyActions } from '@suite-common/trading';
 import { Form, useField } from '@suite-native/forms';
 import {
     PreloadedState,
@@ -24,10 +24,14 @@ import { BuyFormType } from '../../../types/buy';
 import { TradeableAsset } from '../../../types/general';
 import { clearBuyFormQuoteData, useBuyForm } from '../useBuyForm';
 
-jest.mock('../../../utils/general/utils', () => ({
-    ...jest.requireActual('../../../utils/general/utils'),
-    getRandomAccountDescriptor: () => 'random_string',
-}));
+jest.mock('@trezor/react-utils', () => {
+    const originalModule = jest.requireActual('@trezor/react-utils');
+
+    return {
+        ...originalModule,
+        useDebounce: () => (fn: () => unknown) => fn(),
+    };
+});
 
 describe('useBuyForm', () => {
     const renderUseTradingBuyForm = (store: TestStore) =>
@@ -65,8 +69,14 @@ describe('useBuyForm', () => {
         });
     };
 
-    afterEach(() => {
+    beforeEach(() => {
         jest.resetAllMocks();
+        global.fetch = jest.fn().mockImplementation(() =>
+            Promise.resolve({
+                json: () => Promise.resolve({}),
+                ok: true,
+            }),
+        );
     });
 
     it('should update form value when account in redux store is changed', async () => {
@@ -82,84 +92,15 @@ describe('useBuyForm', () => {
         });
     });
 
-    describe('createInvityAPIKey', () => {
-        it('should set random value to invityAPIKey on mount', async () => {
-            const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
-            const store = await getInitializedStore();
-
-            await renderUseTradingBuyForm(store);
-
-            expect(invityAPISpy).toHaveBeenCalledWith('random_string');
-        });
-
-        it('should update invityAPIKey when account is changed', async () => {
-            const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
-            const store = await getInitializedStore();
-            await renderUseTradingBuyForm(store);
-            invityAPISpy.mockClear();
-
-            act(() => {
-                store.dispatch(tradingBuyActions.setTradingAccountKey('btc-account-2'));
-            });
-
-            expect(invityAPISpy).toHaveBeenCalledWith('descriptor-btc-account-2');
-        });
-
-        it('should not call createInvityAPIKey when descriptor is not changed', async () => {
-            const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
-            const store = await getInitializedStore();
-            await renderUseTradingBuyForm(store);
-            invityAPISpy.mockClear();
-
-            act(() => {
-                store.dispatch(tradingBuyActions.setTradingAccountKey('btc-account-2'));
-            });
-
-            act(() => {
-                store.dispatch(tradingBuyActions.setTradingAccountKey('btc-account-2'));
-            });
-
-            expect(invityAPISpy).toHaveBeenCalledTimes(1);
-        });
-
-        it('should call createInvityAPIKey with random string when descriptor is empty string', async () => {
-            const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
-            const store = await getInitializedStore();
-            await renderUseTradingBuyForm(store);
-            invityAPISpy.mockClear();
-
-            act(() => {
-                store.dispatch(tradingBuyActions.setTradingAccountKey('btc-account-3'));
-            });
-
-            expect(invityAPISpy).toHaveBeenCalledTimes(1);
-            expect(invityAPISpy).toHaveBeenCalledWith('random_string');
-        });
-
-        it('should call createInvityAPIKey with random string when descriptor is undefined ', async () => {
-            const invityAPISpy = jest.spyOn(invityAPI, 'createInvityAPIKey');
-            const store = await getInitializedStore();
-            await renderUseTradingBuyForm(store);
-            invityAPISpy.mockClear();
-
-            act(() => {
-                store.dispatch(tradingBuyActions.setTradingAccountKey(undefined));
-            });
-
-            expect(invityAPISpy).toHaveBeenCalledTimes(1);
-            expect(invityAPISpy).toHaveBeenLastCalledWith('random_string');
-        });
-    });
-
     it('should dispatch tradingBuy/assetChanged on asset change', async () => {
         const store = await getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
         const { result } = await renderUseTradingBuyForm(store);
 
+        dispatchSpy.mockClear();
         act(() => {
             result.current.setValue('asset', usdcAsset);
         });
-
         expect(dispatchSpy).toHaveBeenCalledTimes(1);
         expect(dispatchSpy).toHaveBeenCalledWith(buyActions.assetChanged());
     });
@@ -220,6 +161,7 @@ describe('useBuyForm', () => {
         const dispatchSpy = jest.spyOn(store, 'dispatch');
         const { result } = await renderUseTradingBuyForm(store);
 
+        dispatchSpy.mockClear();
         act(() => {
             result.current.setValue('fiatCurrency', 'eur');
         });
@@ -230,7 +172,7 @@ describe('useBuyForm', () => {
 
     it('should clear cryptoValue when user edits fiatValue', async () => {
         const store = await getInitializedStore();
-        const { result } = await renderUseTradingBuyForm(store);
+        const { result } = await renderUseTradingBuyForm(store); //
         const { result: fieldResult } = renderHook(() => useField({ name: 'fiatValue' }), {
             wrapper: ({ children }) => <Form form={result.current}>{children}</Form>,
         });

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
@@ -184,15 +184,12 @@ describe('useBuyQuotes', () => {
                 result.current.setValue('fiatValue', '100');
             });
 
+            dispatchSpy.mockClear();
             act(() => {
                 result.current.setValue(field, value);
             });
 
-            // 1st call - buyActions/assetChanged
-            // 2nd call - buyActions/fiatCurrencyChanged
-            // 3rd call - initial handleRequestThunkMock
-            // 4th call - re-fetch of handleRequestThunkMock
-            expect(dispatchSpy).toHaveBeenCalledTimes(4);
+            expect(dispatchSpy).toHaveBeenCalledTimes(1);
             expect(dispatchSpy).toHaveBeenLastCalledWith(
                 expect.objectContaining({
                     type: 'handleRequestThunkMock',
@@ -209,20 +206,18 @@ describe('useBuyQuotes', () => {
             result.current.setValue('asset', usdcAsset);
             result.current.setValue('fiatCurrency', 'usd');
         });
+
         act(() => {
             result.current.setValue('fiatValue', '100');
         });
 
         expect(dispatchSpy).toHaveBeenCalledTimes(3);
 
+        dispatchSpy.mockClear();
         mockTimeSpent = INVITY_API_RELOAD_QUOTES_AFTER_SECONDS;
         rerender({});
 
-        // 1st call - tradingBuy/assetChanged
-        // 2nd call - tradingBuy/fiatCurrencyChanged
-        // 3rd call - initial handleRequestThunkMock
-        // 4th call - re-fetch of handleRequestThunkMock
-        expect(dispatchSpy).toHaveBeenCalledTimes(4);
+        expect(dispatchSpy).toHaveBeenCalledTimes(1);
         expect(dispatchSpy).toHaveBeenLastCalledWith(
             expect.objectContaining({
                 type: 'handleRequestThunkMock',
@@ -234,6 +229,8 @@ describe('useBuyQuotes', () => {
         const store = await getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
         const { result, rerender } = await renderUseBuyQuotes(store);
+
+        dispatchSpy.mockClear();
         act(() => {
             result.current.setValue('fiatCurrency', 'usd');
         });

--- a/suite-native/module-trading/src/hooks/buy/useBuyData.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyData.ts
@@ -3,12 +3,23 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { selectTradingBuyLoadingTimestampAndStatus, tradingThunks } from '@suite-common/trading';
 
+import { selectBuySelectedReceiveAccount } from '../../selectors/buySelectors';
+import { getRandomAccountDescriptor } from '../../utils/general/utils';
+
 export const useBuyData = (reloadRequestOrdinal: number) => {
     const dispatch = useDispatch();
+    const selectedReceiveAccount = useSelector(selectBuySelectedReceiveAccount);
+
+    const descriptor = selectedReceiveAccount?.account?.descriptor;
 
     useEffect(() => {
-        dispatch(tradingThunks.loadInitialDataThunk({ activeSection: 'buy' }));
-    }, [dispatch, reloadRequestOrdinal]);
+        dispatch(
+            tradingThunks.loadInitialDataThunk({
+                activeSection: 'buy',
+                forcedApiKey: !descriptor ? getRandomAccountDescriptor() : undefined,
+            }),
+        );
+    }, [descriptor, dispatch, reloadRequestOrdinal]);
 
     return useSelector(selectTradingBuyLoadingTimestampAndStatus);
 };

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -8,7 +8,6 @@ import { useFormatters } from '@suite-common/formatters';
 import {
     TradingAmountLimitProps,
     getBestRatedQuote,
-    invityAPI,
     selectTradingBuyQuotesRequest,
 } from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';
@@ -30,29 +29,7 @@ import { BuyFormType, BuyFormValues } from '../../types/buy';
 import { buyFormValidationSchema } from '../../utils/buy/buyFormValidationSchema';
 import { truncateDecimals } from '../../utils/general/amountUtils';
 import { getSymbolFromTradeableAsset } from '../../utils/general/tradeableAssetUtils';
-import { getRandomAccountDescriptor } from '../../utils/general/utils';
 import { useConvertFormValueToBaseUnit } from '../general/useConvertFormValueToBaseUnit';
-
-const useReceiveAccountChangeEffect = ({ getValues, setValue }: BuyFormType) => {
-    const selectedReceiveAccount = useSelector(selectBuySelectedReceiveAccount);
-
-    // make sure invityAPIKey is initialized with some unique string on form mount
-    useEffect(() => {
-        invityAPI.createInvityAPIKey(getRandomAccountDescriptor());
-    }, []);
-
-    useEffect(() => {
-        const prevReceiveAccount = getValues('receiveAccount');
-        const descriptor = selectedReceiveAccount?.account?.descriptor;
-
-        setValue('receiveAccount', selectedReceiveAccount);
-
-        // when user changes receive account set invityAPIKey accordingly
-        if (descriptor !== prevReceiveAccount?.account?.descriptor) {
-            invityAPI.createInvityAPIKey(descriptor || getRandomAccountDescriptor());
-        }
-    }, [selectedReceiveAccount, getValues, setValue]);
-};
 
 const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: BuyFormType) => {
     const dispatch = useDispatch();
@@ -122,6 +99,14 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: 
 
         return unsubscribe;
     }, [dispatch, setValue, watch]);
+};
+
+const useReceiveAccountChangeEffect = ({ setValue }: BuyFormType) => {
+    const selectedReceiveAccount = useSelector(selectBuySelectedReceiveAccount);
+
+    useEffect(() => {
+        setValue('receiveAccount', selectedReceiveAccount);
+    }, [setValue, selectedReceiveAccount]);
 };
 
 const useBuyQuotesChangeEffect = ({ getValues, setValue }: BuyFormType) => {

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeData.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeData.ts
@@ -6,11 +6,18 @@ import {
     tradingThunks,
 } from '@suite-common/trading';
 
+import { getRandomAccountDescriptor } from '../../utils/general/utils';
+
 export const useExchangeData = (reloadRequestOrdinal: number) => {
     const dispatch = useDispatch();
 
     useEffect(() => {
-        dispatch(tradingThunks.loadInitialDataThunk({ activeSection: 'exchange' }));
+        dispatch(
+            tradingThunks.loadInitialDataThunk({
+                activeSection: 'exchange',
+                forcedApiKey: getRandomAccountDescriptor(),
+            }),
+        );
     }, [dispatch, reloadRequestOrdinal]);
 
     return useSelector(selectTradingExchangeLoadingTimestampAndStatus);

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -31,6 +31,15 @@ export const extraDependencies: ExtraDependencies = mergeDeepObject(extraDepende
             transports,
         }),
         selectTradingEnvironment,
+        // this selector is not used in native app, but it is used in @suite-common/trading in loadInitialDataThunk
+        //  and without defining the selector, it would use extraDependenciesMock value there
+        selectSelectedAccount: () => ({
+            status: 'none',
+            loader: undefined,
+            account: undefined,
+            network: undefined,
+            params: undefined,
+        }),
     } as Partial<ExtraDependencies['selectors']>,
     thunks: {} as Partial<ExtraDependencies['thunks']>,
     actions: {} as Partial<ExtraDependencies['actions']>,


### PR DESCRIPTION
Refresh invity apikey and tradeinfo on changing account

## Related Issue

Resolve #18918


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=18918-mobile-buy-on-change-of-tradingaccountkey-dispatch-loadinitialdatathunk&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=18918-mobile-buy-on-change-of-tradingaccountkey-dispatch-loadinitialdatathunk&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=18918-mobile-buy-on-change-of-tradingaccountkey-dispatch-loadinitialdatathunk&lookback=7)