### PR TITLE
Feat e2e initial staking test

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/stakingSection.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/stakingSection.ts
@@ -7,6 +7,8 @@ export class StakingSection {
     readonly watchPeriod = '01:00';
     // Locators
     readonly stakingTabButton: Locator;
+    readonly stakingDashboardCard: Locator;
+    readonly stakingEmptyCard: Locator;
     readonly pendingAmount: Locator;
     readonly stakedAmount: Locator;
     readonly rewardsAmount: Locator;
@@ -18,9 +20,13 @@ export class StakingSection {
     readonly speedUpButton: Locator;
     readonly pendingTransactionText: Locator;
     readonly stakeMoreButton: Locator;
+    readonly startStakingButton: Locator;
     readonly continueButton: Locator;
+    readonly confirmButton: Locator;
     readonly acknowledgeCheckbox: Locator;
+    readonly everstakeAcknowledgeCheckbox: Locator;
     readonly confirmAndStakeButton: Locator;
+    readonly progressLabels: Locator;
     readonly transactionStatus: Locator;
     readonly transactionStatusContainer: Locator;
     readonly addingToPoolStatusContainer: Locator;
@@ -32,6 +38,8 @@ export class StakingSection {
 
     constructor(private readonly page: Page) {
         this.stakingTabButton = this.page.getByTestId('@wallet/menu/staking');
+        this.stakingDashboardCard = this.page.getByTestId('@wallet/staking/card');
+        this.stakingEmptyCard = this.page.getByTestId('@wallet/staking/empty-card');
         this.pendingAmount = this.page.getByTestId('@account/staking/pending');
         this.stakedAmount = this.page.getByTestId('@account/staking/staked');
         this.rewardsAmount = this.page.getByTestId('@account/staking/rewards');
@@ -47,9 +55,15 @@ export class StakingSection {
         this.speedUpButton = this.page.getByRole('button', { name: 'Speed up' });
         this.pendingTransactionText = this.page.getByText('Pending transaction•1');
         this.stakeMoreButton = this.page.getByRole('button', { name: 'Stake more' });
+        this.startStakingButton = this.page.getByRole('button', { name: 'Start staking' });
         this.continueButton = this.page.getByRole('button', { name: 'Continue' });
+        this.confirmButton = this.page.getByRole('button', { name: 'Confirm' });
         this.acknowledgeCheckbox = this.page.getByTestId('@staking/acknowledge-checkbox');
+        this.everstakeAcknowledgeCheckbox = this.page.getByTestId(
+            '@staking/everstake-acknowledge-checkbox',
+        );
         this.confirmAndStakeButton = this.page.getByRole('button', { name: 'Confirm & stake' });
+        this.progressLabels = this.page.getByTestId('@staking/progress-labels');
         this.transactionStatus = this.page.getByTestId('@staking/transaction-status');
         this.transactionStatusContainer = this.page.getByTestId(
             '@staking/transaction-status/container',
@@ -102,5 +116,27 @@ export class StakingSection {
             'background-color',
             hexToRgba(currentPhaseColors.rewardsStep),
         );
+    }
+
+    async expectStakingAmounts(options: {
+        pending: string | 'hidden';
+        staked: string | 'hidden';
+        rewards: string | 'hidden';
+        unstaking: string | 'hidden';
+    }) {
+        const amounts = [
+            { locator: this.pendingAmount, value: options.pending },
+            { locator: this.stakedAmount, value: options.staked },
+            { locator: this.rewardsAmount, value: options.rewards },
+            { locator: this.unstakingAmount, value: options.unstaking },
+        ];
+
+        for (const { locator, value } of amounts) {
+            if (value === 'hidden') {
+                await expect(locator).toBeHidden();
+            } else {
+                await expect(locator).toHaveText(value);
+            }
+        }
     }
 }

--- a/packages/suite-desktop-core/e2e/tests/staking/initial-stake.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/staking/initial-stake.test.ts
@@ -18,6 +18,27 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
             await onboardingPage.completeOnboarding();
             await settingsPage.navigateTo('coins');
             await blockbookMock.start('eth');
+            // Set initial empty state for ETH account
+            blockbookMock.updateAccountState({
+                txs: 0,
+                nonTokenTxs: 0,
+                internalTxs: 0,
+                transactions: [],
+                nonce: '0',
+                stakingPools: [
+                    {
+                        contract: '0x624087DD1904ab122A32878Ce9e933C7071F53B9',
+                        name: 'Everstake',
+                        pendingBalance: '0',
+                        pendingDepositedBalance: '0',
+                        depositedBalance: '0',
+                        withdrawTotalAmount: '0',
+                        claimableAmount: '0',
+                        restakedReward: '0',
+                        autocompoundBalance: '0',
+                    },
+                ],
+            });
 
             await settingsPage.coins.disableNetwork('btc');
             await settingsPage.coins.enableNetwork('eth');
@@ -26,30 +47,15 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
 
             await dashboardPage.dashboardMenuButton.click();
             await page.discoveryShouldFinish();
-
-            blockbookMock.updateAccountState({
-                stakingPools: [
-                    {
-                        contract: '0x624087DD1904ab122A32878Ce9e933C7071F53B9',
-                        name: 'Everstake',
-                        pendingBalance: '0', //sets to zero
-                        pendingDepositedBalance: '0', //sets to zero
-                        depositedBalance: '3000000000000000000000',
-                        withdrawTotalAmount: '4000000000000000000000',
-                        claimableAmount: '5000000000000000000000',
-                        restakedReward: '234000000000000000000',
-                        autocompoundBalance: '7000000000000000000000',
-                    },
-                ],
-            });
         },
     );
 
     test(
-        'stake on ETH account',
+        'first stake on ETH account',
         {
             annotation: createTestAnnotation({
-                testCase: 'Verifies that a user can stake from his Ethereum account.',
+                testCase:
+                    'Verifies that a user can do first stake from his clean Ethereum account.',
                 category: TestCategory.ETH,
                 priority: TestPriority.Critical,
                 stream: TestStream.Trends,
@@ -60,17 +66,18 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                 await page.clock.install();
                 await walletPage.openAccount({ symbol: 'eth', type: 'normal', atIndex: 0 });
                 await stakingSection.stakingTabButton.click();
-                await stakingSection.expectStakingAmounts({
-                    pending: 'hidden',
-                    staked: '3,000',
-                    rewards: '234',
-                    unstaking: '4,000',
-                });
-                await stakingSection.expectProgressIndicatorsToMatchPhase('receivingRewards');
+                await expect(stakingSection.stakingDashboardCard).toBeHidden();
+                await expect(stakingSection.stakingEmptyCard).toBeVisible();
+                await expect(stakingSection.stakingEmptyCard).toContainText('Stake ETH');
             });
 
             await test.step('Open and fill staking form', async () => {
-                await stakingSection.stakeMoreButton.click();
+                await stakingSection.startStakingButton.click();
+                await expect(page.getByTestId('@modal/header')).toHaveText('Staking in a nutshell');
+                await stakingSection.continueButton.click();
+                await expect(page.getByTestId('@modal/header')).toHaveText('Stake ETH');
+                await stakingSection.everstakeAcknowledgeCheckbox.click();
+                await stakingSection.confirmButton.click();
                 await expect(stakingSection.availableBalanceWithSymbol).toHaveText('1,234 ETH');
                 await stakingSection.cryptoInput.fill('0.100204158497493752');
             });
@@ -111,24 +118,24 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
             await test.step('Stake', async () => {
                 blockbookMock.updateAccountState({
                     balance: '1233899795841502506248', // lowered by staked amount
-                    transactions: [ETH_STAKE_PENDING_TX, ETH_BASE_TX],
+                    transactions: [ETH_STAKE_PENDING_TX],
                     unconfirmedTxs: 1,
-                    txs: 2,
-                    nonTokenTxs: 2,
+                    txs: 1,
+                    nonTokenTxs: 1,
                     stakingPools: [
                         {
                             contract: '0x624087DD1904ab122A32878Ce9e933C7071F53B9',
                             name: 'Everstake',
                             pendingBalance: '100204158497493752', // increased by staked amount
                             pendingDepositedBalance: '0',
-                            depositedBalance: '3000000000000000000000',
-                            withdrawTotalAmount: '4000000000000000000000',
-                            claimableAmount: '5000000000000000000000',
-                            restakedReward: '234000000000000000000',
-                            autocompoundBalance: '7000000000000000000000',
+                            depositedBalance: '0',
+                            withdrawTotalAmount: '0',
+                            claimableAmount: '0',
+                            restakedReward: '0',
+                            autocompoundBalance: '0',
                         },
                     ],
-                    nonce: '2',
+                    nonce: '1',
                 });
                 await devicePrompt.sendButton.click();
             });
@@ -140,9 +147,9 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                 await expect(stakingSection.speedUpButton).toBeEnabled();
                 await stakingSection.expectStakingAmounts({
                     pending: '0.100204158497493752',
-                    staked: '3,000',
-                    rewards: '234',
-                    unstaking: '4,000',
+                    staked: '0',
+                    rewards: '0',
+                    unstaking: 'hidden',
                 });
             });
 
@@ -156,11 +163,11 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                             name: 'Everstake',
                             pendingBalance: '0', // lowered by confirmation
                             pendingDepositedBalance: '100204158497493752', // increased by confirmation
-                            depositedBalance: '3000000000000000000000',
-                            withdrawTotalAmount: '4000000000000000000000',
-                            claimableAmount: '5000000000000000000000',
-                            restakedReward: '234000000000000000000',
-                            autocompoundBalance: '7000000000000000000000',
+                            depositedBalance: '0',
+                            withdrawTotalAmount: '0',
+                            claimableAmount: '0',
+                            restakedReward: '0',
+                            autocompoundBalance: '0',
                         },
                     ],
                 });
@@ -169,9 +176,9 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                 await stakingSection.expectProgressIndicatorsToMatchPhase('addingToPool');
                 await stakingSection.expectStakingAmounts({
                     pending: '0.100204158497493752',
-                    staked: '3,000',
-                    rewards: '234',
-                    unstaking: '4,000',
+                    staked: '0',
+                    rewards: '0',
+                    unstaking: 'hidden',
                 });
                 await expect(stakingSection.pendingTransactionText).toBeHidden();
                 await expect(stakingSection.speedUpButton).toBeHidden();
@@ -185,33 +192,24 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                             name: 'Everstake',
                             pendingBalance: '0',
                             pendingDepositedBalance: '0', // lowered by activation
-                            depositedBalance: '3000100204158497493752', // increased by activation
-                            withdrawTotalAmount: '4000000000000000000000',
-                            claimableAmount: '5000000000000000000000',
-                            restakedReward: '234000000000000000000',
-                            autocompoundBalance: '7000000000000000000000',
+                            depositedBalance: '100204158497493752', // increased by activation
+                            withdrawTotalAmount: '0',
+                            claimableAmount: '0',
+                            restakedReward: '0',
+                            autocompoundBalance: '0',
                         },
                     ],
                 });
                 await page.clock.fastForward(stakingSection.watchPeriod);
                 await stakingSection.expectStakingAmounts({
                     pending: 'hidden',
-                    staked: '3,000.100204158497493752',
-                    rewards: '234',
-                    unstaking: '4,000',
+                    staked: '0.100204158497493752',
+                    rewards: '0',
+                    unstaking: 'hidden',
                 });
                 await stakingSection.expectProgressIndicatorsToMatchPhase('receivingRewards');
-            });
-
-            await test.step('Verify banner about instant staking', async () => {
-                await expect(stakingSection.instantBannerHeader).toHaveText(
-                    '0.100204158497493752 ETH staked instantly!',
-                );
-                await expect(stakingSection.instantBannerParagraph).toHaveText(
-                    "You've instantly staked 0.100204158497493752 ETH. The remaining ETH will be staked within 1 day.",
-                );
-                await stakingSection.instantBannerGotItButton.click();
-                await expect(stakingSection.instantBanner).toBeHidden();
+                await expect(stakingSection.stakeMoreButton).toBeEnabled();
+                await expect(stakingSection.unstakeToClaimButton).toBeDisabled();
             });
         },
     );

--- a/packages/suite-desktop-core/e2e/tests/staking/unstake.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/staking/unstake.test.ts
@@ -47,10 +47,12 @@ test.describe('ETH unstaking', { tag: ['@group=staking'] }, () => {
                 await page.clock.install();
                 await walletPage.openAccount({ symbol: 'eth', type: 'normal', atIndex: 0 });
                 await stakingSection.stakingTabButton.click();
-                await expect(stakingSection.pendingAmount).toHaveText('3,000');
-                await expect(stakingSection.stakedAmount).toHaveText('3,000');
-                await expect(stakingSection.rewardsAmount).toHaveText('234');
-                await expect(stakingSection.unstakingAmount).toHaveText('4,000');
+                await stakingSection.expectStakingAmounts({
+                    pending: '3,000',
+                    staked: '3,000',
+                    rewards: '234',
+                    unstaking: '4,000',
+                });
             });
 
             await test.step('Open unstaking form', async () => {
@@ -113,7 +115,12 @@ test.describe('ETH unstaking', { tag: ['@group=staking'] }, () => {
             await test.step('Verify pending transaction and not being able to unstake more', async () => {
                 await expect(stakingSection.pendingTransactionText).toBeVisible();
                 await expect(stakingSection.speedUpButton).toBeEnabled();
-                await expect(stakingSection.unstakingAmount).toHaveText('4,000');
+                await stakingSection.expectStakingAmounts({
+                    pending: '3,000',
+                    staked: '3,000',
+                    rewards: '234',
+                    unstaking: '4,000',
+                });
                 await expect(stakingSection.unstakeToClaimButton).toBeDisabled();
             });
 
@@ -130,13 +137,18 @@ test.describe('ETH unstaking', { tag: ['@group=staking'] }, () => {
                             depositedBalance: '3000000000000000000000',
                             withdrawTotalAmount: '11000000000000000000000', // Increases by 7000
                             claimableAmount: '5000000000000000000000',
-                            restakedReward: '2340000000000000000000',
+                            restakedReward: '234000000000000000000',
                             autocompoundBalance: '0',
                         },
                     ],
                 });
                 await page.clock.fastForward(stakingSection.watchPeriod);
-                await expect(stakingSection.unstakingAmount).toHaveText('11,000');
+                await stakingSection.expectStakingAmounts({
+                    pending: '3,000',
+                    staked: '3,000',
+                    rewards: '234',
+                    unstaking: '11,000',
+                });
                 await expect(stakingSection.pendingTransactionText).toBeHidden();
                 await expect(stakingSection.speedUpButton).toBeHidden();
             });

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/EverstakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/EverstakeModal.tsx
@@ -113,6 +113,7 @@ export const EverstakeModal = ({ onCancel }: EverstakeModalProps) => {
             </Column>
             <Card>
                 <Checkbox
+                    data-testid="@staking/everstake-acknowledge-checkbox"
                     verticalAlignment="center"
                     onClick={() => setHasAgreed(!hasAgreed)}
                     isChecked={hasAgreed}

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
@@ -101,6 +101,7 @@ export const EmptyStakingCard = () => {
 
     return (
         <DashboardSection
+            data-testid="@wallet/staking/empty-card"
             heading={<Translation id="TR_STAKE_NETWORK" values={{ symbol: displaySymbol }} />}
         >
             {!isDeviceConnected && <ConnectDeviceGenericPromo />}

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
@@ -194,7 +194,7 @@ export const StakingCard = ({
     const isEthereumNetwork = selectedAccount.networkType === 'ethereum';
 
     return (
-        <Card>
+        <Card data-testid="@wallet/staking/card">
             <Column flex="1" gap={spacings.xxl}>
                 {(isStakeConfirming || isTxStatusShown) && (
                     <ProgressLabels labels={progressLabelsData} />


### PR DESCRIPTION
Another staking test. This time account starts empty and user see the welcome flow.
Plus I have refactored verification methods shared between these tests.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-e2e-new-staking-test&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-e2e-new-staking-test&lookback=7)