### PR TITLE
chore(message-system): Update id of message about deprecated coins

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2025-07-28T00:00:00+00:00",
-    "sequence": 96,
+    "timestamp": "2025-07-28T17:00:00+00:00",
+    "sequence": 97,
     "actions": [
         {
             "conditions": [
@@ -856,7 +856,7 @@
                 }
             ],
             "message": {
-                "id": "1b7241ad-01ae-44c8-9e98-ab330b3136b0",
+                "id": "997dd618-7e84-4af4-970d-0f9175db30cd",
                 "priority": 94,
                 "dismissible": true,
                 "variant": "warning",


### PR DESCRIPTION
## Description

Updating id of of message informing about deprecated coins, so users who dismissed that message see this again as the backends are going to be deactivated soon.

## Screenshots:
<img width="1470" height="170" alt="coin_deprecation_info" src="https://github.com/user-attachments/assets/11c702ca-6ad0-472f-886a-ca9951573d68" />

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/message-system-update-deprecated-coins&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/message-system-update-deprecated-coins&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/message-system-update-deprecated-coins&lookback=7)