### PR TITLE
feat(e2e): update manual test template

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/manual/accounts/pagination.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/accounts/pagination.test.ts
@@ -1,4 +1,4 @@
-import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
+import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
@@ -20,6 +20,7 @@ test.describe.skip('Pagination', { tag: ['@group=manual'] }, () => {
                 ],
                 category: TestCategory.Accounts,
                 priority: TestPriority.Medium,
+                stream: TestStream.Engagement,
             }),
         },
         async () => {},

--- a/packages/suite-desktop-core/e2e/tests/manual/autoupdate/auto-update.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/autoupdate/auto-update.test.ts
@@ -1,4 +1,9 @@
-import { TestCategory, TestOsMatrix, TestPriority } from '../../../support/enums/testAnnotations';
+import {
+    TestCategory,
+    TestOsMatrix,
+    TestPriority,
+    TestStream,
+} from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
@@ -31,6 +36,7 @@ test.describe.skip('Auto update', { tag: ['@group=manual'] }, () => {
                 ],
                 category: TestCategory.Application,
                 priority: TestPriority.Critical,
+                stream: TestStream.Foundation,
                 osMatrix: [
                     TestOsMatrix.Linux,
                     TestOsMatrix.Windows,

--- a/packages/suite-desktop-core/e2e/tests/manual/browser/mobile-browser.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/browser/mobile-browser.test.ts
@@ -1,4 +1,9 @@
-import { TestCategory, TestOsMatrix, TestPriority } from '../../../support/enums/testAnnotations';
+import {
+    TestCategory,
+    TestOsMatrix,
+    TestPriority,
+    TestStream,
+} from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
@@ -23,6 +28,7 @@ test.describe.skip('Mobile browser', { tag: ['@group=manual'] }, () => {
                 ],
                 category: TestCategory.Wallets,
                 priority: TestPriority.Critical,
+                stream: TestStream.Foundation,
                 osMatrix: [TestOsMatrix.Android],
             }),
         },

--- a/packages/suite-desktop-core/e2e/tests/manual/browser/webusb-transport.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/browser/webusb-transport.test.ts
@@ -1,4 +1,9 @@
-import { TestCategory, TestOsMatrix, TestPriority } from '../../../support/enums/testAnnotations';
+import {
+    TestCategory,
+    TestOsMatrix,
+    TestPriority,
+    TestStream,
+} from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
@@ -27,6 +32,7 @@ test.describe.skip('Web usb transport', { tag: ['@group=manual'] }, () => {
                 ],
                 category: TestCategory.Wallets,
                 priority: TestPriority.Critical,
+                stream: TestStream.Foundation,
                 osMatrix: [
                     TestOsMatrix.Linux,
                     TestOsMatrix.Windows,

--- a/packages/suite-desktop-core/e2e/tests/manual/btc/receive.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/btc/receive.test.ts
@@ -1,4 +1,4 @@
-import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
+import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
@@ -24,6 +24,7 @@ test.describe.skip('Receive transaction', { tag: ['@group=manual'] }, () => {
                 ],
                 category: TestCategory.BTC,
                 priority: TestPriority.Critical,
+                stream: TestStream.Engagement,
             }),
         },
         async () => {},

--- a/packages/suite-desktop-core/e2e/tests/manual/dashboard/portfolio.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/dashboard/portfolio.test.ts
@@ -1,4 +1,4 @@
-import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
+import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
@@ -17,6 +17,7 @@ test.describe.skip('Portfolio', { tag: ['@group=manual'] }, () => {
                 ],
                 category: TestCategory.Dashboard,
                 priority: TestPriority.High,
+                stream: TestStream.Foundation,
             }),
         },
         async () => {},

--- a/packages/suite-desktop-core/e2e/tests/manual/metadata/labels.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/metadata/labels.test.ts
@@ -19,7 +19,7 @@ test.describe.skip('Metadata - labels on non-Linux systems', { tag: ['@group=man
                 steps: ['Define me please.'],
                 category: TestCategory.NotCategorized,
                 priority: TestPriority.Medium,
-                stream: TestStream.NotDefined,
+                stream: TestStream.Engagement,
                 osMatrix: [TestOsMatrix.Windows, TestOsMatrix.MacOSArm, TestOsMatrix.MacOSIntel],
             }),
         },

--- a/packages/suite-desktop-core/e2e/tests/manual/settings/check-update.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/settings/check-update.test.ts
@@ -1,4 +1,4 @@
-import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
+import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
@@ -16,6 +16,7 @@ test.describe.skip('Check for update', { tag: ['@group=manual'] }, () => {
                 ],
                 category: TestCategory.Settings,
                 priority: TestPriority.High,
+                stream: TestStream.Foundation,
             }),
         },
         async () => {},

--- a/packages/suite-desktop-core/e2e/tests/manual/settings/wallet-loading.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/settings/wallet-loading.test.ts
@@ -1,4 +1,4 @@
-import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
+import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
@@ -21,6 +21,7 @@ test.describe.skip('Wallet loading', { tag: ['@group=manual'] }, () => {
                 ],
                 category: TestCategory.Settings,
                 priority: TestPriority.Medium,
+                stream: TestStream.Engagement,
             }),
         },
         async () => {},

--- a/packages/suite-desktop-core/e2e/tests/manual/wallet/address-scan.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/wallet/address-scan.test.ts
@@ -1,4 +1,4 @@
-import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
+import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
@@ -20,6 +20,7 @@ test.describe.skip('Address scan', { tag: ['@group=manual'] }, () => {
                 ],
                 category: TestCategory.Wallets,
                 priority: TestPriority.Critical,
+                stream: TestStream.Foundation,
             }),
         },
         async () => {},

--- a/packages/suite-desktop-core/e2e/tests/manual/wallet/device-switch.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/wallet/device-switch.test.ts
@@ -1,4 +1,4 @@
-import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
+import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
@@ -22,6 +22,7 @@ test.describe.skip('Device switch', { tag: ['@group=manual'] }, () => {
                 ],
                 category: TestCategory.Wallets,
                 priority: TestPriority.Medium,
+                stream: TestStream.Engagement,
             }),
         },
         async () => {},

--- a/packages/suite-desktop-core/e2e/tests/manual/wallet/remember-wallet.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/wallet/remember-wallet.test.ts
@@ -1,4 +1,4 @@
-import { TestCategory, TestPriority } from '../../../support/enums/testAnnotations';
+import { TestCategory, TestPriority, TestStream } from '../../../support/enums/testAnnotations';
 import { test } from '../../../support/fixtures';
 import { createTestAnnotation } from '../../../support/reporters/annotations';
 
@@ -28,6 +28,7 @@ test.describe.skip('Wallet remembering', { tag: ['@group=manual'] }, () => {
                 ],
                 category: TestCategory.Wallets,
                 priority: TestPriority.High,
+                stream: TestStream.Engagement,
             }),
         },
         async () => {},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

added TestStream category to all manual tests that were missing it or set to not defined
## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=e2e_update&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=e2e_update&lookback=7)