### PR TITLE
Hide the signature format switch if it doesn't matter

### DIFF
--- a/packages/suite/src/views/wallet/sign-verify/index.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/index.tsx
@@ -104,6 +104,12 @@ const SignVerify = () => {
         }
     };
 
+    // Empty accountTypes means there is only 'normal' accountType and therefore the signatures are same.
+    const signFormatsDiffer =
+        selectedAccount.account!.networkType === 'bitcoin' &&
+        selectedAccount.account!.accountType !== 'legacy' &&
+        Object.keys(selectedAccount.network!.accountTypes).length >= 1;
+
     return (
         <WalletLayout title="TR_NAV_SIGN_VERIFY" isSubpage account={selectedAccount}>
             <WalletSubpageHeading title="TR_NAV_SIGN_VERIFY">
@@ -166,43 +172,45 @@ const SignVerify = () => {
                                         data-testid="@sign-verify/sign-address"
                                         {...pathField}
                                     />
-                                    <SelectBar
-                                        label={
-                                            <Tooltip
-                                                maxWidth={330}
-                                                content={
-                                                    <Translation
-                                                        id="TR_FORMAT_TOOLTIP"
-                                                        values={{
-                                                            FormatDescription: chunks => (
-                                                                <p>{chunks}</p>
-                                                            ),
-                                                            span: chunks => (
-                                                                <strong>{chunks}</strong>
-                                                            ),
-                                                        }}
-                                                    />
-                                                }
-                                                hasIcon
-                                            >
-                                                <Translation id="TR_FORMAT" />
-                                            </Tooltip>
-                                        }
-                                        options={[
-                                            {
-                                                value: false,
-                                                label: <Translation id="TR_BIP_SIG_FORMAT" />,
-                                            },
-                                            {
-                                                value: true,
-                                                label: (
-                                                    <Translation id="TR_COMPATIBILITY_SIG_FORMAT" />
-                                                ),
-                                            },
-                                        ]}
-                                        data-testid="@sign-verify/format"
-                                        {...isElectrumField}
-                                    />
+                                    {signFormatsDiffer && (
+                                        <SelectBar
+                                            label={
+                                                <Tooltip
+                                                    maxWidth={330}
+                                                    content={
+                                                        <Translation
+                                                            id="TR_FORMAT_TOOLTIP"
+                                                            values={{
+                                                                FormatDescription: chunks => (
+                                                                    <p>{chunks}</p>
+                                                                ),
+                                                                span: chunks => (
+                                                                    <strong>{chunks}</strong>
+                                                                ),
+                                                            }}
+                                                        />
+                                                    }
+                                                    hasIcon
+                                                >
+                                                    <Translation id="TR_FORMAT" />
+                                                </Tooltip>
+                                            }
+                                            options={[
+                                                {
+                                                    value: false,
+                                                    label: <Translation id="TR_BIP_SIG_FORMAT" />,
+                                                },
+                                                {
+                                                    value: true,
+                                                    label: (
+                                                        <Translation id="TR_COMPATIBILITY_SIG_FORMAT" />
+                                                    ),
+                                                },
+                                            ]}
+                                            data-testid="@sign-verify/format"
+                                            {...isElectrumField}
+                                        />
+                                    )}
                                 </Row>
                                 <Divider margin={{}} />
                                 <Input


### PR DESCRIPTION
The format switch in Sign & Verify is hidden if the signiture is same in both formats - Only shown for non-legacy bitcoin and litecoin

## Related Issue

Resolve #7674

## Screenshots

Bitcoin:
<img width="1809" height="849" alt="sign-bitcoin" src="https://github.com/user-attachments/assets/a805aebd-8741-4000-8185-afd71be9ebdf" />

Ethereum:
<img width="1794" height="807" alt="sign-ethereum" src="https://github.com/user-attachments/assets/7cce98eb-2dda-41ed-82ba-1a4f449e9612" />
