### PR TITLE
fix(blockchain-link): disable fullHistory loading for Solana accounts to prevent infinite loading

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -99,7 +99,7 @@ function nonNullable<T>(value: T): value is NonNullable<T> {
 const getAllSignatures = async (
     api: SolanaAPI,
     descriptor: MessageTypes.GetAccountInfo['payload']['descriptor'],
-    fullHistory = true,
+    fullHistory = false,
 ) => {
     let lastSignature: SignatureWithSlot | undefined;
     let keepFetching = true;


### PR DESCRIPTION
## Description

Changed fullHistory from true to false for Solana accounts to fix the infinite loading state and make the "Review & Send" button clickable again.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20292

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/solana-disable-full-history-loading&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/solana-disable-full-history-loading&lookback=7)