### PR TITLE
new bridge port 21328

### DIFF
--- a/packages/connect/src/device/TransportList.ts
+++ b/packages/connect/src/device/TransportList.ts
@@ -21,6 +21,15 @@ const getOrCreateTransport = (
     transportType: ConnectSettingsTransport,
     params: Params,
 ) => {
+    if (transportType === 'BridgeTransport') {
+        // Temporary handling of BridgeTransport which translates to two instances listening on ports 21328/21325
+        const existing = transports.filter(t => t.name === transportType);
+
+        return existing.length
+            ? existing
+            : [new BridgeTransport({ ...params, port: 21328 }), new BridgeTransport(params)];
+    }
+
     if (typeof transportType === 'string') {
         const existing = tryGetTransport(transports, transportType);
         if (existing) return existing;
@@ -30,8 +39,6 @@ const getOrCreateTransport = (
                 return new WebUsbTransport(params);
             case 'NodeUsbTransport':
                 return new NodeUsbTransport(params);
-            case 'BridgeTransport':
-                return new BridgeTransport(params);
             case 'UdpTransport':
                 return new UdpTransport(params);
         }
@@ -69,7 +76,7 @@ const createTransports = (
     // BridgeTransport is the ultimate fallback
     const transportTypes = transports?.length ? transports : ['BridgeTransport' as const];
 
-    return transportTypes.map(type => getOrCreateTransport(existing, type, params));
+    return transportTypes.flatMap(type => getOrCreateTransport(existing, type, params));
 };
 
 export const createTransportList =

--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -33,7 +33,7 @@ class TrezordNodeProcess implements BridgeInterface {
 
     private async startProxy(mode: 'start' | 'startDev' | 'startTest') {
         if (this.proxy.running) return;
-        await this.proxy.run({ port: 21325, api: bridgeDev || bridgeTest ? 'udp' : 'usb' });
+        await this.proxy.run({ api: bridgeDev || bridgeTest ? 'udp' : 'usb' });
         // Call `start` again in case of respawning due to keepAlive
         this.proxy.watch('started', () => this.proxy.request(mode, []));
         await this.proxy.request(mode, []);

--- a/packages/suite/src/views/settings/SettingsDebug/Transport.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Transport.tsx
@@ -24,7 +24,7 @@ const TRANSPORTS_WEB = ['BridgeTransport', 'WebUsbTransport'] as const;
 const TRANSPORTS_DESKTOP = ['BridgeTransport', 'NodeUsbTransport', 'UdpTransport'] as const;
 const TRANSPORT_DESCRIPTIONS: Record<Transport, string> = {
     BridgeTransport:
-        'Client for bridge http interface regardless node-bridge or trezord-go implementation. It expects bridge to run on http://127.0.0.1:21325/.\
+        'Client for bridge http interface regardless node-bridge or trezord-go implementation. It expects bridge to run on http://127.0.0.1:21328/ or https://localhost:21325/.\
         This is the most general transport that may be used for both desktop and web version of Trezor Suite.',
     WebUsbTransport: 'Similar to NodeUsbTransport but using WebUSB API. Supported only in Chrome.',
     NodeUsbTransport: 'Direct access to usb using node.js implementation.',

--- a/packages/transport-bridge/src/bin.ts
+++ b/packages/transport-bridge/src/bin.ts
@@ -3,7 +3,6 @@ import { Log } from '@trezor/utils';
 import { TrezordNode } from './http';
 
 const trezordNode = new TrezordNode({
-    port: 21325,
     api: process.argv.includes('udp') ? 'udp' : 'usb',
     logger: new Log('@trezor/transport-bridge', true),
 });

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -20,10 +20,6 @@ import { Log, Throttler, arrayPartition } from '@trezor/utils';
 
 import { createCore } from './core';
 
-const defaults = {
-    port: 21325,
-};
-
 const str = (value: Record<string, any> | string) =>
     typeof value === 'string' ? value : JSON.stringify(value);
 
@@ -83,6 +79,8 @@ const validateProtocolMessageBody =
         }
     };
 
+const COMPATIBILITY_PORT = 21325;
+
 export class TrezordNode {
     version = '3.1.0';
     bundledVersion?: string;
@@ -95,8 +93,9 @@ export class TrezordNode {
         req: Parameters<RequestHandler<unknown, unknown>>[0];
         res: Response;
     }[];
-    port: number;
-    server?: HttpServer<never>;
+    private readonly requestedPort: number;
+    private port?: number;
+    server: HttpServer<never>[] = [];
     core: ReturnType<typeof createCore>;
     logger: Log;
     assetPrefix: string;
@@ -104,21 +103,20 @@ export class TrezordNode {
     throttler = new Throttler(500);
 
     constructor({
-        port,
         api,
         assetPrefix = '',
         logger,
         protocolMessages,
         bundledVersion,
+        port = 21328,
     }: {
-        port: number;
         api: 'usb' | 'udp' | AbstractApi;
         assetPrefix?: string;
         logger: Log;
         protocolMessages?: boolean;
         bundledVersion?: string;
+        port?: number;
     }) {
-        this.port = port || defaults.port;
         this.logger = logger;
         this.descriptors = [];
         this.bundledVersion = bundledVersion;
@@ -129,6 +127,7 @@ export class TrezordNode {
 
         this.assetPrefix = assetPrefix;
         this.protocolMessages = protocolMessages ?? true;
+        this.requestedPort = port;
     }
 
     private checkAffectedSubscriptions() {
@@ -198,7 +197,7 @@ export class TrezordNode {
         );
     }
 
-    public start() {
+    public async start() {
         // whenever sessions module reports changes to descriptors (including sessions), resolve affected /listen subscriptions
         this.core.sessionsClient.on('descriptors', descriptors => {
             this.logger?.debug(
@@ -209,22 +208,34 @@ export class TrezordNode {
             );
         });
 
-        return new Promise<void>((resolve, reject) => {
-            this.logger.info('Starting Trezor Bridge HTTP server');
-            const app = new HttpServer({
-                port: this.port,
-                logger: this.logger,
-            });
+        this.logger.info('Starting Trezor Bridge HTTP server');
+        // for compatibility reasons, we start two servers sharing the same request handlers and state.
+        // compatibility case 1:
+        //   user still has the old bridge client (targeting port 21325), but he already runs the latest suite-desktop version. We need to make sure that bridge is still available on port 21325 -> we need 2 servers
+        // compatibility case 2:
+        //   user has the latest bridge client (checking all the possible ports), but he runs the old suite-desktop version. This is easy and does not require us to start 2 servers, bridge client will fallback to the old port.
 
+        const primaryApp = new HttpServer({
+            ports: [this.requestedPort],
+            logger: this.logger,
+        });
+
+        const compatibilityApp = new HttpServer({
+            ports: [COMPATIBILITY_PORT],
+            logger: this.logger,
+        });
+
+        const bindHandlers = (app: HttpServer<any>) => {
             app.use([
                 (req, res, next, context) => {
                     // directly navigating to status page of bridge in browser. when request is not issued by js, there is no origin header
                     if (
                         !req.headers.origin &&
                         req.headers.host &&
-                        [`127.0.0.1:${this.port}`, `localhost:${this.port}`].includes(
-                            req.headers.host,
-                        )
+                        [
+                            `127.0.0.1:${app.getServerAddress().port}`,
+                            `localhost:${app.getServerAddress().port}`,
+                        ].includes(req.headers.host)
                     ) {
                         next(req, res);
                     } else {
@@ -446,7 +457,7 @@ export class TrezordNode {
             app.get('/', [
                 (_req, res) => {
                     res.writeHead(301, {
-                        Location: `http://127.0.0.1:${this.port}/status`,
+                        Location: `http://127.0.0.1:${app.getServerAddress().port}/status`,
                     });
                     res.end();
                 },
@@ -477,7 +488,7 @@ export class TrezordNode {
                     const signal = this.createAbortSignal(res);
                     await this.core.enumerate({ signal });
                     const props = {
-                        intro: `To download full logs go to http://127.0.0.1:${this.port}/logs`,
+                        intro: `To download full logs go to http://127.0.0.1:${app.getServerAddress().port}/logs`,
                         version: this.version,
                         bundledVersion: this.bundledVersion,
                         devices: this.descriptors,
@@ -510,16 +521,34 @@ export class TrezordNode {
             app.post('/', [this.handleInfo.bind(this)]);
 
             app.post('/configure', [this.handleInfo.bind(this)]);
+        };
 
-            app.start().then(result => {
-                if (result.success) {
-                    this.server = app;
+        // start both at once
+        const compatibilityAppRes =
+            this.requestedPort === COMPATIBILITY_PORT // Don't even try to start compatibilityApp when the primaryApp requests the same port
+                ? Promise.resolve({ success: false } as const)
+                : compatibilityApp.start();
 
-                    return resolve();
-                } else {
-                    reject(result.error);
+        const primaryAppRes = await primaryApp.start();
+
+        // if primary succeeds -> resolve
+        if (primaryAppRes.success) {
+            bindHandlers(primaryApp);
+            this.server.push(primaryApp);
+            this.port = primaryAppRes.payload.port;
+        }
+
+        return compatibilityAppRes.then(res => {
+            if (res.success) {
+                bindHandlers(compatibilityApp);
+                this.server.push(compatibilityApp);
+
+                if (!this.port) {
+                    this.port = res.payload.port;
                 }
-            });
+            } else if (!primaryAppRes.success) {
+                throw new Error(primaryAppRes.error); // -> neither compatibility, nor primary app started -> only this case means reject
+            }
         });
     }
 
@@ -529,20 +558,20 @@ export class TrezordNode {
         this.throttler.dispose();
         this.core.dispose();
 
-        return this.server?.stop().finally(() => {
-            this.server = undefined;
+        return Promise.all(this.server.map(server => server.stop())).finally(() => {
+            this.server = [];
             this.logger.info('Trezor Bridge HTTP server stopped');
         });
     }
 
     public async status() {
-        const running = await fetch(`http://127.0.0.1:${this.port}/`)
+        const running = await fetch(`http://127.0.0.1:${this.port ?? this.requestedPort}/`)
             .then(resp => resp.ok)
             .catch(() => false);
 
         return {
             service: running,
-            process: Boolean(this.server),
+            process: Boolean(this.server[0]),
         };
     }
 

--- a/packages/transport-bridge/tests/http.test.ts
+++ b/packages/transport-bridge/tests/http.test.ts
@@ -115,7 +115,7 @@ describe('http', () => {
                 ...params,
             });
             await trezordNode.start();
-            const url = trezordNode.server?.getRouteAddress('/') || '/';
+            const url = trezordNode.server[0]!.getRouteAddress('/') || '/';
 
             await bridgeApiCall({
                 url: `${url}enumerate`,
@@ -422,7 +422,7 @@ describe('http', () => {
 
                 await new Promise(resolve => setTimeout(resolve, 1000));
 
-                const url = trezordNode.server!.getRouteAddress('/')!;
+                const url = trezordNode.server[0]!.getRouteAddress('/') || '/';
                 const response = await bridgeApiCall({
                     url,
                     method: 'GET',
@@ -447,7 +447,7 @@ describe('http', () => {
 
             await new Promise(resolve => setTimeout(resolve, 1000));
 
-            const url = trezordNode.server!.getRouteAddress('/')!;
+            const url = trezordNode.server[0]!.getRouteAddress('/') || '/';
 
             await bridgeApiCall({
                 url: url + 'enumerate',
@@ -482,7 +482,7 @@ describe('http', () => {
 
             await new Promise(resolve => setTimeout(resolve, 1000));
 
-            const url = trezordNode.server!.getRouteAddress('/')!;
+            const url = trezordNode.server[0]!.getRouteAddress('/')!;
             const response = await bridgeApiCall({
                 url,
                 method: 'POST',
@@ -503,7 +503,7 @@ describe('http', () => {
 
             await new Promise(resolve => setTimeout(resolve, 1000));
 
-            const url = trezordNode.server!.getRouteAddress('/enumerate')!;
+            const url = trezordNode.server[0]!.getRouteAddress('/enumerate') || '/';
             const response = await bridgeApiCall({
                 url,
                 method: 'POST',
@@ -538,7 +538,7 @@ describe('http', () => {
             await new Promise(resolve => setTimeout(resolve, 100));
 
             const abortController = new AbortController();
-            const url = trezordNode.server!.getRouteAddress('/enumerate')!;
+            const url = trezordNode.server[0]!.getRouteAddress('/enumerate')!;
             const enumeratePromise = bridgeApiCall({
                 url,
                 method: 'POST',
@@ -588,7 +588,7 @@ describe('http', () => {
             await new Promise(resolve => setTimeout(resolve, 100));
 
             const abortController = new AbortController();
-            const url = trezordNode.server!.getRouteAddress('/')!;
+            const url = trezordNode.server[0]!.getRouteAddress('/')!;
             await bridgeApiCall({
                 url: url + 'enumerate',
                 method: 'POST',
@@ -695,7 +695,7 @@ describe('http', () => {
 
                 await server.start();
 
-                const url = server.server!.getRouteAddress('/listen')!;
+                const url = server.server[0]!.getRouteAddress('/listen')!;
                 const client = new Client({ url });
                 const onListenResolvedSpy = jest.fn();
                 client.on('listen-response', onListenResolvedSpy);

--- a/packages/transport-test/e2e/bridge/controller.ts
+++ b/packages/transport-test/e2e/bridge/controller.ts
@@ -2,6 +2,7 @@
 
 import { WebUSB } from 'usb';
 
+import { BridgeTransport } from '@trezor/transport';
 import { TrezordNode } from '@trezor/transport-bridge/src';
 import { TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
 import { Log, scheduleAction } from '@trezor/utils';
@@ -56,7 +57,6 @@ class Controller extends TrezorUserEnvLinkClass {
                 : env.USE_NODE_BRIDGE
                   ? async () => {
                         this.nodeBridge = new TrezordNode({
-                            port: 21325,
                             api: !env.USE_HW ? 'udp' : 'usb',
                             logger: new Log('test-bridge', false),
                         });
@@ -118,36 +118,18 @@ class Controller extends TrezorUserEnvLinkClass {
             `${env.USE_HW && !env.USE_NODE_BRIDGE ? '[MANUAL ACTION REQUIRED] ' : ''} waiting for bridge ${expected ? 'start' : 'stop'}`,
         );
 
+        const client = new BridgeTransport({ messages: {}, id: 'test' });
+
         return scheduleAction(
             () =>
-                fetch('http://localhost:21325/', {
-                    method: 'POST',
-                    headers: {
-                        ['Origin']: 'https://wallet.trezor.io',
-                    },
-                })
-                    .then(res => {
-                        if (res.ok !== expected) {
-                            throw new Error('Condition not met');
-                        }
+                // use BridgeTransport ping
+                client.ping().then(res => {
+                    if (expected !== res) {
+                        throw new Error('Condition not met');
+                    }
 
-                        return res.text();
-                    })
-                    .then((text: string) => {
-                        console.log(`running bridge: ${text}`);
-
-                        return null;
-                    })
-                    .catch(err => {
-                        if (err.message === 'Condition not met') {
-                            throw err;
-                        }
-                        if (expected) {
-                            throw err;
-                        }
-
-                        return null;
-                    }),
+                    return null;
+                }),
             {
                 deadline: Date.now() + 60_000,
                 gap: 1000,

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -27,7 +27,8 @@ import { createProtocolMessage } from '../utils/bridgeProtocolMessage';
 import { receiveAndParse } from '../utils/receive';
 import { buildMessage } from '../utils/send';
 
-const DEFAULT_URL = 'http://127.0.0.1:21325';
+const DEFAULT_URL = 'http://127.0.0.1';
+const DEFAULT_PORT = 21325;
 
 type BridgeEndpoint =
     | '/'
@@ -63,8 +64,7 @@ type IncompleteRequestOptions = {
 };
 
 type BridgeConstructorParameters = AbstractTransportParams & {
-    // bridge url
-    url?: string;
+    port?: number;
 };
 
 export class BridgeTransport extends AbstractTransport {
@@ -78,9 +78,9 @@ export class BridgeTransport extends AbstractTransport {
     public apiType = 'usb' as const;
 
     constructor(params: BridgeConstructorParameters) {
-        const { url = DEFAULT_URL, ...rest } = params || {};
+        const { port = DEFAULT_PORT, ...rest } = params || {};
         super(rest);
-        this.url = url;
+        this.url = `${DEFAULT_URL}:${port}`;
     }
 
     ping({ signal }: AbstractTransportMethodParams<'ping'> = {}) {

--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -37,6 +37,8 @@
         "@suite-native/sentry": "workspace:*",
         "@suite-native/settings": "workspace:*",
         "@suite-native/storage": "workspace:*",
+        "@trezor/protobuf": "workspace:^",
+        "@trezor/transport": "workspace:^",
         "@trezor/transport-native-bluetooth": "workspace:*",
         "@trezor/transport-native-usb": "workspace:*",
         "@trezor/utils": "workspace:*",

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -8,18 +8,22 @@ import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { selectTokenDefinitionsEnabledNetworks } from '@suite-native/discovery';
 import { selectTradingEnvironment } from '@suite-native/module-trading';
 import { reportSecurityCheck } from '@suite-native/sentry';
+import messages from '@trezor/protobuf/messages.json';
+import { BridgeTransport } from '@trezor/transport';
 import { NativeBluetoothTransport } from '@trezor/transport-native-bluetooth';
 import { NativeUsbTransport } from '@trezor/transport-native-usb';
 import { mergeDeepObject } from '@trezor/utils';
 
 const deviceType = Device.isDevice ? 'device' : 'emulator';
 
+const bridgeTransport = new BridgeTransport({ messages, port: 21325, id: 'bridge' });
+
 const transportsPerDeviceType = {
     device: Platform.select({
-        ios: ['BridgeTransport', NativeBluetoothTransport],
+        ios: [bridgeTransport, NativeBluetoothTransport],
         android: [NativeUsbTransport, NativeBluetoothTransport],
     }),
-    emulator: ['BridgeTransport'],
+    emulator: [bridgeTransport],
 } as const;
 
 const transports = transportsPerDeviceType[deviceType];

--- a/suite-native/state/tsconfig.json
+++ b/suite-native/state/tsconfig.json
@@ -44,6 +44,8 @@
         { "path": "../sentry" },
         { "path": "../settings" },
         { "path": "../storage" },
+        { "path": "../../packages/protobuf" },
+        { "path": "../../packages/transport" },
         {
             "path": "../../packages/transport-native-bluetooth"
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11360,6 +11360,8 @@ __metadata:
     "@suite-native/sentry": "workspace:*"
     "@suite-native/settings": "workspace:*"
     "@suite-native/storage": "workspace:*"
+    "@trezor/protobuf": "workspace:^"
+    "@trezor/transport": "workspace:^"
     "@trezor/transport-native-bluetooth": "workspace:*"
     "@trezor/transport-native-usb": "workspace:*"
     "@trezor/utils": "workspace:*"
@@ -13026,7 +13028,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/transport@workspace:*, @trezor/transport@workspace:packages/transport":
+"@trezor/transport@workspace:*, @trezor/transport@workspace:^, @trezor/transport@workspace:packages/transport":
   version: 0.0.0-use.local
   resolution: "@trezor/transport@workspace:packages/transport"
   dependencies:


### PR DESCRIPTION

when the first device using the protocol THP is delivered, users with the old standalone bridge are going to have a somewhat hard time - the reason is that this bridge version is a standalone installation and we have no means and no plans as well to update it. 

On the other hand, there is the "node bridge", which is a re-implementation of trezord-go rest api provided by trezor-suite and this version is capable of supporting THP protocol. 

We need to onboard maximum amount of users to start using the new version.  And there could be gotchas - if user has the expected port 21325 occupied by the old bridge we won't abe able to start the new one. 

So the proposed solution to this is as follows:
- make node-bridge available on a new port
- all our bridge clients (connect npm packages, suite-desktop) will start to prioritize the newly chosen port and fallback to the legacy one.
- our bridge clients stop searching for the legacy port. 
- we start prompting users to uninstall the legacy bridge #18146 

This will effectively kill the old bridge, even when it is a standalone installation. There might be a couple of implementations that still communicate with the legacy bridge (maybe they have custom implementation, maybe they did not update npm package). If such situation occurs, we might run into problems but my assesment is that this won't be that big deal.

And also the build-in node bridge is from now on available on 2 ports (21328 and 21325) to deal with situation where user has already updated his trezor-suite but he is still using it in the background (as bridge) with some outdated 3rd party implementaition.


Also cc @Hannsek we should implement this feature (new bridge port and fallback in trezorlib)


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=bridge-port-negotiation&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=bridge-port-negotiation&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=bridge-port-negotiation&lookback=7)