### PR TITLE
feat(suite): revision check other-error notification instead of banner

### DIFF
--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -67,7 +67,6 @@ export const Preloader = ({ children }: PropsWithChildren) => {
     const isEntropyCheckEnabledAndFailed = useSelector(selectIsEntropyCheckEnabledAndFailed);
     const isAnalyticsConsentConfirmed = useSelector(selectIsAnalyticsConfirmed);
 
-    // report firmware authenticity failures even when the UI is disabled
     useReportDeviceCompromised();
 
     const dispatch = useDispatch();

--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -26,6 +26,7 @@ import { RouterAppWithParams } from '../../../constants/suite/routes';
 import { AnalyticsConsentScreen } from '../../../views/start/AnalyticsConsentScreen';
 import { PrerequisitesGuide } from '../PrerequisitesGuide/PrerequisitesGuide';
 import { DeviceCompromised } from '../SecurityCheck/DeviceCompromised';
+import { useDeviceCompromisedNotification } from '../SecurityCheck/useDeviceCompromisedNotification';
 import { useReportDeviceCompromised } from '../SecurityCheck/useReportDeviceCompromised';
 import { LoggedOutLayout } from '../layouts/LoggedOutLayout';
 import { SuiteLayout } from '../layouts/SuiteLayout/SuiteLayout';
@@ -68,6 +69,7 @@ export const Preloader = ({ children }: PropsWithChildren) => {
     const isAnalyticsConsentConfirmed = useSelector(selectIsAnalyticsConfirmed);
 
     useReportDeviceCompromised();
+    useDeviceCompromisedNotification();
 
     const dispatch = useDispatch();
 

--- a/packages/suite/src/components/suite/SecurityCheck/useDeviceCompromisedNotification.ts
+++ b/packages/suite/src/components/suite/SecurityCheck/useDeviceCompromisedNotification.ts
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+
+import { TranslationKey } from '@suite-common/intl-types';
+import { isDeviceAcquired } from '@suite-common/suite-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
+
+import {
+    RevisionCheckErrorWithNotification,
+    isRevisionCheckErrorWithNotification,
+} from 'src/constants/suite/firmware';
+import { useDevice, useDispatch } from 'src/hooks/suite';
+
+const revisionCheckNotifications: Record<RevisionCheckErrorWithNotification, TranslationKey> = {
+    'other-error': 'TR_FIRMWARE_REVISION_CHECK_OTHER_ERROR',
+};
+
+/**
+ * Dispatch one-time toast notifications for firmware authenticity check errors.
+ */
+export const useDeviceCompromisedNotification = () => {
+    const { device } = useDevice();
+    const dispatch = useDispatch();
+
+    const revCheck = isDeviceAcquired(device) ? device.authenticityChecks?.firmwareRevision : null;
+    const isError = revCheck && !revCheck.success;
+    const errorType = isError ? revCheck.error : null;
+
+    useEffect(() => {
+        if (errorType === null) return;
+        if (isRevisionCheckErrorWithNotification(errorType)) {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'firmware-authenticity-check-error',
+                    translationKey: revisionCheckNotifications[errorType],
+                }),
+            );
+        }
+    }, [dispatch, errorType]);
+};

--- a/packages/suite/src/components/suite/SecurityCheck/useReportDeviceCompromised.ts
+++ b/packages/suite/src/components/suite/SecurityCheck/useReportDeviceCompromised.ts
@@ -1,25 +1,14 @@
 import { useEffect, useMemo } from 'react';
 
-import { TranslationKey } from '@suite-common/intl-types';
 import { FirmwareCheckType } from '@suite-common/suite-types';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
-import { notificationsActions } from '@suite-common/toast-notifications';
 import { FIRMWARE } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { isArrayMember } from '@trezor/utils';
 
-import {
-    RevisionCheckErrorWithNotification,
-    hashCheckErrorScenarios,
-    isRevisionCheckErrorWithNotification,
-    revisionCheckErrorScenarios,
-} from 'src/constants/suite/firmware';
-import { useDevice, useDispatch } from 'src/hooks/suite';
+import { hashCheckErrorScenarios, revisionCheckErrorScenarios } from 'src/constants/suite/firmware';
+import { useDevice } from 'src/hooks/suite';
 import { captureSentryMessage, withSentryScope } from 'src/utils/suite/sentry';
-
-const revisionCheckNotifications: Record<RevisionCheckErrorWithNotification, TranslationKey> = {
-    'other-error': 'TR_FIRMWARE_REVISION_CHECK_OTHER_ERROR',
-};
 
 const reportCheck = (
     level: 'error' | 'warning',
@@ -67,7 +56,6 @@ const useCommonData = () => {
 const useReportRevisionCheck = () => {
     const commonData = useCommonData();
     const { device } = useDevice();
-    const dispatch = useDispatch();
 
     const revisionCheck = isDeviceAcquired(device)
         ? device.authenticityChecks.firmwareRevision
@@ -82,18 +70,6 @@ const useReportRevisionCheck = () => {
             reportCheckFail('Firmware revision', { ...commonData, errorType }, errorPayload);
         }
     }, [commonData, errorType, errorPayload]);
-
-    useEffect(() => {
-        if (errorType === null) return;
-        if (isRevisionCheckErrorWithNotification(errorType)) {
-            dispatch(
-                notificationsActions.addToast({
-                    type: 'firmware-authenticity-check-error',
-                    translationKey: revisionCheckNotifications[errorType],
-                }),
-            );
-        }
-    }, [dispatch, errorType]);
 };
 
 const useReportHashCheck = () => {

--- a/packages/suite/src/components/suite/SecurityCheck/useReportDeviceCompromised.ts
+++ b/packages/suite/src/components/suite/SecurityCheck/useReportDeviceCompromised.ts
@@ -1,14 +1,25 @@
 import { useEffect, useMemo } from 'react';
 
+import { TranslationKey } from '@suite-common/intl-types';
 import { FirmwareCheckType } from '@suite-common/suite-types';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
 import { FIRMWARE } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { isArrayMember } from '@trezor/utils';
 
-import { hashCheckErrorScenarios, revisionCheckErrorScenarios } from 'src/constants/suite/firmware';
-import { useDevice } from 'src/hooks/suite';
+import {
+    RevisionCheckErrorWithNotification,
+    hashCheckErrorScenarios,
+    isRevisionCheckErrorWithNotification,
+    revisionCheckErrorScenarios,
+} from 'src/constants/suite/firmware';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 import { captureSentryMessage, withSentryScope } from 'src/utils/suite/sentry';
+
+const revisionCheckNotifications: Record<RevisionCheckErrorWithNotification, TranslationKey> = {
+    'other-error': 'TR_FIRMWARE_REVISION_CHECK_OTHER_ERROR',
+};
 
 const reportCheck = (
     level: 'error' | 'warning',
@@ -56,6 +67,8 @@ const useCommonData = () => {
 const useReportRevisionCheck = () => {
     const commonData = useCommonData();
     const { device } = useDevice();
+    const dispatch = useDispatch();
+
     const revisionCheck = isDeviceAcquired(device)
         ? device.authenticityChecks.firmwareRevision
         : null;
@@ -64,11 +77,23 @@ const useReportRevisionCheck = () => {
     const errorPayload = isError ? revisionCheck.errorPayload : null;
 
     useEffect(() => {
-        if (!errorType) return;
+        if (errorType === null) return;
         if (revisionCheckErrorScenarios[errorType].shouldReport) {
             reportCheckFail('Firmware revision', { ...commonData, errorType }, errorPayload);
         }
     }, [commonData, errorType, errorPayload]);
+
+    useEffect(() => {
+        if (errorType === null) return;
+        if (isRevisionCheckErrorWithNotification(errorType)) {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'firmware-authenticity-check-error',
+                    translationKey: revisionCheckNotifications[errorType],
+                }),
+            );
+        }
+    }, [dispatch, errorType]);
 };
 
 const useReportHashCheck = () => {
@@ -82,7 +107,7 @@ const useReportHashCheck = () => {
     const attemptCount = isError ? hashCheck.attemptCount : null;
 
     useEffect(() => {
-        if (!errorType) return;
+        if (errorType === null) return;
         if (!hashCheckErrorScenarios[errorType].shouldReport) return;
         const willBeRetried =
             isArrayMember(errorType, FIRMWARE.HASH_CHECK_RETRIABLE_ERRORS) &&
@@ -102,6 +127,10 @@ const useReportHashCheck = () => {
     }, [commonData, warningPayload]);
 };
 
+/**
+ * Optionally report both FW authenticity checks (revision and hash) to Sentry and/or show toast notifications,
+ * based on behavior scenarios definitions. This may happen even when no UI is displayed for the checks.
+ */
 export const useReportDeviceCompromised = () => {
     useReportRevisionCheck();
     useReportHashCheck();

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareAuthenticityCheckBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareAuthenticityCheckBanner.tsx
@@ -6,16 +6,18 @@ import { spacings } from '@trezor/theme';
 import { TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL } from '@trezor/urls';
 
 import { Translation, TrezorLink } from 'src/components/suite';
-import { SkippedHashCheckError } from 'src/constants/suite/firmware';
+import { SkippedHashCheckError, SkippedRevisionCheckError } from 'src/constants/suite/firmware';
 import { useSelector } from 'src/hooks/suite';
 import {
     selectFirmwareHashCheckErrorIfEnabled,
     selectFirmwareRevisionCheckErrorIfEnabled,
 } from 'src/reducers/suite/suiteReducer';
 
-const revisionCheckMessages: Record<FirmwareRevisionCheckError, TranslationKey> = {
+const revisionCheckMessages: Record<
+    Exclude<FirmwareRevisionCheckError, SkippedRevisionCheckError>,
+    TranslationKey
+> = {
     'cannot-perform-check-offline': 'TR_DEVICE_FIRMWARE_REVISION_CHECK_UNABLE_TO_PERFORM',
-    'other-error': 'TR_FIRMWARE_REVISION_CHECK_OTHER_ERROR',
     'revision-mismatch': 'TR_FIRMWARE_REVISION_CHECK_FAILED',
     'firmware-version-unknown': 'TR_FIRMWARE_REVISION_CHECK_FAILED',
 };

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -130,8 +130,8 @@ export const NotificationRenderer = ({
             );
         case 'clear-storage':
             return success(render, notification, 'TR_STORAGE_CLEARED');
-        case 'firmware-check-authenticity-success':
-            return success(render, notification, 'TR_FIRMWARE_CHECK_AUTHENTICITY_SUCCESS');
+        case 'firmware-authenticity-check-error':
+            return error(render, notification, notification.translationKey);
         case 'device-authenticity-success':
             return success(render, notification, 'TR_DEVICE_AUTHENTICITY_SUCCESS');
         case 'device-authenticity-error':

--- a/packages/suite/src/constants/suite/firmware.ts
+++ b/packages/suite/src/constants/suite/firmware.ts
@@ -9,46 +9,104 @@ import { FilterPropertiesByType } from '@trezor/type-utils';
 /*
  * Various scenarios how firmware authenticity check errors are handled in Suite
  * see suite-native/device/src/config/firmware.ts for Suite Lite
+ * TODO deduplicate them by creating a new suite-common package
  */
 
 type BehaviorBaseType = {
     shouldReport: boolean; // whether to report the check result to Sentry
     isConclusive: boolean; // result is considered final, not expected to change when check is rerun
+    shouldNotify: boolean; // whether to do one-time toast notification
 };
 
-// will be ignored completely
+// no permanent UI, and no restriction of access to device
 type SkippedBehavior = BehaviorBaseType & { type: 'skipped' };
 // display a warning banner
 type SoftWarningBehavior = BehaviorBaseType & { type: 'softWarning' };
 // display "Device Compromised" modal, after closing it display a warning banner, block receiving address
 type HardModalBehavior = BehaviorBaseType & { type: 'hardModal'; shouldReport: true };
 
-type RevisionErrorBehavior = SoftWarningBehavior | HardModalBehavior;
+type RevisionErrorBehavior = SkippedBehavior | SoftWarningBehavior | HardModalBehavior;
 type RevisionCheckErrorScenarios = Record<FirmwareRevisionCheckError, RevisionErrorBehavior>;
 
 type HashErrorBehavior = SkippedBehavior | HardModalBehavior;
 type HashCheckErrorScenarios = Record<FirmwareHashCheckError, HashErrorBehavior>;
 
 export const revisionCheckErrorScenarios = {
-    'revision-mismatch': { type: 'hardModal', shouldReport: true, isConclusive: true },
-    'firmware-version-unknown': { type: 'hardModal', shouldReport: true, isConclusive: true },
+    'revision-mismatch': {
+        type: 'hardModal',
+        shouldReport: true,
+        shouldNotify: false,
+        isConclusive: true,
+    },
+    'firmware-version-unknown': {
+        type: 'hardModal',
+        shouldReport: true,
+        shouldNotify: false,
+        isConclusive: true,
+    },
     'cannot-perform-check-offline': {
         type: 'softWarning',
         shouldReport: false,
+        shouldNotify: false,
         isConclusive: false,
     },
-    'other-error': { type: 'softWarning', shouldReport: true, isConclusive: false },
+    'other-error': {
+        type: 'skipped',
+        shouldReport: true,
+        shouldNotify: true,
+        isConclusive: false,
+    },
 } satisfies RevisionCheckErrorScenarios;
 
 export const hashCheckErrorScenarios = {
-    'takes-too-long': { type: 'hardModal', shouldReport: true, isConclusive: false },
-    'hash-mismatch': { type: 'hardModal', shouldReport: true, isConclusive: true },
-    'check-skipped': { type: 'skipped', shouldReport: false, isConclusive: false },
-    'check-unsupported': { type: 'skipped', shouldReport: false, isConclusive: false },
+    'hash-mismatch': {
+        type: 'hardModal',
+        shouldReport: true,
+        shouldNotify: false,
+        isConclusive: true,
+    },
+    'takes-too-long': {
+        type: 'hardModal',
+        shouldReport: true,
+        shouldNotify: false,
+        isConclusive: false,
+    },
+    'check-skipped': {
+        type: 'skipped',
+        shouldReport: false,
+        shouldNotify: false,
+        isConclusive: false,
+    },
+    'check-unsupported': {
+        type: 'skipped',
+        shouldReport: false,
+        shouldNotify: false,
+        isConclusive: false,
+    },
     // could mean counterfeit firmware, but it's also caught by revision check, which handles edge-cases better
-    'unknown-release': { type: 'skipped', shouldReport: false, isConclusive: true },
-    'other-error': { type: 'hardModal', shouldReport: true, isConclusive: false },
+    'unknown-release': {
+        type: 'skipped',
+        shouldReport: false,
+        shouldNotify: false,
+        isConclusive: true,
+    },
+    'other-error': {
+        type: 'hardModal',
+        shouldReport: true,
+        shouldNotify: false,
+        isConclusive: false,
+    },
 } satisfies HashCheckErrorScenarios;
+
+// TODO: when this is moved to suite-common, extract the following derived types & typeguards to a new file
+export type SkippedRevisionCheckError = keyof FilterPropertiesByType<
+    typeof revisionCheckErrorScenarios,
+    { type: 'skipped' }
+>;
+
+export const isSkippedRevisionCheckError = (
+    error: FirmwareRevisionCheckError,
+): error is SkippedRevisionCheckError => revisionCheckErrorScenarios[error].type === 'skipped';
 
 export type SkippedHashCheckError = keyof FilterPropertiesByType<
     typeof hashCheckErrorScenarios,
@@ -72,3 +130,24 @@ export const FW_HASH_CHECK_DEFAULT_TIMEOUTS: ExhaustiveFirmwareHashCheckTimeouts
     [DeviceModelInternal.T3W1]: undefined,
     [DeviceModelInternal.UNKNOWN]: undefined,
 };
+
+export type RevisionCheckErrorWithNotification = keyof FilterPropertiesByType<
+    typeof revisionCheckErrorScenarios,
+    { shouldNotify: true }
+>;
+
+export const isRevisionCheckErrorWithNotification = (
+    error: FirmwareRevisionCheckError,
+): error is RevisionCheckErrorWithNotification =>
+    revisionCheckErrorScenarios[error].shouldNotify === true;
+
+export type HashCheckErrorWithNotification = keyof FilterPropertiesByType<
+    typeof hashCheckErrorScenarios,
+    { shouldNotify: true }
+>;
+
+export const isHashCheckErrorWithNotification = (
+    error: FirmwareHashCheckError,
+): error is HashCheckErrorWithNotification =>
+    // @ts-expect-error if this no longer gives error, then TODO hash check notifications must be implemented
+    hashCheckErrorScenarios[error].shouldNotify === true;

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -22,6 +22,7 @@ import { ExperimentalFeature } from 'src/constants/suite/experimental';
 import {
     hashCheckErrorScenarios,
     isSkippedHashCheckError,
+    isSkippedRevisionCheckError,
     revisionCheckErrorScenarios,
 } from 'src/constants/suite/firmware';
 import { SIDEBAR_WIDTH_NUMERIC } from 'src/constants/suite/layout';
@@ -542,6 +543,8 @@ export const selectFirmwareRevisionCheckError = (state: AppState) => {
 
     // null means not performed, then don't consider it failed
     if (!checkResult || checkResult.success) return null;
+
+    if (isSkippedRevisionCheckError(checkResult.error)) return null;
 
     return checkResult.error;
 };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -8129,10 +8129,6 @@ export default defineMessages({
         id: 'TR_CUSTOM_FIRMWARE_GITHUB',
         defaultMessage: 'Find all official releases on',
     },
-    TR_FIRMWARE_CHECK_AUTHENTICITY_SUCCESS: {
-        id: 'TR_FIRMWARE_CHECK_AUTHENTICITY_SUCCESS',
-        defaultMessage: 'Firmware authentic',
-    },
     TR_DEVICE_AUTHENTICITY_SUCCESS: {
         id: 'TR_DEVICE_AUTHENTICITY_SUCCESS',
         defaultMessage: 'Device check passed',

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -60,7 +60,6 @@ export type ToastPayload = (
               | 'backup-failed'
               | 'sign-message-success'
               | 'verify-message-success'
-              | 'firmware-check-authenticity-success'
               | 'device-authenticity-success'
               | 'clear-storage'
               | 'add-token-success'
@@ -129,6 +128,10 @@ export type ToastPayload = (
     | {
           type: 'tor-toggle-error';
           error: TranslationKey;
+      }
+    | {
+          type: 'firmware-authenticity-check-error';
+          translationKey: TranslationKey;
       }
     | {
           type: 'successful-claim';


### PR DESCRIPTION
## Description

- For FW **revision** check `other-error`, use just a toast notification instead of banner 
- Define this behavior in scenario definitions, so it is type-safe  

## Related Issue

Resolve #17511

## Screenshots:

[See testing branch](https://dev.suite.sldev.cz/suite-web/feat/fw-rev-check-other-error-banner-TESTING/web/), which contains cherrypicked [testing playground](https://github.com/trezor/trezor-suite/commits/FW-check-UI-testing-branch)

[Screencast from 2025-07-25 12-46-48.webm](https://github.com/user-attachments/assets/3d6616ea-15a9-4ead-92bc-f49a620ef2b3)


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/fw-rev-check-other-error-banner&lookback=7)