### PR TITLE
fix(suite): Use local currency when importing csv values denominated in crypto

### DIFF
--- a/packages/suite/src/hooks/wallet/useSendFormImport.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormImport.ts
@@ -113,10 +113,7 @@ export const useSendFormImport = ({
                         output.amount = cryptoAmount;
                     }
 
-                    const fiatRateKey = getFiatRateKey(
-                        network.symbol,
-                        itemCurrency as BaseCurrencyCode,
-                    );
+                    const fiatRateKey = getFiatRateKey(network.symbol, localCurrencyOption.value);
                     const fiatRate = currentRates?.[fiatRateKey];
 
                     // calculate Fiat from Amount


### PR DESCRIPTION
Previously  conversion was done from crypto to same crypto (e.g. btc-btc when sending sending bitcoin). Now it correctly converts to local currency. 

## Related Issue

Resolve #19146

## Screenshots:

Importing:
```
abc;0.02;BTC;
def;0.01;USD;
xyz;0.05;BTC;
```
<img width="893" height="1073" alt="csv-import" src="https://github.com/user-attachments/assets/dc90ac6d-894f-43b8-b2b7-0f21e69c3224" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/import-csv-crypto-base&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/import-csv-crypto-base&lookback=7)