### PR TITLE
chore(connect): add __precomposed internal param to methods

### DIFF
--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -346,7 +346,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
 
     abstract init(): void;
 
-    async getMethodInfo(): Promise<MethodInfo> {
+    getMethodInfo(): MethodInfo {
         return {
             useUi: this.useUi,
             useDevice: this.useDevice,
@@ -355,7 +355,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
             requiredPermissions: this.requiredPermissions,
             info: this.info,
             confirmation: this.confirmation,
-            precomposed: await this.payloadToPrecomposed(),
+            precomposed: undefined, // will be filled in only if method.payloadToPrecomposed is implemented and both __info and __precompose param are sent
             // this could be used for more. it could tell clients what are min firmware versions (firmwareRange) and much more
         };
     }

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -420,7 +420,11 @@ const onCall = async (context: CoreContext, message: IFrameCallMessage) => {
     }
 
     if (method.payload.__info) {
-        const response = await method.getMethodInfo();
+        const response = method.getMethodInfo();
+
+        if (method.payload.__precomposed) {
+            response.precomposed = await method.payloadToPrecomposed();
+        }
         sendCoreMessage(createResponseMessage(method.responseID, true, response));
 
         return Promise.resolve();

--- a/packages/connect/src/types/params.ts
+++ b/packages/connect/src/types/params.ts
@@ -26,6 +26,11 @@ export interface CommonParams {
      * todo: this should be moved to another argument instead of mixing this with params
      */
     __info?: boolean;
+    /**
+     * internal flag, only effective if `__info` is set to true.
+     * if set to true, the method will return precomposed result, which is used in suite
+     */
+    __precomposed?: boolean;
 }
 
 export type Params<T> = CommonParams & T & { bundle?: undefined };

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -39,6 +39,7 @@ export const connectPopupCallThunkInner = createThunk<
             const methodInfo = await TrezorConnect[method]({
                 ...payload,
                 __info: true,
+                __precomposed: true,
             });
             if (!methodInfo.success) {
                 throw methodInfo.payload;

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -136,6 +136,7 @@ const preCallHook = async <M extends keyof typeof TrezorConnect>({
                 const methodInfo = await TrezorConnect.ethereumSignTransaction({
                     ...modifiedPayload,
                     __info: true,
+                    __precomposed: true,
                 });
                 if (!methodInfo.success) {
                     throw methodInfo.payload;


### PR DESCRIPTION
cherry-picked from #19900 where I would like to prevent some pricier operations in the common flow. not sure if this is the best approach, would like to hear from you guys

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=exclude-precompose&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=exclude-precompose&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=exclude-precompose&lookback=7)