### PR TITLE
Reenable `wipeDevice` with `skipFinalReload`

### DIFF
--- a/packages/connect/src/api/wipeDevice.ts
+++ b/packages/connect/src/api/wipeDevice.ts
@@ -9,7 +9,7 @@ export default class WipeDevice extends AbstractMethod<'wipeDevice'> {
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS, UI.BOOTLOADER];
         this.useDeviceState = false;
         this.requiredPermissions = ['management'];
-        this.skipFinalReload = false;
+        this.skipFinalReload = this.payload.skipFinalReload ?? false;
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
     }
 


### PR DESCRIPTION
## Description

In https://github.com/trezor/trezor-suite/commit/86d982eb3193c6fa3bb50c1050af2aff3e408fd4 we basically disabled custom `skipFinalReload` param for the explicitly listed methods. Which is probably fine for all of them, except `WipeDevice` which has to skip final `GetFeatures` only when in bootloader mode (after being wiped, it doesn't respond anymore).

I fixed it for this method alone, but in the future we may completely remove this param and decide it solely inside Connect; I believe this is the last case where the param is relevant.

## Related issues

Should resolve #20166

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/wipe-device&lookback=7)