### PR TITLE
fix(e2e): fix hardcoded strings in E2E tests, replace with TR Ids

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
@@ -3,6 +3,7 @@ import { Locator, Page } from '@playwright/test';
 import { TradingCountryCode } from '@suite-common/trading';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
+import messages from '@trezor/suite/src/support/messages';
 
 import { Fees } from './fees';
 import { getCompanyNameFromList, invityEndpoint } from '../../../fixtures/invity';
@@ -293,7 +294,7 @@ export class TradingPage {
         const quoteRequestPromise = this.page.waitForRequest(invityEndpoint.sellQuotes);
         await this.youPayCryptoInput.fill(amount);
         await expect(
-            this.page.getByText('Not enough funds'),
+            this.page.getByText(messages['AMOUNT_IS_NOT_ENOUGH'].defaultMessage),
             'Insufficient funds in the account to run sell flow test. Please contact the "tech_qa" Slack group immediately.',
         ).toBeHidden();
         await expect(quoteRequestPromise).toHavePayload({
@@ -317,7 +318,7 @@ export class TradingPage {
         await this.youPayCryptoInput.fill(amount);
         await this.page.waitForRequest(invityEndpoint.sellQuotes);
         await expect(
-            this.page.getByText('Not enough funds'),
+            this.page.getByText(messages['AMOUNT_IS_NOT_ENOUGH'].defaultMessage),
             'Insufficient funds in the account to run sell flow test. Please contact the "tech_qa" Slack group immediately.',
         ).toBeHidden();
 

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-bitcoin.test.ts
@@ -1,4 +1,5 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
+import messages from '@trezor/suite/src/support/messages';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import {
@@ -133,7 +134,9 @@ test.describe('Trading - Buy BTC', { tag: ['@group=trading', '@webOnly'] }, () =
         await test.step('Wait 30s for watch refresh and status change to Approved', async () => {
             await tradingMock.changeBuyWatchResponseTo('SUCCESS');
             await page.clock.fastForward(tradingMock.watchPeriod);
-            await expect(tradingPage.transactionDetailStatus).toHaveText('Buy Successful');
+            await expect(tradingPage.transactionDetailStatus).toHaveText(
+                messages['TR_BUY_DETAIL_SUCCESS_TITLE'].defaultMessage,
+            );
             await expect(tradingPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);
             await expect(tradingPage.confirmationCryptoAmount).toHaveText(bestBuyCryptoAmount);
             await expect(tradingPage.confirmationProvider).toHaveText(bestBuyProvider);

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-ethereum.test.ts
@@ -1,4 +1,5 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
+import messages from '@trezor/suite/src/support/messages';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import { buyQuotesEthereum, buyTradeEthereum, invityEndpoint } from '../../fixtures/invity';
@@ -85,7 +86,9 @@ test.describe('Trading - Buy Ethereum', { tag: ['@group=trading', '@webOnly'] },
         await tradingPage.waitForRedirectCompletion();
 
         await test.step('Verify transaction detail', async () => {
-            await expect(tradingPage.transactionDetailStatus).toHaveText('Buy Successful');
+            await expect(tradingPage.transactionDetailStatus).toHaveText(
+                messages['TR_BUY_DETAIL_SUCCESS_TITLE'].defaultMessage,
+            );
             await expect(tradingPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);
             await expect(tradingPage.confirmationCryptoAmount).toHaveText(formattedCryptoAmount);
             await expect(tradingPage.confirmationProvider).toHaveText(provider);

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
@@ -1,4 +1,5 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
+import messages from '@trezor/suite/src/support/messages';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import {
@@ -66,7 +67,9 @@ test.describe('Trading - Buy Solana', { tag: ['@group=trading', '@webOnly'] }, (
         await tradingPage.waitForRedirectCompletion();
 
         await test.step('Verify transaction detail', async () => {
-            await expect(tradingPage.transactionDetailStatus).toHaveText('Buy Successful');
+            await expect(tradingPage.transactionDetailStatus).toHaveText(
+                messages['TR_BUY_DETAIL_SUCCESS_TITLE'].defaultMessage,
+            );
             await expect(tradingPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);
             await expect(tradingPage.confirmationCryptoAmount).toHaveText(formattedCryptoAmount);
             await expect(tradingPage.confirmationProvider).toHaveText(provider);

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
@@ -1,4 +1,5 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
+import messages from '@trezor/suite/src/support/messages';
 
 import { expect, test } from '../../support/fixtures';
 
@@ -48,7 +49,7 @@ test.describe('Trading - Sell inputs', { tag: ['@group=trading', '@webOnly'] }, 
                 await tradingPage.youPayCryptoInput.fill('10');
                 await expect
                     .soft(tradingPage.cryptoInputBottomText)
-                    .toHaveText('Not enough funds', {
+                    .toHaveText(messages['AMOUNT_IS_NOT_ENOUGH'].defaultMessage, {
                         timeout: 15_000,
                     });
             });

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
@@ -1,4 +1,5 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
+import messages from '@trezor/suite/src/support/messages';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import {
@@ -113,7 +114,9 @@ test.describe('Trading - Sell Solana', { tag: ['@group=trading', '@webOnly'] }, 
                 await route.fulfill({ json: { status: 'SUCCESS' } });
             });
             await page.clock.fastForward(tradingMock.watchPeriod);
-            await expect(tradingPage.transactionDetailStatus).toHaveText('Sell Successful');
+            await expect(tradingPage.transactionDetailStatus).toHaveText(
+                messages['TR_SELL_DETAIL_SUCCESS_TITLE'].defaultMessage,
+            );
             await expect(tradingPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);
             await expect(tradingPage.confirmationCryptoAmount).toHaveText(formattedCryptoAmount);
             await expect(tradingPage.confirmationProvider).toHaveText(provider);

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
@@ -1,4 +1,5 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
+import messages from '@trezor/suite/src/support/messages';
 
 import {
     getCompanyNameFromList,
@@ -90,7 +91,9 @@ test.describe('Trading - Swap coin to token', { tag: ['@group=trading', '@webOnl
         await test.step('Send crypto to provider', async () => {
             await devicePrompt.sendButton.click();
             await expect(page.getByTestId('@toast/tx-sent')).toContainText(toastText);
-            await expect(tradingPage.transactionDetailStatus).toHaveText('Swap Successful');
+            await expect(tradingPage.transactionDetailStatus).toHaveText(
+                messages['TR_EXCHANGE_DETAIL_SUCCESS_TITLE'].defaultMessage,
+            );
             await expect(tradingPage.confirmationCryptoAmount.first()).toHaveText(
                 formattedSendAmount,
             );

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
@@ -1,4 +1,5 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
+import messages from '@trezor/suite/src/support/messages';
 
 import {
     getCompanyNameFromList,
@@ -14,7 +15,10 @@ import { transformAddress } from '../../support/testExtends/customMatchers';
 const transactionStates = [
     { transactionStatus: 'CONFIRMING', displayedText: 'Pending' },
     { transactionStatus: 'CONVERTING', displayedText: 'Converting' },
-    { transactionStatus: 'SUCCESS', displayedText: 'Swap Successful' },
+    {
+        transactionStatus: 'SUCCESS',
+        displayedText: messages['TR_EXCHANGE_DETAIL_SUCCESS_TITLE'].defaultMessage,
+    },
 ];
 
 // Expected values based on our mocked responses

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
@@ -1,4 +1,5 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
+import messages from '@trezor/suite/src/support/messages';
 
 import {
     getCompanyNameFromList,
@@ -87,7 +88,9 @@ test.describe('Trading - Swap token to coin', { tag: ['@group=trading', '@webOnl
         await test.step('Send crypto to provider', async () => {
             await devicePrompt.sendButton.click();
             await expect(page.getByTestId('@toast/tx-sent')).toContainText(toastText);
-            await expect(tradingPage.transactionDetailStatus).toHaveText('Swap Successful');
+            await expect(tradingPage.transactionDetailStatus).toHaveText(
+                messages['TR_EXCHANGE_DETAIL_SUCCESS_TITLE'].defaultMessage,
+            );
             await expect(tradingPage.confirmationCryptoAmount.first()).toHaveText(
                 formattedSendAmount,
             );

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
@@ -1,4 +1,5 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
+import messages from '@trezor/suite/src/support/messages';
 
 import {
     getCompanyNameFromList,
@@ -87,7 +88,9 @@ test.describe('Trading - Swap tokens', { tag: ['@group=trading', '@webOnly'] }, 
         await test.step('Send crypto to provider', async () => {
             await devicePrompt.sendButton.click();
             await expect(page.getByTestId('@toast/tx-sent')).toContainText(toastText);
-            await expect(tradingPage.transactionDetailStatus).toHaveText('Swap Successful');
+            await expect(tradingPage.transactionDetailStatus).toHaveText(
+                messages['TR_EXCHANGE_DETAIL_SUCCESS_TITLE'].defaultMessage,
+            );
             await expect(tradingPage.confirmationCryptoAmount.first()).toHaveText(
                 formattedSendAmount,
             );


### PR DESCRIPTION
## Description

Fix E2E tests that relied on exact strings, broken by crowdin sync PR https://github.com/trezor/trezor-suite/pull/20460 where E2E did not run.
Now E2E expects strings from `messages.ts`, which will work as long as crowdin is synced, and English language is selected in the plwrght app.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/e2e-crowdin-strings&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/e2e-crowdin-strings&lookback=7)