### PR TITLE
fix(suite): Add missing SuiteBanners to LoggedOutLayout and unify usage across layouts

### DIFF
--- a/packages/suite/src/components/onboarding/OnboardingLayout.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingLayout.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react';
 
 import styled from 'styled-components';
 
-import { selectBannerMessage } from '@suite-common/message-system';
 import { Button, Row, variables } from '@trezor/components';
 import { spacings, spacingsPx, zIndices } from '@trezor/theme';
 import { TREZOR_SUPPORT_URL } from '@trezor/urls';
@@ -10,7 +9,7 @@ import { TREZOR_SUPPORT_URL } from '@trezor/urls';
 import { GuideButton, GuideRouter } from 'src/components/guide';
 import { OnboardingProgressBar } from 'src/components/onboarding';
 import { Translation } from 'src/components/suite';
-import { MessageSystemBanner } from 'src/components/suite/banners';
+import { SuiteBanners } from 'src/components/suite/banners';
 import { MAX_ONBOARDING_WIDTH } from 'src/constants/suite/layout';
 import { useSelector } from 'src/hooks/suite';
 
@@ -166,15 +165,12 @@ type OnboardingLayoutProps = {
 };
 
 export const OnboardingLayout = ({ children }: OnboardingLayoutProps) => {
-    const bannerMessage = useSelector(selectBannerMessage);
     const theme = useSelector(state => state.suite.settings.theme);
 
     return (
         <TrafficLightOffset>
             <Wrapper>
-                {bannerMessage && (
-                    <MessageSystemBanner message={bannerMessage} margin={spacings.xs} />
-                )}
+                <SuiteBanners isOnboarding fill />
 
                 <Body data-testid="@onboarding-layout/body">
                     <ScrollingWrapper>

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
@@ -28,9 +28,9 @@ import { NoConnectionBanner } from './NoConnectionBanner';
 import { SafetyChecksBanner } from './SafetyChecksBanner';
 import { TranslationMode } from './TranslationModeBanner';
 
-const Container = styled.div<{ $isVisible?: boolean }>`
+const Container = styled.div<{ $fill?: boolean }>`
     width: 100%;
-    max-width: ${MAX_CONTENT_WIDTH};
+    max-width: ${({ $fill }) => ($fill ? 'none' : MAX_CONTENT_WIDTH)};
     padding: ${spacingsPx.sm} ${spacingsPx.md};
     display: flex;
     flex-direction: column;
@@ -38,7 +38,12 @@ const Container = styled.div<{ $isVisible?: boolean }>`
     position: relative; /* because it must be on the top of the draggable area on Mac */
 `;
 
-export const SuiteBanners = () => {
+type SuiteBannersProps = {
+    isOnboarding?: boolean;
+    fill?: boolean;
+};
+
+export const SuiteBanners = ({ isOnboarding, fill }: SuiteBannersProps) => {
     const bridge = useSelector(selectTransportOfType('BridgeTransport'));
     const device = useSelector(selectSelectedDevice);
     const isOnline = useSelector(state => state.suite.online);
@@ -53,6 +58,16 @@ export const SuiteBanners = () => {
     useEffect(() => {
         setSafetyChecksDismissed(false);
     }, [device?.features?.safety_checks]);
+
+    if (isOnboarding) {
+        if (isOnboarding) {
+            return bannerMessage ? (
+                <Container $fill={fill}>
+                    <MessageSystemBanner message={bannerMessage} />
+                </Container>
+            ) : null;
+        }
+    }
 
     let banner = null;
     let priority = 0;
@@ -95,7 +110,7 @@ export const SuiteBanners = () => {
     if (!isBannerVisible) return null;
 
     return (
-        <Container>
+        <Container $fill={fill}>
             {isMessageSystemBannerVisible && <MessageSystemBanner message={bannerMessage} />}
             {isTranslationMode() && <TranslationMode />}
             {!isOnline && <NoConnectionBanner />}

--- a/packages/suite/src/components/suite/layouts/LoggedOutLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/LoggedOutLayout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useRef, useState } from 'react';
 
-import { ElevationContext, ElevationDown, ElevationUp, Modal } from '@trezor/components';
+import { Column, ElevationContext, ElevationDown, ElevationUp, Modal } from '@trezor/components';
 
 import { GuideButton, GuideRouter } from 'src/components/guide';
 import { useLayoutSize, useSelector } from 'src/hooks/suite';
@@ -10,6 +10,7 @@ import { LayoutContext, LayoutContextPayload } from 'src/support/suite/LayoutCon
 
 import { Metadata } from '../Metadata';
 import { LoggedOutSidebar } from './LoggedOutSidebar';
+import { SuiteBanners } from '../banners';
 import { DebugLegend } from './SuiteLayout/DebugLegend';
 import {
     AppWrapper,
@@ -49,16 +50,19 @@ export const LoggedOutLayout = ({ children }: LoggedOutLayout) => {
                                     <ElevationDown>
                                         <LoggedOutSidebar />
                                     </ElevationDown>
-                                    <AppWrapper
-                                        data-testid="@app"
-                                        ref={scrollRef}
-                                        id="layout-scroll"
-                                    >
-                                        {layoutHeader}
-                                        <ElevationUp>
-                                            <ContentWrapper>{children}</ContentWrapper>
-                                        </ElevationUp>
-                                    </AppWrapper>
+                                    <Column width="100%" alignItems="center">
+                                        <SuiteBanners />
+                                        <AppWrapper
+                                            data-testid="@app"
+                                            ref={scrollRef}
+                                            id="layout-scroll"
+                                        >
+                                            {layoutHeader}
+                                            <ElevationUp>
+                                                <ContentWrapper>{children}</ContentWrapper>
+                                            </ElevationUp>
+                                        </AppWrapper>
+                                    </Column>
                                 </Columns>
                             </Body>
                         </LayoutContext.Provider>

--- a/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayoutWithoutModalSwitcher.tsx
+++ b/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayoutWithoutModalSwitcher.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react';
 
 import styled from 'styled-components';
 
-import { selectBannerMessage } from '@suite-common/message-system';
 import {
     Column,
     ElevationDown,
@@ -12,11 +11,11 @@ import {
     useElevation,
     variables,
 } from '@trezor/components';
-import { Elevation, spacings, spacingsPx } from '@trezor/theme';
+import { Elevation, spacingsPx } from '@trezor/theme';
 
 import { GuideButton, GuideRouter } from 'src/components/guide';
 // importing directly, otherwise unit tests fail, seems to be a styled-components issue
-import { MessageSystemBanner } from 'src/components/suite/banners';
+import { SuiteBanners } from 'src/components/suite/banners';
 import { MAX_ONBOARDING_WIDTH } from 'src/constants/suite/layout';
 import { useSelector } from 'src/hooks/suite';
 
@@ -71,7 +70,6 @@ export const WelcomeLayoutWithoutModalSwitcher = ({
     children,
     hideSidebar,
 }: WelcomeLayoutWithoutModalSwitcherProps) => {
-    const bannerMessage = useSelector(selectBannerMessage);
     const theme = useSelector(state => state.suite.settings.theme);
 
     return (
@@ -90,19 +88,7 @@ export const WelcomeLayoutWithoutModalSwitcher = ({
                             </ElevationDown>
                         ) : null}
 
-                        <Right
-                            bannerSlot={
-                                bannerMessage && (
-                                    <MessageSystemBanner
-                                        message={bannerMessage}
-                                        margin={spacings.xs}
-                                        width="100%"
-                                    />
-                                )
-                            }
-                        >
-                            {children}
-                        </Right>
+                        <Right bannerSlot={<SuiteBanners fill />}>{children}</Right>
 
                         <GuideButton />
                         <GuideRouter />


### PR DESCRIPTION
## Description

- Added `SuiteBanners` to `LoggedOutLayout` (was missing)

- Unified usage of `SuiteBanners` in `OnboardingLayout` and `WelcomeLayoutWithoutModalSwitcher`

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16505

## Screenshots:

<img width="1474" height="1005" alt="image" src="https://github.com/user-attachments/assets/9a9bc770-64bb-434f-83ad-8bca22052c3b" />

<img width="1479" height="892" alt="image" src="https://github.com/user-attachments/assets/cfa72645-3741-4cc1-acc3-411683718e6a" />

<img width="1482" height="778" alt="image" src="https://github.com/user-attachments/assets/c96df589-6b19-4251-9d1f-c3988a224ade" />

<img width="1482" height="852" alt="image" src="https://github.com/user-attachments/assets/70a0e01a-8e49-4f01-9262-3c624c63efe1" />

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/missing-suite-banners-in-layouts&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/missing-suite-banners-in-layouts&lookback=7)