### PR TITLE
Feat: add codesign public key

### DIFF
--- a/packages/env-utils/src/envUtils.native.ts
+++ b/packages/env-utils/src/envUtils.native.ts
@@ -3,8 +3,8 @@ import { Dimensions, Platform } from 'react-native';
 import Constants from 'expo-constants';
 import { getLocales } from 'expo-localization';
 
-import { publicKey } from './jws';
-import { EnvUtils } from './types';
+import { firmwareConfigPublicKey, publicKey } from './jws';
+import { EnvUtils, JWSPublicKeyUse } from './types';
 
 const isWeb = () => false;
 
@@ -79,7 +79,15 @@ const getOsNameWeb = () => '';
 
 const getOsFamily = (): 'Linux' => 'Linux';
 
-export const getJWSPublicKey = () => (isCodesignBuild() ? publicKey.codesign : publicKey.dev);
+export const getJWSPublicKey = (use: JWSPublicKeyUse, useCodeSignKey = false) => {
+    if (['message-system', 'token-definitions'].includes(use)) {
+        return isCodesignBuild() ? publicKey.codesign : publicKey.dev;
+    }
+
+    return isCodesignBuild() || useCodeSignKey
+        ? firmwareConfigPublicKey.codesign
+        : firmwareConfigPublicKey.dev;
+};
 
 export const envUtils: EnvUtils = {
     isWeb,

--- a/packages/env-utils/src/envUtils.ts
+++ b/packages/env-utils/src/envUtils.ts
@@ -143,12 +143,14 @@ const getOsFamily = () => {
 
 const getDeviceType = () => getUserAgentParser().getDevice().type;
 
-export const getJWSPublicKey = (use: JWSPublicKeyUse) => {
+export const getJWSPublicKey = (use: JWSPublicKeyUse, useCodeSignKey = false) => {
     if (['message-system', 'token-definitions'].includes(use)) {
         return isCodesignBuild() ? publicKey.codesign : publicKey.dev;
     }
 
-    return isCodesignBuild() ? firmwareConfigPublicKey.codesign : firmwareConfigPublicKey.dev;
+    return isCodesignBuild() || useCodeSignKey
+        ? firmwareConfigPublicKey.codesign
+        : firmwareConfigPublicKey.dev;
 };
 
 export const envUtils: EnvUtils = {

--- a/packages/env-utils/src/jws.ts
+++ b/packages/env-utils/src/jws.ts
@@ -16,7 +16,8 @@ hsz3etxANvUgLQ4r0eEhqVUEL5l+dRMgEv4Ycvr3UEcMkSFRPoA8ktxX1A==
 `,
     codesign: `
 -----BEGIN PUBLIC KEY-----
-TODO
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEfEsFXNi5sdMxwiOYh4oRGorCM2RO
+IEsfw3m+vWBrLb/r/GYWUVkVXWsZukLwPRZ8asP+7Ifd2ap7GZ2iQzWKCA==
 -----END PUBLIC KEY-----
 `,
 };

--- a/packages/env-utils/src/types.ts
+++ b/packages/env-utils/src/types.ts
@@ -35,5 +35,5 @@ export interface EnvUtils {
     getOsName: () => '' | 'android' | 'linux' | 'windows' | 'macos' | 'chromeos' | 'ios';
     getOsNameWeb: () => string | undefined;
     getOsFamily: () => 'Windows' | 'MacOS' | 'Linux';
-    getJWSPublicKey: (use: JWSPublicKeyUse) => string;
+    getJWSPublicKey: (use: JWSPublicKeyUse, useCodeSignKey?: boolean) => string;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Extracting pieces for new firmware release process. 

- 4952ae72243492140b33bce34b3065b70fae09a8 - public key for production and signed environments
- 7794222be356290020d26b20fe73e5eb69912a11 - adding the possibility to set the singing key  to codesign so we can use non-codesign builds like development to use codesign release config.

## Related Issue

https://github.com/trezor/trezor-suite/issues/19763


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/add-codesign-public-key&lookback=7)