### PR TITLE
Reenable failed accounts rediscovery

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
@@ -5,9 +5,8 @@ import styled from 'styled-components';
 
 import {
     restartDiscoveryThunk,
-    selectHasRunningDiscovery,
-    selectIsRediscoverNeeded,
     selectSelectedDevice,
+    selectShowRediscoverButton,
 } from '@suite-common/wallet-core';
 import { Button, IconButton, Row, Tooltip, motionEasing } from '@trezor/components';
 import { spacings, spacingsPx, typography } from '@trezor/theme';
@@ -47,12 +46,10 @@ const animationConfig: MotionProps = {
 export const RefreshAfterDiscoveryNeeded = () => {
     const dispatch = useDispatch();
     const selectedDevice = useSelector(selectSelectedDevice);
-    const isRediscoverNeeded = useSelector(state =>
-        selectIsRediscoverNeeded(state, selectedDevice?.state?.staticSessionId),
-    );
     const isSidebarCollapsed = useIsSidebarCollapsed();
-    const isDiscoveryInProgress = useSelector(selectHasRunningDiscovery);
-    const isDiscoveryButtonVisible = isRediscoverNeeded && !isDiscoveryInProgress;
+    const isDiscoveryButtonVisible = useSelector(state =>
+        selectShowRediscoverButton(state, selectedDevice?.state?.staticSessionId),
+    );
 
     if (!selectedDevice?.connected) {
         return null;
@@ -71,7 +68,6 @@ export const RefreshAfterDiscoveryNeeded = () => {
                         >
                             <Tooltip content={<Translation id="REFRESH" />}>
                                 <IconButton
-                                    isDisabled={isDiscoveryInProgress}
                                     variant="tertiary"
                                     size="tiny"
                                     icon="repeat"
@@ -86,7 +82,6 @@ export const RefreshAfterDiscoveryNeeded = () => {
                             </AccountsMenuNotice>
 
                             <Button
-                                isDisabled={isDiscoveryInProgress}
                                 variant="tertiary"
                                 size="tiny"
                                 icon="repeat"

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -6,6 +6,7 @@ import {
     changeNetworks,
     deviceActions,
     runAdditionalDiscoveryThunk,
+    selectNetworksToDiscover,
     selectSelectedDevice,
     startInitialDiscovery,
 } from '@suite-common/wallet-core';
@@ -61,7 +62,14 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
                         }),
                     );
                 } else if (device.state.staticSessionId) {
-                    dispatch(runAdditionalDiscoveryThunk(device.state.staticSessionId));
+                    const networksToDiscover = selectNetworksToDiscover(
+                        getState(),
+                        device.state.staticSessionId,
+                    );
+
+                    if (networksToDiscover.length) {
+                        dispatch(runAdditionalDiscoveryThunk(device.state.staticSessionId));
+                    }
                 }
             }
         }

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -6,7 +6,7 @@ import {
     restartDiscoveryThunk,
     selectDeviceSupportedNetworks,
     selectEnabledNetworks,
-    selectIsRediscoverNeeded,
+    selectShowRediscoverButton,
 } from '@suite-common/wallet-core';
 import { Button, Tooltip, motionEasing } from '@trezor/components';
 import { hasBitcoinOnlyFirmware, isBitcoinOnlyDevice } from '@trezor/device-utils';
@@ -84,8 +84,8 @@ export const SettingsCoins = () => {
     const dispatch = useDispatch();
     const { isDiscoveryRunning } = useDiscovery();
     const staticSessionId = device?.state?.staticSessionId;
-    const isDiscoveryButtonVisible = useSelector(
-        state => !isDiscoveryRunning && selectIsRediscoverNeeded(state, staticSessionId),
+    const isDiscoveryButtonVisible = useSelector(state =>
+        selectShowRediscoverButton(state, staticSessionId),
     );
 
     const supportedEnabledNetworks = enabledNetworks.filter(enabledNetwork =>

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -28,11 +28,7 @@ import {
     selectSupportedNetworkByDevice,
 } from '../device/deviceSelectors';
 import { selectDeviceThunk } from '../device/deviceThunks';
-import {
-    selectAccountsToBeForgotten,
-    selectIsRediscoverNeeded,
-    selectNetworksToDiscover,
-} from '../selectors';
+import { selectAccountsToBeForgotten, selectNetworksToDiscover } from '../selectors';
 import { selectEnabledNetworks } from '../settings/walletSettingsReducer';
 
 const USER_UI_CANCEL_CODE = 'USER_UI_CANCEL';
@@ -754,16 +750,6 @@ export const runAdditionalDiscoveryThunk = createThunk(
             dispatch(accountsActions.removeAccount(accountsToRemove));
         }
 
-        const isRediscoverNeeded = selectIsRediscoverNeeded(
-            getState(),
-            device.state.staticSessionId,
-        );
-
-        if (!isRediscoverNeeded) {
-            console.warn('no rediscovery needed');
-
-            return;
-        }
         dispatch(
             discoveryActions.startDiscovery(device.path, {
                 isAddingHiddenWallet: false,
@@ -779,12 +765,9 @@ export const runAdditionalDiscoveryThunk = createThunk(
             getState,
         );
 
-        const networksToDiscover = selectNetworksToDiscover(
-            getState(),
-            device.state.staticSessionId,
-        );
+        const networksToDiscover = selectNetworksToDiscover(getState(), staticSessionId);
 
-        if (networksToDiscover.length === 0) {
+        if (!networksToDiscover.length) {
             console.warn('no networks to discover');
 
             return;

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -73,14 +73,9 @@ export const selectAllAccountsToList = createMemoizedSelector(
 
 export const selectNetworksToDiscover = (
     state: DiscoveryRootState & DeviceRootState & AccountsRootState & WalletSettingsRootState,
-    staticSessionId?: StaticSessionId,
+    staticSessionId: StaticSessionId,
 ) => {
     const enabledNetworks = selectEnabledNetworks(state);
-
-    if (!staticSessionId) {
-        return enabledNetworks;
-    }
-
     const device = selectSelectedDevice(state);
     const deviceNetworks = selectSupportedNetworkByDevice(device);
     const enabledSupportedNetworks = enabledNetworks.filter(network =>
@@ -98,16 +93,13 @@ export const selectNetworksToDiscover = (
     return enabledSupportedNetworks.filter(network => !discoveredNetworks.includes(network));
 };
 
-export const selectIsRediscoverNeeded = (
+export const selectShowRediscoverButton = (
     state: DiscoveryRootState & DeviceRootState & AccountsRootState & WalletSettingsRootState,
     staticSessionId?: StaticSessionId,
-) => {
-    if (!staticSessionId) return false;
-
-    const networksToDiscover = selectNetworksToDiscover(state, staticSessionId);
-
-    return networksToDiscover.length > 0;
-};
+) =>
+    staticSessionId &&
+    selectNetworksToDiscover(state, staticSessionId).length > 0 &&
+    !selectHasRunningDiscovery(state);
 
 export const selectAccountsToBeForgotten = (
     state: DiscoveryRootState & AccountsRootState & WalletSettingsRootState,

--- a/suite-native/discovery/src/discoveryMiddleware.ts
+++ b/suite-native/discovery/src/discoveryMiddleware.ts
@@ -8,6 +8,7 @@ import {
     deviceActions,
     discoveryActions,
     restartDiscoveryThunk,
+    selectNetworksToDiscover,
     selectSelectedDevice,
     startDiscoveryThunk,
 } from '@suite-common/wallet-core';
@@ -74,7 +75,14 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
                 if (!device?.state) {
                     dispatch(startDiscoveryThunk({}));
                 } else if (device.state.staticSessionId) {
-                    dispatch(restartDiscoveryThunk());
+                    const networksToDiscover = selectNetworksToDiscover(
+                        getState(),
+                        device.state.staticSessionId,
+                    );
+
+                    if (networksToDiscover.length) {
+                        dispatch(restartDiscoveryThunk());
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description

After that huge rediscovery reimplementation, a check was added that rediscovery only runs when enabled networks have changed. That's not :100: correct as e.g. when discovery fails for a specific coin, you want to rediscover it by clicking `Retry` button, which does nothing now.

On the other hand, when the check is done **after** removing failed accounts, it runs discovery whenever a user navigates to a different route.

My quick and dirty solution is to move the first enabled networks check (before removing failed accounts) outside `runAdditionalDiscoveryThunk` into `discoveryMiddleware` (so rediscovery by changing route or other redux actions is done only when enabled networks change) and leave only the second enabled networks check (after removing failed accounts) inside the thunk (so whenever rediscovery is initiated manually, it rediscovers even failed accounts).

P.S. I'm working on more correct rediscovery flow in Suite so this probably won't be there for a long time anyway.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/rediscover-always&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/rediscover-always&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/rediscover-always&lookback=7)