### PR TITLE
chore(suite): pass account label in account details component

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
@@ -117,7 +117,13 @@ export const AccountDetails = ({ selectedAccount, isBalanceShown }: AccountDetai
                         networkType={selectedAccount.networkType}
                         path={path}
                         defaultVisibleValue={
-                            <AccountLabel account={selectedAccount} showAccountTypeBadge />
+                            <AccountLabel
+                                account={{
+                                    ...selectedAccount,
+                                    accountLabel: selectedAccountLabels.accountLabel,
+                                }}
+                                showAccountTypeBadge
+                            />
                         }
                         payload={{
                             type: 'accountLabel',

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx
@@ -11,7 +11,6 @@ import { AccountItemsGroup } from './AccountItemsGroup';
 interface AccountSectionProps {
     account: Account;
     selected: boolean;
-    accountLabel?: string;
     onItemClick?: () => void;
 }
 
@@ -43,7 +42,10 @@ export const AccountSection = ({ account, selected, onItemClick }: AccountSectio
     return showGroup && (isStakeShown || tokens.shownWithBalance.length) ? (
         <AccountItemsGroup
             key={`${descriptor}-${symbol}`}
-            account={account}
+            account={{
+                ...account,
+                accountLabel: account.accountLabel,
+            }}
             selected={selected}
             showStaking={isStakeShown}
             tokens={tokens.shownWithBalance}
@@ -53,7 +55,10 @@ export const AccountSection = ({ account, selected, onItemClick }: AccountSectio
         <AccountItem
             type="coin"
             key={`${descriptor}-${symbol}`}
-            account={account}
+            account={{
+                ...account,
+                accountLabel: account.accountLabel,
+            }}
             isSelected={selected}
             onClick={onItemClick}
             formattedBalance={formattedBalance}

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -56,9 +56,11 @@ const Accounts = ({
                 return (
                     <AccountSection
                         key={account.key}
-                        account={account}
+                        account={{
+                            ...account,
+                            accountLabel: accountLabels[account.key],
+                        }}
                         selected={selected}
-                        accountLabel={accountLabels[account.key]}
                         onItemClick={onItemClick}
                     />
                 );


### PR DESCRIPTION
## Description

This PR fixes failing e2e metadata tests introduced in https://github.com/trezor/trezor-suite/pull/20301.

`accountLabel` is now correctly passed to `AccountMenu` and `AccountDetails`


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/metadata-tests&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/metadata-tests&lookback=7)