### PR TITLE
WalletConnect changes

### DIFF
--- a/packages/connect/src/types/api/solana/index.ts
+++ b/packages/connect/src/types/api/solana/index.ts
@@ -27,6 +27,7 @@ export const SolanaTxTokenAccountInfo = Type.Object({
 export type SolanaTxAdditionalInfo = Static<typeof SolanaTxAdditionalInfo>;
 export const SolanaTxAdditionalInfo = Type.Object({
     tokenAccountsInfos: Type.Optional(Type.Array(SolanaTxTokenAccountInfo, { minItems: 1 })),
+    isDevnet: Type.Optional(Type.Boolean()),
 });
 
 export type SolanaSignTransaction = Static<typeof SolanaSignTransaction>;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
@@ -162,7 +162,7 @@ const TxSimulationAsset = ({
     );
 };
 
-const TxSimulationBanner = ({
+export const TxSimulationBanner = ({
     title,
     description,
     type = 'error',

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
@@ -36,6 +36,8 @@ import { ConnectAppIcon } from 'src/components/suite/ConnectAppIcon';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
 
+import { TxSimulationBanner } from './TxSimulationModal';
+
 const NetworkItemWrapper = styled.div<{ $isDisabled: boolean }>`
     display: flex;
     flex-direction: row;
@@ -65,6 +67,7 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
     const [selectedDefaultAccount, setSelectedDefaultAccount] = useState<Account | null>(
         selectableAccounts[0] || null,
     );
+    const [ignoreWarning, setIgnoreWarning] = useState(false);
     const { isLoading, isMalicious } = useDappScan(pendingProposal?.params.proposer.metadata.url);
 
     const handleAccept = () => {
@@ -117,9 +120,8 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                         onClick={handleAccept}
                         isDisabled={
                             pendingProposal.expired ||
-                            pendingProposal.isScam ||
                             noNetworksActivated ||
-                            isMalicious
+                            ((pendingProposal.isScam || isMalicious) && !ignoreWarning)
                         }
                         isLoading={isLoading}
                     >
@@ -272,9 +274,13 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                 )}
 
                 {(isMalicious || pendingProposal.isScam) && (
-                    <Banner variant="destructive">
-                        <Translation id="TR_WALLETCONNECT_IS_SCAM" />
-                    </Banner>
+                    <TxSimulationBanner
+                        type="error"
+                        title={<Translation id="TR_WALLETCONNECT_IS_SCAM" />}
+                        description={<></>}
+                        disclaimerAccepted={ignoreWarning}
+                        setDisclaimerAccepted={setIgnoreWarning}
+                    />
                 )}
                 {pendingProposal.validation === 'INVALID' && (
                     <Banner variant="destructive">

--- a/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
@@ -27,7 +27,7 @@ const preCallHook = async <M extends keyof typeof TrezorConnect>({
         if (method === 'solanaSignTransaction' && txSigningPrecomposed) {
             const typedPayload = payload as any as SolanaSignTransaction;
             const path = getSerializedPath(validatePath(typedPayload.path)) as Bip43Path;
-            const network = getNetwork('sol'); // solanaSignTransaction has no parameter for testnet
+            const network = getNetwork(typedPayload.additionalInfo?.isDevnet ? 'dsol' : 'sol');
             // Try to find matching account
             let selectedAccount = selectAccountForNetworkSymbolAndPath(
                 getState(),

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -38,6 +38,7 @@ export const networks = {
         },
         coingeckoId: 'bitcoin',
         tradeCryptoId: 'bitcoin',
+        caipId: 'bip122:000000000019d6689c085ae165831e93',
     },
     eth: {
         symbol: 'eth',
@@ -76,6 +77,7 @@ export const networks = {
         },
         coingeckoId: 'ethereum',
         tradeCryptoId: 'ethereum',
+        caipId: 'eip155:1',
     },
     pol: {
         symbol: 'pol',
@@ -108,6 +110,7 @@ export const networks = {
         },
         coingeckoId: 'polygon-pos',
         tradeCryptoId: 'polygon-ecosystem-token',
+        caipId: 'eip155:137',
     },
     bsc: {
         symbol: 'bsc',
@@ -132,6 +135,7 @@ export const networks = {
         },
         coingeckoId: 'binance-smart-chain',
         tradeCryptoId: 'binancecoin',
+        caipId: 'eip155:56',
     },
     arb: {
         symbol: 'arb',
@@ -165,6 +169,7 @@ export const networks = {
         },
         coingeckoId: 'arbitrum-one',
         tradeCryptoId: 'arbitrum-one--0x0000000000000000000000000000000000000000',
+        caipId: 'eip155:42161',
     },
     base: {
         symbol: 'base',
@@ -198,6 +203,7 @@ export const networks = {
         },
         coingeckoId: 'base',
         tradeCryptoId: 'base--0x0000000000000000000000000000000000000000',
+        caipId: 'eip155:8453',
     },
     op: {
         symbol: 'op',
@@ -231,6 +237,7 @@ export const networks = {
         },
         coingeckoId: 'optimistic-ethereum',
         tradeCryptoId: 'optimistic-ethereum--0x0000000000000000000000000000000000000000',
+        caipId: 'eip155:10',
     },
     sol: {
         symbol: 'sol',
@@ -260,6 +267,7 @@ export const networks = {
         },
         coingeckoId: 'solana',
         tradeCryptoId: 'solana',
+        caipId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
     },
     ada: {
         // icarus derivation
@@ -366,6 +374,7 @@ export const networks = {
         },
         coingeckoId: 'litecoin',
         tradeCryptoId: 'litecoin',
+        caipId: 'bip122:12a765e31ffd4059bada1e25190f6e98',
     },
     bch: {
         symbol: 'bch',
@@ -396,6 +405,7 @@ export const networks = {
         accountTypes: {},
         coingeckoId: 'dogecoin',
         tradeCryptoId: 'dogecoin',
+        caipId: 'bip122:1a91e3dace36e2be3bf030a65679fe82',
     },
     zec: {
         symbol: 'zec',
@@ -447,6 +457,7 @@ export const networks = {
         },
         coingeckoId: undefined,
         tradeCryptoId: 'test-bitcoin', // fake, coingecko does not have testnets
+        caipId: 'bip122:00000000da84f2bafbbc53dee25a72ae',
     },
     regtest: {
         symbol: 'regtest',
@@ -537,6 +548,7 @@ export const networks = {
         accountTypes: {},
         coingeckoId: undefined,
         tradeCryptoId: undefined,
+        caipId: 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
     },
     tada: {
         // icarus derivation

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -122,6 +122,7 @@ type NetworkWithSpecificKey<TKey extends NetworkSymbol> = {
     isDebugOnlyNetwork?: boolean;
     coingeckoId?: string;
     tradeCryptoId?: string;
+    caipId?: string; // CAIP-2 chain id, used by WalletConnect
 };
 export type Network = NetworkWithSpecificKey<NetworkSymbol>;
 

--- a/suite-common/walletconnect/src/adapters/solana.ts
+++ b/suite-common/walletconnect/src/adapters/solana.ts
@@ -33,10 +33,11 @@ const solanaSignTransaction = createThunk<
         transaction: string;
         feePayer?: string;
         origin: string;
+        isDevnet: boolean;
     }
 >(
-    `${WALLETCONNECT_MODULE}/solanaRequest`,
-    async ({ session, transaction, feePayer, origin }, { dispatch, getState }) => {
+    `${WALLETCONNECT_MODULE}/solanaSignTransaction`,
+    async ({ session, transaction, feePayer, origin, isDevnet }, { dispatch, getState }) => {
         // Convert from base64 to hex
         const transactionBuffer = Buffer.from(transaction, 'base64');
         const serializedTx = transactionBuffer.toString('hex');
@@ -44,7 +45,7 @@ const solanaSignTransaction = createThunk<
         const device = selectSelectedDevice(getState());
         const accounts = selectAccounts(getState());
         const estimatedFee = await TrezorConnect.blockchainEstimateFee({
-            coin: 'sol',
+            coin: isDevnet ? 'dsol' : 'sol',
             request: {
                 specific: {
                     data: serializedTx,
@@ -52,7 +53,7 @@ const solanaSignTransaction = createThunk<
             },
         });
         if (!estimatedFee.success) {
-            throw new Error('Failed to estimate fee');
+            throw new Error('Failed to estimate fee. ' + estimatedFee.payload.error);
         }
         // Get from argument or use decoded from estimate fee
         feePayer = feePayer || estimatedFee.payload.levels[0].feePayer;
@@ -72,6 +73,9 @@ const solanaSignTransaction = createThunk<
                     useEmptyPassphrase: device?.useEmptyPassphrase,
                     serializedTx,
                     serialize: true,
+                    additionalInfo: {
+                        isDevnet,
+                    },
                 },
                 source: {
                     type: 'walletconnect' as const,
@@ -87,7 +91,7 @@ const solanaSignTransaction = createThunk<
         const typedPayload = response.payload as CallMethodResponse<'solanaSignTransaction'>;
         if (!response.success || !typedPayload.serializedTx) {
             console.error('solana_signTransaction error', response);
-            throw new Error('solana_signTransaction error');
+            throw new Error('Solana signing error');
         }
 
         return {
@@ -107,6 +111,7 @@ const solanaRequestThunk = createThunk<
     if (!session) {
         throw new Error('Session not found');
     }
+    const isDevnet = session.lastAccount?.symbol === 'dsol';
 
     switch (event.params.request.method) {
         case 'solana_getAccounts':
@@ -122,7 +127,7 @@ const solanaRequestThunk = createThunk<
             const { origin } = event.verifyContext.verified;
 
             const response = await dispatch(
-                solanaSignTransaction({ session, transaction, feePayer, origin }),
+                solanaSignTransaction({ session, transaction, feePayer, origin, isDevnet }),
             ).unwrap();
 
             const signature = bs58.encode(Buffer.from(response.signature, 'hex'));
@@ -134,17 +139,16 @@ const solanaRequestThunk = createThunk<
             const { origin } = event.verifyContext.verified;
 
             const signResponse = await dispatch(
-                solanaSignTransaction({ session, transaction, origin }),
+                solanaSignTransaction({ session, transaction, origin, isDevnet }),
             ).unwrap();
 
             const pushResponse = await TrezorConnect.pushTransaction({
-                // NOTE: I don't see any parameter that would determine devnet/mainnet
-                coin: 'sol',
+                coin: isDevnet ? 'dsol' : 'sol',
                 tx: signResponse.transaction,
             });
             if (!pushResponse.success) {
                 console.error('eth_sendTransaction push error', pushResponse);
-                throw new Error('eth_sendTransaction push error');
+                throw new Error('Solana transaction push error');
             }
 
             return { signature: pushResponse.payload.txid };
@@ -152,7 +156,7 @@ const solanaRequestThunk = createThunk<
         case 'solana_signMessage': {
             // Signing arbitrary messages for Solana is not supported in FW
             // We indicate support for it in the adapter for compatibility, since some apps request it but don't actually use it
-            throw new Error('solana_signMessage not supported');
+            throw new Error('Solana message signing is not supported');
         }
     }
 });

--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -141,7 +141,7 @@ export const sessionRequestThunk = createThunk<
 
         const result = await dispatch(adapter.requestThunk({ event }));
         if (!result || result.error) {
-            throw new Error('Device request failed');
+            throw result?.error || new Error('Device request failed');
         }
 
         await walletKit.respondSessionRequest({

--- a/suite-common/walletconnect/src/walletConnectUtils.tsx
+++ b/suite-common/walletconnect/src/walletConnectUtils.tsx
@@ -4,32 +4,21 @@ import { PendingConnectionProposalNetwork, WalletConnectSession } from './wallet
 
 export const getSessionNetworks = (session: WalletConnectSession) => {
     const networks: PendingConnectionProposalNetwork[] = [];
-    // EVMs
-    session.namespaces.eip155?.chains?.forEach(chain => {
-        const supported = networksCollection.find(nc => chain === `eip155:${nc.chainId}`);
-        if (supported) {
-            networks.push({
-                namespaceId: 'eip155',
-                symbol: supported?.symbol,
-                name: supported?.name ?? `Unknown (${chain})`,
-                status: 'active',
-                required: false,
-            });
-        }
-    });
-    // Solana
-    if (session.namespaces.solana?.chains?.length) {
-        const supported = networksCollection.find(nc => nc.symbol === 'sol');
-        if (supported) {
-            networks.push({
-                namespaceId: 'solana',
-                symbol: supported.symbol,
-                name: supported.name,
-                status: 'active',
-                required: false,
-            });
-        }
-    }
+
+    Object.entries(session.namespaces).forEach(([namespaceId, namespace]) =>
+        namespace?.chains?.forEach(chain => {
+            const supported = networksCollection.find(nc => chain === nc.caipId);
+            if (supported) {
+                networks.push({
+                    namespaceId,
+                    symbol: supported?.symbol,
+                    name: supported?.name ?? `Unknown (${chain})`,
+                    status: 'active',
+                    required: false,
+                });
+            }
+        }),
+    );
 
     return networks;
 };


### PR DESCRIPTION
## Description

Couple of WalletConnect changes based on discussion with Reown. 

### feat(suite): add CAIP-2 id to networks config

Makes things cleaner to have these IDs in networksConfig rather than spread out between different WalletConnect adapters.

### feat(connect): solanaSignTransaction - indicate if using devnet

Add `isDevnet` parameter to `additionalInfo` in `solanaSignTransaction` . 
It has no effect on signing, but is indicated to the user in Suite modals.

### feat(suite): walletconnect solana devnet support

Properly support Solana devnet. Previously we only connected to mainnet, because the RPC calls lacked parameters to determine if it's devnet or not. 
Now we differentiate it based on the currently selected account for that WalletConnect sessions in Suite. 

### feat(suite): walletconnect checkbox to bypass scam warning

If users really want to connect to an app we consider a scam, they should be able to. It's just necessary to check the disclaimer "I understand the risks—proceed anyway"

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/walletconnect-changes&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/walletconnect-changes&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/walletconnect-changes&lookback=7)