### PR TITLE
feat(suite-native): add view only by default FF

### DIFF
--- a/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
@@ -88,6 +88,7 @@ describe('redirectMiddleware', () => {
                 payload: {
                     device: getConnectDevice({ mode: 'initialize' }),
                     settings: { defaultWalletLoading: 'standard' },
+                    isViewOnlyByDefaultEnabled: true,
                 },
             };
 
@@ -103,6 +104,7 @@ describe('redirectMiddleware', () => {
                 payload: {
                     device: getConnectDevice({ mode: 'normal', firmware: 'required' }),
                     settings: { defaultWalletLoading: 'standard' },
+                    isViewOnlyByDefaultEnabled: true,
                 },
             };
 

--- a/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
@@ -38,6 +38,7 @@ const connect: Fixture<
                     settings: {
                         defaultWalletLoading: 'standard',
                     },
+                    isViewOnlyByDefaultEnabled: true,
                 },
             },
         ],
@@ -67,6 +68,7 @@ const connect: Fixture<
                     settings: {
                         defaultWalletLoading: 'standard',
                     },
+                    isViewOnlyByDefaultEnabled: true,
                 },
             },
         ],
@@ -102,6 +104,7 @@ const connect: Fixture<
                     settings: {
                         defaultWalletLoading: 'standard',
                     },
+                    isViewOnlyByDefaultEnabled: true,
                 },
             },
         ],
@@ -132,6 +135,7 @@ const connect: Fixture<
                     settings: {
                         defaultWalletLoading: 'standard',
                     },
+                    isViewOnlyByDefaultEnabled: true,
                 },
             },
         ],
@@ -168,6 +172,7 @@ const connect: Fixture<
                     settings: {
                         defaultWalletLoading: 'standard',
                     },
+                    isViewOnlyByDefaultEnabled: true,
                 },
             },
         ],
@@ -207,6 +212,7 @@ const connect: Fixture<
                     settings: {
                         defaultWalletLoading: 'standard',
                     },
+                    isViewOnlyByDefaultEnabled: true,
                 },
             },
         ],
@@ -244,6 +250,7 @@ const connect: Fixture<
                     settings: {
                         defaultWalletLoading: 'standard',
                     },
+                    isViewOnlyByDefaultEnabled: true,
                 },
             },
         ],
@@ -284,6 +291,7 @@ const connect: Fixture<
                     settings: {
                         defaultWalletLoading: 'standard',
                     },
+                    isViewOnlyByDefaultEnabled: true,
                 },
             },
         ],
@@ -315,6 +323,7 @@ const connect: Fixture<
                     settings: {
                         defaultWalletLoading: 'standard',
                     },
+                    isViewOnlyByDefaultEnabled: true,
                 },
             },
         ],

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -77,6 +77,7 @@ export const extraDependencies: ExtraDependencies = {
         selectIsWindowVisible,
         selectTradingEnvironment: (state: AppState) =>
             state.suite.settings.debug.invityServerEnvironment,
+        selectIsViewOnlyByDefaultEnabled: (_: AppState) => true,
     },
     actions: {
         setAccountAddMetadata: metadataActions.setAccountAdd,

--- a/suite-common/bluetooth/tests/bluetoothReducer.test.ts
+++ b/suite-common/bluetooth/tests/bluetoothReducer.test.ts
@@ -152,6 +152,7 @@ describe('bluetoothReducer', () => {
             deviceActions.connectDevice({
                 device: trezorDevice as Device,
                 settings: { defaultWalletLoading: 'passphrase' },
+                isViewOnlyByDefaultEnabled: true,
             }),
         );
         expect(store.getState().bluetooth.knownDevices).toEqual([nearbyDevice]);

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -68,6 +68,7 @@ export type ExtraDependencies = {
         selectTradingEnvironment: SuiteCompatibleSelector<
             'production' | 'staging' | 'dev' | 'localhost' | undefined
         >;
+        selectIsViewOnlyByDefaultEnabled: SuiteCompatibleSelector<boolean>;
     };
     // You should only use ActionCreatorWithPayload from redux-toolkit!
     // That means you will need to convert actual action creators in packages/suite to use createAction from redux-toolkit,

--- a/suite-common/test-utils/src/extraDependenciesMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesMock.ts
@@ -96,6 +96,7 @@ export const extraDependenciesMock: ExtraDependencies = {
         }),
         selectIsWindowVisible: mockSelector('selectIsWindowVisible', true),
         selectTradingEnvironment: mockSelector('selectTradingEnvironment', 'localhost'),
+        selectIsViewOnlyByDefaultEnabled: mockSelector('selectIsViewOnlyByDefaultEnabled', true),
     },
     actions: {
         setAccountAddMetadata: mockAction('setAccountAddMetadata'),

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -10,7 +10,12 @@ export type ConnectDeviceSettings = {
     defaultWalletLoading: WalletType;
 };
 
-export type DeviceConnectActionPayload = { device: Device; settings: ConnectDeviceSettings };
+export type DeviceConnectActionPayload = {
+    device: Device;
+    settings: ConnectDeviceSettings;
+    // Note: temporary condition until view only by default is not controlled by feature flag on native
+    isViewOnlyByDefaultEnabled: boolean;
+};
 
 const connectDevice = createAction(DEVICE.CONNECT, (payload: DeviceConnectActionPayload) => ({
     payload,
@@ -18,7 +23,7 @@ const connectDevice = createAction(DEVICE.CONNECT, (payload: DeviceConnectAction
 
 const createDeviceInstance = createAction(
     `${DEVICE_MODULE_PREFIX}/createDeviceInstance`,
-    (payload: { device: TrezorDevice }) => ({ payload }),
+    (payload: { device: TrezorDevice; isViewOnlyByDefaultEnabled: boolean }) => ({ payload }),
 );
 
 const connectUnacquiredDevice = createAction(

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -119,6 +119,7 @@ const connectDevice = (
     draft: DeviceReducerState,
     device: Device,
     settings: ConnectDeviceSettings,
+    isViewOnlyByDefaultEnabled: boolean,
 ) => {
     const currentTime = new Date().getTime();
 
@@ -183,7 +184,7 @@ const connectDevice = (
         ...deviceCommonFields,
         state: device._state,
         useEmptyPassphrase,
-        remember: isNative() ? false : true,
+        remember: isNative() && !isViewOnlyByDefaultEnabled ? false : true,
         temporaryRemember: false,
         available: true,
         instance: deviceInstance,
@@ -446,7 +447,11 @@ const resetAuthFailed = (draft: DeviceReducerState) => {
  * @returns
  */
 // TODO: this now can only be used for imported device!
-const createInstance = (draft: DeviceReducerState, device: TrezorDevice) => {
+const createInstance = (
+    draft: DeviceReducerState,
+    device: TrezorDevice,
+    isViewOnlyByDefaultEnabled: boolean,
+) => {
     // only acquired devices
     if (!device || !device.features) return;
 
@@ -456,8 +461,7 @@ const createInstance = (draft: DeviceReducerState, device: TrezorDevice) => {
     const newDevice: TrezorDevice = {
         ...device,
         passphraseOnDevice: false,
-        // TODO: On mobile, we don't want to remember the device by default, because it's not supported yet
-        remember: isNative() ? isPortfolioTrackerDevice : true,
+        remember: isViewOnlyByDefaultEnabled,
         // In mobile app, we need to keep device state defined by the constant
         // to be able to filter device accounts for portfolio tracker
         state: isPortfolioTrackerDevice ? device.state : undefined,
@@ -687,12 +691,12 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
             state.devicesWithFailedEntropyCheck.push(payload);
         })
         .addCase(deviceActions.createDeviceInstance, (state, { payload }) => {
-            createInstance(state, payload.device);
+            createInstance(state, payload.device, payload.isViewOnlyByDefaultEnabled);
         })
         .addMatcher(
             isAnyOf(deviceActions.connectDevice, deviceActions.connectUnacquiredDevice),
-            (state, { payload: { device, settings } }) => {
-                connectDevice(state, device, settings);
+            (state, { payload: { device, settings, isViewOnlyByDefaultEnabled } }) => {
+                connectDevice(state, device, settings, isViewOnlyByDefaultEnabled);
             },
         );
 });

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -30,7 +30,7 @@ import TrezorConnect, {
     StaticSessionId,
     UI,
 } from '@trezor/connect';
-import { getEnvironment } from '@trezor/env-utils';
+import { getEnvironment, isNative } from '@trezor/env-utils';
 import { exhaustive } from '@trezor/type-utils';
 import { isChanged } from '@trezor/utils';
 
@@ -40,6 +40,7 @@ import {
     selectDeviceByBaseStaticSessionId,
     selectDeviceById,
     selectDevices,
+    selectIsPortfolioTrackerDevice,
     selectSelectedDevice,
 } from './deviceSelectors';
 import { selectAccountByKey } from '../accounts/accountsSelectors';
@@ -340,12 +341,25 @@ export const createImportedDeviceThunk = createThunk<
     { rejectValue: { error: 'already-created' } }
 >(
     `${DEVICE_MODULE_PREFIX}/createImportedDevice`,
-    (_, { dispatch, getState, rejectWithValue, fulfillWithValue }) => {
+    (_, { dispatch, getState, rejectWithValue, fulfillWithValue, extra }) => {
         const device = selectDeviceById(getState(), PORTFOLIO_TRACKER_DEVICE_ID);
 
         if (device) return rejectWithValue({ error: 'already-created' });
 
-        dispatch(deviceActions.createDeviceInstance({ device: portfolioTrackerDevice }));
+        const isNativeViewOnlyByDefaultEnabled =
+            extra.selectors.selectIsViewOnlyByDefaultEnabled(getState());
+        const isPortfolioTrackerDevice = selectIsPortfolioTrackerDevice(getState());
+
+        dispatch(
+            deviceActions.createDeviceInstance({
+                device: portfolioTrackerDevice,
+                isViewOnlyByDefaultEnabled:
+                    // Note: temporary condition until view only by default is not controlled by feature flag on native
+                    isNative() && !isNativeViewOnlyByDefaultEnabled && !isPortfolioTrackerDevice
+                        ? false
+                        : true,
+            }),
+        );
 
         return fulfillWithValue({ device: portfolioTrackerDevice });
     },
@@ -470,14 +484,24 @@ export const deviceConnectThunks = createThunk<void, DeviceConnectThunksParams, 
     `${DEVICE_MODULE_PREFIX}/deviceConnectThunk`,
     ({ type, device }, { dispatch, getState, extra }) => {
         const settings = extra.selectors.selectSuiteSettings(getState());
+        const isViewOnlyByDefaultEnabled =
+            extra.selectors.selectIsViewOnlyByDefaultEnabled(getState());
 
         switch (type) {
             case DEVICE.CONNECT:
-                dispatch(deviceActions.connectDevice({ device, settings }));
+                dispatch(
+                    deviceActions.connectDevice({ device, settings, isViewOnlyByDefaultEnabled }),
+                );
                 dispatch(connectThpDeviceThunk({ device }));
                 break;
             case DEVICE.CONNECT_UNACQUIRED:
-                dispatch(deviceActions.connectUnacquiredDevice({ device, settings }));
+                dispatch(
+                    deviceActions.connectUnacquiredDevice({
+                        device,
+                        settings,
+                        isViewOnlyByDefaultEnabled,
+                    }),
+                );
                 dispatch(autoInitThpAfterDeviceConnectionThunk({ device }));
                 break;
             default:

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -80,8 +80,11 @@ const applyDeviceStatesThunk = createThunk(
             newDeviceState: DeviceState;
             devicePath: DeviceUniquePath;
         },
-        { dispatch, getState },
+        { dispatch, getState, extra },
     ) => {
+        const { selectIsViewOnlyByDefaultEnabled } = extra.selectors;
+        const isNativeViewOnlyByDefaultEnabled = selectIsViewOnlyByDefaultEnabled(getState());
+
         try {
             const devices = selectDevices(getState());
             const devicesByPath = devices.filter(d => d.path === devicePath);
@@ -130,8 +133,9 @@ const applyDeviceStatesThunk = createThunk(
                             metadata: {},
                             instance: getNewInstanceNumber(selectDevices(getState()), device),
                             useEmptyPassphrase: !isAddingHiddenWallet,
-                            // TODO: On mobile, we don't want to remember the device by default, because it's not supported yet
-                            remember: isNative() ? false : true,
+                            // TODO: On mobile, we only support view only by default with a FF, until it's released. Remove the condition when removing the FF.
+                            remember:
+                                isNative() && !isNativeViewOnlyByDefaultEnabled ? false : true,
                             state: newDeviceState,
                         },
                     }),

--- a/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
+++ b/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
@@ -26,6 +26,7 @@ describe('featureFlagsSlice', () => {
                 isTradingExchangeEnabled: false,
                 isTradingSellEnabled: false,
                 isCheckBackupsEnabled: false,
+                isViewOnlyByDefaultEnabled: false,
             });
         });
 
@@ -50,6 +51,7 @@ describe('featureFlagsSlice', () => {
                 isTradingExchangeEnabled: false,
                 isTradingSellEnabled: false,
                 isCheckBackupsEnabled: false,
+                isViewOnlyByDefaultEnabled: false,
             });
         });
     });

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -73,5 +73,8 @@ export const featureFlagsSlice = createSlice({
 export const selectIsFeatureFlagEnabled = (state: FeatureFlagsRootState, key: FeatureFlag) =>
     state.featureFlags[key];
 
+export const selectIsViewOnlyByDefaultEnabled = (state: FeatureFlagsRootState) =>
+    state.featureFlags[FeatureFlag.IsViewOnlyByDefaultEnabled];
+
 export const { toggleFeatureFlag } = featureFlagsSlice.actions;
 export const featureFlagsReducer = featureFlagsSlice.reducer;

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -13,6 +13,7 @@ export const FeatureFlag = {
     IsTradingExchangeEnabled: 'isTradingExchangeEnabled',
     IsTradingSellEnabled: 'isTradingSellEnabled',
     IsCheckBackupsEnabled: 'isCheckBackupsEnabled',
+    IsViewOnlyByDefaultEnabled: 'isViewOnlyByDefaultEnabled',
 } as const;
 
 export type FeatureFlag = (typeof FeatureFlag)[keyof typeof FeatureFlag];
@@ -42,6 +43,8 @@ export const featureFlagsInitialState: FeatureFlagsState = {
         process.env.EXPO_PUBLIC_FF_IS_TRADING_SELL_ENABLED === 'true',
     [FeatureFlag.IsCheckBackupsEnabled]:
         process.env.EXPO_PUBLIC_FF_IS_CHECK_BACKUPS_ENABLED === 'true',
+    [FeatureFlag.IsViewOnlyByDefaultEnabled]:
+        process.env.EXPO_PUBLIC_FF_IS_VIEW_ONLY_BY_DEFAULT_ENABLED === 'true',
 };
 
 export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
@@ -54,6 +57,7 @@ export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsTradingExchangeEnabled,
     FeatureFlag.IsTradingSellEnabled,
     FeatureFlag.IsCheckBackupsEnabled,
+    FeatureFlag.IsViewOnlyByDefaultEnabled,
 ];
 
 export const featureFlagsSlice = createSlice({

--- a/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
@@ -17,6 +17,7 @@ const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsTradingBuyEnabled]: '💰 Trading Buy',
     [FeatureFlagEnum.IsTradingExchangeEnabled]: '💰 Trading Swap',
     [FeatureFlagEnum.IsTradingSellEnabled]: '💰 Trading Sell',
+    [FeatureFlagEnum.IsViewOnlyByDefaultEnabled]: 'View Only by Default',
 } as const satisfies Record<FeatureFlagEnum, string>;
 
 const FeatureFlag = ({ featureFlag }: { featureFlag: FeatureFlagEnum }) => {

--- a/suite-native/module-home/src/screens/HomeScreen/useShowViewOnlyAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/useShowViewOnlyAlert.tsx
@@ -14,6 +14,7 @@ import { useAlert } from '@suite-native/alerts';
 import { EventType, analytics } from '@suite-native/analytics';
 import { CenteredTitleHeader, LottieAnimation, VStack } from '@suite-native/atoms';
 import { selectIsDeviceReadyToUseAndAuthorized } from '@suite-native/device';
+import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import { Translation } from '@suite-native/intl';
 import {
     selectViewOnlyCancelationTimestamp,
@@ -30,6 +31,8 @@ export const useShowViewOnlyAlert = () => {
     const dispatch = useDispatch();
     const { showAlert } = useAlert();
     const { showToast } = useToast();
+
+    const isViewOnlyByDefaultEnabled = useFeatureFlag(FeatureFlag.IsViewOnlyByDefaultEnabled);
 
     const device = useSelector(selectSelectedDevice);
     const isDeviceReadyToUseAndAuthorized = useSelector(selectIsDeviceReadyToUseAndAuthorized);
@@ -95,7 +98,8 @@ export const useShowViewOnlyAlert = () => {
                 isDeviceReadyToUseAndAuthorized &&
                 !isPortfolioTrackerDevice &&
                 !hasDiscovery &&
-                !viewOnlyCancelationTimestamp;
+                !viewOnlyCancelationTimestamp &&
+                !isViewOnlyByDefaultEnabled;
 
             //show after a delay
             if (canBeShowed) {
@@ -115,6 +119,7 @@ export const useShowViewOnlyAlert = () => {
             isDeviceReadyToUseAndAuthorized,
             isDeviceRemembered,
             isPortfolioTrackerDevice,
+            isViewOnlyByDefaultEnabled,
             showViewOnlyAlert,
             viewOnlyCancelationTimestamp,
         ]),

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -6,6 +6,7 @@ import { ExtraDependencies } from '@suite-common/redux-utils';
 import { extraDependenciesMock } from '@suite-common/test-utils/src/extraDependenciesMock'; // precise import path to avoid circular dependencies
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { selectTokenDefinitionsEnabledNetworks } from '@suite-native/discovery';
+import { selectIsViewOnlyByDefaultEnabled } from '@suite-native/feature-flags';
 import { selectTradingEnvironment } from '@suite-native/module-trading';
 import { NativeBluetoothTransport } from '@trezor/transport-native-bluetooth';
 import { NativeUsbTransport } from '@trezor/transport-native-usb';
@@ -31,6 +32,7 @@ export const extraDependencies: ExtraDependencies = mergeDeepObject(extraDepende
             transports,
         }),
         selectTradingEnvironment,
+        selectIsViewOnlyByDefaultEnabled,
         // this selector is not used in native app, but it is used in @suite-common/trading in loadInitialDataThunk
         //  and without defining the selector, it would use extraDependenciesMock value there
         selectSelectedAccount: () => ({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- create FF for view only by default
- if feature flag is enabled, all connected devices are view only by default (most of the added logic will be removed and simplified when FF will be deleted)
- view only popup is only displayed if FF is not enabled

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/20197

## Screenshots:


https://github.com/user-attachments/assets/d65a80fe-f977-4e29-a9bf-5eeb55d92d50



https://github.com/user-attachments/assets/ef19cfc0-25f9-4d49-8a22-b242d6d014c2





🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/view-only-ff&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/view-only-ff&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/view-only-ff&lookback=7)