### PR TITLE
fix(suite): make sure that 'first' wallet account is properly identified

### DIFF
--- a/packages/suite-web/src/support/usePlaywright.ts
+++ b/packages/suite-web/src/support/usePlaywright.ts
@@ -1,7 +1,8 @@
 import { useEffect } from 'react';
-import { useStore } from 'react-redux';
 
 import TrezorConnect from '@trezor/connect';
+
+import { useStore } from 'src/hooks/suite/useStore';
 
 /**
  * Utility for running tests in Playwright.

--- a/packages/suite/src/hooks/suite/useStore.ts
+++ b/packages/suite/src/hooks/suite/useStore.ts
@@ -1,0 +1,5 @@
+import { useStore as useReduxStore } from 'react-redux';
+
+import { Store } from 'src/types/suite';
+
+export const useStore: () => Store = useReduxStore;

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
+import { useStore } from 'react-redux';
 
 import {
     getAccountsByDeviceState,
+    selectAllAccountsToList,
     selectCurrentFiatRates,
     selectDeviceThunk,
     selectLocalCurrency,
@@ -27,7 +29,7 @@ import { FiatHeader } from 'src/components/wallet/FiatHeader';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTotalFiatBalance } from 'src/hooks/wallet/useTotalFiatBalance';
 import { selectLabelingDataForWallet } from 'src/reducers/suite/metadataReducer';
-import { AcquiredDevice, ForegroundAppProps } from 'src/types/suite';
+import { AcquiredDevice, AppState, ForegroundAppProps } from 'src/types/suite';
 
 import { EjectConfirmation } from './EjectConfirmation';
 import { useWalletLabeling } from '../../../../components/suite/labeling/WalletLabeling';
@@ -54,6 +56,7 @@ export const WalletInstance = ({
     const localCurrency = useSelector(selectLocalCurrency);
     const editing = useSelector(state => state.metadata.editing);
     const dispatch = useDispatch();
+    const store = useStore();
 
     const { defaultAccountLabelString } = useWalletLabeling();
 
@@ -82,17 +85,21 @@ export const WalletInstance = ({
                 ? getAccountsByDeviceState(accounts, instance.state)
                 : [];
 
+            // NOTE: to determine which account is the first one, we need to filter out empty accounts
+            // that are currently displayed in the UI
+            const unfilteredUIAccounGroups = selectAllAccountsToList(store.getState() as AppState);
+            const currentFirstAccount = unfilteredUIAccounGroups[0];
             // NOTE: attempt to determine, if the currently selected account
-            // has a corresponding account in the next device accounts
+            // has a corresponding account in the next wallet accounts
             // if not, enforce switching URL to dashboard
             const nextAccount = nextDeviceAccounts.find(
                 account =>
                     account.symbol === selectedAccount.params?.symbol &&
                     account.index === selectedAccount.params?.accountIndex &&
                     account.accountType === selectedAccount.params?.accountType &&
-                    // NOTE: do not switch to empty accounts, but only if the current account is first or all accounts are empty
+                    // NOTE: do not switch to empty accounts, unless the current account is first and all other accounts in the next wallet are empty
                     (!account.empty ||
-                        (selectedAccount.params.accountIndex === 0 &&
+                        (selectedAccount.account?.descriptor === currentFirstAccount?.descriptor &&
                             nextDeviceAccounts.every(account => account.empty))),
             );
 

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useStore } from 'react-redux';
 
 import {
     getAccountsByDeviceState,
@@ -27,9 +26,10 @@ import { redirectAfterWalletSelectedThunk } from 'src/actions/wallet/addWalletTh
 import { MetadataLabeling, Translation, WalletLabeling } from 'src/components/suite';
 import { FiatHeader } from 'src/components/wallet/FiatHeader';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useStore } from 'src/hooks/suite/useStore';
 import { useTotalFiatBalance } from 'src/hooks/wallet/useTotalFiatBalance';
 import { selectLabelingDataForWallet } from 'src/reducers/suite/metadataReducer';
-import { AcquiredDevice, AppState, ForegroundAppProps } from 'src/types/suite';
+import { AcquiredDevice, ForegroundAppProps } from 'src/types/suite';
 
 import { EjectConfirmation } from './EjectConfirmation';
 import { useWalletLabeling } from '../../../../components/suite/labeling/WalletLabeling';
@@ -87,7 +87,7 @@ export const WalletInstance = ({
 
             // NOTE: to determine which account is the first one, we need to filter out empty accounts
             // that are currently displayed in the UI
-            const unfilteredUIAccounGroups = selectAllAccountsToList(store.getState() as AppState);
+            const unfilteredUIAccounGroups = selectAllAccountsToList(store.getState());
             const currentFirstAccount = unfilteredUIAccounGroups[0];
             // NOTE: attempt to determine, if the currently selected account
             // has a corresponding account in the next wallet accounts
@@ -99,7 +99,9 @@ export const WalletInstance = ({
                     account.accountType === selectedAccount.params?.accountType &&
                     // NOTE: do not switch to empty accounts, unless the current account is first and all other accounts in the next wallet are empty
                     (!account.empty ||
-                        (selectedAccount.account?.descriptor === currentFirstAccount?.descriptor &&
+                        (selectedAccount.account &&
+                            selectedAccount.account?.descriptor ===
+                                currentFirstAccount?.descriptor &&
                             nextDeviceAccounts.every(account => account.empty))),
             );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The problem here was that previous code was wrong. 
The determination of the "first" account in the UI was incorrectly done.

It was just "a fisrt account in the account group".

So now, I changed that the first account is really the one user sees as first in the list. And we only allow switching to an empty account if this account is first and all other accounts are empty.

## Related Issue

Resolves https://github.com/trezor/trezor-suite/issues/4465#issuecomment-3018190672 (again lol)

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=4465-account-doesnt-exist-won-die&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=4465-account-doesnt-exist-won-die&lookback=7)