### PR TITLE
chore(suite): add account type label in multiple places

### DIFF
--- a/packages/suite/src/components/suite/AccountLabel.tsx
+++ b/packages/suite/src/components/suite/AccountLabel.tsx
@@ -1,11 +1,6 @@
 import styled from 'styled-components';
 
-import type {
-    AccountType,
-    Bip43Path,
-    NetworkSymbol,
-    NetworkType,
-} from '@suite-common/wallet-config';
+import { Account } from '@suite-common/wallet-types';
 import { BadgeSize, Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -21,27 +16,18 @@ const TabularNums = styled.span`
 `;
 
 interface AccountLabelProps {
-    accountLabel?: string;
-    accountType: AccountType;
-    symbol: NetworkSymbol;
-    index?: number;
     showAccountTypeBadge?: boolean;
     accountTypeBadgeSize?: BadgeSize;
-    path?: Bip43Path;
-    networkType?: NetworkType;
+    account: Account;
 }
 
 export const AccountLabel = ({
-    accountLabel,
-    accountType = 'normal',
-    path,
-    networkType,
     showAccountTypeBadge,
     accountTypeBadgeSize = 'medium',
-    symbol,
-    index,
+    account,
 }: AccountLabelProps) => {
     const { getDefaultAccountLabel } = useDefaultAccountLabel();
+    const { symbol, accountType, index, path, networkType, accountLabel } = account;
 
     return (
         <Row gap={spacings.sm}>

--- a/packages/suite/src/components/suite/labeling/AccountLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/AccountLabeling.tsx
@@ -25,22 +25,19 @@ export const AccountLabeling = ({
     const devices = useSelector(selectDevices);
 
     const accounts = !Array.isArray(account) ? [account] : account;
-    const { symbol, index, accountType, key, path, networkType } = accounts[0];
 
-    const labels = useSelector(state => selectLabelingDataForAccount(state, key));
+    const labels = useSelector(state => selectLabelingDataForAccount(state, accounts[0].key));
 
     if (accounts.length < 1) return null;
 
     const accountLabel = (
         <AccountLabel
-            accountLabel={labels.accountLabel}
-            accountType={accountType}
-            symbol={symbol}
-            index={index}
+            account={{
+                ...accounts[0],
+                accountLabel: labels.accountLabel,
+            }}
             showAccountTypeBadge={showAccountTypeBadge}
             accountTypeBadgeSize={accountTypeBadgeSize}
-            path={path}
-            networkType={networkType}
         />
     );
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
@@ -117,15 +117,7 @@ export const AccountDetails = ({ selectedAccount, isBalanceShown }: AccountDetai
                         networkType={selectedAccount.networkType}
                         path={path}
                         defaultVisibleValue={
-                            <AccountLabel
-                                showAccountTypeBadge
-                                accountLabel={selectedAccountLabels.accountLabel}
-                                accountType={accountType}
-                                symbol={selectedAccount.symbol}
-                                index={index}
-                                path={path}
-                                networkType={selectedAccount.networkType}
-                            />
+                            <AccountLabel account={selectedAccount} showAccountTypeBadge />
                         }
                         payload={{
                             type: 'accountLabel',

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -122,10 +122,12 @@ export const ConfirmValueModal = ({
                         <Row gap={spacings.xxs}>
                             <CoinLogo size={14} symbol={account.symbol} />
                             <AccountLabel
-                                accountLabel={accountLabel}
-                                accountType={account.accountType}
-                                symbol={account.symbol}
-                                index={account.index}
+                                account={{
+                                    ...account,
+                                    accountLabel,
+                                }}
+                                accountTypeBadgeSize="small"
+                                showAccountTypeBadge
                             />
                         </Row>
                     )

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectAccountModal.tsx
@@ -138,12 +138,13 @@ export const SelectAccountModal = ({ data }: SelectAccountModalProps) => {
                                                     )}
                                                     {suiteAccount ? (
                                                         <AccountLabel
-                                                            accountLabel={
-                                                                suiteAccountLabels[suiteAccount.key]
-                                                            }
-                                                            accountType={suiteAccount.accountType}
-                                                            symbol={suiteAccount.symbol}
-                                                            index={suiteAccount.index}
+                                                            account={{
+                                                                ...suiteAccount,
+                                                                accountLabel:
+                                                                    suiteAccountLabels[
+                                                                        suiteAccount.key
+                                                                    ],
+                                                            }}
                                                         />
                                                     ) : (
                                                         account.label

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/SignMessageModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/SignMessageModal.tsx
@@ -97,12 +97,13 @@ export const SignMessageModal = ({
                                 <CoinLogo size={14} symbol={network.symbol} />
                                 {account ? (
                                     <AccountLabel
-                                        accountLabel={
-                                            accountLabels[account.key] || account.accountLabel
-                                        }
-                                        accountType={account.accountType}
-                                        symbol={account.symbol}
-                                        index={account.index}
+                                        account={{
+                                            ...account,
+                                            accountLabel:
+                                                accountLabels[account.key] || account.accountLabel,
+                                        }}
+                                        showAccountTypeBadge
+                                        accountTypeBadgeSize="small"
                                     />
                                 ) : (
                                     network.name

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -52,7 +52,7 @@ export const TransactionReviewSummary = ({
     ) as string;
     const rawFeeInfo = useSelector(state => selectRawNetworkFeeInfo(state, account.symbol));
     const locale = useLocales();
-    const { symbol, accountType, index, networkType } = account;
+    const { symbol, networkType } = account;
     const network = networks[symbol];
     const fee = getFee(account.networkType, tx);
     const estimateTime = getEstimatedTime(networkType, rawFeeInfo, tx);
@@ -69,10 +69,12 @@ export const TransactionReviewSummary = ({
             <Row gap={spacings.xxs}>
                 <CoinLogo size={14} symbol={symbol} />
                 <AccountLabel
-                    accountLabel={accountLabel || account.accountLabel}
-                    accountType={accountType}
-                    symbol={symbol}
-                    index={index}
+                    account={{
+                        ...account,
+                        accountLabel: accountLabel || account.accountLabel,
+                    }}
+                    showAccountTypeBadge
+                    accountTypeBadgeSize="small"
                 />
             </Row>
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
@@ -320,12 +320,13 @@ export const TxSimulationModal = () => {
                             <Row gap={spacings.xxs}>
                                 <CoinLogo size={14} symbol={account.symbol} />
                                 <AccountLabel
-                                    accountLabel={
-                                        accountLabels[account.key] || account.accountLabel
-                                    }
-                                    accountType={account.accountType}
-                                    symbol={account.symbol}
-                                    index={account.index}
+                                    account={{
+                                        ...account,
+                                        accountLabel:
+                                            accountLabels[account.key] || account.accountLabel,
+                                    }}
+                                    showAccountTypeBadge
+                                    accountTypeBadgeSize="small"
                                 />
                             </Row>
                         )}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
@@ -31,7 +31,6 @@ import { spacings, spacingsPx } from '@trezor/theme';
 import { onCancel } from 'src/actions/suite/modalActions';
 import { goto } from 'src/actions/suite/routerActions';
 import { AccountLabel, Translation } from 'src/components/suite';
-import { AccountTypeBadge } from 'src/components/suite/AccountTypeBadge';
 import { ConnectAppIcon } from 'src/components/suite/ConnectAppIcon';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
@@ -229,19 +228,13 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                                         <CoinLogo type="token" symbol={account.symbol} size={24} />
                                     )}
                                     <AccountLabel
+                                        account={{
+                                            ...account,
+                                            accountLabel: accountLabels[account.key],
+                                        }}
                                         key={account.descriptor}
-                                        accountLabel={accountLabels[account.key]}
-                                        accountType={account.accountType}
-                                        networkType={account.networkType}
-                                        symbol={account.symbol}
-                                        index={account.index}
-                                        path={account.path}
-                                    />
-                                    <AccountTypeBadge
-                                        accountType={account.accountType}
-                                        networkType={account.networkType}
-                                        size="small"
-                                        onElevation
+                                        showAccountTypeBadge
+                                        accountTypeBadgeSize="small"
                                     />
                                 </Row>
                             )}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx
@@ -88,13 +88,11 @@ export const WalletConnectSwitchAccountModal = ({
                                 <CoinLogo type="token" symbol={account.symbol} size={24} />
                             )}
                             <AccountLabel
+                                account={{
+                                    ...account,
+                                    accountLabel: accountLabels[account.key],
+                                }}
                                 key={account.descriptor}
-                                accountLabel={accountLabels[account.key]}
-                                accountType={account.accountType}
-                                networkType={account.networkType}
-                                symbol={account.symbol}
-                                index={account.index}
-                                path={account.path}
                             />
                             <AccountTypeBadge
                                 accountType={account.accountType}

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
@@ -60,7 +60,13 @@ export const TransactionRenderer = ({ render: View, ...props }: TransactionRende
             {...props}
             messageValues={{
                 amount: <HiddenPlaceholder>{formattedAmount}</HiddenPlaceholder>,
-                account: <AccountLabeling account={found} />,
+                account: (
+                    <AccountLabeling
+                        account={found}
+                        showAccountTypeBadge
+                        accountTypeBadgeSize="small"
+                    />
+                ),
                 confirmations,
             }}
             action={{

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx
@@ -36,7 +36,6 @@ export const Left = styled.div`
 interface AccountItemProps {
     account: Account;
     type: AccountItemType;
-    accountLabel?: string;
     isSelected: boolean;
     isGroupSelected?: boolean;
     formattedBalance: string;
@@ -54,7 +53,6 @@ export const AccountItem = forwardRef(
         {
             account,
             type,
-            accountLabel,
             isSelected,
             isGroupSelected,
             formattedBalance,
@@ -114,13 +112,9 @@ export const AccountItem = forwardRef(
                 handleHeaderClick={handleHeaderClick}
                 dataTestKey={dataTestKey}
                 type={type}
-                symbol={symbol}
                 account={account}
                 ref={ref}
                 customFiatValue={customFiatValue}
-                accountLabel={accountLabel}
-                accountType={accountType}
-                index={index}
                 formattedBalance={formattedBalance}
             />
         );

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItemContent.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItemContent.tsx
@@ -3,7 +3,6 @@ import { JSX } from 'react';
 import styled from 'styled-components';
 
 import { useFormatters } from '@suite-common/formatters';
-import { AccountType, NetworkSymbol } from '@suite-common/wallet-config';
 import { selectIsDiscreteModeActive, selectLocalCurrency } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import { BaseCurrencyAmount, isTestnet } from '@suite-common/wallet-utils';
@@ -39,10 +38,6 @@ type ItemContentProps = {
     customFiatValue?: BaseCurrencyAmount;
     account: Account;
     type: AccountItemType;
-    accountLabel?: string;
-    accountType: AccountType;
-    symbol: NetworkSymbol;
-    index?: number;
     formattedBalance: string;
     dataTestKey?: string;
     isFiatLoading?: boolean;
@@ -59,10 +54,6 @@ export const AccountItemContent = ({
     customFiatValue,
     account,
     type,
-    accountLabel,
-    accountType,
-    symbol,
-    index,
     formattedBalance,
     dataTestKey,
     isFiatLoading,
@@ -80,18 +71,11 @@ export const AccountItemContent = ({
         <Column flex="1" overflow={discreetMode ? 'visible' : 'hidden'} gap={spacings.xxxs}>
             <Row gap={spacings.md} margin={{ right: spacings.xxs }} justifyContent="space-between">
                 <AccountLabelContainer data-testid={`${dataTestKey}/label`}>
-                    {type === 'coin' && (
-                        <AccountLabel
-                            accountLabel={accountLabel}
-                            accountType={accountType}
-                            symbol={symbol}
-                            index={index}
-                        />
-                    )}
+                    {type === 'coin' && <AccountLabel account={account} />}
                     {type === 'staking' && <Translation id="TR_NAV_STAKING" />}
                     {type === 'tokens' && <Translation id="TR_NAV_TOKENS" />}
                 </AccountLabelContainer>
-                {customFiatValue && !isTestnet(symbol) ? (
+                {customFiatValue && !isTestnet(account.symbol) ? (
                     <HiddenPlaceholder>
                         {isFiatLoading ? (
                             <SkeletonRectangle animate={shouldAnimate} />
@@ -107,7 +91,7 @@ export const AccountItemContent = ({
                 ) : (
                     <BaseCurrencyValue
                         amount={formattedBalance}
-                        symbol={symbol}
+                        symbol={account.symbol}
                         fiatAmountFormatterOptions={{
                             minimumFractionDigits: 0,
                             maximumFractionDigits: 0,
@@ -118,7 +102,11 @@ export const AccountItemContent = ({
                 )}
             </Row>
             {isBalanceShown && type !== 'tokens' && (
-                <CoinBalance data-testid="@wallet" value={formattedBalance} symbol={symbol} />
+                <CoinBalance
+                    data-testid="@wallet"
+                    value={formattedBalance}
+                    symbol={account.symbol}
+                />
             )}
             {!isBalanceShown && (
                 <Column gap={spacings.xs}>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow.tsx
@@ -2,7 +2,6 @@ import { forwardRef } from 'react';
 
 import styled from 'styled-components';
 
-import { AccountType, NetworkSymbol } from '@suite-common/wallet-config';
 import { BaseCurrencyAmount } from '@suite-common/wallet-utils';
 import { spacingsPx, typography } from '@trezor/theme';
 
@@ -19,12 +18,8 @@ type AccountRowProps = {
     handleHeaderClick: () => void;
     dataTestKey?: string;
     type: AccountItemType;
-    symbol: NetworkSymbol;
     account: Account;
     customFiatValue?: BaseCurrencyAmount;
-    accountLabel?: string;
-    accountType: AccountType;
-    index?: number;
     formattedBalance: string;
     isFiatLoading?: boolean;
 };
@@ -56,12 +51,8 @@ export const AccountRow = forwardRef<HTMLDivElement, AccountRowProps>(
             handleHeaderClick,
             dataTestKey,
             type,
-            symbol,
             account,
             customFiatValue,
-            accountLabel,
-            accountType,
-            index,
             formattedBalance,
             isFiatLoading,
         },
@@ -77,16 +68,12 @@ export const AccountRow = forwardRef<HTMLDivElement, AccountRowProps>(
             tabIndex={0}
         >
             <Left>
-                <AccountItemLeft type={type} symbol={symbol} account={account} />
+                <AccountItemLeft type={type} symbol={account.symbol} account={account} />
             </Left>
             <AccountItemContent
                 customFiatValue={customFiatValue}
                 account={account}
                 type={type}
-                accountLabel={accountLabel}
-                accountType={accountType}
-                symbol={symbol}
-                index={index}
                 formattedBalance={formattedBalance}
                 dataTestKey={dataTestKey}
                 isFiatLoading={Boolean(isFiatLoading)}

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
@@ -40,7 +40,6 @@ const Section = styled.div<{ $selected?: boolean; $isSidebarCollapsed?: boolean 
 
 interface AccountItemsGroupProps {
     account: Account;
-    accountLabel?: string;
     selected: boolean;
     showStaking: boolean;
     tokens?: Account['tokens'];
@@ -49,7 +48,6 @@ interface AccountItemsGroupProps {
 
 export const AccountItemsGroup = ({
     account,
-    accountLabel,
     selected,
     showStaking,
     tokens,
@@ -80,7 +78,6 @@ export const AccountItemsGroup = ({
                         (routeName === 'wallet-index' ||
                             (routeName === 'wallet-staking' && !showStaking))
                     }
-                    accountLabel={accountLabel}
                     formattedBalance={account.formattedBalance}
                     isGroup
                     isGroupSelected={selected}

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx
@@ -15,12 +15,7 @@ interface AccountSectionProps {
     onItemClick?: () => void;
 }
 
-export const AccountSection = ({
-    account,
-    selected,
-    accountLabel,
-    onItemClick,
-}: AccountSectionProps) => {
+export const AccountSection = ({ account, selected, onItemClick }: AccountSectionProps) => {
     const {
         symbol,
         accountType,
@@ -49,7 +44,6 @@ export const AccountSection = ({
         <AccountItemsGroup
             key={`${descriptor}-${symbol}`}
             account={account}
-            accountLabel={accountLabel}
             selected={selected}
             showStaking={isStakeShown}
             tokens={tokens.shownWithBalance}
@@ -62,7 +56,6 @@ export const AccountSection = ({
             account={account}
             isSelected={selected}
             onClick={onItemClick}
-            accountLabel={accountLabel}
             formattedBalance={formattedBalance}
             tokens={tokens.shownWithBalance}
             dataTestKey={dataTestKey}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
@@ -7,7 +7,7 @@ import { Column, InfoItem, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils';
 
-import { AccountLabeling, Translation } from 'src/components/suite';
+import { AccountLabel, Translation } from 'src/components/suite';
 import { TradingPayGetLabelType } from 'src/types/trading/trading';
 import { TradingCoinLogo } from 'src/views/wallet/trading/common/TradingCoinLogo';
 import { TradingCryptoAmount } from 'src/views/wallet/trading/common/TradingCryptoAmount';
@@ -44,8 +44,11 @@ export const TradingInfoItem = ({
                 {account && (
                     <Text variant="tertiary" typographyStyle="label" as="div">
                         <Row gap={spacings.xxs}>
-                            <AccountLabeling account={account} />
-                            {account.accountType !== 'normal' ? `(${account.accountType})` : ''}
+                            <AccountLabel
+                                account={account}
+                                showAccountTypeBadge
+                                accountTypeBadgeSize="small"
+                            />
                         </Row>
                     </Text>
                 )}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSend.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSend.tsx
@@ -56,7 +56,11 @@ export const TradingOfferExchangeSend = () => {
                         data-testid="@trading/exchange-send/from-account"
                         label={<Translation id="TR_EXCHANGE_SEND_FROM" />}
                     >
-                        <AccountLabeling account={account} />
+                        <AccountLabeling
+                            account={account}
+                            showAccountTypeBadge
+                            accountTypeBadgeSize="small"
+                        />
                     </InfoItem>
                     <InfoItem
                         data-testid="@trading/exchange-send/to-address"

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendSwap.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendSwap.tsx
@@ -217,7 +217,11 @@ export const TradingOfferExchangeSendSwap = () => {
     return (
         <Column gap={spacings.lg} flex="1">
             <InfoItem label={<Translation id="TR_EXCHANGE_SEND_FROM" />}>
-                <AccountLabeling account={account} />
+                <AccountLabeling
+                    account={account}
+                    showAccountTypeBadge
+                    accountTypeBadgeSize="small"
+                />
             </InfoItem>
             <InfoItem
                 label={<Translation id="TR_EXCHANGE_SWAP_SEND_TO" values={translationValues} />}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSignData.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSignData.tsx
@@ -40,7 +40,11 @@ export const TradingOfferExchangeSignData = () => {
     return (
         <Column gap={spacings.lg} flex="1">
             <InfoItem label={<Translation id="TR_EXCHANGE_SEND_FROM" />}>
-                <AccountLabeling account={account} />
+                <AccountLabeling
+                    account={account}
+                    showAccountTypeBadge
+                    accountTypeBadgeSize="small"
+                />
             </InfoItem>
             <InfoItem
                 label={

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellTransaction.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellTransaction.tsx
@@ -96,7 +96,11 @@ export const TradingSelectedOfferSellTransaction = () => {
                             <Translation id="TR_SELL_SEND_FROM" />
                         </LabelText>
                         <Value data-testid="@trading/form/verify/account">
-                            <AccountLabeling account={account} />
+                            <AccountLabeling
+                                account={account}
+                                showAccountTypeBadge
+                                accountTypeBadgeSize="small"
+                            />
                         </Value>
                     </Row>
                     <Row>


### PR DESCRIPTION
## Description

This PR implements missing account labels on multiple places.

## Related Issue

Resolve #19728

## Screenshots:

<details>
  <summary>Screenshots</summary>
<img width="800" height="569" alt="image" src="https://github.com/user-attachments/assets/ac423081-cc6d-4dee-8cc6-608cfdb4a16e" />
<img width="400" height="573" alt="image" src="https://github.com/user-attachments/assets/b9758ef1-8846-40fc-bcf6-59f43ef97f7a" />
<img width="769" height="351" alt="image" src="https://github.com/user-attachments/assets/57148e0d-d652-4f2f-983f-1d8f721a648b" />
<img width="802" height="332" alt="image" src="https://github.com/user-attachments/assets/0165590e-1088-4409-b330-2ebd2f81cc66" />
<img width="608" height="630" alt="image" src="https://github.com/user-attachments/assets/e768e7fa-f0ff-4834-97e2-2962ef88d411" />
<img width="738" height="539" alt="image" src="https://github.com/user-attachments/assets/74c0ff1c-eb64-4c58-a7b4-6531cf066cc5" />
<img width="342" height="75" alt="image" src="https://github.com/user-attachments/assets/b992c19d-d07e-4a6e-af38-0a3c202686f3" />

</details>





🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/account-type-label&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/account-type-label&lookback=7)