### PR TITLE
refactor(connect): DeviceCurrentSession common fail handler

### DIFF
--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -58,11 +58,11 @@ const isExpectedResponse = <Key extends Messages.MessageKey | Messages.MessageKe
 
 const success = <T>(payload: T) => ({ success: true as const, payload });
 const error = (error: Error) => ({ success: false as const, error });
-const fail = (msg: string) =>
+const fail = (resp: { error: string; message?: string }) =>
     error(
         new Error(
-            msg,
-            isErrorWithoutDeviceInteraction(msg) ? { cause: 'transport-error' } : undefined,
+            resp.message || resp.error,
+            isErrorWithoutDeviceInteraction(resp.error) ? { cause: 'transport-error' } : undefined,
         ),
     );
 
@@ -356,7 +356,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
             logger.warn('Received transport error', result.error, result.message);
         }
 
-        return result.success ? success(result.payload) : fail(result.message || result.error);
+        return result.success ? success(result.payload) : fail(result);
     }
 
     async send<T extends Messages.MessageKey>(
@@ -375,7 +375,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
             ...options,
         });
 
-        return result.success ? success(result.payload) : fail(result.message || result.error);
+        return result.success ? success(result.payload) : fail(result);
     }
 
     async receive(options: AbortableOptions = {}) {
@@ -388,7 +388,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
             ...options,
         });
 
-        return result.success ? success(result.payload) : fail(result.message || result.error);
+        return result.success ? success(result.payload) : fail(result);
     }
 
     cancelCall() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

error handling unification leftover from https://github.com/trezor/trezor-suite/pull/20049

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/connect-common-error-handler&lookback=7)