### PR TITLE
chore(message-system): cleanup feature flag types

### DIFF
--- a/suite-common/message-system/schema/config.schema.v1.json
+++ b/suite-common/message-system/schema/config.schema.v1.json
@@ -121,7 +121,7 @@
                                 "minItems": 1,
                                 "items": {
                                     "title": "Feature",
-                                    "description": "Only used for 'feature' category. Feature flag can disable a feature for a specific version of a specific app.",
+                                    "description": "Only used for 'feature' category. Feature flag can disable a feature for a specific version of a specific app. Custom properties may be used to pass additional data to the feature flag.",
                                     "type": "object",
                                     "required": ["domain", "flag"],
                                     "properties": {
@@ -129,9 +129,6 @@
                                             "type": "string"
                                         },
                                         "flag": {
-                                            "type": "boolean"
-                                        },
-                                        "isPublic": {
                                             "type": "boolean"
                                         }
                                     },

--- a/suite-common/message-system/src/messageSystemSelectors.ts
+++ b/suite-common/message-system/src/messageSystemSelectors.ts
@@ -134,7 +134,7 @@ export const selectIsFeatureDisabled = (
 ) => {
     const featureFlag = selectFeatureConfig(state, domain)?.flag;
 
-    return typeof featureFlag === 'boolean' ? !featureFlag : (defaultValue ?? false);
+    return featureFlag !== undefined ? !featureFlag : (defaultValue ?? false);
 };
 
 const selectValidMessages = (state: MessageSystemRootState) => state.messageSystem.validMessages;

--- a/suite-common/suite-types/src/messageSystem.ts
+++ b/suite-common/suite-types/src/messageSystem.ts
@@ -406,12 +406,11 @@ export interface Modal {
     image: string;
 }
 /**
- * Only used for 'feature' category. Feature flag can disable a feature for a specific version of a specific app.
+ * Only used for 'feature' category. Feature flag can disable a feature for a specific version of a specific app. Custom properties may be used to pass additional data to the feature flag.
  */
 export interface Feature {
     domain: string;
     flag: boolean;
-    isPublic?: boolean;
     [k: string]: unknown;
 }
 /**


### PR DESCRIPTION
## Description

Message system `feature` can bear arbitrary payload already, so clean up the type definitions.

:thought_balloon:  the `flag: boolean` still has sense semantically when you use arbitrary payload: whether the remotely controlled value shall be heeded or discarded.

## Related Issue

Related to #20110, only to make things clearer

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/add-message-system-feature-value&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/add-message-system-feature-value&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/add-message-system-feature-value&lookback=7)