### PR TITLE
fix(suite): walletconnect undefined icons

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
@@ -140,7 +140,7 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                 <Card>
                     <Row gap={spacings.md}>
                         <ConnectAppIcon
-                            src={pendingProposal.params.proposer.metadata.icons[0]}
+                            src={pendingProposal.params.proposer.metadata.icons?.[0]}
                             size={spacings.xxxxl}
                             type="walletConnect"
                         />

--- a/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectList.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectList.tsx
@@ -38,7 +38,10 @@ export const WalletConnectList = () => {
                         padding={spacings.md}
                         data-testid={`@settings/walletconnect-apps/${index}`}
                     >
-                        <ConnectAppIcon src={session.peer.metadata.icons[0]} type="walletConnect" />
+                        <ConnectAppIcon
+                            src={session.peer.metadata.icons?.[0]}
+                            type="walletConnect"
+                        />
                         <Column flex="1">
                             <Row columnGap={spacings.sm} rowGap={spacings.xxxs} flexWrap="wrap">
                                 <Text>{session.peer.metadata.name}</Text>

--- a/suite-common/walletconnect/src/adapters/ethereum.ts
+++ b/suite-common/walletconnect/src/adapters/ethereum.ts
@@ -57,7 +57,7 @@ const ethereumRequestThunk = createThunk<
             origin: event.verifyContext.verified.origin,
             manifest: {
                 appName: session.peer.metadata.name,
-                appIcon: session.peer.metadata.icons[0],
+                appIcon: session.peer.metadata.icons?.[0],
             },
         },
     };

--- a/suite-common/walletconnect/src/adapters/solana.ts
+++ b/suite-common/walletconnect/src/adapters/solana.ts
@@ -78,7 +78,7 @@ const solanaSignTransaction = createThunk<
                     origin,
                     manifest: {
                         appName: session.peer.metadata.name,
-                        appIcon: session.peer.metadata.icons[0],
+                        appIcon: session.peer.metadata.icons?.[0],
                     },
                 },
             }),

--- a/suite-native/module-connect-popup/src/screens/WalletConnectPairScreen.tsx
+++ b/suite-native/module-connect-popup/src/screens/WalletConnectPairScreen.tsx
@@ -61,7 +61,7 @@ export const SessionDetailCard = ({ session }: { session: WalletConnectSession }
                 <TouchableOpacity onPress={() => (isExpanded.value = !isExpanded.value)}>
                     <HStack spacing="sp12" alignItems="center">
                         <ConnectAppIcon
-                            src={session.peer.metadata.icons[0]}
+                            src={session.peer.metadata.icons?.[0]}
                             type="walletConnect"
                             size="medium"
                         />

--- a/suite-native/module-connect-popup/src/screens/WalletConnectSessionPopupScreen.tsx
+++ b/suite-native/module-connect-popup/src/screens/WalletConnectSessionPopupScreen.tsx
@@ -105,7 +105,7 @@ export const WalletConnectSessionPopupScreen = () => {
                     <Card>
                         <HStack alignItems="center" spacing="sp16">
                             <ConnectAppIcon
-                                src={pendingProposal?.params.proposer.metadata.icons[0]}
+                                src={pendingProposal?.params.proposer.metadata.icons?.[0]}
                                 type="walletConnect"
                                 size="large"
                             />


### PR DESCRIPTION
## Description

In WalletConnect metadata, there's an `icons` array which is required by types. It can be empty, but not undefined, however I found a 3rd party site where it's undefined, causing a crash. 

This PR adds a nullability check before accessing the array anywhere.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/walletconnect-undefined-icons&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/walletconnect-undefined-icons&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/walletconnect-undefined-icons&lookback=7)