### PR TITLE
chore(suite): updated approval translations

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -566,14 +566,6 @@ export default defineMessages({
         defaultMessage: 'is being processed',
         id: 'TR_EXCHANGE_APPROVAL_FORM_PENDING_SUFFIX',
     },
-    TR_EXCHANGE_APPROVAL_FORM_APPROVED: {
-        defaultMessage: 'Ready to swap: {amount} {coinSymbol}',
-        id: 'TR_EXCHANGE_APPROVAL_FORM_APPROVED',
-    },
-    TR_EXCHANGE_APPROVAL_FORM_APPROVED_PLAIN: {
-        defaultMessage: 'Ready to swap',
-        id: 'TR_EXCHANGE_APPROVAL_FORM_APPROVED_PLAIN',
-    },
     TR_EXCHANGE_APPROVAL_FORM_READY_TO_SWAP: {
         defaultMessage: 'Ready to swap',
         id: 'TR_EXCHANGE_APPROVAL_FORM_READY_TO_SWAP',

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
@@ -7,7 +7,6 @@ import {
     TradingExchangeType,
     cryptoIdToNetwork,
     tradingExchangeActions,
-    useTradingInfo,
 } from '@suite-common/trading';
 import { getExplorerUrl } from '@suite-common/wallet-config';
 import { Button, Card, Column, Icon, IconVariant, Paragraph, Row } from '@trezor/components';
@@ -111,11 +110,6 @@ export const TradingFormApproval = ({
             state: { isFormLoading },
         },
     } = context;
-
-    const { cryptoIdToCoinSymbol } = useTradingInfo();
-
-    const preapprovedAmount = selectedQuote?.preapprovedStringAmount;
-    const coinSymbol = selectedQuote?.send ? cryptoIdToCoinSymbol(selectedQuote?.send) : undefined;
 
     const currentQuoteStatus = selectedQuote?.status;
     const previousQuoteStatus = usePrevious(currentQuoteStatus);
@@ -371,18 +365,7 @@ export const TradingFormApproval = ({
 
                                         <ApprovalStep
                                             label={
-                                                <Translation
-                                                    id={
-                                                        preapprovedAmount &&
-                                                        preapprovedAmount !== '0'
-                                                            ? 'TR_EXCHANGE_APPROVAL_FORM_APPROVED'
-                                                            : 'TR_EXCHANGE_APPROVAL_FORM_APPROVED_PLAIN'
-                                                    }
-                                                    values={{
-                                                        amount: preapprovedAmount,
-                                                        coinSymbol,
-                                                    }}
-                                                />
+                                                <Translation id="TR_EXCHANGE_APPROVAL_FORM_READY_TO_SWAP" />
                                             }
                                             icon={<IconCheck variant="primary" />}
                                         />


### PR DESCRIPTION
## Description

We will not be displaying pre-approved amount in swap form.
Changed `Ready to swap: {amount} {coinSymbol}` translation to `Ready to swap`.

## Related Issue

Resolve #19949 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/approval-translation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/approval-translation&lookback=7)