### PR TITLE
feat(trading): disable trading during discovery

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingContainer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingContainer.tsx
@@ -1,6 +1,11 @@
 import { ElementType } from 'react';
 
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { Column } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
 import { useSelector } from 'src/hooks/suite';
+import { DiscoveryWarning } from 'src/views/wallet/staking/components/StakingDashboard/components/DiscoveryWarning';
 import { TradingFooter } from 'src/views/wallet/trading/common/TradingFooter/TradingFooter';
 import { TradingLayoutHeader } from 'src/views/wallet/trading/common/TradingLayout/TradingLayoutHeader';
 
@@ -10,6 +15,7 @@ export interface TradingContainerProps {
 
 export const TradingContainer = ({ SectionComponent }: TradingContainerProps) => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     if (selectedAccount.status !== 'loaded') {
         return <TradingLayoutHeader />;
@@ -17,6 +23,11 @@ export const TradingContainer = ({ SectionComponent }: TradingContainerProps) =>
 
     return (
         <TradingLayoutHeader>
+            {isDiscoveryRunning && (
+                <Column margin={{ bottom: spacings.md }}>
+                    <DiscoveryWarning />
+                </Column>
+            )}
             <SectionComponent selectedAccount={selectedAccount} />
             <TradingFooter />
         </TradingLayoutHeader>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
@@ -9,6 +9,7 @@ import {
     tradingExchangeActions,
 } from '@suite-common/trading';
 import { getExplorerUrl } from '@suite-common/wallet-config';
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Button, Card, Column, Icon, IconVariant, Paragraph, Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -123,6 +124,7 @@ export const TradingFormApproval = ({
 
     const currentQuoteStatus = selectedQuote?.status;
     const previousQuoteStatus = usePrevious(currentQuoteStatus);
+    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     const [isApproveButtonLoading, setIsApproveButtonLoading] = useState(false);
     const [isRevokeButtonLoading, setIsRevokeButtonLoading] = useState(false);
@@ -279,22 +281,25 @@ export const TradingFormApproval = ({
         isApproveButtonLoading ||
         (approvalStep === 'LOADING' && approvalType === 'REVOKE') ||
         isFormLoading ||
-        isScheduledQuotesRefresh;
+        isScheduledQuotesRefresh ||
+        isDiscoveryRunning;
 
     const isSwapButtonDisabled =
         isSwapButtonLoading ||
         (approvalStep === 'LOADING' && approvalType === 'APPROVE') ||
         isFormLoading ||
-        isScheduledQuotesRefresh;
+        isScheduledQuotesRefresh ||
+        isDiscoveryRunning;
 
     const isRevokeButtonDisabled =
         isRevokeButtonLoading ||
         (approvalStep === 'LOADING' && approvalType === 'APPROVE') ||
         isFormLoading ||
-        isScheduledQuotesRefresh;
+        isScheduledQuotesRefresh ||
+        isDiscoveryRunning;
 
     const isRefreshButtonDisabled =
-        isRefreshButtonLoading || isFormLoading || isScheduledQuotesRefresh;
+        isRefreshButtonLoading || isFormLoading || isScheduledQuotesRefresh || isDiscoveryRunning;
 
     return (
         <Column gap={spacings.md} alignItems="center">

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -12,7 +12,7 @@ import {
     tradingExchangeActions,
     useTradingInfo,
 } from '@suite-common/trading';
-import { selectAreFeesLoading } from '@suite-common/wallet-core';
+import { selectAreFeesLoading, selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { TokenAddress } from '@suite-common/wallet-types';
 import { isAmountTooHigh } from '@suite-common/wallet-utils';
 import { Button, Column, Paragraph, Row, TextButton, Tooltip } from '@trezor/components';
@@ -91,6 +91,7 @@ export const TradingFormOffer = () => {
     const quote = preselectedQuote ?? getSelectedQuote(context, bestScoredQuote);
     const bestScoredQuoteAmounts = getCryptoQuoteAmountProps(quote, context);
     const areFeesLoading = useSelector(state => selectAreFeesLoading(state, account.symbol));
+    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     const selectedCrypto = getSelectedCrypto(context);
     const receiveCurrency = bestScoredQuoteAmounts?.receiveCurrency;
@@ -181,7 +182,11 @@ export const TradingFormOffer = () => {
     });
 
     const isButtonDisabled =
-        tradingDeviceDisconnected || state.isLoadingOrInvalid || !quote || amountTooHigh;
+        isDiscoveryRunning ||
+        tradingDeviceDisconnected ||
+        state.isLoadingOrInvalid ||
+        !quote ||
+        amountTooHigh;
 
     const isLoading = requiresTokenApproval
         ? state.isFormLoading || isFetchingApprovalStatus || isQuoteOutdated

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSend.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSend.tsx
@@ -1,17 +1,20 @@
 import { useEffect } from 'react';
 
 import type { TradingExchangeType } from '@suite-common/trading';
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Button, Column, Divider, InfoItem, Spinner, Text } from '@trezor/components';
 import { useAsyncClickHandler } from '@trezor/react-utils';
 import { spacings } from '@trezor/theme';
 
 import { AccountLabeling, Address, Translation } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingWatchTrade } from 'src/hooks/wallet/trading/useTradingWatchTrade';
 import { useTradingNavigation } from 'src/hooks/wallet/useTradingNavigation';
 
 export const TradingOfferExchangeSend = () => {
     const { handleClick, disabled } = useAsyncClickHandler();
+    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     const {
         device,
@@ -66,7 +69,7 @@ export const TradingOfferExchangeSend = () => {
                         <Button
                             data-testid="@trading/offer/confirm-on-trezor-and-send"
                             isLoading={isFormLoading || disabled}
-                            isDisabled={!device?.connected || disabled}
+                            isDisabled={!device?.connected || isDiscoveryRunning || disabled}
                             onClick={() => handleClick(() => sendTransaction())}
                         >
                             <Translation id="TR_EXCHANGE_CONFIRM_ON_TREZOR_SEND" />

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellTransaction.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellTransaction.tsx
@@ -1,12 +1,14 @@
 import styled from 'styled-components';
 
 import type { TradingSellType } from '@suite-common/trading';
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Button, Column, Spinner, Text } from '@trezor/components';
 import { useAsyncClickHandler } from '@trezor/react-utils';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings, spacingsPx, typography } from '@trezor/theme';
 
 import { AccountLabeling, Translation } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingWatchTrade } from 'src/hooks/wallet/trading/useTradingWatchTrade';
 
@@ -43,6 +45,7 @@ const Address = styled.div``;
 
 export const TradingSelectedOfferSellTransaction = () => {
     const { handleClick, disabled } = useAsyncClickHandler();
+    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
     const {
         device,
         account,
@@ -129,7 +132,7 @@ export const TradingSelectedOfferSellTransaction = () => {
                         <Button
                             minWidth={200}
                             isLoading={isFormLoading || disabled}
-                            isDisabled={!device?.connected || disabled}
+                            isDisabled={!device?.connected || isDiscoveryRunning || disabled}
                             onClick={() => handleClick(() => onConfirmAndSendClick())}
                             data-testid="@trading/offer/confirm-on-trezor-and-send"
                         >

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerify.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerify.tsx
@@ -9,6 +9,7 @@ import {
     useTradingInfo,
 } from '@suite-common/trading';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { isHexValid, isInteger } from '@suite-common/wallet-utils';
 import addressValidator from '@trezor/address-validator';
 import { Button, Column, Divider, Input, Paragraph, Tooltip } from '@trezor/components';
@@ -18,7 +19,7 @@ import { spacings } from '@trezor/theme';
 
 import * as modalActions from 'src/actions/suite/modalActions';
 import { Translation } from 'src/components/suite';
-import { useDispatch } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTranslation } from 'src/hooks/suite/useTranslation';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { TradingVerifyAccountReturnProps } from 'src/types/trading/tradingVerify';
@@ -41,6 +42,7 @@ export const TradingVerify = ({ tradingVerifyAccount, cryptoId }: TradingVerifyP
 
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
+    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
     const context = useTradingFormContext<TradingTradeBuyExchangeType>();
     const { cryptoIdToNativeCoinSymbol, cryptoIdToSymbolAndContractAddress } = useTradingInfo();
     const {
@@ -263,7 +265,7 @@ export const TradingVerify = ({ tradingVerifyAccount, cryptoId }: TradingVerifyP
                             <Button
                                 data-testid="@trading/offer/confirm-on-trezor-button"
                                 isLoading={isFormLoading || disabled}
-                                isDisabled={disabled || isFormLoading}
+                                isDisabled={disabled || isDiscoveryRunning || isFormLoading}
                                 onClick={() => {
                                     handleClick(() => {
                                         if (selectedAccountOption.account && accountAddress) {


### PR DESCRIPTION
## Description

- added discovery warning
- confirm buttons during discovery are disabled

## Related Issue

Resolve #19617

## Screenshots:
<img width="975" height="590" alt="image" src="https://github.com/user-attachments/assets/f7930968-6c2a-4423-ba4f-1d9d0e47fe13" />
<img width="1067" height="708" alt="image" src="https://github.com/user-attachments/assets/513dedd8-bdfe-4bbf-b0b3-73072a5a3b8b" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-discovery-running&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-discovery-running&lookback=7)