### PR TITLE
refactor(suite-native): introduce firmware update stack navigator

### DIFF
--- a/suite-native/module-check-backup/src/hooks/useNavigateToCheckBackup.ts
+++ b/suite-native/module-check-backup/src/hooks/useNavigateToCheckBackup.ts
@@ -15,7 +15,7 @@ const checkBackupUnsupportedDeviceModels: DeviceModelInternal[] = [DeviceModelIn
 
 type NavigationProp = StackNavigationProps<
     DeviceSettingsStackParamList,
-    DeviceSettingsStackRoutes.DeviceSettings | DeviceSettingsStackRoutes.ConfirmFirmwareUpdate
+    DeviceSettingsStackRoutes.DeviceSettings
 >;
 
 export const useNavigateToCheckBackup = () => {

--- a/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
@@ -17,6 +17,7 @@ import { Translation } from '@suite-native/intl';
 import {
     DeviceSettingsStackParamList,
     DeviceSettingsStackRoutes,
+    FirmwareUpdateStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
 import { useToast } from '@suite-native/toasts';
@@ -26,7 +27,7 @@ import { DeviceSettingsItemCard } from './DeviceSettingsItemCard';
 
 type NavigationProp = StackNavigationProps<
     DeviceSettingsStackParamList,
-    DeviceSettingsStackRoutes.ConfirmFirmwareUpdate
+    DeviceSettingsStackRoutes.FirmwareUpdateStack
 >;
 
 export const DeviceFirmwareCard = () => {
@@ -58,7 +59,9 @@ export const DeviceFirmwareCard = () => {
             return;
         }
 
-        navigation.navigate(DeviceSettingsStackRoutes.ConfirmFirmwareUpdate);
+        navigation.navigate(DeviceSettingsStackRoutes.FirmwareUpdateStack, {
+            screen: FirmwareUpdateStackRoutes.ConfirmFirmwareUpdate,
+        });
     };
 
     const firmwareUpdateProps = ((): InlineAlertBoxProps | undefined => {

--- a/suite-native/module-device-settings/src/navigation/DeviceSettingsStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/DeviceSettingsStackNavigator.tsx
@@ -12,12 +12,11 @@ import {
 import { DeviceAuthenticityStackNavigator } from './DeviceAuthenticityStackNavigator';
 import { DeviceNameStackNavigator } from './DeviceNameStackNavigator';
 import { DevicePinProtectionStackNavigator } from './DevicePinProtectionStackNavigator';
+import { FirmwareUpdateStackNavigator } from './FirmwareUpdateStackNavigator';
 import { WipeDeviceStackNavigator } from './WipeDeviceStackNavigator';
-import { ConfirmFirmwareUpdateScreen } from '../screens/ConfirmFirmwareUpdateScreen';
 import { ContinueOnTrezorScreen } from '../screens/ContinueOnTrezorScreen';
 import { DeviceAuthenticityScreen } from '../screens/DeviceAuthenticityScreen';
 import { DeviceSettingsModalScreen } from '../screens/DeviceSettingsModalScreen';
-import { FirmwareInstallationScreen } from '../screens/FirmwareInstallationScreen';
 import { PinProtectionScreen } from '../screens/PinProtectionScreen';
 
 const DeviceSettingsStack = createNativeStackNavigator<DeviceSettingsStackParamList>();
@@ -40,6 +39,10 @@ export const DeviceSettingsStackNavigator = () => (
             component={PinProtectionScreen}
         />
         <DeviceSettingsStack.Screen
+            name={DeviceSettingsStackRoutes.FirmwareUpdateStack}
+            component={FirmwareUpdateStackNavigator}
+        />
+        <DeviceSettingsStack.Screen
             name={DeviceSettingsStackRoutes.DeviceAuthenticity}
             component={DeviceAuthenticityScreen}
         />
@@ -52,16 +55,8 @@ export const DeviceSettingsStackNavigator = () => (
             component={WipeDeviceStackNavigator}
         />
         <DeviceSettingsStack.Screen
-            name={DeviceSettingsStackRoutes.ConfirmFirmwareUpdate}
-            component={ConfirmFirmwareUpdateScreen}
-        />
-        <DeviceSettingsStack.Screen
             name={DeviceSettingsStackRoutes.ContinueOnTrezor}
             component={ContinueOnTrezorScreen}
-        />
-        <DeviceSettingsStack.Screen
-            name={DeviceSettingsStackRoutes.FirmwareInstallation}
-            component={FirmwareInstallationScreen}
         />
         <DeviceSettingsStack.Screen
             name={DeviceSettingsStackRoutes.DeviceNameStack}

--- a/suite-native/module-device-settings/src/navigation/FirmwareUpdateStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/FirmwareUpdateStackNavigator.tsx
@@ -1,0 +1,28 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import {
+    FirmwareUpdateStackParamList,
+    FirmwareUpdateStackRoutes,
+    stackNavigationOptionsConfig,
+} from '@suite-native/navigation';
+
+import { ConfirmFirmwareUpdateScreen } from '../screens/ConfirmFirmwareUpdateScreen';
+import { FirmwareInstallationScreen } from '../screens/FirmwareInstallationScreen';
+
+const FirmwareUpdateStack = createNativeStackNavigator<FirmwareUpdateStackParamList>();
+
+export const FirmwareUpdateStackNavigator = () => (
+    <FirmwareUpdateStack.Navigator
+        initialRouteName={FirmwareUpdateStackRoutes.ConfirmFirmwareUpdate}
+        screenOptions={{ ...stackNavigationOptionsConfig }}
+    >
+        <FirmwareUpdateStack.Screen
+            name={FirmwareUpdateStackRoutes.ConfirmFirmwareUpdate}
+            component={ConfirmFirmwareUpdateScreen}
+        />
+        <FirmwareUpdateStack.Screen
+            name={FirmwareUpdateStackRoutes.FirmwareInstallation}
+            component={FirmwareInstallationScreen}
+        />
+    </FirmwareUpdateStack.Navigator>
+);

--- a/suite-native/module-device-settings/src/screens/ConfirmFirmwareUpdateScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/ConfirmFirmwareUpdateScreen.tsx
@@ -13,9 +13,9 @@ import {
 import { Translation } from '@suite-native/intl';
 import { useNavigateToCheckBackup } from '@suite-native/module-check-backup';
 import {
-    DeviceSettingsStackParamList,
-    DeviceSettingsStackRoutes,
     DynamicScreenHeader,
+    FirmwareUpdateStackParamList,
+    FirmwareUpdateStackRoutes,
     Screen,
     StackNavigationProps,
 } from '@suite-native/navigation';
@@ -23,8 +23,8 @@ import {
 import { useDeviceConnectionGuard } from '../hooks/useDeviceConnectionGuard';
 
 type NavigationProp = StackNavigationProps<
-    DeviceSettingsStackParamList,
-    DeviceSettingsStackRoutes.ConfirmFirmwareUpdate
+    FirmwareUpdateStackParamList,
+    FirmwareUpdateStackRoutes.ConfirmFirmwareUpdate
 >;
 
 export const ConfirmFirmwareUpdateScreen = () => {
@@ -41,7 +41,7 @@ export const ConfirmFirmwareUpdateScreen = () => {
     };
 
     const handleUpdateConfirmation = useCallback(() => {
-        navigation.navigate(DeviceSettingsStackRoutes.FirmwareInstallation);
+        navigation.navigate(FirmwareUpdateStackRoutes.FirmwareInstallation);
     }, [navigation]);
 
     if (!isDeviceConnected) return;

--- a/suite-native/module-device-settings/src/screens/FirmwareInstallationScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/FirmwareInstallationScreen.tsx
@@ -3,41 +3,31 @@ import { useNavigation } from '@react-navigation/native';
 import { Box } from '@suite-native/atoms';
 import { FirmwareInstallationScreenContent } from '@suite-native/firmware';
 import {
-    DeviceSettingsStackParamList,
-    DeviceSettingsStackRoutes,
+    FirmwareUpdateStackParamList,
+    FirmwareUpdateStackRoutes,
     Screen,
     StackNavigationProps,
+    useNavigateToInitialScreen,
 } from '@suite-native/navigation';
 
 type NavigationProp = StackNavigationProps<
-    DeviceSettingsStackParamList,
-    DeviceSettingsStackRoutes.FirmwareInstallation
+    FirmwareUpdateStackParamList,
+    FirmwareUpdateStackRoutes.FirmwareInstallation
 >;
 
 export const FirmwareInstallationScreen = () => {
+    const navigateToInitialScreen = useNavigateToInitialScreen();
     const navigation = useNavigation<NavigationProp>();
 
-    const handleFirmwareInstallationSuccess = () => {
-        const initialRoute = navigation.getState().routes.at(0)
-            ?.name as DeviceSettingsStackRoutes.DeviceSettings;
-
-        if (initialRoute) {
-            navigation.navigate(initialRoute);
-        } else {
-            // This cause should not happen, but just to be safe
-            navigation.popToTop();
-        }
-    };
-
     const handleFirmwareInstallationFailure = () => {
-        navigation.navigate(DeviceSettingsStackRoutes.ConfirmFirmwareUpdate);
+        navigation.navigate(FirmwareUpdateStackRoutes.ConfirmFirmwareUpdate);
     };
 
     return (
         <Screen>
             <Box flex={1}>
                 <FirmwareInstallationScreenContent
-                    onFirmwareInstallationSuccess={handleFirmwareInstallationSuccess}
+                    onFirmwareInstallationSuccess={navigateToInitialScreen}
                     onFirmwareInstallationFailure={handleFirmwareInstallationFailure}
                     navigationLocation="settings"
                 />

--- a/suite-native/module-home/src/screens/HomeScreen/components/FirmwareUpdateAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/FirmwareUpdateAlert.tsx
@@ -20,6 +20,7 @@ import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceSettingsStackRoutes,
+    FirmwareUpdateStackRoutes,
     RootStackParamList,
     RootStackRoutes,
     StackNavigationProps,
@@ -77,7 +78,10 @@ export const FirmwareUpdateAlert = () => {
 
     const handleUpdateFirmware = () => {
         navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
-            screen: DeviceSettingsStackRoutes.ConfirmFirmwareUpdate,
+            screen: DeviceSettingsStackRoutes.FirmwareUpdateStack,
+            params: {
+                screen: FirmwareUpdateStackRoutes.ConfirmFirmwareUpdate,
+            },
         });
     };
 

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -25,6 +25,7 @@ import {
     DeviceOnboardingStackRoutes,
     DevicePinProtectionStackRoutes,
     DeviceSettingsStackRoutes,
+    FirmwareUpdateStackRoutes,
     HomeStackRoutes,
     OnboardingStackRoutes,
     ReceiveStackRoutes,
@@ -202,9 +203,8 @@ export type DeviceSettingsStackParamList = {
         type: PinActionType;
     };
     [DeviceSettingsStackRoutes.DeviceAuthenticity]: undefined;
+    [DeviceSettingsStackRoutes.FirmwareUpdateStack]: NavigatorScreenParams<FirmwareUpdateStackParamList>;
     [DeviceSettingsStackRoutes.DeviceAuthenticityStack]: NavigatorScreenParams<DeviceAuthenticityStackParamList>;
-    [DeviceSettingsStackRoutes.ConfirmFirmwareUpdate]: undefined;
-    [DeviceSettingsStackRoutes.FirmwareInstallation]: undefined;
     [DeviceSettingsStackRoutes.ContinueOnTrezor]: undefined;
     [DeviceSettingsStackRoutes.DeviceNameStack]: NavigatorScreenParams<DeviceNameStackParamList>;
     [DeviceSettingsStackRoutes.WipeDeviceStack]: NavigatorScreenParams<WipeDeviceStackParamList>;
@@ -217,6 +217,11 @@ export type DevicePinProtectionStackParamList = {
     [DevicePinProtectionStackRoutes.EnterCurrentPin]: undefined;
     [DevicePinProtectionStackRoutes.EnterNewPin]: undefined;
     [DevicePinProtectionStackRoutes.ConfirmNewPin]: undefined;
+};
+
+export type FirmwareUpdateStackParamList = {
+    [FirmwareUpdateStackRoutes.ConfirmFirmwareUpdate]: undefined;
+    [FirmwareUpdateStackRoutes.FirmwareInstallation]: undefined;
 };
 
 export type WipeDeviceStackParamList = {

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -73,10 +73,9 @@ export enum DeviceSettingsStackRoutes {
     DeviceSettings = 'DeviceSettings',
     PinProtection = 'PinProtection',
     DevicePinProtectionStack = 'DevicePinProtectionStack',
+    FirmwareUpdateStack = 'FirmwareUpdateStack',
     DeviceAuthenticity = 'DeviceAuthenticity',
     DeviceAuthenticityStack = 'DeviceAuthenticityStack',
-    ConfirmFirmwareUpdate = 'ConfirmFirmwareUpdate',
-    FirmwareInstallation = 'FirmwareInstallation',
     ContinueOnTrezor = 'ContinueOnTrezor',
     WipeDeviceStack = 'WipeDeviceStack',
     DeviceNameStack = 'DeviceNameStack',
@@ -88,6 +87,11 @@ export enum DevicePinProtectionStackRoutes {
     EnterCurrentPin = 'EnterCurrentPin',
     EnterNewPin = 'EnterNewPin',
     ConfirmNewPin = 'ConfirmNewPin',
+}
+
+export enum FirmwareUpdateStackRoutes {
+    ConfirmFirmwareUpdate = 'ConfirmFirmwareUpdate',
+    FirmwareInstallation = 'FirmwareInstallation',
 }
 
 export enum DeviceCheckBackupStackRoutes {


### PR DESCRIPTION
Use a stack to simplify going back to the initial screen. It may either be the dashboard, or device settings.


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native/firmware-update-navigation&lookback=7)