### PR TITLE
fix(suite): prevent disconnect tooltip from showing when modal is active

### DIFF
--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -70,9 +70,16 @@ const suite =
                 }
 
                 setTimeout(() => {
+                    const hasModalContext = state.modal.context !== '@modal/context-none';
+                    const { route } = state.router;
+                    const isForegroundApp =
+                        route && !route.isFullscreenApp && !!route.isForegroundApp;
+                    const isModalActive = hasModalContext || isForegroundApp;
+
                     if (
                         !state.suite.flags.hasSeenDisconnectTooltip &&
-                        state.wallet.accounts.length > 0
+                        state.wallet.accounts.length > 0 &&
+                        !isModalActive
                     ) {
                         api.dispatch(goto('suite-switch-device', { params: { cancelable: true } }));
                     }


### PR DESCRIPTION


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/disconnect-prompt-interrupting-flows&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/disconnect-prompt-interrupting-flows&lookback=7)