### PR TITLE
fix(transport-bridge): error propagation

### DIFF
--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -96,6 +96,7 @@ export abstract class AbstractApi extends TypedEmitter<{
         | typeof ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE
         | typeof ERRORS.INTERFACE_DATA_TRANSFER
         | typeof ERRORS.DEVICE_DISCONNECTED_DURING_ACTION
+        | typeof ERRORS.ABORTED_BY_TIMEOUT
         | typeof ERRORS.ABORTED_BY_SIGNAL
         | typeof ERRORS.UNEXPECTED_ERROR
     >;

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -563,7 +563,14 @@ export class UsbApi extends AbstractApi {
             return this.error({ error: ERRORS.DEVICE_DISCONNECTED_DURING_ACTION });
         }
 
-        return this.unknownError(err);
+        return this.unknownError(err, [
+            ERRORS.DEVICE_NOT_FOUND,
+            ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE,
+            ERRORS.DEVICE_DISCONNECTED_DURING_ACTION,
+            ERRORS.ABORTED_BY_TIMEOUT,
+            ERRORS.ABORTED_BY_SIGNAL,
+            ERRORS.UNEXPECTED_ERROR,
+        ]);
     }
 
     public dispose() {

--- a/packages/transport/src/utils/bridgeApiCall.ts
+++ b/packages/transport/src/utils/bridgeApiCall.ts
@@ -74,6 +74,20 @@ export async function bridgeApiCall(options: HttpRequestOptions) {
         return error({ error: ERRORS.HTTP_ERROR, message: err.message });
     }
 
+    const getErrorStr = (err: typeof resParsed) => {
+        if (typeof err === 'string') {
+            return err;
+        }
+        if ('message' in err) {
+            return err.message as string; // UNEXPECTED_ERROR
+        }
+        if ('error' in err) {
+            return err.error as string; // typed transport ERROR
+        }
+
+        return err.toString();
+    };
+
     const BRIDGE_ERROR_DEVICE_CLOSED = 'closed device' as const;
     // https://github.dev/trezor/trezord-go/blob/8f35971d3c36ea8b91ff54810397526ef8e741c5/wire/protobuf.go#L14
     const BRIDGE_MALFORMED_PROTOBUF = 'malformed protobuf' as const;
@@ -83,15 +97,11 @@ export async function bridgeApiCall(options: HttpRequestOptions) {
     // if status is not 200. response should be interpreted as error.
     if (!res.ok) {
         // this block only changes error messages from old bridge to the same messages returned by new bridge / connect usb stack
-        const errStr =
-            typeof resParsed !== 'string' && 'error' in resParsed
-                ? (resParsed.error as string)
-                : (resParsed as string);
-
+        const errStr = getErrorStr(resParsed);
         if (errStr === BRIDGE_ERROR_DEVICE_CLOSED) {
             return error({ error: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE });
         }
-        if (errStr === BRIDGE_MALFORMED_PROTOBUF) {
+        if (errStr === BRIDGE_MALFORMED_PROTOBUF || errStr === PROTOCOL_MALFORMED) {
             return error({ error: PROTOCOL_MALFORMED });
         }
         if (errStr === BRIDGE_MALFORMED_WIRE_FORMAT) {

--- a/packages/transport/tests/apiUsb.test.ts
+++ b/packages/transport/tests/apiUsb.test.ts
@@ -58,7 +58,7 @@ describe('api/usb', () => {
 
         const result = await promise;
         if (result.success) throw new Error('Unexpected success');
-        expect(result.error).toContain('unexpected error');
+        expect(result.error).toContain('Aborted by signal');
         expect(reset).toHaveBeenCalledTimes(1);
     });
 
@@ -86,7 +86,7 @@ describe('api/usb', () => {
 
         const result = await promise;
         if (result.success) throw new Error('Unexpected success');
-        expect(result.message).toContain('Aborted by signal');
+        expect(result.error).toContain('Aborted by signal');
         expect(reset).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fix transport-bridge error propagation.

errors from bridge server are returned to connect as TRANSPORT.ERROR:
```
@trezor/transport-bridge Handling request for POST /read/1
@trezor/transport-bridge core: readUtil protocol v1
@trezor/transport-bridge usb: device.transferIn
@trezor/transport-bridge usb: device.transferIn done. status: ok, byteLength: 64.
@trezor/transport-bridge core: readUtil catch: Malformed protocol format
```

however due to this bug it is always parsed to unexpected error. this was changed relatively not so long ago:
https://github.com/trezor/trezor-suite/commit/2dcaafd766e411ac9e19390ce09b244acf369df3
👀 👉 @mroz22 


```
Device sending a preventive cancel on the first encounter with the device
DeviceCommands Sending Cancel {}
@trezor/connect handleMessage device-changed
@trezor/transport BridgeTransport unexpected error:  unexpected error
DeviceCommands Received transport error unexpected error unexpected error
DeviceCommands Sending GetFeatures {}
@trezor/transport BridgeTransport unexpected error:  unexpected error
DeviceCommands Received transport error unexpected error unexpected error
Device Device._runInner error:  unexpected error
```

this is crucial fix to properly catch `THP` protocol during `Device.handshake` process while using NodeBridge

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bridge-errors&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bridge-errors&lookback=7)