### PR TITLE
fix(suite-desktop-core): preventive handling for destroyed renderer

### DIFF
--- a/packages/ipc-proxy/src/__tests__/mockedElectron.ts
+++ b/packages/ipc-proxy/src/__tests__/mockedElectron.ts
@@ -5,6 +5,7 @@ import { ElectronIpcMainInvokeEvent } from '../proxy-handler';
 const ipcMainEvent: ElectronIpcMainInvokeEvent = {
     senderFrame: {
         url: 'http://localhost:8000/',
+        isDestroyed: () => false,
     },
 };
 

--- a/packages/ipc-proxy/src/__tests__/validateIpcMessage.test.ts
+++ b/packages/ipc-proxy/src/__tests__/validateIpcMessage.test.ts
@@ -1,7 +1,9 @@
 import { ElectronIpcMainInvokeEvent } from '../proxy-handler';
 import { validateIpcMessage } from '../validateIpcMessage';
 
-const createSenderFrame = (url: string) => ({ senderFrame: { url } });
+const createSenderFrame = (url: string, destroyed?: boolean): ElectronIpcMainInvokeEvent => ({
+    senderFrame: { url, isDestroyed: () => destroyed === true },
+});
 
 describe(validateIpcMessage.name, () => {
     it('passes when in DEV (localhost.8000)', () => {
@@ -39,5 +41,13 @@ describe(validateIpcMessage.name, () => {
         };
 
         expect(subject).toThrow('Invalid ipcEvent: {}');
+    });
+
+    it('fails when senderFrame has been destroyed', () => {
+        const subject = () => {
+            validateIpcMessage(createSenderFrame('http://localhost:8000/', true));
+        };
+
+        expect(subject).toThrow('ipcEvent.senderFrame is destroyed');
     });
 });

--- a/packages/ipc-proxy/src/proxy-handler.ts
+++ b/packages/ipc-proxy/src/proxy-handler.ts
@@ -47,6 +47,7 @@ interface IpcMainHandlers<Api> {
 export interface ElectronIpcMainInvokeEvent {
     senderFrame: {
         url: string;
+        isDestroyed: () => boolean;
     } | null;
 }
 

--- a/packages/ipc-proxy/src/validateIpcMessage.ts
+++ b/packages/ipc-proxy/src/validateIpcMessage.ts
@@ -14,4 +14,8 @@ export const validateIpcMessage = (ipcEvent: ElectronIpcMainInvokeEvent) => {
     } else {
         throw new Error(`Invalid ipcEvent: ${JSON.stringify(ipcEvent)}`);
     }
+
+    if (ipcEvent?.senderFrame?.isDestroyed()) {
+        throw new Error('ipcEvent.senderFrame is destroyed');
+    }
 };

--- a/packages/suite-desktop-core/src/hang-detect.ts
+++ b/packages/suite-desktop-core/src/hang-detect.ts
@@ -32,6 +32,9 @@ export const hangDetect = (mainWindow: BrowserWindow, statePatch?: Record<string
 
     const handshake = new Promise<HandshakeResult>(resolve => {
         const timeoutCallback = async () => {
+            // if renderer process was killed during timeout, then do not invoke any renderer api
+            if (mainWindow.isDestroyed()) return {};
+
             // TODO: what happen if handshake will be fired up after timeout?
             const result = await showDialog(mainWindow);
             if (result === 'wait') {


### PR DESCRIPTION
## Description

Attempt to prevent https://satoshilabs.sentry.io/issues/6739270430/?project=5193825
```
electron: Frame property was accessed after it navigated or was destroyed.
```

but we don't really know what causes it :confused: 

## Notes

Previous attempt #19681

At first I identified a lot [async handlers like this one](https://github.com/trezor/trezor-suite/commit/e4cc2d172d973c3c6c930cab8212a17184c89e46#diff-20325fa663c3e5e2a5d24f2a3f149e62b4c1a7b4ead1d6fcb4d933abfac78fc5) but there the `isDestroyed()` fix is useless, because `mainWindowProxy.getInstance()` [will return undefined if destroyed](https://github.com/trezor/trezor-suite/blob/308b1a470d27b4863ca479e20a2beee33d26c7be/packages/suite-desktop-core/src/libs/main-window-proxy.ts#L27-L29) so that is already handled :heavy_check_mark: 

Possibly related issues for Electron 35: could be spontaneously resolved by bumping Electron in #19951
https://github.com/electron/electron/issues/45653
https://github.com/electron/electron/issues/45610
https://github.com/electron/electron/issues/45215
https://github.com/electron/electron/issues/45142

Read more [here](https://www.electronjs.org/docs/latest/api/web-contents)

---

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sanitize-for-electron-frame-destroyed&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sanitize-for-electron-frame-destroyed&lookback=7)