### PR TITLE
chore(message-system): T1B1 update banner, A/B test on trading, Polygon sync issue update

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -728,8 +728,24 @@
                             "vendor": "*"
                         },
                         {
+                            "model": "T1B1",
+                            "firmware": "1.13.0",
+                            "bootloader": "*",
+                            "variant": "*",
+                            "firmwareRevision": "*",
+                            "vendor": "*"
+                        },
+                        {
                             "model": "1",
                             "firmware": ">=1.12.1 <=1.13.0",
+                            "bootloader": "*",
+                            "variant": "*",
+                            "firmwareRevision": "*",
+                            "vendor": "*"
+                        },
+                        {
+                            "model": "1",
+                            "firmware": "1.13.0",
                             "bootloader": "*",
                             "variant": "*",
                             "firmwareRevision": "*",

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,6 +1,6 @@
 {
     "version": 1,
-    "timestamp": "2025-07-30T17:17:00+00:00",
+    "timestamp": "2025-07-31T00:00:00+00:00",
     "sequence": 99,
     "actions": [
         {
@@ -721,7 +721,7 @@
                     "devices": [
                         {
                             "model": "T1B1",
-                            "firmware": "1.12.1",
+                            "firmware": ">=1.12.1 <=1.13.0",
                             "bootloader": "*",
                             "variant": "*",
                             "firmwareRevision": "*",
@@ -729,7 +729,7 @@
                         },
                         {
                             "model": "1",
-                            "firmware": "1.12.1",
+                            "firmware": ">=1.12.1 <=1.13.0",
                             "bootloader": "*",
                             "variant": "*",
                             "firmwareRevision": "*",

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1463,5 +1463,31 @@
                 ]
             }
         }
+    ],
+    "experiments": [
+        {
+            "conditions": [
+                {
+                    "environment": {
+                        "desktop": "*",
+                        "mobile": "!",
+                        "web": "!"
+                    }
+                }
+            ],
+            "experiment": {
+                "id": "092db279-98dc-418e-bbfa-ef70716fb211",
+                "groups": [
+                    {
+                        "variant": "A",
+                        "percentage": 80
+                    },
+                    {
+                        "variant": "B",
+                        "percentage": 20
+                    }
+                ]
+            }
+        }
     ]
 }

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2025-07-30T17:00:00+00:00",
-    "sequence": 98,
+    "timestamp": "2025-07-30T17:17:00+00:00",
+    "sequence": 99,
     "actions": [
         {
             "conditions": [
@@ -1166,7 +1166,7 @@
                 "id": "41de1456-f845-4f36-9ec6-9c639a8155b1",
                 "priority": 92,
                 "dismissible": true,
-                "variant": "info",
+                "variant": "warning",
                 "category": ["banner"],
                 "content": {
                     "en": "We are experiencing syncing issues with the Polygon PoS network. This may temporarily result in errors or slow response times on Polygon PoS. This issue does not affect the safety of your Polygon PoS funds in any way. We apologize for the inconvenience.",


### PR DESCRIPTION
## Description

1. Adding A/B test for Trading feedback form
2. Changing message variant of the Polygon sync issues from "info" to "warning"
3. Adding message informing about FW update for devices with FW 1.13.0

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/message-system-update-0730&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/message-system-update-0730&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/message-system-update-0730&lookback=7)