### PR TITLE
chore(suite-common): align solana send flow with new firmware

### DIFF
--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -28,6 +28,7 @@ import {
 } from '@suite-common/wallet-utils';
 import { BlockbookTransaction } from '@trezor/blockchain-link-types';
 import TrezorConnect, { PROTO, Success, SuccessWithDevice, Unsuccessful } from '@trezor/connect';
+import { getSolanaTokenDefinition } from '@trezor/connect/src/api/solana/solanaDefinitions';
 import { PushedTransaction } from '@trezor/connect/src/types/api/pushTransaction';
 import { exhaustive } from '@trezor/type-utils';
 import { cloneObject } from '@trezor/utils';
@@ -601,6 +602,17 @@ export const enhancePrecomposedTransactionThunk = createThunk<
             )
                 .then(response => response.ok)
                 .catch(() => false);
+        }
+
+        if (
+            selectedAccount.networkType === 'solana' &&
+            enhancedPrecomposedTransaction.token?.contract
+        ) {
+            const tokenDefinition = await getSolanaTokenDefinition({
+                mintAddress: enhancedPrecomposedTransaction.token.contract,
+            });
+
+            isTokenKnown = !!tokenDefinition;
         }
 
         dispatch(


### PR DESCRIPTION
## Description

This PR aligns Solana send flow with the newest firmware changes that show token contract info only for unrecognized tokens.

## Related Issue

Resolve #19769 

## Screenshots:
|Recognized token|Unrecognized token|
|------------------|--------------------|
|<img width="608" height="580" alt="Screenshot 2025-07-16 at 10 09 45" src="https://github.com/user-attachments/assets/4f24448a-2df4-457c-af02-55a5780da40a" />|<img width="614" height="664" alt="Screenshot 2025-07-16 at 10 10 02" src="https://github.com/user-attachments/assets/4728678c-f13f-4003-890d-ff6e974d040c" />|


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/align-solana-send-with-firmware&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/align-solana-send-with-firmware&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/align-solana-send-with-firmware&lookback=7)