### PR TITLE
fix(suite): Do not validate ASCII for Sign & Verify

### DIFF
--- a/packages/suite/src/hooks/wallet/sign-verify/useSignVerifyForm.ts
+++ b/packages/suite/src/hooks/wallet/sign-verify/useSignVerifyForm.ts
@@ -35,7 +35,6 @@ const signVerifySchema: yup.ObjectSchema<SignVerifyFields> = yup.object({
         .when('hex', {
             is: true,
             then: schema => schema.isHex(),
-            otherwise: schema => schema.isAscii(),
         }),
     address: yup
         .string()


### PR DESCRIPTION
Allows signing of non-ASCII messages

## Related Issue

Resolve #15800

## Screenshots:
<img width="768" height="370" alt="sign-and-verify-suite" src="https://github.com/user-attachments/assets/9560e991-d53f-4869-aeae-deb22fece24e" />
<img width="373" height="467" alt="sign-and-verify-trezor" src="https://github.com/user-attachments/assets/37fd7e16-bdbe-45c0-9b37-a99b609c631f" />

