### PR TITLE
fix(suite): ensure action button disables correctly on fiat change

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -259,12 +259,11 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
                 handleSubmit(() => {
                     handleChange();
                 })();
-
-                previousValues.current = values;
             }
+            previousValues.current = values;
         },
         500,
-        [previousValues, pageType, handleChange, handleSubmit],
+        [values, previousValues, pageType],
     );
 
     // call change handler on every change of select inputs


### PR DESCRIPTION
## Description

- added `values` into useDebounce dependencies to catch fiat/crypto input updates
- removed unstable functions (`handleChange`, `handleSubmit`) from dependency array
- moved previousValues.current update outside condition so both fiat and crypto changes are stored

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/14928
Resolve https://github.com/trezor/trezor-suite/issues/14927

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-fiat-form-debounce&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-fiat-form-debounce&lookback=7)