### PR TITLE
fix(node-utils): http server using ports is able to start and stop mu…

### DIFF
--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -94,12 +94,11 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
     private routes: Route[] = [];
     private readonly emitter: TypedEmitter<BaseEvents> = this;
     private ports: number[] = [];
+    private port: number | undefined;
     private sockets: Record<number, net.Socket> = {};
 
     constructor({ logger, port, ports }: { logger: Log; port?: number; ports?: number[] }) {
         super();
-
-        // either try to take the first member of ports array
 
         if (ports && ports.length > 0) {
             this.ports = ports;
@@ -149,8 +148,7 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
     }
 
     public start() {
-        const port = this.ports.shift();
-
+        const port = this.port || this.ports.shift();
         if (typeof port !== 'number') {
             // this should not happen
             throw new Error('There is no port available in ports array');
@@ -220,6 +218,8 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
                 if (address) {
                     this.emitter.emit('server/listening', address);
                 }
+                // even if server was instructed to start on a random port, take the real port and save it for future use (toggling server on and off)
+                this.port = address.port;
 
                 return resolve({ success: true, payload: address });
             });

--- a/packages/node-utils/src/tests/http.test.ts
+++ b/packages/node-utils/src/tests/http.test.ts
@@ -491,4 +491,36 @@ describe('HttpServer', () => {
 
         await Promise.all([server.stop(), server2.stop()]);
     });
+
+    test('port negotiation - it is possible to start and stop server multiple times', async () => {
+        const [freePort1] = await getFreePort(1);
+
+        server = new HttpServer<Events>({ logger: muteLogger, ports: [freePort1] });
+        await server.start();
+        expect(server.getServerAddress()).toMatchObject({
+            port: freePort1,
+        });
+
+        await server.stop();
+        await server.start();
+        expect(server.getServerAddress()).toMatchObject({
+            port: freePort1,
+        });
+
+        await server.stop();
+    });
+
+    test('port negotiation - even when started using random port, the resulting port is stored for future use', async () => {
+        server = new HttpServer<Events>({ logger: muteLogger, ports: [0] });
+        await server.start();
+        const address = server.getServerAddress();
+        expect(address).toBeDefined();
+        expect(address.port).toBeGreaterThan(0);
+
+        // stop and start again, the port should be the same
+        await server.stop();
+        await server.start();
+        const newAddress = server.getServerAddress();
+        expect(newAddress.port).toEqual(address.port);
+    });
 });


### PR DESCRIPTION
…ltiple times

before this fix, toggling stop and start would cause the server to run out of ports.


one little followup fix for #20103

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=http-server-followup&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=http-server-followup&lookback=7)