### PR TITLE
fix(nixos): sharp dependency build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
             pkgs.pango # build dependencies for node-canvas
             pkgs.shellcheck
             pkgs.playwright-test  # From playwright-web-flake
+            pkgs.vips
           ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
             pkgs.nsis
             pkgs.p7zip

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
         "electron": "37.2.0",
         "@types/node": "22.13.10",
         "bn.js": "5.2.2",
+        "node-addon-api": "8.5.0",
         "node-gyp": "10.2.0",
         "reselect": "5.1.1",
         "### We need promise to be same version in mobile unless it produces undefined behavior, check PR #15815": "1.0.0",

--- a/shell.nix
+++ b/shell.nix
@@ -40,6 +40,7 @@ in
       pkg-config
       pixman cairo giflib libjpeg libpng librsvg pango            # build dependencies for node-canvas
       shellcheck
+      vips
     ] ++ lib.optionals stdenv.isLinux [
       nsis openjpeg osslsigncode p7zip squashfsTools gccPkgs.gcc # binaries used by node_module: electron-builder
       udev  # used by node_module: usb

--- a/yarn.lock
+++ b/yarn.lock
@@ -32195,39 +32195,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-addon-api@npm:^1.6.3":
-  version: 1.7.2
-  resolution: "node-addon-api@npm:1.7.2"
+"node-addon-api@npm:8.5.0":
+  version: 8.5.0
+  resolution: "node-addon-api@npm:8.5.0"
   dependencies:
     node-gyp: "npm:latest"
-  checksum: 10/6bf8217a8cd8148f4bbfd319b46d33587e9fb2e63e3c856ded67a76715167f7a6b17e1d9b8bbf3b8508befeb6a4adb10d92b8998ed5c19ca8448343f4cea11d6
-  languageName: node
-  linkType: hard
-
-"node-addon-api@npm:^3.0.0":
-  version: 3.2.1
-  resolution: "node-addon-api@npm:3.2.1"
-  dependencies:
-    node-gyp: "npm:latest"
-  checksum: 10/681b52dfa3e15b0a8e5cf283cc0d8cd5fd2a57c559ae670fcfd20544cbb32f75de7648674110defcd17ab2c76ebef630aa7d2d2f930bc7a8cc439b20fe233518
-  languageName: node
-  linkType: hard
-
-"node-addon-api@npm:^7.0.0":
-  version: 7.1.1
-  resolution: "node-addon-api@npm:7.1.1"
-  dependencies:
-    node-gyp: "npm:latest"
-  checksum: 10/ee1e1ed6284a2f8cd1d59ac6175ecbabf8978dcf570345e9a8095a9d0a2b9ced591074ae77f9009287b00c402352b38aa9322a34f2199cdc9f567b842a636b94
-  languageName: node
-  linkType: hard
-
-"node-addon-api@npm:^8.0.0":
-  version: 8.1.0
-  resolution: "node-addon-api@npm:8.1.0"
-  dependencies:
-    node-gyp: "npm:latest"
-  checksum: 10/25124c99a12d2a94cd39ff942e16399640ab04747e09085ee85dd8f3903ef67b621c12a1b30de49c5498522237785dace2de87910715448ce547ee726ce777e0
+  checksum: 10/9a893f4f835fbc3908e0070f7bcacf36e37fd06be8008409b104c30df4092a0d9a29927b3a74cdbc1d34338274ba4116d597a41f573e06c29538a1a70d07413f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
straight out of my stash :) related to https://github.com/trezor/trezor-suite/pull/17825

problem description [in slack](https://satoshilabs.slack.com/archives/G019WLX2P7B/p1748001721648059?thread_ts=1747123484.872809&cid=G019WLX2P7B)

`yarn install` in shell-nix fails with:

```
➤ YN0009: │ sharp@npm:0.34.2 couldn't be built successfully (exit code 1, logs can be found here: /tmp/xfs-fcfc7afa/build.log)
^C➤ YN0009: │ @parcel/watcher@npm:2.5.0 couldn't be built successfully (exit code 129, logs can be found here: /tmp/xfs-ccfdf164/build.log)
```

there are 2 reasons for that:
- nix derivation didnt have [libvips](https://github.com/libvips/libvips) installed
- `node-addon-api` version was incompatible:

```
yarn why node-addon-api


├─ @parcel/watcher@npm:2.5.0
│  └─ node-addon-api@npm:7.1.1 (via npm:^7.0.0)
│
├─ blake-hash@npm:2.0.0
│  └─ node-addon-api@npm:3.2.1 (via npm:^3.0.0)
│
├─ iconv-corefoundation@npm:1.1.7
│  └─ node-addon-api@npm:1.7.2 (via npm:^1.6.3)
│
└─ usb@npm:2.15.0
   └─ node-addon-api@npm:8.1.0 (via npm:^8.0.0)
```

there was version 3.2.1 installed in the root of monorepo (see node_modules/node-addon-api/package.json)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/nix-sharp&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/nix-sharp&lookback=7)