### PR TITLE
Coin Control - fetch UTXO transaction details only

### DIFF
--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
@@ -4,7 +4,7 @@ import styled, { useTheme } from 'styled-components';
 
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
-import { fetchAllTransactionsForAccountThunk } from '@suite-common/wallet-core';
+import { fetchUtxoTransactionsForAccountThunk } from '@suite-common/wallet-core';
 import {
     convertAmountUnitsToSubunits,
     filterAndCategorizeUtxos,
@@ -149,9 +149,8 @@ export const CoinControl = ({ close }: CoinControlProps) => {
     // fetch all transactions so that we can show a transaction timestamp for each UTXO
     useEffect(() => {
         const promise = dispatch(
-            fetchAllTransactionsForAccountThunk({
+            fetchUtxoTransactionsForAccountThunk({
                 accountKey: account.key,
-                noLoading: true,
             }),
         );
 

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -320,6 +320,49 @@ export const fetchTransactionsPageThunk = createThunk(
     },
 );
 
+type FetchUtxoTransactionsForAccountThunkParams = {
+    accountKey: AccountKey;
+};
+
+export const fetchUtxoTransactionsForAccountThunk = createSingleInstanceThunk(
+    `${TRANSACTIONS_MODULE_PREFIX}/fetchUtxoTransactionsForAccountThunk`,
+    async (
+        { accountKey }: FetchUtxoTransactionsForAccountThunkParams,
+        { dispatch, getState, signal },
+    ) => {
+        const account = selectAccountByKey(getState(), accountKey);
+        if (!account) {
+            throw new Error(`Account not found: ${accountKey}`);
+        }
+
+        if (account.utxo === undefined || account.utxo.length === 0) {
+            return selectAccountTransactions(getState(), accountKey);
+        }
+
+        const result = await TrezorConnect.blockchainGetTransactions({
+            coin: account.symbol,
+            txs: account.utxo.map(utxo => utxo.txid),
+        });
+
+        if (signal.aborted) {
+            throw new Error('Aborted');
+        }
+
+        if (!result.success) {
+            throw new Error(result.payload.error);
+        }
+
+        dispatch(
+            transactionsActions.addTransaction({
+                transactions: result.payload,
+                account,
+            }),
+        );
+
+        return selectAccountTransactions(getState(), accountKey);
+    },
+);
+
 /**
  * @param noLoading - disable loading indicator, it's not used directly in this thunk, but it's used in reducer
  */

--- a/suite-native/module-send/src/screens/SendUtxoScreen.tsx
+++ b/suite-native/module-send/src/screens/SendUtxoScreen.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import {
     AccountsRootState,
-    fetchAllTransactionsForAccountThunk,
+    fetchUtxoTransactionsForAccountThunk,
     selectAccountByKey,
 } from '@suite-common/wallet-core';
 import { isSameUtxo, useFilteredUtxos } from '@suite-common/wallet-utils';
@@ -45,9 +45,8 @@ export const SendUtxoScreen = ({
     // we need to fetch all transactions for the account to have the additional UTXOs data available
     useEffect(() => {
         const promise = dispatch(
-            fetchAllTransactionsForAccountThunk({
+            fetchUtxoTransactionsForAccountThunk({
                 accountKey,
-                noLoading: true,
             }),
         );
 


### PR DESCRIPTION
## Description
When using CoinControl on desktop/mobile with account that has a lot of transactions - it took a lot of time to fetch the UTXOs transaction details since we were fetching all of the account transaction.

Especially on mobile it kept the TX details in the state and account details page were fully loaded (instead of infinity scroll).


Benchmarks done with testing accounts.
**Android benchmarks:**
- Bitcoin 1
    - Fetch only UTXOs: 120.07ms
    - Old fetch all: 21000ms
- Bitcoin 2
    - Fetch only UTXOs: 136.04ms
    - Old fetch all: 8213ms
- Bitcoin 3
    - Fetch only UTXOs: 75.16ms
    - Old fetch all: 2502ms

**Desktop benchmark:**
- Bitcoin 1
    - Fetch only UTXOs: 52.45ms
    - Old fetch all: 2798ms
- Bitcoin 2
    - Fetch only UTXOs: 53ms
    - Old fetch all: 1205ms
- Bitcoin 3
    - Fetch only UTXOs: 45ms
    - Old fetch all: 399ms


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20218

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/fetch-utxo-transactions-only&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/fetch-utxo-transactions-only&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/fetch-utxo-transactions-only&lookback=7)