### PR TITLE
chore(suite-native): add e2e for wipe device

### DIFF
--- a/suite-native/app/e2e/pageObjects/deviceSettingsActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceSettingsActions.ts
@@ -11,8 +11,23 @@ class DeviceSettingsActions {
             .withTimeout(10000);
     }
 
+    async waitForHomescreenAndUninitializedTitle() {
+        await waitFor(element(by.id('@screen/Home')))
+            .toBeVisible()
+            .withTimeout(10000);
+        await waitFor(element(by.id('@homescreen/uninitializedConnectedDeviceText')))
+            .toBeVisible()
+            .withTimeout(10000);
+    }
+
     async waitForPinProtectionScreen() {
         await waitFor(element(by.id('@screen/PinProtection')))
+            .toBeVisible()
+            .withTimeout(10000);
+    }
+
+    async waitForWipeDeviceContinueOnTrezor() {
+        await waitFor(element(by.id('@screen/ContinueOnTrezor')))
             .toBeVisible()
             .withTimeout(10000);
     }
@@ -70,6 +85,12 @@ class DeviceSettingsActions {
         await changeDeviceNameButton.tap();
     }
 
+    async tapWipeDevice() {
+        const wipeDeviceButton = element(by.id('@wipeDevice/redirectToWipeDeviceScreen'));
+        await scrollUntilVisible(wipeDeviceButton);
+        await wipeDeviceButton.tap();
+    }
+
     async submitNewDeviceName(value: string) {
         const changeDeviceNameInput = element(by.id('@device-name/input'));
         const changeDeviceNameSubmitButton = element(by.id('@device-name/submit-button'));
@@ -84,6 +105,15 @@ class DeviceSettingsActions {
         const checkDeviceAuthenticityButton = element(by.id('@device-authenticity/check-button'));
         await waitFor(checkDeviceAuthenticityButton).toBeVisible().withTimeout(5_000);
         await checkDeviceAuthenticityButton.tap();
+    }
+
+    async confirmStepperItems(items: number) {
+        const confirmButton = element(by.id('@cardStepper/confirm-button'));
+
+        for (let i = 0; i < items; i++) {
+            await waitFor(confirmButton).toBeVisible().withTimeout(10000);
+            await confirmButton.tap();
+        }
     }
 }
 

--- a/suite-native/app/e2e/tests/deviceSettings.test.ts
+++ b/suite-native/app/e2e/tests/deviceSettings.test.ts
@@ -101,4 +101,16 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () =>
 
         expect(element(by.label('new name'))).toBeVisible();
     });
+
+    test('Wipe device', async () => {
+        await onDeviceSettings.tapWipeDevice();
+
+        await onDeviceSettings.confirmStepperItems(2);
+        await onDeviceSettings.waitForWipeDeviceContinueOnTrezor();
+        await TrezorUserEnvLink.pressNo();
+        await onDeviceSettings.confirmStepperItems(1);
+        await TrezorUserEnvLink.pressYes();
+
+        await onDeviceSettings.waitForHomescreenAndUninitializedTitle();
+    });
 });

--- a/suite-native/atoms/src/CardStepper/CardStepperItem.tsx
+++ b/suite-native/atoms/src/CardStepper/CardStepperItem.tsx
@@ -131,6 +131,7 @@ export const CardStepperItem = ({
                                 style={applyStyle(buttonStyle)}
                                 colorScheme={buttonsColorSchemeMap[buttonsActionType].primary}
                                 onPress={onPressConfirmButton}
+                                testID="@cardStepper/confirm-button"
                             >
                                 {primaryButtonText}
                             </Button>

--- a/suite-native/atoms/src/TitleHeader/TitleHeader.tsx
+++ b/suite-native/atoms/src/TitleHeader/TitleHeader.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 import { NativeSpacing, NativeTypographyStyle } from '@trezor/theme';
 
 import { VStack } from '../Stack';
-import { Text } from '../Text';
+import { Text, TextProps } from '../Text';
 
 export type TitleHeaderProps = {
     title?: ReactNode;
@@ -11,7 +11,7 @@ export type TitleHeaderProps = {
     subtitle?: ReactNode;
     textAlign?: 'left' | 'center';
     titleSpacing?: NativeSpacing;
-};
+} & TextProps;
 
 export const TitleHeader = ({
     title,
@@ -19,10 +19,11 @@ export const TitleHeader = ({
     titleVariant = 'titleSmall',
     textAlign = 'left',
     titleSpacing = 'sp8',
+    ...textProps
 }: TitleHeaderProps) => (
     <VStack spacing={titleSpacing} alignItems={textAlign === 'center' ? 'center' : 'flex-start'}>
         {title && (
-            <Text variant={titleVariant} textAlign={textAlign}>
+            <Text {...textProps} variant={titleVariant} textAlign={textAlign}>
                 {title}
             </Text>
         )}

--- a/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
+++ b/suite-native/module-device-settings/src/components/WipeDeviceCard.tsx
@@ -31,6 +31,7 @@ export const WipeDeviceCard = () => {
             subtitle={<Translation id="moduleDeviceSettings.wipeDevice.subtitle" />}
             onPress={handleRedirect}
             variant="danger"
+            testID="@wipeDevice/redirectToWipeDeviceScreen"
         />
     );
 };

--- a/suite-native/module-home/src/screens/HomeScreen/components/UninitializedConnectedDeviceState.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/UninitializedConnectedDeviceState.tsx
@@ -49,6 +49,7 @@ export const UninitializedConnectedDeviceState = () => {
                     subtitle={
                         <Translation id="moduleHome.emptyState.uninitializedDevice.subtitle" />
                     }
+                    testID="@homescreen/uninitializedConnectedDeviceText"
                 />
                 <Button size="large" onPress={handleAddAccount} style={applyStyle(buttonStyle)}>
                     <Translation id="moduleHome.emptyState.uninitializedDevice.button" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- adds e2e tests for wipe device flow

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19712

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/wipe-e2e&lookback=7)