### PR TITLE
fix(suite-native): validate address for contract address on insert for ETH

### DIFF
--- a/suite-native/module-send/src/hooks/useAddressValidationAlerts/useAddressValidationAlerts.ts
+++ b/suite-native/module-send/src/hooks/useAddressValidationAlerts/useAddressValidationAlerts.ts
@@ -60,7 +60,7 @@ export const useAddressValidationAlerts = ({ inputIndex }: UseAddressValidationA
             !wasAddressChecksummed;
 
         const shouldCheckContractAddress =
-            wasTokenAlertDisplayed &&
+            (wasTokenAlertDisplayed || !shouldShowTokenAlert) &&
             ['eth', 'tsep', 'thol'].includes(symbol) &&
             !wasContractAlertDisplayed;
 


### PR DESCRIPTION
Previously address was not validated for contract address for ETH, only for tokens. This adds validation for ETH


## Related Issue

Resolve #19453

## Screenshots:

https://github.com/user-attachments/assets/395a956f-e4b9-4613-8ac3-ca078ff00cdd



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/contract-address-warning&lookback=7)