### PR TITLE
feat(suite): connect device switcher bar

### DIFF
--- a/packages/components/src/components/Modal/ModalBackdrop.tsx
+++ b/packages/components/src/components/Modal/ModalBackdrop.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import FocusLock from 'react-focus-lock';
 
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { ZIndexValues, spacings, zIndices } from '@trezor/theme';
 
@@ -19,11 +19,19 @@ export type ModalBackdropProps = {
     alignment?: ModalAlignment;
     padding?: Padding;
     zIndex?: ZIndexValues;
+    opaque?: boolean;
 };
 
-const Backdrop = styled.div`
-    backdrop-filter: blur(5px);
-    background: rgb(0 0 0 / 30%);
+const Backdrop = styled.div<{ $opaque?: boolean }>`
+    ${({ $opaque, theme }) =>
+        $opaque
+            ? css`
+                  background: ${theme.backgroundSurfaceElevationNegative};
+              `
+            : css`
+                  backdrop-filter: blur(5px);
+                  background: rgb(0 0 0 / 30%);
+              `}
     height: 100%;
 `;
 
@@ -37,6 +45,7 @@ export const ModalBackdrop = ({
     alignment = { x: 'center', y: 'center' },
     padding = spacings.xs,
     zIndex = zIndices.modal,
+    opaque = false,
 }: ModalBackdropProps) => {
     const modalTarget = useModalTarget();
 
@@ -44,7 +53,7 @@ export const ModalBackdrop = ({
         // eslint-disable-next-line jsx-a11y/no-autofocus
         <FocusLock autoFocus={false}>
             <Box position={{ type: 'absolute', inset: 0 }} zIndex={zIndex}>
-                <Backdrop onClick={onClick}>
+                <Backdrop onClick={onClick} $opaque={opaque}>
                     <Box padding={padding} height="100%">
                         <Column
                             alignItems={mapAlignmentToAlignItems(alignment)}

--- a/packages/suite/src/components/suite/ConnectAppBar.tsx
+++ b/packages/suite/src/components/suite/ConnectAppBar.tsx
@@ -1,0 +1,95 @@
+import styled from 'styled-components';
+
+import {
+    CALL_SOURCE_WALLETCONNECT,
+    connectPopupActions,
+    selectConnectPopupCall,
+} from '@suite-common/connect-popup';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { Box, Icon, Row, Text } from '@trezor/components';
+import { borders, spacings } from '@trezor/theme';
+
+import { DeviceStatus } from 'src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+import { TrafficLightOffset } from './TrafficLightOffset';
+import { Translation } from './Translation';
+
+export const ConnectBarWrapper = styled.div`
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+`;
+
+interface ConnectAppBarProps {
+    canSwitchDevice?: boolean;
+}
+
+export const ConnectAppBar = ({ canSwitchDevice }: ConnectAppBarProps) => {
+    const connectPopupCall = useSelector(selectConnectPopupCall);
+    const dispatch = useDispatch();
+    const device = useSelector(selectSelectedDevice);
+
+    if (!connectPopupCall || connectPopupCall.state === 'finished') return null;
+
+    const isWalletConnect =
+        connectPopupCall.state !== 'error' &&
+        connectPopupCall.source?.type === CALL_SOURCE_WALLETCONNECT;
+
+    const onSelectDevice = () => {
+        if (!canSwitchDevice || isWalletConnect) return;
+        dispatch(connectPopupActions.switchDevice());
+    };
+
+    return (
+        <ConnectBarWrapper>
+            <Box
+                hasBackground
+                padding={{
+                    horizontal: spacings.xl,
+                    vertical: spacings.md,
+                }}
+                borderWidth={{ bottom: borders.widths.large }}
+            >
+                <TrafficLightOffset>
+                    <Row gap={spacings.sm} alignItems="center" justifyContent="space-between">
+                        {device?.features?.internal_model && (
+                            <Row
+                                gap={spacings.lg}
+                                alignItems="center"
+                                onClick={onSelectDevice}
+                                cursor={canSwitchDevice && !isWalletConnect ? 'pointer' : 'default'}
+                            >
+                                <DeviceStatus
+                                    deviceModel={device.features.internal_model}
+                                    device={device}
+                                />
+                                {canSwitchDevice && !isWalletConnect && (
+                                    <Icon size={20} name="caretCircleDown" />
+                                )}
+                            </Row>
+                        )}
+                        {connectPopupCall.state !== 'error' && (
+                            <Row gap={spacings.xs} alignItems="center">
+                                <Icon
+                                    name={isWalletConnect ? 'walletConnect' : 'plugs'}
+                                    variant="tertiary"
+                                />
+                                <Text variant="tertiary">
+                                    <Translation
+                                        id={
+                                            isWalletConnect
+                                                ? 'TR_WALLETCONNECT'
+                                                : 'TR_TREZOR_CONNECT'
+                                        }
+                                    />
+                                </Text>
+                            </Row>
+                        )}
+                    </Row>
+                </TrafficLightOffset>
+            </Box>
+        </ConnectBarWrapper>
+    );
+};

--- a/packages/suite/src/components/suite/ConnectModalBackdrop.tsx
+++ b/packages/suite/src/components/suite/ConnectModalBackdrop.tsx
@@ -1,0 +1,39 @@
+import { useSelector } from 'react-redux';
+
+import { selectConnectPopupCall } from '@suite-common/connect-popup';
+import {
+    ModalBackdrop,
+    ModalBackdropProps,
+} from '@trezor/components/src/components/Modal/ModalBackdrop';
+import { spacings } from '@trezor/theme';
+
+import { ConnectAppBar } from './ConnectAppBar';
+
+interface ConnectModalBackdropProps extends ModalBackdropProps {
+    canSwitchDevice?: boolean;
+}
+
+export const ConnectModalBackdrop = ({
+    children,
+    canSwitchDevice,
+    ...rest
+}: ConnectModalBackdropProps) => {
+    const connectPopupCall = useSelector(selectConnectPopupCall);
+
+    if (!connectPopupCall || connectPopupCall.state === 'finished') {
+        // Not in a connect popup call, fallback to default ModalBackdrop
+        return <ModalBackdrop {...rest}>{children}</ModalBackdrop>;
+    }
+
+    return (
+        <ModalBackdrop
+            {...rest}
+            onClick={() => {}}
+            opaque
+            padding={{ top: spacings.xxxxxl, bottom: spacings.xs, horizontal: spacings.xs }}
+        >
+            <ConnectAppBar canSwitchDevice={canSwitchDevice} />
+            {children}
+        </ModalBackdrop>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectAccountModal.tsx
@@ -21,6 +21,7 @@ import { spacings } from '@trezor/theme';
 import { onReceiveAccount } from 'src/actions/suite/modalActions';
 import { AccountLabel } from 'src/components/suite/AccountLabel';
 import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
+import { ConnectModalBackdrop } from 'src/components/suite/ConnectModalBackdrop';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
@@ -63,116 +64,123 @@ export const SelectAccountModal = ({ data }: SelectAccountModalProps) => {
     const filteredAccounts = accounts?.filter(account => account.type === selectedAccountType);
 
     return (
-        <Modal
-            onCancel={close}
-            variant="primary"
-            heading={
-                <Translation id="TR_SELECT_ACCOUNT" values={{ networkName: data.coinInfo.label }} />
-            }
-            description={
-                <>
-                    <ConnectCallSource />
-                </>
-            }
-        >
-            <Column gap={spacings.sm}>
-                <SubTabs activeItemId={selectedAccountType}>
-                    {accountTypes?.map((type, index) => (
-                        <SubTabs.Item
-                            key={index}
-                            id={type}
-                            onClick={() => {
-                                setSelectedAccountType(type);
-                            }}
-                            data-testid={`@select-account-modal/subtab/${type}`}
+        <ConnectModalBackdrop onClick={close} canSwitchDevice>
+            <Modal.ModalBase
+                onCancel={close}
+                variant="primary"
+                heading={
+                    <Translation
+                        id="TR_SELECT_ACCOUNT"
+                        values={{ networkName: data.coinInfo.label }}
+                    />
+                }
+                description={
+                    <>
+                        <ConnectCallSource />
+                    </>
+                }
+            >
+                <Column gap={spacings.sm}>
+                    <SubTabs activeItemId={selectedAccountType}>
+                        {accountTypes?.map((type, index) => (
+                            <SubTabs.Item
+                                key={index}
+                                id={type}
+                                onClick={() => {
+                                    setSelectedAccountType(type);
+                                }}
+                                data-testid={`@select-account-modal/subtab/${type}`}
+                            >
+                                {typeLabels[type]}
+                            </SubTabs.Item>
+                        ))}
+                    </SubTabs>
+
+                    <Card paddingType="none">
+                        <Table
+                            isRowHighlightedOnHover
+                            colWidths={[{ width: 'auto' }, { width: '200px' }, { width: '80px' }]}
                         >
-                            {typeLabels[type]}
-                        </SubTabs.Item>
-                    ))}
-                </SubTabs>
-
-                <Card paddingType="none">
-                    <Table
-                        isRowHighlightedOnHover
-                        colWidths={[{ width: 'auto' }, { width: '200px' }, { width: '80px' }]}
-                    >
-                        <Table.Header>
-                            <Table.Row>
-                                <Table.Cell>
-                                    <Translation id="TR_ACCOUNT" />
-                                </Table.Cell>
-                                <Table.Cell>
-                                    <Translation id="TR_BALANCE" />
-                                </Table.Cell>
-                                <Table.Cell></Table.Cell>
-                            </Table.Row>
-                        </Table.Header>
-                        <Table.Body>
-                            {filteredAccounts?.map((account, index) => {
-                                const symbol = data.coinInfo.shortcut.toLowerCase();
-                                const suiteAccount = suiteAccounts.find(
-                                    a => a.descriptor === account.descriptor && a.symbol === symbol,
-                                );
-
-                                return (
-                                    <Table.Row
-                                        key={account.descriptor}
-                                        onClick={() => confirm(index)}
-                                        data-testid={`@select-account-modal/accounts/${account.type}/${index}`}
-                                    >
-                                        <Table.Cell>
-                                            <Row gap={spacings.sm}>
-                                                {symbol in NETWORK_ICONS && (
-                                                    <CoinLogo
-                                                        type="network"
-                                                        symbol={symbol as NetworkSymbol}
-                                                        size={24}
-                                                    />
-                                                )}
-                                                {suiteAccount ? (
-                                                    <AccountLabel
-                                                        accountLabel={
-                                                            suiteAccountLabels[suiteAccount.key]
-                                                        }
-                                                        accountType={suiteAccount.accountType}
-                                                        symbol={suiteAccount.symbol}
-                                                        index={suiteAccount.index}
-                                                    />
-                                                ) : (
-                                                    account.label
-                                                )}
-                                            </Row>
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            {account.empty ? (
-                                                <Translation id="TR_ACCOUNT_IS_EMPTY_TITLE" />
-                                            ) : (
-                                                account.balance
-                                            )}
-                                        </Table.Cell>
-                                        <Table.Cell align="end">
-                                            <Icon size="large" name="caretRight" />
-                                        </Table.Cell>
-                                    </Table.Row>
-                                );
-                            })}
-                            {data.type !== 'end' && (
+                            <Table.Header>
                                 <Table.Row>
                                     <Table.Cell>
-                                        <SkeletonRectangle width="100px" animate />
+                                        <Translation id="TR_ACCOUNT" />
                                     </Table.Cell>
                                     <Table.Cell>
-                                        <SkeletonRectangle width="80px" animate />
+                                        <Translation id="TR_BALANCE" />
                                     </Table.Cell>
-                                    <Table.Cell align="end">
-                                        <SkeletonCircle size="24px" />
-                                    </Table.Cell>
+                                    <Table.Cell></Table.Cell>
                                 </Table.Row>
-                            )}
-                        </Table.Body>
-                    </Table>
-                </Card>
-            </Column>
-        </Modal>
+                            </Table.Header>
+                            <Table.Body>
+                                {filteredAccounts?.map((account, index) => {
+                                    const symbol = data.coinInfo.shortcut.toLowerCase();
+                                    const suiteAccount = suiteAccounts.find(
+                                        a =>
+                                            a.descriptor === account.descriptor &&
+                                            a.symbol === symbol,
+                                    );
+
+                                    return (
+                                        <Table.Row
+                                            key={account.descriptor}
+                                            onClick={() => confirm(index)}
+                                            data-testid={`@select-account-modal/accounts/${account.type}/${index}`}
+                                        >
+                                            <Table.Cell>
+                                                <Row gap={spacings.sm}>
+                                                    {symbol in NETWORK_ICONS && (
+                                                        <CoinLogo
+                                                            type="network"
+                                                            symbol={symbol as NetworkSymbol}
+                                                            size={24}
+                                                        />
+                                                    )}
+                                                    {suiteAccount ? (
+                                                        <AccountLabel
+                                                            accountLabel={
+                                                                suiteAccountLabels[suiteAccount.key]
+                                                            }
+                                                            accountType={suiteAccount.accountType}
+                                                            symbol={suiteAccount.symbol}
+                                                            index={suiteAccount.index}
+                                                        />
+                                                    ) : (
+                                                        account.label
+                                                    )}
+                                                </Row>
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                {account.empty ? (
+                                                    <Translation id="TR_ACCOUNT_IS_EMPTY_TITLE" />
+                                                ) : (
+                                                    account.balance
+                                                )}
+                                            </Table.Cell>
+                                            <Table.Cell align="end">
+                                                <Icon size="large" name="caretRight" />
+                                            </Table.Cell>
+                                        </Table.Row>
+                                    );
+                                })}
+                                {data.type !== 'end' && (
+                                    <Table.Row>
+                                        <Table.Cell>
+                                            <SkeletonRectangle width="100px" animate />
+                                        </Table.Cell>
+                                        <Table.Cell>
+                                            <SkeletonRectangle width="80px" animate />
+                                        </Table.Cell>
+                                        <Table.Cell align="end">
+                                            <SkeletonCircle size="24px" />
+                                        </Table.Cell>
+                                    </Table.Row>
+                                )}
+                            </Table.Body>
+                        </Table>
+                    </Card>
+                </Column>
+            </Modal.ModalBase>
+        </ConnectModalBackdrop>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectFeeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectFeeModal.tsx
@@ -12,6 +12,7 @@ import { spacings } from '@trezor/theme';
 
 import { onReceiveFee } from 'src/actions/suite/modalActions';
 import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
+import { ConnectModalBackdrop } from 'src/components/suite/ConnectModalBackdrop';
 import { Translation } from 'src/components/suite/Translation';
 import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -157,44 +158,46 @@ export const SelectFeeModal = ({ data }: SelectAccountModalProps) => {
     };
 
     return (
-        <Modal
-            onCancel={onClose}
-            onBackClick={onChangeAccount}
-            variant="primary"
-            heading={<Translation id="TR_SELECT_FEE" />}
-            description={
-                <>
-                    <ConnectCallSource />
-                </>
-            }
-            bottomContent={
-                <>
-                    <Button onClick={onSend} isDisabled={!errors} variant="primary">
-                        <Translation id="TR_CONTINUE" />
-                    </Button>
-                    <Button onClick={onClose} variant="tertiary">
-                        <Translation id="TR_CANCEL" />
-                    </Button>
-                </>
-            }
-        >
-            <Column gap={spacings.md}>
-                {popupCall?.state === 'ongoing' && popupCall?.payload?.outputs && (
-                    <OutputsSummary account={account} outputs={popupCall.payload.outputs} />
-                )}
-                <Fees
-                    account={account}
-                    feeInfo={feeInfo}
-                    control={control}
-                    register={register}
-                    setValue={setValue}
-                    getValues={getValues}
-                    errors={errors}
-                    isDirty={isDirty}
-                    changeFeeLevel={changeFeeLevel}
-                    trigger={trigger}
-                />
-            </Column>
-        </Modal>
+        <ConnectModalBackdrop onClick={onClose} canSwitchDevice>
+            <Modal.ModalBase
+                onCancel={onClose}
+                onBackClick={onChangeAccount}
+                variant="primary"
+                heading={<Translation id="TR_SELECT_FEE" />}
+                description={
+                    <>
+                        <ConnectCallSource />
+                    </>
+                }
+                bottomContent={
+                    <>
+                        <Button onClick={onSend} isDisabled={!errors} variant="primary">
+                            <Translation id="TR_CONTINUE" />
+                        </Button>
+                        <Button onClick={onClose} variant="tertiary">
+                            <Translation id="TR_CANCEL" />
+                        </Button>
+                    </>
+                }
+            >
+                <Column gap={spacings.md}>
+                    {popupCall?.state === 'ongoing' && popupCall?.payload?.outputs && (
+                        <OutputsSummary account={account} outputs={popupCall.payload.outputs} />
+                    )}
+                    <Fees
+                        account={account}
+                        feeInfo={feeInfo}
+                        control={control}
+                        register={register}
+                        setValue={setValue}
+                        getValues={getValues}
+                        errors={errors}
+                        isDirty={isDirty}
+                        changeFeeLevel={changeFeeLevel}
+                        trigger={trigger}
+                    />
+                </Column>
+            </Modal.ModalBase>
+        </ConnectModalBackdrop>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
@@ -10,6 +10,7 @@ import { ConfirmOnDevice } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
 import { DeviceConfirmImage } from 'src/components/suite';
+import { ConnectModalBackdrop } from 'src/components/suite/ConnectModalBackdrop';
 import { Translation } from 'src/components/suite/Translation';
 import messages from 'src/support/messages';
 import { TrezorDevice } from 'src/types/suite';
@@ -33,7 +34,11 @@ export const ConfirmActionModal = ({ title, device, onCancel }: ConfirmActionPro
     };
 
     return (
-        <Modal.Backdrop onClick={onCancel} data-testid="@suite/modal/confirm-action-on-device">
+        <ConnectModalBackdrop
+            onClick={onCancel}
+            data-testid="@suite/modal/confirm-action-on-device"
+            canSwitchDevice
+        >
             <ConfirmOnDevice
                 title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
                 deviceModelInternal={getDeviceInternalModel(device)}
@@ -51,6 +56,6 @@ export const ConfirmActionModal = ({ title, device, onCancel }: ConfirmActionPro
                     <Translation id={title ?? 'TR_CONFIRM_ACTION_ON_YOUR'} />
                 </H2>
             </Modal.ModalBase>
-        </Modal.Backdrop>
+        </ConnectModalBackdrop>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/SignMessageModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/SignMessageModal.tsx
@@ -10,6 +10,7 @@ import { spacings, spacingsPx } from '@trezor/theme';
 
 import { AccountLabel } from 'src/components/suite/AccountLabel';
 import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
+import { ConnectModalBackdrop } from 'src/components/suite/ConnectModalBackdrop';
 import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
@@ -67,7 +68,7 @@ export const SignMessageModal = ({
     const account = accounts.find(a => a.symbol === network?.symbol && a.path === serializedPath);
 
     return (
-        <Modal.Backdrop>
+        <ConnectModalBackdrop onClick={onCancel} canSwitchDevice>
             <ConfirmOnDevice
                 title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
                 deviceModelInternal={deviceModelInternal}
@@ -111,6 +112,7 @@ export const SignMessageModal = ({
                         <ConnectCallSource />
                     </Row>
                 }
+                onCancel={onCancel}
             >
                 <Column gap={spacings.xs}>
                     {account && (
@@ -166,6 +168,6 @@ export const SignMessageModal = ({
                     </Card>
                 </Column>
             </Modal.ModalBase>
-        </Modal.Backdrop>
+        </ConnectModalBackdrop>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -31,6 +31,7 @@ import { Deferred } from '@trezor/utils';
 
 import * as modalActions from 'src/actions/suite/modalActions';
 import { Translation } from 'src/components/suite';
+import { ConnectModalBackdrop } from 'src/components/suite/ConnectModalBackdrop';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
 import { selectAccountIncludingChosenInTrading } from 'src/reducers/wallet/selectedAccountReducer';
@@ -421,7 +422,7 @@ export const TransactionReviewModalContent = ({
     };
 
     return (
-        <Modal.Backdrop>
+        <ConnectModalBackdrop canSwitchDevice>
             {!isRbfConfirmedError && (
                 <ConfirmOnDevice
                     title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
@@ -468,6 +469,6 @@ export const TransactionReviewModalContent = ({
             >
                 <Content />
             </Modal.ModalBase>
-        </Modal.Backdrop>
+        </ConnectModalBackdrop>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectAddressConfirmation.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectAddressConfirmation.tsx
@@ -10,6 +10,7 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 import { ConfirmOnDevice, mapTrezorModelToIcon } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
+import { ConnectModalBackdrop } from 'src/components/suite/ConnectModalBackdrop';
 import { Translation } from 'src/components/suite/Translation';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 
@@ -48,7 +49,7 @@ export const ConnectAddressConfirmation = () => {
     if (!popupCall || popupCall?.state !== 'address-confirmation') return null;
 
     return (
-        <Modal.Backdrop>
+        <ConnectModalBackdrop onClick={onFinish}>
             <ConfirmOnDevice
                 title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
                 deviceModelInternal={device?.features?.internal_model}
@@ -148,6 +149,6 @@ export const ConnectAddressConfirmation = () => {
                     </Card>
                 </Column>
             </Modal.ModalBase>
-        </Modal.Backdrop>
+        </ConnectModalBackdrop>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
@@ -3,6 +3,7 @@ import { Card, Column, H3, Icon, Modal, Paragraph, Row } from '@trezor/component
 import { spacings } from '@trezor/theme';
 
 import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
+import { ConnectModalBackdrop } from 'src/components/suite/ConnectModalBackdrop';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
@@ -44,28 +45,30 @@ export const ConnectErrorModal = () => {
     };
 
     return (
-        <Modal
-            variant="primary"
-            bottomContent={
-                <>
-                    <Modal.Button variant="tertiary" onClick={onFinish} size="medium">
-                        <Translation id="TR_CLOSE" />
-                    </Modal.Button>
-                </>
-            }
-        >
-            <Column gap={spacings.xs}>
-                <Row alignItems="center" gap={spacings.sm}>
-                    <Icon name="warning" size={32} variant={getVariant()} />
-                    <H3 variant={getVariant()}>{getTitle()}</H3>
-                </Row>
-                <ConnectCallSource />
-                <Paragraph>{getSubtitle()}</Paragraph>
+        <ConnectModalBackdrop>
+            <Modal.ModalBase
+                variant="primary"
+                bottomContent={
+                    <>
+                        <Modal.Button variant="tertiary" onClick={onFinish} size="medium">
+                            <Translation id="TR_CLOSE" />
+                        </Modal.Button>
+                    </>
+                }
+            >
+                <Column gap={spacings.xs}>
+                    <Row alignItems="center" gap={spacings.sm}>
+                        <Icon name="warning" size={32} variant={getVariant()} />
+                        <H3 variant={getVariant()}>{getTitle()}</H3>
+                    </Row>
+                    <ConnectCallSource />
+                    <Paragraph>{getSubtitle()}</Paragraph>
 
-                <Card margin={{ top: spacings.md }} data-testid="@connect-popup-error/message">
-                    {getErrorText()}
-                </Card>
-            </Column>
-        </Modal>
+                    <Card margin={{ top: spacings.md }} data-testid="@connect-popup-error/message">
+                        {getErrorText()}
+                    </Card>
+                </Column>
+            </Modal.ModalBase>
+        </ConnectModalBackdrop>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
@@ -13,6 +13,9 @@ export const ConnectErrorModal = () => {
     const onFinish = () => {
         dispatch(connectPopupActions.finishCall());
     };
+    const onSwitchDevice = () => {
+        dispatch(connectPopupActions.switchDevice());
+    };
 
     if (!popupCall || (popupCall?.state !== 'error' && popupCall?.state !== 'call-error'))
         return null;
@@ -21,6 +24,11 @@ export const ConnectErrorModal = () => {
         popupCall.error?.code === 'Method_Cancel' ||
         popupCall.error?.code === 'Method_Interrupted' ||
         popupCall.error?.code === 'Failure_ActionCancelled';
+    const isDeviceReconnectError =
+        popupCall.error?.code === 'Device_NotFound' ||
+        popupCall.error?.code === 'Device_Disconnected' ||
+        popupCall.error?.code === 'Device_UsedElsewhere' ||
+        popupCall.error?.code === 'Device_InvalidState';
 
     const getVariant = () => {
         if (isCancelled) return 'warning';
@@ -50,6 +58,11 @@ export const ConnectErrorModal = () => {
                 variant="primary"
                 bottomContent={
                     <>
+                        {isDeviceReconnectError && (
+                            <Modal.Button onClick={onSwitchDevice} size="medium">
+                                <Translation id="TR_SWITCH_DEVICE" />
+                            </Modal.Button>
+                        )}
                         <Modal.Button variant="tertiary" onClick={onFinish} size="medium">
                             <Translation id="TR_CLOSE" />
                         </Modal.Button>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectLoadingModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectLoadingModal.tsx
@@ -3,6 +3,7 @@ import { Card, Column, Modal, Row, Spinner } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
+import { ConnectModalBackdrop } from 'src/components/suite/ConnectModalBackdrop';
 import { useSelector } from 'src/hooks/suite';
 
 export const ConnectLoadingModal = () => {
@@ -11,20 +12,22 @@ export const ConnectLoadingModal = () => {
     if (!popupCall || popupCall?.state !== 'ongoing') return null;
 
     return (
-        <Modal
-            data-testid="@connect-popup-loading"
-            variant="primary"
-            size="small"
-            heading={popupCall.methodInfo.methodTitle}
-            description={<ConnectCallSource />}
-        >
-            <Column gap={spacings.xs}>
-                <Card>
-                    <Row alignItems="center" justifyContent="center" margin={spacings.xxl}>
-                        <Spinner />
-                    </Row>
-                </Card>
-            </Column>
-        </Modal>
+        <ConnectModalBackdrop>
+            <Modal.ModalBase
+                data-testid="@connect-popup-loading"
+                variant="primary"
+                size="small"
+                heading={popupCall.methodInfo.methodTitle}
+                description={<ConnectCallSource />}
+            >
+                <Column gap={spacings.xs}>
+                    <Card>
+                        <Row alignItems="center" justifyContent="center" margin={spacings.xxl}>
+                            <Spinner />
+                        </Row>
+                    </Card>
+                </Column>
+            </Modal.ModalBase>
+        </ConnectModalBackdrop>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
@@ -9,6 +9,7 @@ import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
 import { ConnectAppIcon } from 'src/components/suite/ConnectAppIcon';
+import { ConnectModalBackdrop } from 'src/components/suite/ConnectModalBackdrop';
 import { ConnectProcessLabel } from 'src/components/suite/ConnectProcessLabel';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { getPermissionText } from 'src/views/settings/SettingsConnectedApps/ConnectPermissions';
@@ -55,103 +56,105 @@ export const ConnectPermissionsModal = () => {
     };
 
     return (
-        <Modal
-            onCancel={onCancel}
-            bottomContent={
-                <>
-                    <Modal.Button
-                        variant="primary"
-                        onClick={onConfirm}
-                        data-testid="@connect-permissions-modal/confirm-button"
-                    >
-                        {confirmLabel || <Translation id="TR_CONFIRM" />}
-                    </Modal.Button>
-                    <Modal.Button
-                        variant="tertiary"
-                        onClick={onCancel}
-                        data-testid="@connect-permissions-modal/cancel-button"
-                    >
-                        <Translation id="TR_CANCEL" />
-                    </Modal.Button>
-                </>
-            }
-            heading={<Translation id="TR_GRANT_PERMISSIONS" />}
-            description={<Translation id="TR_GRANT_PERMISSIONS_DESCRIPTION" />}
-        >
-            <Column gap={spacings.xs}>
-                <Text>
-                    <Translation id="TR_APP" />
-                </Text>
-
-                <Card>
-                    <Row gap={spacings.md}>
-                        <ConnectAppIcon
-                            src={source.manifest?.appIcon}
-                            size={spacings.xxxxl}
-                            type={
-                                source.type === CALL_SOURCE_WALLETCONNECT
-                                    ? 'walletConnect'
-                                    : 'trezorConnect'
-                            }
-                        />
-
-                        <Column gap={spacings.xxs}>
-                            <Row gap={spacings.sm}>
-                                {source.manifest?.appName ? (
-                                    <>
-                                        <Text>{source.manifest.appName}</Text>
-                                        <Text variant="tertiary">{source.origin}</Text>
-                                    </>
-                                ) : (
-                                    <Text>{source.origin}</Text>
-                                )}
-                            </Row>
-                            <Row>
-                                {source.process && (
-                                    <ConnectProcessLabel
-                                        process={source.process}
-                                        data-testid="@connect-permissions-modal/paragraph-process"
-                                    />
-                                )}
-                            </Row>
-                        </Column>
-                    </Row>
-                </Card>
-
-                <Text>
-                    <Translation id="TR_PERMISSIONS" />
-                </Text>
-
-                <Card>
-                    <List>
-                        {permissionTypes.map(permission => (
-                            <List.Item
-                                key={permission}
-                                bulletComponent={<Icon name="checkCircle" variant="primary" />}
-                            >
-                                {getPermissionText(permission)}
-                            </List.Item>
-                        ))}
-                    </List>
-                </Card>
-                {source.type !== CALL_SOURCE_WALLETCONNECT && (
+        <ConnectModalBackdrop onClick={onCancel} canSwitchDevice>
+            <Modal.ModalBase
+                onCancel={onCancel}
+                bottomContent={
                     <>
-                        <Text>
-                            <Translation id="TR_OPTIONAL" />
-                        </Text>
-
-                        <Card>
-                            <Checkbox
-                                data-testid="@connect-permissions-modal/remember-checkbox"
-                                isChecked={isRemembered}
-                                onClick={() => setIsRemembered(!isRemembered)}
-                            >
-                                <Translation id="TR_CONNECT_MODAL_REMEMBER" />
-                            </Checkbox>
-                        </Card>
+                        <Modal.Button
+                            variant="primary"
+                            onClick={onConfirm}
+                            data-testid="@connect-permissions-modal/confirm-button"
+                        >
+                            {confirmLabel || <Translation id="TR_CONFIRM" />}
+                        </Modal.Button>
+                        <Modal.Button
+                            variant="tertiary"
+                            onClick={onCancel}
+                            data-testid="@connect-permissions-modal/cancel-button"
+                        >
+                            <Translation id="TR_CANCEL" />
+                        </Modal.Button>
                     </>
-                )}
-            </Column>
-        </Modal>
+                }
+                heading={<Translation id="TR_GRANT_PERMISSIONS" />}
+                description={<Translation id="TR_GRANT_PERMISSIONS_DESCRIPTION" />}
+            >
+                <Column gap={spacings.xs}>
+                    <Text>
+                        <Translation id="TR_APP" />
+                    </Text>
+
+                    <Card>
+                        <Row gap={spacings.md}>
+                            <ConnectAppIcon
+                                src={source.manifest?.appIcon}
+                                size={spacings.xxxxl}
+                                type={
+                                    source.type === CALL_SOURCE_WALLETCONNECT
+                                        ? 'walletConnect'
+                                        : 'trezorConnect'
+                                }
+                            />
+
+                            <Column gap={spacings.xxs}>
+                                <Row gap={spacings.sm}>
+                                    {source.manifest?.appName ? (
+                                        <>
+                                            <Text>{source.manifest.appName}</Text>
+                                            <Text variant="tertiary">{source.origin}</Text>
+                                        </>
+                                    ) : (
+                                        <Text>{source.origin}</Text>
+                                    )}
+                                </Row>
+                                <Row>
+                                    {source.process && (
+                                        <ConnectProcessLabel
+                                            process={source.process}
+                                            data-testid="@connect-permissions-modal/paragraph-process"
+                                        />
+                                    )}
+                                </Row>
+                            </Column>
+                        </Row>
+                    </Card>
+
+                    <Text>
+                        <Translation id="TR_PERMISSIONS" />
+                    </Text>
+
+                    <Card>
+                        <List>
+                            {permissionTypes.map(permission => (
+                                <List.Item
+                                    key={permission}
+                                    bulletComponent={<Icon name="checkCircle" variant="primary" />}
+                                >
+                                    {getPermissionText(permission)}
+                                </List.Item>
+                            ))}
+                        </List>
+                    </Card>
+                    {source.type !== CALL_SOURCE_WALLETCONNECT && (
+                        <>
+                            <Text>
+                                <Translation id="TR_OPTIONAL" />
+                            </Text>
+
+                            <Card>
+                                <Checkbox
+                                    data-testid="@connect-permissions-modal/remember-checkbox"
+                                    isChecked={isRemembered}
+                                    onClick={() => setIsRemembered(!isRemembered)}
+                                >
+                                    <Translation id="TR_CONNECT_MODAL_REMEMBER" />
+                                </Checkbox>
+                            </Card>
+                        </>
+                    )}
+                </Column>
+            </Modal.ModalBase>
+        </ConnectModalBackdrop>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
@@ -39,6 +39,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { AccountLabel } from 'src/components/suite/AccountLabel';
 import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
+import { ConnectModalBackdrop } from 'src/components/suite/ConnectModalBackdrop';
 import { Translation } from 'src/components/suite/Translation';
 import { TxAddress } from 'src/components/suite/copy/TxAddress';
 import { Fees } from 'src/components/wallet/Fees/Fees';
@@ -297,7 +298,7 @@ export const TxSimulationModal = () => {
     };
 
     return (
-        <Modal.Backdrop>
+        <ConnectModalBackdrop canSwitchDevice>
             <Modal.ModalBase
                 size="small"
                 heading={
@@ -570,6 +571,6 @@ export const TxSimulationModal = () => {
                     </Column>
                 </Column>
             </Modal.ModalBase>
-        </Modal.Backdrop>
+        </ConnectModalBackdrop>
     );
 };

--- a/packages/suite/src/support/suite/useConnectPopupModals.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupModals.tsx
@@ -1,11 +1,14 @@
 import { useEffect } from 'react';
 
-import { selectConnectPopupCall } from '@suite-common/connect-popup';
+import { connectPopupCallThunkInner, selectConnectPopupCall } from '@suite-common/connect-popup';
+import TrezorConnect from '@trezor/connect';
 
 import { CONTEXT_NONE, CONTEXT_USER } from 'src/actions/suite/constants/modalConstants';
 import { onCancel as cancelModal, openModal } from 'src/actions/suite/modalActions';
+import { goto } from 'src/actions/suite/routerActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectModalType } from 'src/reducers/suite/modalReducer';
+import { selectRouteName } from 'src/reducers/suite/routerReducer';
 
 export const useConnectPopupModals = () => {
     const dispatch = useDispatch();
@@ -14,6 +17,7 @@ export const useConnectPopupModals = () => {
     // Modal opening control
     const modalContext = useSelector(state => state.modal.context);
     const modalType = useSelector(selectModalType);
+    const activeRoute = useSelector(selectRouteName);
     useEffect(() => {
         const isConnectModal =
             modalContext === CONTEXT_USER &&
@@ -62,6 +66,21 @@ export const useConnectPopupModals = () => {
                 // Not used on desktop
                 return;
             }
+            case 'switch-device': {
+                if (modalContext !== CONTEXT_NONE) {
+                    TrezorConnect.cancel('switching-device');
+                    dispatch(cancelModal());
+                    dispatch(
+                        goto('suite-switch-device', {
+                            params: {
+                                cancelable: true,
+                            },
+                        }),
+                    );
+                }
+
+                return;
+            }
             case 'finished':
             default: {
                 if (isConnectModal) {
@@ -71,5 +90,21 @@ export const useConnectPopupModals = () => {
                 return;
             }
         }
-    }, [popupCall?.state, modalType, modalContext, dispatch]);
+    }, [popupCall?.state, modalType, modalContext, activeRoute, dispatch]);
+
+    // Restart thunk once device is selected
+    useEffect(() => {
+        if (
+            popupCall?.state === 'switch-device' &&
+            activeRoute !== 'suite-switch-device' &&
+            // this check prevents restarting the call immediately after it was created, since the route may not be updated yet
+            popupCall?.timestamp < Date.now() - 500
+        ) {
+            dispatch(
+                connectPopupCallThunkInner({
+                    ...popupCall,
+                }),
+            );
+        }
+    }, [popupCall, activeRoute, dispatch]);
 };

--- a/suite-common/connect-popup/src/connectPopupActions.ts
+++ b/suite-common/connect-popup/src/connectPopupActions.ts
@@ -83,6 +83,8 @@ const setSelectedFee = createAction(
     }),
 );
 
+const switchDevice = createAction(`${ACTION_PREFIX}/switchDevice`);
+
 export const connectPopupActions = {
     initiateCall,
     requestPermissions,
@@ -97,4 +99,5 @@ export const connectPopupActions = {
     forgetAppPermissions,
     txSimulation,
     setSelectedFee,
+    switchDevice,
 } as const;

--- a/suite-common/connect-popup/src/connectPopupReducer.ts
+++ b/suite-common/connect-popup/src/connectPopupReducer.ts
@@ -152,6 +152,15 @@ export const prepareConnectPopupReducer = createReducerWithExtraDeps(
                         selectedFee: payload.selectedFee,
                     };
                 }
+            })
+            .addCase(connectPopupActions.switchDevice, state => {
+                if (state.activeCall && state.activeCall.state !== 'error') {
+                    state.activeCall = {
+                        ...state.activeCall,
+                        state: 'switch-device',
+                        timestamp: Date.now(),
+                    };
+                }
             });
     },
 );

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -144,7 +144,10 @@ export const connectPopupCallThunkInner = createThunk<
             getPopupCallDeferred().resolve(response);
         } catch (error) {
             console.error('connectPopupCallThunk', error);
-            if (error?.code === 'Method_Cancel') {
+            if (error?.error === 'switching-device') {
+                // Do nothing, call will be restarted after device switch
+                return;
+            } else if (error?.code === 'Method_Cancel') {
                 dispatch(connectPopupActions.finishCall());
             } else {
                 dispatch(connectPopupActions.setError(serializeError(error)));

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -1,3 +1,4 @@
+import TrezorConnect from '@trezor/connect';
 import { ErrorCode } from '@trezor/connect/src/constants/errors';
 import { MethodPermission } from '@trezor/connect/src/core/AbstractMethod';
 
@@ -39,7 +40,7 @@ export type ConnectCallSource = {
 
 export type ConnectPopupCallLoaded = {
     // Common properties that are always present
-    method: string;
+    method: keyof typeof TrezorConnect;
     methodInfo: {
         methodTitle: string;
         confirmLabel: string;
@@ -93,6 +94,10 @@ export type ConnectPopupCallLoaded = {
           state: 'tx-simulation';
           selectedAccountKey?: string;
           fromAddress: string;
+      }
+    | {
+          state: 'switch-device';
+          timestamp: number;
       }
 );
 


### PR DESCRIPTION
## Description

This PR introduces device switching across the new Connect flow by adding a top bar with a device switcher to all relevant modals. This is achieved by wrapping modal backdrops with a new component `ConnectModalBackdrop` that provides integration with Connect.

This also makes the modal background fully opaque, preventing the Suite UI from showing through and making the Connect flow feel like a standalone route.

Device switching works by interrupting the current flow without returning a response. The flow is then restarted once a new device is selected, which is possible thanks to improvements in #20170.

## Screenshots:

<img width="1481" height="1033" alt="Screenshot 2025-07-16 at 11 32 06" src="https://github.com/user-attachments/assets/10e169bd-d746-4dcb-a4a7-05e2e01d2497" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connect-suite-device-switch&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-suite-device-switch&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-suite-device-switch&lookback=7)