### PR TITLE
fix(suite): walletconnect SIWE flow

### DIFF
--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -29,7 +29,7 @@ export const sessionAuthenticateThunk = createThunk<
     {
         event: WalletKitTypes.SessionAuthenticate;
     }
->(`${WALLETCONNECT_MODULE}/sessionAuthenticateThunk`, async ({ event }, { getState }) => {
+>(`${WALLETCONNECT_MODULE}/sessionAuthenticateThunk`, async ({ event }, { getState, dispatch }) => {
     // Support for Sign-In with Ethereum (SIWE) message, enhanced by ReCaps (ReCap Capabilities)
     try {
         const device = selectSelectedDevice(getState());
@@ -70,13 +70,25 @@ export const sessionAuthenticateThunk = createThunk<
             iss,
         );
 
-        await walletKit.approveSessionAuthenticate({
+        const { session } = await walletKit.approveSessionAuthenticate({
             id: event.id,
             auths: [auth],
         });
+        if (session) {
+            dispatch(
+                walletConnectActions.saveSession({
+                    ...session,
+                    validation: event.verifyContext.verified.validation,
+                }),
+            );
+        }
     } catch (error) {
-        console.error(error);
-
+        dispatch(
+            notificationsActions.addToast({
+                type: 'error',
+                error: `WalletConnect pairing failed - ${error.message}`,
+            }),
+        );
         await walletKit.rejectSessionAuthenticate({
             id: event.id,
             reason: getSdkError('USER_REJECTED'),


### PR DESCRIPTION
## Description

Improve WalletConnect SIWE (Sign in with Ethereum) flow. 
This is a flow where the connection is authorized by signing a message on the device. 
Can be tested with: https://appkit-lab.reown.com/library/wagmi-siwe/

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/walletconnect-siwe&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/walletconnect-siwe&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/walletconnect-siwe&lookback=7)