### PR TITLE
fix(suite): walletconnect hide account selection if none are available

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
@@ -212,38 +212,46 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                 <Text>
                     <Translation id="TR_DEFAULT_ACCOUNT" />
                 </Text>
-                <Card paddingType="none">
-                    {/* Wrapped to keep consistent styling */}
-                    <ElevationUp>
-                        <Select
-                            isSearchable={false}
-                            isClearable={false}
-                            isRenderedInModal={true}
-                            size="large"
-                            value={selectedDefaultAccount}
-                            options={selectableAccounts}
-                            formatOptionLabel={(account: Account) => (
-                                <Row gap={spacings.xs}>
-                                    {account.symbol && (
-                                        <CoinLogo type="token" symbol={account.symbol} size={24} />
-                                    )}
-                                    <AccountLabel
-                                        account={{
-                                            ...account,
-                                            accountLabel: accountLabels[account.key],
-                                        }}
-                                        key={account.descriptor}
-                                        showAccountTypeBadge
-                                        accountTypeBadgeSize="small"
-                                    />
-                                </Row>
-                            )}
-                            onChange={(option: Option) => setSelectedDefaultAccount(option)}
-                        />
-                    </ElevationUp>
-                </Card>
+                {selectableAccounts.length > 0 && (
+                    <Card paddingType="none">
+                        {/* Wrapped to keep consistent styling */}
+                        <ElevationUp>
+                            <Select
+                                isSearchable={false}
+                                isClearable={false}
+                                isRenderedInModal={true}
+                                size="large"
+                                value={selectedDefaultAccount}
+                                options={selectableAccounts}
+                                formatOptionLabel={(account: Account) => (
+                                    <Row gap={spacings.xs}>
+                                        {account.symbol && (
+                                            <CoinLogo
+                                                type="token"
+                                                symbol={account.symbol}
+                                                size={24}
+                                            />
+                                        )}
+                                        <AccountLabel
+                                            account={{
+                                                ...account,
+                                                accountLabel: accountLabels[account.key],
+                                            }}
+                                            key={account.descriptor}
+                                            showAccountTypeBadge
+                                            accountTypeBadgeSize="small"
+                                        />
+                                    </Row>
+                                )}
+                                onChange={(option: Option) => setSelectedDefaultAccount(option)}
+                            />
+                        </ElevationUp>
+                    </Card>
+                )}
 
-                {(requiredNetworksNotActivated || noNetworksActivated) && (
+                {(requiredNetworksNotActivated ||
+                    noNetworksActivated ||
+                    selectableAccounts.length === 0) && (
                     <Banner
                         variant="warning"
                         rightContent={


### PR DESCRIPTION
## Description

Fully hide WalletConnect account selection if it's empty. This makes sure the error message is visible, before it could be obscured by the dropdown. 

## Screenshots:

Before - warning obscured by opened dropdown

<img width="685" height="583" alt="image (10)" src="https://github.com/user-attachments/assets/966cc8f7-0771-4547-80ba-88b0645e3450" />

After

<img width="685" height="514" alt="Screenshot 2025-07-29 at 15 51 17" src="https://github.com/user-attachments/assets/e5211d05-91cd-407f-b631-2ab6a6771585" />
