### PR TITLE
Feat: bluetooth server device update/disconnect handler

### DIFF
--- a/packages/transport-bluetooth/src/server/adapter_manager.rs
+++ b/packages/transport-bluetooth/src/server/adapter_manager.rs
@@ -17,7 +17,7 @@ use tokio::{
 
 use crate::server::{
     device::{DeviceConnectionStatus, TrezorDevice},
-    types::{AdapterState, ChannelMessage, KnownDevice, NotificationEvent},
+    types::{AbortProcess, AdapterState, ChannelMessage, KnownDevice, NotificationEvent},
     utils, ConnectionBroadcast,
 };
 
@@ -312,6 +312,7 @@ impl AdapterManager {
                 removed.push(id.clone());
                 // check if device was connected
                 if let DeviceConnectionStatus::Connected = device.get_connection_status() {
+                    let _ = device.disconnect().await;
                     disconnected.push(id);
                 }
             }
@@ -321,7 +322,7 @@ impl AdapterManager {
 
         // notify about each disconnected device
         let devices = self.get_devices().await;
-        for id in removed.iter() {
+        for id in disconnected.iter() {
             self.dispatch_notification(NotificationEvent::DeviceDisconnected {
                 id: id.clone(),
                 devices: devices.clone(),
@@ -421,28 +422,63 @@ impl AdapterManager {
                         }
                     }
                     CentralEvent::DeviceUpdated(id) => {
-                        if let Some(device) = self_ref.get_device(&id).await {
-                            info!("DeviceUpdated {:?} : {:?}", id, device);
-                            let devices = self_ref.get_devices().await;
-                            self_ref
-                                .dispatch_notification(NotificationEvent::DeviceUpdated {
-                                    id: id.to_string(),
-                                    devices,
-                                })
-                                .await;
+                        if let Some(mut device) = self_ref.get_device(&id).await {
+                            let mut emit_update = false;
+                            if let Ok(peripheral) =
+                                self_ref.get_peripheral_or_die(&id.to_string()).await
+                            {
+                                if let Ok(updated) = device.update_properties(peripheral).await {
+                                    emit_update = updated;
+                                }
+                            };
+
+                            if emit_update {
+                                info!("DeviceUpdated {:?} : {:?}", id, device);
+                                let devices = self_ref.get_devices().await;
+                                self_ref
+                                    .dispatch_notification(NotificationEvent::DeviceUpdated {
+                                        id: id.to_string(),
+                                        devices,
+                                    })
+                                    .await;
+                            }
                         }
                     }
                     CentralEvent::DeviceDisconnected(id) => {
-                        if let Some(device) = self_ref.get_device(&id).await {
+                        if let Some(mut device) = self_ref.get_device(&id).await {
                             info!("DeviceDisconnected: {:?} : {:?}", id, device);
-                            // TODO: disconnect TrezorDevice
-                            let devices = self_ref.get_devices().await;
+
                             self_ref
-                                .dispatch_notification(NotificationEvent::DeviceDisconnected {
-                                    id: id.to_string(),
-                                    devices,
-                                })
+                                .send_to_listeners(ChannelMessage::Abort(
+                                    AbortProcess::DeviceDisconnected(id.to_string()),
+                                ))
                                 .await;
+
+                            let mut emit_event = false;
+                            if let Ok(peripheral) =
+                                self_ref.get_peripheral_or_die(&id.to_string()).await
+                            {
+                                if let Ok(updated) = device.update_properties(peripheral).await {
+                                    emit_event = updated;
+                                }
+                            }
+
+                            if let DeviceConnectionStatus::Connected =
+                                device.get_connection_status()
+                            {
+                                let _ = device.disconnect().await;
+                                emit_event = true;
+                            }
+
+                            if emit_event {
+                                let devices = self_ref.get_devices().await;
+                                self_ref
+                                    .dispatch_notification(NotificationEvent::DeviceDisconnected {
+                                        id: id.to_string(),
+                                        devices,
+                                    })
+                                    .await;
+                            }
                         }
                     }
                     // CentralEvent::DeviceConnected fires up too early. Device may be connected but in pairing process

--- a/packages/transport-bluetooth/src/server/device.rs
+++ b/packages/transport-bluetooth/src/server/device.rs
@@ -17,6 +17,10 @@ use uuid::{uuid, Uuid};
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub enum DeviceConnectionStatus {
     Disconnected,
+    Pairing { pin: Option<String> },
+    Paired,
+    PairingError { error: String },
+    Connecting,
     Connected,
 }
 
@@ -55,6 +59,15 @@ pub struct TrezorDevice {
     /// id changes on second connection after pairing (linux)
     id: String,
     props: Arc<Mutex<TrezorDeviceProps>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DeviceError {
+    #[error("Properties missing")]
+    PropertiesMissing,
+
+    #[error("BtleplugError: {0}")]
+    Btleplug(#[from] btleplug::Error),
 }
 
 impl serde::Serialize for TrezorDevice {
@@ -166,9 +179,28 @@ impl TrezorDevice {
         }
     }
 
-    pub fn set_connection_status(&self, status: DeviceConnectionStatus) {
+    pub fn set_connection_status(&self, new_status: DeviceConnectionStatus) {
         if let Ok(mut props) = self.props.lock() {
-            props.connection_status = status;
+            props.connection_status =
+                self.update_connection_status(&props.connection_status, new_status);
+            if let DeviceConnectionStatus::Connected = &props.connection_status {
+                props.connected = true;
+            } else if let DeviceConnectionStatus::Disconnected = &props.connection_status {
+                props.connected = false;
+            }
+        }
+    }
+
+    fn update_connection_status(
+        &self,
+        current_status: &DeviceConnectionStatus,
+        new_status: DeviceConnectionStatus,
+    ) -> DeviceConnectionStatus {
+        // do not override status if device pairing failed
+        if let DeviceConnectionStatus::PairingError { error: _ } = &current_status {
+            current_status.clone()
+        } else {
+            new_status
         }
     }
 
@@ -191,5 +223,94 @@ impl TrezorDevice {
             Ok(p) => p.discovery_timestamp,
             Err(_) => 0,
         }
+    }
+
+    pub async fn update_properties(&mut self, peripheral: Peripheral) -> Result<bool, DeviceError> {
+        let mut is_updated = false;
+
+        let PeripheralProperties {
+            local_name,
+            manufacturer_data,
+            rssi,
+            ..
+        } = &peripheral
+            .properties()
+            .await?
+            .ok_or(DeviceError::PropertiesMissing)?;
+
+        let is_connected = peripheral.is_connected().await.unwrap_or(false);
+        let mut props = match self.props.lock() {
+            Ok(p) => p,
+            Err(_) => {
+                return Err(DeviceError::PropertiesMissing);
+            }
+        };
+
+        // manufacturer_data are dynamically changed
+        // linux + windows: manufacturer_data are received after discovery
+        // linux: manufacturer_data are not visible if device is not in pairing mode even if it's already paired
+        // linux uses random mac address to send SCAN_REQ which is not recognized by Trezor while sending SCAN_RES (empty data)
+        if let Some(new_data) = manufacturer_data.get(&MANUFACTURER_DATA) {
+            if !new_data.is_empty() && &props.data != new_data {
+                props.data = new_data.clone();
+                is_updated = true;
+            }
+        }
+
+        // local_name may be changed
+        // examples: bootloader, default label, device label change
+        let name = local_name.clone().unwrap_or("".to_string());
+        if props.name != name {
+            props.name = name;
+            is_updated = true;
+        }
+
+        props.rssi = rssi.unwrap_or(0);
+        if is_connected != props.connected {
+            is_updated = true;
+            props.connected = is_connected;
+
+            if is_connected {
+                #[cfg(target_os = "linux")]
+                {
+                    props.address = BluetoothDevice::get_address(peripheral);
+                }
+            } else {
+                props.connection_status = self.update_connection_status(
+                    &props.connection_status,
+                    DeviceConnectionStatus::Disconnected,
+                );
+            }
+        }
+
+        // throttle update events
+        let timestamp = utils::get_timestamp();
+        if timestamp - props.event_timestamp > 500 {
+            is_updated = true;
+        }
+
+        if is_updated {
+            props.event_timestamp = timestamp;
+        }
+        props.timestamp = timestamp;
+
+        Ok(is_updated)
+    }
+
+    pub async fn disconnect(&self) -> Result<(), DeviceError> {
+        let mut props = match self.props.lock() {
+            Ok(p) => p,
+            Err(_) => {
+                return Err(DeviceError::PropertiesMissing);
+            }
+        };
+
+        props.connected = false;
+        props.connection_status = self.update_connection_status(
+            &props.connection_status,
+            DeviceConnectionStatus::Disconnected,
+        );
+
+        Ok(())
     }
 }

--- a/packages/transport-bluetooth/src/server/types.rs
+++ b/packages/transport-bluetooth/src/server/types.rs
@@ -4,6 +4,7 @@ use btleplug::api::CentralState;
 #[derive(serde::Serialize, Clone, Debug)]
 pub enum AbortProcess {
     ClientDisconnected(String), // websocket client disconnected
+    DeviceDisconnected(String), // device disconnected
     Scan,                       // stop scan
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

~~1. skip already discovered peripherals. macos emits this event each time adapter state is changed (enabled/disabled)~~

2. handle CentralEvent::DeviceUpdated event and update device properties (advertisement data change, name, timestamp)

3. handle CentralEvent::DeviceDisconnected event and udpate device properies (connection status)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/bt-server-device-update&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/bt-server-device-update&lookback=7)