### PR TITLE
feat(suite): Delete wallet switcher lock during discovery

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
@@ -1,16 +1,15 @@
 import styled, { css } from 'styled-components';
 
 import { selectSelectedDevice } from '@suite-common/wallet-core';
-import { Icon, Tooltip } from '@trezor/components';
+import { Icon } from '@trezor/components';
 import { focusStyleTransition, getFocusShadowStyle } from '@trezor/components/src/utils/utils';
 import { borders, spacingsPx } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { SidebarDeviceStatus } from './SidebarDeviceStatus';
 import { useResponsiveContext } from '../../../../../support/suite/ResponsiveContext';
-import { Translation } from '../../../Translation';
 import { ExpandedSidebarOnly } from '../Sidebar/ExpandedSidebarOnly';
 
 const CaretContainer = styled.div`
@@ -43,7 +42,7 @@ const Wrapper = styled.div<{ $isSidebarCollapsed?: boolean }>`
     }
 `;
 
-const InnerContainer = styled.div<{ $isDisabled?: boolean }>`
+const InnerContainer = styled.div`
     position: relative;
     width: 100%;
     display: flex;
@@ -51,55 +50,41 @@ const InnerContainer = styled.div<{ $isDisabled?: boolean }>`
     gap: ${spacingsPx.md};
     min-height: 42px;
     -webkit-app-region: no-drag;
-
-    cursor: ${({ $isDisabled }) => ($isDisabled ? 'not-allowed' : 'pointer')};
 `;
 
 export const DeviceSelector = () => {
     const selectedDevice = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();
-    const { isDiscoveryRunning } = useDiscovery();
 
     const handleSwitchDeviceClick = () => {
-        if (!isDiscoveryRunning) {
-            dispatch(
-                goto('suite-switch-device', {
-                    params: {
-                        cancelable: true,
-                    },
-                }),
-            );
-        }
+        dispatch(
+            goto('suite-switch-device', {
+                params: {
+                    cancelable: true,
+                },
+            }),
+        );
     };
 
     const { isSidebarCollapsed } = useResponsiveContext();
 
     return (
         <Wrapper $isSidebarCollapsed={isSidebarCollapsed}>
-            <Tooltip
-                isActive={isDiscoveryRunning}
-                isFullWidth
-                placement="bottom"
-                cursor={isDiscoveryRunning ? 'not-allowed' : undefined}
-                content={<Translation id="TR_UNAVAILABLE_WHILE_LOADING" />}
+            <InnerContainer
+                onClick={handleSwitchDeviceClick}
+                tabIndex={0}
+                data-testid="@menu/switch-device"
             >
-                <InnerContainer
-                    onClick={handleSwitchDeviceClick}
-                    $isDisabled={isDiscoveryRunning}
-                    tabIndex={0}
-                    data-testid="@menu/switch-device"
-                >
-                    <SidebarDeviceStatus />
+                <SidebarDeviceStatus />
 
-                    <ExpandedSidebarOnly>
-                        {selectedDevice && selectedDevice.state && (
-                            <CaretContainer>
-                                <Icon size={20} name="caretCircleDown" />
-                            </CaretContainer>
-                        )}
-                    </ExpandedSidebarOnly>
-                </InnerContainer>
-            </Tooltip>
+                <ExpandedSidebarOnly>
+                    {selectedDevice && selectedDevice.state && (
+                        <CaretContainer>
+                            <Icon size={20} name="caretCircleDown" />
+                        </CaretContainer>
+                    )}
+                </ExpandedSidebarOnly>
+            </InnerContainer>
         </Wrapper>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It should be possible to switch account while discovery is in progress

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=delete-wallet-switcher-lock&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=delete-wallet-switcher-lock&lookback=7)