### PR TITLE
fix(eslint): restrict suite-common imports outside of suite packages

### DIFF
--- a/packages/components/eslint.config.mjs
+++ b/packages/components/eslint.config.mjs
@@ -24,4 +24,22 @@ export default [
             ],
         },
     },
+    {
+        rules: {
+            '@typescript-eslint/no-restricted-imports': [
+                'error',
+                {
+                    paths: [{ name: '.' }, { name: '..' }, { name: '../..' }],
+                    patterns: [
+                        '@trezor/*/lib',
+                        '@trezor/*/lib/**',
+                        '@trezor/*/libDev',
+                        '@trezor/*/libDev/**',
+                        '@suite-common/**',
+                        '@suite-native/**',
+                    ],
+                },
+            ],
+        },
+    },
 ];

--- a/packages/components/src/components/AssetLogo/AssetLogo.tsx
+++ b/packages/components/src/components/AssetLogo/AssetLogo.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
+// TODO: suite-common imports in non-suite packages should not be allowed
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { getNetwork, getNetworkByCoingeckoId, isNetworkSymbol } from '@suite-common/wallet-config';
 import { getAssetLogoUrl } from '@trezor/asset-utils';
 import { Elevation, borders, mapElevationToBackground, mapElevationToBorder } from '@trezor/theme';

--- a/packages/components/src/components/Icon/Icon.stories.tsx
+++ b/packages/components/src/components/Icon/Icon.stories.tsx
@@ -1,5 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 
+// TODO: suite-common imports in non-suite packages should not be allowed
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { icons } from '@suite-common/icons/src/icons';
 
 import { Icon as IconComponent, allowedIconFrameProps, iconSizes, iconVariants } from './Icon';

--- a/packages/components/src/components/Icon/Icon.tsx
+++ b/packages/components/src/components/Icon/Icon.tsx
@@ -3,6 +3,8 @@ import { ReactSVG } from 'react-svg';
 
 import styled, { DefaultTheme, css } from 'styled-components';
 
+// TODO: suite-common imports in non-suite packages should not be allowed
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { IconName, icons } from '@suite-common/icons/src/icons';
 import { CSSColor, Color } from '@trezor/theme';
 

--- a/packages/components/src/components/Icon/icons.stories.tsx
+++ b/packages/components/src/components/Icon/icons.stories.tsx
@@ -3,6 +3,8 @@ import React, { useState } from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import styled, { useTheme } from 'styled-components';
 
+// TODO: suite-common imports in non-suite packages should not be allowed
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { IconName, icons } from '@suite-common/icons/src/icons';
 import { typography } from '@trezor/theme';
 

--- a/packages/components/src/components/IconCircle/IconCircle.stories.tsx
+++ b/packages/components/src/components/IconCircle/IconCircle.stories.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { Meta, StoryObj } from '@storybook/react';
 
+// TODO: suite-common imports in non-suite packages should not be allowed
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { IconName, icons } from '@suite-common/icons/src/icons';
 
 import {

--- a/packages/components/src/components/animations/DeviceAnimation.tsx
+++ b/packages/components/src/components/animations/DeviceAnimation.tsx
@@ -2,6 +2,8 @@ import { CSSProperties, MouseEventHandler, forwardRef } from 'react';
 
 import styled, { useTheme } from 'styled-components';
 
+// TODO: suite-common imports in non-suite packages should not be allowed
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { DEFAULT_FLAGSHIP_MODEL } from '@suite-common/suite-constants';
 import { DeviceModelInternal, getNarrowedDeviceModelInternal } from '@trezor/device-utils';
 

--- a/packages/components/src/components/animations/LottieAnimation.tsx
+++ b/packages/components/src/components/animations/LottieAnimation.tsx
@@ -3,6 +3,8 @@ import React, { useEffect, useState } from 'react';
 import Lottie, { LottieOptions } from 'lottie-react';
 import styled from 'styled-components';
 
+// TODO: suite-common imports in non-suite packages should not be allowed
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { DEFAULT_FLAGSHIP_MODEL } from '@suite-common/suite-constants';
 import { DeviceModelInternal, getNarrowedDeviceModelInternal } from '@trezor/device-utils';
 

--- a/packages/components/src/config/variables.ts
+++ b/packages/components/src/config/variables.ts
@@ -1,3 +1,5 @@
+// TODO: suite-common imports in non-suite packages should not be allowed
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { icons } from '@suite-common/icons/src/icons';
 import { aboveBreakpoint, belowBreakpoint, breakpoints } from '@trezor/theme';
 

--- a/packages/connect-ui/package.json
+++ b/packages/connect-ui/package.json
@@ -11,7 +11,6 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@suite-common/validators": "workspace:*",
         "@trezor/components": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/connect-analytics": "workspace:*",

--- a/packages/connect-ui/src/components/Passphrase/PassphraseTypeCard.tsx
+++ b/packages/connect-ui/src/components/Passphrase/PassphraseTypeCard.tsx
@@ -4,7 +4,6 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { AnimatePresence, motion } from 'framer-motion';
 import styled, { css, useTheme } from 'styled-components';
 
-import { formInputsMaxLength } from '@suite-common/validators';
 import {
     Button,
     Checkbox,
@@ -27,6 +26,8 @@ type WrapperProps = {
     $type: WalletType;
     $singleColModal?: boolean;
 };
+
+const PASSPHRASE_MAX_LENGTH = 50;
 
 const Wrapper = styled.div<WrapperProps>`
     display: flex;
@@ -194,7 +195,7 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardLegacyProps) => {
     const ref = useRef<HTMLInputElement>(null);
     const caretRef = useRef<number>(0);
 
-    const isTooLong = countBytesInString(value) > formInputsMaxLength.passphrase;
+    const isTooLong = countBytesInString(value) > PASSPHRASE_MAX_LENGTH;
 
     const { onSubmit } = props;
     const submit = useCallback(

--- a/packages/connect-ui/tsconfig.json
+++ b/packages/connect-ui/tsconfig.json
@@ -2,9 +2,6 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
-        {
-            "path": "../../suite-common/validators"
-        },
         { "path": "../components" },
         { "path": "../connect" },
         { "path": "../connect-analytics" },

--- a/packages/connect/eslint.config.mjs
+++ b/packages/connect/eslint.config.mjs
@@ -15,6 +15,20 @@ export default [
                 { additionalTestBlockFunctions: ['conditionalTest'] },
             ],
             'import/no-default-export': 'off', // Todo: shall be solved one day, but now its heavily used
+            '@typescript-eslint/no-restricted-imports': [
+                'error',
+                {
+                    paths: [{ name: '.' }, { name: '..' }, { name: '../..' }],
+                    patterns: [
+                        '@trezor/*/lib',
+                        '@trezor/*/lib/**',
+                        '@trezor/*/libDev',
+                        '@trezor/*/libDev/**',
+                        '@suite-common/**',
+                        '@suite-native/**',
+                    ],
+                },
+            ],
         },
     },
 ];

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -50,4 +50,25 @@ export const typescriptConfig = [
             '@typescript-eslint/no-empty-object-type': 'off', // Todo: we shall solve this, this is bad practice
         },
     },
+    {
+        // restrict import of suite-common and suite-native packages outside of suite
+        files: ['packages/**/*.{js,mjs,cjs,ts,jsx,tsx}'],
+        ignores: ['packages/suite*/**/*'],
+        rules: {
+            '@typescript-eslint/no-restricted-imports': [
+                'error',
+                {
+                    paths: [{ name: '.' }, { name: '..' }, { name: '../..' }],
+                    patterns: [
+                        '@trezor/*/lib',
+                        '@trezor/*/lib/**',
+                        '@trezor/*/libDev',
+                        '@trezor/*/libDev/**',
+                        '@suite-common/**',
+                        '@suite-native/**',
+                    ],
+                },
+            ],
+        },
+    },
 ];

--- a/packages/theme/src/coinsColors.ts
+++ b/packages/theme/src/coinsColors.ts
@@ -1,3 +1,5 @@
+// TODO: suite-common imports in non-suite packages should not be allowed
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { CSSColor } from './types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12064,7 +12064,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/connect-ui@workspace:packages/connect-ui"
   dependencies:
-    "@suite-common/validators": "workspace:*"
     "@trezor/components": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/connect-analytics": "workspace:*"


### PR DESCRIPTION
Imports from `@suite-common/` in packages that are not directly Suite related, like Connect and Blockchain-link needs to be explicitly forbidden. 
This PR adds an Eslint rule to enforce that. 
Existing violations in Components/Theme are ignored using `eslint-disable-next-line`. 

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-common-import-ban&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-common-import-ban&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-common-import-ban&lookback=7)