### PR TITLE
chore: remove unused 'validating' operation

### DIFF
--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -304,7 +304,7 @@ export interface FirmwareProgress {
     type: typeof UI_REQUEST.FIRMWARE_PROGRESS;
     payload: {
         device: Device;
-        operation: 'downloading' | 'flashing' | 'validating';
+        operation: 'downloading' | 'flashing';
         progress: number;
     };
 }

--- a/packages/suite/src/components/firmware/FirmwareProgressBar.tsx
+++ b/packages/suite/src/components/firmware/FirmwareProgressBar.tsx
@@ -23,7 +23,6 @@ export const FirmwareProgressBar = () => {
         TranslationKey
     > = {
         installing: 'TR_INSTALLING',
-        validating: 'TR_VALIDATION',
         restarting: isActiveOnboarding
             ? 'TR_RESTARTING_TREZOR'
             : 'TR_RESTARTING_TREZOR_ENTER_PIN_IF_NEEDED',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3689,11 +3689,6 @@ export default defineMessages({
         description: 'Info what is happening with users device.',
         id: 'TR_RESTARTING_TREZOR_ENTER_PIN_IF_NEEDED',
     },
-    TR_VALIDATION: {
-        defaultMessage: 'Validating firmware',
-        description: 'Info what is happening with users device.',
-        id: 'TR_VALIDATION',
-    },
     TR_WALLET_DUPLICATE_DESC: {
         defaultMessage: "The Passphrase wallet you're accessing has already been discovered.",
         id: 'TR_WALLET_DUPLICATE_DESC',

--- a/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
+++ b/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
@@ -52,7 +52,7 @@ export type UseFirmwareInstallationParams =
     | undefined;
 
 export type FirmwareOperationStatus = {
-    operation: 'installing' | 'validating' | 'restarting' | 'completed' | null;
+    operation: 'installing' | 'restarting' | 'completed' | null;
     progress: number;
 };
 
@@ -136,19 +136,14 @@ export const useFirmwareInstallation = (
             };
         }
 
-        if (firmware.uiEvent?.type === UI.FIRMWARE_PROGRESS) {
-            switch (firmware.uiEvent.payload.operation) {
-                case 'flashing':
-                    return {
-                        operation: 'installing',
-                        progress: firmware.uiEvent.payload.progress,
-                    };
-                case 'validating':
-                    return {
-                        operation: 'validating',
-                        progress: 100,
-                    };
-            }
+        if (
+            firmware.uiEvent?.type === UI.FIRMWARE_PROGRESS &&
+            firmware.uiEvent.payload.operation === 'flashing'
+        ) {
+            return {
+                operation: 'installing',
+                progress: firmware.uiEvent.payload.progress,
+            };
         }
 
         // Automatically restarting from bootloader to normal mode at the end of non-intermediary installation:

--- a/suite-native/firmware/src/hooks/useFirmware.tsx
+++ b/suite-native/firmware/src/hooks/useFirmware.tsx
@@ -121,11 +121,6 @@ export const useFirmware = (
                 title: 'firmware.firmwareUpdateProgress.confirming.title',
                 subtitle: 'firmware.firmwareUpdateProgress.generalSubtitle',
             };
-        } else if (operation === 'validating') {
-            text = {
-                title: 'firmware.firmwareUpdateProgress.validating.title',
-                subtitle: 'firmware.firmwareUpdateProgress.generalSubtitle',
-            };
         } else if (operation === 'restarting') {
             text = {
                 title: 'firmware.firmwareUpdateProgress.restarting.title',

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -2168,7 +2168,6 @@ export const en = {
                 title: 'Installing firmware',
             },
             restarting: { title: 'Restarting Trezor.' },
-            validating: { title: 'Validating firmware.' },
             completed: {
                 title: 'Firmware installed',
                 subtitle: 'You’re all set.',


### PR DESCRIPTION
Removes dead code forgotten from https://github.com/trezor/trezor-suite/pull/16949

**QA:** Firmware installation should work exaclty the same as before, especially the installation status (`Installing firmware` and `Completed`), on both mobile and desktop.
![Screenshot 2025-07-09 at 15 20 17](https://github.com/user-attachments/assets/a56672fe-6361-4fe7-8d5c-a7f7370f5779)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-validating-operation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-validating-operation&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/remove-validating-operation&lookback=7)