### PR TITLE
Feat/bt server set state

### DIFF
--- a/packages/transport-bluetooth/src/server/adapter_manager.rs
+++ b/packages/transport-bluetooth/src/server/adapter_manager.rs
@@ -17,7 +17,7 @@ use tokio::{
 
 use crate::server::{
     device::{DeviceConnectionStatus, TrezorDevice},
-    types::{AdapterState, ChannelMessage, NotificationEvent},
+    types::{AdapterState, ChannelMessage, KnownDevice, NotificationEvent},
     utils, ConnectionBroadcast,
 };
 
@@ -34,6 +34,7 @@ struct ManagerState {
     is_scanning: bool,
     listeners: Vec<ConnectionBroadcast>,
     peripherals: DashMap<String, TrezorDevice>,
+    known_peripherals: Vec<KnownDevice>,
 }
 
 impl Debug for AdapterManager {
@@ -67,6 +68,7 @@ impl AdapterManager {
             is_scanning: false,
             listeners: Vec::new(),
             peripherals: DashMap::new(),
+            known_peripherals: Vec::new(),
         }));
 
         Ok(Self {
@@ -251,9 +253,22 @@ impl AdapterManager {
         state.is_scanning = value;
     }
 
+    pub async fn set_known_peripherals(&self, value: Vec<KnownDevice>) {
+        let mut state = self.manager_state.lock().await;
+        state.known_peripherals = value;
+    }
+
+    async fn is_known_peripheral(&self, id: &str) -> bool {
+        let state = self.manager_state.lock().await;
+
+        state.known_peripherals.iter().any(|x| x.id == id)
+    }
+
     async fn add_device(&self, id: &PeripheralId) -> Result<TrezorDevice, AdapterError> {
-        let peripheral = self.get_peripheral_or_die(&id.to_string()).await?;
-        let device = match TrezorDevice::new(peripheral).await {
+        let id = id.to_string();
+        let peripheral = self.get_peripheral_or_die(&id).await?;
+        let is_known = self.is_known_peripheral(&id).await;
+        let device = match TrezorDevice::new(peripheral, is_known).await {
             Ok(device) => device,
             Err(_) => {
                 return Err(AdapterError::AdapterMissing);

--- a/packages/transport-bluetooth/src/server/device.rs
+++ b/packages/transport-bluetooth/src/server/device.rs
@@ -100,7 +100,7 @@ pub const CHARACTERISTIC_RX: Uuid = uuid!("8c000002-a59b-4d58-a9ad-073df69fa1b1"
 pub const CHARACTERISTIC_TX: Uuid = uuid!("8c000003-a59b-4d58-a9ad-073df69fa1b1"); // trezor-firmware BT_UUID_TRZ_RX_VAL
 
 impl TrezorDevice {
-    pub async fn new(peripheral: Peripheral) -> Result<Self, Box<dyn Error>> {
+    pub async fn new(peripheral: Peripheral, is_known: bool) -> Result<Self, Box<dyn Error>> {
         let PeripheralProperties {
             local_name,
             manufacturer_data,
@@ -124,14 +124,16 @@ impl TrezorDevice {
             false => DeviceConnectionStatus::Disconnected,
         };
         let discovery_timestamp = utils::get_timestamp();
-        let paired = BluetoothDevice::is_paired(&peripheral)
-            .await
-            .unwrap_or(false);
+        let paired = match is_known {
+            false => BluetoothDevice::is_paired(&peripheral)
+                .await
+                .unwrap_or(false),
+            true => true,
+        };
         let address = BluetoothDevice::get_address(peripheral);
 
         info!(
-            "create TrezorDevice {}, {}, {:?}",
-            id, address, manufacturer_data
+            "create TrezorDevice known: {is_known}, id: {id}, address: {address}, manufacturer_data: {manufacturer_data:?}"
         );
 
         let props = TrezorDeviceProps {

--- a/packages/transport-bluetooth/src/server/message_handler.rs
+++ b/packages/transport-bluetooth/src/server/message_handler.rs
@@ -69,6 +69,7 @@ pub async fn handle_message(
         WsRequestMethod::Enumerate => methods::enumerate(manager).await,
         WsRequestMethod::StartScan => methods::start_scan(manager, broadcast).await,
         WsRequestMethod::StopScan => methods::stop_scan(manager, broadcast).await,
+        WsRequestMethod::SetState(params) => methods::set_state(manager, params).await,
     };
 
     match payload {

--- a/packages/transport-bluetooth/src/server/methods/mod.rs
+++ b/packages/transport-bluetooth/src/server/methods/mod.rs
@@ -1,9 +1,11 @@
 pub mod enumerate;
 pub mod get_info;
+pub mod set_state;
 pub mod start_scan;
 pub mod stop_scan;
 
 pub use self::enumerate::enumerate;
 pub use self::get_info::get_info;
+pub use self::set_state::set_state;
 pub use self::start_scan::start_scan;
 pub use self::stop_scan::stop_scan;

--- a/packages/transport-bluetooth/src/server/methods/set_state.rs
+++ b/packages/transport-bluetooth/src/server/methods/set_state.rs
@@ -1,0 +1,13 @@
+use crate::server::{
+    adapter_manager::AdapterManager,
+    types::{MethodResult, SetStateParams, WsResponsePayload},
+};
+use log::info;
+
+pub async fn set_state(manager: AdapterManager, params: SetStateParams) -> MethodResult {
+    info!("set_state {:?}", params);
+
+    manager.set_known_peripherals(params.devices).await;
+
+    Ok(WsResponsePayload::Success(true))
+}

--- a/packages/transport-bluetooth/src/server/types.rs
+++ b/packages/transport-bluetooth/src/server/types.rs
@@ -47,6 +47,7 @@ pub enum WsRequestMethod {
     Enumerate,
     StartScan,
     StopScan,
+    SetState(SetStateParams),
 }
 
 #[derive(serde::Deserialize, Debug)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
based on https://github.com/trezor/trezor-suite/pull/20356

add server `set_state` method, pass known devices from suite so it can be used to determine if discovered device is paired (macos doesnt share that information)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/bt-server-set-state&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/bt-server-set-state&lookback=7)