### PR TITLE
Improved `typedCall` errors

### DIFF
--- a/packages/connect/src/api/resetDevice.ts
+++ b/packages/connect/src/api/resetDevice.ts
@@ -4,6 +4,7 @@ import { getRandomInt } from '@trezor/utils';
 
 import { generateEntropy, verifyEntropy } from '../api/firmware/verifyEntropy';
 import { ERRORS, PROTO } from '../constants';
+import { TransportError } from '../constants/errors';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI } from '../events';
 import { getFirmwareRange } from './common/paramsValidator';
@@ -64,7 +65,7 @@ export default class ResetDevice extends AbstractMethod<'resetDevice', PROTO.Res
 
         // error.message should be one of ERRORS_WITHOUT_DEVICE_INTERACTION, otherwise it could be a fake device's attempt to bypass the entropy check.
         const handleErr = (error: any) => {
-            throw error.cause === 'transport-error'
+            throw error instanceof TransportError
                 ? error
                 : ERRORS.TypedError('Failure_EntropyCheck', error.message);
         };

--- a/packages/connect/src/constants/errors.ts
+++ b/packages/connect/src/constants/errors.ts
@@ -67,8 +67,8 @@ export class TrezorError extends Error {
 
     message: string;
 
-    constructor(code: ErrorCode, message: string) {
-        super(message);
+    constructor(code: ErrorCode, message: string, options?: ErrorOptions) {
+        super(message, options);
         this.code = code;
         this.message = message;
     }
@@ -79,6 +79,11 @@ export class TrezorError extends Error {
     }
 }
 
+export const nestError = (cause: Error) =>
+    cause instanceof TrezorError
+        ? new TrezorError(cause.code, cause.message, { cause })
+        : new Error(cause.message, { cause });
+
 export class TransportError extends Error {}
 
 export const TypedError = (id: ErrorCode, message?: string) =>
@@ -86,20 +91,11 @@ export const TypedError = (id: ErrorCode, message?: string) =>
 
 // serialize Error/TypeError object into payload error type (Error object/class is converted to string while sent via postMessage)
 export const serializeError = (payload: any) => {
-    if (payload && payload.error instanceof Error) {
-        return { error: payload.error.message, code: payload.error.code };
-    }
-    if (payload instanceof TrezorError) {
-        return { error: payload.message, code: payload.code };
-    }
-    if (payload instanceof Error) {
-        return {
-            error: payload.message,
-            code: 'code' in payload ? payload.code : 'Failure_UnknownCode',
-        };
-    }
+    const error = payload?.error instanceof Error ? payload.error : payload;
 
-    return { ...payload };
+    return error instanceof Error
+        ? { error: error.message, code: 'code' in error ? error.code : 'Failure_UnknownCode' }
+        : { ...payload };
 };
 
 // trezord error prefix.

--- a/packages/connect/src/constants/errors.ts
+++ b/packages/connect/src/constants/errors.ts
@@ -79,6 +79,8 @@ export class TrezorError extends Error {
     }
 }
 
+export class TransportError extends Error {}
+
 export const TypedError = (id: ErrorCode, message?: string) =>
     new TrezorError(id, message || ERROR_CODES[id]);
 

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -59,12 +59,7 @@ const isExpectedResponse = <Key extends Messages.MessageKey | Messages.MessageKe
 const success = <T>(payload: T) => ({ success: true as const, payload });
 const error = (error: Error) => ({ success: false as const, error });
 const fail = (msg: string) =>
-    error(
-        new Error(
-            msg,
-            isErrorWithoutDeviceInteraction(msg) ? { cause: 'transport-error' } : undefined,
-        ),
-    );
+    error(isErrorWithoutDeviceInteraction(msg) ? new ERRORS.TransportError(msg) : new Error(msg));
 
 const getFeaturesTimeout = () =>
     // Due to performance issues in suite-native during app start, original timeout is not sufficient.

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -58,6 +58,7 @@ const isExpectedResponse = <Key extends Messages.MessageKey | Messages.MessageKe
 
 const success = <T>(payload: T) => ({ success: true as const, payload });
 const error = (error: Error) => ({ success: false as const, error });
+const nestedError = (cause: Error) => error(ERRORS.nestError(cause));
 const fail = (msg: string) =>
     error(isErrorWithoutDeviceInteraction(msg) ? new ERRORS.TransportError(msg) : new Error(msg));
 
@@ -121,8 +122,8 @@ export class DeviceCurrentSession implements TypedCallProvider {
 
         this.abortController = new AbortController();
         const { signal } = this.abortController;
-        const abortPromise = new Promise<ReturnType<typeof fail>>(resolve =>
-            signal.addEventListener('abort', () => resolve(error(signal.reason))),
+        const abortPromise = new Promise<Error>(resolve =>
+            signal.addEventListener('abort', () => resolve(signal.reason)),
         );
         const callPromise = this.callLoop(type, msg, abortPromise);
         this.callPromise = callPromise;
@@ -172,7 +173,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
     private async callLoop<T extends Messages.MessageKey>(
         type: T,
         msg: Messages.MessagePayload<T>,
-        abortPromise: Promise<ReturnType<typeof fail>>,
+        abortPromise: Promise<Error>,
     ) {
         let [name, data] = [type, msg];
         let pinUnlocked = false;
@@ -191,7 +192,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
 
             const [abortedDuringCall, response] = await Promise.race([
                 callPromise.then(res => [false, res] as const),
-                abortPromise.then(res => [true, res] as const),
+                abortPromise.then(res => [true, nestedError(res)] as const),
             ]);
 
             if (name === 'ButtonAck' && abortedDuringCall && !this.disposed) {
@@ -218,7 +219,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
 
             await callPromise;
 
-            if (this.disposed) return error(this.disposed);
+            if (this.disposed) return nestedError(this.disposed);
 
             if (!response.success) return response;
 
@@ -266,7 +267,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
                 case 'PinMatrixRequest': {
                     const promptRes = await Promise.race([
                         this.device.prompt(DEVICE.PIN, { type: res.message.type }),
-                        abortPromise,
+                        abortPromise.then(nestedError),
                     ]);
 
                     if (!promptRes.success) {
@@ -282,7 +283,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
                 case 'PassphraseRequest': {
                     const promptRes = await Promise.race([
                         this.device.prompt(DEVICE.PASSPHRASE, {}),
-                        abortPromise,
+                        abortPromise.then(nestedError),
                     ]);
 
                     if (!promptRes.success) {
@@ -301,7 +302,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
                 case 'WordRequest': {
                     const promptRes = await Promise.race([
                         this.device.prompt(DEVICE.WORD, { type: res.message.type }),
-                        abortPromise,
+                        abortPromise.then(nestedError),
                     ]);
 
                     if (!promptRes.success) {
@@ -326,7 +327,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
     }
 
     async call(name: string, data: Record<string, unknown>, options: AbortableOptions = {}) {
-        if (this.disposed) return Promise.resolve(error(this.disposed));
+        if (this.disposed) return Promise.resolve(nestedError(this.disposed));
 
         logger.debug('Sending', name, filterForLog(name, data));
 
@@ -351,7 +352,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
     }
 
     async send(name: string, data: Record<string, unknown>, options: AbortableOptions = {}) {
-        if (this.disposed) return Promise.resolve(error(this.disposed));
+        if (this.disposed) return Promise.resolve(nestedError(this.disposed));
 
         const result = await this.transport.send({
             name,
@@ -366,7 +367,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
     }
 
     async receive(options: AbortableOptions = {}) {
-        if (this.disposed) return Promise.resolve(error(this.disposed));
+        if (this.disposed) return Promise.resolve(nestedError(this.disposed));
 
         const result = await this.transport.receive({
             session: this.session,

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -321,7 +321,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
                 default: {
                     // reload features after successful PIN; TODO improve
                     if (!this.disposed && pinUnlocked && !this.device.features.unlocked) {
-                        await this.device.getFeatures();
+                        await this.device.getFeatures().catch(() => {});
                     }
 
                     return success(res);


### PR DESCRIPTION
This could fix some recurring Sentry errors and also improve stack traces sent there.

- https://github.com/trezor/trezor-suite/pull/20271/commits/a06b3c1540a795774ac207ea1ebc8fd6beea99df - catch one of the errors possibly thrown from `callLoop` - it should never throw in order to work as intended
- https://github.com/trezor/trezor-suite/pull/20271/commits/c68e88a4f10dbd1b64f1f4a2497d42074d68a8c7 - interactionless transport errors needed in entropy check workflow are now identified by `instanceof TransportError` instead of `cause: 'transport-error'` because a) it's generally not intended use of `cause` and b) I intend to use it in a different way (Cc: @komret)
- https://github.com/trezor/trezor-suite/pull/20271/commits/182e999c2135f1dbb30d95c594107e85ecd233ee - errors thrown from `DeviceCurrentSession` because of aborting/disposing from outside are now wrapped in a new error (as its `cause`) with the same message/code but different stack trace; in Sentry we should know which flow was interrupted rather than from where it was interrupted (we'll probably have both tho)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/typed-call-errors&lookback=7)