### PR TITLE
chore(message-system): Trading not available in UK on iOS for 25.6.1 and newer

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,8 +1,56 @@
 {
     "version": 1,
-    "timestamp": "2025-06-26T00:00:00+00:00",
+    "timestamp": "2025-07-04T00:00:00+00:00",
     "sequence": 92,
     "actions": [
+        {
+            "conditions": [
+                {
+                    "environment": {
+                        "desktop": "!",
+                        "mobile": ">=25.6.1",
+                        "web": "!"
+                    },
+                    "os": {
+                        "macos": "!",
+                        "linux": "!",
+                        "windows": "!",
+                        "android": "!",
+                        "ios": "*",
+                        "chromeos": "!"
+                    },
+                    "countryCodes": ["GB"]
+                }
+            ],
+            "message": {
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "priority": 91,
+                "dismissible": false,
+                "variant": "info",
+                "category": "feature",
+                "content": {
+                    "en-GB": "Trading is not available in your country yet.",
+                    "en": "Trading is not available in your country yet.",
+                    "es": "El comercio aún no está disponible en tu país.",
+                    "cs": "Obchodování zatím není ve vaší zemi dostupné.",
+                    "de": "Der Handel ist in deinem Land noch nicht verfügbar.",
+                    "fr": "Le trading n'est pas encore disponible dans votre pays.",
+                    "it": "Il trading non è ancora disponibile nel tuo paese.",
+                    "pt": "A negociação ainda não está disponível no seu país.",
+                    "tr": "Ticaret henüz ülkenizde kullanılamıyor.",
+                    "ru": "Торговля пока недоступна в вашей стране.",
+                    "ja": "お住まいの国ではまだ取引をご利用いただけません。",
+                    "uk": "Торгівля наразі недоступна y вашій країні.",
+                    "hu": "A kereskedés még nem érhető el az Ön országában."
+                },
+                "feature": [
+                    {
+                        "domain": "trading.restrictions.blacklist",
+                        "flag": true
+                    }
+                ]
+            }
+        },
         {
             "conditions": [
                 {

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -7,8 +7,8 @@
             "conditions": [
                 {
                     "environment": {
-                        "desktop": ">25.5.0",
-                        "mobile": ">25.5.0",
+                        "desktop": ">=25.5.1",
+                        "mobile": ">=25.5.1",
                         "web": "*"
                     },
                     "countryCodes": ["GB"]


### PR DESCRIPTION
## Description

1. Adding a message informing users in the United Kingdom that trading is not available in that country.
2. Updating a message informing users in the United Kingdom about risk of investment on all trade screens.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/add-message-trading-not-available-uk&lookback=7)