### PR TITLE
chore(wallet-core): use basic detail for all networks except solana

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -74,7 +74,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
             coin: account.symbol,
             identity: tryGetAccountIdentity(account),
             descriptor: account.descriptor,
-            details: 'txids',
+            details: account.networkType === 'solana' ? 'txids' : 'basic',
             suppressBackupWarning: true,
             tokenAccountsPubKeys,
         });

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -795,7 +795,7 @@ export const isAccountOutdated = (account: Account, freshInfo: AccountInfo) => {
         case 'ethereum':
             return (
                 freshInfo.misc!.nonce !== account.misc.nonce ||
-                freshInfo.balance !== account.balance || // balance can change because of beacon chain txs (staking) |
+                freshInfo.balance !== account.balance || // balance can change because of beacon chain/internal txs
                 JSON.stringify(freshInfo?.misc?.stakingPools) !==
                     JSON.stringify(account?.misc?.stakingPools)
             );


### PR DESCRIPTION
## Description

- no need to fetch txids for all networks except Solana
- request takes unnecessarily more time and consumes more computing power of blockbook/database


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/basic&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/basic&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/basic&lookback=7)