### PR TITLE
fix(suite-native): fix unstable selector mock in tests

### DIFF
--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeLegalSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeLegalSheet.comp.test.tsx
@@ -12,23 +12,21 @@ jest.mock('@suite-common/wallet-core', () => {
     };
 });
 
-jest.mock('@suite-common/trading', () => {
-    const exchangeProviders = {
-        invity: { companyName: 'Invity Finance' },
-        changelly: { companyName: 'Changelly' },
-    };
+const mockedProviders = {
+    invity: { companyName: 'Invity Finance' },
+    changelly: { companyName: 'Changelly' },
+};
 
-    return {
-        ...jest.requireActual('@suite-common/trading'),
-        useTradingInfo: () => ({
-            cryptoIdToSymbolAndContractAddress: (cryptoId: string) => ({
-                coinSymbol: cryptoId === 'btc' ? 'btc' : 'eth',
-                contractAddress: undefined,
-            }),
+jest.mock('@suite-common/trading', () => ({
+    ...jest.requireActual('@suite-common/trading'),
+    useTradingInfo: () => ({
+        cryptoIdToSymbolAndContractAddress: (cryptoId: string) => ({
+            coinSymbol: cryptoId === 'btc' ? 'btc' : 'eth',
+            contractAddress: undefined,
         }),
-        selectTradingExchangeProviders: () => exchangeProviders,
-    };
-});
+    }),
+    selectTradingExchangeProviders: () => mockedProviders,
+}));
 
 describe('ExchangeLegalSheet', () => {
     const renderLegalSheet = (props?: Partial<ExchangeLegalSheetProps>) =>


### PR DESCRIPTION
fix warnings about unstable selector in tests

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/test-unstable-selector&lookback=7)