### PR TITLE
WalletConnect finalization

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/permissions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/permissions.test.ts
@@ -30,6 +30,7 @@ test.describe('TrezorConnect', { tag: ['@group=connect', '@desktopOnly'] }, () =
         async ({ settingsPage, connectPermissionsModal, page }) => {
             await settingsPage.navigateTo('connect');
 
+            await page.getByTestId('@settings/connect-apps/tabs/trezor-connect').click();
             await page.getByTestId('@settings/connect-apps/no-apps').waitFor({ state: 'visible' });
 
             TrezorConnect.getAddress({

--- a/packages/suite/src/actions/suite/__tests__/initAction.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/initAction.test.ts
@@ -23,6 +23,7 @@ import {
     prepareDeviceReducer,
     updateMissingTxFiatRatesThunk,
 } from '@suite-common/wallet-core';
+import { walletConnectInitThunk } from '@suite-common/walletconnect';
 import TrezorConnect from '@trezor/connect';
 
 import { ROUTER, SUITE } from 'src/actions/suite/constants';
@@ -121,6 +122,7 @@ const fixtures: Fixture[] = [
             updateMissingTxFiatRatesThunk.fulfilled.type,
             periodicCheckStakeDataThunk.pending.type,
             initStakeDataThunk.pending.type,
+            walletConnectInitThunk.pending.type,
             SUITE.READY,
         ],
     },
@@ -166,6 +168,7 @@ const fixtures: Fixture[] = [
             ROUTER.LOCATION_CHANGE,
             periodicCheckStakeDataThunk.pending.type,
             initStakeDataThunk.pending.type,
+            walletConnectInitThunk.pending.type,
             SUITE.READY,
         ],
     },
@@ -209,6 +212,7 @@ const fixtures: Fixture[] = [
             ROUTER.LOCATION_CHANGE,
             periodicCheckStakeDataThunk.pending.type,
             initStakeDataThunk.pending.type,
+            walletConnectInitThunk.pending.type,
             SUITE.READY,
         ],
     },

--- a/packages/suite/src/actions/suite/initAction.ts
+++ b/packages/suite/src/actions/suite/initAction.ts
@@ -18,7 +18,6 @@ import * as languageActions from 'src/actions/settings/languageActions';
 import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
 import * as modalActions from 'src/actions/suite/modalActions';
 import * as routerActions from 'src/actions/suite/routerActions';
-import { selectHasExperimentalFeature } from 'src/reducers/suite/suiteReducer';
 import type { Dispatch, GetState } from 'src/types/suite';
 
 import { SUITE } from './constants';
@@ -148,9 +147,7 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
     dispatch(periodicCheckStakeDataThunk());
 
     // 14. init wallet connect
-    if (selectHasExperimentalFeature('walletconnect')(getState())) {
-        dispatch(walletConnectActions.walletConnectInitThunk());
-    }
+    dispatch(walletConnectActions.walletConnectInitThunk());
 
     // 15. backend connected, suite is ready to use
     dispatch(onSuiteReady());

--- a/packages/suite/src/components/settings/SettingsLayout.tsx
+++ b/packages/suite/src/components/settings/SettingsLayout.tsx
@@ -11,10 +11,7 @@ import {
     SubpageNavigation,
 } from 'src/components/suite/layouts/SuiteLayout';
 import { useDiscovery, useDispatch, useLayout, useSelector } from 'src/hooks/suite';
-import {
-    selectHasExperimentalFeature,
-    selectIsDebugModeActive,
-} from 'src/reducers/suite/suiteReducer';
+import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 import { AccountHeaderProvider } from 'src/support/suite/AccountHeaderProvider';
 import { SettingsLoading } from 'src/views/settings/SettingsLoader';
 
@@ -26,8 +23,6 @@ type SettingsLayoutProps = {
 
 const SettingsHeader = () => {
     const isDebugModeActive = useSelector(selectIsDebugModeActive);
-    const enabledTrezorConnectWS = useSelector(selectHasExperimentalFeature('trezor-connect-ws'));
-    const enabledWalletConnect = useSelector(selectHasExperimentalFeature('walletconnect'));
 
     const dispatch = useDispatch();
 
@@ -58,7 +53,6 @@ const SettingsHeader = () => {
                 id: 'settings-connected-apps',
                 title: <Translation id="TR_CONNECTED_APPS" />,
                 position: 'primary',
-                isHidden: !(enabledTrezorConnectWS || enabledWalletConnect),
                 'data-testid': '@settings/menu/connected-apps',
                 callback: () => dispatch(goto('settings-connected-apps', { preserveParams: true })),
             },
@@ -71,7 +65,7 @@ const SettingsHeader = () => {
                 callback: () => dispatch(goto('settings-debug', { preserveParams: true })),
             },
         ],
-        [dispatch, isDebugModeActive, enabledTrezorConnectWS, enabledWalletConnect],
+        [dispatch, isDebugModeActive],
     );
 
     return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
@@ -543,27 +543,31 @@ export const TxSimulationModal = () => {
                         />
                     )}
 
-                    <Text variant="tertiary" margin={{ left: spacings.xs }}>
-                        <Translation
-                            id="TR_SIMULATION_POWERED_BY"
-                            values={{ provider: <Link href="https://blockaid.io">Blockaid</Link> }}
-                        />
-                    </Text>
+                    <Column margin={{ left: spacings.xs }} gap={spacings.md}>
+                        <Text variant="tertiary">
+                            <Translation
+                                id="TR_SIMULATION_POWERED_BY"
+                                values={{
+                                    provider: <Link href="https://blockaid.io">Blockaid</Link>,
+                                }}
+                            />
+                        </Text>
 
-                    {isSigningTransaction && account && (
-                        <Fees
-                            account={account}
-                            feeInfo={feeInfo}
-                            control={control}
-                            register={register}
-                            setValue={setValue}
-                            getValues={getValues}
-                            errors={errors}
-                            isDirty={isDirty}
-                            changeFeeLevel={changeFeeLevel}
-                            trigger={trigger}
-                        />
-                    )}
+                        {isSigningTransaction && account && (
+                            <Fees
+                                account={account}
+                                feeInfo={feeInfo}
+                                control={control}
+                                register={register}
+                                setValue={setValue}
+                                getValues={getValues}
+                                errors={errors}
+                                isDirty={isDirty}
+                                changeFeeLevel={changeFeeLevel}
+                                trigger={trigger}
+                            />
+                        )}
+                    </Column>
                 </Column>
             </Modal.ModalBase>
         </Modal.Backdrop>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
@@ -452,7 +452,9 @@ export const TxSimulationModal = () => {
                                                         )?.[1]?.name_tag,
                                                     },
                                                     {
-                                                        label: <Translation id="TR_ADDRESS" />,
+                                                        label: (
+                                                            <Translation id="TR_CONTRACT_ADDRESS" />
+                                                        ),
                                                         value: (
                                                             <TxAddress
                                                                 txAddress={targetContract}

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -309,7 +309,10 @@ export const NotificationRenderer = ({
             return success(render, notification, 'TR_THP_RESET_CREDENTIALS_SUCCESS');
         case 'sign-transaction-timeout':
             return error(render, notification, 'TR_SIGN_TRANSACTION_TIMEOUT');
-
+        case 'connect-popup-success':
+            return success(render, notification, 'TR_CONNECT_POPUP_SUCCESS', 'check', {
+                appName: notification.appName,
+            });
         default:
             return exhaustive(type);
     }

--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -10,8 +10,7 @@ export type ExperimentalFeature =
     | 'password-manager'
     | 'tor-external'
     | 'nft-section'
-    | 'trezor-connect-ws'
-    | 'walletconnect';
+    | 'trezor-connect-ws';
 
 export type ExperimentalFeatureConfig = {
     title: TranslationKey;
@@ -55,9 +54,5 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
         onToggle: async ({ newValue }) => {
             await desktopApi.connectPopupSetEnabled(newValue);
         },
-    },
-    walletconnect: {
-        title: 'TR_WALLETCONNECT',
-        description: 'TR_EXPERIMENTAL_WALLETCONNECT_DESCRIPTION',
     },
 };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -10498,4 +10498,8 @@ export default defineMessages({
         id: 'TR_CONTRACT_APPROVE_TITLE',
         defaultMessage: 'Approve to',
     },
+    TR_CONNECT_POPUP_SUCCESS: {
+        id: 'TR_CONNECT_POPUP_SUCCESS',
+        defaultMessage: 'Success! {appName} request completed',
+    },
 } as const);

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7018,7 +7018,7 @@ export default defineMessages({
     },
     TR_CONTRACT_ADDRESS: {
         id: 'TR_CONTRACT_ADDRESS',
-        defaultMessage: 'Contract address:',
+        defaultMessage: 'Contract address',
     },
     TR_POLICY_ID_ADDRESS: {
         id: 'TR_POLICY_ID_ADDRESS',

--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -105,8 +105,10 @@ export const useConnectPopupDesktop = () => {
 
             setCurrentlyOngoing(true);
             // Remember visibility state
-            desktopApi.appIsVisible().then(isVisible => setWasVisible(isVisible));
-            desktopApi.appFocus();
+            desktopApi.appIsVisible().then(isVisible => {
+                setWasVisible(isVisible && document.visibilityState === 'visible');
+                desktopApi.appFocus();
+            });
         }
 
         if (popupCall?.state === 'finished') {

--- a/packages/suite/src/views/settings/SettingsConnectedApps/SettingsConnectedApps.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/SettingsConnectedApps.tsx
@@ -1,9 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { selectDevices } from '@suite-common/wallet-core';
-import { selectSessions } from '@suite-common/walletconnect';
 import { Column, Icon, Row, SubTabs } from '@trezor/components';
-import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { isDesktop } from '@trezor/env-utils';
 import { spacings } from '@trezor/theme';
 
@@ -18,12 +15,7 @@ import { WalletConnectList } from './WalletConnectList';
 
 export const SettingsConnectedApps = () => {
     const dispatch = useDispatch();
-    const hasSupportedDevice =
-        useSelector(selectDevices).find(device => !hasBitcoinOnlyFirmware(device)) !== undefined;
-    const hasExistingWalletConnectSessions = useSelector(selectSessions).length > 0;
-    const wcFeatureFlag = useSelector(selectHasExperimentalFeature('walletconnect'));
     const connectFeatureFlag = useSelector(selectHasExperimentalFeature('trezor-connect-ws'));
-    const wcEnabled = wcFeatureFlag && (hasSupportedDevice || hasExistingWalletConnectSessions);
 
     const tabs = [
         {
@@ -31,7 +23,7 @@ export const SettingsConnectedApps = () => {
             icon: 'walletConnect' as const,
             title: <Translation id="TR_WALLETCONNECT" />,
             component: <WalletConnectList />,
-            isEnabled: wcEnabled,
+            isEnabled: true,
         },
         {
             id: 'trezor-connect',
@@ -57,6 +49,7 @@ export const SettingsConnectedApps = () => {
                         <SubTabs.Item
                             key={tab.id}
                             id={tab.id}
+                            data-testid={`@settings/connect-apps/tabs/${tab.id}`}
                             onClick={() => setActiveItemId(tab.id)}
                         >
                             <Row alignItems="center" gap={spacings.xs}>
@@ -66,9 +59,7 @@ export const SettingsConnectedApps = () => {
                         </SubTabs.Item>
                     ))}
                 </SubTabs>
-                {wcEnabled && (
-                    <WalletConnectButton handleOpened={() => setActiveItemId('walletconnect')} />
-                )}
+                <WalletConnectButton handleOpened={() => setActiveItemId('walletconnect')} />
             </Row>
             {tabs.find(tab => tab.id === activeItemdId)?.component}
         </Column>

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -2,6 +2,7 @@ import { AsyncThunkAction } from '@reduxjs/toolkit';
 
 import { EventType, analytics } from '@suite-common/analytics';
 import { CustomThunkAPI, createThunk } from '@suite-common/redux-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
 import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
 import { PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import TrezorConnect, { CallMethodParams } from '@trezor/connect';
@@ -124,6 +125,12 @@ export const connectPopupCallThunkInner = createThunk<
             }
             if (!postCallOngoing) {
                 dispatch(connectPopupActions.finishCall());
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'connect-popup-success',
+                        appName: source.manifest.appName,
+                    }),
+                );
             }
 
             analytics.report({

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -12,7 +12,7 @@ import { DEEPLINK_VERSION } from '@trezor/connect/src/data/version';
 import { connectPopupActions } from './connectPopupActions';
 import { getPermissionDeferred, getPopupCallDeferred } from './connectPopupPromiseManager';
 import { selectConnectAppPermissions, selectConnectPopupCall } from './connectPopupReducer';
-import { ConnectCallSource } from './connectPopupTypes';
+import { CALL_SOURCE_WALLETCONNECT, ConnectCallSource } from './connectPopupTypes';
 import { postCallHooks, preCallHooks } from './methodHooks';
 
 const CONNECT_POPUP_MODULE = '@common/connect-popup';
@@ -73,7 +73,7 @@ export const connectPopupCallThunkInner = createThunk<
                     ),
             );
 
-            if (!isRemembered) {
+            if (!isRemembered && source.type !== CALL_SOURCE_WALLETCONNECT) {
                 dispatch(extra.actions.lockDevice(true));
                 dispatch(connectPopupActions.requestPermissions());
                 await getPermissionDeferred(true).promise;

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -140,6 +140,10 @@ export type ToastPayload = (
     | {
           type: 'cannot-open-bluetooth-settings-error';
       }
+    | {
+          type: 'connect-popup-success';
+          appName: string;
+      }
 ) &
     NotificationOptions;
 

--- a/suite-common/walletconnect/package.json
+++ b/suite-common/walletconnect/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.8.2",
-        "@reown/walletkit": "^1.2.5",
+        "@reown/walletkit": "^1.2.8",
         "@suite-common/analytics": "workspace:*",
         "@suite-common/connect-popup": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
@@ -20,8 +20,8 @@
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "@walletconnect/core": "^2.20.3",
-        "@walletconnect/utils": "^2.20.3",
+        "@walletconnect/core": "^2.21.5",
+        "@walletconnect/utils": "^2.21.5",
         "bs58": "^6.0.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5467,6 +5467,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@msgpack/msgpack@npm:3.1.2":
+  version: 3.1.2
+  resolution: "@msgpack/msgpack@npm:3.1.2"
+  checksum: 10/e04ff37d7c89ffdd6b4fbcd1770af60b16c98afdf1c3c16190170dfe34764048eb45e3654016ac62cc616c7e4b09e611f8863317ca5f18b3a72974fb131e562e
+  languageName: node
+  linkType: hard
+
 "@napi-rs/simple-git-android-arm-eabi@npm:0.1.16":
   version: 0.1.16
   resolution: "@napi-rs/simple-git-android-arm-eabi@npm:0.1.16"
@@ -5656,14 +5663,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/ciphers@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@noble/ciphers@npm:1.2.1"
-  checksum: 10/7fa0d32529d8da6323b08afec97218f6d6bc0d1e135243bf10f7587a2819495c3f3f4a5af1f41045501bb1ade94238c76960366a5d6441970e49ba9cacb88740
-  languageName: node
-  linkType: hard
-
-"@noble/ciphers@npm:1.3.0":
+"@noble/ciphers@npm:1.3.0, @noble/ciphers@npm:^1.3.0":
   version: 1.3.0
   resolution: "@noble/ciphers@npm:1.3.0"
   checksum: 10/051660051e3e9e2ca5fb9dece2885532b56b7e62946f89afa7284a0fb8bc02e2bd1c06554dba68162ff42d295b54026456084198610f63c296873b2f1cd7a586
@@ -5688,15 +5688,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:1.8.1":
-  version: 1.8.1
-  resolution: "@noble/curves@npm:1.8.1"
-  dependencies:
-    "@noble/hashes": "npm:1.7.1"
-  checksum: 10/e861db372cc0734b02a4c61c0f5a6688d4a7555edca3d8a9e7c846c9aa103ca52d3c3818e8bc333a1a95b5be7f370ff344668d5d759471b11c2d14c7f24b3984
-  languageName: node
-  linkType: hard
-
 "@noble/curves@npm:1.9.0":
   version: 1.9.0
   resolution: "@noble/curves@npm:1.9.0"
@@ -5706,7 +5697,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:^1.0.0, @noble/curves@npm:^1.6.0, @noble/curves@npm:~1.9.0":
+"@noble/curves@npm:1.9.1":
   version: 1.9.1
   resolution: "@noble/curves@npm:1.9.1"
   dependencies:
@@ -5715,12 +5706,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:~1.8.1":
-  version: 1.8.2
-  resolution: "@noble/curves@npm:1.8.2"
+"@noble/curves@npm:1.9.2, @noble/curves@npm:^1.0.0, @noble/curves@npm:^1.6.0, @noble/curves@npm:~1.9.0":
+  version: 1.9.2
+  resolution: "@noble/curves@npm:1.9.2"
   dependencies:
-    "@noble/hashes": "npm:1.7.2"
-  checksum: 10/540e7b7a8fe92ecd5cef846f84d07180662eb7fd7d8e9172b8960c31827e74f148fe4630da962138a6be093ae9f8992d14ab23d3682a2cc32be839aa57c03a46
+    "@noble/hashes": "npm:1.8.0"
+  checksum: 10/f60f00ad86296054566b67be08fd659999bb64b692bfbf11dbe3be1f422ad4d826bf5ebb2015ce2e246538eab2b677707e0a46ffa8323a6fae7a9a30ec1fe318
   languageName: node
   linkType: hard
 
@@ -5735,20 +5726,6 @@ __metadata:
   version: 1.7.0
   resolution: "@noble/hashes@npm:1.7.0"
   checksum: 10/ab038a816c8c9bb986e92797e3d9c5a5b37c020e0c3edc55bcae5061dbdd457f1f0a22787f83f4787c17415ba0282a20a1e455d36ed0cdcace4ce21ef1869f60
-  languageName: node
-  linkType: hard
-
-"@noble/hashes@npm:1.7.1":
-  version: 1.7.1
-  resolution: "@noble/hashes@npm:1.7.1"
-  checksum: 10/ca3120da0c3e7881d6a481e9667465cc9ebbee1329124fb0de442e56d63fef9870f8cc96f264ebdb18096e0e36cebc0e6e979a872d545deb0a6fed9353f17e05
-  languageName: node
-  linkType: hard
-
-"@noble/hashes@npm:1.7.2, @noble/hashes@npm:~1.7.1":
-  version: 1.7.2
-  resolution: "@noble/hashes@npm:1.7.2"
-  checksum: 10/b5af9e4b91543dcc46a811b5b2c57bfdeb41728361979a19d6110a743e2cb0459872553f68d3a46326d21959964db2776b8c8b4db85ac1d9f63ebcaddf7d59b6
   languageName: node
   linkType: hard
 
@@ -7647,18 +7624,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reown/walletkit@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "@reown/walletkit@npm:1.2.5"
+"@reown/walletkit@npm:^1.2.8":
+  version: 1.2.8
+  resolution: "@reown/walletkit@npm:1.2.8"
   dependencies:
-    "@walletconnect/core": "npm:2.20.3"
+    "@walletconnect/core": "npm:2.21.4"
     "@walletconnect/jsonrpc-provider": "npm:1.0.14"
     "@walletconnect/jsonrpc-utils": "npm:1.0.8"
     "@walletconnect/logger": "npm:2.1.2"
-    "@walletconnect/sign-client": "npm:2.20.3"
-    "@walletconnect/types": "npm:2.20.3"
-    "@walletconnect/utils": "npm:2.20.3"
-  checksum: 10/f2e51b8a42e18feff35bd0c3947f34b440e2f7184e81568d32df9ef338ffba19d77a5c1304878a9b73d865d4c27349e86d7c5a877d550a0c9392c28acb42519b
+    "@walletconnect/sign-client": "npm:2.21.4"
+    "@walletconnect/types": "npm:2.21.4"
+    "@walletconnect/utils": "npm:2.21.4"
+  checksum: 10/41394c96ddd2a1a0d6c256834803e1143ad20d57bb1cb341c389470c8c24f4bb44794c82192897851d0174b21f3c2a9c0da42bcc8c71c49672f22e6e040c65e4
   languageName: node
   linkType: hard
 
@@ -7826,7 +7803,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@scure/base@npm:^1.1.3, @scure/base@npm:~1.2.2, @scure/base@npm:~1.2.4, @scure/base@npm:~1.2.5":
+"@scure/base@npm:1.2.6, @scure/base@npm:^1.1.3, @scure/base@npm:~1.2.5":
   version: 1.2.6
   resolution: "@scure/base@npm:1.2.6"
   checksum: 10/c1a7bd5e0b0c8f94c36fbc220f4a67cc832b00e2d2065c7d8a404ed81ab1c94c5443def6d361a70fc382db3496e9487fb9941728f0584782b274c18a4bed4187
@@ -7851,17 +7828,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@scure/bip32@npm:1.6.2":
-  version: 1.6.2
-  resolution: "@scure/bip32@npm:1.6.2"
-  dependencies:
-    "@noble/curves": "npm:~1.8.1"
-    "@noble/hashes": "npm:~1.7.1"
-    "@scure/base": "npm:~1.2.2"
-  checksum: 10/474ee315a8631aa1a7d378b0521b4494e09a231519ec53d879088cb88c8ff644a89b27a02a8bf0b5a9b1c4c0417acc70636ccdb121b800c34594ae53c723f8d7
-  languageName: node
-  linkType: hard
-
 "@scure/bip32@npm:1.7.0, @scure/bip32@npm:^1.3.1, @scure/bip32@npm:^1.5.0":
   version: 1.7.0
   resolution: "@scure/bip32@npm:1.7.0"
@@ -7880,16 +7846,6 @@ __metadata:
     "@noble/hashes": "npm:~1.4.0"
     "@scure/base": "npm:~1.1.6"
   checksum: 10/7d71fd58153de22fe8cd65b525f6958a80487bc9d0fbc32c71c328aeafe41fa259f989d2f1e0fa4fdfeaf83b8fcf9310d52ed9862987e46c2f2bfb9dd8cf9fc1
-  languageName: node
-  linkType: hard
-
-"@scure/bip39@npm:1.5.4":
-  version: 1.5.4
-  resolution: "@scure/bip39@npm:1.5.4"
-  dependencies:
-    "@noble/hashes": "npm:~1.7.1"
-    "@scure/base": "npm:~1.2.4"
-  checksum: 10/9f08b433511d7637bc48c51aa411457d5f33da5a85bd03370bf394822b0ea8c007ceb17247a3790c28237303d8fc20c4e7725765940cd47e1365a88319ad0d5c
   languageName: node
   linkType: hard
 
@@ -9919,7 +9875,7 @@ __metadata:
   resolution: "@suite-common/walletconnect@workspace:suite-common/walletconnect"
   dependencies:
     "@reduxjs/toolkit": "npm:2.8.2"
-    "@reown/walletkit": "npm:^1.2.5"
+    "@reown/walletkit": "npm:^1.2.8"
     "@suite-common/analytics": "workspace:*"
     "@suite-common/connect-popup": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
@@ -9928,8 +9884,8 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@walletconnect/core": "npm:^2.20.3"
-    "@walletconnect/utils": "npm:^2.20.3"
+    "@walletconnect/core": "npm:^2.21.5"
+    "@walletconnect/utils": "npm:^2.21.5"
     bs58: "npm:^6.0.0"
   languageName: unknown
   linkType: soft
@@ -14703,9 +14659,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/core@npm:2.20.3":
-  version: 2.20.3
-  resolution: "@walletconnect/core@npm:2.20.3"
+"@walletconnect/core@npm:2.21.4":
+  version: 2.21.4
+  resolution: "@walletconnect/core@npm:2.21.4"
   dependencies:
     "@walletconnect/heartbeat": "npm:1.2.2"
     "@walletconnect/jsonrpc-provider": "npm:1.0.14"
@@ -14718,19 +14674,19 @@ __metadata:
     "@walletconnect/relay-auth": "npm:1.1.0"
     "@walletconnect/safe-json": "npm:1.0.2"
     "@walletconnect/time": "npm:1.0.2"
-    "@walletconnect/types": "npm:2.20.3"
-    "@walletconnect/utils": "npm:2.20.3"
+    "@walletconnect/types": "npm:2.21.4"
+    "@walletconnect/utils": "npm:2.21.4"
     "@walletconnect/window-getters": "npm:1.0.1"
-    es-toolkit: "npm:1.33.0"
+    es-toolkit: "npm:1.39.3"
     events: "npm:3.3.0"
-    uint8arrays: "npm:3.1.0"
-  checksum: 10/6b1e2246e77c1be2fefdca5530c2695b68594c9dcde21ccb960ecfc37738caedb90d81e347538d127103c0c87615d2691997e86cc5aa0762cfb67b8506739e1f
+    uint8arrays: "npm:3.1.1"
+  checksum: 10/3f206088b06c34fc6fe71c9a8463d9e6f0d123d99c8b9d74d449c7a70e58ea28b15ca109b7d79742a0e424db02b27f15c466e623138902ee9d776cd07c5f31bf
   languageName: node
   linkType: hard
 
-"@walletconnect/core@npm:^2.20.3":
-  version: 2.21.0
-  resolution: "@walletconnect/core@npm:2.21.0"
+"@walletconnect/core@npm:^2.21.5":
+  version: 2.21.5
+  resolution: "@walletconnect/core@npm:2.21.5"
   dependencies:
     "@walletconnect/heartbeat": "npm:1.2.2"
     "@walletconnect/jsonrpc-provider": "npm:1.0.14"
@@ -14743,13 +14699,13 @@ __metadata:
     "@walletconnect/relay-auth": "npm:1.1.0"
     "@walletconnect/safe-json": "npm:1.0.2"
     "@walletconnect/time": "npm:1.0.2"
-    "@walletconnect/types": "npm:2.21.0"
-    "@walletconnect/utils": "npm:2.21.0"
+    "@walletconnect/types": "npm:2.21.5"
+    "@walletconnect/utils": "npm:2.21.5"
     "@walletconnect/window-getters": "npm:1.0.1"
-    es-toolkit: "npm:1.33.0"
+    es-toolkit: "npm:1.39.3"
     events: "npm:3.3.0"
-    uint8arrays: "npm:3.1.0"
-  checksum: 10/a3184dde6fb752ed85d2f466c6e16dc50866b724dafc4cdedc1f152d4a2ff5283e8f254995adb11a49fd8ae70014d561f3a5401fd0edbda864cc132b5a165ba0
+    uint8arrays: "npm:3.1.1"
+  checksum: 10/d807416b4b449000a536d5074aee83b71b0e2f7c99efa8fb37334be781f13c335d1d317fa33e3d004720ee4288ffbb95d93ea3d623fabbf28067205ad43727cc
   languageName: node
   linkType: hard
 
@@ -14904,20 +14860,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/sign-client@npm:2.20.3":
-  version: 2.20.3
-  resolution: "@walletconnect/sign-client@npm:2.20.3"
+"@walletconnect/sign-client@npm:2.21.4":
+  version: 2.21.4
+  resolution: "@walletconnect/sign-client@npm:2.21.4"
   dependencies:
-    "@walletconnect/core": "npm:2.20.3"
+    "@walletconnect/core": "npm:2.21.4"
     "@walletconnect/events": "npm:1.0.1"
     "@walletconnect/heartbeat": "npm:1.2.2"
     "@walletconnect/jsonrpc-utils": "npm:1.0.8"
     "@walletconnect/logger": "npm:2.1.2"
     "@walletconnect/time": "npm:1.0.2"
-    "@walletconnect/types": "npm:2.20.3"
-    "@walletconnect/utils": "npm:2.20.3"
+    "@walletconnect/types": "npm:2.21.4"
+    "@walletconnect/utils": "npm:2.21.4"
     events: "npm:3.3.0"
-  checksum: 10/d7898c2ec47b8b0fd25fb08b9bb32756d086db703c3b54543d89f93507b5c93a57df76233a35ecf14702217a96418ebc1449d56c19c9243e3457434e39d33be4
+  checksum: 10/189ac608a36b0be0f967e97c9857619557f4772d8cf989ebd9f37cb94f00d6d10344d0320f9c041bbdbd15940ff7964f7202b15cb8e6c3f7a015e37578649cbd
   languageName: node
   linkType: hard
 
@@ -14930,9 +14886,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/types@npm:2.20.3":
-  version: 2.20.3
-  resolution: "@walletconnect/types@npm:2.20.3"
+"@walletconnect/types@npm:2.21.4":
+  version: 2.21.4
+  resolution: "@walletconnect/types@npm:2.21.4"
   dependencies:
     "@walletconnect/events": "npm:1.0.1"
     "@walletconnect/heartbeat": "npm:1.2.2"
@@ -14940,13 +14896,13 @@ __metadata:
     "@walletconnect/keyvaluestorage": "npm:1.1.1"
     "@walletconnect/logger": "npm:2.1.2"
     events: "npm:3.3.0"
-  checksum: 10/ce654bd1fc186cca55ede47e755dc8f3f95bd68a44c07041184a9565f8ed58cc74a9a2129abcbfc283250367aa106c682da64a3f5f9aa726a7e3b3dd3c36b674
+  checksum: 10/fdd0e121beac8bf97b436b79d533d2324727637345a11f6fc90ef424f212a0610cf8b371e72f63364f82cb6ccf53a75cefa1e316e846f52c6bedb89bccd893b5
   languageName: node
   linkType: hard
 
-"@walletconnect/types@npm:2.21.0":
-  version: 2.21.0
-  resolution: "@walletconnect/types@npm:2.21.0"
+"@walletconnect/types@npm:2.21.5":
+  version: 2.21.5
+  resolution: "@walletconnect/types@npm:2.21.5"
   dependencies:
     "@walletconnect/events": "npm:1.0.1"
     "@walletconnect/heartbeat": "npm:1.2.2"
@@ -14954,96 +14910,63 @@ __metadata:
     "@walletconnect/keyvaluestorage": "npm:1.1.1"
     "@walletconnect/logger": "npm:2.1.2"
     events: "npm:3.3.0"
-  checksum: 10/ebc3231a996531fd240e7d08b00bc2aca3046a5f3273fc28e3d8d7e283d1c7ef52394d9dfedb55e292955ae1ba0fe363967d0caf6750d9e55215aac02d84188d
+  checksum: 10/8d6db4dac47725883ce5ab4c6437e3e8ba0f2317524919b7810b885ec7b464ab44b1ec0870f7f0a48d3024a42630123cd19ff83bee5229cada6d0e11451cc041
   languageName: node
   linkType: hard
 
-"@walletconnect/types@npm:2.21.1":
-  version: 2.21.1
-  resolution: "@walletconnect/types@npm:2.21.1"
+"@walletconnect/utils@npm:2.21.4":
+  version: 2.21.4
+  resolution: "@walletconnect/utils@npm:2.21.4"
   dependencies:
-    "@walletconnect/events": "npm:1.0.1"
-    "@walletconnect/heartbeat": "npm:1.2.2"
-    "@walletconnect/jsonrpc-types": "npm:1.0.4"
-    "@walletconnect/keyvaluestorage": "npm:1.1.1"
-    "@walletconnect/logger": "npm:2.1.2"
-    events: "npm:3.3.0"
-  checksum: 10/679a7886306b2ef30d062f77a46215ef046f73f0449f54e6a4a2f4cc74738c35b44181619ac4e529a921cee957832aff3d4d046af0d511983e763472110fc2ef
-  languageName: node
-  linkType: hard
-
-"@walletconnect/utils@npm:2.20.3":
-  version: 2.20.3
-  resolution: "@walletconnect/utils@npm:2.20.3"
-  dependencies:
-    "@noble/ciphers": "npm:1.2.1"
-    "@noble/curves": "npm:1.8.1"
-    "@noble/hashes": "npm:1.7.1"
+    "@msgpack/msgpack": "npm:3.1.2"
+    "@noble/ciphers": "npm:1.3.0"
+    "@noble/curves": "npm:1.9.2"
+    "@noble/hashes": "npm:1.8.0"
+    "@scure/base": "npm:1.2.6"
     "@walletconnect/jsonrpc-utils": "npm:1.0.8"
     "@walletconnect/keyvaluestorage": "npm:1.1.1"
     "@walletconnect/relay-api": "npm:1.0.11"
     "@walletconnect/relay-auth": "npm:1.1.0"
     "@walletconnect/safe-json": "npm:1.0.2"
     "@walletconnect/time": "npm:1.0.2"
-    "@walletconnect/types": "npm:2.20.3"
+    "@walletconnect/types": "npm:2.21.4"
     "@walletconnect/window-getters": "npm:1.0.1"
     "@walletconnect/window-metadata": "npm:1.0.1"
+    blakejs: "npm:1.2.1"
     bs58: "npm:6.0.0"
     detect-browser: "npm:5.3.0"
     query-string: "npm:7.1.3"
-    uint8arrays: "npm:3.1.0"
-    viem: "npm:2.23.2"
-  checksum: 10/d029e408d1e350dc12e548ad2dbc65c907d6b4a8bf15458793bb864119cdd21667ea0f2ef572b79f89db69892d44d8894cb8d28feb2f755fb2d2fc02bbefcfac
+    uint8arrays: "npm:3.1.1"
+    viem: "npm:2.31.0"
+  checksum: 10/937cb5c6c3a68e973eedbfe3686a9a9d419da84c4670b9b00b64122539fbca0d4a693c4157895297ecb5c1b1ea0d9227bdb05590371c8a6aa4c509480976cc73
   languageName: node
   linkType: hard
 
-"@walletconnect/utils@npm:2.21.0":
-  version: 2.21.0
-  resolution: "@walletconnect/utils@npm:2.21.0"
+"@walletconnect/utils@npm:2.21.5, @walletconnect/utils@npm:^2.21.5":
+  version: 2.21.5
+  resolution: "@walletconnect/utils@npm:2.21.5"
   dependencies:
-    "@noble/ciphers": "npm:1.2.1"
-    "@noble/curves": "npm:1.8.1"
-    "@noble/hashes": "npm:1.7.1"
+    "@msgpack/msgpack": "npm:3.1.2"
+    "@noble/ciphers": "npm:1.3.0"
+    "@noble/curves": "npm:1.9.2"
+    "@noble/hashes": "npm:1.8.0"
+    "@scure/base": "npm:1.2.6"
     "@walletconnect/jsonrpc-utils": "npm:1.0.8"
     "@walletconnect/keyvaluestorage": "npm:1.1.1"
     "@walletconnect/relay-api": "npm:1.0.11"
     "@walletconnect/relay-auth": "npm:1.1.0"
     "@walletconnect/safe-json": "npm:1.0.2"
     "@walletconnect/time": "npm:1.0.2"
-    "@walletconnect/types": "npm:2.21.0"
+    "@walletconnect/types": "npm:2.21.5"
     "@walletconnect/window-getters": "npm:1.0.1"
     "@walletconnect/window-metadata": "npm:1.0.1"
+    blakejs: "npm:1.2.1"
     bs58: "npm:6.0.0"
     detect-browser: "npm:5.3.0"
     query-string: "npm:7.1.3"
-    uint8arrays: "npm:3.1.0"
-    viem: "npm:2.23.2"
-  checksum: 10/6c317c3407ff434b2e34a8a5d8c16b4563f72af16dd89ad89b47bf0b2bc058a93a350115df2a80c45ac3876bc90470fd4f5229107393191044f688f8a5ad7bcd
-  languageName: node
-  linkType: hard
-
-"@walletconnect/utils@npm:^2.20.3":
-  version: 2.21.1
-  resolution: "@walletconnect/utils@npm:2.21.1"
-  dependencies:
-    "@noble/ciphers": "npm:1.2.1"
-    "@noble/curves": "npm:1.8.1"
-    "@noble/hashes": "npm:1.7.1"
-    "@walletconnect/jsonrpc-utils": "npm:1.0.8"
-    "@walletconnect/keyvaluestorage": "npm:1.1.1"
-    "@walletconnect/relay-api": "npm:1.0.11"
-    "@walletconnect/relay-auth": "npm:1.1.0"
-    "@walletconnect/safe-json": "npm:1.0.2"
-    "@walletconnect/time": "npm:1.0.2"
-    "@walletconnect/types": "npm:2.21.1"
-    "@walletconnect/window-getters": "npm:1.0.1"
-    "@walletconnect/window-metadata": "npm:1.0.1"
-    bs58: "npm:6.0.0"
-    detect-browser: "npm:5.3.0"
-    query-string: "npm:7.1.3"
-    uint8arrays: "npm:3.1.0"
-    viem: "npm:2.23.2"
-  checksum: 10/9dbf16975967067570472d1796927adea6a656e28a56939c4928c5e5f81d45a0af7fc6826cc4c9a461444fa8b33a679eb44bc453e261d5f6c815204419671ea0
+    uint8arrays: "npm:3.1.1"
+    viem: "npm:2.31.0"
+  checksum: 10/32942bdb39455e532d10c67352bdffe2804285bf5c1caaed0db70686f761ff42fb934cb91a75584be732923806d48a7e3f7df14e360d642cb534c0593ba09c9b
   languageName: node
   linkType: hard
 
@@ -16927,7 +16850,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"blakejs@npm:^1.2.1":
+"blakejs@npm:1.2.1, blakejs@npm:^1.2.1":
   version: 1.2.1
   resolution: "blakejs@npm:1.2.1"
   checksum: 10/0638b1bd058b21892633929c43005aa6a4cc4b2ac5b338a146c3c076622f1b360795bd7a4d1f077c9b01863ed2df0c1504a81c5b520d164179120434847e6cd7
@@ -21479,15 +21402,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-toolkit@npm:1.33.0":
-  version: 1.33.0
-  resolution: "es-toolkit@npm:1.33.0"
+"es-toolkit@npm:1.39.3":
+  version: 1.39.3
+  resolution: "es-toolkit@npm:1.39.3"
   dependenciesMeta:
     "@trivago/prettier-plugin-sort-imports@4.3.0":
       unplugged: true
     prettier-plugin-sort-re-exports@0.0.1:
       unplugged: true
-  checksum: 10/db613d885c407dc3b84b3939b8b0c9976f658bfb03fa0f9cd3a3fe8383a60a75e1e4f34584e86c3fbf00def50ea0ca5f1a5264a1014018286dedbed08426b5f0
+  checksum: 10/18cf6dee69170f802a50d447cac3af0026c199b501fe9a151633a402ea0523463b73aacbde53072cc610914d68031e2856fbb8a305b020e34bd7f6ac24d37e6d
   languageName: node
   linkType: hard
 
@@ -26957,12 +26880,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isows@npm:1.0.6":
-  version: 1.0.6
-  resolution: "isows@npm:1.0.6"
+"isows@npm:1.0.7":
+  version: 1.0.7
+  resolution: "isows@npm:1.0.7"
   peerDependencies:
     ws: "*"
-  checksum: 10/ab9e85b50bcc3d70aa5ec875aa2746c5daf9321cb376ed4e5434d3c2643c5d62b1f466d93a05cd2ad0ead5297224922748c31707cb4fbd68f5d05d0479dce99c
+  checksum: 10/044b949b369872882af07b60b613b5801ae01b01a23b5b72b78af80c8103bbeed38352c3e8ceff13a7834bc91fd2eb41cf91ec01d59a041d8705680e6b0ec546
   languageName: node
   linkType: hard
 
@@ -32977,11 +32900,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ox@npm:0.6.7":
-  version: 0.6.7
-  resolution: "ox@npm:0.6.7"
+"ox@npm:0.7.1":
+  version: 0.7.1
+  resolution: "ox@npm:0.7.1"
   dependencies:
     "@adraffy/ens-normalize": "npm:^1.10.1"
+    "@noble/ciphers": "npm:^1.3.0"
     "@noble/curves": "npm:^1.6.0"
     "@noble/hashes": "npm:^1.5.0"
     "@scure/bip32": "npm:^1.5.0"
@@ -32993,7 +32917,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/442fb31e1afb68922bf942025930d8cd6d8c677696e9a6de308008b3608669f22127cadbc0f77181e012d23d7b74318e5f85e63b06b16eecbc887d7fac32a6dc
+  checksum: 10/761e941b6ca6d3a84235bb19a7e1f282e54a8cbc1374aaf4ce0232de50d42cd351074ef3e83d09af71f7522b085cfa92168adb19744dac2556fe83b3bba46f71
   languageName: node
   linkType: hard
 
@@ -40486,16 +40410,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uint8arrays@npm:3.1.0":
-  version: 3.1.0
-  resolution: "uint8arrays@npm:3.1.0"
-  dependencies:
-    multiformats: "npm:^9.4.2"
-  checksum: 10/caf1cd6a1cdbd7c59d6c8698c06a6d603380942b5745b3fddcd1b16f7a84a4f351fb8c6ac41f4cb2c59c226bb6d954733a6e20a42dec6f3fd266a02270a5088d
-  languageName: node
-  linkType: hard
-
-"uint8arrays@npm:^3.0.0":
+"uint8arrays@npm:3.1.1, uint8arrays@npm:^3.0.0":
   version: 3.1.1
   resolution: "uint8arrays@npm:3.1.1"
   dependencies:
@@ -41525,24 +41440,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"viem@npm:2.23.2":
-  version: 2.23.2
-  resolution: "viem@npm:2.23.2"
+"viem@npm:2.31.0":
+  version: 2.31.0
+  resolution: "viem@npm:2.31.0"
   dependencies:
-    "@noble/curves": "npm:1.8.1"
-    "@noble/hashes": "npm:1.7.1"
-    "@scure/bip32": "npm:1.6.2"
-    "@scure/bip39": "npm:1.5.4"
+    "@noble/curves": "npm:1.9.1"
+    "@noble/hashes": "npm:1.8.0"
+    "@scure/bip32": "npm:1.7.0"
+    "@scure/bip39": "npm:1.6.0"
     abitype: "npm:1.0.8"
-    isows: "npm:1.0.6"
-    ox: "npm:0.6.7"
-    ws: "npm:8.18.0"
+    isows: "npm:1.0.7"
+    ox: "npm:0.7.1"
+    ws: "npm:8.18.2"
   peerDependencies:
     typescript: ">=5.0.4"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/847fdb57a6941f67c4ff97c79d99368c48e78b9c070df8fb3f3310d58bbd075fd78e9a506abccb82fcdbcf0c6c13aba7cfb021e37fda0777ea1eb0ccecf25fe1
+  checksum: 10/960ef6578fc91903f7c99b548af6fa0b56b5776bbd949b687834e0184ccab66a806da08fd87230a6ea1af35477c9bd5e086c308668ec178567bf9ba9eb78d44d
   languageName: node
   linkType: hard
 
@@ -42732,6 +42647,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ws@npm:8.18.2, ws@npm:^8.11.0, ws@npm:^8.12.1, ws@npm:^8.13.0, ws@npm:^8.17.1, ws@npm:^8.18.0, ws@npm:^8.18.1":
+  version: 8.18.2
+  resolution: "ws@npm:8.18.2"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10/018e04ec95561d88248d53a2eaf094b4ae131e9b062f2679e6e8a62f04649bc543448f1e038125225ac6bbb25f54c1e65d7a2cc9dbc1e28b43e5e6b7162ad88e
+  languageName: node
+  linkType: hard
+
 "ws@npm:^6.2.3":
   version: 6.2.3
   resolution: "ws@npm:6.2.3"
@@ -42753,21 +42683,6 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10/9c796b84ba80ffc2c2adcdfc9c8e9a219ba99caa435c9a8d45f9ac593bba325563b3f83edc5eb067cc6d21b9a6bf2c930adf76dd40af5f58a5ca6859e81858f0
-  languageName: node
-  linkType: hard
-
-"ws@npm:^8.11.0, ws@npm:^8.12.1, ws@npm:^8.13.0, ws@npm:^8.17.1, ws@npm:^8.18.0, ws@npm:^8.18.1":
-  version: 8.18.1
-  resolution: "ws@npm:8.18.1"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 10/3f38e9594f2af5b6324138e86b74df7d77bbb8e310bf8188679dd80bac0d1f47e51536a1923ac3365f31f3d8b25ea0b03e4ade466aa8292a86cd5defca64b19b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Bunch of smaller WalletConnect - related changes

### feat(suite): remember walletconnect permissions

We agreed with Hans that there's no need to show the permissions modal again if the user has already approved the WalletConnect connection itself.

### fix(suite): contract address string

Use "Contract address" instead of just "Address" in TX simulation modal. 
I also removed the colon in the locale string, I already did it before, but somehow it got overwritten by Crowdin sync. 

### fix(suite): alignment in tx simulation modal

Just tiny fix that aligns text

### fix(suite): improve window visibility handling in connect

Improved detection by double checking with `document.visibilityState`. Now Suite should relatively accurately know if it was visible before the call and hide itself based on that after it's finished.

### feat(suite): show success notification for connect calls

<img width="462" height="159" alt="Screenshot 2025-07-18 at 13 01 59 copy" src="https://github.com/user-attachments/assets/40bc4a7a-e0ec-4c49-a0b1-c2a5f65250ef" />


### feat(suite): move walletconnect out of experimental

Get ready for launch in next release 🚀 

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/walletconnect-improvements&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/walletconnect-improvements&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/walletconnect-improvements&lookback=7)