### PR TITLE
fix(suite): don't allow sending wrong data to device in approval

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -125,6 +125,10 @@ export const TradingFormOffer = () => {
         context.getValues().sendCryptoSelect &&
         !isSendingEvmNativeToken(context.getValues().sendCryptoSelect?.value);
 
+    const isQuoteOutdated =
+        isTradingExchangeContext(context) &&
+        (quote as ExchangeTrade)?.send !== context.getValues().sendCryptoSelect?.value;
+
     useEffect(() => {
         if (isTradingExchangeContext(context) && requiresTokenApproval) {
             const { fetchApprovalStatus } = context;
@@ -187,7 +191,9 @@ export const TradingFormOffer = () => {
                 ) : (
                     <TradingFormOfferCryptoAmount
                         amount={
-                            !state.isLoadingOrInvalid && bestScoredQuoteAmounts?.receiveAmount
+                            !state.isLoadingOrInvalid &&
+                            bestScoredQuoteAmounts?.receiveAmount &&
+                            !isQuoteOutdated
                                 ? bestScoredQuoteAmounts.receiveAmount
                                 : '0'
                         }
@@ -251,7 +257,7 @@ export const TradingFormOffer = () => {
                     <TextButton
                         onClick={onCompareAllOffersClick}
                         size="small"
-                        isDisabled={state.isLoadingOrInvalid}
+                        isDisabled={state.isLoadingOrInvalid || isQuoteOutdated}
                         isLoading={isCompareLoading}
                         data-testid="@trading/form/compare-button"
                         type="button"
@@ -262,7 +268,9 @@ export const TradingFormOffer = () => {
                 {isTradingExchangeContext(context) ? (
                     <TradingFormOffersSwitcher
                         context={context}
-                        isFormLoading={state.isFormLoading && !preselectedQuote}
+                        isFormLoading={
+                            (state.isFormLoading || isQuoteOutdated) && !preselectedQuote
+                        }
                         isFormInvalid={state.isFormInvalid && !preselectedQuote}
                         providers={providers}
                     />
@@ -279,7 +287,7 @@ export const TradingFormOffer = () => {
             {requiresTokenApproval && bestScoredQuote && !state.isFormInvalid ? (
                 <TradingFormApproval
                     openApproveModal={() => setIsApproveModalOpen(true)}
-                    isFetchingApprovalStatus={isFetchingApprovalStatus}
+                    isFetchingApprovalStatus={isFetchingApprovalStatus || isQuoteOutdated}
                     approvalType={approvalType}
                     setApprovalType={setApprovalType}
                 />


### PR DESCRIPTION
## Description

Hide previous quote approval until new quote is fetched.
This disallows users to continue with outdated data in the approval step.

## Related Issue

Resolve #19874 

## Screenshots:

https://github.com/user-attachments/assets/7c944efd-2a10-4615-8457-9be98d9f2d01



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/approval-wrong-data&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/approval-wrong-data&lookback=7)