### PR TITLE
fix(suite): disable send button when TX validity expires

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -123,6 +123,7 @@ export const TransactionReviewModalContent = ({
     const [areDetailsVisible, setAreDetailsVisible] = useState(false);
     const deviceModelInternal = device?.features?.internal_model;
     const { precomposedTx, serializedTx } = txInfoState;
+    const [hasTxExpired, setHasTxExpired] = useState(false);
 
     const router = useSelector(state => state.router);
 
@@ -152,6 +153,7 @@ export const TransactionReviewModalContent = ({
 
         const timeoutId = setTimeout(() => {
             if (mounted && !isSending) {
+                setHasTxExpired(true);
                 TrezorConnect.cancel('tx-timeout');
             }
         }, timeLeft);
@@ -355,7 +357,7 @@ export const TransactionReviewModalContent = ({
             return (
                 <Modal.Button
                     data-testid="@modal/send"
-                    isDisabled={!serializedTx}
+                    isDisabled={!serializedTx || hasTxExpired}
                     isLoading={isSending}
                     variant={isCancelRbfAction ? 'destructive' : 'primary'}
                     onClick={handleSend}


### PR DESCRIPTION
## Description

Ensure the send button is disabled when the Solana TX validity timer runs out.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19918

## Screenshots:

https://github.com/user-attachments/assets/9ac01f4e-e04e-4261-b458-7328b1d0b422


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/solana-tx-timeout-modal-state&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/solana-tx-timeout-modal-state&lookback=7)