### PR TITLE
Remove `bchaddrjs` dependency

### DIFF
--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -39,7 +39,6 @@
     },
     "dependencies": {
         "@trezor/utils": "workspace:*",
-        "bchaddrjs": "^0.5.2",
         "bech32": "^2.0.0",
         "bip66": "^2.0.0",
         "bitcoin-ops": "^1.4.1",
@@ -48,6 +47,7 @@
         "bn.js": "^5.2.2",
         "bs58": "^6.0.0",
         "bs58check": "^4.0.0",
+        "cashaddrjs": "0.4.4",
         "create-hmac": "^1.1.7",
         "int64-buffer": "^1.1.0",
         "pushdata-bitcoin": "^1.0.1",
@@ -58,7 +58,6 @@
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
-        "@types/bchaddrjs": "^0.4.3",
         "@types/bn.js": "^5.2.0",
         "@types/create-hmac": "^1.1.3",
         "@types/events": "^3.0.3",

--- a/packages/utxo-lib/src/bchUtils.ts
+++ b/packages/utxo-lib/src/bchUtils.ts
@@ -1,0 +1,128 @@
+/* Utils ported from unmaintained bchaddrjs library */
+import bs58check from 'bs58check';
+import * as cashaddr from 'cashaddrjs';
+
+type Format = 'legacy' | 'cashaddr';
+type Network = 'mainnet' | 'testnet';
+type Type = 'p2pkh' | 'p2sh';
+
+const VERSION_BYTE: Record<Format, Record<Network, Record<Type, number>>> = {
+    legacy: {
+        mainnet: {
+            p2pkh: 0x00,
+            p2sh: 0x05,
+        },
+        testnet: {
+            p2pkh: 0x6f,
+            p2sh: 0xc4,
+        },
+    },
+    cashaddr: {
+        mainnet: {
+            p2pkh: 0,
+            p2sh: 1,
+        },
+        testnet: {
+            p2pkh: 0,
+            p2sh: 1,
+        },
+    },
+};
+
+type DecodedAddress = {
+    hash: number[] | Uint8Array;
+    format: Format;
+    network: Network;
+    type: Type;
+};
+
+const decodeBase58Address = (address: string): DecodedAddress => {
+    const payload = bs58check.decode(address);
+    if (payload.length !== 21) {
+        throw new Error('Invalid base58 address payload length');
+    }
+    const version = payload[0];
+    const hash = Array.prototype.slice.call(payload, 1);
+    switch (version) {
+        case 0x00:
+            return { hash, format: 'legacy', network: 'mainnet', type: 'p2pkh' };
+        case 0x05:
+            return { hash, format: 'legacy', network: 'mainnet', type: 'p2sh' };
+        case 0x6f:
+            return { hash, format: 'legacy', network: 'testnet', type: 'p2pkh' };
+        case 0xc4:
+            return { hash, format: 'legacy', network: 'testnet', type: 'p2sh' };
+        default:
+            throw new Error('Unknown version byte: ' + version);
+    }
+};
+
+const decodeCashAddressWithPrefix = (address: string): DecodedAddress => {
+    const decoded = cashaddr.decode(address);
+    const hash = Array.prototype.slice.call(decoded.hash, 0);
+    const type: Type = decoded.type === 'P2PKH' ? 'p2pkh' : 'p2sh';
+    switch (decoded.prefix) {
+        case 'bitcoincash':
+            return { hash, format: 'cashaddr', network: 'mainnet', type };
+        case 'bchtest':
+        case 'bchreg':
+            return { hash, format: 'cashaddr', network: 'testnet', type };
+        default:
+            throw new Error('Unknown cashaddr prefix: ' + decoded.prefix);
+    }
+};
+
+const decodeCashAddress = (address: string): DecodedAddress => {
+    if (address.indexOf(':') !== -1) {
+        return decodeCashAddressWithPrefix(address);
+    } else {
+        const prefixes = ['bitcoincash', 'bchtest', 'bchreg'];
+        for (const prefix of prefixes) {
+            try {
+                return decodeCashAddressWithPrefix(prefix + ':' + address);
+            } catch {
+                /* ignore */
+            }
+        }
+    }
+    throw new Error('Invalid cashaddr address');
+};
+
+const decodeAddress = (address: string): DecodedAddress => {
+    try {
+        return decodeBase58Address(address);
+    } catch {
+        /* ignore */
+    }
+    try {
+        return decodeCashAddress(address);
+    } catch {
+        /* ignore */
+    }
+    throw new Error('Invalid Bitcoin Cash address');
+};
+
+export const isCashAddress = (address: string): boolean =>
+    decodeAddress(address).format === 'cashaddr';
+
+export const toLegacyAddress = (address: string): string => {
+    const decoded = decodeAddress(address);
+    if (decoded.format === 'legacy') {
+        return address;
+    }
+    const version = VERSION_BYTE['legacy'][decoded.network][decoded.type];
+    const buffer = Buffer.alloc(1 + decoded.hash.length);
+    buffer[0] = version;
+    buffer.set(decoded.hash, 1);
+
+    return bs58check.encode(buffer);
+};
+
+export const toCashAddress = (address: string): string => {
+    const decoded = decodeAddress(address);
+    const prefix = decoded.network === 'mainnet' ? 'bitcoincash' : 'bchtest';
+    const type = decoded.type === 'p2pkh' ? 'P2PKH' : 'P2SH';
+    const hash = new Uint8Array(decoded.hash);
+
+    return cashaddr.encode(prefix, type, hash);
+};

--- a/packages/utxo-lib/src/bs58check.ts
+++ b/packages/utxo-lib/src/bs58check.ts
@@ -1,7 +1,7 @@
-import bchaddrjs from 'bchaddrjs';
 import bs58 from 'bs58';
 import bs58check from 'bs58check';
 
+import { isCashAddress, toCashAddress, toLegacyAddress } from './bchUtils';
 import { blake256 } from './crypto';
 import { bitcoin as BITCOIN_NETWORK, isNetworkType } from './networks';
 
@@ -59,8 +59,8 @@ export function decodeAddress(address: string, network = BITCOIN_NETWORK) {
     // Identify them by checking if the version is multibyte (2 bytes instead of 1)
     let payload: Buffer;
     if (isNetworkType('bitcoinCash', network)) {
-        if (!bchaddrjs.isCashAddress(address)) throw Error(`${address} is not a cash address`);
-        payload = Buffer.from(bs58check.decode(bchaddrjs.toLegacyAddress(address)));
+        if (!isCashAddress(address)) throw Error(`${address} is not a cash address`);
+        payload = Buffer.from(bs58check.decode(toLegacyAddress(address)));
     } else {
         payload = Buffer.from(decode(address, network));
     }
@@ -96,5 +96,5 @@ export function encodeAddress(hash: Buffer, version: number, network = BITCOIN_N
 
     const encoded = encode(payload, network);
 
-    return isNetworkType('bitcoinCash', network) ? bchaddrjs.toCashAddress(encoded) : encoded;
+    return isNetworkType('bitcoinCash', network) ? toCashAddress(encoded) : encoded;
 }

--- a/packages/utxo-lib/src/types/cashaddrjs.d.ts
+++ b/packages/utxo-lib/src/types/cashaddrjs.d.ts
@@ -1,0 +1,1 @@
+declare module 'cashaddrjs';

--- a/packages/utxo-lib/tests/bchUtils.test.ts
+++ b/packages/utxo-lib/tests/bchUtils.test.ts
@@ -1,0 +1,47 @@
+import { isCashAddress, toCashAddress, toLegacyAddress } from '../src/bchUtils';
+
+describe('bcashutils', () => {
+    const mainnetCashAddr = 'bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a';
+    const mainnetLegacy = '1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu';
+    const testnetCashAddr = 'bchtest:qregmr8wn2yzhg7wgxsdakkc93g7yh3anvnxaqskqf';
+    const testnetLegacy = 'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn';
+    const invalidAddr = 'notARealAddress123';
+
+    describe('isCashAddress', () => {
+        it('returns true for valid cashaddr', () => {
+            expect(isCashAddress(mainnetCashAddr)).toBe(true);
+            expect(isCashAddress(testnetCashAddr)).toBe(true);
+        });
+        it('returns false for legacy addresses', () => {
+            expect(isCashAddress(mainnetLegacy)).toBe(false);
+            expect(isCashAddress(testnetLegacy)).toBe(false);
+        });
+        it('throws for invalid address', () => {
+            expect(() => isCashAddress(invalidAddr)).toThrow();
+        });
+    });
+
+    describe('toLegacyAddress', () => {
+        it('converts mainnet cashaddr to legacy', () => {
+            expect(toLegacyAddress(mainnetCashAddr)).toBe(mainnetLegacy);
+        });
+        it('returns legacy address unchanged', () => {
+            expect(toLegacyAddress(mainnetLegacy)).toBe(mainnetLegacy);
+        });
+        it('throws for invalid address', () => {
+            expect(() => toLegacyAddress(invalidAddr)).toThrow();
+        });
+    });
+
+    describe('toCashAddress', () => {
+        it('converts mainnet legacy to cashaddr', () => {
+            expect(toCashAddress(mainnetLegacy)).toBe(mainnetCashAddr);
+        });
+        it('returns cashaddr unchanged', () => {
+            expect(toCashAddress(mainnetCashAddr)).toBe(mainnetCashAddr);
+        });
+        it('throws for invalid address', () => {
+            expect(() => toCashAddress(invalidAddr)).toThrow();
+        });
+    });
+});

--- a/scripts/list-outdated-dependencies/foundation-dependencies.txt
+++ b/scripts/list-outdated-dependencies/foundation-dependencies.txt
@@ -18,6 +18,7 @@ blakejs
 bn.js
 bs58
 bs58check
+cashaddrjs
 chalk
 core-js
 cors

--- a/scripts/list-outdated-dependencies/trends-dependencies.txt
+++ b/scripts/list-outdated-dependencies/trends-dependencies.txt
@@ -30,7 +30,6 @@
 @testing-library/jest-dom
 @testing-library/react
 @testing-library/user-event
-@types/bchaddrjs
 @types/invity-api
 @types/jws
 @types/redux-logger
@@ -40,7 +39,6 @@
 ajv
 babel-jest
 babel-loader
-bchaddrjs
 copy-webpack-plugin
 eth-phishing-detect
 html-webpack-plugin

--- a/yarn.lock
+++ b/yarn.lock
@@ -12985,11 +12985,9 @@ __metadata:
   dependencies:
     "@trezor/eslint": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/bchaddrjs": "npm:^0.4.3"
     "@types/bn.js": "npm:^5.2.0"
     "@types/create-hmac": "npm:^1.1.3"
     "@types/events": "npm:^3.0.3"
-    bchaddrjs: "npm:^0.5.2"
     bech32: "npm:^2.0.0"
     bip66: "npm:^2.0.0"
     bitcoin-ops: "npm:^1.4.1"
@@ -12998,6 +12996,7 @@ __metadata:
     bn.js: "npm:^5.2.2"
     bs58: "npm:^6.0.0"
     bs58check: "npm:^4.0.0"
+    cashaddrjs: "npm:0.4.4"
     create-hmac: "npm:^1.1.7"
     int64-buffer: "npm:^1.1.0"
     minimaldata: "npm:^1.0.2"
@@ -13134,13 +13133,6 @@ __metadata:
   dependencies:
     "@babel/types": "npm:^7.20.7"
   checksum: 10/f0352d537448e1e37f27e6bb8c962d7893720a92fde9d8601a68a93dbc14e15c088b4c0c8f71021d0966d09fba802ef3de11fdb6766c33993f8cf24f1277c6a9
-  languageName: node
-  linkType: hard
-
-"@types/bchaddrjs@npm:^0.4.3":
-  version: 0.4.3
-  resolution: "@types/bchaddrjs@npm:0.4.3"
-  checksum: 10/ebffc96914a95b3251ca5ce023105a4977a02032a994a2765f8620ffe43c55a283753f50347b592f8b89726e14d15be884563e723bdadf7689f43fd9b868fdff
   languageName: node
   linkType: hard
 
@@ -16701,15 +16693,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base-x@npm:^3.0.2":
-  version: 3.0.9
-  resolution: "base-x@npm:3.0.9"
-  dependencies:
-    safe-buffer: "npm:^5.0.1"
-  checksum: 10/957101d6fd09e1903e846fd8f69fd7e5e3e50254383e61ab667c725866bec54e5ece5ba49ce385128ae48f9ec93a26567d1d5ebb91f4d56ef4a9cc0d5a5481e8
-  languageName: node
-  linkType: hard
-
 "base-x@npm:^5.0.0, base-x@npm:^5.0.1":
   version: 5.0.1
   resolution: "base-x@npm:5.0.1"
@@ -16758,18 +16741,6 @@ __metadata:
   version: 0.6.1
   resolution: "batch@npm:0.6.1"
   checksum: 10/61f9934c7378a51dce61b915586191078ef7f1c3eca707fdd58b96ff2ff56d9e0af2bdab66b1462301a73c73374239e6542d9821c0af787f3209a23365d07e7f
-  languageName: node
-  linkType: hard
-
-"bchaddrjs@npm:^0.5.2":
-  version: 0.5.2
-  resolution: "bchaddrjs@npm:0.5.2"
-  dependencies:
-    bs58check: "npm:2.1.2"
-    buffer: "npm:^6.0.3"
-    cashaddrjs: "npm:0.4.4"
-    stream-browserify: "npm:^3.0.0"
-  checksum: 10/ca79899b72efcad8fa696814532a4ded103402fcb18389ae8969df89d9e5415ea4209e707c6625fad855a2a20f9e23cf535902b235c05b897ce5375a19a4dc38
   languageName: node
   linkType: hard
 
@@ -17172,26 +17143,6 @@ __metadata:
   dependencies:
     base-x: "npm:^5.0.0"
   checksum: 10/7c9bb2b2d93d997a8c652de3510d89772007ac64ee913dc4e16ba7ff47624caad3128dcc7f360763eb6308760c300b3e9fd91b8bcbd489acd1a13278e7949c4e
-  languageName: node
-  linkType: hard
-
-"bs58@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "bs58@npm:4.0.1"
-  dependencies:
-    base-x: "npm:^3.0.2"
-  checksum: 10/b3c5365bb9e0c561e1a82f1a2d809a1a692059fae016be233a6127ad2f50a6b986467c3a50669ce4c18929dcccb297c5909314dd347a25a68c21b68eb3e95ac2
-  languageName: node
-  linkType: hard
-
-"bs58check@npm:2.1.2":
-  version: 2.1.2
-  resolution: "bs58check@npm:2.1.2"
-  dependencies:
-    bs58: "npm:^4.0.0"
-    create-hash: "npm:^1.1.0"
-    safe-buffer: "npm:^5.1.2"
-  checksum: 10/43bdf08a5dd04581b78f040bc4169480e17008da482ffe2a6507327bbc4fc5c28de0501f7faf22901cfe57fbca79cbb202ca529003fedb4cb8dccd265b38e54d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Lib [bchaddrjs](https://github.com/ealmansi/bchaddrjs) is not maintained and has some outdated deps that triggered a [dependabot alert](https://github.com/trezor/trezor-suite/security/dependabot/336). We only use three functions from it so I ported them to our codebase with the help of Cursor AI. I had to add [cashaddr] as a direct dependency (https://github.com/ealmansi/cashaddrjs) because it is a dependency of `bchaddrjs`, however I could still drop the old versions of `bs58`, `bs58check`, and `base-x`.

QA: Please test making a BCH transaction. This PR should not change anything functionally.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-bchaddrjs&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-bchaddrjs&lookback=7)