### PR TITLE
fix(suite): connect popup check if device connected

### DIFF
--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -92,6 +92,9 @@ export const connectPopupCallThunkInner = createThunk<
             if (!device) {
                 throw TypedError('Device_NotFound');
             }
+            if (!device.connected) {
+                throw TypedError('Device_Disconnected');
+            }
 
             const txSigningPrecomposed: PrecomposedTransactionFinal | undefined =
                 methodInfo.payload.precomposed;


### PR DESCRIPTION
## Description

Check if device is actually connected.
Previously you could select a disconnected remembered wallet in Suite, which would lead to confusion, because Connect would actually talk to the currently connected wallet, but it would result in passphrase mismatch. 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-suite-check-if-device-connected&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-suite-check-if-device-connected&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-suite-check-if-device-connected&lookback=7)