### PR TITLE
fix(suite): blacklist webusb methods in connect wrapper

### DIFF
--- a/suite-common/connect-init/src/blacklist.ts
+++ b/suite-common/connect-init/src/blacklist.ts
@@ -1,7 +1,7 @@
-import { ConnectKey } from './types';
+import { ConnectWebKey } from './types';
 
 // List of methods that don't work with device, so they don't need to be patched
-export const blacklist: ConnectKey[] = [
+export const blacklist: ConnectWebKey[] = [
     'manifest',
     'init',
     'setTransports',
@@ -30,4 +30,7 @@ export const blacklist: ConnectKey[] = [
     // so locking device must be avoided (blocks a lot of Suite features needlessly)
     // TODO find a better solution to wrap this method only when device is used
     'getAccountInfo',
+    // WebUSB methods from Connect web
+    'requestWebUSBDevice',
+    'disableWebUSB',
 ];

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -23,7 +23,7 @@ import { getSynchronize } from '@trezor/utils';
 
 import { blacklist } from './blacklist';
 import { cardanoConnectPatch } from './cardanoConnectPatch';
-import { ConnectKey } from './types';
+import { ConnectKey, ConnectWebKey } from './types';
 
 const CONNECT_INIT_MODULE = '@common/connect-init';
 
@@ -128,7 +128,7 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
         const synchronize = getSynchronize();
 
         Object.keys(TrezorConnect)
-            .filter(k => !blacklist.includes(k as ConnectKey))
+            .filter(k => !blacklist.includes(k as ConnectWebKey))
             .forEach(key => {
                 // typescript complains about params and return type, need to be "any"
                 const original: any = TrezorConnect[key as ConnectKey];

--- a/suite-common/connect-init/src/types.ts
+++ b/suite-common/connect-init/src/types.ts
@@ -1,3 +1,4 @@
 import TrezorConnect from '@trezor/connect';
 
 export type ConnectKey = keyof typeof TrezorConnect;
+export type ConnectWebKey = ConnectKey | 'requestWebUSBDevice' | 'disableWebUSB';


### PR DESCRIPTION
## Description

Seems like the Connect wrapper in `connectInitThunks` is having issues with WebUSB methods such as `requestWebUSBDevice`. 
We need to add it to the blacklist.

## Related Issue

Resolve #20253


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/webusb-connect-wrapper-blacklist&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/webusb-connect-wrapper-blacklist&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/webusb-connect-wrapper-blacklist&lookback=7)