### PR TITLE
fix: types for FiatRatesBySymbol, add typedObjectFromEntries util

### DIFF
--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -1,5 +1,7 @@
 import type tls from 'tls';
 
+import type { BaseCurrencyCode } from '@suite-common/suite-config';
+
 import type { Transaction as BlockbookTransaction, VinVout } from './blockbook';
 import type {
     AddressAlias,
@@ -116,9 +118,9 @@ export type TransactionDetail = {
     totalOutput: string;
 };
 
-export interface FiatRatesBySymbol {
-    [symbol: string]: number | undefined;
-}
+export type FiatRatesBySymbol = {
+    [K in BaseCurrencyCode]?: number | undefined;
+};
 
 export interface AccountBalanceHistory {
     time: number;

--- a/packages/suite/src/utils/wallet/graph/utilsWorker.ts
+++ b/packages/suite/src/utils/wallet/graph/utilsWorker.ts
@@ -1,7 +1,9 @@
 import { fromUnixTime, getUnixTime, startOfMonth } from 'date-fns';
 
+import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { toFiatCurrency } from '@suite-common/wallet-utils';
 import type { FiatRatesBySymbol } from '@trezor/connect';
+import { typedObjectFromEntries, typedObjectKeys } from '@trezor/utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import {
@@ -15,14 +17,13 @@ import { ObjectType, TypeName, sumFiatValueMapInPlace } from './utilsShared';
 const calcFiatValueMap = (
     amount: string,
     rates: FiatRatesBySymbol,
-): { [k: string]: string | undefined } => {
-    const fiatValueMap: { [k: string]: string | undefined } = {};
-    Object.keys(rates).forEach(fiatSymbol => {
-        fiatValueMap[fiatSymbol] = toFiatCurrency(amount, rates?.[fiatSymbol]) ?? '0';
-    });
-
-    return fiatValueMap;
-};
+): { [K in BaseCurrencyCode]?: string | undefined } =>
+    typedObjectFromEntries(
+        typedObjectKeys(rates).map(fiatSymbol => [
+            fiatSymbol,
+            toFiatCurrency(amount, rates[fiatSymbol]) ?? '0',
+        ]),
+    );
 
 const isAccountAggregatedHistory = (
     history: AggregatedAccountHistory | AggregatedDashboardHistory,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -55,6 +55,7 @@ export * from './throttler';
 export * from './throwError';
 export * from './topologicalSort';
 export * from './typedEventEmitter';
+export * from './typedObjectFromEntries';
 export * from './typedObjectKeys';
 export * from './urlToOnion';
 export * from './zip';

--- a/packages/utils/src/typedObjectFromEntries.ts
+++ b/packages/utils/src/typedObjectFromEntries.ts
@@ -1,0 +1,5 @@
+export function typedObjectFromEntries<T extends readonly (readonly [string, any])[]>(
+    entries: T,
+): { [K in T[number] as K[0]]: K[1] } {
+    return Object.fromEntries(entries) as any;
+}

--- a/packages/utils/tests/typedObjectFromEntries.type-test.ts
+++ b/packages/utils/tests/typedObjectFromEntries.type-test.ts
@@ -1,0 +1,21 @@
+import { typedObjectFromEntries } from '../src/typedObjectFromEntries';
+import { typedObjectKeys } from '../src/typedObjectKeys';
+
+const map = {
+    a: 1,
+    b: 2,
+};
+
+export const _test: { [K in keyof typeof map]: number } = typedObjectFromEntries([
+    ['a', 10],
+    ['b', 20],
+] as const);
+
+export const _test2: { [K in keyof typeof map]: number } = typedObjectFromEntries(
+    typedObjectKeys(map).map(k => [k, map[k] * 2]),
+);
+
+// @ts-expect-error String cannot be assigned to number as map-value
+export const _test3: { [K in keyof typeof map]: number } = typedObjectFromEntries(
+    typedObjectKeys(map).map(k => [k, '']),
+);

--- a/packages/utils/tests/typedObjectKeys.type-test.ts
+++ b/packages/utils/tests/typedObjectKeys.type-test.ts
@@ -1,0 +1,6 @@
+import { typedObjectKeys } from '../src/typedObjectKeys';
+
+type AB = { a: number; b: number } | { b: string };
+const ab: AB = { b: 'B' };
+
+export const _test: 'b'[] = typedObjectKeys(ab);

--- a/suite-common/fiat-services/src/coingecko.ts
+++ b/suite-common/fiat-services/src/coingecko.ts
@@ -122,6 +122,7 @@ export const findClosestTimestampValue = (
  *
  * @param {TickerId} ticker
  * @param {number[]} timestamps
+ * @param {BaseCurrencyCode} fiatCurrencyCode
  */
 export const getFiatRatesForTimestamps = async (
     ticker: TickerId,


### PR DESCRIPTION
Part of: https://github.com/trezor/trezor-suite/issues/5939

Better types for `FiatRatesBySymbol` in chart. Also introducing `typedObjectFromEntries` for typed object manipulation.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=btc-as-base-currency4&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=btc-as-base-currency4&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=btc-as-base-currency4&lookback=7)