### PR TITLE
feat(suite): do not enforce FW update when debug mode

### DIFF
--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -22,6 +22,7 @@ import { useDevice, useOnboarding, useSelector } from 'src/hooks/suite';
 import { PrerequisitesGuide, Translation } from '../suite';
 import { FirmwareButtonsRow } from './Buttons/FirmwareButtonsRow';
 import { FirmwareSwitchWarning } from './FirmwareSwitchWarning';
+import { selectIsDebugModeActive } from '../../reducers/suite/suiteReducer';
 
 const Description = styled.div`
     align-items: center;
@@ -123,6 +124,7 @@ export const FirmwareInitial = ({
         });
     const { isActive: isOnboarding, updateAnalytics } = useOnboarding();
     const devices = useSelector(selectDevices);
+    const isDebug = useSelector(selectIsDebugModeActive);
     const [bitcoinOnlyOffer, setBitcoinOnlyOffer] = useState(false);
     const [showSkipConfirmation, setShowSkipConfirmation] = useState(false);
 
@@ -133,10 +135,10 @@ export const FirmwareInitial = ({
 
     // This is essential for detecting potentially malicious devices,
     // as the firmware revision check is a critical part of the verification process.
-    //
+    // In debug mode you may bypass it.
     // See: https://github.com/trezor/trezor-suite/issues/19157
     const isFirmwareInstallationMandatory =
-        device.features.internal_model === DeviceModelInternal.T1B1;
+        device.features.internal_model === DeviceModelInternal.T1B1 && !isDebug;
 
     // todo: move to utils device.ts
     const devicesConnected = devices.filter(device => device?.connected);


### PR DESCRIPTION
## Description

When onboarding uninitialized device with FW already on it, we enforce FW update on T1B1.
→ Enable skipping when debug mode. 

## Related Issue

Followup to https://github.com/trezor/trezor-suite/issues/19157

## Screenshots:

[skip wen debg.webm](https://github.com/user-attachments/assets/230678e3-adec-44dd-bfdb-ff0360daead7)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/debug-mode-do-not-enforce-fw-update&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/debug-mode-do-not-enforce-fw-update&lookback=7)