### PR TITLE
Mobile Connect/WalletConnect fixes

### DIFF
--- a/suite-common/walletconnect/package.json
+++ b/suite-common/walletconnect/package.json
@@ -19,6 +19,7 @@
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/env-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "@walletconnect/core": "^2.21.5",
         "@walletconnect/utils": "^2.21.5",

--- a/suite-common/walletconnect/src/walletConnectConstants.ts
+++ b/suite-common/walletconnect/src/walletConnectConstants.ts
@@ -1,3 +1,5 @@
+import { isNative } from '@trezor/env-utils';
+
 export const WALLETCONNECT_MODULE = '@suite/walletconnect';
 
 export const PROJECT_ID = '203549d0480d0f24d994780f34889b03';
@@ -6,5 +8,11 @@ export const WALLETCONNECT_METADATA = {
     name: 'Trezor Suite',
     description: 'Manage your Trezor device',
     url: 'https://suite.trezor.io',
-    icons: ['https://trezor.io/favicon/apple-touch-icon.png'],
+    icons: ['https://trezor.io/images/suite/appIcon.png'],
+    redirect: isNative()
+        ? {
+              native: 'trezorsuitelite://walletconnect/',
+              linkMode: true,
+          }
+        : {},
 };

--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -9,12 +9,13 @@ import {
 } from '@walletconnect/utils';
 
 import { EventType, analytics } from '@suite-common/analytics';
+import * as trezorConnectPopupActions from '@suite-common/connect-popup';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getNetwork } from '@suite-common/wallet-config';
-import { selectAllAccountsToList, selectSelectedDevice } from '@suite-common/wallet-core';
+import { selectAllAccountsToList } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
-import TrezorConnect from '@trezor/connect';
+import { CallMethodResponse } from '@trezor/connect';
 
 import { getAdapterByMethod, getNamespaces, processNamespaces } from './adapters';
 import { walletConnectActions } from './walletConnectActions';
@@ -32,7 +33,6 @@ export const sessionAuthenticateThunk = createThunk<
 >(`${WALLETCONNECT_MODULE}/sessionAuthenticateThunk`, async ({ event }, { getState, dispatch }) => {
     // Support for Sign-In with Ethereum (SIWE) message, enhanced by ReCaps (ReCap Capabilities)
     try {
-        const device = selectSelectedDevice(getState());
         const accounts = selectAllAccountsToList(getState());
         const supportedNamespaces = getNamespaces(accounts);
         const authPayload = populateAuthPayload({
@@ -50,22 +50,34 @@ export const sessionAuthenticateThunk = createThunk<
             iss,
         });
 
-        const signature = await TrezorConnect.ethereumSignMessage({
-            path: ethAccount.path,
-            message,
-            device,
-            useEmptyPassphrase: device?.useEmptyPassphrase,
-        });
-
-        if (signature.success === false) {
-            throw new Error('Failed to sign message');
+        dispatch(
+            trezorConnectPopupActions.connectPopupCallThunk({
+                source: {
+                    type: 'walletconnect' as const,
+                    origin: event.verifyContext.verified.origin,
+                    manifest: {
+                        appName: event.params.requester.metadata.name,
+                        appIcon: event.params.requester.metadata.icons?.[0],
+                    },
+                },
+                method: 'ethereumSignMessage',
+                payload: {
+                    path: ethAccount.path,
+                    message,
+                },
+            }),
+        );
+        const response = await trezorConnectPopupActions.getPopupCallDeferred(true).promise;
+        if (!response.success) {
+            throw new Error('Sign message error');
         }
+        const typedPayload = response.payload as CallMethodResponse<'ethereumSignMessage'>;
 
         const auth = buildAuthObject(
             authPayload,
             {
                 t: 'eip191',
-                s: `0x${signature.payload.signature}`,
+                s: `0x${typedPayload.signature}`,
             },
             iss,
         );

--- a/suite-common/walletconnect/tsconfig.json
+++ b/suite-common/walletconnect/tsconfig.json
@@ -10,6 +10,7 @@
         { "path": "../wallet-core" },
         { "path": "../wallet-types" },
         { "path": "../../packages/connect" },
+        { "path": "../../packages/env-utils" },
         { "path": "../../packages/utils" }
     ]
 }

--- a/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
@@ -53,9 +53,11 @@ const contentStyle = prepareNativeStyle(() => ({
     flexShrink: 1,
 }));
 
-const touchableOpacityStyle = prepareNativeStyle(utils => ({
-    ...utils.boxShadows.small,
-}));
+const touchableOpacityStyle = prepareNativeStyle<Pick<CompactCardWithIconLayoutProps, 'noShadow'>>(
+    (utils, { noShadow }) => ({
+        ...(noShadow ? {} : utils.boxShadows.small),
+    }),
+);
 
 export const CompactCardWithIconLayout = ({
     icon,
@@ -73,7 +75,7 @@ export const CompactCardWithIconLayout = ({
 
     return (
         <TouchableOpacity
-            style={applyStyle(touchableOpacityStyle)}
+            style={applyStyle(touchableOpacityStyle, { noShadow })}
             disabled={isDisabled}
             onPress={onPress}
             {...pressableProps}

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -497,7 +497,7 @@ export const en = {
             versionUnsupported: 'Unsupported version. Please update your Trezor Suite app.',
             methodNotAllowed: 'Method not allowed for security reasons.',
             methodCanceled: 'Call canceled by user.',
-            unknownError: 'Unknown error occurred.',
+            unknownError: 'Unknown error occurred ({code}).',
         },
         bottomSheets: {
             confirmOnDeviceMessage: 'Go to your device and verify the details of the operation.',

--- a/suite-native/module-connect-popup/src/components/ButtonRequestsOverlay.tsx
+++ b/suite-native/module-connect-popup/src/components/ButtonRequestsOverlay.tsx
@@ -1,15 +1,16 @@
 import { useSelector } from 'react-redux';
 
 import { selectSelectedDevice } from '@suite-common/wallet-core';
-import { VStack } from '@suite-native/atoms';
+import { Box } from '@suite-native/atoms';
 import { ConfirmOnTrezorImage } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 const overlayStyle = prepareNativeStyle(() => ({
     position: 'absolute',
-    bottom: 0,
-    width: '100%',
+    left: 0,
+    right: 0,
+    bottom: 20,
 }));
 
 export const ButtonRequestsOverlay = () => {
@@ -21,17 +22,12 @@ export const ButtonRequestsOverlay = () => {
     }
 
     return (
-        <VStack
-            alignItems="center"
-            justifyContent="center"
-            flex={1}
-            style={applyStyle(overlayStyle)}
-        >
+        <Box style={applyStyle(overlayStyle)}>
             <ConfirmOnTrezorImage
                 bottomSheetText={
                     <Translation id="moduleConnectPopup.bottomSheets.confirmOnDeviceMessage" />
                 }
             />
-        </VStack>
+        </Box>
     );
 };

--- a/suite-native/module-connect-popup/src/components/TxSimulation/ContractInfoBottomSheet.tsx
+++ b/suite-native/module-connect-popup/src/components/TxSimulation/ContractInfoBottomSheet.tsx
@@ -49,6 +49,7 @@ export const ContractInfoBottomSheet = ({
             isVisible={isVisible}
             onClose={onClose}
             title={<Translation id="moduleConnectPopup.simulation.contractInfo" />}
+            paddingBottom="sp24"
         >
             <Card>
                 <VStack>

--- a/suite-native/module-connect-popup/src/components/TxSimulation/FeeInfoBottomSheet.tsx
+++ b/suite-native/module-connect-popup/src/components/TxSimulation/FeeInfoBottomSheet.tsx
@@ -82,6 +82,7 @@ export const FeeInfoBottomSheet = ({
             isVisible={isVisible}
             onClose={onClose}
             title={<Translation id="moduleConnectPopup.simulation.feeInfo" />}
+            paddingBottom="sp24"
         >
             <Card>
                 <VStack>

--- a/suite-native/module-connect-popup/src/screens/ConnectPopupScreen.tsx
+++ b/suite-native/module-connect-popup/src/screens/ConnectPopupScreen.tsx
@@ -92,6 +92,7 @@ export const ConnectPopupScreen = () => {
                         return <Translation id="moduleConnectPopup.errors.versionUnsupported" />;
                     case 'Method_NotAllowed':
                         return <Translation id="moduleConnectPopup.errors.methodNotAllowed" />;
+                    case 'Device_Disconnected':
                     case 'Device_NotFound':
                         return <Translation id="moduleConnectPopup.errors.deviceNotConnected" />;
                     case 'Method_Interrupted':
@@ -101,7 +102,12 @@ export const ConnectPopupScreen = () => {
                     case 'Method_InvalidParameter':
                         return <Translation id="moduleConnectPopup.errors.invalidParams" />;
                     default:
-                        return <Translation id="moduleConnectPopup.errors.unknownError" />;
+                        return (
+                            <Translation
+                                id="moduleConnectPopup.errors.unknownError"
+                                values={{ code: popupCall.error.code }}
+                            />
+                        );
                 }
             };
             const onClose = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10025,6 +10025,7 @@ __metadata:
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/env-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@walletconnect/core": "npm:^2.21.5"
     "@walletconnect/utils": "npm:^2.21.5"


### PR DESCRIPTION
## Description

Batch of smaller Connect / WalletConnect fixes for mobile.

### feat(suite-native): add padding to bottom sheets in tx simulation

Hopefully resolve #20283
I could not reproduce the bug on my device however. 

### feat(suite-native): additional context in connect popup errors

If the error is unknown we display the error code. 

### feat(suite): use connect flow for WalletConnect SIWE

Previously, when using WalletConnect with Sign in with Ethereum it would not give any indication in the app, it would only show up on Trezor. Now it uses the Connect popup flow, so it indicates to the user that they need to sign on device.

### feat(suite-native): add walletconnect deeplink

Add deeplink to WalletConnect manifest. 

### fix(suite-native): make button requests overlay appear again

The image telling users to confirm on device in Connect flow disappeared due to some changes, this fixes it.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-mobile-improvements&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-mobile-improvements&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-mobile-improvements&lookback=7)