### PR TITLE
fix(suite): apply correct custom gas limit during ETH staking

### DIFF
--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -171,6 +171,7 @@ export const signTransaction =
                 from: account.descriptor,
                 identity,
                 gasPrice: transactionInfo.feePerByte,
+                feeLimit: transactionInfo.feeLimit,
                 maxFeePerGas: transactionInfo.maxFeePerGas,
                 maxPriorityFeePerGas: transactionInfo.maxPriorityFeePerGas,
                 nonce,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed an issue where the custom gas limit is not applied for claim ETH transactions

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18109

## Screenshots:
![image](https://github.com/user-attachments/assets/91ff6050-b10c-4a51-bef5-46dcfea1275d)
![image](https://github.com/user-attachments/assets/332df3f9-6c00-462d-8c3b-a26d41083162)

