### PR TITLE
Chore: trezor-bluetooth server params

### DIFF
--- a/packages/transport-bluetooth/src/client/bluetooth-api.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-api.ts
@@ -94,7 +94,7 @@ export class BluetoothApi extends AbstractApi {
         buffer.copy(chunk);
 
         return this.api
-            .send('write', [path, Array.from(chunk)])
+            .send('write', { id: path, data: Array.from(chunk) })
             .then(() => this.success(undefined))
             .catch(e => this.error({ error: ERRORS.INTERFACE_DATA_TRANSFER, message: e.message }));
     }

--- a/packages/transport-bluetooth/src/client/trezor-bluetooth.ts
+++ b/packages/transport-bluetooth/src/client/trezor-bluetooth.ts
@@ -8,6 +8,21 @@ import {
     TrezorBluetoothSettings,
 } from './types';
 
+type SetStateParams = {
+    devices: Pick<BluetoothDevice, 'id' | 'macAddress'>[];
+};
+
+type ConnectDeviceParams = {
+    id: string;
+    timeout: number;
+};
+
+type WriteParams = {
+    id: string;
+    data: number[];
+    withResponse?: boolean;
+};
+
 // Client for trezor-bluetooth rust websocket server
 export class TrezorBluetooth extends WebsocketClient<NotificationEvent> {
     readonly settings: TrezorBluetoothSettings;
@@ -38,26 +53,44 @@ export class TrezorBluetooth extends WebsocketClient<NotificationEvent> {
         return Promise.resolve(this.sendRawMessage('PING'));
     }
 
+    connectDevice(params: ConnectDeviceParams) {
+        // adjust websocket timeout and allow the server to respond with timeout error (timeout on the server)
+        const wsTimeout =
+            typeof params.timeout === 'number' && params.timeout > 0
+                ? params.timeout + 3000
+                : undefined;
+
+        return this.sendMessage({ method: 'connect_device', params }, { timeout: wsTimeout });
+    }
+
+    write(params: WriteParams) {
+        const withResponse = false;
+
+        return this.sendMessage({ method: 'write', params: { ...params, withResponse } });
+    }
+
+    send(method: 'set_state', state: SetStateParams): Promise<boolean>;
     send(method: 'get_info', adapter?: boolean): Promise<BluetoothInfo>;
     send(method: 'enumerate'): Promise<BluetoothDevice[]>;
     send(method: 'start_scan'): Promise<BluetoothDevice[]>;
     send(method: 'stop_scan'): Promise<boolean>;
-    send(method: 'connect_device', args: [string, number]): Promise<boolean>; // args: id, timeout
+    send(method: 'connect_device', params: ConnectDeviceParams): Promise<boolean>; // args: id, timeout
     send(method: 'disconnect_device', id: string): Promise<boolean>;
     send(method: 'forget_device', id: string): Promise<boolean>;
     send(method: 'open_device', id: string): Promise<boolean>;
     send(method: 'close_device', id: string): Promise<boolean>;
     send(method: 'read', id: string): Promise<boolean>;
-    send(method: 'write', args: [string, number[]]): Promise<boolean>; // args: id, data
+    send(method: 'write', params: WriteParams): Promise<boolean>;
     public send(method: string, params?: any) {
-        // connect_device timeout is dynamically set,
-        // adjust websocket client and allow the server to respond with timeout error (timeout on the server)
-        const timeout =
-            method === 'connect_device' && Array.isArray(params) && typeof params[1] === 'number'
-                ? params[1] + 3000
-                : undefined;
+        if (method === 'connect_device') {
+            return this.connectDevice(params);
+        }
 
-        return this.sendMessage({ method, params }, { timeout });
+        if (method === 'write') {
+            return this.write(params);
+        }
+
+        return this.sendMessage({ method, params });
     }
 
     protected onMessage(message: string | Buffer) {

--- a/packages/transport-bluetooth/src/server/message_handler.rs
+++ b/packages/transport-bluetooth/src/server/message_handler.rs
@@ -7,6 +7,11 @@ use crate::server::{
 use hyper_tungstenite::tungstenite::Message;
 use log::info;
 
+#[derive(serde::Deserialize)]
+struct WsRequestFallback {
+    id: Option<String>,
+}
+
 pub async fn handle_message(
     message: Message,
     broadcast: ConnectionBroadcast,
@@ -44,8 +49,14 @@ pub async fn handle_message(
     let request = match serde_json::from_str::<WsRequest>(&msg) {
         Ok(req) => req,
         Err(err) => {
+            // Try to parse just the "id" from the malformed message
+            let partial_id = serde_json::from_str::<WsRequestFallback>(&msg)
+                .ok()
+                .and_then(|partial| partial.id)
+                .unwrap_or_else(|| "-1".to_string());
+
             let json_error = serde_json::json!({
-                "id": "-1", // TODO: try to read "id" from malformed json? this could not be exact WsRequest but it can have "id"
+                "id": partial_id,
                 "error": format!("WsRequest serialization error: {err:?}"),
             });
             return Some(Message::text(json_error.to_string()));

--- a/packages/transport-bluetooth/src/server/types.rs
+++ b/packages/transport-bluetooth/src/server/types.rs
@@ -13,6 +13,33 @@ pub enum ChannelMessage {
     Notification(NotificationEvent),
 }
 
+// partial TrezorDevice
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+pub struct KnownDevice {
+    pub id: String,
+    #[serde(rename = "macAddress")]
+    pub mac_address: String,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+pub struct SetStateParams {
+    pub devices: Vec<KnownDevice>,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+pub struct ConnectDeviceParams {
+    pub id: String,
+    pub timeout: u32,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+pub struct WriteParams {
+    pub id: String,
+    pub data: Vec<u8>,
+    #[serde(rename = "withResponse")]
+    pub with_response: bool,
+}
+
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 #[serde(tag = "method", content = "params", rename_all = "snake_case")]
 pub enum WsRequestMethod {

--- a/packages/transport-bluetooth/src/ui/index.html
+++ b/packages/transport-bluetooth/src/ui/index.html
@@ -52,6 +52,7 @@
                 <button id="stop_scan">Stop scan</button>
                 <button id="get_info">Get info</button>
                 <button id="enumerate">Enumerate</button>
+                <button id="set_state">Set state</button>
             </section>
 
             <section>

--- a/packages/transport-bluetooth/src/ui/index.ts
+++ b/packages/transport-bluetooth/src/ui/index.ts
@@ -66,7 +66,7 @@ const createDevice = (api: TrezorBluetooth, d: BluetoothDevice) => {
     connectBtn.textContent = d.connected ? 'Disconnect' : 'Connect';
     connectBtn.addEventListener('click', () => {
         if (!d.connected) {
-            api.send('connect_device', [d.id, 30000])
+            api.send('connect_device', { id: d.id, timeout: 30000 })
                 .then(r => {
                     writeOutput(r);
                     (document.getElementById('connect_device_input') as HTMLInputElement).value =
@@ -199,7 +199,7 @@ async function init() {
 
     getElement('connect_device').onclick = () => {
         const id = getDeviceId();
-        api.send('connect_device', [id, 30000])
+        api.send('connect_device', { id, timeout: 30000 })
             .then(r => {
                 writeOutput(r);
             })
@@ -254,7 +254,7 @@ async function init() {
 
     getElement('write').onclick = () => {
         const id = getDeviceId();
-        api.send('write', [id, [63, 35, 35, 0, 55]]) // GetFeatures
+        api.send('write', { id, data: [63, 35, 35, 0, 55] }) // GetFeatures
             .then(r => {
                 writeOutput(r);
             })
@@ -272,6 +272,29 @@ async function init() {
             .catch(e => {
                 writeOutput({ error: e.message });
             });
+    };
+
+    getElement('set_state').onclick = () => {
+        const value = getDeviceId().split(',');
+        const state = { devices: value.map(d => ({ id: d, macAddress: d })) };
+        api.send('set_state', state)
+            .then(r => {
+                writeOutput(r);
+            })
+            .catch(e => {
+                writeOutput({ error: e.message });
+            });
+    };
+
+    getElement('send_message').onclick = () => {
+        const input = document.getElementById('send_message_input') as HTMLInputElement;
+        try {
+            const json = JSON.parse(input.value);
+            const resp = api.sendMessage(json);
+            writeOutput(resp);
+        } catch (e) {
+            writeOutput(e);
+        }
     };
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Tiny prerequisite. it would be nice to merge it before https://github.com/trezor/trezor-suite/pull/20211 so i can adjust the params
1. unify server params and send object instead of tuples (connect_device, write methods) 
2. added new method "set_state" to pass known devices from suite
3. fix: catch json serialize error and try to get at least the "id" to be able to respond with error



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bt-server-params&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bt-server-params&lookback=7)