### PR TITLE
Btc as base currency2

### DIFF
--- a/packages/suite/src/components/suite/BaseCurrencyValue.tsx
+++ b/packages/suite/src/components/suite/BaseCurrencyValue.tsx
@@ -26,7 +26,7 @@ interface Params {
     timestamp: number | null;
 }
 
-type FiatValueProps = UseFiatFromCryptoValueParams & {
+type BaseCurrencyValueProps = UseFiatFromCryptoValueParams & {
     children?: (props: Params) => ReactElement | null;
     showApproximationIndicator?: boolean;
     disableHiddenPlaceholder?: boolean;
@@ -49,10 +49,10 @@ type FiatValueProps = UseFiatFromCryptoValueParams & {
  * The function will be called (and rendered) with 1 object param: {fiatValue, fiatRateValue, fiatRateTimestamp}.
  *
  *  In case of a custom source of fiat rates returned timestamp is always null;
- * @param {FiatValueProps} { amount, symbol, fiatCurrency, ...props }
+ * @param {BaseCurrencyValueProps} { amount, symbol, fiatCurrency, ...props }
  * @returns
  */
-export const FiatValue = ({
+export const BaseCurrencyValue = ({
     children,
     amount, // expects a value in full units (BTC not sats)
     className,
@@ -67,7 +67,7 @@ export const FiatValue = ({
     shouldConvert = true,
     showLoadingSkeleton,
     isLoading,
-}: FiatValueProps) => {
+}: BaseCurrencyValueProps) => {
     const { shouldAnimate } = useLoadingSkeleton();
     const { localCurrency, fiatAmount, rate, currentRate } = useFiatFromCryptoValue({
         amount,
@@ -77,7 +77,7 @@ export const FiatValue = ({
         useHistoricRate,
     });
 
-    const { FiatAmountFormatter } = useFormatters();
+    const { BaseCurrencyAmountFormatter } = useFormatters();
     const value = shouldConvert ? fiatAmount : amount;
 
     const WrapperComponent = disableHiddenPlaceholder ? SameWidthNums : HiddenPlaceholder;
@@ -99,7 +99,7 @@ export const FiatValue = ({
         const fiatValueComponent = (
             <WrapperComponent className={className}>
                 {showApproximationIndicator && <>≈&nbsp;</>}
-                <FiatAmountFormatter
+                <BaseCurrencyAmountFormatter
                     currency={localCurrency.toUpperCase()}
                     value={value}
                     {...fiatAmountFormatterOptions}
@@ -109,7 +109,7 @@ export const FiatValue = ({
 
         const fiatRateComponent = rate ? (
             <SameWidthNums>
-                <FiatAmountFormatter
+                <BaseCurrencyAmountFormatter
                     currency={localCurrency}
                     value={rate}
                     {...fiatRateFormatterOptions}

--- a/packages/suite/src/components/suite/FiatValue.tsx
+++ b/packages/suite/src/components/suite/FiatValue.tsx
@@ -39,17 +39,17 @@ type FiatValueProps = UseFiatFromCryptoValueParams & {
 };
 
 /**
- * If used without children prop it returns a value of an crypto assets in fiat currency.
+ * If used without children prop it returns a value of a crypto assets in fiat currency.
  * If prop `fiatCurrency` is not specified, the currency is read from suite settings.
- * null is returned if there was some problem with conversion (eg. missing rates)
+ * null is returned if there was some problem with conversion (e.g., missing rates)
  *
  * If `symbol` is not NetworkSymbol (necessary to type forcing), it will handle that case as well.
  *
- * Advanced usage is with passing a function as a children prop.
+ * Advanced usage is with passing a function as a children's prop.
  * The function will be called (and rendered) with 1 object param: {fiatValue, fiatRateValue, fiatRateTimestamp}.
  *
- *  In case of custom source of fiat rates returned timestamp is always null;
- * @param {FiatValuePropsProps} { amount, symbol, fiatCurrency, ...props }
+ *  In case of a custom source of fiat rates returned timestamp is always null;
+ * @param {FiatValueProps} { amount, symbol, fiatCurrency, ...props }
  * @returns
  */
 export const FiatValue = ({

--- a/packages/suite/src/components/suite/Ticker/PriceTicker.tsx
+++ b/packages/suite/src/components/suite/Ticker/PriceTicker.tsx
@@ -4,7 +4,7 @@ import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { TokenAddress } from '@suite-common/wallet-types';
 import { typography } from '@trezor/theme';
 
-import { FiatValue } from 'src/components/suite';
+import { BaseCurrencyValue } from 'src/components/suite';
 
 import { LastUpdateTooltip } from './LastUpdateTooltip';
 import { NoRatesTooltip } from './NoRatesTooltip';
@@ -37,7 +37,7 @@ export const PriceTicker = ({
     const emptyStateComponent = noEmptyStateTooltip ? <Empty>—</Empty> : <NoRatesTooltip />;
 
     return (
-        <FiatValue
+        <BaseCurrencyValue
             amount="1"
             symbol={symbol}
             tokenAddress={contractAddress}
@@ -56,6 +56,6 @@ export const PriceTicker = ({
                     emptyStateComponent
                 )
             }
-        </FiatValue>
+        </BaseCurrencyValue>
     );
 };

--- a/packages/suite/src/components/suite/Ticker/TrendTicker.tsx
+++ b/packages/suite/src/components/suite/Ticker/TrendTicker.tsx
@@ -7,7 +7,7 @@ import { getFiatRateKey, localizePercentage } from '@suite-common/wallet-utils';
 import { Icon } from '@trezor/components';
 import { spacingsPx, typography } from '@trezor/theme';
 
-import { FiatValue } from 'src/components/suite';
+import { BaseCurrencyValue } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { selectLanguage } from 'src/reducers/suite/suiteReducer';
 
@@ -63,7 +63,7 @@ export const TrendTicker = ({
     const emptyStateComponent = noEmptyStateTooltip ? <Empty>—</Empty> : <NoRatesTooltip />;
 
     return (
-        <FiatValue amount="1" symbol={symbol} showLoadingSkeleton={showLoadingSkeleton}>
+        <BaseCurrencyValue amount="1" symbol={symbol} showLoadingSkeleton={showLoadingSkeleton}>
             {({ rate, timestamp }) =>
                 rate && timestamp && percentageChange ? (
                     <PercentageWrapper $isRateGoingUp={isRateGoingUp}>
@@ -78,6 +78,6 @@ export const TrendTicker = ({
                     emptyStateComponent
                 )
             }
-        </FiatValue>
+        </BaseCurrencyValue>
     );
 };

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipAccount.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipAccount.tsx
@@ -20,7 +20,7 @@ const formatAmount = (
     sign: SignOperator,
     formatters: Formatters,
 ) => {
-    const { FiatAmountFormatter } = formatters;
+    const { BaseCurrencyAmountFormatter } = formatters;
 
     return (
         <Row>
@@ -38,7 +38,7 @@ const formatAmount = (
             {fiatAmount && localCurrency && (
                 <>
                     (
-                    <FiatAmountFormatter currency={localCurrency} value={fiatAmount} />)
+                    <BaseCurrencyAmountFormatter currency={localCurrency} value={fiatAmount} />)
                 </>
             )}
         </Row>

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipDashboard.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipDashboard.tsx
@@ -25,7 +25,7 @@ export const GraphTooltipDashboard = ({
     sentValueFn,
     ...props
 }: GraphTooltipDashboardProps) => {
-    const { FiatAmountFormatter } = useFormatters();
+    const { BaseCurrencyAmountFormatter } = useFormatters();
 
     // Note: payload is [] when discovery is paused.
     if (!active || !payload?.length) {
@@ -36,11 +36,11 @@ export const GraphTooltipDashboard = ({
     const sentAmountString = sentValueFn(payload[0].payload);
 
     const receivedAmount = (
-        <FiatAmountFormatter currency={localCurrency} value={receivedAmountString ?? '0'} />
+        <BaseCurrencyAmountFormatter currency={localCurrency} value={receivedAmountString ?? '0'} />
     );
 
     const sentAmount = (
-        <FiatAmountFormatter currency={localCurrency} value={sentAmountString ?? '0'} />
+        <BaseCurrencyAmountFormatter currency={localCurrency} value={sentAmountString ?? '0'} />
     );
 
     return (

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/GraphYAxisTick.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/GraphYAxisTick.tsx
@@ -24,7 +24,7 @@ export const GraphYAxisTick = ({
     localCurrency,
     symbol,
 }: GraphYAxisTickProps) => {
-    const { FiatAmountFormatter } = useFormatters();
+    const { BaseCurrencyAmountFormatter } = useFormatters();
 
     const theme = useTheme();
     const ref = useRef<SVGGElement>(null);
@@ -47,7 +47,7 @@ export const GraphYAxisTick = ({
                 style={{ fontVariantNumeric: 'tabular-nums' }}
             >
                 {localCurrency && (
-                    <FiatAmountFormatter
+                    <BaseCurrencyAmountFormatter
                         value={payload.value}
                         currency={localCurrency}
                         minimumFractionDigits={0}

--- a/packages/suite/src/components/suite/index.tsx
+++ b/packages/suite/src/components/suite/index.tsx
@@ -8,7 +8,7 @@ import { WordInput } from './WordInput';
 import { WordInputAdvanced } from './WordInputAdvanced';
 import { Loading } from './Loading';
 import { BundleLoader } from './BundleLoader';
-import { FiatValue } from './FiatValue';
+import { BaseCurrencyValue } from './BaseCurrencyValue';
 import { WebUsbButton } from './WebUsbButton';
 import { HiddenPlaceholder } from './HiddenPlaceholder';
 import { QuestionTooltip } from './QuestionTooltip';
@@ -59,7 +59,7 @@ export {
     DeviceConfirmImage,
     CheckItem,
     PrerequisitesGuide,
-    FiatValue,
+    BaseCurrencyValue,
     Translation,
     WordInput,
     WordInputAdvanced,

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
@@ -10,7 +10,7 @@ import { spacingsPx, typography, zIndices } from '@trezor/theme';
 import {
     AccountLabel,
     AmountUnitSwitchWrapper,
-    FiatValue,
+    BaseCurrencyValue,
     FormattedCryptoAmount,
     MetadataLabeling,
 } from 'src/components/suite';
@@ -149,7 +149,7 @@ export const AccountDetails = ({ selectedAccount, isBalanceShown }: AccountDetai
                             </AmountUnitSwitchWrapper>
                         </CryptoBalance>
                         <ForegroundWrapper>
-                            <FiatValue
+                            <BaseCurrencyValue
                                 amount={formattedBalance}
                                 symbol={symbol}
                                 showApproximationIndicator

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -20,7 +20,12 @@ import { TokenInfo } from '@trezor/connect';
 import { spacings } from '@trezor/theme';
 import { exhaustive } from '@trezor/type-utils';
 
-import { Address, FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
+import {
+    Address,
+    BaseCurrencyValue,
+    FormattedCryptoAmount,
+    Translation,
+} from 'src/components/suite';
 import { Account } from 'src/types/wallet';
 
 const getCardanoFingerprint = (
@@ -98,7 +103,7 @@ const Value = ({ value, type, symbol, token, isFee, isFiatVisible, state }: Valu
                     />
                     {symbol && isFiatVisible && (
                         <Text variant="tertiary" data-testid="@modal/fiat-amount">
-                            <FiatValue
+                            <BaseCurrencyValue
                                 disableHiddenPlaceholder
                                 amount={formattedValue}
                                 tokenAddress={

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
@@ -8,7 +8,7 @@ import { Banner, Column, InfoItem, Modal, Paragraph, Tooltip } from '@trezor/com
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
-import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
+import { BaseCurrencyValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
 import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useDevice, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
@@ -134,7 +134,7 @@ const ClaimModalLoaded = ({ onCancel, selectedAccount }: ClaimModalModalProps) =
                             />
                         </Paragraph>
                         <Paragraph typographyStyle="label" variant="tertiary">
-                            <FiatValue
+                            <BaseCurrencyValue
                                 showApproximationIndicator
                                 amount={claimableAmount}
                                 symbol={account.symbol}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeAvailableBalance.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeAvailableBalance.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { InfoItem, Row, Text } from '@trezor/components';
 
-import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
+import { BaseCurrencyValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
 
 interface StakeAvailableBalanceProps {
     formattedBalance: string;
@@ -14,7 +14,7 @@ export const StakeAvailableBalance = ({ formattedBalance, symbol }: StakeAvailab
     <InfoItem label={<Translation id="TR_STAKE_AVAILABLE" />}>
         <Row justifyContent="space-between">
             <FormattedCryptoAmount value={formattedBalance} symbol={symbol} />{' '}
-            <FiatValue amount={formattedBalance} symbol={symbol} showApproximationIndicator>
+            <BaseCurrencyValue amount={formattedBalance} symbol={symbol} showApproximationIndicator>
                 {({ value }) =>
                     value ? (
                         <Text typographyStyle="label" variant="tertiary">
@@ -22,7 +22,7 @@ export const StakeAvailableBalance = ({ formattedBalance, symbol }: StakeAvailab
                         </Text>
                     ) : null
                 }
-            </FiatValue>
+            </BaseCurrencyValue>
         </Row>
     </InfoItem>
 );

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeInputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeInputs.tsx
@@ -8,7 +8,7 @@ import { InputWithOptions } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils';
 
-import { FiatValue, Translation } from 'src/components/suite';
+import { BaseCurrencyValue, Translation } from 'src/components/suite';
 import { useSelector, useTranslation } from 'src/hooks/suite';
 import { useStakeFormContext } from 'src/hooks/wallet/useStakeForm';
 import { selectLanguage } from 'src/reducers/suite/suiteReducer';
@@ -162,7 +162,11 @@ export const StakeInputs = () => {
                     ),
                 }}
                 fiatValue={
-                    <FiatValue amount={amount} symbol={account.symbol} showApproximationIndicator>
+                    <BaseCurrencyValue
+                        amount={amount}
+                        symbol={account.symbol}
+                        showApproximationIndicator
+                    >
                         {({ value }) =>
                             value ? (
                                 <Text typographyStyle="label" variant="tertiary">
@@ -170,7 +174,7 @@ export const StakeInputs = () => {
                                 </Text>
                             ) : null
                         }
-                    </FiatValue>
+                    </BaseCurrencyValue>
                 }
                 options={[
                     {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeInfoCards/EstimatedGains.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeInfoCards/EstimatedGains.tsx
@@ -6,7 +6,7 @@ import { Column, Grid, Image, Paragraph, Text } from '@trezor/components';
 import { negativeSpacings, spacings } from '@trezor/theme';
 import { HELP_CENTER_ETH_STAKING, HELP_CENTER_SOL_STAKING } from '@trezor/urls';
 
-import { FiatValue, FormattedCryptoAmount, TrezorLink } from 'src/components/suite';
+import { BaseCurrencyValue, FormattedCryptoAmount, TrezorLink } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 import { useStakeFormContext } from 'src/hooks/wallet/useStakeForm';
 import { CRYPTO_INPUT } from 'src/types/wallet/stakeForms';
@@ -75,7 +75,7 @@ export const EstimatedGains = () => {
                             <FormattedCryptoAmount value={value} symbol={account.symbol} />
                         </Text>
                         <Paragraph align="end">
-                            <FiatValue amount={value} symbol={account.symbol} />
+                            <BaseCurrencyValue amount={value} symbol={account.symbol} />
                         </Paragraph>
                     </Grid>
                 ))}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransaction.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransaction.tsx
@@ -7,7 +7,7 @@ import { HELP_CENTER_CANCEL_TRANSACTION } from '@trezor/urls';
 import { BigNumber } from '@trezor/utils';
 
 import { useCancelTxContext } from '../../../../../../../hooks/wallet/useCancelTxContext';
-import { FiatValue } from '../../../../../FiatValue';
+import { BaseCurrencyValue } from '../../../../../BaseCurrencyValue';
 import { FormattedCryptoAmount } from '../../../../../FormattedCryptoAmount';
 import { Translation } from '../../../../../Translation';
 import { TrezorLink } from '../../../../../TrezorLink';
@@ -88,7 +88,7 @@ export const CancelTransaction = ({ tx, selectedAccount }: CancelTransactionProp
                             symbol={tx.symbol}
                         />
                         <Text variant="tertiary" typographyStyle="label">
-                            <FiatValue
+                            <BaseCurrencyValue
                                 disableHiddenPlaceholder
                                 amount={fee ?? '0'}
                                 symbol={tx.symbol}
@@ -112,7 +112,7 @@ export const CancelTransaction = ({ tx, selectedAccount }: CancelTransactionProp
                             symbol={tx.symbol}
                         />
                         <Text variant="tertiary" typographyStyle="label">
-                            <FiatValue
+                            <BaseCurrencyValue
                                 disableHiddenPlaceholder
                                 amount={formattedOutputAmount}
                                 symbol={tx.symbol}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee.tsx
@@ -7,7 +7,7 @@ import { Card, Divider, InfoItem, Row, Text } from '@trezor/components';
 import { FeeRate } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
-import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
+import { BaseCurrencyValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { UseRbfProps, useRbfContext } from 'src/hooks/wallet/useRbfForm';
 
@@ -85,7 +85,7 @@ const ChangeFeeLoaded = (props: ChangeFeeProps) => {
                             symbol={tx.symbol}
                         />
                         <Text variant="tertiary" typographyStyle="label">
-                            <FiatValue
+                            <BaseCurrencyValue
                                 disableHiddenPlaceholder
                                 amount={fee}
                                 symbol={tx.symbol}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
@@ -18,7 +18,12 @@ import {
 import { Table, Text } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
-import { FiatValue, FormattedCryptoAmount, FormattedDate, Translation } from 'src/components/suite';
+import {
+    BaseCurrencyValue,
+    FormattedCryptoAmount,
+    FormattedDate,
+    Translation,
+} from 'src/components/suite';
 import { AmountComponent } from 'src/components/wallet/AmountComponent';
 import { useSelector } from 'src/hooks/suite';
 import { WalletAccountTransaction } from 'src/types/wallet';
@@ -64,7 +69,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                 id="TR_TODAY_DATE"
                                 values={{
                                     date: (
-                                        <FiatValue amount="1" symbol={tx.symbol}>
+                                        <BaseCurrencyValue amount="1" symbol={tx.symbol}>
                                             {({ timestamp }) =>
                                                 timestamp ? (
                                                     <FormattedDate
@@ -74,7 +79,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                                     />
                                                 ) : null
                                             }
-                                        </FiatValue>
+                                        </BaseCurrencyValue>
                                     ),
                                 }}
                             />
@@ -105,7 +110,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         </Table.Cell>
                         <Table.Cell align="end">
                             <Text variant="default">
-                                <FiatValue
+                                <BaseCurrencyValue
                                     amount={amount.abs().toString()}
                                     symbol={tx.symbol}
                                     historicRate={historicRate}
@@ -115,7 +120,10 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         </Table.Cell>
                         <Table.Cell align="end">
                             <Text variant="default">
-                                <FiatValue amount={amount.abs().toString()} symbol={tx.symbol} />
+                                <BaseCurrencyValue
+                                    amount={amount.abs().toString()}
+                                    symbol={tx.symbol}
+                                />
                             </Text>
                         </Table.Cell>
                     </Table.Row>
@@ -140,7 +148,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         </Table.Cell>
                         <Table.Cell align="end">
                             <Text variant="default">
-                                <FiatValue
+                                <BaseCurrencyValue
                                     amount={formatNetworkAmount(transfer.amount, tx.symbol)}
                                     symbol={tx.symbol}
                                     historicRate={historicRate}
@@ -150,7 +158,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         </Table.Cell>
                         <Table.Cell align="end">
                             <Text variant="default">
-                                <FiatValue
+                                <BaseCurrencyValue
                                     amount={formatNetworkAmount(transfer.amount, tx.symbol)}
                                     symbol={tx.symbol}
                                 />
@@ -193,7 +201,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                             <Table.Cell align="end">
                                 {selectedAccount.account && (
                                     <Text variant="default">
-                                        <FiatValue
+                                        <BaseCurrencyValue
                                             amount={formatAmount(
                                                 transfer.amount,
                                                 transfer.decimals,
@@ -209,7 +217,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                             <Table.Cell align="end">
                                 {selectedAccount.account && (
                                     <Text variant="default">
-                                        <FiatValue
+                                        <BaseCurrencyValue
                                             amount={formatAmount(
                                                 transfer.amount,
                                                 transfer.decimals,
@@ -241,7 +249,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         </Table.Cell>
                         <Table.Cell align="end">
                             <Text variant="default">
-                                <FiatValue
+                                <BaseCurrencyValue
                                     amount={cardanoWithdrawal}
                                     symbol={tx.symbol}
                                     historicRate={historicRate}
@@ -251,7 +259,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         </Table.Cell>
                         <Table.Cell align="end">
                             <Text variant="default">
-                                <FiatValue amount={cardanoWithdrawal} symbol={tx.symbol} />
+                                <BaseCurrencyValue amount={cardanoWithdrawal} symbol={tx.symbol} />
                             </Text>
                         </Table.Cell>
                     </Table.Row>
@@ -274,7 +282,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         </Table.Cell>
                         <Table.Cell align="end">
                             <Text variant="default">
-                                <FiatValue
+                                <BaseCurrencyValue
                                     amount={cardanoDeposit}
                                     symbol={tx.symbol}
                                     historicRate={historicRate}
@@ -284,7 +292,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         </Table.Cell>
                         <Table.Cell align="end">
                             <Text variant="default">
-                                <FiatValue amount={cardanoDeposit} symbol={tx.symbol} />
+                                <BaseCurrencyValue amount={cardanoDeposit} symbol={tx.symbol} />
                             </Text>
                         </Table.Cell>
                     </Table.Row>
@@ -308,7 +316,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         </Table.Cell>
                         <Table.Cell align="end">
                             <Text variant="default">
-                                <FiatValue
+                                <BaseCurrencyValue
                                     amount={fee}
                                     symbol={tx.symbol}
                                     historicRate={historicRate}
@@ -318,7 +326,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         </Table.Cell>
                         <Table.Cell align="end">
                             <Text variant="default">
-                                <FiatValue amount={fee} symbol={tx.symbol} />
+                                <BaseCurrencyValue amount={fee} symbol={tx.symbol} />
                             </Text>
                         </Table.Cell>
                     </Table.Row>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
@@ -54,7 +54,7 @@ const TxSimulationAsset = ({
     assetExposure?: AssetExposure;
     network: Network;
 }) => {
-    const { FiatAmountFormatter } = useFormatters();
+    const { BaseCurrencyAmountFormatter } = useFormatters();
 
     const AssetIcon = () => {
         const asset = (assetDiff || assetExposure)?.asset;
@@ -108,7 +108,10 @@ const TxSimulationAsset = ({
                     {inAmount.usd_price && (
                         <Text variant="tertiary" key={`in-usd-${inIndex}`}>
                             {`+ `}
-                            <FiatAmountFormatter value={inAmount.usd_price} currency="USD" />
+                            <BaseCurrencyAmountFormatter
+                                value={inAmount.usd_price}
+                                currency="USD"
+                            />
                         </Text>
                     )}
                 </>
@@ -126,7 +129,10 @@ const TxSimulationAsset = ({
                     {outAmount.usd_price && (
                         <Text variant="tertiary" key={`out-usd-${outIndex}`}>
                             {`- `}
-                            <FiatAmountFormatter value={outAmount.usd_price} currency="USD" />
+                            <BaseCurrencyAmountFormatter
+                                value={outAmount.usd_price}
+                                currency="USD"
+                            />
                         </Text>
                     )}
                 </>
@@ -143,7 +149,7 @@ const TxSimulationAsset = ({
                         </Text>
                         {spender.exposure.usd_price && (
                             <Text variant="tertiary" key={`spender-usd-${index}`}>
-                                <FiatAmountFormatter
+                                <BaseCurrencyAmountFormatter
                                     value={spender.exposure.usd_price}
                                     currency="USD"
                                 />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeInputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeInputs.tsx
@@ -7,7 +7,7 @@ import { Column, FractionButtonProps, Text } from '@trezor/components';
 import { InputWithOptions } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
-import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
+import { BaseCurrencyValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
 import { useSelector, useTranslation } from 'src/hooks/suite';
 import { useUnstakeFormContext } from 'src/hooks/wallet/useUnstakeForm';
 import { selectLanguage } from 'src/reducers/suite/suiteReducer';
@@ -133,7 +133,7 @@ export const UnstakeInputs = () => {
                     ),
                 }}
                 fiatValue={
-                    <FiatValue amount={amount} symbol={symbol} showApproximationIndicator>
+                    <BaseCurrencyValue amount={amount} symbol={symbol} showApproximationIndicator>
                         {({ value }) =>
                             value ? (
                                 <Text typographyStyle="label" variant="tertiary">
@@ -141,7 +141,7 @@ export const UnstakeInputs = () => {
                                 </Text>
                             ) : null
                         }
-                    </FiatValue>
+                    </BaseCurrencyValue>
                 }
                 options={[
                     {
@@ -169,14 +169,14 @@ export const UnstakeInputs = () => {
                                     symbol={symbol}
                                 />
                                 <Text typographyStyle="hint">
-                                    <FiatValue amount={depositedBalance} symbol={symbol}>
+                                    <BaseCurrencyValue amount={depositedBalance} symbol={symbol}>
                                         {({ value }) => value && <span>{value}</span>}
-                                    </FiatValue>
+                                    </BaseCurrencyValue>
                                     {isRewardsVisible && (
                                         <>
                                             {' + '}
                                             <Text variant="primary">
-                                                <FiatValue
+                                                <BaseCurrencyValue
                                                     amount={restakedReward}
                                                     symbol={symbol}
                                                 />
@@ -202,7 +202,10 @@ export const UnstakeInputs = () => {
                                               symbol={symbol}
                                           />
                                           <Text variant="primary">
-                                              <FiatValue amount={restakedReward} symbol={symbol} />
+                                              <BaseCurrencyValue
+                                                  amount={restakedReward}
+                                                  symbol={symbol}
+                                              />
                                           </Text>
                                       </Column>
                                   ),

--- a/packages/suite/src/components/wallet/Fees/CustomFee/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CustomFee.tsx
@@ -15,7 +15,7 @@ import { Column, Row, Text } from '@trezor/components';
 import { PrecomposedTransactionCardano } from '@trezor/connect';
 import { spacings } from '@trezor/theme';
 
-import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
+import { BaseCurrencyValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
 import { useTranslation } from 'src/hooks/suite';
 import { TranslationFunction } from 'src/hooks/suite/useTranslation';
 
@@ -147,7 +147,7 @@ export const CustomFee = <TFieldValues extends FormState>({
                                 variant="tertiary"
                                 typographyStyle="hint"
                             >
-                                <FiatValue
+                                <BaseCurrencyValue
                                     disableHiddenPlaceholder
                                     amount={cachedNetworkAmount}
                                     symbol={symbol}

--- a/packages/suite/src/components/wallet/Fees/StandardFee/BitcoinFeeCards.tsx
+++ b/packages/suite/src/components/wallet/Fees/StandardFee/BitcoinFeeCards.tsx
@@ -4,7 +4,7 @@ import { getFeeUnits } from '@suite-common/wallet-utils';
 import { FeeRate } from '@trezor/product-components';
 
 import { Translation } from 'src/components/suite';
-import { FiatValue } from 'src/components/suite/FiatValue';
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
 import { useLocales, useSelector } from 'src/hooks/suite';
 
 import { FeeCard } from './FeeCard';
@@ -56,7 +56,7 @@ export const BitcoinFeeCards = ({
                         topRightChild={getTimeEstimate(fee)}
                         bottomLeftChild={
                             <span data-testid={`@fee-card/${fee.value}-fiat-amount`}>
-                                <FiatValue
+                                <BaseCurrencyValue
                                     disableHiddenPlaceholder
                                     amount={fee?.networkAmount ?? ''}
                                     symbol={symbol}

--- a/packages/suite/src/components/wallet/Fees/StandardFee/EthereumFeeCards.tsx
+++ b/packages/suite/src/components/wallet/Fees/StandardFee/EthereumFeeCards.tsx
@@ -7,7 +7,7 @@ import { Badge, Grid, Row, Text } from '@trezor/components';
 import { FeeRate } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
-import { FiatValue, Translation } from 'src/components/suite';
+import { BaseCurrencyValue, Translation } from 'src/components/suite';
 import { useLocales, useSelector } from 'src/hooks/suite';
 import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 
@@ -71,7 +71,7 @@ export const EthereumFeeCards = ({
                         topRightChild={getTimeEstimate(fee)}
                         bottomLeftChild={
                             <span data-testid={`@fee-card/${fee.value}-fiat-amount`}>
-                                <FiatValue
+                                <BaseCurrencyValue
                                     disableHiddenPlaceholder
                                     amount={fee.networkAmount || ''}
                                     symbol={symbol}

--- a/packages/suite/src/components/wallet/Fees/StandardFee/MiscFeeCards.tsx
+++ b/packages/suite/src/components/wallet/Fees/StandardFee/MiscFeeCards.tsx
@@ -2,7 +2,7 @@ import { selectAreFeesLoading } from '@suite-common/wallet-core';
 import { getFeeUnits } from '@suite-common/wallet-utils';
 import { Text } from '@trezor/components';
 
-import { FiatValue, Translation } from 'src/components/suite';
+import { BaseCurrencyValue, Translation } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 
 import { FeeCard } from './FeeCard';
@@ -38,7 +38,7 @@ export const MiscFeeCards = ({
                     </span>
                 }
                 bottomLeftChild={
-                    <FiatValue
+                    <BaseCurrencyValue
                         disableHiddenPlaceholder
                         amount={fee.networkAmount || ''}
                         symbol={symbol}

--- a/packages/suite/src/components/wallet/FiatHeader.tsx
+++ b/packages/suite/src/components/wallet/FiatHeader.tsx
@@ -69,8 +69,8 @@ export const FiatHeader = ({
 }: FiatHeaderProps) => {
     const language = useSelector(selectLanguage);
     const fiatAmount = useFiatAmount({ amount, symbol });
-    const { FiatAmountFormatter } = useFormatters();
-    const formattedAmount = FiatAmountFormatter({
+    const { BaseCurrencyAmountFormatter } = useFormatters();
+    const formattedAmount = BaseCurrencyAmountFormatter({
         value: fiatAmount ?? '0',
         currency: localCurrency,
     });

--- a/packages/suite/src/components/wallet/TransactionItem/CoinjoinBatchItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/CoinjoinBatchItem.tsx
@@ -108,7 +108,7 @@ export const CoinjoinBatchItem = ({
     isPending,
 }: CoinjoinBatchItemProps) => {
     const lastTx = transactions[0];
-    const { FiatAmountFormatter } = useFormatters();
+    const { BaseCurrencyAmountFormatter } = useFormatters();
     const historicFiatRates = useSelector(selectHistoricFiatRates);
     const amount = sumTransactions(transactions);
     const fiatAmount = sumTransactionsFiat(transactions, localCurrency, historicFiatRates);
@@ -152,7 +152,7 @@ export const CoinjoinBatchItem = ({
                                     fiatAmount={
                                         !isTestnet(lastTx.symbol) && !isMissingFiatRates ? (
                                             <HiddenPlaceholder>
-                                                <FiatAmountFormatter
+                                                <BaseCurrencyAmountFormatter
                                                     currency={localCurrency}
                                                     value={fiatAmount.absoluteValue().toFixed()}
                                                 />

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionRow.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionRow.tsx
@@ -9,7 +9,7 @@ import {
 } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
+import { BaseCurrencyValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { ExtendedMessageDescriptor } from 'src/types/suite';
 import { WalletAccountTransaction } from 'src/types/wallet';
@@ -52,7 +52,7 @@ export const CustomRow = ({
             }
             fiatAmount={
                 useFiatValues ? (
-                    <FiatValue
+                    <BaseCurrencyValue
                         amount={amount}
                         symbol={transaction.symbol}
                         historicRate={historicRate}
@@ -146,7 +146,7 @@ export const CoinjoinRow = ({
         <TransactionTargetLayout
             fiatAmount={
                 useFiatValues ? (
-                    <FiatValue
+                    <BaseCurrencyValue
                         amount={formatNetworkAmount(
                             new BigNumber(transaction.amount).abs().toString(),
                             transaction.symbol,

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -15,7 +15,7 @@ import { copyToClipboard } from '@trezor/dom-utils';
 
 import {
     AddressLabeling,
-    FiatValue,
+    BaseCurrencyValue,
     FormattedCryptoAmount,
     MetadataLabeling,
     Translation,
@@ -108,7 +108,7 @@ export const TransactionTarget = ({
     const fiatAmountComponent = useMemo(
         () =>
             !isTestnet(transaction.symbol) && amount ? (
-                <FiatValue
+                <BaseCurrencyValue
                     amount={amount}
                     symbol={transaction.symbol}
                     historicRate={historicRate}

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { Column, TOOLTIP_DELAY_NORMAL, Tooltip } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
+import { exhaustive } from '@trezor/type-utils';
 
 import { useGoToWithAnalytics } from 'src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics';
 import { NavigationItemBase } from 'src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem';
@@ -82,6 +83,8 @@ export const AccountItem = forwardRef(
                     return 'wallet-staking';
                 case 'tokens':
                     return 'wallet-tokens';
+                default:
+                    return exhaustive(type);
             }
         };
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItemContent.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItemContent.tsx
@@ -18,8 +18,8 @@ import { spacings } from '@trezor/theme';
 
 import {
     AccountLabel,
+    BaseCurrencyValue,
     CoinBalance,
-    FiatValue,
     HiddenPlaceholder,
     Translation,
 } from 'src/components/suite';
@@ -67,7 +67,7 @@ export const AccountItemContent = ({
     dataTestKey,
     isFiatLoading,
 }: ItemContentProps) => {
-    const { FiatAmountFormatter } = useFormatters();
+    const { BaseCurrencyAmountFormatter } = useFormatters();
     const localCurrency = useSelector(selectLocalCurrency);
     const discreetMode = useSelector(selectIsDiscreteModeActive);
     const { shouldAnimate } = useLoadingSkeleton();
@@ -96,7 +96,7 @@ export const AccountItemContent = ({
                         {isFiatLoading ? (
                             <SkeletonRectangle animate={shouldAnimate} />
                         ) : (
-                            <FiatAmountFormatter
+                            <BaseCurrencyAmountFormatter
                                 value={customFiatValue}
                                 currency={localCurrency}
                                 minimumFractionDigits={0}
@@ -105,7 +105,7 @@ export const AccountItemContent = ({
                         )}
                     </HiddenPlaceholder>
                 ) : (
-                    <FiatValue
+                    <BaseCurrencyValue
                         amount={formattedBalance}
                         symbol={symbol}
                         fiatAmountFormatterOptions={{
@@ -114,7 +114,7 @@ export const AccountItemContent = ({
                         }}
                     >
                         {FiatValueRenderComponent}
-                    </FiatValue>
+                    </BaseCurrencyValue>
                 )}
             </Row>
             {isBalanceShown && type !== 'tokens' && (

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItemContent.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItemContent.tsx
@@ -75,7 +75,8 @@ export const AccountItemContent = ({
     const isBalanceShown = account.backendType !== 'coinjoin' || account.status !== 'initial';
 
     return (
-        // content is constant size in discreet mode, so overflow: hidden is unnecessary. Though it would cut off CSS blur effect, so we may turn it off
+        // Content is constant size in discreet mode, so overflow: hidden is unnecessary.
+        // Though it would cut off CSS blur effect, so we may turn it off
         <Column flex="1" overflow={discreetMode ? 'visible' : 'hidden'} gap={spacings.xxxs}>
             <Row gap={spacings.md} margin={{ right: spacings.xxs }} justifyContent="space-between">
                 <AccountLabelContainer data-testid={`${dataTestKey}/label`}>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItemLeft.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItemLeft.tsx
@@ -1,6 +1,7 @@
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { Column, Icon } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
+import { exhaustive } from '@trezor/type-utils';
 
 import { Account, AccountItemType } from '../../../../../types/wallet';
 import { TokenIconSetWrapper } from '../../../TokenIconSetWrapper';
@@ -23,5 +24,7 @@ export const AccountItemLeft = ({ type, symbol, account }: AccountItemLeftProps)
             return <Icon name="piggyBankFilled" variant="tertiary" />;
         case 'tokens':
             return <TokenIconSetWrapper accounts={[account]} symbol={account.symbol} />;
+        default:
+            return exhaustive(type);
     }
 };

--- a/packages/suite/src/hooks/suite/useFormattersConfig.ts
+++ b/packages/suite/src/hooks/suite/useFormattersConfig.ts
@@ -7,11 +7,11 @@ import { selectLanguage } from 'src/reducers/suite/suiteReducer';
 export const useFormattersConfig = (): FormatterProviderConfig => {
     const locale = useSelector(selectLanguage);
     const bitcoinAmountUnit = useSelector(state => state.wallet.settings.bitcoinAmountUnit);
-    const fiatCurrency = useSelector(selectLocalCurrency);
+    const baseCurrency = useSelector(selectLocalCurrency);
 
     return {
         locale,
-        fiatCurrency,
+        baseCurrency,
         bitcoinAmountUnit,
         is24HourFormat: true,
     };

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -46,6 +46,7 @@ export type {
     RbfTransactionParams,
     ReceiveInfo,
 } from '@suite-common/wallet-types';
+
 export type { WalletParams } from 'src/utils/suite/router';
 export type AccountItemType = 'coin' | 'tokens' | 'staking';
 

--- a/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCardTokensAndStakingInfo.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCardTokensAndStakingInfo.tsx
@@ -3,7 +3,12 @@ import { Account } from '@suite-common/wallet-types';
 import { Column, Divider, Icon, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { CoinBalance, FiatValue, HiddenPlaceholder, Translation } from 'src/components/suite';
+import {
+    BaseCurrencyValue,
+    CoinBalance,
+    HiddenPlaceholder,
+    Translation,
+} from 'src/components/suite';
 import { TokenIconSetWrapper } from 'src/components/wallet/TokenIconSetWrapper';
 
 type AssetCardTokensAndStakingInfoProps = {
@@ -44,7 +49,7 @@ export const AssetCardTokensAndStakingInfo = ({
                             </Text>
                         </HiddenPlaceholder>
                         <HiddenPlaceholder>
-                            <FiatValue amount={assetStakingBalance} symbol={symbol} />
+                            <BaseCurrencyValue amount={assetStakingBalance} symbol={symbol} />
                         </HiddenPlaceholder>
                     </>
                 )}
@@ -61,7 +66,7 @@ export const AssetCardTokensAndStakingInfo = ({
                         <Translation id="TR_NAV_TOKENS" />
                     </Text>
                 </Row>
-                <FiatValue
+                <BaseCurrencyValue
                     amount={tokensFiatBalance ?? '0'}
                     symbol={symbol}
                     shouldConvert={false}

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
@@ -17,8 +17,8 @@ import { spacings } from '@trezor/theme';
 import { goto } from 'src/actions/suite/routerActions';
 import {
     AmountUnitSwitchWrapper,
+    BaseCurrencyValue,
     CoinBalance,
-    FiatValue,
     PriceTicker,
     Translation,
     TrendTicker,
@@ -150,7 +150,10 @@ export const AssetRow = memo(
                                 gap={spacings.xxxs}
                                 data-testid={`@dashboard/asset/${symbol}/fiat-amount`}
                             >
-                                <FiatValue amount={assetNativeCryptoBalance} symbol={symbol} />
+                                <BaseCurrencyValue
+                                    amount={assetNativeCryptoBalance}
+                                    symbol={symbol}
+                                />
 
                                 <Text typographyStyle="hint" color={theme.textSubdued}>
                                     <AmountUnitSwitchWrapper symbol={symbol}>

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetStakingRow.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetStakingRow.tsx
@@ -2,7 +2,12 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 import { Column, Icon, Table, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { CoinBalance, FiatValue, HiddenPlaceholder, Translation } from 'src/components/suite';
+import {
+    BaseCurrencyValue,
+    CoinBalance,
+    HiddenPlaceholder,
+    Translation,
+} from 'src/components/suite';
 
 import { AssetTableExtraRowsSection as Section } from './AssetTableExtraRowsSection';
 
@@ -33,7 +38,7 @@ export const AssetStakingRow = ({
                 {stakingTotalBalance && (
                     <Column alignItems="flex-start" justifyContent="center" gap={spacings.xxxs}>
                         <HiddenPlaceholder>
-                            <FiatValue amount={stakingTotalBalance} symbol={symbol} />
+                            <BaseCurrencyValue amount={stakingTotalBalance} symbol={symbol} />
                         </HiddenPlaceholder>
                         <HiddenPlaceholder>
                             <Text typographyStyle="hint" variant="tertiary">

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetTokenRow.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetTokenRow.tsx
@@ -2,7 +2,7 @@ import { Network } from '@suite-common/wallet-config';
 import { Table } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { FiatValue, Translation } from 'src/components/suite';
+import { BaseCurrencyValue, Translation } from 'src/components/suite';
 
 import { AssetTableExtraRowsSection as Section } from './AssetTableExtraRowsSection';
 
@@ -28,7 +28,7 @@ export const AssetTokenRow = ({
                 <Translation id="TR_NAV_TOKENS" />
             </Table.Cell>
             <Table.Cell colSpan={4}>
-                <FiatValue
+                <BaseCurrencyValue
                     amount={tokensDisplayFiatBalance ?? '0'}
                     symbol={network.symbol}
                     shouldConvert={false}

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
@@ -10,7 +10,7 @@ import { borders, spacings, spacingsPx, typography } from '@trezor/theme';
 
 import { openModal } from 'src/actions/suite/modalActions';
 import {
-    FiatValue,
+    BaseCurrencyValue,
     FormattedCryptoAmount,
     MetadataLabeling,
     Translation,
@@ -119,7 +119,7 @@ const TransactionDetailButton = styled(TextButton)`
     }
 `;
 
-const StyledFiatValue = styled(FiatValue)`
+const StyledFiatValue = styled(BaseCurrencyValue)`
     margin-left: auto;
     padding-left: ${spacingsPx.xxs};
     color: ${({ theme }) => theme.textSubdued};

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
@@ -15,7 +15,7 @@ import { NumberInput } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { FiatValue, Translation } from 'src/components/suite';
+import { BaseCurrencyValue, Translation } from 'src/components/suite';
 import { useLayoutSize, useSelector, useTranslation } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
@@ -174,7 +174,7 @@ export const Amount = ({ output, outputId }: AmountProps) => {
                 />
 
                 {isWithRate && (
-                    <FiatValue amount="1" symbol={symbol}>
+                    <BaseCurrencyValue amount="1" symbol={symbol}>
                         {({ rate }) =>
                             rate && (
                                 <>
@@ -194,7 +194,7 @@ export const Amount = ({ output, outputId }: AmountProps) => {
                                 </>
                             )
                         }
-                    </FiatValue>
+                    </BaseCurrencyValue>
                 )}
             </Flex>
 

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
@@ -43,7 +43,7 @@ import { spacings } from '@trezor/theme';
 import { SUITE } from 'src/actions/suite/constants';
 import { copyAddressToClipboard, showCopyAddressModal } from 'src/actions/suite/copyAddressActions';
 import {
-    FiatValue,
+    BaseCurrencyValue,
     FormattedCryptoAmount,
     HiddenPlaceholder,
     Translation,
@@ -355,7 +355,7 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
                                             contractAddress={selectedToken?.contract}
                                         />
                                     </HiddenPlaceholder>{' '}
-                                    <FiatValue
+                                    <BaseCurrencyValue
                                         tokenAddress={selectedToken?.contract as TokenAddress}
                                         amount={selectedToken?.balance || account.formattedBalance}
                                         symbol={account.symbol}

--- a/packages/suite/src/views/wallet/send/TotalSent/TotalSent.tsx
+++ b/packages/suite/src/views/wallet/send/TotalSent/TotalSent.tsx
@@ -7,7 +7,7 @@ import { formatAmount, formatNetworkAmount } from '@suite-common/wallet-utils';
 import { Card, Column, InfoItem, SkeletonRectangle } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
+import { BaseCurrencyValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 
@@ -93,7 +93,7 @@ export const TotalSent = () => {
                                         contractAddress={tokenInfo.contract}
                                     />
                                 ) : (
-                                    <FiatValue
+                                    <BaseCurrencyValue
                                         disableHiddenPlaceholder
                                         amount={formatNetworkAmount(
                                             transactionInfo.totalSpent,

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/components/Rewards/RewardsList.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/components/Rewards/RewardsList.tsx
@@ -8,7 +8,7 @@ import { spacings } from '@trezor/theme';
 
 import { DashboardSection } from 'src/components/dashboard';
 import {
-    FiatValue,
+    BaseCurrencyValue,
     FormattedCryptoAmount,
     FormattedDate,
     HiddenPlaceholder,
@@ -130,7 +130,7 @@ export const RewardsList = ({ account }: RewardsListProps) => {
                                             </HiddenPlaceholder>
                                             <HiddenPlaceholder>
                                                 <Text typographyStyle="hint" variant="tertiary">
-                                                    <FiatValue
+                                                    <BaseCurrencyValue
                                                         amount={formatNetworkAmount(
                                                             reward?.amount,
                                                             account.symbol,

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ClaimCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ClaimCard.tsx
@@ -8,7 +8,7 @@ import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { openModal } from 'src/actions/suite/modalActions';
-import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
+import { BaseCurrencyValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
@@ -73,7 +73,7 @@ export const ClaimCard = () => {
                 <FormattedCryptoAmount value={claimableAmount} symbol={selectedAccount?.symbol} />
             </Paragraph>
             <Paragraph typographyStyle="hint" variant="tertiary">
-                <FiatValue
+                <BaseCurrencyValue
                     showApproximationIndicator
                     amount={claimableAmount}
                     symbol={selectedAccount?.symbol}

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
@@ -28,7 +28,7 @@ import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { openModal } from 'src/actions/suite/modalActions';
-import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
+import { BaseCurrencyValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
 import { useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
@@ -75,9 +75,13 @@ const Item = ({
                     />
                 </Paragraph>
                 <Paragraph typographyStyle="hint" variant="tertiary">
-                    <FiatValue amount={fiatAmount} symbol={symbol} showApproximationIndicator>
+                    <BaseCurrencyValue
+                        amount={fiatAmount}
+                        symbol={symbol}
+                        showApproximationIndicator
+                    >
                         {({ value }) => (value ? <span>{value}</span> : null)}
-                    </FiatValue>
+                    </BaseCurrencyValue>
                 </Paragraph>
             </>
         )}

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -44,7 +44,7 @@ import { goto } from 'src/actions/suite/routerActions';
 import { showAddress } from 'src/actions/wallet/receiveActions';
 import {
     Address,
-    FiatValue,
+    BaseCurrencyValue,
     FormattedCryptoAmount,
     PriceTicker,
     Translation,
@@ -214,7 +214,7 @@ export const TokenRow = ({
             <Table.Cell>
                 <Column alignItems="flex-start">
                     {!hideRates && (
-                        <FiatValue
+                        <BaseCurrencyValue
                             amount={token.balance || ''}
                             symbol={network.symbol}
                             tokenAddress={token.contract as TokenAddress}

--- a/packages/suite/src/views/wallet/trading/common/TradingBalance.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingBalance.tsx
@@ -3,7 +3,7 @@ import { TokenAddress } from '@suite-common/wallet-types';
 import { amountToSmallestUnit } from '@suite-common/wallet-utils';
 import { Text } from '@trezor/components';
 
-import { FiatValue, HiddenPlaceholder, Translation } from 'src/components/suite';
+import { BaseCurrencyValue, HiddenPlaceholder, Translation } from 'src/components/suite';
 import { useFiatFromCryptoValue } from 'src/hooks/suite/useFiatFromCryptoValue';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { TradingAccountOptionsGroupOptionProps } from 'src/types/trading/trading';
@@ -63,7 +63,7 @@ export const TradingBalance = ({
                     stringBalance &&
                     fiatAmount &&
                     symbol && (
-                        <FiatValue
+                        <BaseCurrencyValue
                             amount={stringBalance}
                             symbol={symbol}
                             tokenAddress={tokenAddress}
@@ -84,9 +84,11 @@ export const TradingBalance = ({
             {stringBalance && fiatAmount && symbol && stringBalance !== '0' && (
                 <>
                     {' '}
-                    (
-                    <FiatValue amount={stringBalance} symbol={symbol} tokenAddress={tokenAddress} />
-                    )
+                    <BaseCurrencyValue
+                        amount={stringBalance}
+                        symbol={symbol}
+                        tokenAddress={tokenAddress}
+                    />
                 </>
             )}
         </Text>

--- a/packages/suite/src/views/wallet/trading/common/TradingFiatAmount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingFiatAmount.tsx
@@ -6,10 +6,10 @@ interface TradingFiatAmountProps {
 }
 
 export const TradingFiatAmount = ({ amount, currency }: TradingFiatAmountProps) => {
-    const { FiatAmountFormatter } = useFormatters();
+    const { BaseCurrencyAmountFormatter } = useFormatters();
 
     if (amount) {
-        return <FiatAmountFormatter value={amount} currency={currency} />;
+        return <BaseCurrencyAmountFormatter value={amount} currency={currency} />;
     }
 
     return <>{currency?.toUpperCase()}</>;

--- a/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingExchangeHeaderSummary.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingExchangeHeaderSummary.tsx
@@ -9,7 +9,7 @@ import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { H3, Icon, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
+import { BaseCurrencyValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { TradingCryptoAmount } from 'src/views/wallet/trading/common/TradingCryptoAmount';
@@ -69,7 +69,7 @@ export const TradingExchangeHeaderSummary = ({
                             />
                         ),
                         feeAmountFiat: (
-                            <FiatValue
+                            <BaseCurrencyValue
                                 disableHiddenPlaceholder
                                 amount={feeAmount}
                                 symbol={symbol}

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/BalancePrivacyBreakdown/CryptoAmountWithHeader.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/BalancePrivacyBreakdown/CryptoAmountWithHeader.tsx
@@ -6,7 +6,7 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { variables } from '@trezor/components';
 
-import { FiatValue } from 'src/components/suite/FiatValue';
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 
 const Container = styled.div`
@@ -60,7 +60,7 @@ export const CryptoAmountWithHeader = ({
         </Header>
 
         <CryptoAmount value={formatNetworkAmount(value, symbol)} symbol={symbol} $color={color} />
-        <FiatValue
+        <BaseCurrencyValue
             amount={formatNetworkAmount(value, symbol)}
             symbol={symbol}
             showApproximationIndicator

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/DayHeader.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/DayHeader.tsx
@@ -30,7 +30,7 @@ export const DayHeader = ({
     isMissingFiatRates,
     isHovered,
 }: DayHeaderProps) => {
-    const { FiatAmountFormatter } = useFormatters();
+    const { BaseCurrencyAmountFormatter } = useFormatters();
 
     const parsedDate = parseTransactionDateKey(dateKey);
     const showFiatValue = !isTestnet(symbol);
@@ -60,7 +60,7 @@ export const DayHeader = ({
                 <ColFiat>
                     <HiddenPlaceholder>
                         {totalFiatAmountPerDay.gt(0) && <span>+</span>}
-                        <FiatAmountFormatter
+                        <BaseCurrencyAmountFormatter
                             currency={localCurrency}
                             value={totalFiatAmountPerDay.toFixed()}
                         />

--- a/packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx
@@ -70,7 +70,7 @@ export const SummaryCards = ({
     isLoading,
     className,
 }: SummaryCardProps) => {
-    const { FiatAmountFormatter } = useFormatters();
+    const { BaseCurrencyAmountFormatter } = useFormatters();
     const [fromTimestamp, toTimestamp] = dataInterval;
     // aggregate values from shown graph data
     const numOfTransactions = data.reduce((acc, d) => (acc += d.txs), 0) || account.history.total;
@@ -115,7 +115,7 @@ export const SummaryCards = ({
                         value={totalReceivedAmount.toFixed()}
                         secondaryValue={
                             totalReceivedFiatMap[localCurrency] ? (
-                                <FiatAmountFormatter
+                                <BaseCurrencyAmountFormatter
                                     currency={localCurrency}
                                     value={totalReceivedFiatMap[localCurrency]!}
                                 />
@@ -130,7 +130,7 @@ export const SummaryCards = ({
                         value={totalSentAmount.negated().toFixed()}
                         secondaryValue={
                             totalSentFiatMap[localCurrency] ? (
-                                <FiatAmountFormatter
+                                <BaseCurrencyAmountFormatter
                                     currency={localCurrency}
                                     value={totalSentFiatMap[localCurrency]!}
                                 />

--- a/suite-common/formatters/src/FormatterProvider.tsx
+++ b/suite-common/formatters/src/FormatterProvider.tsx
@@ -9,6 +9,10 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 import { NetworkNameFormatter } from './formatters/NetworkNameFormatter';
 import { SignValueFormatter } from './formatters/SignValueFormatter';
 import {
+    FiatAmountFormatterDataContext,
+    prepareBaseCurrencyAmountFormatter,
+} from './formatters/prepareBaseCurrencyAmountFormatter';
+import {
     CryptoAmountFormatterDataContext,
     CryptoAmountFormatterInputValue,
     prepareCryptoAmountFormatter,
@@ -19,10 +23,6 @@ import {
     DisplaySymbolFormatterDataContext,
     prepareDisplaySymbolFormatter,
 } from './formatters/prepareDisplaySymbolFormatter';
-import {
-    FiatAmountFormatterDataContext,
-    prepareFiatAmountFormatter,
-} from './formatters/prepareFiatAmountFormatter';
 import { MonthNameFormatter } from './formatters/prepareMonthNameFormatter';
 import { prepareTimeFormatter } from './formatters/prepareTimeFormatter';
 import { Formatter } from './makeFormatter';
@@ -42,7 +42,7 @@ export type Formatters = {
     DisplaySymbolFormatter: Formatter<NetworkSymbol, string, DisplaySymbolFormatterDataContext>;
     NetworkNameFormatter: Formatter<NetworkSymbol, string>;
     SignValueFormatter: Formatter<SignValue | undefined, string>;
-    FiatAmountFormatter: Formatter<
+    BaseCurrencyAmountFormatter: Formatter<
         string | number,
         string | null,
         FiatAmountFormatterDataContext<FormatNumberOptions>
@@ -58,7 +58,7 @@ export const FormatterProviderContext = createContext<Formatters>({} as Formatte
 export const getFormatters = (config: FormatterConfig): Formatters => {
     const CryptoAmountFormatter = prepareCryptoAmountFormatter(config);
     const DisplaySymbolFormatter = prepareDisplaySymbolFormatter(config);
-    const FiatAmountFormatter = prepareFiatAmountFormatter(config);
+    const BaseCurrencyAmountFormatter = prepareBaseCurrencyAmountFormatter(config);
     const DateFormatter = prepareDateFormatter(config);
     const TimeFormatter = prepareTimeFormatter(config);
     const DateTimeFormatter = prepareDateTimeFormatter(config);
@@ -67,7 +67,7 @@ export const getFormatters = (config: FormatterConfig): Formatters => {
         CryptoAmountFormatter,
         DisplaySymbolFormatter,
         NetworkNameFormatter,
-        FiatAmountFormatter,
+        BaseCurrencyAmountFormatter,
         DateFormatter,
         SignValueFormatter,
         TimeFormatter,

--- a/suite-common/formatters/src/formatters/prepareBaseCurrencyAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareBaseCurrencyAmountFormatter.ts
@@ -15,17 +15,17 @@ const handleBigNumberFormatting = (
     dataContext: FiatAmountFormatterDataContext<FormatNumberOptions>,
     config: FormatterConfig,
 ) => {
-    const { intl, fiatCurrency } = config;
+    const { intl, baseCurrency } = config;
     const { style, currency, minimumFractionDigits, maximumFractionDigits } = dataContext;
-    const fiatValue = new BigNumber(value);
-    const currencyForDisplay = currency ?? fiatCurrency;
+    const baseCurrencyValue = new BigNumber(value);
+    const currencyForDisplay = currency ?? baseCurrency;
 
-    if (fiatValue.gt(Number.MAX_VALUE)) {
-        // backup when number is too big, the formatting is different than should be for currencies
+    if (baseCurrencyValue.gt(Number.MAX_VALUE)) {
+        // backup when number is too big, the formatting is different from what should be for currencies
         return `${value} ${currencyForDisplay}`;
     }
 
-    return intl.formatNumber(fiatValue.toNumber(), {
+    return intl.formatNumber(baseCurrencyValue.toNumber(), {
         ...dataContext,
         style: style || 'currency',
         currency: currencyForDisplay,
@@ -34,14 +34,14 @@ const handleBigNumberFormatting = (
     });
 };
 
-export const prepareFiatAmountFormatter = (config: FormatterConfig) =>
+export const prepareBaseCurrencyAmountFormatter = (config: FormatterConfig) =>
     makeFormatter<
         string | number,
         string | null,
         FiatAmountFormatterDataContext<FormatNumberOptions>
     >((value, dataContext, shouldRedactNumbers) => {
-        const fiatValue = new BigNumber(value);
-        if (fiatValue.isNaN()) {
+        const baseValue = new BigNumber(value);
+        if (baseValue.isNaN()) {
             return null;
         }
 

--- a/suite-common/formatters/src/tests/MockedFormatterProvider.tsx
+++ b/suite-common/formatters/src/tests/MockedFormatterProvider.tsx
@@ -14,7 +14,7 @@ export const MockedFormatterProvider = ({ children }: MockedFormatterProviderPro
 
     const formatters = getFormatters({
         locale: 'en',
-        fiatCurrency: 'usd',
+        baseCurrency: 'usd',
         bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN,
         intl,
         is24HourFormat: true,

--- a/suite-common/formatters/src/types.ts
+++ b/suite-common/formatters/src/types.ts
@@ -6,7 +6,7 @@ import { PROTO } from '@trezor/connect';
 export type FormatterProviderConfig = {
     locale: string;
     bitcoinAmountUnit: PROTO.AmountUnit;
-    fiatCurrency: BaseCurrencyCode;
+    baseCurrency: BaseCurrencyCode;
     is24HourFormat: boolean;
 };
 

--- a/suite-common/wallet-utils/src/discreetModeUtils.ts
+++ b/suite-common/wallet-utils/src/discreetModeUtils.ts
@@ -3,6 +3,7 @@ import { createContext, useContext } from 'react';
 export const DISCREET_PLACEHOLDER = '###';
 
 const numericalSubstringRegex = /[\d\-.,]*\d+[.\d]*/g;
+
 /**
  * Search the input for all numerical substrings and replace them with DISCREET_PLACEHOLDER.
  * @param value whole string value, usually number with symbol, or just number
@@ -14,14 +15,14 @@ export const redactNumericalSubstring = (value: string | number): string =>
 type RedactNumbersContextData = { shouldRedactNumbers: boolean };
 
 /**
- * Context to inform all components in tree below that they should redact numbers in the displayed output.
+ * Context to inform all components in a tree below that they should redact numbers in the displayed output.
  */
 export const RedactNumbersContext = createContext<RedactNumbersContextData>({
     shouldRedactNumbers: false,
 });
 
 /**
- * Determine whether we are under a component which currently requests to redact the numbers for discreet mode.
+ * Determine whether we are under a component that currently requests to redact the numbers for discreet mode.
  * It may only return true if the component is wrapped in HiddenPlaceholder upstream.
  * See also a helper RedactNumericalValue
  * @returns shouldRedactNumbers whether numbers should be redacted in displayed output

--- a/suite-native/accounts/src/components/AccountSectionTitle.tsx
+++ b/suite-native/accounts/src/components/AccountSectionTitle.tsx
@@ -5,7 +5,7 @@ import { selectCurrentFiatRates, selectLocalCurrency } from '@suite-common/walle
 import { Account } from '@suite-common/wallet-types';
 import { getAccountFiatBalance } from '@suite-common/wallet-utils';
 import { HStack, Text, VStack } from '@suite-native/atoms';
-import { CryptoAmountFormatter, FiatAmountFormatter } from '@suite-native/formatters';
+import { BaseCurrencyAmountFormatter, CryptoAmountFormatter } from '@suite-native/formatters';
 import {
     NativeStakingRootState,
     doesCoinSupportStaking,
@@ -40,7 +40,7 @@ export const AccountSectionTitle: React.FC<AccountSectionTitleProps> = ({
 
             {hasAnyKnownTokens && (
                 <VStack spacing={0} alignItems="flex-end">
-                    <FiatAmountFormatter
+                    <BaseCurrencyAmountFormatter
                         numberOfLines={1}
                         adjustsFontSizeToFit
                         value={fiatBalance}

--- a/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
@@ -5,9 +5,9 @@ import { AccountsRootState, selectFormattedAccountType } from '@suite-common/wal
 import { Account, AccountKey } from '@suite-common/wallet-types';
 import { Badge } from '@suite-native/atoms';
 import {
+    BaseCurrencyAmountFormatter,
     CryptoAmountFormatter,
     CryptoToFiatAmountFormatter,
-    FiatAmountFormatter,
     NetworkDisplaySymbolNameFormatter,
 } from '@suite-native/formatters';
 import { CryptoIcon, CryptoIconWithNetwork } from '@suite-native/icons';
@@ -127,7 +127,7 @@ export const AccountsListItem = ({
             }
             mainValue={
                 shouldShowTokenBadge && fiatBalance !== undefined ? (
-                    <FiatAmountFormatter
+                    <BaseCurrencyAmountFormatter
                         numberOfLines={1}
                         adjustsFontSizeToFit
                         value={fiatBalance}

--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -8,7 +8,7 @@ import { useSelectorDeepComparison } from '@suite-common/redux-utils';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountsListItemBase, StakingBadge } from '@suite-native/accounts';
 import { Badge, Box, Text } from '@suite-native/atoms';
-import { CryptoAmountFormatter, FiatAmountFormatter } from '@suite-native/formatters';
+import { BaseCurrencyAmountFormatter, CryptoAmountFormatter } from '@suite-native/formatters';
 import { CryptoIconWithPercentage, Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import {
@@ -64,7 +64,7 @@ const CryptoAmount = React.memo(({ symbol }: AssetItemSubComponentProps) => {
 const FiatAmount = React.memo(({ symbol }: AssetItemSubComponentProps) => {
     const fiatValue = useSelector((state: AssetsRootState) => selectAssetFiatValue(state, symbol));
 
-    return <FiatAmountFormatter symbol={symbol} value={fiatValue} />;
+    return <BaseCurrencyAmountFormatter symbol={symbol} value={fiatValue} />;
 });
 
 const PercentageIcon = React.memo(({ symbol }: AssetItemSubComponentProps) => {

--- a/suite-native/device-manager/src/components/WalletItemBase.tsx
+++ b/suite-native/device-manager/src/components/WalletItemBase.tsx
@@ -1,7 +1,7 @@
 import { Pressable } from 'react-native';
 
 import { HStack, Radio, Text } from '@suite-native/atoms';
-import { FiatAmountFormatter } from '@suite-native/formatters';
+import { BaseCurrencyAmountFormatter } from '@suite-native/formatters';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -80,7 +80,7 @@ export const WalletItemBase = ({
                 </HStack>
                 <HStack alignItems="center" spacing="sp12">
                     {fiatBalance && (
-                        <FiatAmountFormatter
+                        <BaseCurrencyAmountFormatter
                             value={fiatBalance}
                             variant="hint"
                             color="textSubdued"

--- a/suite-native/formatters/src/components/BaseCurrencyAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/BaseCurrencyAmountFormatter.tsx
@@ -18,7 +18,7 @@ type FiatAmountFormatterProps = FormatterProps<string | null> &
         isLoading?: boolean;
     };
 
-export const FiatAmountFormatter = React.memo(
+export const BaseCurrencyAmountFormatter = React.memo(
     ({
         symbol,
         value,
@@ -27,7 +27,7 @@ export const FiatAmountFormatter = React.memo(
         isLoading = false,
         ...otherProps
     }: FiatAmountFormatterProps) => {
-        const { FiatAmountFormatter: formatter } = useFormatters();
+        const { BaseCurrencyAmountFormatter: formatter } = useFormatters();
 
         if (!!symbol && isTestnet(symbol)) {
             return <EmptyAmountText variant={variant} />;

--- a/suite-native/formatters/src/components/CryptoToFiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/CryptoToFiatAmountFormatter.tsx
@@ -3,7 +3,7 @@ import { TextProps } from '@suite-native/atoms';
 
 import { useFiatFromCryptoValue } from '../hooks/useFiatFromCryptoValue';
 import { FormatterProps } from '../types';
-import { FiatAmountFormatter } from './FiatAmountFormatter';
+import { BaseCurrencyAmountFormatter } from './BaseCurrencyAmountFormatter';
 
 type CryptoToFiatAmountFormatterProps = FormatterProps<string | number | null> &
     TextProps & {
@@ -33,7 +33,7 @@ export const CryptoToFiatAmountFormatter = ({
     });
 
     return (
-        <FiatAmountFormatter
+        <BaseCurrencyAmountFormatter
             symbol={symbol}
             value={fiatValue}
             isLoading={isLoading}

--- a/suite-native/formatters/src/components/FiatBalanceFormatter.tsx
+++ b/suite-native/formatters/src/components/FiatBalanceFormatter.tsx
@@ -26,7 +26,7 @@ export const FiatBalanceFormatter = ({
     testID,
 }: BalanceFormatterProps) => {
     const { applyStyle } = useNativeStyles();
-    const { FiatAmountFormatter: formatter } = useFormatters();
+    const { BaseCurrencyAmountFormatter: formatter } = useFormatters();
 
     if (!value) return <EmptyAmountText />;
 

--- a/suite-native/formatters/src/components/TokenToFiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/TokenToFiatAmountFormatter.tsx
@@ -34,7 +34,7 @@ export const TokenToFiatAmountFormatter = ({
     useHistoricRate,
     ...rest
 }: TokenToFiatAmountFormatterProps) => {
-    const { FiatAmountFormatter } = useFormatters();
+    const { BaseCurrencyAmountFormatter } = useFormatters();
     const fiatValue = useFiatFromCryptoValue({
         cryptoValue: String(value),
         symbol,
@@ -44,7 +44,7 @@ export const TokenToFiatAmountFormatter = ({
         useHistoricRate,
     });
 
-    const formattedFiatValue = FiatAmountFormatter.format(fiatValue ?? 0);
+    const formattedFiatValue = BaseCurrencyAmountFormatter.format(fiatValue ?? 0);
 
     return signValue ? (
         <Box flexDirection="row">

--- a/suite-native/formatters/src/hooks/useFormattersConfig.ts
+++ b/suite-native/formatters/src/hooks/useFormattersConfig.ts
@@ -9,16 +9,16 @@ import { selectBitcoinAmountUnit, selectLocalCurrency } from '@suite-common/wall
 const is24HourFormat = getCalendars()[0].uses24hourClock ?? true;
 
 export const useFormattersConfig = (): FormatterProviderConfig => {
-    const fiatCurrencyCode = useSelector(selectLocalCurrency);
+    const baseCurrencyCode = useSelector(selectLocalCurrency);
     const bitcoinAmountUnit = useSelector(selectBitcoinAmountUnit);
 
     return useMemo(
         () => ({
             locale: 'en',
-            fiatCurrency: fiatCurrencyCode,
+            baseCurrency: baseCurrencyCode,
             bitcoinAmountUnit,
             is24HourFormat,
         }),
-        [fiatCurrencyCode, bitcoinAmountUnit],
+        [baseCurrencyCode, bitcoinAmountUnit],
     );
 };

--- a/suite-native/formatters/src/index.ts
+++ b/suite-native/formatters/src/index.ts
@@ -5,7 +5,7 @@ export { AccountAddressFormatter } from './components/AccountAddressFormatter';
 export { FiatBalanceFormatter } from './components/FiatBalanceFormatter';
 export { TransactionIdFormatter } from './components/TransactionIdFormatter';
 export { PercentageDifferenceFormatter } from './components/PercentageDifferenceFormatter';
-export { FiatAmountFormatter } from './components/FiatAmountFormatter';
+export { BaseCurrencyAmountFormatter } from './components/BaseCurrencyAmountFormatter';
 export { CryptoAmountFormatter } from './components/CryptoAmountFormatter';
 export { NetworkDisplaySymbolNameFormatter } from './components/NetworkDisplaySymbolNameFormatter';
 export { TokenAmountFormatter } from './components/TokenAmountFormatter';

--- a/suite-native/graph/src/components/AxisLabel.tsx
+++ b/suite-native/graph/src/components/AxisLabel.tsx
@@ -4,7 +4,7 @@ import { Dimensions, View } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 
 import { useDiscreetMode } from '@suite-native/atoms';
-import { FiatAmountFormatter } from '@suite-native/formatters';
+import { BaseCurrencyAmountFormatter } from '@suite-native/formatters';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type AxisLabelProps = {
@@ -71,7 +71,11 @@ export const AxisLabel = ({ x, value }: AxisLabelProps) => {
             onLayout={handleLayoutOverflow}
             ref={viewRef}
         >
-            <FiatAmountFormatter value={String(value)} variant="label" color="textDisabled" />
+            <BaseCurrencyAmountFormatter
+                value={String(value)}
+                variant="label"
+                color="textDisabled"
+            />
         </View>
     );
 };

--- a/suite-native/module-accounts-management/src/components/CoinPriceCard.tsx
+++ b/suite-native/module-accounts-management/src/components/CoinPriceCard.tsx
@@ -4,7 +4,7 @@ import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { AccountKey } from '@suite-common/wallet-types';
 import { Box, Card, PriceChangeBadge, Text } from '@suite-native/atoms';
-import { FiatAmountFormatter } from '@suite-native/formatters';
+import { BaseCurrencyAmountFormatter } from '@suite-native/formatters';
 import { CryptoIconWithNetwork } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -80,7 +80,7 @@ export const CoinPriceCard = ({ accountKey }: CoinPriceCardProps) => {
                             values={{ coinName }}
                         />
                     </Text>
-                    <FiatAmountFormatter
+                    <BaseCurrencyAmountFormatter
                         symbol={symbol}
                         value={currentValue ? `${currentValue}` : null}
                         variant="titleSmall"

--- a/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.tsx
@@ -22,7 +22,7 @@ const asNonEmptyStringValue = (value: unknown): string => (value as string) ?? '
 const useMismatchedAmountMessage = (fieldName: keyof BuyFormValues) => {
     const { watch } = useBuyFormContext();
     const { translate } = useTranslate();
-    const { CryptoAmountFormatter, FiatAmountFormatter } = useFormatters();
+    const { CryptoAmountFormatter, BaseCurrencyAmountFormatter } = useFormatters();
     const { convertStrToBaseUnit } = useConvertFormValueToBaseUnit();
 
     const [asset, quote, amountInCrypto, value] = watch([
@@ -55,10 +55,10 @@ const useMismatchedAmountMessage = (fieldName: keyof BuyFormValues) => {
             isBalance: true,
         });
     } else if (!amountInCrypto && fieldName === 'fiatValue' && fiatStringAmount && fiatCurrency) {
-        requestedAmount = FiatAmountFormatter.format(asNonEmptyStringValue(value), {
+        requestedAmount = BaseCurrencyAmountFormatter.format(asNonEmptyStringValue(value), {
             currency: fiatCurrency,
         });
-        quoteAmount = FiatAmountFormatter.format(
+        quoteAmount = BaseCurrencyAmountFormatter.format(
             truncateDecimals(fiatStringAmount, MAX_FIAT_DECIMALS),
             {
                 currency: fiatCurrency,

--- a/suite-native/module-trading/src/components/general/FiatAmountBadge.tsx
+++ b/suite-native/module-trading/src/components/general/FiatAmountBadge.tsx
@@ -6,7 +6,7 @@ export type FiatAmountBadgeProps = {
 };
 
 export const FiatAmountBadge = ({ amount }: FiatAmountBadgeProps) => {
-    const { FiatAmountFormatter } = useFormatters();
+    const { BaseCurrencyAmountFormatter } = useFormatters();
 
     if (!amount) {
         return null;
@@ -14,7 +14,7 @@ export const FiatAmountBadge = ({ amount }: FiatAmountBadgeProps) => {
 
     return (
         <Text variant="body" color="textDefault">
-            <FiatAmountFormatter value={amount} />
+            <BaseCurrencyAmountFormatter value={amount} />
         </Text>
     );
 };

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -238,7 +238,7 @@ const useValidations = (
 
 export const useBuyForm = (): BuyFormType => {
     const { translate } = useTranslate();
-    const { FiatAmountFormatter, CryptoAmountFormatter } = useFormatters();
+    const { BaseCurrencyAmountFormatter, CryptoAmountFormatter } = useFormatters();
     const defaultValues = useSelector(selectBuyFormDefaultValues);
     const limits = useSelector(selectBuyAmountLimits);
     const { convertNumberToBaseUnit } = useConvertFormValueToBaseUnit();
@@ -249,7 +249,7 @@ export const useBuyForm = (): BuyFormType => {
         context: {
             ...limits,
             translate,
-            FiatAmountFormatter,
+            FiatAmountFormatter: BaseCurrencyAmountFormatter,
             CryptoAmountFormatter,
             convertNumberToBaseUnit,
         },

--- a/suite-native/module-trading/src/hooks/history/useChangeStringsExtractor.ts
+++ b/suite-native/module-trading/src/hooks/history/useChangeStringsExtractor.ts
@@ -18,7 +18,7 @@ export const useChangeStringsExtractor = (
     toStringValue: string | undefined;
     formattedRate?: string | undefined;
 } => {
-    const { CryptoAmountFormatter, FiatAmountFormatter } = useFormatters();
+    const { CryptoAmountFormatter, BaseCurrencyAmountFormatter } = useFormatters();
     const { cryptoIdToSymbolAndContractAddress } = useTradingInfo();
 
     const tradeOperationData = getTradeOperationData(trade);
@@ -67,7 +67,7 @@ export const useChangeStringsExtractor = (
         }
 
         return (
-            FiatAmountFormatter.format(value, {
+            BaseCurrencyAmountFormatter.format(value, {
                 currency,
             }) ?? undefined
         );

--- a/suite-native/module-trading/src/types/buy.ts
+++ b/suite-native/module-trading/src/types/buy.ts
@@ -18,7 +18,7 @@ export type BuyFormValues = BaseFormValues<'fiatValue' | 'cryptoValue', BuyTrade
 
 export type BuyFormContext = Partial<TradingAmountLimitProps> & {
     translate: ReturnType<typeof useTranslate>['translate'];
-    FiatAmountFormatter: Formatters['FiatAmountFormatter'];
+    FiatAmountFormatter: Formatters['BaseCurrencyAmountFormatter'];
     CryptoAmountFormatter: Formatters['CryptoAmountFormatter'];
     convertNumberToBaseUnit: ReturnType<
         typeof useConvertFormValueToBaseUnit

--- a/suite-native/test-utils/src/BasicProviderForTests.tsx
+++ b/suite-native/test-utils/src/BasicProviderForTests.tsx
@@ -19,7 +19,7 @@ const theme = prepareNativeTheme({ colorVariant: 'standard' });
 
 const DEFAULT_FORMATTERS_CONFIG: FormatterProviderConfig = {
     locale: 'en' as const,
-    fiatCurrency: 'usd' as const,
+    baseCurrency: 'usd' as const,
     bitcoinAmountUnit: 0,
     is24HourFormat: true,
 };


### PR DESCRIPTION
Part of: https://github.com/trezor/trezor-suite/issues/5939

This is part of the refactoring to convert Fiat -> BaseCurrency as we have also Gold, Silver, and we also introduce Bitcoin as a Base Currency (unit of account)

This focuses on the Amount Formatted.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=btc-as-base-currency2&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=btc-as-base-currency2&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=btc-as-base-currency2&lookback=7)