### PR TITLE
chore(suite-desktop): skip contract value check in solana e2e swap tests

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
@@ -15,7 +15,6 @@ const provider = getCompanyNameFromList(swapQuotesTetherBTC[2].exchange, 'swapLi
 const formattedSendAmount = `${localizeNumber(sendAmount)} USDT`;
 const formattedReceiveAmount = `${localizeNumber(swapQuotesTetherBTC[2].receiveStringAmount!)} BTC`;
 const { sendAddress, receiveAddress, send: tetherMint } = swapTradeTetherBTC;
-const tetherRawMintAddress = tetherMint.split('--')[1];
 const formattedSendAddress = formatAddress(sendAddress);
 const toastText = `${formattedSendAmount} sent from Solana #1`;
 
@@ -78,7 +77,6 @@ test.describe('Trading - Swap token to coin', { tag: ['@group=trading', '@webOnl
             await tradingPage.initiateSendConfirmation({ confirmAlsoToken: true });
             await expect(devicePrompt.headerParagraph).toContainText('Solana #1');
             await expect(devicePrompt.outputValueOf('address')).toHaveText(formattedSendAddress);
-            await expect(devicePrompt.outputValueOf('contract')).toHaveText(tetherRawMintAddress);
             await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
                 formattedSendAmount,
             );

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
@@ -15,7 +15,6 @@ const provider = getCompanyNameFromList(swapQuotesSolanaTokens[0].exchange, 'swa
 const formattedSendAmount = `${localizeNumber(sendAmount)} USDT`;
 const formattedReceiveAmount = `${localizeNumber(swapQuotesSolanaTokens[0].receiveStringAmount!)} USDC`;
 const { sendAddress, receiveAddress, send: tetherMint, receive: usdcMint } = swapTradeSolanaTokens;
-const tetherRawMintAddress = tetherMint.split('--')[1];
 const formattedSendAddress = formatAddress(sendAddress);
 const toastText = `${formattedSendAmount} sent from Solana #1`;
 
@@ -78,7 +77,6 @@ test.describe('Trading - Swap tokens', { tag: ['@group=trading', '@webOnly'] }, 
             await tradingPage.initiateSendConfirmation({ confirmAlsoToken: true });
             await expect(devicePrompt.headerParagraph).toContainText('Solana #1');
             await expect(devicePrompt.outputValueOf('address')).toHaveText(formattedSendAddress);
-            await expect(devicePrompt.outputValueOf('contract')).toHaveText(tetherRawMintAddress);
             await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
                 formattedSendAmount,
             );


### PR DESCRIPTION
## Description

In #19769 I aligned Solana send flows with new firmware where we no longer show token contract info when sending recognized tokens. This PR aligns e2e tests with that change.

## Related Issue


## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/solana-swap-tests&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/solana-swap-tests&lookback=7)