### PR TITLE
chore: better naming of base-currency (formarlly FiatCurrency)

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
@@ -1,6 +1,6 @@
 import { Locator, Page } from '@playwright/test';
 
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { Fees } from './fees';
@@ -50,7 +50,7 @@ export class TradingPage {
     readonly buyBestOfferButton: Locator;
     readonly youPayFiatInput: Locator;
     readonly youPayCurrencyDropdown: Locator;
-    readonly youPayCurrencyOption = (currency: FiatCurrencyCode) =>
+    readonly youPayCurrencyOption = (currency: BaseCurrencyCode) =>
         this.page.getByTestId(`@trading/form/fiat-currency-select/option/${currency}`);
     readonly youPayFiatCryptoSwitchButton: Locator;
     readonly youPayCryptoInput: Locator;
@@ -229,7 +229,7 @@ export class TradingPage {
     }
 
     @step()
-    async selectFiatCurrency(currencyCode: FiatCurrencyCode) {
+    async selectFiatCurrency(currencyCode: BaseCurrencyCode) {
         const currentCurrency = await this.youPayCurrencyDropdown.textContent();
         if (currentCurrency === currencyCode.toUpperCase()) {
             return;
@@ -259,7 +259,7 @@ export class TradingPage {
         amount: string,
         cryptoCurrency: string = 'bitcoin',
         wantCrypto: boolean = false,
-        fiatCurrencyCode: FiatCurrencyCode = 'czk',
+        fiatCurrencyCode: BaseCurrencyCode = 'czk',
         country: string = 'CZ',
     ) {
         const inputField = wantCrypto ? this.youPayCryptoInput : this.youPayFiatInput;
@@ -285,7 +285,7 @@ export class TradingPage {
     async fillSellForm(
         amount: string,
         cryptoCurrency: string = 'bitcoin',
-        fiatCurrencyCode: FiatCurrencyCode = 'eur',
+        fiatCurrencyCode: BaseCurrencyCode = 'eur',
         country: string = 'CZ',
     ) {
         await this.selectCountryOfResidence(country);

--- a/packages/suite/src/components/wallet/TransactionItem/CoinjoinBatchItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/CoinjoinBatchItem.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { useFormatters } from '@suite-common/formatters';
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { selectHistoricFiatRates } from '@suite-common/wallet-core';
 import { Timestamp } from '@suite-common/wallet-types';
 import {
@@ -98,7 +98,7 @@ const Round = ({ transaction }: { transaction: WalletAccountTransaction }) => {
 
 type CoinjoinBatchItemProps = {
     transactions: WalletAccountTransaction[];
-    localCurrency: FiatCurrencyCode;
+    localCurrency: BaseCurrencyCode;
     isPending: boolean;
 };
 

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -9,7 +9,7 @@ import {
 } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { getNetworkSymbolForProtocol } from '@suite-common/suite-utils';
 import { selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { FormState } from '@suite-common/wallet-types';
@@ -49,7 +49,7 @@ SendContext.displayName = 'SendContext';
 // Props of @wallet-views/send/index
 export interface SendFormProps {
     selectedAccount: AppState['wallet']['selectedAccount'];
-    localCurrency: FiatCurrencyCode;
+    localCurrency: BaseCurrencyCode;
     fees: AppState['wallet']['fees'];
     online: boolean;
     sendRaw?: boolean;

--- a/packages/suite/src/hooks/wallet/useSendFormFields.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormFields.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { FieldPath, UseFormReturn } from 'react-hook-form';
 
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { FormOptions, FormState, Rate, TokenAddress } from '@suite-common/wallet-types';
 import {
@@ -19,7 +19,7 @@ import { useBitcoinAmountUnit } from './useBitcoinAmountUnit';
 import { useSelector } from '../suite';
 
 export type GetCurrentRateParams = {
-    currencyCode: FiatCurrencyCode;
+    currencyCode: BaseCurrencyCode;
     tokenAddress: TokenAddress;
 };
 
@@ -86,7 +86,7 @@ export const useSendFormFields = ({
             }
 
             const fiatRate = getCurrentFiatRate({
-                currencyCode: output.currency.value as FiatCurrencyCode,
+                currencyCode: output.currency.value as BaseCurrencyCode,
                 tokenAddress: output.token as TokenAddress,
             });
             if (!fiatRate?.rate) {

--- a/packages/suite/src/hooks/wallet/useSendFormImport.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormImport.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { FiatCurrencyCode, fiatCurrencies } from '@suite-common/suite-config';
+import { BaseCurrencyCode, baseCurrencies } from '@suite-common/suite-config';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { DEFAULT_PAYMENT } from '@suite-common/wallet-constants';
 import { updateFiatRatesThunk } from '@suite-common/wallet-core';
@@ -53,7 +53,7 @@ export const useSendFormImport = ({
         const uniqueCurrencies = [...new Set(currencies)];
 
         for (const currency of uniqueCurrencies) {
-            const fiatRateKey = getFiatRateKey(network.symbol, currency as FiatCurrencyCode);
+            const fiatRateKey = getFiatRateKey(network.symbol, currency as BaseCurrencyCode);
             const fiatRate = currentRates?.[fiatRateKey];
 
             if (fiatRate) {
@@ -67,7 +67,7 @@ export const useSendFormImport = ({
                                 symbol: network.symbol,
                             },
                         ],
-                        localCurrency: currency as FiatCurrencyCode,
+                        localCurrency: currency as BaseCurrencyCode,
                         rateType: 'current',
                         fetchAttemptTimestamp: Date.now() as Timestamp,
                     }),
@@ -112,7 +112,7 @@ export const useSendFormImport = ({
 
                     const fiatRateKey = getFiatRateKey(
                         network.symbol,
-                        itemCurrency as FiatCurrencyCode,
+                        itemCurrency as BaseCurrencyCode,
                     );
                     const fiatRate = currentRates?.[fiatRateKey];
 
@@ -124,7 +124,7 @@ export const useSendFormImport = ({
                         output.fiat = toFiatCurrency(cryptoValue, fiatRate.rate, 2) || '';
                     }
                 } else if (
-                    Object.keys(fiatCurrencies).find(currency => currency === itemCurrency) &&
+                    Object.keys(baseCurrencies).find(currency => currency === itemCurrency) &&
                     itemRate
                 ) {
                     // csv amount in fiat currency

--- a/packages/suite/src/hooks/wallet/useTotalFiatBalance.ts
+++ b/packages/suite/src/hooks/wallet/useTotalFiatBalance.ts
@@ -1,4 +1,4 @@
-import { FiatCurrencyCode } from '@suite-common/suite-config/src/fiat';
+import type { BaseCurrencyCode } from '@suite-common/suite-config';
 import { Account, RatesByKey } from '@suite-common/wallet-types';
 import { getTotalFiatBalance } from '@suite-common/wallet-utils/src/accountUtils';
 
@@ -7,7 +7,7 @@ import { getTokens } from 'src/utils/wallet/tokenUtils';
 
 export const useTotalFiatBalance = (
     accounts: Account[],
-    localCurrency: FiatCurrencyCode,
+    localCurrency: BaseCurrencyCode,
     rates?: RatesByKey,
 ) => {
     const tokenDefinitions = useSelector(state => state.tokenDefinitions);

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3160,9 +3160,9 @@ export default defineMessages({
         defaultMessage: 'Enable the passphrase feature to continue with the verification process.',
         id: 'TR_PLEASE_ENABLE_PASSPHRASE',
     },
-    TR_PRIMARY_FIAT: {
-        defaultMessage: 'Fiat currency',
-        id: 'TR_PRIMARY_FIAT',
+    TR_BASE_CURRENCY: {
+        defaultMessage: 'Currency',
+        id: 'TR_BASE_CURRENCY',
     },
     TR_RANDOM_SEED_WORDS_DISCLAIMER: {
         defaultMessage:

--- a/packages/suite/src/types/wallet/sendForm.ts
+++ b/packages/suite/src/types/wallet/sendForm.ts
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction } from 'react';
 import { FieldPath, UseFormReturn } from 'react-hook-form';
 
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { Network } from '@suite-common/wallet-config';
 import {
     Account,
@@ -29,7 +29,7 @@ import { GetCurrentRateParams } from 'src/hooks/wallet/useSendFormFields';
 export type UseSendFormState = {
     account: Account;
     network: Network;
-    localCurrencyOption: { value: FiatCurrencyCode; label: Uppercase<FiatCurrencyCode> };
+    localCurrencyOption: { value: BaseCurrencyCode; label: Uppercase<BaseCurrencyCode> };
     composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
     online: boolean;
     metadataEnabled: boolean;

--- a/packages/suite/src/utils/suite/validation.ts
+++ b/packages/suite/src/utils/suite/validation.ts
@@ -1,5 +1,5 @@
 import { Formatter } from '@suite-common/formatters';
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { getDisplaySymbol, isNetworkSymbol } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 import {
@@ -113,7 +113,7 @@ export const validateCryptoLimits =
 
 interface ValidateFiatLimitsOptions {
     amountLimits?: AmountLimitProps;
-    localCurrency: FiatCurrencyCode;
+    localCurrency: BaseCurrencyCode;
     decimals: number;
     rate?: number;
     formatter: Formatter<string, string>;

--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -2,7 +2,7 @@ import { format } from 'date-fns';
 import type { TDocumentDefinitions } from 'pdfmake/interfaces';
 import { fromWei } from 'web3-utils';
 
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { trezorLogo } from '@suite-common/suite-constants';
 import { TokenDefinitions, getIsPhishingTransaction } from '@suite-common/token-definitions';
 import { NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
@@ -34,7 +34,7 @@ type Data = {
     accountName: string;
     type: ExportFileType;
     transactions: AccountTransactionForExports[];
-    localCurrency: FiatCurrencyCode;
+    localCurrency: BaseCurrencyCode;
 };
 
 type Fields = {

--- a/packages/suite/src/utils/wallet/graph/utils.ts
+++ b/packages/suite/src/utils/wallet/graph/utils.ts
@@ -1,7 +1,7 @@
 import { differenceInMonths } from 'date-fns';
 
 import { getFiatRatesForTimestamps } from '@suite-common/fiat-services';
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { resetTime } from '@suite-common/suite-utils';
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
@@ -22,7 +22,7 @@ export const deviceGraphDataFilterFn = (d: GraphData, deviceState: StaticSession
 export const ensureHistoryRates = async (
     symbol: NetworkSymbol,
     data: BlockchainAccountBalanceHistory[],
-    fiatCurrency: FiatCurrencyCode,
+    fiatCurrency: BaseCurrencyCode,
     isElectrumBackend: boolean,
 ): Promise<BlockchainAccountBalanceHistory[]> => {
     if (!getNetwork(symbol).coingeckoId) return data;

--- a/packages/suite/src/utils/wallet/tokenUtils.ts
+++ b/packages/suite/src/utils/wallet/tokenUtils.ts
@@ -1,4 +1,4 @@
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import {
     EnhancedTokenInfo,
     TokenDefinition,
@@ -38,7 +38,7 @@ export const sortTokensWithRates = (a: TokensWithRates, b: TokensWithRates) => {
 
 export const enhanceTokensWithRates = (
     tokens: Account['tokens'],
-    fiatCurrency: FiatCurrencyCode,
+    fiatCurrency: BaseCurrencyCode,
     symbol: NetworkSymbol,
     rates?: RatesByKey,
 ) => {

--- a/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux';
 import styled, { useTheme } from 'styled-components';
 
 import { AssetFiatBalance } from '@suite-common/assets';
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { selectCoinDefinitions } from '@suite-common/token-definitions';
 import { Network } from '@suite-common/wallet-config';
 import { selectAnyAccountIsStakingActive } from '@suite-common/wallet-core';
@@ -86,7 +86,7 @@ type AssetCardProps = {
     stakingAccounts: Account[];
     assetTokens: TokenInfo[];
     index?: number;
-    localCurrency: FiatCurrencyCode;
+    localCurrency: BaseCurrencyCode;
     currentFiatRates?: RatesByKey;
     accounts: Account[];
     isStakeNetwork?: boolean;

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
@@ -3,7 +3,7 @@ import { memo } from 'react';
 import { useTheme } from 'styled-components';
 
 import { AssetFiatBalance } from '@suite-common/assets';
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { selectCoinDefinitions } from '@suite-common/token-definitions';
 import { Network } from '@suite-common/wallet-config';
 import { selectAnyAccountIsStakingActive } from '@suite-common/wallet-core';
@@ -43,7 +43,7 @@ export interface AssetTableRowProps {
     isStakeNetwork?: boolean;
     assetsFiatBalances: AssetFiatBalance[];
     accounts: Account[];
-    localCurrency: FiatCurrencyCode;
+    localCurrency: BaseCurrencyCode;
     currentFiatRates?: RatesByKey;
 }
 

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetTable.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetTable.tsx
@@ -1,5 +1,5 @@
 import { AssetFiatBalance } from '@suite-common/assets';
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { RatesByKey } from '@suite-common/wallet-types';
 import { Table } from '@trezor/components';
 import { spacings } from '@trezor/theme';
@@ -14,7 +14,7 @@ interface AssetTableProps {
     discoveryInProgress?: boolean;
     assetsData: AssetData[];
     assetsFiatBalances: AssetFiatBalance[];
-    localCurrency: FiatCurrencyCode;
+    localCurrency: BaseCurrencyCode;
     currentFiatRates?: RatesByKey;
 }
 

--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -1,7 +1,7 @@
 import styled, { useTheme } from 'styled-components';
 
 import { AssetFiatBalance } from '@suite-common/assets';
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import {
     type Network,
     type NetworkSymbol,
@@ -67,7 +67,7 @@ export type AssetData = {
 const useAssetsFiatBalances = (
     assetsData: AssetData[],
     accounts: { [key: string]: Account[] },
-    localCurrency: FiatCurrencyCode,
+    localCurrency: BaseCurrencyCode,
     currentFiatRates?: RatesByKey,
 ) =>
     assetsData.reduce<AssetFiatBalance[]>((acc, asset) => {

--- a/packages/suite/src/views/dashboard/AssetsView/assetsViewUtils.ts
+++ b/packages/suite/src/views/dashboard/AssetsView/assetsViewUtils.ts
@@ -1,4 +1,4 @@
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { TokenDefinition } from '@suite-common/token-definitions';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { Account, RatesByKey } from '@suite-common/wallet-types';
@@ -17,7 +17,7 @@ export const handleTokensAndStakingData = (
     accountsThatStaked: Account[],
     isStakingActive: boolean,
     symbol: NetworkSymbol,
-    localCurrency: FiatCurrencyCode,
+    localCurrency: BaseCurrencyCode,
     coinDefinitions?: TokenDefinition,
     currentFiatRates?: RatesByKey,
 ) => {

--- a/packages/suite/src/views/settings/SettingsGeneral/BaseCurrency.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/BaseCurrency.tsx
@@ -1,25 +1,26 @@
-import { FiatCurrencyCode, fiatCurrencies } from '@suite-common/suite-config';
+import { BaseCurrencyCode, baseCurrencies } from '@suite-common/suite-config';
 import { selectLocalCurrency, setLocalCurrency } from '@suite-common/wallet-core';
 import { EventType, analytics } from '@trezor/suite-analytics';
+import { typedObjectKeys } from '@trezor/utils';
 
 import { SettingsSectionItem } from 'src/components/settings';
 import { ActionColumn, ActionSelect, TextColumn, Translation } from 'src/components/suite';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
-const buildCurrencyOption = (currency: string) => ({
+const buildCurrencyOption = (currency: BaseCurrencyCode) => ({
     value: currency,
     label: currency.toUpperCase(),
 });
 
-export const Fiat = () => {
+export const BaseCurrency = () => {
     const localCurrency = useSelector(selectLocalCurrency);
     const dispatch = useDispatch();
 
-    const options = Object.keys(fiatCurrencies).map(c => buildCurrencyOption(c));
+    const options = typedObjectKeys(baseCurrencies).map(c => buildCurrencyOption(c));
     const value = buildCurrencyOption(localCurrency);
 
-    const handleChange = (option: { value: FiatCurrencyCode; label: string }) => {
+    const handleChange = (option: { value: BaseCurrencyCode; label: string }) => {
         dispatch(setLocalCurrency(option.value));
         analytics.report({
             type: EventType.SettingsGeneralChangeFiat,
@@ -31,7 +32,7 @@ export const Fiat = () => {
 
     return (
         <SettingsSectionItem anchorId={SettingsAnchor.Fiat}>
-            <TextColumn title={<Translation id="TR_PRIMARY_FIAT" />} />
+            <TextColumn title={<Translation id="TR_BASE_CURRENCY" />} />
             <ActionColumn>
                 <ActionSelect
                     useKeyPressScroll

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -20,6 +20,7 @@ import { Analytics } from './Analytics';
 import { AutoEject } from './AutoEject';
 import { AutoStart } from './AutoStart';
 import { AutomaticUpdate } from './AutomaticUpdate';
+import { BaseCurrency } from './BaseCurrency';
 import { BitcoinAmountUnit } from './BitcoinAmountUnit';
 import { ClearStorage } from './ClearStorage';
 import { ConnectLabelingProvider } from './ConnectLabelingProvider';
@@ -27,7 +28,6 @@ import { DesktopSuiteBanner } from './DesktopSuiteBanner';
 import { DisconnectLabelingProvider } from './DisconnectLabelingProvider';
 import { EarlyAccess } from './EarlyAccess';
 import { Experimental } from './Experimental';
-import { Fiat } from './Fiat';
 import { Labeling } from './Labeling';
 import { Language } from './Language';
 import { ShowApplicationLog } from './ShowApplicationLog';
@@ -75,7 +75,7 @@ export const SettingsGeneral = () => {
 
                 <SettingsSection title={<Translation id="TR_LOCALIZATION" />} icon="flag">
                     <Language />
-                    <Fiat />
+                    <BaseCurrency />
                     {hasBitcoinNetworks && <BitcoinAmountUnit />}
                 </SettingsSection>
             </div>

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
@@ -1,4 +1,4 @@
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { formInputsMaxLength } from '@suite-common/validators';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { Output, TokenAddress } from '@suite-common/wallet-types';
@@ -27,7 +27,7 @@ import {
     validateReserveOrBalance,
 } from 'src/utils/suite/validation';
 
-import { FiatInput } from './FiatInput';
+import { BaseCurrencyInput } from './BaseCurrencyInput';
 import { SendMaxSwitch } from './SendMaxSwitch';
 
 interface AmountProps {
@@ -70,7 +70,7 @@ export const Amount = ({ output, outputId }: AmountProps) => {
 
     const currentRate = getCurrentFiatRate({
         tokenAddress: (token?.contract ?? '') as TokenAddress,
-        currencyCode: (output.currency?.value ?? '') as FiatCurrencyCode,
+        currencyCode: (output.currency?.value ?? '') as BaseCurrencyCode,
     });
 
     const isWithRate = !!currentRate?.rate || !!currentRate?.isLoading;
@@ -184,7 +184,7 @@ export const Amount = ({ output, outputId }: AmountProps) => {
                                         variant="tertiary"
                                         margin={{ top: isBelowLaptop ? 0 : spacings.xxxxl }}
                                     />
-                                    <FiatInput
+                                    <BaseCurrencyInput
                                         output={output}
                                         outputId={outputId}
                                         // To fix alignment with the other input

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
@@ -1,7 +1,7 @@
 import { Controller } from 'react-hook-form';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { formInputsMaxLength } from '@suite-common/validators';
 import { updateFiatRatesThunk } from '@suite-common/wallet-core';
 import {
@@ -36,7 +36,7 @@ type FiatInputProps = {
     labelRight?: React.ReactNode;
 };
 
-export const FiatInput = ({
+export const BaseCurrencyInput = ({
     output,
     outputId,
     labelLeft,
@@ -61,14 +61,14 @@ export const FiatInput = ({
     const { translationString } = useTranslation();
     const dispatch = useDispatch();
 
-    const fiatInputName = `outputs.${outputId}.fiat` as const;
+    const baseCurrencyInputName = `outputs.${outputId}.fiat` as const;
     const currencyInputName = `outputs.${outputId}.currency` as const;
     const amountInputName = `outputs.${outputId}.amount` as const;
     const tokenInputName = `outputs.${outputId}.token` as const;
 
     const outputError = errors.outputs ? errors.outputs[outputId] : undefined;
     const error = outputError ? outputError.fiat : undefined;
-    const fiatValue = getDefaultValue(fiatInputName, output.fiat || '');
+    const baseCurrencyValue = getDefaultValue(baseCurrencyInputName, output.fiat || '');
     const tokenContractAddress = getDefaultValue(tokenInputName, output.token);
 
     const amountValue = getDefaultValue(amountInputName, '');
@@ -89,7 +89,7 @@ export const FiatInput = ({
         ) {
             const fiatValueBigNumber = formattedAmount.multipliedBy(rate);
 
-            setValue(fiatInputName, fiatValueBigNumber.toFixed(2), {
+            setValue(baseCurrencyInputName, fiatValueBigNumber.toFixed(2), {
                 shouldValidate: true,
             });
             // call compose to store draft, precomposedTx should be the same
@@ -102,7 +102,7 @@ export const FiatInput = ({
     // usually this happens after Fiat > Amount recalculation (from here, onChange event)
     // or as a result on composeTransaction process
     const amountError = outputError ? outputError.amount : undefined;
-    const errorToDisplay = !error && fiatValue && amountError ? amountError : error;
+    const errorToDisplay = !error && baseCurrencyValue && amountError ? amountError : error;
 
     const isLowAnonymity = isLowAnonymityWarning(outputError);
     const inputState = isLowAnonymity ? 'warning' : getInputState(errorToDisplay);
@@ -151,7 +151,7 @@ export const FiatInput = ({
                                 tokenAddress: token?.contract as TokenAddress,
                             },
                         ],
-                        localCurrency: selected.value as FiatCurrencyCode,
+                        localCurrency: selected.value as BaseCurrencyCode,
                         rateType: 'current',
                         fetchAttemptTimestamp: Date.now() as Timestamp,
                     }),
@@ -177,9 +177,9 @@ export const FiatInput = ({
             control={control}
             inputState={inputState}
             onChange={handleChange}
-            name={fiatInputName}
-            data-testid={fiatInputName}
-            defaultValue={fiatValue}
+            name={baseCurrencyInputName}
+            data-testid={baseCurrencyInputName}
+            defaultValue={baseCurrencyValue}
             maxLength={formInputsMaxLength.fiat}
             rules={rules}
             bottomText={bottomText || null}

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import {
     TokenDefinitions,
     selectCoinDefinitions,
@@ -255,7 +255,7 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
                         tokenAddress: (newlySelectedToken?.contract || '') as TokenAddress,
                     },
                 ],
-                localCurrency: currencyValue.value as FiatCurrencyCode,
+                localCurrency: currencyValue.value as BaseCurrencyCode,
                 rateType: 'current',
                 fetchAttemptTimestamp: Date.now() as Timestamp,
             }),

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx
@@ -2,7 +2,7 @@ import { ReactNode, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { isTokenDefinitionKnown, selectCoinDefinitions } from '@suite-common/token-definitions';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { selectHistoricFiatRates } from '@suite-common/wallet-core';
@@ -38,7 +38,7 @@ interface TransactionsGroupProps {
     transactions: WalletAccountTransaction[];
     children?: ReactNode;
     symbol: NetworkSymbol;
-    localCurrency: FiatCurrencyCode;
+    localCurrency: BaseCurrencyCode;
     index: number;
     isPending: boolean;
 }

--- a/suite-common/analytics/src/events/suite-native/types.ts
+++ b/suite-common/analytics/src/events/suite-native/types.ts
@@ -1,4 +1,4 @@
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { UNIT_ABBREVIATION } from '@suite-common/suite-constants';
 import { TradingType } from '@suite-common/trading';
 import type { AccountType, NetworkSymbol } from '@suite-common/wallet-config';
@@ -21,7 +21,7 @@ export type SuiteNativeAnalyticsEvent =
           payload: {
               appLanguage: string;
               deviceLanguage?: string;
-              localCurrency: FiatCurrencyCode;
+              localCurrency: BaseCurrencyCode;
               bitcoinUnit: UNIT_ABBREVIATION;
               screenWidth: number;
               screenHeight: number;
@@ -117,7 +117,7 @@ export type SuiteNativeAnalyticsEvent =
     | {
           type: EventType.SettingsChangeCurrency;
           payload: {
-              localCurrency: FiatCurrencyCode;
+              localCurrency: BaseCurrencyCode;
           };
       }
     | {

--- a/suite-common/fiat-services/src/coingecko.ts
+++ b/suite-common/fiat-services/src/coingecko.ts
@@ -1,4 +1,4 @@
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { networks } from '@suite-common/wallet-config';
 import { HistoricRates, TickerId } from '@suite-common/wallet-types';
 import { parseAsset } from '@trezor/blockchain-link-utils/src/blockfrost';
@@ -126,7 +126,7 @@ export const findClosestTimestampValue = (
 export const getFiatRatesForTimestamps = async (
     ticker: TickerId,
     timestamps: number[],
-    fiatCurrencyCode: FiatCurrencyCode,
+    fiatCurrencyCode: BaseCurrencyCode,
 ): Promise<HistoricalResponse | null> => {
     const coinUrls = buildCoinUrls(ticker); // Assuming this now returns an array of URLs
     const urlEndpoint = `market_chart/range`;
@@ -173,7 +173,7 @@ export const getFiatRatesForTimestamps = async (
  */
 export const fetchLastWeekRates = async (
     ticker: TickerId,
-    fiatCurrencyCode: FiatCurrencyCode,
+    fiatCurrencyCode: BaseCurrencyCode,
 ): Promise<HistoricalResponse | null> => {
     const urlEndpoint = `market_chart`;
     const urlParams = `vs_currency=${fiatCurrencyCode}&days=7`;

--- a/suite-common/fiat-services/src/rates.ts
+++ b/suite-common/fiat-services/src/rates.ts
@@ -1,6 +1,6 @@
 import { getUnixTime, subWeeks } from 'date-fns';
 
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { isBlockbookBasedNetwork } from '@suite-common/wallet-config';
 import type {
     FiatRatesResult,
@@ -26,14 +26,14 @@ const parallelRequestsCache = new ParallelRequestsCache();
 
 type FiatRatesParams = {
     ticker: TickerId;
-    localCurrency: FiatCurrencyCode;
+    localCurrency: BaseCurrencyCode;
     isElectrumBackend: boolean;
 };
 
 const getConnectFiatRatesForTimestamp = async (
     ticker: TickerId,
     timestamps: number[],
-    currency: FiatCurrencyCode,
+    currency: BaseCurrencyCode,
 ): Promise<
     | ReturnType<typeof TrezorConnect.blockchainGetFiatRatesForTimestamps>
     | { success: false; payload: null }
@@ -205,7 +205,7 @@ export const fetchLastWeekFiatRates = ({
 export const getFiatRatesForTimestamps = (
     ticker: TickerId,
     timestamps: number[],
-    localCurrency: FiatCurrencyCode,
+    localCurrency: BaseCurrencyCode,
     isElectrumBackend: boolean,
 ): Promise<HistoricRates | null> =>
     parallelRequestsCache.cache(

--- a/suite-common/formatters/src/types.ts
+++ b/suite-common/formatters/src/types.ts
@@ -1,12 +1,12 @@
 import { IntlShape } from 'react-intl';
 
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { PROTO } from '@trezor/connect';
 
 export type FormatterProviderConfig = {
     locale: string;
     bitcoinAmountUnit: PROTO.AmountUnit;
-    fiatCurrency: FiatCurrencyCode;
+    fiatCurrency: BaseCurrencyCode;
     is24HourFormat: boolean;
 };
 

--- a/suite-common/graph/src/graphDataFetching.ts
+++ b/suite-common/graph/src/graphDataFetching.ts
@@ -4,7 +4,7 @@ import { A, D, F, G, O, pipe } from '@mobily/ts-belt';
 import { fromUnixTime, getUnixTime } from 'date-fns';
 
 import { getFiatRatesForTimestamps } from '@suite-common/fiat-services';
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
 import { fetchTransactionsFromNowUntilTimestamp } from '@suite-common/wallet-core';
 import { Timestamp, TokenAddress } from '@suite-common/wallet-types';
@@ -306,7 +306,7 @@ export const getFiatRatesForNetworkInTimeFrame = async ({
     timestamps: number[];
     symbol: NetworkSymbol;
     contractId?: TokenAddress;
-    fiatCurrency: FiatCurrencyCode;
+    fiatCurrency: BaseCurrencyCode;
     forceRefetch?: boolean;
     isElectrumBackend: boolean;
 }) => {
@@ -348,7 +348,7 @@ export const getMultipleAccountBalanceHistoryWithFiat = async ({
     startOfTimeFrameDate: Date | null;
     endOfTimeFrameDate: Date;
     numberOfPoints?: number;
-    fiatCurrency: FiatCurrencyCode;
+    fiatCurrency: BaseCurrencyCode;
     forceRefetch?: boolean;
     isElectrumBackend: boolean;
     dispatch: ReturnType<typeof useDispatch>;

--- a/suite-common/graph/src/graphUtils.ts
+++ b/suite-common/graph/src/graphUtils.ts
@@ -1,7 +1,7 @@
 import { A, D, pipe } from '@mobily/ts-belt';
 import { differenceInMinutes, eachMinuteOfInterval, fromUnixTime, getUnixTime } from 'date-fns';
 
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import {
@@ -64,7 +64,7 @@ export const mapCryptoBalanceMovementToFixedTimeFrame = ({
             [key: string]: number | undefined;
         };
     }>;
-    fiatCurrency: FiatCurrencyCode;
+    fiatCurrency: BaseCurrencyCode;
 }): readonly FiatGraphPointWithCryptoBalance[] =>
     pipe(
         fiatRates,

--- a/suite-common/graph/src/hooks.ts
+++ b/suite-common/graph/src/hooks.ts
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { A } from '@mobily/ts-belt';
 import { roundToNearestMinutes, subHours } from 'date-fns';
 
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { selectHasRunningDiscovery, selectIsDeviceAuthorized } from '@suite-common/wallet-core';
 
 import { getAccountMovementEvents } from './graphBalanceEvents';
@@ -17,7 +17,7 @@ import {
 } from './types';
 
 export type CommonUseGraphParams = {
-    fiatCurrency: FiatCurrencyCode;
+    fiatCurrency: BaseCurrencyCode;
 };
 
 type useGraphForAccountsParams<TIsPortfolioGraph extends boolean = boolean> =

--- a/suite-common/suite-config/src/baseCurrency.ts
+++ b/suite-common/suite-config/src/baseCurrency.ts
@@ -1,4 +1,4 @@
-export const fiatCurrencies = {
+export const baseCurrencies = {
     usd: { code: 'usd', label: 'United States Dollar' },
     eur: { code: 'eur', label: 'Euro' },
     gbp: { code: 'gbp', label: 'Pound Sterling' },
@@ -47,5 +47,5 @@ export const fiatCurrencies = {
     xdr: { code: 'xdr', label: 'Special drawing rights' },
 } as const;
 
-export type FiatCurrencyCode = keyof typeof fiatCurrencies;
-export type FiatCurrency = (typeof fiatCurrencies)[FiatCurrencyCode];
+export type BaseCurrencyCode = keyof typeof baseCurrencies;
+export type BaseCurrency = (typeof baseCurrencies)[BaseCurrencyCode];

--- a/suite-common/suite-config/src/index.ts
+++ b/suite-common/suite-config/src/index.ts
@@ -1,5 +1,5 @@
 export * from './features';
-export * from './fiat';
+export * from './baseCurrency';
 export * from './tor';
 export * from './routes';
 export * from './settings';

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts
@@ -1,6 +1,6 @@
 import { A, D, F, pipe } from '@mobily/ts-belt';
 
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import {
     TokenDefinitionsRootState,
     selectIsSpecificCoinDefinitionKnown,
@@ -69,7 +69,7 @@ export const selectIsFiatRateLoading = (
 export const selectIsTickerLoading = (
     state: FiatRatesRootState,
     ticker: TickerId,
-    fiatCurrency: FiatCurrencyCode,
+    fiatCurrency: BaseCurrencyCode,
     rateType: RateTypeWithoutHistoric = 'current',
 ) => {
     const fiatRateKey = getFiatRateKeyFromTicker(ticker, fiatCurrency);
@@ -129,7 +129,7 @@ export const selectTickerFromAccounts = (
 export const selectTickersToBeUpdated = (
     state: FiatRatesRootState & TokenDefinitionsRootState,
     currentTimestamp: UnixTimestamp,
-    fiatCurrency: FiatCurrencyCode,
+    fiatCurrency: BaseCurrencyCode,
     rateType: RateTypeWithoutHistoric,
 ): TickerId[] => {
     const tickers = selectTickerFromAccounts(state);
@@ -146,7 +146,7 @@ export const selectTickersToBeUpdated = (
 
 export const selectTransactionsWithMissingRates = (
     state: FiatRatesRootState & TransactionsRootState & AccountsRootState,
-    localCurrency: FiatCurrencyCode,
+    localCurrency: BaseCurrencyCode,
 ) => {
     const accountTransactions = selectTransactions(state);
     const historicFiatRates = selectHistoricFiatRates(state);
@@ -156,7 +156,7 @@ export const selectTransactionsWithMissingRates = (
         D.mapWithKey((accountKey, txs) => ({
             account: selectAccountByKey(state, accountKey as AccountKey),
             txs: txs.filter(tx => {
-                const fiatRateKey = getFiatRateKey(tx.symbol, localCurrency as FiatCurrencyCode);
+                const fiatRateKey = getFiatRateKey(tx.symbol, localCurrency as BaseCurrencyCode);
                 const roundedTimestamp = roundTimestampToNearestPastHour(tx.blockTime as Timestamp);
                 const historicRate = historicFiatRates?.[fiatRateKey]?.[roundedTimestamp];
 

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -1,6 +1,6 @@
 import { fetchCurrentFiatRates, fetchLastWeekFiatRates } from '@suite-common/fiat-services';
 import { createThunk } from '@suite-common/redux-utils';
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { selectIsSpecificCoinDefinitionKnown } from '@suite-common/token-definitions';
 import { getNetworkFeatures } from '@suite-common/wallet-config';
 import {
@@ -28,7 +28,7 @@ import { selectIsElectrumBackendSelected } from '../blockchain/blockchainSelecto
 type UpdateTxsFiatRatesThunkPayload = {
     accountKey: AccountKey;
     txs: WalletAccountTransaction[];
-    localCurrency: FiatCurrencyCode;
+    localCurrency: BaseCurrencyCode;
 };
 
 // TODO: Refactor this to batch requests as much as possible
@@ -92,18 +92,19 @@ export const updateTxsFiatRatesThunk = createThunk(
 
 type UpdateCurrentFiatRatesThunkPayload = {
     tickers: TickerId[];
-    localCurrency: FiatCurrencyCode;
+    localCurrency: BaseCurrencyCode;
     fetchAttemptTimestamp: Timestamp;
     rateType: RateTypeWithoutHistoric;
     forceFetchToken?: boolean;
 };
 
-export const updateFiatRatesThunk = createThunk(
+export const updateFiatRatesThunk = createThunk<
+    PromiseSettledResult<FiatRatesResult>[],
+    UpdateCurrentFiatRatesThunkPayload,
+    void
+>(
     `${FIAT_RATES_MODULE_PREFIX}/updateFiatRates`,
-    async (
-        { tickers, localCurrency, rateType, forceFetchToken }: UpdateCurrentFiatRatesThunkPayload,
-        { getState },
-    ) => {
+    async ({ tickers, localCurrency, rateType, forceFetchToken }, { getState }) => {
         const fetchRate = async (ticker: TickerId) => {
             if (isTestnet(ticker.symbol)) {
                 throw new Error('Testnet');
@@ -170,7 +171,7 @@ export const updateFiatRatesThunk = createThunk(
 
 export const updateMissingTxFiatRatesThunk = createThunk(
     `${FIAT_RATES_MODULE_PREFIX}/updateMissingTxRates`,
-    ({ localCurrency }: { localCurrency: FiatCurrencyCode }, { dispatch, getState }) => {
+    ({ localCurrency }: { localCurrency: BaseCurrencyCode }, { dispatch, getState }) => {
         const transactionsWithMissingRates = selectTransactionsWithMissingRates(
             getState(),
             localCurrency,
@@ -184,7 +185,7 @@ export const updateMissingTxFiatRatesThunk = createThunk(
 
 type FetchFiatRatesThunkPayload = {
     rateType: RateTypeWithoutHistoric;
-    localCurrency: FiatCurrencyCode;
+    localCurrency: BaseCurrencyCode;
 };
 
 export const fetchFiatRatesThunk = createThunk(
@@ -241,7 +242,7 @@ const ratesTimeouts: Record<RateTypeWithoutHistoric, TimerId | null> = {
 
 type PeriodicFetchFiatRatesThunkPayload = {
     rateType: RateTypeWithoutHistoric;
-    localCurrency: FiatCurrencyCode;
+    localCurrency: BaseCurrencyCode;
 };
 
 export const periodicFetchFiatRatesThunk = createThunk(

--- a/suite-common/wallet-core/src/settings/walletSettingsActions.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsActions.ts
@@ -1,6 +1,6 @@
 import { Dispatch, createAction } from '@reduxjs/toolkit';
 
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { PROTO } from '@trezor/connect';
 
@@ -11,7 +11,7 @@ export const setLocalCurrency = createAction(
     WALLET_SETTINGS.SET_LOCAL_CURRENCY,
     (localCurrency: string) => ({
         payload: {
-            localCurrency: localCurrency.toLowerCase() as FiatCurrencyCode,
+            localCurrency: localCurrency.toLowerCase() as BaseCurrencyCode,
         },
     }),
 );

--- a/suite-common/wallet-core/src/stake/stakeTypes.ts
+++ b/suite-common/wallet-core/src/stake/stakeTypes.ts
@@ -1,6 +1,6 @@
 import { FormState as ReactHookFormState, UseFormReturn } from 'react-hook-form';
 
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import type { Network } from '@suite-common/wallet-config';
 import {
     Account,
@@ -54,7 +54,7 @@ export interface AmountLimitsString {
 export interface BaseStakeContextValues {
     account: Account;
     network: Network;
-    localCurrency: FiatCurrencyCode;
+    localCurrency: BaseCurrencyCode;
     composedLevels?: PrecomposedLevels;
     isComposing: boolean;
     clearForm: () => void;

--- a/suite-common/wallet-types/src/fiatRates.ts
+++ b/suite-common/wallet-types/src/fiatRates.ts
@@ -1,4 +1,4 @@
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import type { FiatRatesBySymbol } from '@trezor/connect';
 
@@ -43,7 +43,7 @@ export type FiatRatesResult = {
 
 export type TickerResult = {
     tickerId: TickerId;
-    localCurrency: FiatCurrencyCode;
+    localCurrency: BaseCurrencyCode;
     rates: FiatRatesResult[];
 };
 

--- a/suite-common/wallet-types/src/settings.ts
+++ b/suite-common/wallet-types/src/settings.ts
@@ -1,4 +1,4 @@
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { PROTO } from '@trezor/connect';
 
@@ -18,7 +18,7 @@ export const WalletType = {
 export type WalletType = (typeof WalletType)[keyof typeof WalletType];
 
 export interface WalletSettings {
-    localCurrency: FiatCurrencyCode;
+    localCurrency: BaseCurrencyCode;
     discreetMode: boolean;
     enabledNetworks: NetworkSymbol[];
     hideSuspiciousTransactions: boolean;

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -1,4 +1,4 @@
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { TrezorDevice } from '@suite-common/suite-types';
 import {
     type AccountType,
@@ -580,7 +580,7 @@ export const areTokenFiatRatesLoading = (
     (account.tokens ?? []).some(token => {
         const tokenFiatRateKey = getFiatRateKey(
             account.symbol,
-            localCurrency as FiatCurrencyCode,
+            localCurrency as BaseCurrencyCode,
             token.contract as TokenAddress,
         );
 
@@ -602,7 +602,7 @@ export const getAccountTokensFiatBalance = (
         .reduce((total, token) => {
             const tokenFiatRateKey = getFiatRateKey(
                 account.symbol,
-                localCurrency as FiatCurrencyCode,
+                localCurrency as BaseCurrencyCode,
                 token.contract as TokenAddress,
             );
 
@@ -620,19 +620,21 @@ export const getStakingFiatBalance = (account: Account, rate: number | undefined
     return toFiatCurrency(balance, rate, 2);
 };
 
+type GetAccountFiatBalanceParams = {
+    account: Account;
+    localCurrency: BaseCurrencyCode;
+    rates?: RatesByKey;
+    shouldIncludeTokens?: boolean;
+    shouldIncludeStaking?: boolean;
+};
+
 export const getAccountFiatBalance = ({
     account,
     localCurrency,
     rates,
     shouldIncludeTokens = true,
     shouldIncludeStaking = true,
-}: {
-    account: Account;
-    localCurrency: FiatCurrencyCode;
-    rates?: RatesByKey;
-    shouldIncludeTokens?: boolean;
-    shouldIncludeStaking?: boolean;
-}) => {
+}: GetAccountFiatBalanceParams) => {
     const coinFiatRateKey = getFiatRateKey(account.symbol, localCurrency);
     const coinFiatRate = rates?.[coinFiatRateKey];
 
@@ -664,20 +666,23 @@ export const getAccountFiatBalance = ({
     return totalBalance.toFixed();
 };
 
+type GetTotalFiatBalanceParams = {
+    deviceAccounts: Account[];
+    localCurrency: BaseCurrencyCode;
+    rates?: RatesByKey;
+    shouldIncludeTokens?: boolean;
+    shouldIncludeStaking?: boolean;
+};
+
 export const getTotalFiatBalance = ({
     deviceAccounts,
     localCurrency,
     rates,
     shouldIncludeTokens = true,
     shouldIncludeStaking = true,
-}: {
-    deviceAccounts: Account[];
-    localCurrency: FiatCurrencyCode;
-    rates?: RatesByKey;
-    shouldIncludeTokens?: boolean;
-    shouldIncludeStaking?: boolean;
-}) => {
+}: GetTotalFiatBalanceParams) => {
     let instanceBalance = new BigNumber(0);
+
     deviceAccounts.forEach(a => {
         const accountFiatBalance =
             getAccountFiatBalance({

--- a/suite-common/wallet-utils/src/fiatRatesUtils.ts
+++ b/suite-common/wallet-utils/src/fiatRatesUtils.ts
@@ -1,5 +1,5 @@
 import { getFiatRatesForTimestamps } from '@suite-common/fiat-services';
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import {
     FiatRateKey,
@@ -15,7 +15,7 @@ const ONE_HOUR_IN_SECONDS = 60 * 60;
 
 export const getFiatRateKey = (
     symbol: NetworkSymbol,
-    fiatCurrency: FiatCurrencyCode,
+    fiatCurrency: BaseCurrencyCode,
     tokenAddress?: TokenAddress,
 ): FiatRateKey => {
     if (tokenAddress) {
@@ -27,7 +27,7 @@ export const getFiatRateKey = (
 
 export const getFiatRateKeyFromTicker = (
     ticker: TickerId,
-    fiatCurrency: FiatCurrencyCode,
+    fiatCurrency: BaseCurrencyCode,
 ): FiatRateKey => {
     const { symbol, tokenAddress } = ticker;
 
@@ -118,7 +118,7 @@ export const selectHistoricRatesByTransactions = (
 export const fetchTransactionsRates = async (
     tickerId: TickerId,
     timestamps: Timestamp[],
-    localCurrency: FiatCurrencyCode,
+    localCurrency: BaseCurrencyCode,
     isElectrumBackend: boolean,
     rates: TickerResult[],
 ) => {

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -9,7 +9,7 @@ import {
 
 import { fromWei, numberToHex, padLeft, toWei } from 'web3-utils';
 
-import { fiatCurrencies } from '@suite-common/suite-config';
+import { baseCurrencies } from '@suite-common/suite-config';
 import { Network, NetworkType } from '@suite-common/wallet-config';
 import {
     COMPOSE_ERROR_TYPES,
@@ -488,7 +488,7 @@ export const getDefaultValues = (currency: Output['currency']): FormState => ({
 export const buildCurrencyOptions = (selected: CurrencyOption) => {
     const result: CurrencyOption[] = [];
 
-    Object.keys(fiatCurrencies).forEach(currency => {
+    Object.keys(baseCurrencies).forEach(currency => {
         if (selected.value === currency) {
             return;
         }

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -2,7 +2,7 @@ import { addDays, startOfMonth } from 'date-fns';
 import { fromWei, toWei } from 'web3-utils';
 
 import { AccountLabels } from '@suite-common/metadata-types';
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { SignOperator } from '@suite-common/suite-types';
 import {
     Account,
@@ -225,7 +225,7 @@ export const sumTransactions = (transactions: WalletAccountTransaction[]) => {
 
 export const sumTransactionsFiat = (
     transactions: WalletAccountTransaction[],
-    fiatCurrency: FiatCurrencyCode,
+    fiatCurrency: BaseCurrencyCode,
     historicFiatRates: RatesByTimestamps | undefined,
 ) => {
     let totalAmount = new BigNumber(0);

--- a/suite-native/app/e2e/pageObjects/settingsActions.ts
+++ b/suite-native/app/e2e/pageObjects/settingsActions.ts
@@ -1,4 +1,4 @@
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { PROTO } from '@trezor/connect';
 
 import { TREZOR_E2E_DEVICE_LABEL, scrollUntilVisible } from '../utils';
@@ -39,7 +39,7 @@ class SettingsActions {
         await discreetModeToggleElement.tap();
     }
 
-    async changeLocalizationCurrency(currencyCode: FiatCurrencyCode) {
+    async changeLocalizationCurrency(currencyCode: BaseCurrencyCode) {
         const currencySelectorTriggerElement = element(
             by.id('@settings/localization/currency-selector'),
         );

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -6,7 +6,7 @@ import {
     selectIsFeatureEnabled,
 } from '@suite-common/message-system';
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
 import {
     AccountsRootState,
@@ -101,7 +101,7 @@ const getTotalFiatBalanceNative = ({
     rates,
 }: {
     deviceAccounts: Account[];
-    localCurrency: FiatCurrencyCode;
+    localCurrency: BaseCurrencyCode;
     rates?: RatesByKey;
 }) => {
     let instanceBalance = new BigNumber(0);

--- a/suite-native/module-accounts-import/src/accountsImportThunks.ts
+++ b/suite-native/module-accounts-import/src/accountsImportThunks.ts
@@ -1,5 +1,5 @@
 import { createThunk } from '@suite-common/redux-utils';
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import {
     getSupportedDefinitionTypes,
     getTokenDefinitionThunk,
@@ -80,7 +80,7 @@ export const importAccountThunk = createThunk(
 
 export const getAccountInfoThunk = createThunk<
     AccountInfo,
-    { symbol: NetworkSymbol; fiatCurrency: FiatCurrencyCode; xpubAddress: string },
+    { symbol: NetworkSymbol; fiatCurrency: BaseCurrencyCode; xpubAddress: string },
     { rejectValue: string }
 >(
     `${ACCOUNTS_IMPORT_MODULE_PREFIX}/getAccountInfo`,

--- a/suite-native/module-settings/src/components/CurrencySelector.tsx
+++ b/suite-native/module-settings/src/components/CurrencySelector.tsx
@@ -1,6 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 
-import { FiatCurrency, FiatCurrencyCode, fiatCurrencies } from '@suite-common/suite-config';
+import { BaseCurrency, BaseCurrencyCode, baseCurrencies } from '@suite-common/suite-config';
 import { selectLocalCurrency, setLocalCurrency } from '@suite-common/wallet-core';
 import { EventType, analytics } from '@suite-native/analytics';
 import { Select } from '@suite-native/atoms';
@@ -8,18 +8,18 @@ import { Translation } from '@suite-native/intl';
 
 import { PreferencesSettingsCard } from './PreferencesSettingsCard';
 
-export const transformFiatCurrencyToSelectItem = ({ code, label }: FiatCurrency) => ({
+export const transformFiatCurrencyToSelectItem = ({ code, label }: BaseCurrency) => ({
     value: code,
     label: `${code.toUpperCase()} · ${label}`,
 });
 
-const fiatCurrencyItems = Object.values(fiatCurrencies).map(transformFiatCurrencyToSelectItem);
+const fiatCurrencyItems = Object.values(baseCurrencies).map(transformFiatCurrencyToSelectItem);
 
 export const CurrencySelector = () => {
     const selectedFiatCurrencyCode = useSelector(selectLocalCurrency);
     const dispatch = useDispatch();
 
-    const handleSelectCurrency = (localCurrency: FiatCurrencyCode) => {
+    const handleSelectCurrency = (localCurrency: BaseCurrencyCode) => {
         dispatch(setLocalCurrency(localCurrency));
         analytics.report({
             type: EventType.SettingsChangeCurrency,
@@ -32,7 +32,7 @@ export const CurrencySelector = () => {
             iconName="translate"
             title={<Translation id="moduleSettings.preferences.fiatCurrencyLabel" />}
         >
-            <Select<FiatCurrencyCode>
+            <Select<BaseCurrencyCode>
                 items={fiatCurrencyItems}
                 selectValue={selectedFiatCurrencyCode}
                 onSelectItem={handleSelectCurrency}


### PR DESCRIPTION
Part of: https://github.com/trezor/trezor-suite/issues/5939

This is part of the refactoring to convert Fiat -> BaseCurrency as we have also Gold, Silver, and we also introduce Bitcoin as a Base Currency (unit of account)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=btc-as-base-currency&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=btc-as-base-currency&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=btc-as-base-currency&lookback=7)