### PR TITLE
feat(suite-native): enable bridge transport on android

### DIFF
--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -17,7 +17,7 @@ const deviceType = Device.isDevice ? 'device' : 'emulator';
 const transportsPerDeviceType = {
     device: Platform.select({
         ios: ['BridgeTransport', NativeBluetoothTransport],
-        android: [NativeUsbTransport, NativeBluetoothTransport],
+        android: ['BridgeTransport', NativeUsbTransport, NativeBluetoothTransport],
     }),
     emulator: ['BridgeTransport'],
 } as const;


### PR DESCRIPTION
## Description

Enable bridge transport on Android for testing with real device + emulator

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/android-enable-bridge-transport&lookback=7)