### PR TITLE
fix(suite): cancel THP flow on device when modal is closed

### DIFF
--- a/packages/suite/src/components/thp/ThpConnectionModal.tsx
+++ b/packages/suite/src/components/thp/ThpConnectionModal.tsx
@@ -1,7 +1,6 @@
 import { TrezorDevice } from '@suite-common/suite-types';
-import { thpActions } from '@suite-common/thp';
+import TrezorConnect from '@trezor/connect';
 
-import { useDispatch } from '../../hooks/suite';
 import { ConfirmActionModal } from '../suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal';
 
 type ThpConnectionModalProps = {
@@ -9,11 +8,7 @@ type ThpConnectionModalProps = {
 };
 
 export const ThpConnectionModal = ({ device }: ThpConnectionModalProps) => {
-    const dispatch = useDispatch();
-
-    const onCancel = () => {
-        dispatch(thpActions.resetThpFlow());
-    };
+    const onCancel = () => TrezorConnect.cancel();
 
     return (
         <ConfirmActionModal


### PR DESCRIPTION
Cancelling the THP pairing modal did not cancel the flow on the device, resulting in a mismatch between Suite and the device.

To test, initiate THP pairing, cancel it in Suite.

## Screenshots:
<img width="546" height="577" alt="Screenshot 2025-07-14 at 11 14 26" src="https://github.com/user-attachments/assets/9298b268-8cf7-43fd-adeb-0544c0ba999e" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-cancel&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-cancel&lookback=7)