### PR TITLE
feat(suite): add asset symbol to confirm address modal heading

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
@@ -1,8 +1,15 @@
 import { useCallback } from 'react';
 
 import { selectConnectPopupCall } from '@suite-common/connect-popup';
-import { selectTradingModalAccountKey } from '@suite-common/trading';
+import {
+    cryptoIdToSymbol,
+    selectTradingModalAccountKey,
+    useTradingInfo,
+} from '@suite-common/trading';
+import { getDisplaySymbol, getNetwork } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config/src/utils';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 
 import { showAddress } from 'src/actions/wallet/receiveActions';
 import { Translation } from 'src/components/suite';
@@ -24,6 +31,8 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
     const device = useSelector(selectSelectedDevice);
     const account = useSelector(selectAccountIncludingChosenInTrading);
     const isTradingFlow = useSelector(selectTradingModalAccountKey);
+    const { modalCryptoId } = useSelector(state => state.wallet.tradingNew);
+    const { cryptoIdToSymbolAndContractAddress } = useTradingInfo();
     const isConnectPopup = useSelector(
         state => selectConnectPopupCall(state)?.state === 'address-confirmation',
     );
@@ -36,10 +45,67 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
     if (isConnectPopup) return <ConnectAddressConfirmation />;
     if (!device) return null;
 
+    const getHeading = () => {
+        if (modalCryptoId) {
+            const symbol = cryptoIdToSymbol(modalCryptoId);
+            const { coinSymbol, contractAddress } =
+                cryptoIdToSymbolAndContractAddress(modalCryptoId);
+            const networkCurrencyName = coinSymbol && getDisplaySymbol(coinSymbol, contractAddress);
+
+            if (contractAddress) {
+                const networkName = symbol ? getNetwork(symbol).name : coinSymbol?.toUpperCase();
+
+                return (
+                    <Translation
+                        id="TR_ADDRESS_MODAL_TITLE_EXCHANGE"
+                        values={{
+                            networkName,
+                            networkCurrencyName,
+                        }}
+                    />
+                );
+            }
+
+            return (
+                <Translation
+                    id="TR_ADDRESS_MODAL_TITLE"
+                    values={{
+                        networkName: networkCurrencyName,
+                    }}
+                />
+            );
+        }
+
+        if (!account) {
+            return <Translation id="TR_RECEIVE" />;
+        }
+
+        const hasTokens = hasNetworkFeatures(account, 'tokens');
+        if (hasTokens) {
+            return (
+                <Translation
+                    id="TR_RECEIVE_NETWORK_INCLUDING_TOKENS"
+                    values={{
+                        networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
+                    }}
+                />
+            );
+        }
+
+        return (
+            <Translation
+                id="TR_RECEIVE_NETWORK"
+                values={{
+                    networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
+                }}
+            />
+        );
+    };
+
     return (
         <ConfirmValueModal
             account={account}
-            heading={<Translation id="TR_RECEIVE" />}
+            heading={getHeading()}
             label={<Translation id="TR_ADDRESS" />}
             validateOnDevice={validateAddress}
             areStepsVisible={!isTradingFlow}

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3179,6 +3179,10 @@ export default defineMessages({
         defaultMessage: 'Receive {networkDisplaySymbol}',
         id: 'TR_RECEIVE_NETWORK',
     },
+    TR_RECEIVE_NETWORK_INCLUDING_TOKENS: {
+        defaultMessage: 'Receive {networkDisplaySymbol} including tokens',
+        id: 'TR_RECEIVE_NETWORK_INCLUDING_TOKENS',
+    },
     TR_BUY_NETWORK: {
         defaultMessage: 'Buy {networkDisplaySymbol}',
         id: 'TR_BUY_NETWORK',


### PR DESCRIPTION
## Related Issue

Resolve #19356

## Screenshots:
### Trading
![image](https://github.com/user-attachments/assets/2f8c1b65-ea9e-4f5f-b298-4a6bf852e340)
![image](https://github.com/user-attachments/assets/cdc12e22-9d85-4d89-9c5e-d9cdc4823638)

### Receive section
![image](https://github.com/user-attachments/assets/8cddffaf-64d4-4072-9d44-ef7136769e85)
![image](https://github.com/user-attachments/assets/9f7fcff8-a1f6-4f71-8fdd-e38cf0925da7)



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/confirm-address-modal-heading&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/confirm-address-modal-heading&lookback=7)