### PR TITLE
chore(message-system): remove message about Base network sync issues

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2025-07-10T00:00:00+00:00",
-    "sequence": 92,
+    "timestamp": "2025-07-14T00:00:00+00:00",
+    "sequence": 93,
     "actions": [
         {
             "conditions": [
@@ -1210,44 +1210,6 @@
                     "tr": "BNB Smart Chain ağı ile senkronizasyon sorunları yaşıyoruz. Bu, geçici olarak BNB Smart Chain üzerinde hatalara veya yavaş yanıt sürelerine neden olabilir. Bu sorun, BNB Smart Chain üzerindeki fonlarınızın güvenliğini hiçbir şekilde etkilemez. Rahatsızlık için özür dileriz.",
                     "pt": "Estamos enfrentando problemas de sincronização com a rede BNB Smart Chain. Isso pode resultar temporariamente em erros ou tempos de resposta lentos em BNB Smart Chain. Este problema não afeta de forma alguma a segurança dos seus fundos em BNB Smart Chain. Pedimos desculpas pelo inconveniente.",
                     "uk": "У нас виникли проблеми з синхронізацією мережі BNB Smart Chain. Це може тимчасово призвести до помилок або повільної реакції в BNB Smart Chain. Ця проблема жодним чином не впливає на безпеку ваших коштів у BNB Smart Chain. Приносимо вибачення за незручності."
-                }
-            }
-        },
-        {
-            "conditions": [
-                {
-                    "settings": [
-                        {
-                            "base": true
-                        }
-                    ],
-                    "environment": {
-                        "desktop": "*",
-                        "mobile": "*",
-                        "web": "*"
-                    }
-                }
-            ],
-            "message": {
-                "id": "ad073a57-2e13-4ebf-8501-bc727f9c8676",
-                "priority": 92,
-                "dismissible": true,
-                "variant": "warning",
-                "category": ["banner"],
-                "content": {
-                    "en-GB": "We are experiencing syncing issues with the Base network. This may temporarily result in errors or slow response times on Base. This issue does not affect the safety of your Base funds in any way. We apologise for the inconvenience.",
-                    "en": "We are experiencing syncing issues with the Base network. This may temporarily result in errors or slow response times on Base. This issue does not affect the safety of your Base funds in any way. We apologize for the inconvenience.",
-                    "es": "Estamos experimentando problemas de sincronización con la red de Base. Esto puede resultar temporalmente en errores o tiempos de respuesta lentos en Base. Este problema no afecta en absoluto la seguridad de sus fondos en Base. Pedimos disculpas por las molestias.",
-                    "cs": "Potýkáme se s dočasnými potížemi se synchronizací sítě Base, které mohou vést k chybám nebo pomalejší odezvě. Bezpečnost vašich prostředků na síti Base tím však není nijak ohrožena. Omlouváme se za nepříjemnosti a děkujeme za pochopení.",
-                    "ru": "У нас возникли проблемы с синхронизацией сети Base. Это может временно привести к ошибкам или медленной реакции в сети Base. Эта проблема никоим образом не влияет на безопасность ваших средств в Base. Приносим извинения за неудобства.",
-                    "ja": "Baseネットワークの同期に問題が発生しています。これにより、Baseで一時的にエラーや応答の遅延が発生する可能性があります。この問題は、Baseの資金の安全性にはまったく影響しません。ご不便をおかけして申し訳ありません。",
-                    "hu": "Problémák merültek fel a Base hálózat szinkronizálásával. Ez ideiglenesen hibákat vagy lassú válaszidőket eredményezhet a Base hálózaton. Ez a probléma semmilyen módon nem érinti a Base-en tárolt pénzeszközeinek biztonságát. Elnézést kérünk a kellemetlenségért.",
-                    "it": "Stiamo riscontrando problemi di sincronizzazione con la rete Base. Ciò potrebbe comportare temporaneamente errori o tempi di risposta lenti su Base. Questo problema non influisce in alcun modo sulla sicurezza dei tuoi fondi su Base. Ci scusiamo per l'inconveniente.",
-                    "fr": "Nous rencontrons des problèmes de synchronisation avec le réseau Base. Cela peut entraîner temporairement des erreurs ou des temps de réponse lents sur Base. Ce problème n’affecte en aucun cas la sécurité de vos fonds sur Base. Nous nous excusons pour la gêne occasionnée.",
-                    "de": "Wir haben Probleme mit der Synchronisierung des Netzwerks Base. Dies kann vorübergehend zu Fehlern oder langsamen Antwortzeiten auf Base führen. Dieses Problem beeinträchtigt die Sicherheit Ihrer Gelder auf Base in keiner Weise. Wir entschuldigen uns für die Unannehmlichkeiten.",
-                    "tr": "Base ağı ile senkronizasyon sorunları yaşıyoruz. Bu, geçici olarak Base üzerinde hatalara veya yavaş yanıt sürelerine neden olabilir. Bu sorun, Base üzerindeki fonlarınızın güvenliğini hiçbir şekilde etkilemez. Rahatsızlık için özür dileriz.",
-                    "pt": "Estamos enfrentando problemas de sincronização com a rede Base. Isso pode resultar temporariamente em erros ou tempos de resposta lentos em Base. Este problema não afeta de forma alguma a segurança dos seus fundos em Base. Pedimos desculpas pelo inconveniente.",
-                    "uk": "У нас виникли проблеми з синхронізацією мережі Base. Це може тимчасово призвести до помилок або повільної реакції в Base. Ця проблема жодним чином не впливає на безпеку ваших коштів у Base. Приносимо вибачення за незручності."
                 }
             }
         },


### PR DESCRIPTION
## Description

Removing the message informing about Base network sync issues

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/disable-message-base-sync-issues&lookback=7)