### PR TITLE
chore(suite): use full locale code instead of 2 letters code

### DIFF
--- a/.github/workflows/bot-crowdin-sync.yml
+++ b/.github/workflows/bot-crowdin-sync.yml
@@ -47,7 +47,7 @@ jobs:
           git config --global user.name "trezor-ci"
           git config --global user.email "${{ secrets.TREZOR_BOT_EMAIL }}"
           git checkout -B ${{ env.BRANCH_NAME }}
-          yarn workspace @trezor/suite translations:download --token=${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          yarn workspace @trezor/suite translations:download --token=${{ secrets.CROWDIN_PERSONAL_TOKEN }} --verbose
           yarn workspace @trezor/suite translations:backport-en
           if [ "${{ github.event.inputs.remove_unused_translations }}" = "true" ]; then
             yarn workspace @trezor/suite translations:list-unused --cleanup

--- a/packages/suite/crowdin.yml
+++ b/packages/suite/crowdin.yml
@@ -6,7 +6,7 @@ files:
   [
     {
       "source": "master.json",
-      "translation": "%two_letters_code%.json",
+      "translation": "%locale%.json",
       "update_option": "update_as_unapproved",
     },
   ]


### PR DESCRIPTION
Use full locale Crowdin code since we want ti differentiate `zs` and `zh-tw`.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19994

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/crowdin-full-locale-code&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/crowdin-full-locale-code&lookback=7)