### PR TITLE
feat(token-definitions): add support for Stellar `code:issuer` format.

### DIFF
--- a/.github/workflows/release-suite-definitions.yml
+++ b/.github/workflows/release-suite-definitions.yml
@@ -58,6 +58,8 @@ jobs:
           yarn coins simple cardano jws
           yarn coins simple solana jws
           yarn coins advanced solana json
+          yarn coins simple stellar jws
+          yarn coins advanced stellar jws
 
       - name: Build and sign ${{ github.event.inputs.environment }} token-definitions files
         if: ${{ github.event.inputs.environment == 'production-definitions' && github.ref == 'refs/heads/develop' }}

--- a/suite-common/token-definitions/README.md
+++ b/suite-common/token-definitions/README.md
@@ -13,7 +13,7 @@ Scripts:
     - `simple` (used for Suite)
     - `advanced` (planned to be used for Solana token symbols and names)
 - and chain
-    - `ethereum`, `polygon-pos`, `solana`,...
+    - `ethereum`, `polygon-pos`, `solana`, `stellar`...
 - and file type
     - `jws` for signed data
     - `json` for unsigned data
@@ -59,5 +59,5 @@ Scripts:
 ## Naming
 
 - Token definitions: include both coin and nft definitions
-- Coin definitions: contain just tokens ERC20 and SPL
+- Coin definitions: contain just tokens ERC20, SPL and Stellar classic assets (`code:issuer` format)
 - NFT definitions: contain just nfts ERC1155 and ERC721

--- a/suite-common/token-definitions/README.md
+++ b/suite-common/token-definitions/README.md
@@ -10,8 +10,8 @@ Scripts:
 
 - options `yarn nfts` and `yarn coins`
 - has to be called with structure type
-    - `simple` (used for Suite)
-    - `advanced` (planned to be used for Solana token symbols and names)
+    - `simple` (array of contract addresses)
+    - `advanced` (object with token symbols and names per contract address)
 - and chain
     - `ethereum`, `polygon-pos`, `solana`, `stellar`...
 - and file type

--- a/suite-common/token-definitions/scripts/utils/__tests__/fetchCoins.test.ts
+++ b/suite-common/token-definitions/scripts/utils/__tests__/fetchCoins.test.ts
@@ -1,0 +1,140 @@
+import { blockfrostUtils } from '@trezor/blockchain-link-utils';
+
+import { getContractAddress } from '../fetchCoins';
+
+describe('getContractAddress', () => {
+    describe('Cardano platform', () => {
+        it('should return policy ID for valid Cardano asset', () => {
+            const platforms = {
+                cardano: 'valid_cardano_asset_string',
+            };
+
+            const mockParseAsset = jest.spyOn(blockfrostUtils, 'parseAsset');
+            mockParseAsset.mockReturnValue({ policyId: 'mock_policy_id' } as any);
+
+            const result = getContractAddress('cardano', platforms);
+
+            expect(result).toBe('mock_policy_id');
+            expect(mockParseAsset).toHaveBeenCalledWith('valid_cardano_asset_string');
+
+            mockParseAsset.mockRestore();
+        });
+    });
+
+    describe('Stellar platform', () => {
+        it('should handle uppercase code with hyphen separator', () => {
+            const platforms = {
+                stellar: 'USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+            };
+            expect(getContractAddress('stellar', platforms)).toBe(
+                'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+            );
+        });
+
+        it('should handle lowercase code with hyphen separator', () => {
+            const platforms = {
+                stellar: 'usdc-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+            };
+            expect(getContractAddress('stellar', platforms)).toBe(
+                'usdc:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+            );
+        });
+
+        it('should handle code with colon separator', () => {
+            const platforms = {
+                stellar: 'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+            };
+            expect(getContractAddress('stellar', platforms)).toBe(
+                'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+            );
+        });
+
+        it('should return undefined for invalid format', () => {
+            const platforms = {
+                stellar: 'INVALID_FORMAT',
+            };
+            expect(getContractAddress('stellar', platforms)).toBeUndefined();
+        });
+
+        it('should return undefined for code too long', () => {
+            const platforms = {
+                stellar:
+                    'VERYLONGCODENAME-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+            };
+            expect(getContractAddress('stellar', platforms)).toBeUndefined();
+        });
+
+        it('should return undefined for invalid issuer format', () => {
+            const platforms = {
+                stellar: 'USDC-AA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+            };
+            expect(getContractAddress('stellar', platforms)).toBeUndefined();
+        });
+
+        it('should handle format with numeric suffix', () => {
+            const platforms = {
+                stellar: 'BLND-GDJEHTBE6ZHUXSWFI642DCGLUOECLHPF3KSXHPXTSTJ7E3JF6MQ5EZYY-1',
+            };
+            expect(getContractAddress('stellar', platforms)).toBe(
+                'BLND:GDJEHTBE6ZHUXSWFI642DCGLUOECLHPF3KSXHPXTSTJ7E3JF6MQ5EZYY',
+            );
+        });
+
+        it('should handle format with multi-digit numeric suffix', () => {
+            const platforms = {
+                stellar: 'USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN-123',
+            };
+            expect(getContractAddress('stellar', platforms)).toBe(
+                'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+            );
+        });
+
+        it('should return undefined for format with non-numeric suffix', () => {
+            const platforms = {
+                stellar: 'TOKEN-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN-abc',
+            };
+            expect(getContractAddress('stellar', platforms)).toBeUndefined();
+        });
+    });
+
+    describe('Other platforms', () => {
+        it('should return address as-is for other platforms', () => {
+            const platforms = {
+                ethereum: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            };
+            expect(getContractAddress('ethereum', platforms)).toBe(
+                '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            );
+        });
+
+        it('should return address as-is for binance-smart-chain', () => {
+            const platforms = {
+                'binance-smart-chain': '0x55d398326f99059ff775485246999027b3197955',
+            };
+            expect(getContractAddress('binance-smart-chain', platforms)).toBe(
+                '0x55d398326f99059ff775485246999027b3197955',
+            );
+        });
+    });
+
+    describe('Edge cases', () => {
+        it('should return undefined when platform not found in platforms object', () => {
+            const platforms = {
+                ethereum: '0x1234567890abcdef',
+            };
+            expect(getContractAddress('polygon', platforms)).toBeUndefined();
+        });
+
+        it('should return undefined when platforms object is empty', () => {
+            const platforms = {};
+            expect(getContractAddress('ethereum', platforms)).toBeUndefined();
+        });
+
+        it('should return undefined when address is empty string', () => {
+            const platforms = {
+                ethereum: '',
+            };
+            expect(getContractAddress('ethereum', platforms)).toBeUndefined();
+        });
+    });
+});

--- a/suite-common/token-definitions/scripts/utils/fetchCoins.ts
+++ b/suite-common/token-definitions/scripts/utils/fetchCoins.ts
@@ -5,11 +5,29 @@ import { AdvancedTokenStructure, SimpleTokenStructure } from '../../src/tokenDef
 import { COIN_LIST_URL } from '../constants';
 import { CoinData } from '../types';
 
-const getContractAddress = (assetPlatformId: string, platforms: CoinData['platforms']) => {
+export const getContractAddress = (assetPlatformId: string, platforms: CoinData['platforms']) => {
     const address = platforms[assetPlatformId];
     if (address) {
         if (assetPlatformId === 'cardano') {
             return blockfrostUtils.parseAsset(address).policyId;
+        }
+
+        if (assetPlatformId === 'stellar') {
+            // Stellar address format: CODE-ISSUER, CODE:ISSUER, or CODE-ISSUER-NUMBER
+            // CODE: 1-12 alphanumeric characters
+            // ISSUER: 56 characters starting with 'G'
+            // NUMBER: optional numeric suffix
+            const stellarMatch = address.match(
+                /^([A-Za-z0-9]{1,12})[-:]([G][A-Z0-9]{55})(?:-\d+)?$/,
+            );
+            if (stellarMatch) {
+                const code = stellarMatch[1];
+                const issuer = stellarMatch[2];
+
+                return `${code}:${issuer}`; // Return as CODE:ISSUER format
+            } else {
+                return undefined; // Invalid Stellar address format
+            }
         }
 
         return address;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

From https://github.com/trezor/trezor-suite/issues/20421#issuecomment-3127001368, we can see that the stellar data returned by CoinGecko is quite chaotic, so we should add corresponding support to convert it into a unified format.

<!--- Describe your changes in detail -->

## Related Issue

Resolve #20447

## Screenshots:

N/A
