### PR TITLE
fix(e2e-suite): Disable specific exception in discovery test 

### DIFF
--- a/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts
@@ -18,6 +18,7 @@ type suiteBaseFixture = {
     emulatorStartConf: StartEmuModelRequired;
     emulatorSetupConf: SetupEmu;
     electronConf: ElectronConf;
+    ignoreJSExceptions: Array<string>;
     url: string;
     trezorUserEnvLink: TrezorUserEnvLinkClass;
     page: Page;
@@ -136,6 +137,7 @@ const suiteBaseTest = base.extend<suiteBaseFixture>({
     emulatorStartConf: { model: 'T3T1', wipe: true },
     emulatorSetupConf: {},
     electronConf: {},
+    ignoreJSExceptions: [],
 
     url: async ({}, use, testInfo) => {
         await use(getUrl(testInfo));
@@ -189,13 +191,25 @@ const suiteBaseTest = base.extend<suiteBaseFixture>({
         );
     },
     exceptionLogger: [
-        async ({ page }, use) => {
+        async ({ page, ignoreJSExceptions }, use, testInfo) => {
             const errors: Error[] = [];
+            const ignored: Error[] = [];
             page.on('pageerror', error => {
-                errors.push(error);
+                if (ignoreJSExceptions.some(exception => error.message.includes(exception))) {
+                    ignored.push(error);
+                } else {
+                    errors.push(error);
+                }
             });
 
             await use();
+
+            if (ignored.length > 0) {
+                testInfo.annotations.push({
+                    type: 'Warning, Ignored JS exceptions',
+                    description: `\n${ignored.map(error => `${error.message}\n${error.stack}`).join('\n-----\n')}`,
+                });
+            }
 
             if (errors.length > 0) {
                 throw new Error(

--- a/packages/suite-desktop-core/e2e/tests/wallet/discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/discovery.test.ts
@@ -16,7 +16,10 @@ const coinsToActivate = [
     'xrp',
     'zec',
 ] as NetworkSymbol[];
+
 test.describe('Discovery', { tag: ['@group=wallet'] }, () => {
+    //TODO: Remove ignoreJSExceptions when bug fixed #19436
+    test.use({ ignoreJSExceptions: ['Device disconnected'] });
     test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
     });


### PR DESCRIPTION
Adds new fixture config that allows to ignore specific JS exceptions. Those are then shown as warning in annotations
Disable specific exception in discovery test in order to unblock it

the exception is minor one and is documented in bug. Most likely wont be fixed soon. And we don't want to lose the value of the test in meantime
<img width="1334" height="846" alt="image" src="https://github.com/user-attachments/assets/52e30ad5-d358-4061-aa26-c9d0c192973a" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-stabilize-tests&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-stabilize-tests&lookback=7)