### PR TITLE
fix(connect): explicitly check button request name in ethereumSignTypedData

### DIFF
--- a/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
@@ -118,8 +118,20 @@ export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignT
         );
     }
 
-    getButtonRequestData(code: string) {
-        if (code === 'ButtonRequest_Other' || code === 'ButtonRequest_SignTx') {
+    getButtonRequestData(code: string, name?: string) {
+        if (
+            (code === 'ButtonRequest_Other' &&
+                name &&
+                [
+                    'should_show_domain',
+                    'should_show_struct',
+                    'should_show_array',
+                    'confirm_typed_value',
+                    'confirm_empty_typed_message',
+                    'confirm_typed_data_final',
+                ].includes(name)) ||
+            code === 'ButtonRequest_SignTx'
+        ) {
             return {
                 type: 'message' as const,
                 coin: this.params.network?.shortcut ?? 'ETH',


### PR DESCRIPTION
## Description

Unfortunately in `ethereumSignTypedData` we get unrelated `ButtonRequest_Other` events, for example from passphrase confirmation before the signing, resulting in confusing UI. 
Not sure why FW doesn't use a different button request code for that...

This PR adds an explicit list of names to filter only the relevant button requests.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/ethereumsigntypeddata-buttonrequest-ignore-passphrase&lookback=7)