### PR TITLE
fix(suite): fee for networks with tokens and different symbol

### DIFF
--- a/packages/suite/src/views/wallet/send/TotalSent/TotalSent.tsx
+++ b/packages/suite/src/views/wallet/send/TotalSent/TotalSent.tsx
@@ -90,7 +90,6 @@ export const TotalSent = () => {
                                         disableHiddenPlaceholder
                                         value={formatNetworkAmount(transactionInfo.fee, symbol)}
                                         symbol={symbol}
-                                        contractAddress={tokenInfo.contract}
                                     />
                                 ) : (
                                     <BaseCurrencyValue


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- use display network symbol for fee

## Screenshots:

before:

<img width="806" height="938" alt="Screenshot 2025-07-17 at 17 42 39" src="https://github.com/user-attachments/assets/988fdf93-46b1-4acc-a2f2-bdef4852511f" />

after:

<img width="771" height="455" alt="Screenshot 2025-07-17 at 17 47 02" src="https://github.com/user-attachments/assets/160436b6-ec7e-446a-8077-d59cddb5784d" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/fee-l2&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/fee-l2&lookback=7)