### PR TITLE
feat(suite): nicer MessageSystemDebugInfo

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystemDebugInfo.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystemDebugInfo.tsx
@@ -11,6 +11,23 @@ import { useSelector } from 'src/hooks/suite';
 const serializeCategory = (category: Message['category']): string =>
     typeof category === 'string' ? category : category.join(', ');
 
+const MessageItemContent = ({ message }: { message: Message }) => {
+    if (message.category.includes('feature')) {
+        return <pre>{JSON.stringify(message.feature, null, 2)}</pre>;
+    }
+
+    return <Paragraph>{message.content.en}</Paragraph>;
+};
+
+const MessageItem = ({ message }: { message: Message }) => (
+    <div>
+        <Paragraph typographyStyle="highlight">
+            {message.id} ({serializeCategory(message.category)})
+        </Paragraph>
+        <MessageItemContent message={message} />
+    </div>
+);
+
 export const MessageSystemDebugInfo = () => {
     const config = useSelector(selectMessageSystemConfig);
     const allValidMessages = useSelector(selectAllValidMessages);
@@ -45,12 +62,7 @@ export const MessageSystemDebugInfo = () => {
                 <Modal onCancel={handleCloseValidMessages}>
                     <Column gap={spacings.sm}>
                         {allValidMessages.map(m => (
-                            <div key={m.id}>
-                                <Paragraph typographyStyle="highlight">
-                                    {m.id} ({serializeCategory(m.category)})
-                                </Paragraph>
-                                <Paragraph>{m.content.en}</Paragraph>
-                            </div>
+                            <MessageItem key={m.id} message={m} />
                         ))}
                     </Column>
                 </Modal>


### PR DESCRIPTION
## Description

Enhance the dialog in Debug Settings that lists active message-system messages, so it shows feature payload instead of placehodler for `feature` type messages.

## Screenshots:

**Before:**

<img width="731" height="454" alt="MessageSystemDebugInfo B4" src="https://github.com/user-attachments/assets/d95aebbf-5fd7-481c-ac6c-bbabd5784669" />


**After:**

<img width="731" height="454" alt="MessageSystemDebugInfo" src="https://github.com/user-attachments/assets/52797320-4755-4b25-bafa-0daae51b7db1" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/nicer-MessageSystemDebugInfo&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/nicer-MessageSystemDebugInfo&lookback=7)