### PR TITLE
Entropy check exceptions

### DIFF
--- a/packages/connect/src/api/resetDevice.ts
+++ b/packages/connect/src/api/resetDevice.ts
@@ -62,7 +62,7 @@ export default class ResetDevice extends AbstractMethod<'resetDevice', PROTO.Res
         const cmd = this.device.getCommands();
         const paths = ["m/84'/0'/0'", "m/44'/60'/0'"] as const;
 
-        // error.message should be one of these https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/transports/abstract.ts#L59
+        // error.message should be one of ERRORS_WITHOUT_DEVICE_INTERACTION, otherwise it could be a fake device's attempt to bypass the entropy check.
         const handleErr = (error: any) => {
             throw error.cause === 'transport-error'
                 ? error

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -2,12 +2,10 @@ import { FIRMWARE_MODULE_PREFIX } from '@suite-common/firmware';
 import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
+import { failEntropyCheckThunk, selectSelectedDevice } from '@suite-common/wallet-core';
 import TrezorConnect, { ERRORS } from '@trezor/connect';
-import { getFirmwareVersion } from '@trezor/device-utils';
 
 import * as modalActions from 'src/actions/suite/modalActions';
-import { reportCheckFail } from 'src/components/suite/SecurityCheck/useReportDeviceCompromised';
 import * as DEVICE from 'src/constants/suite/device';
 import { Dispatch, GetState } from 'src/types/suite';
 
@@ -120,26 +118,7 @@ export const resetDevice =
 
         if (!result.success) {
             dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
-            if (result.payload.code === 'Failure_EntropyCheck') {
-                reportCheckFail('Entropy', {
-                    model: device?.features?.internal_model,
-                    revision: device?.features?.revision,
-                    version: getFirmwareVersion(device),
-                    vendor: device?.features?.fw_vendor,
-                    error: result.payload.error,
-                });
-                const temporarilySkippedErrorsToBeInvestigated = [
-                    // These errors show up in Sentry and they probably lead to false positives.
-                    // We should improve the logs to include stack traces so that we can investigate and fix this problem, then remove this condition.
-                    'unexpected error',
-                    'A transfer error has occurred',
-                    // This one was not in Sentry but can be triggered by manually disconnecting the device. Investigate. https://github.com/trezor/trezor-suite-private/issues/135
-                    'device disconnected during action',
-                ];
-                if (!temporarilySkippedErrorsToBeInvestigated.includes(result.payload.error)) {
-                    dispatch(deviceActions.setEntropyCheckFail(device.id));
-                }
-            }
+            dispatch(failEntropyCheckThunk({ device, error: result.payload.error }));
         }
 
         return result;

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -128,8 +128,15 @@ export const resetDevice =
                     vendor: device?.features?.fw_vendor,
                     error: result.payload.error,
                 });
-                // TODO: temporary exception to avoid false positives, see https://github.com/trezor/trezor-suite-private/issues/135
-                if (result.payload.error !== 'device disconnected during action') {
+                const temporarilySkippedErrorsToBeInvestigated = [
+                    // These errors show up in Sentry and they probably lead to false positives.
+                    // We should improve the logs to include stack traces so that we can investigate and fix this problem, then remove this condition.
+                    'unexpected error',
+                    'A transfer error has occurred',
+                    // This one was not in Sentry but can be triggered by manually disconnecting the device. Investigate. https://github.com/trezor/trezor-suite-private/issues/135
+                    'device disconnected during action',
+                ];
+                if (!temporarilySkippedErrorsToBeInvestigated.includes(result.payload.error)) {
                     dispatch(deviceActions.setEntropyCheckFail(device.id));
                 }
             }

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -1,6 +1,6 @@
 import { bluetoothActions } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
-import { TrezorDevice } from '@suite-common/suite-types';
+import { AcquiredDevice, TrezorDevice } from '@suite-common/suite-types';
 import {
     getDeviceInstances,
     getFirstDeviceInstance,
@@ -30,6 +30,7 @@ import TrezorConnect, {
     StaticSessionId,
     UI,
 } from '@trezor/connect';
+import { getFirmwareVersion } from '@trezor/device-utils';
 import { getEnvironment } from '@trezor/env-utils';
 import { exhaustive } from '@trezor/type-utils';
 import { isChanged } from '@trezor/utils';
@@ -584,5 +585,35 @@ export const toggleAutoEjectThunk = createThunk(
                 );
             }
         });
+    },
+);
+
+type FailEntropyCheckParams = {
+    device: AcquiredDevice;
+    error: string;
+};
+
+export const failEntropyCheckThunk = createThunk(
+    `${DEVICE_MODULE_PREFIX}/failEntropyCheckThunk`,
+    ({ device, error }: FailEntropyCheckParams, { dispatch, extra }) => {
+        const contextData = {
+            model: device?.features?.internal_model,
+            revision: device?.features?.revision,
+            version: getFirmwareVersion(device),
+            vendor: device?.features?.fw_vendor,
+        };
+        extra.utils.reportCheckFail('Entropy', contextData, error);
+
+        const temporarilySkippedErrorsToBeInvestigated = [
+            // These errors show up in Sentry and they probably lead to false positives.
+            // We should improve the logs to include stack traces so that we can investigate and fix this problem, then remove this condition.
+            'unexpected error',
+            'A transfer error has occurred',
+            // This one was not in Sentry but can be triggered by manually disconnecting the device. Investigate. https://github.com/trezor/trezor-suite-private/issues/135
+            'device disconnected during action',
+        ];
+        if (!temporarilySkippedErrorsToBeInvestigated.includes(error)) {
+            dispatch(deviceActions.setEntropyCheckFail(device.id));
+        }
     },
 );

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -3,14 +3,14 @@ import { createThunk } from '@suite-common/redux-utils';
 import {
     ConnectDeviceSettings,
     deviceActions,
+    failEntropyCheckThunk,
     selectDevicePath,
     selectIsDeviceInitialized,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
-import { WalletBackupType, reportCheckFail } from '@suite-native/device';
+import { WalletBackupType } from '@suite-native/device';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import TrezorConnect, { PROTO } from '@trezor/connect';
-import { getFirmwareVersion } from '@trezor/device-utils';
 import { exhaustive } from '@trezor/type-utils';
 
 const NATIVE_DEVICE_MODULE_PREFIX = 'nativeDevice';
@@ -132,24 +132,7 @@ export const createAndBackupWalletThunk = createThunk(
 
         const result = deviceResponse.payload;
         if (!result.success && result.payload.code === 'Failure_EntropyCheck') {
-            const contextData = {
-                model: device?.features?.internal_model,
-                revision: device?.features?.revision,
-                version: getFirmwareVersion(device),
-                vendor: device?.features?.fw_vendor,
-            };
-            reportCheckFail('Entropy', contextData, result.payload.error);
-            const temporarilySkippedErrorsToBeInvestigated = [
-                // These errors show up in Sentry and they probably lead to false positives.
-                // We should improve the logs to include stack traces so that we can investigate and fix this problem, then remove this condition.
-                'unexpected error',
-                'A transfer error has occurred',
-                // This one was not in Sentry but can be triggered by manually disconnecting the device. Investigate. https://github.com/trezor/trezor-suite-private/issues/135
-                'device disconnected during action',
-            ];
-            if (!temporarilySkippedErrorsToBeInvestigated.includes(result.payload.error)) {
-                dispatch(deviceActions.setEntropyCheckFail(device.id));
-            }
+            dispatch(failEntropyCheckThunk({ device, error: result.payload.error }));
         }
 
         return result;

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -139,8 +139,15 @@ export const createAndBackupWalletThunk = createThunk(
                 vendor: device?.features?.fw_vendor,
             };
             reportCheckFail('Entropy', contextData, result.payload.error);
-            // TODO: temporary exception to avoid false positives, see https://github.com/trezor/trezor-suite-private/issues/135
-            if (result.payload.error !== 'device disconnected during action') {
+            const temporarilySkippedErrorsToBeInvestigated = [
+                // These errors show up in Sentry and they probably lead to false positives.
+                // We should improve the logs to include stack traces so that we can investigate and fix this problem, then remove this condition.
+                'unexpected error',
+                'A transfer error has occurred',
+                // This one was not in Sentry but can be triggered by manually disconnecting the device. Investigate. https://github.com/trezor/trezor-suite-private/issues/135
+                'device disconnected during action',
+            ];
+            if (!temporarilySkippedErrorsToBeInvestigated.includes(result.payload.error)) {
                 dispatch(deviceActions.setEntropyCheckFail(device.id));
             }
         }

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -5,6 +5,7 @@ import * as Device from 'expo-device';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { extraDependenciesMock } from '@suite-common/test-utils/src/extraDependenciesMock'; // precise import path to avoid circular dependencies
 import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { reportCheckFail } from '@suite-native/device';
 import { selectTokenDefinitionsEnabledNetworks } from '@suite-native/discovery';
 import { selectIsViewOnlyByDefaultEnabled } from '@suite-native/feature-flags';
 import { selectTradingEnvironment } from '@suite-native/module-trading';
@@ -66,6 +67,7 @@ export const extraDependencies: ExtraDependencies = mergeDeepObject(extraDepende
                 appUrl: '@trezor/suite',
             },
         },
+        reportCheckFail,
     } as Partial<ExtraDependencies['utils']>,
 } as OneLevelPartial<ExtraDependencies>) as ExtraDependencies;
 


### PR DESCRIPTION
There are some Sentry alerts and customers' reports indicating false positive results of the entropy check. Ignoring unexpected errors until we improve the logging and fix the issue.

Recent Sentry alerts: https://satoshilabs.sentry.io/issues/?environment=production&query=is%3Aunresolved%20Entropy%20check%20failed&referrer=issue-list&statsPeriod=90d

Testing Sentry alert after refactoring: https://satoshilabs.sentry.io/issues/6770100169/?environment=develop&query=is%3Aunresolved&referrer=issue-stream

Not tested on mobile yet :(

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/entropy-check-exceptions&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/entropy-check-exceptions&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/entropy-check-exceptions&lookback=7)