### PR TITLE
feat(suite): add trading fees disclamer (buy, sell, swap)

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1332,6 +1332,10 @@ export default defineMessages({
             "Some fees may not be included in the displayed price. The final cost will be shown on the provider's website.",
         id: 'TR_TRADING_FEES_ON_WEBSITE',
     },
+    TR_TRADING_FEES_DISCLAIMER: {
+        defaultMessage: 'See how fees are calculated for your {tradingType}.',
+        id: 'TR_TRADING_FEES_DISCLAIMER',
+    },
     TR_TRADING_NETWORK_FEE: {
         defaultMessage: 'Network fee',
         id: 'TR_TRADING_NETWORK_FEE',

--- a/packages/suite/src/utils/wallet/trading/tradingUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/tradingUtils.ts
@@ -39,6 +39,15 @@ interface TradingGetDecimalsProps {
     network?: Network | null;
 }
 
+export const translationKeys: Record<
+    TradingType,
+    Extract<ExtendedMessageDescriptor['id'], 'TR_BUY' | 'TR_TRADING_SELL' | 'TR_TRADING_SWAP'>
+> = {
+    buy: 'TR_BUY',
+    sell: 'TR_TRADING_SELL',
+    exchange: 'TR_TRADING_SWAP',
+};
+
 export const getTradingCryptoInfo = (
     cryptoSelect:
         | TradingAccountOptionsGroupOptionProps

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormFeeDisclamer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormFeeDisclamer.tsx
@@ -1,0 +1,38 @@
+import { TradingType } from '@suite-common/trading';
+import { Button, Flex, Paragraph } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+import { INVITY_SCHEDULE_OF_FEES } from '@trezor/urls';
+
+import { Translation } from 'src/components/suite';
+import { useTranslation } from 'src/hooks/suite';
+import { translationKeys } from 'src/utils/wallet/trading/tradingUtils';
+
+type TradingFormFeesDisclamerProps = {
+    tradingType: TradingType;
+};
+
+export const TradingFormFeesDisclamer = ({ tradingType }: TradingFormFeesDisclamerProps) => {
+    const { translationString } = useTranslation();
+
+    return (
+        <Flex gap={spacings.sm}>
+            <Paragraph variant="tertiary">
+                <Translation
+                    id="TR_TRADING_FEES_DISCLAIMER"
+                    values={{
+                        tradingType: translationString(translationKeys[tradingType]).toLowerCase(),
+                    }}
+                />
+            </Paragraph>
+            <Button
+                href={INVITY_SCHEDULE_OF_FEES}
+                icon="arrowUpRight"
+                iconAlignment="end"
+                variant="tertiary"
+                size="tiny"
+            >
+                <Translation id="TR_LEARN_MORE" />
+            </Button>
+        </Flex>
+    );
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInputs.tsx
@@ -33,6 +33,8 @@ import { TradingFormInputFiatCrypto } from 'src/views/wallet/trading/common/Trad
 import { TradingFormInputPaymentMethod } from 'src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod';
 import { TradingFormSwitcherExchangeRates } from 'src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormSwitcherExchangeRates';
 
+import { TradingFormFeesDisclamer } from './TradingFormFeeDisclamer';
+
 const generateFractionButtons = (
     helpers: TradingUseFormActionsReturnProps,
 ): FractionButtonProps[] => [
@@ -141,6 +143,7 @@ export const TradingFormInputs = () => {
                 />
                 <TradingFormInputPaymentMethod label="TR_TRADING_RECEIVE_METHOD" />
                 <TradingFormInputCountry label="TR_TRADING_COUNTRY" />
+                <TradingFormFeesDisclamer tradingType={context.type} />
             </>
         );
     }
@@ -238,6 +241,7 @@ export const TradingFormInputs = () => {
                     trigger={trigger}
                 />
                 <TradingFormSwitcherExchangeRates rateType={rateType} setValue={setValue} />
+                <TradingFormFeesDisclamer tradingType={context.type} />
             </>
         );
     }
@@ -265,6 +269,7 @@ export const TradingFormInputs = () => {
             />
             <TradingFormInputPaymentMethod label="TR_TRADING_PAYMENT_METHOD" />
             <TradingFormInputCountry label="TR_TRADING_COUNTRY" />
+            <TradingFormFeesDisclamer tradingType={context.type} />
         </>
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionInfo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionInfo.tsx
@@ -1,24 +1,15 @@
-import type { TradingTransaction, TradingType } from '@suite-common/trading';
+import type { TradingTransaction } from '@suite-common/trading';
 import { InfoSegments } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { FormattedDate } from 'src/components/suite';
 import { useTranslation } from 'src/hooks/suite';
-import { ExtendedMessageDescriptor } from 'src/types/suite';
+import { translationKeys } from 'src/utils/wallet/trading/tradingUtils';
 import { TradingTransactionStatus } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionStatus';
 
 interface TradingTransactionInfoProps {
     trade: TradingTransaction;
 }
-
-const translationKeys: Record<
-    TradingType,
-    Extract<ExtendedMessageDescriptor['id'], 'TR_BUY' | 'TR_TRADING_SELL' | 'TR_TRADING_SWAP'>
-> = {
-    buy: 'TR_BUY',
-    sell: 'TR_TRADING_SELL',
-    exchange: 'TR_TRADING_SWAP',
-};
 
 export const TradingTransactionInfo = ({ trade }: TradingTransactionInfoProps) => {
     const { date } = trade;


### PR DESCRIPTION
## Description

Added a trading disclaimer with a link to detailed fee information to the Buy, Sell, and Swap screens.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20309

## Screenshots:

<img width="1459" height="788" alt="image" src="https://github.com/user-attachments/assets/a15cbd96-0947-4e83-b111-56387d884c6d" />

<img width="1460" height="979" alt="image" src="https://github.com/user-attachments/assets/5c6ec0d7-a8fa-48d4-a971-90ee10acb8a5" />

<img width="1462" height="954" alt="image" src="https://github.com/user-attachments/assets/4c960769-4b29-4148-8c61-5bacdf0130c5" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-fees-disclamer&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-fees-disclamer&lookback=7)