### PR TITLE
fix(suite-native): do not show view only popup outside homescreen

### DIFF
--- a/suite-native/module-home/src/screens/HomeScreen/useShowViewOnlyAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/useShowViewOnlyAlert.tsx
@@ -1,5 +1,7 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+
+import { useFocusEffect } from '@react-navigation/native';
 
 import {
     deviceActions,
@@ -83,36 +85,38 @@ export const useShowViewOnlyAlert = () => {
         });
     }, [showAlert, handleEnable, handleCancel]);
 
-    useEffect(() => {
-        let isMounted = true;
-        let timerId: TimerId;
+    useFocusEffect(
+        useCallback(() => {
+            let isMounted = true;
+            let timerId: TimerId;
 
-        const canBeShowed =
-            !isDeviceRemembered &&
-            isDeviceReadyToUseAndAuthorized &&
-            !isPortfolioTrackerDevice &&
-            !hasDiscovery &&
-            !viewOnlyCancelationTimestamp;
+            const canBeShowed =
+                !isDeviceRemembered &&
+                isDeviceReadyToUseAndAuthorized &&
+                !isPortfolioTrackerDevice &&
+                !hasDiscovery &&
+                !viewOnlyCancelationTimestamp;
 
-        //show after a delay
-        if (canBeShowed) {
-            timerId = setTimeout(() => {
-                if (isMounted) {
-                    showViewOnlyAlert();
-                }
-            }, SHOW_TIMEOUT);
-        }
+            //show after a delay
+            if (canBeShowed) {
+                timerId = setTimeout(() => {
+                    if (isMounted) {
+                        showViewOnlyAlert();
+                    }
+                }, SHOW_TIMEOUT);
+            }
 
-        return () => {
-            clearTimeout(timerId);
-            isMounted = false;
-        };
-    }, [
-        hasDiscovery,
-        isDeviceReadyToUseAndAuthorized,
-        isDeviceRemembered,
-        isPortfolioTrackerDevice,
-        showViewOnlyAlert,
-        viewOnlyCancelationTimestamp,
-    ]);
+            return () => {
+                clearTimeout(timerId);
+                isMounted = false;
+            };
+        }, [
+            hasDiscovery,
+            isDeviceReadyToUseAndAuthorized,
+            isDeviceRemembered,
+            isPortfolioTrackerDevice,
+            showViewOnlyAlert,
+            viewOnlyCancelationTimestamp,
+        ]),
+    );
 };


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- Prevent showing view only popup over onboarding after recovery if Suite has already been used (and coins has been selected).

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19631

## Screenshots:


https://github.com/user-attachments/assets/81bd0119-053f-4561-822a-ff6ae3336342




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/view-only-popup-homescreen-only&lookback=7)