### PR TITLE
feat(suite): add warning to the enabling of auto-eject

### DIFF
--- a/packages/suite/src/actions/suite/autoEjectThunks.ts
+++ b/packages/suite/src/actions/suite/autoEjectThunks.ts
@@ -1,0 +1,52 @@
+import { createThunk } from '@suite-common/redux-utils';
+import { TrezorDevice } from '@suite-common/suite-types';
+import { forgetDisconnectedDevices, selectDevices } from '@suite-common/wallet-core';
+
+import * as storageActions from 'src/actions/suite/storageActions';
+
+import { goto } from './routerActions';
+import { setAutoEject } from './suiteActions';
+
+const AUTO_EJECT_PREFIX = '@suite/autoEject';
+
+export const setAutoEjectEnabledThunk = createThunk(
+    `${AUTO_EJECT_PREFIX}/enableAutoEjectThunk`,
+    (
+        {
+            enabled,
+            disconnectedDevices,
+        }: {
+            enabled: boolean;
+            disconnectedDevices: TrezorDevice[];
+        },
+        { dispatch, getState },
+    ) => {
+        if (!enabled) {
+            dispatch(setAutoEject(false));
+
+            return;
+        }
+
+        disconnectedDevices.forEach(device => {
+            dispatch(forgetDisconnectedDevices({ device, forceForget: true }));
+        });
+
+        const allDevices = selectDevices(getState());
+        allDevices.forEach(device => {
+            if (device.features) {
+                dispatch(storageActions.forgetDevice(device));
+            }
+        });
+
+        dispatch(storageActions.saveSuiteSettings());
+
+        dispatch(setAutoEject(true));
+
+        const currentDevices = selectDevices(getState());
+        const connectedDevices = currentDevices.filter(device => device.connected && device.state);
+
+        if (connectedDevices.length === 0) {
+            dispatch(goto('suite-index'));
+        }
+    },
+);

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -250,20 +250,6 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS:
                     api.dispatch(storageActions.saveWalletSettings());
                     break;
-
-                case SUITE.SET_AUTO_EJECT: {
-                    if (action?.payload === true) {
-                        const devices = selectDevices(api.getState());
-
-                        devices.forEach(device => {
-                            if (device.features) {
-                                api.dispatch(storageActions.forgetDevice(device));
-                            }
-                        });
-                    }
-                    api.dispatch(storageActions.saveSuiteSettings());
-                    break;
-                }
                 case SUITE.SET_LANGUAGE:
                 case SUITE.SET_FLAG:
                 case SUITE.SET_DEBUG_MODE:

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2802,6 +2802,10 @@ export default defineMessages({
         defaultMessage: 'Privacy',
         id: 'TR_PRIVACY',
     },
+    TR_CONFIRM_AUTO_EJECT: {
+        defaultMessage: 'Enable auto eject',
+        id: 'TR_CONFIRM_AUTO_EJECT',
+    },
     TR_AUTO_EJECT: {
         defaultMessage: 'Auto-eject wallets',
         id: 'TR_AUTO_EJECT',
@@ -2810,6 +2814,15 @@ export default defineMessages({
         defaultMessage:
             'Automatically eject all wallets when your Trezor is disconnected.\nYour balances will be removed from Trezor Suite until you reconnect your device.',
         id: 'TR_AUTO_EJECT_DESCRIPTION',
+    },
+    TR_AUTO_EJECT_CONFIRMATION_DESCRIPTION: {
+        defaultMessage:
+            'Your wallets and their balances will disappear from Suite. They will reappear only when you reconnect your Trezor.',
+        id: 'TR_AUTO_EJECT_CONFIRMATION_DESCRIPTION',
+    },
+    TR_AUTO_EJECT_CONFIRMATION_TITLE: {
+        defaultMessage: 'Are you sure you want to enable auto eject?',
+        id: 'TR_AUTO_EJECT_CONFIRMATION_TITLE',
     },
     TR_LANGUAGE: {
         defaultMessage: 'Language',

--- a/packages/suite/src/views/settings/SettingsGeneral/AutoEject.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/AutoEject.tsx
@@ -1,26 +1,82 @@
-import { Switch } from '@trezor/components';
+import { useState } from 'react';
+
+import { selectDevices } from '@suite-common/wallet-core';
+import { Modal, Switch } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
-import { setAutoEject } from 'src/actions/suite/suiteActions';
+import { setAutoEjectEnabledThunk } from 'src/actions/suite/autoEjectThunks';
 import { SettingsSectionItem } from 'src/components/settings';
 import { ActionColumn, TextColumn, Translation } from 'src/components/suite';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectIsAutoEjectEnabled } from 'src/reducers/suite/suiteReducer';
 
+const AutoEjectConfirmationModal = ({
+    onCancel,
+    onSubmit,
+}: {
+    onCancel: () => void;
+    onSubmit: () => void;
+}) => {
+    const handleConfirmClick = () => {
+        onSubmit();
+        onCancel();
+    };
+
+    return (
+        <Modal
+            heading={<Translation id="TR_AUTO_EJECT_CONFIRMATION_TITLE" />}
+            onCancel={onCancel}
+            size="small"
+            bottomContent={
+                <>
+                    <Modal.Button onClick={handleConfirmClick} data-testid="@log/export-button">
+                        <Translation id="TR_CONFIRM_AUTO_EJECT" />
+                    </Modal.Button>
+                    <Modal.Button onClick={onCancel} variant="tertiary">
+                        <Translation id="TR_CANCEL" />
+                    </Modal.Button>
+                </>
+            }
+        >
+            <Translation id="TR_AUTO_EJECT_CONFIRMATION_DESCRIPTION" />
+        </Modal>
+    );
+};
+
 export const AutoEject = () => {
     const isAutoEjectEnabled = useSelector(selectIsAutoEjectEnabled);
     const dispatch = useDispatch();
+    const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
 
-    const handleSwitchClick = () => {
-        dispatch(setAutoEject(!isAutoEjectEnabled));
+    const devices = useSelector(selectDevices);
+
+    const disconnectedDevices = devices.filter(device => !device.connected && device.state);
+    const hasAnyDisconnectedWallet = disconnectedDevices.length > 0;
+
+    const toggleAutoEject = () => {
+        const nextIsAutoEjectedEnabled = !isAutoEjectEnabled;
+        dispatch(
+            setAutoEjectEnabledThunk({
+                disconnectedDevices,
+                enabled: nextIsAutoEjectedEnabled,
+            }),
+        );
 
         analytics.report({
             type: EventType.SettingsGeneralAutoEject,
             payload: {
-                value: !isAutoEjectEnabled,
+                value: nextIsAutoEjectedEnabled,
             },
         });
+    };
+
+    const handleSubmit = () => {
+        if (!isAutoEjectEnabled && hasAnyDisconnectedWallet) {
+            setIsConfirmationModalOpen(true);
+        } else {
+            toggleAutoEject();
+        }
     };
 
     return (
@@ -32,10 +88,16 @@ export const AutoEject = () => {
             <ActionColumn>
                 <Switch
                     isChecked={isAutoEjectEnabled}
-                    onChange={handleSwitchClick}
+                    onChange={handleSubmit}
                     data-testid="@settings/auto-eject-switch"
                 />
             </ActionColumn>
+            {isConfirmationModalOpen && (
+                <AutoEjectConfirmationModal
+                    onCancel={() => setIsConfirmationModalOpen(false)}
+                    onSubmit={toggleAutoEject}
+                />
+            )}
         </SettingsSectionItem>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There are some remaning cases in view-only-by-default. Namely a warning of what happens when you enable auto-eject. 

This modal: https://www.figma.com/design/wGshbwWuR7shAA1i1UBqR8/View-only?node-id=5960-102699&t=8SYFO0J0x5PmtpaT-0

Try: it should pop up logically behaving modal with text when you click in settigns to enable auto-eject

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=add-warning-on-autoeject&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=add-warning-on-autoeject&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=add-warning-on-autoeject&lookback=7)