### PR TITLE
chore(message-system): T1B1 update banner, A/B test on trading, Polygon sync issue update

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2025-07-30T17:00:00+00:00",
-    "sequence": 98,
+    "timestamp": "2025-08-01T00:00:00+00:00",
+    "sequence": 99,
     "actions": [
         {
             "conditions": [

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -653,7 +653,7 @@
                     "devices": [
                         {
                             "model": "T1B1",
-                            "firmware": "1.12.1",
+                            "firmware": ">=1.12.1 <=1.13.0",
                             "bootloader": "*",
                             "variant": "*",
                             "firmwareRevision": "*",
@@ -661,7 +661,7 @@
                         },
                         {
                             "model": "1",
-                            "firmware": "1.12.1",
+                            "firmware": ">=1.12.1 <=1.13.0",
                             "bootloader": "*",
                             "variant": "*",
                             "firmwareRevision": "*",

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1152,43 +1152,6 @@
                 {
                     "settings": [
                         {
-                            "pol": true
-                        }
-                    ],
-                    "environment": {
-                        "desktop": "*",
-                        "mobile": "*",
-                        "web": "*"
-                    }
-                }
-            ],
-            "message": {
-                "id": "41de1456-f845-4f36-9ec6-9c639a8155b1",
-                "priority": 92,
-                "dismissible": true,
-                "variant": "info",
-                "category": ["banner"],
-                "content": {
-                    "en": "We are experiencing syncing issues with the Polygon PoS network. This may temporarily result in errors or slow response times on Polygon PoS. This issue does not affect the safety of your Polygon PoS funds in any way. We apologize for the inconvenience.",
-                    "es": "Estamos experimentando problemas de sincronización con la red de Polygon PoS. Esto puede resultar temporalmente en errores o tiempos de respuesta lentos en Polygon PoS. Este problema no afecta en absoluto la seguridad de sus fondos de Polygon PoS. Pedimos disculpas por las molestias.",
-                    "cs": "Potýkáme se s dočasnými potížemi se synchronizací sítě Polygon PoS, které mohou vést k chybám nebo pomalejší odezvě. Bezpečnost vašich prostředků na síti Polygon PoS tím však není nijak ohrožena. Omlouváme se za nepříjemnosti a děkujeme za pochopení.",
-                    "ru": "У нас возникли проблемы с синхронизацией сети Polygon PoS. Это может временно привести к ошибкам или медленным временам ответа на Polygon PoS. Эта проблема никоим образом не влияет на безопасность ваших средств Polygon PoS. Приносим извинения за неудобства.",
-                    "ja": "Polygon PoSネットワークの同期に問題が発生しています。これにより、Polygon PoSで一時的にエラーや応答時間が遅くなる場合があります。この問題は、Polygon PoSの資金の安全性にまったく影響しません。ご不便をおかけして申し訳ありません。",
-                    "hu": "Problémák merültek fel az Polygon PoS hálózat szinkronizálásával. Ez ideiglenesen hibákat vagy lassú válaszidőket eredményezhet az Polygon PoS-en. Ez a probléma semmilyen módon nem érinti az Polygon PoS pénzügyeinek biztonságát. Elnézést kérünk a kellemetlenségért.",
-                    "it": "Stiamo riscontrando problemi di sincronizzazione con la rete Polygon PoS. Ciò potrebbe comportare temporaneamente errori o tempi di risposta lenti su Polygon PoS. Questo problema non influisce in alcun modo sulla sicurezza dei tuoi fondi Polygon PoS. Ci scusiamo per l'inconveniente.",
-                    "fr": "Nous rencontrons des problèmes de synchronisation avec le réseau Polygon PoS. Cela peut entraîner temporairement des erreurs ou des temps de réponse lents sur Polygon PoS. Ce problème n'affecte en aucun cas la sécurité de vos fonds Polygon PoS. Nous nous excusons pour la gêne occasionnée.",
-                    "de": "Wir haben Probleme mit der Synchronisierung des Polygon PoS-Netzwerks. Dies kann vorübergehend zu Fehlern oder langsamen Antwortzeiten auf Polygon PoS führen. Dieses Problem beeinträchtigt die Sicherheit Ihrer Polygon PoS-Fonds in keiner Weise. Wir entschuldigen uns für die Unannehmlichkeiten.",
-                    "tr": "Polygon PoS ağı ile senkronizasyon sorunları yaşıyoruz. Bu, geçici olarak Polygon PoS'da hatalara veya yavaş yanıt sürelerine neden olabilir. Bu sorun, Polygon PoS fonlarınızın güvenliğini hiçbir şekilde etkilemez. Rahatsızlık için özür dileriz.",
-                    "pt": "Estamos enfrentando problemas de sincronização com a rede Polygon PoS. Isso pode resultar temporariamente em erros ou tempos de respuesta lentos na Polygon PoS. Este problema não afeta de forma alguma a segurança dos seus fundos Polygon PoS. Pedimos desculpas pelo inconveniente.",
-                    "uk": "У нас виникли проблеми з синхронізацією мережі Polygon PoS. Це може тимчасово призвести до помилок або повільних часів відповіді на Polygon PoS. Ця проблема ніяк не впливає на безпеку ваших коштів Polygon PoS. Приносимо вибачення за незручності."
-                }
-            }
-        },
-        {
-            "conditions": [
-                {
-                    "settings": [
-                        {
                             "INPUT HERE": true
                         }
                     ],

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1166,7 +1166,7 @@
                 "id": "c5b85f25-7d59-428a-9742-78df00a53577",
                 "priority": 92,
                 "dismissible": true,
-                "variant": "info",
+                "variant": "warning",
                 "category": ["banner"],
                 "content": {
                     "en": "We are experiencing syncing issues with the INPUT HERE network. This may temporarily result in errors or slow response times on INPUT HERE. This issue does not affect the safety of your INPUT HERE funds in any way. We apologize for the inconvenience.",

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1463,5 +1463,31 @@
                 ]
             }
         }
+    ],
+    "experiments": [
+        {
+            "conditions": [
+                {
+                    "environment": {
+                        "desktop": "*",
+                        "mobile": "!",
+                        "web": "!"
+                    }
+                }
+            ],
+            "experiment": {
+                "id": "092db279-98dc-418e-bbfa-ef70716fb211",
+                "groups": [
+                    {
+                        "variant": "A",
+                        "percentage": 80
+                    },
+                    {
+                        "variant": "B",
+                        "percentage": 20
+                    }
+                ]
+            }
+        }
     ]
 }


### PR DESCRIPTION
## Description

1. Adding A/B test for Trading feedback form
2. Removing message about the Polygon sync issues 
3. Changing message variant of the sync issues template from "info" to "warning"
4. Adding message informing about FW update for devices with FW 1.13.0
5. Bumping sequence from "98" to "99" and updating timestamp

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/message-system-update-0731&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/message-system-update-0731&lookback=7)