### PR TITLE
refactor(suite): cleanup in Onboarding component structure

### DIFF
--- a/packages/suite/src/views/onboarding/UnexpectedState/DeviceDifferent.tsx
+++ b/packages/suite/src/views/onboarding/UnexpectedState/DeviceDifferent.tsx
@@ -4,7 +4,7 @@ import { OnboardingStepBox } from 'src/components/onboarding';
 import { Translation } from 'src/components/suite';
 import { useOnboarding } from 'src/hooks/suite';
 
-const IsSameDevice = () => {
+export const DeviceDifferent = () => {
     const { resetOnboarding, enableOnboardingReducer } = useOnboarding();
 
     return (
@@ -33,5 +33,3 @@ const IsSameDevice = () => {
         />
     );
 };
-
-export default IsSameDevice;

--- a/packages/suite/src/views/onboarding/UnexpectedState/ShowPinMatrix.tsx
+++ b/packages/suite/src/views/onboarding/UnexpectedState/ShowPinMatrix.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+
+import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { Button, Column } from '@trezor/components';
+import TrezorConnect, { UI } from '@trezor/connect';
+import { spacings } from '@trezor/theme';
+
+import { OnboardingStepBox } from 'src/components/onboarding';
+import { PinMatrix, Translation } from 'src/components/suite';
+import { useOnboarding, useSelector } from 'src/hooks/suite';
+
+export const ShowPinMatrix = () => {
+    const [pin, setPin] = useState('');
+    const device = useSelector(selectSelectedDevice);
+    const { activeStepId, showPinMatrix } = useOnboarding();
+    const handlePinSubmit = () => {
+        TrezorConnect.uiResponse({ type: UI.RECEIVE_PIN, payload: pin });
+        setPin('');
+    };
+
+    // After the PIN is set it may happen that it takes too long for an user to finish the onboarding process.
+    // Then the device will get auto locked and requests to show a PIN matrix next before changing its setting.
+    // (which could happen on Final step where we set device name and homescreen)
+    if (device?.features && activeStepId !== 'set-pin' && showPinMatrix) {
+        return (
+            <OnboardingStepBox
+                heading={<Translation id="TR_ENTER_PIN" />}
+                device={device}
+                isActionAbortable={false}
+            >
+                <Column gap={spacings.md}>
+                    <PinMatrix pin={pin} setPin={setPin} onSubmit={handlePinSubmit} />
+                    <Button onClick={handlePinSubmit} data-testid="@pin/submit-button">
+                        <Translation id="TR_CONFIRM" />
+                    </Button>
+                </Column>
+            </OnboardingStepBox>
+        );
+    }
+};

--- a/packages/suite/src/views/onboarding/UnexpectedState/index.tsx
+++ b/packages/suite/src/views/onboarding/UnexpectedState/index.tsx
@@ -1,18 +1,15 @@
-import { JSX, useMemo, useState } from 'react';
+import { JSX } from 'react';
 
 import styled from 'styled-components';
 
 import { selectSelectedDevice } from '@suite-common/wallet-core';
-import { Button, Column } from '@trezor/components';
-import TrezorConnect, { UI } from '@trezor/connect';
-import { spacings } from '@trezor/theme';
 
-import { OnboardingStepBox } from 'src/components/onboarding';
-import { PinMatrix, PrerequisitesGuide, Translation } from 'src/components/suite';
+import { PrerequisitesGuide } from 'src/components/suite';
 import { useOnboarding, useSelector } from 'src/hooks/suite';
 import { selectPrerequisite } from 'src/reducers/suite/suiteReducer';
 
-import IsSameDevice from './components/IsSameDevice';
+import { DeviceDifferent } from './DeviceDifferent';
+import { ShowPinMatrix } from './ShowPinMatrix';
 
 const UnexpectedContainer = styled.div`
     margin-top: 100px;
@@ -25,76 +22,38 @@ interface UnexpectedStateProps {
 /**
  * This component handles unexpected device states across various steps in the onboarding.
  */
-const UnexpectedState = ({ children }: UnexpectedStateProps) => {
-    const [pin, setPin] = useState('');
+export const UnexpectedState = ({ children }: UnexpectedStateProps) => {
     const device = useSelector(selectSelectedDevice);
     const prerequisite = useSelector(selectPrerequisite);
 
     const { prevDeviceId, activeStep, activeStepId, showPinMatrix } = useOnboarding();
 
-    const isNotSameDevice = useMemo(() => {
-        // if no device was connected before, assume it is same device
-        if (!prevDeviceId) {
-            return false;
-        }
-        const deviceId = device?.id;
-        if (!deviceId) {
-            // we don't know
-            return null;
-        }
-
-        return deviceId !== prevDeviceId;
-    }, [prevDeviceId, device]);
-
-    const UnexpectedStateComponent = useMemo(() => {
-        if (!activeStep?.prerequisites) return null;
-
-        // there may be specif onboarding prerequisites
-        if (activeStep?.prerequisites.includes('device-different') && isNotSameDevice) {
-            // in case we can 100% detect that user reconnected different device than he had previously connected
-            return <IsSameDevice />;
-        }
-
-        // otherwise handle common prerequisite which are determined and passed as prop from Preloader component
-        if (prerequisite && activeStep?.prerequisites?.includes(prerequisite)) {
-            return <PrerequisitesGuide />;
-        }
-    }, [activeStep, prerequisite, isNotSameDevice]);
-
-    const handlePinSubmit = () => {
-        TrezorConnect.uiResponse({ type: UI.RECEIVE_PIN, payload: pin });
-        setPin('');
-    };
-
-    if (!activeStep) {
-        return null;
-    }
-
     // After the PIN is set it may happen that it takes too long for an user to finish the onboarding process.
     // Then the device will get auto locked and requests to show a PIN matrix next before changing its setting.
     // (which could happen on Final step where we set device name and homescreen)
-    if (device?.features && activeStepId !== 'set-pin' && showPinMatrix) {
+    if (activeStepId !== 'set-pin' && showPinMatrix) {
+        return <ShowPinMatrix />;
+    }
+
+    const isDeviceDifferent = prevDeviceId && device?.id && prevDeviceId !== device.id;
+    // there may be specif onboarding prerequisites
+    if (activeStep?.prerequisites?.includes('device-different') && isDeviceDifferent) {
+        // in case we can 100% detect that user reconnected different device than he had previously connected
         return (
-            <OnboardingStepBox
-                heading={<Translation id="TR_ENTER_PIN" />}
-                device={device}
-                isActionAbortable={false}
-            >
-                <Column gap={spacings.md}>
-                    <PinMatrix pin={pin} setPin={setPin} onSubmit={handlePinSubmit} />
-                    <Button onClick={handlePinSubmit} data-testid="@pin/submit-button">
-                        <Translation id="TR_CONFIRM" />
-                    </Button>
-                </Column>
-            </OnboardingStepBox>
+            <UnexpectedContainer>
+                <DeviceDifferent />
+            </UnexpectedContainer>
         );
     }
 
-    if (UnexpectedStateComponent) {
-        return <UnexpectedContainer>{UnexpectedStateComponent}</UnexpectedContainer>;
+    // otherwise handle common prerequisite which are determined and passed as prop from Preloader component
+    if (prerequisite && activeStep?.prerequisites?.includes(prerequisite)) {
+        return (
+            <UnexpectedContainer>
+                <PrerequisitesGuide />
+            </UnexpectedContainer>
+        );
     }
 
     return children;
 };
-
-export default UnexpectedState;

--- a/packages/suite/src/views/onboarding/index.tsx
+++ b/packages/suite/src/views/onboarding/index.tsx
@@ -7,7 +7,7 @@ import { OnboardingLayout } from 'src/components/onboarding';
 import { ReduxModal } from 'src/components/suite/modals/ReduxModal/ReduxModal';
 import * as STEP from 'src/constants/onboarding/steps';
 import { useFilteredModal, useOnboarding } from 'src/hooks/suite';
-import UnexpectedState from 'src/views/onboarding/UnexpectedState';
+import { UnexpectedState } from 'src/views/onboarding/UnexpectedState';
 import { BackupStep } from 'src/views/onboarding/steps/Backup';
 import BasicSettingsStep from 'src/views/onboarding/steps/BasicSettings';
 import CreateOrRecover from 'src/views/onboarding/steps/CreateOrRecover';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
grooming in suite `Onboarding` component, it was a little messy and kinda hard to understand.

this is not just some random PR :) i need to add new view: Device.status === 'busy' https://github.com/trezor/trezor-suite/pull/20260

- `IsSameDevice` renamed to `DeviceDifferent` as this is what it actually do.
- `UnexpectedState` simplified:
  removed unnecessary react memoization (isNotSameDevice, UnexpectedStateComponent)
  also moved ShowPinMatrix logic to separate component

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/onboarding-cleanup&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/onboarding-cleanup&lookback=7)