### PR TITLE
fix(suite-desktop): prevent OS from sleep when FW update is running

### DIFF
--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -6,6 +6,7 @@ import { parseElectrumUrl } from '@trezor/utils';
 
 import { getStoredFirmwares } from './firmware';
 import { APP_NAME } from '../libs/constants';
+import { PowerSaveBlocker } from '../libs/power-save-blocker';
 
 import { MainThreadEmitter, ModuleInit, ModuleInitBackground } from './index';
 
@@ -78,6 +79,15 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
 
                 if (method === 'blockchainSetCustomBackend') {
                     emitOnSetCustomBackendToMainThreadToAllowDomains({ params, mainThreadEmitter });
+                }
+
+                if (method === 'firmwareUpdate') {
+                    const powerSaveBlocker = new PowerSaveBlocker();
+                    powerSaveBlocker.startBlockingPowerSave();
+                    const response = await TrezorConnect.firmwareUpdate(params[0]);
+                    powerSaveBlocker.stopBlockingPowerSave();
+
+                    return response;
                 }
 
                 return (TrezorConnect[method] as any)(...params);

--- a/packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts
@@ -2,6 +2,7 @@ import { BLUETOOTH_PREFIX } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import TrezorConnect, { Device } from '@trezor/connect';
+import { desktopApi } from '@trezor/suite-desktop-api';
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
 import {
@@ -24,6 +25,9 @@ export const bluetoothConnectDeviceThunk = createThunk<
         dispatch(startConnectingBluetoothDevice({ deviceId }));
 
         const result = await bluetoothIpc.connectDevice(deviceId);
+
+        // restore focus in case if OS bluetooth setting is opened above the app (linux/mac)
+        desktopApi.appFocus();
 
         if (!result.success) {
             // This can fail, but we are silent about this as the device may not be there anymore


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. enable power save blocker on firmware update, prevent OS from sleep while FW update is running
2. focus after successful BT connection (pairing), while pairing OS bluetooth settings are  focused (linux/mac)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-bt-fw-update&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-bt-fw-update&lookback=7)