### PR TITLE
fix(native): CoinControl design tweaks, fixed utxo comparison

### DIFF
--- a/packages/theme/src/fontWeights.ts
+++ b/packages/theme/src/fontWeights.ts
@@ -2,6 +2,7 @@
 export const fontWeights = {
     medium: '500',
     semiBold: '600',
+    bold: '700',
 } as const;
 
 export type FontWeight = keyof typeof fontWeights;

--- a/suite-native/atoms/src/Button/TextButton.tsx
+++ b/suite-native/atoms/src/Button/TextButton.tsx
@@ -18,6 +18,7 @@ export type TextButtonVariant = 'primary' | 'tertiary';
 type TextButtonProps = Omit<ButtonProps, 'colorScheme'> & {
     isUnderlined?: boolean;
     variant?: TextButtonVariant;
+    isBold?: boolean;
 };
 
 const variantToColorsMap = {
@@ -36,14 +37,29 @@ const buttonContainerStyle = prepareNativeStyle(() => ({
 }));
 
 const textStyle = prepareNativeStyle(
-    (utils, { buttonSize, isUnderlined }: { buttonSize: ButtonSize; isUnderlined: boolean }) => ({
+    (
+        utils,
+        {
+            buttonSize,
+            isUnderlined,
+            isBold,
+        }: { buttonSize: ButtonSize; isUnderlined: boolean; isBold: boolean },
+    ) => ({
         ...utils.typography[buttonToTextSizeMap[buttonSize]],
-        extend: {
-            condition: isUnderlined,
-            style: {
-                textDecorationLine: 'underline',
+        extend: [
+            {
+                condition: isUnderlined,
+                style: {
+                    textDecorationLine: 'underline',
+                },
             },
-        },
+            {
+                condition: isBold,
+                style: {
+                    fontWeight: utils.fontWeights.bold,
+                },
+            },
+        ],
     }),
 );
 
@@ -56,6 +72,7 @@ export const TextButton = ({
     size = 'medium',
     isDisabled = false,
     isUnderlined = false,
+    isBold = false,
     ...pressableProps
 }: TextButtonProps) => {
     const { applyStyle, utils } = useNativeStyles();
@@ -105,7 +122,7 @@ export const TextButton = ({
                 )}
                 <Animated.Text
                     style={[
-                        applyStyle(textStyle, { buttonSize: size, isUnderlined }),
+                        applyStyle(textStyle, { buttonSize: size, isUnderlined, isBold }),
                         animatedTextStyle,
                     ]}
                 >

--- a/suite-native/module-send/src/components/CoinControl/UtxoCard.tsx
+++ b/suite-native/module-send/src/components/CoinControl/UtxoCard.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+import { TouchableOpacity } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
@@ -28,8 +30,12 @@ import {
 import { Utxo } from '@trezor/blockchain-link-types';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
-const AccountAddressFormatterStyle = prepareNativeStyle(() => ({
+const accountAddressFormatterStyle = prepareNativeStyle(() => ({
     maxWidth: '80%',
+}));
+
+const cardStyle = prepareNativeStyle(utils => ({
+    borderWidth: utils.borders.widths.large,
 }));
 
 export type Props = {
@@ -74,46 +80,55 @@ export const UtxoCard = ({ utxo, onToggle, accountKey, symbol, isSelected = fals
         rate: currentRates?.rate,
     });
 
-    return (
-        <Card noPadding borderColor={isSelected ? 'backgroundSecondaryDefault' : 'transparent'}>
-            <VStack>
-                <HStack
-                    paddingTop="sp16"
-                    paddingHorizontal="sp12"
-                    justifyContent="space-between"
-                    alignItems="center"
-                >
-                    <VStack>
-                        <HStack alignItems="center">
-                            <CryptoAmountFormatter
-                                color="textDefault"
-                                variant="highlight"
-                                value={utxo.amount}
-                                isBalance={false}
-                                symbol={symbol}
-                            />
-                            {fiatAmount && (
-                                <>
-                                    <Text color="textSubdued">≈</Text>
-                                    <BaseCurrencyAmountFormatter
-                                        color="textSubdued"
-                                        variant="highlight"
-                                        symbol={symbol}
-                                        value={fiatAmount}
-                                    />
-                                </>
-                            )}
-                        </HStack>
+    const handleToggle = useCallback(() => {
+        onToggle(utxo);
+    }, [onToggle, utxo]);
 
-                        <AccountAddressFormatter
-                            style={applyStyle(AccountAddressFormatterStyle)}
-                            value={utxo.address}
-                            variant="hint"
-                            color="textSubdued"
-                        />
-                    </VStack>
-                    <CheckBox isChecked={isSelected} onChange={() => onToggle(utxo)} />
-                </HStack>
+    return (
+        <Card
+            noPadding
+            borderColor={isSelected ? 'backgroundSecondaryDefault' : 'transparent'}
+            style={applyStyle(cardStyle)}
+        >
+            <VStack spacing="sp12">
+                <TouchableOpacity onPress={handleToggle}>
+                    <HStack
+                        paddingTop="sp16"
+                        paddingHorizontal="sp12"
+                        justifyContent="space-between"
+                        alignItems="center"
+                    >
+                        <VStack>
+                            <HStack alignItems="center">
+                                <CryptoAmountFormatter
+                                    color="textDefault"
+                                    variant="highlight"
+                                    value={utxo.amount}
+                                    isBalance={false}
+                                    symbol={symbol}
+                                />
+                                {fiatAmount && (
+                                    <>
+                                        <Text color="textSubdued">≈</Text>
+                                        <BaseCurrencyAmountFormatter
+                                            color="textSubdued"
+                                            symbol={symbol}
+                                            value={fiatAmount}
+                                        />
+                                    </>
+                                )}
+                            </HStack>
+
+                            <AccountAddressFormatter
+                                style={applyStyle(accountAddressFormatterStyle)}
+                                value={utxo.address}
+                                variant="hint"
+                                color="textSubdued"
+                            />
+                        </VStack>
+                        <CheckBox isChecked={isSelected} onChange={handleToggle} />
+                    </HStack>
+                </TouchableOpacity>
                 <Divider />
                 <HStack
                     justifyContent="space-between"
@@ -121,11 +136,11 @@ export const UtxoCard = ({ utxo, onToggle, accountKey, symbol, isSelected = fals
                     paddingHorizontal="sp12"
                 >
                     {transactionBlockTime && (
-                        <Text variant="hint">
+                        <Text color="textSubdued" variant="hint">
                             <DateFormatter value={transactionBlockTime} />
                         </Text>
                     )}
-                    <TextButton variant="tertiary" onPress={handleShowDetails} size="small">
+                    <TextButton variant="primary" onPress={handleShowDetails} isBold size="small">
                         <Translation id="moduleSend.coinControl.utxos.showDetails" />
                     </TextButton>
                 </HStack>

--- a/suite-native/module-send/src/components/CoinControl/UtxoList.tsx
+++ b/suite-native/module-send/src/components/CoinControl/UtxoList.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { FlashList } from '@shopify/flash-list';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { isSameUtxo } from '@suite-common/wallet-utils';
 import { Box } from '@suite-native/atoms';
 import { Utxo } from '@trezor/blockchain-link-types';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -26,18 +27,15 @@ type UtxoListProps = {
 export const UtxoList = ({
     utxos,
     accountKey,
-    selectedUtxos: tempSelectedUtxos,
+    selectedUtxos,
     onUtxoToggle,
     symbol,
 }: UtxoListProps) => {
     const { applyStyle } = useNativeStyles();
 
     const isSelected = useCallback(
-        (utxo: Utxo) =>
-            tempSelectedUtxos.some(
-                selected => selected.txid === utxo.txid && selected.vout === utxo.vout,
-            ),
-        [tempSelectedUtxos],
+        (utxo: Utxo) => selectedUtxos.some(selected => isSameUtxo(selected, utxo)),
+        [selectedUtxos],
     );
 
     const renderItem = useCallback(
@@ -58,7 +56,7 @@ export const UtxoList = ({
     return (
         <FlashList
             data={utxos}
-            extraData={tempSelectedUtxos}
+            extraData={selectedUtxos}
             keyExtractor={utxo => `${utxo.txid}-${utxo.vout}`}
             renderItem={renderItem}
             contentContainerStyle={applyStyle(UtxoListStyle)}

--- a/suite-native/module-send/src/hooks/useUtxoSelection.ts
+++ b/suite-native/module-send/src/hooks/useUtxoSelection.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { useAtom } from 'jotai';
 
+import { isSameUtxo } from '@suite-common/wallet-utils';
 import { Utxo } from '@trezor/blockchain-link-types';
 import { BigNumber } from '@trezor/utils';
 
@@ -31,16 +32,12 @@ export const useUtxoSelection = (accountKey: string): UseUtxoSelectionReturn => 
 
     const handleUtxoSelection = (utxo: Utxo) => {
         setSelectedUtxosMap(prev => {
-            const isSelected = selectedUtxos.some(
-                selected => selected.txid === utxo.txid && selected.vout === utxo.vout,
-            );
+            const isSelected = selectedUtxos.some(selected => isSameUtxo(selected, utxo));
 
             return {
                 ...prev,
                 [accountKey]: isSelected
-                    ? selectedUtxos.filter(
-                          selected => !(selected.txid === utxo.txid && selected.vout === utxo.vout),
-                      )
+                    ? selectedUtxos.filter(selected => !isSameUtxo(selected, utxo))
                     : [...selectedUtxos, utxo],
             };
         });

--- a/suite-native/module-send/src/screens/SendUtxoScreen.tsx
+++ b/suite-native/module-send/src/screens/SendUtxoScreen.tsx
@@ -9,7 +9,7 @@ import {
     fetchAllTransactionsForAccountThunk,
     selectAccountByKey,
 } from '@suite-common/wallet-core';
-import { useFilteredUtxos } from '@suite-common/wallet-utils';
+import { isSameUtxo, useFilteredUtxos } from '@suite-common/wallet-utils';
 import { BaseSearchInput, SearchInputWithCancel, Text, VStack } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 import { Screen, SendStackParamList, SendStackRoutes, StackProps } from '@suite-native/navigation';
@@ -56,10 +56,18 @@ export const SendUtxoScreen = ({
         };
     }, [accountKey, dispatch]);
 
-    const handleUtxoSelect = (utxo: Utxo) =>
-        tempSelectedUtxos.includes(utxo)
-            ? setTempSelectedUtxos(tempSelectedUtxos.filter(txid => txid !== utxo))
-            : setTempSelectedUtxos([...tempSelectedUtxos, utxo]);
+    const handleUtxoSelect = (utxo: Utxo) => {
+        const exists = tempSelectedUtxos.some(selected => isSameUtxo(selected, utxo));
+        if (exists) {
+            setTempSelectedUtxos(
+                tempSelectedUtxos.filter(
+                    selected => !(isSameUtxo(selected, utxo) ? selected : null),
+                ),
+            );
+        } else {
+            setTempSelectedUtxos([...tempSelectedUtxos, utxo]);
+        }
+    };
 
     const totalTempSelectedUtxos = useMemo(
         () =>
@@ -70,7 +78,11 @@ export const SendUtxoScreen = ({
     );
 
     const onSelectionSubmit = () => {
-        setSelectedUtxos(account?.utxo?.filter(u => tempSelectedUtxos.includes(u)) ?? []);
+        setSelectedUtxos(
+            account?.utxo?.filter(u =>
+                tempSelectedUtxos.some(tempUtxo => isSameUtxo(u, tempUtxo)),
+            ) ?? [],
+        );
         setTempSelectedUtxos([]);
         navigation.goBack();
     };

--- a/suite-native/module-send/src/utils.ts
+++ b/suite-native/module-send/src/utils.ts
@@ -37,3 +37,6 @@ export const constructFormDraft = ({
     feeLimit: feeLevel.feeLimit ?? '',
     ...restFormValues,
 });
+
+export const isSameUtxo = (utxo1: Utxo, utxo2: Utxo): boolean =>
+    utxo1.txid === utxo2.txid && utxo1.vout === utxo2.vout;


### PR DESCRIPTION
**Implemented design tweaks**:
- `Show details` button
- Separator margin
- Top half of the card is now clickable
- Datetime color updated

Fixed UTXO object comparison (that was introduced in https://github.com/trezor/trezor-suite/pull/20133)

## Related Issue

Resolves https://github.com/trezor/trezor-suite/issues/20193 https://github.com/trezor/trezor-suite/issues/20194

## Screenshots:
FEEDBACK
<img width="1641" height="905" alt="Screenshot 2025-07-15 at 9 46 21" src="https://github.com/user-attachments/assets/acd98d3c-123b-47c8-b18a-6e1e3554d968" />
AFTER
<img width="445" height="963" alt="Screenshot 2025-07-15 at 9 52 27" src="https://github.com/user-attachments/assets/e33ea2b7-c51e-4d91-b8f5-1767634106b0" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/coincontrol-design-tweaks&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/coincontrol-design-tweaks&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/coincontrol-design-tweaks&lookback=7)