### PR TITLE
feat(suite): disable cancel and bump for uncontrolled inputs

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
@@ -117,9 +117,10 @@ export const TxDetailModal = ({
         hasRbfParams(tx) &&
         networkFeatures?.includes('rbf') &&
         !tx.deadline &&
+        tx.type !== 'joint' &&
         selectedAccount.status === 'loaded';
 
-    const canCancelTransaction = network.networkType === 'bitcoin';
+    const canCancelTransaction = network.networkType === 'bitcoin' && tx.type !== 'joint';
 
     if (section === 'bump-fee' && canReplaceTransaction) {
         return (

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -144,7 +144,10 @@ export const TransactionItem = memo(
         const isExpandable = allOutputs.length - DEFAULT_LIMIT > 0;
         const toExpand = allOutputs.length - DEFAULT_LIMIT - limit;
 
-        const isTxCancellable = transaction.type !== 'self' && network.networkType === 'bitcoin';
+        const isTxCancellable =
+            transaction.type !== 'self' &&
+            transaction.type !== 'joint' &&
+            network.networkType === 'bitcoin';
 
         const openTxDetailsModal = ({ flow }: OpenModalParams) => {
             if (isActionDisabled) return; // open explorer

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionGroupedList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionGroupedList.tsx
@@ -65,7 +65,7 @@ export const TransactionGroupedList = ({
                         disableBumpFee={
                             network.networkType === 'ethereum'
                                 ? item.tx.txid !== transactionWithLowestNonce?.txid
-                                : false
+                                : item.tx.type === 'joint'
                         }
                     />
                 ),


### PR DESCRIPTION
Disables cancel and bump for `txs` where user does not control all inputs.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18011



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/bump-and-cancel-shouldnt-be-available-for-uncontrolled-inputs&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/bump-and-cancel-shouldnt-be-available-for-uncontrolled-inputs&lookback=7)