### PR TITLE
fix(blockchain-link): improve ping reliability and disconnect cleanup

### DIFF
--- a/packages/blockchain-link/src/workers/ripple/index.ts
+++ b/packages/blockchain-link/src/workers/ripple/index.ts
@@ -501,8 +501,16 @@ class RippleWorker extends BaseWorker<Client> {
         return client;
     }
 
-    disconnect() {
-        return this.api?.disconnect();
+    async disconnect() {
+        try {
+            if (this.api?.isConnected()) {
+                await this.api.disconnect();
+            }
+        } catch (error) {
+            this.debug('Disconnect failed', error);
+        } finally {
+            this.cleanup();
+        }
     }
 
     async messageHandler(event: { data: MessageTypes.Message }) {
@@ -543,7 +551,7 @@ class RippleWorker extends BaseWorker<Client> {
 
         if (this.state.hasSubscriptions() || this.settings.keepAlive) {
             try {
-                await this.api.getServerInfo();
+                await this.api.request({ command: 'ping' });
             } catch (error) {
                 this.debug(`Error in timeout ping request: ${error}`);
             }

--- a/packages/blockchain-link/tests/unit/connection.test.ts
+++ b/packages/blockchain-link/tests/unit/connection.test.ts
@@ -13,7 +13,7 @@ const getMethod = (instanceName: string) => {
             method = 'GET_BLOCK';
             break;
         case 'ripple':
-            method = 'server_info';
+            method = 'ping';
             break;
         default:
             method = 'getBlockHash';
@@ -138,14 +138,7 @@ workers.forEach(instance => {
             await new Promise(resolve => setTimeout(resolve, 500));
 
             expect(callback).toHaveBeenCalled();
-
-            // xrpl.js calls this.getServerInfo() inside the connect() method,
-            // which results in the mock server sending a response and then removing the first fixture
-            if (instance.name === 'ripple') {
-                expect(server.getFixtures()!.length).toEqual(1);
-            } else {
-                expect(server.getFixtures()!.length).toEqual(2);
-            }
+            expect(server.getFixtures()!.length).toEqual(2);
         });
 
         it('Handle connect event', () =>


### PR DESCRIPTION
## Description

Replaced `getServerInfo` with a `ping` command to improve heartbeat reliability for Ripple.
Also updated the disconnect method to ensure cleanup is always called, even if disconnect fails.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17595


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/xrpl-disconnect-problem&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/xrpl-disconnect-problem&lookback=7)