### PR TITLE
refactor(suite): revert send max switch in send form

### DIFF
--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -976,6 +976,224 @@ export const setMax = [
         },
     },
     {
+        description:
+            'setMax sequence: compose final with address, disable setMax, add second output',
+        connect: [
+            undefined, // updateFeeInfoThunk
+            {
+                success: true,
+                payload: [
+                    {
+                        type: 'final',
+                        max: '100000000',
+                    },
+                ],
+            },
+            {
+                success: true,
+                payload: [
+                    {
+                        type: 'nonfinal',
+                        max: '100000000',
+                    },
+                ],
+            },
+            {
+                success: true,
+                payload: [
+                    {
+                        type: 'nonfinal',
+                        max: '100000000',
+                    },
+                ],
+            },
+            {
+                success: true,
+                payload: [
+                    {
+                        type: 'final',
+                        totalSpent: '120000000',
+                    },
+                ],
+            },
+        ],
+        actions: [
+            {
+                type: 'input',
+                element: 'outputs.0.address',
+                value: '3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX',
+                result: {
+                    composeTransactionCalls: 0,
+                    composedLevels: undefined,
+                },
+            },
+            {
+                type: 'hover',
+                element: 'outputs.0.amount',
+            },
+            {
+                type: 'click',
+                element: 'outputs.0.setMax',
+                result: {
+                    composeTransactionCalls: 1,
+                    formValues: {
+                        setMaxOutputId: 0,
+                        outputs: [
+                            {
+                                address: '3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX',
+                                amount: '1',
+                                fiat: '1.00',
+                            },
+                        ],
+                    },
+                    composedLevels: {
+                        normal: { type: 'final' },
+                    },
+                },
+            },
+            // add second output
+            {
+                type: 'click',
+                element: 'add-output',
+                result: {
+                    composeTransactionCalls: 1,
+                    formValues: {
+                        setMaxOutputId: 0,
+                        outputs: [
+                            {
+                                address: '3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX',
+                                amount: '1',
+                                fiat: '1.00',
+                            },
+                            { address: '' },
+                        ],
+                    },
+                    composedLevels: {
+                        normal: { type: 'final' },
+                    },
+                },
+            },
+            // fill address in second output
+            {
+                type: 'input',
+                element: 'outputs.1.address',
+                value: '3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX',
+                result: {
+                    formValues: {
+                        setMaxOutputId: 0,
+                        outputs: [
+                            {
+                                address: '3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX',
+                                amount: '1',
+                                fiat: '1.00',
+                            },
+                            { address: '3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX', amount: '' },
+                        ],
+                    },
+                    composeTransactionParams: {
+                        outputs: [
+                            // corner-case: send-max was changed to send-max-noaddress
+                            // see sendFormUtils.getBitcoinComposeOutputs
+                            {
+                                type: 'send-max-noaddress',
+                                address: '3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX',
+                            },
+                        ],
+                    },
+                },
+            },
+            // disable send max
+            {
+                type: 'click',
+                element: 'outputs.0.setMax',
+                result: {
+                    formValues: {
+                        setMaxOutputId: undefined,
+                    },
+                    composeTransactionParams: {
+                        outputs: [
+                            // corner-case: payment was changed to payment-noaddress
+                            // see sendFormUtils.getBitcoinComposeOutputs
+                            {
+                                type: 'payment-noaddress',
+                                address: '3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX',
+                                amount: '100000000',
+                            },
+                        ],
+                    },
+                },
+            },
+            // fill fiat in second output
+            {
+                type: 'input',
+                element: 'outputs.1.fiat',
+                value: '0.20',
+                result: {
+                    formValues: {
+                        outputs: [
+                            {
+                                address: '3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX',
+                                amount: '1',
+                                fiat: '1.00',
+                            },
+                            {
+                                address: '3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX',
+                                amount: '0.20000000',
+                                fiat: '0.20',
+                            },
+                        ],
+                    },
+                    composeTransactionParams: {
+                        outputs: [
+                            {
+                                type: 'payment',
+                                address: '3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX',
+                                amount: '100000000',
+                            },
+                            {
+                                type: 'payment',
+                                address: '3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX',
+                                amount: '20000000',
+                            },
+                        ],
+                    },
+                },
+            },
+            // remove second output
+            // {
+            //     type: 'click',
+            //     element: 'outputs.1.remove',
+            //     result: {
+            //         composeTransactionParams: {
+            //             outputs: [
+            //                 { type: 'payment', address: '3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX', amount: '100000000' }
+            //             ]
+            //         },
+            //     },
+            // }
+        ],
+        finalResult: {
+            composeTransactionCalls: 4,
+            formValues: {
+                setMaxOutputId: undefined,
+                outputs: [
+                    { address: '3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX', amount: '1', fiat: '1.00' },
+                    {
+                        address: '3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX',
+                        amount: '0.20000000',
+                        fiat: '0.20',
+                    },
+                ],
+            },
+            composedLevels: {
+                normal: {
+                    type: 'final',
+                    totalSpent: '120000000',
+                },
+            },
+        },
+    },
+    {
         description: 'ETH',
         store: {
             send: {

--- a/packages/suite/src/hooks/wallet/useSendFormFields.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormFields.ts
@@ -187,9 +187,13 @@ export const useSendFormFields = ({
     );
 
     const setMax = useCallback(
-        (outputId: number) => {
+        (outputId: number, active: boolean, clearInput?: boolean) => {
             clearErrors([`outputs.${outputId}.amount`, `outputs.${outputId}.fiat`]);
-            setValue('setMaxOutputId', outputId);
+            if (clearInput || !active) {
+                setValue(`outputs.${outputId}.amount`, '');
+                setValue(`outputs.${outputId}.fiat`, '');
+            }
+            setValue('setMaxOutputId', active ? undefined : outputId);
         },
         [clearErrors, setValue],
     );

--- a/packages/suite/src/types/wallet/sendForm.ts
+++ b/packages/suite/src/types/wallet/sendForm.ts
@@ -87,7 +87,7 @@ export type SendContextValues<TFormValues extends FormState = FormState> =
             setAmount: (outputIndex: number, amount: string) => void;
             changeFeeLevel: (currentLevel: FeeLevel['label']) => void;
             resetDefaultValue: (field: FieldPath<TFormValues>) => void;
-            setMax: (index: number, active: boolean) => void;
+            setMax: (index: number, active: boolean, clearInput?: boolean) => void;
             getDefaultValue: GetDefaultValue;
             toggleOption: (option: FormOptions) => void;
             // useSendFormOutputs utils:

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
@@ -11,7 +11,7 @@ import {
     isLowAnonymityWarning,
 } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
-import { Banner, Button, Flex, Icon, Row, Text } from '@trezor/components';
+import { Banner, Flex, Icon, Row, Text } from '@trezor/components';
 import { NumberInput } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
@@ -29,6 +29,7 @@ import {
 } from 'src/utils/suite/validation';
 
 import { BaseCurrencyInput } from './BaseCurrencyInput';
+import { SendMaxSwitch } from './SendMaxSwitch';
 
 interface AmountProps {
     output: Partial<Output>;
@@ -58,13 +59,14 @@ export const Amount = ({ output, outputId }: AmountProps) => {
 
     const amountName = `outputs.${outputId}.amount` as const;
     const tokenInputName = `outputs.${outputId}.token`;
-    const isSetMaxActive = getDefaultValue('setMaxOutputId') === outputId;
+    const maxOutputId = getDefaultValue('setMaxOutputId');
+    const isSetMaxActive = maxOutputId === outputId;
     const outputError = errors.outputs ? errors.outputs[outputId] : undefined;
     const error = outputError ? outputError.amount : undefined;
 
     // corner-case: do not display "setMax" button if FormState got ANY error (setMax probably cannot be calculated)
     const isSetMaxVisible = isSetMaxActive && !error && !Object.keys(errors).length;
-    const maxButtonId = `outputs.${outputId}.setMax`;
+    const maxSwitchId = `outputs.${outputId}.setMax`;
 
     const amountValue = getDefaultValue(amountName, output.amount || '');
     const tokenValue = getDefaultValue(tokenInputName, output.token);
@@ -129,15 +131,19 @@ export const Amount = ({ output, outputId }: AmountProps) => {
         },
     };
 
-    const onMaxClicked = () => {
-        setMax(outputId, isSetMaxActive);
+    const onSwitchChange = () => {
+        const clearInput = network.networkType === 'solana';
+
+        setMax(outputId, isSetMaxActive, clearInput);
         composeTransaction(amountName);
     };
 
     const sendMaxSwitch = (
-        <Button data-testid={maxButtonId} size="tiny" variant="tertiary" onClick={onMaxClicked}>
-            <Translation id="AMOUNT_SEND_MAX" />
-        </Button>
+        <SendMaxSwitch
+            isSetMaxActive={isSetMaxActive}
+            data-testid={maxSwitchId}
+            onChange={onSwitchChange}
+        />
     );
 
     return (

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/SendMaxSwitch.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/SendMaxSwitch.tsx
@@ -1,0 +1,24 @@
+import { Switch } from '@trezor/components';
+
+import { Translation } from 'src/components/suite';
+
+type SendMaxSwitchProps = {
+    isSetMaxActive: boolean;
+    'data-testid'?: string;
+    onChange: () => void;
+};
+
+export const SendMaxSwitch = ({
+    isSetMaxActive,
+    'data-testid': dataTest,
+    onChange,
+}: SendMaxSwitchProps) => (
+    <Switch
+        labelPosition="start"
+        isChecked={isSetMaxActive}
+        data-testid={dataTest}
+        size="small"
+        onChange={onChange}
+        label={<Translation id="AMOUNT_SEND_MAX" />}
+    />
+);


### PR DESCRIPTION
## Description

- Reverted the "Send Max" button back to the original switch in the send form.
- Added a condition for Solana: when the switch is turned off, the amount input is cleared to avoid confusing fee calculation behavior.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/17340

## Video:

https://github.com/user-attachments/assets/9162b0cd-9840-43ef-b838-2bbefbf88560

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/send-max-button-revert&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/send-max-button-revert&lookback=7)