### PR TITLE
chore: refactoring of toFiatCurrency and fromFiatCurrency to NOT do any formatting

### DIFF
--- a/packages/connect-common/src/storage.ts
+++ b/packages/connect-common/src/storage.ts
@@ -1,5 +1,6 @@
 // https://github.com/trezor/connect/blob/develop/src/js/storage/index.js
 
+import { Branded } from '@trezor/type-utils';
 import { TypedEmitter } from '@trezor/utils';
 
 const storageVersion = 2;
@@ -17,7 +18,7 @@ export interface Permission {
  */
 export interface PreferredDevice {
     label?: string;
-    path: string & { __type: 'DeviceUniquePath' };
+    path: string & Branded<'DeviceUniquePath'>;
     state?: `${string}@${string}:${number}`;
     internalState?: string;
     internalStateExpiration?: number;

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -1,5 +1,6 @@
 import { FeaturesNarrowing, FirmwareType } from '@trezor/device-utils';
 import type { ThpStateSerialized } from '@trezor/protocol';
+import { Branded } from '@trezor/type-utils';
 
 import type { PROTO } from '../constants';
 import type { ReleaseInfo } from './firmware';
@@ -73,7 +74,7 @@ export type FirmwareHashCheckResult =
           errorPayload?: unknown;
       };
 
-export type DeviceUniquePath = string & { __type: 'DeviceUniquePath' };
+export type DeviceUniquePath = string & Branded<'DeviceUniquePath'>;
 export const DeviceUniquePath = (id: string) => id as DeviceUniquePath;
 
 type BaseDevice = {

--- a/packages/suite/src/actions/wallet/stake/stakeFormActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormActions.ts
@@ -10,7 +10,7 @@ import {
 import {
     calculateMax,
     calculateTotal,
-    formatAmount,
+    convertAmountSubunitsToUnits,
     getExternalComposeOutput,
 } from '@suite-common/wallet-utils';
 import { FeeLevel } from '@trezor/connect';
@@ -158,7 +158,7 @@ export const composeStakingTransaction = (
     Object.keys(wrappedResponse).forEach(key => {
         const tx = wrappedResponse[key];
         if (tx.type !== 'error') {
-            tx.max = tx.max ? formatAmount(tx.max, decimals) : undefined;
+            tx.max = tx.max ? convertAmountSubunitsToUnits(tx.max, decimals) : undefined;
             tx.estimatedFeeLimit = customFeeLimit ?? tx.estimatedFeeLimit;
         }
         if (tx.type === 'error' && tx.error === 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE') {

--- a/packages/suite/src/actions/wallet/trading/tradingCommonActions.ts
+++ b/packages/suite/src/actions/wallet/trading/tradingCommonActions.ts
@@ -1,7 +1,7 @@
 import { Output } from '@suite-common/wallet-types/src';
 import {
-    amountToSmallestUnit,
-    formatAmount,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     getAccountDecimals,
     hasNetworkFeatures,
     parseFormDraftKey,
@@ -55,7 +55,9 @@ export const convertDrafts = () => (dispatch: Dispatch, getState: GetState) => {
 
         if (draft) {
             const areSatsSelected = settings.bitcoinAmountUnit === PROTO.AmountUnit.SATOSHI;
-            const conversion = areSatsSelected ? amountToSmallestUnit : formatAmount;
+            const conversion = areSatsSelected
+                ? convertAmountUnitsToSubunits
+                : convertAmountSubunitsToUnits;
             const decimals = getAccountDecimals(relatedAccount.symbol)!;
 
             if (draft.cryptoInput) {

--- a/packages/suite/src/components/suite/BaseCurrencyValue.tsx
+++ b/packages/suite/src/components/suite/BaseCurrencyValue.tsx
@@ -78,7 +78,7 @@ export const BaseCurrencyValue = ({
     });
 
     const { BaseCurrencyAmountFormatter } = useFormatters();
-    const value = shouldConvert ? fiatAmount : amount;
+    const value = shouldConvert ? fiatAmount?.toFixed(2) : amount;
 
     const WrapperComponent = disableHiddenPlaceholder ? SameWidthNums : HiddenPlaceholder;
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { TokenAddress } from '@suite-common/wallet-types';
-import { formatAmount, formatNetworkAmount } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits, formatNetworkAmount } from '@suite-common/wallet-utils';
 import {
     Card,
     Column,
@@ -85,7 +85,7 @@ const Value = ({ value, type, symbol, token, isFee, isFiatVisible, state }: Valu
         case 'amount': {
             const isTokenAmount = !isFee && token;
             const formattedValue = isTokenAmount
-                ? formatAmount(value, token.decimals)
+                ? convertAmountSubunitsToUnits(value, token.decimals)
                 : formatNetworkAmount(value, symbol);
 
             return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TradingDCAModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TradingDCAModal.tsx
@@ -6,7 +6,7 @@ import { TrezorDevice } from '@suite-common/suite-types';
 import { cryptoIdToNetwork, getTradingNetworkDecimals } from '@suite-common/trading/src/utils';
 import { Network, getNetwork } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
-import { formatAmount } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
 import {
     Button,
     Column,
@@ -153,7 +153,7 @@ const AddressSelect = ({
             }
             formatOptionLabel={(accountAddress: AccountAddress) => {
                 const balance = accountAddress.balance
-                    ? formatAmount(accountAddress.balance, networkDecimals)
+                    ? convertAmountSubunitsToUnits(accountAddress.balance, networkDecimals)
                     : accountAddress.balance;
 
                 return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
@@ -5,7 +5,7 @@ import {
 } from '@suite-common/wallet-core';
 import { Timestamp, TokenAddress } from '@suite-common/wallet-types';
 import {
-    formatAmount,
+    convertAmountSubunitsToUnits,
     formatCardanoDeposit,
     formatCardanoWithdrawal,
     formatNetworkAmount,
@@ -202,7 +202,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                 {selectedAccount.account && (
                                     <Text variant="default">
                                         <BaseCurrencyValue
-                                            amount={formatAmount(
+                                            amount={convertAmountSubunitsToUnits(
                                                 transfer.amount,
                                                 transfer.decimals,
                                             )}
@@ -218,7 +218,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                 {selectedAccount.account && (
                                     <Text variant="default">
                                         <BaseCurrencyValue
-                                            amount={formatAmount(
+                                            amount={convertAmountSubunitsToUnits(
                                                 transfer.amount,
                                                 transfer.decimals,
                                             )}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
@@ -6,7 +6,11 @@ import { type NetworkSymbolExtended, isNetworkSymbol } from '@suite-common/walle
 import { getExplorerUrl } from '@suite-common/wallet-config/src/getExplorerUrls';
 import { selectExplorer } from '@suite-common/wallet-core';
 import { WalletAccountTransaction } from '@suite-common/wallet-types';
-import { formatAmount, formatNetworkAmount, isNftTokenTransfer } from '@suite-common/wallet-utils';
+import {
+    convertAmountSubunitsToUnits,
+    formatNetworkAmount,
+    isNftTokenTransfer,
+} from '@suite-common/wallet-utils';
 import { AnonymitySet, TokenTransfer } from '@trezor/blockchain-link';
 import {
     CollapsibleBox,
@@ -250,7 +254,7 @@ const TokenSpecificBalanceDetailsRow = ({
                                 linkTypographyStyle="label"
                             />
                         ) : (
-                            formatAmount(transfer.amount, transfer.decimals)
+                            convertAmountSubunitsToUnits(transfer.amount, transfer.decimals)
                         );
 
                         return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnecoCoinjoinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnecoCoinjoinModal.tsx
@@ -1,4 +1,4 @@
-import { formatAmount, getAccountDecimals } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits, getAccountDecimals } from '@suite-common/wallet-utils';
 import { Column, H3, Modal, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -57,7 +57,10 @@ export const UnecoCoinjoinModal = () => {
                         values={{
                             crypto: (
                                 <FormattedCryptoAmount
-                                    value={formatAmount(UNECONOMICAL_COINJOIN_THRESHOLD, decimals)}
+                                    value={convertAmountSubunitsToUnits(
+                                        UNECONOMICAL_COINJOIN_THRESHOLD,
+                                        decimals,
+                                    )}
                                     symbol={symbol}
                                     isRawString
                                 />

--- a/packages/suite/src/components/wallet/AmountComponent.tsx
+++ b/packages/suite/src/components/wallet/AmountComponent.tsx
@@ -1,4 +1,8 @@
-import { formatAmount, getTxOperation, isNftTokenTransfer } from '@suite-common/wallet-utils';
+import {
+    convertAmountSubunitsToUnits,
+    getTxOperation,
+    isNftTokenTransfer,
+} from '@suite-common/wallet-utils';
 import { TokenTransfer } from '@trezor/connect';
 import { TypographyStyle } from '@trezor/theme';
 
@@ -37,7 +41,7 @@ export const AmountComponent = ({
     if (withSign) {
         return (
             <FormattedCryptoAmount
-                value={formatAmount(transfer.amount, transfer.decimals)}
+                value={convertAmountSubunitsToUnits(transfer.amount, transfer.decimals)}
                 symbol={transfer.symbol}
                 contractAddress={transfer.contract}
                 signValue={operation}
@@ -45,5 +49,5 @@ export const AmountComponent = ({
         );
     }
 
-    return formatAmount(transfer.amount, transfer.decimals);
+    return convertAmountSubunitsToUnits(transfer.amount, transfer.decimals);
 };

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -4,7 +4,7 @@ import { ToastPayload, notificationsActions } from '@suite-common/toast-notifica
 import { selectHistoricFiatRatesByTimestamp, selectLocalCurrency } from '@suite-common/wallet-core';
 import { Timestamp, TokenAddress } from '@suite-common/wallet-types';
 import {
-    formatAmount,
+    convertAmountSubunitsToUnits,
     formatNetworkAmount,
     getFiatRateKey,
     getTargetAmount,
@@ -77,7 +77,7 @@ export const TransactionTarget = ({
             case 'internal':
                 return payload.amount && formatNetworkAmount(payload.amount, transaction.symbol);
             case 'token':
-                return formatAmount(payload.amount, payload.decimals);
+                return convertAmountSubunitsToUnits(payload.amount, payload.decimals);
         }
     }, [type, payload, transaction, isSolanaUnstakeTx]);
 

--- a/packages/suite/src/hooks/suite/useFiatFromCryptoValue.ts
+++ b/packages/suite/src/hooks/suite/useFiatFromCryptoValue.ts
@@ -29,7 +29,7 @@ export const useFiatFromCryptoValue = ({
     const currentRate = useSelector(state => selectFiatRatesByFiatRateKey(state, fiatRateKey));
 
     const rate = useHistoricRate ? historicRate : currentRate?.rate;
-    const fiatAmount: string | null = rate ? toFiatCurrency(amount, rate) : null;
+    const fiatAmount: BigNumber | null = rate ? toFiatCurrency({ amount, rate }) : null;
 
     return { localCurrency, fiatAmount, rate, currentRate };
 };

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingCurrencySwitcher.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingCurrencySwitcher.ts
@@ -9,7 +9,10 @@ import {
 } from '@suite-common/trading';
 import { Network } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
-import { amountToSmallestUnit, formatAmount } from '@suite-common/wallet-utils';
+import {
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
+} from '@suite-common/wallet-utils';
 import { useDidUpdate } from '@trezor/react-utils';
 
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
@@ -60,7 +63,7 @@ export const useTradingCurrencySwitcher = <T extends TradingAllFormProps>({
 
         if (!amountInCrypto) {
             const amount = shouldSendInSats
-                ? amountToSmallestUnit(quoteCryptoAmount ?? '', networkDecimals)
+                ? convertAmountUnitsToSubunits(quoteCryptoAmount ?? '', networkDecimals)
                 : quoteCryptoAmount;
 
             setValue(inputNames.cryptoInput, amount === '-1' ? '' : amount);
@@ -77,7 +80,9 @@ export const useTradingCurrencySwitcher = <T extends TradingAllFormProps>({
     };
 
     useDidUpdate(() => {
-        const conversion = shouldSendInSats ? amountToSmallestUnit : formatAmount;
+        const conversion = shouldSendInSats
+            ? convertAmountUnitsToSubunits
+            : convertAmountSubunitsToUnits;
 
         if (!cryptoInputValue) {
             return;

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.ts
@@ -10,7 +10,11 @@ import {
     updateFiatRatesThunk,
 } from '@suite-common/wallet-core';
 import { FiatRatesResult, Rate, Timestamp, TokenAddress } from '@suite-common/wallet-types';
-import { amountToSmallestUnit, getFiatRateKey, toFiatCurrency } from '@suite-common/wallet-utils';
+import {
+    convertAmountUnitsToSubunits,
+    getFiatRateKey,
+    toFiatCurrency,
+} from '@suite-common/wallet-utils';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
@@ -101,7 +105,9 @@ export const useTradingFiatValues = ({
         sendCryptoSelect,
         network,
     });
-    const formattedBalance = shouldSendInSats ? amountToSmallestUnit(balance, decimals) : balance;
+    const formattedBalance = shouldSendInSats
+        ? convertAmountUnitsToSubunits(balance, decimals)
+        : balance;
     const fiatValue = toFiatCurrency(balance, fiatRate?.rate, 2);
 
     return {

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.ts
@@ -108,7 +108,7 @@ export const useTradingFiatValues = ({
     const formattedBalance = shouldSendInSats
         ? convertAmountUnitsToSubunits(balance, decimals)
         : balance;
-    const fiatValue = toFiatCurrency(balance, fiatRate?.rate, 2);
+    const fiatValue = toFiatCurrency({ amount: balance, rate: fiatRate?.rate })?.toFixed(2) ?? null;
 
     return {
         fiatValue,

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -129,11 +129,11 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
                 return;
             }
 
-            const cryptoAmount = fromFiatCurrency(
-                fiatAmount,
-                networkDecimals,
-                tradingFiatValues.fiatRate?.rate,
-            );
+            const cryptoAmount =
+                fromFiatCurrency({
+                    localAmount: fiatAmount,
+                    rate: tradingFiatValues.fiatRate?.rate,
+                })?.toFixed(networkDecimals) ?? null;
 
             const formattedCryptoAmount =
                 cryptoAmount && shouldSendInSats

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -23,8 +23,8 @@ import {
 import { selectAccounts, selectSelectedDevice } from '@suite-common/wallet-core';
 import { TokenAddress } from '@suite-common/wallet-types';
 import {
-    amountToSmallestUnit,
-    formatAmount,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     fromFiatCurrency,
     isZero,
 } from '@suite-common/wallet-utils';
@@ -103,7 +103,7 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
         const rate = await tradingFiatValues.fiatRatesUpdater(value);
         const amount = getValues(TRADING_FORM_OUTPUT_AMOUNT);
         const formattedAmount = new BigNumber(
-            shouldSendInSats ? formatAmount(amount, networkDecimals) : amount,
+            shouldSendInSats ? convertAmountSubunitsToUnits(amount, networkDecimals) : amount,
         );
 
         if (
@@ -137,7 +137,7 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
 
             const formattedCryptoAmount =
                 cryptoAmount && shouldSendInSats
-                    ? amountToSmallestUnit(cryptoAmount, networkDecimals)
+                    ? convertAmountUnitsToSubunits(cryptoAmount, networkDecimals)
                     : (cryptoAmount ?? '');
             setValue(TRADING_FORM_OUTPUT_AMOUNT, formattedCryptoAmount, { shouldValidate: true });
         },
@@ -206,7 +206,7 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
                   .decimalPlaces(networkDecimals)
                   .toString();
         const cryptoInputValue = shouldSendInSats
-            ? amountToSmallestUnit(amount, networkDecimals)
+            ? convertAmountUnitsToSubunits(amount, networkDecimals)
             : amount;
         clearErrors([TRADING_FORM_OUTPUT_FIAT, TRADING_FORM_OUTPUT_AMOUNT]);
         setValue(TRADING_FORM_OUTPUT_AMOUNT, cryptoInputValue, { shouldDirty: true });

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -167,7 +167,10 @@ export const useTradingExchangeForm = ({
         fiatCurrency: output?.currency?.value as FiatCurrencyCode,
     });
     const fiatOfBestScoredQuote = quotes?.[0]?.sendStringAmount
-        ? toFiatCurrency(quotes?.[0]?.sendStringAmount, fiatValues?.fiatRate?.rate, 2)
+        ? (toFiatCurrency({
+              amount: quotes?.[0]?.sendStringAmount,
+              rate: fiatValues?.fiatRate?.rate,
+          })?.toFixed(2) ?? null)
         : null;
 
     const formIsValid = Object.keys(formState.errors).length === 0;

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -14,8 +14,8 @@ import { getNetworkSymbolForProtocol } from '@suite-common/suite-utils';
 import { selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { FormState } from '@suite-common/wallet-types';
 import {
-    amountToSmallestUnit,
-    formatAmount,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     getDefaultValues,
     getFeeInfo,
     useExcludedUtxos,
@@ -296,7 +296,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
                 const protocolAmount = protocol.sendForm.amount.toString();
 
                 const formattedAmount = shouldSendInSats
-                    ? amountToSmallestUnit(protocolAmount, state.network.decimals)
+                    ? convertAmountUnitsToSubunits(protocolAmount, state.network.decimals)
                     : protocolAmount;
 
                 sendFormUtils.setAmount(outputIndex, formattedAmount);
@@ -373,7 +373,9 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     useDidUpdate(() => {
         const { outputs } = getValues();
 
-        const conversionToUse = shouldSendInSats ? amountToSmallestUnit : formatAmount;
+        const conversionToUse = shouldSendInSats
+            ? convertAmountUnitsToSubunits
+            : convertAmountSubunitsToUnits;
 
         outputs.forEach((output, index) => {
             if (!output.amount) {

--- a/packages/suite/src/hooks/wallet/useSendFormFields.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormFields.ts
@@ -5,7 +5,7 @@ import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { FormOptions, FormState, Rate, TokenAddress } from '@suite-common/wallet-types';
 import {
-    amountToSmallestUnit,
+    convertAmountUnitsToSubunits,
     formatNetworkAmount,
     fromFiatCurrency,
     getFiatRateKey,
@@ -127,7 +127,7 @@ export const useSendFormFields = ({
                 const amount = fromFiatCurrency(fiat, decimals, fiatRate);
 
                 return shouldSendInSats
-                    ? amountToSmallestUnit(amount || '0', network.decimals)
+                    ? convertAmountUnitsToSubunits(amount || '0', network.decimals)
                     : amount;
             };
 

--- a/packages/suite/src/hooks/wallet/useSendFormFields.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormFields.ts
@@ -107,7 +107,9 @@ export const useSendFormFields = ({
                     ? formatNetworkAmount(amount, network.symbol)
                     : amount;
 
-                return toFiatCurrency(formattedAmount, fiatRate, 2);
+                return (
+                    toFiatCurrency({ amount: formattedAmount, rate: fiatRate })?.toFixed(2) ?? null
+                );
             };
 
             return calculateFiatFromAmountOrViceVersa({
@@ -124,7 +126,10 @@ export const useSendFormFields = ({
         (outputId: number, fiat: string, token?: TokenInfo) => {
             const calculateFormattedAmountValue = (fiat: string, fiatRate: number) => {
                 const decimals = token ? token.decimals : network.decimals;
-                const amount = fromFiatCurrency(fiat, decimals, fiatRate);
+
+                const amount =
+                    fromFiatCurrency({ localAmount: fiat, rate: fiatRate })?.toFixed(decimals) ??
+                    null;
 
                 return shouldSendInSats
                     ? convertAmountUnitsToSubunits(amount || '0', network.decimals)

--- a/packages/suite/src/hooks/wallet/useSendFormImport.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormImport.ts
@@ -6,8 +6,8 @@ import { DEFAULT_PAYMENT } from '@suite-common/wallet-constants';
 import { updateFiatRatesThunk } from '@suite-common/wallet-core';
 import { FiatRates, FiatRatesResult, Output, Rate, Timestamp } from '@suite-common/wallet-types';
 import {
-    amountToSmallestUnit,
-    formatAmount,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     fromFiatCurrency,
     getFiatRateKey,
     toFiatCurrency,
@@ -105,7 +105,10 @@ export const useSendFormImport = ({
                     const cryptoAmount = item.amount || '';
                     if (shouldSendInSats) {
                         // try to convert to satoshis
-                        output.amount = amountToSmallestUnit(cryptoAmount, network.decimals);
+                        output.amount = convertAmountUnitsToSubunits(
+                            cryptoAmount,
+                            network.decimals,
+                        );
                     } else {
                         output.amount = cryptoAmount;
                     }
@@ -119,7 +122,7 @@ export const useSendFormImport = ({
                     // calculate Fiat from Amount
                     if (fiatRate?.rate) {
                         const cryptoValue = shouldSendInSats
-                            ? formatAmount(output.amount, network.decimals)
+                            ? convertAmountSubunitsToUnits(output.amount, network.decimals)
                             : output.amount;
                         output.fiat = toFiatCurrency(cryptoValue, fiatRate.rate, 2) || '';
                     }
@@ -134,7 +137,7 @@ export const useSendFormImport = ({
                     const cryptoValue = fromFiatCurrency(output.fiat, network.decimals, itemRate);
                     const cryptoAmount =
                         cryptoValue && shouldSendInSats
-                            ? amountToSmallestUnit(cryptoValue, network.decimals)
+                            ? convertAmountUnitsToSubunits(cryptoValue, network.decimals)
                             : (cryptoValue ?? '');
 
                     output.amount = cryptoAmount;

--- a/packages/suite/src/hooks/wallet/useSendFormImport.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormImport.ts
@@ -124,7 +124,11 @@ export const useSendFormImport = ({
                         const cryptoValue = shouldSendInSats
                             ? convertAmountSubunitsToUnits(output.amount, network.decimals)
                             : output.amount;
-                        output.fiat = toFiatCurrency(cryptoValue, fiatRate.rate, 2) || '';
+                        output.fiat =
+                            toFiatCurrency({
+                                amount: cryptoValue,
+                                rate: fiatRate.rate,
+                            })?.toFixed(2) || '';
                     }
                 } else if (
                     Object.keys(baseCurrencies).find(currency => currency === itemCurrency) &&
@@ -133,8 +137,13 @@ export const useSendFormImport = ({
                     // csv amount in fiat currency
                     output.currency = { value: itemCurrency, label: itemCurrency.toUpperCase() };
                     output.fiat = item.amount || '';
+
                     // calculate Amount from Fiat
-                    const cryptoValue = fromFiatCurrency(output.fiat, network.decimals, itemRate);
+                    const cryptoValue = fromFiatCurrency({
+                        localAmount: output.fiat,
+                        rate: itemRate,
+                    })?.toFixed(network.decimals);
+
                     const cryptoAmount =
                         cryptoValue && shouldSendInSats
                             ? convertAmountUnitsToSubunits(cryptoValue, network.decimals)

--- a/packages/suite/src/hooks/wallet/useStakeForm.ts
+++ b/packages/suite/src/hooks/wallet/useStakeForm.ts
@@ -61,8 +61,16 @@ export const useStakeForm = ({ selectedAccount }: UseStakeFormsProps): StakeCont
         currency: symbol,
         minCrypto: MIN_AMOUNT_FOR_STAKING.toString(),
         maxCrypto: account.formattedBalance,
-        minFiat: toFiatCurrency(MIN_AMOUNT_FOR_STAKING.toString(), currentRate?.rate) ?? undefined,
-        maxFiat: toFiatCurrency(account.formattedBalance, currentRate?.rate) ?? undefined,
+        minFiat:
+            toFiatCurrency({
+                amount: MIN_AMOUNT_FOR_STAKING.toString(),
+                rate: currentRate?.rate,
+            })?.toFixed(2) ?? undefined,
+        maxFiat:
+            toFiatCurrency({
+                amount: account.formattedBalance,
+                rate: currentRate?.rate,
+            })?.toFixed(2) ?? undefined,
     };
 
     const defaultValues = useMemo(() => {
@@ -214,8 +222,10 @@ export const useStakeForm = ({ selectedAccount }: UseStakeFormsProps): StakeCont
             clearWithdrawalWarnings();
 
             if (currentRate) {
-                const fiatValue = toFiatCurrency(amount, currentRate?.rate);
-                setValue(FIAT_INPUT, fiatValue || '', { shouldValidate: true });
+                const fiatValue =
+                    toFiatCurrency({ amount, rate: currentRate?.rate })?.toFixed(2) || '';
+
+                setValue(FIAT_INPUT, fiatValue, { shouldValidate: true });
             }
 
             setValue('setMaxOutputId', undefined, { shouldDirty: true });
@@ -240,14 +250,18 @@ export const useStakeForm = ({ selectedAccount }: UseStakeFormsProps): StakeCont
             clearWithdrawalWarnings();
             if (!currentRate) return;
 
-            const cryptoValue = fromFiatCurrency(amount, network.decimals, currentRate?.rate);
-            setValue(CRYPTO_INPUT, cryptoValue || '', { shouldDirty: true, shouldValidate: true });
-            setValue(OUTPUT_AMOUNT, cryptoValue || '', {
+            const cryptoValue =
+                fromFiatCurrency({ localAmount: amount, rate: currentRate?.rate })?.toFixed(
+                    network.decimals,
+                ) || '';
+
+            setValue(CRYPTO_INPUT, cryptoValue, { shouldDirty: true, shouldValidate: true });
+            setValue(OUTPUT_AMOUNT, cryptoValue, {
                 shouldDirty: true,
             });
             await composeRequest(FIAT_INPUT);
 
-            shouldShowAdvice(cryptoValue || '', account.formattedBalance);
+            shouldShowAdvice(cryptoValue, account.formattedBalance);
         },
         [
             account.formattedBalance,
@@ -341,7 +355,10 @@ export const useStakeForm = ({ selectedAccount }: UseStakeFormsProps): StakeCont
                 setValue(OUTPUT_AMOUNT, max, { shouldValidate: true, shouldDirty: true });
                 clearErrors(CRYPTO_INPUT);
 
-                const fiatValue = currentRate ? toFiatCurrency(max, currentRate?.rate) : '';
+                const fiatValue = currentRate
+                    ? toFiatCurrency({ amount: max, rate: currentRate?.rate })?.toFixed(2)
+                    : '';
+
                 setValue(FIAT_INPUT, fiatValue || '', { shouldValidate: true, shouldDirty: true });
             }
 

--- a/packages/suite/src/hooks/wallet/useUnstakeForm.ts
+++ b/packages/suite/src/hooks/wallet/useUnstakeForm.ts
@@ -72,7 +72,9 @@ export const useUnstakeForm = ({ selectedAccount }: UseStakeFormsProps): Unstake
     const amountLimits: AmountLimitProps = {
         currency: symbol,
         maxCrypto: autocompoundBalance,
-        maxFiat: toFiatCurrency(autocompoundBalance, currentRate?.rate) ?? undefined,
+        maxFiat:
+            toFiatCurrency({ amount: autocompoundBalance, rate: currentRate?.rate })?.toFixed(2) ??
+            undefined,
     };
 
     const defaultValues = useMemo(() => {
@@ -198,7 +200,7 @@ export const useUnstakeForm = ({ selectedAccount }: UseStakeFormsProps): Unstake
     const onCryptoAmountChange = useCallback(
         async (amount: string) => {
             if (currentRate) {
-                const fiatValue = toFiatCurrency(amount, currentRate?.rate);
+                const fiatValue = toFiatCurrency({ amount, rate: currentRate?.rate })?.toFixed(2);
                 setValue(FIAT_INPUT, fiatValue || '', {
                     shouldDirty: true,
                     shouldValidate: true,
@@ -219,7 +221,11 @@ export const useUnstakeForm = ({ selectedAccount }: UseStakeFormsProps): Unstake
         async (amount: string) => {
             if (!currentRate) return;
 
-            const cryptoValue = fromFiatCurrency(amount, network.decimals, currentRate?.rate);
+            const cryptoValue = fromFiatCurrency({
+                localAmount: amount,
+                rate: currentRate?.rate,
+            })?.toFixed(network.decimals);
+
             setValue(CRYPTO_INPUT, cryptoValue || '', { shouldDirty: true, shouldValidate: true });
             setValue(OUTPUT_AMOUNT, cryptoValue || '', {
                 shouldDirty: true,

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -8,7 +8,7 @@ import {
 } from '@suite-common/wallet-config';
 import type { BackendSettings, WalletSettings } from '@suite-common/wallet-types';
 import {
-    amountToSmallestUnit,
+    convertAmountUnitsToSubunits,
     formatNetworkAmount,
     networkAmountToSmallestUnit,
 } from '@suite-common/wallet-utils';
@@ -411,7 +411,7 @@ export const runLegacyMigrations: OnUpgradeFunc<SuiteDBSchema> = async (
                     totalSpent: unformat(origTx.totalSpent),
                     tokens: origTx.tokens.map(tok => ({
                         ...tok,
-                        amount: amountToSmallestUnit(tok.amount, tok.decimals),
+                        amount: convertAmountUnitsToSubunits(tok.amount, tok.decimals),
                     })),
                     targets: origTx.targets.map(target => ({
                         ...target,

--- a/packages/suite/src/utils/suite/validation.ts
+++ b/packages/suite/src/utils/suite/validation.ts
@@ -127,7 +127,7 @@ export const validateFiatLimits =
     (value: string) => {
         if (value && amountLimits) {
             const currency = amountLimits.currency.toLowerCase();
-            const cryptoAmount = fromFiatCurrency(value, decimals, rate);
+            const cryptoAmount = fromFiatCurrency({ localAmount: value, rate })?.toFixed(decimals);
             if (!cryptoAmount) return translationString('TR_FIAT_RATES_NOT_AVAILABLE');
 
             if (amountLimits.minFiat && new BigNumber(value).lt(amountLimits.minFiat)) {

--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -14,7 +14,7 @@ import {
     WalletAccountTransaction,
 } from '@suite-common/wallet-types';
 import {
-    formatAmount,
+    convertAmountSubunitsToUnits,
     formatNetworkAmount,
     getFiatRateKey,
     getNftTokenId,
@@ -82,7 +82,7 @@ const formatAmounts =
             ...token,
             amount: isNftTokenTransfer(token)
                 ? `ID ${getNftTokenId(token)}`
-                : formatAmount(token.amount, token.decimals),
+                : convertAmountSubunitsToUnits(token.amount, token.decimals),
         })),
         internalTransfers: tx.internalTransfers.map(internal => ({
             ...internal,

--- a/packages/suite/src/utils/wallet/graph/utilsWorker.ts
+++ b/packages/suite/src/utils/wallet/graph/utilsWorker.ts
@@ -23,7 +23,7 @@ const calcFiatValueMap = (
     typedObjectFromEntries(
         typedObjectKeys(rates).map(fiatSymbol => [
             fiatSymbol,
-            toFiatCurrency(amount, rates[fiatSymbol]) ?? '0',
+            toFiatCurrency({ amount, rate: rates[fiatSymbol] })?.toFixed(2) ?? '0',
         ]),
     );
 

--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -80,10 +80,10 @@ const useAssetsFiatBalances = (
                 .reduce((balance, account) => balance + Number(account.formattedBalance), 0)
                 .toString() ?? '0';
 
-        const fiatBalance = toFiatCurrency(amount, fiatRate?.rate, 2) ?? '0';
+        const fiatBalance = toFiatCurrency({ amount, rate: fiatRate?.rate })?.toFixed(2) ?? '0';
 
         return [...acc, { fiatBalance, symbol: asset.network.symbol }];
-    }, []);
+    }, [] as AssetFiatBalance[]);
 
 export const AssetsView = () => {
     const { dashboardAssetsGridMode } = useSelector(s => s.suite.flags);

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
@@ -6,7 +6,7 @@ import { getTxsPerPage } from '@suite-common/suite-utils';
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 import { fetchAllTransactionsForAccountThunk } from '@suite-common/wallet-core';
 import {
-    amountToSmallestUnit,
+    convertAmountUnitsToSubunits,
     filterAndCategorizeUtxos,
     formatNetworkAmount,
 } from '@suite-common/wallet-utils';
@@ -93,7 +93,7 @@ export const CoinControl = ({ close }: CoinControlProps) => {
     );
     const totalOutputsInSats = shouldSendInSats
         ? totalOutputs
-        : Number(amountToSmallestUnit(totalOutputs.toString(), network.decimals));
+        : Number(convertAmountUnitsToSubunits(totalOutputs.toString(), network.decimals));
     const missingToInput = totalOutputsInSats - totalInputs;
     const isMissingToAmount = missingToInput > 0; // relevant when the amount field is not validated, e.g. there is an error in the address
     const missingAmountTooBig = missingToInput > Number.MAX_SAFE_INTEGER;

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
@@ -3,7 +3,7 @@ import { formInputsMaxLength } from '@suite-common/validators';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { Output, TokenAddress } from '@suite-common/wallet-types';
 import {
-    amountToSmallestUnit,
+    convertAmountUnitsToSubunits,
     findToken,
     formatNetworkAmount,
     getInputState,
@@ -110,7 +110,7 @@ export const Amount = ({ output, outputId }: AmountProps) => {
 
                 if (dust && amountBig.lt(dust)) {
                     if (shouldSendInSats) {
-                        dust = amountToSmallestUnit(dust, decimals);
+                        dust = convertAmountUnitsToSubunits(dust, decimals);
                     }
 
                     return translationString('AMOUNT_IS_BELOW_DUST', {

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
@@ -13,8 +13,8 @@ import {
 } from '@suite-common/wallet-types';
 import {
     buildCurrencyOptions,
+    convertAmountSubunitsToUnits,
     findToken,
-    formatAmount,
     getInputState,
     isLowAnonymityWarning,
 } from '@suite-common/wallet-utils';
@@ -78,7 +78,9 @@ export const BaseCurrencyInput = ({
 
     const recalculateFiat = (rate: number) => {
         const formattedAmount = new BigNumber(
-            shouldSendInSats ? formatAmount(amountValue, network.decimals) : amountValue,
+            shouldSendInSats
+                ? convertAmountSubunitsToUnits(amountValue, network.decimals)
+                : amountValue,
         );
 
         if (

--- a/packages/suite/src/views/wallet/send/TotalSent/TotalSent.tsx
+++ b/packages/suite/src/views/wallet/send/TotalSent/TotalSent.tsx
@@ -3,7 +3,7 @@ import { PropsWithChildren, useMemo } from 'react';
 import styled from 'styled-components';
 
 import { selectAreFeesLoading } from '@suite-common/wallet-core';
-import { formatAmount, formatNetworkAmount } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits, formatNetworkAmount } from '@suite-common/wallet-utils';
 import { Card, Column, InfoItem, SkeletonRectangle } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -66,7 +66,7 @@ export const TotalSent = () => {
                                     disableHiddenPlaceholder
                                     value={
                                         tokenInfo
-                                            ? formatAmount(
+                                            ? convertAmountSubunitsToUnits(
                                                   transactionInfo.totalSpent,
                                                   tokenInfo.decimals,
                                               )

--- a/packages/suite/src/views/wallet/trading/common/TradingAddressOptions.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingAddressOptions.tsx
@@ -6,7 +6,7 @@ import { CryptoId } from 'invity-api';
 
 import { TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT, useTradingInfo } from '@suite-common/trading';
 import { getDisplaySymbol, getNetwork } from '@suite-common/wallet-config';
-import { formatAmount } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
 import { Column, InfoSegments, Select } from '@trezor/components';
 import type { AccountAddress } from '@trezor/connect';
 
@@ -106,7 +106,7 @@ export const TradingAddressOptions = <TFieldValues extends TradingBuyAddressOpti
                             network: getNetwork(account.symbol),
                         });
                         const balance = accountAddress.balance
-                            ? formatAmount(accountAddress.balance, networkDecimals)
+                            ? convertAmountSubunitsToUnits(accountAddress.balance, networkDecimals)
                             : accountAddress.balance;
 
                         const { coinSymbol, contractAddress } =

--- a/packages/suite/src/views/wallet/trading/common/TradingBalance.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingBalance.tsx
@@ -1,6 +1,6 @@
 import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { TokenAddress } from '@suite-common/wallet-types';
-import { amountToSmallestUnit } from '@suite-common/wallet-utils';
+import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 import { Text } from '@trezor/components';
 
 import { BaseCurrencyValue, HiddenPlaceholder, Translation } from 'src/components/suite';
@@ -40,7 +40,7 @@ export const TradingBalance = ({
     const stringBalance = !isNaN(Number(balance)) ? balance : '0';
     const formattedBalance =
         stringBalance && shouldSendInSats
-            ? amountToSmallestUnit(stringBalance, networkDecimals)
+            ? convertAmountUnitsToSubunits(stringBalance, networkDecimals)
             : stringBalance;
 
     const { fiatAmount } = useFiatFromCryptoValue({

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAccountOption.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAccountOption.tsx
@@ -1,5 +1,5 @@
 import { cryptoIdToNetwork, parseCryptoId } from '@suite-common/trading';
-import { amountToSmallestUnit } from '@suite-common/wallet-utils';
+import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 import { Badge, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -33,7 +33,7 @@ export const TradingFormInputAccountOption = ({
 
     const balanceLabel = tradingGetAccountLabel(option.label, shouldSendInSats);
     const balance = shouldSendInSats
-        ? amountToSmallestUnit(option.balance, decimals)
+        ? convertAmountUnitsToSubunits(option.balance, decimals)
         : option.balance;
     const accountType = optionGroups.find(group =>
         group.options.find(

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInputs.tsx
@@ -11,7 +11,7 @@ import {
     type TradingSellFormProps,
 } from '@suite-common/trading';
 import { TokenAddress } from '@suite-common/wallet-types';
-import { formatAmount } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
 import { Column, FractionButton, FractionButtonProps, Row } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils/src/firmwareUtils';
 import { spacings } from '@trezor/theme';
@@ -85,7 +85,10 @@ export const TradingFormInputs = () => {
         const tokenAddress = (output.token ?? undefined) as TokenAddress | undefined;
         const outputAmount =
             shouldSendInSats && output.amount
-                ? formatAmount(output.amount, getTradingNetworkDecimals({ sendCryptoSelect }))
+                ? convertAmountSubunitsToUnits(
+                      output.amount,
+                      getTradingNetworkDecimals({ sendCryptoSelect }),
+                  )
                 : output.amount;
 
         return (
@@ -165,7 +168,10 @@ export const TradingFormInputs = () => {
         const supportedCryptoCurrencies = exchangeInfo?.buyCryptoIds;
         const outputAmount =
             shouldSendInSats && output.amount
-                ? formatAmount(output.amount, getTradingNetworkDecimals({ sendCryptoSelect }))
+                ? convertAmountSubunitsToUnits(
+                      output.amount,
+                      getTradingNetworkDecimals({ sendCryptoSelect }),
+                  )
                 : output.amount;
 
         return (

--- a/packages/transport/src/types/index.ts
+++ b/packages/transport/src/types/index.ts
@@ -1,12 +1,14 @@
+import { Branded } from '@trezor/type-utils';
+
 import type { DEVICE_TYPE } from '../api/abstract';
 
 export * from './apiCall';
 
-export type Session = `${number}` & { __type: 'Session' };
+export type Session = `${number}` & Branded<'Session'>;
 export const Session = (input: `${number}`) => `${input}` as Session;
-export type PathInternal = string & { __type: 'PathInternal' };
+export type PathInternal = string & Branded<'PathInternal'>;
 export const PathInternal = (input: string) => input as PathInternal;
-export type PathPublic = `${number}` & { __type: 'PathPublic' };
+export type PathPublic = `${number}` & Branded<'PathPublic'>;
 export const PathPublic = (input: `${number}`) => `${input}` as PathPublic;
 
 export type DescriptorApiLevel = {
@@ -34,8 +36,12 @@ export type Descriptor = Omit<DescriptorApiLevel, 'path'> & {
 
 export interface Logger {
     info(...args: any): void;
+
     debug(...args: any): void;
+
     log(...args: any): void;
+
     warn(...args: any): void;
+
     error(...args: any): void;
 }

--- a/packages/type-utils/src/branded.ts
+++ b/packages/type-utils/src/branded.ts
@@ -1,0 +1,8 @@
+export class Branded<T extends string> {
+    __type!: T;
+}
+
+export class BrandedArity2<P1 extends string, P2> {
+    __type1!: P1;
+    __type2!: P2;
+}

--- a/packages/type-utils/src/index.ts
+++ b/packages/type-utils/src/index.ts
@@ -4,3 +4,4 @@ export * from './timeout';
 export * from './utils';
 export * from './object';
 export * from './exhaustive';
+export * from './branded';

--- a/packages/utils/tests/typedObjectFromEntries.test.ts
+++ b/packages/utils/tests/typedObjectFromEntries.test.ts
@@ -1,0 +1,21 @@
+import { typedObjectFromEntries } from '../src/typedObjectFromEntries';
+import { typedObjectKeys } from '../src/typedObjectKeys';
+
+const map = {
+    a: 1,
+    b: 2,
+};
+
+export const _test: { [K in keyof typeof map]: number } = typedObjectFromEntries([
+    ['a', 10],
+    ['b', 20],
+] as const);
+
+export const _test2: { [K in keyof typeof map]: number } = typedObjectFromEntries(
+    typedObjectKeys(map).map(k => [k, map[k] * 2]),
+);
+
+// @ts-expect-error String cannot be assigned to number as map-value
+export const _test3: { [K in keyof typeof map]: number } = typedObjectFromEntries(
+    typedObjectKeys(map).map(k => [k, '']),
+);

--- a/packages/utils/tests/typedObjectKeys.test.ts
+++ b/packages/utils/tests/typedObjectKeys.test.ts
@@ -1,0 +1,6 @@
+import { typedObjectKeys } from '../src/typedObjectKeys';
+
+type AB = { a: number; b: number } | { b: string };
+const ab: AB = { b: 'B' };
+
+export const _test: 'b'[] = typedObjectKeys(ab);

--- a/suite-common/assets/src/utils.ts
+++ b/suite-common/assets/src/utils.ts
@@ -2,6 +2,7 @@ export interface AssetFiatBalance {
     fiatBalance: string | null;
     symbol: string;
 }
+
 export interface AssetFiatBalanceWithPercentage extends AssetFiatBalance {
     fiatPercentage: number;
     fiatPercentageOffset: number;

--- a/suite-common/assets/tsconfig.json
+++ b/suite-common/assets/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
-    "references": []
+    "references": [
+        { "path": "../../packages/utils" }
+    ]
 }

--- a/suite-common/formatters/src/FormatterProvider.tsx
+++ b/suite-common/formatters/src/FormatterProvider.tsx
@@ -5,6 +5,7 @@ import { FormatNumberOptions } from '@formatjs/intl';
 
 import { SignValue } from '@suite-common/suite-types';
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import type { BigNumber } from '@trezor/utils';
 
 import { NetworkNameFormatter } from './formatters/NetworkNameFormatter';
 import { SignValueFormatter } from './formatters/SignValueFormatter';
@@ -43,7 +44,7 @@ export type Formatters = {
     NetworkNameFormatter: Formatter<NetworkSymbol, string>;
     SignValueFormatter: Formatter<SignValue | undefined, string>;
     BaseCurrencyAmountFormatter: Formatter<
-        string | number,
+        string | number | BigNumber,
         string | null,
         FiatAmountFormatterDataContext<FormatNumberOptions>
     >;

--- a/suite-common/formatters/src/formatters/prepareBaseCurrencyAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareBaseCurrencyAmountFormatter.ts
@@ -11,7 +11,7 @@ export type FiatAmountFormatterDataContext<T> = {
 };
 
 const handleBigNumberFormatting = (
-    value: string | number,
+    value: string | number | BigNumber,
     dataContext: FiatAmountFormatterDataContext<FormatNumberOptions>,
     config: FormatterConfig,
 ) => {
@@ -22,7 +22,7 @@ const handleBigNumberFormatting = (
 
     if (baseCurrencyValue.gt(Number.MAX_VALUE)) {
         // backup when number is too big, the formatting is different from what should be for currencies
-        return `${value} ${currencyForDisplay}`;
+        return `${value instanceof BigNumber ? value.toFixed() : value} ${currencyForDisplay}`;
     }
 
     return intl.formatNumber(baseCurrencyValue.toNumber(), {
@@ -36,7 +36,7 @@ const handleBigNumberFormatting = (
 
 export const prepareBaseCurrencyAmountFormatter = (config: FormatterConfig) =>
     makeFormatter<
-        string | number,
+        string | number | BigNumber,
         string | null,
         FiatAmountFormatterDataContext<FormatNumberOptions>
     >((value, dataContext, shouldRedactNumbers) => {
@@ -48,4 +48,4 @@ export const prepareBaseCurrencyAmountFormatter = (config: FormatterConfig) =>
         const formattedValue = handleBigNumberFormatting(value, dataContext, config);
 
         return shouldRedactNumbers ? redactNumericalSubstring(formattedValue) : formattedValue;
-    }, 'FiatAmountFormatter');
+    }, 'BaseCurrencyAmountFormatter');

--- a/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
@@ -7,8 +7,8 @@ import {
     networks,
 } from '@suite-common/wallet-config';
 import {
-    amountToSmallestUnit,
-    formatAmount,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     redactNumericalSubstring,
 } from '@suite-common/wallet-utils';
 import { PROTO } from '@trezor/connect';
@@ -66,7 +66,7 @@ const convertToUnit = (
         smallestUnitsOverride === true ||
         (isBalance && areAmountUnitsSupported && bitcoinAmountUnit === PROTO.AmountUnit.SATOSHI)
     ) {
-        return amountToSmallestUnit(value, decimals);
+        return convertAmountUnitsToSubunits(value, decimals);
     }
 
     // if it's not balance and sats units are disabled, values other than balances are in sats so we need to convert it to BTC
@@ -74,7 +74,7 @@ const convertToUnit = (
         !isBalance &&
         (bitcoinAmountUnit !== PROTO.AmountUnit.SATOSHI || !areAmountUnitsSupported)
     ) {
-        return formatAmount(value, decimals ?? BASE_CRYPTO_MAX_DISPLAYED_DECIMALS);
+        return convertAmountSubunitsToUnits(value, decimals ?? BASE_CRYPTO_MAX_DISPLAYED_DECIMALS);
     }
 
     return value;

--- a/suite-common/formatters/src/utils/convert.ts
+++ b/suite-common/formatters/src/utils/convert.ts
@@ -1,6 +1,6 @@
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import {
-    amountToSmallestUnit,
+    convertAmountUnitsToSubunits,
     formatNetworkAmount,
     fromFiatCurrency,
     toFiatCurrency,
@@ -46,5 +46,5 @@ export const convertFiatToCryptoAmount = ({
         return cryptoAmount;
     }
 
-    return amountToSmallestUnit(new BigNumber(cryptoAmount), decimals);
+    return convertAmountUnitsToSubunits(new BigNumber(cryptoAmount), decimals);
 };

--- a/suite-common/formatters/src/utils/convert.ts
+++ b/suite-common/formatters/src/utils/convert.ts
@@ -19,14 +19,14 @@ export const convertCryptoToFiatAmount = ({
     symbol,
     isAmountInSats = true,
     rate,
-}: ConvertInput): string | null => {
+}: ConvertInput): BigNumber | null => {
     if (!amount) {
         return null;
     }
 
     const networkAmount = isAmountInSats ? formatNetworkAmount(amount, symbol) : amount;
 
-    return toFiatCurrency(networkAmount, rate);
+    return toFiatCurrency({ amount: networkAmount, rate });
 };
 
 export const convertFiatToCryptoAmount = ({
@@ -34,17 +34,17 @@ export const convertFiatToCryptoAmount = ({
     symbol,
     isAmountInSats = true,
     rate,
-}: ConvertInput): string | null => {
+}: ConvertInput): BigNumber | null => {
     if (!amount) {
         return null;
     }
 
     const { decimals } = getNetwork(symbol);
-    const cryptoAmount = fromFiatCurrency(amount, decimals, rate);
+    const cryptoAmount = fromFiatCurrency({ localAmount: amount, rate });
 
     if (!cryptoAmount || !isAmountInSats) {
         return cryptoAmount;
     }
 
-    return convertAmountUnitsToSubunits(new BigNumber(cryptoAmount), decimals);
+    return new BigNumber(convertAmountUnitsToSubunits(new BigNumber(cryptoAmount), decimals));
 };

--- a/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
+++ b/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
@@ -2,7 +2,7 @@ import { BuyTrade, BuyTradeQuoteRequest } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
 import { Network } from '@suite-common/wallet-config';
-import { formatAmount } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
 
 import { TRADING_BUY_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
@@ -47,7 +47,9 @@ const getQuoteRequestData = ({
         formValues;
     const decimals = getTradingNetworkDecimals({ network });
     const cryptoStringAmount =
-        cryptoInput && shouldSendInSats ? formatAmount(cryptoInput, decimals) : cryptoInput;
+        cryptoInput && shouldSendInSats
+            ? convertAmountSubunitsToUnits(cryptoInput, decimals)
+            : cryptoInput;
 
     const request = {
         wantCrypto: amountInCrypto,

--- a/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
@@ -2,7 +2,7 @@ import { ExchangeTrade, ExchangeTradeQuoteRequest } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
 import { Network } from '@suite-common/wallet-config';
-import { formatAmount } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
 
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
@@ -41,7 +41,7 @@ export const getQuoteRequestData = ({
     const unformattedOutputAmount = outputs[0].amount ?? '';
     const sendStringAmount =
         unformattedOutputAmount && shouldSendInSats
-            ? formatAmount(unformattedOutputAmount, decimals)
+            ? convertAmountSubunitsToUnits(unformattedOutputAmount, decimals)
             : unformattedOutputAmount;
 
     if (

--- a/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
@@ -2,7 +2,7 @@ import { isRejectedWithValue } from '@reduxjs/toolkit';
 import { ExchangeTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { amountToSmallestUnit } from '@suite-common/wallet-utils';
+import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 
 import { exchangeThunks, tradingThunks } from '../';
 import { SendDexTransactionThunkProps } from './sendDexTransactionThunk';
@@ -87,7 +87,7 @@ export const sendTransactionThunk = createThunk<
         }
 
         const sendStringAmount = shouldSendInSats
-            ? amountToSmallestUnit(selectedTrade.sendStringAmount, decimals)
+            ? convertAmountUnitsToSubunits(selectedTrade.sendStringAmount, decimals)
             : selectedTrade.sendStringAmount;
         const sendPaymentExtraId =
             selectedTrade.partnerPaymentExtraId || trade?.partnerPaymentExtraId;

--- a/suite-common/trading/src/thunks/sell/__tests__/handleSellRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/handleSellRequestThunk.test.ts
@@ -3,7 +3,7 @@ import { CryptoId, SellFiatTrade } from 'invity-api';
 
 import { configureMockStore, extraDependenciesMock } from '@suite-common/test-utils';
 import { getNetwork } from '@suite-common/wallet-config';
-import { amountToSmallestUnit } from '@suite-common/wallet-utils';
+import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 
 import { sellThunks } from '../../';
 import { invityAPI } from '../../../invityAPI';
@@ -166,7 +166,7 @@ describe('handleSellRequestThunk', () => {
                         ...input.formValues,
                         outputs: input.formValues.outputs.map(output => ({
                             ...output,
-                            amount: amountToSmallestUnit(output.amount, 8),
+                            amount: convertAmountUnitsToSubunits(output.amount, 8),
                         })),
                     },
                     shouldSendInSats: true,

--- a/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
+++ b/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
@@ -2,7 +2,7 @@ import { SellFiatTrade, SellFiatTradeQuoteRequest } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
 import { Network } from '@suite-common/wallet-config';
-import { formatAmount } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
 import { Timer } from '@trezor/react-utils';
 
 import { TRADING_DEFAULT_SELL_FLOWS, TRADING_SELL_THUNK_PREFIX } from '../../constants';
@@ -46,7 +46,7 @@ const getQuoteRequestData = ({
     const unformattedOutputAmount = outputs[0].amount;
     const cryptoStringAmount =
         unformattedOutputAmount && shouldSendInSats
-            ? formatAmount(unformattedOutputAmount, decimals)
+            ? convertAmountSubunitsToUnits(unformattedOutputAmount, decimals)
             : unformattedOutputAmount;
     const currencySelect = outputs[0].currency;
 

--- a/suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts
@@ -3,7 +3,7 @@ import { SellFiatTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
 import { Account } from '@suite-common/wallet-types';
-import { amountToSmallestUnit } from '@suite-common/wallet-utils';
+import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 
 import { tradingThunks } from '../';
 import { TRADING_SELL_THUNK_PREFIX } from '../../constants';
@@ -65,7 +65,7 @@ export const sendSellTransactionThunk = createThunk(
         }
 
         const cryptoStringAmount = shouldSendInSats
-            ? amountToSmallestUnit(selectedTrade.cryptoStringAmount, decimals)
+            ? convertAmountUnitsToSubunits(selectedTrade.cryptoStringAmount, decimals)
             : selectedTrade.cryptoStringAmount;
         const { destinationPaymentExtraId } = selectedTrade;
 

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -17,11 +17,11 @@ import {
     RbfTransactionParams,
 } from '@suite-common/wallet-types';
 import {
-    amountToSmallestUnit,
     calculateMax,
     calculateTotal,
     calculateTotalGasCost,
-    formatAmount,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     getAccountIdentity,
     getEthereumEstimateFeeParams,
     getExternalComposeOutput,
@@ -57,7 +57,7 @@ export const calculate = (
     );
 
     const availableTokenBalance = token
-        ? amountToSmallestUnit(token.balance!, token.decimals)
+        ? convertAmountUnitsToSubunits(token.balance!, token.decimals)
         : undefined;
 
     if (output.type === 'send-max' || output.type === 'send-max-noaddress') {
@@ -242,7 +242,7 @@ export const composeEthereumTransactionFeeLevelsThunk = createThunk<
         Object.keys(resultLevels).forEach(key => {
             const tx = resultLevels[key];
             if (tx.type !== 'error') {
-                tx.max = tx.max ? formatAmount(tx.max, decimals) : undefined;
+                tx.max = tx.max ? convertAmountSubunitsToUnits(tx.max, decimals) : undefined;
                 tx.estimatedFeeLimit = !customFeeLimit.isNaN()
                     ? customFeeLimit.toFixed(0)
                     : undefined;

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -8,10 +8,10 @@ import {
     PrecomposedTransaction,
 } from '@suite-common/wallet-types';
 import {
-    amountToSmallestUnit,
     calculateMax,
     calculateTotal,
-    formatAmount,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     getAccountIdentity,
     getExternalComposeOutput,
 } from '@suite-common/wallet-utils';
@@ -43,7 +43,7 @@ const calculate = (
     let amount: string;
     let max: string | undefined;
     const availableTokenBalance = token
-        ? amountToSmallestUnit(token.balance!, token.decimals)
+        ? convertAmountUnitsToSubunits(token.balance!, token.decimals)
         : undefined;
     if (output.type === 'send-max' || output.type === 'send-max-noaddress') {
         max = availableTokenBalance || calculateMax(availableBalance, feeInLamports);
@@ -67,8 +67,8 @@ const calculate = (
         const errorMessage = {
             id: 'REMAINING_BALANCE_LESS_THAN_RENT' as const,
             values: {
-                remainingSolBalance: formatAmount(remainingSolBalance, decimals),
-                rent: formatAmount(rent, decimals),
+                remainingSolBalance: convertAmountSubunitsToUnits(remainingSolBalance, decimals),
+                rent: convertAmountSubunitsToUnits(rent, decimals),
             },
         };
 
@@ -148,7 +148,10 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
                 formState.outputs[0].amount = tokenInfo.balance;
             } else {
                 // minimal amount for purpose of fee estimation, at least to cover rent + 1 lamport
-                formState.outputs[0].amount = formatAmount((account.misc?.rent ?? 0) + 1, decimals);
+                formState.outputs[0].amount = convertAmountSubunitsToUnits(
+                    (account.misc?.rent ?? 0) + 1,
+                    decimals,
+                );
             }
         }
 
@@ -244,7 +247,7 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
         Object.keys(resultLevels).forEach(key => {
             const tx = resultLevels[key];
             if (tx.type !== 'error') {
-                tx.max = tx.max ? formatAmount(tx.max, decimals) : undefined;
+                tx.max = tx.max ? convertAmountSubunitsToUnits(tx.max, decimals) : undefined;
             }
             if (tx.type === 'error' && tx.error === 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE') {
                 tx.errorMessage = {

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -16,8 +16,8 @@ import {
     PrecomposedTransactionFinalCardano,
 } from '@suite-common/wallet-types';
 import {
-    amountToSmallestUnit,
-    formatAmount,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     formatNetworkAmount,
     getAccountDecimals,
     getAreSatoshisUsed,
@@ -114,7 +114,9 @@ export const convertSendFormDraftsBtcAmountUnitsThunk = createThunk(
             const areSatsSupported = hasNetworkFeatures(relatedAccount, 'amount-unit');
 
             const amountFormatter =
-                areSatsAmountUnit && areSatsSupported ? amountToSmallestUnit : formatAmount;
+                areSatsAmountUnit && areSatsSupported
+                    ? convertAmountUnitsToSubunits
+                    : convertAmountSubunitsToUnits;
 
             const updatedDraft = cloneObject(draft);
             const amountDecimals = getAccountDecimals(relatedAccount.symbol)!;
@@ -310,7 +312,7 @@ export const pushSendFormTransactionThunk = createThunk<
 
         // get total amount without fee OR token amount
         const formattedAmount = token
-            ? `${formatAmount(
+            ? `${convertAmountSubunitsToUnits(
                   precomposedTransaction.totalSpent,
                   token.decimals,
               )} ${token.symbol!.toUpperCase()}`

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -7,12 +7,13 @@ import {
 } from '@trezor/blockchain-link-types/src/blockbook-api';
 import { SolanaStakingAccount } from '@trezor/blockchain-link-types/src/solana';
 import { AccountInfo, PROTO, StaticSessionId, TokenInfo } from '@trezor/connect';
+import { Branded } from '@trezor/type-utils';
 
 export type MetadataItem = string;
 export type XpubAddress = string;
 
-export type TokenSymbol = string & { __type: 'TokenSymbol' };
-export type TokenAddress = string & { __type: 'TokenAddress' };
+export type TokenSymbol = string & Branded<'TokenSymbol'>;
+export type TokenAddress = string & Branded<'TokenAddress'>;
 
 export type AddressType = 'contract' | 'fingerprint' | 'policyId';
 
@@ -102,7 +103,7 @@ export type AccountBackendSpecific =
       };
 
 export type AccountKey = string; // <AccountDescriptor>-<NetworkSymbol>-<DeviceStaticSessionId>
-export type AccountDescriptor = string & { __type: 'AccountDescriptor' }; // Descriptor or xpub/zpub/..
+export type AccountDescriptor = string & Branded<'AccountDescriptor'>; // Descriptor or xpub/zpub/..
 
 export type Account = {
     deviceState: StaticSessionId;

--- a/suite-common/wallet-types/src/fiatRates.ts
+++ b/suite-common/wallet-types/src/fiatRates.ts
@@ -1,6 +1,7 @@
 import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import type { FiatRatesBySymbol } from '@trezor/connect';
+import { Branded } from '@trezor/type-utils';
 
 import { TokenAddress } from './account';
 
@@ -20,9 +21,9 @@ export interface HistoricRates {
     ts: number;
 }
 
-export type FiatRateKey = string & { __type: 'FiatRateKey' };
+export type FiatRateKey = string & Branded<'FiatRateKey'>;
 
-export type Timestamp = number & { __type: 'Timestamp' };
+export type Timestamp = number & Branded<'Timestamp'>;
 
 export type RateType = 'current' | 'lastWeek' | 'historic';
 export type RateTypeWithoutHistoric = Exclude<RateType, 'historic'>;

--- a/suite-common/wallet-types/src/send.ts
+++ b/suite-common/wallet-types/src/send.ts
@@ -1,5 +1,7 @@
+import { Branded } from '@trezor/type-utils';
+
 import { AccountKey, TokenAddress } from './account';
 
 export type SendFormDraftKey =
     | AccountKey
-    | (`${AccountKey}-${TokenAddress}` & { __type: 'SendFormDraftKey' });
+    | (`${AccountKey}-${TokenAddress}` & Branded<'SendFormDraftKey'>);

--- a/suite-common/wallet-types/src/wallet.ts
+++ b/suite-common/wallet-types/src/wallet.ts
@@ -1,6 +1,8 @@
+import { Branded } from '@trezor/type-utils';
+
 /**
  * First testnet address => 44/1/0/0/0
  *
  * See `packages/connect/src/device/workflow/validateState.ts` where it is retrieved
  */
-export type WalletDescriptor = string & { __type: 'WalletDescriptor' };
+export type WalletDescriptor = string & Branded<'WalletDescriptor'>;

--- a/suite-common/wallet-utils/src/AmountTypes.ts
+++ b/suite-common/wallet-utils/src/AmountTypes.ts
@@ -1,0 +1,17 @@
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { Branded } from '@trezor/type-utils';
+import { BigNumber } from '@trezor/utils';
+
+/**
+ * Bitcoin, Ether, Dogecoin, ...
+ */
+export type AmountUnit<T extends NetworkSymbol> = BigNumber & Branded<`amount-whole-${T}`>;
+export const asAmountUnit = <T extends NetworkSymbol>(value: BigNumber, _symbol: T) =>
+    value as unknown as AmountUnit<T>;
+
+/**
+ * Sats, ...
+ */
+export type AmountSubunit<T extends NetworkSymbol> = BigNumber & Branded<`amount-sub-${T}`>;
+export const asAmountSubunit = <T extends NetworkSymbol>(value: BigNumber, _symbol: T) =>
+    value as unknown as AmountSubunit<T>;

--- a/suite-common/wallet-utils/src/__tests__/AccountTypes.test-types.ts
+++ b/suite-common/wallet-utils/src/__tests__/AccountTypes.test-types.ts
@@ -1,0 +1,11 @@
+import { BigNumber } from '@trezor/utils';
+
+import { AmountUnit, asAmountSubunit, asAmountUnit } from '../AmountTypes';
+
+export const test_ok: AmountUnit<'btc'> = asAmountUnit(new BigNumber(1), 'btc');
+
+// @ts-expect-error
+export const testErrorSymbolMismatch: AmountUnit<'btc'> = asAmountUnit(new BigNumber(1), 'eth');
+
+// @ts-expect-error
+export const testErrorSubunit: AmountUnit<'btc'> = asAmountSubunit(new BigNumber(1), 'btc');

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -1,9 +1,13 @@
 import { testMocks } from '@suite-common/test-utils';
 import { Account } from '@suite-common/wallet-types';
+import { BigNumber } from '@trezor/utils';
 
+import { asAmountSubunit, asAmountUnit } from '../AmountTypes';
 import * as fixtures from '../__fixtures__/accountUtils';
 import {
     accountSearchFn,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     enhanceAddresses,
     findAccountDevice,
     formatNetworkAmount,
@@ -24,6 +28,8 @@ import {
     sortByBIP44AddressIndex,
     sortByCoin,
     substituteBip43Path,
+    subunitsToUnits,
+    unitsToSubunits,
 } from '../accountUtils';
 
 const { getSuiteDevice, getWalletAccount } = testMocks;
@@ -333,5 +339,33 @@ describe('account utils', () => {
         accountInfo.addresses.change = [];
         account.addresses = enhanceAddresses(accountInfo, account);
         expect(account.addresses.change).toEqual([]);
+    });
+});
+
+describe(convertAmountUnitsToSubunits.name, () => {
+    it('converts BTC->Sats', () => {
+        expect(convertAmountUnitsToSubunits('1', 8)).toEqual(String(100_000_000));
+    });
+});
+
+describe(unitsToSubunits.name, () => {
+    it('converts BTC->Sats', () => {
+        expect(unitsToSubunits(asAmountUnit(new BigNumber(1), 'btc'), 'btc').toString()).toEqual(
+            String(100_000_000),
+        );
+    });
+});
+
+describe(convertAmountSubunitsToUnits.name, () => {
+    it('converts Sats->BTC', () => {
+        expect(convertAmountSubunitsToUnits('1', 8)).toEqual('0.00000001');
+    });
+});
+
+describe(subunitsToUnits.name, () => {
+    it('converts Sats->BTC', () => {
+        expect(subunitsToUnits(asAmountSubunit(new BigNumber(1), 'btc'), 'btc').toString()).toEqual(
+            '0.00000001',
+        );
     });
 });

--- a/suite-common/wallet-utils/src/__tests__/fiatConverter.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/fiatConverter.test.ts
@@ -1,49 +1,48 @@
 import { fromFiatCurrency, toFiatCurrency } from '../fiatConverterUtils';
 
-const rateNumber = 3007.1079886708517;
+const rate = 3007.1079886708517;
 const rateString = '3007.1079886708517';
-const decimals = 18;
 
 describe('fiatConverter utils: toFiatCurrency', () => {
     it('to existing fiat currency', () => {
-        expect(toFiatCurrency('1', rateNumber)).toBe('3007.11');
-        expect(toFiatCurrency('0', rateNumber)).toBe('0.00');
-        expect(toFiatCurrency('1.00000000000', rateNumber)).toBe('3007.11');
+        expect(toFiatCurrency({ amount: '1', rate })?.toFixed(2)).toBe('3007.11');
+        expect(toFiatCurrency({ amount: '0', rate })?.toFixed(2)).toBe('0.00');
+        expect(toFiatCurrency({ amount: '1.00000000000', rate })?.toFixed(2)).toBe('3007.11');
     });
 
     it('non-numeric amount to fiat currency', () => {
-        expect(toFiatCurrency('12133.3131.3141.4', rateNumber)).toBe(null);
+        expect(toFiatCurrency({ amount: '12133.3131.3141.4', rate })).toBe(null);
     });
 
     it('to existing fiat missing network rates', () => {
-        expect(toFiatCurrency('1', undefined)).toBe(null);
+        expect(toFiatCurrency({ amount: '1', rate: undefined })).toBe(null);
     });
 });
 
 describe('fiatConverter utils: fromFiatCurrency', () => {
     it('from existing fiat currency', () => {
-        expect(fromFiatCurrency(rateString, decimals, rateNumber)).toBe('1.000000000000000000');
-        expect(fromFiatCurrency('0', decimals, rateNumber)).toBe('0.000000000000000000');
-        expect(fromFiatCurrency(rateString, decimals, rateNumber)).toBe('1.000000000000000000');
+        expect(fromFiatCurrency({ localAmount: rateString, rate })?.toFixed(2)).toBe('1.00');
+        expect(fromFiatCurrency({ localAmount: '0', rate })?.toFixed(2)).toBe('0.00');
+        expect(fromFiatCurrency({ localAmount: rateString, rate })?.toFixed(2)).toBe('1.00');
     });
 
     it('non-numeric amount to fiat currency', () => {
-        expect(fromFiatCurrency('12133.3131.3141.4', decimals, rateNumber)).toBe(null);
+        expect(fromFiatCurrency({ localAmount: '12133.3131.3141.4', rate })).toBe(null);
     });
 
     it('different decimals', () => {
-        expect(fromFiatCurrency(rateString, 1, rateNumber)).toBe('1.0');
-        expect(fromFiatCurrency('0', 0, rateNumber)).toBe('0');
-        expect(fromFiatCurrency(rateString, 5, rateNumber)).toBe('1.00000');
+        expect(fromFiatCurrency({ localAmount: rateString, rate })?.toFixed(2)).toBe('1.00');
+        expect(fromFiatCurrency({ localAmount: '0', rate })?.toFixed(2)).toBe('0.00');
+        expect(fromFiatCurrency({ localAmount: rateString, rate })?.toFixed(2)).toBe('1.00');
     });
 
     it('from fiat currency with comma decimal separator', () => {
-        expect(fromFiatCurrency('3007,1079886708517', decimals, rateNumber)).toBe(
-            '1.000000000000000000',
+        expect(fromFiatCurrency({ localAmount: '3007,1079886708517', rate })?.toFixed(2)).toBe(
+            '1.00',
         );
     });
 
     it('missing fiat rates', () => {
-        expect(fromFiatCurrency('1', decimals, undefined)).toBe(null);
+        expect(fromFiatCurrency({ localAmount: '1', rate: undefined })).toBe(null);
     });
 });

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -46,6 +46,7 @@ import {
 import { arrayDistinct, bufferUtils } from '@trezor/utils';
 import { BigNumber, BigNumberValue } from '@trezor/utils/src/bigNumber';
 
+import { AmountSubunit, AmountUnit } from './AmountTypes';
 import { toFiatCurrency } from './fiatConverterUtils';
 import { getFiatRateKey } from './fiatRatesUtils';
 import { getAccountTotalStakingBalance } from './stakingUtils';
@@ -288,7 +289,12 @@ export const getAccountTypeUrl = (path: string) => {
 
 export const getAccountDecimals = (symbol: NetworkSymbol) => networks[symbol]?.decimals;
 
-export const formatAmount = (amount: BigNumberValue, decimals: number) => {
+/**
+ * BTC -> Sats, etc...
+ *
+ * @deprecated Use `subunitsToUnits` instead!
+ */
+export const convertAmountSubunitsToUnits = (amount: BigNumberValue, decimals: number) => {
     const safeAmount = amount || '0';
     const bAmount = new BigNumber(safeAmount);
 
@@ -301,7 +307,12 @@ export const formatAmount = (amount: BigNumberValue, decimals: number) => {
     return bAmount.div(factor).toString(10);
 };
 
-export const amountToSmallestUnit = (amount: BigNumberValue, decimals: number) => {
+/**
+ * Sats -> BTC, etc...
+ *
+ * @deprecated Use `unitsToSubunits` instead!
+ */
+export const convertAmountUnitsToSubunits = (amount: BigNumberValue, decimals: number) => {
     try {
         const bAmount = new BigNumber(amount);
         if (bAmount.isNaN()) {
@@ -315,6 +326,9 @@ export const amountToSmallestUnit = (amount: BigNumberValue, decimals: number) =
     }
 };
 
+/**
+ * @deprecated Use `subunitsToUnits` instead!
+ */
 export const satoshiAmountToBtc = (amount: BigNumberValue) => {
     try {
         const satsAmount = new BigNumber(amount);
@@ -329,6 +343,9 @@ export const satoshiAmountToBtc = (amount: BigNumberValue) => {
     }
 };
 
+/**
+ * @deprecated Use `subunitsToUnits` instead!
+ */
 export const networkAmountToSmallestUnit = (amount: string | null, symbol: NetworkSymbol) => {
     if (!amount) return '0';
 
@@ -336,7 +353,34 @@ export const networkAmountToSmallestUnit = (amount: string | null, symbol: Netwo
 
     if (!decimals) return amount;
 
-    return amountToSmallestUnit(amount, decimals);
+    return convertAmountUnitsToSubunits(amount, decimals);
+};
+
+/**
+ * Converts Bitcoins to Sats (and similarly for other coins)
+ */
+export const unitsToSubunits = <T extends NetworkSymbol, K extends T>(
+    value: AmountUnit<T>,
+    symbol: K,
+): AmountSubunit<T> => {
+    const decimals = getAccountDecimals(symbol);
+
+    const factor = new BigNumber(10).exponentiatedBy(decimals);
+
+    return value.multipliedBy(factor) as AmountSubunit<T>;
+};
+
+/**
+ * Converts Sats to Bitcoin (and similarly for other coins)
+ */
+export const subunitsToUnits = <T extends NetworkSymbol, K extends T>(
+    value: AmountSubunit<T>,
+    symbol: K,
+): AmountUnit<T> => {
+    const decimals = getAccountDecimals(symbol);
+    const factor = new BigNumber(10).exponentiatedBy(decimals);
+
+    return value.div(factor) as AmountUnit<T>;
 };
 
 export const formatNetworkAmount = (
@@ -349,7 +393,7 @@ export const formatNetworkAmount = (
 
     if (!decimals) return amount;
 
-    let formattedAmount = formatAmount(amount, decimals);
+    let formattedAmount = convertAmountSubunitsToUnits(amount, decimals);
 
     if (withSymbol) {
         let formattedSymbol = getNetworkDisplaySymbol(symbol);
@@ -366,7 +410,10 @@ export const formatNetworkAmount = (
 };
 
 export const formatTokenAmount = (tokenTransfer: TokenTransfer) => {
-    const formattedAmount = formatAmount(tokenTransfer.amount, tokenTransfer.decimals);
+    const formattedAmount = convertAmountSubunitsToUnits(
+        tokenTransfer.amount,
+        tokenTransfer.decimals,
+    );
     const formattedTokenSymbol = tokenTransfer.symbol?.toUpperCase();
 
     return formattedTokenSymbol ? `${formattedAmount} ${formattedTokenSymbol}` : formattedAmount;
@@ -466,7 +513,7 @@ export const enhanceTokens = (tokens: Account['tokens']) => {
             ...t,
             name: t.name || symbol,
             symbol: symbol.toLowerCase(),
-            balance: formatAmount(t.balance || 0, t.decimals),
+            balance: convertAmountSubunitsToUnits(t.balance || 0, t.decimals),
         };
     });
 };

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -383,6 +383,9 @@ export const subunitsToUnits = <T extends NetworkSymbol, K extends T>(
     return value.div(factor) as AmountUnit<T>;
 };
 
+/**
+ * @deprecated use `subunitsToUnits` if you don't need formatting. If you need formating, use function that does ONLY formatting.
+ */
 export const formatNetworkAmount = (
     amount: string,
     symbol: NetworkSymbol,
@@ -656,7 +659,9 @@ export const getAccountTokensFiatBalance = (
             const tokenFiatRate = rates?.[tokenFiatRateKey];
 
             return tokenFiatRate?.rate && token.balance
-                ? total.plus(toFiatCurrency(token.balance, tokenFiatRate.rate, 2) ?? 0)
+                ? total.plus(
+                      toFiatCurrency({ amount: token.balance, rate: tokenFiatRate.rate }) ?? 0,
+                  )
                 : total;
         }, new BigNumber(0))
         .toFixed();
@@ -664,7 +669,7 @@ export const getAccountTokensFiatBalance = (
 export const getStakingFiatBalance = (account: Account, rate: number | undefined) => {
     const balance = getAccountTotalStakingBalance(account) ?? '0';
 
-    return toFiatCurrency(balance, rate, 2);
+    return toFiatCurrency({ amount: balance, rate });
 };
 
 type GetAccountFiatBalanceParams = {
@@ -690,7 +695,10 @@ export const getAccountFiatBalance = ({
     let totalBalance = new BigNumber(0);
 
     // account fiat balance
-    const accountBalance = toFiatCurrency(account.formattedBalance, coinFiatRate.rate, 2);
+    const accountBalance = toFiatCurrency({
+        amount: account.formattedBalance,
+        rate: coinFiatRate.rate,
+    });
     totalBalance = totalBalance.plus(accountBalance ?? 0);
 
     // sum fiat value of all tokens

--- a/suite-common/wallet-utils/src/cardanoUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoUtils.ts
@@ -11,8 +11,8 @@ import { CARDANO, CardanoCertificate, CardanoOutput, PROTO } from '@trezor/conne
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import {
-    amountToSmallestUnit,
-    formatAmount,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     formatNetworkAmount,
     networkAmountToSmallestUnit,
 } from './accountUtils';
@@ -81,7 +81,7 @@ export const transformUserOutputs = (
                       {
                           unit: output.token,
                           quantity: output.amount
-                              ? amountToSmallestUnit(output.amount, tokenDecimals)
+                              ? convertAmountUnitsToSubunits(output.amount, tokenDecimals)
                               : '0',
                       },
                   ]
@@ -195,5 +195,5 @@ export const formatMaxOutputAmount = (
     const tokenDecimals =
         account.tokens?.find(t => t.contract === maxOutput.assets[0].unit)?.decimals ?? 0;
 
-    return formatAmount(maxAmount, tokenDecimals);
+    return convertAmountSubunitsToUnits(maxAmount, tokenDecimals);
 };

--- a/suite-common/wallet-utils/src/fiatConverterUtils.ts
+++ b/suite-common/wallet-utils/src/fiatConverterUtils.ts
@@ -1,6 +1,16 @@
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-export const toFiatCurrency = (amount: string, rate?: number, decimals = 2) => {
+type ToFiatCurrencyParams = {
+    amount: string | BigNumber;
+    rate: number | undefined;
+};
+
+/**
+ * This function SHALL NEVER round or change precision. This is simply just a multiplication of two numbers.
+ *
+ * Formatting MUST be handled only in formatters in the components, etc... NOT HERE!
+ */
+export const toFiatCurrency = ({ amount, rate }: ToFiatCurrencyParams) => {
     if (!rate) {
         return null;
     }
@@ -15,10 +25,20 @@ export const toFiatCurrency = (amount: string, rate?: number, decimals = 2) => {
         return null;
     }
 
-    return decimals === -1 ? localAmount.toFixed() : localAmount.toFixed(decimals);
+    return localAmount;
 };
 
-export const fromFiatCurrency = (localAmount: string, decimals: number, rate?: number) => {
+type FromFiatCurrencyParams = {
+    localAmount: string;
+    rate: number | undefined;
+};
+
+/**
+ * This function SHALL NEVER round or change precision. This is simply just a division of two numbers.
+ *
+ * Formatting MUST be handled only in formatters in the components, etc... NOT HERE!
+ */
+export const fromFiatCurrency = ({ localAmount, rate }: FromFiatCurrencyParams) => {
     if (!rate) {
         return null;
     }
@@ -29,7 +49,6 @@ export const fromFiatCurrency = (localAmount: string, decimals: number, rate?: n
     }
 
     const amount = new BigNumber(formattedLocalAmount).div(rate);
-    const amountStr = amount.isNaN() ? null : amount.toFixed(decimals);
 
-    return amountStr;
+    return amount.isNaN() ? null : amount;
 };

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -42,7 +42,7 @@ import {
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import {
-    amountToSmallestUnit,
+    convertAmountUnitsToSubunits,
     formatNetworkAmount,
     getUtxoOutpoint,
     networkAmountToSmallestUnit,
@@ -120,7 +120,7 @@ const getSerializedErc20Transfer = (token: TokenInfo, to: string, amount: string
     // 32 bytes address parameter, remove '0x' prefix
     const erc20recipient = padLeft(to, 64).substring(2);
     // convert amount to satoshi
-    const tokenAmount = amountToSmallestUnit(amount, token.decimals);
+    const tokenAmount = convertAmountUnitsToSubunits(amount, token.decimals);
     // 32 bytes amount paramter, remove '0x' prefix
     const erc20amount = padLeft(numberToHex(tokenAmount), 64).substring(2);
 
@@ -407,7 +407,7 @@ export const getExternalComposeOutput = (
 
     const tokenInfo = findToken(account.tokens, token);
     const decimals = tokenInfo ? tokenInfo.decimals : network.decimals;
-    const formattedAmount = amountToSmallestUnit(amount, decimals);
+    const formattedAmount = convertAmountUnitsToSubunits(amount, decimals);
 
     let output: ExternalOutput;
     if (isMaxActive) {

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -246,14 +246,14 @@ export const sumTransactionsFiat = (
             const cardanoWithdrawal = formatCardanoWithdrawal(tx);
             if (cardanoWithdrawal) {
                 totalAmount = totalAmount.plus(
-                    toFiatCurrency(cardanoWithdrawal, historicRate, -1) ?? 0,
+                    toFiatCurrency({ amount: cardanoWithdrawal, rate: historicRate }) ?? 0,
                 );
             }
 
             const cardanoDeposit = formatCardanoDeposit(tx);
             if (cardanoDeposit) {
                 totalAmount = totalAmount.minus(
-                    toFiatCurrency(cardanoDeposit, historicRate, -1) ?? 0,
+                    toFiatCurrency({ amount: cardanoDeposit, rate: historicRate }) ?? 0,
                 );
             }
         }
@@ -272,34 +272,39 @@ export const sumTransactionsFiat = (
 
                 if (transferType === 'sent') {
                     totalAmount = totalAmount.minus(
-                        toFiatCurrency(tokenAmount, historicTokenRate, -1) ?? 0,
+                        toFiatCurrency({ amount: tokenAmount, rate: historicTokenRate }) ?? 0,
                     );
                 }
 
                 if (transferType === 'recv') {
                     totalAmount = totalAmount.plus(
-                        toFiatCurrency(tokenAmount, historicTokenRate, -1) ?? 0,
+                        toFiatCurrency({ amount: tokenAmount, rate: historicTokenRate }) ?? 0,
                     );
                 }
             });
         } else {
             // count in only if Inputs/Outputs includes my account (EVM does not need to)
             if (tx.type === 'sent') {
-                totalAmount = totalAmount.minus(toFiatCurrency(amount, historicRate, -1) ?? 0);
+                totalAmount = totalAmount.minus(
+                    toFiatCurrency({ amount, rate: historicRate }) ?? 0,
+                );
             }
 
             if (tx.type === 'recv' || tx.type === 'joint') {
-                totalAmount = totalAmount.plus(toFiatCurrency(amount, historicRate, -1) ?? 0);
+                totalAmount = totalAmount.plus(toFiatCurrency({ amount, rate: historicRate }) ?? 0);
             }
         }
 
         if (isTxFeePaid(tx)) {
-            totalAmount = totalAmount.minus(toFiatCurrency(fee, historicRate, -1) ?? 0);
+            totalAmount = totalAmount.minus(
+                toFiatCurrency({ amount: fee, rate: historicRate }) ?? 0,
+            );
         }
 
         tx.internalTransfers.forEach(internalTx => {
             const amountInternal = formatNetworkAmount(internalTx.amount, tx.symbol);
-            const amountInternalFiat = toFiatCurrency(amountInternal, historicRate, -1) ?? 0;
+            const amountInternalFiat =
+                toFiatCurrency({ amount: amountInternal, rate: historicRate }) ?? 0;
 
             if (internalTx.type === 'sent') {
                 totalAmount = totalAmount.minus(amountInternalFiat);

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -26,10 +26,15 @@ import {
     TokenInfo,
     TokenTransfer,
 } from '@trezor/connect';
+import { Branded } from '@trezor/type-utils';
 import { arrayPartition } from '@trezor/utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { formatAmount, formatNetworkAmount, isTokenTransferMatchesSearch } from './accountUtils';
+import {
+    convertAmountSubunitsToUnits,
+    formatNetworkAmount,
+    isTokenTransferMatchesSearch,
+} from './accountUtils';
 import { getFiatRateKey, roundTimestampToNearestPastHour } from './fiatRatesUtils';
 import { getMyInputsFromTransaction } from './getMyInputsFromTransaction';
 import { toFiatCurrency } from '../src/fiatConverterUtils';
@@ -91,7 +96,7 @@ export const parseTransactionDateKey = (key: string) => {
     return new Date(Number(year), Number(month) - 1, Number(day));
 };
 
-export type MonthKey = string & { __type: 'MonthKey' };
+export type MonthKey = string & Branded<'MonthKey'>;
 export const generateTransactionMonthKey = (d: Date): MonthKey =>
     // Adding days because of time zones of UTC
     addDays(startOfMonth(d), 1).toUTCString() as MonthKey;
@@ -263,7 +268,7 @@ export const sumTransactionsFiat = (
                     token.contract as TokenAddress,
                 );
                 const historicTokenRate = historicFiatRates?.[tokenFiatRateKey]?.[roundedTimestamp];
-                const tokenAmount = formatAmount(token.amount, token.decimals);
+                const tokenAmount = convertAmountSubunitsToUnits(token.amount, token.decimals);
 
                 if (transferType === 'sent') {
                     totalAmount = totalAmount.minus(
@@ -607,7 +612,7 @@ const getEthereumRbfParams = (
               address: token.to,
               token: token.contract,
               amount: token.amount,
-              formattedAmount: formatAmount(token.amount, token.decimals),
+              formattedAmount: convertAmountSubunitsToUnits(token.amount, token.decimals),
           }
         : {
               address: vout[0].addresses![0],

--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -117,7 +117,7 @@ export const selectAccountTokenFiatBalance = createMemoizedSelector(
 
         if (!rate || !balance) return '0';
 
-        return toFiatCurrency(balance, rate) ?? '0';
+        return toFiatCurrency({ amount: balance, rate })?.toFixed(2) ?? '0';
     },
 );
 

--- a/suite-native/formatters/src/components/CryptoToFiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/CryptoToFiatAmountFormatter.tsx
@@ -35,7 +35,7 @@ export const CryptoToFiatAmountFormatter = ({
     return (
         <BaseCurrencyAmountFormatter
             symbol={symbol}
-            value={fiatValue}
+            value={fiatValue?.toFixed() ?? null}
             isLoading={isLoading}
             {...otherProps}
         />

--- a/suite-native/formatters/src/components/FiatBalanceFormatter.tsx
+++ b/suite-native/formatters/src/components/FiatBalanceFormatter.tsx
@@ -3,13 +3,14 @@ import React from 'react';
 import { useFormatters } from '@suite-common/formatters';
 import { Box, Text } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { BigNumber } from '@trezor/utils';
 
 import { FormatterProps } from '../types';
 import { AmountText } from './AmountText';
 import { EmptyAmountText } from './EmptyAmountText';
 import { parseBalanceAmount } from '../utils';
 
-type BalanceFormatterProps = FormatterProps<string | null> & {
+type BalanceFormatterProps = FormatterProps<string | null | BigNumber> & {
     isForcedDiscreetMode?: boolean;
     testID?: string;
 };

--- a/suite-native/formatters/src/hooks/useFiatFromCryptoValue.ts
+++ b/suite-native/formatters/src/hooks/useFiatFromCryptoValue.ts
@@ -46,7 +46,7 @@ export const useFiatFromCryptoValue = ({
     if (tokenAddress) {
         const decimalValue = convertTokenValueToDecimal(cryptoValue, tokenDecimals);
 
-        return toFiatCurrency(decimalValue.toString(), rate);
+        return toFiatCurrency({ amount: decimalValue.toString(), rate });
     }
 
     return convertCryptoToFiatAmount({

--- a/suite-native/module-send/src/components/CryptoAmountInput.tsx
+++ b/suite-native/module-send/src/components/CryptoAmountInput.tsx
@@ -4,6 +4,7 @@ import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import { useFormatters } from '@suite-common/formatters';
+import { getNetwork } from '@suite-common/wallet-config';
 import { Input, Text } from '@suite-native/atoms';
 import { useCryptoFiatConverters } from '@suite-native/formatters';
 import { useField, useFormContext } from '@suite-native/forms';
@@ -53,6 +54,7 @@ export const CryptoAmountInput = ({
     const { applyStyle } = useNativeStyles();
     const { setValue, trigger } = useFormContext<SendOutputsFormValues>();
     const { cryptoAmountTransformer } = useAmountInputTransformers(symbol);
+    const { decimals } = getNetwork(symbol);
     const { DisplaySymbolFormatter: formatter } = useFormatters();
     const debounce = useDebounce();
 
@@ -83,7 +85,7 @@ export const CryptoAmountInput = ({
         onChange(transformedValue);
 
         const fiatValue = converters?.convertCryptoToFiat?.(transformedValue);
-        if (fiatValue) setValue(fiatFieldName, fiatValue);
+        if (fiatValue) setValue(fiatFieldName, fiatValue?.toFixed(decimals));
         setValue('setMaxOutputId', undefined);
         debounce(() => {
             trigger(cryptoFieldName);

--- a/suite-native/module-send/src/components/FiatAmountInput.tsx
+++ b/suite-native/module-send/src/components/FiatAmountInput.tsx
@@ -2,6 +2,7 @@ import { Pressable } from 'react-native';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
+import { getNetwork } from '@suite-common/wallet-config';
 import { selectLocalCurrency } from '@suite-common/wallet-core';
 import { Input } from '@suite-native/atoms';
 import { useCryptoFiatConverters } from '@suite-native/formatters';
@@ -29,6 +30,7 @@ export const FiatAmountInput = ({
     const { setValue } = useFormContext<SendOutputsFormValues>();
     const fiatCurrencyCode = useSelector(selectLocalCurrency);
     const { fiatAmountTransformer } = useAmountInputTransformers(symbol);
+    const { decimals } = getNetwork(symbol);
     const converters = useCryptoFiatConverters({ symbol, tokenContract });
 
     const cryptoFieldName = getOutputFieldName(recipientIndex, 'amount');
@@ -57,7 +59,9 @@ export const FiatAmountInput = ({
         onChange(transformedValue);
 
         const cryptoValue = converters?.convertFiatToCrypto?.(transformedValue);
-        if (cryptoValue) setValue(cryptoFieldName, cryptoValue, { shouldValidate: true });
+        if (cryptoValue) {
+            setValue(cryptoFieldName, cryptoValue.toFixed(decimals), { shouldValidate: true });
+        }
 
         setValue('setMaxOutputId', undefined);
         onFocus?.();

--- a/suite-native/module-send/src/components/SendMaxButton.tsx
+++ b/suite-native/module-send/src/components/SendMaxButton.tsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { isFulfilled } from '@reduxjs/toolkit';
 
+import { getNetwork } from '@suite-common/wallet-config';
 import { AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { isAddressValid } from '@suite-common/wallet-utils';
@@ -34,6 +35,8 @@ export const SendMaxButton = ({ outputIndex, accountKey, tokenContract }: SendMa
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
+
+    const decimals = symbol && getNetwork(symbol).decimals;
 
     const tokenBalance = useSelector((state: TokensRootState) =>
         selectAccountTokenBalance(state, accountKey, tokenContract),
@@ -91,7 +94,9 @@ export const SendMaxButton = ({ outputIndex, accountKey, tokenContract }: SendMa
         });
 
         const fiatValue = converters?.convertCryptoToFiat(maxAmountValue);
-        if (fiatValue) setValue(getOutputFieldName(outputIndex, 'fiat'), fiatValue);
+        if (fiatValue && decimals !== null) {
+            setValue(getOutputFieldName(outputIndex, 'fiat'), fiatValue?.toFixed(decimals));
+        }
     };
 
     return (

--- a/suite-native/module-send/src/hooks/useSendForm.ts
+++ b/suite-native/module-send/src/hooks/useSendForm.ts
@@ -23,7 +23,7 @@ import {
     updateFeeInfoThunk,
 } from '@suite-common/wallet-core';
 import { TokenAddress } from '@suite-common/wallet-types';
-import { amountToSmallestUnit, getExcludedUtxos } from '@suite-common/wallet-utils';
+import { convertAmountUnitsToSubunits, getExcludedUtxos } from '@suite-common/wallet-utils';
 import { useForm } from '@suite-native/forms';
 import {
     SendStackParamList,
@@ -277,7 +277,7 @@ export const useSendForm = (accountKey: string, tokenContract?: TokenAddress) =>
 
     const amount = isAmountInSats
         ? getValues('outputs.0.amount')
-        : amountToSmallestUnit(getValues('outputs.0.amount'), network?.decimals ?? 0);
+        : convertAmountUnitsToSubunits(getValues('outputs.0.amount'), network?.decimals ?? 0);
 
     return {
         handleSubmitSendForm,

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -13,7 +13,7 @@ import {
 } from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';
 import { WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
-import { amountToSmallestUnit } from '@suite-common/wallet-utils';
+import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 import { EventType, analytics } from '@suite-native/analytics';
 import { useForm } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
@@ -207,7 +207,10 @@ const useBuyQuoteChangeEffect = ({ getValues, setValue, watch }: BuyFormType) =>
         if (!amountInCrypto && cryptoValue !== truncatedCryptoAmount) {
             const value =
                 isAmountInSats && truncatedCryptoAmount && symbol
-                    ? amountToSmallestUnit(truncatedCryptoAmount, getNetwork(symbol).decimals)
+                    ? convertAmountUnitsToSubunits(
+                          truncatedCryptoAmount,
+                          getNetwork(symbol).decimals,
+                      )
                     : truncatedCryptoAmount;
             setValue('cryptoValue', value);
         }

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
@@ -6,7 +6,7 @@ import { ExchangeTrade } from 'invity-api';
 import { selectTradingExchangeProviders } from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';
 import { WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
-import { amountToSmallestUnit } from '@suite-common/wallet-utils';
+import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 import { useForm } from '@suite-native/forms';
 
 import { selectGroupedExchangeQuotes } from '../../selectors/exchangeSelectors';
@@ -61,7 +61,7 @@ const useExchangeQuoteChangeEffect = ({ watch, setValue }: ExchangeFormType) => 
 
         const value =
             isAmountInSats && amount && symbol
-                ? amountToSmallestUnit(amount, getNetwork(symbol).decimals)
+                ? convertAmountUnitsToSubunits(amount, getNetwork(symbol).decimals)
                 : amount;
         setValue('receiveCryptoAmount', value);
     }, [selectedQuote, isAmountInSats, symbol, setValue]);


### PR DESCRIPTION
THIS MAY BREAK THINKS :exclamation: 

This removes the formatting responsibility from rate-conversion function. Formatting SHALL ALWAYS be a responsibility of the components/formatters all math shall be done in BigNumber in whole precision.


## Testing
- Staking, especially fiat input and limits validations and rounding
- SendForm, especially fiat input and limits validations and rounding
- Trading especially fiat input and limits validations and rounding
- Fiat Rates in general, all places where the fiat rates are visible
- Chart/Graph (fiat rates)

Extra focus to rounding and precision.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=btc-as-base-currency5&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=btc-as-base-currency5&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=btc-as-base-currency5&lookback=7)