### PR TITLE
chore(connect): whitelist RebootToBootloader to be called before initialize

### DIFF
--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -37,6 +37,7 @@ const allowedCallsBeforeInitialize: Messages.MessageKey[] = [
     'ChangeLanguage',
     'DataChunkAck',
     // During firmware update, we can call these messages
+    'RebootToBootloader',
     'FirmwareErase',
     'FirmwareUpload',
     // There are other, which are allowed by firmware (ApplySettings,...) but we do not use them this way in connect.


### PR DESCRIPTION
Add `RebootToBootloader` to `allowedCallsBeforeInitialize`

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/connect-whitelist-RebootToBootloader&lookback=7)