### PR TITLE
feat(connect): base58 encoding of solanaGetPublicKey

### DIFF
--- a/packages/connect-explorer/src/pages/methods/solana/solanaGetPublicKey.mdx
+++ b/packages/connect-explorer/src/pages/methods/solana/solanaGetPublicKey.mdx
@@ -81,6 +81,7 @@ Result with only one public key
         path: Array<number>, // hardended path
         serializedPath: string,
         publicKey: string,
+        publicKeyBase58: string,
     }
 }
 ```

--- a/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
+++ b/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
@@ -1,3 +1,5 @@
+import bs58 from 'bs58';
+
 import { Assert } from '@trezor/schema-utils';
 
 import { PROTO } from '../../../constants';
@@ -69,6 +71,7 @@ export default class SolanaGetPublicKey extends AbstractMethod<
                 path: batch.address_n,
                 serializedPath: getSerializedPath(batch.address_n),
                 publicKey: message.public_key,
+                publicKeyBase58: bs58.encode(Buffer.from(message.public_key, 'hex')),
             });
 
             if (this.hasBundle) {

--- a/packages/connect/src/types/api/solana/index.ts
+++ b/packages/connect/src/types/api/solana/index.ts
@@ -9,6 +9,7 @@ export const SolanaPublicKey = Type.Intersect([
     PublicKey,
     Type.Object({
         publicKey: Type.String(),
+        publicKeyBase58: Type.String(),
     }),
 ]);
 

--- a/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
+++ b/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
@@ -1,4 +1,4 @@
-import TrezorConnect, { Address } from '@trezor/connect';
+import TrezorConnect, { Address, SolanaPublicKey } from '@trezor/connect';
 import { HDNodeResponse } from '@trezor/connect/src/types/api/getPublicKey';
 
 import { connectPopupActions } from '../connectPopupActions';
@@ -70,6 +70,9 @@ export function postCallHook<M extends keyof typeof TrezorConnect>({
                 // NOTE: it's possible in some cases there will be a mismatch between the public key format on the device and the one in the app
                 // For BTC
                 if (method === 'getPublicKey') return item.xpubSegwit || item.xpub;
+                // For SOL
+                if (method === 'solanaGetPublicKey')
+                    return (item as any as SolanaPublicKey).publicKeyBase58;
 
                 // For other altcoins
                 return item.publicKey;


### PR DESCRIPTION
## Description

Add Base58-encoded version to `solanaGetPublicKey` response. 
This is the commonly used format for Solana and it is displayed on device when verifying, so previously what we would show wouldn't match the device. 

Also update Connect confirmation flow in Suite to use this format.

**For Connect 10** - I would probably deprecate `solanaGetPublicKey` and keep only `solanaGetAddress`.

## Screenshots:

After fix - previously this would show hex in Suite.

<img width="1168" height="746" alt="Screenshot 2025-07-11 at 14 55 14" src="https://github.com/user-attachments/assets/8607fba5-ecda-48ff-928a-5c5c87f0e27a" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/solana-getpublickey-base58&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/solana-getpublickey-base58&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/solana-getpublickey-base58&lookback=7)