### PR TITLE
fix(connect-examples): expo issue with typebox

### DIFF
--- a/packages/connect-examples/mobile-expo/metro.config.js
+++ b/packages/connect-examples/mobile-expo/metro.config.js
@@ -1,0 +1,20 @@
+const { getDefaultConfig } = require('expo/metro-config');
+
+/** @type {import('expo/metro-config').MetroConfig} */
+const config = getDefaultConfig(__dirname);
+
+// Workaround for https://github.com/expo/expo/issues/37171#issuecomment-2958700127
+config.resolver.resolveRequest = function packageExportsResolver(context, moduleImport, platform) {
+    if (moduleImport === '@sinclair/typebox' || moduleImport.startsWith('@sinclair/typebox/')) {
+        return context.resolveRequest(
+            { ...context, isESMImport: false }, // Disable ESM resolution, even when using `import ..`
+            moduleImport,
+            platform,
+        );
+    }
+
+    // Fall back to normal resolution
+    return context.resolveRequest(context, moduleImport, platform);
+};
+
+module.exports = config;


### PR DESCRIPTION
## Description

An issue appeared with Expo and `@sinclair/typebox` in our Connect mobile example. 

It seems to be known and I implemented a workaround found here: https://github.com/expo/expo/issues/37171#issuecomment-2958700127

It doesn't seem to affect all configurations, but if it starts appearing more and it's not fixed upstream, we can mention it in the docs.