### PR TITLE
Add `evmApproval` capability

### DIFF
--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -265,5 +265,10 @@ export const config = {
             capabilities: ['entropyCheck'],
             min: { T1B1: '1.13.1', T2T1: '2.8.7', T2B1: '2.8.7', T3B1: '2.8.7', T3T1: '2.8.7' },
         },
+        {
+            capabilities: ['evmApproval'],
+            min: { T1B1: '0', T2T1: '2.9.0', T2B1: '2.9.0', T3B1: '2.9.0', T3T1: '2.9.0' },
+            comment: ['EVM approval flow for ERC20 tokens, introduced in firmware 2.9.0'],
+        },
     ],
 };

--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -170,6 +170,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 xvg: 'update-required',
                 zcr: 'update-required',
                 chunkify: 'no-support',
+                evmApproval: 'no-support',
                 ...T1B1_UPDATE_REQUIRED,
             });
         });
@@ -192,6 +193,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 sol: 'no-capability',
                 dsol: 'no-capability',
                 chunkify: 'update-required',
+                evmApproval: 'update-required',
                 ...T1B1_UPDATE_REQUIRED,
             });
         });
@@ -225,6 +227,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 xem: 'no-support',
                 chunkify: 'update-required',
                 entropyCheck: 'update-required',
+                evmApproval: 'update-required',
             });
         });
 
@@ -300,6 +303,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 eth: 'no-support',
                 bsc: 'update-required',
                 chunkify: 'update-required',
+                evmApproval: 'update-required',
                 ...T1B1_UPDATE_REQUIRED,
             });
         });
@@ -324,6 +328,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 eth: 'no-support',
                 bnb: 'no-support',
                 chunkify: 'no-support',
+                evmApproval: 'no-support',
                 ...T1B1_UPDATE_REQUIRED,
             });
         });
@@ -349,6 +354,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 bnb: 'no-support',
                 bsc: 'no-support',
                 chunkify: 'no-support',
+                evmApproval: 'no-support',
                 ...T1B1_UPDATE_REQUIRED,
             });
         });

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -6,12 +6,11 @@ import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants'
 import {
     composeSendFormTransactionFeeLevelsThunk,
     selectConvertedNetworkFeeInfo,
-    selectDeviceFirmwareVersion,
+    selectDeviceUnavailableCapabilities,
 } from '@suite-common/wallet-core';
 import { Account, FormOptions, FormState } from '@suite-common/wallet-types';
 import { getEvmTransactionTextSignature } from '@suite-common/wallet-utils';
 import { Success, Unsuccessful } from '@trezor/connect';
-import { isNewerOrEqual } from '@trezor/utils/src/versionUtils';
 
 import { TRADING_THUNK_PREFIX } from '../../constants';
 import {
@@ -79,9 +78,7 @@ export const recomposeAndSignTxThunk = createThunk<
         const options: FormOptions[] = ['broadcast'];
         const network = getNetwork(account.symbol);
         const feeInfo = selectConvertedNetworkFeeInfo(getState(), account.symbol);
-        const firmwareVersion = selectDeviceFirmwareVersion(getState());
-        const isNewApproveFlowSupported =
-            firmwareVersion && isNewerOrEqual(firmwareVersion, '2.9.0');
+        const unavailableCapabilities = selectDeviceUnavailableCapabilities(getState());
         const activeTradingSection = selectTradingActiveSection(
             getState(),
         ) as TradingTradeSellExchangeType;
@@ -100,7 +97,7 @@ export const recomposeAndSignTxThunk = createThunk<
         // Otherwise if ethereumDataHex is present, token is not used as details are in the ethereumDataHex.
         const shouldIncludeToken =
             !!(ethereumDataHex && isTransferEvmTxType) ||
-            !(ethereumDataHex && !isTransferEvmTxType && !isNewApproveFlowSupported);
+            !(ethereumDataHex && !isTransferEvmTxType && unavailableCapabilities?.['evmApproval']);
 
         // prepare the fee levels, set custom values from composed
         // WORKAROUND: sendFormEthereumActions and sendFormRippleActions use form outputs instead of composed transaction data


### PR DESCRIPTION
## Description

This PR implements `evmApproval` capability instead of checking for firmware version directly

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/evm-approval-capability&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/evm-approval-capability&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/evm-approval-capability&lookback=7)