### PR TITLE
feat(suite-native): Introduce AnimatedDoubleView to atoms

### DIFF
--- a/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleInput.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleInput.tsx
@@ -1,0 +1,79 @@
+import { ReactNode, RefObject, useCallback, useRef, useState } from 'react';
+
+import { useUpdateEffect } from '@suite-native/helpers';
+
+import {
+    ANIMATED_DOUBLE_VIEW_SWITCH_ANIMATION_DURATION,
+    ActiveView,
+    AnimatedDoubleView,
+    RenderViewProps,
+} from './AnimatedDoubleView';
+import { InputType } from '../Input/Input';
+
+export type RenderInputProps = RenderViewProps & {
+    inputRef: RefObject<InputType | null>;
+};
+
+export type AnimatedDoubleInputProps = {
+    renderPrimary: (props: RenderInputProps) => ReactNode;
+    renderSecondary: (props: RenderInputProps) => ReactNode;
+    onInputSwitch?: (activeView: ActiveView) => void;
+    switchLabel?: string;
+};
+
+const noop = () => {};
+
+export const AnimatedDoubleInput = ({
+    renderPrimary,
+    renderSecondary,
+    onInputSwitch = noop,
+    switchLabel,
+}: AnimatedDoubleInputProps) => {
+    const primaryInputRef = useRef<InputType | null>(null);
+    const secondaryInputRef = useRef<InputType | null>(null);
+    const [activeInputRef, setActiveInputRef] =
+        useState<RefObject<InputType | null>>(primaryInputRef);
+
+    // focus input after the view switch animation is done
+    // do not focus input on initial render
+    useUpdateEffect(
+        useCallback(() => {
+            const timeoutID = setTimeout(() => {
+                if (activeInputRef.current) {
+                    activeInputRef.current.focus();
+                }
+            }, ANIMATED_DOUBLE_VIEW_SWITCH_ANIMATION_DURATION);
+
+            return () => {
+                clearTimeout(timeoutID);
+            };
+        }, [activeInputRef]),
+    );
+
+    const focusInput = useCallback(
+        (activeView: ActiveView) => {
+            setActiveInputRef(activeView === 'primary' ? primaryInputRef : secondaryInputRef);
+            onInputSwitch(activeView);
+        },
+        [onInputSwitch],
+    );
+
+    return (
+        <AnimatedDoubleView
+            renderPrimary={props =>
+                renderPrimary({
+                    ...props,
+                    inputRef: primaryInputRef,
+                })
+            }
+            renderSecondary={props =>
+                renderSecondary({
+                    ...props,
+                    inputRef: secondaryInputRef,
+                })
+            }
+            onViewSwitch={focusInput}
+            switchLabel={switchLabel}
+        />
+    );
+};

--- a/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleView.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleView.tsx
@@ -1,0 +1,66 @@
+import { useCallback, useState } from 'react';
+import Animated, { LinearTransition } from 'react-native-reanimated';
+
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+import {
+    ANIMATION_DURATION,
+    AnimatedViewWrapper,
+    AnimatedViewWrapperProps,
+} from './AnimatedViewWrapper';
+import { SwitchViewsButton } from './SwitchViewsButton';
+
+export type { RenderViewProps } from './AnimatedViewWrapper';
+
+export type ActiveView = 'primary' | 'secondary';
+
+export type AnimatedDoubleViewProps = {
+    renderPrimary: AnimatedViewWrapperProps['renderView'];
+    renderSecondary: AnimatedViewWrapperProps['renderView'];
+    onViewSwitch?: (activeView: ActiveView) => void;
+    switchLabel?: string;
+};
+
+export const ANIMATED_DOUBLE_VIEW_SWITCH_ANIMATION_DURATION = ANIMATION_DURATION;
+export const ANIMATED_DOUBLE_VIEW_WRAPPER_HEIGHT = 108;
+
+const viewsWrapperStyle = prepareNativeStyle(() => ({
+    height: ANIMATED_DOUBLE_VIEW_WRAPPER_HEIGHT,
+    justifyContent: 'space-between',
+}));
+
+const noop = () => {};
+
+export const AnimatedDoubleView = ({
+    renderPrimary,
+    renderSecondary,
+    onViewSwitch = noop,
+    switchLabel,
+}: AnimatedDoubleViewProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    const [activeView, setActiveView] = useState<ActiveView>('primary');
+
+    const handleViewSwitch = useCallback(() => {
+        const nextActiveView = activeView === 'primary' ? 'secondary' : 'primary';
+
+        setActiveView(nextActiveView);
+        onViewSwitch(nextActiveView);
+    }, [onViewSwitch, activeView]);
+
+    return (
+        <Animated.View layout={LinearTransition} style={applyStyle(viewsWrapperStyle)}>
+            <AnimatedViewWrapper
+                renderView={renderPrimary}
+                focused={activeView === 'primary'}
+                handleViewSwitch={handleViewSwitch}
+            />
+            <SwitchViewsButton onPress={handleViewSwitch} label={switchLabel} />
+            <AnimatedViewWrapper
+                renderView={renderSecondary}
+                focused={activeView === 'secondary'}
+                handleViewSwitch={handleViewSwitch}
+            />
+        </Animated.View>
+    );
+};

--- a/suite-native/atoms/src/AnimatedDoubleView/AnimatedViewWrapper.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/AnimatedViewWrapper.tsx
@@ -1,0 +1,72 @@
+import { ReactNode, useEffect } from 'react';
+import { Pressable } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+export type RenderViewProps = {
+    isDisabled: boolean;
+    onPress: (() => void) | undefined;
+};
+
+export type AnimatedViewWrapperProps = {
+    renderView: (props: RenderViewProps) => ReactNode;
+    focused: boolean;
+    handleViewSwitch: () => void;
+};
+
+export const ANIMATION_DURATION = 300;
+const SCALE_FOCUSED = 1;
+const SCALE_UNFOCUSED = 0.9;
+const TRANSLATE_Y_FOCUSED = 0;
+const TRANSLATE_Y_UNFOCUSED = 55;
+
+const withPredefinedTiming = (toValue: number) =>
+    withTiming(toValue, { duration: ANIMATION_DURATION });
+
+const getScale = (focused: boolean) => (focused ? SCALE_FOCUSED : SCALE_UNFOCUSED);
+const getTranslateY = (focused: boolean) => (focused ? TRANSLATE_Y_FOCUSED : TRANSLATE_Y_UNFOCUSED);
+
+export const wrapperStyle = prepareNativeStyle<{ focused: boolean }>((_, { focused }) => ({
+    position: 'absolute',
+    top: focused ? 0 : 2,
+    flex: 1,
+    width: '100%',
+}));
+
+export const AnimatedViewWrapper = ({
+    renderView,
+    focused,
+    handleViewSwitch,
+}: AnimatedViewWrapperProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    const scale = useSharedValue(getScale(focused));
+    const translateY = useSharedValue(getTranslateY(focused));
+
+    useEffect(() => {
+        scale.value = withPredefinedTiming(getScale(focused));
+        translateY.value = withPredefinedTiming(getTranslateY(focused));
+    }, [focused, scale, translateY]);
+
+    const animatedStyle = useAnimatedStyle(
+        () => ({
+            transform: [{ scale: scale.value }, { translateY: translateY.value }],
+            zIndex: focused ? 1 : 0,
+        }),
+        [focused],
+    );
+
+    const onPress = focused ? undefined : handleViewSwitch;
+
+    return (
+        <Animated.View style={[applyStyle(wrapperStyle, { focused }), animatedStyle]}>
+            <Pressable onPress={onPress}>
+                {renderView({
+                    isDisabled: !focused,
+                    onPress,
+                })}
+            </Pressable>
+        </Animated.View>
+    );
+};

--- a/suite-native/atoms/src/AnimatedDoubleView/SwitchViewsButton.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/SwitchViewsButton.tsx
@@ -1,0 +1,45 @@
+import { TouchableOpacity } from 'react-native';
+
+import { Icon } from '@suite-native/icons';
+import { useTranslate } from '@suite-native/intl';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+import { Box } from '../Box';
+
+type SwitchAmountsButtonProps = { onPress: () => void; label?: string };
+
+const BUTTON_TOP_OFFSET = 42;
+const BUTTON_PADDING = 6;
+
+const buttonWrapperStyle = prepareNativeStyle(() => ({
+    alignSelf: 'center',
+    top: BUTTON_TOP_OFFSET,
+    zIndex: 3, // To stay above both of the absolute inputs.
+}));
+
+const buttonStyle = prepareNativeStyle(utils => ({
+    padding: BUTTON_PADDING,
+    backgroundColor: utils.colors.backgroundTertiaryDefaultOnElevation1,
+    borderColor: utils.colors.borderDashed,
+    borderWidth: utils.borders.widths.small,
+    borderRadius: utils.borders.radii.round,
+}));
+
+export const SwitchViewsButton = ({ onPress, label }: SwitchAmountsButtonProps) => {
+    const { applyStyle } = useNativeStyles();
+    const { translate } = useTranslate();
+
+    return (
+        <Box style={applyStyle(buttonWrapperStyle)}>
+            <TouchableOpacity
+                style={applyStyle(buttonStyle)}
+                onPress={onPress}
+                accessibilityLabel={
+                    label ?? translate('atoms.animatedDoubleView.defaultSwitchLabel')
+                }
+            >
+                <Icon size="mediumLarge" name="arrowsCounterClockwise" />
+            </TouchableOpacity>
+        </Box>
+    );
+};

--- a/suite-native/atoms/src/AnimatedDoubleView/__tests__/AnimatedDoubleInput.comp.test.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/__tests__/AnimatedDoubleInput.comp.test.tsx
@@ -1,0 +1,50 @@
+import { renderWithBasicProvider, userEvent } from '@suite-native/test-utils';
+
+import { Input } from '../../Input/Input';
+import { AnimatedDoubleInput, AnimatedDoubleInputProps } from '../AnimatedDoubleInput';
+
+describe('AnimatedDoubleInput', () => {
+    const renderAnimatedDoubleInput = (props: Partial<AnimatedDoubleInputProps>) =>
+        renderWithBasicProvider(
+            <AnimatedDoubleInput
+                renderPrimary={({ onPress, isDisabled, inputRef }) => (
+                    <Input
+                        ref={inputRef}
+                        onPress={onPress}
+                        editable={!isDisabled}
+                        value="Primary Input value"
+                        label="Primary Input label"
+                    />
+                )}
+                renderSecondary={({ onPress, isDisabled, inputRef }) => (
+                    <Input
+                        ref={inputRef}
+                        onPress={onPress}
+                        editable={!isDisabled}
+                        value="Secondary Input value"
+                        label="Secondary Input label"
+                    />
+                )}
+                {...props}
+            />,
+        );
+
+    it('should call onViewSwitch when Switch button is pressed', async () => {
+        const onInputSwitch = jest.fn();
+        const { getByLabelText } = renderAnimatedDoubleInput({ onInputSwitch });
+
+        const switchButton = getByLabelText('Switch');
+        await userEvent.press(switchButton);
+
+        expect(onInputSwitch).toHaveBeenCalledTimes(1);
+        expect(onInputSwitch).toHaveBeenCalledWith('secondary');
+    });
+
+    it('should propagate switch label', () => {
+        const switchLabel = 'Custom Switch Label';
+        const { getByLabelText, queryByLabelText } = renderAnimatedDoubleInput({ switchLabel });
+
+        expect(queryByLabelText('Switch')).toBeNull();
+        expect(getByLabelText(switchLabel)).toBeOnTheScreen();
+    });
+});

--- a/suite-native/atoms/src/AnimatedDoubleView/__tests__/AnimatedDoubleView.comp.test.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/__tests__/AnimatedDoubleView.comp.test.tsx
@@ -1,0 +1,68 @@
+import { renderWithBasicProvider, userEvent } from '@suite-native/test-utils';
+
+import { Box } from '../../Box';
+import { AnimatedDoubleView, AnimatedDoubleViewProps } from '../AnimatedDoubleView';
+
+describe('AnimatedDoubleView', () => {
+    const renderAnimatedDoubleView = (props: Partial<AnimatedDoubleViewProps>) =>
+        renderWithBasicProvider(
+            <AnimatedDoubleView
+                renderPrimary={() => <Box accessibilityLabel="PRIMARY_VIEW" />}
+                renderSecondary={() => <Box accessibilityLabel="SECONDARY_VIEW" />}
+                {...props}
+            />,
+        );
+
+    it('should render primary and secondary component and switcher in between', () => {
+        const { getByLabelText } = renderAnimatedDoubleView({});
+
+        expect(getByLabelText('PRIMARY_VIEW')).toBeOnTheScreen();
+        expect(getByLabelText('SECONDARY_VIEW')).toBeOnTheScreen();
+        expect(getByLabelText('Switch')).toBeOnTheScreen();
+    });
+
+    it('should call onViewSwitch when Switch button is pressed', async () => {
+        const onViewSwitch = jest.fn();
+        const { getByLabelText } = renderAnimatedDoubleView({ onViewSwitch });
+
+        const switchButton = getByLabelText('Switch');
+        await userEvent.press(switchButton);
+        await userEvent.press(switchButton);
+
+        expect(onViewSwitch).toHaveBeenCalledTimes(2);
+        expect(onViewSwitch).toHaveBeenNthCalledWith(1, 'secondary');
+        expect(onViewSwitch).toHaveBeenNthCalledWith(2, 'primary');
+    });
+
+    it('should propagate switch label', () => {
+        const switchLabel = 'Custom Switch Label';
+        const { getByLabelText, queryByLabelText } = renderAnimatedDoubleView({ switchLabel });
+
+        expect(queryByLabelText('Switch')).toBeNull();
+        expect(getByLabelText(switchLabel)).toBeOnTheScreen();
+    });
+
+    it('should switch active view on second view press', async () => {
+        const onViewSwitch = jest.fn();
+        const { getByLabelText } = renderAnimatedDoubleView({ onViewSwitch });
+
+        await userEvent.press(getByLabelText('SECONDARY_VIEW'));
+        await userEvent.press(getByLabelText('PRIMARY_VIEW'));
+
+        expect(onViewSwitch).toHaveBeenCalledTimes(2);
+        expect(onViewSwitch).toHaveBeenNthCalledWith(1, 'secondary');
+        expect(onViewSwitch).toHaveBeenNthCalledWith(2, 'primary');
+    });
+
+    it('should do nothing when pressing active view', async () => {
+        const onViewSwitch = jest.fn();
+        const { getByLabelText } = renderAnimatedDoubleView({ onViewSwitch });
+
+        await userEvent.press(getByLabelText('PRIMARY_VIEW'));
+        await userEvent.press(getByLabelText('Switch'));
+        await userEvent.press(getByLabelText('SECONDARY_VIEW'));
+
+        expect(onViewSwitch).toHaveBeenCalledTimes(1);
+        expect(onViewSwitch).toHaveBeenNthCalledWith(1, 'secondary');
+    });
+});

--- a/suite-native/atoms/src/index.ts
+++ b/suite-native/atoms/src/index.ts
@@ -76,5 +76,6 @@ export * from './SwipeableWalkthrough/SwipeableWalkthroughScreenHeader';
 export * from './SwipeableWalkthrough/SwipeableWalkthroughStep';
 export * from './SwipeableWalkthrough/SwipeableWalkthroughStepHeader';
 export * from './SwipeableWalkthrough/SwipeableWalkthroughCloseButton';
+export * from './AnimatedDoubleView/AnimatedDoubleView';
 
 export { useDebugView } from './DebugView';

--- a/suite-native/atoms/src/index.ts
+++ b/suite-native/atoms/src/index.ts
@@ -77,5 +77,6 @@ export * from './SwipeableWalkthrough/SwipeableWalkthroughStep';
 export * from './SwipeableWalkthrough/SwipeableWalkthroughStepHeader';
 export * from './SwipeableWalkthrough/SwipeableWalkthroughCloseButton';
 export * from './AnimatedDoubleView/AnimatedDoubleView';
+export * from './AnimatedDoubleView/AnimatedDoubleInput';
 
 export { useDebugView } from './DebugView';

--- a/suite-native/helpers/jest.config.js
+++ b/suite-native/helpers/jest.config.js
@@ -2,12 +2,4 @@ const { ...baseConfig } = require('../../jest.config.native');
 
 module.exports = {
     ...baseConfig,
-    coverageThreshold: {
-        global: {
-            statements: 80,
-            branches: 80,
-            functions: 80,
-            lines: 80,
-        },
-    },
 };

--- a/suite-native/helpers/package.json
+++ b/suite-native/helpers/package.json
@@ -12,6 +12,7 @@
     },
     "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
+        "@reduxjs/toolkit": "2.8.2",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-native/toasts": "workspace:*",
         "@trezor/connect": "workspace:*",

--- a/suite-native/helpers/redux.d.ts
+++ b/suite-native/helpers/redux.d.ts
@@ -1,0 +1,7 @@
+import { AsyncThunkAction } from '@reduxjs/toolkit';
+
+declare module 'redux' {
+    export interface Dispatch {
+        <TThunk extends AsyncThunkAction<any, any, any>>(thunk: TThunk): ReturnType<TThunk>;
+    }
+}

--- a/suite-native/helpers/src/hooks/__tests__/useUpdateEffect.test.ts
+++ b/suite-native/helpers/src/hooks/__tests__/useUpdateEffect.test.ts
@@ -1,0 +1,39 @@
+import { EffectCallback } from 'react';
+
+import { renderHookWithBasicProvider } from '@suite-native/test-utils';
+
+import { useUpdateEffect } from '../useUpdateEffect';
+
+describe('useUpdateEffect', () => {
+    const renderUseUpdateEffect = (initialEffect: EffectCallback) =>
+        renderHookWithBasicProvider(({ effect }) => useUpdateEffect(effect), {
+            initialProps: { effect: initialEffect },
+        });
+
+    it('should do nothing on mount', () => {
+        const effect = jest.fn();
+        renderUseUpdateEffect(effect);
+
+        expect(effect).not.toHaveBeenCalled();
+    });
+
+    it('should call effect on update', () => {
+        const effect = jest.fn();
+        const { rerender } = renderUseUpdateEffect(jest.fn());
+
+        rerender({ effect });
+
+        expect(effect).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call dispose callback on unmount', () => {
+        const dispose = jest.fn();
+        const effect = () => dispose;
+        const { rerender, unmount } = renderUseUpdateEffect(jest.fn());
+
+        rerender({ effect });
+        unmount();
+
+        expect(dispose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/suite-native/helpers/src/hooks/useUpdateEffect.ts
+++ b/suite-native/helpers/src/hooks/useUpdateEffect.ts
@@ -1,0 +1,15 @@
+import { EffectCallback, useEffect, useRef } from 'react';
+
+export const useUpdateEffect = (effect: EffectCallback) => {
+    const isFirstMount = useRef(true);
+
+    useEffect(() => {
+        if (isFirstMount.current) {
+            isFirstMount.current = false;
+
+            return undefined;
+        }
+
+        return effect();
+    }, [effect]);
+};

--- a/suite-native/helpers/src/index.ts
+++ b/suite-native/helpers/src/index.ts
@@ -1,4 +1,5 @@
 export * from './hooks/useCopyToClipboard';
 export * from './hooks/useAmountInputTransformers';
 export * from './hooks/useIsMultiline';
+export * from './hooks/useUpdateEffect';
 export * from './splitAddressToChunks';

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -2321,6 +2321,11 @@ export const en = {
             confirmButton: 'Got it',
         },
     },
+    atoms: {
+        animatedDoubleView: {
+            defaultSwitchLabel: 'Switch',
+        },
+    },
 };
 
 export type Translations = typeof en;

--- a/suite-native/module-send/src/components/AmountInputs.tsx
+++ b/suite-native/module-send/src/components/AmountInputs.tsx
@@ -1,22 +1,18 @@
-import { useRef, useState } from 'react';
-import { View } from 'react-native';
-import Animated, { LinearTransition, useSharedValue, withTiming } from 'react-native-reanimated';
+import Animated, { LinearTransition } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import { useRoute } from '@react-navigation/native';
 
 import { AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { EventType, analytics } from '@suite-native/analytics';
-import { HStack, InputType, Text, VStack } from '@suite-native/atoms';
+import { ActiveView, AnimatedDoubleInput, HStack, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { SendStackParamList, SendStackRoutes, StackProps } from '@suite-native/navigation';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { AmountErrorMessage } from './AmountErrorMessage';
 import { CryptoAmountInput } from './CryptoAmountInput';
 import { FiatAmountInput } from './FiatAmountInput';
 import { SendMaxButton } from './SendMaxButton';
-import { SwitchAmountsButton } from './SwitchAmountsButton';
 import { useDisplayBaseCurrency } from '../hooks/useDisplayBaseCurrency';
 
 type AmountInputProps = {
@@ -25,29 +21,9 @@ type AmountInputProps = {
 
 type RouteProps = StackProps<SendStackParamList, SendStackRoutes.SendOutputs>['route'];
 
-const ANIMATION_DURATION = 300;
-const SCALE_FOCUSED = 1;
-const SCALE_UNFOCUSED = 0.9;
-const TRANSLATE_Y_FOCUSED = 0;
-const TRANSLATE_Y_UNFOCUSED = 55;
-
-const DEFAULT_INPUTS_WRAPPER_HEIGHT = 108;
-const FIATLESS_INPUTS_WRAPPER_HEIGHT = 60;
-
-const inputsWrapperStyle = prepareNativeStyle<{ isFiatDisplayed: boolean }>(
-    (_, { isFiatDisplayed }) => ({
-        height: isFiatDisplayed ? DEFAULT_INPUTS_WRAPPER_HEIGHT : FIATLESS_INPUTS_WRAPPER_HEIGHT,
-        justifyContent: 'space-between',
-    }),
-);
-
-const withPredefinedTiming = (toValue: number) =>
-    withTiming(toValue, { duration: ANIMATION_DURATION });
-
 export const AmountInputs = ({ index }: AmountInputProps) => {
     const route = useRoute<RouteProps>();
     const { accountKey, tokenContract } = route.params;
-    const { applyStyle } = useNativeStyles();
 
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
@@ -55,98 +31,65 @@ export const AmountInputs = ({ index }: AmountInputProps) => {
 
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(symbol);
 
-    const [isCryptoSelected, setIsCryptoSelected] = useState(true);
-    const amountInputsWrapperRef = useRef<View>(null);
-
-    const cryptoRef = useRef<InputType | null>(null);
-    const cryptoScale = useSharedValue(SCALE_FOCUSED);
-    const cryptoTranslateY = useSharedValue(TRANSLATE_Y_FOCUSED);
-
-    const fiatScale = useSharedValue(SCALE_UNFOCUSED);
-    const fiatTranslateY = useSharedValue(TRANSLATE_Y_UNFOCUSED);
-    const fiatRef = useRef<InputType | null>(null);
-
-    const handleSwitchInputs = () => {
-        if (isCryptoSelected) {
-            cryptoScale.value = withPredefinedTiming(SCALE_UNFOCUSED);
-            cryptoTranslateY.value = withPredefinedTiming(TRANSLATE_Y_UNFOCUSED);
-            fiatScale.value = withPredefinedTiming(SCALE_FOCUSED);
-            fiatTranslateY.value = withPredefinedTiming(TRANSLATE_Y_FOCUSED);
-
-            setTimeout(() => fiatRef.current?.focus(), ANIMATION_DURATION);
-        } else {
-            cryptoScale.value = withPredefinedTiming(SCALE_FOCUSED);
-            cryptoTranslateY.value = withPredefinedTiming(TRANSLATE_Y_FOCUSED);
-            fiatScale.value = withPredefinedTiming(SCALE_UNFOCUSED);
-            fiatTranslateY.value = withPredefinedTiming(TRANSLATE_Y_UNFOCUSED);
-
-            setTimeout(() => cryptoRef.current?.focus(), ANIMATION_DURATION);
-        }
-
+    const onInputSwitch = (activeView: ActiveView) => {
         analytics.report({
             type: EventType.SendAmountInputSwitched,
-            payload: { changedTo: isCryptoSelected ? 'fiat' : 'crypto' },
+            payload: { changedTo: activeView === 'primary' ? 'crypto' : 'fiat' },
         });
-
-        setIsCryptoSelected(!isCryptoSelected);
     };
 
     if (!symbol) return null;
 
     return (
-        <View ref={amountInputsWrapperRef}>
-            <VStack spacing="sp12">
-                <HStack flex={1} justifyContent="space-between" alignItems="center">
-                    <Animated.View layout={LinearTransition}>
-                        <Text variant="hint">
-                            <Translation id="moduleSend.outputs.recipients.amountLabel" />
-                        </Text>
-                    </Animated.View>
-                    <SendMaxButton
-                        outputIndex={index}
-                        accountKey={accountKey}
-                        tokenContract={tokenContract}
-                    />
-                </HStack>
-                <Animated.View
-                    layout={LinearTransition}
-                    style={applyStyle(inputsWrapperStyle, {
-                        isFiatDisplayed: shallDisplayBaseCurrency,
-                    })}
-                >
-                    <CryptoAmountInput
-                        recipientIndex={index}
-                        scaleValue={cryptoScale}
-                        translateValue={cryptoTranslateY}
-                        inputRef={cryptoRef}
-                        accountKey={accountKey}
-                        isDisabled={!isCryptoSelected}
-                        symbol={symbol}
-                        onPress={!isCryptoSelected ? handleSwitchInputs : undefined}
-                        tokenContract={tokenContract}
-                    />
-                    {shallDisplayBaseCurrency && (
-                        <>
-                            <SwitchAmountsButton onPress={handleSwitchInputs} />
-                            <FiatAmountInput
-                                recipientIndex={index}
-                                scaleValue={fiatScale}
-                                translateValue={fiatTranslateY}
-                                inputRef={fiatRef}
-                                accountKey={accountKey}
-                                isDisabled={isCryptoSelected}
-                                symbol={symbol}
-                                tokenContract={tokenContract}
-                                onPress={isCryptoSelected ? handleSwitchInputs : undefined}
-                            />
-                        </>
-                    )}
+        <VStack spacing="sp12">
+            <HStack flex={1} justifyContent="space-between" alignItems="center">
+                <Animated.View layout={LinearTransition}>
+                    <Text variant="hint">
+                        <Translation id="moduleSend.outputs.recipients.amountLabel" />
+                    </Text>
                 </Animated.View>
-                <AmountErrorMessage
+                <SendMaxButton
                     outputIndex={index}
-                    isFiatDisplayed={shallDisplayBaseCurrency}
+                    accountKey={accountKey}
+                    tokenContract={tokenContract}
                 />
-            </VStack>
-        </View>
+            </HStack>
+            {shallDisplayBaseCurrency ? (
+                <AnimatedDoubleInput
+                    renderPrimary={({ onPress, isDisabled, inputRef }) => (
+                        <CryptoAmountInput
+                            recipientIndex={index}
+                            inputRef={inputRef}
+                            accountKey={accountKey}
+                            symbol={symbol}
+                            tokenContract={tokenContract}
+                            isDisabled={isDisabled}
+                            onPress={onPress}
+                        />
+                    )}
+                    renderSecondary={({ onPress, isDisabled, inputRef }) => (
+                        <FiatAmountInput
+                            recipientIndex={index}
+                            inputRef={inputRef}
+                            accountKey={accountKey}
+                            isDisabled={isDisabled}
+                            symbol={symbol}
+                            tokenContract={tokenContract}
+                            onPress={onPress}
+                        />
+                    )}
+                    onInputSwitch={onInputSwitch}
+                />
+            ) : (
+                <CryptoAmountInput
+                    recipientIndex={index}
+                    accountKey={accountKey}
+                    symbol={symbol}
+                    tokenContract={tokenContract}
+                />
+            )}
+
+            <AmountErrorMessage outputIndex={index} isFiatDisplayed={shallDisplayBaseCurrency} />
+        </VStack>
     );
 };

--- a/suite-native/module-send/src/components/CryptoAmountInput.tsx
+++ b/suite-native/module-send/src/components/CryptoAmountInput.tsx
@@ -1,6 +1,4 @@
 import { ReactNode } from 'react';
-import { Pressable } from 'react-native';
-import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import { useFormatters } from '@suite-common/formatters';
@@ -12,22 +10,12 @@ import { useField, useFormContext } from '@suite-native/forms';
 import { useAmountInputTransformers } from '@suite-native/helpers';
 import { TokensRootState, selectAccountTokenSymbol } from '@suite-native/tokens';
 import { useDebounce } from '@trezor/react-utils';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Color } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils';
 
 import { SendOutputsFormValues } from '../sendOutputsFormSchema';
 import { SendAmountInputProps } from '../types';
 import { getOutputFieldName } from '../utils';
-
-export const sendAmountInputWrapperStyle = prepareNativeStyle<{ isDisabled: boolean }>(
-    (_, { isDisabled }) => ({
-        position: 'absolute',
-        top: isDisabled ? 2 : 0,
-        flex: 1,
-        width: '100%',
-    }),
-);
 
 export const SendAmountCurrencyLabelWrapper = ({
     children,
@@ -44,16 +32,12 @@ export const SendAmountCurrencyLabelWrapper = ({
 export const CryptoAmountInput = ({
     recipientIndex,
     inputRef,
-    scaleValue,
-    translateValue,
     symbol,
     tokenContract,
     accountKey,
     onPress,
-    onFocus,
     isDisabled = false,
 }: SendAmountInputProps) => {
-    const { applyStyle } = useNativeStyles();
     const { setValue, trigger } = useFormContext<SendOutputsFormValues>();
     const { cryptoAmountTransformer } = useAmountInputTransformers(symbol);
     const baseCurrencyCode = useSelector(selectLocalCurrency);
@@ -75,14 +59,6 @@ export const CryptoAmountInput = ({
 
     const converters = useCryptoFiatConverters({ symbol, tokenContract });
 
-    const cryptoAnimatedStyle = useAnimatedStyle(
-        () => ({
-            transform: [{ scale: scaleValue.value }, { translateY: translateValue.value }],
-            zIndex: isDisabled ? 0 : 1,
-        }),
-        [isDisabled],
-    );
-
     const baseCurrencyDecimals = getDecimalsForBaseCurrency({
         code: baseCurrencyCode,
         isInSats: isBaseCurrencyInSats,
@@ -97,7 +73,6 @@ export const CryptoAmountInput = ({
         setValue('setMaxOutputId', undefined);
         debounce(() => {
             trigger(cryptoFieldName);
-            onFocus?.();
         });
     };
 
@@ -106,30 +81,23 @@ export const CryptoAmountInput = ({
     };
 
     return (
-        <Animated.View
-            style={[applyStyle(sendAmountInputWrapperStyle, { isDisabled }), cryptoAnimatedStyle]}
-        >
-            <Pressable onPress={onPress} /* onPress doesn't work on Android for disabled Input */>
-                <Input
-                    ref={inputRef}
-                    value={value}
-                    placeholder="0"
-                    keyboardType="numeric"
-                    accessibilityLabel="amount to send input"
-                    testID={cryptoFieldName}
-                    editable={!isDisabled}
-                    onChangeText={handleChangeValue}
-                    onBlur={handleBlur}
-                    onPress={onPress}
-                    onFocus={onFocus}
-                    hasError={!isDisabled && hasError}
-                    rightIcon={
-                        <SendAmountCurrencyLabelWrapper isDisabled={isDisabled}>
-                            {tokenSymbol ?? formatter.format(symbol)}
-                        </SendAmountCurrencyLabelWrapper>
-                    }
-                />
-            </Pressable>
-        </Animated.View>
+        <Input
+            ref={inputRef}
+            value={value}
+            placeholder="0"
+            keyboardType="numeric"
+            accessibilityLabel="amount to send input"
+            testID={cryptoFieldName}
+            editable={!isDisabled}
+            onChangeText={handleChangeValue}
+            onBlur={handleBlur}
+            onPress={onPress}
+            hasError={!isDisabled && hasError}
+            rightIcon={
+                <SendAmountCurrencyLabelWrapper isDisabled={isDisabled}>
+                    {tokenSymbol ?? formatter.format(symbol)}
+                </SendAmountCurrencyLabelWrapper>
+            }
+        />
     );
 };

--- a/suite-native/module-send/src/components/FiatAmountInput.tsx
+++ b/suite-native/module-send/src/components/FiatAmountInput.tsx
@@ -1,5 +1,3 @@
-import { Pressable } from 'react-native';
-import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import { TokenDefinitionsRootState } from '@suite-common/token-definitions';
@@ -16,27 +14,22 @@ import { useCryptoFiatConverters } from '@suite-native/formatters';
 import { useField, useFormContext } from '@suite-native/forms';
 import { useAmountInputTransformers } from '@suite-native/helpers';
 import { selectAccountTokenDecimals } from '@suite-native/tokens';
-import { useNativeStyles } from '@trezor/styles';
 import { BigNumber } from '@trezor/utils';
 
-import { SendAmountCurrencyLabelWrapper, sendAmountInputWrapperStyle } from './CryptoAmountInput';
+import { SendAmountCurrencyLabelWrapper } from './CryptoAmountInput';
 import { SendOutputsFormValues } from '../sendOutputsFormSchema';
 import { SendAmountInputProps } from '../types';
 import { getOutputFieldName } from '../utils';
 
 export const FiatAmountInput = ({
     recipientIndex,
-    scaleValue,
-    translateValue,
     inputRef,
     symbol,
     tokenContract,
     onPress,
-    onFocus,
     isDisabled = false,
     accountKey,
 }: SendAmountInputProps) => {
-    const { applyStyle } = useNativeStyles();
     const { setValue } = useFormContext<SendOutputsFormValues>();
     const baseCurrencyCode = useSelector(selectLocalCurrency);
     const isBaseCurrencyInSats = useSelector(selectIsBaseCurrencyInSats);
@@ -50,14 +43,6 @@ export const FiatAmountInput = ({
 
     const cryptoFieldName = getOutputFieldName(recipientIndex, 'amount');
     const fiatFieldName = getOutputFieldName(recipientIndex, 'fiat');
-
-    const fiatAnimatedStyle = useAnimatedStyle(
-        () => ({
-            transform: [{ scale: scaleValue.value }, { translateY: translateValue.value }],
-            zIndex: isDisabled ? 0 : 1,
-        }),
-        [isDisabled],
-    );
 
     const { onChange, onBlur, value } = useField({
         name: fiatFieldName,
@@ -84,34 +69,26 @@ export const FiatAmountInput = ({
         }
 
         setValue('setMaxOutputId', undefined);
-        onFocus?.();
     };
 
     return (
-        <Animated.View
-            style={[applyStyle(sendAmountInputWrapperStyle, { isDisabled }), fiatAnimatedStyle]}
-        >
-            <Pressable onPress={onPress} /* onPress doesn't work on Android for disabled Input */>
-                <Input
-                    ref={inputRef}
-                    value={value}
-                    placeholder="0"
-                    keyboardType="numeric"
-                    accessibilityLabel="amount to send input"
-                    testID={fiatFieldName}
-                    editable={!isDisabled}
-                    onChangeText={handleChangeValue}
-                    onBlur={onBlur}
-                    onPress={onPress}
-                    onFocus={onFocus}
-                    hasError={!isDisabled && hasError}
-                    rightIcon={
-                        <SendAmountCurrencyLabelWrapper isDisabled={isDisabled}>
-                            {isBaseCurrencyInSats ? 'sat' : baseCurrencyCode.toUpperCase()}
-                        </SendAmountCurrencyLabelWrapper>
-                    }
-                />
-            </Pressable>
-        </Animated.View>
+        <Input
+            ref={inputRef}
+            value={value}
+            placeholder="0"
+            keyboardType="numeric"
+            accessibilityLabel="amount to send input"
+            testID={fiatFieldName}
+            editable={!isDisabled}
+            onChangeText={handleChangeValue}
+            onBlur={onBlur}
+            onPress={onPress}
+            hasError={!isDisabled && hasError}
+            rightIcon={
+                <SendAmountCurrencyLabelWrapper isDisabled={isDisabled}>
+                    {isBaseCurrencyInSats ? 'sat' : baseCurrencyCode.toUpperCase()}
+                </SendAmountCurrencyLabelWrapper>
+            }
+        />
     );
 };

--- a/suite-native/module-send/src/types.ts
+++ b/suite-native/module-send/src/types.ts
@@ -1,6 +1,5 @@
 import { RefObject } from 'react';
 import { TextInputProps } from 'react-native';
-import { SharedValue } from 'react-native-reanimated';
 
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import {
@@ -20,14 +19,11 @@ export type NativeSupportedFeeLevel = Exclude<FeeLevelLabel, 'low'>;
 export type SendAmountInputProps = {
     recipientIndex: number;
     symbol: NetworkSymbol;
-    inputRef: RefObject<InputType | null>;
-    scaleValue: SharedValue<number>;
-    translateValue: SharedValue<number>;
+    inputRef?: RefObject<InputType | null>;
     accountKey?: AccountKey;
     tokenContract?: TokenAddress;
     isDisabled?: boolean;
     onPress?: TextInputProps['onPress'];
-    onFocus?: () => void;
 };
 
 export type FeeLevelsMaxAmount = Record<FeeLevelLabel, string | undefined>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10780,6 +10780,7 @@ __metadata:
   resolution: "@suite-native/helpers@workspace:suite-native/helpers"
   dependencies:
     "@mobily/ts-belt": "npm:^3.13.1"
+    "@reduxjs/toolkit": "npm:2.8.2"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-native/toasts": "workspace:*"
     "@trezor/connect": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Introduced `AnimatedDoubleView` and `AnimatedDoubleInput` components.
- `module-send/AmountInputs` now uses `AnimatedDoubleInput` internally.
- `module-send/AmountInputs` refactored - unused code removed on multiple places.

## Related Issue

Resolve #20268

## Screenshots:
[https://github.com/user-attachments/assets/ec41f37f-fd64-4868-9576-58dbfc770da3](url)



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=20268-Extract-AmountInputs-into-reusable-component&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=20268-Extract-AmountInputs-into-reusable-component&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=20268-Extract-AmountInputs-into-reusable-component&lookback=7)