### PR TITLE
fix(suite): use sign transaction modal for infinite approvals

### DIFF
--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -83,18 +83,19 @@ const buttonRequest =
 
                 return action;
             }
+        }
+        if (
+            action.type === UI.REQUEST_BUTTON &&
+            action.payload.name === 'confirm_ethereum_approve' &&
+            (action.payload.code === 'ButtonRequest_Other' ||
+                action.payload.code === 'ButtonRequest_Warning')
+        ) {
+            api.dispatch({
+                ...action,
+                payload: { ...action.payload, code: 'ButtonRequest_SignTx' },
+            });
 
-            if (
-                action.type === UI.REQUEST_BUTTON &&
-                action.payload.name === 'confirm_ethereum_approve'
-            ) {
-                api.dispatch({
-                    ...action,
-                    payload: { ...action.payload, code: 'ButtonRequest_SignTx' },
-                });
-
-                return action;
-            }
+            return action;
         }
 
         if (action.type === UI.REQUEST_BUTTON && action.payload.code === 'ButtonRequest_Address') {


### PR DESCRIPTION
## Description

`TransactionReviewModal` is now shown for every step in infinite approval flow instead of confirming infinite value in `ConfirmActionModal`.


## Related Issue

## Screenshots:

https://github.com/user-attachments/assets/10193759-da4f-4ad0-aa1c-652be5b79171



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/infinite-approvals-modal-fix&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/infinite-approvals-modal-fix&lookback=7)