### PR TITLE
Dispose worker after disconnecting

### DIFF
--- a/packages/connect/src/backend/Blockchain.ts
+++ b/packages/connect/src/backend/Blockchain.ts
@@ -55,7 +55,7 @@ export type BlockchainOptions = {
 };
 
 export class Blockchain {
-    link: BlockchainLink;
+    readonly link: BlockchainLink;
     serverInfo?: ServerInfo;
 
     readonly identity?: string;
@@ -99,19 +99,13 @@ export class Blockchain {
         });
     }
 
-    onError(error: ERRORS.TrezorError) {
-        const pendingSubscriptions =
-            this.link.listenerCount('block') ||
-            this.link.listenerCount('notification') ||
-            this.link.listenerCount('fiatRates');
-
-        this.link.dispose();
+    private onBackendDisconnected(pendingSubscriptions = false) {
         this.postMessage(
             createBlockchainMessage(BLOCKCHAIN.ERROR, {
                 coin: this.coinInfo,
                 identity: this.identity,
-                error: error.message,
-                code: error.code,
+                error: ERRORS.ERROR_CODES.Backend_Disconnected,
+                code: 'Backend_Disconnected',
             }),
         );
         this.onDisconnected?.(!!pendingSubscriptions);
@@ -137,7 +131,13 @@ export class Blockchain {
         }
 
         this.link.on('disconnected', () => {
-            this.onError(ERRORS.TypedError('Backend_Disconnected'));
+            const pendingSubscriptions =
+                this.link.listenerCount('block') ||
+                this.link.listenerCount('notification') ||
+                this.link.listenerCount('fiatRates');
+
+            this.link.dispose();
+            this.onBackendDisconnected(!!pendingSubscriptions);
         });
 
         return info;
@@ -305,7 +305,7 @@ export class Blockchain {
 
     disconnect() {
         this.link.removeAllListeners();
-        this.link.disconnect();
-        this.onError(ERRORS.TypedError('Backend_Disconnected'));
+        this.link.disconnect().then(() => this.link.dispose());
+        this.onBackendDisconnected();
     }
 }

--- a/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
@@ -67,7 +67,9 @@ jest.mock('@trezor/blockchain-link', () => ({
             return true;
         }
 
-        disconnect() {}
+        disconnect() {
+            return Promise.resolve(true);
+        }
 
         removeAllListeners() {}
 


### PR DESCRIPTION
`Blockchain` class refactored so `Blockchain.disconnect()` method still emits disconnected events synchronously but `BlockchainLink.dispose()` is called after `BlockchainLink.disconnect()` is resolved.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/backend-disposing&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/backend-disposing&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/backend-disposing&lookback=7)