### PR TITLE
fix(suite): do not set path to empty string on device disconnect

### DIFF
--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -359,8 +359,6 @@ const disconnectDevice = (draft: DeviceReducerState, device: TrezorDevice) => {
         if (skip) {
             d.connected = false;
             d.available = false;
-            // @ts-expect-error
-            d.path = '';
         } else {
             draft.devices.splice(draft.devices.indexOf(d), 1);
         }


### PR DESCRIPTION
this was no longer desirable I believe. 

QA notes: 
this is related to remembered devices feature. It did not work quite well but I am not sure how to simulate the problem I am fixing here :D 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=discovery-nitpicks-15&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=discovery-nitpicks-15&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=discovery-nitpicks-15&lookback=7)