### PR TITLE
fix(suite): reuse existing device instance in discovery

### DIFF
--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -132,12 +132,14 @@ const applyDeviceStatesThunk = createThunk(
                     }),
                 );
             } else {
+                const instance =
+                    device.instance ?? getNewInstanceNumber(selectDevices(getState()), device);
                 dispatch(
                     deviceActions.addAuthorizedDevice({
                         device: {
                             ...device,
                             metadata: {},
-                            instance: getNewInstanceNumber(selectDevices(getState()), device),
+                            instance,
                             useEmptyPassphrase: !isAddingHiddenWallet,
                             // TODO: On mobile, we don't want to remember the device by default, because it's not supported yet
                             remember: isNative() ? false : true,


### PR DESCRIPTION
## Description

Reuse existing device instance in discovery `applyDeviceStatesThunk`.
Previously it would always get a new instance, resulting in mismatch with the state.

## Related Issue

Resolve #20089

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/discoverythunks-reuse-device-instance&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/discoverythunks-reuse-device-instance&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/discoverythunks-reuse-device-instance&lookback=7)