### PR TITLE
chore(message-system): change message system sequence

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
     "timestamp": "2025-07-10T00:00:00+00:00",
-    "sequence": 93,
+    "sequence": 92,
     "actions": [
         {
             "conditions": [


### PR DESCRIPTION
## Description

Changing message system sequence from '93' to '92' in order to stay consistent in bumping sequence (considering the current sequence in `release-message-system-production`)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/change-message-sequence&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/change-message-sequence&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/change-message-sequence&lookback=7)