### PR TITLE
fix(trading): fix delay when selecting max value in swap

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -215,9 +215,22 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
     };
 
     const setAllAmount = () => {
+        if (tokenData) {
+            const maxAmount = new BigNumber(tokenData.balance || '0')
+                .decimalPlaces(tokenData.decimals)
+                .toString();
+
+            const cryptoInputValue = shouldSendInSats
+                ? convertAmountUnitsToSubunits(maxAmount, networkDecimals)
+                : maxAmount;
+
+            setValue(TRADING_FORM_OUTPUT_AMOUNT, cryptoInputValue, { shouldDirty: true });
+        } else {
+            setValue(TRADING_FORM_OUTPUT_AMOUNT, '', { shouldDirty: true });
+        }
+
         setValue(TRADING_FORM_OUTPUT_MAX, 0, { shouldDirty: true });
         setValue(TRADING_FORM_OUTPUT_FIAT, '', { shouldDirty: true });
-        setValue(TRADING_FORM_OUTPUT_AMOUNT, '', { shouldDirty: true });
         clearErrors([TRADING_FORM_OUTPUT_FIAT, TRADING_FORM_OUTPUT_AMOUNT]);
 
         setFractionButton(1);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Resolves delay after Max value to swap is selected

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16432

## Screenshots:
### Before
https://github.com/user-attachments/assets/03e634d1-66e9-4feb-9033-f4249479d704


### After
https://github.com/user-attachments/assets/b450a79d-4f86-430c-a5a0-d3803eea3b6e




🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/swap-max-value-delay&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/swap-max-value-delay&lookback=7)