### PR TITLE
fix/native/enable utxo selection for multiple accounts

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -1761,7 +1761,7 @@ export const en = {
             total: 'Total fee',
         },
         coinControl: {
-            cta: 'Select coins',
+            cta: 'Coin control',
             title: 'Coin control',
             search: {
                 placeholder: 'Search for address or transaction ID',

--- a/suite-native/module-send/src/atoms/coinControlAtoms.ts
+++ b/suite-native/module-send/src/atoms/coinControlAtoms.ts
@@ -1,5 +1,5 @@
 import { atom } from 'jotai';
 
-import { Utxo } from '@trezor/blockchain-link-types';
+import { SelectedUtxos } from '../types';
 
-export const selectedUtxosAtom = atom<Utxo[]>([]);
+export const selectedUtxosAtom = atom<SelectedUtxos>({});

--- a/suite-native/module-send/src/components/CoinControl/SendUtxoScreenHeader.tsx
+++ b/suite-native/module-send/src/components/CoinControl/SendUtxoScreenHeader.tsx
@@ -6,11 +6,12 @@ import { ScreenHeader } from '@suite-native/navigation';
 import { useUtxoSelection } from '../../hooks/useUtxoSelection';
 
 type SendUtxoScreenHeaderProps = {
+    accountKey: string;
     onDelete?: () => void;
 };
 
-export const SendUtxoScreenHeader = ({ onDelete }: SendUtxoScreenHeaderProps) => {
-    const { selectedUtxos, setSelectedUtxos } = useUtxoSelection();
+export const SendUtxoScreenHeader = ({ onDelete, accountKey }: SendUtxoScreenHeaderProps) => {
+    const { selectedUtxos, setSelectedUtxos } = useUtxoSelection(accountKey);
     const { translate } = useTranslate();
     const { showAlert } = useAlert();
 

--- a/suite-native/module-send/src/components/CoinControl/SwitchCoinControlButton.tsx
+++ b/suite-native/module-send/src/components/CoinControl/SwitchCoinControlButton.tsx
@@ -26,7 +26,8 @@ type SwitchCoinControlButtonProps = {
 };
 
 export const SwitchCoinControlButton = ({ accountKey, amount }: SwitchCoinControlButtonProps) => {
-    const { selectedUtxos, totalSelectedAmount, isCoinControlEnabled } = useUtxoSelection();
+    const { selectedUtxos, totalSelectedAmount, isCoinControlEnabled } =
+        useUtxoSelection(accountKey);
     const navigation = useNavigation<NavigationProps>();
 
     const isMissingUtxos = isCoinControlEnabled && amount && totalSelectedAmount.isLessThan(amount);

--- a/suite-native/module-send/src/components/CoinControl/__tests__/SendUtxosScreenHeader.comp.test.tsx
+++ b/suite-native/module-send/src/components/CoinControl/__tests__/SendUtxosScreenHeader.comp.test.tsx
@@ -24,7 +24,9 @@ describe('SendUtxosScreenHeader', () => {
             setSelectedUtxos: jest.fn(),
         });
 
-        const { getByTestId } = renderWithBasicProvider(<SendUtxoScreenHeader />);
+        const { getByTestId } = renderWithBasicProvider(
+            <SendUtxoScreenHeader accountKey="testAccKey" />,
+        );
 
         expect(getByTestId('coin-control-delete-button')).toBeTruthy();
     });
@@ -35,7 +37,9 @@ describe('SendUtxosScreenHeader', () => {
             setSelectedUtxos: jest.fn(),
         });
 
-        const { queryByTestId } = renderWithBasicProvider(<SendUtxoScreenHeader />);
+        const { queryByTestId } = renderWithBasicProvider(
+            <SendUtxoScreenHeader accountKey="testAccKey" />,
+        );
 
         expect(queryByTestId('coin-control-delete-button')).toBeNull();
     });

--- a/suite-native/module-send/src/components/OutputsReviewFooter.tsx
+++ b/suite-native/module-send/src/components/OutputsReviewFooter.tsx
@@ -99,7 +99,7 @@ export const OutputsReviewFooter = ({
     const { showAlert } = useAlert();
     const [isSendInProgress, setIsSendInProgress] = useState(false);
     const wasAppLeftDuringReview = useAtomValue(wasAppLeftDuringReviewAtom);
-    const { setSelectedUtxos } = useUtxoSelection();
+    const { setSelectedUtxos } = useUtxoSelection(accountKey);
 
     const isTransactionProcessedByBackend = !!useSelector((state: TransactionsRootState) =>
         selectTransactionByAccountKeyAndTxid(state, accountKey, txid),

--- a/suite-native/module-send/src/components/SendMaxButton.tsx
+++ b/suite-native/module-send/src/components/SendMaxButton.tsx
@@ -29,7 +29,7 @@ type SendMaxButtonProps = {
 export const SendMaxButton = ({ outputIndex, accountKey, tokenContract }: SendMaxButtonProps) => {
     const dispatch = useDispatch();
     const debounce = useDebounce();
-    const { selectedUtxos } = useUtxoSelection();
+    const { selectedUtxos } = useUtxoSelection(accountKey);
 
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),

--- a/suite-native/module-send/src/hooks/__tests__/useUtxoSelection.hook.test.ts
+++ b/suite-native/module-send/src/hooks/__tests__/useUtxoSelection.hook.test.ts
@@ -1,9 +1,11 @@
 import { useAtom } from 'jotai';
 
 import { renderHook } from '@suite-native/test-utils';
-import { Utxo } from '@trezor/blockchain-link-types';
 
+import { SelectedUtxos } from '../../types';
 import { useUtxoSelection } from '../useUtxoSelection';
+
+const accountKey = 'testAccKey';
 
 jest.mock('jotai', () => ({
     useAtom: jest.fn(() => [[], jest.fn()]),
@@ -28,7 +30,7 @@ describe('useUtxoSelection', () => {
     it('should return an empty array when no UTXOs are selected', () => {
         (useAtom as jest.Mock).mockReturnValue([[], mockSetSelectedUtxos]);
 
-        const { result } = renderHook(() => useUtxoSelection());
+        const { result } = renderHook(() => useUtxoSelection(accountKey));
 
         expect(result.current.selectedUtxos).toEqual([]);
         expect(result.current.totalSelectedAmount.toString()).toEqual('0');
@@ -36,30 +38,56 @@ describe('useUtxoSelection', () => {
     });
 
     it('should calculate total selected amount correctly', () => {
-        const mockUtxos: Utxo[] = [
-            {
-                txid: 'txid1',
-                vout: 0,
-                amount: '1000',
-                blockHeight: 123456,
-                address: 'address1',
-                path: 'm/44/0/0/0',
-                confirmations: 10,
-            },
-            {
-                txid: 'txid2',
-                vout: 1,
-                amount: '2000',
-                blockHeight: 123457,
-                address: 'address2',
-                path: 'm/44/0/0/1',
-                confirmations: 20,
-            },
-        ];
+        const mockUtxos: SelectedUtxos = {
+            [accountKey]: [
+                {
+                    txid: 'txid1',
+                    vout: 0,
+                    amount: '1000',
+                    blockHeight: 123456,
+                    address: 'address1',
+                    path: 'm/44/0/0/0',
+                    confirmations: 10,
+                },
+                {
+                    txid: 'txid2',
+                    vout: 1,
+                    amount: '2000',
+                    blockHeight: 123457,
+                    address: 'address2',
+                    path: 'm/44/0/0/1',
+                    confirmations: 20,
+                },
+            ],
+        };
         (useAtom as jest.Mock).mockReturnValue([mockUtxos, mockSetSelectedUtxos]);
 
-        const { result } = renderHook(() => useUtxoSelection());
+        const { result } = renderHook(() => useUtxoSelection(accountKey));
 
         expect(result.current.totalSelectedAmount.toString()).toEqual('3000');
+    });
+
+    it('should handle correct account key UTXO selection', () => {
+        (useAtom as jest.Mock).mockReturnValue([
+            {
+                ['testAccKey2']: [
+                    {
+                        txid: 'txid1',
+                        vout: 0,
+                        amount: '1000',
+                        blockHeight: 123456,
+                        address: 'address1',
+                        path: 'm/44/0/0/0',
+                        confirmations: 10,
+                    },
+                ],
+            },
+            mockSetSelectedUtxos,
+        ]);
+
+        const { result } = renderHook(() => useUtxoSelection(accountKey));
+
+        expect(result.current.selectedUtxos).toEqual([]);
+        expect(result.current.totalSelectedAmount.toString()).toEqual('0');
     });
 });

--- a/suite-native/module-send/src/hooks/useSendForm.ts
+++ b/suite-native/module-send/src/hooks/useSendForm.ts
@@ -66,7 +66,7 @@ export const useSendForm = (accountKey: string, tokenContract?: TokenAddress) =>
     const navigation =
         useNavigation<StackNavigationProps<SendStackParamList, SendStackRoutes.SendOutputs>>();
 
-    const { selectedUtxos } = useUtxoSelection();
+    const { selectedUtxos } = useUtxoSelection(accountKey);
 
     const [feeLevelsMaxAmount, setFeeLevelsMaxAmount] = useState<FeeLevelsMaxAmount>();
 

--- a/suite-native/module-send/src/hooks/useUtxoSelection.ts
+++ b/suite-native/module-send/src/hooks/useUtxoSelection.ts
@@ -15,8 +15,13 @@ type UseUtxoSelectionReturn = {
     setSelectedUtxos: (utxos: Utxo[]) => void;
 };
 
-export const useUtxoSelection = (): UseUtxoSelectionReturn => {
-    const [selectedUtxos, setSelectedUtxos] = useAtom(selectedUtxosAtom);
+export const useUtxoSelection = (accountKey: string): UseUtxoSelectionReturn => {
+    const [selectedUtxosMap, setSelectedUtxosMap] = useAtom(selectedUtxosAtom);
+
+    const selectedUtxos = useMemo(
+        () => selectedUtxosMap[accountKey] || [],
+        [selectedUtxosMap, accountKey],
+    );
 
     const isCoinControlEnabled = useMemo(() => selectedUtxos.length > 0, [selectedUtxos]);
     const totalSelectedAmount = useMemo(
@@ -25,11 +30,27 @@ export const useUtxoSelection = (): UseUtxoSelectionReturn => {
     );
 
     const handleUtxoSelection = (utxo: Utxo) => {
-        setSelectedUtxos(prev =>
-            prev.some(selected => selected.address === utxo.address)
-                ? prev.filter(selected => selected.address !== utxo.address)
-                : [...prev, utxo],
-        );
+        setSelectedUtxosMap(prev => {
+            const isSelected = selectedUtxos.some(
+                selected => selected.txid === utxo.txid && selected.vout === utxo.vout,
+            );
+
+            return {
+                ...prev,
+                [accountKey]: isSelected
+                    ? selectedUtxos.filter(
+                          selected => !(selected.txid === utxo.txid && selected.vout === utxo.vout),
+                      )
+                    : [...selectedUtxos, utxo],
+            };
+        });
+    };
+
+    const setSelectedUtxos = (utxos: Utxo[]) => {
+        setSelectedUtxosMap(prev => ({
+            ...prev,
+            [accountKey]: utxos,
+        }));
     };
 
     return {

--- a/suite-native/module-send/src/screens/SendOutputsScreen.tsx
+++ b/suite-native/module-send/src/screens/SendOutputsScreen.tsx
@@ -18,7 +18,7 @@ export const SendOutputsScreen = ({
 }: StackProps<SendStackParamList, SendStackRoutes.SendOutputs>) => {
     const { accountKey, tokenContract } = params;
     const sendForm = useSendForm(accountKey, tokenContract);
-    const { totalSelectedAmount, selectedUtxos } = useUtxoSelection();
+    const { totalSelectedAmount, selectedUtxos } = useUtxoSelection(accountKey);
 
     if (!sendForm) {
         return null;

--- a/suite-native/module-send/src/screens/SendUtxoScreen.tsx
+++ b/suite-native/module-send/src/screens/SendUtxoScreen.tsx
@@ -27,7 +27,7 @@ export const SendUtxoScreen = ({
 
     const searchInputRef = useRef<TextInput>(null);
 
-    const { selectedUtxos, setSelectedUtxos } = useUtxoSelection();
+    const { selectedUtxos, setSelectedUtxos } = useUtxoSelection(accountKey);
     const [searchQuery, setSearchQuery] = useState<string>('');
 
     const [tempSelectedUtxos, setTempSelectedUtxos] = useState<Utxo[]>(selectedUtxos ?? []);
@@ -66,6 +66,7 @@ export const SendUtxoScreen = ({
             isScrollable={false}
             header={
                 <SendUtxoScreenHeader
+                    accountKey={accountKey}
                     onDelete={() => {
                         navigation.goBack();
                     }}

--- a/suite-native/module-send/src/types.ts
+++ b/suite-native/module-send/src/types.ts
@@ -10,6 +10,7 @@ import {
     ReviewOutputState,
     TokenAddress,
 } from '@suite-common/wallet-types';
+import { Utxo } from '@trezor/blockchain-link-types';
 
 export type StatefulReviewOutput = ReviewOutput & { state: ReviewOutputState };
 
@@ -29,3 +30,4 @@ export type SendAmountInputProps = {
 };
 
 export type FeeLevelsMaxAmount = Record<FeeLevelLabel, string | undefined>;
+export type SelectedUtxos = { [accountKey: AccountKey]: Utxo[] };


### PR DESCRIPTION
This PR fixes edge case when user selects UTXOs in Coin Control feature and decide to switch to a different wallet where it looks like it still selected.

`useUtxoSelection` now saves the selected UTXOs per `accountKey` and persists the selection for each wallet send form state. (as the form does)

Also, a copy update - `Select coins` is switched to `Coin control` button


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/enable-utxo-selection-for-multiple-accounts&lookback=7)