### PR TITLE
fix(suite-common): prevent getAccountInfo calls when app window is hidden

### DIFF
--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -233,8 +233,8 @@ export const syncAccountsWithBlockchainThunk = createThunk(
         // First clear, to cancel last planned sync
         tryClearTimeout(blockchain[symbol].syncTimeout);
 
-        // non-blockbook + networks using external nodes will not be updated when app window is not active
-        const shouldSync = isWindowVisible || isTrezorInfraBasedNetwork(symbol);
+        // Only Trezor infra networks sync, and only when app window is active
+        const shouldSync = isWindowVisible;
 
         if (shouldSync) {
             // non-blockbook + networks using external nodes will not update periodically if not visible in UI (sidebar)


### PR DESCRIPTION
## Description

Previously, Trezor infra networks (blockbook/stellar) were still syncing even if the app was minimized or running in the background. This caused unnecessary `getAccountInfo` calls.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20002

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/stop-getAccountInfo-sync-in-background&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/stop-getAccountInfo-sync-in-background&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/stop-getAccountInfo-sync-in-background&lookback=7)