### PR TITLE
chore(suite): refactor promise handling in connect popup flow

### DIFF
--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -3,6 +3,8 @@ import { useEffect, useRef, useState } from 'react';
 import {
     connectPopupCallThunk,
     connectPopupCancelThunk,
+    getPopupCallDeferred,
+    queuePopupCall,
     selectConnectPopupCall,
 } from '@suite-common/connect-popup';
 import { CALL_SOURCE_DESKTOP_WS } from '@suite-common/connect-popup/src/connectPopupTypes';
@@ -24,7 +26,8 @@ export const useConnectPopupDesktop = () => {
         const init = async () => {
             if (desktopApi.available && (await desktopApi.connectPopupEnabled())) {
                 desktopApi.on('connect-popup/call', async params => {
-                    const response = await dispatch(
+                    await queuePopupCall();
+                    dispatch(
                         connectPopupCallThunk({
                             method: params.method as keyof typeof TrezorConnect,
                             payload: params.payload,
@@ -39,7 +42,8 @@ export const useConnectPopupDesktop = () => {
                                 manifest: params.manifest,
                             },
                         }),
-                    ).unwrap();
+                    );
+                    const response = await getPopupCallDeferred(true).promise;
                     desktopApi.connectPopupResponse({ ...response, id: params.id });
                 });
                 desktopApi.on('connect-popup/cancel', params => {

--- a/suite-common/connect-popup/src/connectPopupActions.ts
+++ b/suite-common/connect-popup/src/connectPopupActions.ts
@@ -20,12 +20,7 @@ const initiateCall = createAction(
     }),
 );
 
-const requestPermissions = createAction(
-    `${ACTION_PREFIX}/requestPermissions`,
-    (payload: Pick<ConnectPopupCall & { state: 'permission-request' }, 'decision'>) => ({
-        payload,
-    }),
-);
+const requestPermissions = createAction(`${ACTION_PREFIX}/requestPermissions`);
 
 const approvePermissions = createAction(`${ACTION_PREFIX}/approvePermissions`);
 
@@ -76,7 +71,7 @@ const forgetAppPermissions = createAction(
 
 const txSimulation = createAction(
     `${ACTION_PREFIX}/txSimulation`,
-    (payload: Pick<ConnectPopupCall & { state: 'tx-simulation' }, 'decision' | 'fromAddress'>) => ({
+    (payload: Pick<ConnectPopupCall & { state: 'tx-simulation' }, 'fromAddress'>) => ({
         payload,
     }),
 );

--- a/suite-common/connect-popup/src/connectPopupPromiseManager.ts
+++ b/suite-common/connect-popup/src/connectPopupPromiseManager.ts
@@ -1,0 +1,34 @@
+import { CallMethodAnyResponse } from '@trezor/connect';
+import { Deferred, createDeferred } from '@trezor/utils';
+
+// Custom helper, createDeferredManager didn't fit the needs here
+const createDeferredWrapper = <Resolve = void>(id: string) => {
+    let _deferred: Deferred<Resolve> | undefined;
+
+    const getDeferred = (clear: boolean = false) => {
+        if (!_deferred || clear) {
+            _deferred = createDeferred(id);
+            _deferred.promise.finally(() => {
+                // Reset when the call is finished
+                _deferred = undefined;
+            });
+        }
+
+        return _deferred;
+    };
+
+    const awaitDeferred = async () => {
+        await _deferred?.promise;
+    };
+
+    return { getDeferred, awaitDeferred };
+};
+
+// Deferred for the entire Connect call
+const callDeferredWrapper = createDeferredWrapper<Awaited<CallMethodAnyResponse>>('popup-call');
+export const getPopupCallDeferred = callDeferredWrapper.getDeferred;
+export const queuePopupCall = callDeferredWrapper.awaitDeferred;
+
+// Deferred for the permission request
+const permissionDeferredWrapper = createDeferredWrapper('popup-permission');
+export const getPermissionDeferred = permissionDeferredWrapper.getDeferred;

--- a/suite-common/connect-popup/src/connectPopupReducer.ts
+++ b/suite-common/connect-popup/src/connectPopupReducer.ts
@@ -3,6 +3,7 @@ import { PayloadAction } from '@reduxjs/toolkit';
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 
 import { connectPopupActions } from './connectPopupActions';
+import { getPermissionDeferred } from './connectPopupPromiseManager';
 import {
     AppRememberedPermission,
     CALL_SOURCE_WALLETCONNECT,
@@ -45,12 +46,11 @@ export const prepareConnectPopupReducer = createReducerWithExtraDeps(
                     state: 'ongoing',
                 };
             })
-            .addCase(connectPopupActions.requestPermissions, (state, { payload }) => {
+            .addCase(connectPopupActions.requestPermissions, state => {
                 if (state.activeCall?.state === 'ongoing')
                     state.activeCall = {
                         ...state.activeCall,
                         state: 'permission-request',
-                        ...payload,
                     };
             })
             .addCase(connectPopupActions.approvePermissions, state => {
@@ -58,10 +58,9 @@ export const prepareConnectPopupReducer = createReducerWithExtraDeps(
                     state.activeCall?.state === 'permission-request' ||
                     state.activeCall?.state === 'tx-simulation'
                 ) {
-                    state.activeCall.decision?.resolve();
+                    getPermissionDeferred()?.resolve();
                     state.activeCall = {
                         ...state.activeCall,
-                        decision: undefined,
                         state: 'ongoing',
                     };
                 }
@@ -71,10 +70,9 @@ export const prepareConnectPopupReducer = createReducerWithExtraDeps(
                     state.activeCall?.state === 'permission-request' ||
                     state.activeCall?.state === 'tx-simulation'
                 ) {
-                    state.activeCall.decision?.reject(payload);
+                    getPermissionDeferred()?.reject(payload);
                     state.activeCall = {
                         ...state.activeCall,
-                        decision: undefined,
                         state: 'finished',
                     };
                 }

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -4,23 +4,18 @@ import { EventType, analytics } from '@suite-common/analytics';
 import { CustomThunkAPI, createThunk } from '@suite-common/redux-utils';
 import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
 import { PrecomposedTransactionFinal } from '@suite-common/wallet-types';
-import TrezorConnect, { CallMethodParams, CallMethodResponse } from '@trezor/connect';
+import TrezorConnect, { CallMethodParams } from '@trezor/connect';
 import { TypedError, serializeError } from '@trezor/connect/src/constants/errors';
 import { MethodPermission } from '@trezor/connect/src/core/AbstractMethod';
 import { DEEPLINK_VERSION } from '@trezor/connect/src/data/version';
-import { createDeferred } from '@trezor/utils';
 
 import { connectPopupActions } from './connectPopupActions';
+import { getPermissionDeferred, getPopupCallDeferred } from './connectPopupPromiseManager';
 import { selectConnectAppPermissions, selectConnectPopupCall } from './connectPopupReducer';
 import { ConnectCallSource } from './connectPopupTypes';
 import { postCallHooks, preCallHooks } from './methodHooks';
 
 const CONNECT_POPUP_MODULE = '@common/connect-popup';
-
-type ConnectPopupCallThunkResponse<M extends keyof typeof TrezorConnect> = Promise<{
-    success: boolean;
-    payload: CallMethodResponse<M>;
-}>;
 
 type ConnectPopupCallThunkParams<M extends keyof typeof TrezorConnect> = {
     method: M;
@@ -29,7 +24,7 @@ type ConnectPopupCallThunkParams<M extends keyof typeof TrezorConnect> = {
 };
 
 export const connectPopupCallThunkInner = createThunk<
-    ConnectPopupCallThunkResponse<keyof typeof TrezorConnect>,
+    void,
     ConnectPopupCallThunkParams<keyof typeof TrezorConnect>
 >(
     `${CONNECT_POPUP_MODULE}/callThunk`,
@@ -78,14 +73,9 @@ export const connectPopupCallThunkInner = createThunk<
             );
 
             if (!isRemembered) {
-                const decision = createDeferred();
                 dispatch(extra.actions.lockDevice(true));
-                dispatch(
-                    connectPopupActions.requestPermissions({
-                        decision,
-                    }),
-                );
-                await decision.promise;
+                dispatch(connectPopupActions.requestPermissions());
+                await getPermissionDeferred(true).promise;
             }
 
             const device = selectSelectedDevice(getState());
@@ -143,7 +133,7 @@ export const connectPopupCallThunkInner = createThunk<
                 },
             });
 
-            return response;
+            getPopupCallDeferred().resolve(response);
         } catch (error) {
             console.error('connectPopupCallThunk', error);
             if (error?.code === 'Method_Cancel') {
@@ -161,10 +151,10 @@ export const connectPopupCallThunkInner = createThunk<
                 },
             });
 
-            return {
+            getPopupCallDeferred().resolve({
                 success: false,
                 payload: serializeError(error),
-            };
+            });
         } finally {
             dispatch(extra.actions.lockDevice(false));
         }
@@ -175,11 +165,8 @@ export const connectPopupCallThunkInner = createThunk<
 // Original thunk is exposed as well for using .fulfilled, .rejected, etc.
 export const connectPopupCallThunk = <M extends keyof typeof TrezorConnect>(
     params: ConnectPopupCallThunkParams<M>,
-): AsyncThunkAction<
-    ConnectPopupCallThunkResponse<M>,
-    ConnectPopupCallThunkParams<M>,
-    CustomThunkAPI
-> => connectPopupCallThunkInner(params) as any;
+): AsyncThunkAction<void, ConnectPopupCallThunkParams<M>, CustomThunkAPI> =>
+    connectPopupCallThunkInner(params) as any;
 
 export const connectPopupDeeplinkThunk = createThunk<void, { url: string }>(
     `${CONNECT_POPUP_MODULE}/deeplinkThunk`,
@@ -237,7 +224,7 @@ export const connectPopupDeeplinkThunk = createThunk<void, { url: string }>(
             return;
         }
 
-        const response = await dispatch(
+        dispatch(
             connectPopupCallThunk({
                 source: {
                     type: 'deeplink',
@@ -250,7 +237,8 @@ export const connectPopupDeeplinkThunk = createThunk<void, { url: string }>(
                 method: method as keyof typeof TrezorConnect,
                 payload,
             }),
-        ).unwrap();
+        );
+        const response = await getPopupCallDeferred(true).promise;
         callbackUrl.searchParams.set('response', JSON.stringify(response));
         dispatch(
             connectPopupActions.deeplinkCallback({
@@ -321,6 +309,7 @@ export const connectPopupVerifyAddressThunk = createThunk<void, { index: number 
 export const connectPopupCancelThunk = createThunk<void, { error?: string }>(
     `${CONNECT_POPUP_MODULE}/cancelThunk`,
     ({ error }, { dispatch }) => {
+        getPermissionDeferred().reject(TypedError('Method_Cancel'));
         TrezorConnect.cancel(error);
         // todo: probably not needed to call explicitly anymore
         dispatch(deviceActions.removeButtonRequests({}));

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -1,6 +1,5 @@
 import { ErrorCode } from '@trezor/connect/src/constants/errors';
 import { MethodPermission } from '@trezor/connect/src/core/AbstractMethod';
-import { Deferred } from '@trezor/utils';
 
 export type ManifestPartial = {
     appName: string;
@@ -65,16 +64,13 @@ export type ConnectPopupCallLoaded = {
 } & (
     | {
           state: 'ongoing';
-          decision?: undefined;
           selectedAccountKey?: string;
       }
     | {
           state: 'finished';
-          decision?: undefined;
       }
     | {
           state: 'permission-request';
-          decision: Deferred<void>;
       }
     | {
           state: 'deeplink-callback';
@@ -95,7 +91,6 @@ export type ConnectPopupCallLoaded = {
       }
     | {
           state: 'tx-simulation';
-          decision: Deferred<void>;
           selectedAccountKey?: string;
           fromAddress: string;
       }

--- a/suite-common/connect-popup/src/index.ts
+++ b/suite-common/connect-popup/src/index.ts
@@ -3,3 +3,4 @@ export * from './connectPopupThunks';
 export * from './connectPopupMiddleware';
 export * from './connectPopupReducer';
 export * from './connectPopupTypes';
+export * from './connectPopupPromiseManager';

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -9,10 +9,10 @@ import { Account, PrecomposedTransactionFinal } from '@suite-common/wallet-types
 import TrezorConnect from '@trezor/connect';
 import type { EthereumSignTransaction } from '@trezor/connect';
 import { getSerializedPath, validatePath } from '@trezor/connect/src/utils/pathUtils';
-import { createDeferred } from '@trezor/utils';
 
 import { connectPopupActions } from '../connectPopupActions';
 import { createPlaceholderAccount } from './utils';
+import { getPermissionDeferred } from '../connectPopupPromiseManager';
 import { selectConnectPopupCall } from '../connectPopupReducer';
 
 import { PostCallHookParams, PreCallHookParams } from './index';
@@ -105,14 +105,12 @@ const preCallHook = async <M extends keyof typeof TrezorConnect>({
                 showOnTrezor: false,
             });
             if (!accountAddress.success) throw new Error(accountAddress.payload.error);
-            const decision = createDeferred();
             dispatch(
                 connectPopupActions.txSimulation({
-                    decision,
                     fromAddress: accountAddress.payload.address,
                 }),
             );
-            await decision.promise;
+            await getPermissionDeferred(true).promise;
         }
 
         // Modify payload to include selected fee, if present

--- a/suite-common/walletconnect/src/adapters/ethereum.ts
+++ b/suite-common/walletconnect/src/adapters/ethereum.ts
@@ -9,7 +9,7 @@ import { selectAccounts, selectSelectedDevice } from '@suite-common/wallet-core'
 import { ethereumGetCurrentNonceThunk } from '@suite-common/wallet-core/src/send/sendFormEthereumThunks';
 import { Account } from '@suite-common/wallet-types';
 import { getAccountIdentity, sanitizeHex } from '@suite-common/wallet-utils';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { CallMethodResponse } from '@trezor/connect';
 import { isAscii } from '@trezor/utils';
 
 import { WALLETCONNECT_MODULE } from '../walletConnectConstants';
@@ -70,7 +70,7 @@ const ethereumRequestThunk = createThunk<
                 ? Buffer.from(message.slice(2), 'hex').toString('utf8')
                 : message;
             const isReadable = isAscii(messageDecoded);
-            const response = await dispatch(
+            dispatch(
                 trezorConnectPopupActions.connectPopupCallThunk({
                     ...popupCallCommonParams,
                     method: 'ethereumSignMessage',
@@ -80,18 +80,20 @@ const ethereumRequestThunk = createThunk<
                         hex: !isReadable,
                     },
                 }),
-            ).unwrap();
+            );
+            const response = await trezorConnectPopupActions.getPopupCallDeferred(true).promise;
             if (!response.success) {
                 console.error('personal_sign error', response);
                 throw new Error('personal_sign error');
             }
+            const typedPayload = response.payload as CallMethodResponse<'ethereumSignMessage'>;
 
-            return sanitizeHex(response.payload.signature);
+            return sanitizeHex(typedPayload.signature);
         }
         case 'eth_signTypedData_v4': {
             const [address, data] = event.params.request.params;
             const account = getAccount(address);
-            const response = await dispatch(
+            dispatch(
                 trezorConnectPopupActions.connectPopupCallThunk({
                     ...popupCallCommonParams,
                     method: 'ethereumSignTypedData',
@@ -101,13 +103,15 @@ const ethereumRequestThunk = createThunk<
                         metamask_v4_compat: true,
                     },
                 }),
-            ).unwrap();
+            );
+            const response = await trezorConnectPopupActions.getPopupCallDeferred(true).promise;
             if (!response.success) {
                 console.error('eth_signTypedData_v4 error', response);
                 throw new Error('eth_signTypedData_v4 error');
             }
+            const typedPayload = response.payload as CallMethodResponse<'ethereumSignTypedData'>;
 
-            return sanitizeHex(response.payload.signature);
+            return sanitizeHex(typedPayload.signature);
         }
         case 'eth_sendTransaction': {
             const chainId = Number(event.params.chainId.replace('eip155:', ''));
@@ -166,22 +170,25 @@ const ethereumRequestThunk = createThunk<
                 device,
                 useEmptyPassphrase: device?.useEmptyPassphrase,
             };
-            const signResponse = await dispatch(
+            dispatch(
                 trezorConnectPopupActions.connectPopupCallThunk({
                     ...popupCallCommonParams,
                     method: 'ethereumSignTransaction',
                     payload,
                 }),
-            ).unwrap();
+            );
+            const signResponse = await trezorConnectPopupActions.getPopupCallDeferred(true).promise;
             if (!signResponse.success) {
                 console.error('eth_sendTransaction error', signResponse);
                 throw new Error('eth_sendTransaction error');
             }
+            const typedSignPayload =
+                signResponse.payload as CallMethodResponse<'ethereumSignTransaction'>;
 
             const pushResponse = await TrezorConnect.pushTransaction({
                 coin: account.symbol,
                 identity: getAccountIdentity(account),
-                tx: signResponse.payload.serializedTx,
+                tx: typedSignPayload.serializedTx,
             });
             if (!pushResponse.success) {
                 console.error('eth_sendTransaction push error', pushResponse);

--- a/suite-common/walletconnect/src/adapters/solana.ts
+++ b/suite-common/walletconnect/src/adapters/solana.ts
@@ -7,7 +7,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import { Network, getNetwork, networksCollection } from '@suite-common/wallet-config';
 import { selectAccounts, selectSelectedDevice } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { CallMethodResponse } from '@trezor/connect';
 
 import { WALLETCONNECT_MODULE } from '../walletConnectConstants';
 import { selectSessionByTopic } from '../walletConnectReducer';
@@ -63,7 +63,7 @@ const solanaSignTransaction = createThunk<
             throw new Error('Account not found');
         }
 
-        const response = await dispatch(
+        dispatch(
             trezorConnectPopupActions.connectPopupCallThunk({
                 method: 'solanaSignTransaction',
                 payload: {
@@ -82,15 +82,17 @@ const solanaSignTransaction = createThunk<
                     },
                 },
             }),
-        ).unwrap();
-        if (!response.success || !response.payload.serializedTx) {
+        );
+        const response = await trezorConnectPopupActions.getPopupCallDeferred(true).promise;
+        const typedPayload = response.payload as CallMethodResponse<'solanaSignTransaction'>;
+        if (!response.success || !typedPayload.serializedTx) {
             console.error('solana_signTransaction error', response);
             throw new Error('solana_signTransaction error');
         }
 
         return {
-            signature: response.payload.signature,
-            transaction: response.payload.serializedTx,
+            signature: typedPayload.signature,
+            transaction: typedPayload.serializedTx,
         };
     },
 );


### PR DESCRIPTION
## Description

This PR solves two problems with promises in the current implementation of the Trezor Connect Popup flow in the Suite:

1. Get rid of Deferred in Redux state - this is not serializable and spams a bunch of errors in console
2. Get rid of awaiting the call thunk - this is not desirable in Redux architecture and limits some things I want to do

This is solved by adding a centralized promise manager in `@suite-common/connect-popup`, which holds the Deferred object and provides it to all the necessary parts of the application.
It also introduces predictable queuing of Connect WS calls.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/connect-suite-promise-manager&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/connect-suite-promise-manager&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/connect-suite-promise-manager&lookback=7)