### PR TITLE
Feat/suite: thp initialization

### DIFF
--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -5,6 +5,7 @@ import { IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy
 import { parseElectrumUrl } from '@trezor/utils';
 
 import { getStoredFirmwares } from './firmware';
+import { APP_NAME } from '../libs/constants';
 
 import { MainThreadEmitter, ModuleInit, ModuleInitBackground } from './index';
 
@@ -59,11 +60,16 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
                 logger.debug(SERVICE_NAME, `call ${method}`);
                 if (method === 'init') {
                     logger.info(SERVICE_NAME, `Retrieving stored firmwares`);
+                    const [settings] = params;
                     const localFirmwares = await getStoredFirmwares();
-                    const settings = {
-                        ...params[0],
-                        localFirmwares: localFirmwares.success ? localFirmwares.payload : undefined,
-                    };
+                    if (settings.thp) {
+                        // upgrade THP hostName with codesign (dev/local) suffix
+                        settings.thp.hostName = APP_NAME;
+                    }
+                    if (localFirmwares.success) {
+                        settings.localFirmwares = localFirmwares.payload;
+                    }
+
                     const response = await TrezorConnect.init(settings);
                     await setProxy();
 

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -78,6 +78,12 @@ export const extraDependencies: ExtraDependencies = {
         selectTradingEnvironment: (state: AppState) =>
             state.suite.settings.debug.invityServerEnvironment,
         selectIsViewOnlyByDefaultEnabled: (_: AppState) => true,
+        selectThpSettings: (state: AppState) => ({
+            hostName: 'Trezor Suite', // NOTE: this is displayed on Trezor. not the same as manifest.appName
+            pairingMethods: ['CodeEntry'],
+            staticKey: state.thp?.staticKey,
+            knownCredentials: state.thp?.credentials,
+        }),
     },
     actions: {
         setAccountAddMetadata: metadataActions.setAccountAdd,

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -42,7 +42,7 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
     `${CONNECT_INIT_MODULE}/initThunk`,
     async (connectInitHooks, { dispatch, getState, extra }) => {
         const {
-            selectors: { selectDebugSettings },
+            selectors: { selectDebugSettings, selectThpSettings },
             actions: { lockDevice },
             utils: { connectInitSettings },
         } = extra;
@@ -164,6 +164,7 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
                 binFilesBaseUrl,
                 pendingTransportEvent: selectIsPendingTransportEvent(getState()),
                 transports,
+                thp: selectThpSettings(getState()),
                 debug: showConnectLogs,
             });
         } catch (error) {

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -69,6 +69,7 @@ export type ExtraDependencies = {
             'production' | 'staging' | 'dev' | 'localhost' | undefined
         >;
         selectIsViewOnlyByDefaultEnabled: SuiteCompatibleSelector<boolean>;
+        selectThpSettings: SuiteCompatibleSelector<NonNullable<ConnectSettings['thp']>>;
     };
     // You should only use ActionCreatorWithPayload from redux-toolkit!
     // That means you will need to convert actual action creators in packages/suite to use createAction from redux-toolkit,

--- a/suite-common/test-utils/src/extraDependenciesMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesMock.ts
@@ -97,6 +97,7 @@ export const extraDependenciesMock: ExtraDependencies = {
         selectIsWindowVisible: mockSelector('selectIsWindowVisible', true),
         selectTradingEnvironment: mockSelector('selectTradingEnvironment', 'localhost'),
         selectIsViewOnlyByDefaultEnabled: mockSelector('selectIsViewOnlyByDefaultEnabled', true),
+        selectThpSettings: mockSelector('selectThpSettings', { pairingMethods: ['CodeEntry'] }),
     },
     actions: {
         setAccountAddMetadata: mockAction('setAccountAddMetadata'),

--- a/suite-common/thp/src/index.ts
+++ b/suite-common/thp/src/index.ts
@@ -1,6 +1,6 @@
 export { prepareThpReducer, THP_BUTTON_REQUESTS_NAMES } from './thpReducer';
 export type { ThpStep } from './thpReducer';
-export { selectThpStep, selectThpCredentials, selectThpStaticKey } from './thpSelectors';
+export { selectThpStep, selectThpCredentials } from './thpSelectors';
 export { thpActions } from './thpActions';
 export { connectThpDeviceThunk } from './connectThpDeviceThunk';
 export { autoInitThpAfterDeviceConnectionThunk } from './autoInitThpAfterDeviceConnectionThunk';

--- a/suite-common/thp/src/thpSelectors.ts
+++ b/suite-common/thp/src/thpSelectors.ts
@@ -7,5 +7,3 @@ export type WithThpState = {
 export const selectThpStep = (state: WithThpState) => state.thp.step;
 
 export const selectThpCredentials = (state: WithThpState) => state.thp.credentials;
-
-export const selectThpStaticKey = (state: WithThpState) => state.thp.staticKey;

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -42,6 +42,12 @@ export const extraDependencies: ExtraDependencies = mergeDeepObject(extraDepende
             network: undefined,
             params: undefined,
         }),
+        selectThpSettings: state => ({
+            hostName: 'Trezor Suite', // NOTE: this is displayed on Trezor. not the same as manifest.appName
+            pairingMethods: ['CodeEntry', 'NFC'],
+            staticKey: state.thp?.staticKey,
+            knownCredentials: state.thp?.credentials,
+        }),
     } as Partial<ExtraDependencies['selectors']>,
     thunks: {} as Partial<ExtraDependencies['thunks']>,
     actions: {} as Partial<ExtraDependencies['actions']>,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- add thp settings to TrezorConnect.init
- thp setting are (will be) different for desktop and mobile apps (different pairing methods)
- extraDependecies selector could be modified in the future to get `pairingMethods` from the reducer

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-bt-thp-init&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-bt-thp-init&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/suite-bt-thp-init&lookback=7)