### PR TITLE
fix(e2e): Fixed remember device test

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -95,6 +95,7 @@ export class OnboardingPage {
     @step()
     async completeOnboarding() {
         await this.disableNecessaryFirmwareChecks();
+        await this.disableDisconnectPrompt();
         await this.optionallyDismissFwHashCheckError();
         await this.analyticsSection.continueButton.click();
         await this.onboardingContinueButton.click();
@@ -168,6 +169,11 @@ export class OnboardingPage {
 
     @step()
     async disableDisconnectPrompt() {
+        // Desktop starts with already disabled disconnect prompt. Web needs to disable it.
+        if (!isWebProject(this.testInfo)) {
+            return;
+        }
+
         // eslint-disable-next-line @typescript-eslint/no-shadow
         await this.page.evaluate(SuiteActions => {
             window.store.dispatch({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We already disable this prompt in all desktop tests. I think it is correct to disable it for web as well.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-remembered-device&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-remembered-device&lookback=7)