### PR TITLE
`discoverAccounts` followup's followup

### DIFF
--- a/packages/connect/e2e/tests/device/discoverAccounts.test.ts
+++ b/packages/connect/e2e/tests/device/discoverAccounts.test.ts
@@ -73,13 +73,10 @@ describe(`TrezorConnect.discoverAccounts`, () => {
         */
 
         const result = await TrezorConnect.discoverAccounts({
-            accounts: [
-                { symbol: 'btc' },
-                { symbol: 'btc', type: 'legacy' },
-                { symbol: 'btc', type: 'segwit' },
-                { symbol: 'btc', type: 'taproot' },
+            coins: [
+                { symbol: 'btc', known: [{ type: 'legacy' }, { type: 'taproot' }] },
                 { symbol: 'eth' },
-                { symbol: 'etc', type: 'normal', skip: 4 },
+                { symbol: 'etc', known: [{ type: 'normal', skip: 4 }], knownOnly: true },
                 { symbol: 'ltc' },
                 { symbol: 'ada' },
                 { symbol: 'xrp' },

--- a/packages/connect/src/api/discoverAccounts.ts
+++ b/packages/connect/src/api/discoverAccounts.ts
@@ -195,17 +195,31 @@ export default class DiscoverAccounts extends AbstractMethod<'discoverAccounts',
 
     /** This should have zero overhead thanks to descriptor caching */
     private async filterCardanoDerivations(accounts: CardanoRequest[]) {
-        const tryGetDescriptor = (coin?: CardanoRequest) =>
-            coin && this.getDescriptor(coin.coinInfo, coin.account.path, coin.derivation, 0);
+        const legacyRequest = accounts.find(a => a.account.type === 'legacy');
+        const ledgerRequest = accounts.find(a => a.account.type === 'ledger');
+        const filterableRequest = legacyRequest ?? ledgerRequest;
 
-        const normal = await tryGetDescriptor(accounts.find(a => a.account.type === 'normal'));
-        const ledger = await tryGetDescriptor(accounts.find(a => a.account.type === 'ledger'));
-        const legacy = await tryGetDescriptor(accounts.find(a => a.account.type === 'legacy'));
+        const getDescriptor = (derivation: keyof typeof CARDANO_DERIVATIONS) =>
+            filterableRequest &&
+            this.getDescriptor(
+                filterableRequest.coinInfo,
+                filterableRequest.account.path,
+                CARDANO_DERIVATIONS[derivation],
+                0,
+            ).then(({ descriptor }) => descriptor);
 
-        // legacy omitted if normal or ledger is present and has the same descriptor
-        const omitLegacy = legacy && legacy.descriptor === (normal ?? ledger)?.descriptor;
-        // ledger omitted if normal is present and has the same descriptor
-        const omitLedger = ledger && ledger.descriptor === normal?.descriptor;
+        // normal descriptor or undefined when no legacy/ledger was requested as in that case it's useless
+        const normalDescriptor = await getDescriptor('normal');
+
+        // legacy omitted if it's requested and has the same descriptor as normal
+        const omitLegacy = legacyRequest && (await getDescriptor('legacy')) === normalDescriptor;
+
+        // ledger omitted if it's requested and has the same descriptor as normal,
+        // but if legacy was already checked and not omitted, ledger won't be as well
+        const omitLedger =
+            ledgerRequest &&
+            (!legacyRequest || omitLegacy) &&
+            (await getDescriptor('ledger')) === normalDescriptor;
 
         return arrayPartition(
             accounts.map(item =>

--- a/packages/connect/src/api/discoverAccounts.ts
+++ b/packages/connect/src/api/discoverAccounts.ts
@@ -67,24 +67,24 @@ export default class DiscoverAccounts extends AbstractMethod<'discoverAccounts',
 
         // validate bundle type
         validateParams(payload, [
-            { name: 'accounts', type: 'array', required: true, allowEmpty: true },
+            { name: 'coins', type: 'array', required: true, allowEmpty: true },
         ]);
 
-        this.params = payload.accounts.flatMap(item => {
+        this.params = payload.coins.flatMap(coin => {
             // validate incoming parameters
-            validateParams(item, [
+            validateParams(coin, [
                 { name: 'symbol', type: 'string', required: true },
-                { name: 'type', type: 'string' },
+                { name: 'known', type: 'array', allowEmpty: true },
+                { name: 'knownOnly', type: 'boolean' },
                 { name: 'identity', type: 'string' },
                 { name: 'details', type: 'string' },
                 { name: 'pageSize', type: 'number' },
-                { name: 'skip', type: 'number' },
             ]);
 
-            const { symbol, type, ...rest } = item;
+            const { symbol, known: knownAccs, knownOnly, ...rest } = coin;
 
             // validate coin info
-            const coinInfo = getCoinInfo(item.symbol);
+            const coinInfo = getCoinInfo(symbol);
             if (!coinInfo) {
                 throw ERRORS.TypedError('Method_UnknownCoin');
             }
@@ -94,19 +94,34 @@ export default class DiscoverAccounts extends AbstractMethod<'discoverAccounts',
 
             const firmwareRange = getFirmwareRange(this.name, coinInfo, DEFAULT_FIRMWARE_RANGE);
 
-            return ACCOUNT_TYPES.filter(a => a.symbol === symbol && (!type || a.type === type)).map(
-                account => ({
+            // Take all the defined account types based on requested coin symbol
+            const symbolAccounts = ACCOUNT_TYPES.filter(a => a.symbol === symbol);
+
+            knownAccs?.forEach(account => {
+                validateParams(account, [
+                    { name: 'type', type: 'string', required: true },
+                    { name: 'skip', type: 'number' },
+                ]);
+                // Do not try to explicitly request account type which doesn't exist for requested coin
+                if (!symbolAccounts.some(a => a.type === account.type)) {
+                    throw new Error(`Unknown account type: ${symbol}/${account.type}`);
+                }
+            });
+
+            return symbolAccounts
+                .map(account => [account, knownAccs?.find(t => t.type === account.type)] as const) // Pair all coin accounts with possibly known account types
+                .filter(([_, known]) => (known ? typeof known.skip === 'number' : !knownOnly)) // Include passed known accounts with skip param (the other ones are known completely) and unpassed accounts if knownOnly wasn't requested
+                .map(([account, known]) => ({
                     pageSize: TXS_PER_PAGE,
                     details: DETAILS,
                     coinInfo,
                     firmwareRange,
-                    skip: 0,
+                    skip: known?.skip ?? 0, // Use the possibly passed skip param or fall back to zero
                     account,
                     ...rest,
                     offset: isEvmLedger(account, coinInfo) ? 1 : 0,
                     derivation: isCardano(account) ? CARDANO_DERIVATIONS[account.type] : undefined,
-                }),
-            );
+                }));
         });
     }
 

--- a/packages/connect/src/types/api/discoverAccounts.ts
+++ b/packages/connect/src/types/api/discoverAccounts.ts
@@ -73,19 +73,16 @@ export type AdditionalParams = Pick<
     identity?: string;
 };
 
-type TypedAccountParam = AccountTypeKey &
-    AdditionalParams & {
-        skip?: number;
-    };
-
-type UntypedAccountParam = AdditionalParams & {
-    symbol: AccountTypeItem['symbol'];
-    type?: undefined;
-    skip?: undefined;
-};
+type CoinParam<T extends AccountTypeKey['symbol'] = AccountTypeKey['symbol']> = T extends T
+    ? AdditionalParams & {
+          symbol: T;
+          known?: { type: Extract<AccountTypeKey, { symbol: T }>['type']; skip?: number }[];
+          knownOnly?: boolean;
+      }
+    : never;
 
 type DiscoverAccountsParams = {
-    accounts: (TypedAccountParam | UntypedAccountParam)[];
+    coins: CoinParam[];
 };
 
 type ProgressBaseType = AccountTypeKey & { index: number; path: string; backendType?: string };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import {
     restartDiscoveryThunk,
     selectSelectedDevice,
-    selectShouldRediscoverNetworks,
+    selectShowRediscoverButton,
 } from '@suite-common/wallet-core';
 import { Button, IconButton, Row, Tooltip, motionEasing } from '@trezor/components';
 import { spacings, spacingsPx, typography } from '@trezor/theme';
@@ -48,7 +48,7 @@ export const RefreshAfterDiscoveryNeeded = () => {
     const selectedDevice = useSelector(selectSelectedDevice);
     const isSidebarCollapsed = useIsSidebarCollapsed();
     const isDiscoveryButtonVisible = useSelector(state =>
-        selectShouldRediscoverNetworks(state, selectedDevice?.state?.staticSessionId),
+        selectShowRediscoverButton(state, selectedDevice),
     );
 
     if (!selectedDevice?.connected) {

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -29,6 +29,7 @@ const isActionDeviceRelated = (action: AnyAction): boolean => {
             deviceActions.forgetDevice,
             // ?
             deviceActions.setDeviceState,
+            deviceActions.setDiscovered,
         )(action)
     ) {
         return true;

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -7,7 +7,7 @@ import {
     deviceActions,
     runAdditionalDiscoveryThunk,
     selectSelectedDevice,
-    selectShouldRediscoverNetworks,
+    selectShouldRediscover,
     startDiscoveryThunk,
 } from '@suite-common/wallet-core';
 
@@ -76,12 +76,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
                         }),
                     );
                 } else if (device.state.staticSessionId) {
-                    const shouldRediscover = selectShouldRediscoverNetworks(
-                        getState(),
-                        device.state.staticSessionId,
-                    );
-
-                    if (shouldRediscover) {
+                    if (selectShouldRediscover(getState(), device)) {
                         dispatch(runAdditionalDiscoveryThunk(device.state.staticSessionId));
                     }
                 }

--- a/packages/suite/src/utils/wallet/selectDiscoveryOverallStatus.ts
+++ b/packages/suite/src/utils/wallet/selectDiscoveryOverallStatus.ts
@@ -69,7 +69,7 @@ const getDiscoveryStatus = ({
         };
     }
 
-    if (discovery?.status === 'progress') {
+    if (discovery?.status === 'progress' || discovery?.status === 'starting') {
         return {
             status: 'loading',
             type: 'discovery',

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -6,7 +6,7 @@ import {
     restartDiscoveryThunk,
     selectDeviceSupportedNetworks,
     selectEnabledNetworks,
-    selectShouldRediscoverNetworks,
+    selectShowRediscoverButton,
 } from '@suite-common/wallet-core';
 import { Button, Tooltip, motionEasing } from '@trezor/components';
 import { hasBitcoinOnlyFirmware, isBitcoinOnlyDevice } from '@trezor/device-utils';
@@ -83,9 +83,8 @@ export const SettingsCoins = () => {
     const isDeviceLocked = !!device && isLocked();
     const dispatch = useDispatch();
     const { isDiscoveryRunning } = useDiscovery();
-    const staticSessionId = device?.state?.staticSessionId;
     const isDiscoveryButtonVisible = useSelector(state =>
-        selectShouldRediscoverNetworks(state, staticSessionId),
+        selectShowRediscoverButton(state, device),
     );
 
     const supportedEnabledNetworks = enabledNetworks.filter(enabledNetwork =>

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -33,6 +33,7 @@ export interface ExtendedDevice {
     temporaryRemember?: boolean; // device should be remembered only for fw update or this session
     connected: boolean; // device is connected
     available: boolean; // device cannot be used because of features.passphrase_protection is different then expected
+    discovered?: boolean;
 
     instance?: number;
     ts: number;

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -118,6 +118,13 @@ const toggleIsDeviceAutoEjectEnabled = createAction(
 
 const toggleConnectionModal = createAction(`${DEVICE_MODULE_PREFIX}/toggleConnectionModal`);
 
+const setDiscovered = createAction(
+    `${DEVICE_MODULE_PREFIX}/setDiscovered`,
+    (staticSessionId: StaticSessionId, success: boolean) => ({
+        payload: { staticSessionId, success },
+    }),
+);
+
 export const deviceActions = {
     toggleConnectionModal,
     connectDevice,
@@ -139,4 +146,5 @@ export const deviceActions = {
     setEntropyCheckFail,
     setThpCredentials,
     toggleIsDeviceAutoEjectEnabled,
+    setDiscovered,
 };

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -205,6 +205,7 @@ const connectDevice = (draft: DeviceReducerState, device: Device) => {
 
 const addAuthorizedDevice = (draft: DeviceReducerState, device: TrezorDevice) => {
     device.walletNumber = deviceUtils.getNewWalletNumber(draft.devices, device);
+    delete device.discovered;
     draft.devices.push(device);
 };
 
@@ -338,6 +339,7 @@ const setDeviceState = (
     affectedDevice[0].state = state;
     affectedDevice[0].useEmptyPassphrase = useEmptyPassphrase;
     affectedDevice[0].walletNumber = deviceUtils.getNewWalletNumber(draft.devices, device);
+    delete affectedDevice[0].discovered;
 
     affectedDevice[0].remember = shouldDeviceBeRemembered({
         isDeviceAutoEjectEnabled: draft.isDeviceAutoEjectEnabled,
@@ -626,6 +628,12 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
         })
         .addCase(deviceActions.toggleConnectionModal, state => {
             state.isConnectionModalOpen = !state.isConnectionModalOpen;
+        })
+        .addCase(deviceActions.setDiscovered, (state, { payload }) => {
+            const device = state.devices.find(
+                d => d.state?.staticSessionId === payload.staticSessionId,
+            );
+            if (device) device.discovered = payload.success;
         })
         .addMatcher(
             isAnyOf(deviceActions.connectDevice, deviceActions.connectUnacquiredDevice),

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -457,6 +457,7 @@ export const runDiscoveryThunk = createThunk(
                         device.path,
                     ),
                 );
+                dispatch(deviceActions.setDiscovered(deviceState.staticSessionId, false));
 
                 return;
             }
@@ -464,6 +465,7 @@ export const runDiscoveryThunk = createThunk(
             if (!isAddingHiddenWallet) {
                 dispatch(discoveryActions.updateDiscovery({ status: 'complete' }, device.path));
                 dispatch(extra.thunks.fetchAndSaveMetadata(deviceState.staticSessionId));
+                dispatch(deviceActions.setDiscovered(deviceState.staticSessionId, true));
 
                 return;
             }
@@ -475,6 +477,7 @@ export const runDiscoveryThunk = createThunk(
             if (!allAccountsEmpty) {
                 dispatch(discoveryActions.updateDiscovery({ status: 'complete' }, device.path));
                 dispatch(extra.thunks.fetchAndSaveMetadata(deviceState.staticSessionId));
+                dispatch(deviceActions.setDiscovered(deviceState.staticSessionId, true));
 
                 // finish here, device state was applied from bundle progress handler
                 return;
@@ -505,6 +508,7 @@ export const runDiscoveryThunk = createThunk(
             if (!getDeviceState2Res.success) {
                 const { error, code } = getDeviceState2Res.payload;
                 dispatch(applyDeviceStateErrorThunk({ error, code, devicePath: device.path }));
+                dispatch(deviceActions.setDiscovered(deviceState.staticSessionId, false));
 
                 return;
             }
@@ -534,6 +538,7 @@ export const runDiscoveryThunk = createThunk(
 
             dispatch(discoveryActions.updateDiscovery({ status: 'complete' }, device.path));
             dispatch(extra.thunks.fetchAndSaveMetadata(deviceState.staticSessionId));
+            dispatch(deviceActions.setDiscovered(deviceState.staticSessionId, true));
         } catch (error) {
             dispatch(
                 discoveryActions.updateDiscovery({ status: 'failed', error }, passedDevice.path),
@@ -694,6 +699,7 @@ export const runAdditionalDiscoveryThunk = createThunk(
                 updatedDevice.path,
             ),
         );
+        dispatch(deviceActions.setDiscovered(staticSessionId, result.success));
     },
 );
 

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -351,10 +351,14 @@ export const runDiscoveryThunk = createThunk(
                 return;
             }
 
+            const deviceState = deviceStateResponse.payload._state;
+
+            assertStaticSessionId(deviceState);
+
             if (!isAddingHiddenWallet) {
                 await dispatch(
                     applyDeviceStatesThunk({
-                        newDeviceState: deviceStateResponse.payload._state,
+                        newDeviceState: deviceState,
                         isAddingHiddenWallet,
                         devicePath: passedDevice.path,
                     }),
@@ -363,14 +367,12 @@ export const runDiscoveryThunk = createThunk(
 
             device = reselectDevice();
 
-            assertStaticSessionId(deviceStateResponse.payload._state);
-
             const duplicate = selectDevices(getState())
                 .filter(d => d.state?.staticSessionId)
                 .find(
                     d =>
                         d.state!.staticSessionId!.split(':')[0] ===
-                        deviceStateResponse.payload._state.staticSessionId!.split(':')[0],
+                        deviceState.staticSessionId!.split(':')[0],
                 );
 
             if (isAddingHiddenWallet && duplicate?.state?.staticSessionId) {
@@ -389,7 +391,7 @@ export const runDiscoveryThunk = createThunk(
 
             const accountsParam = selectDiscoveryAccountsParam(
                 getState(),
-                deviceStateResponse.payload._state.staticSessionId,
+                deviceState.staticSessionId,
             );
 
             // no networks to discover, complete discovery
@@ -400,7 +402,6 @@ export const runDiscoveryThunk = createThunk(
 
             // we do not create empty accounts right away, but store the progress events for later
             const accountQueue: CreateAccountActionProps[] = [];
-            const deviceState = deviceStateResponse.payload._state;
             const onBundleProgress = (event: ProgressEvent) => {
                 const currentDiscovery = selectDiscoveryByDevicePath(getState(), device.path);
                 if (!currentDiscovery) {
@@ -458,7 +459,7 @@ export const runDiscoveryThunk = createThunk(
             const result = await TrezorConnect.discoverAccounts({
                 device: {
                     instance,
-                    state: { staticSessionId: deviceStateResponse.payload._state.staticSessionId },
+                    state: { staticSessionId: deviceState.staticSessionId },
                 },
                 useEmptyPassphrase: !isAddingHiddenWallet,
                 accounts: accountsParam,
@@ -485,21 +486,13 @@ export const runDiscoveryThunk = createThunk(
                 return;
             }
 
-            assertStaticSessionId(deviceStateResponse.payload._state);
-
             if (!isAddingHiddenWallet) {
                 dispatch(
                     completeDiscoveryThunk({
-                        staticSessionId: deviceStateResponse.payload._state.staticSessionId,
+                        staticSessionId: deviceState.staticSessionId,
                         devicePath: device.path,
                     }),
                 );
-
-                return;
-            }
-
-            if (!deviceStateResponse.payload._state.staticSessionId) {
-                console.error('Discovery: staticSessionId missing in device state response');
 
                 return;
             }
@@ -511,7 +504,7 @@ export const runDiscoveryThunk = createThunk(
             if (!allAccountsEmpty) {
                 dispatch(
                     completeDiscoveryThunk({
-                        staticSessionId: deviceStateResponse.payload._state.staticSessionId,
+                        staticSessionId: deviceState.staticSessionId,
                         devicePath: device.path,
                     }),
                 );
@@ -552,7 +545,7 @@ export const runDiscoveryThunk = createThunk(
             if (
                 // todo: not sure about instance, now it looks that there are 2 devices created in connect
                 getDeviceState2Res.payload._state.staticSessionId?.split(':')[0] !==
-                deviceStateResponse.payload._state.staticSessionId?.split(':')[0]
+                deviceState.staticSessionId?.split(':')[0]
             ) {
                 dispatch(
                     discoveryActions.updateDiscovery(
@@ -566,7 +559,7 @@ export const runDiscoveryThunk = createThunk(
 
             await dispatch(
                 applyDeviceStatesThunk({
-                    newDeviceState: deviceStateResponse.payload._state,
+                    newDeviceState: deviceState,
                     isAddingHiddenWallet,
                     devicePath: passedDevice.path,
                 }),
@@ -574,7 +567,7 @@ export const runDiscoveryThunk = createThunk(
 
             dispatch(
                 completeDiscoveryThunk({
-                    staticSessionId: deviceStateResponse.payload._state.staticSessionId,
+                    staticSessionId: deviceState.staticSessionId,
                     devicePath: device.path,
                 }),
             );

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -330,6 +330,8 @@ export const runDiscoveryThunk = createThunk(
 
             assertStaticSessionId(deviceState);
 
+            const { discovered } = device;
+
             if (!isAddingHiddenWallet) {
                 await dispatch(
                     applyDeviceStatesThunk({
@@ -367,13 +369,8 @@ export const runDiscoveryThunk = createThunk(
             const accountsParam = selectDiscoveryAccountsParam(
                 getState(),
                 deviceState.staticSessionId,
+                discovered,
             );
-
-            // no networks to discover, complete discovery
-            if (!accountsParam.length) {
-                // TODO: find out how to early return discovery; calling completeDiscoveryThunk does not work
-                console.warn('No networks to discover, todo: stop discovery');
-            }
 
             // we do not create empty accounts right away, but store the progress events for later
             const accountQueue: CreateAccountActionProps[] = [];
@@ -437,7 +434,7 @@ export const runDiscoveryThunk = createThunk(
                     state: { staticSessionId: deviceState.staticSessionId },
                 },
                 useEmptyPassphrase: !isAddingHiddenWallet,
-                accounts: accountsParam,
+                coins: accountsParam,
             });
 
             TrezorConnect.off(UI.BUNDLE_PROGRESS, onBundleProgress);
@@ -653,13 +650,11 @@ export const runAdditionalDiscoveryThunk = createThunk(
         // NOTE: keep here the previous device as default to prevent TS from screaming
         const updatedDevice = selectDeviceByStaticSessionId(getState(), staticSessionId) ?? device;
 
-        const accountsParam = selectDiscoveryAccountsParam(getState(), staticSessionId);
-
-        if (!accountsParam.length) {
-            console.warn('no rediscovery needed');
-
-            return;
-        }
+        const accountsParam = selectDiscoveryAccountsParam(
+            getState(),
+            staticSessionId,
+            device.discovered,
+        );
 
         const onBundleProgress = (event: ProgressEvent) => {
             const discovery = selectDiscoveryByDevicePath(getState(), device.path);
@@ -682,7 +677,7 @@ export const runAdditionalDiscoveryThunk = createThunk(
         const result = await TrezorConnect.discoverAccounts({
             device: updatedDevice,
             useEmptyPassphrase: updatedDevice.useEmptyPassphrase,
-            accounts: accountsParam,
+            coins: accountsParam,
         });
 
         TrezorConnect.off(UI.BUNDLE_PROGRESS, onBundleProgress);

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -610,14 +610,6 @@ export const runAdditionalDiscoveryThunk = createThunk(
             dispatch(accountsActions.removeAccount(accountsToRemove));
         }
 
-        const accountsParam = selectDiscoveryAccountsParam(getState(), staticSessionId);
-
-        if (!accountsParam.length) {
-            console.warn('no rediscovery needed');
-
-            return;
-        }
-
         dispatch(
             discoveryActions.startDiscovery(device.path, {
                 isAddingHiddenWallet: false,
@@ -625,6 +617,44 @@ export const runAdditionalDiscoveryThunk = createThunk(
                 isAddingHiddenWalletWithRespectToSettings: false,
             }),
         );
+
+        // NOTE: prepare the device to the corresponding state eg. insert the passphrase
+        const deviceStateResponse = await TrezorConnect.getDeviceState({
+            device: {
+                path: device.path,
+                instance: device.instance,
+                state: device.state.staticSessionId,
+            },
+            useEmptyPassphrase: device.useEmptyPassphrase,
+        });
+
+        if (!deviceStateResponse.success) {
+            const { error, code } = deviceStateResponse.payload;
+            dispatch(applyDeviceStateErrorThunk({ error, code, devicePath: device.path }));
+
+            return;
+        }
+
+        assertStaticSessionId(deviceStateResponse.payload._state);
+
+        dispatch(
+            deviceActions.setDeviceState({
+                device,
+                state: deviceStateResponse.payload._state,
+                useEmptyPassphrase: device.useEmptyPassphrase,
+            }),
+        );
+
+        // NOTE: keep here the previous device as default to prevent TS from screaming
+        const updatedDevice = selectDeviceByStaticSessionId(getState(), staticSessionId) ?? device;
+
+        const accountsParam = selectDiscoveryAccountsParam(getState(), staticSessionId);
+
+        if (!accountsParam.length) {
+            console.warn('no rediscovery needed');
+
+            return;
+        }
 
         const onBundleProgress = (event: ProgressEvent) => {
             const discovery = selectDiscoveryByDevicePath(getState(), device.path);
@@ -644,37 +674,11 @@ export const runAdditionalDiscoveryThunk = createThunk(
 
         TrezorConnect.on<DiscoverAccountsProgress>(UI.BUNDLE_PROGRESS, onBundleProgress);
 
-        // NOTE: prepare the device to the corresponding state eg. insert the passphrase
-        const deviceStateResponse = await TrezorConnect.getDeviceState({
-            device: {
-                path: device.path,
-                instance: device.instance,
-                state: device.state.staticSessionId,
-            },
-            useEmptyPassphrase: device.useEmptyPassphrase,
-        });
-
-        if (deviceStateResponse.success) {
-            assertStaticSessionId(deviceStateResponse.payload._state);
-            dispatch(
-                deviceActions.setDeviceState({
-                    device,
-                    state: deviceStateResponse.payload._state,
-                    useEmptyPassphrase: device.useEmptyPassphrase,
-                }),
-            );
-        }
-
-        // NOTE: keep here the previous device as default to prevent TS from screaming
-        const updatedDevice = selectDeviceByStaticSessionId(getState(), staticSessionId) ?? device;
-
         const result = await TrezorConnect.discoverAccounts({
             device: updatedDevice,
             useEmptyPassphrase: updatedDevice.useEmptyPassphrase,
             accounts: accountsParam,
         });
-
-        console.warn('runAdditionalDiscovery: TrezorConnect.getAccountInfo, result: ', result);
 
         TrezorConnect.off(UI.BUNDLE_PROGRESS, onBundleProgress);
 

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -252,7 +252,8 @@ type ApplyDeviceStateErrorThunkProps = {
     code: string | undefined;
     devicePath: DeviceUniquePath;
 };
-export const applyDeviceStateErrorThunk = createThunk(
+
+const applyDeviceStateErrorThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/applyDeviceStateError`,
     ({ error, code, devicePath }: ApplyDeviceStateErrorThunkProps, { dispatch, getState }) => {
         // means that `cancelDiscoveryThunk` has been called and device returned code:Method_Cancel and this specific `error`
@@ -272,11 +273,7 @@ export const applyDeviceStateErrorThunk = createThunk(
         // The error is not from deliberate cancellation, so we mark the discovery as failed
         dispatch(
             discoveryActions.updateDiscovery(
-                {
-                    status: 'failed',
-                    error,
-                    errorCode: code,
-                },
+                { status: 'failed', error, errorCode: code },
                 devicePath,
             ),
         );
@@ -306,9 +303,7 @@ export const runDiscoveryThunk = createThunk(
             if (isAddingHiddenWallet && device.features && !device.features.passphrase_protection) {
                 dispatch(
                     discoveryActions.updateDiscovery(
-                        {
-                            status: 'passphrase-enable-on-device',
-                        },
+                        { status: 'passphrase-enable-on-device' },
                         device.path,
                     ),
                 );
@@ -319,12 +314,7 @@ export const runDiscoveryThunk = createThunk(
 
                 if (!response.success) {
                     dispatch(
-                        discoveryActions.updateDiscovery(
-                            {
-                                status: 'cancelled',
-                            },
-                            device.path,
-                        ),
+                        discoveryActions.updateDiscovery({ status: 'cancelled' }, device.path),
                     );
 
                     return;
@@ -333,12 +323,7 @@ export const runDiscoveryThunk = createThunk(
 
             if (isAddingHiddenWallet) {
                 dispatch(
-                    discoveryActions.updateDiscovery(
-                        {
-                            status: 'enter-passphrase',
-                        },
-                        device.path,
-                    ),
+                    discoveryActions.updateDiscovery({ status: 'enter-passphrase' }, device.path),
                 );
             }
 
@@ -473,9 +458,7 @@ export const runDiscoveryThunk = createThunk(
             const result = await TrezorConnect.discoverAccounts({
                 device: {
                     instance,
-                    state: {
-                        staticSessionId: deviceStateResponse.payload._state.staticSessionId,
-                    },
+                    state: { staticSessionId: deviceStateResponse.payload._state.staticSessionId },
                 },
                 useEmptyPassphrase: !isAddingHiddenWallet,
                 accounts: accountsParam,
@@ -545,20 +528,13 @@ export const runDiscoveryThunk = createThunk(
 
             dispatch(
                 discoveryActions.updateDiscovery(
-                    {
-                        status: 'confirm-empty-passphrase',
-                        emptyWallet: true,
-                    },
+                    { status: 'confirm-empty-passphrase', emptyWallet: true },
                     device.path,
                 ),
             );
 
             const getDeviceState2Res = await TrezorConnect.getDeviceState({
-                device: {
-                    path: device.path,
-                    instance,
-                    state: undefined,
-                },
+                device: { path: device.path, instance, state: undefined },
                 useEmptyPassphrase: false,
             });
 
@@ -580,9 +556,7 @@ export const runDiscoveryThunk = createThunk(
             ) {
                 dispatch(
                     discoveryActions.updateDiscovery(
-                        {
-                            status: 'passphrase-mismatch',
-                        },
+                        { status: 'passphrase-mismatch' },
                         device.path,
                     ),
                 );
@@ -735,7 +709,7 @@ export const runAdditionalDiscoveryThunk = createThunk(
             );
         }
 
-        // NOTE: keep here the previous device as default to prevent TS from screeming
+        // NOTE: keep here the previous device as default to prevent TS from screaming
         const updatedDevice = selectDeviceByStaticSessionId(getState(), staticSessionId) ?? device;
 
         const result = await TrezorConnect.discoverAccounts({
@@ -748,22 +722,18 @@ export const runAdditionalDiscoveryThunk = createThunk(
 
         TrezorConnect.off(UI.BUNDLE_PROGRESS, onBundleProgress);
 
-        if (!result.success) {
-            dispatch(
-                discoveryActions.updateDiscovery(
-                    {
-                        status: 'failed',
-                        error: result.payload.error,
-                        errorCode: result.payload.code,
-                    },
-                    updatedDevice.path,
-                ),
-            );
-
-            return;
-        }
-
-        dispatch(discoveryActions.updateDiscovery({ status: 'complete' }, updatedDevice.path));
+        dispatch(
+            discoveryActions.updateDiscovery(
+                result.success
+                    ? { status: 'complete' }
+                    : {
+                          status: 'failed',
+                          error: result.payload.error,
+                          errorCode: result.payload.code,
+                      },
+                updatedDevice.path,
+            ),
+        );
     },
 );
 
@@ -825,7 +795,7 @@ export const restartDiscoveryThunk = createThunk(
     (_, { dispatch, getState }) => {
         const device = selectSelectedDevice(getState());
         if (!device) return;
-        const staticSessionId = device?.state?.staticSessionId;
+        const staticSessionId = device.state?.staticSessionId;
         if (staticSessionId) {
             // we already have staticSessionId (=passphrase state), we probably failed during blockchain discovery
             dispatch(runAdditionalDiscoveryThunk(staticSessionId));

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -222,31 +222,6 @@ const transformProgressEventData = (
     return { accountPayload, discoveryPayload };
 };
 
-const completeDiscoveryThunk = createThunk(
-    `${DISCOVERY_MODULE_PREFIX}/complete`,
-    (
-        {
-            staticSessionId,
-            devicePath,
-        }: {
-            staticSessionId: StaticSessionId;
-            devicePath: DeviceUniquePath;
-        },
-        { dispatch, extra },
-    ) => {
-        dispatch(
-            discoveryActions.updateDiscovery(
-                {
-                    status: 'complete',
-                },
-                devicePath,
-            ),
-        );
-
-        dispatch(extra.thunks.fetchAndSaveMetadata(staticSessionId));
-    },
-);
-
 type ApplyDeviceStateErrorThunkProps = {
     error: string | undefined;
     code: string | undefined;
@@ -282,7 +257,7 @@ const applyDeviceStateErrorThunk = createThunk(
 
 export const runDiscoveryThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/run`,
-    async (passedDevice: TrezorDevice, { dispatch, getState }): Promise<void> => {
+    async (passedDevice: TrezorDevice, { dispatch, getState, extra }): Promise<void> => {
         try {
             let device: TrezorDevice = passedDevice;
 
@@ -487,12 +462,8 @@ export const runDiscoveryThunk = createThunk(
             }
 
             if (!isAddingHiddenWallet) {
-                dispatch(
-                    completeDiscoveryThunk({
-                        staticSessionId: deviceState.staticSessionId,
-                        devicePath: device.path,
-                    }),
-                );
+                dispatch(discoveryActions.updateDiscovery({ status: 'complete' }, device.path));
+                dispatch(extra.thunks.fetchAndSaveMetadata(deviceState.staticSessionId));
 
                 return;
             }
@@ -502,12 +473,8 @@ export const runDiscoveryThunk = createThunk(
             const allAccountsEmpty = result.payload.nonempty === 0;
             // there is at least one account with balance - passphrase is not empty
             if (!allAccountsEmpty) {
-                dispatch(
-                    completeDiscoveryThunk({
-                        staticSessionId: deviceState.staticSessionId,
-                        devicePath: device.path,
-                    }),
-                );
+                dispatch(discoveryActions.updateDiscovery({ status: 'complete' }, device.path));
+                dispatch(extra.thunks.fetchAndSaveMetadata(deviceState.staticSessionId));
 
                 // finish here, device state was applied from bundle progress handler
                 return;
@@ -565,12 +532,8 @@ export const runDiscoveryThunk = createThunk(
                 }),
             );
 
-            dispatch(
-                completeDiscoveryThunk({
-                    staticSessionId: deviceState.staticSessionId,
-                    devicePath: device.path,
-                }),
-            );
+            dispatch(discoveryActions.updateDiscovery({ status: 'complete' }, device.path));
+            dispatch(extra.thunks.fetchAndSaveMetadata(deviceState.staticSessionId));
         } catch (error) {
             dispatch(
                 discoveryActions.updateDiscovery({ status: 'failed', error }, passedDevice.path),

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -1,10 +1,11 @@
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
-import { NetworkSymbol, networksCollection } from '@suite-common/wallet-config';
+import { NetworkSymbol, networks, networksCollection } from '@suite-common/wallet-config';
 import { ReviewOutput } from '@suite-common/wallet-types';
 import {
     findAccountsByAddress,
     isAccountDiscoverable,
     sortByCoin,
+    tryGetAccountIdentity,
 } from '@suite-common/wallet-utils';
 import { StaticSessionId, type TrezorConnect } from '@trezor/connect';
 import { arrayToDictionary } from '@trezor/utils';
@@ -78,20 +79,22 @@ type DiscoveryAccountsParam = Parameters<TrezorConnect['discoverAccounts']>[0]['
 
 export const selectDiscoveryAccountsParam = (
     state: CompoundRootState,
-    staticSessionId: StaticSessionId,
+    deviceState: StaticSessionId,
     knownOnly?: boolean,
 ): DiscoveryAccountsParam => {
-    const networks = selectEnabledSupportedNetworks(state);
-    const knownAccounts = selectAccountsByDeviceState(state, staticSessionId);
+    const symbols = selectEnabledSupportedNetworks(state);
+    const knownAccounts = selectAccountsByDeviceState(state, deviceState);
     const discoverableAccounts = knownAccounts.filter(isAccountDiscoverable);
 
     const symbolMap = arrayToDictionary(discoverableAccounts, acc => acc.symbol, true);
 
-    return networks.map(symbol => {
+    return symbols.map(symbol => {
         const symbolAccounts = symbolMap[symbol];
+        const { networkType } = networks[symbol];
+        const identity = tryGetAccountIdentity({ networkType, deviceState });
 
         // undiscovered network; discover as a whole
-        if (!symbolAccounts) return { symbol };
+        if (!symbolAccounts) return { symbol, identity };
 
         // discovered network; separate by account type
         const typeMap = arrayToDictionary(symbolAccounts, acc => acc.accountType, true);
@@ -110,7 +113,7 @@ export const selectDiscoveryAccountsParam = (
             else return { type };
         });
 
-        return { symbol, known, knownOnly } as DiscoveryAccountsParam[number];
+        return { symbol, identity, known, knownOnly } as DiscoveryAccountsParam[number];
     });
 };
 
@@ -121,11 +124,11 @@ export const selectShouldRediscoverNetworks = (
     if (!staticSessionId) return false;
     if (selectHasRunningDiscovery(state)) return false;
 
-    const networks = selectEnabledSupportedNetworks(state);
+    const symbols = selectEnabledSupportedNetworks(state);
     const accounts = selectAccountsByDeviceState(state, staticSessionId);
     const discoveredNetworks = new Set(accounts.map(account => account.symbol));
 
-    return networks.some(network => !discoveredNetworks.has(network));
+    return symbols.some(symbol => !discoveredNetworks.has(symbol));
 };
 
 export const selectAccountsToBeForgotten = (

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -1,7 +1,11 @@
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { NetworkSymbol, networksCollection } from '@suite-common/wallet-config';
 import { ReviewOutput } from '@suite-common/wallet-types';
-import { findAccountsByAddress, sortByCoin } from '@suite-common/wallet-utils';
+import {
+    findAccountsByAddress,
+    isAccountDiscoverable,
+    sortByCoin,
+} from '@suite-common/wallet-utils';
 import { StaticSessionId, type TrezorConnect } from '@trezor/connect';
 import { arrayToDictionary } from '@trezor/utils';
 
@@ -70,37 +74,43 @@ export const selectAllSuccessfulAccountsToList = createMemoizedSelector(
     },
 );
 
+type DiscoveryAccountsParam = Parameters<TrezorConnect['discoverAccounts']>[0]['coins'];
+
 export const selectDiscoveryAccountsParam = (
     state: CompoundRootState,
     staticSessionId: StaticSessionId,
-): Parameters<TrezorConnect['discoverAccounts']>[0]['accounts'] => {
+    knownOnly?: boolean,
+): DiscoveryAccountsParam => {
     const networks = selectEnabledSupportedNetworks(state);
-    const accounts = selectAccountsByDeviceState(state, staticSessionId);
+    const knownAccounts = selectAccountsByDeviceState(state, staticSessionId);
+    const discoverableAccounts = knownAccounts.filter(isAccountDiscoverable);
 
-    const symbolMap = arrayToDictionary(accounts, acc => acc.symbol, true);
+    const symbolMap = arrayToDictionary(discoverableAccounts, acc => acc.symbol, true);
 
-    return networks.flatMap(symbol => {
+    return networks.map(symbol => {
         const symbolAccounts = symbolMap[symbol];
 
         // undiscovered network; discover as a whole
-        if (!symbolAccounts) return [{ symbol }];
+        if (!symbolAccounts) return { symbol };
 
         // discovered network; separate by account type
         const typeMap = arrayToDictionary(symbolAccounts, acc => acc.accountType, true);
 
-        return Object.entries(typeMap).flatMap(([type, accs]) => {
+        const known = Object.entries(typeMap).map(([type, accs]) => {
             // account with the highest index
             const lastAccount = accs.reduce((last, current) =>
                 current.index > last.index ? current : last,
             );
 
             // last account is a failed one; try to discover it again
-            if (lastAccount.failed) return [{ symbol, type, skip: lastAccount.index }];
+            if (lastAccount.failed) return { type, skip: lastAccount.index };
             // last account is a used one; skip it and try to discover next one
-            else if (!lastAccount.empty) return [{ symbol, type, skip: lastAccount.index + 1 }];
-            // last account is an empty one; no need to discover
-            else return [];
+            else if (!lastAccount.empty) return { type, skip: lastAccount.index + 1 };
+            // last account is an empty one; skip this type completely
+            else return { type };
         });
+
+        return { symbol, known, knownOnly } as DiscoveryAccountsParam[number];
     });
 };
 

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -1,4 +1,5 @@
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
+import { TrezorDevice } from '@suite-common/suite-types';
 import { NetworkSymbol, networks, networksCollection } from '@suite-common/wallet-config';
 import { ReviewOutput } from '@suite-common/wallet-types';
 import {
@@ -117,12 +118,17 @@ export const selectDiscoveryAccountsParam = (
     });
 };
 
-export const selectShouldRediscoverNetworks = (
+const selectShouldRediscoverHelper = (
     state: CompoundRootState,
-    staticSessionId?: StaticSessionId,
+    device: TrezorDevice | undefined,
+    allowUndiscovered: boolean,
 ) => {
+    const staticSessionId = device?.state?.staticSessionId;
     if (!staticSessionId) return false;
+
     if (selectHasRunningDiscovery(state)) return false;
+
+    if (allowUndiscovered && !device.discovered) return true;
 
     const symbols = selectEnabledSupportedNetworks(state);
     const accounts = selectAccountsByDeviceState(state, staticSessionId);
@@ -130,6 +136,12 @@ export const selectShouldRediscoverNetworks = (
 
     return symbols.some(symbol => !discoveredNetworks.has(symbol));
 };
+
+export const selectShowRediscoverButton = (state: CompoundRootState, device?: TrezorDevice) =>
+    selectShouldRediscoverHelper(state, device, false);
+
+export const selectShouldRediscover = (state: CompoundRootState, device?: TrezorDevice) =>
+    selectShouldRediscoverHelper(state, device, true);
 
 export const selectAccountsToBeForgotten = (
     state: DiscoveryRootState & AccountsRootState & WalletSettingsRootState,

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -58,6 +58,9 @@ export const isAccountSuccessful = (account: Account): account is SuccessfulAcco
 
 export const isAccountFailed = (account: Account): account is FailedAccount => !!account.failed;
 
+export const isAccountDiscoverable = ({ accountType }: Account) =>
+    accountType !== 'imported' && accountType !== 'placeholder' && accountType !== 'coinjoin';
+
 export const getFirstFreshAddress = (
     account: Account,
     receiveAddresses: ReceiveInfo[],

--- a/suite-native/discovery/src/discoveryMiddleware.ts
+++ b/suite-native/discovery/src/discoveryMiddleware.ts
@@ -9,7 +9,7 @@ import {
     discoveryActions,
     restartDiscoveryThunk,
     selectSelectedDevice,
-    selectShouldRediscoverNetworks,
+    selectShouldRediscover,
     startDiscoveryThunk,
 } from '@suite-common/wallet-core';
 import {
@@ -72,15 +72,10 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
                 device.connected &&
                 isDeviceAcquired(device)
             ) {
-                if (!device?.state) {
+                if (!device.state) {
                     dispatch(startDiscoveryThunk({}));
                 } else if (device.state.staticSessionId) {
-                    const shouldRediscover = selectShouldRediscoverNetworks(
-                        getState(),
-                        device.state.staticSessionId,
-                    );
-
-                    if (shouldRediscover) {
+                    if (selectShouldRediscover(getState(), device)) {
                         dispatch(restartDiscoveryThunk());
                     }
                 }


### PR DESCRIPTION
## Description

Continue with discovery fixing and polishing.

- https://github.com/trezor/trezor-suite/pull/20241/commits/997118bf83d07d501fe7d51b315c2c2eeadcfe62 - pure refactoring; some linebreaks removed
- https://github.com/trezor/trezor-suite/pull/20241/commits/301afe783a57064ea2caa56ba1bb277071e0ea6c - pure refactoring; consistently use `deviceState` instead of `deviceStateResponse.payload._state` and remove useless assertions
- https://github.com/trezor/trezor-suite/pull/20241/commits/937b9d0dcd43988b2b7ce395eee9468c2d383aa8 - pure refactoring; replace `completeDiscoveryThunk` calls by its implementation which saves couple of lines
- https://github.com/trezor/trezor-suite/pull/20241/commits/956212fd340b125cf96067b3d450a1dc7105dee4 - move parts of `runAdditionalDiscoveryThunk` so it makes more sense
- https://github.com/trezor/trezor-suite/pull/20241/commits/83052bd45bad7ca18331ee821078d9e25ae4fcd5 - `selectDiscoveryOverallStatus` now returns `loading` even when discovery status is `starting` so dashboard graph skeleton is shown immediately
- https://github.com/trezor/trezor-suite/pull/20241/commits/a324b359c1c2531526c4719969906a57f3fca8c2 - persisted `device` object now has `discovered` flag which is cleared right before running discovery (already existing actions `addAuthorizedDevice`/`setDeviceState`) and set right after it (new action `setDiscovered`), so it's possible to tell whether known wallet state (mostly discovered accounts) can be trusted or new full discovery is needed
- https://github.com/trezor/trezor-suite/pull/20241/commits/9cb1d39d3a140266baa33a9b6595f5841223d817 - `discoverAccounts` api and behavior changed so for given coin, either just account types passed as `known` or all implemented account types are discovered based on `knownOnly` param; this should resolve the issue when account type is sometimes not rediscovered for incompletely discovered wallet
- https://github.com/trezor/trezor-suite/pull/20241/commits/702fa3fb76c5a3d87e38fbc5f795892a97998fd3 - normal/legacy/ledger cardano accounts are now filtered every time when some of them is required, not just when both the duplicate ones are required
- https://github.com/trezor/trezor-suite/pull/20241/commits/a1de5e8fb7486c11f86a1d6e73864f3f3ac3154b - reformat `discoverAccounts` params to comply with the new api; also the new `discovered` flag is passed as `knownOnly` which means that only known account types are requested when the last discovery succeeded, otherwise unknown are discovered as well
- https://github.com/trezor/trezor-suite/pull/20241/commits/f54215a9f2495f63e5f59c785517565e494698ab - reintroduced support of backend identities for EVM coins so they work even when there's more then 10 accounts on a single wallet
- https://github.com/trezor/trezor-suite/pull/20241/commits/50598ffd01487595ce77175e757afe86fe76a564 - `selectShouldRediscoverNetworks` split into `selectShowRediscoverButton` (for coin settings buttons) and `selectShouldRediscover`, which takes into account `discovered` flag, therefore every connected remembered device which failed to be discovered last time is immediately rediscovered

## Related Issue

Followup of #19886

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/rediscovery-followup&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/rediscovery-followup&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/rediscovery-followup&lookback=7)