### PR TITLE
fix: value for sats and BTC as base currency above Movile Graph

### DIFF
--- a/suite-common/graph/src/types.ts
+++ b/suite-common/graph/src/types.ts
@@ -1,13 +1,14 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
+import { BaseCurrencyAmount } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 export type FiatGraphPoint = {
     date: Date;
     value: number;
-    // Because graph latest point doesn't include staking, some tokens etc. we display this value when user is not touching the graph
-    // But we can't override value of the "real" latest point, because we calculate percentage change based on it
-    valueLatestTotal?: string;
+    // Because graph latest point doesn't include staking, some tokens etc. we display this value when user is not touching the graph,
+    // But we can't override the value of the "real" latest point, because we calculate percentage change based on it
+    valueLatestTotal?: BaseCurrencyAmount;
 };
 
 export type FiatGraphPointWithCryptoBalance = {

--- a/suite-native/device-manager/package.json
+++ b/suite-native/device-manager/package.json
@@ -27,7 +27,6 @@
         "@suite-native/navigation": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
-        "@trezor/utils": "workspace:*",
         "jotai": "^2.12.5",
         "react": "19.0.0",
         "react-native": "0.79.3",

--- a/suite-native/device-manager/src/components/WalletItem.tsx
+++ b/suite-native/device-manager/src/components/WalletItem.tsx
@@ -15,12 +15,9 @@ type WalletItemProps = {
 export const WalletItem = ({ onPress, deviceState, isSelectable = true }: WalletItemProps) => {
     const device = useSelector((state: any) => selectDeviceByState(state, deviceState));
     const selectedDevice = useSelector(selectSelectedDevice);
-    const fiatBalance = useSelector((state: any) =>
+    const baseCurrencyAmount = useSelector((state: any) =>
         device?.state?.staticSessionId
-            ? selectDeviceTotalFiatBalanceByDeviceState(
-                  state,
-                  device?.state?.staticSessionId,
-              ).toFixed(2)
+            ? selectDeviceTotalFiatBalanceByDeviceState(state, device?.state?.staticSessionId)
             : undefined,
     );
 
@@ -40,7 +37,7 @@ export const WalletItem = ({ onPress, deviceState, isSelectable = true }: Wallet
             isSelectable={isSelectable}
             isSelected={showAsSelected}
             walletNumber={device.walletNumber}
-            fiatBalance={fiatBalance}
+            baseCurrencyAmount={baseCurrencyAmount}
         />
     );
 };

--- a/suite-native/device-manager/src/components/WalletItemBase.tsx
+++ b/suite-native/device-manager/src/components/WalletItemBase.tsx
@@ -1,12 +1,11 @@
 import { Pressable } from 'react-native';
 
-import { asBaseCurrencyAmount } from '@suite-common/wallet-utils';
+import { BaseCurrencyAmount } from '@suite-common/wallet-utils';
 import { HStack, Radio, Text } from '@suite-native/atoms';
 import { BaseCurrencyAmountFormatter } from '@suite-native/formatters';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import { BigNumber } from '@trezor/utils';
 
 type WalletItemBaseVariant = 'standard' | 'passphrase';
 
@@ -16,7 +15,7 @@ type WalletItemBaseProps = {
     isSelectable: boolean;
     isSelected: boolean;
     walletNumber?: number;
-    fiatBalance?: string;
+    baseCurrencyAmount?: BaseCurrencyAmount;
 };
 
 type WalletItemBaseStyleProps = { isSelected: boolean; isSelectable: boolean };
@@ -60,7 +59,7 @@ export const WalletItemBase = ({
     isSelected,
     isSelectable,
     walletNumber,
-    fiatBalance,
+    baseCurrencyAmount,
 }: WalletItemBaseProps) => {
     const { applyStyle } = useNativeStyles();
     const isStandard = variant === 'standard';
@@ -81,9 +80,9 @@ export const WalletItemBase = ({
                     </Text>
                 </HStack>
                 <HStack alignItems="center" spacing="sp12">
-                    {fiatBalance && (
+                    {baseCurrencyAmount && (
                         <BaseCurrencyAmountFormatter
-                            value={asBaseCurrencyAmount(new BigNumber(fiatBalance))}
+                            value={baseCurrencyAmount}
                             variant="hint"
                             color="textSubdued"
                         />

--- a/suite-native/device-manager/tsconfig.json
+++ b/suite-native/device-manager/tsconfig.json
@@ -21,7 +21,6 @@
         { "path": "../link" },
         { "path": "../navigation" },
         { "path": "../../packages/styles" },
-        { "path": "../../packages/theme" },
-        { "path": "../../packages/utils" }
+        { "path": "../../packages/theme" }
     ]
 }

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -35,7 +35,11 @@ import {
     selectSelectedDeviceAuthenticity,
 } from '@suite-common/wallet-core';
 import { Account, RatesByKey } from '@suite-common/wallet-types';
-import { asBaseCurrencyAmount, getAccountFiatBalance } from '@suite-common/wallet-utils';
+import {
+    BaseCurrencyAmount,
+    asBaseCurrencyAmount,
+    getAccountFiatBalance,
+} from '@suite-common/wallet-utils';
 import {
     FeatureFlag,
     FeatureFlagsRootState,
@@ -96,16 +100,18 @@ export const selectDeviceError = (
     return device?.error;
 };
 
+type GetTotalFiatBalanceNativeParams = {
+    deviceAccounts: Account[];
+    localCurrency: BaseCurrencyCode;
+    rates?: RatesByKey;
+};
+
 // FIXME: this function can be removed and substituted with @suite-common/wallet-utils/getTotalFiatBalance when Solana supports staking on mobile.
 const getTotalFiatBalanceNative = ({
     deviceAccounts,
     localCurrency,
     rates,
-}: {
-    deviceAccounts: Account[];
-    localCurrency: BaseCurrencyCode;
-    rates?: RatesByKey;
-}) => {
+}: GetTotalFiatBalanceNativeParams): BaseCurrencyAmount => {
     let instanceBalance = new BigNumber(0);
     deviceAccounts.forEach(a => {
         const accountFiatBalance =

--- a/suite-native/formatters/src/tests/utils.test.ts
+++ b/suite-native/formatters/src/tests/utils.test.ts
@@ -1,7 +1,7 @@
 import { parseBalanceAmount } from '../utils';
 
-describe('parseBalanceAmount', () => {
-    test('should parse balance amount correctly with valid input', () => {
+describe(parseBalanceAmount.name, () => {
+    it('parses balance amount correctly with valid input', () => {
         const result = parseBalanceAmount('$1,234.56');
         expect(result).toEqual({
             currencySymbol: '$',
@@ -10,7 +10,7 @@ describe('parseBalanceAmount', () => {
         });
     });
 
-    test('should parse balance amount correctly with valid input and no decimal part', () => {
+    it('parses balance amount correctly with valid input and no decimal part', () => {
         const result = parseBalanceAmount('€2,000');
         expect(result).toEqual({
             currencySymbol: '€',
@@ -19,7 +19,7 @@ describe('parseBalanceAmount', () => {
         });
     });
 
-    test('should parse balance amount correctly with valid input and only decimal part', () => {
+    it('parses balance amount correctly with valid input and only decimal part', () => {
         const result = parseBalanceAmount('CZK0.99');
         expect(result).toEqual({
             currencySymbol: 'CZK',
@@ -28,7 +28,25 @@ describe('parseBalanceAmount', () => {
         });
     });
 
-    test('should handle invalid input with missing currency symbol', () => {
+    it('handles BTC correctly', () => {
+        const result = parseBalanceAmount('BTC 0.01');
+        expect(result).toEqual({
+            currencySymbol: 'BTC',
+            wholeNumber: '0',
+            decimalNumber: '.01',
+        });
+    });
+
+    it('handles sats correctly', () => {
+        const result = parseBalanceAmount('1,477,571 sat');
+        expect(result).toEqual({
+            currencySymbol: 'sat',
+            wholeNumber: '1,477,571',
+            decimalNumber: '',
+        });
+    });
+
+    it('handles invalid input with missing currency symbol', () => {
         const result = parseBalanceAmount('10,000.00');
         expect(result).toEqual({
             currencySymbol: null,

--- a/suite-native/formatters/src/utils.ts
+++ b/suite-native/formatters/src/utils.ts
@@ -1,13 +1,25 @@
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-/** Matches three groups: 1. currency symbol,  2. whole number part and 3. decimal part. */
+/** Matches three groups: 1. currency symbol, 2. whole number part and 3. decimal part. */
 const BALANCE_PARSING_REGEX = /^(\D+)([\d,]+)(?:\.(\d+))?$/u;
 
 export const convertTokenValueToDecimal = (value: string | number, decimals: number) =>
     BigNumber(value).div(BigNumber(10).exponentiatedBy(decimals));
 
+const normalizeValueForBtcAndSats = (value: string) => {
+    const [first, second] = value.split(' ');
+
+    if (!second) {
+        return first;
+    }
+
+    return second === 'sat' ? `${second}${first}` : `${first}${second}`;
+};
+
 export const parseBalanceAmount = (value: string) => {
-    const regexGroups = value.match(BALANCE_PARSING_REGEX);
+    const normalizedValue = normalizeValueForBtcAndSats(value);
+
+    const regexGroups = normalizedValue.match(BALANCE_PARSING_REGEX);
     const [_, currencySymbol, wholeNumberPart, decimalNumberPart] = regexGroups ?? [
         null,
         null,

--- a/suite-native/graph/src/components/GraphFiatBalance.tsx
+++ b/suite-native/graph/src/components/GraphFiatBalance.tsx
@@ -42,18 +42,18 @@ const Skeleton = () => (
 
 const Balance = ({ selectedPointAtom, latestValue }: BalanceProps) => {
     const point = useAtomValue(selectedPointAtom);
-    const fiatValue =
-        latestValue !== undefined
-            ? latestValue
-            : asBaseCurrencyAmount(
-                  new BigNumber(
-                      point?.valueLatestTotal || (point?.value ? String(point.value) : '0'),
-                  ),
-              );
+
+    const baseCurrencyValue =
+        latestValue ??
+        point?.valueLatestTotal ??
+        asBaseCurrencyAmount(new BigNumber(point?.value ? String(point.value) : '0'));
 
     return (
         <DiscreetTextTrigger testID="@home/portfolio/fiat-balance-header/discreet-trigger">
-            <FiatBalanceFormatter value={fiatValue} testID="@home/portfolio/fiat-balance-header" />
+            <FiatBalanceFormatter
+                value={baseCurrencyValue}
+                testID="@home/portfolio/fiat-balance-header"
+            />
         </DiscreetTextTrigger>
     );
 };
@@ -77,7 +77,7 @@ export const GraphFiatBalance = ({
     const showBalanceFallback =
         !hasDeviceDiscovery && ((hasBalance && showLoading) || !isHistoryEnabledAccount);
 
-    // If discovery finished but graph still loading or missing first point we just show latest total balance
+    // If discovery finished but the graph still loading or missing first point, we just show the latest total balance
     if (showBalanceFallback) {
         return (
             <Box style={applyStyle(wrapperStyle)}>

--- a/suite-native/graph/src/hooks.ts
+++ b/suite-native/graph/src/hooks.ts
@@ -195,17 +195,19 @@ export const useGraphForAllDeviceAccounts = ({ baseCurrencyCode }: CommonUseGrap
     };
 };
 
+type UseGraphAtomsParams<TGraphPoint extends FiatGraphPoint> = {
+    referencePointAtom: WritableAtom<TGraphPoint | null, [TGraphPoint | null], void>;
+    selectedPointAtom: WritableAtom<TGraphPoint | null, [TGraphPoint | null], void>;
+    graphPoints: TGraphPoint[];
+    totalFiatBalance: BaseCurrencyAmount;
+};
+
 export const useGraphAtoms = <TGraphPoint extends FiatGraphPoint>({
     referencePointAtom,
     selectedPointAtom,
     graphPoints,
     totalFiatBalance,
-}: {
-    referencePointAtom: WritableAtom<TGraphPoint | null, [TGraphPoint | null], void>;
-    selectedPointAtom: WritableAtom<TGraphPoint | null, [TGraphPoint | null], void>;
-    graphPoints: TGraphPoint[];
-    totalFiatBalance: BaseCurrencyAmount;
-}): {
+}: UseGraphAtomsParams<TGraphPoint>): {
     handleGestureStart: () => void;
     setInitialSelectedPoints: () => void;
     setSelectedPoint: (point: TGraphPoint) => void;
@@ -234,7 +236,7 @@ export const useGraphAtoms = <TGraphPoint extends FiatGraphPoint>({
         if (lastPoint && referencePoint) {
             setSelectedPoint({
                 ...lastPoint,
-                valueLatestTotal: totalFiatBalance.toFixed(2),
+                valueLatestTotal: totalFiatBalance,
             });
             setReferencePoint(referencePoint);
         }
@@ -248,7 +250,7 @@ export const useGraphAtoms = <TGraphPoint extends FiatGraphPoint>({
         if (!isGestureActive && lastPoint) {
             setSelectedPoint({
                 ...lastPoint,
-                valueLatestTotal: totalFiatBalance.toFixed(2),
+                valueLatestTotal: totalFiatBalance,
             });
         }
     }, [isGestureActive, setInitialSelectedPoints, totalFiatBalance, lastPoint, setSelectedPoint]);

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
@@ -56,7 +56,7 @@ const IgnoredNetworksBanner = () => {
 };
 
 export const PortfolioGraph = forwardRef<PortfolioGraphRef>((_props, ref) => {
-    const fiatCurrencyCode = useSelector(selectLocalCurrency);
+    const baseCurrencyCode = useSelector(selectLocalCurrency);
     const hasDeviceHistoryEnabledAccounts = useSelector(selectHasDeviceHistoryEnabledAccounts);
     const hasDeviceDiscovery = useSelector(selectHasRunningDiscovery);
     const loadingTakesLongerThanExpected = useIsDiscoveryDurationTooLong();
@@ -71,7 +71,7 @@ export const PortfolioGraph = forwardRef<PortfolioGraphRef>((_props, ref) => {
         onSelectTimeFrame,
         timeframe,
     } = useGraphForAllDeviceAccounts({
-        baseCurrencyCode: fiatCurrencyCode,
+        baseCurrencyCode,
     });
 
     const { handleGestureStart, setInitialSelectedPoints, setSelectedPoint } = useGraphAtoms({
@@ -90,6 +90,7 @@ export const PortfolioGraph = forwardRef<PortfolioGraphRef>((_props, ref) => {
     );
 
     const showHeader = isAnyMainnetAccountPresent || isLoading;
+
     const showGraph = hasDeviceHistoryEnabledAccounts || hasDeviceDiscovery;
 
     return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -10323,7 +10323,6 @@ __metadata:
     "@suite-native/navigation": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
-    "@trezor/utils": "workspace:*"
     jotai: "npm:^2.12.5"
     react: "npm:19.0.0"
     react-native: "npm:0.79.3"


### PR DESCRIPTION
<img width="538" height="597" alt="image" src="https://github.com/user-attachments/assets/5d7b97f6-6ccb-4d42-b783-c039683dc5df" />
<img width="538" height="597" alt="image" src="https://github.com/user-attachments/assets/c12a7590-719f-4b64-afb0-1750e172f87d" />


<img width="561" height="428" alt="image" src="https://github.com/user-attachments/assets/131399e4-a5ba-46ee-85ef-03e4a8293e3b" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-mobile&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-mobile&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-mobile&lookback=7)