### PR TITLE
Show error for not enough gas coin while sending token

### DIFF
--- a/suite-native/module-send/src/screens/SendOutputsScreen.tsx
+++ b/suite-native/module-send/src/screens/SendOutputsScreen.tsx
@@ -124,6 +124,7 @@ export const SendOutputsScreen = ({
             feeLevelsMaxAmount,
             decimals: tokenInfo?.decimals ?? network?.decimals,
             isTaprootAvailable: !deviceUnavailableCapabilities?.taproot,
+            accountNativeAvailableBalance: account?.availableBalance,
         },
         defaultValues: getDefaultValues({
             tokenContract,

--- a/suite-native/module-send/src/sendOutputsFormSchema.ts
+++ b/suite-native/module-send/src/sendOutputsFormSchema.ts
@@ -26,6 +26,7 @@ export type SendFormFormContext = {
     decimals?: number;
     accountDescriptor?: string;
     isTaprootAvailable?: boolean;
+    accountNativeAvailableBalance?: string;
 };
 
 const isAmountDust = (amount: string, context?: SendFormFormContext) => {
@@ -83,6 +84,25 @@ const isAmountHigherThanBalance = (
     }
 
     return !normalMaxAmount || amountBigNumber.gt(normalMaxAmount);
+};
+
+const hasEnoughBalanceForFees = (context?: SendFormFormContext) => {
+    if (!context) {
+        return false;
+    }
+
+    const { symbol, networkFeeInfo, accountNativeAvailableBalance, isTokenFlow } = context;
+
+    if (!isTokenFlow) {
+        return true;
+    }
+    if (!symbol || !networkFeeInfo || !accountNativeAvailableBalance) {
+        return false;
+    }
+
+    const amountBigNumber = new BigNumber(accountNativeAvailableBalance);
+
+    return amountBigNumber.gt(networkFeeInfo.minFee);
 };
 
 export const sendOutputsFormValidationSchema = yup.object({
@@ -164,6 +184,16 @@ export const sendOutputsFormValidationSchema = yup.object({
                             }
 
                             return true;
+                        },
+                    )
+                    .test(
+                        'has-enough-balance-for-fees',
+                        `Insufficient balance to cover the transaction fees.`,
+                        function (
+                            _,
+                            { options: { context } }: yup.TestContext<SendFormFormContext>,
+                        ) {
+                            return hasEnoughBalanceForFees(context);
                         },
                     )
                     .test(


### PR DESCRIPTION
If there is less gas coin on account than min fee and user wants to send token, the form throws error.

## Related Issue

Resolve #18395
partially mitigates [#18465](https://github.com/trezor/trezor-suite/issues/18465) by not getting into fees screen where `formatAmount` is called with `NaN` for fee

## Screenshots:
<img width=300 src="https://github.com/user-attachments/assets/35a57845-3444-43d1-bc5b-852842d86603" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=18395-sending-token-from-an-account-with-0-eth-for-fee-results-in-a-blank-screen&lookback=7)