### PR TITLE
Chore: adjust bluetooth manufacturers data

### DIFF
--- a/packages/suite/src/actions/bluetooth/__tests__/desktopBluetoothReducer.test.ts
+++ b/packages/suite/src/actions/bluetooth/__tests__/desktopBluetoothReducer.test.ts
@@ -15,7 +15,7 @@ import {
 const manufacturerData: BluetoothManufacturerData = {
     deviceModel: DeviceModelInternal.T3W1,
     deviceColor: 0,
-    filterPolicy: null,
+    filterPolicy: undefined,
 };
 
 const bluetoothReducer = bluetoothSlice.prepareReducer(extraDependenciesMock);

--- a/packages/suite/src/actions/bluetooth/__tests__/remapKnownDevicesForLinux.test.ts
+++ b/packages/suite/src/actions/bluetooth/__tests__/remapKnownDevicesForLinux.test.ts
@@ -1,4 +1,4 @@
-import { BluetoothFilterPolicy, BluetoothManufacturerData } from '@suite-common/bluetooth';
+import { BluetoothManufacturerData } from '@suite-common/bluetooth';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { DesktopBluetoothDevice } from '../DesktopBluetoothDevice';
@@ -7,7 +7,7 @@ import { remapKnownDevicesForLinux } from '../remapKnownDevicesForLinux';
 const manufacturerData: BluetoothManufacturerData = {
     deviceModel: DeviceModelInternal.T3W1,
     deviceColor: 0,
-    filterPolicy: BluetoothFilterPolicy.UNFILTERED,
+    filterPolicy: undefined,
 };
 
 const nearbyDeviceA: DesktopBluetoothDevice = {

--- a/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
+++ b/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
@@ -1,5 +1,5 @@
 import { BLUETOOTH_PREFIX, bluetoothActions, selectKnownDevices } from '@suite-common/bluetooth';
-import { createThunk } from '@suite-common/redux-utils/';
+import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { BluetoothDevice, bluetoothIpc } from '@trezor/transport-bluetooth';
 
@@ -48,9 +48,14 @@ export const initBluetoothThunk = createThunk<void, void, void>(
         const attemptDeviceConnect = async ({ device }: { device: DesktopBluetoothDevice }) => {
             const knownDevices = selectKnownDevices<DesktopBluetoothDevice>(getState());
             const autoConnectingDevices = selectConnectingDevices(getState());
+            // do not hijack BT connection
+            const isConnectable =
+                device.connectionStatus.type === 'disconnected' &&
+                (!device.manufacturerData.filterPolicy?.connected ||
+                    device.manufacturerData.filterPolicy.pairing);
 
             if (
-                !device.connected &&
+                isConnectable &&
                 knownDevices.find(d => d.id === device.id) !== undefined &&
                 !autoConnectingDevices.includes(device.id)
             ) {

--- a/packages/suite/src/components/suite/bluetooth/BluetoothConnect.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothConnect.tsx
@@ -27,7 +27,7 @@ import { closeModalApp } from '../../../actions/suite/routerActions';
 import { useDispatch, useSelector } from '../../../hooks/suite';
 
 const SCAN_TIMEOUT = 30_000;
-const UNPAIRED_DEVICES_LAST_UPDATED_LIMIT_SECONDS = 30;
+const UNPAIRED_DEVICES_LAST_UPDATED_LIMIT = 30_000;
 
 type BluetoothConnectProps = {
     uiMode: BluetoothConnectUiMode;
@@ -48,8 +48,7 @@ export const BluetoothConnect = ({ uiMode }: BluetoothConnectProps) => {
     const knownDevices = useSelector(selectKnownDevices);
     const nearbyDevices = useSelector(selectNearbyDevices);
 
-    const lastUpdatedBoundaryTimestamp =
-        Date.now() / 1000 - UNPAIRED_DEVICES_LAST_UPDATED_LIMIT_SECONDS;
+    const lastUpdatedBoundaryTimestamp = Date.now() - UNPAIRED_DEVICES_LAST_UPDATED_LIMIT;
 
     const devices = allDevices.filter(it => {
         const isDeviceUnresponsiveForTooLong =

--- a/packages/suite/src/components/suite/bluetooth/BluetoothDebugInfo.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDebugInfo.tsx
@@ -10,7 +10,7 @@ const TimeAgo = ({ timestamp }: { timestamp: number }) => {
     const [secAgo, setSecAgo] = useState(0);
 
     useEffect(() => {
-        setSecAgo(Math.floor(Date.now() / 1000 - timestamp));
+        setSecAgo(Math.floor((Date.now() - timestamp) / 1000));
         const interval = setInterval(() => setSecAgo(t => t + 1), 1000);
 
         return () => clearInterval(interval);

--- a/packages/transport-bluetooth/src/client/types.ts
+++ b/packages/transport-bluetooth/src/client/types.ts
@@ -26,12 +26,13 @@ export interface BluetoothDevice {
      * Manufacturer Specific Data:
      *
      * Bytes:
-     *      [0]: fist byte is advertising type.
-     *             0 - advertising with whitelist,
-     *             1 - without whitelist (pairing mode),
-     *             2 - also pairing mode but bond memory is full, cannot bond another dive
-     *      [1]: second is device color (interpreted same way as from Device Fetures)
-     *      [2-6]: four remaining bytes represent internal device name, i.e. T3W1
+     *      [0]: advertising type:
+     *             0      - advertising with whitelist
+     *             | 0x01 - without whitelist (pairing mode)
+     *             | 0x02 - bond memory is full. cannot bond another device
+     *             | 0x04 - device currently connected here or elsewhere
+     *      [1]: device color
+     *      [2]: device code (see MODEL_BLE_CODE)
      */
     data: number[]; // advertisement data bytes
     connected: boolean;

--- a/packages/transport-bluetooth/src/server/device.rs
+++ b/packages/transport-bluetooth/src/server/device.rs
@@ -91,10 +91,10 @@ impl serde::Serialize for TrezorDevice {
     }
 }
 
-const MANUFACTURER_DATA: u16 = 65535;
-pub const SERVICE_UUID: Uuid = uuid!("8c000001-a59b-4d58-a9ad-073df69fa1b1");
-pub const CHARACTERISTIC_RX: Uuid = uuid!("8c000002-a59b-4d58-a9ad-073df69fa1b1");
-pub const CHARACTERISTIC_TX: Uuid = uuid!("8c000003-a59b-4d58-a9ad-073df69fa1b1");
+const MANUFACTURER_DATA: u16 = 3881; // trezor-firmware CONFIG_BT_COMPANY_ID=0x0F29
+pub const SERVICE_UUID: Uuid = uuid!("8c000001-a59b-4d58-a9ad-073df69fa1b1"); // trezor-firmware BT_UUID_TRZ_VAL
+pub const CHARACTERISTIC_RX: Uuid = uuid!("8c000002-a59b-4d58-a9ad-073df69fa1b1"); // trezor-firmware BT_UUID_TRZ_TX_VAL
+pub const CHARACTERISTIC_TX: Uuid = uuid!("8c000003-a59b-4d58-a9ad-073df69fa1b1"); // trezor-firmware BT_UUID_TRZ_RX_VAL
 
 impl TrezorDevice {
     pub async fn new(peripheral: Peripheral) -> Result<Self, Box<dyn Error>> {

--- a/packages/transport-bluetooth/src/ui/index.ts
+++ b/packages/transport-bluetooth/src/ui/index.ts
@@ -50,7 +50,7 @@ const createDevice = (api: TrezorBluetooth, d: BluetoothDevice) => {
 
     p = document.createElement('p');
     const timestamp = d.lastUpdatedTimestamp
-        ? new Date(d.lastUpdatedTimestamp * 1000).toLocaleTimeString('en-US', { hour12: false })
+        ? new Date(d.lastUpdatedTimestamp).toLocaleTimeString('en-US', { hour12: false })
         : 'Unknown';
     p.textContent = `Last seen: ${timestamp}`;
     details.appendChild(p);

--- a/suite-common/bluetooth/src/index.ts
+++ b/suite-common/bluetooth/src/index.ts
@@ -5,7 +5,7 @@ export type {
 } from './types';
 export type { BluetoothState } from './bluetoothReducer';
 export type { WithBluetoothState } from './bluetoothSelectors';
-export { BluetoothFilterPolicy } from './types';
+export type { BluetoothFilterPolicy } from './types';
 
 export { BLUETOOTH_PREFIX, bluetoothActions } from './bluetoothActions';
 export { prepareInitialState, prepareBluetoothReducerCreator } from './bluetoothReducer';

--- a/suite-common/bluetooth/src/manufacturerDataUtils.ts
+++ b/suite-common/bluetooth/src/manufacturerDataUtils.ts
@@ -2,42 +2,78 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { BluetoothFilterPolicy, BluetoothManufacturerData } from './types';
 
-const parseDeviceModel = (bytes: number[]): DeviceModelInternal => {
-    // TODO: There's a bug in FW, the device model is reversed.
-    const deviceModel = String.fromCharCode(...bytes.reverse()) as DeviceModelInternal;
-
-    return DeviceModelInternal[deviceModel] ?? DeviceModelInternal.UNKNOWN;
+// MODEL_BLE_CODE defined in trezor-firmware
+// https://github.com/trezor/trezor-firmware/blob/main/core/embed/models/T3W1/model_T3W1.h#L36
+const MODEL_BLE_CODE: Record<number, DeviceModelInternal> = {
+    6: DeviceModelInternal.T3W1,
 };
 
-const parseFilterPolicy = (value: number): BluetoothFilterPolicy | null =>
-    BluetoothFilterPolicy[value] ? (value as BluetoothFilterPolicy) : null;
+// flags defined in trezor-firmware
+// https://github.com/trezor/trezor-firmware/blob/main/nordic/trezor/trezor-ble/src/ble/advertising.c#L35
+const ADV_FLAG_PAIRING = 0x01;
+const ADV_FLAG_BOND_MEM_FULL = 0x02;
+const ADV_FLAG_DEV_CONNECTED = 0x04;
+
+const parseDeviceModel = (bytes: number): DeviceModelInternal =>
+    MODEL_BLE_CODE[bytes] ?? DeviceModelInternal.UNKNOWN;
+
+const parseFilterPolicy = (value: number): BluetoothFilterPolicy => ({
+    pairing: !!(value & ADV_FLAG_PAIRING),
+    bond_memory_full: !!(value & ADV_FLAG_BOND_MEM_FULL),
+    connected: !!(value & ADV_FLAG_DEV_CONNECTED),
+});
+
+const serializeFilterPolicy = (policy?: BluetoothFilterPolicy) => {
+    let value = 0;
+    if (policy) {
+        if (policy.pairing) {
+            value |= ADV_FLAG_PAIRING;
+        }
+        if (policy.bond_memory_full) {
+            value |= ADV_FLAG_BOND_MEM_FULL;
+        }
+        if (policy.connected) {
+            value |= ADV_FLAG_DEV_CONNECTED;
+        }
+    }
+
+    return value;
+};
+
+Object.keys(MODEL_BLE_CODE)
+    .map(k => Number(k))
+    .find(k => MODEL_BLE_CODE[k]);
+
+const serializeDeviceModel = (m: DeviceModelInternal) =>
+    Object.keys(MODEL_BLE_CODE)
+        .map(k => Number(k))
+        .find(k => MODEL_BLE_CODE[k] === m) || 0;
 
 /**
  * Manufacturer Specific Data
  *
  * 1st byte = filter policy
  * 2nd byte = device color, interpreted the same way as from Device Features
- * remaining four bytes = internal device model, e.g. T3W1
+ * 3rd byte = internal device model
  */
 export const parseManufacturerData = (bytes: number[]): BluetoothManufacturerData => {
-    if (bytes.length !== 6) {
+    if (bytes.length < 3) {
         return {
             deviceModel: DeviceModelInternal.UNKNOWN,
             deviceColor: 0,
-            filterPolicy: null,
+            filterPolicy: undefined,
         };
     }
 
     return {
-        deviceModel: parseDeviceModel(bytes.slice(2)),
+        deviceModel: parseDeviceModel(bytes[2]),
         deviceColor: bytes[1],
         filterPolicy: parseFilterPolicy(bytes[0]),
     };
 };
 
 export const serializeManufacturerData = (data: BluetoothManufacturerData): number[] => [
-    data.filterPolicy ?? 0,
+    serializeFilterPolicy(data.filterPolicy),
     data.deviceColor,
-    // TODO: There's a bug in FW, the device model is reversed.
-    ...Array.from(data.deviceModel, char => char.charCodeAt(0)).reverse(),
+    serializeDeviceModel(data.deviceModel),
 ];

--- a/suite-common/bluetooth/src/types.ts
+++ b/suite-common/bluetooth/src/types.ts
@@ -9,16 +9,16 @@ export type BluetoothAdapterStatus =
 
 export type BluetoothScanStatus = 'idle' | 'running' | 'error';
 
-export enum BluetoothFilterPolicy {
-    FILTERED = 0, // accepts connections from known devices
-    UNFILTERED = 1, // accepts connections from all devices (aka pairing mode)
-    BOND_MEMORY_FULL = 2, // same as UNFILTERED but new connections cannot be established
-}
+export type BluetoothFilterPolicy = {
+    pairing: boolean; // accepts connections from all devices
+    connected: boolean; // currently connected here or elsewhere
+    bond_memory_full: boolean; // new connections cannot be established
+};
 
 export type BluetoothManufacturerData = {
     deviceModel: DeviceModelInternal;
     deviceColor: number; // TODO: add proper strict type, plain number is currently used in the codebase
-    filterPolicy: BluetoothFilterPolicy | null;
+    filterPolicy?: BluetoothFilterPolicy;
 };
 
 export type DeviceBluetoothConnectionStatus =

--- a/suite-common/bluetooth/tests/bluetoothReducer.test.ts
+++ b/suite-common/bluetooth/tests/bluetoothReducer.test.ts
@@ -17,7 +17,7 @@ import { BluetoothDeviceCommon } from '../src/types';
 const manufacturerData: BluetoothManufacturerData = {
     deviceModel: DeviceModelInternal.T3W1,
     deviceColor: 0,
-    filterPolicy: null,
+    filterPolicy: undefined,
 };
 
 const bluetoothReducer =

--- a/suite-common/bluetooth/tests/bluetoothSelectors.test.ts
+++ b/suite-common/bluetooth/tests/bluetoothSelectors.test.ts
@@ -1,6 +1,6 @@
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { BluetoothFilterPolicy, BluetoothManufacturerData, prepareSelectAllDevices } from '../src';
+import { BluetoothManufacturerData, prepareSelectAllDevices } from '../src';
 import { BluetoothState } from '../src/bluetoothReducer';
 import { WithBluetoothState } from '../src/bluetoothSelectors';
 import { BluetoothDeviceCommon } from '../src/types';
@@ -8,7 +8,7 @@ import { BluetoothDeviceCommon } from '../src/types';
 const manufacturerData: BluetoothManufacturerData = {
     deviceModel: DeviceModelInternal.T3W1,
     deviceColor: 0,
-    filterPolicy: BluetoothFilterPolicy.UNFILTERED,
+    filterPolicy: undefined,
 };
 
 const initialState: BluetoothState<BluetoothDeviceCommon> = {

--- a/suite-common/bluetooth/tests/manufacturerDataUtils.test.ts
+++ b/suite-common/bluetooth/tests/manufacturerDataUtils.test.ts
@@ -1,33 +1,65 @@
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { BluetoothFilterPolicy, parseManufacturerData, serializeManufacturerData } from '../src';
+import { parseManufacturerData, serializeManufacturerData } from '../src';
+
+const filterPolicy = {
+    pairing: false,
+    connected: false,
+    bond_memory_full: false,
+};
 
 describe(parseManufacturerData.name, () => {
     test.each([
         ['empty array', []],
-        ['shorter array', [1, 2, 3, 4, 5]],
-        ['longer array', [1, 2, 3, 4, 5, 6, 7]],
+        ['shorter array', [1, 2]],
     ])('parses %s as invalid', (_, bytes) => {
         expect(parseManufacturerData(bytes)).toEqual({
             deviceModel: DeviceModelInternal.UNKNOWN,
             deviceColor: 0,
-            filterPolicy: null,
+            filterPolicy: undefined,
         });
     });
 
     test('parses invalid data correctly', () => {
-        expect(parseManufacturerData([3, 42, 84, 51, 87, 49])).toEqual({
+        expect(parseManufacturerData([31, 42, 84, 51, 87, 49])).toEqual({
             deviceModel: DeviceModelInternal.UNKNOWN,
             deviceColor: 42,
-            filterPolicy: null,
+            filterPolicy: {
+                pairing: true,
+                connected: true,
+                bond_memory_full: true,
+            },
         });
     });
 
     test('parses valid data correctly', () => {
-        expect(parseManufacturerData([1, 42, 49, 87, 51, 84])).toEqual({
+        expect(parseManufacturerData([1, 0, 6])).toEqual({
             deviceModel: DeviceModelInternal.T3W1,
-            deviceColor: 42,
-            filterPolicy: BluetoothFilterPolicy.UNFILTERED,
+            deviceColor: 0,
+            filterPolicy: {
+                ...filterPolicy,
+                pairing: true,
+            },
+        });
+        expect(parseManufacturerData([3, 0, 6]).filterPolicy).toEqual({
+            pairing: true,
+            connected: false,
+            bond_memory_full: true,
+        });
+        expect(parseManufacturerData([5, 0, 6]).filterPolicy).toEqual({
+            pairing: true,
+            connected: true,
+            bond_memory_full: false,
+        });
+        expect(parseManufacturerData([6, 0, 6]).filterPolicy).toEqual({
+            pairing: false,
+            connected: true,
+            bond_memory_full: true,
+        });
+        expect(parseManufacturerData([7, 0, 6]).filterPolicy).toEqual({
+            pairing: true,
+            connected: true,
+            bond_memory_full: true,
         });
     });
 });
@@ -38,8 +70,11 @@ describe(serializeManufacturerData.name, () => {
             serializeManufacturerData({
                 deviceModel: DeviceModelInternal.T3W1,
                 deviceColor: 2,
-                filterPolicy: BluetoothFilterPolicy.UNFILTERED,
+                filterPolicy: {
+                    ...filterPolicy,
+                    pairing: true,
+                },
             }),
-        ).toEqual([1, 2, 49, 87, 51, 84]);
+        ).toEqual([1, 2, 6]);
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. manufacturers data id changed to `0x0F29`
2. manufacturers data format changed to `[policy, color, device]`
   policy is not a binary 0|1 value (enum). it could have multiple states at once: pairing mode, memory full, currently connected: http://github.com/trezor/trezor-firmware/pull/5122
3. reconnect bluetooth device condition. fix: https://github.com/trezor/trezor-suite/issues/19611
4. bluetooth device timestamp in miliseconds
   

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bt-manufacturers-data&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bt-manufacturers-data&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/bt-manufacturers-data&lookback=7)