### PR TITLE
feat(suite-native): report skips of onboarding analytics

### DIFF
--- a/suite-common/analytics/src/events/suite-native/types.ts
+++ b/suite-common/analytics/src/events/suite-native/types.ts
@@ -510,6 +510,8 @@ export type SuiteNativeAnalyticsEvent =
               firmware: 'install' | 'update' | 'skip' | 'up-to-date';
               seedType: 'shamir-single' | 'shamir-advanced' | '12-words' | '24-words';
               recoveryStepBack: boolean;
+              wasBackupSkipped: boolean;
+              wasPinSkipped: boolean;
           }>;
       }
     | {

--- a/suite-native/module-device-onboarding/src/hooks/useReportOnboardingSuccessAnalytics.ts
+++ b/suite-native/module-device-onboarding/src/hooks/useReportOnboardingSuccessAnalytics.ts
@@ -1,0 +1,39 @@
+import { useCallback } from 'react';
+import { Platform } from 'react-native';
+import { useSelector } from 'react-redux';
+
+import { useAtomValue } from 'jotai';
+
+import {
+    selectDeviceModel,
+    selectIsDeviceBackupRequired,
+    selectIsDeviceProtectedByPin,
+} from '@suite-common/wallet-core';
+import { EventType, analytics } from '@suite-native/analytics';
+
+import { onboardingAnalyticsAtom } from '../../atoms';
+
+export const useReportOnboardingSuccessAnalytics = () => {
+    const deviceModel = useSelector(selectDeviceModel);
+    const isDeviceBackupRequired = useSelector(selectIsDeviceBackupRequired);
+    const isDeviceProtectedByPin = useSelector(selectIsDeviceProtectedByPin);
+    const onboardingAnalytics = useAtomValue(onboardingAnalyticsAtom);
+
+    const reportOnboardingSuccessAnalytics = useCallback(() => {
+        analytics.report({
+            type: EventType.DeviceSetupCompleted,
+            payload: {
+                deviceModel,
+                osName: Platform.OS,
+                wasBackupSkipped: isDeviceBackupRequired,
+                wasPinSkipped: !isDeviceProtectedByPin,
+                duration: onboardingAnalytics.startTimestamp
+                    ? Date.now() - onboardingAnalytics.startTimestamp
+                    : undefined,
+                ...onboardingAnalytics,
+            },
+        });
+    }, [deviceModel, isDeviceBackupRequired, isDeviceProtectedByPin, onboardingAnalytics]);
+
+    return reportOnboardingSuccessAnalytics;
+};

--- a/suite-native/module-device-onboarding/src/screens/CreatePinScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/CreatePinScreen.tsx
@@ -1,13 +1,10 @@
 import { useCallback } from 'react';
-import { Platform } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/core';
-import { useAtomValue } from 'jotai';
 
 import { selectDeviceModel, selectHasBitcoinOnlyFirmware } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
-import { EventType, analytics } from '@suite-native/analytics';
 import { Box, Image, TitleHeader } from '@suite-native/atoms';
 import { usePinAction } from '@suite-native/device';
 import { Translation, TxKeyPath } from '@suite-native/intl';
@@ -29,7 +26,7 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 import { getScreenHeight } from '@trezor/env-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
-import { onboardingAnalyticsAtom } from '../../atoms';
+import { useReportOnboardingSuccessAnalytics } from '../hooks/useReportOnboardingSuccessAnalytics';
 
 const SCREEN_HEIGHT = getScreenHeight();
 
@@ -59,8 +56,8 @@ export const CreatePinScreen = () => {
     const hasBitcoinOnlyFirmware = useSelector(selectHasBitcoinOnlyFirmware);
     const isCoinEnablingInitFinished = useSelector(selectIsCoinEnablingInitFinished);
     const { applyStyle } = useNativeStyles();
-    const onboardingAnalytics = useAtomValue(onboardingAnalyticsAtom);
     const { showAlert, hideAlert } = useAlert();
+    const reportOnboardingSuccessAnalytics = useReportOnboardingSuccessAnalytics();
 
     const handlePinCreated = useCallback(() => {
         if (hasBitcoinOnlyFirmware || isCoinEnablingInitFinished) {
@@ -74,24 +71,12 @@ export const CreatePinScreen = () => {
             navigation.navigate(RootStackRoutes.CoinEnablingInit);
         }
 
-        analytics.report({
-            type: EventType.DeviceSetupCompleted,
-            payload: {
-                deviceModel,
-                osName: Platform.OS,
-                seed: 'create',
-                duration: onboardingAnalytics.startTimestamp
-                    ? Date.now() - onboardingAnalytics.startTimestamp
-                    : undefined,
-                ...onboardingAnalytics,
-            },
-        });
+        reportOnboardingSuccessAnalytics();
     }, [
-        deviceModel,
         hasBitcoinOnlyFirmware,
         isCoinEnablingInitFinished,
         navigation,
-        onboardingAnalytics,
+        reportOnboardingSuccessAnalytics,
     ]);
 
     const handlePinCanceled = useCallback(


### PR DESCRIPTION

## Description
- when user skips backup or skips pin setup during onboarding, this information is included in the `DeviceSetupCompleted` analytics event
- onboarding analytics reporting refactored to a separate hook
## Related Issue

Resolve #19825 



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/report-skip-to-onboarding-analytics&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/report-skip-to-onboarding-analytics&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/report-skip-to-onboarding-analytics&lookback=7)