### PR TITLE
fix(native): fetch all transactions in SendUtxoScreen

### DIFF
--- a/suite-native/module-send/src/screens/SendUtxoScreen.tsx
+++ b/suite-native/module-send/src/screens/SendUtxoScreen.tsx
@@ -1,10 +1,14 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { TextInput } from 'react-native';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
+import {
+    AccountsRootState,
+    fetchAllTransactionsForAccountThunk,
+    selectAccountByKey,
+} from '@suite-common/wallet-core';
 import { useFilteredUtxos } from '@suite-common/wallet-utils';
 import { BaseSearchInput, SearchInputWithCancel, Text, VStack } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
@@ -21,6 +25,7 @@ export const SendUtxoScreen = ({
     route: { params },
 }: StackProps<SendStackParamList, SendStackRoutes.SendUtxo>) => {
     const { accountKey, amount } = params;
+    const dispatch = useDispatch();
 
     const { translate } = useTranslate();
     const navigation = useNavigation();
@@ -36,6 +41,20 @@ export const SendUtxoScreen = ({
         selectAccountByKey(state, accountKey),
     );
     const filteredUtxos = useFilteredUtxos(account?.utxo ?? [], searchQuery);
+
+    // we need to fetch all transactions for the account to have the additional UTXOs data available
+    useEffect(() => {
+        const promise = dispatch(
+            fetchAllTransactionsForAccountThunk({
+                accountKey,
+                noLoading: true,
+            }),
+        );
+
+        return () => {
+            promise.abort();
+        };
+    }, [accountKey, dispatch]);
 
     const handleUtxoSelect = (utxo: Utxo) =>
         tempSelectedUtxos.includes(utxo)
@@ -59,7 +78,7 @@ export const SendUtxoScreen = ({
     const onSearchChange = useCallback((query: string) => {
         setSearchQuery(query);
     }, []);
-    if (!account) return null;
+    if (account === null) return null;
 
     return (
         <Screen


### PR DESCRIPTION
This PR fixes fetching additional data (mainly timestamp and data for `TransactionDetail` screen) in `SendUtxoScreen` (Coin Control feature) on mobile.

Unfortunatelly we have to fetch all account's transaction since connect is not capable of fetching specific `tx`. (see [docs](https://connect.trezor.io/9/methods/bitcoin/getAccountInfo/#get-account-info), but this behaviour is same on desktop) Ideal solution would be fetching details only for needed UTXOs.

**Changes**: 
- dispatch `fetchAllTransactionsForAccountThunk ` for selected `accountKey` when user opens a Coin Control

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/coin-control-fetch-all-transactions&lookback=7)