### PR TITLE
fix(suite-e2e): Improve redirect workaround for sell tests

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
@@ -461,6 +461,16 @@ export class TradingPage {
     }
 
     @step()
+    async waitForSellRedirectCompletion() {
+        await expect(this.page.getByText('Buy & sell')).toBeHidden();
+        //TODO: Workaround because of bug #19743, device switcher should not be opened
+        await Promise.all([
+            expect(this.page.getByText('Buy & sell')).toBeVisible({ timeout: 30_000 }),
+            this.page.getByTestId('@switch-device/cancel-button').click({ timeout: 30_000 }),
+        ]);
+    }
+
+    @step()
     async verifyBuyFormOpened(cryptoName: string) {
         await expect(this.accountDropdown).toContainText(cryptoName);
         await expect(this.page.getByText('You buy')).toBeVisible();

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
@@ -45,13 +45,7 @@ test.describe('Trading - Sell BTC', { tag: ['@group=trading', '@webOnly'] }, () 
         });
     });
 
-    test('Sell Bitcoin for best offer', async ({
-        page,
-        dashboardPage,
-        tradingPage,
-        walletPage,
-        devicePrompt,
-    }) => {
+    test('Sell Bitcoin for best offer', async ({ page, tradingPage, walletPage, devicePrompt }) => {
         await test.step('Open sell form', async () => {
             await walletPage.openTrading();
             await tradingPage.sellTabButton.click();
@@ -73,9 +67,7 @@ test.describe('Trading - Sell BTC', { tag: ['@group=trading', '@webOnly'] }, () 
             });
         });
 
-        await tradingPage.waitForRedirectCompletion();
-        //TODO: Workaround because of bug #19743, device switcher should not be opened
-        await dashboardPage.deviceSwitchingCloseButton.click();
+        await tradingPage.waitForSellRedirectCompletion();
 
         await test.step('Verify all confirmation values', async () => {
             await expect(tradingPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);
@@ -100,7 +92,7 @@ test.describe('Trading - Sell BTC', { tag: ['@group=trading', '@webOnly'] }, () 
         // Rest of the flow is not implemented as we don't know how to mock the send request and actually not send the crypto
     });
 
-    test('Bitcoin sell fees', async ({ dashboardPage, walletPage, tradingPage, devicePrompt }) => {
+    test('Bitcoin sell fees', async ({ walletPage, tradingPage, devicePrompt }) => {
         const testCases: FeeSwitchTestCase[] = [
             // TODO: #18316 Uncomment and update when bug is fixed
             // {
@@ -149,9 +141,7 @@ test.describe('Trading - Sell BTC', { tag: ['@group=trading', '@webOnly'] }, () 
                     await tradingPage.termsConfirmButton.click();
                 });
 
-                await tradingPage.waitForRedirectCompletion();
-                //TODO: Workaround because of bug #19743, device switcher should not be opened
-                await dashboardPage.deviceSwitchingCloseButton.click();
+                await tradingPage.waitForSellRedirectCompletion();
 
                 await test.step('Initiate send and verify Fee', async () => {
                     await tradingPage.initiateSendConfirmation();

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum-token.test.ts
@@ -44,7 +44,7 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=trading', '@webOnly'] }
         },
     );
 
-    test('Sell Ethereum token USDC', async ({ tradingPage, dashboardPage, devicePrompt }) => {
+    test('Sell Ethereum token USDC', async ({ tradingPage, devicePrompt }) => {
         await test.step('Fill in a sell request', async () => {
             await tradingPage.fillSellForm(
                 cryptoAmount,
@@ -59,9 +59,7 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=trading', '@webOnly'] }
             await tradingPage.termsConfirmButton.click();
         });
 
-        await tradingPage.waitForRedirectCompletion();
-        //TODO: Workaround because of bug #19743, device switcher should not be opened
-        await dashboardPage.deviceSwitchingCloseButton.click();
+        await tradingPage.waitForSellRedirectCompletion();
 
         await test.step('Verify all confirmation values', async () => {
             await expect(tradingPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum.test.ts
@@ -81,7 +81,7 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=trading', '@webOnly'] }
             await tradingPage.termsConfirmButton.click();
         });
 
-        await tradingPage.waitForRedirectCompletion();
+        await tradingPage.waitForSellRedirectCompletion();
 
         await test.step('Verify all confirmation values', async () => {
             await expect(tradingPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
@@ -60,7 +60,7 @@ test.describe('Trading - Sell Solana', { tag: ['@group=trading', '@webOnly'] }, 
         },
     );
 
-    test('Sell Solana', async ({ page, dashboardPage, tradingPage, tradingMock, devicePrompt }) => {
+    test('Sell Solana', async ({ page, tradingPage, tradingMock, devicePrompt }) => {
         await test.step('Fill in a sell request', async () => {
             const solanaFeePromise = tradingPage.fees.promiseForResponseSolanaFeeCalls();
             await tradingPage.fillSellForm(cryptoAmount, 'solana');
@@ -76,9 +76,7 @@ test.describe('Trading - Sell Solana', { tag: ['@group=trading', '@webOnly'] }, 
             await tradingPage.termsConfirmButton.click();
         });
 
-        await tradingPage.waitForRedirectCompletion();
-        //TODO: Workaround because of bug #19743, device switcher should not be opened
-        await dashboardPage.deviceSwitchingCloseButton.click();
+        await tradingPage.waitForSellRedirectCompletion();
 
         await test.step('Verify all confirmation values', async () => {
             await expect(tradingPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);


### PR DESCRIPTION
The modal switcher that opens after the redirect started to show up sometimes sooner then the sell layout loaded.
And once the switcher opened, it halted the load of the sell layout.
So I have solve that with Promise.all

Closing the switcher does continues the flow. So seems this blocking isn't a bug.
But anyway there is a bug for the swticher being opened in this case. So hopefully that will get soon resolved. In the meantime, the workaround is fixed.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-sell-tests&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-sell-tests&lookback=7)