### PR TITLE
test(suite-common): Add unit tests for wallet-config

### DIFF
--- a/suite-common/wallet-config/jest.config.js
+++ b/suite-common/wallet-config/jest.config.js
@@ -1,0 +1,5 @@
+const { ...baseConfig } = require('../../jest.config.base');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-common/wallet-config/package.json
+++ b/suite-common/wallet-config/package.json
@@ -7,6 +7,7 @@
     "main": "src/index",
     "scripts": {
         "depcheck": "yarn g:depcheck",
+        "test:unit": "yarn g:jest -c=../../jest.config.base.js",
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {

--- a/suite-common/wallet-config/src/__tests__/utils.test.ts
+++ b/suite-common/wallet-config/src/__tests__/utils.test.ts
@@ -1,0 +1,44 @@
+import { networks } from '../networksConfig';
+import { getMainnets, getTestnets, isAccountOfNetwork } from '../utils';
+
+const { btc: bitcoin, eth: ethereum, test: testnet, regtest } = networks;
+
+const mockNetworks = [bitcoin, ethereum, testnet, regtest];
+
+describe(getMainnets.name, () => {
+    it('returns non-testnet, non-debug-only networks when debug is false', () => {
+        const result = getMainnets(false, mockNetworks);
+        expect(result).toEqual([bitcoin, ethereum]);
+    });
+});
+
+describe(getTestnets.name, () => {
+    it('returns testnet, non-debug-only networks when debug is false', () => {
+        const result = getTestnets(false, mockNetworks);
+        expect(result).toEqual([testnet]);
+    });
+
+    it('includes all testnets when debug is true', () => {
+        const result = getTestnets(true, mockNetworks);
+        expect(result).toEqual([testnet, regtest]);
+    });
+});
+
+describe(isAccountOfNetwork.name, () => {
+    test.each(mockNetworks)('returns true for "normal" accountType for network %#', network =>
+        expect(isAccountOfNetwork(network, 'normal')).toBe(true),
+    );
+
+    test.each(['coinjoin', 'taproot', 'segwit', 'legacy'])(
+        'returns true for "%s" from accountTypes in bitcoin',
+        accountType => expect(isAccountOfNetwork(bitcoin, accountType)).toBe(true),
+    );
+
+    it('returns false for non-existing accountType in bitcoin', () => {
+        expect(isAccountOfNetwork(bitcoin, 'foobar')).toBe(false);
+    });
+
+    it('returns false for non-existing accountType in ethereum', () => {
+        expect(isAccountOfNetwork(ethereum, 'segwit')).toBe(false);
+    });
+});

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -19,11 +19,11 @@ export const networksCollection: Network[] = Object.values(networks);
  */
 export const networkSymbolCollection = networksCollection.map(n => n.symbol);
 
-export const getMainnets = (debug = false) =>
-    networksCollection.filter(n => !n.testnet && (!n.isDebugOnlyNetwork || debug));
+export const getMainnets = (debug = false, allNetworks = networksCollection) =>
+    allNetworks.filter(n => !n.testnet && (!n.isDebugOnlyNetwork || debug));
 
-export const getTestnets = (debug = false) =>
-    networksCollection.filter(n => n.testnet === true && (!n.isDebugOnlyNetwork || debug));
+export const getTestnets = (debug = false, allNetworks = networksCollection) =>
+    allNetworks.filter(n => n.testnet === true && (!n.isDebugOnlyNetwork || debug));
 
 export const getTestnetSymbols = () => getTestnets().map(n => n.symbol);
 


### PR DESCRIPTION
Added unit tests for `getMainnets`, `getTestnets` and `isAccountOfNetwork`

## Related Issue

Resolve #14444
