### PR TITLE
Chore/native/handle redirect to connecting screen

### DIFF
--- a/suite-native/device/jest.config.js
+++ b/suite-native/device/jest.config.js
@@ -1,0 +1,5 @@
+const { ...baseConfig } = require('../../jest.config.native');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-native/device/src/__tests__/deviceUtils.test.ts
+++ b/suite-native/device/src/__tests__/deviceUtils.test.ts
@@ -1,0 +1,62 @@
+import { testMocks } from '@suite-common/test-utils';
+import { thpActions } from '@suite-common/thp';
+import { deviceConnectThunks } from '@suite-common/wallet-core';
+
+import { isDeviceConnectAction } from '../utils';
+
+const { getConnectDevice } = testMocks;
+
+describe('isDeviceConnectAction', () => {
+    it('should return true for thpActions.finishThpFlow action', () => {
+        const action = thpActions.finishThpFlow();
+
+        expect(isDeviceConnectAction(action)).toBe(true);
+    });
+
+    it('should return true for deviceConnectThunks.fulfilled action without THP', () => {
+        const device = getConnectDevice({
+            thp: undefined,
+        });
+
+        const action = {
+            type: deviceConnectThunks.fulfilled.type,
+            meta: {
+                arg: { device },
+            },
+        };
+
+        expect(isDeviceConnectAction(action)).toBe(true);
+    });
+
+    it('should return false for deviceConnectThunks.fulfilled action with THP', () => {
+        const device = getConnectDevice({
+            thp: {
+                channel: '00',
+                credentials: [],
+                expectedResponses: [],
+                recvBit: 0,
+                recvNonce: 0,
+                sendBit: 0,
+                sendNonce: 0,
+            },
+        });
+
+        const action = {
+            type: deviceConnectThunks.fulfilled.type,
+            meta: {
+                arg: { device },
+            },
+        };
+
+        expect(isDeviceConnectAction(action)).toBe(false);
+    });
+
+    it('should return false for unrelated action', () => {
+        const action = {
+            type: 'SOME_OTHER_ACTION',
+            payload: {},
+        };
+
+        expect(isDeviceConnectAction(action)).toBe(false);
+    });
+});

--- a/suite-native/device/src/hooks/useDeviceChecks.ts
+++ b/suite-native/device/src/hooks/useDeviceChecks.ts
@@ -1,62 +1,16 @@
 import { useSelector } from 'react-redux';
 
-import { selectIsFirmwareAuthenticityCheckDismissed } from '@suite-common/wallet-core';
-import {
-    selectIsDeviceAuthenticityCheckEnabled,
-    selectIsOnboardingFinished,
-} from '@suite-native/settings';
-
-import {
-    selectHasFirmwareAuthenticityCheckHardFailed,
-    selectIsDeviceAuthenticityCheckFailed,
-    selectIsEntropyCheckEnabledAndFailed,
-} from '../selectors';
+import { selectIsEntropyCheckEnabledAndFailed } from '../selectors';
 
 export const useDeviceChecks = (isDeviceCompromisedModalFocused: boolean) => {
-    const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
-    const hasFirmwareAuthenticityCheckHardFailed = useSelector(
-        selectHasFirmwareAuthenticityCheckHardFailed,
-    );
-    const isFirmwareAuthenticityCheckDismissed = useSelector(
-        selectIsFirmwareAuthenticityCheckDismissed,
-    );
-    const isDeviceAuthenticityCheckFailed = useSelector(selectIsDeviceAuthenticityCheckFailed);
-    const isDeviceAuthenticityCheckEnabled = useSelector(selectIsDeviceAuthenticityCheckEnabled);
-    const isDeviceAuthenticityEnabledAndFailed =
-        isDeviceAuthenticityCheckEnabled && isDeviceAuthenticityCheckFailed;
-
     const isEntropyCheckEnabledAndFailed = useSelector(selectIsEntropyCheckEnabledAndFailed);
-
-    const isFirmwareAuthenticityCheckHardFailedAndNotDismissed =
-        hasFirmwareAuthenticityCheckHardFailed && !isFirmwareAuthenticityCheckDismissed;
-
-    // any failing check should navigate to the DeviceCompromisedModal
-    const shouldNavigateToDeviceCompromisedModal =
-        isOnboardingFinished &&
-        (isDeviceAuthenticityEnabledAndFailed ||
-            isEntropyCheckEnabledAndFailed ||
-            isFirmwareAuthenticityCheckHardFailedAndNotDismissed);
 
     // but the DeviceCompromisedModal shall not be persistent for Entropy check, because you cannot exit the modal via normal means
     const shouldKeepDeviceCompromisedModal =
         isDeviceCompromisedModalFocused && !isEntropyCheckEnabledAndFailed;
 
-    const getFailedCheck = (): 'device-authenticity' | 'entropy' | 'firmware-authenticity' => {
-        if (isDeviceAuthenticityEnabledAndFailed) {
-            return 'device-authenticity';
-        }
-        if (isEntropyCheckEnabledAndFailed) {
-            return 'entropy';
-        }
-
-        return 'firmware-authenticity';
-    };
-
-    const failedCheck = getFailedCheck();
-
     return {
-        shouldNavigateToDeviceCompromisedModal,
+        // any failing check should navigate to the DeviceCompromisedModal
         shouldKeepDeviceCompromisedModal,
-        failedCheck,
     };
 };

--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -7,11 +7,9 @@ import { useAtom, useAtomValue } from 'jotai';
 import { selectIsThpInProgress, selectThpStep } from '@suite-common/thp';
 import {
     selectIsDeviceConnected,
-    selectIsDeviceConnectedAndAuthorized,
     selectIsDeviceInitialized,
     selectIsDeviceRemembered,
     selectIsDeviceThpRequired,
-    selectIsDeviceUsingPassphrase,
     selectIsNoPhysicalDeviceConnected,
     selectIsPortfolioTrackerDevice,
 } from '@suite-common/wallet-core';
@@ -29,16 +27,13 @@ import {
     useNavigateToInitialScreen,
     useNavigationRouteMatch,
 } from '@suite-native/navigation';
-import {
-    selectIsCoinEnablingInitFinished,
-    selectIsOnboardingFinished,
-} from '@suite-native/settings';
+import { selectIsOnboardingFinished } from '@suite-native/settings';
 
 import {
     isOnboardingDeviceDisconnectedAlertDisplayedAtom,
     wasDeviceOnboardingCancelledAtom,
 } from '../deviceAtoms';
-import { selectIsDeviceSetupSupported } from '../selectors';
+import { selectIsDeviceCompromised, selectIsDeviceSetupSupported } from '../selectors';
 import { useDeviceChecks } from './useDeviceChecks';
 
 type NavigationProp = StackNavigationProps<RootStackParamList, RootStackRoutes>;
@@ -55,17 +50,15 @@ export const useHandleDeviceConnection = () => {
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
     const isDeviceRemembered = useSelector(selectIsDeviceRemembered);
-    const isDeviceConnectedAndAuthorized = useSelector(selectIsDeviceConnectedAndAuthorized);
     const hasDeviceRequestedPin = useSelector(selectDeviceRequestedPin);
     const isDeviceConnected = useSelector(selectIsDeviceConnected);
     const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
     const isDeviceThpRequired = useSelector(selectIsDeviceThpRequired);
     const isThpInProgress = useSelector(selectIsThpInProgress);
     const thpStep = useSelector(selectThpStep);
-    const isDeviceUsingPassphrase = useSelector(selectIsDeviceUsingPassphrase);
     const isFirmwareInstallationRunning = useSelector(selectIsFirmwareInstallationRunning);
     const isDeviceSetupSupported = useSelector(selectIsDeviceSetupSupported);
-    const isCoinEnablingInitFinished = useSelector(selectIsCoinEnablingInitFinished);
+    const isDeviceCompromised = useSelector(selectIsDeviceCompromised);
 
     const { isBiometricsOverlayVisible } = useIsBiometricsOverlayVisible();
     const isOnboardingDeviceDisconnectedAlertDisplayed = useAtomValue(
@@ -101,11 +94,7 @@ export const useHandleDeviceConnection = () => {
         lastRoute as RootStackRoutes,
     );
 
-    const {
-        failedCheck,
-        shouldNavigateToDeviceCompromisedModal,
-        shouldKeepDeviceCompromisedModal,
-    } = useDeviceChecks(isDeviceCompromisedModalFocused);
+    const { shouldKeepDeviceCompromisedModal } = useDeviceChecks(isDeviceCompromisedModalFocused);
 
     // Nothing can be accomplished before a THP connection is established.
     useEffect(() => {
@@ -134,7 +123,8 @@ export const useHandleDeviceConnection = () => {
             !isOnboardingDeviceDisconnectedAlertDisplayed &&
             !isFirmwareInstallationRunning &&
             (!isDeviceOnboardingStackFocused || isDeviceOnboardingConnectAndUnlockScreenFocused) &&
-            !shouldNavigateToDeviceCompromisedModal
+            !wasDeviceOnboardingCancelled &&
+            !isDeviceCompromised
         ) {
             if (!wasDeviceOnboardingCancelled) {
                 navigation.navigate(RootStackRoutes.DeviceOnboardingStack, {
@@ -167,58 +157,9 @@ export const useHandleDeviceConnection = () => {
         isOnboardingDeviceDisconnectedAlertDisplayed,
         isDeviceOnboardingConnectAndUnlockScreenFocused,
         wasDeviceOnboardingCancelled,
-        shouldNavigateToDeviceCompromisedModal,
+        isDeviceCompromised,
         isAuthorizeDeviceStackFocused,
         navigateToInitialScreen,
-    ]);
-
-    // At the moment when unauthorized physical device is selected,
-    // redirect to the Connecting screen where is handled the connection logic.
-    useEffect(() => {
-        if (isThpInProgress || isFirmwareInstallationRunning || isSuspiciousDeviceScreenFocused) {
-            return;
-        }
-
-        if (
-            isDeviceInitialized &&
-            isDeviceConnected &&
-            isOnboardingFinished &&
-            !isPortfolioTrackerDevice &&
-            !isDeviceConnectedAndAuthorized &&
-            !isBiometricsOverlayVisible &&
-            !shouldNavigateToDeviceCompromisedModal &&
-            !isDeviceOnboardingStackFocused &&
-            !isDeviceUsingPassphrase &&
-            !shouldBlockSendReviewRedirect
-        ) {
-            if (isCoinEnablingInitFinished) {
-                navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
-                    screen: AuthorizeDeviceStackRoutes.ConnectingDevice,
-                });
-            } else {
-                navigation.navigate(RootStackRoutes.CoinEnablingInit);
-            }
-        }
-        if (shouldNavigateToDeviceCompromisedModal) {
-            navigation.navigate(RootStackRoutes.DeviceCompromisedModal, { failedCheck });
-        }
-    }, [
-        isThpInProgress,
-        failedCheck,
-        isCoinEnablingInitFinished,
-        isDeviceConnected,
-        isDeviceOnboardingStackFocused,
-        isOnboardingFinished,
-        isPortfolioTrackerDevice,
-        isDeviceConnectedAndAuthorized,
-        isBiometricsOverlayVisible,
-        navigation,
-        isDeviceUsingPassphrase,
-        shouldBlockSendReviewRedirect,
-        isFirmwareInstallationRunning,
-        isDeviceInitialized,
-        shouldNavigateToDeviceCompromisedModal,
-        isSuspiciousDeviceScreenFocused,
     ]);
 
     // In case that the physical device is disconnected, redirect to the home screen and

--- a/suite-native/device/src/index.ts
+++ b/suite-native/device/src/index.ts
@@ -1,4 +1,5 @@
 export * from './middlewares/deviceMiddleware';
+export * from './middlewares/deviceConnectionMiddleware';
 export * from './hooks/useConnectDeviceHandler';
 export * from './hooks/useHandleDeviceConnection';
 export * from './hooks/useDetectDeviceError';

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -1,0 +1,89 @@
+import {
+    Dispatch,
+    ListenerEffectAPI,
+    UnknownAction,
+    createListenerMiddleware,
+} from '@reduxjs/toolkit';
+
+import {
+    selectIsDeviceConnectedAndAuthorized,
+    selectIsDeviceInitialized,
+    selectIsDeviceUsingPassphrase,
+} from '@suite-common/wallet-core';
+import { selectIsFirmwareInstallationRunning } from '@suite-native/firmware';
+import {
+    AuthorizeDeviceStackRoutes,
+    RootStackRoutes,
+    checkIsRouteAccessAllowed,
+    navigationContainerRef,
+} from '@suite-native/navigation';
+import { selectIsCoinEnablingInitFinished } from '@suite-native/settings';
+
+import { NativeDeviceRootState, selectIsDeviceCompromised } from '../selectors';
+import { isDeviceConnectAction } from '../utils';
+
+const DEVICE_CONNECTION_BLACKLISTED_ROUTES = [
+    RootStackRoutes.DeviceCompromisedModal,
+    RootStackRoutes.DeviceOnboardingStack,
+    RootStackRoutes.SendStack,
+];
+
+export const deviceConnectionMiddleware = createListenerMiddleware<NativeDeviceRootState>();
+
+const handleDeviceConnectNavigation = ({
+    isCoinEnablingInitFinished,
+}: {
+    isCoinEnablingInitFinished: boolean;
+}) => {
+    if (isCoinEnablingInitFinished) {
+        navigationContainerRef.navigate(RootStackRoutes.AuthorizeDeviceStack, {
+            screen: AuthorizeDeviceStackRoutes.ConnectingDevice,
+        });
+    } else {
+        navigationContainerRef.navigate(RootStackRoutes.CoinEnablingInit);
+    }
+};
+
+deviceConnectionMiddleware.startListening({
+    predicate: (action, currentState) =>
+        isDeviceConnectAction(action) &&
+        // TODO this should dissappear after we merge device onboarding redirect here as well
+        // https://github.com/trezor/trezor-suite/issues/20157
+        // If device is not initialized and is compromised, we display the modal (reason why this condition is here) and then want to redirect to uninitialized device landing.
+        (selectIsDeviceInitialized(currentState) || selectIsDeviceCompromised(currentState)),
+    effect: (
+        _action: UnknownAction,
+        { getState }: ListenerEffectAPI<NativeDeviceRootState, Dispatch<UnknownAction>>,
+    ) => {
+        const shouldNavigateToDeviceCompromisedModal = selectIsDeviceCompromised(getState());
+        const isCoinEnablingInitFinished = selectIsCoinEnablingInitFinished(getState());
+
+        if (
+            !checkIsRouteAccessAllowed({
+                blacklist: DEVICE_CONNECTION_BLACKLISTED_ROUTES,
+            })
+        )
+            return;
+
+        // During firmware installation, device restarts (disconnect + connect) and we want to ignore it.
+        if (selectIsFirmwareInstallationRunning(getState())) return;
+
+        if (shouldNavigateToDeviceCompromisedModal) {
+            // When the compromised modal is closed on first connection and no coins would be selected, we will need to redirect user
+            // to coin enabling so he can continue to the app with running discovery.
+            navigationContainerRef.navigate(RootStackRoutes.DeviceCompromisedModal);
+
+            return;
+        }
+
+        // If device is authorized already (usually in case of remembered device which has already been authorized)
+        const isDeviceConnectedAndAuthorized = selectIsDeviceConnectedAndAuthorized(getState());
+        // Passphrase protected devices are only connected through passphrase form
+        // The passphrase flow handles connection differently and redirect to connecting screen is not wanted.
+        const isDeviceUsingPassphrase = selectIsDeviceUsingPassphrase(getState());
+
+        if (isDeviceUsingPassphrase || isDeviceConnectedAndAuthorized) return;
+
+        handleDeviceConnectNavigation({ isCoinEnablingInitFinished });
+    },
+});

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -31,6 +31,7 @@ import {
     selectIsDeviceInBootloader,
     selectIsDiscoveredDeviceAccountless,
     selectIsEntropyCheckFailed,
+    selectIsFirmwareAuthenticityCheckDismissed,
     selectIsUnacquiredDevice,
     selectSelectedDevice,
     selectSelectedDeviceAuthenticity,
@@ -46,20 +47,25 @@ import {
     FeatureFlagsRootState,
     selectIsFeatureFlagEnabled,
 } from '@suite-native/feature-flags';
-import { SettingsSliceRootState } from '@suite-native/settings';
+import { NativeFirmwareRootState } from '@suite-native/firmware';
+import {
+    SettingsSliceRootState,
+    selectIsDeviceAuthenticityCheckEnabled,
+} from '@suite-native/settings';
 import { doesCoinSupportStaking } from '@suite-native/staking';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { BigNumber } from '@trezor/utils';
 
 import { isDeviceSetupSupported, isFirmwareVersionSupported } from './utils';
 
-type NativeDeviceRootState = DeviceRootState &
+export type NativeDeviceRootState = DeviceRootState &
     AccountsRootState &
     DiscoveryRootState &
     SettingsSliceRootState &
     WalletSettingsRootState &
     FiatRatesRootState &
     FeatureFlagsRootState &
+    NativeFirmwareRootState &
     MessageSystemRootState;
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<NativeDeviceRootState>();
@@ -254,4 +260,58 @@ export const selectShouldFactoryResetBeVisible = createMemoizedSelector(
     [selectIsDeviceInBootloader, selectHasDeviceFirmwareInstalled],
     (isDeviceInBootloader, hasDeviceFirmwareInstalled) =>
         isDeviceInBootloader && hasDeviceFirmwareInstalled,
+);
+
+export const selectIsDeviceCompromised = createMemoizedSelector(
+    [
+        selectIsDeviceAuthenticityCheckEnabled,
+        selectIsDeviceAuthenticityCheckFailed,
+        selectIsEntropyCheckEnabledAndFailed,
+        selectIsFirmwareAuthenticityCheckDismissed,
+        selectHasFirmwareAuthenticityCheckHardFailed,
+    ],
+    (
+        isDeviceAuthenticityCheckEnabled,
+        isDeviceAuthenticityCheckFailed,
+        isEntropyCheckEnabledAndFailed,
+        isFirmwareAuthenticityCheckDismissed,
+        hasFirmwareAuthenticityCheckHardFailed,
+    ) => {
+        const isDeviceAuthenticityEnabledAndFailed =
+            isDeviceAuthenticityCheckEnabled && isDeviceAuthenticityCheckFailed;
+
+        const isFirmwareAuthenticityCheckHardFailedAndNotDismissed =
+            hasFirmwareAuthenticityCheckHardFailed && !isFirmwareAuthenticityCheckDismissed;
+
+        return (
+            isDeviceAuthenticityEnabledAndFailed ||
+            isEntropyCheckEnabledAndFailed ||
+            isFirmwareAuthenticityCheckHardFailedAndNotDismissed
+        );
+    },
+);
+
+export const selectCompromisedDeviceFailedCheck = createMemoizedSelector(
+    [
+        selectIsDeviceAuthenticityCheckEnabled,
+        selectIsDeviceAuthenticityCheckFailed,
+        selectIsEntropyCheckEnabledAndFailed,
+    ],
+    (
+        isDeviceAuthenticityCheckEnabled,
+        isDeviceAuthenticityCheckFailed,
+        isEntropyCheckEnabledAndFailed,
+    ) => {
+        const isDeviceAuthenticityEnabledAndFailed =
+            isDeviceAuthenticityCheckEnabled && isDeviceAuthenticityCheckFailed;
+
+        if (isDeviceAuthenticityEnabledAndFailed) {
+            return 'device-authenticity';
+        }
+        if (isEntropyCheckEnabledAndFailed) {
+            return 'entropy';
+        }
+
+        return 'firmware-authenticity';
+    },
 );

--- a/suite-native/device/src/utils.ts
+++ b/suite-native/device/src/utils.ts
@@ -1,7 +1,10 @@
 import { G } from '@mobily/ts-belt';
+import { UnknownAction } from '@reduxjs/toolkit';
 import * as semver from 'semver';
 
 import { AnyAction } from '@suite-common/redux-utils';
+import { thpActions } from '@suite-common/thp';
+import { deviceConnectThunks } from '@suite-common/wallet-core';
 import { Device, DeviceEvent, VersionArray } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { exhaustive } from '@trezor/type-utils';
@@ -52,4 +55,22 @@ export const isDeviceSetupSupported = (model: DeviceModelInternal) => {
         default:
             return exhaustive(model);
     }
+};
+
+export const isDeviceConnectAction = (action: UnknownAction) => {
+    // For THP, we don't use deviceConnectThunks, because THP confirmation is required before we can communicate with the device,
+    // therefore we postpone until THP flow is finished.
+    if (thpActions.finishThpFlow.match(action)) {
+        return true;
+    }
+
+    if (deviceConnectThunks.fulfilled.match(action)) {
+        const { device } = action.meta.arg;
+
+        if (device.thp === undefined) {
+            return true;
+        }
+    }
+
+    return false;
 };

--- a/suite-native/firmware/src/nativeFirmwareSlice.ts
+++ b/suite-native/firmware/src/nativeFirmwareSlice.ts
@@ -8,7 +8,7 @@ const initialState: NativeFirmwareState = {
     isFirmwareInstallationRunning: false,
 };
 
-type NativeFirmwareRootState = {
+export type NativeFirmwareRootState = {
     nativeFirmware: NativeFirmwareState;
 };
 

--- a/suite-native/module-authenticity-checks/package.json
+++ b/suite-native/module-authenticity-checks/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "@react-navigation/core": "7.12.4",
-        "@react-navigation/native": "7.1.17",
+        "@reduxjs/toolkit": "2.8.2",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/intl": "workspace:*",

--- a/suite-native/module-authenticity-checks/redux.d.ts
+++ b/suite-native/module-authenticity-checks/redux.d.ts
@@ -1,0 +1,7 @@
+import { AsyncThunkAction } from '@reduxjs/toolkit';
+
+declare module 'redux' {
+    export interface Dispatch {
+        <TThunk extends AsyncThunkAction<any, any, any>>(thunk: TThunk): ReturnType<TThunk>;
+    }
+}

--- a/suite-native/module-authenticity-checks/src/components/DeviceAuthenticityCheckFailModalContent.tsx
+++ b/suite-native/module-authenticity-checks/src/components/DeviceAuthenticityCheckFailModalContent.tsx
@@ -13,6 +13,7 @@ export const DeviceAuthenticityCheckFailModalContent = () => {
     const navigateToInitialScreen = useNavigateToInitialScreen();
     const selectedDevice = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();
+
     const handleClose = () => {
         if (selectedDevice) {
             dispatch(deviceActions.deviceDisconnect(selectedDevice));

--- a/suite-native/module-authenticity-checks/src/components/FirmwareAuthenticityCheckFailModalContent.tsx
+++ b/suite-native/module-authenticity-checks/src/components/FirmwareAuthenticityCheckFailModalContent.tsx
@@ -1,34 +1,40 @@
 import { useDispatch, useSelector } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/core';
 
-import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
+import {
+    deviceActions,
+    selectIsDeviceInitialized,
+    selectSelectedDevice,
+} from '@suite-common/wallet-core';
 import { Button } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
-    AppTabsRoutes,
-    HomeStackRoutes,
     RootStackParamList,
     RootStackRoutes,
     ScreenHeader,
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
+import { selectIsCoinEnablingInitFinished } from '@suite-native/settings';
 import { TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_MOBILE_URL } from '@trezor/urls';
 
 import { DeviceCompromisedModalContent } from './DeviceCompromisedModalContent';
 
 const supportUrlWithChat = `${TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_MOBILE_URL}#open-chat`;
 
-type NavigationProp = StackToStackCompositeNavigationProps<
+type NavigationProps = StackToStackCompositeNavigationProps<
     RootStackParamList,
-    RootStackRoutes.AppTabs,
+    RootStackRoutes.DeviceCompromisedModal,
     RootStackParamList
 >;
 
 export const FirmwareAuthenticityCheckFailModalContent = () => {
-    const device = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();
-    const navigation = useNavigation<NavigationProp>();
+    const navigation = useNavigation<NavigationProps>();
+
+    const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
+    const isCoinEnablingInitFinished = useSelector(selectIsCoinEnablingInitFinished);
+    const device = useSelector(selectSelectedDevice);
 
     const dismissCheck = () => {
         if (device?.id) {
@@ -36,24 +42,18 @@ export const FirmwareAuthenticityCheckFailModalContent = () => {
         }
     };
 
-    // After dismissCheck, an effect could fire in useHandleDeviceConnection to navigate away, but it's not guaranteed!
-    // To be sure we don't lock user on on this screen, we navigate home.
     const handleClose = () => {
-        // the modal is most likely entered from OnboardingStack, ConnectingDevice or Home, so let's send user back
-        if (navigation.canGoBack()) {
-            navigation.goBack();
-        }
-        // Home screen set only as fallback if can't go back
-        else {
-            navigation.navigate(RootStackRoutes.AppTabs, {
-                screen: AppTabsRoutes.HomeStack,
-                params: { screen: HomeStackRoutes.Home },
-            });
-        }
         dismissCheck();
+
+        if (!isCoinEnablingInitFinished && isDeviceInitialized) {
+            navigation.navigate(RootStackRoutes.CoinEnablingInit);
+        } else {
+            if (navigation.canGoBack()) navigation.goBack();
+        }
     };
 
     const screenHeaderContent = <ScreenHeader closeActionType="close" closeAction={handleClose} />;
+
     const closeButtonContent = (
         <Button colorScheme="redElevation0" onPress={handleClose}>
             <Translation id="generic.buttons.close" />

--- a/suite-native/module-authenticity-checks/src/screens/DeviceCompromisedModalScreen.tsx
+++ b/suite-native/module-authenticity-checks/src/screens/DeviceCompromisedModalScreen.tsx
@@ -1,4 +1,6 @@
-import { RootStackParamList, RootStackRoutes, StackProps } from '@suite-native/navigation';
+import { useSelector } from 'react-redux';
+
+import { selectCompromisedDeviceFailedCheck } from '@suite-native/device';
 import { exhaustive } from '@trezor/type-utils';
 
 import { DeviceAuthenticityCheckFailModalContent } from '../components/DeviceAuthenticityCheckFailModalContent';
@@ -11,10 +13,8 @@ import { FirmwareAuthenticityCheckFailModalContent } from '../components/Firmwar
  * - FW authenticity check failure
  * - device authenticity check failure
  */
-export const DeviceCompromisedModalScreen = ({
-    route,
-}: StackProps<RootStackParamList, RootStackRoutes.DeviceCompromisedModal>) => {
-    const { failedCheck } = route.params;
+export const DeviceCompromisedModalScreen = () => {
+    const failedCheck = useSelector(selectCompromisedDeviceFailedCheck);
 
     switch (failedCheck) {
         case 'device-authenticity':

--- a/suite-native/navigation/src/checkIsRouteAccessAllowed.ts
+++ b/suite-native/navigation/src/checkIsRouteAccessAllowed.ts
@@ -1,0 +1,11 @@
+import { navigationContainerRef } from './components/NavigationContainerWithAnalytics';
+import { RootStackRoutes } from './routes';
+
+export const checkIsRouteAccessAllowed = ({ blacklist }: { blacklist: RootStackRoutes[] }) => {
+    const activeRouteName = navigationContainerRef.getState()?.routes.at(-1)
+        ?.name as RootStackRoutes;
+
+    if (!activeRouteName) return false;
+
+    return !blacklist.includes(activeRouteName);
+};

--- a/suite-native/navigation/src/components/NavigationContainerWithAnalytics.tsx
+++ b/suite-native/navigation/src/components/NavigationContainerWithAnalytics.tsx
@@ -4,20 +4,22 @@ import {
     DarkTheme,
     DefaultTheme,
     NavigationContainer,
-    useNavigationContainerRef,
+    createNavigationContainerRef,
 } from '@react-navigation/native';
 
 import { EventType, analytics } from '@suite-native/analytics';
 import { addSentryBreadcrumb, setSentryTag } from '@suite-native/sentry';
 import { useNativeStyles } from '@trezor/styles';
 
+import { RootStackParamList } from '../navigators';
 import { useReportSendFlowExitToAnalytics } from '../useReportSendFlowExitToAnalytics';
 
 export const IsNavigationReadyContext = createContext(false);
 
+export const navigationContainerRef = createNavigationContainerRef<RootStackParamList>();
+
 export const NavigationContainerWithAnalytics = ({ children }: { children: ReactNode }) => {
     const [isNavigationReady, setIsNavigationReady] = useState(false);
-    const navigationContainerRef = useNavigationContainerRef();
     const routeNameRef = useRef<string | undefined>(undefined);
     const {
         utils: { colors, isDarkColor },

--- a/suite-native/navigation/src/hooks/useNavigationRoute.ts
+++ b/suite-native/navigation/src/hooks/useNavigationRoute.ts
@@ -3,7 +3,7 @@ import type { NavigationState } from '@react-navigation/routers';
 
 import { AppTabsParamList } from '../navigators';
 
-type AppNavigationState = NavigationState<AppTabsParamList>;
+export type AppNavigationState = NavigationState<AppTabsParamList>;
 /**
  * Recursively get the most specific active route name from the hierarchy of navigation states.
  */

--- a/suite-native/navigation/src/index.ts
+++ b/suite-native/navigation/src/index.ts
@@ -5,6 +5,7 @@ export * from './config';
 export * from './useHandleHardwareBackNavigation';
 export * from './useNavigateToInitialScreen';
 export * from './useScrollDivider';
+export * from './checkIsRouteAccessAllowed';
 export * from './hooks/useNavigationRoute';
 export * from './hooks/useOverrideBackNavigation';
 export * from './components/TabBar';

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -315,9 +315,7 @@ export type RootStackParamList = {
     [RootStackRoutes.WalletConnectPair]: undefined;
     [RootStackRoutes.SettingsScreenStack]: NavigatorScreenParams<SettingsStackParamList>;
     [RootStackRoutes.BackupFailedModal]: undefined;
-    [RootStackRoutes.DeviceCompromisedModal]: {
-        failedCheck: 'device-authenticity' | 'entropy' | 'firmware-authenticity';
-    };
+    [RootStackRoutes.DeviceCompromisedModal]: undefined;
     [RootStackRoutes.TradingWebView]: {
         closeCallbackUrl: string;
         source?: { uri?: string; html?: string };

--- a/suite-native/state/src/store.ts
+++ b/suite-native/state/src/store.ts
@@ -4,7 +4,7 @@ import { logger } from 'redux-logger';
 
 import { prepareFiatRatesMiddleware } from '@suite-common/wallet-core';
 import { blockchainMiddleware } from '@suite-native/blockchain';
-import { prepareDeviceMiddleware } from '@suite-native/device';
+import { deviceConnectionMiddleware, prepareDeviceMiddleware } from '@suite-native/device';
 import { prepareDiscoveryMiddleware } from '@suite-native/discovery';
 import { messageSystemMiddleware } from '@suite-native/message-system';
 import { sendFormMiddleware } from '@suite-native/module-send/src/sendFormMiddleware';
@@ -48,6 +48,8 @@ export const initStore = async (preloadedState?: PreloadedState) =>
                 },
                 serializableCheck: false,
                 immutableCheck: false,
-            }).concat(middlewares),
+            })
+                .prepend(deviceConnectionMiddleware.middleware)
+                .concat(middlewares),
         enhancers: getDefaultEnhancers => getDefaultEnhancers().concat(enhancers),
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10783,7 +10783,7 @@ __metadata:
   resolution: "@suite-native/module-authenticity-checks@workspace:suite-native/module-authenticity-checks"
   dependencies:
     "@react-navigation/core": "npm:7.12.4"
-    "@react-navigation/native": "npm:7.1.17"
+    "@reduxjs/toolkit": "npm:2.8.2"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/intl": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- create a listener middleware that listens only to specific actions so we're able to create a single decision tree for device connection navigations
- create a hook that allows for route blacklisting so that specific flows which require it are able to ignore device connection

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20156
Resolve https://github.com/trezor/trezor-suite/issues/20754

## Screenshots:

https://github.com/user-attachments/assets/29e7c17d-6ea0-48ed-9426-e9286e0c6316






🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/handle-redirect-to-connecting-screen&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/handle-redirect-to-connecting-screen&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/handle-redirect-to-connecting-screen&lookback=7)