### PR TITLE
Look at all outputs when adding OP_RETURN

### DIFF
--- a/packages/suite/src/hooks/wallet/useSendFormOutputs.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormOutputs.ts
@@ -55,9 +55,10 @@ export const useSendFormOutputs = ({
     const addOpReturn = () => {
         // const outputs = getValues('outputs');
         const values = getValues();
-        const lastOutput = values.outputs[values.outputs.length - 1];
-        const isLastOutputDirty = lastOutput.address.length > 0 || lastOutput.amount.length > 0;
-        if (isLastOutputDirty) {
+        const outputsDirty = values.outputs.some(
+            output => output.address.length > 0 || output.amount.length > 0,
+        );
+        if (outputsDirty) {
             outputsFieldArray.append({ ...DEFAULT_OPRETURN });
         } else {
             reset(


### PR DESCRIPTION
Deletes all outputs only if they are all empty.

## Description

Previously adding OP_RETURN only looked at the last output when deciding whether to delete all outputs. Now it only deletes all ouputs when all are empty.

## Related Issue

Resolve #20069

## Screenshot

![op-return](https://github.com/user-attachments/assets/dc2524bb-de2a-4f41-a1df-c195acd851b4)