### PR TITLE
fix(suite): don't remember wallet in bootloader mode

### DIFF
--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -592,6 +592,7 @@ const forgetDisconnectedDevices = [
                         path: '1',
                         instance: 2,
                         remember: true,
+                        state: '1stTestnetAddress@device_1_id:0',
                     }),
                     getSuiteDevice({
                         path: '2',
@@ -605,6 +606,25 @@ const forgetDisconnectedDevices = [
             { path: '1', instance: undefined },
             { path: '1', instance: 1 },
         ],
+    },
+    {
+        description: `bootloader mode device`,
+        state: {
+            suite: {},
+            device: {
+                selectedDevice: SUITE_DEVICE,
+                devices: [
+                    getSuiteDevice({
+                        path: '1',
+                        instance: undefined,
+                        remember: true,
+                        mode: 'bootloader',
+                    }),
+                ],
+            },
+        },
+        device: CONNECT_DEVICE,
+        result: [{ path: '1', instance: undefined }],
     },
 ];
 

--- a/packages/suite/src/views/settings/SettingsGeneral/AutoEject.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/AutoEject.tsx
@@ -6,9 +6,10 @@ import { SettingsSectionItem } from 'src/components/settings';
 import { ActionColumn, TextColumn, Translation } from 'src/components/suite';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectIsAutoEjectEnabled } from 'src/reducers/suite/suiteReducer';
 
 export const AutoEject = () => {
-    const isAutoEjectEnabled = useSelector(state => state.suite.settings.autoEject);
+    const isAutoEjectEnabled = useSelector(selectIsAutoEjectEnabled);
     const dispatch = useDispatch();
 
     const handleSwitchClick = () => {

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -203,7 +203,10 @@ export const getNewWalletNumber = (devices: TrezorDevice[], device: TrezorDevice
  */
 export const findInstanceIndex = (draft: TrezorDevice[], device: AcquiredDevice) =>
     draft.findIndex(
-        d => d.features && d.id && d.id === device.id && d.instance === device.instance,
+        d =>
+            d.features &&
+            d.instance === device.instance &&
+            (d.id ? d.id === device.id : d.path === device.path && d.mode === device.mode), // if id is not present, e.g. in bootloader, fall back to path+mode
     );
 
 /**

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -185,7 +185,15 @@ export const forgetDisconnectedDevices = createThunk(
         const settings = extra.selectors.selectSuiteSettings(getState());
 
         deviceInstances.forEach(d => {
-            if (d.features && (forceForget || !d.remember)) {
+            if (
+                d.features &&
+                (forceForget ||
+                    !d.remember ||
+                    // Forget if not in normal state
+                    !d.id ||
+                    !d.state ||
+                    d.mode !== 'normal')
+            ) {
                 dispatch(deviceActions.forgetDevice({ device: d, settings }));
             }
         });


### PR DESCRIPTION
## Description

Fix issue with new auto-eject flow (#19713) where devices in non-normal states (eg. bootloader, wiped) are remembered.

## Related Issue

Resolve #20073


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/remember-wallet-bootloader&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/remember-wallet-bootloader&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/remember-wallet-bootloader&lookback=7)