### PR TITLE
Fix/coincontrol mobile improvements

### DIFF
--- a/suite-native/module-send/src/components/CoinControl/SendUtxoScreenFooter.tsx
+++ b/suite-native/module-send/src/components/CoinControl/SendUtxoScreenFooter.tsx
@@ -17,7 +17,11 @@ type SendUtxoScreenFooterProps = {
 
 const gradientStyle = prepareNativeStyle(utils => ({
     height: utils.spacings.sp16,
-    top: -utils.spacings.sp32,
+    top: -utils.spacings.sp16,
+}));
+
+const footerStyle = prepareNativeStyle(utils => ({
+    backgroundColor: utils.colors.backgroundSurfaceElevation0,
 }));
 
 export const SendUtxoScreenFooter = ({
@@ -38,7 +42,13 @@ export const SendUtxoScreenFooter = ({
     return (
         <>
             <ScreenFooterGradient style={applyStyle(gradientStyle)} />
-            <VStack paddingHorizontal="sp16" paddingBottom="sp16" spacing="sp12">
+            <VStack
+                style={applyStyle(footerStyle)}
+                paddingHorizontal="sp16"
+                paddingBottom="sp16"
+                paddingTop="sp16"
+                spacing="sp12"
+            >
                 <VStack spacing="sp4">
                     <HStack justifyContent="space-between">
                         <Text variant={missingToAmount ? 'hint' : 'body'}>

--- a/suite-native/module-send/src/components/CoinControl/UtxoCard.tsx
+++ b/suite-native/module-send/src/components/CoinControl/UtxoCard.tsx
@@ -92,13 +92,17 @@ export const UtxoCard = ({ utxo, onToggle, accountKey, symbol, isSelected = fals
                                 isBalance={false}
                                 symbol={symbol}
                             />
-                            <Text color="textSubdued">≈</Text>
-                            <BaseCurrencyAmountFormatter
-                                color="textSubdued"
-                                variant="highlight"
-                                symbol={symbol}
-                                value={fiatAmount}
-                            />
+                            {fiatAmount && (
+                                <>
+                                    <Text color="textSubdued">≈</Text>
+                                    <BaseCurrencyAmountFormatter
+                                        color="textSubdued"
+                                        variant="highlight"
+                                        symbol={symbol}
+                                        value={fiatAmount}
+                                    />
+                                </>
+                            )}
                         </HStack>
 
                         <AccountAddressFormatter

--- a/suite-native/module-send/src/components/CoinControl/UtxoList.tsx
+++ b/suite-native/module-send/src/components/CoinControl/UtxoList.tsx
@@ -9,7 +9,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { UtxoCard } from './UtxoCard';
 
-const UtxoListStyle = prepareNativeStyle(() => ({ paddingBottom: 16, gap: 16, display: 'flex' }));
+const UtxoListStyle = prepareNativeStyle(utils => ({ paddingBottom: utils.spacings.sp16 }));
 
 const spacerStyle = prepareNativeStyle(utils => ({
     height: utils.spacings.sp16,
@@ -63,6 +63,7 @@ export const UtxoList = ({
             renderItem={renderItem}
             contentContainerStyle={applyStyle(UtxoListStyle)}
             ItemSeparatorComponent={rowSeparator}
+            estimatedItemSize={120}
         />
     );
 };

--- a/suite-native/module-send/src/screens/SendUtxoScreen.tsx
+++ b/suite-native/module-send/src/screens/SendUtxoScreen.tsx
@@ -81,7 +81,7 @@ export const SendUtxoScreen = ({
             }
             noBottomPadding
         >
-            <VStack flex={1}>
+            <VStack flex={1} spacing="sp24">
                 <SearchInputWithCancel
                     onChange={onSearchChange}
                     placeholder={translate('moduleSend.coinControl.search.placeholder')}

--- a/suite-native/module-send/src/screens/SendUtxoScreen.tsx
+++ b/suite-native/module-send/src/screens/SendUtxoScreen.tsx
@@ -79,8 +79,9 @@ export const SendUtxoScreen = ({
                     symbol={account.symbol}
                 />
             }
+            noBottomPadding
         >
-            <VStack spacing="sp24" flex={1}>
+            <VStack flex={1}>
                 <SearchInputWithCancel
                     onChange={onSearchChange}
                     placeholder={translate('moduleSend.coinControl.search.placeholder')}


### PR DESCRIPTION
Changes:
- fixed gradient footer position when mobile keyboard is on screen
- do not show `=` when fiat conversion rates are available

BEFORE:
<img width="720" height="1600" alt="image" src="https://github.com/user-attachments/assets/094d1beb-2f86-47a2-b2fe-d3f725b37497" />
AFTER:
<img width="468" height="992" alt="Screenshot 2025-07-10 at 14 45 45" src="https://github.com/user-attachments/assets/27f541e1-0b19-4c73-826b-6c4d33ac8ab6" />
<img width="464" height="974" alt="Screenshot 2025-07-10 at 14 49 56" src="https://github.com/user-attachments/assets/8a3cae94-08c7-415c-b56d-1dcc6dfef132" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/coincontrol-mobile-improvements&lookback=7)