### PR TITLE
feat(connect): DeviceStatus busy

### DIFF
--- a/packages/connect/src/constants/errors.ts
+++ b/packages/connect/src/constants/errors.ts
@@ -48,6 +48,7 @@ export const ERROR_CODES = {
 
     Failure_ActionCancelled: 'Action canceled by user',
     Failure_FirmwareError: 'Firmware installation failed',
+    Failure_Busy: 'Device busy',
     Failure_UnknownCode: 'Unknown error',
     Failure_PinCancelled: 'PIN canceled',
     Failure_PinInvalid: 'PIN invalid',

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -177,6 +177,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     // DeviceState list [this.instance]: DeviceState | undefined
     private state: DeviceState[] = [];
     private stateStorage?: IStateStorage = undefined;
+    private busy?: boolean;
 
     private _unavailableCapabilities: UnavailableCapabilities = {};
     public get unavailableCapabilities(): Readonly<UnavailableCapabilities> {
@@ -508,8 +509,14 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 } else {
                     await this.getFeatures();
                 }
+
+                this.busy = false;
             } catch (error) {
                 _log.warn('Device._runInner error: ', error.message);
+
+                if (error.code === 'Failure_Busy') {
+                    this.busy = true;
+                }
 
                 if (error.code === 'Device_ThpPairingTagInvalid') {
                     // return as TypedError
@@ -1065,6 +1072,14 @@ export class Device extends TypedEmitter<DeviceEvents> {
         return 'normal';
     }
 
+    private getStatus(): DeviceStatus {
+        if (this.isUsedElsewhere()) return 'occupied';
+        if (this.wasUsedElsewhere) return 'used';
+        if (this.busy) return 'busy';
+
+        return 'available';
+    }
+
     // simplified object to pass via postMessage
     toMessageObject(): DeviceTyped {
         const { name, uniquePath: path } = this;
@@ -1090,14 +1105,12 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 transportSessionOwner: this.sessionAcquired ? undefined : sessionOwner,
                 bluetoothProps: this.bluetoothProps,
                 thp: this.thp?.serialize(),
+                status: this.busy ? 'busy' : undefined,
             };
         }
         const defaultLabel = 'My Trezor';
         const label =
             this.features.label === '' || !this.features.label ? defaultLabel : this.features.label;
-        const status: DeviceStatus = this.isUsedElsewhere()
-            ? 'occupied'
-            : (this.wasUsedElsewhere && 'used') || 'available';
 
         return {
             ...base,
@@ -1106,7 +1119,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
             label,
             _state: this.getState(),
             state: this.getState()?.staticSessionId,
-            status,
+            status: this.getStatus(),
             mode: this.getMode(),
             color: this.color,
             firmware: this.firmwareStatus,

--- a/packages/connect/src/device/workflow/handshake.ts
+++ b/packages/connect/src/device/workflow/handshake.ts
@@ -2,6 +2,7 @@ import { PROTOCOL_MALFORMED } from '@trezor/protocol';
 import { TRANSPORT_ERROR } from '@trezor/transport';
 import { resolveAfter, versionUtils } from '@trezor/utils';
 
+import { TypedError } from '../../constants/errors';
 import { DataManager } from '../../data/DataManager';
 import { WorkflowContext } from '../../types/workflow';
 import { Log } from '../../utils/debug';
@@ -90,6 +91,13 @@ export const handshakeCancel = async ({ device, logger, signal }: Context) => {
             ) {
                 logger?.debug(`handshake Cancel protocol v2 detected`);
                 await device.setupThp();
+            }
+
+            if (
+                result.payload.type === 'Failure' &&
+                result.payload.message.code === 'Failure_Busy'
+            ) {
+                throw TypedError(result.payload.message.code, result.payload.message.message);
             }
 
             return;

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -9,8 +9,9 @@ import type { ReleaseInfo } from './firmware';
  * - `available`  no other application has an active session
  * - `occupied`   other application has an active session
  * - `used`       another has released the device and no other application has an active session
+ * - `busy`       this application has an active session but device is currently busy (example: connect to host device screen after RebootToBootloader)
  */
-export type DeviceStatus = 'available' | 'occupied' | 'used';
+export type DeviceStatus = 'available' | 'occupied' | 'used' | 'busy';
 
 export type DeviceMode = 'normal' | 'bootloader' | 'initialize' | 'seedless';
 
@@ -126,7 +127,7 @@ export type UnknownDevice = BaseDevice & {
     firmwareRelease?: typeof undefined;
     firmwareType?: typeof undefined;
     color?: typeof undefined;
-    status?: typeof undefined;
+    status?: DeviceStatus;
     mode?: typeof undefined;
     _state?: typeof undefined;
     state?: typeof undefined;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

adding new DeviceStatus `busy`

Trezor will return protocol `v1` Failure: Failure_Busy for example after reboot to bootloader before user clicks on "connect to host device"

https://github.com/trezor/trezor-firmware/commit/54202b9f53d107abf2aae4fc371548887a848836

we can show some info during firmware update if device.status === 'busy' 

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-device-busy&lookback=7)