### PR TITLE
fix(react-native-usb): do not close pending requests when Suite goes to background

### DIFF
--- a/packages/react-native-usb/android/src/main/java/io/trezor/rnusb/ReactNativeUsbModule.kt
+++ b/packages/react-native-usb/android/src/main/java/io/trezor/rnusb/ReactNativeUsbModule.kt
@@ -192,6 +192,7 @@ class ReactNativeUsbModule : Module() {
             ReactNativeUsbAttachedReceiver.setOnDeviceConnectCallback(null)
             ReactNativeUsbDetachedReceiver.setOnDeviceDisconnectCallback(null)
 
+            cancelAllPendingRequests()
             closeAllOpenedDevices()
 
             try {
@@ -264,10 +265,14 @@ class ReactNativeUsbModule : Module() {
 
     private fun closeAllOpenedDevices() {
         Log.d(LOG_TAG, "Closing all devices")
-        pendingRequests.values.forEach { it.cancel() }
-        pendingRequests.clear()
+
         openedConnections.values.forEach { it.close() }
         openedConnections.clear()
+    }
+
+    private fun cancelAllPendingRequests() {
+        pendingRequests.values.forEach { it.cancel() }
+        pendingRequests.clear()
     }
 
     private fun claimInterface(deviceName: String, interfaceNumber: Int) {

--- a/packages/transport-native-usb/src/nativeUsb.ts
+++ b/packages/transport-native-usb/src/nativeUsb.ts
@@ -11,7 +11,10 @@ export class NativeUsbTransport extends AbstractApiTransport {
         super({
             api: new UsbApi({
                 usbInterface: new WebUSB(),
-                logger,
+                logger:
+                    process.env.EXPO_PUBLIC_IS_NATIVE_USB_LOGGER_ENABLED === 'true'
+                        ? console
+                        : logger,
             }),
             logger,
             ...rest,

--- a/suite-native/app/.env.development
+++ b/suite-native/app/.env.development
@@ -4,6 +4,7 @@ EXPO_PUBLIC_ENVIRONMENT=debug
 
 # EXPO_PUBLIC_IS_ANALYTICS_LOGGER_ENABLED=true
 # EXPO_PUBLIC_IS_SENTRY_ON_DEBUG_BUILD_ENABLED=true # always enabled outside debug build
+# EXPO_PUBLIC_IS_NATIVE_USB_LOGGER_ENABLED=true
 
 
 ### Initial states for Feature Flags, see suite-native/feature-flags/src/featureFlagsSlice.ts

--- a/suite-native/app/README.md
+++ b/suite-native/app/README.md
@@ -81,8 +81,9 @@ You can override ENV variables locally using `.env.development.local` (or `.env.
 
 > If you use `.env` file, it has the lowest priority. See [what other .env\* files you can use](https://github.com/bkeepers/dotenv/blob/c6e583a/README.md#what-other-env-files-can-i-use).
 
-- `EXPO_PUBLIC_IS_ANALYTICS_LOGGER_ENABLED=true` in `.env.development.local` to debug analytics locally and
-- `EXPO_PUBLIC_IS_SENTRY_ON_DEBUG_BUILD_ENABLED=true` to debug Sentry locally.
+- `EXPO_PUBLIC_IS_ANALYTICS_LOGGER_ENABLED=true` in `.env.development.local` to debug analytics locally,
+- `EXPO_PUBLIC_IS_SENTRY_ON_DEBUG_BUILD_ENABLED=true` to debug Sentry locally and
+- `EXPO_PUBLIC_IS_NATIVE_USB_LOGGER_ENABLED=true` to debug @trezor/transport-native-usb locally.
 - `EXPO_PUBLIC_FF_*` overrides initial state for Feature Flags. See [.env.development](./.env.development) for examples to copy to `.env.development.local` file and [featureFlagsSlice.ts](../feature-flags/src/featureFlagsSlice.ts) for all available values.
 
 ## Native changes - bumping runtimeVersion


### PR DESCRIPTION


## Description

We call `closeAllOpenedDevices` every time Suite Lite goes into the background, because this makes the Trezor accessible to other apps. Without closing the device, the user can’t use any third-party app after Suite has been opened, nor can they use Suite Web (which we need, for example, for T1 onboarding or checking the backup).

However, we should not cancel all pending requests at that point, because we want certain actions—like displaying a receive address—to remain active while the user checks it in the source app. We don’t want to cancel any pending requests just because the app went into the background. We only want to close the device when Suite itself is closed (killed).

I also added an easy way to turn on logging from transport-native-usb by switching ENV variable. I can put it in separate PR if needed.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19556



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/do-not-cancel-flow-on-background&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/do-not-cancel-flow-on-background&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/do-not-cancel-flow-on-background&lookback=7)