### PR TITLE
Chore: add new releases json from data repo

### DIFF
--- a/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.10.0-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.10.0-bitcoinonly.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 10, 0],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 10, 0],
+    "firmware_revision": "f4424ece1ccb7fc0d6cad00ff840fac287a34f07",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.10.0-bitcoinonly.bin",
+    "fingerprint": "20a4068c34ff6dd7d8c510350409376cf7ea744ba668fdcf16da8f1d81fed289",
+    "changelog": "* Bootloader 1.10.0.\n* Allow decreasing the output value in RBF transactions.\n* Support long PIN of up to 50 digits.\n* Display nLockTime in human-readable form."
+}

--- a/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.10.1-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.10.1-bitcoinonly.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 10, 1],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 10, 0],
+    "firmware_revision": "3204fd682429eed23a82b748c05ae569c7f4481f",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.10.1-bitcoinonly.bin",
+    "fingerprint": "74227362016a8763c4d5f5b06eeb7eabe5fbd7ed05798b586cc7f4bfef50d7fe",
+    "changelog": "* Safety checks setting in T1."
+}

--- a/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.10.2-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.10.2-bitcoinonly.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 10, 2],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 10, 0],
+    "firmware_revision": "24bb4016388fca4b998285b95dcd408f4ed0bff6",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.10.2-bitcoinonly.bin",
+    "fingerprint": "e597b6aef5a2e817f532d27b8501f99f189e432a887877bdd3498cd3a0afc431",
+    "changelog": "* Security improvements."
+}

--- a/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.10.3-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.10.3-bitcoinonly.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 10, 3],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 10, 0],
+    "firmware_revision": "9276b1702361f70e094286e2f89e919d8a230d5c",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.10.3-bitcoinonly.bin",
+    "fingerprint": "d1143d2cba9c7dba4d57703d2b7da87859d8668472ffc651177ead6b94e89117",
+    "changelog": "* Small code improvements"
+}

--- a/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.10.4-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.10.4-bitcoinonly.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 10, 4],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 10, 0],
+    "firmware_revision": "595b14254c1abb2be3f69e42c7932f1eca8cf1b1",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.10.4-bitcoinonly.bin",
+    "fingerprint": "30d858b022e218f27854f071d568e5a696c937f1316d83b93aadcd178f3b0a38",
+    "changelog": "* Support Taproot.\n* Show address confirmation in SignMessage."
+}

--- a/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.10.5-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.10.5-bitcoinonly.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 10, 5],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 10, 0],
+    "firmware_revision": "3f12742669bd782cac374a1750d517f4fd88c43b",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.10.5-bitcoinonly.bin",
+    "fingerprint": "1d319f643fe2ba5c247b178c7f73b989ab4e43d914a60468566ee7cc5bb9dde0",
+    "changelog": "* Small code improvements."
+}

--- a/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.11.1-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.11.1-bitcoinonly.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 11, 1],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 10, 0],
+    "firmware_revision": "85a26d2c9593bcdf858c2d718d79951ca927a0c3",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.11.1-bitcoinonly.bin",
+    "fingerprint": "8e17b95b5d302f203de3a8fe27959efd25e3d5140ac9b5e60412f1b3f624995d",
+    "changelog": "* Support Electrum signatures in VerifyMessage.\n* Trezor will refuse to sign UTXOs that do not match the provided derivation path (e.g., transactions belonging to a different wallet, or synthetic transaction inputs)."
+}

--- a/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.11.2-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.11.2-bitcoinonly.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 11, 2],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 11, 0],
+    "firmware_revision": "0d87b55ba4fed7eecc72bf2a94ee473830b095e9",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.11.2-bitcoinonly.bin",
+    "fingerprint": "7e51546f4411ecf44688c681ada72a18495fd08e91f3a0429ab91bc4415b362a",
+    "changelog": "* Show the fee rate on the signing confirmation screen. \n* Show thousands separator when displaying large amounts \n* Fix potential security issues in recovery workflow. \n* Fix key extraction vulnerability in Cothority Collective Signing (CoSi). \n* Fix nonce bias in CoSi signing."
+}

--- a/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.12.1-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.12.1-bitcoinonly.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 12, 1],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 12, 0],
+    "min_firmware_version": [1, 12, 0],
+    "bootloader_version": [1, 12, 1],
+    "firmware_revision": "1eb0eb9d91b092e571aac63db4ebff2a07fd8a1f",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.12.1-bitcoinonly.bin",
+    "fingerprint": "985fb6a8c87f7547fb810f6c4a8331ebf19c677445810358778eb21eca78a181",
+    "changelog": "* Fee rate shown when replacing transaction.\n* Ledger Live legacy derivation path m/44'/coin_type'/0'/account is now supported.\n* SLIP-0019 proofs of ownership for native SegWit implemented.\n* SLIP-0025 coinjoin accounts implemented for testing purposes.\n* Bech32 addresses now not converting to uppercase in QR code to increase compatibility.\n* Decimals of fee rate extended to 2 digits.\n* Only \"sat\" displayed instead of \"sat BTC\".\n* Bootloader 1.12.1. included."
+}

--- a/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.13.0-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.13.0-bitcoinonly.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 13, 0],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 12, 0],
+    "min_firmware_version": [1, 12, 0],
+    "bootloader_version": [1, 12, 1],
+    "firmware_revision": "592590cf66a9b62dfeee7e4d2afb6e01005e5b2c",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.13.0-bitcoinonly.bin",
+    "fingerprint": "253042fb209c78e02482c645b16cc9894c19124e9c9c0c1051b3c68b6e7c700b",
+    "changelog": "* Multisig-related changes.\n* Reworked PIN processing.\n* Allow showing XPUB using a QR code."
+}

--- a/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.13.1-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.13.1-bitcoinonly.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 13, 1],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 12, 0],
+    "min_firmware_version": [1, 12, 0],
+    "bootloader_version": [1, 12, 1],
+    "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.13.1-bitcoinonly.bin",
+    "fingerprint": "f27095f2e08278a209567e254b9921f6e34b28a9c0fc702a268f210e23057c27",
+    "changelog": "*"
+}

--- a/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.8.3-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.8.3-bitcoinonly.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 8, 3],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 8, 0],
+    "firmware_revision": "df0963ec48f01f3d07ffca556e21ff0070cab099",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.8.3-bitcoinonly.bin",
+    "fingerprint": "13d6089cb935f453eaddbfe193e0ab37924a7aa66f684355a4fe5c660c18247a",
+    "changelog": "* Small code improvements"
+}

--- a/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.9.0-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.9.0-bitcoinonly.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 9, 0],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 8, 0],
+    "firmware_revision": "0b7a8449f8dd003fc415262b05102d113247d3de",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.9.0-bitcoinonly.bin",
+    "fingerprint": "93a670dd20d044bf76cfce6eecd2a85918acdebe616229dbb31250fd03a33870",
+    "changelog": "* Introduce Wipe Code\n* Introduce passphrase cache"
+}

--- a/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.9.1-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.9.1-bitcoinonly.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 9, 1],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 8, 0],
+    "firmware_revision": "c6b2580cd245ee924507f45e9675f857a3d78768",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.9.1-bitcoinonly.bin",
+    "fingerprint": "ee743e3bd1e424ceb45a1d877a5422e7af449706f636c459cdd8bb0d4796cba5",
+    "changelog": "* Refactor Bitcoin signing"
+}

--- a/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.9.2-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.9.2-bitcoinonly.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 9, 2],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 8, 0],
+    "firmware_revision": "cde8f31ec2ddcb7d35e36edbcf8a71dda983a9ea",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.9.2-bitcoinonly.bin",
+    "fingerprint": "2762c0ff78c96e23d1d348330e0a3cdf45d83c8fc8c2d48853b7cb602ddc19bb",
+    "changelog": "* Adds support for multiple change outputs in outgoing transactions."
+}

--- a/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.9.3-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.9.3-bitcoinonly.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 9, 3],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 8, 0],
+    "firmware_revision": "0d5f00668fb3d1c093ff3c879311a91d3a7175c8",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.9.3-bitcoinonly.bin",
+    "fingerprint": "76f899d60ffd9685713cb420d017565c05c43aadaf0e62b645a50a8db69afef6",
+    "changelog": "* Improves the Passphrase feature by showing the entered passphrase on the Trezor screen before opening the wallet.\n* Fixes smaller issues in the user interface."
+}

--- a/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.9.4-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t1b1/bitcoinonly/t1b1-1.9.4-bitcoinonly.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 9, 4],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 8, 0],
+    "firmware_revision": "ffa96205fb5e22b43e7b08a3dbc3cdeee0931de3",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.9.4-bitcoinonly.bin",
+    "fingerprint": "3f73dfbcfc48f66c8814f6562524d81888230e0acd1c19b52b6e8772c6c67e7f",
+    "changelog": "* Replacement transaction signing for replace-by-fee.\n* Support for Output Descriptors export.\n* Show Ypub/Zpub correctly for multisig GetAddress.\n* Show amounts in mBTC, uBTC and sat denominations."
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.10.0-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.10.0-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 10, 0],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 10, 0],
+    "firmware_revision": "f4424ece1ccb7fc0d6cad00ff840fac287a34f07",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.10.0-universal.bin",
+    "fingerprint": "595ba3e8e887cba185e03098f9538e18164f72f9fc82445e691abcd03e5cf0a4",
+    "changelog": "* Bootloader 1.10.0.\n* Allow decreasing the output value in RBF transactions.\n* Support long PIN of up to 50 digits.\n* Display nLockTime in human-readable form."
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.10.1-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.10.1-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 10, 1],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 10, 0],
+    "firmware_revision": "3204fd682429eed23a82b748c05ae569c7f4481f",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.10.1-universal.bin",
+    "fingerprint": "36400becf1cdddec22b8150d56ff59eef76d37fef60dc465a6f82b4858903886",
+    "changelog": "* Safety checks setting in T1."
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.10.2-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.10.2-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 10, 2],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 10, 0],
+    "firmware_revision": "24bb4016388fca4b998285b95dcd408f4ed0bff6",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.10.2-universal.bin",
+    "fingerprint": "99707b90a504f7e402f26c3d59cbbdacbc52754cebcce79cc47be528fc889338",
+    "changelog": "* Security improvements."
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.10.3-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.10.3-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 10, 3],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 10, 0],
+    "firmware_revision": "9276b1702361f70e094286e2f89e919d8a230d5c",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.10.3-universal.bin",
+    "fingerprint": "bf0cc936a9afbf0a4ae7b727a2817fb69fba432d7230a0ff7b79b4a73b845197",
+    "changelog": "* Remove Lisk.\n* Re-enabled Firo support.\n* Stricter protobuf field handling in Stellar."
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.10.4-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.10.4-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 10, 4],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 10, 0],
+    "firmware_revision": "595b14254c1abb2be3f69e42c7932f1eca8cf1b1",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.10.4-universal.bin",
+    "fingerprint": "74dfdfb9addb9d90fedb2c88794b7236af521d21ef0096f9080c25b597c8af86",
+    "changelog": "* Support Taproot.\n* Show address confirmation in SignMessage.\n* Support for Ethereum EIP-1559 transactions."
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.10.5-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.10.5-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 10, 5],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 10, 0],
+    "firmware_revision": "3f12742669bd782cac374a1750d517f4fd88c43b",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.10.5-universal.bin",
+    "fingerprint": "7619fcc73c43ca8a3e6aad3dc3eb6551fed05bb218340efe01a02bb96e9f346b",
+    "changelog": "* Support for blindly signing EIP-712 data."
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.11.1-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.11.1-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 11, 1],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 10, 0],
+    "firmware_revision": "85a26d2c9593bcdf858c2d718d79951ca927a0c3",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.11.1-universal.bin",
+    "fingerprint": "f7c60d0b8c2853afd576867c6562aba5ea52bdc2ce34d0dbb8751f52867c3665",
+    "changelog": "* Support Electrum signatures in VerifyMessage.\n* Trezor will refuse to sign UTXOs that do not match the provided derivation path (e.g., transactions belonging to a different wallet, or synthetic transaction inputs).\n* Zcash v5 transaction format."
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.11.2-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.11.2-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 11, 2],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 11, 0],
+    "firmware_revision": "0d87b55ba4fed7eecc72bf2a94ee473830b095e9",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.11.2-universal.bin",
+    "fingerprint": "d8b55b68dfe8a8449ce7391e841073ef5d29349638d85b750508bbef5d2de5ec",
+    "changelog": "* Show the fee rate on the signing confirmation screen. \n* Show thousands separator when displaying large amounts \n* Fix potential security issues in recovery workflow. \n* Fix key extraction vulnerability in Cothority Collective Signing (CoSi). \n* Fix nonce bias in CoSi signing."
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.12.1-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.12.1-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 12, 1],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 12, 0],
+    "min_firmware_version": [1, 12, 0],
+    "bootloader_version": [1, 12, 1],
+    "firmware_revision": "1eb0eb9d91b092e571aac63db4ebff2a07fd8a1f",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.12.1-universal.bin",
+    "fingerprint": "3c694191f5b66a65cb5bb209adbf113cb40209e644b77162ba996bb7ee8f382b",
+    "changelog": "* Fee rate shown when replacing transaction.\n* Ledger Live legacy derivation path m/44'/coin_type'/0'/account is now supported.\n* SLIP-0019 proofs of ownership for native SegWit implemented.\n* SLIP-0025 coinjoin accounts implemented for testing purposes.\n* Bech32 addresses now not converting to uppercase in QR code to increase compatibility.\n* Decimals of fee rate extended to 2 digits.\n* Only \"sat\" displayed instead of \"sat BTC\".\n* Bootloader 1.12.1. included.\n* Stellar addresses now shown in full + as a QR code.\n* Ethereum fees now wrapped to the next line when needed."
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.13.0-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.13.0-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 13, 0],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 12, 0],
+    "min_firmware_version": [1, 12, 0],
+    "bootloader_version": [1, 12, 1],
+    "firmware_revision": "592590cf66a9b62dfeee7e4d2afb6e01005e5b2c",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.13.0-universal.bin",
+    "fingerprint": "356433bd9de6cb564bf7778fc5de73c56197459523358f267e9235af9e1ce46d",
+    "changelog": "* Multisig-related changes.\n* Reworked PIN processing.\n* Allow showing XPUB using a QR code."
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.13.1-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.13.1-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 13, 1],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 12, 0],
+    "min_firmware_version": [1, 12, 0],
+    "bootloader_version": [1, 12, 1],
+    "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.13.1-universal.bin",
+    "fingerprint": "f588657818ccf99b0046ede3f87eeaf17a0e6e6f1b7853344e18b846ca835328",
+    "changelog": "* Clear sign ETH staking transactions on Everstake pool.\n* Use GWei when formatting large ETH amounts."
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.3.6-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.3.6-universal.json
@@ -1,0 +1,12 @@
+{
+    "required": false,
+    "version": [1, 3, 6],
+    "min_bridge_version": [1, 1, 5],
+    "min_bootloader_version": [1, 0, 0],
+    "min_firmware_version": [1, 0, 0],
+    "firmware_revision": "36b9d80120348700264bba518a533d4f82d79cbd",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.3.6-universal.bin",
+    "fingerprint": "03b559a758961b2bfd4443e6c36c10025268cf033ecd376fdd7a79ff658bf511",
+    "changelog": "* Enable advanced transactions such as ones with REPLACE-BY-FEE and CHECKLOCKTIMEVERIFY\n* Fix message signing for altcoins\n* Message verification now shows address\n* Enable GPG signing support\n* Enable Ed25519 curve (for SSH and GPG)\n* Use separate deterministic hierarchy for NIST256P1 and Ed25519 curves\n* Users using SSH already need to regenerate their keys using the new firmware!!!"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.4.0-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.4.0-universal.json
@@ -1,0 +1,12 @@
+{
+    "required": false,
+    "version": [1, 4, 0],
+    "min_bridge_version": [1, 1, 5],
+    "min_bootloader_version": [1, 0, 0],
+    "min_firmware_version": [1, 0, 0],
+    "firmware_revision": "e0e190b3dc29bcb0f6ab9699c439fe7bfbcde370",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.4.0-universal.bin",
+    "fingerprint": "5764715dbcf8ed88bc0ae1c2f715277f22b67f26c15e1f7543b2b44913b5c255",
+    "changelog": "* U2F support\n* Ethereum support\n* GPG decryption support\n* Zcash support"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.4.1-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.4.1-universal.json
@@ -1,0 +1,12 @@
+{
+    "required": false,
+    "version": [1, 4, 1],
+    "min_bridge_version": [1, 1, 5],
+    "min_bootloader_version": [1, 0, 0],
+    "min_firmware_version": [1, 0, 0],
+    "firmware_revision": "ae37ea8a9a2ab96e60714451a7a9502e0ef1ffc9",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.4.1-universal.bin",
+    "fingerprint": "92636493f76f352213e681bbc26eb3a8844f7b8a3044214b65c3c2c10a0f788c",
+    "changelog": "* Support for Zcash JoinSplit transactions\n* Enable device lock after 10 minutes of inactivity\n* Enable device lock by pressing left button for 2 seconds\n* Confirm dialog for U2F counter change"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.4.2-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.4.2-universal.json
@@ -1,0 +1,12 @@
+{
+    "required": false,
+    "version": [1, 4, 2],
+    "min_bridge_version": [1, 1, 5],
+    "min_bootloader_version": [1, 0, 0],
+    "min_firmware_version": [1, 0, 0],
+    "firmware_revision": "14399f100e862608c24a7e214e9ce971c4d32457",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.4.2-universal.bin",
+    "fingerprint": "a4b39f01bd134d01d7534821445bf779dbe6c25f0fcf7c7cb285a79b17f25e0a",
+    "changelog": "* New Matrix-based recovery method\n* Minor Ethereum fixes (including EIP-155 replay protection)\n* Minor USB, U2F and GPG fixes"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.5.0-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.5.0-universal.json
@@ -1,0 +1,12 @@
+{
+    "required": false,
+    "version": [1, 5, 0],
+    "min_bridge_version": [1, 1, 5],
+    "min_bootloader_version": [1, 0, 0],
+    "min_firmware_version": [1, 0, 0],
+    "firmware_revision": "6b74139b4530a4687b4a317b8b08f4329704efc4",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.5.0-universal.bin",
+    "fingerprint": "c4eddafd29b580d8482cda68e61bdcf1740d77520ef3a603758646bbffe957ea",
+    "changelog": "* Enable Segwit for Testnet and Litecoin\n* Enable ERC-20 tokens for Ethereum chains"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.5.1-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.5.1-universal.json
@@ -1,0 +1,12 @@
+{
+    "required": false,
+    "version": [1, 5, 1],
+    "min_bridge_version": [1, 1, 5],
+    "min_bootloader_version": [1, 0, 0],
+    "min_firmware_version": [1, 0, 0],
+    "firmware_revision": "f0d2e7a37142a6d4c7f7e45a6e4427e53123d614",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.5.1-universal.bin",
+    "fingerprint": "1c1fa9802cbd6a947a4f3e78f209d3efe49eb4abbacb101bbc3a0a709c742707",
+    "changelog": "* Wipe storage after 16 wrong PIN attempts\n* Enable Segwit for Bitcoin\n* Bcash aka Bitcoin Cash support\n* Message signing/verification for Ethereum and Segwit\n* Make address dialog nicer (switch text/QR via button)\n* Use checksum for Ethereum addresses\n* Add more ERC-20 tokens, handle unrecognized ERC-20 tokens\n* Allow \"dry run\" recovery procedure\n* Allow separated backup procedure"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.5.2-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.5.2-universal.json
@@ -1,0 +1,12 @@
+{
+    "required": true,
+    "version": [1, 5, 2],
+    "min_bridge_version": [1, 1, 5],
+    "min_bootloader_version": [1, 0, 0],
+    "min_firmware_version": [1, 0, 0],
+    "firmware_revision": "e4cc08775fc9c204f295442f930326eb7877f2d4",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.5.2-universal.bin",
+    "fingerprint": "99f71379dec893fbe109832a1150f338660be686fe6b4903ff10ff751ba4e448",
+    "changelog": "* clean memory on start\n* fix storage import from older versions"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.6.0-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.6.0-universal.json
@@ -1,0 +1,12 @@
+{
+    "required": false,
+    "version": [1, 6, 0],
+    "min_bridge_version": [1, 1, 5],
+    "min_bootloader_version": [1, 0, 0],
+    "min_firmware_version": [1, 0, 0],
+    "firmware_revision": "723cf295a72ce07b96047901bb8c2e461a2488f8",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.6.0-universal.bin",
+    "fingerprint": "e40f6ce12724c2d24234a7752953b88fd9ec28b3ec72c0dbfa280095a67a06ca",
+    "changelog": "* Native SegWit (Bech32) address support\n* Show recognized BIP44/BIP49 paths in GetAddress dialog\n* NEM support\n* Expanse and UBIQ chains support\n* Bitcoin Gold, DigiByte, Monacoin support\n* Ed25519 collective signatures (CoSi) support"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.6.1-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.6.1-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": true,
+    "version": [1, 6, 1],
+    "min_bridge_version": [1, 1, 5],
+    "min_bootloader_version": [1, 0, 0],
+    "min_firmware_version": [1, 0, 0],
+    "bootloader_version": [1, 4, 0],
+    "firmware_revision": "9588e8f2736b60916f51e470deb18f55112a6ebc",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.6.1-universal.bin",
+    "fingerprint": "83c3190a94e524ac83a1704eb584a2ab53f8a65a893b1ab52e7135812857c807",
+    "changelog": "* Use fixed-width font for addresses\n* Lots of under-the-hood improvements\n* Fixed issue with write-protection settings"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.6.2-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.6.2-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 6, 2],
+    "min_bridge_version": [1, 1, 5],
+    "min_bootloader_version": [1, 0, 0],
+    "min_firmware_version": [1, 0, 0],
+    "bootloader_version": [1, 5, 0],
+    "firmware_revision": "c9113fd3f5fcd78e9e560dbac75ed5aae359eb2d",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.6.2-universal.bin",
+    "fingerprint": "d31304f793854e343df6ccf1804f7e2abf48ddcd82a379ca2d3711d54127e138",
+    "changelog": "* Add possibility to set custom auto-lock delay\n* Bitcoin Cash cashaddr support\n* Zcash Overwinter hardfork support\n* Support for new coins:\n  - Decred, Bitcoin Private, Fujicoin, Groestlcoin, Vertcoin, Viacoin, Zcoin\n* Support for new Ethereum networks:\n  - EOS Classic, Ethereum Social, Ellaism, Callisto, EtherGem, Wanchain\n* Support for 500+ new Ethereum tokens"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.6.3-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.6.3-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 6, 3],
+    "min_bridge_version": [1, 1, 5],
+    "min_bootloader_version": [1, 0, 0],
+    "min_firmware_version": [1, 0, 0],
+    "bootloader_version": [1, 5, 1],
+    "firmware_revision": "ef86786ff750351ec454c7bae33b4966cfa862d7",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.6.3-universal.bin",
+    "fingerprint": "e8dbb4b7fe8384afd4c99790277c2f2f366a1a0f3957aa3545c75371a99a8fcc",
+    "changelog": "* Implement RSKIP-60 Ethereum checksum encoding\n* Add support for new Ethereum networks (ESN, AKA, ETHO, MUSI, PIRL, ATH, GO)\n* Add support for new 80 Ethereum tokens\n* Improve MPU configuration"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.7.1-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.7.1-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 7, 1],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 6, 0],
+    "firmware_revision": "83f1906cad648c560cd560577317046606398630",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.7.1-universal.bin",
+    "fingerprint": "1c303c50bb45d3f35da9e962d8405d0b8e89cc45e122496a48fce3995fa71d48",
+    "changelog": "* Switch from HID to WebUSB\n* Add support for Stellar\n* Add support for Lisk\n* Add support for Zcash Sapling hardfork\n* Implement seedless setup"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.7.2-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.7.2-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 7, 2],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 6, 0],
+    "firmware_revision": "0b26c529ec49daf584f322f3ef959c79694c8cf5",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.7.2-universal.bin",
+    "fingerprint": "4d5c7ac191dba315b2433af27c187925fb713d06984cc6f566231d809dd8d370",
+    "changelog": "* Add support for OMNI layer: OMNI/MAID/USDT\n* U2F fixes\n* Don't ask for PIN if it has been just set"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.7.3-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.7.3-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 7, 3],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 6, 1],
+    "firmware_revision": "f641e798f91a15c3b09e8dc6a163195dd56f86d2",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.7.3-universal.bin",
+    "fingerprint": "10acc6aa4f24aff36627473b98c23dc4f6d0220d33bc1e09cb572f02410ffdaf",
+    "changelog": "* Fix USB issue on some Windows 10 installations"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.8.0-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.8.0-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 8, 0],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 8, 0],
+    "firmware_revision": "964a622bb512aa85cfcc3e451fc70729cc15bb4f",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.8.0-universal.bin",
+    "fingerprint": "d65f0c07a6a9c53d8b5287798eb53154b33f9e87cd38a3701970e3d0a750a659",
+    "changelog": "* Security improvements\n* Upgraded to new storage format\n* Stellar and NEM fixes\n* New coins: ATS, KMD, XPM, XSN, ZCL\n* New ETH tokens"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.8.1-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.8.1-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 8, 1],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 8, 0],
+    "firmware_revision": "0a6a5f85729e663fbeae5ce9e5745918ff6f9d5d",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.8.1-universal.bin",
+    "fingerprint": "019e849c1eb285a03a92bbad6d18a328af3b4dc6999722ebb47677b403a4cd16",
+    "changelog": "* Fix fault when using the device with no PIN* Fix OMNI transactions parsing"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.8.2-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.8.2-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 8, 2],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 8, 0],
+    "firmware_revision": "3c19e3167d69902305a27f10e43abb5fc7a0254d",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.8.2-universal.bin",
+    "fingerprint": "909742eddcffdc72ca854557962ecad90e97585770f514170abe7a691b0c6eb1",
+    "changelog": "* Security improvements\n* Fix display of non-divisible OMNI amounts"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.8.3-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.8.3-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 8, 3],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 8, 0],
+    "firmware_revision": "df0963ec48f01f3d07ffca556e21ff0070cab099",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.8.3-universal.bin",
+    "fingerprint": "496aecfab867504b2283a9f057a0b2fd9d17970a22c81f6ad74232e7b914ce68",
+    "changelog": "* Small code improvements"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.9.0-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.9.0-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 9, 0],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 8, 0],
+    "firmware_revision": "0b7a8449f8dd003fc415262b05102d113247d3de",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.9.0-universal.bin",
+    "fingerprint": "1f40d1e68f9d182888b5b60da5209eff047ec68fcc96a5c9b61b0e55dd07d458",
+    "changelog": "* Introduce Wipe Code\n* Introduce passphrase cache"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.9.1-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.9.1-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 9, 1],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 8, 0],
+    "firmware_revision": "c6b2580cd245ee924507f45e9675f857a3d78768",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.9.1-universal.bin",
+    "fingerprint": "30cde253c46d4fc705f98634a35d06a494cf2a36824622a9c6a573e07f14292d",
+    "changelog": "* Refactor Bitcoin signing"
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.9.2-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.9.2-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 9, 2],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 8, 0],
+    "firmware_revision": "cde8f31ec2ddcb7d35e36edbcf8a71dda983a9ea",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.9.2-universal.bin",
+    "fingerprint": "45b83acd1330ddfd5567edbae5ff8028df1c48a493f01d47cc5499ee0be9b991",
+    "changelog": "* Reintroduces the ability to spend pre-Overwinter (2018) funds on Zcash-like coins.\n* Adds support for multiple change outputs in outgoing transactions.\n* Adds a security check to prevent potential issues with paths used in altcoin transactions."
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.9.3-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.9.3-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 9, 3],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 8, 0],
+    "firmware_revision": "0d5f00668fb3d1c093ff3c879311a91d3a7175c8",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.9.3-universal.bin",
+    "fingerprint": "2589f456559f813d1149be1022e62f2d48fbe28f4d02de933bd888d91035cace",
+    "changelog": "* Improves the Passphrase feature by showing the entered passphrase on the Trezor screen before opening the wallet.\n* Adds support for Verge (XVG).\n* Drops support for Metaverse (ETP), GINcoin (GIN), Pesetacoin (PTC), and Zel (ZEL).\n* Re-enables spending coins from Bitcoin paths (fixing some compatibility issues with Bitcoin Cash wallets).\n* Fixes smaller issues in the user interface."
+}

--- a/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.9.4-universal.json
+++ b/packages/connect-common/files/firmware/t1b1/universal/t1b1-1.9.4-universal.json
@@ -1,0 +1,13 @@
+{
+    "required": false,
+    "version": [1, 9, 4],
+    "min_bridge_version": [2, 0, 25],
+    "min_bootloader_version": [1, 5, 0],
+    "min_firmware_version": [1, 6, 2],
+    "bootloader_version": [1, 8, 0],
+    "firmware_revision": "ffa96205fb5e22b43e7b08a3dbc3cdeee0931de3",
+    "translations": {},
+    "url": "firmware/t1b1/universal/t1b1-1.9.4-universal.bin",
+    "fingerprint": "867017bd784cc4e9ce6f0875c61ea86f89b19380d54045c34608b85472998000",
+    "changelog": "* Replacement transaction signing for replace-by-fee.\n* Support for Output Descriptors export.\n* Show Ypub/Zpub correctly for multisig GetAddress.\n* Show amounts in mBTC, uBTC and sat denominations."
+}

--- a/packages/connect-common/files/firmware/t2b1/bitcoinonly/t2b1-2.6.3-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2b1/bitcoinonly/t2b1-2.6.3-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 6, 3],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 1],
+    "min_firmware_version": [2, 6, 1],
+    "bootloader_version": [2, 1, 4],
+    "firmware_revision": "2c7cc6e0255dee2339b445b5551eaffb88dbd1b4",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2b1/translation-t2b1-cs-CZ-2.6.3.bin",
+        "de-DE": "firmware/translations/t2b1/translation-t2b1-de-DE-2.6.3.bin",
+        "es-ES": "firmware/translations/t2b1/translation-t2b1-es-ES-2.6.3.bin",
+        "fr-FR": "firmware/translations/t2b1/translation-t2b1-fr-FR-2.6.3.bin",
+        "it-IT": "firmware/translations/t2b1/translation-t2b1-it-IT-2.6.3.bin",
+        "pt-BR": "firmware/translations/t2b1/translation-t2b1-pt-BR-2.6.3.bin"
+    },
+    "url": "firmware/t2b1/universal/t2b1-2.6.3-bitcoinonly.bin",
+    "fingerprint": "6aecc9d9fd137a661f38ce36713aa0889b77ec4d35d91c68e01bda225cda2850",
+    "changelog": "* QR Code for Extended Public Keys (XPUBs). \n* The new bootloader version 2.1.4 is now included for enhanced system performance and security. \n* The screen will now automatically turn off when the device is locked, helping to extend the life of the OLED display and save energy."
+}

--- a/packages/connect-common/files/firmware/t2b1/bitcoinonly/t2b1-2.6.4-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2b1/bitcoinonly/t2b1-2.6.4-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 6, 4],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 1],
+    "min_firmware_version": [2, 6, 1],
+    "bootloader_version": [2, 1, 4],
+    "firmware_revision": "42e9ed0e09033d474dee1a560fe5870646fa440e",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2b1/translation-t2b1-cs-CZ-2.6.4.bin",
+        "de-DE": "firmware/translations/t2b1/translation-t2b1-de-DE-2.6.4.bin",
+        "es-ES": "firmware/translations/t2b1/translation-t2b1-es-ES-2.6.4.bin",
+        "fr-FR": "firmware/translations/t2b1/translation-t2b1-fr-FR-2.6.4.bin",
+        "it-IT": "firmware/translations/t2b1/translation-t2b1-it-IT-2.6.4.bin",
+        "pt-BR": "firmware/translations/t2b1/translation-t2b1-pt-BR-2.6.4.bin"
+    },
+    "url": "firmware/t2b1/universal/t2b1-2.6.4-bitcoinonly.bin",
+    "fingerprint": "013d595fc621c12324afd90721c6a37d055d853f6af54d5432e27e6a425656dd",
+    "changelog": "* Resolved an issue related to the invalid encoding of signatures from the Optiga chip."
+}

--- a/packages/connect-common/files/firmware/t2b1/bitcoinonly/t2b1-2.7.0-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2b1/bitcoinonly/t2b1-2.7.0-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 7, 0],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 1],
+    "min_firmware_version": [2, 6, 1],
+    "bootloader_version": [2, 1, 4],
+    "firmware_revision": "45e8a842a31e62a6d43d7f6ccac62a45e1198ef0",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2b1/translation-t2b1-cs-CZ-2.7.0.bin",
+        "de-DE": "firmware/translations/t2b1/translation-t2b1-de-DE-2.7.0.bin",
+        "es-ES": "firmware/translations/t2b1/translation-t2b1-es-ES-2.7.0.bin",
+        "fr-FR": "firmware/translations/t2b1/translation-t2b1-fr-FR-2.7.0.bin",
+        "it-IT": "firmware/translations/t2b1/translation-t2b1-it-IT-2.7.0.bin",
+        "pt-BR": "firmware/translations/t2b1/translation-t2b1-pt-BR-2.7.0.bin"
+    },
+    "url": "firmware/t2b1/universal/t2b1-2.7.0-bitcoinonly.bin",
+    "fingerprint": "bb91489a4790b3668e2f5d574a729a0f43009510550fecb5e04c0937d355b2cf",
+    "changelog": "* Add translations capability. \n* Add loader to homescreen when locking the device. \n* Allow for going back to previous word in recovery process. \n* Display descriptors for BTC Taproot public keys. \n* Add missing semicolon character to the passphrase entry."
+}

--- a/packages/connect-common/files/firmware/t2b1/bitcoinonly/t2b1-2.7.2-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2b1/bitcoinonly/t2b1-2.7.2-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 7, 2],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 1],
+    "min_firmware_version": [2, 6, 1],
+    "bootloader_version": [2, 1, 4],
+    "firmware_revision": "da75d8f4b67410b40a9cfd2954d183d81dd6e8e8",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2b1/translation-t2b1-cs-CZ-2.7.2.bin",
+        "de-DE": "firmware/translations/t2b1/translation-t2b1-de-DE-2.7.2.bin",
+        "es-ES": "firmware/translations/t2b1/translation-t2b1-es-ES-2.7.2.bin",
+        "fr-FR": "firmware/translations/t2b1/translation-t2b1-fr-FR-2.7.2.bin",
+        "it-IT": "firmware/translations/t2b1/translation-t2b1-it-IT-2.7.2.bin",
+        "pt-BR": "firmware/translations/t2b1/translation-t2b1-pt-BR-2.7.2.bin"
+    },
+    "url": "firmware/t2b1/universal/t2b1-2.7.2-bitcoinonly.bin",
+    "fingerprint": "5b6e312430de9db6ad3a843e1ba311f8cff9c6a691c20c0e69b711451a729f40",
+    "changelog": "* Introducing repeated backups. \n* Multi-share backups can now have any number of shares."
+}

--- a/packages/connect-common/files/firmware/t2b1/bitcoinonly/t2b1-2.8.0-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2b1/bitcoinonly/t2b1-2.8.0-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 0],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 1],
+    "min_firmware_version": [2, 6, 1],
+    "bootloader_version": [2, 1, 4],
+    "firmware_revision": "dd4671a5104952ef505d28d1f9e94d1484b4607a",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2b1/translation-t2b1-cs-CZ-2.8.0.bin",
+        "de-DE": "firmware/translations/t2b1/translation-t2b1-de-DE-2.8.0.bin",
+        "es-ES": "firmware/translations/t2b1/translation-t2b1-es-ES-2.8.0.bin",
+        "fr-FR": "firmware/translations/t2b1/translation-t2b1-fr-FR-2.8.0.bin",
+        "it-IT": "firmware/translations/t2b1/translation-t2b1-it-IT-2.8.0.bin",
+        "pt-BR": "firmware/translations/t2b1/translation-t2b1-pt-BR-2.8.0.bin"
+    },
+    "url": "firmware/t2b1/universal/t2b1-2.8.0-bitcoinonly.bin",
+    "fingerprint": "ae088439d44fc8643b8de28e0d7a8720cd3dbb247619f2742604bbe884542558",
+    "changelog": "* Removed CoSi functionality. \n* Increased Optiga read timeout to avoid spurious RSODs."
+}

--- a/packages/connect-common/files/firmware/t2b1/bitcoinonly/t2b1-2.8.10-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2b1/bitcoinonly/t2b1-2.8.10-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 10],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 1],
+    "min_firmware_version": [2, 6, 1],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2b1/translation-t2b1-cs-CZ-2.8.10.bin",
+        "de-DE": "firmware/translations/t2b1/translation-t2b1-de-DE-2.8.10.bin",
+        "es-ES": "firmware/translations/t2b1/translation-t2b1-es-ES-2.8.10.bin",
+        "fr-FR": "firmware/translations/t2b1/translation-t2b1-fr-FR-2.8.10.bin",
+        "it-IT": "firmware/translations/t2b1/translation-t2b1-it-IT-2.8.10.bin",
+        "pt-BR": "firmware/translations/t2b1/translation-t2b1-pt-BR-2.8.10.bin"
+    },
+    "url": "firmware/t2b1/universal/t2b1-2.8.10-bitcoinonly.bin",
+    "fingerprint": "5bd50bbcf6435f97b6dc46f96ad11235965cd8a78619c573c3c0aca6822e9ed2",
+    "changelog": "* Replaced \"next page\" icon with \"...\" ellipsis when confirming long message.\n* Allow firmware upgrade even if language change failed."
+}

--- a/packages/connect-common/files/firmware/t2b1/bitcoinonly/t2b1-2.8.7-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2b1/bitcoinonly/t2b1-2.8.7-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 7],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 1],
+    "min_firmware_version": [2, 6, 1],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "8a254aa8eae82f99630df63f40e4d290066a3efc",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2b1/translation-t2b1-cs-CZ-2.8.7.bin",
+        "de-DE": "firmware/translations/t2b1/translation-t2b1-de-DE-2.8.7.bin",
+        "es-ES": "firmware/translations/t2b1/translation-t2b1-es-ES-2.8.7.bin",
+        "fr-FR": "firmware/translations/t2b1/translation-t2b1-fr-FR-2.8.7.bin",
+        "it-IT": "firmware/translations/t2b1/translation-t2b1-it-IT-2.8.7.bin",
+        "pt-BR": "firmware/translations/t2b1/translation-t2b1-pt-BR-2.8.7.bin"
+    },
+    "url": "firmware/t2b1/universal/t2b1-2.8.7-bitcoinonly.bin",
+    "fingerprint": "6381f8a373f9f91a3cf4000a762b8dbf553d11a4a6d433c8863b2fa9eecfd9f1",
+    "changelog": "* Show last typed PIN number for short period of time.\n* Multisig-related changes.\n* Included new version of bootloader (2.1.8).\n* Fix translation of the 'Enable labeling' screen."
+}

--- a/packages/connect-common/files/firmware/t2b1/bitcoinonly/t2b1-2.8.9-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2b1/bitcoinonly/t2b1-2.8.9-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 9],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 1],
+    "min_firmware_version": [2, 6, 1],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "fad9682201cf9289bba2adb66e6e07ed1cf78936",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2b1/translation-t2b1-cs-CZ-2.8.9.bin",
+        "de-DE": "firmware/translations/t2b1/translation-t2b1-de-DE-2.8.9.bin",
+        "es-ES": "firmware/translations/t2b1/translation-t2b1-es-ES-2.8.9.bin",
+        "fr-FR": "firmware/translations/t2b1/translation-t2b1-fr-FR-2.8.9.bin",
+        "it-IT": "firmware/translations/t2b1/translation-t2b1-it-IT-2.8.9.bin",
+        "pt-BR": "firmware/translations/t2b1/translation-t2b1-pt-BR-2.8.9.bin"
+    },
+    "url": "firmware/t2b1/universal/t2b1-2.8.9-bitcoinonly.bin",
+    "fingerprint": "bde9c5ef485548746150e07a9c5081c25f2bdf127707a41f3c487ca83a6c0667",
+    "changelog": "* Ability to cancel recovery on word count selection screen.\n* New UI for confirming long messages."
+}

--- a/packages/connect-common/files/firmware/t2b1/universal/t2b1-2.6.3-universal.json
+++ b/packages/connect-common/files/firmware/t2b1/universal/t2b1-2.6.3-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 6, 3],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 1],
+    "min_firmware_version": [2, 6, 1],
+    "bootloader_version": [2, 1, 4],
+    "firmware_revision": "2c7cc6e0255dee2339b445b5551eaffb88dbd1b4",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.6.3.bin",
+        "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.6.3.bin",
+        "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.6.3.bin",
+        "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.6.3.bin",
+        "it-IT": "firmware/translations/t2b1/translation-T2B1-it-IT-2.6.3.bin",
+        "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.6.3.bin"
+    },
+    "url": "firmware/t2b1/universal/t2b1-2.6.3-universal.bin",
+    "fingerprint": "1aea81cf4a823951540a041ae52d1950efade73531f7640c85805f8950f11a38",
+    "changelog": "* QR Code for Extended Public Keys (XPUBs). \n* The new bootloader version 2.1.4 is now included for enhanced system performance and security. \n* The screen will now automatically turn off when the device is locked, helping to extend the life of the OLED display and save energy."
+}

--- a/packages/connect-common/files/firmware/t2b1/universal/t2b1-2.6.4-universal.json
+++ b/packages/connect-common/files/firmware/t2b1/universal/t2b1-2.6.4-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 6, 4],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 1],
+    "min_firmware_version": [2, 6, 1],
+    "bootloader_version": [2, 1, 4],
+    "firmware_revision": "42e9ed0e09033d474dee1a560fe5870646fa440e",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.6.4.bin",
+        "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.6.4.bin",
+        "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.6.4.bin",
+        "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.6.4.bin",
+        "it-IT": "firmware/translations/t2b1/translation-T2B1-it-IT-2.6.4.bin",
+        "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.6.4.bin"
+    },
+    "url": "firmware/t2b1/universal/t2b1-2.6.4-universal.bin",
+    "fingerprint": "5ac16cb5002aa607908be376378a7fd1a1bc18f7b05e7a047cb1365840cc93ef",
+    "changelog": "* Trezor Safe 3 now supports Solana, expanding the range of cryptocurrencies it can securely manage. [Universal fw only] \n* Ethereum fees are now uniformly presented in Gwei, enhancing clarity and consistency for users. [Universal fw only] \n* Issue with missing address confirmation screens is now fixed. [Universal fw only] \n* Resolved an issue related to the invalid encoding of signatures from the Optiga chip."
+}

--- a/packages/connect-common/files/firmware/t2b1/universal/t2b1-2.7.0-universal.json
+++ b/packages/connect-common/files/firmware/t2b1/universal/t2b1-2.7.0-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 7, 0],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 1],
+    "min_firmware_version": [2, 6, 1],
+    "bootloader_version": [2, 1, 4],
+    "firmware_revision": "45e8a842a31e62a6d43d7f6ccac62a45e1198ef0",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.7.0.bin",
+        "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.7.0.bin",
+        "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.7.0.bin",
+        "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.7.0.bin",
+        "it-IT": "firmware/translations/t2b1/translation-T2B1-it-IT-2.7.0.bin",
+        "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.7.0.bin"
+    },
+    "url": "firmware/t2b1/universal/t2b1-2.7.0-universal.bin",
+    "fingerprint": "522eb5db073c0f039f7164360668e75a43399d0b4e40edfd06f77f4401cd98aa",
+    "changelog": "* Add translations capability. \n* Add loader to homescreen when locking the device. \n* Allow for going back to previous word in recovery process. \n* Clear sign ETH staking transactions on Everstake pool. [Universal fw only] \n* Display descriptors for BTC Taproot public keys. \n* Multiple Solana instructions improved. [Universal fw only] \n* Add missing semicolon character to the passphrase entry."
+}

--- a/packages/connect-common/files/firmware/t2b1/universal/t2b1-2.7.2-universal.json
+++ b/packages/connect-common/files/firmware/t2b1/universal/t2b1-2.7.2-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 7, 2],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 1],
+    "min_firmware_version": [2, 6, 1],
+    "bootloader_version": [2, 1, 4],
+    "firmware_revision": "da75d8f4b67410b40a9cfd2954d183d81dd6e8e8",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.7.2.bin",
+        "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.7.2.bin",
+        "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.7.2.bin",
+        "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.7.2.bin",
+        "it-IT": "firmware/translations/t2b1/translation-T2B1-it-IT-2.7.2.bin",
+        "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.7.2.bin"
+    },
+    "url": "firmware/t2b1/universal/t2b1-2.7.2-universal.bin",
+    "fingerprint": "d072560f34782faf5537aa08a48c4e24671d4c60e9c291a00bfbf12cbc425666",
+    "changelog": "* Introducing repeated backups. \n* Multi-share backups can now have any number of shares. \n* Added support for Cardano Conway certificates [Universal fw only]."
+}

--- a/packages/connect-common/files/firmware/t2b1/universal/t2b1-2.8.0-universal.json
+++ b/packages/connect-common/files/firmware/t2b1/universal/t2b1-2.8.0-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 0],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 1],
+    "min_firmware_version": [2, 6, 1],
+    "bootloader_version": [2, 1, 4],
+    "firmware_revision": "dd4671a5104952ef505d28d1f9e94d1484b4607a",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.8.0.bin",
+        "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.8.0.bin",
+        "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.8.0.bin",
+        "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.8.0.bin",
+        "it-IT": "firmware/translations/t2b1/translation-T2B1-it-IT-2.8.0.bin",
+        "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.8.0.bin"
+    },
+    "url": "firmware/t2b1/universal/t2b1-2.8.0-universal.bin",
+    "fingerprint": "cf3ce230a69a681199f74cf6ac8c6c431f8fa7e0d0183437f93c5cc029fbd155",
+    "changelog": "* Removed CoSi functionality. \n* Increased Optiga read timeout to avoid spurious RSODs."
+}

--- a/packages/connect-common/files/firmware/t2b1/universal/t2b1-2.8.10-universal.json
+++ b/packages/connect-common/files/firmware/t2b1/universal/t2b1-2.8.10-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 10],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 1],
+    "min_firmware_version": [2, 6, 1],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.8.10.bin",
+        "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.8.10.bin",
+        "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.8.10.bin",
+        "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.8.10.bin",
+        "it-IT": "firmware/translations/t2b1/translation-T2B1-it-IT-2.8.10.bin",
+        "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.8.10.bin"
+    },
+    "url": "firmware/t2b1/universal/t2b1-2.8.10-universal.bin",
+    "fingerprint": "db555520689b1af7c18cb20fc2631fbf07ce4f7dd735c7e64ab279e1ad03a33a",
+    "changelog": "* Solana: rent fee calculation [#4933]\n* Solana: loadable token definitions [#3541]\n* Replaced \"next page\" icon with \"...\" ellipsis when confirming long message.\n* Fixed Solana staking dialog title.\n* Updated EIP-1559 fee-related labels.\n* Allow firmware upgrade even if language change failed.\n* Solana: fees calculation is now exact [#4965]"
+}

--- a/packages/connect-common/files/firmware/t2b1/universal/t2b1-2.8.7-universal.json
+++ b/packages/connect-common/files/firmware/t2b1/universal/t2b1-2.8.7-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 7],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 1],
+    "min_firmware_version": [2, 6, 1],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "8a254aa8eae82f99630df63f40e4d290066a3efc",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.8.7.bin",
+        "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.8.7.bin",
+        "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.8.7.bin",
+        "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.8.7.bin",
+        "it-IT": "firmware/translations/t2b1/translation-T2B1-it-IT-2.8.7.bin",
+        "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.8.7.bin"
+    },
+    "url": "firmware/t2b1/universal/t2b1-2.8.7-universal.bin",
+    "fingerprint": "554c6586df79e1281dd377bfb99d7b2594dbac66d749837c6a78b9c5e0751098",
+    "changelog": "* Show last typed PIN number for short period of time.\n* Multisig-related changes.\n* Simplify UI of Cardano transactions initiated by Trezor Suite.\n* Included new version of bootloader (2.1.8).\n* Fix ETH account number detection.\n* New EVM call contract flow UI.\n* Fix translation of the 'Enable labeling' screen."
+}

--- a/packages/connect-common/files/firmware/t2b1/universal/t2b1-2.8.9-universal.json
+++ b/packages/connect-common/files/firmware/t2b1/universal/t2b1-2.8.9-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 9],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 1],
+    "min_firmware_version": [2, 6, 1],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "fad9682201cf9289bba2adb66e6e07ed1cf78936",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2b1/translation-T2B1-cs-CZ-2.8.9.bin",
+        "de-DE": "firmware/translations/t2b1/translation-T2B1-de-DE-2.8.9.bin",
+        "es-ES": "firmware/translations/t2b1/translation-T2B1-es-ES-2.8.9.bin",
+        "fr-FR": "firmware/translations/t2b1/translation-T2B1-fr-FR-2.8.9.bin",
+        "it-IT": "firmware/translations/t2b1/translation-T2B1-it-IT-2.8.9.bin",
+        "pt-BR": "firmware/translations/t2b1/translation-T2B1-pt-BR-2.8.9.bin"
+    },
+    "url": "firmware/t2b1/universal/t2b1-2.8.9-universal.bin",
+    "fingerprint": "f6e03b48ab163f302bb886da197b6a0e7b390efdc5815b419535c5dee5cac1f7",
+    "changelog": "* Ability to cancel recovery on word count selection screen.\n* New UI for confirming long messages.\n* Solana staking confirmation dialogs."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.1.5-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.1.5-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 1, 5],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 1, 0],
+    "firmware_revision": "df0963ec48f01f3d07ffca556e21ff0070cab099",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.1.5.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.1.5.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.1.5.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.1.5.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.1.5.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.1.5.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.1.5-bitcoinonly.bin",
+    "fingerprint": "9de90d9f8ca12506f3b9a4cbe7616294144d965d67daa3a03bfe6c0b74a44843",
+    "changelog": "* Fix UI for Shamir with 33 words"
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.1.6-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.1.6-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 1, 6],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "629fa58d396e732f230866ebe733d268370d7879",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.1.6.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.1.6.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.1.6.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.1.6.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.1.6.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.1.6.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.1.6-bitcoinonly.bin",
+    "fingerprint": "4e7f0f95d71631159b9e873f36a812c93a10eca1fad5f38c78ae7fbe4c1f6ed4",
+    "changelog": "* Small code improvements."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.1.7-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.1.7-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 1, 7],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "2cabc8b40ce237ee8a7e1926b6269040519d447a",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.1.7.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.1.7.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.1.7.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.1.7.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.1.7.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.1.7.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.1.7-bitcoinonly.bin",
+    "fingerprint": "fd92ac173a2cf93cc07ced3287e07800ed10466dc38c0c7240d9b20c689dd1d1",
+    "changelog": "* Super Shamir (with Groups)\n* Fix low memory issue"
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.1.8-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.1.8-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 1, 8],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "8eb6ce08995514c67d175b7197feeadeccc48ff0",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.1.8.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.1.8.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.1.8.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.1.8.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.1.8.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.1.8.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.1.8-bitcoinonly.bin",
+    "fingerprint": "ec752e9fa99a29979497e093b32bdb2b592783e2b48c87d8f6f0c18c73cd3022",
+    "changelog": "* Show XPUBs in GetAddress for multisig\n* Security improvements"
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.3.0-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.3.0-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 3, 0],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "0b7a8449f8dd003fc415262b05102d113247d3de",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.3.0.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.3.0.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.3.0.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.3.0.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.3.0.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.3.0.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.3.0-bitcoinonly.bin",
+    "fingerprint": "bddc0fd3b52fd32d94b776048f62b3d03dcb6ab90140e482a042a2863093115f",
+    "changelog": "* Introduce Wipe code\n* Introduce SD card protection\n* Introduce passphrase cache\n* Security fixes"
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.3.1-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.3.1-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 3, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "c6b2580cd245ee924507f45e9675f857a3d78768",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.3.1.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.3.1.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.3.1.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.3.1.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.3.1.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.3.1.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.3.1-bitcoinonly.bin",
+    "fingerprint": "41795ec196f74c5d6acecc09047a5eacf1dfca47b0aeaa8442a69568efe20ddb",
+    "changelog": "* Refactor Bitcoin signing"
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.3.2-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.3.2-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 3, 2],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "63ebb8ccb56fc17a72eef91db36a37ff3176519d",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.3.2.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.3.2.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.3.2.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.3.2.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.3.2.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.3.2.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.3.2-bitcoinonly.bin",
+    "fingerprint": "389cb54fb6fc75489b788ad669ce51f41d47a67af54b8745a0dfe48da38a777f",
+    "changelog": "* Introduces 'Autolock' feature, which automatically locks the device to enforce the PIN entry after a certain period.\n* Fixes compatibility issues with Casa and GreenAddress.\n* Adds support for multiple change outputs in outgoing transactions.\n* Improves some interface elements."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.3.3-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.3.3-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 3, 3],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "0d5f00668fb3d1c093ff3c879311a91d3a7175c8",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.3.3.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.3.3.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.3.3.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.3.3.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.3.3.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.3.3.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.3.3-bitcoinonly.bin",
+    "fingerprint": "dda77cd7893a5f413f8fc4b2f44d1d43ed4b26e8ced5e6e578cc6b302c1a2310",
+    "changelog": "* Advances the Passphrase feature by showing the entered passphrase on the Trezor screen before opening the wallet.\n* Introduces a hard limit on transaction fees to prevent accidentally paying extra hefty fees (the limit can be manually disabled).\n* Fixes smaller issues with the user interface, customization, and more."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.3.4-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.3.4-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 3, 4],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "50854b9210f7674262c1541272a8c7fd1767b7a9",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.3.4.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.3.4.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.3.4.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.3.4.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.3.4.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.3.4.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.3.4-bitcoinonly.bin",
+    "fingerprint": "085acbba98163284ef86dea637f9442b924e80fea245f5ebb60d5aab3be2b7b6",
+    "changelog": "* Small code improvements."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.3.5-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.3.5-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 3, 5],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "ffa96205fb5e22b43e7b08a3dbc3cdeee0931de3",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.3.5.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.3.5.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.3.5.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.3.5.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.3.5.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.3.5.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.3.5-bitcoinonly.bin",
+    "fingerprint": "53e7ee5bfc75cfa6412d8de5461b1ea8d9b7e10970ce7cadae9cbb1e17bbb77d",
+    "changelog": "* Replacement transaction signing for replace-by-fee and PayJoin.\n* Support for Output Descriptors export.\n* Paginated display for signing/verifying long messages.\n* Show Ypub/Zpub correctly for multisig GetAddress.\n* Show amounts in mBTC, uBTC and sat denominations."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.3.6-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.3.6-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 3, 6],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "b19cbf67c6c7c38513947b703df6d4409c59bc98",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.3.6.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.3.6.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.3.6.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.3.6.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.3.6.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.3.6.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.3.6-bitcoinonly.bin",
+    "fingerprint": "e2cab40bb4c6ae65417b80ad564b905796038a0f5e6d0f50cead257fdd3a9c2d",
+    "changelog": "* Add compatibility paths for Unchained Capital"
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.4.0-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.4.0-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 4, 0],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "ea3596ad89a7993ad7b9d62798de94325ad1717a",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.4.0.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.4.0.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.4.0.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.4.0.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.4.0.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.4.0.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.4.0-bitcoinonly.bin",
+    "fingerprint": "89c91287ab7a9cd3ec246b6822a0d04b7d40401abef706cccafbb7b98bd6a3d7",
+    "changelog": "* Locking the device by holding finger on the homescreen.\n* Support PIN of unlimited length.\n* Allow decreasing the output value in RBF transactions.\n* Reduce memory fragmentation.\n* Improve wording when showing multisig XPUBs."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.4.1-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.4.1-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 4, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "24bb4016388fca4b998285b95dcd408f4ed0bff6",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.4.1.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.4.1.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.4.1.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.4.1.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.4.1.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.4.1.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.4.1-bitcoinonly.bin",
+    "fingerprint": "fce4503fcadb68dc72144a562ec0a59e7c8d083e403e01bfc4c584161d79f596",
+    "changelog": "* Security and major perfomance improvements.\n* Fix red screen on shutdown."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.4.2-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.4.2-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 4, 2],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "9276b1702361f70e094286e2f89e919d8a230d5c",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.4.2.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.4.2.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.4.2.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.4.2.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.4.2.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.4.2.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.4.2-bitcoinonly.bin",
+    "fingerprint": "60fee3c9775d8ccf71099f6f7d277463efd128414cfb9be45656b1a26eeb7301",
+    "changelog": "* Memory optimization of BTC signing."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.4.3-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.4.3-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 4, 3],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "595b14254c1abb2be3f69e42c7932f1eca8cf1b1",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.4.3.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.4.3.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.4.3.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.4.3.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.4.3.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.4.3.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.4.3-bitcoinonly.bin",
+    "fingerprint": "1744efccabd479526392b281b7e0fc7aa2b4ecb454007dff7ca8c1f8171fad90",
+    "changelog": "* Support Taproot.\n* Show address confirmation in SignMessage."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.5.1-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.5.1-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 5, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "85a26d2c9593bcdf858c2d718d79951ca927a0c3",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.5.1.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.5.1.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.5.1.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.5.1.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.5.1.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.5.1.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.5.1-bitcoinonly.bin",
+    "fingerprint": "db5d7b211532f717a32fe0b1bd3e3df6ad5464079a896a7f7492ab6e9e030bb5",
+    "changelog": "* Support Electrum signatures in VerifyMessage.\n* Bitcoin bech32 addresses QR codes have bigger pixels which are easier to scan.\n* Trezor will refuse to sign UTXOs that do not match the provided derivation path (e.g., transactions belonging to a different wallet, or synthetic transaction inputs)."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.5.2-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.5.2-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 5, 2],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "0d87b55ba4fed7eecc72bf2a94ee473830b095e9",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.5.2.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.5.2.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.5.2.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.5.2.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.5.2.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.5.2.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.5.2-bitcoinonly.bin",
+    "fingerprint": "76aa25f9602cfb03cd3e07a82ac09226344eb355355aec216295e43b675eedf7",
+    "changelog": "* Show the fee rate on the signing confirmation screen. \n* Show thousands separator when displaying large amounts."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.5.3-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.5.3-bitcoinonly.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 5, 3],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "2f03ace311584988d5aeab58fd1acf24ef54711a",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.5.3.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.5.3.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.5.3.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.5.3.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.5.3.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.5.3.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.5.3-bitcoinonly.bin",
+    "fingerprint": "c094c84ba958129885fa725ee6ddb781b580fd2c7851e83aef9054ba4a10526c",
+    "changelog": "* Add SLIP-0025 CoinJoin accounts. \n* Show red error header when Trezor doesn't see USB data connection. \n* Show fee rate when replacing transaction. \n* Optimize the signing of BTC transactions. \n* Extend decimals of fee rate to 2 digits. \n* Display only “sat” instead of “sat BTC”."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.6.0-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.6.0-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 6, 0],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 0],
+    "firmware_revision": "88e1f8c7a5c7615723664c64b0a25adc0c409dee",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.6.0.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.6.0.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.6.0.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.6.0.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.6.0.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.6.0.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.6.0-bitcoinonly.bin",
+    "fingerprint": "54f084dab4be1e64dc2cb970a6de87969407e4d6c48d79acdcf5d374ec0f29d6",
+    "changelog": " Show source account path in BTC signing. \n* Ability to reboot the device into bootloader mode directly, without needing to unplug the device. \n* Support for Ledger Live legacy derivation path \"m/44'/coin_type'/0'/account\". \n* Redesigned UI. \n* Homescreen now supports full-screen images."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.6.3-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.6.3-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 6, 3],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 4],
+    "firmware_revision": "2c7cc6e0255dee2339b445b5551eaffb88dbd1b4",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.6.3.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.6.3.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.6.3.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.6.3.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.6.3.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.6.3.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.6.3-bitcoinonly.bin",
+    "fingerprint": "1765518ca4025d4d46362d07128bb38413831511a2aff0dee1b05e6e58ff5317",
+    "changelog": "* QR Code for Extended Public Keys (XPUBs). \n* Adjusted buttons for multipage content scrolling, providing a more intuitive and user-friendly experience. \n* The new bootloader version 2.1.4 is now included for enhanced system performance and security."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.6.4-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.6.4-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 6, 4],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 4],
+    "firmware_revision": "42e9ed0e09033d474dee1a560fe5870646fa440e",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.6.4.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.6.4.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.6.4.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.6.4.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.6.4.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.6.4.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.6.4-bitcoinonly.bin",
+    "fingerprint": "e78da8a00354dd1223da081600f881b71bd297dd565e7a2c0a9880e52575d127",
+    "changelog": "* The display of spaced addresses has been refined, offering a more user-friendly and visually optimized experience. \n* Boot-up logo display has been optimized, contributing to a smoother and more visually appealing device startup."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.7.0-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.7.0-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 7, 0],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 4],
+    "firmware_revision": "45e8a842a31e62a6d43d7f6ccac62a45e1198ef0",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.7.0.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.7.0.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.7.0.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.7.0.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.7.0.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.7.0.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.7.0-bitcoinonly.bin",
+    "fingerprint": "c94f07150a6f0bb2862d4c31c6059862aab14f0073dea581118eef51a983bc30",
+    "changelog": "* Add translations capability. \n* Allow for going back to previous word in recovery process. \n* Display descriptors for BTC Taproot public keys. \n* Fixed blank display delay on startup when display orientation is set to other than north."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.7.2-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.7.2-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 7, 2],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 4],
+    "firmware_revision": "da75d8f4b67410b40a9cfd2954d183d81dd6e8e8",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.7.2.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.7.2.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.7.2.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.7.2.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.7.2.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.7.2.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.7.2-bitcoinonly.bin",
+    "fingerprint": "cba515383705ec6420c54dd1ffdb33ea7ce4bb04bc6d992c2923880daa53d3e1",
+    "changelog": "* Introducing repeated backups. \n* Multi-share backups can now have any number of shares."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.8.1-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.8.1-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 6],
+    "firmware_revision": "632b9561559b7ab6824bb7eeac072874e07b7b82",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.8.1.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.8.1.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.8.1.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.8.1.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.8.1.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.8.1.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.8.1-bitcoinonly.bin",
+    "fingerprint": "38ab127fcf4263a18a3b07593301fdd2c6a1a96360b62c131adb849b5d18fae3",
+    "changelog": "* Fixed displaying of a progress indicator for the formatting operation.\n* Improve precision of PIN validation countdown."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.8.10-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.8.10-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 10],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.8.10.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.8.10.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.8.10.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.8.10.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.8.10.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.8.10.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.8.10-bitcoinonly.bin",
+    "fingerprint": "c280cfbe83b261ef30c64eb58f55538b3cceee01ba7d8f57d6e8cbf92527066b",
+    "changelog": "* Replaced \"next page\" icon with \"...\" ellipsis when confirming long message.\n* Fixed upgrade confirmation text overflow.\n* Allow firmware upgrade even if language change failed."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.8.7-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.8.7-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 7],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "8a254aa8eae82f99630df63f40e4d290066a3efc",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.8.7.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.8.7.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.8.7.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.8.7.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.8.7.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.8.7.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.8.7-bitcoinonly.bin",
+    "fingerprint": "7bdf5de0c00c5d15c06d526a5b0d22cfd8343eb3e7aa01ee3c4ed60dd063bbf1",
+    "changelog": "* Show last typed PIN number for short period of time.\n* Multisig-related changes.\n* Included new version of bootloader (2.1.8).\n* Fix translation of the 'Enable labeling' screen."
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.8.8-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.8.8-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 8],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "592590cf66a9b62dfeee7e4d2afb6e01005e5b2c",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.8.8.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.8.8.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.8.8.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.8.8.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.8.8.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.8.8.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.8.8-bitcoinonly.bin",
+    "fingerprint": "81928bbb5bc855f46a2ccb210173f9676b69d153a513bfa0101abfc063f7aef5",
+    "changelog": "* Fix \"PIN attempts exceeded\" screen\n* Fixed a bug resulting in restarting the recovery flow when inputting 33-word mnemonic"
+}

--- a/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.8.9-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t2t1/bitcoinonly/t2t1-2.8.9-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 9],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "fad9682201cf9289bba2adb66e6e07ed1cf78936",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-t2t1-cs-CZ-2.8.9.bin",
+        "de-DE": "firmware/translations/t2t1/translation-t2t1-de-DE-2.8.9.bin",
+        "es-ES": "firmware/translations/t2t1/translation-t2t1-es-ES-2.8.9.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-t2t1-fr-FR-2.8.9.bin",
+        "it-IT": "firmware/translations/t2t1/translation-t2t1-it-IT-2.8.9.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-t2t1-pt-BR-2.8.9.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.8.9-bitcoinonly.bin",
+    "fingerprint": "e5878fa067df9d1256cdcd86f10869930d85e090c39f807c23f8845472e8d995",
+    "changelog": "* Ability to cancel recovery on word count selection screen.\n* New UI for confirming long messages."
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.0.10-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.0.10-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 0, 10],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 5],
+    "bootloader_version": [2, 0, 2],
+    "firmware_revision": "5c3a5d4577b568d90bfa3528d0243d74848d994f",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.0.10.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.0.10.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.0.10.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.0.10.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.0.10.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.0.10.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.0.10-universal.bin",
+    "fingerprint": "fcaa6ee206c2c121eb2d45d065d66f0879f14be45c244d4acf908be1de22275e",
+    "changelog": "* Fix Monero payment ID computation\n* Fix issue with touch screen and flickering\n* Add support for OMNI layer: OMNI/MAID/USDT\n* Add support for new coins: BTX, CPC, GAME, RVN\n* Add support for new Ethereum tokens"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.0.5-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.0.5-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": true,
+    "version": [2, 0, 5],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 5],
+    "bootloader_version": [2, 0, 0],
+    "firmware_revision": "8852fb54820032f4f287414aa250df981d25445f",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.0.5.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.0.5.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.0.5.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.0.5.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.0.5.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.0.5.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.0.5-universal.bin",
+    "fingerprint": "851172eab96c07bf9efb43771cb0fd14dc0320a68de047132c7bd787a1ad64e9",
+    "changelog": "* First public release"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.0.6-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.0.6-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 0, 6],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 5],
+    "bootloader_version": [2, 0, 0],
+    "firmware_revision": "886888b7750402d9a9e12bd990e75c0a8dc6cc86",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.0.6.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.0.6.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.0.6.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.0.6.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.0.6.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.0.6.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.0.6-universal.bin",
+    "fingerprint": "4eccabf2fd7e121ed0da657c064a65c5694402497e60ea2ac2dcf1e118db9cc6",
+    "changelog": "* Fix layout for Ethereum transactions\n* Fix public key generation for SSH and GPG\n* Add special characters to passphrase keyboard"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.0.7-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.0.7-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 0, 7],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 5],
+    "bootloader_version": [2, 0, 0],
+    "firmware_revision": "5c621800110a791c84865b6b381908e8c2f15283",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.0.7.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.0.7.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.0.7.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.0.7.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.0.7.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.0.7.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.0.7-universal.bin",
+    "fingerprint": "f3a42e640e526fba6574fafa520fc7d97ef9f557d24da24d9a2ea4176a4c4164",
+    "changelog": "* Bitcoin Cash cashaddr support\n* Zcash Overwinter hardfork support\n* NEM support\n* Lisk support\n* Show warning on home screen if PIN is not set\n* Support for new coins:\n  - Bitcoin Private, Fujicoin, Vertcoin, Viacoin, Zcoin\n* Support for new Ethereum networks:\n  - EOS Classic, Ethereum Social, Ellaism, Callisto, EtherGem, Wanchain\n* Support for 500+ new Ethereum tokens"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.0.8-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.0.8-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 0, 8],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 5],
+    "bootloader_version": [2, 0, 0],
+    "firmware_revision": "939a93221941df8d454569a674f6fb082bf1d423",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.0.8.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.0.8.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.0.8.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.0.8.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.0.8.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.0.8.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.0.8-universal.bin",
+    "fingerprint": "642b6215bda981f8eacafee34dbee5cdeee7d47d49f605bbe2828a8d9b79813d",
+    "changelog": "* Monero support\n* Cardano support\n* Stellar support\n* Ripple support\n* Tezos support\n* Decred support\n* Groestlcoin support\n* Zencash support\n* Zcash sapling hardfork support\n* Implemented seedless setup"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.0.9-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.0.9-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 0, 9],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 5],
+    "bootloader_version": [2, 0, 0],
+    "firmware_revision": "7c2e9ed5a51dc00dec9d195878c5ad57016b4889",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.0.9.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.0.9.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.0.9.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.0.9.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.0.9.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.0.9.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.0.9-universal.bin",
+    "fingerprint": "87be93d6966e7a9eff78dc7b434d1a138ec8d1ee0300882d16f90b606f3a806b",
+    "changelog": "* Small Monero and Segwit bugfixes"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.1.0-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.1.0-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 1, 0],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 5],
+    "bootloader_version": [2, 0, 3],
+    "firmware_revision": "3f0e3a334e03f49ff819d14cbbec00194c586c27",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.1.0.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.1.0.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.1.0.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.1.0.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.1.0.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.1.0.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.1.0-universal.bin",
+    "fingerprint": "bb5b0308807b45d41d1e2ab66a468152997ad69a01099789d8a35e464cde999f",
+    "changelog": "* Security improvements\n* Upgraded to new storage format\n* Ripple, Stellar, Cardano and NEM fixes\n* New coins: ATS, AXE, FLO, GIN, KMD, NIX,\n  PIVX, REOSC, XPM, XSN, ZCL\n* New ETH tokens"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.1.1-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.1.1-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 1, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 5],
+    "firmware_revision": "7af1d5859458e87efd6957885566aed890a9f781",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.1.1.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.1.1.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.1.1.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.1.1.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.1.1.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.1.1.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.1.1-universal.bin",
+    "fingerprint": "1b3166a878658fcd2ff82c7ac9a2587da544fd105f678cc7b4d41cba5a8d4c01",
+    "changelog": "* Hotfix for touchscreen freeze\n* Don't rotate the screen via swipe gesture\n* Set screen rotation via user setting\n* More strict path validations\n* Display non-zero locktime values\n* EOS support\n* Monero UI fixes\n* Speed and memory optimizations"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.1.4-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.1.4-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 1, 4],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 1, 0],
+    "firmware_revision": "6a1a02ca3c595067ed02a78f2d6c36eb58eaa9ed",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.1.4.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.1.4.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.1.4.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.1.4.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.1.4.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.1.4.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.1.4-universal.bin",
+    "fingerprint": "820611a92605b1ccc612b9bf8550617aec6962bd2484fcb6ae4792bc498654e4",
+    "changelog": "* Shamir Backup with Recovery persistence\n* Touchscreen freeze fix\n* Fix display of non-divisible OMNI amounts"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.1.5-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.1.5-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 1, 5],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 1, 0],
+    "firmware_revision": "df0963ec48f01f3d07ffca556e21ff0070cab099",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.1.5.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.1.5.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.1.5.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.1.5.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.1.5.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.1.5.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.1.5-universal.bin",
+    "fingerprint": "40e4bfaf3c5ec77872c1aaaac085aafcc443f60279ca2bb38d29c669233fdf62",
+    "changelog": "* Fix for sluggish U2F authentication when using Shamir\n* Fix UI for Shamir with 33 words\n* Fix Wanchain signing"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.1.6-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.1.6-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 1, 6],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "629fa58d396e732f230866ebe733d268370d7879",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.1.6.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.1.6.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.1.6.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.1.6.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.1.6.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.1.6.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.1.6-universal.bin",
+    "fingerprint": "e2032ad84108a85d4014d477b955b9181a1a56e6f222ef21bb7d47b503a02f0b",
+    "changelog": "* Super Shamir (with Groups)\n* FIDO2 support with credential management"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.1.7-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.1.7-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 1, 7],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "2cabc8b40ce237ee8a7e1926b6269040519d447a",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.1.7.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.1.7.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.1.7.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.1.7.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.1.7.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.1.7.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.1.7-universal.bin",
+    "fingerprint": "acf1b4c6fec3624a8fc53f9130ff53d690c3fa1c134bd4ca3e58ee7b5a0441d8",
+    "changelog": "* Super Shamir (with Groups)\n* FIDO2 support with credential management\n* Fix low memory issue"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.1.8-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.1.8-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 1, 8],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "8eb6ce08995514c67d175b7197feeadeccc48ff0",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.1.8.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.1.8.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.1.8.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.1.8.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.1.8.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.1.8.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.1.8-universal.bin",
+    "fingerprint": "8a5fa12132651b6e33344fd025d0d90885f5cc1c342427ebcea4f0ae98b50d8c",
+    "changelog": "* Support Tezos 005-BABYLON hardfork\n* Show XPUBs in GetAddress for multisig\n* Security improvements"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.3.0-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.3.0-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 3, 0],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "0b7a8449f8dd003fc415262b05102d113247d3de",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.3.0.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.3.0.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.3.0.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.3.0.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.3.0.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.3.0.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.3.0-universal.bin",
+    "fingerprint": "212929f63fe1393e2ff57e06537a38cff281e3cfb3a4e17235079e2f08871e6c",
+    "changelog": "* Introduce Wipe code\n* Introduce SD card protection\n* Introduce passphrase cache\n* U2F UX improvements\n* Security fixes"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.3.1-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.3.1-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 3, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "c6b2580cd245ee924507f45e9675f857a3d78768",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.3.1.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.3.1.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.3.1.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.3.1.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.3.1.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.3.1.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.3.1-universal.bin",
+    "fingerprint": "37178a5ec24e34f8a0599aebcadaf206af3ebadef2fc596665d617dd3e05a5db",
+    "changelog": "* Refactor Bitcoin signing"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.3.2-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.3.2-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 3, 2],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "63ebb8ccb56fc17a72eef91db36a37ff3176519d",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.3.2.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.3.2.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.3.2.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.3.2.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.3.2.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.3.2.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.3.2-universal.bin",
+    "fingerprint": "f5ccdca0cbe163ecb93df726da72b69abb93f70d24d295db00b3ca2738216160",
+    "changelog": "* Introduces 'Autolock' feature, which automatically locks the device to enforce the PIN entry after a certain period.\n* Updates the Cardano support to enable staking and other Shelley updates.\n* Reintroduces the ability to spend pre-Overwinter (2018) funds on Zcash-like coins.\n* Fixes compatibility issues with Casa and GreenAddress.\n* Adds support for multiple change outputs in outgoing transactions.\n* Improves some interface elements."
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.3.3-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.3.3-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 3, 3],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "0d5f00668fb3d1c093ff3c879311a91d3a7175c8",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.3.3.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.3.3.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.3.3.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.3.3.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.3.3.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.3.3.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.3.3-universal.bin",
+    "fingerprint": "46326222f8afcb82e1cd07867bc3bf8836f4e9d0f367e23b58d1e9bc32cd032e",
+    "changelog": "* Advances the Passphrase feature by showing the entered passphrase on the Trezor screen before opening the wallet.\n* Adds support for Verge (XVG).\n* Drops support for Metaverse (ETP), GINcoin (GIN), Pesetacoin (PTC), and Zel (ZEL).\n* Introduces a hard limit on transaction fees to prevent accidentally paying extra hefty fees (the limit can be manually disabled).\n* Resolves the problems with generating the Crown addresses.\n* Re-enables spending altcoins from Bitcoin paths (fixing some compatibility issues with Bitcoin Cash wallets).\n* Fixes smaller issues with the user interface, customization, and more."
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.3.4-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.3.4-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 3, 4],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "50854b9210f7674262c1541272a8c7fd1767b7a9",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.3.4.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.3.4.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.3.4.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.3.4.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.3.4.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.3.4.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.3.4-universal.bin",
+    "fingerprint": "58b51a6587993965979a744f8fcd5c4761f11ce4bec6b059a5d56bd0987d6658",
+    "changelog": "* This firmware only contains the changes needed after the latest Monero update (HF13) by introducing support for the CLSAG transactions."
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.3.5-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.3.5-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 3, 5],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "ffa96205fb5e22b43e7b08a3dbc3cdeee0931de3",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.3.5.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.3.5.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.3.5.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.3.5.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.3.5.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.3.5.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.3.5-universal.bin",
+    "fingerprint": "c0a6cacfed5c7a691314919c22307c29fbe9522071a9a28669769c014762d386",
+    "changelog": "* Replacement transaction signing for replace-by-fee and PayJoin.\n* Support for Output Descriptors export.\n* Paginated display for signing/verifying long messages.\n* Show Ypub/Zpub correctly for multisig GetAddress.\n* Show amounts in mBTC, uBTC and sat denominations."
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.3.6-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.3.6-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 3, 6],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "b19cbf67c6c7c38513947b703df6d4409c59bc98",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.3.6.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.3.6.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.3.6.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.3.6.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.3.6.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.3.6.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.3.6-universal.bin",
+    "fingerprint": "0efa3ba6135caea7693d145d60441eeb46283fe0b8b1fd59a04af33a638ad237",
+    "changelog": "* Add compatibility paths for Unchained Capital"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.4.0-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.4.0-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 4, 0],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "ea3596ad89a7993ad7b9d62798de94325ad1717a",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.4.0.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.4.0.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.4.0.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.4.0.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.4.0.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.4.0.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.4.0-universal.bin",
+    "fingerprint": "d90265ee6d7d499c7d938b5322f71f27042da8a6fdaed54c224d31b65e868def",
+    "changelog": "* Locking the device by holding finger on the homescreen.\n* Support PIN of unlimited length.\n* Allow decreasing the output value in RBF transactions.\n* Reduce memory fragmentation.\n* Update FIDO icons.\n* Improve wording when showing multisig XPUBs."
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.4.1-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.4.1-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 4, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "24bb4016388fca4b998285b95dcd408f4ed0bff6",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.4.1.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.4.1.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.4.1.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.4.1.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.4.1.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.4.1.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.4.1-universal.bin",
+    "fingerprint": "84bc47bb197b3ae7bfb096f03d4a528ccf6c9ef4dfee0aac4022971e4ec91d68",
+    "changelog": "* Security and major perfomance improvements.\n* Cardano fixes.\n* Fix red screen on shutdown."
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.4.2-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.4.2-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 4, 2],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "9276b1702361f70e094286e2f89e919d8a230d5c",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.4.2.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.4.2.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.4.2.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.4.2.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.4.2.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.4.2.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.4.2-universal.bin",
+    "fingerprint": "54ccf155510b5292bd17ed748409d0d135112e24e62eb74184639460beecb213",
+    "changelog": "* Support for Ethereum EIP1559 transactions.\n* Re-enabled Firo support.\n* Memory optimization of BTC signing and CBOR decoding.\n* Support for large Cardano transactions.\n* Remove Lisk."
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.4.3-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.4.3-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 4, 3],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "595b14254c1abb2be3f69e42c7932f1eca8cf1b1",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.4.3.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.4.3.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.4.3.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.4.3.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.4.3.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.4.3.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.4.3-universal.bin",
+    "fingerprint": "a07f69d8d2065006a79c6b5636bd046496dbcb3820b41f1d604d8a4605ca4056",
+    "changelog": "* Support Taproot.\n* Show address confirmation in SignMessage.\n* Support for advanced Cardano transactions and different derivations for compatibility.\n* Ethereum support for EIP712 (signing typed data)."
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.5.1-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.5.1-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 5, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "85a26d2c9593bcdf858c2d718d79951ca927a0c3",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.5.1.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.5.1.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.5.1.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.5.1.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.5.1.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.5.1.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.5.1-universal.bin",
+    "fingerprint": "782d4934897018cac779eebb0d7c66e21da7789b9cd35e1f99f097bdfd9b7d33",
+    "changelog": "* Support Electrum signatures in VerifyMessage.\n* Support Cardano Alonzo-era transactions (Plutus).\n* Bitcoin bech32 addresses QR codes have bigger pixels which are easier to scan.\n* EIP-1559 transaction correctly show final Hold to Confirm screen.\n* Trezor will refuse to sign UTXOs that do not match the provided derivation path (e.g., transactions belonging to a different wallet, or synthetic transaction inputs).\n* Zcash v5 transaction format."
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.5.2-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.5.2-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 5, 2],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "0d87b55ba4fed7eecc72bf2a94ee473830b095e9",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.5.2.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.5.2.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.5.2.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.5.2.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.5.2.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.5.2.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.5.2-universal.bin",
+    "fingerprint": "659b1b698546fa63f24200e148b6f9a7044df31d11a0a5ec7c044f2dd83f4a27",
+    "changelog": "* Add support for Monero HF15 features. \n* Show the fee rate on the signing confirmation screen. \n* Support for Cardano Babbage era transaction items \n* Add \"Show All\"/\"Show Simple\" choice to Cardano transaction signing \n* Show thousands separator when displaying large amounts. \n* Fix Decred transaction weight calculation."
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.5.3-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.5.3-universal.json
@@ -1,0 +1,19 @@
+{
+    "required": false,
+    "version": [2, 5, 3],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "firmware_revision": "2f03ace311584988d5aeab58fd1acf24ef54711a",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.5.3.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.5.3.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.5.3.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.5.3.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.5.3.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.5.3.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.5.3-universal.bin",
+    "fingerprint": "4f57dca1abc1a60d82c4fef7c96e86d784fc7a1e5e3da724dd2ae4d14c6350bf",
+    "changelog": "* Add SLIP-0025 CoinJoin accounts. \n* Show red error header when Trezor doesn't see USB data connection. \n* Add support for Zcash unified addresses. \n* Show fee rate when replacing transaction. \n* Optimize the signing of BTC transactions. \n* Support for Cardano CIP-36 governance registration format. \n* Extend decimals of fee rate to 2 digits. \n* Display only “sat” instead of “sat BTC”. \n* Fix sending XMR transaction to an integrated address. \n* Fix XMR primary address display."
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.6.0-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.6.0-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 6, 0],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 0],
+    "firmware_revision": "88e1f8c7a5c7615723664c64b0a25adc0c409dee",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.6.0.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.6.0.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.6.0.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.6.0.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.6.0.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.6.0.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.6.0-universal.bin",
+    "fingerprint": "050526db604b9acceef2a5a8561bc99ecbe337909283ebb927b556d8e9b13872",
+    "changelog": "* Show source account path in BTC signing. \n* Address confirmation screen added to EIP712 signing flow. \n* Ability to reboot the device into bootloader mode directly, without needing to unplug the device. \n* Support for Ledger Live legacy derivation path \"m/44'/coin_type'/0'/account\". \n* Redesigned UI. \n* Homescreen now supports full-screen images. \n* Force basic attestation in FIDO2 for google.com."
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.6.3-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.6.3-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 6, 3],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 4],
+    "firmware_revision": "2c7cc6e0255dee2339b445b5551eaffb88dbd1b4",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.6.3.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.6.3.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.6.3.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.6.3.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.6.3.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.6.3.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.6.3-universal.bin",
+    "fingerprint": "9ff0874f2ce3579a7502747578cef65c824097d906e7150b0142f6b9aa395a43",
+    "changelog": "* QR Code for Extended Public Keys (XPUBs). \n* Adjusted buttons for multipage content scrolling, providing a more intuitive and user-friendly experience. \n* The new bootloader version 2.1.4 is now included for enhanced system performance and security."
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.6.4-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.6.4-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 6, 4],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 4],
+    "firmware_revision": "42e9ed0e09033d474dee1a560fe5870646fa440e",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.6.4.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.6.4.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.6.4.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.6.4.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.6.4.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.6.4.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.6.4-universal.bin",
+    "fingerprint": "441faa92156e8ae0b8247f9434c3ec8cf6ffd872f16fc593b22c4460dfd93913",
+    "changelog": "* Trezor Model T now supports Solana, expanding the range of cryptocurrencies it can securely manage. [Universal fw only] \n* Ethereum fees are now uniformly presented in Gwei, enhancing clarity and consistency for users. [Universal fw only] \n* The display of spaced addresses has been refined, offering a more user-friendly and visually optimized experience. \n* Boot-up logo display has been optimized, contributing to a smoother and more visually appealing device startup."
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.7.0-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.7.0-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 7, 0],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 4],
+    "firmware_revision": "45e8a842a31e62a6d43d7f6ccac62a45e1198ef0",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.7.0.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.7.0.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.7.0.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.7.0.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.7.0.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.7.0.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.7.0-universal.bin",
+    "fingerprint": "53a645218792e413ad06c27320b7d1adc944b690ce831301bbf11c30352d3278",
+    "changelog": "* Add translations capability. \n* Allow for going back to previous word in recovery process. \n* Clear sign ETH staking transactions on Everstake pool. [Universal fw only] \n* Display descriptors for BTC Taproot public keys. \n* Fixed blank display delay on startup when display orientation is set to other than north. \n* Multiple Solana instructions improved. [Universal fw only]"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.7.2-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.7.2-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 7, 2],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 4],
+    "firmware_revision": "da75d8f4b67410b40a9cfd2954d183d81dd6e8e8",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.7.2.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.7.2.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.7.2.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.7.2.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.7.2.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.7.2.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.7.2-universal.bin",
+    "fingerprint": "d64fcf47a8ead6edf0329583e312136d1548d30990c29cfaa2ce7c67197babcc",
+    "changelog": "* Introducing repeated backups. \n* Multi-share backups can now have any number of shares. \n* Added support for Cardano Conway certificates [Universal fw only]."
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.8.1-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.8.1-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 6],
+    "firmware_revision": "632b9561559b7ab6824bb7eeac072874e07b7b82",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.8.1.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.8.1.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.8.1.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.8.1.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.8.1.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.8.1.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.8.1-universal.bin",
+    "fingerprint": "d3af84a212d32785449ca6575e3cf2a641920b353a82dec9f059083ea5d4b149",
+    "changelog": "* Fixed displaying of a progress indicator for the formatting operation.\n* Improve precision of PIN validation countdown.\n* Solana: Improved support for AToken Create operation."
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.8.10-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.8.10-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 10],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.8.10.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.8.10.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.8.10.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.8.10.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.8.10.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.8.10.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.8.10-universal.bin",
+    "fingerprint": "91feae69ada0f98b72f19191f1d1e083b579c26079f7e6fcd751fae0902ec72f",
+    "changelog": "* Add Nostr support (in debug mode only!).\n* Solana: rent fee calculation [#4933]\n* Solana: loadable token definitions [#3541]\n* Replaced \"next page\" icon with \"...\" ellipsis when confirming long message.\n* Fixed upgrade confirmation text overflow.\n* Fixed Solana staking dialog fonts.\n* Updated EIP-1559 fee-related labels.\n* Allow firmware upgrade even if language change failed.\n* Solana: fees calculation is now exact [#4965]"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.8.7-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.8.7-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 7],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "8a254aa8eae82f99630df63f40e4d290066a3efc",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.8.7.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.8.7.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.8.7.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.8.7.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.8.7.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.8.7.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.8.7-universal.bin",
+    "fingerprint": "7f7bae53913c3a339f22adddb16db70b11bcf908af1c7a5986bae09af9d4ab62",
+    "changelog": "* Show last typed PIN number for short period of time.\n* Multisig-related changes.\n* Simplify UI of Cardano transactions initiated by Trezor Suite.\n* Included new version of bootloader (2.1.8).\n* Fix ETH account number detection.\n* New EVM call contract flow UI.\n* Fix translation of the 'Enable labeling' screen."
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.8.8-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.8.8-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 8],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "592590cf66a9b62dfeee7e4d2afb6e01005e5b2c",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.8.8.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.8.8.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.8.8.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.8.8.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.8.8.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.8.8.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.8.8-universal.bin",
+    "fingerprint": "f4888bed3e75205464910f3956d1f3ad19bb73e093b31c9141a66226a7081990",
+    "changelog": "* Fix \"PIN attempts exceeded\" screen\n* Fixed a bug resulting in restarting the recovery flow when inputting 33-word mnemonic"
+}

--- a/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.8.9-universal.json
+++ b/packages/connect-common/files/firmware/t2t1/universal/t2t1-2.8.9-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 9],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 0, 0],
+    "min_firmware_version": [2, 0, 8],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "fad9682201cf9289bba2adb66e6e07ed1cf78936",
+    "translations": {
+        "cs-CZ": "firmware/translations/t2t1/translation-T2T1-cs-CZ-2.8.9.bin",
+        "de-DE": "firmware/translations/t2t1/translation-T2T1-de-DE-2.8.9.bin",
+        "es-ES": "firmware/translations/t2t1/translation-T2T1-es-ES-2.8.9.bin",
+        "fr-FR": "firmware/translations/t2t1/translation-T2T1-fr-FR-2.8.9.bin",
+        "it-IT": "firmware/translations/t2t1/translation-T2T1-it-IT-2.8.9.bin",
+        "pt-BR": "firmware/translations/t2t1/translation-T2T1-pt-BR-2.8.9.bin"
+    },
+    "url": "firmware/t2t1/universal/t2t1-2.8.9-universal.bin",
+    "fingerprint": "ec61dba50be195f1cbb78688a0b92fb293c23150b68f5dab3b44420a106fca17",
+    "changelog": "* Ability to cancel recovery on word count selection screen.\n* Account info for ETH transactions.\n* New UI for confirming long messages.\n* Solana staking confirmation dialogs."
+}

--- a/packages/connect-common/files/firmware/t3b1/bitcoinonly/t3b1-2.8.10-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t3b1/bitcoinonly/t3b1-2.8.10-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 10],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 7],
+    "min_firmware_version": [2, 8, 3],
+    "bootloader_version": [2, 1, 10],
+    "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3b1/translation-t3b1-cs-CZ-2.8.10.bin",
+        "de-DE": "firmware/translations/t3b1/translation-t3b1-de-DE-2.8.10.bin",
+        "es-ES": "firmware/translations/t3b1/translation-t3b1-es-ES-2.8.10.bin",
+        "fr-FR": "firmware/translations/t3b1/translation-t3b1-fr-FR-2.8.10.bin",
+        "it-IT": "firmware/translations/t3b1/translation-t3b1-it-IT-2.8.10.bin",
+        "pt-BR": "firmware/translations/t3b1/translation-t3b1-pt-BR-2.8.10.bin"
+    },
+    "url": "firmware/t3b1/universal/t3b1-2.8.10-bitcoinonly.bin",
+    "fingerprint": "5a0aa661b61d056f72b83bf0d5c7eb4ddc84d6370fb977be794b145e49e8ff3f",
+    "changelog": "* Upgrade bundled bootloader to 2.1.10.\n* Replaced \"next page\" icon with \"...\" ellipsis when confirming long message.\n* Allow firmware upgrade even if language change failed."
+}

--- a/packages/connect-common/files/firmware/t3b1/bitcoinonly/t3b1-2.8.3-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t3b1/bitcoinonly/t3b1-2.8.3-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 3],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 7],
+    "min_firmware_version": [2, 8, 3],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "7f373ae71eca855dd41b4a0fdcc7cadaa13a8281",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3b1/translation-t3b1-cs-CZ-2.8.3.bin",
+        "de-DE": "firmware/translations/t3b1/translation-t3b1-de-DE-2.8.3.bin",
+        "es-ES": "firmware/translations/t3b1/translation-t3b1-es-ES-2.8.3.bin",
+        "fr-FR": "firmware/translations/t3b1/translation-t3b1-fr-FR-2.8.3.bin",
+        "it-IT": "firmware/translations/t3b1/translation-t3b1-it-IT-2.8.3.bin",
+        "pt-BR": "firmware/translations/t3b1/translation-t3b1-pt-BR-2.8.3.bin"
+    },
+    "url": "firmware/t3b1/universal/t3b1-2.8.3-bitcoinonly.bin",
+    "fingerprint": "070a61b2a8653e4f9857810b6610d0a15f76ba627c7b6e5654a6de9a1c529049",
+    "changelog": "* Fix persistent word when going to previous word during recovery process.\n* Fix display orientation south."
+}

--- a/packages/connect-common/files/firmware/t3b1/bitcoinonly/t3b1-2.8.7-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t3b1/bitcoinonly/t3b1-2.8.7-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 7],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 7],
+    "min_firmware_version": [2, 8, 3],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "8a254aa8eae82f99630df63f40e4d290066a3efc",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3b1/translation-t3b1-cs-CZ-2.8.7.bin",
+        "de-DE": "firmware/translations/t3b1/translation-t3b1-de-DE-2.8.7.bin",
+        "es-ES": "firmware/translations/t3b1/translation-t3b1-es-ES-2.8.7.bin",
+        "fr-FR": "firmware/translations/t3b1/translation-t3b1-fr-FR-2.8.7.bin",
+        "it-IT": "firmware/translations/t3b1/translation-t3b1-it-IT-2.8.7.bin",
+        "pt-BR": "firmware/translations/t3b1/translation-t3b1-pt-BR-2.8.7.bin"
+    },
+    "url": "firmware/t3b1/universal/t3b1-2.8.7-bitcoinonly.bin",
+    "fingerprint": "4737a6e12d0ebff19fec3aceb212adff57bbcea7a44f8208caf91cc656382d94",
+    "changelog": "* Show last typed PIN number for short period of time.\n* Multisig-related changes.\n* Included new version of bootloader (2.1.8).\n* Fix translation of the 'Enable labeling' screen."
+}

--- a/packages/connect-common/files/firmware/t3b1/bitcoinonly/t3b1-2.8.9-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t3b1/bitcoinonly/t3b1-2.8.9-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 9],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 7],
+    "min_firmware_version": [2, 8, 3],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "fad9682201cf9289bba2adb66e6e07ed1cf78936",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3b1/translation-t3b1-cs-CZ-2.8.9.bin",
+        "de-DE": "firmware/translations/t3b1/translation-t3b1-de-DE-2.8.9.bin",
+        "es-ES": "firmware/translations/t3b1/translation-t3b1-es-ES-2.8.9.bin",
+        "fr-FR": "firmware/translations/t3b1/translation-t3b1-fr-FR-2.8.9.bin",
+        "it-IT": "firmware/translations/t3b1/translation-t3b1-it-IT-2.8.9.bin",
+        "pt-BR": "firmware/translations/t3b1/translation-t3b1-pt-BR-2.8.9.bin"
+    },
+    "url": "firmware/t3b1/universal/t3b1-2.8.9-bitcoinonly.bin",
+    "fingerprint": "d3905f15221f7b2733e5496986ceb1a3b39f390c4439e2d3cc89d5f3b7423278",
+    "changelog": "* Ability to cancel recovery on word count selection screen.\n* New UI for confirming long messages."
+}

--- a/packages/connect-common/files/firmware/t3b1/universal/t3b1-2.8.10-universal.json
+++ b/packages/connect-common/files/firmware/t3b1/universal/t3b1-2.8.10-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 10],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 7],
+    "min_firmware_version": [2, 8, 3],
+    "bootloader_version": [2, 1, 10],
+    "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3b1/translation-T3B1-cs-CZ-2.8.10.bin",
+        "de-DE": "firmware/translations/t3b1/translation-T3B1-de-DE-2.8.10.bin",
+        "es-ES": "firmware/translations/t3b1/translation-T3B1-es-ES-2.8.10.bin",
+        "fr-FR": "firmware/translations/t3b1/translation-T3B1-fr-FR-2.8.10.bin",
+        "it-IT": "firmware/translations/t3b1/translation-T3B1-it-IT-2.8.10.bin",
+        "pt-BR": "firmware/translations/t3b1/translation-T3B1-pt-BR-2.8.10.bin"
+    },
+    "url": "firmware/t3b1/universal/t3b1-2.8.10-universal.bin",
+    "fingerprint": "ad763b0193bf2814bdb9807b51226e1c7639693e912e9334db3f446091943369",
+    "changelog": "* Upgrade bundled bootloader to 2.1.10.\n* Add Nostr support (in debug mode only!).\n* Solana: rent fee calculation [#4933]\n* Solana: loadable token definitions [#3541]\n* Replaced \"next page\" icon with \"...\" ellipsis when confirming long message.\n* Fixed Solana staking dialog title.\n* Updated EIP-1559 fee-related labels.\n* Allow firmware upgrade even if language change failed.\n* Solana: fees calculation is now exact [#4965]"
+}

--- a/packages/connect-common/files/firmware/t3b1/universal/t3b1-2.8.3-universal.json
+++ b/packages/connect-common/files/firmware/t3b1/universal/t3b1-2.8.3-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 3],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 7],
+    "min_firmware_version": [2, 8, 3],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "7f373ae71eca855dd41b4a0fdcc7cadaa13a8281",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3b1/translation-T3B1-cs-CZ-2.8.3.bin",
+        "de-DE": "firmware/translations/t3b1/translation-T3B1-de-DE-2.8.3.bin",
+        "es-ES": "firmware/translations/t3b1/translation-T3B1-es-ES-2.8.3.bin",
+        "fr-FR": "firmware/translations/t3b1/translation-T3B1-fr-FR-2.8.3.bin",
+        "it-IT": "firmware/translations/t3b1/translation-T3B1-it-IT-2.8.3.bin",
+        "pt-BR": "firmware/translations/t3b1/translation-T3B1-pt-BR-2.8.3.bin"
+    },
+    "url": "firmware/t3b1/universal/t3b1-2.8.3-universal.bin",
+    "fingerprint": "b659bdc5ddce208d46ce649fc7a8995ae49541c7c41a88ddaac5dfc038ffb5de",
+    "changelog": "* Renamed MATIC to POL, following a network upgrade.\n* Fix persistent word when going to previous word during recovery process.\n* Fix display orientation south."
+}

--- a/packages/connect-common/files/firmware/t3b1/universal/t3b1-2.8.7-universal.json
+++ b/packages/connect-common/files/firmware/t3b1/universal/t3b1-2.8.7-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 7],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 7],
+    "min_firmware_version": [2, 8, 3],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "8a254aa8eae82f99630df63f40e4d290066a3efc",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3b1/translation-T3B1-cs-CZ-2.8.7.bin",
+        "de-DE": "firmware/translations/t3b1/translation-T3B1-de-DE-2.8.7.bin",
+        "es-ES": "firmware/translations/t3b1/translation-T3B1-es-ES-2.8.7.bin",
+        "fr-FR": "firmware/translations/t3b1/translation-T3B1-fr-FR-2.8.7.bin",
+        "it-IT": "firmware/translations/t3b1/translation-T3B1-it-IT-2.8.7.bin",
+        "pt-BR": "firmware/translations/t3b1/translation-T3B1-pt-BR-2.8.7.bin"
+    },
+    "url": "firmware/t3b1/universal/t3b1-2.8.7-universal.bin",
+    "fingerprint": "1dd5ec22c2609beb6d17a97bf9b4f42a18af1c12db2446d29a945f4ece8727f6",
+    "changelog": "* Show last typed PIN number for short period of time.\n* Multisig-related changes.\n* Simplify UI of Cardano transactions initiated by Trezor Suite.\n* Included new version of bootloader (2.1.8).\n* Fix ETH account number detection.\n* New EVM call contract flow UI.\n* Fix translation of the 'Enable labeling' screen."
+}

--- a/packages/connect-common/files/firmware/t3b1/universal/t3b1-2.8.9-universal.json
+++ b/packages/connect-common/files/firmware/t3b1/universal/t3b1-2.8.9-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 9],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 7],
+    "min_firmware_version": [2, 8, 3],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "fad9682201cf9289bba2adb66e6e07ed1cf78936",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3b1/translation-T3B1-cs-CZ-2.8.9.bin",
+        "de-DE": "firmware/translations/t3b1/translation-T3B1-de-DE-2.8.9.bin",
+        "es-ES": "firmware/translations/t3b1/translation-T3B1-es-ES-2.8.9.bin",
+        "fr-FR": "firmware/translations/t3b1/translation-T3B1-fr-FR-2.8.9.bin",
+        "it-IT": "firmware/translations/t3b1/translation-T3B1-it-IT-2.8.9.bin",
+        "pt-BR": "firmware/translations/t3b1/translation-T3B1-pt-BR-2.8.9.bin"
+    },
+    "url": "firmware/t3b1/universal/t3b1-2.8.9-universal.bin",
+    "fingerprint": "5b3a639c5b6423d87f4c0a3855dc4be8ad7e5be6d6b1b33f93ab1a54f3f36a91",
+    "changelog": "* Ability to cancel recovery on word count selection screen.\n* New UI for confirming long messages.\n* Solana staking confirmation dialogs."
+}

--- a/packages/connect-common/files/firmware/t3t1/bitcoinonly/t3t1-2.7.2-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t3t1/bitcoinonly/t3t1-2.7.2-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 7, 2],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 6],
+    "min_firmware_version": [2, 7, 2],
+    "bootloader_version": [2, 1, 6],
+    "firmware_revision": "da75d8f4b67410b40a9cfd2954d183d81dd6e8e8",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3t1/translation-t3t1-cs-CZ-2.7.2.bin",
+        "de-DE": "firmware/translations/t3t1/translation-t3t1-de-DE-2.7.2.bin",
+        "es-ES": "firmware/translations/t3t1/translation-t3t1-es-ES-2.7.2.bin",
+        "fr-FR": "firmware/translations/t3t1/translation-t3t1-fr-FR-2.7.2.bin",
+        "it-IT": "firmware/translations/t3t1/translation-t3t1-it-IT-2.7.2.bin",
+        "pt-BR": "firmware/translations/t3t1/translation-t3t1-pt-BR-2.7.2.bin"
+    },
+    "url": "firmware/t3t1/universal/t3t1-2.7.2-bitcoinonly.bin",
+    "fingerprint": "246cca86b0a8cfcac6b7e6b3fcf55f543a8a9c9fd1f8ff88cd0de00640cb25eb",
+    "changelog": "* Introducing repeated backups. \n* Multi-share backups can now have any number of shares."
+}

--- a/packages/connect-common/files/firmware/t3t1/bitcoinonly/t3t1-2.8.0-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t3t1/bitcoinonly/t3t1-2.8.0-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 0],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 6],
+    "min_firmware_version": [2, 7, 2],
+    "bootloader_version": [2, 1, 6],
+    "firmware_revision": "dd4671a5104952ef505d28d1f9e94d1484b4607a",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3t1/translation-t3t1-cs-CZ-2.8.0.bin",
+        "de-DE": "firmware/translations/t3t1/translation-t3t1-de-DE-2.8.0.bin",
+        "es-ES": "firmware/translations/t3t1/translation-t3t1-es-ES-2.8.0.bin",
+        "fr-FR": "firmware/translations/t3t1/translation-t3t1-fr-FR-2.8.0.bin",
+        "it-IT": "firmware/translations/t3t1/translation-t3t1-it-IT-2.8.0.bin",
+        "pt-BR": "firmware/translations/t3t1/translation-t3t1-pt-BR-2.8.0.bin"
+    },
+    "url": "firmware/t3t1/universal/t3t1-2.8.0-bitcoinonly.bin",
+    "fingerprint": "3dc847cc396fe83f5a324242097a4cf97fc64acf90516efcfcf23b6d3103a992",
+    "changelog": "* Added tutorial flow. \n* Added Animated device label on homescreen/lockscreen. \n* Added word counter during wallet creation. \n* Improved change homescreen flow. \n* Improved swipe behavior and animations. \n* Increased Optiga read timeout to avoid spurious RSODs. \n* Fixed swipe back from address QR code screen. \n* Fixed device authenticity check. \n* Removed CoSi functionality."
+}

--- a/packages/connect-common/files/firmware/t3t1/bitcoinonly/t3t1-2.8.1-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t3t1/bitcoinonly/t3t1-2.8.1-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 6],
+    "min_firmware_version": [2, 7, 2],
+    "bootloader_version": [2, 1, 6],
+    "firmware_revision": "632b9561559b7ab6824bb7eeac072874e07b7b82",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3t1/translation-t3t1-cs-CZ-2.8.1.bin",
+        "de-DE": "firmware/translations/t3t1/translation-t3t1-de-DE-2.8.1.bin",
+        "es-ES": "firmware/translations/t3t1/translation-t3t1-es-ES-2.8.1.bin",
+        "fr-FR": "firmware/translations/t3t1/translation-t3t1-fr-FR-2.8.1.bin",
+        "it-IT": "firmware/translations/t3t1/translation-t3t1-it-IT-2.8.1.bin",
+        "pt-BR": "firmware/translations/t3t1/translation-t3t1-pt-BR-2.8.1.bin"
+    },
+    "url": "firmware/t3t1/universal/t3t1-2.8.1-bitcoinonly.bin",
+    "fingerprint": "6b17de0c89c9a7876687d6b9c44673f4aca7f8819237a755090848a3829bc36b",
+    "changelog": "* Added PIN keyboard animation.\n* Added menu entry animation.\n* Added screen brightness settings.\n* Screen transitions and animations were improved and are now more smooth.\n* Improved precision of PIN validation countdown.\n* Improved instruction screens during multi-share recovery process.\n* New UI of firmware update.\n* Improved share words swiping animation during wallet creation.\n* Fixed title sometimes not fitting into result screen.\n* Improved touch layer precision.\n* Fixed “More info” screen during multi-share backup creation.\n* Fixed title sometimes not fitting into result screen.\n* Adjusted detection of swipes: vertical swipes are preferred over horizontal swipes now."
+}

--- a/packages/connect-common/files/firmware/t3t1/bitcoinonly/t3t1-2.8.10-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t3t1/bitcoinonly/t3t1-2.8.10-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 10],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 6],
+    "min_firmware_version": [2, 7, 2],
+    "bootloader_version": [2, 1, 10],
+    "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3t1/translation-t3t1-cs-CZ-2.8.10.bin",
+        "de-DE": "firmware/translations/t3t1/translation-t3t1-de-DE-2.8.10.bin",
+        "es-ES": "firmware/translations/t3t1/translation-t3t1-es-ES-2.8.10.bin",
+        "fr-FR": "firmware/translations/t3t1/translation-t3t1-fr-FR-2.8.10.bin",
+        "it-IT": "firmware/translations/t3t1/translation-t3t1-it-IT-2.8.10.bin",
+        "pt-BR": "firmware/translations/t3t1/translation-t3t1-pt-BR-2.8.10.bin"
+    },
+    "url": "firmware/t3t1/universal/t3t1-2.8.10-bitcoinonly.bin",
+    "fingerprint": "11d3f68d08f3f95c04dd526826f81eb7918df85928cfcef73beeae3132342bf0",
+    "changelog": "* Visual cues to distinguish unlocked state on Homescreen.\n* Replaced \"next page\" icon with \"...\" ellipsis when confirming long message.\n* Allow firmware upgrade even if language change failed."
+}

--- a/packages/connect-common/files/firmware/t3t1/bitcoinonly/t3t1-2.8.3-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t3t1/bitcoinonly/t3t1-2.8.3-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 3],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 6],
+    "min_firmware_version": [2, 7, 2],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "7f373ae71eca855dd41b4a0fdcc7cadaa13a8281",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3t1/translation-t3t1-cs-CZ-2.8.3.bin",
+        "de-DE": "firmware/translations/t3t1/translation-t3t1-de-DE-2.8.3.bin",
+        "es-ES": "firmware/translations/t3t1/translation-t3t1-es-ES-2.8.3.bin",
+        "fr-FR": "firmware/translations/t3t1/translation-t3t1-fr-FR-2.8.3.bin",
+        "it-IT": "firmware/translations/t3t1/translation-t3t1-it-IT-2.8.3.bin",
+        "pt-BR": "firmware/translations/t3t1/translation-t3t1-pt-BR-2.8.3.bin"
+    },
+    "url": "firmware/t3t1/universal/t3t1-2.8.3-bitcoinonly.bin",
+    "fingerprint": "9eaf99a9420d2a3b9377102eb06b938f5a1886ecb06cccde7fd3cb7a39e1abd7",
+    "changelog": "* Added reassuring screen when entering empty passphrase on device.\n* Fix persistent word when going to previous word during recovery process.\n* Added missing info about remaining shares in super-shamir recovery."
+}

--- a/packages/connect-common/files/firmware/t3t1/bitcoinonly/t3t1-2.8.7-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t3t1/bitcoinonly/t3t1-2.8.7-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 7],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 6],
+    "min_firmware_version": [2, 7, 2],
+    "bootloader_version": [2, 1, 9],
+    "firmware_revision": "8a254aa8eae82f99630df63f40e4d290066a3efc",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3t1/translation-t3t1-cs-CZ-2.8.7.bin",
+        "de-DE": "firmware/translations/t3t1/translation-t3t1-de-DE-2.8.7.bin",
+        "es-ES": "firmware/translations/t3t1/translation-t3t1-es-ES-2.8.7.bin",
+        "fr-FR": "firmware/translations/t3t1/translation-t3t1-fr-FR-2.8.7.bin",
+        "it-IT": "firmware/translations/t3t1/translation-t3t1-it-IT-2.8.7.bin",
+        "pt-BR": "firmware/translations/t3t1/translation-t3t1-pt-BR-2.8.7.bin"
+    },
+    "url": "firmware/t3t1/universal/t3t1-2.8.7-bitcoinonly.bin",
+    "fingerprint": "2f58de2b7c2c29b6a2f14909ad0941e4aa9dd6d3e1416ab66c512a743b5385a9",
+    "changelog": "* Show last typed PIN number for short period of time.\n* Multisig-related changes.\n* Included new version of bootloader (2.1.9).\n* Fix XPUB confirmed success screen title.\n* Fix incorrect navigation in handy menu while signing BTC message.\n* Fix translation of the 'Enable labeling' screen."
+}

--- a/packages/connect-common/files/firmware/t3t1/bitcoinonly/t3t1-2.8.9-bitcoinonly.json
+++ b/packages/connect-common/files/firmware/t3t1/bitcoinonly/t3t1-2.8.9-bitcoinonly.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 9],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 6],
+    "min_firmware_version": [2, 7, 2],
+    "bootloader_version": [2, 1, 10],
+    "firmware_revision": "fad9682201cf9289bba2adb66e6e07ed1cf78936",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3t1/translation-t3t1-cs-CZ-2.8.9.bin",
+        "de-DE": "firmware/translations/t3t1/translation-t3t1-de-DE-2.8.9.bin",
+        "es-ES": "firmware/translations/t3t1/translation-t3t1-es-ES-2.8.9.bin",
+        "fr-FR": "firmware/translations/t3t1/translation-t3t1-fr-FR-2.8.9.bin",
+        "it-IT": "firmware/translations/t3t1/translation-t3t1-it-IT-2.8.9.bin",
+        "pt-BR": "firmware/translations/t3t1/translation-t3t1-pt-BR-2.8.9.bin"
+    },
+    "url": "firmware/t3t1/universal/t3t1-2.8.9-bitcoinonly.bin",
+    "fingerprint": "ac995c394f7a7b3ea4cbd9c04977621d6d2fbef30bba856f707f585f34866ac4",
+    "changelog": "* Ability to cancel recovery flow on word count selection screen.\n* New UI for confirming long messages.\n* Changed \"swipe to continue\" to \"tap to continue\". Screens still respond to swipe-up, but the preferred interaction method is now tapping the lower part of the screen."
+}

--- a/packages/connect-common/files/firmware/t3t1/universal/t3t1-2.7.2-universal.json
+++ b/packages/connect-common/files/firmware/t3t1/universal/t3t1-2.7.2-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 7, 2],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 6],
+    "min_firmware_version": [2, 7, 2],
+    "bootloader_version": [2, 1, 6],
+    "firmware_revision": "da75d8f4b67410b40a9cfd2954d183d81dd6e8e8",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.7.2.bin",
+        "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.7.2.bin",
+        "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.7.2.bin",
+        "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.7.2.bin",
+        "it-IT": "firmware/translations/t3t1/translation-T3T1-it-IT-2.7.2.bin",
+        "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.7.2.bin"
+    },
+    "url": "firmware/t3t1/universal/t3t1-2.7.2-universal.bin",
+    "fingerprint": "4daa5fd3c4c92ee0d76855997dde09a7ee25f4165b118c521ab10957c5fc92b0",
+    "changelog": "* Introducing repeated backups. \n* Multi-share backups can now have any number of shares. \n* Added support for Cardano Conway certificates [Universal fw only]."
+}

--- a/packages/connect-common/files/firmware/t3t1/universal/t3t1-2.8.0-universal.json
+++ b/packages/connect-common/files/firmware/t3t1/universal/t3t1-2.8.0-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 0],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 6],
+    "min_firmware_version": [2, 7, 2],
+    "bootloader_version": [2, 1, 6],
+    "firmware_revision": "dd4671a5104952ef505d28d1f9e94d1484b4607a",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.8.0.bin",
+        "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.8.0.bin",
+        "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.8.0.bin",
+        "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.8.0.bin",
+        "it-IT": "firmware/translations/t3t1/translation-T3T1-it-IT-2.8.0.bin",
+        "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.8.0.bin"
+    },
+    "url": "firmware/t3t1/universal/t3t1-2.8.0-universal.bin",
+    "fingerprint": "bd199ce0934769aca5c3a91f71fd48e533d88c8cf087b76ac49db415fa08c286",
+    "changelog": "* Added tutorial flow. \n* Added Animated device label on homescreen/lockscreen. \n* Added word counter during wallet creation. \n* Improved change homescreen flow. \n* Improved swipe behavior and animations. \n* Increased Optiga read timeout to avoid spurious RSODs. \n* Fixed swipe back from address QR code screen. \n* Fixed device authenticity check. \n* Removed CoSi functionality."
+}

--- a/packages/connect-common/files/firmware/t3t1/universal/t3t1-2.8.1-universal.json
+++ b/packages/connect-common/files/firmware/t3t1/universal/t3t1-2.8.1-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 1],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 6],
+    "min_firmware_version": [2, 7, 2],
+    "bootloader_version": [2, 1, 6],
+    "firmware_revision": "632b9561559b7ab6824bb7eeac072874e07b7b82",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.8.1.bin",
+        "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.8.1.bin",
+        "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.8.1.bin",
+        "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.8.1.bin",
+        "it-IT": "firmware/translations/t3t1/translation-T3T1-it-IT-2.8.1.bin",
+        "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.8.1.bin"
+    },
+    "url": "firmware/t3t1/universal/t3t1-2.8.1-universal.bin",
+    "fingerprint": "6a064df4a928e1264d682a34cc014fc9272f312e0f8a8270ff88d6f1408fe68b",
+    "changelog": "* Added PIN keyboard animation.\n* Added menu entry animation.\n* Added screen brightness settings.\n* Screen transitions and animations were improved and are now more smooth.\n* Improved precision of PIN validation countdown.\n* Improved instruction screens during multi-share recovery process.\n* New UI of firmware update.\n* Improved share words swiping animation during wallet creation.\n* Solana: Improved support for AToken Create operation.\n* Fixed title sometimes not fitting into result screen.\n* Improved touch layer precision.\n* Fixed “More info” screen during multi-share backup creation.\n* Fixed title sometimes not fitting into result screen.\n* Adjusted detection of swipes: vertical swipes are preferred over horizontal swipes now."
+}

--- a/packages/connect-common/files/firmware/t3t1/universal/t3t1-2.8.10-universal.json
+++ b/packages/connect-common/files/firmware/t3t1/universal/t3t1-2.8.10-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 10],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 6],
+    "min_firmware_version": [2, 7, 2],
+    "bootloader_version": [2, 1, 10],
+    "firmware_revision": "2a65d18200580005dc419b9569ed97fae440806a",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.8.10.bin",
+        "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.8.10.bin",
+        "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.8.10.bin",
+        "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.8.10.bin",
+        "it-IT": "firmware/translations/t3t1/translation-T3T1-it-IT-2.8.10.bin",
+        "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.8.10.bin"
+    },
+    "url": "firmware/t3t1/universal/t3t1-2.8.10-universal.bin",
+    "fingerprint": "f6f50b4a419b041a59620ef681047c27af0902798e0227397c532dd70736694a",
+    "changelog": "* Add Nostr support (in debug mode only!).\n* Visual cues to distinguish unlocked state on Homescreen.\n* Solana: rent fee calculation [#4933]\n* Solana: loadable token definitions [#3541]\n* Replaced \"next page\" icon with \"...\" ellipsis when confirming long message.\n* Updated EIP-1559 fee-related labels.\n* Allow firmware upgrade even if language change failed.\n* Solana: fees calculation is now exact [#4965]"
+}

--- a/packages/connect-common/files/firmware/t3t1/universal/t3t1-2.8.3-universal.json
+++ b/packages/connect-common/files/firmware/t3t1/universal/t3t1-2.8.3-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 3],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 6],
+    "min_firmware_version": [2, 7, 2],
+    "bootloader_version": [2, 1, 8],
+    "firmware_revision": "7f373ae71eca855dd41b4a0fdcc7cadaa13a8281",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.8.3.bin",
+        "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.8.3.bin",
+        "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.8.3.bin",
+        "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.8.3.bin",
+        "it-IT": "firmware/translations/t3t1/translation-T3T1-it-IT-2.8.3.bin",
+        "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.8.3.bin"
+    },
+    "url": "firmware/t3t1/universal/t3t1-2.8.3-universal.bin",
+    "fingerprint": "0de51126c17cc0ac623800638dc851c0abd5b787cad5f3aa5843ea2c4cf8248a",
+    "changelog": "* Added reassuring screen when entering empty passphrase on device.\n* Improved ETH send and staking flow.\n* Redesigned FIDO2 UI.\n* Renamed MATIC to POL, following a network upgrade.\n* Fix persistent word when going to previous word during recovery process.\n* Added missing info about remaining shares in super-shamir recovery."
+}

--- a/packages/connect-common/files/firmware/t3t1/universal/t3t1-2.8.7-universal.json
+++ b/packages/connect-common/files/firmware/t3t1/universal/t3t1-2.8.7-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 7],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 6],
+    "min_firmware_version": [2, 7, 2],
+    "bootloader_version": [2, 1, 9],
+    "firmware_revision": "8a254aa8eae82f99630df63f40e4d290066a3efc",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.8.7.bin",
+        "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.8.7.bin",
+        "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.8.7.bin",
+        "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.8.7.bin",
+        "it-IT": "firmware/translations/t3t1/translation-T3T1-it-IT-2.8.7.bin",
+        "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.8.7.bin"
+    },
+    "url": "firmware/t3t1/universal/t3t1-2.8.7-universal.bin",
+    "fingerprint": "be15ee1f4b7891dc965512455f8d17067ff54a7047e28ed06cec8d56529ab2ef",
+    "changelog": "* Show last typed PIN number for short period of time.\n* Multisig-related changes.\n* Simplify UI of Cardano transactions initiated by Trezor Suite.\n* Included new version of bootloader (2.1.9).\n* Fix ETH account number detection.\n* Show account info in ETH send/stake flow.\n* Fix XPUB confirmed success screen title.\n* New EVM call contract flow UI.\n* Fix incorrect navigation in handy menu while signing BTC message.\n* Fix translation of the 'Enable labeling' screen."
+}

--- a/packages/connect-common/files/firmware/t3t1/universal/t3t1-2.8.9-universal.json
+++ b/packages/connect-common/files/firmware/t3t1/universal/t3t1-2.8.9-universal.json
@@ -1,0 +1,20 @@
+{
+    "required": false,
+    "version": [2, 8, 9],
+    "min_bridge_version": [2, 0, 7],
+    "min_bootloader_version": [2, 1, 6],
+    "min_firmware_version": [2, 7, 2],
+    "bootloader_version": [2, 1, 10],
+    "firmware_revision": "fad9682201cf9289bba2adb66e6e07ed1cf78936",
+    "translations": {
+        "cs-CZ": "firmware/translations/t3t1/translation-T3T1-cs-CZ-2.8.9.bin",
+        "de-DE": "firmware/translations/t3t1/translation-T3T1-de-DE-2.8.9.bin",
+        "es-ES": "firmware/translations/t3t1/translation-T3T1-es-ES-2.8.9.bin",
+        "fr-FR": "firmware/translations/t3t1/translation-T3T1-fr-FR-2.8.9.bin",
+        "it-IT": "firmware/translations/t3t1/translation-T3T1-it-IT-2.8.9.bin",
+        "pt-BR": "firmware/translations/t3t1/translation-T3T1-pt-BR-2.8.9.bin"
+    },
+    "url": "firmware/t3t1/universal/t3t1-2.8.9-universal.bin",
+    "fingerprint": "3a0228ae58bfd65ba341b33a34138d0d70a9a16f5d2db387f9ee2659d797dedf",
+    "changelog": "* Ability to cancel recovery flow on word count selection screen.\n* New UI for confirming long messages.\n* Solana staking confirmation dialogs.\n* Changed \"swipe to continue\" to \"tap to continue\". Screens still respond to swipe-up, but the preferred interaction method is now tapping the lower part of the screen."
+}

--- a/packages/connect-common/scripts/check-all-firmware-revisions.sh
+++ b/packages/connect-common/scripts/check-all-firmware-revisions.sh
@@ -4,9 +4,18 @@ PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" || exit ; pwd -P )
 
 cd "$PARENT_PATH/../files/firmware" || exit
 
+IS_LEGACY="false"
+
 for dir in */ ; do
+    DEVICE=${dir%/}
+    # TODO: we excude t3w1 until we have releases on it.
+    if [[ $EXCLUDED_DIR == "$DEVICE" || $DEVICE == "t3w1" ]]; then continue; fi
+        is_legacy_for_device="$IS_LEGACY"
+    if [[ "$DEVICE" == "1" || "$DEVICE" == "2" ]]; then
+        is_legacy_for_device="true"
+    fi
     if [ -d "$dir" ]; then
-        if ! "$PARENT_PATH/check-firmware-revisions.sh" "${dir%/}" ; then
+        if ! "$PARENT_PATH/check-firmware-revisions.sh" "$DEVICE" "$is_legacy_for_device" ; then
             exit 1
         fi;
     fi

--- a/packages/connect-common/scripts/check-firmware-revisions.sh
+++ b/packages/connect-common/scripts/check-firmware-revisions.sh
@@ -2,13 +2,14 @@
 
 PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" || exit ; pwd -P )
 
-if [[ $# -ne 1 ]]
+if [[ $# -ne 2 ]]
     then
-        echo "must provide 1 argument. $# provided"
+        echo "must provide 2 argument. $# provided"
         exit 1
 fi
 
 DEVICE=$1
+IS_LEGACY=$2
 
 RELEASES_FOLDER="$PARENT_PATH"/../files/firmware
 
@@ -36,7 +37,18 @@ git fetch origin
 git checkout "$BRANCH"
 git reset "origin/$BRANCH" --hard
 
-DATA=$(jq -r '.[] | .version |= join(".") | .firmware_revision + "%" + .version' < "$RELEASES_FOLDER/$DEVICE"/releases.json)
+DATA=""
+
+# When checking legacy "1" and "2" directories we do not check `bitcoinonly` and `universal` directories
+# with new format, we only check it for legacy `releases.json`. For the rest we check it for both formats.
+if [[ "$IS_LEGACY" == "true" ]]; then
+  DATA=$(jq -r '.[] | .version |= join(".") | .firmware_revision + "%" + .version' < "$RELEASES_FOLDER/$DEVICE"/releases.json)
+else
+  DATA=$(
+    jq -r '.[] | .version |= join(".") | .firmware_revision + "%" + .version' < "$RELEASES_FOLDER/$DEVICE"/releases.json
+    jq -r '.version |= join(".") | .firmware_revision + "%" + .version' "$RELEASES_FOLDER/$DEVICE"/{bitcoinonly,universal}/*.json
+  )
+fi
 
 for ROW in $DATA;
 do 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- dd7aec37cb5e91ba562588e75c71232549aba1c9 - Include new releases JSONs in bundle as they were already approved in https://github.com/trezor/data/pull/140

- 1bf45e42f682f41ca74892d1ad64082dd282b714 - Updating revision check scripts to check both legacy and new format of releases JSONs, once we get rid of legacy we will check only the new ones.

This is not used yet but there will be a following PR that will change to use these new configs and remove the legacy `releases.json`.

## Related Issue

Related to https://github.com/trezor/trezor-suite/issues/19763
