### PR TITLE
chore(suite-e2e): adopt trezor env with released fw

### DIFF
--- a/docker/docker-compose.suite-ci-e2e.yml
+++ b/docker/docker-compose.suite-ci-e2e.yml
@@ -1,6 +1,6 @@
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b3b12fac7bcb069ebcb8f29135e5baae73af722d
+    image: ghcr.io/trezor/trezor-user-env:892c5195958f7f777f0577b062e117c61897fcd6
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp


### PR DESCRIPTION
Adopting trezor user env with firmwares that are in currently released suite version


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore-e2e-adopt-new-trezor-env&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore-e2e-adopt-new-trezor-env&lookback=7)