### PR TITLE
refactor(suite-common): useFirmwareInstallation uiEvents

### DIFF
--- a/packages/suite/src/components/firmware/FirmwareInstallationStandalone.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInstallationStandalone.tsx
@@ -1,6 +1,6 @@
 import { useFirmwareInstallation } from '@suite-common/firmware';
 import { Banner, Card, Column } from '@trezor/components';
-import TrezorConnect, { UI } from '@trezor/connect';
+import TrezorConnect from '@trezor/connect';
 import type TrezorConnectWeb from '@trezor/connect-web';
 import { spacings } from '@trezor/theme';
 
@@ -21,7 +21,7 @@ export const FirmwareInstallationStandalone = ({
     install,
     onPromptClose,
 }: FirmwareInstallationStandaloneProps) => {
-    const { status, showReconnectPrompt, uiEvent, targetType } = useFirmwareInstallation();
+    const { status, showReconnectPrompt, targetType, reconnectEvent } = useFirmwareInstallation();
     const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
 
     // Device needs to be paired twice when using web usb transport. // Once in
@@ -31,9 +31,9 @@ export const FirmwareInstallationStandalone = ({
     // in normal mode, till it is paired again.
     const isDeviceNotSelected =
         isWebUsbTransport &&
-        uiEvent?.type === UI.FIRMWARE_RECONNECT &&
-        uiEvent.payload.disconnected &&
-        uiEvent.payload.i > 2 && // Add some latency for cases when the device is already paired or is restarting.
+        reconnectEvent &&
+        reconnectEvent.disconnected &&
+        reconnectEvent.i > 2 && // Add some latency for cases when the device is already paired or is restarting.
         status !== 'done';
 
     return (

--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -4,7 +4,7 @@ import { useFirmwareInstallation } from '@suite-common/firmware';
 import { TranslationKey } from '@suite-common/intl-types';
 import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
 import { BulletList, Column, DeviceAnimation, H2, Modal, Paragraph } from '@trezor/components';
-import { DEVICE, Device, UI } from '@trezor/connect';
+import { Device } from '@trezor/connect';
 import { DeviceModelInternal, getFirmwareVersion } from '@trezor/device-utils';
 import { ConfirmOnDevice } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
@@ -65,10 +65,10 @@ interface ReconnectDevicePromptProps {
 export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePromptProps) => {
     const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
     const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
-    const { showManualReconnectPrompt, status, uiEvent } = useFirmwareInstallation();
+    const { showManualReconnectPrompt, status, reconnectEvent, buttonEvent } =
+        useFirmwareInstallation();
     const { device } = useDevice();
-    const eventDevice =
-        uiEvent && uiEvent.type === DEVICE.BUTTON ? uiEvent.payload.device : undefined;
+    const eventDevice = buttonEvent?.device;
 
     const isManualRebootRequired =
         // Automatic reboot isn't supported:
@@ -77,15 +77,10 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
         status === 'error';
 
     const getRebootPhase = () => {
-        if (
-            device?.mode === 'bootloader' &&
-            uiEvent?.type === DEVICE.BUTTON &&
-            isManualRebootRequired
-        ) {
+        if (device?.mode === 'bootloader' && buttonEvent && isManualRebootRequired) {
             return 'done';
         }
-        const rebootToBootloaderNotSupported =
-            uiEvent?.type === UI.FIRMWARE_RECONNECT && !uiEvent.payload.disconnected;
+        const rebootToBootloaderNotSupported = reconnectEvent && !reconnectEvent.disconnected;
         const rebootToBootloaderCancelled = device?.connected && device?.mode !== 'bootloader';
 
         return rebootToBootloaderNotSupported || rebootToBootloaderCancelled
@@ -100,10 +95,7 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
         onClose !== undefined && isManualRebootRequired && rebootPhase == 'waiting-for-reboot';
     const showWebUsbButton = rebootPhase === 'disconnected' && isWebUsbTransport;
 
-    const toNormal =
-        uiEvent?.type === UI.FIRMWARE_RECONNECT &&
-        uiEvent.payload.target === 'normal' &&
-        uiEvent.payload.method === 'manual';
+    const toNormal = reconnectEvent?.target === 'normal' && reconnectEvent.method === 'manual';
 
     const getHeading = () => {
         if (isRebootDone) {
@@ -123,13 +115,8 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
         }
 
         // internal_model cannot be read from features while in bootloader mode.
-        const deviceModelFromEvent = eventDevice?.features?.internal_model;
-
-        if (deviceModelFromEvent === undefined) {
-            // Fallback. This should never happen.
-            return 'TR_SWITCH_TO_BOOTLOADER_HOLD_LEFT_BUTTON';
-        }
-
+        const deviceModelFromEvent =
+            eventDevice?.features?.internal_model || DeviceModelInternal.UNKNOWN;
         const deviceFwVersion = getFirmwareVersion(eventDevice);
         const switchToBootloaderMap: Record<DeviceModelInternal, TranslationKey> = {
             // just to have something, I assume new models will have touch screen
@@ -156,7 +143,7 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
                     title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
                     deviceModelInternal={deviceModelInternal}
                     deviceUnitColor={device?.features?.unit_color}
-                    isConfirmed={uiEvent?.type !== 'button'}
+                    isConfirmed={!buttonEvent}
                 />
             )}
             <Modal.ModalBase

--- a/packages/suite/src/views/firmware/FirmwareModal.tsx
+++ b/packages/suite/src/views/firmware/FirmwareModal.tsx
@@ -48,7 +48,7 @@ export const FirmwareModal = ({
         setStatus,
         deviceWillBeWiped,
         error,
-        uiEvent,
+        buttonEvent,
         confirmOnDevice,
         showConfirmationPill,
     } = useFirmwareInstallation({ shouldSwitchFirmwareType });
@@ -59,8 +59,7 @@ export const FirmwareModal = ({
     const dispatch = useDispatch();
     const intl = useIntl();
     const [isChecked, setIsChecked] = useState(false);
-    const uiEventDevice =
-        uiEvent && 'device' in uiEvent.payload ? uiEvent.payload.device : undefined;
+    const uiEventDevice = buttonEvent?.device;
     const { isProgressCheckDisplayed, handleDismissProgressCheck } =
         useFirmwareInstallationProgressCheck();
 
@@ -68,8 +67,7 @@ export const FirmwareModal = ({
     // It can be canceled only via `trezorCancel`
     const isCancelable = ['initial', 'check-seed', 'done', 'error'].includes(status);
 
-    const isAwaitingPinEntry =
-        uiEvent?.type === 'button' && uiEvent.payload.code === 'ButtonRequest_PinEntry';
+    const isAwaitingPinEntry = buttonEvent?.code === 'ButtonRequest_PinEntry';
 
     const handleClose = () => {
         if (device?.status !== 'available') {

--- a/packages/suite/src/views/onboarding/steps/FirmwareInstallation.tsx
+++ b/packages/suite/src/views/onboarding/steps/FirmwareInstallation.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 import { useFirmwareInstallation } from '@suite-common/firmware';
 import { Button } from '@trezor/components';
-import { UI } from '@trezor/connect';
 import { spacingsPx } from '@trezor/theme';
 
 import { FirmwareOffer, FirmwareProgressBar, ReconnectDevicePrompt } from 'src/components/firmware';
@@ -26,16 +25,16 @@ interface FirmwareInstallationProps {
 }
 
 export const FirmwareInstallation = ({ install, onSuccess }: FirmwareInstallationProps) => {
-    const { status, showReconnectPrompt, uiEvent, targetType } = useFirmwareInstallation();
+    const { status, showReconnectPrompt, targetType, reconnectEvent } = useFirmwareInstallation();
     const isActionAbortable = useSelector(selectIsActionAbortable);
     const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
 
     const getInnerActionComponent = () => {
         if (
             isWebUsbTransport &&
-            uiEvent?.type === UI.FIRMWARE_RECONNECT &&
-            uiEvent.payload.disconnected &&
-            uiEvent.payload.i > 2 && // Add some latency for cases when the device is already paired or is restarting.
+            reconnectEvent &&
+            reconnectEvent.disconnected &&
+            reconnectEvent.i > 2 && // Add some latency for cases when the device is already paired or is restarting.
             status !== 'done'
         ) {
             // Device needs to be paired twice when using web usb transport.

--- a/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
+++ b/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
@@ -65,15 +65,29 @@ export const useFirmwareInstallation = (
     const firmware = useSelector(selectFirmware);
     const device = useSelector(selectSelectedDevice);
 
+    const [reconnectEvent, buttonEvent, progressEvent] = useMemo(() => {
+        if (firmware.uiEvent) {
+            if (firmware.uiEvent.type === UI.FIRMWARE_RECONNECT) {
+                return [firmware.uiEvent.payload];
+            }
+            if (firmware.uiEvent.type === DEVICE.BUTTON) {
+                return [undefined, firmware.uiEvent.payload];
+            }
+            if (firmware.uiEvent.type === UI.FIRMWARE_PROGRESS) {
+                return [undefined, undefined, firmware.uiEvent.payload];
+            }
+        }
+
+        return [];
+    }, [firmware.uiEvent]);
+
     // Device in its state before installation is cached when installation begins.
     // Until then, access device as normal.
     const originalDevice = firmware.cachedDevice || device;
 
     // To instruct user to reboot to bootloader manually, UI.FIRMWARE_DISCONNECT event is emitted first,
     // and UI.FIRMWARE_RECONNECT is emitted after the device disconnects.
-    const showManualReconnectPrompt =
-        firmware.uiEvent?.type === UI.FIRMWARE_RECONNECT &&
-        firmware.uiEvent.payload.method === 'manual';
+    const showManualReconnectPrompt = reconnectEvent?.method === 'manual';
 
     const showReconnectPrompt =
         // For some magic reason, the `ButtonRequest_Other` is present in FW after THP pairing;
@@ -81,11 +95,8 @@ export const useFirmwareInstallation = (
         firmware.status !== 'done' &&
         // T1 emits ButtonRequest_ProtectCall in reboot_and_wait flow,
         // T2 devices emit ButtonRequest_Other in reboot_and_wait and reboot_and_upgrade flows:
-        ((firmware.uiEvent?.type === DEVICE.BUTTON &&
-            firmware.uiEvent.payload.code &&
-            ['ButtonRequest_ProtectCall', 'ButtonRequest_Other'].includes(
-                firmware.uiEvent.payload.code,
-            )) ||
+        ((buttonEvent?.code &&
+            ['ButtonRequest_ProtectCall', 'ButtonRequest_Other'].includes(buttonEvent.code)) ||
             showManualReconnectPrompt);
 
     const deviceWillBeWiped = determineIfDeviceWillBeWiped(
@@ -103,29 +114,23 @@ export const useFirmwareInstallation = (
         // Show the confirmation pill before starting the installation using the "wait" or "manual" method,
         // after ReconnectDevicePrompt is closed and user selects the option to install firmware while in bootloader.
         // Also, in case the device is PIN-locked at the start of the process.
-        (firmware.uiEvent?.type === DEVICE.BUTTON &&
-            firmware.uiEvent.payload.code !== undefined &&
+        (buttonEvent?.code &&
             ['ButtonRequest_FirmwareUpdate', 'ButtonRequest_PinEntry'].includes(
-                firmware.uiEvent.payload.code,
+                buttonEvent.code,
             )) ||
         // Show the confirmation pill right after ReconnectDevicePrompt is closed while using the "wait" or "manual" method,
         // before the user selects the option to install firmware while in bootloader
         // When a PIN-protected device reconnects to normal mode after installation, PIN is requested and the pill is shown.
         // There is a false positive in case such device is wiped (including PIN) during custom installation.
-        (firmware.uiEvent?.type === UI.FIRMWARE_RECONNECT &&
-            (firmware.uiEvent.payload.target === 'bootloader' ||
-                (firmware.uiEvent.payload.target === 'normal' &&
+        (reconnectEvent &&
+            (reconnectEvent.target === 'bootloader' ||
+                (reconnectEvent.target === 'normal' &&
                     originalDevice?.features?.pin_protection &&
                     !deviceWillBeWiped))) ||
         isThpConfirmationRequested;
 
     const showConfirmationPill =
-        (!showReconnectPrompt &&
-            !!firmware.uiEvent &&
-            !(
-                firmware.uiEvent.type === UI.FIRMWARE_PROGRESS &&
-                firmware.uiEvent.payload.operation === 'downloading'
-            )) ||
+        (!showReconnectPrompt && progressEvent?.operation === 'downloading') ||
         isThpConfirmationRequested;
 
     const updateStatus = useMemo<FirmwareOperationStatus>(() => {
@@ -136,26 +141,20 @@ export const useFirmwareInstallation = (
             };
         }
 
-        if (
-            firmware.uiEvent?.type === UI.FIRMWARE_PROGRESS &&
-            firmware.uiEvent.payload.operation === 'flashing'
-        ) {
+        if (progressEvent?.operation === 'flashing') {
             return {
                 operation: 'installing',
-                progress: firmware.uiEvent.payload.progress,
+                progress: progressEvent.progress,
             };
         }
 
         // Automatically restarting from bootloader to normal mode at the end of non-intermediary installation:
-        if (
-            firmware.uiEvent?.type === UI.FIRMWARE_RECONNECT &&
-            firmware.uiEvent.payload.method === 'wait'
-        ) {
+        if (reconnectEvent?.method === 'wait') {
             return { operation: 'restarting', progress: 100 };
         }
 
         return { operation: null, progress: 0 };
-    }, [firmware.uiEvent, firmware.status]);
+    }, [firmware.status, reconnectEvent, progressEvent]);
 
     const targetFirmwareType = useMemo(() => {
         const isCurrentlyBitcoinOnly = hasBitcoinOnlyFirmware(originalDevice);
@@ -196,5 +195,8 @@ export const useFirmwareInstallation = (
         deviceWillBeWiped,
         showReconnectPrompt,
         showConfirmationPill,
+        reconnectEvent,
+        buttonEvent,
+        progressEvent,
     };
 };

--- a/suite-native/firmware/src/hooks/useFirmware.tsx
+++ b/suite-native/firmware/src/hooks/useFirmware.tsx
@@ -95,8 +95,7 @@ export const useFirmware = (
     const confirmOnDevice =
         confirmOnDeviceCommon ||
         // This is needed for firmware reinstall to show Confirm on device correctly
-        // @ts-expect-error types are not correct here, IDK why
-        firmwareInstallation.uiEvent?.payload?.code === 'ButtonRequest_Other';
+        firmwareInstallation.buttonEvent?.code === 'ButtonRequest_Other';
 
     const originalFirmwareVersion = getFirmwareVersion(firmwareInstallation.originalDevice);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

related to https://github.com/trezor/trezor-suite/pull/20281

`useFirmwareInstallation` provides `uiEvent` from the state. every time this event is validated it actually requires 3 conditions: uiEvent presence + uiEvent.type + uiEvent.payload.

by moving it to memoized const im reducing validation process to only one condition: event presence and i believe this cleans the code a little bit (additionally this fixes one ts-error in suite-native)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/useFirmwareInstallation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/useFirmwareInstallation&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/useFirmwareInstallation&lookback=7)