### PR TITLE
fix(connect): retry invalid state even without popup

### DIFF
--- a/packages/connect/e2e/tests/device/passphrase.test.ts
+++ b/packages/connect/e2e/tests/device/passphrase.test.ts
@@ -152,6 +152,7 @@ describe('TrezorConnect passphrase', () => {
         });
 
         // use invalid state on default instance
+        TrezorConnect.on('ui-request_passphrase', passphraseHandler('a'));
         const invalidState = await TrezorConnect.getAddress({
             device: {
                 instance: 0,

--- a/packages/connect/src/device/workflow/validateState.ts
+++ b/packages/connect/src/device/workflow/validateState.ts
@@ -108,7 +108,14 @@ export const validateState = async (context: WorkflowContext) => {
                 }
             }
         } else if (invalidDeviceState) {
-            throw ERRORS.TypedError('Device_InvalidState');
+            // reset sessionId and try again
+            device.setState({ sessionId: undefined });
+            await device.initialize(method.useCardanoDerivation);
+            // if still not valid, throw error
+            invalidDeviceState = await getInvalidDeviceState(context);
+            if (invalidDeviceState) {
+                throw ERRORS.TypedError('Device_InvalidState');
+            }
         }
     } catch (error) {
         // other error


### PR DESCRIPTION
## Description

Previously, if the `sessionId` was invalid the flow would immediately fail with a `Device_InvalidState` error. 
Unless using Connect Popup, where it prompts user whether they want to retry. 

With this PR, we will now automatically retry once when encountering an invalid `sessionId`. If the retry also fails, we then throw the `Device_InvalidState` error.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-retry-invalid-state&lookback=7)