### PR TITLE
fix(suite-common): skip thp autoinit when there is a selected device

### DIFF
--- a/suite-common/thp/src/autoInitThpAfterDeviceConnectionThunk.ts
+++ b/suite-common/thp/src/autoInitThpAfterDeviceConnectionThunk.ts
@@ -1,6 +1,6 @@
 import { selectFirmware } from '@suite-common/firmware/src/firmwareReducer';
 import { createThunk } from '@suite-common/redux-utils';
-import { acquireDevice, selectDevices } from '@suite-common/wallet-core';
+import { acquireDevice, selectDevices, selectSelectedDevice } from '@suite-common/wallet-core';
 import { Device } from '@trezor/connect';
 
 import { THP_PREFIX } from './thpActions';
@@ -21,8 +21,8 @@ export const autoInitThpAfterDeviceConnectionThunk = createThunk<
     const reselectedTrezorDevice = selectDevices(getState())?.find(
         stateDevice => stateDevice.path === device.path,
     );
-
-    if (device?.thp !== undefined && !isFwInstall) {
+    const selectedDevice = selectSelectedDevice(getState());
+    if (device?.thp !== undefined && !isFwInstall && selectedDevice === undefined) {
         dispatch(acquireDevice({ requestedDevice: reselectedTrezorDevice }));
     }
 });

--- a/suite-common/thp/tests/autoInitThpAfterDeviceConnectionThunk.test.ts
+++ b/suite-common/thp/tests/autoInitThpAfterDeviceConnectionThunk.test.ts
@@ -1,0 +1,109 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { FirmwareUpdateState, prepareFirmwareReducer } from '@suite-common/firmware';
+import { configureMockStore, extraDependenciesMock, testMocks } from '@suite-common/test-utils';
+import { acquireDevice, prepareDeviceReducer } from '@suite-common/wallet-core';
+import { Device } from '@trezor/connect';
+
+import { autoInitThpAfterDeviceConnectionThunk } from '../src/autoInitThpAfterDeviceConnectionThunk';
+import { ThpState, prepareThpReducer } from '../src/thpReducer';
+
+const thpReduce = prepareThpReducer(extraDependenciesMock);
+const firmwareReduce = prepareFirmwareReducer(extraDependenciesMock);
+const deviceReduce = prepareDeviceReducer(extraDependenciesMock);
+
+const device = testMocks.getSuiteDevice({
+    thp: {
+        credentials: [],
+        channel: '',
+        sendBit: 0,
+        recvBit: 0,
+        sendNonce: 0,
+        recvNonce: 0,
+        expectedResponses: [],
+    },
+}) as Device;
+const initialThpState: ThpState = { step: null, lastThpCode: undefined, credentials: [] };
+const initialFirmwareState: FirmwareUpdateState = {
+    error: '',
+    cachedDevice: undefined,
+    status: 'initial',
+    targetType: undefined,
+    uiEvent: undefined,
+    useDevkit: false,
+};
+
+const testCases: {
+    description: string;
+    deviceArg?: Device;
+    isFirmwareInstallation?: boolean;
+    isDeviceSelected?: boolean;
+    shouldAcquireDevice: boolean;
+}[] = [
+    {
+        description: 'acquires device if conditions are met',
+        shouldAcquireDevice: true,
+    },
+    {
+        description: 'does not acquire device if the device does not support THP',
+        deviceArg: { ...device, thp: undefined },
+        shouldAcquireDevice: false,
+    },
+    {
+        description: 'does not acquire device if firmware installation is in progress',
+        isFirmwareInstallation: true,
+        shouldAcquireDevice: false,
+    },
+    {
+        description: 'does not acquire device if a device is selected',
+        isDeviceSelected: true,
+        shouldAcquireDevice: false,
+    },
+];
+
+type CreateStoreParams = {
+    isFirmwareInstallation?: boolean;
+    isDeviceSelected?: boolean;
+};
+
+const createStore = ({ isFirmwareInstallation, isDeviceSelected }: CreateStoreParams) =>
+    configureMockStore({
+        extra: {},
+        reducer: combineReducers({
+            thp: thpReduce,
+            firmware: firmwareReduce,
+            device: deviceReduce,
+        }),
+        preloadedState: {
+            thp: initialThpState,
+            firmware: isFirmwareInstallation
+                ? { ...initialFirmwareState, status: 'installing' }
+                : initialFirmwareState,
+            device: {
+                devices: [device],
+                selectedDevice: isDeviceSelected ? device : undefined,
+            },
+        },
+    });
+
+describe(autoInitThpAfterDeviceConnectionThunk.name, () => {
+    testCases.forEach(
+        ({
+            description,
+            deviceArg,
+            isFirmwareInstallation,
+            isDeviceSelected,
+            shouldAcquireDevice,
+        }) => {
+            it(description, () => {
+                const store = createStore({ isFirmwareInstallation, isDeviceSelected });
+                store.dispatch(
+                    autoInitThpAfterDeviceConnectionThunk({ device: deviceArg ?? device }),
+                );
+                expect(store.getActions().some(a => a.type === acquireDevice.pending.type)).toBe(
+                    shouldAcquireDevice,
+                );
+            });
+        },
+    );
+});

--- a/suite-common/thp/tests/connectThpDeviceThunk.test.ts
+++ b/suite-common/thp/tests/connectThpDeviceThunk.test.ts
@@ -88,7 +88,7 @@ describe(connectThpDeviceThunk.name, () => {
         expect(store.getState().thp.step).toEqual(null);
     });
 
-    it('wont updates the connection counter for credential during Firmware Installation', () => {
+    it("won't update the connection counter for credential during Firmware Installation", () => {
         const store = configureMockStore({
             extra: {},
             reducer: combineReducers({ thp: thpReduce, firmware: firmwareReduce }),


### PR DESCRIPTION
Prevent THP auto-init when there is a selected device. I'm doing this because this is in line with how other devices behave when you connect them, i.e. nothing happens. Also there was a UI bug - when the flow auto-initialized while DeviceSwitcher was open, the modal was not visible: https://github.com/trezor/trezor-suite/issues/19829. I could not check whether the selected device is the device that is connecting because a disconnected selected device has empty path.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/skip-autoconnect-when-selcted&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/skip-autoconnect-when-selcted&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/skip-autoconnect-when-selcted&lookback=7)