### PR TITLE
fix(suite): disable change homescreen button

### DIFF
--- a/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
@@ -186,7 +186,7 @@ export const Homescreen = ({ isDeviceLocked }: HomescreenProps) => {
                     </Col>
 
                     <ActionColumn>
-                        <ActionButton onClick={onChangeHomescreen}>
+                        <ActionButton onClick={onChangeHomescreen} isDisabled={isDeviceLocked}>
                             <Translation id="TR_CHANGE_HOMESCREEN" />
                         </ActionButton>
                         <ActionButton


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
found while working on [homescreen streaming](https://github.com/trezor/trezor-suite/pull/20068)

Change homescreen button was active during the upload

btw. Tooltip message is misleading - my device is connected but currently locked/occupied by the process.
Is this a known issue?

![this](https://github.com/user-attachments/assets/17e54188-429d-4de7-8a3c-af2ede6b3415)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-disable-homescreen-button&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-disable-homescreen-button&lookback=7)