### PR TITLE
EVM transaction review changes

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -73,7 +73,9 @@ const getOutputTitle = (
         case 'reduce-output':
             return <Translation id="AMOUNT" />;
         case 'contract':
-            return <Translation id={networkType === 'solana' ? 'TR_TOKEN' : 'TR_CONTRACT'} />;
+            return (
+                <Translation id={networkType === 'solana' ? 'TR_TOKEN' : 'TR_CONTRACT_ADDRESS'} />
+            );
         case 'address':
         case 'regular_legacy':
             return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -1,11 +1,12 @@
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { TokenAddress } from '@suite-common/wallet-types';
 import { convertAmountSubunitsToUnits, formatNetworkAmount } from '@suite-common/wallet-utils';
 import {
+    Box,
     Card,
     Column,
     DotIndicator,
@@ -15,9 +16,11 @@ import {
     Note,
     Row,
     Text,
+    TextButton,
+    useElevation,
 } from '@trezor/components';
 import { TokenInfo } from '@trezor/connect';
-import { spacings } from '@trezor/theme';
+import { Elevation, mapElevationToBackground, spacings } from '@trezor/theme';
 import { exhaustive } from '@trezor/type-utils';
 
 import {
@@ -41,11 +44,75 @@ const getCardanoFingerprint = (
     return token?.fingerprint;
 };
 
-const DataWrapper = styled.p`
+const DataWrapper = styled.p<{ $isExpanded: boolean; $elevation: Elevation }>`
     word-break: break-all;
     font-variant-numeric: tabular-nums;
     letter-spacing: 0;
+    cursor: pointer;
+    position: relative;
+
+    ${({ $isExpanded, $elevation, theme }) =>
+        !$isExpanded &&
+        css`
+            max-height: 100px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+
+            /* Bottom shadow */
+            &::after {
+                content: '';
+                position: absolute;
+                bottom: 0;
+                left: 0;
+                right: 0;
+                height: 40px;
+                background: linear-gradient(
+                    to bottom,
+                    rgb(0 0 0 / 0%) 0%,
+                    ${mapElevationToBackground({ theme, $elevation })} 100%
+                );
+                pointer-events: none;
+            }
+        `}
 `;
+
+const MAX_COLLAPSED_DATA_LENGTH = 400;
+
+const Data = ({ value }: { value: string }) => {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const { parentElevation } = useElevation();
+    const isTooLong = value.length > MAX_COLLAPSED_DATA_LENGTH;
+
+    if (!isTooLong) {
+        return (
+            <DataWrapper $isExpanded $elevation={parentElevation}>
+                {value}
+            </DataWrapper>
+        );
+    }
+
+    return (
+        <Box>
+            <DataWrapper
+                onClick={() => setIsExpanded(!isExpanded)}
+                $isExpanded={isExpanded}
+                $elevation={parentElevation}
+            >
+                {isExpanded ? value : value.slice(0, MAX_COLLAPSED_DATA_LENGTH)}
+            </DataWrapper>
+            <Row justifyContent="center">
+                <TextButton
+                    variant="tertiary"
+                    icon={isExpanded ? 'caretUp' : 'caretDown'}
+                    iconAlignment="start"
+                    onClick={() => setIsExpanded(!isExpanded)}
+                >
+                    <Translation id={isExpanded ? 'TR_SHOW_LESS' : 'TR_SHOW_MORE'} />
+                </TextButton>
+            </Row>
+        </Box>
+    );
+};
 
 const Status = ({ state }: { state: TransactionReviewOutputElementProps['state'] }) => {
     switch (state) {
@@ -81,7 +148,7 @@ const Value = ({ value, type, symbol, token, isFee, isFiatVisible, state }: Valu
         case 'safe-address':
             return <Address value={value} />;
         case 'data':
-            return <DataWrapper>{value}</DataWrapper>;
+            return <Data value={value} />;
         case 'amount': {
             const isTokenAmount = !isFee && token;
             const formattedValue = isTokenAmount

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7055,7 +7055,7 @@ export default defineMessages({
     },
     TR_CONTRACT_ADDRESS: {
         id: 'TR_CONTRACT_ADDRESS',
-        defaultMessage: 'Contract address:',
+        defaultMessage: 'Contract address',
     },
     TR_POLICY_ID_ADDRESS: {
         id: 'TR_POLICY_ID_ADDRESS',

--- a/packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx
+++ b/packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx
@@ -96,7 +96,12 @@ const NftsRow = ({
                                     <Column maxWidth={200} gap={spacings.md}>
                                         <InfoItem
                                             typographyStyle="label"
-                                            label={<Translation id="TR_CONTRACT_ADDRESS" />}
+                                            label={
+                                                <>
+                                                    <Translation id="TR_CONTRACT_ADDRESS" />
+                                                    {': '}
+                                                </>
+                                            }
                                             gap={spacings.zero}
                                         >
                                             <Row>

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
@@ -370,7 +370,10 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
                                             {account.networkType === 'cardano' ? (
                                                 <Translation id="TR_POLICY_ID_ADDRESS" />
                                             ) : (
-                                                <Translation id="TR_CONTRACT_ADDRESS" />
+                                                <>
+                                                    <Translation id="TR_CONTRACT_ADDRESS" />
+                                                    {': '}
+                                                </>
                                             )}
                                             <TokenAddressRow
                                                 typographyStyle="hint"

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -256,7 +256,12 @@ export const TokenRow = ({
                             <Card paddingType="small">
                                 <Column maxWidth={200} gap={spacings.md}>
                                     <TokenAddressItem
-                                        label={<Translation id="TR_CONTRACT_ADDRESS" />}
+                                        label={
+                                            <>
+                                                <Translation id="TR_CONTRACT_ADDRESS" />
+                                                {': '}
+                                            </>
+                                        }
                                         address={token.contract}
                                         type="contract"
                                     />

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -352,9 +352,15 @@ const constructNewFlow = ({
                 // this is displayed only for tokens without definitions
                 if (precomposedTx.token && !precomposedTx.isTokenKnown && !isSolana) {
                     outputs.push(tokenOutput);
+                    outputs.push({ type: 'address', value: o.address });
+                } else if (precomposedForm.ethereumDataHex) {
+                    // EVM contract call
+                    outputs.push({ type: 'contract', value: o.address });
+                } else {
+                    // regular transfer
+                    outputs.push({ type: 'address', value: o.address });
                 }
 
-                outputs.push({ type: 'address', value: o.address });
                 if (!isSolana && !isUpdatedEthereumSendFlow) {
                     outputs.push({
                         type: 'amount',


### PR DESCRIPTION
## Description

With this change, we show "Contract" instead of "Recipient Address", in line with what firmware does.

Also, we collapse long EVM data, initially showing only the first few lines. 

## Screenshots:

<img width="695" alt="Screenshot 2025-07-08 at 10 19 56" src="https://github.com/user-attachments/assets/31980ead-d240-4f7e-862a-92feb1008fb6" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/suite-transaction-review-evm&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-transaction-review-evm&lookback=7)