### PR TITLE
fix(suite): make sure that there is loading state when loading all tr…

### DIFF
--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/Transactions.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/Transactions.tsx
@@ -16,7 +16,7 @@ export const Transactions = () => {
         selectIsLoadingAccountTransactions(state, accountKey),
     );
     const areAllTransactionsLoaded = useSelector(state =>
-        selectAreAllTransactionsLoaded(state, accountKey),
+        Boolean(selectAreAllTransactionsLoaded(state, accountKey)),
     );
     const allTransactions = useSelector(state =>
         selectAccountTransactionsWithNulls(state, accountKey),
@@ -31,6 +31,7 @@ export const Transactions = () => {
 
     return (
         <TransactionList
+            areAllTransactionsLoaded={areAllTransactionsLoaded}
             allTransactions={allTransactions}
             account={account}
             transactions={stakeTxs}

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
@@ -29,6 +29,7 @@ import { useFetchTransactions } from './useFetchTransactions';
 
 interface TransactionListProps {
     allTransactions: WalletAccountTransaction[];
+    areAllTransactionsLoaded: boolean;
     transactions: WalletAccountTransaction[];
     symbol: WalletAccountTransaction['symbol'];
     isLoading?: boolean;
@@ -42,6 +43,7 @@ interface TransactionListProps {
 
 export const TransactionList = ({
     allTransactions,
+    areAllTransactionsLoaded,
     transactions,
     isLoading,
     account,
@@ -164,7 +166,8 @@ export const TransactionList = ({
             )}
 
             {/* TODO: show this skeleton also while searching in txs */}
-            {isLoading ? (
+            {isLoading ||
+            (!areAllTransactionsLoaded && searchQuery && searchedTransactions.length === 0) ? (
                 <SkeletonStack $col $childMargin="0px 0px 16px 0px">
                     <SkeletonTransactionItem />
                     <SkeletonTransactionItem />

--- a/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
@@ -1,11 +1,14 @@
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
 
 import { hasNetworkPotentialFraudTransactions } from '@suite-common/token-definitions';
-import { selectIsHideSuspiciousTransactions } from '@suite-common/wallet-core';
+import {
+    selectAreAllTransactionsLoaded,
+    selectIsHideSuspiciousTransactions,
+} from '@suite-common/wallet-core';
 import { Card, Column, Text } from '@trezor/components';
 
 import { Translation } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
 import { Account, WalletAccountTransaction } from 'src/types/wallet';
 
 import { TransactionList } from './TransactionList';
@@ -39,6 +42,9 @@ export const WalletTransactionList = ({
     const fraudTransactionPossible =
         suspiciousTransactionsHidden && hasNetworkPotentialFraudTransactions(symbol);
     const [visiblePages, setVisiblePages] = useState(1);
+    const areAllTransactionsLoaded = useSelector(state =>
+        Boolean(selectAreAllTransactionsLoaded(state, account.key)),
+    );
     const result = useVisibleTransactions({
         account,
         numberOfPagesRequested: visiblePages,
@@ -48,6 +54,7 @@ export const WalletTransactionList = ({
     return (
         <TransactionList
             key={account.key} // NOTE: ensure that transaction list is unmounted when account key changes
+            areAllTransactionsLoaded={areAllTransactionsLoaded}
             customPageFetching={fraudTransactionPossible}
             customNoTransactions={<NoVisibleTransactions />}
             allTransactions={result.allTransactions}


### PR DESCRIPTION
…ansactions for the query search

<!--- Provide a general summary of your changes in the Title above -->

## Description

There was no loading state when the search was active. The search triggers loading of all pages so there is a good chance, that the searched transaction is among pages that haven't been yet loaded.

So, I display the loading state when search is active and not all pages were yet loaded.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19623

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=19623-solana-tx-search-doesn-work&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=19623-solana-tx-search-doesn-work&lookback=7)