### PR TITLE
chore(message-system): update Bitcoin Testnet4 message

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2025-07-21T00:00:00+00:00",
-    "sequence": 94,
+    "timestamp": "2025-07-23T00:00:00+00:00",
+    "sequence": 95,
     "actions": [
         {
             "conditions": [
@@ -1277,17 +1277,17 @@
                 "category": ["banner"],
                 "content": {
                     "en": "Update Trezor Suite for enhanced security, all the latest features, and to keep everything running as smoothly as possible.",
-                    "es": "Actualiza Trezor Suite para mejorar la seguridad, disfrutar de las funciones más recientes y para que todo funcione sin problemas.",
-                    "cs": "Aktualizujte Trezor Suite, abyste získali lepší zabezpečení a nejnovější funkce.",
-                    "ru": "Обновите Trezor Suite, чтобы улучшить безопасность, использовать все новейшие функции и обеспечить максимально эффективную работу.",
-                    "ja": "Trezor Suiteをアップデートすることで、セキュリティの強化、最新機能の搭載、スムーズな動作が可能になります。",
-                    "hu": "Frissítse a Trezor Suite-ot a fokozott biztonság, a legújabb funkciók és a lehető leggördülékenyebb működés érdekében.",
-                    "it": "Aggiornate Trezor Suite per ottenere una maggiore sicurezza, tutte le funzioni più recenti e per far funzionare tutto nel modo più fluido possibile.",
-                    "fr": "Mettez à jour Trezor Suite pour bénéficier d’une sécurité renforcée, de toutes les dernières fonctionnalités, et pour garantir un fonctionnement optimal.",
-                    "de": "Aktualisiere Trezor Suite für mehr Sicherheit, neue Funktionen und reibungslose Abläufe.",
-                    "tr": "Geliştirilmiş güvenlik, en yeni özellikler ve her şeyin olabildiğince sorunsuz çalışması için Trezor Suite'i güncelleyin.",
-                    "pt": "Atualize o Trezor Suite para maior segurança, todos os recursos mais recentes e para manter tudo funcionando da forma mais suave possível.",
-                    "uk": "Оновіть Trezor Suite для підвищення безпеки, використання всіх новітніх функцій та забезпечення максимально плавної роботи."
+                    "es": "La cuenta de Bitcoin Testnet ha sido actualizada al nuevo Testnet4.",
+                    "cs": "Účet Bitcoin Testnet byl aktualizován na nový Testnet4.",
+                    "ru": "Аккаунт Bitcoin Testnet был обновлён до нового Testnet4.",
+                    "ja": "Bitcoin Testnetのアカウントは新しいTestnet4に更新されました。",
+                    "hu": "A Bitcoin Testnet fiók frissítve lett az új Testnet4-re.",
+                    "it": "L'account Bitcoin Testnet è stato aggiornato al nuovo Testnet4.",
+                    "fr": "Le compte Bitcoin Testnet a été mis à jour vers le nouveau Testnet4.",
+                    "de": "Das Bitcoin Testnet-Konto wurde auf das neue Testnet4 aktualisiert.",
+                    "tr": "Bitcoin Testnet hesabı yeni Testnet4'e güncellendi.",
+                    "pt": "A conta do Bitcoin Testnet foi atualizada para o novo Testnet4.",
+                    "uk": "Обліковий запис Bitcoin Testnet оновлено до нового Testnet4."
                 },
                 "cta": {
                     "action": "internal-link",
@@ -1332,35 +1332,35 @@
                 "variant": "info",
                 "category": ["banner"],
                 "content": {
-                    "en": "Testnet account has been updated to new Testnet 4.",
-                    "es": "Testnet account has been updated to new Testnet 4.",
-                    "cs": "Testnet account has been updated to new Testnet 4.",
-                    "ru": "Testnet account has been updated to new Testnet 4.",
-                    "ja": "Testnet account has been updated to new Testnet 4.",
-                    "hu": "Testnet account has been updated to new Testnet 4.",
-                    "it": "Testnet account has been updated to new Testnet 4.",
-                    "fr": "Testnet account has been updated to new Testnet 4.",
-                    "de": "Testnet account has been updated to new Testnet 4.",
-                    "tr": "Testnet account has been updated to new Testnet 4.",
-                    "pt": "Testnet account has been updated to new Testnet 4.",
-                    "uk": "Testnet account has been updated to new Testnet 4.."
+                    "en": "Bitcoin Testnet account has been updated to new Testnet4.",
+                    "es": "La cuenta de Bitcoin Testnet ha sido actualizada al nuevo Testnet4.",
+                    "cs": "Účet Bitcoin Testnet byl aktualizován na nový Testnet4.",
+                    "ru": "Аккаунт Bitcoin Testnet был обновлён до нового Testnet4.",
+                    "ja": "Bitcoinテストネットのアカウントは新しいTestnet4に更新されました。",
+                    "hu": "A Bitcoin Testnet fiók frissítve lett az új Testnet4-re.",
+                    "it": "L'account Bitcoin Testnet è stato aggiornato al nuovo Testnet4.",
+                    "fr": "Le compte Bitcoin Testnet a été mis à jour vers le nouveau Testnet4.",
+                    "de": "Das Bitcoin-Testnet-Konto wurde auf das neue Testnet4 aktualisiert.",
+                    "tr": "Bitcoin Testnet hesabı yeni Testnet4'e güncellendi.",
+                    "pt": "A conta do Bitcoin Testnet foi atualizada para o novo Testnet4.",
+                    "uk": "Обліковий запис Bitcoin Testnet оновлено до нового Testnet4."
                 },
                 "cta": {
                     "action": "external-link",
                     "link": "https://trezor.io/learn/a/bitcoin-testnet#testnet4",
                     "label": {
                         "en": "Learn More",
-                        "es": "Learn More",
-                        "cs": "Learn More",
-                        "ru": "Learn More",
-                        "ja": "Learn More",
-                        "hu": "Learn More",
-                        "it": "Learn More",
-                        "fr": "Learn More",
-                        "de": "Learn More",
-                        "tr": "Learn More",
-                        "pt": "Learn More",
-                        "uk": "Learn More"
+                        "es": "Más Información",
+                        "cs": "Více Informací",
+                        "ru": "Подробнее",
+                        "ja": "詳細はこちら",
+                        "hu": "További Információ",
+                        "it": "Scopri di Più",
+                        "fr": "En Savoir Plus",
+                        "de": "Mehr Erfahren",
+                        "tr": "Daha Fazla Bilgi",
+                        "pt": "Saiba Mais",
+                        "uk": "Дізнатись більше"
                     }
                 }
             }


### PR DESCRIPTION
## Description

Changing the current English wording and translations of the message about Bitcoin Testnet4.

## Screenshots:

en
<img width="1592" height="217" alt="image" src="https://github.com/user-attachments/assets/1340abb4-21f5-46c9-9bbf-fc36e0ee4808" />

es
<img width="1594" height="232" alt="image" src="https://github.com/user-attachments/assets/731298c5-ad2f-42f1-a6e0-2e5e564cc13d" />

de
<img width="1504" height="226" alt="image" src="https://github.com/user-attachments/assets/a2935394-0730-4c55-970f-cd9d93f757f2" />

tr
<img width="1598" height="225" alt="image" src="https://github.com/user-attachments/assets/9da100a8-1469-4f9f-acc4-6253f5284869" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/message-system-btc-testnet4&lookback=7)