### PR TITLE
fix(suite): missing useEmptyPassphrase parameter in ethereumSignTypedData

### DIFF
--- a/suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts
@@ -73,10 +73,15 @@ export const signDataAndConfirmThunk = createThunk(
 
         dispatch(tradingActions.setModalAccountKey(account.key));
         const result = await TrezorConnect.ethereumSignTypedData({
-            device,
             path: account.path,
             metamask_v4_compat: false,
             data: typedData,
+            device: {
+                path: device?.path,
+                instance: device?.instance,
+                state: device?.state,
+            },
+            useEmptyPassphrase: device?.useEmptyPassphrase,
         });
 
         if (!result.success) {


### PR DESCRIPTION
## Description

Add missing `useEmptyPassphrase` parameter in `ethereumSignTypedData` call in trading

## Related Issue

Resolve #20232

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-missing-useemptypassphrase&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-missing-useemptypassphrase&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-missing-useemptypassphrase&lookback=7)