### PR TITLE
[DO NOT MERGE]: POC of Confirm on Trezor screen header

### DIFF
--- a/suite-native/navigation/src/components/ScreenContentWrapper.tsx
+++ b/suite-native/navigation/src/components/ScreenContentWrapper.tsx
@@ -20,7 +20,12 @@ type ScreenContentProps = {
     refreshControl?: ScrollViewProps['refreshControl'];
 };
 
-const screenContentWrapperStyle = prepareNativeStyle(() => ({ flexGrow: 1 }));
+const screenContentWrapperStyle = prepareNativeStyle(utils => ({
+    flexGrow: 1,
+
+    backgroundColor: utils.colors.backgroundSurfaceElevation0,
+    borderRadius: utils.borders.radii.r16,
+}));
 
 export const ScreenContentWrapper = ({
     children,

--- a/suite-native/navigation/src/components/ScreenHeader.tsx
+++ b/suite-native/navigation/src/components/ScreenHeader.tsx
@@ -1,8 +1,9 @@
 import { ComponentProps, ReactElement, ReactNode } from 'react';
+import { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
 import { RequireOneOrNone } from 'type-fest';
 
-import { Box } from '@suite-native/atoms';
+import { AnimatedBox, Box, IconButton, Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
@@ -65,5 +66,55 @@ export const ScreenHeader = ({
                 {rightIcon}
             </Box>
         </Box>
+    );
+};
+
+const deviceInteractionHeaderContainerStyle = prepareNativeStyle(utils => ({
+    backgroundColor: utils.colors.textDefault,
+    overflow: 'hidden',
+    alignItems: 'center',
+}));
+
+const deviceInteractionHeaderStyle = prepareNativeStyle(utils => ({
+    backgroundColor: utils.colors.textDefault,
+    width: '100%',
+}));
+
+export const DeviceInteractionScreenHeader = () => {
+    const { applyStyle } = useNativeStyles();
+
+    const isScreenToggled = useSharedValue(false);
+    const animatedStyle = useAnimatedStyle(() => ({
+        height: withTiming(isScreenToggled.value ? 700 : 70, { duration: 500 }),
+    }));
+
+    return (
+        <>
+            <AnimatedBox style={[applyStyle(deviceInteractionHeaderContainerStyle), animatedStyle]}>
+                <Box style={[applyStyle(headerStyle), applyStyle(deviceInteractionHeaderStyle)]}>
+                    <Box style={applyStyle(iconWrapperStyle)} testID="@screen/sub-header/icon-left">
+                        <GoBackIcon closeActionType="close" />
+                    </Box>
+                    <Text color="textDefaultInverted">Continue on your Trezor</Text>
+                    <Box
+                        style={applyStyle(iconWrapperStyle)}
+                        testID="@screen/sub-header/icon-right"
+                    >
+                        <IconButton
+                            iconName="arrowRight"
+                            size="medium"
+                            colorScheme="tertiaryElevation0"
+                            onPress={() => (isScreenToggled.value = !isScreenToggled.value)}
+                            accessibilityRole="button"
+                            accessibilityLabel="Go back"
+                        />
+                    </Box>
+                </Box>
+                <Box style={{ flex: 1, alignItems: 'center', paddingTop: 300 }}>
+                    <Box style={{ backgroundColor: 'red', height: 100, width: 100 }}></Box>
+                    <Text color="textDefaultInverted">This is a beautiful Trezor render 🙀</Text>
+                </Box>
+            </AnimatedBox>
+        </>
     );
 };

--- a/suite-native/transactions/src/screens/TransactionDetailScreen.tsx
+++ b/suite-native/transactions/src/screens/TransactionDetailScreen.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useSharedValue } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import {
@@ -14,17 +15,16 @@ import { Button, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
 import {
+    DeviceInteractionScreenHeader,
     RootStackParamList,
     RootStackRoutes,
     Screen,
-    ScreenHeader,
     StackProps,
 } from '@suite-native/navigation';
 import { TypedTokenTransfer, WalletAccountTransaction } from '@suite-native/tokens';
 
 import { TransactionDetailData } from '../components/TransactionDetail/TransactionDetailData';
 import { TransactionDetailHeader } from '../components/TransactionDetail/TransactionDetailHeader';
-import { TransactionName } from '../components/TransactionName';
 
 export const TransactionDetailScreen = ({
     route,
@@ -36,9 +36,6 @@ export const TransactionDetailScreen = ({
     ) as WalletAccountTransaction;
     const blockchainExplorer = useSelector((state: BlockchainRootState) =>
         selectBlockchainExplorerBySymbol(state, transaction?.symbol),
-    );
-    const isPending = useSelector((state: TransactionsRootState) =>
-        selectIsTransactionPending(state, txid, accountKey),
     );
 
     const tokenTransfer = transaction?.tokens.find(token => token.contract === tokenContract);
@@ -65,26 +62,7 @@ export const TransactionDetailScreen = ({
     };
 
     return (
-        <Screen
-            header={
-                <ScreenHeader
-                    closeActionType={closeActionType}
-                    title={
-                        <Translation
-                            id="transactions.detail.header"
-                            values={{
-                                transactionType: _ => (
-                                    <TransactionName
-                                        transaction={transaction}
-                                        isPending={isPending}
-                                    />
-                                ),
-                            }}
-                        />
-                    }
-                />
-            }
-        >
+        <Screen backgroundColor="textDefault" header={<DeviceInteractionScreenHeader />}>
             <VStack spacing="sp24">
                 <VStack spacing="sp32">
                     <TransactionDetailHeader


### PR DESCRIPTION

## Description
- POC (dirty code and not final solution) version of animated screen header containing confirm on trezor instructions added
- It can be found if you navigate to any transaction detail screen
- many things are still missing (drag to open/close, illustration etc.)

## Screenshots:

https://github.com/user-attachments/assets/aab89feb-d922-44b6-9fc6-31dadd9a300d



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/screen-header-confirm-on-trezor&lookback=7)