### PR TITLE
fix(connect): ignore instance in staticSessionId validation 

### DIFF
--- a/packages/connect/src/device/workflow/validateState.ts
+++ b/packages/connect/src/device/workflow/validateState.ts
@@ -31,10 +31,11 @@ const getState = async ({ device, method }: WorkflowContext) => {
     if (device.features.session_id) {
         device.setState({ sessionId: device.features.session_id });
     }
-    if (expectedState && expectedState !== uniqueState) {
+    // Ignore instance ID, it doesn't necessarily need to match the current instance
+    if (expectedState && expectedState.split(':')[0] !== uniqueState.split(':')[0]) {
         return uniqueState;
     }
-    if (!expectedState) {
+    if (!expectedState || expectedState !== uniqueState) {
         device.setState({ staticSessionId: uniqueState });
     }
 };


### PR DESCRIPTION
## Description

Sometimes the device instance ID can differ from the one specified in staticSessionId. 
It is not really a problem, so we ignore it when validating state.

## Related Issue

Resolve #20089

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-staticsessionid-ignore-instance&lookback=7)