### PR TITLE
Chore/change name to build local firmware file name

### DIFF
--- a/packages/connect/src/utils/firmwareUtils.ts
+++ b/packages/connect/src/utils/firmwareUtils.ts
@@ -58,7 +58,7 @@ export const filterSafeListByFirmware = (
         versionUtils.isNewerOrEqual(firmwareVersion, item.min_firmware_version),
     );
 
-export const buildFirmwareFileName = (
+export const buildLocalFirmwareFileName = (
     firmwareType: FirmwareType,
     internalModel: DeviceModelInternal,
     version: VersionArray,

--- a/packages/suite-desktop-core/src/modules/firmware.ts
+++ b/packages/suite-desktop-core/src/modules/firmware.ts
@@ -1,5 +1,5 @@
 import { FirmwareType } from '@trezor/connect';
-import { buildFirmwareFileName } from '@trezor/connect/src/utils/firmwareUtils';
+import { buildLocalFirmwareFileName } from '@trezor/connect/src/utils/firmwareUtils';
 import { DeviceModelInternal, VersionArray } from '@trezor/device-utils';
 
 import { readDir, save } from '../libs/user-data';
@@ -47,7 +47,7 @@ export const init: ModuleInit = ({ mainThreadEmitter }) => {
                 firmwareType = FirmwareType.Universal,
             } = event;
 
-            const firmwareBinName = buildFirmwareFileName(
+            const firmwareBinName = buildLocalFirmwareFileName(
                 firmwareType,
                 internalModel,
                 binaryVersion,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changing name of function from `buildFirmwareFileName` to `buildLocalFirmwareFileName` since that naming it is going to be used just by local stored FWs, for remote ones the name will be defined in the url attribute in releases JSONs.

## Related Issue

https://github.com/trezor/trezor-suite/issues/19763


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/change-name-to-buildLocalFirmwareFileName&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/change-name-to-buildLocalFirmwareFileName&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/change-name-to-buildLocalFirmwareFileName&lookback=7)