### PR TITLE
fix(suite): start discovery when device becomes acquired

### DIFF
--- a/packages/suite/src/components/suite/AcquireDeviceButton.tsx
+++ b/packages/suite/src/components/suite/AcquireDeviceButton.tsx
@@ -20,7 +20,7 @@ export const AcquireDeviceButton = ({ className, onClick }: AcquireButtonProps) 
 
     const handleClick: MouseEventHandler = e => {
         onClick?.(e);
-        dispatch(acquireDevice({ startDiscovery: true }));
+        dispatch(acquireDevice({}));
     };
 
     return (

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
@@ -18,7 +18,7 @@ export const DeviceAcquire = () => {
 
     const handleClick: MouseEventHandler = e => {
         e.stopPropagation();
-        dispatch(acquireDevice({ startDiscovery: true }));
+        dispatch(acquireDevice({}));
     };
 
     const ctaButton = (

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -45,6 +45,11 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
             );
         }
 
+        // device becomesAcquired (device-change event) and is locked at the same time.
+        // device-change is emitted right before acquireDevice ends (and unlocks)
+        const isDeviceReady =
+            device?.connected && isDeviceAcquired(device) && (!isDeviceLocked || becomesAcquired);
+
         if (
             becomesAcquired ||
             becomesConnected ||
@@ -54,7 +59,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
             changeNetworks.match(action) ||
             accountsActions.changeAccountVisibility.match(action)
         ) {
-            if (device && device.connected && isDeviceAcquired(device) && !isDeviceLocked) {
+            if (isDeviceReady) {
                 if (!device?.state) {
                     // note: currently this is only used in Suite. If a Suite Lite implementation is needed,
                     // refactor this to a parameter because suiteSettings is a suite-only reducer.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fixing second issue described in https://github.com/trezor/trezor-suite/issues/20129

## How to test it

1. Start suite with external (not build-in) bridge transport, go to account and show receive address.
2. refresh suite
3. connected device is unacquired (used in another window)
4. click on "use device here"


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-discovery-unacuired&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-discovery-unacuired&lookback=7)