### PR TITLE
Fix: transport bluetooth binary build

### DIFF
--- a/packages/transport-bluetooth/scripts/Dockerfile
+++ b/packages/transport-bluetooth/scripts/Dockerfile
@@ -1,6 +1,6 @@
 # https://github.com/joseluisq/rust-linux-darwin-builder/blob/master/README.md
 
-FROM joseluisq/rust-linux-darwin-builder:1.75.0
+FROM joseluisq/rust-linux-darwin-builder:1.85.1
 
 RUN apt-get update && apt-get install -y mingw-w64
 

--- a/packages/transport-bluetooth/scripts/build.sh
+++ b/packages/transport-bluetooth/scripts/build.sh
@@ -2,7 +2,7 @@
 set -e
 
 # This has to be built using x86 docker image arm image is not working. For building on arm mac use --platform linux/amd64 for the build command.
-docker build . -f ./scripts/Dockerfile -t trezor-bluetooth-image .
+docker build . -f ./scripts/Dockerfile -t trezor-bluetooth-image
 docker create --name trezor-bluetooth-container trezor-bluetooth-image
 docker cp trezor-bluetooth-container:/output/. ../suite-data/files/bin/bluetooth
 docker rm trezor-bluetooth-container

--- a/packages/transport-bluetooth/src/server/device.rs
+++ b/packages/transport-bluetooth/src/server/device.rs
@@ -35,13 +35,13 @@ struct TrezorDeviceProps {
     /// linux reports paired devices even if device is not sending advertisements.
     /// used for sorting device list in AdapterManager
     #[serde(skip_serializing)]
-    discovery_timestamp: u64,
+    discovery_timestamp: u128,
     /// when it was updated.
     #[serde(rename = "lastUpdatedTimestamp")]
-    timestamp: u64,
+    timestamp: u128,
     /// when the last update event was emitted. used for event overflow throttling
     #[serde(skip_serializing)]
-    event_timestamp: u64,
+    event_timestamp: u128,
     /// signal strength, 0: weak, -100: strong
     rssi: i16,
 }
@@ -181,7 +181,7 @@ impl TrezorDevice {
         }
     }
 
-    pub fn get_discovery_timestamp(&self) -> u64 {
+    pub fn get_discovery_timestamp(&self) -> u128 {
         match self.props.lock() {
             Ok(p) => p.discovery_timestamp,
             Err(_) => 0,

--- a/packages/transport-bluetooth/src/server/methods/start_scan.rs
+++ b/packages/transport-bluetooth/src/server/methods/start_scan.rs
@@ -49,19 +49,21 @@ async fn stop_scanning(adapter: &Adapter) {
 pub async fn start_scan(manager: AdapterManager, broadcast: ConnectionBroadcast) -> MethodResult {
     let adapter = manager.get_powered_adapter_or_die().await?;
 
-    // start or restart scanning process
-    // restart (stop/start) ensures that the event stream is really running in 
-    // workaround for https://github.com/deviceplug/btleplug/issues/255
-    if let Err(err) = start_scanning(&adapter).await {
-        return Err(err.into());
-    }
-
     if manager.is_scanning().await {
         info!("AdapterManager is already scanning");
         let devices = manager.get_devices().await;
         return Ok(WsResponsePayload::Peripherals(devices));
     } else {
         manager.set_scanning(true).await;
+    }
+
+    // let the_task = broadcast.get_abortable_task("get_abortable_task".to_string());
+    // start or restart scanning process
+    // restart (stop/start) ensures that the event stream is really running in
+    // workaround for https://github.com/deviceplug/btleplug/issues/255
+    // windows: calling adapter.stop_scan breaks current broadcast.subscribe stream
+    if let Err(err) = start_scanning(&adapter).await {
+        return Err(err.into());
     }
 
     // listen for Abort and AdapterStateChanged messages from the other threads

--- a/packages/transport-bluetooth/src/server/utils.rs
+++ b/packages/transport-bluetooth/src/server/utils.rs
@@ -35,9 +35,9 @@ pub async fn scan_filter(adapter: &Adapter, id: &PeripheralId) -> Option<Periphe
     None
 }
 
-pub fn get_timestamp() -> u64 {
+pub fn get_timestamp() -> u128 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("Time went backwards")
-        .as_secs()
+        .as_millis()
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. update docker base image to newest version to support rustc edition 2024

CI and local build is [failing with error](https://github.com/trezor/trezor-suite/actions/runs/16420916265/job/46398956442)
```
 #11 5.190   Downloaded bluez-async v0.8.2
#11 5.214 error: failed to download replaced source registry `crates-io`
#11 5.214 
#11 5.214 Caused by:
#11 5.214   failed to parse manifest at `/root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bluez-async-0.8.2/Cargo.toml`
#11 5.214 
#11 5.214 Caused by:
#11 5.214   feature `edition2024` is required
#11 5.214 
#11 5.214   The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.75.0 (1d8b05cdd 2023-11-20)).
#11 5.214   Consider trying a newer version of Cargo (this may require the nightly release).
#11 5.214   See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
```
2. server timestamps in miliseconds. related to client implementation https://github.com/trezor/trezor-suite/pull/20252/commits/efc5fb7d5672fcad0e3f518254622358f92c70df

3. fix start_scaning on windows (see the comment in the code)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/transport-bluetooth-build&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/transport-bluetooth-build&lookback=7)