### PR TITLE
fix(suite): show CustomFee tx size only for bitcoin-like

### DIFF
--- a/packages/suite/src/components/wallet/Fees/CustomFee/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CustomFee.tsx
@@ -91,6 +91,9 @@ export const CustomFee = <TFieldValues extends FormState>({
 
     const feeUnits = getFeeUnits(networkType);
 
+    const shouldShowTxSize =
+        networkType === 'bitcoin' && cachedBytes !== undefined && cachedBytes !== false;
+
     return (
         <>
             <CustomFeeWrapper>
@@ -158,7 +161,7 @@ export const CustomFee = <TFieldValues extends FormState>({
                     </Row>
                 </Column>
             )}
-            {cachedBytes !== undefined && cachedBytes !== false && (
+            {shouldShowTxSize && (
                 <Row alignItems="baseline" justifyContent="space-between">
                     <Text variant="tertiary" typographyStyle="hint">
                         <Translation id="TR_SIZE" />:


### PR DESCRIPTION
## Description

Do not show CustomFee tx size for networks othe than type bitcoin

## Related Issue

Resolve #20326

## Screenshots:

BTC:

<img width="748" height="551" alt="image" src="https://github.com/user-attachments/assets/bba26af7-0862-4e2e-b77b-edad488ebb69" />

LTC:

<img width="728" height="570" alt="image" src="https://github.com/user-attachments/assets/b5379676-6168-48df-b7f2-86e7410374f1" />

ETH:
<img width="745" height="624" alt="image" src="https://github.com/user-attachments/assets/3a6f6168-c1f7-47c8-9896-8d783e5b2365" />




🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tx-size-only-for-bitcoin-like&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tx-size-only-for-bitcoin-like&lookback=7)