### PR TITLE
chore: remove gitlab mentions

### DIFF
--- a/docker/docker-connect-test.sh
+++ b/docker/docker-connect-test.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
 # This script runs @trezor/connect tests.
-# It spins up trezor-user-env and sets required evironment variables.
+# It spins up trezor-user-env and sets required environment variables.
 
 set -euo pipefail
 
 # Running standalone instance of trezor-user-env
-# docker run -it -e SDL_VIDEODRIVER="dummy" -p "9001:9001" -p "21326:21326" -p "21325:21326" registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env
+# docker run -it -e SDL_VIDEODRIVER="dummy" -p "9001:9001" -p "21326:21326" -p "21325:21326"  ghcr.io/trezor/trezor-user-env:latest
 
 # Tweaking trezor-user-env locally
-# docker run -it -e SDL_VIDEODRIVER="dummy" -p "9001:9001" -p "21326:21326" -p "21325:21326" registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env nix-shell
+# docker run -it -e SDL_VIDEODRIVER="dummy" -p "9001:9001" -p "21326:21326" -p "21325:21326" ghcr.io/trezor/trezor-user-env:latest nix-shell
 # do your changes using `vi` and run:
 # [nix-shell:/trezor-user-env]# ./run.sh
 

--- a/docs/features/message-system.md
+++ b/docs/features/message-system.md
@@ -77,7 +77,7 @@ To ensure the authenticity of a configuration file, JSON Web Signatures are used
     - `config.v1.jws` to be uploaded to `https://data.trezor.io/config/$environment/config.vX.jws`
     - `config.v1.ts` to be bundled with application
 - Development private key is baked into project structure together with public keys for both development and production.
-- Production private key is available only on `codesign` branch in CI (both Gitlab and Github).
+- Production private key is available only on `codesign` branch in Github CI.
 - Development private key can be found in `suite-common/message-system/scripts/sign-config.ts` file, the public keys can be found in `packages/suite-build/utils/jws.ts` file.
 
 ### Versioning of implementation

--- a/docs/tests/e2e-connect-popup.md
+++ b/docs/tests/e2e-connect-popup.md
@@ -26,7 +26,3 @@ FILE=path-from-the-error && mkdir -p "${FILE%/*}" && touch "$FILE" && ./nixos-fi
 ## Fixtures
 
 Fixtures are located in [packages/connect-popup](https://github.com/trezor/trezor-suite/tree/develop/packages/connect-popup/e2e/tests)
-
-## Test results
-
-Checkout [latest screenshots](https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/artifacts/develop/file/packages/connect-popup/connect-popup-overview.html?job=connect-popup%3A%20%5Bmethods.test%5D)

--- a/docs/tests/e2e-playwright-suite.md
+++ b/docs/tests/e2e-playwright-suite.md
@@ -1,6 +1,6 @@
 # @trezor/suite-desktop and @trezor/suite-web e2e tests
 
-@trezor/suite uses [Playwright](https://playwright.dev/) to run e2e tests. It also uses [trezor-user-env](https://github.com/trezor/trezor-user-env) which is [daily built](https://gitlab.com/satoshilabs/trezor/trezor-user-env/-/pipelines) into a docker image providing all the necessary instrumentation required to run tests (bridge and emulators).
+@trezor/suite uses [Playwright](https://playwright.dev/) to run e2e tests. It also uses [trezor-user-env](https://github.com/trezor/trezor-user-env) which is [daily built](https://ghcr.io/trezor/trezor-user-env) into a docker image providing all the necessary instrumentation required to run tests (bridge and emulators).
 
 ## Run it locally
 

--- a/packages/connect-popup/e2e/tests/__fixtures__/methods.ts
+++ b/packages/connect-popup/e2e/tests/__fixtures__/methods.ts
@@ -586,7 +586,7 @@ export const fixtures = [
     ...nemSignTransaction,
     ...cipherKeyValue,
     // balance dependent tests
-    // these are using masked seed in gitlab CI
+    // these are using masked seed in github CI
     ...composeTransaction,
     // todo:
     // management methods

--- a/packages/connect/e2e/README.md
+++ b/packages/connect/e2e/README.md
@@ -12,7 +12,6 @@ you may use the following params:
 
 ```
 -f <semver string such as 2.5.2>
--u <url of unix-frozen-debug-build, such as https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/2730055101/artifacts/file/core/build/unix/trezor-emu-core>
 -p <pattern to match tests files>
 -i <in case -p methods, use -i to filter one connect method, such as -i binanceGetAddress>
 ```
@@ -38,7 +37,7 @@ _Too many requests from not whitelisted origins may be penalized with temporary 
 
 Backend connection will be omitted in case of providing `refTxs` so even coins without officially supported backends (like zcash testnet) may sign a transaction in _"offline mode"_. [see docs](https://connect.trezor.io/9/methods/bitcoin/signTransaction/)
 
-To reduce network traffic `Github Actions CI` is using **cached** (offline) mode and whitelisted `GitLab CI` is using **default** (online) mode.
+To reduce network traffic `Github Actions CI` is using **cached** (offline) mode and whitelisted `Github CI` is using **default** (online) mode.
 
 Cached transactions are stored in `./tests/__txcache__` directory in the same structure as in [trezor-firmware](https://github.com/trezor/trezor-firmware/tree/main/tests/txcache) repository.
 


### PR DESCRIPTION
just noticed a couple of places with outadted docs when seaching for the 'gitlab' keyword. 



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=remove-gitlab-mentions&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=remove-gitlab-mentions&lookback=7)