### PR TITLE
fix(suite): T1B1 initialization

### DIFF
--- a/packages/suite/src/hooks/suite/useFirmwareInstallationProgressCheck.ts
+++ b/packages/suite/src/hooks/suite/useFirmwareInstallationProgressCheck.ts
@@ -15,6 +15,8 @@ const MIN_T1B1_FW_VERSION = '1.12.1';
  */
 const getCheckSupport = (device?: TrezorDevice): boolean => {
     const isT1B1 = device?.features?.internal_model === DeviceModelInternal.T1B1;
+    const deviceFWVersion = getFirmwareVersion(device);
+    if (semver.valid(deviceFWVersion) === null) return false;
 
     return isT1B1 && semver.gte(getFirmwareVersion(device), MIN_T1B1_FW_VERSION);
 };


### PR DESCRIPTION
## Description

Device in bootloader mode returns `''` as FW version, so detect it and early return.

## Related Issue

Resolve #20165

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/T1B1-initialization&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/T1B1-initialization&lookback=7)