### PR TITLE
fix(suite-native): device authenticity check test

### DIFF
--- a/suite-native/app/e2e/pageObjects/deviceSettingsActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceSettingsActions.ts
@@ -55,12 +55,14 @@ class DeviceSettingsActions {
     }
 
     async redirectToDeviceAuthenticityScreen() {
-        await waitFor(redirectToDeviceAuthenticityScreenButton).toBeVisible().withTimeout(10000);
+        await scrollUntilVisible(redirectToDeviceAuthenticityScreenButton);
         await redirectToDeviceAuthenticityScreenButton.tap();
     }
 
     async tapEnablePinProtectionButton() {
-        await waitFor(element(by.id('@screen/PinProtection')));
+        await waitFor(element(by.id('@screen/PinProtection')))
+            .toBeVisible()
+            .withTimeout(10000);
 
         const enablePinProtectionButton = element(by.id('@device-pin-protection/enable-button'));
         await waitFor(enablePinProtectionButton).toBeVisible().withTimeout(10000);
@@ -80,10 +82,6 @@ class DeviceSettingsActions {
 
         await waitFor(disablePinProtectionButton).toBeVisible().withTimeout(10000);
         await disablePinProtectionButton.tap();
-    }
-
-    async scrollUntilCheckAuthenticityButtonIsVisible() {
-        await scrollUntilVisible(redirectToDeviceAuthenticityScreenButton);
     }
 
     async tapChangeDeviceNameButton() {

--- a/suite-native/app/e2e/tests/deviceSettings.test.ts
+++ b/suite-native/app/e2e/tests/deviceSettings.test.ts
@@ -81,8 +81,6 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () =>
         });
 
         test('Check device authenticity', async () => {
-            await onDeviceSettings.scrollUntilCheckAuthenticityButtonIsVisible();
-
             await onDeviceSettings.redirectToDeviceAuthenticityScreen();
 
             await onDeviceSettings.tapCheckAuthenticityButton();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Simplify scrollUntilVisible call for device authenticity in settings tests.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-authenticity-check&lookback=7)