### PR TITLE
feat(suite): turn on debug mode confirmation modal

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/settings/settingsPage.ts
@@ -45,6 +45,8 @@ export class SettingsPage {
     readonly settingsMenuButton: Locator;
     readonly settingsHeader: Locator;
     readonly debugTabButton: Locator;
+    readonly debugModalCheckbox: Locator;
+    readonly debugModalButton: Locator;
     readonly connectTabButton: Locator;
     readonly applicationTabButton: Locator;
     readonly deviceTabButton: Locator;
@@ -79,6 +81,8 @@ export class SettingsPage {
         this.settingsMenuButton = this.page.getByTestId('@suite/menu/settings');
         this.settingsHeader = this.page.getByTestId('@settings/menu/title');
         this.debugTabButton = this.page.getByTestId('@settings/menu/debug');
+        this.debugModalCheckbox = this.page.getByTestId('@debug-mode-dialog/turn-on-button');
+        this.debugModalButton = this.page.getByTestId('@debug-mode-dialog/checkbox');
         this.connectTabButton = this.page.getByTestId('@settings/menu/connected-apps');
         this.applicationTabButton = this.page.getByTestId('@settings/menu/general');
         this.deviceTabButton = this.page.getByTestId('@settings/menu/device');
@@ -130,6 +134,8 @@ export class SettingsPage {
         for (let i = 0; i < this.TIMES_CLICK_TO_SET_DEBUG_MODE; i++) {
             await this.settingsHeader.click();
         }
+        await this.debugModalCheckbox.click();
+        await this.debugModalButton.click();
         await expect(this.debugTabButton).toBeVisible();
     }
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/SettingsName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/SettingsName.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { spacingsPx } from '@trezor/theme';
 
+import { openModal } from 'src/actions/suite/modalActions';
 import { setDebugMode } from 'src/actions/suite/suiteActions';
 import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -31,19 +32,16 @@ export const SettingsName = () => {
 
         if (clickCounter === 4) {
             setClickCounter(0);
-            dispatch(setDebugMode({ showDebugMenu: !isDebugModeActive }));
 
+            if (!isDebugModeActive) {
+                dispatch(openModal({ type: 'turn-on-debug-mode' }));
+
+                return;
+            }
+
+            dispatch(setDebugMode({ showDebugMenu: false }));
             if (desktopApi.available) {
-                desktopApi.configLogger(
-                    isDebugModeActive
-                        ? {} // Reset to default values.
-                        : {
-                              level: 'debug',
-                              options: {
-                                  writeToDisk: true,
-                              },
-                          },
-                );
+                desktopApi.configLogger({}); // Reset to default values.
             }
         }
     };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TurnOnDebugModeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TurnOnDebugModeModal.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+
+import { Banner, Card, Column, H3, Modal } from '@trezor/components';
+import { desktopApi } from '@trezor/suite-desktop-api';
+import { spacings } from '@trezor/theme';
+
+import { setDebugMode } from 'src/actions/suite/suiteActions';
+import { CheckItem, Translation } from 'src/components/suite';
+import { useDispatch } from 'src/hooks/suite';
+
+type TurnOnDebugModeModalProps = {
+    onCancel: () => void;
+};
+
+export const TurnOnDebugModeModal = ({ onCancel }: TurnOnDebugModeModalProps) => {
+    const [isConfirmed, setIsConfirmed] = useState(false);
+    const dispatch = useDispatch();
+
+    const handleTurningOnDebugMode = () => {
+        dispatch(setDebugMode({ showDebugMenu: true }));
+
+        if (desktopApi.available) {
+            desktopApi.configLogger({
+                level: 'debug',
+                options: { writeToDisk: true },
+            });
+        }
+
+        onCancel();
+    };
+
+    return (
+        <Modal
+            // Intentionally no backdrop click, because this modal is turned on by repeated clicks on header,
+            // and a next click would close the modal
+            iconName="shieldWarning"
+            size="small"
+            bottomContent={
+                <>
+                    <Modal.Button
+                        onClick={handleTurningOnDebugMode}
+                        isDisabled={!isConfirmed}
+                        data-testid="@debug-mode-dialog/turn-on-button"
+                    >
+                        <Translation id="TR_TURN_ON_DEBUG_MODE_MODAL_BUTTON" />
+                    </Modal.Button>
+                    <Modal.Button variant="tertiary" onClick={onCancel}>
+                        <Translation id="TR_CANCEL" />
+                    </Modal.Button>
+                </>
+            }
+            variant="warning"
+        >
+            <H3>
+                <Translation id="TR_TURN_ON_DEBUG_MODE_TITLE" />
+            </H3>
+            <Column gap={spacings.sm} margin={{ top: spacings.xl }} alignItems="center">
+                <Banner icon="warningFilled">
+                    <Translation id="TR_TURN_ON_DEBUG_MODE_MODAL_DESCRIPTION_1" />
+                </Banner>
+            </Column>
+            <Card margin={{ top: spacings.lg }}>
+                <CheckItem
+                    title={<Translation id="TR_READ_AND_UNDERSTOOD" />}
+                    isChecked={isConfirmed}
+                    onClick={() => setIsConfirmed(!isConfirmed)}
+                    data-testid="@debug-mode-dialog/checkbox"
+                />
+            </Card>
+        </Modal>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -56,6 +56,7 @@ import { ConnectAddressConfirmation } from './ConnectAddressConfirmation';
 import { ConnectErrorModal } from './ConnectErrorModal';
 import { ConnectLoadingModal } from './ConnectLoadingModal';
 import { TradingDCAModal } from './TradingDCAModal';
+import { TurnOnDebugModeModal } from './TurnOnDebugModeModal';
 import { TxSimulationModal } from './TxSimulationModal';
 import { EverstakeModal } from './UnstakeModal/EverstakeModal';
 import { WalletConnectProposalModal } from './WalletConnectProposalModal';
@@ -100,6 +101,8 @@ export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL.CONTE
             return <DeviceAuthenticityOptOutModal onCancel={onCancel} />;
         case 'firmware-authenticity-checks-opt-out':
             return <FirmwareRevisionOptOutModal onCancel={onCancel} />;
+        case 'turn-on-debug-mode':
+            return <TurnOnDebugModeModal onCancel={onCancel} />;
         case 'qr-reader':
             return <QrScannerModal decision={payload.decision} onCancel={onCancel} />;
         case 'transaction-detail':

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3783,6 +3783,19 @@ export default defineMessages({
         id: 'TR_PIN_MISMATCH_HEADING',
         defaultMessage: 'PIN mismatch!',
     },
+    TR_TURN_ON_DEBUG_MODE_TITLE: {
+        id: 'TR_TURN_ON_DEBUG_MODE_TITLE',
+        defaultMessage: 'Turn on Debug mode',
+    },
+    TR_TURN_ON_DEBUG_MODE_MODAL_DESCRIPTION_1: {
+        id: 'TR_TURN_ON_DEBUG_MODE_MODAL_DESCRIPTION_1',
+        defaultMessage:
+            "Only turn on the debug mode if you fully understand the risks and have clear reasons for doing so. If you're uncertain, contact Trezor Support for assistance.",
+    },
+    TR_TURN_ON_DEBUG_MODE_MODAL_BUTTON: {
+        id: 'TR_TURN_ON_DEBUG_MODE_MODAL_BUTTON',
+        defaultMessage: 'Turn on',
+    },
     TR_DEBUG_SETTINGS: {
         id: 'TR_DEBUG_SETTINGS',
         defaultMessage: 'Debug',

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -107,6 +107,9 @@ export type UserContextPayload =
           type: 'firmware-authenticity-checks-opt-out';
       }
     | {
+          type: 'turn-on-debug-mode';
+      }
+    | {
           type: 'metadata-provider';
           decision: Deferred<boolean>;
       }


### PR DESCRIPTION
## Description
When you click 5 times on Settings header, do not enable Debug mode straight away, but open a modal similar to turning off FW authenticity checks or Device authenticity check.

## Related Issue

Resolve #20360

## Screenshots:

<img width="660" height="490" alt="Screenshot from 2025-07-24 09-40-20" src="https://github.com/user-attachments/assets/7f852ee4-8aa6-4e58-888a-9a933838ff52" />


[Screencast from 2025-07-24 09-39-46.webm](https://github.com/user-attachments/assets/5eac9457-a3cd-47be-8442-c7f325a61852)



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/debug-mode-dialog&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/debug-mode-dialog&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/debug-mode-dialog&lookback=7)