### PR TITLE
Feat/suite-desktop:init BluetoothTransport

### DIFF
--- a/packages/suite-desktop-core/src/modules/bluetooth.ts
+++ b/packages/suite-desktop-core/src/modules/bluetooth.ts
@@ -2,13 +2,23 @@ import { ipcMain } from 'electron';
 
 import { IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
 import { getFreePort } from '@trezor/node-utils';
-import { BluetoothIpc, BluetoothIpcApi } from '@trezor/transport-bluetooth';
+import { BluetoothIpc, BluetoothIpcApi, BluetoothTransport } from '@trezor/transport-bluetooth';
 
 import { BluetoothProcess } from '../libs/processes/BluetoothProcess';
 
 import type { ModuleInit } from './index';
 
 export const SERVICE_NAME = '@trezor/transport-bluetooth';
+
+// Export module state and use it trezor-connect module to override init + setTransports params
+// getTransport function is reassigned in onLoad, onQuit
+type BluetoothModuleState = {
+    getTransport: () => BluetoothTransport | undefined;
+};
+
+export const bluetoothModuleState: BluetoothModuleState = {
+    getTransport: () => undefined,
+};
 
 export const init: ModuleInit = () => {
     const { logger } = global;
@@ -31,6 +41,14 @@ export const init: ModuleInit = () => {
         }
     };
 
+    const desktopLogger: ConstructorParameters<typeof BluetoothTransport>[0]['logger'] = {
+        info: (...args) => logger.info(SERVICE_NAME, args),
+        debug: (...args) => logger.debug(SERVICE_NAME, args),
+        log: (...args) => logger.debug(SERVICE_NAME, args),
+        warn: (...args) => logger.warn(SERVICE_NAME, args),
+        error: (...args) => logger.error(SERVICE_NAME, args),
+    };
+
     const initBluetoothIpc = async () => {
         const btProcess = await getBluetoothProcess();
         await btProcess.start();
@@ -38,9 +56,19 @@ export const init: ModuleInit = () => {
         return new BluetoothIpc({
             // @ts-expect-error TODO BluetoothIpc params will be added in upcoming PR
             url: btProcess.getUrl(),
-            logger,
+            logger: desktopLogger,
         });
     };
+
+    const getBluetoothTransport = () =>
+        bluetoothProcess
+            ? new BluetoothTransport({
+                  id: 'BluetoothTransport',
+                  url: bluetoothProcess.getUrl(),
+                  logger: desktopLogger,
+                  messages: {}, // will be added by @trezor/connect transport initialization
+              })
+            : undefined;
 
     const proxyOptions: IpcProxyHandlerOptions<BluetoothIpcApi> = {
         onCreateInstance() {
@@ -80,13 +108,14 @@ export const init: ModuleInit = () => {
 
     const unregisterProxy = createIpcProxyHandler(ipcMain, 'Bluetooth', proxyOptions);
     const onLoad = () => {
-        // empty, binary starts after bluetoothIpc.init
+        bluetoothModuleState.getTransport = getBluetoothTransport;
     };
 
     const onQuit = () => {
         logger.info(SERVICE_NAME, 'Stopping (app quit)');
         unregisterProxy();
         killBluetoothProcess();
+        bluetoothModuleState.getTransport = () => undefined;
     };
 
     return { onLoad, onQuit };

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -1,9 +1,10 @@
 import { ipcMain } from 'electron';
 
-import TrezorConnect, { LocalFirmwares, UI, UI_EVENT } from '@trezor/connect';
+import TrezorConnect, { ConnectSettings, LocalFirmwares, UI, UI_EVENT } from '@trezor/connect';
 import { IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
 import { parseElectrumUrl } from '@trezor/utils';
 
+import { bluetoothModuleState } from './bluetooth';
 import { getStoredFirmwares } from './firmware';
 import { APP_NAME } from '../libs/constants';
 import { PowerSaveBlocker } from '../libs/power-save-blocker';
@@ -41,6 +42,22 @@ const emitOnSetCustomBackendToMainThreadToAllowDomains = ({
     }
 };
 
+// override TrezorConnect.init and TrezorConnect.setTransports params
+// add BluetoothTransport if bluetooth module is enabled
+const getTransportsParam = (
+    transports?: ConnectSettings['transports'],
+): ConnectSettings['transports'] => {
+    const bluetooth = bluetoothModuleState.getTransport();
+    if (!bluetooth) return transports;
+
+    if (transports && transports.length > 0) {
+        return [...transports, bluetooth];
+    }
+
+    // we don't want to break fallback in https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/device/TransportList.ts#L70
+    return [bluetooth, 'BridgeTransport'];
+};
+
 export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store }) => {
     const { logger } = global;
     logger.info(SERVICE_NAME, `Starting service`);
@@ -70,6 +87,7 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
                     if (localFirmwares.success) {
                         settings.localFirmwares = localFirmwares.payload;
                     }
+                    settings.transports = getTransportsParam(settings.transports);
 
                     const response = await TrezorConnect.init(settings);
                     await setProxy();
@@ -88,6 +106,10 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
                     powerSaveBlocker.stopBlockingPowerSave();
 
                     return response;
+                }
+
+                if (method === 'setTransports') {
+                    params[0].transports = getTransportsParam(params[0].transports);
                 }
 
                 return (TrezorConnect[method] as any)(...params);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Based on https://github.com/trezor/trezor-suite/pull/20192

Add `BluetoothTransport` to TrezorConnect.init and TrezorConnect.setTransports params

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-bt-init&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-bt-init&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/suite-bt-init&lookback=7)