### PR TITLE
test(suite): add more FW hash check cases for Preloader.test

### DIFF
--- a/packages/suite/src/actions/backup/__tests__/backupActions.test.ts
+++ b/packages/suite/src/actions/backup/__tests__/backupActions.test.ts
@@ -1,5 +1,5 @@
 import { connectInitThunk } from '@suite-common/connect-init';
-import { initialState as messageSystemInitialState } from '@suite-common/message-system';
+import { messageSystemInitialState } from '@suite-common/message-system';
 import { testMocks } from '@suite-common/test-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { CommonParams } from '@trezor/connect';

--- a/packages/suite/src/actions/suite/__tests__/trezorConnectActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/trezorConnectActions.test.ts
@@ -1,5 +1,5 @@
 import { connectInitThunk } from '@suite-common/connect-init';
-import { initialState as messageSystemInitialState } from '@suite-common/message-system';
+import { messageSystemInitialState } from '@suite-common/message-system';
 import { testMocks } from '@suite-common/test-utils';
 import { prepareDeviceReducer } from '@suite-common/wallet-core';
 import { BLOCKCHAIN_EVENT, DEVICE_EVENT, TRANSPORT_EVENT, UI_EVENT } from '@trezor/connect';

--- a/packages/suite/src/actions/wallet/__tests__/publicKeyActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/publicKeyActions.test.ts
@@ -1,7 +1,7 @@
 import { combineReducers, createReducer } from '@reduxjs/toolkit';
 
 import { connectInitThunk } from '@suite-common/connect-init';
-import { initialState as messageSystemInitialState } from '@suite-common/message-system';
+import { messageSystemInitialState } from '@suite-common/message-system';
 import { configureMockStore, testMocks } from '@suite-common/test-utils';
 import { DeviceReducerState } from '@suite-common/wallet-core';
 

--- a/packages/suite/src/actions/wallet/__tests__/receiveActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/receiveActions.test.ts
@@ -1,5 +1,5 @@
 import { connectInitThunk } from '@suite-common/connect-init';
-import { initialState as messageSystemInitialState } from '@suite-common/message-system';
+import { messageSystemInitialState } from '@suite-common/message-system';
 import { testMocks } from '@suite-common/test-utils';
 import type { NetworkSymbol, NetworkType } from '@suite-common/wallet-config';
 import { prepareDeviceReducer } from '@suite-common/wallet-core';

--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -1,17 +1,12 @@
 import { FC, PropsWithChildren, useEffect } from 'react';
 
 import { selectIsAnalyticsConfirmed } from '@suite-common/analytics';
-import { selectIsFirmwareAuthenticityCheckDismissed } from '@suite-common/wallet-core';
 
 import * as analyticsActions from 'src/actions/suite/analyticsActions';
 import { init } from 'src/actions/suite/initAction';
 import { useGuideKeyboard } from 'src/hooks/guide';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useWindowVisibility } from 'src/hooks/suite/useWindowVisibility';
-import {
-    selectIsEntropyCheckEnabledAndFailed,
-    selectIsFirmwareAuthenticityCheckEnabledAndHardFailed,
-} from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
 import {
     selectIsLoggedOut,
     selectIsTransportInitialized,
@@ -24,7 +19,7 @@ import { ErrorPage } from 'src/views/suite/ErrorPage';
 
 import { DatabaseUpgradeModal } from './DatabaseUpgradeModal';
 import { InitialLoading } from './InitialLoading';
-import { RouterAppWithParams } from '../../../constants/suite/routes';
+import { selectShouldDisplayDeviceCompromised } from './selectShouldDisplayDeviceCompromised';
 import { AnalyticsConsentScreen } from '../../../views/start/AnalyticsConsentScreen';
 import { PrerequisitesGuide } from '../PrerequisitesGuide/PrerequisitesGuide';
 import { DeviceCompromised } from '../SecurityCheck/DeviceCompromised';
@@ -33,13 +28,6 @@ import { useReportDeviceCompromised } from '../SecurityCheck/useReportDeviceComp
 import { LoggedOutLayout } from '../layouts/LoggedOutLayout';
 import { SuiteLayout } from '../layouts/SuiteLayout/SuiteLayout';
 import { WelcomeLayout } from '../layouts/WelcomeLayout/WelcomeLayout';
-
-const ROUTES_TO_SKIP_FIRMWARE_CHECK: RouterAppWithParams['app'][] = [
-    'settings',
-    'firmware',
-    'firmware-type',
-    'firmware-custom',
-];
 
 const getFullscreenApp = (route: AppState['router']['route']): FC | undefined => {
     switch (route?.app) {
@@ -60,14 +48,7 @@ export const Preloader = ({ children }: PropsWithChildren) => {
     const router = useSelector(state => state.router);
     const prerequisite = useSelector(selectPrerequisite);
     const isLoggedOut = useSelector(selectIsLoggedOut);
-    const isFirmwareCheckEnabledAndFailed = useSelector(
-        selectIsFirmwareAuthenticityCheckEnabledAndHardFailed,
-    );
-    const isFirmwareAuthenticityCheckDismissed = useSelector(
-        selectIsFirmwareAuthenticityCheckDismissed,
-    );
-    // Entropy check won't be performed if disabled but we must also check it here to avoid showing the UI when the failed state is stored in database.
-    const isEntropyCheckEnabledAndFailed = useSelector(selectIsEntropyCheckEnabledAndFailed);
+    const shouldDisplayDeviceCompromised = useSelector(selectShouldDisplayDeviceCompromised);
     const isAnalyticsConsentConfirmed = useSelector(selectIsAnalyticsConfirmed);
 
     useReportDeviceCompromised();
@@ -110,12 +91,7 @@ export const Preloader = ({ children }: PropsWithChildren) => {
         return <InitialLoading timeout={90 * 5} />;
     }
 
-    if (
-        (router.route?.app === undefined ||
-            !ROUTES_TO_SKIP_FIRMWARE_CHECK.includes(router.route?.app)) &&
-        ((!isFirmwareAuthenticityCheckDismissed && isFirmwareCheckEnabledAndFailed) ||
-            isEntropyCheckEnabledAndFailed)
-    ) {
+    if (shouldDisplayDeviceCompromised) {
         return <DeviceCompromised />;
     }
 

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -22,8 +22,8 @@ import { ProtocolState } from '../../../../reducers/suite/protocolReducer';
 import { RouterState } from '../../../../reducers/suite/routerReducer';
 import { SuiteState } from '../../../../reducers/suite/suiteReducer';
 import WalletReducers from '../../../../reducers/wallet';
-import { TranslationKey } from '../../Translation';
 import { Preloader } from '../Preloader';
+import * as selectShouldDisplayDeviceCompromisedModule from '../selectShouldDisplayDeviceCompromised';
 
 // render only Translation.id in data-test attribute
 jest.mock('src/components/suite/Translation', () => ({
@@ -277,87 +277,7 @@ const initStore = (state: AppState) => mockStore(state);
 
 const Index = ({ app }: any) => <Preloader>{app || 'foo'}</Preloader>;
 
-const deviceCompromisedFixtures: Array<{
-    description: string;
-    device: DeepPartial<DeviceReducerState>;
-    result: TranslationKey;
-}> = [
-    {
-        description: 'Failed entropy check',
-        device: {
-            devicesWithFailedEntropyCheck: ['deviceId'],
-            selectedDevice: {
-                id: 'deviceId',
-            },
-        },
-        result: 'TR_DEVICE_COMPROMISED_ENTROPY_CHECK_TEXT',
-    },
-    {
-        description: 'Failed firmware hash check',
-        device: {
-            selectedDevice: {
-                authenticityChecks: {
-                    firmwareHash: {
-                        error: 'hash-mismatch',
-                    },
-                },
-                features: {},
-            },
-        },
-        result: 'TR_DEVICE_COMPROMISED_FW_HASH_CHECK_TEXT',
-    },
-    {
-        description: 'Firmware hash check other-error (1st occurrence)',
-        device: {
-            selectedDevice: {
-                connected: true,
-                authenticityChecks: {
-                    firmwareHash: {
-                        error: 'other-error',
-                    },
-                },
-                features: {},
-            },
-        },
-        result: 'TR_FAILED_VERIFY_DEVICE_TEXT',
-    },
-    {
-        description: 'Firmware hash check other-error (2nd occurrence)',
-        device: {
-            selectedDevice: {
-                connected: true,
-                authenticityChecks: {
-                    firmwareHash: {
-                        error: 'other-error',
-                    },
-                },
-                features: {},
-            },
-            lastConnectedAuthenticityChecks: {
-                firmwareHash: {
-                    error: 'other-error',
-                },
-            },
-        },
-        result: 'TR_FAILED_VERIFY_DEVICE_AGAIN_TEXT',
-    },
-    {
-        description: 'Failed firmware revision check',
-        device: {
-            selectedDevice: {
-                authenticityChecks: {
-                    firmwareRevision: {
-                        error: 'revision-mismatch',
-                    },
-                },
-                features: {},
-            },
-        },
-        result: 'TR_DEVICE_COMPROMISED_FW_REVISION_CHECK_TEXT',
-    },
-];
-
-describe('Preloader component', () => {
+describe(`${Preloader.name} component`, () => {
     beforeAll(() => {
         const originalWarn = console.warn;
 
@@ -743,6 +663,22 @@ describe('Preloader component', () => {
         unmount();
     });
 
+    it('displays DeviceCompromised when shouldDisplayDeviceCompromised is true', () => {
+        const spy = jest
+            .spyOn(
+                selectShouldDisplayDeviceCompromisedModule,
+                'selectShouldDisplayDeviceCompromised',
+            )
+            .mockImplementation(() => true);
+
+        const store = initStore(getInitialState());
+        const { unmount } = renderWithProviders(store, <Index app={store.getState().router.app} />);
+        expect(findByTestId('@device-compromised')).not.toBeNull();
+
+        unmount();
+        spy.mockRestore();
+    });
+
     it('Required FW update device', () => {
         const device: DeepPartial<AppState['device']> = {
             selectedDevice: {
@@ -767,19 +703,5 @@ describe('Preloader component', () => {
         expect(findByTestId('TR_SEE_DETAILS')).not.toBeNull();
 
         unmount();
-    });
-
-    deviceCompromisedFixtures.forEach(({ description, device, result }) => {
-        it(description, () => {
-            const store = initStore(getInitialState({ device }));
-            const { getByText, unmount } = renderWithProviders(
-                store,
-                <Index app={store.getState().router.app} />,
-            );
-
-            expect(getByText(result)).not.toBeNull();
-
-            unmount();
-        });
     });
 });

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -307,6 +307,41 @@ const deviceCompromisedFixtures: Array<{
         result: 'TR_DEVICE_COMPROMISED_FW_HASH_CHECK_TEXT',
     },
     {
+        description: 'Firmware hash check other-error (1st occurrence)',
+        device: {
+            selectedDevice: {
+                connected: true,
+                authenticityChecks: {
+                    firmwareHash: {
+                        error: 'other-error',
+                    },
+                },
+                features: {},
+            },
+        },
+        result: 'TR_FAILED_VERIFY_DEVICE_TEXT',
+    },
+    {
+        description: 'Firmware hash check other-error (2nd occurrence)',
+        device: {
+            selectedDevice: {
+                connected: true,
+                authenticityChecks: {
+                    firmwareHash: {
+                        error: 'other-error',
+                    },
+                },
+                features: {},
+            },
+            lastConnectedAuthenticityChecks: {
+                firmwareHash: {
+                    error: 'other-error',
+                },
+            },
+        },
+        result: 'TR_FAILED_VERIFY_DEVICE_AGAIN_TEXT',
+    },
+    {
         description: 'Failed firmware revision check',
         device: {
             selectedDevice: {

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -1,27 +1,18 @@
 import { fireEvent, screen } from '@testing-library/react';
 
 import { AnalyticsState } from '@suite-common/analytics';
-import { FirmwareUpdateState } from '@suite-common/firmware';
-import { MetadataState } from '@suite-common/metadata-types';
-import { NetworkSymbol } from '@suite-common/wallet-config';
 import { DeviceReducerState } from '@suite-common/wallet-core';
 import { TransportInfo } from '@trezor/connect';
 import * as envUtils from '@trezor/env-utils';
-import { TorStatus } from '@trezor/suite-desktop-api';
 import { DeepPartial } from '@trezor/type-utils';
 
-import { desktopUpdateInitialState } from 'src/reducers/suite/desktopUpdateReducer';
+import { AppState } from 'src/reducers/store';
+import { RouterState } from 'src/reducers/suite/routerReducer';
+import { SuiteState } from 'src/reducers/suite/suiteReducer';
+import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
 import { configureStore } from 'src/support/tests/configureStore';
 import { findByTestId, renderWithProviders } from 'src/support/tests/hooksHelper';
 
-import { LOCK_TYPE } from '../../../../actions/suite/constants/suiteConstants';
-import { BackupState } from '../../../../reducers/backup/backupReducer';
-import { OnboardingState } from '../../../../reducers/onboarding/onboardingReducer';
-import { AppState } from '../../../../reducers/store';
-import { ProtocolState } from '../../../../reducers/suite/protocolReducer';
-import { RouterState } from '../../../../reducers/suite/routerReducer';
-import { SuiteState } from '../../../../reducers/suite/suiteReducer';
-import WalletReducers from '../../../../reducers/wallet';
 import { Preloader } from '../Preloader';
 import * as selectShouldDisplayDeviceCompromisedModule from '../selectShouldDisplayDeviceCompromised';
 
@@ -79,195 +70,18 @@ const getInitialState = ({
     device,
     analytics,
 }: GetInitialStateProps = {}): AppState => ({
+    ...initialAppState,
+    router: { ...initialAppState.router, ...router } as unknown as RouterState,
+    device: { ...initialAppState.device, ...device } as DeviceReducerState,
+    analytics: { ...initialAppState.analytics, ...analytics },
+
     suite: {
+        ...initialAppState.suite,
         lifecycle: {
             status: 'ready',
         },
         transport: { transports: [] },
-        settings: {
-            debug: {
-                showDebugMenu: false,
-                transports: [],
-                isUnlockedBootloaderAllowed: false,
-                showConnectLogs: false,
-            },
-            theme: { variant: 'light' },
-            enabledSecurityChecks: {
-                deviceAuthenticity: true,
-                entropy: true,
-                firmwareRevision: true,
-                firmwareHash: true,
-            },
-            language: 'id-ID',
-            torOnionLinks: false,
-            isCoinjoinReceiveWarningHidden: false,
-            isDesktopSuitePromoHidden: false,
-            autodetect: {
-                language: true,
-                theme: true,
-            },
-            addressDisplayType: 'original',
-            defaultWalletLoading: 'passphrase',
-            sidebarWidth: 0,
-            isCoinsFilterVisible: false,
-            autoEject: false,
-        },
-        online: true,
-        locks: {
-            [LOCK_TYPE.UI]: 0,
-            [LOCK_TYPE.ROUTER]: 0,
-            [LOCK_TYPE.DEVICE]: 0,
-        },
-        flags: {
-            initialRun: false,
-            taprootBannerClosed: false,
-            firmwareTypeBannerClosed: false,
-            discreetModeCompleted: false,
-            securityStepsHidden: false,
-            dashboardGraphHidden: false,
-            dashboardAssetsGridMode: false,
-            showTEXDashboardPromoBanner: false,
-            showSettingsDesktopAppPromoBanner: false,
-            stakeEthBannerClosed: false,
-            stakeSolBannerClosed: false,
-            showDashboardStakingPromoBanner: false,
-            isDashboardPassphraseBannerVisible: false,
-            suspiciousTransactionsTooltipClosed: false,
-            showUnhideTokenModal: false,
-            showCopyAddressModal: false,
-            enableAutoupdateOnNextRun: false,
-            isBluetoothEnabled: false,
-            showBluetoothDebugInfo: false,
-            stellarLimitedHistoryBannerClosed: false,
-            solanaLimitedHistoryBannerClosed: false,
-            hasSeenDisconnectTooltip: false,
-        },
-        torStatus: 'Disabled' as TorStatus.Disabled,
-        torBootstrap: null,
-        evmSettings: {
-            confirmExplanationModalClosed: {},
-            explanationBannerClosed: {},
-        },
-        dismissedTradingTerms: {},
-        countryCode: null,
-        prefillFields: {},
-        recentlyDisconnectedDevice: null,
-        seenDisconnectNotificationForDeviceIds: [],
         ...suite,
-    },
-    device: {
-        devices: [],
-        ...device,
-    } as DeviceReducerState, // Todo: maybe one day, fix types
-    bluetooth: {
-        unpairedDeviceNeedsManualOsRemoval: false,
-        isBluetoothListOpen: false,
-        connectingDeviceIds: [],
-        isUnpairingDevice: false,
-        adapterStatus: 'unknown',
-        scanStatus: 'error',
-        nearbyDevices: null,
-        knownDevices: [],
-    },
-    thp: {
-        step: null,
-        lastThpCode: undefined,
-        credentials: [],
-    },
-    window: {
-        isVisible: true,
-        isBelowMobile: false,
-        isBelowTablet: false,
-        isBelowLaptop: false,
-        isBelowDesktop: false,
-        isAboveMobile: false,
-        isAboveTablet: false,
-        isAboveLaptop: false,
-        isAboveDesktop: false,
-    },
-    guide: {
-        open: false,
-        view: 'GUIDE_DEFAULT',
-        indexNode: null,
-        currentNode: null,
-    },
-    messageSystem: {
-        config: {
-            actions: [],
-            version: 0,
-            timestamp: '',
-            sequence: 0,
-        },
-        validMessages: {
-            banner: [],
-            context: [],
-            modal: [],
-            feature: [],
-        },
-        currentSequence: 0,
-        timestamp: 0,
-        dismissedMessages: {},
-        validExperiments: [],
-    },
-    modal: {
-        context: '@modal/context-none',
-    },
-    notifications: [],
-    wallet: {
-        discovery: {},
-        accountSearch: {},
-        settings: {
-            enabledNetworks: [] as NetworkSymbol[],
-        },
-        blockchain: {},
-    } as ReturnType<typeof WalletReducers>, // Todo: maybe one day, fix types
-    desktopUpdate: desktopUpdateInitialState,
-    router: {
-        app: 'suite-index',
-        loaded: true,
-        route: '/dashboard',
-        ...router,
-    } as RouterState, // Todo: maybe one day, fix types
-    recovery: {
-        advancedRecovery: false,
-        wordsCount: 12,
-        status: 'initial',
-    },
-    analytics: { confirmed: true, ...analytics },
-    onboarding: {} as OnboardingState, // Todo: maybe one day, fix types
-    firmware: {} as FirmwareUpdateState, // Todo: maybe one day, fix types
-    backup: {} as BackupState, // Todo: maybe one day, fix types
-    desktop: null,
-    tokenDefinitions: {},
-    geolocation: {
-        countryCode: null,
-    },
-    logs: {
-        logEntries: [],
-    },
-    metadata: {} as MetadataState, // Todo: maybe one day, fix types
-    protocol: {} as ProtocolState, // Todo: maybe one day, fix types
-    connectPopup: {
-        activeCall: undefined,
-        permissions: [],
-    },
-    walletConnect: {
-        sessions: [],
-        pendingProposal: undefined,
-    },
-    bioAuth: {
-        initialNow: 0,
-        bioAuthEnabled: false,
-        blurTimeoutId: null,
-        bioAuthEnabledNextValue: null,
-        lastBioAuthValidatedTimestamp: null,
-        lastWindowBlurTimestamp: null,
-        bioAuthValidationInProgress: false,
-        bioAuthValidationRequested: false,
-        bioAuthValidationRequired: false,
-        windowBlurred: false,
-        bioAuthAvailable: null,
-        hasEverValidatedBioAuth: false,
     },
 });
 

--- a/packages/suite/src/components/suite/Preloader/__tests__/selectShouldDisplayDeviceCompromised.test.ts
+++ b/packages/suite/src/components/suite/Preloader/__tests__/selectShouldDisplayDeviceCompromised.test.ts
@@ -1,0 +1,165 @@
+import { messageSystemInitialState } from '@suite-common/message-system';
+import { DeepPartial } from '@trezor/type-utils';
+
+import { AcquiredDevice, AppState } from 'src/types/suite';
+
+import { selectShouldDisplayDeviceCompromised } from '../selectShouldDisplayDeviceCompromised';
+
+type Fixture = {
+    description: string;
+    state: DeepPartial<AppState>;
+    result: boolean;
+};
+
+const authenticityChecksSuccess: AcquiredDevice['authenticityChecks'] = {
+    firmwareRevision: { success: true },
+    firmwareHash: null,
+};
+
+const authenticityChecksFail: AcquiredDevice['authenticityChecks'] = {
+    firmwareRevision: { success: false, error: 'revision-mismatch' },
+    firmwareHash: { success: false, error: 'hash-mismatch' },
+};
+
+const suiteAllSettingsEnabled: DeepPartial<AppState['suite']> = {
+    settings: {
+        enabledSecurityChecks: { firmwareRevision: true, firmwareHash: true, entropy: true },
+    },
+};
+
+const fixtures: Fixture[] = [
+    {
+        description: 'returns false if all checks pass',
+        state: {
+            router: { route: { app: 'dashboard' } },
+            messageSystem: messageSystemInitialState,
+            device: {
+                selectedDevice: {
+                    features: {},
+                    id: 'deviceId',
+                    authenticityChecks: authenticityChecksSuccess,
+                },
+            },
+            suite: suiteAllSettingsEnabled,
+        },
+        result: false,
+    },
+    {
+        description: 'returns false if check fails, but on a skipped route',
+        state: {
+            router: { route: { app: 'settings' } },
+            messageSystem: messageSystemInitialState,
+            device: {
+                selectedDevice: {
+                    features: {},
+                    id: 'deviceId',
+                    authenticityChecks: authenticityChecksFail,
+                },
+            },
+            suite: suiteAllSettingsEnabled,
+        },
+        result: false,
+    },
+    {
+        description: 'returns true if firmware check failed and not dismissed',
+        state: {
+            router: { route: { app: 'dashboard' } },
+            messageSystem: messageSystemInitialState,
+            device: {
+                selectedDevice: {
+                    features: {},
+                    id: 'deviceId',
+                    authenticityChecks: authenticityChecksFail,
+                },
+            },
+            suite: suiteAllSettingsEnabled,
+        },
+        result: true,
+    },
+    {
+        description: 'returns false if firmware check failed and dismissed',
+        state: {
+            router: { route: { app: 'dashboard' } },
+            messageSystem: messageSystemInitialState,
+            device: {
+                dismissedSecurityChecks: { firmwareAuthenticity: ['deviceId'] },
+                selectedDevice: {
+                    features: {},
+                    id: 'deviceId',
+                    authenticityChecks: authenticityChecksFail,
+                },
+            },
+            suite: suiteAllSettingsEnabled,
+        },
+        result: false,
+    },
+    {
+        description: 'returns false if a firmware check failed but is disabled',
+        state: {
+            router: { route: { app: 'dashboard' } },
+            messageSystem: messageSystemInitialState,
+            device: {
+                selectedDevice: {
+                    features: {},
+                    id: 'deviceId',
+                    authenticityChecks: {
+                        firmwareRevision: { success: false, error: 'revision-mismatch' },
+                        firmwareHash: { success: true },
+                    },
+                },
+            },
+            suite: {
+                settings: {
+                    enabledSecurityChecks: {
+                        firmwareRevision: false,
+                        firmwareHash: true,
+                        entropy: true,
+                    },
+                },
+            },
+        },
+        result: false,
+    },
+    {
+        description: 'returns true if entropy check failed',
+        state: {
+            router: { route: { app: 'dashboard' } },
+            messageSystem: messageSystemInitialState,
+            device: {
+                devicesWithFailedEntropyCheck: ['deviceId'],
+                selectedDevice: {
+                    features: {},
+                    id: 'deviceId',
+                    authenticityChecks: authenticityChecksSuccess,
+                },
+            },
+            suite: suiteAllSettingsEnabled,
+        },
+        result: true,
+    },
+    {
+        description: 'returns false if entropy check failed but is disabled',
+        state: {
+            router: { route: { app: 'dashboard' } },
+            messageSystem: messageSystemInitialState,
+            device: {
+                devicesWithFailedEntropyCheck: ['deviceId'],
+                selectedDevice: {
+                    features: {},
+                    id: 'deviceId',
+                    authenticityChecks: authenticityChecksSuccess,
+                },
+            },
+            suite: { settings: { enabledSecurityChecks: { entropy: false } } },
+        },
+        result: false,
+    },
+];
+
+describe(selectShouldDisplayDeviceCompromised.name, () => {
+    fixtures.forEach(f => {
+        it(f.description, () => {
+            expect(selectShouldDisplayDeviceCompromised(f.state as AppState)).toBe(f.result);
+        });
+    });
+});

--- a/packages/suite/src/components/suite/Preloader/selectShouldDisplayDeviceCompromised.ts
+++ b/packages/suite/src/components/suite/Preloader/selectShouldDisplayDeviceCompromised.ts
@@ -1,0 +1,34 @@
+import { selectIsFirmwareAuthenticityCheckDismissed } from '@suite-common/wallet-core';
+
+import {
+    selectIsEntropyCheckEnabledAndFailed,
+    selectIsFirmwareAuthenticityCheckEnabledAndHardFailed,
+} from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
+import type { AppState } from 'src/types/suite';
+
+import { RouterAppWithParams } from '../../../constants/suite/routes';
+
+const ROUTES_TO_SKIP_FIRMWARE_CHECK: RouterAppWithParams['app'][] = [
+    'settings',
+    'firmware',
+    'firmware-type',
+    'firmware-custom',
+];
+
+export const selectShouldDisplayDeviceCompromised = (state: AppState): boolean => {
+    const { router } = state;
+
+    const isFirmwareCheckEnabledAndFailed =
+        selectIsFirmwareAuthenticityCheckEnabledAndHardFailed(state);
+    const isFirmwareAuthenticityCheckDismissed = selectIsFirmwareAuthenticityCheckDismissed(state);
+
+    // Entropy check won't be performed if disabled but we must also check it here to avoid showing the UI when the failed state is stored in database.
+    const isEntropyCheckEnabledAndFailed = selectIsEntropyCheckEnabledAndFailed(state);
+
+    return (
+        (router.route?.app === undefined ||
+            !ROUTES_TO_SKIP_FIRMWARE_CHECK.includes(router.route?.app)) &&
+        ((!isFirmwareAuthenticityCheckDismissed && isFirmwareCheckEnabledAndFailed) ||
+            isEntropyCheckEnabledAndFailed)
+    );
+};

--- a/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
@@ -56,6 +56,41 @@ const deviceCompromisedFixtures: Array<{
         result: 'TR_DEVICE_COMPROMISED_FW_HASH_CHECK_TEXT',
     },
     {
+        description: 'Firmware hash check other-error (1st occurrence)',
+        device: {
+            selectedDevice: {
+                connected: true,
+                authenticityChecks: {
+                    firmwareHash: {
+                        error: 'other-error',
+                    },
+                },
+                features: {},
+            },
+        },
+        result: 'TR_FAILED_VERIFY_DEVICE_TEXT',
+    },
+    {
+        description: 'Firmware hash check other-error (2nd occurrence)',
+        device: {
+            selectedDevice: {
+                connected: true,
+                authenticityChecks: {
+                    firmwareHash: {
+                        error: 'other-error',
+                    },
+                },
+                features: {},
+            },
+            lastConnectedAuthenticityChecks: {
+                firmwareHash: {
+                    error: 'other-error',
+                },
+            },
+        },
+        result: 'TR_FAILED_VERIFY_DEVICE_AGAIN_TEXT',
+    },
+    {
         description: 'Failed firmware revision check',
         device: {
             selectedDevice: {

--- a/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
@@ -1,0 +1,83 @@
+import { DeviceReducerState } from '@suite-common/wallet-core';
+import { DeepPartial } from '@trezor/type-utils';
+
+import { TranslationKey } from 'src/components/suite/Translation';
+import { AppState } from 'src/reducers/store';
+import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
+import { configureStore } from 'src/support/tests/configureStore';
+import { renderWithProviders } from 'src/support/tests/hooksHelper';
+
+import { DeviceCompromised } from '../DeviceCompromised';
+
+jest.mock('@suite-common/tx-simulation', () => ({}));
+
+// render only Translation.id in data-test attribute
+jest.mock('src/components/suite/Translation', () => ({
+    Translation: ({ id }: any) => <span data-testid={id}>{id}</span>,
+}));
+
+const mockStore = configureStore<AppState, any>();
+
+const initStore = (state: AppState) => mockStore(state);
+
+const getInitialState = (device: DeepPartial<DeviceReducerState>): AppState =>
+    ({
+        ...initialAppState,
+        device,
+    }) as AppState;
+
+const deviceCompromisedFixtures: Array<{
+    description: string;
+    device: DeepPartial<DeviceReducerState>;
+    result: TranslationKey;
+}> = [
+    {
+        description: 'Failed entropy check',
+        device: {
+            devicesWithFailedEntropyCheck: ['deviceId'],
+            selectedDevice: {
+                id: 'deviceId',
+            },
+        },
+        result: 'TR_DEVICE_COMPROMISED_ENTROPY_CHECK_TEXT',
+    },
+    {
+        description: 'Failed firmware hash check',
+        device: {
+            selectedDevice: {
+                authenticityChecks: {
+                    firmwareHash: {
+                        error: 'hash-mismatch',
+                    },
+                },
+                features: {},
+            },
+        },
+        result: 'TR_DEVICE_COMPROMISED_FW_HASH_CHECK_TEXT',
+    },
+    {
+        description: 'Failed firmware revision check',
+        device: {
+            selectedDevice: {
+                authenticityChecks: {
+                    firmwareRevision: {
+                        error: 'revision-mismatch',
+                    },
+                },
+                features: {},
+            },
+        },
+        result: 'TR_DEVICE_COMPROMISED_FW_REVISION_CHECK_TEXT',
+    },
+];
+
+describe(`${DeviceCompromised.name} component`, () => {
+    deviceCompromisedFixtures.forEach(({ description, device, result }) => {
+        it(description, () => {
+            const store = initStore(getInitialState(device));
+            const { getByText, unmount } = renderWithProviders(store, <DeviceCompromised />);
+            expect(getByText(result)).not.toBeNull();
+            unmount();
+        });
+    });
+});

--- a/packages/suite/src/middlewares/suite/__tests__/buttonRequestMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/buttonRequestMiddleware.test.ts
@@ -1,5 +1,5 @@
 import { connectInitThunk } from '@suite-common/connect-init';
-import { initialState as messageSystemInitialState } from '@suite-common/message-system';
+import { messageSystemInitialState } from '@suite-common/message-system';
 import { testMocks } from '@suite-common/test-utils';
 import { deviceActions } from '@suite-common/wallet-core';
 import { UI, UI_EVENT } from '@trezor/connect';

--- a/packages/suite/src/reducers/suite/routerReducer.ts
+++ b/packages/suite/src/reducers/suite/routerReducer.ts
@@ -38,6 +38,8 @@ const initialState: RouterState = {
     },
 };
 
+export const routerInitialState = initialState;
+
 const routerReducer = (state: RouterState = initialState, action: Action): RouterState => {
     switch (action.type) {
         case ROUTER.LOCATION_CHANGE: {

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -10,6 +10,7 @@ import { isWeb } from '@trezor/env-utils';
 import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
 
 import { STORAGE, SUITE } from 'src/actions/suite/constants';
+import { LOCK_TYPE } from 'src/actions/suite/constants/suiteConstants';
 import { ExperimentalFeature } from 'src/constants/suite/experimental';
 import { SIDEBAR_WIDTH_NUMERIC } from 'src/constants/suite/layout';
 import { Action, TorBootstrap, TorStatus } from 'src/types/suite';
@@ -133,7 +134,11 @@ const initialState: SuiteState = {
     torStatus: TorStatus.Disabled,
     torBootstrap: null,
     lifecycle: { status: 'initial' },
-    locks: { device: 0, router: 0, ui: 0 },
+    locks: {
+        [LOCK_TYPE.UI]: 0,
+        [LOCK_TYPE.ROUTER]: 0,
+        [LOCK_TYPE.DEVICE]: 0,
+    },
     flags: {
         initialRun: true,
         // recoveryCompleted: false;
@@ -205,6 +210,8 @@ const initialState: SuiteState = {
     recentlyDisconnectedDevice: null,
     seenDisconnectNotificationForDeviceIds: [],
 };
+
+export const suiteInitialState = initialState;
 
 const changeLock = (
     draft: SuiteState,

--- a/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
+++ b/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
@@ -1,0 +1,120 @@
+import { FirmwareUpdateState } from '@suite-common/firmware';
+import { messageSystemInitialState } from '@suite-common/message-system';
+import { MetadataState } from '@suite-common/metadata-types';
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { deviceReducerInitialState } from '@suite-common/wallet-core';
+
+import { BackupState } from 'src/reducers/backup/backupReducer';
+import { OnboardingState } from 'src/reducers/onboarding/onboardingReducer';
+import { AppState } from 'src/reducers/store';
+import { desktopUpdateInitialState } from 'src/reducers/suite/desktopUpdateReducer';
+import { ProtocolState } from 'src/reducers/suite/protocolReducer';
+import { RouterState } from 'src/reducers/suite/routerReducer';
+import { suiteInitialState } from 'src/reducers/suite/suiteReducer';
+import WalletReducers from 'src/reducers/wallet';
+
+export const initialAppState: AppState = {
+    suite: suiteInitialState,
+    device: deviceReducerInitialState,
+    bluetooth: {
+        unpairedDeviceNeedsManualOsRemoval: false,
+        isBluetoothListOpen: false,
+        connectingDeviceIds: [],
+        isUnpairingDevice: false,
+        adapterStatus: 'unknown',
+        scanStatus: 'error',
+        nearbyDevices: null,
+        knownDevices: [],
+    },
+    thp: {
+        step: null,
+        lastThpCode: undefined,
+        credentials: [],
+    },
+    window: {
+        isVisible: true,
+        isBelowMobile: false,
+        isBelowTablet: false,
+        isBelowLaptop: false,
+        isBelowDesktop: false,
+        isAboveMobile: false,
+        isAboveTablet: false,
+        isAboveLaptop: false,
+        isAboveDesktop: false,
+    },
+    guide: {
+        open: false,
+        view: 'GUIDE_DEFAULT',
+        indexNode: null,
+        currentNode: null,
+    },
+    messageSystem: messageSystemInitialState,
+    modal: {
+        context: '@modal/context-none',
+    },
+    notifications: [],
+    wallet: {
+        discovery: {},
+        accountSearch: {},
+        settings: {
+            enabledNetworks: [] as NetworkSymbol[],
+        },
+        blockchain: {},
+    } as ReturnType<typeof WalletReducers>, // Todo: maybe one day, fix types
+    desktopUpdate: desktopUpdateInitialState,
+    router: {
+        loaded: true,
+        url: '/suite-web/develop/web/',
+        pathname: '/suite-web/develop/web/',
+        app: 'dashboard',
+        route: {
+            name: 'suite-index',
+            pattern: '/',
+            app: 'dashboard',
+        },
+        settingsBackRoute: {
+            name: 'suite-index',
+        },
+    } as RouterState, // TODO: this is state copied from actual app runtime, so how can there be type error???
+    recovery: {
+        advancedRecovery: false,
+        wordsCount: 12,
+        status: 'initial',
+    },
+    analytics: { confirmed: true },
+    onboarding: {} as OnboardingState, // Todo: maybe one day, fix types
+    firmware: {} as FirmwareUpdateState, // Todo: maybe one day, fix types
+    backup: {} as BackupState, // Todo: maybe one day, fix types
+    desktop: null,
+    tokenDefinitions: {},
+    geolocation: {
+        countryCode: null,
+    },
+    logs: {
+        logEntries: [],
+    },
+    metadata: {} as MetadataState, // Todo: maybe one day, fix types
+    protocol: {} as ProtocolState, // Todo: maybe one day, fix types
+    connectPopup: {
+        activeCall: undefined,
+        permissions: [],
+    },
+    walletConnect: {
+        sessions: [],
+        pendingProposal: undefined,
+    },
+    bioAuth: {
+        initialNow: 0,
+        bioAuthEnabled: false,
+        blurTimeoutId: null,
+        bioAuthEnabledNextValue: null,
+        lastBioAuthValidatedTimestamp: null,
+        lastWindowBlurTimestamp: null,
+        bioAuthValidationInProgress: false,
+        bioAuthValidationRequested: false,
+        bioAuthValidationRequired: false,
+        windowBlurred: false,
+        bioAuthAvailable: null,
+        hasEverValidatedBioAuth: false,
+    },
+};

--- a/suite-common/connect-init/src/__tests__/connectInitThunks.test.ts
+++ b/suite-common/connect-init/src/__tests__/connectInitThunks.test.ts
@@ -1,4 +1,4 @@
-import { initialState as messageSystemInitialState } from '@suite-common/message-system';
+import { messageSystemInitialState } from '@suite-common/message-system';
 import { configureMockStore, extraDependenciesMock, testMocks } from '@suite-common/test-utils';
 import { BLOCKCHAIN_EVENT, DEVICE_EVENT, TRANSPORT_EVENT, UI_EVENT } from '@trezor/connect';
 

--- a/suite-common/message-system/src/messageSystemReducer.ts
+++ b/suite-common/message-system/src/messageSystemReducer.ts
@@ -5,7 +5,7 @@ import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { messageSystemActions } from './messageSystemActions';
 import { MessageState, MessageSystemState } from './messageSystemTypes';
 
-export const initialState: MessageSystemState = {
+const initialState: MessageSystemState = {
     config: null,
     currentSequence: 0,
     timestamp: 0,
@@ -20,6 +20,8 @@ export const initialState: MessageSystemState = {
 
     validExperiments: [],
 };
+
+export const messageSystemInitialState = initialState;
 
 export const messageSystemPersistedWhitelist: Array<keyof MessageSystemState> = [
     'config',

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -33,6 +33,8 @@ const initialState: DeviceReducerState = {
     isDeviceAutoEjectEnabled: false,
 };
 
+export const deviceReducerInitialState = initialState;
+
 export type DeviceRootState = {
     device: DeviceReducerState;
 };


### PR DESCRIPTION
Cover FW hash check other-error in Preloader component unit tests (see 1e618d74c61f0d2a441cf7980dbfc93d350052f7).

But as @peter-sanderson pointed out, the Preloader test was poorly designed, its scope was too large.
→ extracted a selector from it so it is testable on its own e849d2770c2a9162f5954de7401c4f752b9fec60
→ extracted DeviceCompromised test 4d595679474d38524aa9532a910e498e1562f121

Plus refactoring of `AppState` fixture – Preloader test was the only place so far, where AppState was mocked **fully**.
So in ad38b9677bd65c510f18a0d5375720c13d396bbf and ce975eeb8fc6005cdf9ed72acbf35629bf1690a0 and ffea6a64b72fadb14832042155a223dc0c2b76d7, move it to test suite utils to make it reusable, and use some `initialState` exported from reducers, instead of writing it explicitely in the test fixture. I believe that referencing `initialState` in test fixtures is a good. 

---

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=more-preloader-tests&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=more-preloader-tests&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=more-preloader-tests&lookback=7)