### PR TITLE
chore: make-naming of Sats<->BTC conversion utils sane

### DIFF
--- a/packages/connect-common/src/storage.ts
+++ b/packages/connect-common/src/storage.ts
@@ -1,5 +1,6 @@
 // https://github.com/trezor/connect/blob/develop/src/js/storage/index.js
 
+import { Branded } from '@trezor/type-utils';
 import { TypedEmitter } from '@trezor/utils';
 
 const storageVersion = 2;
@@ -17,7 +18,7 @@ export interface Permission {
  */
 export interface PreferredDevice {
     label?: string;
-    path: string & { __type: 'DeviceUniquePath' };
+    path: string & Branded<'DeviceUniquePath'>;
     state?: `${string}@${string}:${number}`;
     internalState?: string;
     internalStateExpiration?: number;

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -1,5 +1,6 @@
 import { FeaturesNarrowing, FirmwareType } from '@trezor/device-utils';
 import type { ThpStateSerialized } from '@trezor/protocol';
+import { Branded } from '@trezor/type-utils';
 
 import type { PROTO } from '../constants';
 import type { ReleaseInfo } from './firmware';
@@ -73,7 +74,7 @@ export type FirmwareHashCheckResult =
           errorPayload?: unknown;
       };
 
-export type DeviceUniquePath = string & { __type: 'DeviceUniquePath' };
+export type DeviceUniquePath = string & Branded<'DeviceUniquePath'>;
 export const DeviceUniquePath = (id: string) => id as DeviceUniquePath;
 
 type BaseDevice = {

--- a/packages/suite/src/actions/wallet/stake/stakeFormActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormActions.ts
@@ -10,7 +10,7 @@ import {
 import {
     calculateMax,
     calculateTotal,
-    formatAmount,
+    convertAmountSubunitsToUnits,
     getExternalComposeOutput,
 } from '@suite-common/wallet-utils';
 import { FeeLevel } from '@trezor/connect';
@@ -158,7 +158,7 @@ export const composeStakingTransaction = (
     Object.keys(wrappedResponse).forEach(key => {
         const tx = wrappedResponse[key];
         if (tx.type !== 'error') {
-            tx.max = tx.max ? formatAmount(tx.max, decimals) : undefined;
+            tx.max = tx.max ? convertAmountSubunitsToUnits(tx.max, decimals) : undefined;
             tx.estimatedFeeLimit = customFeeLimit ?? tx.estimatedFeeLimit;
         }
         if (tx.type === 'error' && tx.error === 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE') {

--- a/packages/suite/src/actions/wallet/trading/tradingCommonActions.ts
+++ b/packages/suite/src/actions/wallet/trading/tradingCommonActions.ts
@@ -1,7 +1,7 @@
 import { Output } from '@suite-common/wallet-types/src';
 import {
-    amountToSmallestUnit,
-    formatAmount,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     getAccountDecimals,
     hasNetworkFeatures,
     parseFormDraftKey,
@@ -55,7 +55,9 @@ export const convertDrafts = () => (dispatch: Dispatch, getState: GetState) => {
 
         if (draft) {
             const areSatsSelected = settings.bitcoinAmountUnit === PROTO.AmountUnit.SATOSHI;
-            const conversion = areSatsSelected ? amountToSmallestUnit : formatAmount;
+            const conversion = areSatsSelected
+                ? convertAmountUnitsToSubunits
+                : convertAmountSubunitsToUnits;
             const decimals = getAccountDecimals(relatedAccount.symbol)!;
 
             if (draft.cryptoInput) {

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { TokenAddress } from '@suite-common/wallet-types';
-import { formatAmount, formatNetworkAmount } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits, formatNetworkAmount } from '@suite-common/wallet-utils';
 import {
     Card,
     Column,
@@ -85,7 +85,7 @@ const Value = ({ value, type, symbol, token, isFee, isFiatVisible, state }: Valu
         case 'amount': {
             const isTokenAmount = !isFee && token;
             const formattedValue = isTokenAmount
-                ? formatAmount(value, token.decimals)
+                ? convertAmountSubunitsToUnits(value, token.decimals)
                 : formatNetworkAmount(value, symbol);
 
             return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TradingDCAModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TradingDCAModal.tsx
@@ -6,7 +6,7 @@ import { TrezorDevice } from '@suite-common/suite-types';
 import { cryptoIdToNetwork, getTradingNetworkDecimals } from '@suite-common/trading/src/utils';
 import { Network, getNetwork } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
-import { formatAmount } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
 import {
     Button,
     Column,
@@ -153,7 +153,7 @@ const AddressSelect = ({
             }
             formatOptionLabel={(accountAddress: AccountAddress) => {
                 const balance = accountAddress.balance
-                    ? formatAmount(accountAddress.balance, networkDecimals)
+                    ? convertAmountSubunitsToUnits(accountAddress.balance, networkDecimals)
                     : accountAddress.balance;
 
                 return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
@@ -5,7 +5,7 @@ import {
 } from '@suite-common/wallet-core';
 import { Timestamp, TokenAddress } from '@suite-common/wallet-types';
 import {
-    formatAmount,
+    convertAmountSubunitsToUnits,
     formatCardanoDeposit,
     formatCardanoWithdrawal,
     formatNetworkAmount,
@@ -202,7 +202,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                 {selectedAccount.account && (
                                     <Text variant="default">
                                         <BaseCurrencyValue
-                                            amount={formatAmount(
+                                            amount={convertAmountSubunitsToUnits(
                                                 transfer.amount,
                                                 transfer.decimals,
                                             )}
@@ -218,7 +218,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                 {selectedAccount.account && (
                                     <Text variant="default">
                                         <BaseCurrencyValue
-                                            amount={formatAmount(
+                                            amount={convertAmountSubunitsToUnits(
                                                 transfer.amount,
                                                 transfer.decimals,
                                             )}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
@@ -6,7 +6,11 @@ import { type NetworkSymbolExtended, isNetworkSymbol } from '@suite-common/walle
 import { getExplorerUrl } from '@suite-common/wallet-config/src/getExplorerUrls';
 import { selectExplorer } from '@suite-common/wallet-core';
 import { WalletAccountTransaction } from '@suite-common/wallet-types';
-import { formatAmount, formatNetworkAmount, isNftTokenTransfer } from '@suite-common/wallet-utils';
+import {
+    convertAmountSubunitsToUnits,
+    formatNetworkAmount,
+    isNftTokenTransfer,
+} from '@suite-common/wallet-utils';
 import { AnonymitySet, TokenTransfer } from '@trezor/blockchain-link';
 import {
     CollapsibleBox,
@@ -250,7 +254,7 @@ const TokenSpecificBalanceDetailsRow = ({
                                 linkTypographyStyle="label"
                             />
                         ) : (
-                            formatAmount(transfer.amount, transfer.decimals)
+                            convertAmountSubunitsToUnits(transfer.amount, transfer.decimals)
                         );
 
                         return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnecoCoinjoinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnecoCoinjoinModal.tsx
@@ -1,4 +1,4 @@
-import { formatAmount, getAccountDecimals } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits, getAccountDecimals } from '@suite-common/wallet-utils';
 import { Column, H3, Modal, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -57,7 +57,10 @@ export const UnecoCoinjoinModal = () => {
                         values={{
                             crypto: (
                                 <FormattedCryptoAmount
-                                    value={formatAmount(UNECONOMICAL_COINJOIN_THRESHOLD, decimals)}
+                                    value={convertAmountSubunitsToUnits(
+                                        UNECONOMICAL_COINJOIN_THRESHOLD,
+                                        decimals,
+                                    )}
                                     symbol={symbol}
                                     isRawString
                                 />

--- a/packages/suite/src/components/wallet/AmountComponent.tsx
+++ b/packages/suite/src/components/wallet/AmountComponent.tsx
@@ -1,4 +1,8 @@
-import { formatAmount, getTxOperation, isNftTokenTransfer } from '@suite-common/wallet-utils';
+import {
+    convertAmountSubunitsToUnits,
+    getTxOperation,
+    isNftTokenTransfer,
+} from '@suite-common/wallet-utils';
 import { TokenTransfer } from '@trezor/connect';
 import { TypographyStyle } from '@trezor/theme';
 
@@ -37,7 +41,7 @@ export const AmountComponent = ({
     if (withSign) {
         return (
             <FormattedCryptoAmount
-                value={formatAmount(transfer.amount, transfer.decimals)}
+                value={convertAmountSubunitsToUnits(transfer.amount, transfer.decimals)}
                 symbol={transfer.symbol}
                 contractAddress={transfer.contract}
                 signValue={operation}
@@ -45,5 +49,5 @@ export const AmountComponent = ({
         );
     }
 
-    return formatAmount(transfer.amount, transfer.decimals);
+    return convertAmountSubunitsToUnits(transfer.amount, transfer.decimals);
 };

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -4,7 +4,7 @@ import { ToastPayload, notificationsActions } from '@suite-common/toast-notifica
 import { selectHistoricFiatRatesByTimestamp, selectLocalCurrency } from '@suite-common/wallet-core';
 import { Timestamp, TokenAddress } from '@suite-common/wallet-types';
 import {
-    formatAmount,
+    convertAmountSubunitsToUnits,
     formatNetworkAmount,
     getFiatRateKey,
     getTargetAmount,
@@ -77,7 +77,7 @@ export const TransactionTarget = ({
             case 'internal':
                 return payload.amount && formatNetworkAmount(payload.amount, transaction.symbol);
             case 'token':
-                return formatAmount(payload.amount, payload.decimals);
+                return convertAmountSubunitsToUnits(payload.amount, payload.decimals);
         }
     }, [type, payload, transaction, isSolanaUnstakeTx]);
 

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingCurrencySwitcher.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingCurrencySwitcher.ts
@@ -9,7 +9,10 @@ import {
 } from '@suite-common/trading';
 import { Network } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
-import { amountToSmallestUnit, formatAmount } from '@suite-common/wallet-utils';
+import {
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
+} from '@suite-common/wallet-utils';
 import { useDidUpdate } from '@trezor/react-utils';
 
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
@@ -60,7 +63,7 @@ export const useTradingCurrencySwitcher = <T extends TradingAllFormProps>({
 
         if (!amountInCrypto) {
             const amount = shouldSendInSats
-                ? amountToSmallestUnit(quoteCryptoAmount ?? '', networkDecimals)
+                ? convertAmountUnitsToSubunits(quoteCryptoAmount ?? '', networkDecimals)
                 : quoteCryptoAmount;
 
             setValue(inputNames.cryptoInput, amount === '-1' ? '' : amount);
@@ -77,7 +80,9 @@ export const useTradingCurrencySwitcher = <T extends TradingAllFormProps>({
     };
 
     useDidUpdate(() => {
-        const conversion = shouldSendInSats ? amountToSmallestUnit : formatAmount;
+        const conversion = shouldSendInSats
+            ? convertAmountUnitsToSubunits
+            : convertAmountSubunitsToUnits;
 
         if (!cryptoInputValue) {
             return;

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.ts
@@ -10,7 +10,11 @@ import {
     updateFiatRatesThunk,
 } from '@suite-common/wallet-core';
 import { FiatRatesResult, Rate, Timestamp, TokenAddress } from '@suite-common/wallet-types';
-import { amountToSmallestUnit, getFiatRateKey, toFiatCurrency } from '@suite-common/wallet-utils';
+import {
+    convertAmountUnitsToSubunits,
+    getFiatRateKey,
+    toFiatCurrency,
+} from '@suite-common/wallet-utils';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
@@ -101,7 +105,9 @@ export const useTradingFiatValues = ({
         sendCryptoSelect,
         network,
     });
-    const formattedBalance = shouldSendInSats ? amountToSmallestUnit(balance, decimals) : balance;
+    const formattedBalance = shouldSendInSats
+        ? convertAmountUnitsToSubunits(balance, decimals)
+        : balance;
     const fiatValue = toFiatCurrency(balance, fiatRate?.rate, 2);
 
     return {

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -23,8 +23,8 @@ import {
 import { selectAccounts, selectSelectedDevice } from '@suite-common/wallet-core';
 import { TokenAddress } from '@suite-common/wallet-types';
 import {
-    amountToSmallestUnit,
-    formatAmount,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     fromFiatCurrency,
     isZero,
 } from '@suite-common/wallet-utils';
@@ -103,7 +103,7 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
         const rate = await tradingFiatValues.fiatRatesUpdater(value);
         const amount = getValues(TRADING_FORM_OUTPUT_AMOUNT);
         const formattedAmount = new BigNumber(
-            shouldSendInSats ? formatAmount(amount, networkDecimals) : amount,
+            shouldSendInSats ? convertAmountSubunitsToUnits(amount, networkDecimals) : amount,
         );
 
         if (
@@ -137,7 +137,7 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
 
             const formattedCryptoAmount =
                 cryptoAmount && shouldSendInSats
-                    ? amountToSmallestUnit(cryptoAmount, networkDecimals)
+                    ? convertAmountUnitsToSubunits(cryptoAmount, networkDecimals)
                     : (cryptoAmount ?? '');
             setValue(TRADING_FORM_OUTPUT_AMOUNT, formattedCryptoAmount, { shouldValidate: true });
         },
@@ -206,7 +206,7 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
                   .decimalPlaces(networkDecimals)
                   .toString();
         const cryptoInputValue = shouldSendInSats
-            ? amountToSmallestUnit(amount, networkDecimals)
+            ? convertAmountUnitsToSubunits(amount, networkDecimals)
             : amount;
         clearErrors([TRADING_FORM_OUTPUT_FIAT, TRADING_FORM_OUTPUT_AMOUNT]);
         setValue(TRADING_FORM_OUTPUT_AMOUNT, cryptoInputValue, { shouldDirty: true });

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -14,8 +14,8 @@ import { getNetworkSymbolForProtocol } from '@suite-common/suite-utils';
 import { selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { FormState } from '@suite-common/wallet-types';
 import {
-    amountToSmallestUnit,
-    formatAmount,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     getDefaultValues,
     getFeeInfo,
     useExcludedUtxos,
@@ -296,7 +296,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
                 const protocolAmount = protocol.sendForm.amount.toString();
 
                 const formattedAmount = shouldSendInSats
-                    ? amountToSmallestUnit(protocolAmount, state.network.decimals)
+                    ? convertAmountUnitsToSubunits(protocolAmount, state.network.decimals)
                     : protocolAmount;
 
                 sendFormUtils.setAmount(outputIndex, formattedAmount);
@@ -373,7 +373,9 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     useDidUpdate(() => {
         const { outputs } = getValues();
 
-        const conversionToUse = shouldSendInSats ? amountToSmallestUnit : formatAmount;
+        const conversionToUse = shouldSendInSats
+            ? convertAmountUnitsToSubunits
+            : convertAmountSubunitsToUnits;
 
         outputs.forEach((output, index) => {
             if (!output.amount) {

--- a/packages/suite/src/hooks/wallet/useSendFormFields.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormFields.ts
@@ -5,7 +5,7 @@ import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { FormOptions, FormState, Rate, TokenAddress } from '@suite-common/wallet-types';
 import {
-    amountToSmallestUnit,
+    convertAmountUnitsToSubunits,
     formatNetworkAmount,
     fromFiatCurrency,
     getFiatRateKey,
@@ -127,7 +127,7 @@ export const useSendFormFields = ({
                 const amount = fromFiatCurrency(fiat, decimals, fiatRate);
 
                 return shouldSendInSats
-                    ? amountToSmallestUnit(amount || '0', network.decimals)
+                    ? convertAmountUnitsToSubunits(amount || '0', network.decimals)
                     : amount;
             };
 

--- a/packages/suite/src/hooks/wallet/useSendFormImport.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormImport.ts
@@ -6,8 +6,8 @@ import { DEFAULT_PAYMENT } from '@suite-common/wallet-constants';
 import { updateFiatRatesThunk } from '@suite-common/wallet-core';
 import { FiatRates, FiatRatesResult, Output, Rate, Timestamp } from '@suite-common/wallet-types';
 import {
-    amountToSmallestUnit,
-    formatAmount,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     fromFiatCurrency,
     getFiatRateKey,
     toFiatCurrency,
@@ -105,7 +105,10 @@ export const useSendFormImport = ({
                     const cryptoAmount = item.amount || '';
                     if (shouldSendInSats) {
                         // try to convert to satoshis
-                        output.amount = amountToSmallestUnit(cryptoAmount, network.decimals);
+                        output.amount = convertAmountUnitsToSubunits(
+                            cryptoAmount,
+                            network.decimals,
+                        );
                     } else {
                         output.amount = cryptoAmount;
                     }
@@ -119,7 +122,7 @@ export const useSendFormImport = ({
                     // calculate Fiat from Amount
                     if (fiatRate?.rate) {
                         const cryptoValue = shouldSendInSats
-                            ? formatAmount(output.amount, network.decimals)
+                            ? convertAmountSubunitsToUnits(output.amount, network.decimals)
                             : output.amount;
                         output.fiat = toFiatCurrency(cryptoValue, fiatRate.rate, 2) || '';
                     }
@@ -134,7 +137,7 @@ export const useSendFormImport = ({
                     const cryptoValue = fromFiatCurrency(output.fiat, network.decimals, itemRate);
                     const cryptoAmount =
                         cryptoValue && shouldSendInSats
-                            ? amountToSmallestUnit(cryptoValue, network.decimals)
+                            ? convertAmountUnitsToSubunits(cryptoValue, network.decimals)
                             : (cryptoValue ?? '');
 
                     output.amount = cryptoAmount;

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -8,7 +8,7 @@ import {
 } from '@suite-common/wallet-config';
 import type { BackendSettings, WalletSettings } from '@suite-common/wallet-types';
 import {
-    amountToSmallestUnit,
+    convertAmountUnitsToSubunits,
     formatNetworkAmount,
     networkAmountToSmallestUnit,
 } from '@suite-common/wallet-utils';
@@ -411,7 +411,7 @@ export const runLegacyMigrations: OnUpgradeFunc<SuiteDBSchema> = async (
                     totalSpent: unformat(origTx.totalSpent),
                     tokens: origTx.tokens.map(tok => ({
                         ...tok,
-                        amount: amountToSmallestUnit(tok.amount, tok.decimals),
+                        amount: convertAmountUnitsToSubunits(tok.amount, tok.decimals),
                     })),
                     targets: origTx.targets.map(target => ({
                         ...target,

--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -14,7 +14,7 @@ import {
     WalletAccountTransaction,
 } from '@suite-common/wallet-types';
 import {
-    formatAmount,
+    convertAmountSubunitsToUnits,
     formatNetworkAmount,
     getFiatRateKey,
     getNftTokenId,
@@ -82,7 +82,7 @@ const formatAmounts =
             ...token,
             amount: isNftTokenTransfer(token)
                 ? `ID ${getNftTokenId(token)}`
-                : formatAmount(token.amount, token.decimals),
+                : convertAmountSubunitsToUnits(token.amount, token.decimals),
         })),
         internalTransfers: tx.internalTransfers.map(internal => ({
             ...internal,

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
@@ -6,7 +6,7 @@ import { getTxsPerPage } from '@suite-common/suite-utils';
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 import { fetchAllTransactionsForAccountThunk } from '@suite-common/wallet-core';
 import {
-    amountToSmallestUnit,
+    convertAmountUnitsToSubunits,
     filterAndCategorizeUtxos,
     formatNetworkAmount,
 } from '@suite-common/wallet-utils';
@@ -93,7 +93,7 @@ export const CoinControl = ({ close }: CoinControlProps) => {
     );
     const totalOutputsInSats = shouldSendInSats
         ? totalOutputs
-        : Number(amountToSmallestUnit(totalOutputs.toString(), network.decimals));
+        : Number(convertAmountUnitsToSubunits(totalOutputs.toString(), network.decimals));
     const missingToInput = totalOutputsInSats - totalInputs;
     const isMissingToAmount = missingToInput > 0; // relevant when the amount field is not validated, e.g. there is an error in the address
     const missingAmountTooBig = missingToInput > Number.MAX_SAFE_INTEGER;

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
@@ -3,7 +3,7 @@ import { formInputsMaxLength } from '@suite-common/validators';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { Output, TokenAddress } from '@suite-common/wallet-types';
 import {
-    amountToSmallestUnit,
+    convertAmountUnitsToSubunits,
     findToken,
     formatNetworkAmount,
     getInputState,
@@ -110,7 +110,7 @@ export const Amount = ({ output, outputId }: AmountProps) => {
 
                 if (dust && amountBig.lt(dust)) {
                     if (shouldSendInSats) {
-                        dust = amountToSmallestUnit(dust, decimals);
+                        dust = convertAmountUnitsToSubunits(dust, decimals);
                     }
 
                     return translationString('AMOUNT_IS_BELOW_DUST', {

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
@@ -13,8 +13,8 @@ import {
 } from '@suite-common/wallet-types';
 import {
     buildCurrencyOptions,
+    convertAmountSubunitsToUnits,
     findToken,
-    formatAmount,
     getInputState,
     isLowAnonymityWarning,
 } from '@suite-common/wallet-utils';
@@ -78,7 +78,9 @@ export const BaseCurrencyInput = ({
 
     const recalculateFiat = (rate: number) => {
         const formattedAmount = new BigNumber(
-            shouldSendInSats ? formatAmount(amountValue, network.decimals) : amountValue,
+            shouldSendInSats
+                ? convertAmountSubunitsToUnits(amountValue, network.decimals)
+                : amountValue,
         );
 
         if (

--- a/packages/suite/src/views/wallet/send/TotalSent/TotalSent.tsx
+++ b/packages/suite/src/views/wallet/send/TotalSent/TotalSent.tsx
@@ -3,7 +3,7 @@ import { PropsWithChildren, useMemo } from 'react';
 import styled from 'styled-components';
 
 import { selectAreFeesLoading } from '@suite-common/wallet-core';
-import { formatAmount, formatNetworkAmount } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits, formatNetworkAmount } from '@suite-common/wallet-utils';
 import { Card, Column, InfoItem, SkeletonRectangle } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -66,7 +66,7 @@ export const TotalSent = () => {
                                     disableHiddenPlaceholder
                                     value={
                                         tokenInfo
-                                            ? formatAmount(
+                                            ? convertAmountSubunitsToUnits(
                                                   transactionInfo.totalSpent,
                                                   tokenInfo.decimals,
                                               )

--- a/packages/suite/src/views/wallet/trading/common/TradingAddressOptions.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingAddressOptions.tsx
@@ -6,7 +6,7 @@ import { CryptoId } from 'invity-api';
 
 import { TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT, useTradingInfo } from '@suite-common/trading';
 import { getDisplaySymbol, getNetwork } from '@suite-common/wallet-config';
-import { formatAmount } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
 import { Column, InfoSegments, Select } from '@trezor/components';
 import type { AccountAddress } from '@trezor/connect';
 
@@ -106,7 +106,7 @@ export const TradingAddressOptions = <TFieldValues extends TradingBuyAddressOpti
                             network: getNetwork(account.symbol),
                         });
                         const balance = accountAddress.balance
-                            ? formatAmount(accountAddress.balance, networkDecimals)
+                            ? convertAmountSubunitsToUnits(accountAddress.balance, networkDecimals)
                             : accountAddress.balance;
 
                         const { coinSymbol, contractAddress } =

--- a/packages/suite/src/views/wallet/trading/common/TradingBalance.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingBalance.tsx
@@ -1,6 +1,6 @@
 import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { TokenAddress } from '@suite-common/wallet-types';
-import { amountToSmallestUnit } from '@suite-common/wallet-utils';
+import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 import { Text } from '@trezor/components';
 
 import { BaseCurrencyValue, HiddenPlaceholder, Translation } from 'src/components/suite';
@@ -40,7 +40,7 @@ export const TradingBalance = ({
     const stringBalance = !isNaN(Number(balance)) ? balance : '0';
     const formattedBalance =
         stringBalance && shouldSendInSats
-            ? amountToSmallestUnit(stringBalance, networkDecimals)
+            ? convertAmountUnitsToSubunits(stringBalance, networkDecimals)
             : stringBalance;
 
     const { fiatAmount } = useFiatFromCryptoValue({

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAccountOption.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAccountOption.tsx
@@ -1,5 +1,5 @@
 import { cryptoIdToNetwork, parseCryptoId } from '@suite-common/trading';
-import { amountToSmallestUnit } from '@suite-common/wallet-utils';
+import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 import { Badge, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -33,7 +33,7 @@ export const TradingFormInputAccountOption = ({
 
     const balanceLabel = tradingGetAccountLabel(option.label, shouldSendInSats);
     const balance = shouldSendInSats
-        ? amountToSmallestUnit(option.balance, decimals)
+        ? convertAmountUnitsToSubunits(option.balance, decimals)
         : option.balance;
     const accountType = optionGroups.find(group =>
         group.options.find(

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInputs.tsx
@@ -11,7 +11,7 @@ import {
     type TradingSellFormProps,
 } from '@suite-common/trading';
 import { TokenAddress } from '@suite-common/wallet-types';
-import { formatAmount } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
 import { Column, FractionButton, FractionButtonProps, Row } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils/src/firmwareUtils';
 import { spacings } from '@trezor/theme';
@@ -85,7 +85,10 @@ export const TradingFormInputs = () => {
         const tokenAddress = (output.token ?? undefined) as TokenAddress | undefined;
         const outputAmount =
             shouldSendInSats && output.amount
-                ? formatAmount(output.amount, getTradingNetworkDecimals({ sendCryptoSelect }))
+                ? convertAmountSubunitsToUnits(
+                      output.amount,
+                      getTradingNetworkDecimals({ sendCryptoSelect }),
+                  )
                 : output.amount;
 
         return (
@@ -165,7 +168,10 @@ export const TradingFormInputs = () => {
         const supportedCryptoCurrencies = exchangeInfo?.buyCryptoIds;
         const outputAmount =
             shouldSendInSats && output.amount
-                ? formatAmount(output.amount, getTradingNetworkDecimals({ sendCryptoSelect }))
+                ? convertAmountSubunitsToUnits(
+                      output.amount,
+                      getTradingNetworkDecimals({ sendCryptoSelect }),
+                  )
                 : output.amount;
 
         return (

--- a/packages/transport/src/types/index.ts
+++ b/packages/transport/src/types/index.ts
@@ -1,12 +1,14 @@
+import { Branded } from '@trezor/type-utils';
+
 import type { DEVICE_TYPE } from '../api/abstract';
 
 export * from './apiCall';
 
-export type Session = `${number}` & { __type: 'Session' };
+export type Session = `${number}` & Branded<'Session'>;
 export const Session = (input: `${number}`) => `${input}` as Session;
-export type PathInternal = string & { __type: 'PathInternal' };
+export type PathInternal = string & Branded<'PathInternal'>;
 export const PathInternal = (input: string) => input as PathInternal;
-export type PathPublic = `${number}` & { __type: 'PathPublic' };
+export type PathPublic = `${number}` & Branded<'PathPublic'>;
 export const PathPublic = (input: `${number}`) => `${input}` as PathPublic;
 
 export type DescriptorApiLevel = {
@@ -34,8 +36,12 @@ export type Descriptor = Omit<DescriptorApiLevel, 'path'> & {
 
 export interface Logger {
     info(...args: any): void;
+
     debug(...args: any): void;
+
     log(...args: any): void;
+
     warn(...args: any): void;
+
     error(...args: any): void;
 }

--- a/packages/type-utils/src/branded.ts
+++ b/packages/type-utils/src/branded.ts
@@ -1,0 +1,8 @@
+export class Branded<T extends string> {
+    __type!: T;
+}
+
+export class BrandedArity2<P1 extends string, P2> {
+    __type1!: P1;
+    __type2!: P2;
+}

--- a/packages/type-utils/src/index.ts
+++ b/packages/type-utils/src/index.ts
@@ -4,3 +4,4 @@ export * from './timeout';
 export * from './utils';
 export * from './object';
 export * from './exhaustive';
+export * from './branded';

--- a/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
@@ -7,8 +7,8 @@ import {
     networks,
 } from '@suite-common/wallet-config';
 import {
-    amountToSmallestUnit,
-    formatAmount,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     redactNumericalSubstring,
 } from '@suite-common/wallet-utils';
 import { PROTO } from '@trezor/connect';
@@ -66,7 +66,7 @@ const convertToUnit = (
         smallestUnitsOverride === true ||
         (isBalance && areAmountUnitsSupported && bitcoinAmountUnit === PROTO.AmountUnit.SATOSHI)
     ) {
-        return amountToSmallestUnit(value, decimals);
+        return convertAmountUnitsToSubunits(value, decimals);
     }
 
     // if it's not balance and sats units are disabled, values other than balances are in sats so we need to convert it to BTC
@@ -74,7 +74,7 @@ const convertToUnit = (
         !isBalance &&
         (bitcoinAmountUnit !== PROTO.AmountUnit.SATOSHI || !areAmountUnitsSupported)
     ) {
-        return formatAmount(value, decimals ?? BASE_CRYPTO_MAX_DISPLAYED_DECIMALS);
+        return convertAmountSubunitsToUnits(value, decimals ?? BASE_CRYPTO_MAX_DISPLAYED_DECIMALS);
     }
 
     return value;

--- a/suite-common/formatters/src/utils/convert.ts
+++ b/suite-common/formatters/src/utils/convert.ts
@@ -1,6 +1,6 @@
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import {
-    amountToSmallestUnit,
+    convertAmountUnitsToSubunits,
     formatNetworkAmount,
     fromFiatCurrency,
     toFiatCurrency,
@@ -46,5 +46,5 @@ export const convertFiatToCryptoAmount = ({
         return cryptoAmount;
     }
 
-    return amountToSmallestUnit(new BigNumber(cryptoAmount), decimals);
+    return convertAmountUnitsToSubunits(new BigNumber(cryptoAmount), decimals);
 };

--- a/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
+++ b/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
@@ -2,7 +2,7 @@ import { BuyTrade, BuyTradeQuoteRequest } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
 import { Network } from '@suite-common/wallet-config';
-import { formatAmount } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
 
 import { TRADING_BUY_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
@@ -47,7 +47,9 @@ const getQuoteRequestData = ({
         formValues;
     const decimals = getTradingNetworkDecimals({ network });
     const cryptoStringAmount =
-        cryptoInput && shouldSendInSats ? formatAmount(cryptoInput, decimals) : cryptoInput;
+        cryptoInput && shouldSendInSats
+            ? convertAmountSubunitsToUnits(cryptoInput, decimals)
+            : cryptoInput;
 
     const request = {
         wantCrypto: amountInCrypto,

--- a/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
@@ -2,7 +2,7 @@ import { ExchangeTrade, ExchangeTradeQuoteRequest } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
 import { Network } from '@suite-common/wallet-config';
-import { formatAmount } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
 
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
@@ -41,7 +41,7 @@ export const getQuoteRequestData = ({
     const unformattedOutputAmount = outputs[0].amount ?? '';
     const sendStringAmount =
         unformattedOutputAmount && shouldSendInSats
-            ? formatAmount(unformattedOutputAmount, decimals)
+            ? convertAmountSubunitsToUnits(unformattedOutputAmount, decimals)
             : unformattedOutputAmount;
 
     if (

--- a/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
@@ -2,7 +2,7 @@ import { isRejectedWithValue } from '@reduxjs/toolkit';
 import { ExchangeTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { amountToSmallestUnit } from '@suite-common/wallet-utils';
+import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 
 import { exchangeThunks, tradingThunks } from '../';
 import { SendDexTransactionThunkProps } from './sendDexTransactionThunk';
@@ -87,7 +87,7 @@ export const sendTransactionThunk = createThunk<
         }
 
         const sendStringAmount = shouldSendInSats
-            ? amountToSmallestUnit(selectedTrade.sendStringAmount, decimals)
+            ? convertAmountUnitsToSubunits(selectedTrade.sendStringAmount, decimals)
             : selectedTrade.sendStringAmount;
         const sendPaymentExtraId =
             selectedTrade.partnerPaymentExtraId || trade?.partnerPaymentExtraId;

--- a/suite-common/trading/src/thunks/sell/__tests__/handleSellRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/handleSellRequestThunk.test.ts
@@ -3,7 +3,7 @@ import { CryptoId, SellFiatTrade } from 'invity-api';
 
 import { configureMockStore, extraDependenciesMock } from '@suite-common/test-utils';
 import { getNetwork } from '@suite-common/wallet-config';
-import { amountToSmallestUnit } from '@suite-common/wallet-utils';
+import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 
 import { sellThunks } from '../../';
 import { invityAPI } from '../../../invityAPI';
@@ -166,7 +166,7 @@ describe('handleSellRequestThunk', () => {
                         ...input.formValues,
                         outputs: input.formValues.outputs.map(output => ({
                             ...output,
-                            amount: amountToSmallestUnit(output.amount, 8),
+                            amount: convertAmountUnitsToSubunits(output.amount, 8),
                         })),
                     },
                     shouldSendInSats: true,

--- a/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
+++ b/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
@@ -2,7 +2,7 @@ import { SellFiatTrade, SellFiatTradeQuoteRequest } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
 import { Network } from '@suite-common/wallet-config';
-import { formatAmount } from '@suite-common/wallet-utils';
+import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
 import { Timer } from '@trezor/react-utils';
 
 import { TRADING_DEFAULT_SELL_FLOWS, TRADING_SELL_THUNK_PREFIX } from '../../constants';
@@ -46,7 +46,7 @@ const getQuoteRequestData = ({
     const unformattedOutputAmount = outputs[0].amount;
     const cryptoStringAmount =
         unformattedOutputAmount && shouldSendInSats
-            ? formatAmount(unformattedOutputAmount, decimals)
+            ? convertAmountSubunitsToUnits(unformattedOutputAmount, decimals)
             : unformattedOutputAmount;
     const currencySelect = outputs[0].currency;
 

--- a/suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts
@@ -3,7 +3,7 @@ import { SellFiatTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
 import { Account } from '@suite-common/wallet-types';
-import { amountToSmallestUnit } from '@suite-common/wallet-utils';
+import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 
 import { tradingThunks } from '../';
 import { TRADING_SELL_THUNK_PREFIX } from '../../constants';
@@ -65,7 +65,7 @@ export const sendSellTransactionThunk = createThunk(
         }
 
         const cryptoStringAmount = shouldSendInSats
-            ? amountToSmallestUnit(selectedTrade.cryptoStringAmount, decimals)
+            ? convertAmountUnitsToSubunits(selectedTrade.cryptoStringAmount, decimals)
             : selectedTrade.cryptoStringAmount;
         const { destinationPaymentExtraId } = selectedTrade;
 

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -17,11 +17,11 @@ import {
     RbfTransactionParams,
 } from '@suite-common/wallet-types';
 import {
-    amountToSmallestUnit,
     calculateMax,
     calculateTotal,
     calculateTotalGasCost,
-    formatAmount,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     getAccountIdentity,
     getEthereumEstimateFeeParams,
     getExternalComposeOutput,
@@ -57,7 +57,7 @@ export const calculate = (
     );
 
     const availableTokenBalance = token
-        ? amountToSmallestUnit(token.balance!, token.decimals)
+        ? convertAmountUnitsToSubunits(token.balance!, token.decimals)
         : undefined;
 
     if (output.type === 'send-max' || output.type === 'send-max-noaddress') {
@@ -242,7 +242,7 @@ export const composeEthereumTransactionFeeLevelsThunk = createThunk<
         Object.keys(resultLevels).forEach(key => {
             const tx = resultLevels[key];
             if (tx.type !== 'error') {
-                tx.max = tx.max ? formatAmount(tx.max, decimals) : undefined;
+                tx.max = tx.max ? convertAmountSubunitsToUnits(tx.max, decimals) : undefined;
                 tx.estimatedFeeLimit = !customFeeLimit.isNaN()
                     ? customFeeLimit.toFixed(0)
                     : undefined;

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -8,10 +8,10 @@ import {
     PrecomposedTransaction,
 } from '@suite-common/wallet-types';
 import {
-    amountToSmallestUnit,
     calculateMax,
     calculateTotal,
-    formatAmount,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     getAccountIdentity,
     getExternalComposeOutput,
 } from '@suite-common/wallet-utils';
@@ -43,7 +43,7 @@ const calculate = (
     let amount: string;
     let max: string | undefined;
     const availableTokenBalance = token
-        ? amountToSmallestUnit(token.balance!, token.decimals)
+        ? convertAmountUnitsToSubunits(token.balance!, token.decimals)
         : undefined;
     if (output.type === 'send-max' || output.type === 'send-max-noaddress') {
         max = availableTokenBalance || calculateMax(availableBalance, feeInLamports);
@@ -67,8 +67,8 @@ const calculate = (
         const errorMessage = {
             id: 'REMAINING_BALANCE_LESS_THAN_RENT' as const,
             values: {
-                remainingSolBalance: formatAmount(remainingSolBalance, decimals),
-                rent: formatAmount(rent, decimals),
+                remainingSolBalance: convertAmountSubunitsToUnits(remainingSolBalance, decimals),
+                rent: convertAmountSubunitsToUnits(rent, decimals),
             },
         };
 
@@ -148,7 +148,10 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
                 formState.outputs[0].amount = tokenInfo.balance;
             } else {
                 // minimal amount for purpose of fee estimation, at least to cover rent + 1 lamport
-                formState.outputs[0].amount = formatAmount((account.misc?.rent ?? 0) + 1, decimals);
+                formState.outputs[0].amount = convertAmountSubunitsToUnits(
+                    (account.misc?.rent ?? 0) + 1,
+                    decimals,
+                );
             }
         }
 
@@ -244,7 +247,7 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
         Object.keys(resultLevels).forEach(key => {
             const tx = resultLevels[key];
             if (tx.type !== 'error') {
-                tx.max = tx.max ? formatAmount(tx.max, decimals) : undefined;
+                tx.max = tx.max ? convertAmountSubunitsToUnits(tx.max, decimals) : undefined;
             }
             if (tx.type === 'error' && tx.error === 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE') {
                 tx.errorMessage = {

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -16,8 +16,8 @@ import {
     PrecomposedTransactionFinalCardano,
 } from '@suite-common/wallet-types';
 import {
-    amountToSmallestUnit,
-    formatAmount,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     formatNetworkAmount,
     getAccountDecimals,
     getAreSatoshisUsed,
@@ -114,7 +114,9 @@ export const convertSendFormDraftsBtcAmountUnitsThunk = createThunk(
             const areSatsSupported = hasNetworkFeatures(relatedAccount, 'amount-unit');
 
             const amountFormatter =
-                areSatsAmountUnit && areSatsSupported ? amountToSmallestUnit : formatAmount;
+                areSatsAmountUnit && areSatsSupported
+                    ? convertAmountUnitsToSubunits
+                    : convertAmountSubunitsToUnits;
 
             const updatedDraft = cloneObject(draft);
             const amountDecimals = getAccountDecimals(relatedAccount.symbol)!;
@@ -310,7 +312,7 @@ export const pushSendFormTransactionThunk = createThunk<
 
         // get total amount without fee OR token amount
         const formattedAmount = token
-            ? `${formatAmount(
+            ? `${convertAmountSubunitsToUnits(
                   precomposedTransaction.totalSpent,
                   token.decimals,
               )} ${token.symbol!.toUpperCase()}`

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -7,12 +7,13 @@ import {
 } from '@trezor/blockchain-link-types/src/blockbook-api';
 import { SolanaStakingAccount } from '@trezor/blockchain-link-types/src/solana';
 import { AccountInfo, PROTO, StaticSessionId, TokenInfo } from '@trezor/connect';
+import { Branded } from '@trezor/type-utils';
 
 export type MetadataItem = string;
 export type XpubAddress = string;
 
-export type TokenSymbol = string & { __type: 'TokenSymbol' };
-export type TokenAddress = string & { __type: 'TokenAddress' };
+export type TokenSymbol = string & Branded<'TokenSymbol'>;
+export type TokenAddress = string & Branded<'TokenAddress'>;
 
 export type AddressType = 'contract' | 'fingerprint' | 'policyId';
 
@@ -102,7 +103,7 @@ export type AccountBackendSpecific =
       };
 
 export type AccountKey = string; // <AccountDescriptor>-<NetworkSymbol>-<DeviceStaticSessionId>
-export type AccountDescriptor = string & { __type: 'AccountDescriptor' }; // Descriptor or xpub/zpub/..
+export type AccountDescriptor = string & Branded<'AccountDescriptor'>; // Descriptor or xpub/zpub/..
 
 export type Account = {
     deviceState: StaticSessionId;

--- a/suite-common/wallet-types/src/fiatRates.ts
+++ b/suite-common/wallet-types/src/fiatRates.ts
@@ -1,6 +1,7 @@
 import { BaseCurrencyCode } from '@suite-common/suite-config';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import type { FiatRatesBySymbol } from '@trezor/connect';
+import { Branded } from '@trezor/type-utils';
 
 import { TokenAddress } from './account';
 
@@ -20,9 +21,9 @@ export interface HistoricRates {
     ts: number;
 }
 
-export type FiatRateKey = string & { __type: 'FiatRateKey' };
+export type FiatRateKey = string & Branded<'FiatRateKey'>;
 
-export type Timestamp = number & { __type: 'Timestamp' };
+export type Timestamp = number & Branded<'Timestamp'>;
 
 export type RateType = 'current' | 'lastWeek' | 'historic';
 export type RateTypeWithoutHistoric = Exclude<RateType, 'historic'>;

--- a/suite-common/wallet-types/src/send.ts
+++ b/suite-common/wallet-types/src/send.ts
@@ -1,5 +1,7 @@
+import { Branded } from '@trezor/type-utils';
+
 import { AccountKey, TokenAddress } from './account';
 
 export type SendFormDraftKey =
     | AccountKey
-    | (`${AccountKey}-${TokenAddress}` & { __type: 'SendFormDraftKey' });
+    | (`${AccountKey}-${TokenAddress}` & Branded<'SendFormDraftKey'>);

--- a/suite-common/wallet-types/src/wallet.ts
+++ b/suite-common/wallet-types/src/wallet.ts
@@ -1,6 +1,8 @@
+import { Branded } from '@trezor/type-utils';
+
 /**
  * First testnet address => 44/1/0/0/0
  *
  * See `packages/connect/src/device/workflow/validateState.ts` where it is retrieved
  */
-export type WalletDescriptor = string & { __type: 'WalletDescriptor' };
+export type WalletDescriptor = string & Branded<'WalletDescriptor'>;

--- a/suite-common/wallet-utils/src/AmountTypes.ts
+++ b/suite-common/wallet-utils/src/AmountTypes.ts
@@ -1,0 +1,17 @@
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { Branded } from '@trezor/type-utils';
+import { BigNumber } from '@trezor/utils';
+
+/**
+ * Bitcoin, Ether, Dogecoin, ...
+ */
+export type AmountUnit<T extends NetworkSymbol> = BigNumber & Branded<`amount-whole-${T}`>;
+export const asAmountUnit = <T extends NetworkSymbol>(value: BigNumber, _symbol: T) =>
+    value as unknown as AmountUnit<T>;
+
+/**
+ * Sats, ...
+ */
+export type AmountSubunit<T extends NetworkSymbol> = BigNumber & Branded<`amount-sub-${T}`>;
+export const asAmountSubunit = <T extends NetworkSymbol>(value: BigNumber, _symbol: T) =>
+    value as unknown as AmountSubunit<T>;

--- a/suite-common/wallet-utils/src/__tests__/AccountTypes.test-types.ts
+++ b/suite-common/wallet-utils/src/__tests__/AccountTypes.test-types.ts
@@ -1,0 +1,11 @@
+import { BigNumber } from '@trezor/utils';
+
+import { AmountUnit, asAmountSubunit, asAmountUnit } from '../AmountTypes';
+
+export const test_ok: AmountUnit<'btc'> = asAmountUnit(new BigNumber(1), 'btc');
+
+// @ts-expect-error
+export const testErrorSymbolMismatch: AmountUnit<'btc'> = asAmountUnit(new BigNumber(1), 'eth');
+
+// @ts-expect-error
+export const testErrorSubunit: AmountUnit<'btc'> = asAmountSubunit(new BigNumber(1), 'btc');

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -1,9 +1,13 @@
 import { testMocks } from '@suite-common/test-utils';
 import { Account } from '@suite-common/wallet-types';
+import { BigNumber } from '@trezor/utils';
 
+import { asAmountSubunit, asAmountUnit } from '../AmountTypes';
 import * as fixtures from '../__fixtures__/accountUtils';
 import {
     accountSearchFn,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     enhanceAddresses,
     findAccountDevice,
     formatNetworkAmount,
@@ -24,6 +28,8 @@ import {
     sortByBIP44AddressIndex,
     sortByCoin,
     substituteBip43Path,
+    subunitsToUnits,
+    unitsToSubunits,
 } from '../accountUtils';
 
 const { getSuiteDevice, getWalletAccount } = testMocks;
@@ -333,5 +339,33 @@ describe('account utils', () => {
         accountInfo.addresses.change = [];
         account.addresses = enhanceAddresses(accountInfo, account);
         expect(account.addresses.change).toEqual([]);
+    });
+});
+
+describe(convertAmountUnitsToSubunits.name, () => {
+    it('converts BTC->Sats', () => {
+        expect(convertAmountUnitsToSubunits('1', 8)).toEqual(String(100_000_000));
+    });
+});
+
+describe(unitsToSubunits.name, () => {
+    it('converts BTC->Sats', () => {
+        expect(unitsToSubunits(asAmountUnit(new BigNumber(1), 'btc'), 'btc').toString()).toEqual(
+            String(100_000_000),
+        );
+    });
+});
+
+describe(convertAmountSubunitsToUnits.name, () => {
+    it('converts Sats->BTC', () => {
+        expect(convertAmountSubunitsToUnits('1', 8)).toEqual('0.00000001');
+    });
+});
+
+describe(subunitsToUnits.name, () => {
+    it('converts Sats->BTC', () => {
+        expect(subunitsToUnits(asAmountSubunit(new BigNumber(1), 'btc'), 'btc').toString()).toEqual(
+            '0.00000001',
+        );
     });
 });

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -46,6 +46,7 @@ import {
 import { arrayDistinct, bufferUtils } from '@trezor/utils';
 import { BigNumber, BigNumberValue } from '@trezor/utils/src/bigNumber';
 
+import { AmountSubunit, AmountUnit } from './AmountTypes';
 import { toFiatCurrency } from './fiatConverterUtils';
 import { getFiatRateKey } from './fiatRatesUtils';
 import { getAccountTotalStakingBalance } from './stakingUtils';
@@ -288,7 +289,12 @@ export const getAccountTypeUrl = (path: string) => {
 
 export const getAccountDecimals = (symbol: NetworkSymbol) => networks[symbol]?.decimals;
 
-export const formatAmount = (amount: BigNumberValue, decimals: number) => {
+/**
+ * BTC -> Sats, etc...
+ *
+ * @deprecated Use `subunitsToUnits` instead!
+ */
+export const convertAmountSubunitsToUnits = (amount: BigNumberValue, decimals: number) => {
     const safeAmount = amount || '0';
     const bAmount = new BigNumber(safeAmount);
 
@@ -301,7 +307,12 @@ export const formatAmount = (amount: BigNumberValue, decimals: number) => {
     return bAmount.div(factor).toString(10);
 };
 
-export const amountToSmallestUnit = (amount: BigNumberValue, decimals: number) => {
+/**
+ * Sats -> BTC, etc...
+ *
+ * @deprecated Use `unitsToSubunits` instead!
+ */
+export const convertAmountUnitsToSubunits = (amount: BigNumberValue, decimals: number) => {
     try {
         const bAmount = new BigNumber(amount);
         if (bAmount.isNaN()) {
@@ -315,6 +326,9 @@ export const amountToSmallestUnit = (amount: BigNumberValue, decimals: number) =
     }
 };
 
+/**
+ * @deprecated Use `subunitsToUnits` instead!
+ */
 export const satoshiAmountToBtc = (amount: BigNumberValue) => {
     try {
         const satsAmount = new BigNumber(amount);
@@ -329,6 +343,9 @@ export const satoshiAmountToBtc = (amount: BigNumberValue) => {
     }
 };
 
+/**
+ * @deprecated Use `subunitsToUnits` instead!
+ */
 export const networkAmountToSmallestUnit = (amount: string | null, symbol: NetworkSymbol) => {
     if (!amount) return '0';
 
@@ -336,7 +353,34 @@ export const networkAmountToSmallestUnit = (amount: string | null, symbol: Netwo
 
     if (!decimals) return amount;
 
-    return amountToSmallestUnit(amount, decimals);
+    return convertAmountUnitsToSubunits(amount, decimals);
+};
+
+/**
+ * Converts Bitcoins to Sats (and similarly for other coins)
+ */
+export const unitsToSubunits = <T extends NetworkSymbol, K extends T>(
+    value: AmountUnit<T>,
+    symbol: K,
+): AmountSubunit<T> => {
+    const decimals = getAccountDecimals(symbol);
+
+    const factor = new BigNumber(10).exponentiatedBy(decimals);
+
+    return value.multipliedBy(factor) as AmountSubunit<T>;
+};
+
+/**
+ * Converts Sats to Bitcoin (and similarly for other coins)
+ */
+export const subunitsToUnits = <T extends NetworkSymbol, K extends T>(
+    value: AmountSubunit<T>,
+    symbol: K,
+): AmountUnit<T> => {
+    const decimals = getAccountDecimals(symbol);
+    const factor = new BigNumber(10).exponentiatedBy(decimals);
+
+    return value.div(factor) as AmountUnit<T>;
 };
 
 export const formatNetworkAmount = (
@@ -349,7 +393,7 @@ export const formatNetworkAmount = (
 
     if (!decimals) return amount;
 
-    let formattedAmount = formatAmount(amount, decimals);
+    let formattedAmount = convertAmountSubunitsToUnits(amount, decimals);
 
     if (withSymbol) {
         let formattedSymbol = getNetworkDisplaySymbol(symbol);
@@ -366,7 +410,10 @@ export const formatNetworkAmount = (
 };
 
 export const formatTokenAmount = (tokenTransfer: TokenTransfer) => {
-    const formattedAmount = formatAmount(tokenTransfer.amount, tokenTransfer.decimals);
+    const formattedAmount = convertAmountSubunitsToUnits(
+        tokenTransfer.amount,
+        tokenTransfer.decimals,
+    );
     const formattedTokenSymbol = tokenTransfer.symbol?.toUpperCase();
 
     return formattedTokenSymbol ? `${formattedAmount} ${formattedTokenSymbol}` : formattedAmount;
@@ -466,7 +513,7 @@ export const enhanceTokens = (tokens: Account['tokens']) => {
             ...t,
             name: t.name || symbol,
             symbol: symbol.toLowerCase(),
-            balance: formatAmount(t.balance || 0, t.decimals),
+            balance: convertAmountSubunitsToUnits(t.balance || 0, t.decimals),
         };
     });
 };

--- a/suite-common/wallet-utils/src/cardanoUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoUtils.ts
@@ -11,8 +11,8 @@ import { CARDANO, CardanoCertificate, CardanoOutput, PROTO } from '@trezor/conne
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import {
-    amountToSmallestUnit,
-    formatAmount,
+    convertAmountSubunitsToUnits,
+    convertAmountUnitsToSubunits,
     formatNetworkAmount,
     networkAmountToSmallestUnit,
 } from './accountUtils';
@@ -81,7 +81,7 @@ export const transformUserOutputs = (
                       {
                           unit: output.token,
                           quantity: output.amount
-                              ? amountToSmallestUnit(output.amount, tokenDecimals)
+                              ? convertAmountUnitsToSubunits(output.amount, tokenDecimals)
                               : '0',
                       },
                   ]
@@ -195,5 +195,5 @@ export const formatMaxOutputAmount = (
     const tokenDecimals =
         account.tokens?.find(t => t.contract === maxOutput.assets[0].unit)?.decimals ?? 0;
 
-    return formatAmount(maxAmount, tokenDecimals);
+    return convertAmountSubunitsToUnits(maxAmount, tokenDecimals);
 };

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -42,7 +42,7 @@ import {
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import {
-    amountToSmallestUnit,
+    convertAmountUnitsToSubunits,
     formatNetworkAmount,
     getUtxoOutpoint,
     networkAmountToSmallestUnit,
@@ -120,7 +120,7 @@ const getSerializedErc20Transfer = (token: TokenInfo, to: string, amount: string
     // 32 bytes address parameter, remove '0x' prefix
     const erc20recipient = padLeft(to, 64).substring(2);
     // convert amount to satoshi
-    const tokenAmount = amountToSmallestUnit(amount, token.decimals);
+    const tokenAmount = convertAmountUnitsToSubunits(amount, token.decimals);
     // 32 bytes amount paramter, remove '0x' prefix
     const erc20amount = padLeft(numberToHex(tokenAmount), 64).substring(2);
 
@@ -407,7 +407,7 @@ export const getExternalComposeOutput = (
 
     const tokenInfo = findToken(account.tokens, token);
     const decimals = tokenInfo ? tokenInfo.decimals : network.decimals;
-    const formattedAmount = amountToSmallestUnit(amount, decimals);
+    const formattedAmount = convertAmountUnitsToSubunits(amount, decimals);
 
     let output: ExternalOutput;
     if (isMaxActive) {

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -26,10 +26,15 @@ import {
     TokenInfo,
     TokenTransfer,
 } from '@trezor/connect';
+import { Branded } from '@trezor/type-utils';
 import { arrayPartition } from '@trezor/utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { formatAmount, formatNetworkAmount, isTokenTransferMatchesSearch } from './accountUtils';
+import {
+    convertAmountSubunitsToUnits,
+    formatNetworkAmount,
+    isTokenTransferMatchesSearch,
+} from './accountUtils';
 import { getFiatRateKey, roundTimestampToNearestPastHour } from './fiatRatesUtils';
 import { getMyInputsFromTransaction } from './getMyInputsFromTransaction';
 import { toFiatCurrency } from '../src/fiatConverterUtils';
@@ -91,7 +96,7 @@ export const parseTransactionDateKey = (key: string) => {
     return new Date(Number(year), Number(month) - 1, Number(day));
 };
 
-export type MonthKey = string & { __type: 'MonthKey' };
+export type MonthKey = string & Branded<'MonthKey'>;
 export const generateTransactionMonthKey = (d: Date): MonthKey =>
     // Adding days because of time zones of UTC
     addDays(startOfMonth(d), 1).toUTCString() as MonthKey;
@@ -263,7 +268,7 @@ export const sumTransactionsFiat = (
                     token.contract as TokenAddress,
                 );
                 const historicTokenRate = historicFiatRates?.[tokenFiatRateKey]?.[roundedTimestamp];
-                const tokenAmount = formatAmount(token.amount, token.decimals);
+                const tokenAmount = convertAmountSubunitsToUnits(token.amount, token.decimals);
 
                 if (transferType === 'sent') {
                     totalAmount = totalAmount.minus(
@@ -607,7 +612,7 @@ const getEthereumRbfParams = (
               address: token.to,
               token: token.contract,
               amount: token.amount,
-              formattedAmount: formatAmount(token.amount, token.decimals),
+              formattedAmount: convertAmountSubunitsToUnits(token.amount, token.decimals),
           }
         : {
               address: vout[0].addresses![0],

--- a/suite-native/module-send/src/hooks/useSendForm.ts
+++ b/suite-native/module-send/src/hooks/useSendForm.ts
@@ -23,7 +23,7 @@ import {
     updateFeeInfoThunk,
 } from '@suite-common/wallet-core';
 import { TokenAddress } from '@suite-common/wallet-types';
-import { amountToSmallestUnit, getExcludedUtxos } from '@suite-common/wallet-utils';
+import { convertAmountUnitsToSubunits, getExcludedUtxos } from '@suite-common/wallet-utils';
 import { useForm } from '@suite-native/forms';
 import {
     SendStackParamList,
@@ -277,7 +277,7 @@ export const useSendForm = (accountKey: string, tokenContract?: TokenAddress) =>
 
     const amount = isAmountInSats
         ? getValues('outputs.0.amount')
-        : amountToSmallestUnit(getValues('outputs.0.amount'), network?.decimals ?? 0);
+        : convertAmountUnitsToSubunits(getValues('outputs.0.amount'), network?.decimals ?? 0);
 
     return {
         handleSubmitSendForm,

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -13,7 +13,7 @@ import {
 } from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';
 import { WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
-import { amountToSmallestUnit } from '@suite-common/wallet-utils';
+import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 import { EventType, analytics } from '@suite-native/analytics';
 import { useForm } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
@@ -207,7 +207,10 @@ const useBuyQuoteChangeEffect = ({ getValues, setValue, watch }: BuyFormType) =>
         if (!amountInCrypto && cryptoValue !== truncatedCryptoAmount) {
             const value =
                 isAmountInSats && truncatedCryptoAmount && symbol
-                    ? amountToSmallestUnit(truncatedCryptoAmount, getNetwork(symbol).decimals)
+                    ? convertAmountUnitsToSubunits(
+                          truncatedCryptoAmount,
+                          getNetwork(symbol).decimals,
+                      )
                     : truncatedCryptoAmount;
             setValue('cryptoValue', value);
         }

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
@@ -6,7 +6,7 @@ import { ExchangeTrade } from 'invity-api';
 import { selectTradingExchangeProviders } from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';
 import { WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
-import { amountToSmallestUnit } from '@suite-common/wallet-utils';
+import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 import { useForm } from '@suite-native/forms';
 
 import { selectGroupedExchangeQuotes } from '../../selectors/exchangeSelectors';
@@ -61,7 +61,7 @@ const useExchangeQuoteChangeEffect = ({ watch, setValue }: ExchangeFormType) => 
 
         const value =
             isAmountInSats && amount && symbol
-                ? amountToSmallestUnit(amount, getNetwork(symbol).decimals)
+                ? convertAmountUnitsToSubunits(amount, getNetwork(symbol).decimals)
                 : amount;
         setValue('receiveCryptoAmount', value);
     }, [selectedQuote, isAmountInSats, symbol, setValue]);


### PR DESCRIPTION
This PR introduces a formal way to create Nominal Types and creates a tooling how to use it for `AmountUnits` and `AmountSubunits` to distinguishes between BTC and Sats... 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=btc-as-base-currency6-nominal&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=btc-as-base-currency6-nominal&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=btc-as-base-currency6-nominal&lookback=7)