### PR TITLE
lower min fee rate from 1sat/vb to 0.1sat/vb

### DIFF
--- a/packages/connect-common/files/coins.json
+++ b/packages/connect-common/files/coins.json
@@ -32,7 +32,7 @@
             "max_address_length": 34,
             "maxfee_kb": 2000000,
             "min_address_length": 27,
-            "minfee_kb": 1000,
+            "minfee_kb": 100,
             "name": "Bitcoin",
             "overwintered": false,
             "segwit": true,

--- a/packages/connect/src/data/defaultFeeLevels.ts
+++ b/packages/connect/src/data/defaultFeeLevels.ts
@@ -78,11 +78,15 @@ export const getBitcoinFeeLevels = (coin: CoinsJsonData): FeeInfoWithLevels => {
             };
         });
 
+    // BTC supports lower fees (min 0.1 sat/vb), so do not round for it
+    const minFee =
+        coin.shortcut === 'BTC' ? coin.minfee_kb / 1000 : Math.round(coin.minfee_kb / 1000);
+
     return {
         blockTime: Math.max(1, Math.round(coin.blocktime_seconds / 60)),
         dustLimit: coin.dust_limit,
         maxFee: Math.round(coin.maxfee_kb / 1000),
-        minFee: Math.round(coin.minfee_kb / 1000),
+        minFee,
         minPriorityFee: -1, // unknown/unused
         defaultFees: levels,
     };

--- a/suite-common/wallet-core/src/fees/feesUtils.ts
+++ b/suite-common/wallet-core/src/fees/feesUtils.ts
@@ -4,6 +4,17 @@ import { isEip1559 } from '@suite-common/wallet-utils';
 import TrezorConnect, { FeeLevel } from '@trezor/connect';
 import { BlockchainEstimatedFeeLevel } from '@trezor/connect/src/types/api/blockchainEstimateFee';
 import { isNative } from '@trezor/env-utils';
+import { BigNumber } from '@trezor/utils';
+
+const NETWORK_FEE_OVERRIDES: Record<
+    string,
+    { minFeePerUnit: string; overrideLevels: FeeLevel['label'][] }
+> = {
+    bitcoin: {
+        minFeePerUnit: '1',
+        overrideLevels: ['normal', 'high'],
+    },
+} as const;
 
 // sort FeeLevels in reversed order (Low > High)
 // TODO: consider to use same order in @trezor/connect to avoid double sorting
@@ -76,6 +87,17 @@ export const getNewFeeInfo = async ({
         },
     });
     if (!result.success) return;
+
+    if (network.symbol === 'btc') {
+        const feeOverride = NETWORK_FEE_OVERRIDES.bitcoin;
+        result.payload.levels.forEach(level => {
+            if (feeOverride.overrideLevels.includes(level.label)) {
+                level.feePerUnit = new BigNumber(level.feePerUnit).lte(feeOverride.minFeePerUnit)
+                    ? feeOverride.minFeePerUnit
+                    : level.feePerUnit;
+            }
+        });
+    }
 
     return {
         ...result.payload,


### PR DESCRIPTION
Decreased the minimum fee to `0.1 sat/vb` for BTC. `Normal` and `High` fee rates have minimum of `1 sat/vb`.

In order to test you need to use staging blockbook server. (unless the prod ones are updated as well)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19259 && https://github.com/trezor/trezor-suite/issues/19931

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/improve-calculation-of-speed-up-fee-rate&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/improve-calculation-of-speed-up-fee-rate&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/improve-calculation-of-speed-up-fee-rate&lookback=7)