### PR TITLE
chore: replace cancelled with canceled in error codes

### DIFF
--- a/packages/connect/src/constants/errors.ts
+++ b/packages/connect/src/constants/errors.ts
@@ -16,7 +16,7 @@ export const ERROR_CODES = {
     Method_InvalidParameter: '', // replaced by generic text
     Method_NotAllowed: 'Method not allowed for this configuration', // example: device management in popup mode
     Method_PermissionsNotGranted: 'Permissions not granted', // permission/confirmation not granted in popup
-    Method_Cancel: 'Cancelled', // permission/confirmation not granted in popup OR .cancel() custom error
+    Method_Cancel: 'Canceled', // permission/confirmation not granted in popup OR .cancel() custom error
     Method_Interrupted: 'Popup closed', // interruption: popup closed
     Method_UnknownCoin: 'Coin not found', // coin definition not found
     Method_AddressNotMatch: 'Addresses do not match', // thrown by all getAddress methods with custom UI validation
@@ -46,10 +46,10 @@ export const ERROR_CODES = {
     Device_ThpPairingTagInvalid: 'Pairing tag mismatch', // thrown by RECEIVE_THP_PAIRING_TAG handler
     Device_ThpStateMissing: 'ThpState missing', // thrown by thp related actions
 
-    Failure_ActionCancelled: 'Action cancelled by user',
+    Failure_ActionCancelled: 'Action canceled by user',
     Failure_FirmwareError: 'Firmware installation failed',
     Failure_UnknownCode: 'Unknown error',
-    Failure_PinCancelled: 'PIN cancelled',
+    Failure_PinCancelled: 'PIN canceled',
     Failure_PinInvalid: 'PIN invalid',
     Failure_PinMismatch: 'PIN mismatch',
     Failure_WipeCodeMismatch: 'Wipe code mismatch',

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
@@ -38,7 +38,7 @@ export const createCoinjoinAccount = [
         connect: {
             success: false,
             payload: {
-                error: 'Cancelled',
+                error: 'Canceled',
             },
         },
         params: {
@@ -160,7 +160,7 @@ export const startCoinjoinSession = [
         connect: {
             success: false,
             payload: {
-                error: 'Cancelled',
+                error: 'Canceled',
             },
         },
         state: {

--- a/suite-common/sentry/src/index.ts
+++ b/suite-common/sentry/src/index.ts
@@ -86,7 +86,7 @@ const ignoreErrors = [
     'ResizeObserver loop limit exceeded',
     // comes from bridge originally, we allowed user to init another connect call. should now be wrapped however and not thrown on transport layer
     'other call in progress',
-    'Action cancelled by user',
+    'Action canceled by user',
     'device disconnected during action', // the same as with 'other call in progress'
 ];
 


### PR DESCRIPTION
Switching to American English spelling in the word "Canceled" to match the style we use elsewhere (`TR_CANCELLED` is `Canceled`).

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/canceled&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/canceled&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/canceled&lookback=7)