### PR TITLE
feat(suite): connect address export confirmation step

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/getAddress.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/getAddress.test.ts
@@ -37,6 +37,7 @@ test.describe('TrezorConnect.getAddress', { tag: ['@group=connect', '@desktopOnl
             await expect(connectPermissionsModal.loadingHeader).toHaveText(
                 'Export Bitcoin address',
             );
+            await page.getByTestId('@connect-address-confirmation/confirm-button').click();
             await page.getByTestId('@connect-address-confirmation/verify-button/0').click();
             await expect(
                 page.getByTestId('@connect-address-confirmation/verify-button/0'),
@@ -74,6 +75,7 @@ test.describe('TrezorConnect.getAddress', { tag: ['@group=connect', '@desktopOnl
             await expect(connectPermissionsModal.loadingHeader).toHaveText(
                 'Export multiple Bitcoin addresses',
             );
+            await page.getByTestId('@connect-address-confirmation/confirm-button').click();
 
             // click on the second (last) address
             await page.getByTestId('@connect-address-confirmation/verify-button/1').click();
@@ -99,6 +101,8 @@ test.describe('TrezorConnect.getAddress', { tag: ['@group=connect', '@desktopOnl
             });
 
             await connectPermissionsModal.confirmButton.click();
+            await page.getByTestId('@connect-address-confirmation/confirm-button').click();
+
             await expect(
                 page.getByTestId('@connect-address-confirmation/verify-button/0'),
             ).toBeDisabled();

--- a/packages/suite-desktop-core/e2e/tests/trezor-connect/permissions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trezor-connect/permissions.test.ts
@@ -44,6 +44,7 @@ test.describe('TrezorConnect', { tag: ['@group=connect', '@desktopOnly'] }, () =
             );
             await connectPermissionsModal.rememberCheckbox.click();
             await connectPermissionsModal.confirmButton.click();
+            await page.getByTestId('@connect-address-confirmation/confirm-button').click();
             await page.getByTestId('@connect-address-confirmation/close-button').click();
 
             // permission is already saved, user won't be prompted again for this app
@@ -51,6 +52,7 @@ test.describe('TrezorConnect', { tag: ['@group=connect', '@desktopOnly'] }, () =
                 path: "m/44'/0'/0'/0/0",
                 coin: 'btc',
             });
+            await page.getByTestId('@connect-address-confirmation/confirm-button').click();
             await page.getByTestId('@connect-address-confirmation/close-button').click();
             await page.getByTestId(`@settings/connect-apps/0`).waitFor({ state: 'visible' });
             await page.getByTestId(`@settings/connect-apps/0/dropdown`).click();

--- a/packages/suite/src/components/suite/ConnectCallSource.tsx
+++ b/packages/suite/src/components/suite/ConnectCallSource.tsx
@@ -13,6 +13,7 @@ export const ConnectCallSource = () => {
     if (
         connectPopupCall?.state !== 'ongoing' &&
         connectPopupCall?.state !== 'call-error' &&
+        connectPopupCall?.state !== 'address-confirmation' &&
         connectPopupCall?.state !== 'tx-simulation'
     )
         return null;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectAddressConfirmation.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectAddressConfirmation.tsx
@@ -3,25 +3,37 @@ import { useEffect } from 'react';
 import {
     connectPopupActions,
     connectPopupVerifyAddressThunk,
+    getPermissionDeferred,
     selectConnectPopupCall,
 } from '@suite-common/connect-popup';
+import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
 import { Badge, Button, Card, Column, H3, Icon, Modal, Paragraph, Row } from '@trezor/components';
+import { TypedError } from '@trezor/connect/src/constants/errors';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { ConfirmOnDevice, mapTrezorModelToIcon } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
+import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
 import { ConnectModalBackdrop } from 'src/components/suite/ConnectModalBackdrop';
 import { Translation } from 'src/components/suite/Translation';
+import { WalletLabeling } from 'src/components/suite/labeling';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 
 export const ConnectAddressConfirmation = () => {
     const { device } = useDevice();
+    const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
     const dispatch = useDispatch();
     const popupCall = useSelector(selectConnectPopupCall);
     const onVerify = (index: number) => {
         dispatch(connectPopupVerifyAddressThunk({ index }));
     };
+    const onConfirm = () => {
+        getPermissionDeferred()?.resolve();
+    };
     const onFinish = () => {
+        if (popupCall?.state === 'address-confirmation' && !popupCall?.exported) {
+            getPermissionDeferred()?.reject(TypedError('Method_Cancel'));
+        }
         dispatch(connectPopupActions.finishCall());
     };
     const isLoading =
@@ -30,7 +42,8 @@ export const ConnectAddressConfirmation = () => {
 
     useEffect(() => {
         // Automatically verify addresses that have showOnDevice enabled and are not already verified
-        if (!popupCall || popupCall?.state !== 'address-confirmation') return;
+        if (!popupCall || popupCall?.state !== 'address-confirmation' || !popupCall.exported)
+            return;
         const addressToVerify = popupCall?.addresses.findIndex(
             address =>
                 address.validatePayload.showOnTrezor &&
@@ -49,7 +62,7 @@ export const ConnectAddressConfirmation = () => {
     if (!popupCall || popupCall?.state !== 'address-confirmation') return null;
 
     return (
-        <ConnectModalBackdrop onClick={onFinish}>
+        <ConnectModalBackdrop onClick={onFinish} canSwitchDevice={!popupCall.exported}>
             <ConfirmOnDevice
                 title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
                 deviceModelInternal={device?.features?.internal_model}
@@ -60,6 +73,16 @@ export const ConnectAddressConfirmation = () => {
                 variant="primary"
                 bottomContent={
                     <>
+                        {!popupCall.exported && (
+                            <Modal.Button
+                                variant="primary"
+                                onClick={onConfirm}
+                                size="medium"
+                                data-testid="@connect-address-confirmation/confirm-button"
+                            >
+                                <Translation id="TR_CONFIRM" />
+                            </Modal.Button>
+                        )}
                         <Modal.Button
                             variant="tertiary"
                             onClick={onFinish}
@@ -67,24 +90,45 @@ export const ConnectAddressConfirmation = () => {
                             data-testid="@connect-address-confirmation/close-button"
                             isDisabled={isLoading}
                         >
-                            <Translation id="TR_CLOSE" />
+                            <Translation id={popupCall.exported ? 'TR_CLOSE' : 'TR_CANCEL'} />
                         </Modal.Button>
                     </>
                 }
             >
                 <Column gap={spacings.xs}>
-                    <Row alignItems="center" gap={spacings.sm}>
-                        <Icon name="checkCircle" size={32} variant="primary" />
-                        <H3 variant="primary">
-                            <Translation id="TR_CONNECT_ADDRESS_CONFIRMATION_SUCCESS" />
+                    {popupCall.exported ? (
+                        <Row alignItems="center" gap={spacings.sm}>
+                            <Icon name="checkCircle" size={32} variant="primary" />
+                            <H3 variant="primary">
+                                <Translation id="TR_CONNECT_ADDRESS_CONFIRMATION_SUCCESS" />
+                            </H3>
+                        </Row>
+                    ) : (
+                        <H3>
+                            <Translation id="TR_CONNECT_EXPORT_ACCOUNTS" />
                         </H3>
-                    </Row>
+                    )}
+                    <ConnectCallSource />
                     <Paragraph>
                         <Translation
-                            id="TR_CONNECT_ADDRESS_CONFIRMATION_DESCRIPTION"
+                            id={
+                                popupCall.exported
+                                    ? 'TR_CONNECT_ADDRESS_CONFIRMATION_DESCRIPTION'
+                                    : 'TR_CONNECT_EXPORT_ACCOUNTS_DESCRIPTION'
+                            }
                             values={{
-                                thirdParty:
-                                    popupCall.source.manifest?.appName ?? popupCall.source.origin,
+                                thirdParty: (
+                                    <b>
+                                        {popupCall.source.manifest?.appName ??
+                                            popupCall.source.origin}
+                                    </b>
+                                ),
+                                passphraseWalletLabel: device && (
+                                    <b>
+                                        <WalletLabeling device={device} />
+                                    </b>
+                                ),
+                                deviceLabel: <b>{deviceLabel}</b>,
                             }}
                         />
                     </Paragraph>

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -10522,4 +10522,13 @@ export default defineMessages({
         id: 'TR_CONNECT_POPUP_SUCCESS',
         defaultMessage: 'Success! {appName} request completed',
     },
+    TR_CONNECT_EXPORT_ACCOUNTS: {
+        id: 'TR_CONNECT_EXPORT_ACCOUNTS',
+        defaultMessage: 'Export accounts',
+    },
+    TR_CONNECT_EXPORT_ACCOUNTS_DESCRIPTION: {
+        id: 'TR_CONNECT_EXPORT_ACCOUNTS_DESCRIPTION',
+        defaultMessage:
+            'The following addresses from {passphraseWalletLabel} on {deviceLabel} will be shared with {thirdParty}. Your private keys stay secure and are never exposed.',
+    },
 } as const);

--- a/suite-common/connect-popup/src/connectPopupActions.ts
+++ b/suite-common/connect-popup/src/connectPopupActions.ts
@@ -32,7 +32,12 @@ const finishCall = createAction(`${ACTION_PREFIX}/finishCall`);
 
 const confirmAddresses = createAction(
     `${ACTION_PREFIX}/confirmAddresses`,
-    (payload: Pick<ConnectPopupCall & { state: 'address-confirmation' }, 'addresses'>) => ({
+    (
+        payload: Pick<
+            ConnectPopupCall & { state: 'address-confirmation' },
+            'addresses' | 'exported'
+        >,
+    ) => ({
         payload,
     }),
 );

--- a/suite-common/connect-popup/src/connectPopupReducer.ts
+++ b/suite-common/connect-popup/src/connectPopupReducer.ts
@@ -87,6 +87,7 @@ export const prepareConnectPopupReducer = createReducerWithExtraDeps(
                         ...state.activeCall,
                         state: 'address-confirmation',
                         addresses: payload.addresses,
+                        exported: payload.exported,
                     };
                 }
             })

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -272,6 +272,7 @@ export const connectPopupVerifyAddressThunk = createThunk<void, { index: number 
         // Update loading state of addresses
         dispatch(
             connectPopupActions.confirmAddresses({
+                exported: call.exported,
                 addresses: call.addresses?.map((address, i) => ({
                     ...address,
                     loading: i === index,
@@ -295,6 +296,7 @@ export const connectPopupVerifyAddressThunk = createThunk<void, { index: number 
             const validatedStatus = res.success ? 'valid' : 'failed';
             dispatch(
                 connectPopupActions.confirmAddresses({
+                    exported: call.exported,
                     addresses: call.addresses.map((address, i) => ({
                         ...address,
                         loading: false,
@@ -306,6 +308,7 @@ export const connectPopupVerifyAddressThunk = createThunk<void, { index: number 
             console.error('connectPopupVerifyAddressThunk', error);
             dispatch(
                 connectPopupActions.confirmAddresses({
+                    exported: call.exported,
                     addresses: call.addresses.map((address, i) => ({
                         ...address,
                         loading: false,

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -79,6 +79,7 @@ export type ConnectPopupCallLoaded = {
       }
     | {
           state: 'address-confirmation';
+          exported: boolean;
           addresses: {
               address: string;
               loading: boolean;

--- a/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
+++ b/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
@@ -2,6 +2,7 @@ import TrezorConnect, { Address, SolanaPublicKey } from '@trezor/connect';
 import { HDNodeResponse } from '@trezor/connect/src/types/api/getPublicKey';
 
 import { connectPopupActions } from '../connectPopupActions';
+import { getPermissionDeferred } from '../connectPopupPromiseManager';
 
 import { PostCallHookParams, PreCallHookParams } from './index';
 
@@ -49,7 +50,7 @@ const preCallHook = <M extends keyof typeof TrezorConnect>({
     return payload;
 };
 
-export function postCallHook<M extends keyof typeof TrezorConnect>({
+export async function postCallHook<M extends keyof typeof TrezorConnect>({
     method,
     originalPayload,
     response,
@@ -88,6 +89,14 @@ export function postCallHook<M extends keyof typeof TrezorConnect>({
         dispatch(
             connectPopupActions.confirmAddresses({
                 addresses,
+                exported: false,
+            }),
+        );
+        await getPermissionDeferred(true).promise;
+        dispatch(
+            connectPopupActions.confirmAddresses({
+                addresses,
+                exported: true,
             }),
         );
 

--- a/suite-native/app/e2e/tests/deeplinkPopup.test.ts
+++ b/suite-native/app/e2e/tests/deeplinkPopup.test.ts
@@ -114,10 +114,13 @@ conditionalDescribe(device.getPlatform() === 'android', 'Deeplink connect popup.
 
         await element(by.id('@popup/deeplink-info'));
 
-        await waitFor(element(by.id('@popup/call-device')))
-            .toBeVisible()
-            .withTimeout(30000);
-        await element(by.id('@popup/call-device')).tap();
+        const permissionButton = element(by.id('@popup/call-device'));
+        await waitFor(permissionButton).toBeVisible().withTimeout(30000);
+        await permissionButton.tap();
+
+        const confirmButton = element(by.id('@popup/confirm-addresses'));
+        await waitFor(confirmButton).toBeVisible().withTimeout(10000);
+        await confirmButton.tap();
 
         await TrezorUserEnvLink.pressYes();
 

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -480,6 +480,11 @@ export const en = {
             title: 'Confirm address',
             message: 'Please compare the address on your Trezor with the third-party app.',
         },
+        exportAccounts: {
+            title: 'Export accounts',
+            message:
+                'The following addresses from {passphraseWalletLabel} on {deviceLabel} will be shared with {thirdParty}. Your private keys stay secure and are never exposed.',
+        },
         connectionStatus: {
             loading: 'Loading...',
             discoveryRunning: 'Discovery running, please wait...',

--- a/suite-native/module-connect-popup/src/components/AddressConfirmation.tsx
+++ b/suite-native/module-connect-popup/src/components/AddressConfirmation.tsx
@@ -3,17 +3,32 @@ import { useDispatch, useSelector } from 'react-redux';
 import {
     connectPopupActions,
     connectPopupVerifyAddressThunk,
+    getPermissionDeferred,
     selectConnectPopupCall,
 } from '@suite-common/connect-popup';
+import { selectSelectedDevice, selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
 import { Button, Card, HStack, IconButton, Text, TitleHeader, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
 export const AddressConfirmation = () => {
     const dispatch = useDispatch();
     const popupCall = useSelector(selectConnectPopupCall);
+    const device = useSelector(selectSelectedDevice);
+    const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
+    const passphraseWalletLabel = device?.useEmptyPassphrase ? (
+        <Translation id="deviceManager.wallet.standard" />
+    ) : (
+        <Translation
+            id="deviceManager.wallet.defaultPassphrase"
+            values={{ index: device?.walletNumber }}
+        />
+    );
 
     const onFinish = () => {
         dispatch(connectPopupActions.finishCall());
+    };
+    const onConfirm = () => {
+        getPermissionDeferred()?.resolve();
     };
     const onVerify = (index: number) => {
         dispatch(connectPopupVerifyAddressThunk({ index }));
@@ -23,10 +38,28 @@ export const AddressConfirmation = () => {
 
     return (
         <VStack testID="@popup/address-confirmation" spacing="sp16" flex={1}>
-            <TitleHeader
-                title={<Translation id="moduleConnectPopup.confirmAddress.title" />}
-                subtitle={<Translation id="moduleConnectPopup.confirmAddress.message" />}
-            />
+            {popupCall.exported ? (
+                <TitleHeader
+                    title={<Translation id="moduleConnectPopup.confirmAddress.title" />}
+                    subtitle={<Translation id="moduleConnectPopup.confirmAddress.message" />}
+                />
+            ) : (
+                <TitleHeader
+                    title={<Translation id="moduleConnectPopup.exportAccounts.title" />}
+                    subtitle={
+                        <Translation
+                            id="moduleConnectPopup.exportAccounts.message"
+                            values={{
+                                passphraseWalletLabel: (
+                                    <Text variant="body">{passphraseWalletLabel}</Text>
+                                ),
+                                deviceLabel: <Text variant="body">{deviceLabel}</Text>,
+                                thirdParty: <Text variant="body">{popupCall.source.origin}</Text>,
+                            }}
+                        />
+                    }
+                />
+            )}
             <Card>
                 <VStack>
                     {popupCall.addresses.map((item, index) => (
@@ -52,7 +85,10 @@ export const AddressConfirmation = () => {
                 </VStack>
             </Card>
 
-            <Button testID="@popup/confirm-addresses" onPress={onFinish}>
+            <Button
+                testID="@popup/confirm-addresses"
+                onPress={popupCall.exported ? onFinish : onConfirm}
+            >
                 <Translation id="moduleConnectPopup.confirm" />
             </Button>
         </VStack>


### PR DESCRIPTION
## Description

We added a new step in the getAddress/getPublicKey flow that allows you to review the addresses you will be exporting to the 3rd party and optionally switch the device/passphrase wallet during that. Depends on #20225

## Screenshots:

<img width="1190" height="828" alt="Screenshot 2025-07-22 at 09 49 51" src="https://github.com/user-attachments/assets/5a36bfac-af93-4b44-b45e-c03ea11e1c56" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-export-confirmation&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-export-confirmation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connect-export-confirmation&lookback=7)