### PR TITLE
node-utils: http server port negotiation

### DIFF
--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -7,7 +7,6 @@ import type { RequiredKey } from '@trezor/type-utils';
 import { Log, TypedEmitter, arrayPartition } from '@trezor/utils';
 
 import { findProcessFromIncomingPort } from './findProcessFromIncomingPort';
-import { getFreePort } from './getFreePort';
 
 type Request = RequiredKey<http.IncomingMessage, 'url'>;
 const isRequest = (request: http.IncomingMessage): request is Request => request.url !== undefined;
@@ -94,20 +93,28 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
     public logger: Log;
     private routes: Route[] = [];
     private readonly emitter: TypedEmitter<BaseEvents> = this;
-    private port?: number;
+    private ports: number[] = [];
     private sockets: Record<number, net.Socket> = {};
 
-    constructor({ logger, port }: { logger: Log; port?: number }) {
+    constructor({ logger, port, ports }: { logger: Log; port?: number; ports?: number[] }) {
         super();
 
-        this.port = port;
+        // either try to take the first member of ports array
+
+        if (ports && ports.length > 0) {
+            this.ports = ports;
+        } else if (port) {
+            this.ports = [port];
+        } else {
+            this.ports = [0]; // this will pick a random free ports
+        }
 
         this.logger = logger;
         this.server = http.createServer(this.onRequest);
     }
 
     get logName() {
-        return `http: ${this.port || 'unknown port'}`;
+        return `http: ${this.ports[0] || 'unknown port'}`;
     }
 
     public getServerAddress() {
@@ -141,8 +148,13 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
         };
     }
 
-    public async start() {
-        const port = this.port || (this.port = (await getFreePort())[0]);
+    public start() {
+        const port = this.ports.shift();
+
+        if (typeof port !== 'number') {
+            // this should not happen
+            throw new Error('There is no port available in ports array');
+        }
 
         return new Promise<
             | { success: true; payload: net.AddressInfo }
@@ -173,6 +185,10 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
                 // @ts-expect-error - type is missing
                 const errorCode: string = e.code;
                 const portOccupied = errorCode === 'EADDRINUSE' || errorCode === 'EACCES';
+
+                if (this.ports.length) {
+                    return this.stop().then(() => this.start());
+                }
 
                 if (portOccupied) {
                     const processInfo = await findProcessFromIncomingPort(port).catch(() => {});

--- a/packages/node-utils/src/tests/http.test.ts
+++ b/packages/node-utils/src/tests/http.test.ts
@@ -1,5 +1,7 @@
 import url from 'url';
 
+import { Log } from '@trezor/utils';
+
 import {
     HttpServer,
     ParamsValidatorHandler,
@@ -17,13 +19,13 @@ const muteLogger = {
     info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
-};
+    debug: jest.fn(),
+} as any as Log;
 
 describe('HttpServer', () => {
     let server: HttpServer<Events>;
     beforeEach(() => {
         server = new HttpServer<Events>({
-            // @ts-expect-error
             logger: muteLogger,
         });
     });
@@ -58,7 +60,6 @@ describe('HttpServer', () => {
     });
 
     test('a port can be passed to the constructor', async () => {
-        // @ts-expect-error
         server = new HttpServer<Events>({ logger: muteLogger, port: 65526 });
         await server.start();
         expect(server.getServerAddress()).toMatchObject({

--- a/packages/node-utils/src/tests/http.test.ts
+++ b/packages/node-utils/src/tests/http.test.ts
@@ -2,6 +2,7 @@ import url from 'url';
 
 import { Log } from '@trezor/utils';
 
+import { getFreePort } from '../getFreePort';
 import {
     HttpServer,
     ParamsValidatorHandler,
@@ -467,5 +468,27 @@ describe('HttpServer', () => {
         expect(res.status).toEqual(404);
         res = await fetch(`http://${address.address}:${address.port}/bar`);
         expect(res.status).toEqual(200);
+    });
+
+    test('port negotiation, first available port is occupied, second is free', async () => {
+        const [freePort1, freePort2] = await getFreePort(2);
+        // start server using 'ports' array. first port is empty and will be used
+        server = new HttpServer<Events>({ logger: muteLogger, port: freePort1 });
+        await server.start();
+        expect(server.getServerAddress()).toMatchObject({
+            port: freePort1,
+        });
+
+        const server2 = new HttpServer<Events>({
+            logger: muteLogger,
+            ports: [freePort1, freePort2],
+        });
+
+        await server2.start();
+        expect(server2.getServerAddress()).toMatchObject({
+            port: freePort2,
+        });
+
+        await Promise.all([server.stop(), server2.stop()]);
     });
 });

--- a/packages/suite-desktop-core/e2e/tests/manual/autoupdate/auto-update.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/manual/autoupdate/auto-update.test.ts
@@ -9,7 +9,7 @@ test.describe.skip('Auto update', { tag: ['@group=manual'] }, () => {
             annotation: createTestAnnotation({
                 testCase: 'Verifies that a user can update application.',
                 prerequisites: [
-                    'Current producion version of Trezor Suite',
+                    'Current production version of Trezor Suite',
                     'Release candidate of Trezor Suite',
                     'Build of Trezor Suite that starts with 0x.x.x',
                     'Access to SatoshiLabs VPN',


### PR DESCRIPTION
we might want to instruct http server to chose from an array of possible ports to listen on. This is useful to get rid of rare edgecases when a certain user might have the ports we rely on occupied.

usecases:
- http receiver
- node-bridge once we decide to switch to a new port as part of the old bridge deprecation #18146

regarding the security benefits (ttps://github.com/trezor/trezor-suite-private/issues/9)  - I am afraid it won't bring any since we would need to use random port for this and this is not possible at least for services that need url whitelisting 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=port-negotiation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=port-negotiation&lookback=7)