### PR TITLE
fix(e2e): fix typo in manual test template

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/manual/firmware/bootloader.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/firmware/bootloader.test.ts
@@ -47,7 +47,7 @@ test.describe.skip('Bootloader', { tag: ['@group=manual'] }, () => {
             annotation: createTestAnnotation({
                 testCase: 'Verifies that a user can update the bootloader.',
                 prerequisites: [
-                    'Trezor  device with at least a year old BL/FW (older then the latest)',
+                    'Trezor device with at least a year old BL/FW (older than the latest)',
                     'Connected Trezor Suite',
                 ],
                 steps: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

small nitpick, typo in test description

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=e2e_typo&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=e2e_typo&lookback=7)