### PR TITLE
fix(suite-native): fix Android Text's spacing

### DIFF
--- a/suite-native/app/e2e/pageObjects/tradingBuyActions.ts
+++ b/suite-native/app/e2e/pageObjects/tradingBuyActions.ts
@@ -131,8 +131,10 @@ class TradingBuyActions {
 
     async confirmBuyForm() {
         await element(by.id('@trading/buy/continue-button')).tap();
-        await waitForElementByIdToBeVisible('@trading/buy/confirm-button');
-        await element(by.id('@trading/buy/confirm-button')).tap();
+        const confirmButton = element(by.id('@trading/buy/confirm-button'));
+        const bottomSheetScrollView = element(by.id('@bottom-sheet/scroll-view'));
+        await bottomSheetScrollView.scrollTo('bottom');
+        await confirmButton.tap();
     }
 
     async closePaymentWebview() {

--- a/suite-native/atoms/src/Text.tsx
+++ b/suite-native/atoms/src/Text.tsx
@@ -54,17 +54,6 @@ type TextStyleProps = {
 export const TITLE_MAX_FONT_MULTIPLIER = 1.5;
 export const TEXT_MAX_FONT_MULTIPLIER = 2;
 
-const getAccessibilityFontScale = () => {
-    const fontScale = PixelRatio.getFontScale();
-
-    return fontScale < TEXT_MAX_FONT_MULTIPLIER ? fontScale : TEXT_MAX_FONT_MULTIPLIER;
-};
-
-/**
- * Defines maximal layout scale multiplier based on device accessibility settings.
- */
-export const ACCESSIBILITY_FONTSIZE_MULTIPLIER = getAccessibilityFontScale();
-
 /**
  * Accessibility inducted enlarging of font sizes is limited to prevent layout overflows.
  * Our UI design is not prepared for unlimited up-scaling.
@@ -79,6 +68,21 @@ const variantToMaxFontSizeMultiplier = {
     hint: TEXT_MAX_FONT_MULTIPLIER,
     label: TEXT_MAX_FONT_MULTIPLIER,
 } as const satisfies Record<NativeTypographyStyle, number>;
+
+const getAccessibilityFontScale = (variant?: NativeTypographyStyle) => {
+    const fontScale = PixelRatio.getFontScale();
+
+    const maxFontScale = variant
+        ? variantToMaxFontSizeMultiplier[variant]
+        : TEXT_MAX_FONT_MULTIPLIER;
+
+    return fontScale < maxFontScale ? fontScale : maxFontScale;
+};
+
+/**
+ * Defines maximal layout scale multiplier based on device accessibility settings.
+ */
+export const ACCESSIBILITY_FONTSIZE_MULTIPLIER = getAccessibilityFontScale();
 
 const textStyle = prepareNativeStyle<TextStyleProps>((utils, { variant, color, textAlign }) => ({
     ...utils.typography[variant],
@@ -99,7 +103,7 @@ export const Text = React.forwardRef<RNText, TextProps>(
         ref,
     ) => {
         const { applyStyle } = useNativeStyles();
-        const maxFontSizeMultiplier = variantToMaxFontSizeMultiplier[variant];
+        const maxFontSizeMultiplier = getAccessibilityFontScale(variant);
 
         return (
             <DefaultTextComponent


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- fix spacing issues when fontScale is set to small 
- screenshot copies serve solely as comparison, the app content remain unchaged

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19320

## Screenshots:

## Before

<img width="834" height="436" alt="b2" src="https://github.com/user-attachments/assets/eab175b1-88fe-4bc2-bb7c-bdb69494a0ae" />
<img width="744" height="382" alt="b" src="https://github.com/user-attachments/assets/749f1dd0-a814-42f7-81bc-1b6e426f10e4" />

## After

<img width="804" height="410" alt="lab" src="https://github.com/user-attachments/assets/30400270-e39f-4df2-bf71-eb7a7be204c7" />
<img width="776" height="504" alt="la" src="https://github.com/user-attachments/assets/7d396f3a-3d03-489b-8cca-f2c7a0cc196f" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/text&lookback=7)