### PR TITLE
feat(suite): View only toast when disconnect second device

### DIFF
--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -13,8 +13,8 @@ export const SET_LANGUAGE = '@suite/set-language';
 export const SET_DEBUG_MODE = '@suite/set-debug-mode';
 export const SET_FLAG = '@suite/set-flag';
 export const SET_RECENTLY_DISCONNECTED_DEVICE = '@suite/set-recently-disconnected-device';
-export const SET_SEEN_DISCONNECT_NOTIFICATION_FOR_DEVICE_IDS =
-    '@suite/set-seen-disconnect-notification-for-device-ids';
+export const ADD_DEVICE_ID_TO_SEEN_DISCONNECT_NOTIFICATION =
+    '@suite/add-device-id-to-seen-disconnect-notification';
 export const ONLINE_STATUS = '@suite/online-status';
 export const TOR_STATUS = '@suite/tor-status';
 export const TOR_BOOTSTRAP = '@suite/tor-bootstrap';

--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -13,6 +13,8 @@ export const SET_LANGUAGE = '@suite/set-language';
 export const SET_DEBUG_MODE = '@suite/set-debug-mode';
 export const SET_FLAG = '@suite/set-flag';
 export const SET_RECENTLY_DISCONNECTED_DEVICE = '@suite/set-recently-disconnected-device';
+export const SET_SEEN_DISCONNECT_NOTIFICATION_FOR_DEVICE_IDS =
+    '@suite/set-seen-disconnect-notification-for-device-ids';
 export const ONLINE_STATUS = '@suite/online-status';
 export const TOR_STATUS = '@suite/tor-status';
 export const TOR_BOOTSTRAP = '@suite/tor-bootstrap';

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -97,6 +97,8 @@ const removeCoinjoinRelatedSetting = (state: AppState) => {
             flags: state.suite.flags,
             evmSettings: state.suite.evmSettings,
             dismissedTradingTerms: state.suite.dismissedTradingTerms,
+            seenDisconnectNotificationForDeviceIds:
+                state.suite.seenDisconnectNotificationForDeviceIds,
         },
         'suite',
         true,
@@ -385,6 +387,7 @@ export const saveSuiteSettings = () => async (_dispatch: Dispatch, getState: Get
             flags: suite.flags,
             evmSettings: suite.evmSettings,
             dismissedTradingTerms: suite.dismissedTradingTerms,
+            seenDisconnectNotificationForDeviceIds: suite.seenDisconnectNotificationForDeviceIds,
         },
         'suite',
         true,

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -56,6 +56,10 @@ export type SuiteAction =
           payload: string | null;
       }
     | {
+          type: typeof SUITE.SET_SEEN_DISCONNECT_NOTIFICATION_FOR_DEVICE_IDS;
+          payload: string[];
+      }
+    | {
           type: typeof SUITE.EVM_CONFIRM_EXPLANATION_MODAL;
           symbol: keyof EvmSettings['confirmExplanationModalClosed'];
           route: string;
@@ -149,6 +153,10 @@ export const setFlag = (key: keyof AppState['suite']['flags'], value: boolean): 
 
 export const setRecentlyDisconnectedDevice = (payload: string | null): SuiteAction => ({
     type: SUITE.SET_RECENTLY_DISCONNECTED_DEVICE,
+    payload,
+});
+export const setSeenDisconnectNotificationForDeviceIds = (payload: string[]): SuiteAction => ({
+    type: SUITE.SET_SEEN_DISCONNECT_NOTIFICATION_FOR_DEVICE_IDS,
     payload,
 });
 

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -56,8 +56,8 @@ export type SuiteAction =
           payload: string | null;
       }
     | {
-          type: typeof SUITE.SET_SEEN_DISCONNECT_NOTIFICATION_FOR_DEVICE_IDS;
-          payload: string[];
+          type: typeof SUITE.ADD_DEVICE_ID_TO_SEEN_DISCONNECT_NOTIFICATION;
+          payload: { deviceId: string };
       }
     | {
           type: typeof SUITE.EVM_CONFIRM_EXPLANATION_MODAL;
@@ -155,9 +155,9 @@ export const setRecentlyDisconnectedDevice = (payload: string | null): SuiteActi
     type: SUITE.SET_RECENTLY_DISCONNECTED_DEVICE,
     payload,
 });
-export const setSeenDisconnectNotificationForDeviceIds = (payload: string[]): SuiteAction => ({
-    type: SUITE.SET_SEEN_DISCONNECT_NOTIFICATION_FOR_DEVICE_IDS,
-    payload,
+export const addDeviceIdToSeenDisconnectNotification = (deviceId: string): SuiteAction => ({
+    type: SUITE.ADD_DEVICE_ID_TO_SEEN_DISCONNECT_NOTIFICATION,
+    payload: { deviceId },
 });
 
 export const initialRunCompleted = () => (dispatch: Dispatch, getState: GetState) => {

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -152,6 +152,7 @@ const getInitialState = ({
         countryCode: null,
         prefillFields: {},
         recentlyDisconnectedDevice: null,
+        seenDisconnectNotificationForDeviceIds: [],
         ...suite,
     },
     device: {

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/AutoEjectRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/AutoEjectRenderer.tsx
@@ -1,0 +1,32 @@
+import { resetProtocol } from 'src/actions/suite/protocolActions';
+import type { NotificationRendererProps } from 'src/components/suite';
+import { useDispatch } from 'src/hooks/suite';
+
+import { goto } from '../../../../actions/suite/routerActions';
+import { SettingsAnchor } from '../../../../constants/suite/anchors';
+
+export const AutoEjectRenderer = ({ render: View, notification }: NotificationRendererProps) => {
+    const dispatch = useDispatch();
+
+    const onCancel = () => dispatch(resetProtocol);
+
+    const handleActionClick = () => {
+        dispatch(goto('settings-index', { anchor: SettingsAnchor.AutoEject }));
+    };
+
+    return (
+        <View
+            message="TOAST_AUTO_EJECT_SETTINGS"
+            action={{
+                onClick: handleActionClick,
+                label: 'TR_SETTINGS',
+                position: 'right',
+                variant: 'tertiary',
+            }}
+            onCancel={onCancel}
+            notification={notification}
+            messageValues={undefined}
+            variant="transparent"
+        />
+    );
+};

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -11,6 +11,7 @@ import { NotificationViewProps } from 'src/components/suite';
 import type { ExtendedMessageDescriptor } from 'src/types/suite';
 
 import { ActionRenderer } from './ActionRenderer';
+import { AutoEjectRenderer } from './AutoEjectRenderer';
 import { CoinProtocolRenderer } from './CoinProtocolRenderer';
 import { TransactionRenderer } from './TransactionRenderer';
 
@@ -156,6 +157,8 @@ export const NotificationRenderer = ({
             });
         case 'add-token-success':
             return success(render, notification, 'TR_ADD_TOKEN_TOAST_SUCCESS');
+        case 'auto-eject-settings':
+            return <AutoEjectRenderer render={render} notification={notification} />;
         case 'user-feedback-send-success':
             return success(render, notification, 'TR_GUIDE_FEEDBACK_SENT');
         case 'user-feedback-send-error':

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -143,6 +143,7 @@ export interface SuiteState {
     prefillFields: PrefillFields;
     settings: SuiteSettings;
     recentlyDisconnectedDevice: string | null;
+    seenDisconnectNotificationForDeviceIds: string[];
 }
 
 const initialState: SuiteState = {
@@ -220,6 +221,7 @@ const initialState: SuiteState = {
         autoEject: false,
     },
     recentlyDisconnectedDevice: null,
+    seenDisconnectNotificationForDeviceIds: [],
 };
 
 const changeLock = (
@@ -250,6 +252,10 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
                     ...draft.dismissedTradingTerms,
                     ...action.payload.suiteSettings?.dismissedTradingTerms,
                 };
+                draft.seenDisconnectNotificationForDeviceIds = [
+                    ...draft.seenDisconnectNotificationForDeviceIds,
+                    ...(action.payload.suiteSettings?.seenDisconnectNotificationForDeviceIds ?? []),
+                ];
                 draft.settings = {
                     ...draft.settings,
                     ...action.payload.suiteSettings?.settings,
@@ -287,6 +293,9 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
 
             case SUITE.SET_RECENTLY_DISCONNECTED_DEVICE:
                 draft.recentlyDisconnectedDevice = action.payload;
+                break;
+            case SUITE.SET_SEEN_DISCONNECT_NOTIFICATION_FOR_DEVICE_IDS:
+                draft.seenDisconnectNotificationForDeviceIds = action.payload;
                 break;
 
             case SUITE.EVM_CONFIRM_EXPLANATION_MODAL:

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -294,8 +294,11 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
             case SUITE.SET_RECENTLY_DISCONNECTED_DEVICE:
                 draft.recentlyDisconnectedDevice = action.payload;
                 break;
-            case SUITE.SET_SEEN_DISCONNECT_NOTIFICATION_FOR_DEVICE_IDS:
-                draft.seenDisconnectNotificationForDeviceIds = action.payload;
+            case SUITE.ADD_DEVICE_ID_TO_SEEN_DISCONNECT_NOTIFICATION:
+                draft.seenDisconnectNotificationForDeviceIds = [
+                    ...draft.seenDisconnectNotificationForDeviceIds,
+                    action.payload.deviceId,
+                ];
                 break;
 
             case SUITE.EVM_CONFIRM_EXPLANATION_MODAL:

--- a/packages/suite/src/storage/definitions.ts
+++ b/packages/suite/src/storage/definitions.ts
@@ -66,6 +66,7 @@ export interface SuiteDBSchema extends DBSchema {
             flags: SuiteState['flags'];
             evmSettings: SuiteState['evmSettings'];
             dismissedTradingTerms: SuiteState['dismissedTradingTerms'];
+            seenDisconnectNotificationForDeviceIds: SuiteState['seenDisconnectNotificationForDeviceIds'];
         };
     };
     historicRates: {

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4127,6 +4127,10 @@ export default defineMessages({
         id: 'TOAST_VERIFY_MESSAGE_ERROR',
         defaultMessage: 'Message verification error: {error}',
     },
+    TOAST_AUTO_EJECT_SETTINGS: {
+        id: 'TOAST_AUTO_EJECT_SETTINGS',
+        defaultMessage: 'Wallet balances stay visible',
+    },
     TOAST_AUTO_UPDATER_ERROR: {
         id: 'TOAST_AUTO_UPDATER_ERROR',
         defaultMessage: 'Update error ({state})',

--- a/packages/suite/src/views/dashboard/index.tsx
+++ b/packages/suite/src/views/dashboard/index.tsx
@@ -14,6 +14,7 @@ import { DashboardPromoBanner } from './DashboardPromoBanner/DashboardPromoBanne
 import { DesktopSuitePromoBanner } from './DesktopSuitePromoBanner';
 import { PortfolioCard } from './PortfolioCard/PortfolioCard';
 import { StakeEthCard } from './StakeEthCard/StakeEthCard';
+import { useNotificationForDisconnectedDevice } from './useNotificationForDisconnectedDevice';
 
 const Container = styled.div`
     display: flex;
@@ -23,6 +24,7 @@ const Container = styled.div`
 
 export const Dashboard = () => {
     useLayout('Home', <PageHeader />);
+    useNotificationForDisconnectedDevice();
 
     return (
         <Column gap={spacings.xxxxl} data-testid="@dashboard/index">

--- a/packages/suite/src/views/dashboard/useNotificationForDisconnectedDevice.tsx
+++ b/packages/suite/src/views/dashboard/useNotificationForDisconnectedDevice.tsx
@@ -9,32 +9,32 @@ import { useDispatch, useSelector } from '../../hooks/suite';
 export const useNotificationForDisconnectedDevice = () => {
     const dispatch = useDispatch();
 
+    const selectedDevice = useSelector(selectSelectedDevice);
     const seenDisconnectNotificationForDeviceIds = useSelector(
         state => state.suite.seenDisconnectNotificationForDeviceIds,
     );
+    const recentlyDisconnectedDevice = useSelector(state => state.suite.recentlyDisconnectedDevice);
     const hasSeenDisconnectTooltip = useSelector(
         state => state.suite.flags.hasSeenDisconnectTooltip,
     );
-    const recentlyDisconnectedDevice = useSelector(state => state.suite.recentlyDisconnectedDevice);
-    const selectedDevice = useSelector(selectSelectedDevice);
 
     useEffect(() => {
         const deviceId = selectedDevice?.id;
-        const shouldShowNotification =
-            deviceId && seenDisconnectNotificationForDeviceIds
-                ? seenDisconnectNotificationForDeviceIds.every(id => id !== selectedDevice?.id)
+
+        if (deviceId) {
+            const isNotificationSeenOnThisDevice = seenDisconnectNotificationForDeviceIds
+                ? seenDisconnectNotificationForDeviceIds.some(id => id === selectedDevice?.id)
                 : false;
 
-        const isNotificationVisible =
-            deviceId &&
-            recentlyDisconnectedDevice === deviceId &&
-            shouldShowNotification &&
-            hasSeenDisconnectTooltip;
+            const isNotificationVisible =
+                recentlyDisconnectedDevice === deviceId &&
+                !isNotificationSeenOnThisDevice &&
+                hasSeenDisconnectTooltip;
 
-        if (isNotificationVisible) {
-            dispatch(notificationsActions.addToast({ type: 'auto-eject-settings' }));
-
-            dispatch(addDeviceIdToSeenDisconnectNotification(deviceId));
+            if (isNotificationVisible) {
+                dispatch(notificationsActions.addToast({ type: 'auto-eject-settings' }));
+                dispatch(addDeviceIdToSeenDisconnectNotification(deviceId));
+            }
         }
     }, [
         dispatch,
@@ -42,6 +42,5 @@ export const useNotificationForDisconnectedDevice = () => {
         recentlyDisconnectedDevice,
         seenDisconnectNotificationForDeviceIds,
         selectedDevice?.id,
-        selectedDevice?.state,
     ]);
 };

--- a/packages/suite/src/views/dashboard/useNotificationForDisconnectedDevice.tsx
+++ b/packages/suite/src/views/dashboard/useNotificationForDisconnectedDevice.tsx
@@ -1,0 +1,52 @@
+import { useEffect } from 'react';
+
+import { notificationsActions } from '@suite-common/toast-notifications';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
+
+import { setSeenDisconnectNotificationForDeviceIds } from '../../actions/suite/suiteActions';
+import { useDispatch, useSelector } from '../../hooks/suite';
+
+export const useNotificationForDisconnectedDevice = () => {
+    const dispatch = useDispatch();
+
+    const seenDisconnectNotificationForDeviceIds = useSelector(
+        state => state.suite.seenDisconnectNotificationForDeviceIds,
+    );
+    const hasSeenDisconnectTooltip = useSelector(
+        state => state.suite.flags.hasSeenDisconnectTooltip,
+    );
+    const recentlyDisconnectedDevice = useSelector(state => state.suite.recentlyDisconnectedDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
+
+    useEffect(() => {
+        const deviceId = selectedDevice?.id;
+        const shouldShowNotification =
+            deviceId && seenDisconnectNotificationForDeviceIds
+                ? seenDisconnectNotificationForDeviceIds.every(id => id !== selectedDevice?.id)
+                : false;
+
+        const isNotificationVisible =
+            deviceId &&
+            recentlyDisconnectedDevice === deviceId &&
+            shouldShowNotification &&
+            hasSeenDisconnectTooltip;
+
+        if (isNotificationVisible) {
+            dispatch(notificationsActions.addToast({ type: 'auto-eject-settings' }));
+
+            dispatch(
+                setSeenDisconnectNotificationForDeviceIds([
+                    ...seenDisconnectNotificationForDeviceIds,
+                    deviceId,
+                ]),
+            );
+        }
+    }, [
+        dispatch,
+        hasSeenDisconnectTooltip,
+        recentlyDisconnectedDevice,
+        seenDisconnectNotificationForDeviceIds,
+        selectedDevice?.id,
+        selectedDevice?.state,
+    ]);
+};

--- a/packages/suite/src/views/dashboard/useNotificationForDisconnectedDevice.tsx
+++ b/packages/suite/src/views/dashboard/useNotificationForDisconnectedDevice.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 
-import { setSeenDisconnectNotificationForDeviceIds } from '../../actions/suite/suiteActions';
+import { addDeviceIdToSeenDisconnectNotification } from '../../actions/suite/suiteActions';
 import { useDispatch, useSelector } from '../../hooks/suite';
 
 export const useNotificationForDisconnectedDevice = () => {
@@ -34,12 +34,7 @@ export const useNotificationForDisconnectedDevice = () => {
         if (isNotificationVisible) {
             dispatch(notificationsActions.addToast({ type: 'auto-eject-settings' }));
 
-            dispatch(
-                setSeenDisconnectNotificationForDeviceIds([
-                    ...seenDisconnectNotificationForDeviceIds,
-                    deviceId,
-                ]),
-            );
+            dispatch(addDeviceIdToSeenDisconnectNotification(deviceId));
         }
     }, [
         dispatch,

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -28,6 +28,7 @@ import { Transport } from './Transport';
 import { TransportBackends } from './TransportBackends';
 import { TrezorConnectLogs } from './TrezorConnectLogs';
 import { TriggerHighlight } from './TriggerHighlight';
+import { TriggerToast } from './TriggerToast';
 import { WipeData } from './WipeData';
 
 export const SettingsDebug = () => {
@@ -41,6 +42,7 @@ export const SettingsDebug = () => {
                 <GithubIssue />
                 {!isWeb() && <WipeData />}
                 <TriggerHighlight />
+                <TriggerToast />
             </SettingsSection>
             <SettingsSection title="Invity">
                 <InvityApi />

--- a/packages/suite/src/views/settings/SettingsDebug/TriggerToast.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TriggerToast.tsx
@@ -1,0 +1,25 @@
+import { notificationsActions } from '@suite-common/toast-notifications';
+
+import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
+
+import { useDispatch } from '../../../hooks/suite';
+
+export const TriggerToast = () => {
+    const dispatch = useDispatch();
+
+    return (
+        <SectionItem data-testid="@settings/debug/github">
+            <TextColumn title="Trigger toast" />
+            <ActionColumn>
+                <ActionButton
+                    variant="primary"
+                    onClick={() => {
+                        dispatch(notificationsActions.addToast({ type: 'auto-eject-settings' }));
+                    }}
+                >
+                    Show toast
+                </ActionButton>
+            </ActionColumn>
+        </SectionItem>
+    );
+};

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
@@ -18,7 +18,11 @@ import { mapTrezorModelToIcon } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { setFlag, setRecentlyDisconnectedDevice } from 'src/actions/suite/suiteActions';
+import {
+    setFlag,
+    setRecentlyDisconnectedDevice,
+    setSeenDisconnectNotificationForDeviceIds,
+} from 'src/actions/suite/suiteActions';
 import { Translation } from 'src/components/suite';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -47,14 +51,17 @@ export const DeviceItem = ({ device, instances, onCancel }: DeviceItemProps) => 
     const dispatch = useDispatch();
     const [isEjecting, setIsEjecting] = useState(false);
     const selectedDevice = useSelector(selectSelectedDevice);
+    const deviceId = selectedDevice?.id;
     const recentlyDisconnectedDevice = useSelector(state => state.suite.recentlyDisconnectedDevice);
     const hasSeenDisconnectTooltip = useSelector(
         state => state.suite.flags.hasSeenDisconnectTooltip,
     );
     const [showTooltip, setShowTooltip] = useState(false);
-
     const deviceModelInternal = device.features?.internal_model || DEFAULT_FLAGSHIP_MODEL;
     const instancesWithState = instances.filter(i => i.state);
+    const seenDisconnectNotificationForDeviceIds = useSelector(
+        state => state.suite.seenDisconnectNotificationForDeviceIds,
+    );
 
     useEffect(() => {
         if (recentlyDisconnectedDevice === device.id) {
@@ -79,6 +86,16 @@ export const DeviceItem = ({ device, instances, onCancel }: DeviceItemProps) => 
         setShowTooltip(false);
         dispatch(setRecentlyDisconnectedDevice(null));
         dispatch(setFlag('hasSeenDisconnectTooltip', true));
+
+        if (deviceId) {
+            dispatch(
+                // simplify setSeenDisconnectNotificationForDeviceIds
+                setSeenDisconnectNotificationForDeviceIds([
+                    ...seenDisconnectNotificationForDeviceIds,
+                    deviceId,
+                ]),
+            );
+        }
     };
 
     return (

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
@@ -19,9 +19,9 @@ import { spacings } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
 import {
+    addDeviceIdToSeenDisconnectNotification,
     setFlag,
     setRecentlyDisconnectedDevice,
-    setSeenDisconnectNotificationForDeviceIds,
 } from 'src/actions/suite/suiteActions';
 import { Translation } from 'src/components/suite';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
@@ -59,9 +59,6 @@ export const DeviceItem = ({ device, instances, onCancel }: DeviceItemProps) => 
     const [showTooltip, setShowTooltip] = useState(false);
     const deviceModelInternal = device.features?.internal_model || DEFAULT_FLAGSHIP_MODEL;
     const instancesWithState = instances.filter(i => i.state);
-    const seenDisconnectNotificationForDeviceIds = useSelector(
-        state => state.suite.seenDisconnectNotificationForDeviceIds,
-    );
 
     useEffect(() => {
         if (recentlyDisconnectedDevice === device.id) {
@@ -88,13 +85,7 @@ export const DeviceItem = ({ device, instances, onCancel }: DeviceItemProps) => 
         dispatch(setFlag('hasSeenDisconnectTooltip', true));
 
         if (deviceId) {
-            dispatch(
-                // simplify setSeenDisconnectNotificationForDeviceIds
-                setSeenDisconnectNotificationForDeviceIds([
-                    ...seenDisconnectNotificationForDeviceIds,
-                    deviceId,
-                ]),
-            );
+            dispatch(addDeviceIdToSeenDisconnectNotification(deviceId));
         }
     };
 

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -64,6 +64,7 @@ export type ToastPayload = (
               | 'clear-storage'
               | 'add-token-success'
               | 'auto-updater-no-new'
+              | 'auto-eject-settings'
               | 'qr-incorrect-address'
               | 'copy-to-clipboard'
               | 'tor-is-slow'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

### 1st disconnected device

<img width="1028" height="535" alt="image" src="https://github.com/user-attachments/assets/68eeb584-7711-4fae-847b-2351e5b6504c" />

### 2nd - nth disconnected device

<img width="1345" height="672" alt="Screenshot 2025-08-04 at 10 57 19" src="https://github.com/user-attachments/assets/ce18421e-ab12-42f0-8f40-9a862ab852ef" />




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=view-only-toast&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=view-only-toast&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=view-only-toast&lookback=7)