### PR TITLE
fix(suite-native): use token decimals for fiat to crypto conversion in send

### DIFF
--- a/suite-native/module-send/src/components/AmountInputs.tsx
+++ b/suite-native/module-send/src/components/AmountInputs.tsx
@@ -136,6 +136,7 @@ export const AmountInputs = ({ index }: AmountInputProps) => {
                                 scaleValue={fiatScale}
                                 translateValue={fiatTranslateY}
                                 inputRef={fiatRef}
+                                accountKey={accountKey}
                                 isDisabled={isCryptoSelected}
                                 symbol={symbol}
                                 tokenContract={tokenContract}

--- a/suite-native/module-send/src/components/FiatAmountInput.tsx
+++ b/suite-native/module-send/src/components/FiatAmountInput.tsx
@@ -2,12 +2,18 @@ import { Pressable } from 'react-native';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
+import { TokenDefinitionsRootState } from '@suite-common/token-definitions';
 import { getNetwork } from '@suite-common/wallet-config';
-import { selectLocalCurrency } from '@suite-common/wallet-core';
+import {
+    DeviceRootState,
+    TransactionsRootState,
+    selectLocalCurrency,
+} from '@suite-common/wallet-core';
 import { Input } from '@suite-native/atoms';
 import { useCryptoFiatConverters } from '@suite-native/formatters';
 import { useField, useFormContext } from '@suite-native/forms';
 import { useAmountInputTransformers } from '@suite-native/helpers';
+import { selectAccountTokenDecimals } from '@suite-native/tokens';
 import { useNativeStyles } from '@trezor/styles';
 
 import { SendAmountCurrencyLabelWrapper, sendAmountInputWrapperStyle } from './CryptoAmountInput';
@@ -25,12 +31,17 @@ export const FiatAmountInput = ({
     onPress,
     onFocus,
     isDisabled = false,
+    accountKey,
 }: SendAmountInputProps) => {
     const { applyStyle } = useNativeStyles();
     const { setValue } = useFormContext<SendOutputsFormValues>();
     const fiatCurrencyCode = useSelector(selectLocalCurrency);
     const { fiatAmountTransformer } = useAmountInputTransformers(symbol);
     const { decimals } = getNetwork(symbol);
+    const tokenDecimals = useSelector(
+        (state: DeviceRootState & TokenDefinitionsRootState & TransactionsRootState) =>
+            selectAccountTokenDecimals(state, accountKey, tokenContract),
+    );
     const converters = useCryptoFiatConverters({ symbol, tokenContract });
 
     const cryptoFieldName = getOutputFieldName(recipientIndex, 'amount');
@@ -60,7 +71,10 @@ export const FiatAmountInput = ({
 
         const cryptoValue = converters?.convertFiatToCrypto?.(transformedValue);
         if (cryptoValue) {
-            setValue(cryptoFieldName, cryptoValue.toFixed(decimals), { shouldValidate: true });
+            const cryptoDecimals = tokenDecimals ?? decimals;
+            setValue(cryptoFieldName, cryptoValue.toFixed(cryptoDecimals), {
+                shouldValidate: true,
+            });
         }
 
         setValue('setMaxOutputId', undefined);


### PR DESCRIPTION
Previously network decimals were used for tokens when inserting fiat price for crypto to be sent. If token had less decimals (on solana this is very often) it caused validation error for the amount of crypto that was computed. 

Now it uses token decimals for tokens

## Related Issue

Resolve #17617
Resolve #18404

## Screenshots:

BEFORE:

https://github.com/user-attachments/assets/86803c17-5821-4d3a-b01a-e6a37d91d062

AFTER:

https://github.com/user-attachments/assets/7c5f6731-8eb6-490f-be1d-59987c953b74



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=17617-solana-mobile---not-possible-to-send-tokens-exact-amount-in-fiat-value&lookback=7)