### PR TITLE
Store fiat rates only for defined txs

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -273,7 +273,7 @@ export const saveAccountHistoricRates =
     async (_dispatch: Dispatch, getState: GetState) => {
         if (!(await db.isAccessible())) return Promise.resolve();
         const allTxs = getState().wallet.transactions.transactions;
-        const accTxs = allTxs[accountKey] || [];
+        const accTxs = (allTxs[accountKey] || []).filter(tx => !!tx);
 
         const accHistoricRates = selectHistoricRatesByTransactions(historicRates, accTxs);
 

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -287,7 +287,7 @@ export const saveAccountTransactions =
         const accTxs = allTxs[account.key] || [];
 
         // wrap txs and add its order inside the array
-        const orderedTxs = accTxs.map((tx, order) => ({ tx, order }));
+        const orderedTxs = accTxs.map((tx, order) => ({ tx, order })).filter(({ tx }) => !!tx);
 
         return db.addItems('txs', orderedTxs, true);
     };


### PR DESCRIPTION
## Description

Trying to fix recurring Sentry issue. Historically, there were `undefined | null` transactions allowed in redux (are they still?) and this is the easiest way how to fix the issue.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/storage-fiat-tx-destructure&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/storage-fiat-tx-destructure&lookback=7)