### PR TITLE
fix(native): use useNavigateToInitialScreen instead of plain goBack

### DIFF
--- a/suite-native/module-accounts-management/src/components/AccountDetailScreenHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailScreenHeader.tsx
@@ -11,6 +11,7 @@ import {
     RootStackRoutes,
     ScreenHeader,
     StackToStackCompositeNavigationProps,
+    useNavigateToInitialScreen,
 } from '@suite-native/navigation';
 
 type AccountDetailScreenHeaderProps = {
@@ -51,6 +52,7 @@ export const AccountDetailScreenHeader = ({
     accountKey,
 }: AccountDetailScreenHeaderProps) => {
     const navigation = useNavigation<AccountDetailNavigationProps>();
+    const navigateToInitialScreen = useNavigateToInitialScreen();
     const route = useRoute<RouteProp<RootStackParamList, RootStackRoutes.AccountDetail>>();
     const { closeActionType } = route.params;
 
@@ -78,6 +80,7 @@ export const AccountDetailScreenHeader = ({
                 />
             }
             closeActionType={closeActionType}
+            closeAction={navigateToInitialScreen}
         />
     );
 };

--- a/suite-native/module-send/src/screens/SendAccountsScreen.tsx
+++ b/suite-native/module-send/src/screens/SendAccountsScreen.tsx
@@ -7,11 +7,14 @@ import {
     SendStackParamList,
     SendStackRoutes,
     StackProps,
+    useNavigateToInitialScreen,
 } from '@suite-native/navigation';
 
 export const SendAccountsScreen = ({
     navigation,
 }: StackProps<SendStackParamList, SendStackRoutes.SendAccounts>) => {
+    const navigateToInitialScreen = useNavigateToInitialScreen();
+
     const navigateToSendFormScreen: OnSelectAccount = ({ account, tokenAddress, tokenSymbol }) => {
         analytics.report({
             type: EventType.SendFlowEntered,
@@ -35,6 +38,7 @@ export const SendAccountsScreen = ({
                 <ScreenHeader
                     title={<Translation id="moduleSend.accountsList.title" />}
                     closeActionType="close"
+                    closeAction={navigateToInitialScreen}
                 />
             }
         >


### PR DESCRIPTION
Added `returnToInitialScreen` flag to `ScreenHeader` and `GoBackIcon` in order to support return to the first screen in Navigation Stack. I had to add the flag, because in some screens we need to really call `goBack` in order to not skip bottom sheets.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19725

## Screenshots:

https://github.com/user-attachments/assets/1109001d-432f-472d-8bd4-94531e7583a9

https://github.com/user-attachments/assets/5a0a7ef4-f9e7-4de7-bfca-b6345313085c





🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/go-back-navigation&lookback=7)