### PR TITLE
fix(suite): dont close approve modal on tx cancel

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
@@ -151,7 +151,6 @@ export const ApproveModal = ({
         setIsConfirmButtonLoading(true);
         await sendTransaction();
         setIsConfirmButtonLoading(false);
-        onCancel();
     };
 
     const { coinSymbol, contractAddress } = cryptoIdToSymbolAndContractAddress(selectedQuote.send);


### PR DESCRIPTION
## Description

Approve modal no longer closes automatically when user cancels the transaction, it is only closed after the transaction has been submitted.

## Related Issue

Resolve #20331

## Screenshots:

https://github.com/user-attachments/assets/d66836d7-8bf3-4393-bfbd-65d4768d34ff



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/dont-close-approval-modal-on-tx-cancel&lookback=7)