### PR TITLE
fix(suite): fee symbol for L2s with tokens in review tx modal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -165,7 +165,7 @@ const Value = ({ value, type, symbol, token, isFee, isFiatVisible, state }: Valu
                             // TX fee is so far always paid in network native coin
                             isTokenAmount ? token.symbol : symbol
                         }
-                        contractAddress={token?.contract}
+                        contractAddress={isTokenAmount ? token?.contract : undefined}
                         isTabular={false}
                     />
                     {symbol && isFiatVisible && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- display network symbol was not used in case of token

## Related Issue

Resolve #20176

## Screenshots:

<img width="670" height="693" alt="Screenshot 2025-07-14 at 15 06 44" src="https://github.com/user-attachments/assets/b770d102-466c-4e60-9aae-f9a592816d6a" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/fee-symbol&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/fee-symbol&lookback=7)