### PR TITLE
fix(suite): trading key incompatibility with prefilled token

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeFormDefaultValues.ts
@@ -22,6 +22,7 @@ import {
 import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants';
 import { selectLocalCurrency } from '@suite-common/wallet-core';
 import { FormState, Output } from '@suite-common/wallet-types';
+import { parseAccountKey } from '@suite-common/wallet-utils';
 import { isArrayMember, typedObjectValues } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
@@ -63,7 +64,8 @@ export const useTradingExchangeFormDefaultValues = (
                 cryptoOptions.find(
                     option =>
                         option.value === prefilledFromAccount.cryptoId &&
-                        option.descriptor === prefilledFromAccount.descriptor,
+                        option.descriptor ===
+                            parseAccountKey(prefilledFromAccount.key || '').accountDescriptor,
                 )) ||
             cryptoOptions.find(
                 option =>

--- a/packages/suite/src/middlewares/wallet/__tests__/tradingMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/tradingMiddleware.test.ts
@@ -164,7 +164,7 @@ describe('tradingMiddleware', () => {
             'should clean prefilledFromCryptoId when route is change from sell to buy',
             {
                 cryptoId: undefined,
-                descriptor: undefined,
+                key: undefined,
             },
             tradingMiddlewareFixtures.TRADING_BUY_ROUTE,
             tradingMiddlewareFixtures.TRADING_SELL_ROUTE,
@@ -173,7 +173,7 @@ describe('tradingMiddleware', () => {
             'should clean prefilledFromCryptoId when route is change from buy to sell',
             {
                 cryptoId: undefined,
-                descriptor: undefined,
+                key: undefined,
             },
             tradingMiddlewareFixtures.TRADING_SELL_ROUTE,
             tradingMiddlewareFixtures.TRADING_BUY_ROUTE,
@@ -182,7 +182,7 @@ describe('tradingMiddleware', () => {
             'should clean prefilledFromCryptoId when route is trading abandoned',
             {
                 cryptoId: undefined,
-                descriptor: undefined,
+                key: undefined,
             },
             tradingMiddlewareFixtures.TRADING_SELL_ROUTE,
             tradingMiddlewareFixtures.DEFAULT_ROUTE,
@@ -191,7 +191,7 @@ describe('tradingMiddleware', () => {
             'should prefilledFromCryptoId stay stable when is page changed to the same',
             {
                 cryptoId: 'bitcoin' as CryptoId,
-                descriptor: 'descriptor',
+                key: 'descriptor',
             },
             tradingMiddlewareFixtures.TRADING_SELL_ROUTE,
             tradingMiddlewareFixtures.TRADING_SELL_ROUTE,
@@ -203,7 +203,7 @@ describe('tradingMiddleware', () => {
                     ...initialState,
                     prefilledFromAccount: {
                         cryptoId: 'bitcoin' as CryptoId,
-                        descriptor: 'descriptor',
+                        key: 'descriptor',
                     },
                 },
                 router: routerReducer(routeDefault, {} as Action),

--- a/packages/suite/src/middlewares/wallet/tradingMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/tradingMiddleware.ts
@@ -49,10 +49,8 @@ export const tradingMiddleware =
                 activeSection = 'buy';
                 api.dispatch(tradingActions.setTradingActiveSection(activeSection));
                 api.dispatch(tradingBuyActions.saveTransactionId(undefined));
-                if (prefilledFromAccount.descriptor) {
-                    api.dispatch(
-                        tradingBuyActions.setTradingAccountKey(prefilledFromAccount.descriptor),
-                    );
+                if (prefilledFromAccount.key) {
+                    api.dispatch(tradingBuyActions.setTradingAccountKey(prefilledFromAccount.key));
                 }
             }
 
@@ -60,10 +58,8 @@ export const tradingMiddleware =
                 activeSection = 'sell';
                 api.dispatch(tradingActions.setTradingActiveSection(activeSection));
                 api.dispatch(tradingSellActions.saveTransactionId(undefined));
-                if (prefilledFromAccount.descriptor) {
-                    api.dispatch(
-                        tradingSellActions.setTradingAccountKey(prefilledFromAccount.descriptor),
-                    );
+                if (prefilledFromAccount.key) {
+                    api.dispatch(tradingSellActions.setTradingAccountKey(prefilledFromAccount.key));
                 }
             }
 
@@ -71,11 +67,9 @@ export const tradingMiddleware =
                 activeSection = 'exchange';
                 api.dispatch(tradingActions.setTradingActiveSection(activeSection));
                 api.dispatch(tradingExchangeActions.saveTransactionId(undefined));
-                if (prefilledFromAccount.descriptor) {
+                if (prefilledFromAccount.key) {
                     api.dispatch(
-                        tradingExchangeActions.setTradingAccountKey(
-                            prefilledFromAccount.descriptor,
-                        ),
+                        tradingExchangeActions.setTradingAccountKey(prefilledFromAccount.key),
                     );
                 }
             }
@@ -92,7 +86,7 @@ export const tradingMiddleware =
             if (cleanupPrefilledFromCryptoId) {
                 api.dispatch(
                     tradingActions.setTradingFromPrefilledAccount({
-                        descriptor: undefined,
+                        key: undefined,
                         cryptoId: undefined,
                     }),
                 );

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -173,7 +173,7 @@ export const TokenRow = ({
         dispatch(
             tradingActions.setTradingFromPrefilledAccount({
                 cryptoId: tokenCryptoId,
-                descriptor: account.descriptor,
+                key: account.key,
             }),
         );
 

--- a/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
@@ -246,7 +246,7 @@ export const tradingFixtures = [
                 type: tradingActions.setTradingFromPrefilledAccount.type,
                 payload: {
                     cryptoId: 'ankr' as CryptoId,
-                    descriptor: 'abc',
+                    key: 'abc',
                 },
             },
         ],
@@ -254,7 +254,7 @@ export const tradingFixtures = [
             ...initialState,
             prefilledFromAccount: {
                 cryptoId: 'ankr',
-                descriptor: 'abc',
+                key: 'abc',
             },
         },
     },

--- a/suite-common/trading/src/reducers/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/tradingReducer.ts
@@ -51,9 +51,9 @@ export interface TradingInfo {
     paymentMethods: TradingPaymentMethodListProps[];
 }
 
-export interface TradingPreffiledFromAccount {
+export interface TradingPrefilledFromAccount {
     cryptoId: CryptoId | undefined;
-    descriptor: string | undefined;
+    key: AccountKey | undefined;
 }
 
 export interface TradingState {
@@ -68,7 +68,7 @@ export interface TradingState {
     isLoading: boolean;
     lastLoadedTimestamp: number;
     activeSection: TradingType;
-    prefilledFromAccount: TradingPreffiledFromAccount;
+    prefilledFromAccount: TradingPrefilledFromAccount;
     verifiedAddress: TradingVerifiedAddress;
     settings: TradingSettingsState;
 }
@@ -91,7 +91,7 @@ export const initialState: TradingState = {
     activeSection: 'buy',
     prefilledFromAccount: {
         cryptoId: undefined,
-        descriptor: undefined,
+        key: undefined,
     },
     verifiedAddress: undefined,
     settings: settingsInitialState,
@@ -143,11 +143,11 @@ export const tradingSlice = createSliceWithExtraDeps({
             state,
             action: PayloadAction<{
                 cryptoId: CryptoId | undefined;
-                descriptor: string | undefined;
+                key: string | undefined;
             }>,
         ) {
             state.prefilledFromAccount.cryptoId = action.payload.cryptoId;
-            state.prefilledFromAccount.descriptor = action.payload.descriptor;
+            state.prefilledFromAccount.key = action.payload.key;
         },
         setVerifiedAddress(state, action: PayloadAction<TradingVerifiedAddress>) {
             state.verifiedAddress = action.payload;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- successful screen was not available because of wrong key

## Related Issue

Resolve #20407

## Screenshots:

<img width="1277" height="677" alt="Screenshot 2025-07-28 at 12 33 34" src="https://github.com/user-attachments/assets/166114a6-a95d-4c25-bb56-43e55d8506dc" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/key-account-descriptor-trading-incompatibility&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/key-account-descriptor-trading-incompatibility&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/key-account-descriptor-trading-incompatibility&lookback=7)