### PR TITLE
feat(suite): on selecting uninitialized device goto manual check before onboarding

### DIFF
--- a/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
@@ -97,9 +97,10 @@ export const NeedsAttentionBanner = ({
 
     const onSolveIssueClick = (): void => {
         switch (deviceStatus) {
-            case 'initialize': // wiped device
+            // wiped device - should pass through Manual Device Check before starting onboarding
+            case 'initialize':
                 selectDevice();
-                dispatch(goto('onboarding-index'));
+                dispatch(goto('suite-start'));
                 break;
 
             case 'bootloader': // device without firmware or in the bootloader mode


### PR DESCRIPTION
## Description

See screenshot

## Related Issue

Resolve #15052

## Screenshots:

This button:

<img width="383" height="391" alt="image" src="https://github.com/user-attachments/assets/c5d3ecfb-854d-449a-9374-0bed6da38a9e" />

Now goes to manual check, not straight to onboarding:
<img width="816" height="392" alt="image" src="https://github.com/user-attachments/assets/f9e55da5-e5a8-4388-9c88-30a1b79f1fc3" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/security-check-remembered&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/security-check-remembered&lookback=7)