### PR TITLE
Add kyc warning to Exchange provider in form

### DIFF
--- a/suite-common/trading/src/__tests__/utils.test.ts
+++ b/suite-common/trading/src/__tests__/utils.test.ts
@@ -22,6 +22,7 @@ import {
     getTradingQuotesByPaymentMethod,
     getUnusedAddressFromAccount,
     isCryptoIdForNativeToken,
+    isFinalStatus,
     mapTestnetSymbol,
     testnetToProdCryptoId,
     toTokenCryptoId,
@@ -318,5 +319,33 @@ describe('getBestRatedQuote', () => {
         expect(getBestRatedQuote(EXCHANGE_FIXTURE.MIN_MAX_QUOTES_OK, 'exchange')).toStrictEqual(
             EXCHANGE_FIXTURE.MIN_MAX_QUOTES_OK[EXCHANGE_FIXTURE.MIN_MAX_QUOTES_OK.length - 1],
         );
+    });
+});
+
+describe('isFinalStatus', () => {
+    it.each([
+        ['buy', 'SUCCESS', true],
+        ['buy', 'ERROR', true],
+        ['buy', 'BLOCKED', true],
+        ['buy', 'SUBMITTED', false],
+        ['buy', 'WAITING_FOR_USER', false],
+        ['buy', 'APPROVAL_PENDING', false],
+        ['buy', undefined, false],
+        ['sell', 'SUCCESS', true],
+        ['sell', 'ERROR', true],
+        ['sell', 'BLOCKED', true],
+        ['sell', 'CANCELLED', true],
+        ['sell', 'REFUNDED', true],
+        ['sell', 'SEND_CRYPTO', false],
+        ['sell', 'SUBMITTED', false],
+        ['sell', undefined, false],
+        ['exchange', 'SUCCESS', true],
+        ['exchange', 'ERROR', true],
+        ['exchange', 'KYC', true],
+        ['exchange', 'CONVERTING', false],
+        ['exchange', 'APPROVAL_PENDING', false],
+        ['exchange', undefined, false],
+    ])('should return %s for %s trade with %s status', (tradeType, status, expectedResult) => {
+        expect(isFinalStatus(tradeType as any, status as any)).toBe(expectedResult);
     });
 });

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -28,6 +28,7 @@ import {
     cryptoIdToNetwork,
     getBestRatedQuote,
     getTradingQuotesByPaymentMethod,
+    isExchangeProvider,
     testnetToProdCryptoId,
 } from '../utils';
 import {
@@ -283,7 +284,7 @@ export const selectTradingProviderKycPolicy = (
     const provider = selectTradingProviderByNameAndTradeType(state, name, type);
 
     // Only ExchangeProviderInfo has kycPolicyType property
-    if (provider && 'kycPolicyType' in provider) {
+    if (provider && isExchangeProvider(provider)) {
         return provider.kycPolicyType;
     }
 

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -275,6 +275,21 @@ export const selectTradingProviderByNameAndTradeType = (
     }
 };
 
+export const selectTradingProviderKycPolicy = (
+    state: TradingRootState,
+    name: string | undefined,
+    type: TradingType,
+) => {
+    const provider = selectTradingProviderByNameAndTradeType(state, name, type);
+
+    // Only ExchangeProviderInfo has kycPolicyType property
+    if (provider && 'kycPolicyType' in provider) {
+        return provider.kycPolicyType;
+    }
+
+    return undefined;
+};
+
 export const selectTradingBuyQuotesRequest = (state: TradingRootState) =>
     state.wallet.tradingNew.buy.quotesRequest;
 

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -1,4 +1,12 @@
-import { BuyTrade, CryptoId, ExchangeTrade, SellFiatTrade } from 'invity-api';
+import {
+    BuyTrade,
+    BuyTradeFinalStatus,
+    CryptoId,
+    ExchangeTrade,
+    ExchangeTradeFinalStatus,
+    SellFiatTrade,
+    SellTradeFinalStatus,
+} from 'invity-api';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
@@ -19,9 +27,12 @@ import {
     TradingParsedCryptoIdProps,
     TradingPaymentMethodListProps,
     TradingPaymentMethodProps,
+    TradingProviderInfo,
     TradingTradeBuySellMapProps,
     TradingTradeBuySellType,
     TradingTradeMapProps,
+    TradingTradeStatusType,
+    TradingTradeType,
     TradingType,
 } from './types';
 
@@ -247,3 +258,26 @@ export const getBestRatedQuote = <T extends TradingType>(
 
     return bestRatedQuotes[0];
 };
+
+export const tradeFinalStatuses: Record<TradingType, TradingTradeStatusType[]> = {
+    buy: ['SUCCESS', 'ERROR', 'BLOCKED'] satisfies BuyTradeFinalStatus[],
+    sell: ['SUCCESS', 'ERROR', 'BLOCKED', 'CANCELLED', 'REFUNDED'] satisfies SellTradeFinalStatus[],
+    exchange: ['SUCCESS', 'ERROR', 'KYC'] satisfies ExchangeTradeFinalStatus[],
+};
+
+export const isFinalStatus = (
+    tradingType: TradingType,
+    tradeStatus: TradingTradeStatusType | undefined,
+) => (tradeStatus ? tradeFinalStatuses[tradingType].includes(tradeStatus) : false);
+
+export const isBuyTrade = (quote: TradingTradeType): quote is BuyTrade =>
+    'fiatStringAmount' in quote && 'receiveStringAmount' in quote;
+
+export const isSellFiatTrade = (quote: TradingTradeType): quote is SellFiatTrade =>
+    'cryptoStringAmount' in quote && 'fiatStringAmount' in quote;
+
+export const isExchangeTrade = (quote: TradingTradeType): quote is ExchangeTrade =>
+    'sendStringAmount' in quote && 'receiveStringAmount' in quote;
+
+export const isExchangeProvider = (provider: TradingProviderInfo) =>
+    provider && 'kycPolicyType' in provider;

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -1924,6 +1924,13 @@ export const en = {
         },
     },
     moduleTrading: {
+        kyc: {
+            dex: 'KYC never required. DEX swaps either succeed or fail.',
+            noKyc: 'KYC never required. Exceptional cases automatically refunded.',
+            noRefund: 'KYC is only requested in exceptional cases. KYC required for refunds.',
+            yesRefund: "KYC is only requested in exceptional cases. It's not required for refunds.",
+            kycRequired: 'This provider requires to verify identity.',
+        },
         tradingScreen: {
             buyTitle: 'Buy',
             receiveAccount: 'Receive account',

--- a/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
@@ -3,7 +3,12 @@ import { useSelector } from 'react-redux';
 import { BuyTrade } from 'invity-api';
 
 import { invariant } from '@suite-common/suite-utils';
-import { selectTradingBuyIsLoading, selectTradingBuyProviders } from '@suite-common/trading';
+import {
+    TradingRootState as TradingRootStateCommon,
+    selectTradingBuyIsLoading,
+    selectTradingBuyProviders,
+    selectTradingProviderByNameAndTradeType,
+} from '@suite-common/trading';
 import { EventType, analytics } from '@suite-native/analytics';
 import { HStack, Text } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
@@ -20,26 +25,24 @@ import { ProviderSheet } from '../general/ProviderSheet/ProviderSheet';
 type BuyProviderPickerRightProps = {
     isLoading: boolean;
     selectedValue: BuyTrade | undefined;
-    providers: ReturnType<typeof selectTradingBuyProviders>;
 };
 
 const PROVIDER_PICKER_TEST_ID = '@trading/buy/provider-picker';
 
-const BuyProviderPickerRight = ({
-    isLoading,
-    selectedValue,
-    providers,
-}: BuyProviderPickerRightProps) => {
+const BuyProviderPickerRight = ({ isLoading, selectedValue }: BuyProviderPickerRightProps) => {
     const { translate } = useTranslate();
+    const { exchange } = selectedValue ?? {};
+
+    const provider = useSelector((state: TradingRootStateCommon) =>
+        selectTradingProviderByNameAndTradeType(state, exchange, 'buy'),
+    );
 
     if (isLoading) {
         return <OverviewValueSkeleton />;
     }
 
-    const { exchange } = selectedValue ?? {};
-    const selectedProvider = exchange ? providers?.[exchange] : undefined;
-    invariant(selectedProvider, 'Selected provider should be defined');
-    const { companyName, logo } = selectedProvider;
+    invariant(provider, 'Selected provider should be defined');
+    const { companyName, logo } = provider;
 
     return (
         <HStack>
@@ -114,11 +117,7 @@ export const BuyProviderPicker = () => {
                     isLoading ? undefined : translate('moduleTrading.tradingScreen.kycWarning')
                 }
             >
-                <BuyProviderPickerRight
-                    isLoading={isLoading}
-                    selectedValue={selectedValue}
-                    providers={providers}
-                />
+                <BuyProviderPickerRight isLoading={isLoading} selectedValue={selectedValue} />
             </OverviewRow>
             <ProviderSheet
                 quotes={quotes}

--- a/suite-native/module-trading/src/components/exchange/ExchangeProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeProviderPicker.tsx
@@ -3,12 +3,17 @@ import { useSelector } from 'react-redux';
 import { ExchangeTrade } from 'invity-api';
 
 import { invariant } from '@suite-common/suite-utils';
-import { selectTradingExchangeProviders } from '@suite-common/trading';
+import {
+    TradingRootState,
+    selectTradingProviderByNameAndTradeType,
+    selectTradingProviderKycPolicy,
+} from '@suite-common/trading';
 import { HStack, Text } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 
 import { useExchangeFormContext } from '../../hooks/exchange/useExchangeFormContext';
 import { selectTradingExchangeIsLoading } from '../../selectors/exchangeSelectors';
+import { getKycPolicyWarningTranslation } from '../../utils/general/kycUtils';
 import { OverviewRow } from '../general/OverviewRow';
 import { OverviewValueSkeleton } from '../general/OverviewValueSkeleton';
 import { ProviderLogo } from '../general/ProviderLogo';
@@ -24,16 +29,17 @@ const ExchangeProviderPickerRight = ({
     selectedValue,
 }: ExchangeProviderPickerRightProps) => {
     const { translate } = useTranslate();
-    const providers = useSelector(selectTradingExchangeProviders);
+    const { exchange } = selectedValue ?? {};
+    const provider = useSelector((state: TradingRootState) =>
+        selectTradingProviderByNameAndTradeType(state, exchange, 'exchange'),
+    );
 
     if (isLoading) {
         return <OverviewValueSkeleton />;
     }
 
-    const { exchange = '' } = selectedValue ?? {};
-    const selectedProvider = providers?.[exchange];
-    invariant(selectedProvider, 'Selected provider should be defined');
-    const { companyName, logo } = selectedProvider;
+    invariant(provider, 'Selected provider should be defined');
+    const { companyName, logo } = provider;
 
     return (
         <HStack>
@@ -55,6 +61,10 @@ export const ExchangeProviderPicker = () => {
     const isLoading = useSelector(selectTradingExchangeIsLoading);
 
     const selectedValue = watch('quote');
+    const kycPolicy = useSelector((state: TradingRootState) =>
+        selectTradingProviderKycPolicy(state, selectedValue?.exchange, 'exchange'),
+    );
+    const warning = isLoading ? undefined : getKycPolicyWarningTranslation(kycPolicy);
 
     if (!selectedValue && !isLoading) {
         return null;
@@ -66,6 +76,7 @@ export const ExchangeProviderPicker = () => {
             noBottomBorder
             onPress={noop}
             noCaret={isLoading}
+            warning={warning}
         >
             <ExchangeProviderPickerRight isLoading={isLoading} selectedValue={selectedValue} />
         </OverviewRow>

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeProviderPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeProviderPicker.comp.test.tsx
@@ -1,6 +1,7 @@
 import { Form } from '@suite-native/forms';
 import {
     PreloadedState,
+    act,
     renderHookWithStoreProviderAsync,
     renderWithStoreProviderAsync,
 } from '@suite-native/test-utils';
@@ -48,7 +49,9 @@ describe('ExchangeProviderPicker', () => {
     });
 
     it('should render provider when quote is selected', async () => {
-        exchangeForm.setValue('quote', exchangeQuotes[0]);
+        act(() => {
+            exchangeForm.setValue('quote', exchangeQuotes[0]);
+        });
 
         const { getByText } = await renderExchangeProviderPicker();
 

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeRatePicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeRatePicker.comp.test.tsx
@@ -1,6 +1,7 @@
 import { Form } from '@suite-native/forms';
 import {
     PreloadedState,
+    act,
     renderHookWithStoreProviderAsync,
     renderWithStoreProviderAsync,
 } from '@suite-native/test-utils';
@@ -48,7 +49,9 @@ describe('ExchangeRatePicker', () => {
     });
 
     it('should render rate when quote is selected', async () => {
-        exchangeForm.setValue('quote', exchangeQuotes[0]);
+        act(() => {
+            exchangeForm.setValue('quote', exchangeQuotes[0]);
+        });
 
         const { getByText } = await renderExchangeRatePicker();
 

--- a/suite-native/module-trading/src/components/general/OverviewRow.tsx
+++ b/suite-native/module-trading/src/components/general/OverviewRow.tsx
@@ -13,7 +13,7 @@ export type TradeOverviewOptionProps = {
     noBottomBorder?: boolean;
     noCaret?: boolean;
     testID?: string;
-    warning?: string;
+    warning?: ReactNode;
 };
 
 const pressableStyle = prepareNativeStyle<{ noBottomBorder: boolean }>(

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.tsx
@@ -1,14 +1,14 @@
 import { Pressable } from 'react-native';
 
-import { TradingProviderInfo, TradingTradeType } from '@suite-common/trading';
+import { TradingProviderInfo, TradingTradeType, isBuyTrade } from '@suite-common/trading';
 import { Card, HStack, Radio, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
-import { isBuyTrade } from '../../../utils/general/utils';
 import { ProviderLogo } from '../ProviderLogo';
 import { InfoLineItem } from './InfoLineItem';
 import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
+import { getKycPolicyWarningTranslation } from '../../../utils/general/kycUtils';
 
 export type ProviderListItemProps<T extends TradingTradeType> = {
     isSelected: boolean;
@@ -42,7 +42,7 @@ export const ProviderListItem = <T extends TradingTradeType>({
 
     let isDex = false;
     let isAnonymous = false;
-    let requiresKyc = false;
+    let kycWarning;
 
     if ('kycPolicyType' in provider) {
         const kycPolicy = provider.kycPolicyType;
@@ -50,9 +50,9 @@ export const ProviderListItem = <T extends TradingTradeType>({
         isDex = kycPolicy === 'DEX';
 
         isAnonymous = kycPolicy === 'noKYC' || isDex;
-        requiresKyc = ['KYC-required', 'KYC-norefund', 'KYC-yesrefund'].includes(kycPolicy);
+        kycWarning = getKycPolicyWarningTranslation(kycPolicy);
     } else if (isBuyTrade(quote)) {
-        requiresKyc = true;
+        kycWarning = <Translation id="moduleTrading.providerListItem.kycRequired" />;
     }
 
     return (
@@ -107,10 +107,10 @@ export const ProviderListItem = <T extends TradingTradeType>({
                             textColor="baseContentBrand"
                         />
                     )}
-                    {requiresKyc && (
+                    {kycWarning && (
                         <InfoLineItem
                             iconName="warning"
-                            text={<Translation id="moduleTrading.providerListItem.kycRequired" />}
+                            text={kycWarning}
                             iconColor="iconAlertRed"
                             textColor="textAlertRed"
                         />

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailHeader.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailHeader.tsx
@@ -1,13 +1,17 @@
 import { useSelector } from 'react-redux';
 
-import { TradingRootState, selectTradingTradeByOrderId } from '@suite-common/trading';
+import {
+    TradingRootState,
+    isFinalStatus,
+    selectTradingTradeByOrderId,
+} from '@suite-common/trading';
 import { Box, CircularSpinner, VStack } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { TradeDetailErrorAlert } from './TradeDetailErrorAlert';
 import { TradeDetailWaitingAlert } from './TradeDetailWaitingAlert';
-import { getTradeStatusStep, isFinalStatus } from '../../../utils/general/utils';
+import { getTradeStatusStep } from '../../../utils/general/utils';
 import { TradeStatusBadge } from '../TradeStatusBadge';
 
 type TradeDetailHeaderProps = {

--- a/suite-native/module-trading/src/hooks/general/useWatchTrade.ts
+++ b/suite-native/module-trading/src/hooks/general/useWatchTrade.ts
@@ -7,13 +7,14 @@ import {
     TradingTransactionExchange,
     TradingTransactionSell,
     TradingType,
+    tradeFinalStatuses,
     tradingThunks,
 } from '@suite-common/trading';
 import { Account } from '@suite-common/wallet-types';
 import { EventType, analytics } from '@suite-native/analytics';
 
 import { useReloadTimer } from './useReloadTimer';
-import { getTradeStatusStep, tradeFinalStatuses } from '../../utils/general/utils';
+import { getTradeStatusStep } from '../../utils/general/utils';
 
 export type TradingTradeMapProps = {
     buy: TradingTransactionBuy;

--- a/suite-native/module-trading/src/utils/general/__tests__/kycUtils.test.tsx
+++ b/suite-native/module-trading/src/utils/general/__tests__/kycUtils.test.tsx
@@ -1,0 +1,45 @@
+import { ExchangeKYCType } from 'invity-api';
+
+import { Text } from '@suite-native/atoms';
+import { renderWithBasicProvider } from '@suite-native/test-utils';
+
+import { getKycPolicyWarningTranslation } from '../kycUtils';
+
+describe('getKycPolicyWarningTranslation', () => {
+    const renderTextWithTranslation = (type: ExchangeKYCType | undefined) => {
+        const component = getKycPolicyWarningTranslation(type);
+        if (!component) return null;
+
+        return renderWithBasicProvider(<Text>{component}</Text>);
+    };
+
+    it.each([
+        {
+            kycPolicyType: 'KYC-required' as const,
+            expected: 'This provider requires to verify identity.',
+        },
+        {
+            kycPolicyType: 'KYC-norefund' as const,
+            expected: 'KYC is only requested in exceptional cases. KYC required for refunds.',
+        },
+        {
+            kycPolicyType: 'KYC-yesrefund' as const,
+            expected: "KYC is only requested in exceptional cases. It's not required for refunds.",
+        },
+    ])('should return correct translation for $kycPolicyType', ({ kycPolicyType, expected }) => {
+        const result = renderTextWithTranslation(kycPolicyType);
+
+        expect(result).toBeTruthy();
+        expect(result?.getByText(expected)).toBeTruthy();
+    });
+
+    it.each([
+        { kycPolicyType: 'noKYC' as const },
+        { kycPolicyType: undefined },
+        { kycPolicyType: 'UNKNOWN_TYPE' as any },
+    ])('should return null for $kycPolicyType', ({ kycPolicyType }) => {
+        const component = getKycPolicyWarningTranslation(kycPolicyType);
+
+        expect(component).toBeNull();
+    });
+});

--- a/suite-native/module-trading/src/utils/general/__tests__/utils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/utils.test.ts
@@ -12,7 +12,6 @@ import {
     getTradeOperationData,
     getTradeStatusStep,
     getTradeTitle,
-    isFinalStatus,
 } from '../utils';
 
 describe('utils', () => {
@@ -68,34 +67,6 @@ describe('utils', () => {
                 toValue: undefined,
                 toCurrency: undefined,
             });
-        });
-    });
-
-    describe('isFinalStatus', () => {
-        it.each([
-            ['buy', 'SUCCESS', true],
-            ['buy', 'ERROR', true],
-            ['buy', 'BLOCKED', true],
-            ['buy', 'SUBMITTED', false],
-            ['buy', 'WAITING_FOR_USER', false],
-            ['buy', 'APPROVAL_PENDING', false],
-            ['buy', undefined, false],
-            ['sell', 'SUCCESS', true],
-            ['sell', 'ERROR', true],
-            ['sell', 'BLOCKED', true],
-            ['sell', 'CANCELLED', true],
-            ['sell', 'REFUNDED', true],
-            ['sell', 'SEND_CRYPTO', false],
-            ['sell', 'SUBMITTED', false],
-            ['sell', undefined, false],
-            ['exchange', 'SUCCESS', true],
-            ['exchange', 'ERROR', true],
-            ['exchange', 'KYC', true],
-            ['exchange', 'CONVERTING', false],
-            ['exchange', 'APPROVAL_PENDING', false],
-            ['exchange', undefined, false],
-        ])('should return %s for %s trade with %s status', (tradeType, status, expectedResult) => {
-            expect(isFinalStatus(tradeType as any, status as any)).toBe(expectedResult);
         });
     });
 

--- a/suite-native/module-trading/src/utils/general/kycUtils.tsx
+++ b/suite-native/module-trading/src/utils/general/kycUtils.tsx
@@ -1,0 +1,19 @@
+import { ExchangeKYCType } from 'invity-api';
+
+import { Translation } from '@suite-native/intl';
+
+export const getKycPolicyWarningTranslation = (kycPolicyType: ExchangeKYCType | undefined) => {
+    switch (kycPolicyType) {
+        case 'KYC-required':
+            return <Translation id="moduleTrading.kyc.kycRequired" />;
+
+        case 'KYC-norefund':
+            return <Translation id="moduleTrading.kyc.noRefund" />;
+
+        case 'KYC-yesrefund':
+            return <Translation id="moduleTrading.kyc.yesRefund" />;
+
+        default:
+            return null;
+    }
+};

--- a/suite-native/module-trading/src/utils/general/utils.ts
+++ b/suite-native/module-trading/src/utils/general/utils.ts
@@ -1,47 +1,18 @@
-import {
-    BuyTrade,
-    BuyTradeFinalStatus,
-    BuyTradeStatus,
-    CryptoId,
-    ExchangeTrade,
-    ExchangeTradeFinalStatus,
-    ExchangeTradeStatus,
-    SellFiatTrade,
-    SellTradeFinalStatus,
-    SellTradeStatus,
-} from 'invity-api';
+import { BuyTradeStatus, CryptoId, ExchangeTradeStatus, SellTradeStatus } from 'invity-api';
 
 import {
-    TradingTradeStatusType,
     TradingTradeType,
     TradingTransaction,
-    TradingType,
+    isBuyTrade,
+    isExchangeTrade,
+    isSellFiatTrade,
+    tradeFinalStatuses,
 } from '@suite-common/trading';
 import { useTranslate } from '@suite-native/intl';
 import { exhaustive } from '@trezor/type-utils';
 import { getWeakRandomId } from '@trezor/utils';
 
 import { INVITY_CALLBACK_TREZOR_BUY_URL, TRADING_URL_DEFAULT_BACK } from './formUtils';
-
-export const tradeFinalStatuses: Record<TradingType, TradingTradeStatusType[]> = {
-    buy: ['SUCCESS', 'ERROR', 'BLOCKED'] satisfies BuyTradeFinalStatus[],
-    sell: ['SUCCESS', 'ERROR', 'BLOCKED', 'CANCELLED', 'REFUNDED'] satisfies SellTradeFinalStatus[],
-    exchange: ['SUCCESS', 'ERROR', 'KYC'] satisfies ExchangeTradeFinalStatus[],
-};
-
-export const isFinalStatus = (
-    tradingType: TradingType,
-    tradeStatus: TradingTradeStatusType | undefined,
-) => (tradeStatus ? tradeFinalStatuses[tradingType].includes(tradeStatus) : false);
-
-export const isBuyTrade = (quote: TradingTradeType): quote is BuyTrade =>
-    'fiatStringAmount' in quote && 'receiveStringAmount' in quote;
-
-export const isSellFiatTrade = (quote: TradingTradeType): quote is SellFiatTrade =>
-    'cryptoStringAmount' in quote && 'fiatStringAmount' in quote;
-
-export const isExchangeTrade = (quote: TradingTradeType): quote is ExchangeTrade =>
-    'sendStringAmount' in quote && 'receiveStringAmount' in quote;
 
 type UndefinedTradeOperation = {
     fromValue: undefined;


### PR DESCRIPTION
Reused desktop translations for warnings

## Related Issue

Resolve #19531

## Screenshots:
<img width="300" src="https://github.com/user-attachments/assets/4cdf2c08-9ef7-494a-b826-fc0dde7e40c9" />
<img width="300" src="https://github.com/user-attachments/assets/99ec55a3-ec67-4262-9e05-4afbf6bd4673" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=19531-mobile-swap-add-kyc-warning-to-provider-row-exchange&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=19531-mobile-swap-add-kyc-warning-to-provider-row-exchange&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19531-mobile-swap-add-kyc-warning-to-provider-row-exchange&lookback=7)