### PR TITLE
fix(suite-e2e): workaround for db-migration test till feature is fixed

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/suite/db-migration.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/db-migration.test.ts
@@ -138,7 +138,7 @@ test.describe('Database migration', { tag: ['@group=migrations', '@webOnly'] }, 
                 await onboardingPage.disableNecessaryFirmwareChecks({ skipSuiteLoadedCheck: true });
                 await dashboardPage.openDeviceSwitcher();
                 await expect(page.getByTestId('@deviceStatus-connected')).toBeVisible();
-                await dashboardPage.deviceSwitchingCloseButton.click();
+                await dashboardPage.deviceSwitchingCloseButton.first().click();
                 await page.getByTestId('@account-subpage/back').last().click();
             });
 


### PR DESCRIPTION
Quick workaround. Havel is already working on the feature fix.
Problem is that there atm two close buttons on device switcher modal


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-test-db-migration&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-test-db-migration&lookback=7)