### PR TITLE
fix(connect): getOrCreateTransport with Transport as class instance

### DIFF
--- a/packages/connect/src/device/TransportList.ts
+++ b/packages/connect/src/device/TransportList.ts
@@ -41,8 +41,9 @@ const getOrCreateTransport = (
             return tryGetTransport(transports, transportInstance.name) ?? transportInstance;
         }
     } else if (isTransportInstance(transportType)) {
-        if (tryGetTransport(transports, transportType.name)) {
-            return transportType;
+        const existing = tryGetTransport(transports, transportType.name);
+        if (existing) {
+            return existing;
         }
 
         // custom Transport might be initialized without messages, update them if so


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fix: https://github.com/trezor/trezor-suite/issues/20071

when TrezorConnect.setTransport is called BluetoothTransport (passed as class instance) loose protobuf messages

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-reinit-transport-class&lookback=7)