### PR TITLE
delete unnecessary priority mode for USB transport

### DIFF
--- a/packages/react-native-usb/android/src/main/java/io/trezor/rnusb/ReactNativeUsbModule.kt
+++ b/packages/react-native-usb/android/src/main/java/io/trezor/rnusb/ReactNativeUsbModule.kt
@@ -36,8 +36,6 @@ const val INTERFACE_INDEX = 0
 class ReactNativeUsbModule : Module() {
     private val moduleCoroutineScope = CoroutineScope(Dispatchers.IO)
     private var isAppInForeground = false
-    // We use priority mode to prevent closing device when app is in background for example during firmware update
-    private var isInPriorityMode = false
 
     // List of devices for which permission has already been requested to prevent redundant requests if the user denies permission.
     private var devicesRequestedPermissions = mutableListOf<String>()
@@ -59,10 +57,6 @@ class ReactNativeUsbModule : Module() {
 
         // Defines event names that the module can send to JavaScript.
         Events(ON_DEVICE_CONNECT_EVENT_NAME, ON_DEVICE_DISCONNECT_EVENT_NAME)
-
-        Function("setPriorityMode") { priorityMode: Boolean ->
-            isInPriorityMode = priorityMode
-        }
 
         AsyncFunction("getDevices") {
             return@AsyncFunction getDevices()
@@ -182,10 +176,8 @@ class ReactNativeUsbModule : Module() {
         }
 
         OnActivityEntersBackground {
-            if (!isInPriorityMode) {
-                isAppInForeground = false
-                closeAllOpenedDevices()
-            }
+            isAppInForeground = false
+            closeAllOpenedDevices()
         }
 
         OnDestroy {

--- a/packages/react-native-usb/src/ReactNativeUsbModule.ts
+++ b/packages/react-native-usb/src/ReactNativeUsbModule.ts
@@ -16,7 +16,6 @@ declare class ReactNativeUsbModuleDeclaration extends NativeModule<DeviceEvents>
     releaseInterface: (deviceName: string, interfaceNumber: number) => Promise<void>;
     transferIn: (deviceName: string, endpointNumber: number, length: number) => Promise<number[]>;
     transferOut: (deviceName: string, endpointNumber: number, data: string) => Promise<void>;
-    setPriorityMode: (isInPriorityMode: boolean) => void;
 }
 
 // It loads the native module object from the JSI or falls back to

--- a/packages/react-native-usb/src/index.ts
+++ b/packages/react-native-usb/src/index.ts
@@ -12,9 +12,6 @@ const debugLog = (...args: any[]) => {
     }
 };
 
-export const setPriorityMode = (isInPriorityMode: boolean) =>
-    ReactNativeUsbModule.setPriorityMode(isInPriorityMode);
-
 const open = (deviceName: string) => ReactNativeUsbModule.open(deviceName);
 
 const reset = (deviceName: string) => ReactNativeUsbModule.reset(deviceName);

--- a/suite-native/firmware/package.json
+++ b/suite-native/firmware/package.json
@@ -19,7 +19,6 @@
         "@suite-common/message-system": "workspace:*",
         "@suite-native/link": "workspace:*",
         "@trezor/connect": "workspace:*",
-        "@trezor/react-native-usb": "workspace:*",
         "@trezor/styles": "workspace:*",
         "expo-keep-awake": "14.0.3",
         "react": "19.0.0",

--- a/suite-native/firmware/src/hooks/useFirmware.tsx
+++ b/suite-native/firmware/src/hooks/useFirmware.tsx
@@ -8,7 +8,6 @@ import {
 } from '@suite-common/firmware';
 import { TxKeyPath, useTranslate } from '@suite-native/intl';
 import { getFirmwareVersion } from '@trezor/device-utils';
-import { setPriorityMode } from '@trezor/react-native-usb';
 
 import { nativeFirmwareActions } from '../nativeFirmwareSlice';
 import { useFirmwareAnalytics } from './useFirmwareAnalytics';
@@ -73,7 +72,6 @@ export const useFirmware = (
     }, [progress, status, setMayBeStuckedTimeout, resetMayBeStuckedTimeout]);
 
     const firmwareUpdate = useCallback(async () => {
-        setPriorityMode(true);
         const result = await firmwareUpdateCommon({ ignoreBaseUrl: true })
             .unwrap()
             .catch(error => {
@@ -85,7 +83,6 @@ export const useFirmware = (
             })
             .then(({ connectResponse }) => connectResponse)
             .finally(() => {
-                setPriorityMode(false);
                 resetMayBeStuckedTimeout();
             });
 

--- a/suite-native/firmware/tsconfig.json
+++ b/suite-native/firmware/tsconfig.json
@@ -9,9 +9,6 @@
         },
         { "path": "../link" },
         { "path": "../../packages/connect" },
-        {
-            "path": "../../packages/react-native-usb"
-        },
         { "path": "../../packages/styles" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10443,7 +10443,6 @@ __metadata:
     "@suite-common/message-system": "workspace:*"
     "@suite-native/link": "workspace:*"
     "@trezor/connect": "workspace:*"
-    "@trezor/react-native-usb": "workspace:*"
     "@trezor/styles": "workspace:*"
     expo-keep-awake: "npm:14.0.3"
     react: "npm:19.0.0"


### PR DESCRIPTION

## Description

Priority mode doesn’t help with firmware installation. If you close the app (send it to the background), the process breaks anyway, and in the happy path (when the app stays open and go to background only after FW installation to reconnect the trezor) it’s not needed.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/delete-priority-mode&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/delete-priority-mode&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/delete-priority-mode&lookback=7)