### PR TITLE
test(suite): add support for __info: true param in connect mock

### DIFF
--- a/suite-common/connect-init/src/__tests__/connectInitThunks.test.ts
+++ b/suite-common/connect-init/src/__tests__/connectInitThunks.test.ts
@@ -143,4 +143,31 @@ describe('TrezorConnect Actions', () => {
             payload: true,
         });
     });
+
+    it('Test that connect mock works with __info parameter', async () => {
+        testMocks.setTrezorConnectFixtures();
+        await store.dispatch(connectInitThunk());
+        const res1 = await testMocks.getTrezorConnectMock().getFeatures({ __info: true });
+        expect(res1).toMatchObject({
+            success: true,
+            payload: expect.objectContaining({
+                name: 'getFeatures',
+                useDevice: true,
+            }),
+        });
+
+        const res2 = await testMocks.getTrezorConnectMock().getAccountInfo({
+            coin: 'btc',
+            descriptor: 'xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiK9w',
+            __info: true,
+        });
+
+        expect(res2).toMatchObject({
+            success: true,
+            payload: expect.objectContaining({
+                name: 'getAccountInfo',
+                useDevice: false,
+            }),
+        });
+    });
 });

--- a/suite-common/test-utils/__mocks__/@trezor/connect.ts
+++ b/suite-common/test-utils/__mocks__/@trezor/connect.ts
@@ -6,6 +6,8 @@
 
 const connect = jest.requireActual('@trezor/connect');
 
+const realMethods = { ...connect.default };
+
 // event listeners
 const listeners: Record<string, (e: any) => void> = {};
 // methods response fixtures
@@ -17,18 +19,33 @@ const getNextFixture = (_methodName: string) => {
     return fixture;
 };
 
-const result = (methodName: string, data: any) =>
-    jest.fn(params =>
-        Promise.resolve({
+const result = (methodName: string, defaults: any) =>
+    jest.fn(params => {
+        if (params && params.__info) {
+            realMethods['init']({
+                manifest: {
+                    email: '',
+                    appUrl: '',
+                },
+            });
+
+            // call actual implementation
+            return realMethods[methodName](params).finally(() => {
+                // I needed to call dispose to get rid of 'Jest did not exit one second after the test run has completed.' warning
+                realMethods['dispose']();
+            });
+        }
+
+        return Promise.resolve({
             success: true,
             payload: { _comment: 'Default mock payload' },
-            ...data,
+            ...defaults,
             ...getNextFixture(methodName),
             _method: methodName,
             _fixtures: fixtures,
             _params: params,
-        }),
-    );
+        });
+    });
 
 const ERROR_RESULT = { success: false, payload: { error: 'Default mock error' } };
 
@@ -55,10 +72,10 @@ const DEFAULT_PAYLOAD: Record<string, any> = {
 
 Object.keys(methods).forEach(methodName => {
     if (typeof methods[methodName] === 'function') {
-        const failed = failedByDefaultMethods.includes(methodName)
+        const defaults = failedByDefaultMethods.includes(methodName)
             ? ERROR_RESULT
             : DEFAULT_PAYLOAD[methodName];
-        methods[methodName] = result(methodName, failed);
+        methods[methodName] = result(methodName, defaults);
     }
 });
 


### PR DESCRIPTION
prerequisite for #19900
I think it makes sense to retrieve real __info results from connect even in connect mock  (it is basically static data) - just to avoid further extensive boiler plate mocking this.


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=info-support-in-unit&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=info-support-in-unit&lookback=7)