### PR TITLE
Feat/thp pairing

### DIFF
--- a/packages/connect/src/api/wipeDevice.ts
+++ b/packages/connect/src/api/wipeDevice.ts
@@ -40,6 +40,13 @@ export default class WipeDevice extends AbstractMethod<'wipeDevice'> {
         }
 
         const response = await cmd.typedCall('WipeDevice', 'Success');
+        const thpState = this.device.getThpState();
+        if (thpState) {
+            // device will require THP pairing in the next call
+            // reset state and do not call GetFeatures (finalReload)
+            thpState.resetState();
+            this.skipFinalReload = true;
+        }
 
         return response.message;
     }

--- a/packages/connect/src/constants/errors.ts
+++ b/packages/connect/src/constants/errors.ts
@@ -45,6 +45,7 @@ export const ERROR_CODES = {
     Device_MissingCapabilityBtcOnly: 'Device is missing capability (BTC only)', // thrown by methods which require specific capability when using BTC only firmware
     Device_ThpPairingTagInvalid: 'Pairing tag mismatch', // thrown by RECEIVE_THP_PAIRING_TAG handler
     Device_ThpStateMissing: 'ThpState missing', // thrown by thp related actions
+    Device_ThpPairingMethodsException: 'No common pairing methods', // device doesn't support requested pairing method(s)
 
     Failure_ActionCancelled: 'Action canceled by user',
     Failure_FirmwareError: 'Firmware installation failed',

--- a/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
+++ b/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
@@ -205,6 +205,7 @@ const setupTest = () => {
         registerEvents: () => {},
         log: new Log('Test', false),
         abortSignal: new AbortController().signal,
+        uiPromises: { create: jest.fn() },
     };
 
     return {

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -1146,6 +1146,7 @@ export class Core extends EventEmitter {
                             log: _log,
                             abortSignal: this.abortController.signal,
                             registerEvents: registerDeviceEvents(coreContext),
+                            uiPromises: coreContext.uiPromises,
                         },
                     })
                         .then(payload => {

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -12,7 +12,7 @@ import { ERRORS, PROTO } from '../constants';
 import { getFirmwareLocation, getReleaseByVersion } from '../data/firmwareInfo';
 import type { Device } from '../device/Device';
 import { DeviceList } from '../device/DeviceList';
-import { CoreEventMessage, UI, createUiMessage } from '../events';
+import { CoreEventMessage, UI, UiPromiseCreator, createUiMessage } from '../events';
 import {
     BinaryInfo,
     CommonParams,
@@ -38,11 +38,20 @@ type ReconnectContext = {
     postMessage: PostMessage;
     log: Log;
     abortSignal: AbortSignal;
+    uiPromises: { create: UiPromiseCreator };
 };
 
 const waitForReconnectedDevice = async (
     { bootloader, method, intermediary }: ReconnectParams,
-    { deviceList, device, registerEvents, postMessage, log, abortSignal }: ReconnectContext,
+    {
+        deviceList,
+        device,
+        registerEvents,
+        postMessage,
+        log,
+        abortSignal,
+        uiPromises,
+    }: ReconnectContext,
 ): Promise<Device> => {
     const target = intermediary || !bootloader ? 'normal' : 'bootloader';
 
@@ -71,6 +80,7 @@ const waitForReconnectedDevice = async (
     );
 
     let reconnectedDevice: Device | undefined;
+    let thpPairingError = false;
     do {
         postMessage(
             createUiMessage(UI.FIRMWARE_RECONNECT, {
@@ -102,15 +112,36 @@ const waitForReconnectedDevice = async (
                 'onCallFirmwareUpdate',
                 'we were unable to read device.features on the first interaction after seeing it, retrying...',
             );
+
+            let runFn;
+            if (reconnectedDevice.getThpState()?.properties) {
+                // stop and wait for UI decision
+                const uiPromise = uiPromises.create(UI.RECEIVE_CONFIRMATION, reconnectedDevice);
+                postMessage(
+                    createUiMessage(UI.REQUEST_CONFIRMATION, {
+                        view: thpPairingError ? 'thp-pairing-failed' : 'thp-pairing-start',
+                    }),
+                );
+                const uiResp = await uiPromise.promise;
+                if (!uiResp.payload) {
+                    throw ERRORS.TypedError('Method_PermissionsNotGranted');
+                }
+
+                runFn = () => Promise.resolve(); // enforce pairing UI interaction
+            }
+
             try {
                 registerEvents(reconnectedDevice);
                 // todo: it keeps printing warning "Previous call is still running" on reconnect from bl to normal
-                await reconnectedDevice.run(undefined, {
+                await reconnectedDevice.run(runFn, {
                     skipFirmwareChecks: true,
                     skipLanguageChecks: true,
                 });
-            } catch {
-                // empty
+            } catch (error) {
+                // error in THP pairing
+                if (error.code === 'Device_ThpPairingTagInvalid') {
+                    thpPairingError = true;
+                }
             }
         }
 
@@ -276,6 +307,7 @@ type Context = {
     initDevice: (path?: DeviceUniquePath) => Promise<Device>;
     log: Log;
     abortSignal: AbortSignal;
+    uiPromises: ReconnectContext['uiPromises'];
 };
 
 type OnCallFirmwareUpdateParams = {

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -16,7 +16,7 @@ import { ERRORS, FIRMWARE, PROTO } from '../constants';
 import { DeviceCurrentSession, TypedCallProvider } from './DeviceCurrentSession';
 import { IStateStorage } from './StateStorage';
 import { checkFirmwareRevision } from './checkFirmwareRevision';
-import { getThpChannel } from './thp';
+import { abortThpWorkflow, getThpChannel } from './thp';
 import { checkFirmwareHashWithRetries } from './workflow/checkFirmwareHashWithRetries';
 import { getAllNetworks } from '../data/coinInfo';
 import { getFirmwareReleaseConfigInfo, getFirmwareStatus, getLanguage } from '../data/firmwareInfo';
@@ -439,6 +439,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     async interrupt(reason: Error) {
+        await abortThpWorkflow(this);
         await this.currentSession?.abort(reason);
 
         // reject inner defer

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -499,6 +499,9 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 if (this.protocol.name === 'v2') {
                     const withInteraction = !!fn;
                     await getThpChannel(this, withInteraction);
+                    if (this.getThpState()?.isAutoconnectPaired || withInteraction) {
+                        await this.getFeatures();
+                    }
                 } else if (fn) {
                     await this.initialize(!!options.useCardanoDerivation);
                 } else {

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -110,7 +110,9 @@ export class DeviceCurrentSession implements TypedCallProvider {
         expectedType: Messages.MessageKey | Messages.MessageKey[],
         msg: Messages.MessagePayload = {},
     ) {
-        if (!allowedCallsBeforeInitialize.includes(type) && !this.device?.features?.session_id) {
+        const deviceSessionId =
+            this.device.getThpState()?.sessionId || this.device?.features?.session_id;
+        if (!allowedCallsBeforeInitialize.includes(type) && !deviceSessionId) {
             console.error(
                 'Runtime',
                 `typedCall: Device not initialized when calling ${type}. call Initialize first`,

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -207,6 +207,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
                         // ignore whatever happens
                     }
                 } else {
+                    this.device.getThpState()?.sync('send', 'Cancel');
                     await this.transport.send({
                         name: 'Cancel',
                         data: {},

--- a/packages/connect/src/device/thp/handshake.ts
+++ b/packages/connect/src/device/thp/handshake.ts
@@ -1,0 +1,135 @@
+import { randomBytes } from 'crypto';
+
+import { encodeMessage } from '@trezor/protobuf';
+import { ThpPairingMethod, thp as protocolThp } from '@trezor/protocol';
+
+import { thpCall } from './thpCall';
+import { ERRORS } from '../../constants';
+import { DataManager } from '../../data/DataManager';
+import type { Device } from '../Device';
+
+// intersection of device acceptable methods and host acceptable methods
+const enumFromString = (dm: ThpPairingMethod | keyof typeof ThpPairingMethod) =>
+    typeof dm === 'string' ? protocolThp.ThpPairingMethod[dm] : dm;
+
+const getPairingMethods = (
+    deviceMethods?: (ThpPairingMethod | keyof typeof ThpPairingMethod)[],
+    settingsMethods?: (ThpPairingMethod | keyof typeof ThpPairingMethod)[],
+) =>
+    deviceMethods?.flatMap(dm => {
+        const value = enumFromString(dm);
+        const isRequested =
+            settingsMethods && settingsMethods.find(sm => value === enumFromString(sm));
+
+        return isRequested ? value : [];
+    });
+
+// State HH0
+// TODO: link-to-public-docs
+// https://www.notion.so/satoshilabs/THP-Specification-2-1-203dc5260606804192aecaa58fb961ca
+export const createThpChannel = async (device: Device) => {
+    const thpState = device.getThpState();
+    if (!thpState) {
+        throw ERRORS.TypedError('Device_ThpStateMissing');
+    }
+
+    // set default channel and create random nonce
+    thpState.setChannel(protocolThp.constants.THP_DEFAULT_CHANNEL);
+    const nonce = randomBytes(8);
+    const createChannel = await thpCall(device, 'ThpCreateChannelRequest', { nonce });
+
+    const { properties, ...resp } = createChannel.message;
+
+    // TODO: link-to-public-docs nonce validation is not mentioned by the docs
+    if (nonce.compare(resp.nonce) !== 0) {
+        throw new Error(
+            'Nonce not meet' + nonce.toString('hex') + ' ' + resp.nonce.toString('hex'),
+        );
+    }
+
+    // find common pairing methods
+    const settings = DataManager.getSettings('thp');
+    const pairingMethods = getPairingMethods(properties.pairing_methods, settings?.pairingMethods);
+    if (!pairingMethods?.length) {
+        throw ERRORS.TypedError('Device_ThpPairingMethodsException');
+    }
+
+    // update properties, channel and handshake credentials
+    thpState.setThpProperties(properties);
+    thpState.setChannel(resp.channel);
+    thpState.updateHandshakeCredentials({
+        pairingMethods,
+        handshakeHash: resp.handshakeHash,
+    });
+
+    // ready for transition to state HH1 -> thpHandshake
+};
+
+// State HH1 and HH2
+// TODO: link-to-public-docs
+// https://www.notion.so/satoshilabs/THP-Specification-2-1-203dc5260606804192aecaa58fb961ca
+export const thpHandshake = async (device: Device) => {
+    const thpState = device.getThpState();
+    if (!thpState?.handshakeCredentials) {
+        throw ERRORS.TypedError('Device_ThpStateMissing');
+    }
+
+    const settings = DataManager.getSettings('thp');
+    // get staticKey from settings or create new random
+    const staticKey = settings?.staticKey
+        ? Buffer.from(settings.staticKey, 'hex')
+        : randomBytes(32);
+    const hostStaticKeys = protocolThp.getCurve25519KeyPair(staticKey);
+    // sort credentials by autoconnect field
+    const knownCredentials = (settings?.knownCredentials || []).sort(cre =>
+        cre.autoconnect ? -1 : 1,
+    );
+
+    // 1. Generate a new ephemeral X25519 key pair (host_ephemeral_privkey, host_ephemeral_pubkey).
+    const hostEphemeralKeys = protocolThp.getCurve25519KeyPair(randomBytes(32));
+
+    // 2. Send the message HandshakeInitiationReq(host_ephemeral_pubkey) to the host.
+    const handshakeInit = await thpCall(device, 'ThpHandshakeInitRequest', {
+        key: hostEphemeralKeys.publicKey,
+    });
+
+    const { trezorEncryptedStaticPubkey } = handshakeInit.message;
+
+    // cryptography steps from HH1 to HH2
+    const handshakeCredentials = protocolThp.handleHandshakeInit({
+        handshakeInitResponse: handshakeInit.message,
+        thpState,
+        hostStaticKeys,
+        hostEphemeralKeys,
+        knownCredentials,
+        protobufEncoder: (name, data) => encodeMessage(device.transport.getMessages(), name, data),
+    });
+
+    // update thpState
+    const { hostKey, trezorKey, hostEncryptedStaticPubkey } = handshakeCredentials;
+    thpState.updateHandshakeCredentials({
+        trezorEncryptedStaticPubkey,
+        hostEncryptedStaticPubkey,
+        handshakeHash: handshakeCredentials.handshakeHash,
+        trezorKey,
+        hostKey,
+        staticKey,
+        hostStaticPublicKey: hostStaticKeys.publicKey,
+    });
+
+    thpState.setPairingCredentials(handshakeCredentials.allCredentials);
+
+    const handshakeCompletion = await thpCall(device, 'ThpHandshakeCompletionRequest', {
+        hostPubkey: hostEncryptedStaticPubkey,
+        encryptedPayload: handshakeCredentials.encryptedPayload,
+    });
+
+    thpState.setIsPaired(!!handshakeCompletion.message.state);
+    thpState.setPhase('pairing');
+
+    if (thpState.isPaired && thpState.isAutoconnectPaired) {
+        // finish pairing. device is ready to communicate without further interaction
+        await thpCall(device, 'ThpEndRequest', {});
+        thpState.setPhase('paired');
+    }
+};

--- a/packages/connect/src/device/thp/index.ts
+++ b/packages/connect/src/device/thp/index.ts
@@ -1,9 +1,25 @@
-import { ERRORS } from '../../constants';
 import type { Device } from '../Device';
+import { createThpChannel, thpHandshake } from './handshake';
+import { thpPairing } from './pairing';
 
-export const getThpChannel = async (_device: Device, _withInteraction?: boolean) => {
-    // implementation...
-    await new Promise((_, reject) => {
-        reject(ERRORS.TypedError('Device_ThpStateMissing'));
-    });
+export { abortThpWorkflow } from './thpCall';
+export { getThpCredentials } from './pairing';
+
+export const getThpChannel = async (device: Device, withInteraction?: boolean) => {
+    const thpState = device.getThpState();
+
+    try {
+        if (thpState?.phase === 'handshake') {
+            await createThpChannel(device);
+            await thpHandshake(device);
+        }
+        if (thpState?.phase === 'pairing' && withInteraction) {
+            // start pairing with UI interaction
+            await thpPairing(device);
+        }
+    } catch (error) {
+        thpState?.resetState();
+
+        throw error;
+    }
 };

--- a/packages/connect/src/device/thp/index.ts
+++ b/packages/connect/src/device/thp/index.ts
@@ -4,6 +4,7 @@ import { thpPairing } from './pairing';
 
 export { abortThpWorkflow } from './thpCall';
 export { getThpCredentials } from './pairing';
+export { createThpSession } from './session';
 
 export const getThpChannel = async (device: Device, withInteraction?: boolean) => {
     const thpState = device.getThpState();

--- a/packages/connect/src/device/thp/pairing.ts
+++ b/packages/connect/src/device/thp/pairing.ts
@@ -141,7 +141,7 @@ const waitForPairingTag = async (device: Device) => {
 
     // start listening for the Cancel message from Trezor
     const { readAbort, readCancel } = waitForPairingCancel(device);
-    readCancel
+    const cancelResult = readCancel
         .then(readResult => {
             if (readResult.success) {
                 let error: string;
@@ -157,6 +157,13 @@ const waitForPairingTag = async (device: Device) => {
         .catch(() => {
             // silent
         });
+
+    thpState.setPairingTagPromise({
+        abort: async () => {
+            readAbort.abort();
+            await cancelResult;
+        },
+    });
 
     // start listening for the UI response
     const payload = {
@@ -179,6 +186,8 @@ const waitForPairingTag = async (device: Device) => {
     // wait for readCancel to finish reading
     readAbort.abort();
     await readCancel;
+
+    thpState.setPairingTagPromise(undefined);
 
     if ('error' in pairingResponse) {
         throw new Error(pairingResponse.error);

--- a/packages/connect/src/device/thp/pairing.ts
+++ b/packages/connect/src/device/thp/pairing.ts
@@ -1,0 +1,322 @@
+import { createHash, randomBytes } from 'crypto';
+
+import { thp as protocolThp } from '@trezor/protocol';
+import { createDeferred } from '@trezor/utils';
+
+import { ERRORS } from '../../constants';
+import { DataManager } from '../../data/DataManager';
+import { DEVICE, UiResponseThpPairingTag } from '../../events';
+import type { Device } from '../Device';
+import { abortThpWorkflow, thpCall } from './thpCall';
+
+const processQrCodeTag = async (device: Device, value: string) => {
+    const thpState = device.getThpState();
+    if (!thpState?.handshakeCredentials) {
+        throw ERRORS.TypedError('Device_ThpStateMissing');
+    }
+
+    const tagSha = createHash('sha256')
+        .update(thpState.handshakeCredentials.handshakeHash)
+        .update(Buffer.from(value, 'hex'))
+        .digest('hex');
+    const qrCodeSecret = await thpCall(device, 'ThpQrCodeTag', {
+        tag: tagSha,
+    });
+
+    protocolThp.validateQrCodeTag(
+        thpState.handshakeCredentials,
+        value,
+        qrCodeSecret.message.secret,
+    );
+
+    return qrCodeSecret;
+};
+
+const processNfcTag = async (device: Device, value: string) => {
+    const thpState = device.getThpState();
+    if (!thpState?.handshakeCredentials) {
+        throw ERRORS.TypedError('Device_ThpStateMissing');
+    }
+    if (!thpState?.nfcSecret) {
+        throw new Error('missing nfcSecret');
+    }
+
+    const tagSha = createHash('sha256')
+        .update(Buffer.from([protocolThp.ThpPairingMethod.NFC]))
+        .update(thpState.handshakeCredentials.handshakeHash)
+        .update(Buffer.from(value, 'hex'))
+        .digest('hex');
+
+    const nfcTagTrezor = await thpCall(device, 'ThpNfcTagHost', {
+        tag: tagSha,
+    });
+
+    protocolThp.validateNfcTag(
+        thpState.handshakeCredentials,
+        nfcTagTrezor.message.tag,
+        thpState.nfcSecret,
+    );
+
+    return nfcTagTrezor;
+};
+
+const processCodeEntry = async (device: Device, value: string) => {
+    if (value.length !== 6) {
+        throw ERRORS.TypedError('Device_ThpPairingTagInvalid');
+    }
+    const codeValue = Buffer.from(value, 'ascii');
+
+    const thpState = device.getThpState();
+    if (!thpState?.handshakeCredentials) {
+        throw ERRORS.TypedError('Device_ThpStateMissing');
+    }
+
+    const hostKeys = protocolThp.getCpaceHostKeys(
+        codeValue,
+        thpState.handshakeCredentials.handshakeHash,
+    );
+    const tag = protocolThp
+        .getSharedSecret(thpState.handshakeCredentials.trezorCpacePublicKey, hostKeys.privateKey)
+        .toString('hex');
+
+    const codeEntrySecret = await thpCall(device, 'ThpCodeEntryCpaceHostTag', {
+        tag,
+        cpace_host_public_key: hostKeys.publicKey.toString('hex'),
+    });
+
+    protocolThp.validateCodeEntryTag(
+        thpState.handshakeCredentials,
+        value,
+        codeEntrySecret.message.secret,
+    );
+
+    return codeEntrySecret;
+};
+
+const processThpPairingResponse = (device: Device, payload: UiResponseThpPairingTag['payload']) => {
+    if ('selectedMethod' in payload) {
+        // change pairing method
+        device.getThpState()?.setPairingMethod(payload.selectedMethod);
+
+        return thpCall(device, 'ThpSelectMethod', {
+            selected_pairing_method: payload.selectedMethod,
+        });
+    }
+
+    if (payload.source === 'qr-code') {
+        return processQrCodeTag(device, payload.tag);
+    }
+
+    if (payload.source === 'nfc') {
+        return processNfcTag(device, payload.tag);
+    }
+
+    if (payload.source === 'code-entry') {
+        return processCodeEntry(device, payload.tag);
+    }
+
+    throw new Error(`Unknown THP pairing source ${payload.source}`);
+};
+
+const waitForPairingCancel = (device: Device) => {
+    const readAbort = new AbortController();
+    device.getThpState()?.setExpectedResponses([0x04]); // expect Cancel
+    const readCancel = device.getCurrentSession().receive({
+        signal: readAbort.signal,
+    });
+
+    return {
+        readAbort,
+        readCancel,
+    };
+};
+
+const waitForPairingTag = async (device: Device) => {
+    const thpState = device.getThpState();
+    if (!thpState?.handshakeCredentials) {
+        throw ERRORS.TypedError('Device_ThpStateMissing');
+    }
+
+    const dfd = createDeferred<UiResponseThpPairingTag['payload'] | { error: string }>();
+
+    // start listening for the Cancel message from Trezor
+    const { readAbort, readCancel } = waitForPairingCancel(device);
+    readCancel
+        .then(readResult => {
+            if (readResult.success) {
+                let error: string;
+                if (readResult.payload.type === 'Failure' && readResult.payload.message.message) {
+                    error = readResult.payload.message.message;
+                } else {
+                    error = `Pairing tag cancelled (${readResult.payload.type})`;
+                }
+
+                dfd.resolve({ error });
+            }
+        })
+        .catch(() => {
+            // silent
+        });
+
+    // start listening for the UI response
+    const payload = {
+        availableMethods: thpState.handshakeCredentials.pairingMethods,
+        selectedMethod: thpState.pairingMethod,
+        nfcData: thpState.nfcData?.toString('hex'),
+    };
+    device.prompt('thp_pairing', { payload }).then(response => {
+        if (response.success) {
+            dfd.resolve(response.payload);
+        } else {
+            abortThpWorkflow(device).then(() => {
+                dfd.resolve({ error: response.error.message });
+            });
+        }
+    });
+
+    const pairingResponse = await dfd.promise;
+
+    // wait for readCancel to finish reading
+    readAbort.abort();
+    await readCancel;
+
+    if ('error' in pairingResponse) {
+        throw new Error(pairingResponse.error);
+    }
+
+    // node-bridge + usb: abort received on client side of http request resolves faster than server. result with "device call in progress"
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    return processThpPairingResponse(device, pairingResponse).catch(e => {
+        // catch pairing tag mismatch
+        if (e.code === 'Failure_FirmwareError') {
+            // 'Unexpected Code Entry Tag'
+            throw ERRORS.TypedError('Device_ThpPairingTagInvalid', e.message);
+        }
+
+        throw ERRORS.TypedError(e.code, e.message);
+    });
+};
+
+export const getThpCredentials = async (device: Device, autoconnect = false) => {
+    const thpState = device.getThpState();
+    if (!thpState?.handshakeCredentials) {
+        throw ERRORS.TypedError('Device_ThpStateMissing');
+    }
+
+    const credentials = await thpCall(device, 'ThpCredentialRequest', {
+        autoconnect,
+        host_static_public_key: thpState.handshakeCredentials.hostStaticPublicKey.toString('hex'),
+        credential: thpState.pairingCredentials[0]?.credential,
+    });
+
+    return { ...credentials.message, autoconnect };
+};
+
+export const thpPairingEnd = (device: Device) => {
+    device.getThpState()?.setPhase('paired');
+
+    return thpCall(device, 'ThpEndRequest', {});
+};
+
+// State HH2/HH3 -> HP0 -> HP1 -> HP2 -> HP3 -> HP4
+// Workflow will require user interaction
+// TODO: link-to-public-docs
+// https://www.notion.so/satoshilabs/THP-Specification-2-1-203dc5260606804192aecaa58fb961ca
+export const thpPairing = async (device: Device) => {
+    const thpState = device.getThpState();
+    if (!thpState?.handshakeCredentials) {
+        throw ERRORS.TypedError('Device_ThpStateMissing');
+    }
+
+    // State HH2 and HH3 combined
+    // if thpState.isPaired then transition to HC0 (credentials) otherwise transition to HP0 (pairing)
+    if (thpState.isPaired && thpState.pairingMethod !== protocolThp.ThpPairingMethod.SkipPairing) {
+        // State HC0
+        if (!thpState.isAutoconnectPaired) {
+            // device is paired but credentials may not be persistent
+            // get new credentials to enforce ButtonRequest.thp_connection_request flow if necessary
+            await getThpCredentials(device, false);
+        }
+
+        // State HC1 -> HC2 pairing complete
+        return thpPairingEnd(device);
+    }
+
+    // use first pairing method from the list
+    const [selected_pairing_method] = thpState.handshakeCredentials.pairingMethods;
+    thpState.setPairingMethod(selected_pairing_method);
+
+    // State HP0
+    // ThpPairingRequest will trigger ButtonRequest.thp_pairing_request flow
+    const settings = DataManager.getSettings('thp');
+    await thpCall(device, 'ThpPairingRequest', {
+        host_name: settings?.hostName || 'Unknown hostName',
+        app_name: settings?.appName || 'Unknown appName',
+    });
+
+    // State HP1
+    const selectMethod = await thpCall(device, 'ThpSelectMethod', { selected_pairing_method });
+
+    // selected_pairing_method === ThpPairingMethod.SkipPairing
+    if (selectMethod.type === 'ThpEndResponse') {
+        thpState.setIsPaired(true);
+        device.getThpState()?.setPhase('paired');
+
+        return;
+    }
+
+    // State HP2
+    if (selectMethod.type === 'ThpCodeEntryCommitment') {
+        // store handshakeCommitment and validate later in `processCodeEntry`
+        const codeEntryChallenge = randomBytes(32);
+        const handshakeCommitment = Buffer.from(selectMethod.message.commitment, 'hex');
+        thpState.updateHandshakeCredentials({
+            handshakeCommitment,
+            codeEntryChallenge,
+        });
+
+        // State HP3a
+        const codeEntryCpace = await thpCall(device, 'ThpCodeEntryChallenge', {
+            challenge: codeEntryChallenge.toString('hex'),
+        });
+
+        thpState.updateHandshakeCredentials({
+            trezorCpacePublicKey: Buffer.from(
+                codeEntryCpace.message.cpace_trezor_public_key,
+                'hex',
+            ),
+        });
+
+        // State HP4 -> HP5
+        await waitForPairingTag(device);
+    }
+
+    if (selectMethod.type === 'ThpPairingPreparationsFinished') {
+        if (thpState.pairingMethod === protocolThp.ThpPairingMethod.NFC) {
+            // generate random secret and store it
+            thpState.setNfcSecret(randomBytes(16));
+        }
+
+        // State HP6 and HP7
+        await waitForPairingTag(device);
+    }
+
+    // State HC0
+    // generate new credentials and send
+    const credentials = await getThpCredentials(device, false);
+    device.emit(DEVICE.THP_CREDENTIALS_CHANGED, {
+        credentials,
+        staticKey: thpState.handshakeCredentials.staticKey.toString('hex'),
+    });
+    const settings1 = DataManager.getSettings('thp');
+    if (settings1) {
+        settings1.knownCredentials?.push(credentials);
+        settings1.staticKey = thpState.handshakeCredentials.staticKey.toString('hex');
+    }
+
+    thpState.setPairingCredentials([credentials]);
+    thpState.setIsPaired(true);
+
+    await thpPairingEnd(device);
+};

--- a/packages/connect/src/device/thp/session.ts
+++ b/packages/connect/src/device/thp/session.ts
@@ -1,0 +1,29 @@
+import { thp as protocolThp } from '@trezor/protocol';
+
+import type { Device } from '../Device';
+import { thpCall } from './thpCall';
+
+export const createThpSession = async (device: Device, deriveCardano: boolean) => {
+    let passphrase: protocolThp.ThpCreateNewSession;
+    if (!device.features.passphrase_protection) {
+        passphrase = { passphrase: '' };
+    } else {
+        // same flow as DeviceCurrentSession PassphraseRequest
+        passphrase = await device.prompt('passphrase', {}).then(promptRes => {
+            if (!promptRes.success) {
+                return { passphrase: '' };
+            }
+
+            return promptRes.payload.passphraseOnDevice
+                ? { on_device: true }
+                : { passphrase: promptRes.payload.value };
+        });
+    }
+
+    await thpCall(device, 'ThpCreateNewSession', {
+        ...passphrase,
+        derive_cardano: deriveCardano,
+    });
+
+    return 0;
+};

--- a/packages/connect/src/device/thp/thpCall.ts
+++ b/packages/connect/src/device/thp/thpCall.ts
@@ -61,7 +61,11 @@ export const thpCall = async <T extends MessageKey>(
         throw ERRORS.serializeError({ code: result.error, message: result.error.message });
     }
 
+    thpState.setCancelablePromise(false);
+
     if (result.payload.type === 'ButtonRequest') {
+        thpState.setCancelablePromise(true);
+
         if (result.payload.message.code === 'ButtonRequest_PassphraseEntry') {
             device.emit(DEVICE.PASSPHRASE_ON_DEVICE);
         } else {
@@ -80,4 +84,26 @@ export const thpCall = async <T extends MessageKey>(
     }
 
     return result.payload as ThpCallResponse[T];
+};
+
+export const abortThpWorkflow = async (device: Device) => {
+    const thpState = device.getThpState();
+    if (!thpState || !device.currentRun) {
+        return Promise.resolve(); // not a THP device
+    }
+
+    // check that current workflow is awaiting for Cancel (see ./pairing waitForPairingCancel)
+    // - transport is in read state (read Cancel from the device)
+    // - @trezor/connect is waiting for UI response (pairing tag)
+    // in that case we don't need to update THP sync values because thpState is synchronized
+    // in any other case we need to update sync values before current transport.call process is resolved
+    if (thpState.pairingTagPromise) {
+        await thpState.pairingTagPromise.abort();
+        await device.getCurrentSession().cancelCall();
+        thpState.resetState();
+    } else if (thpState.cancelablePromise) {
+        thpState.sync('send', 'Cancel');
+        await device.getCurrentSession().send('Cancel', {});
+        await device.currentRun;
+    }
 };

--- a/packages/connect/src/device/workflow/validateState.ts
+++ b/packages/connect/src/device/workflow/validateState.ts
@@ -4,6 +4,20 @@ import { DEVICE, UI, createDeviceMessage, createUiMessage } from '../../events';
 import { StaticSessionId } from '../../types';
 import { WorkflowContext } from '../../types/workflow';
 import { toHardened } from '../../utils/pathUtils';
+import { createThpSession } from '../thp';
+
+const getStaticSessionId = (device: WorkflowContext['device']) =>
+    device
+        .getCurrentSession()
+        .typedCall('GetAddress', 'Address', {
+            address_n: [toHardened(44), toHardened(1), toHardened(0), 0, 0],
+            coin_name: 'Testnet',
+            script_type: 'SPENDADDRESS',
+        })
+        .then(
+            ({ message }) =>
+                `${message.address}@${device.features.device_id}:${device.getInstance()}` as StaticSessionId,
+        );
 
 const getState = async ({ device, method }: WorkflowContext) => {
     if (!device.features) return;
@@ -21,13 +35,8 @@ const getState = async ({ device, method }: WorkflowContext) => {
     const expectedState = device.getState()?.staticSessionId;
 
     // add-abort-signal
-    const { message } = await device.getCurrentSession().typedCall('GetAddress', 'Address', {
-        address_n: [toHardened(44), toHardened(1), toHardened(0), 0, 0],
-        coin_name: 'Testnet',
-        script_type: 'SPENDADDRESS',
-    });
 
-    const uniqueState: StaticSessionId = `${message.address}@${device.features.device_id}:${device.getInstance()}`;
+    const uniqueState = await getStaticSessionId(device);
     if (device.features.session_id) {
         device.setState({ sessionId: device.features.session_id });
     }
@@ -73,17 +82,66 @@ const getInvalidDeviceState = async (
     });
 };
 
+const getInvalidThpDeviceState = async (context: WorkflowContext) => {
+    const { device, method } = context;
+    const currentState = device.getState();
+    const expectedState = currentState?.staticSessionId;
+    const expectedSessionId = currentState?.sessionId
+        ? Buffer.from(currentState.sessionId, 'hex')
+        : undefined;
+    let uniqueState;
+    const thpState = device.getThpState()!;
+    if (expectedSessionId) {
+        // validate that expected ThpSession still exists
+        thpState.setSessionId(expectedSessionId);
+        uniqueState = await getStaticSessionId(device).catch(e => {
+            if (e.code === 'Failure_InvalidSession') {
+                // requested sessionId is not valid, reset setSessionId
+                device.setState({
+                    sessionId: undefined,
+                    deriveCardano: undefined,
+                });
+                thpState?.setSessionId(Buffer.alloc(1));
+
+                return undefined;
+            }
+        });
+    }
+
+    if (!uniqueState || (!currentState?.deriveCardano && method.useCardanoDerivation)) {
+        const newSessionId = thpState.createNewSessionId();
+
+        await createThpSession(device, method.useCardanoDerivation);
+        uniqueState = await getStaticSessionId(device);
+        device.setState({
+            sessionId: newSessionId.toString('hex'),
+            deriveCardano: method.useCardanoDerivation,
+        });
+    }
+
+    if (expectedState && expectedState !== uniqueState) {
+        return uniqueState;
+    }
+
+    if (!expectedState) {
+        device.setState({ staticSessionId: uniqueState });
+    }
+};
+
 export const validateState = async (context: WorkflowContext) => {
     const { device, method } = context;
     if (!method.useDeviceState) {
         return;
     }
 
+    const validate =
+        device.protocol.name === 'v2' ? getInvalidThpDeviceState : getInvalidDeviceState;
+
     // Make sure that device will display pin/passphrase
     const isDeviceUnlocked = device.features.unlocked;
     const isUsingPopup = DataManager.getSettings('popup');
     try {
-        let invalidDeviceState = await getInvalidDeviceState(context);
+        let invalidDeviceState = await validate(context);
         if (isUsingPopup) {
             while (invalidDeviceState) {
                 const uiPromise = method.createUiPromise(UI.INVALID_PASSPHRASE_ACTION, device);
@@ -101,7 +159,7 @@ export const validateState = async (context: WorkflowContext) => {
                     device.setState({ sessionId: undefined });
                     await device.initialize(method.useCardanoDerivation);
 
-                    invalidDeviceState = await getInvalidDeviceState(context);
+                    invalidDeviceState = await validate(context);
                 } else {
                     // set new state as requested
                     device.setState({ staticSessionId: invalidDeviceState });

--- a/packages/protocol/src/protocol-thp/ThpState.ts
+++ b/packages/protocol/src/protocol-thp/ThpState.ts
@@ -1,4 +1,10 @@
-import { ThpCredentials, ThpDeviceProperties, ThpMessageSyncBit } from './messages';
+import {
+    ThpCredentials,
+    ThpDeviceProperties,
+    ThpHandshakeCredentials,
+    ThpMessageSyncBit,
+    ThpPairingMethod,
+} from './messages';
 
 export type ThpStateSerialized = {
     properties?: ThpDeviceProperties;
@@ -11,15 +17,22 @@ export type ThpStateSerialized = {
     expectedResponses: number[]; // expected responses from the device
 };
 
+export type ThpPhase = 'handshake' | 'pairing' | 'paired';
+
 export class ThpState {
     private _properties?: ThpDeviceProperties;
     private _pairingCredentials: ThpCredentials[] = [];
+    private _phase: ThpPhase = 'handshake';
+    private _isPaired: boolean = false;
+    private _handshakeCredentials?: ThpHandshakeCredentials;
     private _channel: Buffer = Buffer.alloc(0);
     private _sendBit: ThpMessageSyncBit = 0;
     private _sendNonce: number = 0;
     private _recvBit: ThpMessageSyncBit = 0;
     private _recvNonce: number = 1;
     private _expectedResponses: number[] = [];
+    private _selectedMethod?: ThpPairingMethod;
+    private _nfcSecret?: Buffer;
 
     get properties() {
         return this._properties;
@@ -27,6 +40,34 @@ export class ThpState {
 
     setThpProperties(props: ThpDeviceProperties) {
         this._properties = props;
+    }
+
+    get phase() {
+        return this._phase;
+    }
+
+    setPhase(phase: ThpPhase) {
+        this._phase = phase;
+    }
+
+    get isPaired() {
+        return this._isPaired;
+    }
+
+    get isAutoconnectPaired() {
+        return this._isPaired && this._pairingCredentials[0]?.autoconnect;
+    }
+
+    setIsPaired(isPaired: boolean) {
+        this._isPaired = isPaired;
+    }
+
+    get pairingMethod() {
+        return this._selectedMethod;
+    }
+
+    setPairingMethod(method: ThpPairingMethod) {
+        this._selectedMethod = method;
     }
 
     get pairingCredentials() {
@@ -38,6 +79,23 @@ export class ThpState {
             this._pairingCredentials.push(...credentials);
         } else {
             this._pairingCredentials = [];
+        }
+    }
+
+    setNfcSecret(secret: Buffer) {
+        this._nfcSecret = secret;
+    }
+
+    get nfcSecret() {
+        return this._nfcSecret;
+    }
+
+    get nfcData() {
+        if (this._selectedMethod === ThpPairingMethod.NFC && this._nfcSecret) {
+            return Buffer.concat([
+                this._nfcSecret,
+                this.handshakeCredentials!.handshakeHash.subarray(0, 16),
+            ]);
         }
     }
 
@@ -104,6 +162,33 @@ export class ThpState {
         }
     }
 
+    get handshakeCredentials() {
+        return this._handshakeCredentials;
+    }
+
+    updateHandshakeCredentials(newCredentials: Partial<ThpHandshakeCredentials>) {
+        if (!this._handshakeCredentials) {
+            this._handshakeCredentials = {
+                pairingMethods: [],
+                handshakeHash: Buffer.alloc(0),
+                handshakeCommitment: Buffer.alloc(0),
+                codeEntryChallenge: Buffer.alloc(0),
+                trezorEncryptedStaticPubkey: Buffer.alloc(0),
+                hostEncryptedStaticPubkey: Buffer.alloc(0),
+                staticKey: Buffer.alloc(0),
+                hostStaticPublicKey: Buffer.alloc(0),
+                hostKey: Buffer.alloc(0),
+                trezorKey: Buffer.alloc(0),
+                trezorCpacePublicKey: Buffer.alloc(0),
+            };
+        }
+
+        this._handshakeCredentials = {
+            ...this._handshakeCredentials,
+            ...newCredentials,
+        };
+    }
+
     serialize(): ThpStateSerialized {
         return {
             properties: this._properties,
@@ -158,6 +243,9 @@ export class ThpState {
     }
 
     resetState() {
+        this._phase = 'handshake';
+        this._isPaired = false;
+        this._handshakeCredentials = undefined;
         this._channel = Buffer.alloc(0);
         this._sendBit = 0;
         this._sendNonce = 0;
@@ -165,6 +253,8 @@ export class ThpState {
         this._recvNonce = 1;
         this._expectedResponses = [];
         this._pairingCredentials = [];
+        this._selectedMethod = undefined;
+        this._nfcSecret = undefined;
     }
 
     toString() {

--- a/packages/protocol/src/protocol-thp/ThpState.ts
+++ b/packages/protocol/src/protocol-thp/ThpState.ts
@@ -24,6 +24,8 @@ export class ThpState {
     private _pairingCredentials: ThpCredentials[] = [];
     private _phase: ThpPhase = 'handshake';
     private _isPaired: boolean = false;
+    private _pairingTagPromise: { abort: () => Promise<void> } | undefined;
+    private _cancelablePromise: boolean = false;
     private _handshakeCredentials?: ThpHandshakeCredentials;
     private _channel: Buffer = Buffer.alloc(0);
     private _sendBit: ThpMessageSyncBit = 0;
@@ -33,6 +35,22 @@ export class ThpState {
     private _expectedResponses: number[] = [];
     private _selectedMethod?: ThpPairingMethod;
     private _nfcSecret?: Buffer;
+
+    get pairingTagPromise() {
+        return this._pairingTagPromise;
+    }
+
+    setPairingTagPromise(p?: { abort: () => Promise<void> }) {
+        this._pairingTagPromise = p;
+    }
+
+    get cancelablePromise() {
+        return this._cancelablePromise;
+    }
+
+    setCancelablePromise(p: boolean) {
+        this._cancelablePromise = p;
+    }
 
     get properties() {
         return this._properties;
@@ -245,6 +263,9 @@ export class ThpState {
     resetState() {
         this._phase = 'handshake';
         this._isPaired = false;
+        this._properties = undefined;
+        this._pairingTagPromise = undefined;
+        this._cancelablePromise = false;
         this._handshakeCredentials = undefined;
         this._channel = Buffer.alloc(0);
         this._sendBit = 0;

--- a/packages/protocol/src/protocol-thp/ThpState.ts
+++ b/packages/protocol/src/protocol-thp/ThpState.ts
@@ -35,6 +35,8 @@ export class ThpState {
     private _expectedResponses: number[] = [];
     private _selectedMethod?: ThpPairingMethod;
     private _nfcSecret?: Buffer;
+    private _sessionId: Buffer = Buffer.alloc(1);
+    private _sessionIdCounter: number = 0;
 
     get pairingTagPromise() {
         return this._pairingTagPromise;
@@ -207,6 +209,28 @@ export class ThpState {
         };
     }
 
+    get sessionId() {
+        return this._sessionId;
+    }
+
+    createNewSessionId() {
+        this._sessionIdCounter++;
+        if (this._sessionIdCounter > 255) {
+            this._sessionIdCounter = 1;
+        }
+
+        const sessionId = Buffer.alloc(1);
+        sessionId.writeUint8(this._sessionIdCounter, 0);
+
+        this.setSessionId(sessionId);
+
+        return sessionId;
+    }
+
+    setSessionId(sessionId: Buffer) {
+        this._sessionId = sessionId;
+    }
+
     serialize(): ThpStateSerialized {
         return {
             properties: this._properties,
@@ -276,6 +300,8 @@ export class ThpState {
         this._pairingCredentials = [];
         this._selectedMethod = undefined;
         this._nfcSecret = undefined;
+        this._sessionId = Buffer.alloc(1);
+        this._sessionIdCounter = 0;
     }
 
     toString() {

--- a/packages/protocol/src/protocol-thp/crypto/pairing.ts
+++ b/packages/protocol/src/protocol-thp/crypto/pairing.ts
@@ -26,7 +26,7 @@ export const findKnownPairingCredentials = (
 ) =>
     knownCredentials.filter(c => {
         try {
-            const trezorStaticPubkey = Buffer.from(c.trezor_static_pubkey, 'hex');
+            const trezorStaticPubkey = Buffer.from(c.trezor_static_public_key, 'hex');
             // X25519(SHA-256(trezor_static_pubkey || trezor_ephemeral_pubkey), trezor_static_pubkey).
             const h = hashOfTwo(trezorStaticPubkey, trezorEphemeralPubkey);
 

--- a/packages/protocol/src/protocol-thp/crypto/pairing.ts
+++ b/packages/protocol/src/protocol-thp/crypto/pairing.ts
@@ -1,0 +1,269 @@
+import { createHash, randomBytes } from 'crypto';
+
+import { aesgcm } from './aesgcm';
+import { curve25519, elligator2, getCurve25519KeyPair } from './curve25519';
+import { bigEndianBytesToBigInt, getIvFromNonce, hashOfTwo, hkdf, sha256 } from './tools';
+import { ThpState } from '../ThpState';
+import {
+    ThpCredentialResponse,
+    ThpHandshakeCredentials,
+    ThpHandshakeInitResponse,
+    ThpPairingMethod,
+} from '../messages';
+
+const getProtocolName = () =>
+    Buffer.concat([Buffer.from('Noise_XX_25519_AESGCM_SHA256'), Buffer.alloc(4).fill(0)]);
+
+export const getHandshakeHash = (deviceProperties: Buffer) =>
+    // 1. Set h = SHA-256(protocol_name || device_properties).
+    hashOfTwo(getProtocolName(), deviceProperties);
+
+// 10. Search credentials for a pairs (trezor_static_pubkey, credential) such that trezor_masked_static_pubkey == X25519(SHA-256(trezor_static_pubkey || trezor_ephemeral_pubkey), trezor_static_pubkey).
+export const findKnownPairingCredentials = (
+    knownCredentials: ThpCredentialResponse[],
+    trezorMaskedStaticPubkey: Buffer,
+    trezorEphemeralPubkey: Buffer,
+) =>
+    knownCredentials.filter(c => {
+        try {
+            const trezorStaticPubkey = Buffer.from(c.trezor_static_pubkey, 'hex');
+            // X25519(SHA-256(trezor_static_pubkey || trezor_ephemeral_pubkey), trezor_static_pubkey).
+            const h = hashOfTwo(trezorStaticPubkey, trezorEphemeralPubkey);
+
+            return trezorMaskedStaticPubkey.compare(curve25519(h, trezorStaticPubkey)) === 0;
+        } catch {
+            // silent
+        }
+    });
+
+export const getTrezorState = (credentials: ThpHandshakeCredentials, payload: Buffer) => {
+    // 2. Set trezor_state, success = AES-GCM-DECRYPT(key=key_response, IV=0^96, ad=empty_string, plaintext=trezor_state). Assert that success is True.
+    const aes = aesgcm(credentials.trezorKey, Buffer.alloc(12));
+    aes.auth(Buffer.alloc(0));
+    const trezorState = aes.decrypt(payload.subarray(0, 1), payload.subarray(1, 17));
+
+    return trezorState.readUint8() as 0 | 1;
+};
+
+type Curve25519KeyPair = ReturnType<typeof getCurve25519KeyPair>;
+
+// State HH1
+// TODO: link-to-public-docs
+// https://www.notion.so/satoshilabs/THP-Specification-2-0-18fdc5260606806ab573d0a7cba1897a#193dc526060681b4b871e6b761107fba
+export const handleHandshakeInit = ({
+    handshakeInitResponse,
+    thpState,
+    knownCredentials,
+    hostStaticKeys,
+    hostEphemeralKeys,
+    protobufEncoder,
+}: {
+    handshakeInitResponse: ThpHandshakeInitResponse;
+    thpState: ThpState;
+    knownCredentials: ThpCredentialResponse[];
+    hostEphemeralKeys: Curve25519KeyPair;
+    hostStaticKeys: Curve25519KeyPair;
+    protobufEncoder: (name: string, data: Record<string, unknown>) => { message: Buffer };
+}) => {
+    if (!thpState.handshakeCredentials) {
+        throw new Error('ThpStateMissing');
+    }
+
+    const { trezorEphemeralPubkey, trezorEncryptedStaticPubkey, tag } = handshakeInitResponse;
+    const { sendNonce, recvNonce } = thpState;
+    const { handshakeHash } = thpState.handshakeCredentials;
+    const iv0 = getIvFromNonce(sendNonce); // should be 0
+    const iv1 = getIvFromNonce(recvNonce); // should be 1
+
+    let h: Buffer, point: Buffer, aes: ReturnType<typeof aesgcm>;
+
+    // 1. Set h = SHA-256(protocol_name || device_properties).
+    // h = hash_of_two(PROTOCOL_NAME, deviceProperties); // moved to getHandshakeHash
+    h = handshakeHash;
+    // 2. Set h = SHA-256(h || host_ephemeral_pubkey).
+    h = hashOfTwo(h, hostEphemeralKeys.publicKey);
+    // 3. Set h = SHA-256(h).
+    h = hashOfTwo(h, Buffer.alloc(0));
+    // 4. Set h = SHA-256(h || trezor_ephemeral_pubkey).
+    h = hashOfTwo(h, trezorEphemeralPubkey);
+    // 5. Set ck, k = HKDF(protocol_name, X25519(host_ephemeral_privkey, trezor_ephemeral_pubkey)).
+    point = curve25519(hostEphemeralKeys.privateKey, trezorEphemeralPubkey);
+    let [ck, k] = hkdf(getProtocolName(), point);
+
+    // 6. Set trezor_masked_static_pubkey, success = AES-GCM-DECRYPT(key=k, IV=0^96 (bits, 12 bytes), ad=h, plaintext=encrypted_trezor_static_pubkey). Assert that success is True.
+    aes = aesgcm(k, iv0);
+    aes.auth(h);
+    const trezorStaticPubkey = trezorEncryptedStaticPubkey.subarray(0, 32);
+    const trezorStaticPubkeyTag = trezorEncryptedStaticPubkey.subarray(32, 32 + 16);
+    const trezorMaskedStaticPubkey = aes.decrypt(trezorStaticPubkey, trezorStaticPubkeyTag);
+    // 7. Set h = SHA-256(h || encrypted_trezor_static_pubkey)
+    h = hashOfTwo(h, trezorEncryptedStaticPubkey);
+    // 8. Set ck, k = HKDF(ck, X25519(host_ephemeral_privkey, trezor_masked_static_pubkey))
+    point = curve25519(hostEphemeralKeys.privateKey, trezorMaskedStaticPubkey);
+    [ck, k] = hkdf(ck, point);
+
+    // 9. Set tag_of_empty_string, success = AES-GCM-DECRYPT(key=k, IV=0^96 (bits, 12 bytes), ad=h, plaintext=empty_string). Assert that success is True.
+    aes = aesgcm(k, iv0);
+    aes.auth(h);
+    aes.decrypt(Buffer.alloc(0), tag);
+    // 10. Set h = SHA-256(h || tag)
+    h = hashOfTwo(h, tag);
+
+    // 11. Search credentials for a pairs
+    const allCredentials = findKnownPairingCredentials(
+        knownCredentials,
+        trezorMaskedStaticPubkey,
+        trezorEphemeralPubkey,
+    );
+    // and use first from the list (could be undefined)
+    const credentials: ThpCredentialResponse | undefined = allCredentials[0];
+
+    // 11.1 If found set (temp_host_static_privkey, temp_host_static_pubkey) = (host_static_privkey, host_static_pubkey).
+    // 11.2 If not found set (temp_host_static_privkey, temp_host_static_pubkey) = (X25519(0, B), 0).
+    const hostTempKeys = credentials
+        ? hostStaticKeys
+        : getCurve25519KeyPair(Buffer.alloc(32).fill(0));
+
+    // 12. Set encrypted_host_static_pubkey = AES-GCM-ENCRYPT(key=k, IV=0^95 || 1, ad=h, plaintext=temp_host_static_pubkey).
+    aes = aesgcm(k, iv1);
+    aes.auth(h);
+    const hostEncryptedStaticPubkey = Buffer.concat([
+        aes.encrypt(hostTempKeys.publicKey),
+        aes.finish(),
+    ]);
+    // 13. Set h = SHA-256(h || encrypted_host_static_pubkey).
+    h = hashOfTwo(h, hostEncryptedStaticPubkey);
+    // 14. Set ck, k = HKDF(ck, X25519(temp_host_static_privkey, trezor_ephemeral_pubkey)).
+    point = curve25519(hostTempKeys.privateKey, trezorEphemeralPubkey);
+    [ck, k] = hkdf(ck, point);
+    // 15. Set payload_binary = PROTOBUF-ENCODE(type=HandshakeCompletionReqNoisePayload, host_pairing_credential).
+    const { message } = protobufEncoder('ThpHandshakeCompletionReqNoisePayload', {
+        host_pairing_credential: credentials?.credential,
+    });
+    // 16. Set *encrypted_payload* = AES-GCM-ENCRYPT(*key*=*k*, *IV*=*0^96*, *ad*=*h*, *plaintext*=*payload_binary*).
+    aes = aesgcm(k, iv0);
+    aes.auth(h);
+    const encryptedPayload = Buffer.concat([aes.encrypt(message), aes.finish()]);
+    h = hashOfTwo(h, encryptedPayload);
+
+    // HH2 and HH3
+    // 1. Set key_request, key_response = HKDF(ck, empty_string).
+    const [hostKey, trezorKey] = hkdf(ck, Buffer.alloc(0));
+
+    return {
+        trezorMaskedStaticPubkey,
+        trezorEncryptedStaticPubkey,
+        hostEncryptedStaticPubkey,
+        hostKey,
+        trezorKey,
+        handshakeHash: h,
+        credentials,
+        allCredentials,
+        encryptedPayload,
+    };
+};
+
+export const getCpaceHostKeys = (code: Buffer, handshakeHash: Buffer) => {
+    // TODO: link-to-public-docs
+    // https://www.notion.so/satoshilabs/Pairing-phase-996b0e879fff4ebd9460ae27376fce76
+    // If the user enters code, take the following actions:
+    // 2. Compute *pregenerator* as the first 32 bytes of SHA-512(*prefix* || *code* - 6 bytes || *padding || h*), where *prefix* is the byte-string  0x08 || 0x43 || 0x50 || 0x61 || 0x63 || 0x65 || 0x32 || 0x35 || 0x35 || 0x06 and *padding* is the byte-string 0x50 || 0x00 ^ 80 || 0x20.
+    // 3. Set *generator =* ELLIGATOR2(*pregenerator*).
+    // 4. Generate a random 32-byte *cpace_host_private_key.*
+    // 5. Set *cpace_host_public_key* = X25519(*cpace_host_private_key*, *generator*).
+    // 6. Send the message CodeEntryCpaceHost(*cpace_host_public_key*) to the host.
+
+    const shaCtx = createHash('sha512');
+    shaCtx.update(Buffer.from([0x08, 0x43, 0x50, 0x61, 0x63, 0x65, 0x32, 0x35, 0x35, 0x06]));
+    shaCtx.update(code);
+    shaCtx.update(
+        Buffer.concat([Buffer.from([0x6f]), Buffer.alloc(111).fill(0), Buffer.from([0x20])]),
+    );
+    shaCtx.update(handshakeHash);
+    shaCtx.update(Buffer.from([0x00]));
+    const sha = shaCtx.digest().subarray(0, 32);
+
+    const generator = elligator2(sha);
+
+    const privateKey = randomBytes(32);
+    const publicKey = curve25519(privateKey, generator);
+
+    return { privateKey, publicKey };
+};
+
+export const getSharedSecret = (publicKey: Buffer, privateKey: Buffer) => {
+    // 1. Set *shared_secret* = X25519(*cpace_host_private_key*, *cpace_trezor_public_key*).
+    // 2. Set *tag* = SHA-256(*shared_secret*).
+
+    const sharedSecret = curve25519(privateKey, publicKey);
+
+    return sha256(Buffer.from(sharedSecret));
+};
+
+export const validateCodeEntryTag = (
+    credentials: ThpHandshakeCredentials,
+    value: string,
+    secret: string,
+) => {
+    // 1. Assert that handshake commitment = SHA-256(secret)
+    const sha = createHash('sha256').update(Buffer.from(secret, 'hex')).digest();
+    const { handshakeHash, handshakeCommitment, codeEntryChallenge } = credentials;
+    if (sha.compare(handshakeCommitment) !== 0) {
+        throw new Error(
+            `HP5: commitment mismatch ${handshakeCommitment.toString('hex')} != ${sha.toString('hex')}`,
+        );
+    }
+
+    // 2. Assert that value = SHA-256(ThpPairingMethod.CodeEntry || h || secret || challenge) % 1000000
+    const shaCtx = createHash('sha256');
+    shaCtx.update(Buffer.from([ThpPairingMethod.CodeEntry]));
+    shaCtx.update(handshakeHash);
+    shaCtx.update(Buffer.from(secret, 'hex'));
+    shaCtx.update(codeEntryChallenge);
+
+    const calculatedValue = bigEndianBytesToBigInt(shaCtx.digest()) % 1000000n;
+    if (calculatedValue !== BigInt(value)) {
+        throw new Error(`HP5: code mismatch ${value} != ${calculatedValue.toString()}`);
+    }
+};
+
+export const validateQrCodeTag = (
+    { handshakeHash }: ThpHandshakeCredentials,
+    value: string,
+    secret: string, // ThpQrCodeSecret.secret
+) => {
+    // Assert that value = SHA-256(ThpPairingMethod.QrCode || h || secret)
+    const shaCtx = createHash('sha256');
+    shaCtx.update(Buffer.from([ThpPairingMethod.QrCode]));
+    shaCtx.update(handshakeHash);
+    shaCtx.update(Buffer.from(secret, 'hex'));
+
+    const calculatedValue = shaCtx.digest().subarray(0, 16);
+    const expectedValue = Buffer.from(value, 'hex').subarray(0, 16);
+    if (calculatedValue.compare(expectedValue) !== 0) {
+        throw new Error(
+            `HP6: code mismatch ${calculatedValue.toString('hex')} != ${expectedValue.toString('hex')}`,
+        );
+    }
+};
+
+// validate ThpNfcTagTrezor
+export const validateNfcTag = (
+    { handshakeHash }: ThpHandshakeCredentials,
+    value: string, // ThpNfcTagTrezor.tag
+    secret: Buffer, // ThpState.nfcSecret
+) => {
+    // Assert that value = SHA-256(ThpPairingMethod.NFC || h || secret)
+    const shaCtx = createHash('sha256');
+    shaCtx.update(Buffer.from([ThpPairingMethod.NFC]));
+    shaCtx.update(handshakeHash);
+    shaCtx.update(secret);
+
+    const calculatedValue = shaCtx.digest().subarray(0, 16);
+    const expectedValue = Buffer.from(value, 'hex').subarray(0, 16);
+    if (calculatedValue.compare(expectedValue) !== 0) {
+        throw new Error(
+            `HP7: code mismatch ${calculatedValue.toString('hex')} != ${expectedValue.toString('hex')}`,
+        );
+    }
+};

--- a/packages/protocol/src/protocol-thp/decode.ts
+++ b/packages/protocol/src/protocol-thp/decode.ts
@@ -1,13 +1,21 @@
 import { ThpState } from './ThpState';
 import {
     CRC_LENGTH,
+    TAG_LENGTH,
+    THP_CONTROL_BYTE_DECRYPTED,
+    THP_CONTROL_BYTE_ENCRYPTED,
     THP_CREATE_CHANNEL_RESPONSE,
     THP_ERROR_HEADER_BYTE,
+    THP_HANDSHAKE_COMPLETION_RESPONSE,
+    THP_HANDSHAKE_INIT_RESPONSE,
     THP_READ_ACK_HEADER_BYTE,
 } from './constants';
+import { aesgcm } from './crypto';
 import { TransportProtocolDecode } from '../types';
 import { crc32 } from './crypto/crc32';
-import { ThpError, ThpMessageResponse } from './messages';
+import { getHandshakeHash, getTrezorState } from './crypto/pairing';
+import { getIvFromNonce } from './crypto/tools';
+import { ThpDeviceProperties, ThpError, ThpMessageResponse } from './messages';
 import { clearControlBit, readThpHeader } from './utils';
 
 type ThpMessage = ReturnType<TransportProtocolDecode> & {
@@ -26,6 +34,14 @@ type ProtobufDecoder = (
 
 type MessageV2 = ReturnType<TransportProtocolDecode>;
 
+const decipherMessage = (key: Buffer, recvNonce: number, payload: Buffer, tag: Buffer) => {
+    const aes = aesgcm(key, getIvFromNonce(recvNonce));
+    aes.auth(Buffer.alloc(0));
+    const trezorMaskedStaticPubkey = aes.decrypt(payload, tag);
+
+    return trezorMaskedStaticPubkey.subarray(1); // NOTE: remove session_id (first byte)
+};
+
 // TODO: link-to-public-docs
 // https://www.notion.so/satoshilabs/THP-Specification-2-0-18fdc5260606806ab573d0a7cba1897a
 // example: 41ffff0020639ba57ff4e0c2343c830a0454335731180220002802280328042801c0171551
@@ -35,13 +51,12 @@ type MessageV2 = ReturnType<TransportProtocolDecode>;
 const createChannelResponse = (
     { payload }: ThpMessage,
     protobufDecoder: ProtobufDecoder,
-): ThpMessageResponse => {
+): ThpMessageResponse<'ThpCreateChannelResponse'> => {
     const nonce = payload.subarray(0, 8);
     const channel = payload.subarray(8, 10);
     const props = payload.subarray(10, payload.length - CRC_LENGTH);
-    const properties = protobufDecoder('ThpDeviceProperties', props).message;
-    // TODO: add-crypto
-    // const handshakeHash = handleCreateChannelResponse(props);
+    const properties = protobufDecoder('ThpDeviceProperties', props).message as ThpDeviceProperties;
+    const handshakeHash = getHandshakeHash(props);
 
     return {
         type: 'ThpCreateChannelResponse',
@@ -49,10 +64,60 @@ const createChannelResponse = (
             nonce,
             channel,
             properties,
-            // TODO: add-crypto
-            // handshakeHash,
+            handshakeHash,
         },
-    } as any;
+    };
+};
+
+const readHandshakeInitResponse = ({
+    payload,
+}: ThpMessage): ThpMessageResponse<'ThpHandshakeInitResponse'> => {
+    const trezorEphemeralPubkey = payload.subarray(0, 32);
+    const trezorEncryptedStaticPubkey = payload.subarray(32, 32 + 48);
+    const tag = payload.subarray(32 + 48, 32 + 48 + TAG_LENGTH);
+
+    return {
+        type: 'ThpHandshakeInitResponse',
+        message: {
+            trezorEphemeralPubkey,
+            trezorEncryptedStaticPubkey,
+            tag,
+        },
+    };
+};
+
+const readHandshakeCompletionResponse = ({
+    payload,
+    thpState,
+}: ThpMessage): ThpMessageResponse<'ThpHandshakeCompletionResponse'> => {
+    const state = getTrezorState(thpState.handshakeCredentials!, payload);
+
+    return {
+        type: 'ThpHandshakeCompletionResponse',
+        message: {
+            state,
+        },
+    };
+};
+
+const readProtobufMessage = (
+    { payload, thpState }: ThpMessage,
+    protobufDecoder: ProtobufDecoder,
+): ThpMessageResponse => {
+    const tagPos = payload.length - TAG_LENGTH - CRC_LENGTH;
+    const cipheredMessage = payload.subarray(0, tagPos);
+    const tag = payload.subarray(tagPos, payload.length - CRC_LENGTH);
+    const decipheredMessage = decipherMessage(
+        thpState.handshakeCredentials!.trezorKey,
+        thpState.recvNonce,
+        cipheredMessage,
+        tag,
+    );
+
+    const messageType = decipheredMessage.readUInt16BE(0);
+    const messagePayload = decipheredMessage.subarray(2);
+
+    return protobufDecoder(messageType, messagePayload) as ThpMessageResponse;
 };
 
 const decodeReadAck = (): ThpMessageResponse => ({
@@ -144,7 +209,7 @@ export const decode = (
     thpState?: ThpState,
 ): ThpMessageResponse => {
     if (!thpState) {
-        throw new Error('Cannot decode THP message without ThpState');
+        throw new Error('ThpStateMissing');
     }
 
     validateCrc(decodedMessage);
@@ -167,6 +232,23 @@ export const decode = (
 
     if (magic === THP_CREATE_CHANNEL_RESPONSE) {
         return createChannelResponse(message, protobufDecoder);
+    }
+
+    if (magic === THP_HANDSHAKE_INIT_RESPONSE) {
+        return readHandshakeInitResponse(message);
+    }
+
+    if (magic === THP_HANDSHAKE_COMPLETION_RESPONSE) {
+        return readHandshakeCompletionResponse(message);
+    }
+
+    if (magic === THP_CONTROL_BYTE_ENCRYPTED) {
+        return readProtobufMessage(message, protobufDecoder);
+    }
+
+    // TODO: decrypted message decoding (not implemented in FW)
+    if (magic === THP_CONTROL_BYTE_DECRYPTED) {
+        return readProtobufMessage(message, protobufDecoder);
     }
 
     throw new Error('Unknown message type: ' + magic);

--- a/packages/protocol/src/protocol-thp/encode.ts
+++ b/packages/protocol/src/protocol-thp/encode.ts
@@ -5,9 +5,12 @@ import {
     THP_CONTROL_BYTE_ENCRYPTED,
     THP_CREATE_CHANNEL_REQUEST,
     THP_DEFAULT_CHANNEL,
+    THP_HANDSHAKE_COMPLETION_REQUEST,
+    THP_HANDSHAKE_INIT_REQUEST,
     THP_READ_ACK_HEADER_BYTE,
 } from './constants';
-import { crc32 } from './crypto/crc32';
+import { aesgcm, crc32 } from './crypto';
+import { getIvFromNonce } from './crypto/tools';
 import { addAckBit, addSequenceBit, getControlBit, isThpMessageName } from './utils';
 
 // @trezor/protobuf encodeMessage without direct reference to protobuf root
@@ -17,6 +20,16 @@ type ProtobufEncoder = (
 ) => {
     messageType: number;
     message: Buffer;
+};
+
+const cipherMessage = (key: Buffer, sendNonce: number, handshakeHash: Buffer, payload: Buffer) => {
+    // Set encrypted_payload = AES-GCM-ENCRYPT(key=k, IV=0^96, ad=h, plaintext=payload_binary).
+    const aes = aesgcm(key, getIvFromNonce(sendNonce));
+    aes.auth(handshakeHash);
+    const encryptedPayload = aes.encrypt(payload);
+    const encryptedPayloadTag = aes.finish();
+
+    return Buffer.concat([encryptedPayload, encryptedPayloadTag]);
 };
 
 // utility for **RequestPayload inputs/params
@@ -39,9 +52,37 @@ const createChannelRequestPayload = (data: Record<string, unknown>) => {
     return nonce;
 };
 
-export const encodePayload = (name: string, data: Record<string, unknown>, _thpState: ThpState) => {
+const handshakeInitRequestPayload = (data: Record<string, unknown>, _thpState: ThpState) => {
+    const key = getBytesFromField(data, 'key');
+    if (!key) {
+        throw new Error('ThpHandshakeInitRequest missing key field');
+    }
+
+    return key;
+};
+
+const handshakeCompletionRequestPayload = (data: Record<string, unknown>) => {
+    const hostPubkey = getBytesFromField(data, 'hostPubkey');
+    if (!hostPubkey) {
+        throw new Error('ThpHandshakeCompletionRequest missing hostPubkey field');
+    }
+    const encryptedPayload = getBytesFromField(data, 'encryptedPayload');
+    if (!encryptedPayload) {
+        throw new Error('ThpHandshakeCompletionRequest missing encryptedPayload field');
+    }
+
+    return Buffer.concat([hostPubkey, encryptedPayload]);
+};
+
+export const encodePayload = (name: string, data: Record<string, unknown>, thpState: ThpState) => {
     if (name === 'ThpCreateChannelRequest') {
         return createChannelRequestPayload(data);
+    }
+    if (name === 'ThpHandshakeInitRequest') {
+        return handshakeInitRequestPayload(data, thpState);
+    }
+    if (name === 'ThpHandshakeCompletionRequest') {
+        return handshakeCompletionRequestPayload(data);
     }
 
     return Buffer.alloc(0);
@@ -64,17 +105,47 @@ const createChannelRequest = (data: Buffer, channel: Buffer) => {
     return Buffer.concat([message, crc]);
 };
 
+const handshakeInitRequest = (data: Buffer, channel: Buffer) => {
+    const length = Buffer.alloc(2);
+    length.writeUInt16BE(data.length + CRC_LENGTH);
+
+    const magic = Buffer.from([THP_HANDSHAKE_INIT_REQUEST]);
+    const message = Buffer.concat([magic, channel, length, data]);
+    const crc = crc32(message);
+
+    return Buffer.concat([message, crc]);
+};
+
+const handshakeCompletionRequest = (data: Buffer, channel: Buffer, sendBit: number) => {
+    const length = Buffer.alloc(2);
+    length.writeUInt16BE(data.length + CRC_LENGTH);
+
+    const magic = addSequenceBit(THP_HANDSHAKE_COMPLETION_REQUEST, sendBit);
+    const message = Buffer.concat([magic, channel, length, data]);
+    const crc = crc32(message);
+
+    return Buffer.concat([message, crc]);
+};
+
 const encodeThpMessage = (
     messageType: string,
     data: Buffer,
     channel: Buffer,
-    _thpState: ThpState,
+    thpState: ThpState,
 ) => {
     if (messageType === 'ThpCreateChannelRequest') {
         return createChannelRequest(data, channel);
     }
 
-    throw new Error(`Unknown ThpMessage type ${messageType}`);
+    if (messageType === 'ThpHandshakeInitRequest') {
+        return handshakeInitRequest(data, channel);
+    }
+
+    if (messageType === 'ThpHandshakeCompletionRequest') {
+        return handshakeCompletionRequest(data, channel, thpState.sendBit || 0);
+    }
+
+    throw new Error(`Unknown Thp message type ${messageType}`);
 };
 
 // TODO: link-to-public-docs
@@ -86,25 +157,24 @@ export const encodeProtobufMessage = (
     thpState?: ThpState,
 ) => {
     if (!thpState) {
-        throw new Error('ThpState missing');
+        throw new Error('ThpStateMissing');
     }
 
     const length = Buffer.alloc(2);
     length.writeUInt16BE(1 + 2 + data.length + TAG_LENGTH + CRC_LENGTH); // 1 session_id + 2 messageType + protobuf len + 16 tag + 4 crc
 
+    // TODO: distinguish encrypted and decrypted messages (not implemented in FW)
     const magic = addSequenceBit(THP_CONTROL_BYTE_ENCRYPTED, thpState.sendBit);
     const header = Buffer.concat([magic, channel]);
 
     const messageTypeBytes = Buffer.alloc(2);
     messageTypeBytes.writeUInt16BE(messageType);
-    // TODO: add-crypto
-    // const cipheredMessage = cipherMessage(
-    //     thpState.handshakeCredentials.hostKey,
-    //     thpState.sendNonce,
-    //     Buffer.alloc(0),
-    //     Buffer.concat([thpState.sessionId, messageTypeBytes, data]),
-    // );
-    const cipheredMessage = Buffer.concat([Buffer.alloc(0), messageTypeBytes, data]);
+    const cipheredMessage = cipherMessage(
+        thpState.handshakeCredentials!.hostKey,
+        thpState.sendNonce,
+        Buffer.alloc(0),
+        Buffer.concat([thpState.sessionId, messageTypeBytes, data]),
+    );
     const message = Buffer.concat([header, length, cipheredMessage]);
     const crc = crc32(message);
 
@@ -150,10 +220,9 @@ export const encode = (options: {
     data: Record<string, unknown>;
     thpState?: ThpState;
     protobufEncoder: ProtobufEncoder;
-    header?: Buffer;
 }) => {
     if (!options.thpState) {
-        throw new Error('ThpState missing');
+        throw new Error('ThpStateMissing');
     }
 
     const channel = options.thpState.channel || THP_DEFAULT_CHANNEL;

--- a/packages/protocol/src/protocol-thp/index.ts
+++ b/packages/protocol/src/protocol-thp/index.ts
@@ -2,7 +2,18 @@ export * from './decode';
 export * from './encode';
 export * from './messages';
 export * from './utils';
+export * as constants from './constants';
 
+export {
+    getCpaceHostKeys,
+    getSharedSecret,
+    getHandshakeHash,
+    handleHandshakeInit,
+    validateCodeEntryTag,
+    validateQrCodeTag,
+    validateNfcTag,
+} from './crypto/pairing';
 export { ThpState } from './ThpState';
+export { getCurve25519KeyPair } from './crypto/curve25519';
 
 export const name = 'thp';

--- a/packages/protocol/src/protocol-thp/messages/messageTypes.ts
+++ b/packages/protocol/src/protocol-thp/messages/messageTypes.ts
@@ -37,14 +37,9 @@ export type ThpHandshakeInitRequest = {
 };
 
 export type ThpHandshakeInitResponse = {
-    handshakeHash: Buffer;
     trezorEphemeralPubkey: Buffer;
     trezorEncryptedStaticPubkey: Buffer;
-    trezorMaskedStaticPubkey: Buffer;
     tag: Buffer;
-    hostEncryptedStaticPubkey: Buffer;
-    hostKey: Buffer;
-    trezorKey: Buffer;
 };
 
 export type ThpHandshakeCompletionRequest = {
@@ -54,7 +49,6 @@ export type ThpHandshakeCompletionRequest = {
 
 export type ThpHandshakeCompletionResponse = {
     state: 0 | 1;
-    tag: Buffer;
 };
 
 export type ThpMessageType = ThpProtobufMessageType & {

--- a/packages/protocol/tests/protocol-thp/pairing.test.ts
+++ b/packages/protocol/tests/protocol-thp/pairing.test.ts
@@ -1,0 +1,38 @@
+import { findKnownPairingCredentials } from '../../src/protocol-thp/crypto/pairing';
+
+describe('pairing', () => {
+    it('findKnownPairingCredentials', () => {
+        const knownCredentials = [
+            {
+                trezor_static_pubkey:
+                    '1317c99c16fce04935782ed250cf0cacb12216f739cea55257258a2ff9440763',
+                credential:
+                    '0a0f0a0d5472657a6f72436f6e6e6563741220f69918996c0afa1045b3625d06e7e816b0c4c4bd3902dfd4cad068b3f2425ec8',
+            },
+            {
+                trezor_static_pubkey:
+                    '2bcdbc9fd7949c3f37aa80a53801f52ec554facfe76118030926294250fd6838',
+                credential:
+                    '0a110a0d5472657a6f72436f6e6e65637410011220b97509ef252b07dcc70071c9d13dd70746d8a9fb671765049ca74e58b9058d6b',
+            },
+        ];
+
+        const trezorMaskedStaticPubkey = Buffer.from(
+            'be8d024bbcd5ac116e041035fcc6243ce1d77d7075e351c87aa0831fbf46ce66',
+            'hex',
+        );
+
+        const trezorEphemeralPubkey = Buffer.from(
+            'f817f577f24d7ec08c1ea397df2da916e0ee81423961763dc45395e18fc02121',
+            'hex',
+        );
+
+        const credentials = findKnownPairingCredentials(
+            knownCredentials,
+            trezorMaskedStaticPubkey,
+            trezorEphemeralPubkey,
+        );
+
+        expect(credentials).toEqual([knownCredentials[1]]);
+    });
+});

--- a/packages/protocol/tests/protocol-thp/pairing.test.ts
+++ b/packages/protocol/tests/protocol-thp/pairing.test.ts
@@ -4,13 +4,13 @@ describe('pairing', () => {
     it('findKnownPairingCredentials', () => {
         const knownCredentials = [
             {
-                trezor_static_pubkey:
+                trezor_static_public_key:
                     '1317c99c16fce04935782ed250cf0cacb12216f739cea55257258a2ff9440763',
                 credential:
                     '0a0f0a0d5472657a6f72436f6e6e6563741220f69918996c0afa1045b3625d06e7e816b0c4c4bd3902dfd4cad068b3f2425ec8',
             },
             {
-                trezor_static_pubkey:
+                trezor_static_public_key:
                     '2bcdbc9fd7949c3f37aa80a53801f52ec554facfe76118030926294250fd6838',
                 credential:
                     '0a110a0d5472657a6f72436f6e6e65637410011220b97509ef252b07dcc70071c9d13dd70746d8a9fb671765049ca74e58b9058d6b',

--- a/packages/protocol/tests/protocol-thp/protocol-thp.test.ts
+++ b/packages/protocol/tests/protocol-thp/protocol-thp.test.ts
@@ -51,9 +51,11 @@ describe('protocol-thp', () => {
         expect(decoded.message).toMatchObject({
             channel: Buffer.from('3c83', 'hex'),
             nonce,
+            handshakeHash: Buffer.from(
+                'a1615c6dc1c2a2df8155ea5b54d0f39c320d4908e4b1eaf8d24ab5c4b466e947',
+                'hex',
+            ),
             // properties asserted below
-            // TODO: add-crypto
-            // handshakeHash
         });
 
         // @ts-expect-error

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -220,6 +220,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     this.api.read(path, attemptSignal || signal);
 
                 if (protocol.name === 'v2') {
+                    const prevNonce = thpState?.sendNonce;
                     const callResult = await callThpMessage({
                         thpState,
                         chunks,
@@ -234,7 +235,10 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                         return callResult;
                     }
 
-                    thpState?.sync('send', name);
+                    // sync bit and nonce updated by Cancel
+                    if (prevNonce === thpState?.sendNonce) {
+                        thpState?.sync('send', name);
+                    }
                     const message = parseThpMessage({
                         messages: this.messages,
                         decoded: callResult.payload,

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -236,6 +236,7 @@ export class BridgeTransport extends AbstractTransport {
                     thpState,
                 });
 
+                const prevNonce = thpState?.sendNonce;
                 const response = await this.post(`/call`, {
                     params: session,
                     body: this.getRequestBody(bytes, protocol, thpState),
@@ -249,7 +250,10 @@ export class BridgeTransport extends AbstractTransport {
                 const respBytes = Buffer.from(response.payload.data, 'hex');
                 if (protocol.name === 'v2') {
                     // see callThpMessage in @trezor/transport-bridge
-                    thpState?.sync('send', name);
+                    // sync bit and nonce updated by Cancel
+                    if (prevNonce === thpState?.sendNonce) {
+                        thpState?.sync('send', name);
+                    }
                     const message = parseThpMessage({
                         decoded: protocol.decode(respBytes),
                         messages: this.messages,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

based on https://github.com/trezor/trezor-suite/pull/19490
## Description

1. THP pairing cryptography. set of functions used in handshake and pairing flow. read more about THP pairing here: https://www.notion.so/satoshilabs/THP-Specification-2-1-203dc5260606804192aecaa58fb961ca
2. THP handshake + pairing messages.  encoding/decoding (cipher and decipher) THP messages
3. implement THP handshake and pairing in connect
4. implement THP workflow cancellation. unlike `v1` we need to additionally read `ThpAck` after transport.write('Cancel`)
5. implement THP passphrase flow. unlike protocol `v1`  PassphraseRequest is not sent by the device. we need to establish the session before it can be used. this is replacement for `v1` `Initialize` message flow.
6. implement THP in firmware update flow. `onCallFirmwareUpdate` is paused on THP pairing step and waits forl UI confirmation

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/thp-pairing&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/thp-pairing&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/thp-pairing&lookback=7)