### PR TITLE
Solana: Optimize history fetch and subscriptions for relevant tokens only

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -111,7 +111,7 @@ const getAllSignatures = async (
     let keepFetching = true;
     let allSignatures: SignatureWithSlot[] = [];
 
-    const defaultValueLimit = 1000; // default value of getSignaturesForAddress
+    const defaultValueLimit = 100; // default value of getSignaturesForAddress
     while (keepFetching) {
         const signaturesInfos = await api.rpc
             .getSignaturesForAddress(address(descriptor), {
@@ -245,6 +245,8 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
         .getAccountInfo(publicKey, { encoding: 'base64' })
         .send();
 
+    const tokenMetadata = await request.getTokenMetadata();
+
     const getAllTxIds = async (tokenAccountPubkeys: string[]) => {
         const sortedTokenAccountPubkeys = tokenAccountPubkeys.sort();
 
@@ -334,8 +336,6 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
 
         const transactionsPage = await fetchTransactionPage(api, txIds);
 
-        const tokenMetadata = await request.getTokenMetadata();
-
         const page = transactionsPage
             .filter(isValidTransaction)
             .map(tx =>
@@ -398,7 +398,20 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
         .map(res => res.value)
         .flat();
 
-    const allTxIds = await getAllTxIds(tokenAccounts.map(a => a.pubkey));
+    const recognisedWithBalance = tokenAccounts.filter(acc => {
+        const info = acc.account.data.parsed?.info;
+        const mint = info?.mint;
+        const amount = info?.tokenAmount?.amount;
+
+        return mint && tokenMetadata[mint] && amount !== '0';
+    });
+
+    const allAccounts =
+        tokenAccounts.length > 100
+            ? recognisedWithBalance.map(a => a.pubkey)
+            : [payload.descriptor, ...recognisedWithBalance.map(a => a.pubkey)];
+
+    const allTxIds = await getAllTxIds(allAccounts);
 
     const pageNumber = payload.page ? payload.page - 1 : 0;
     // for the first page of txs, payload.page is undefined, for the second page is 2
@@ -421,8 +434,6 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
     // Fetch token info only if the account owns tokens
     let tokens: TokenInfo[] = [];
     if (tokenAccounts.length > 0) {
-        const tokenMetadata = await request.getTokenMetadata();
-
         tokens = transformTokenInfo(tokenAccounts, tokenMetadata);
     }
 
@@ -622,19 +633,22 @@ const unsubscribeBlock = ({ state }: Context) => {
     state.removeSubscription('block');
 };
 
-const extractTokenAccounts = (accounts: SubscriptionAccountInfo[]): SubscriptionAccountInfo[] =>
-    accounts
-        .map(account =>
-            (
-                account.tokens?.map(
-                    token =>
-                        token.accounts?.map(tokenAccount => ({
-                            descriptor: tokenAccount.publicKey,
-                        })) || [],
-                ) || []
-            ).flat(),
-        )
-        .flat();
+const extractTokenAccounts = (
+    accounts: SubscriptionAccountInfo[],
+    tokenMetadata: TokenDetailByMint,
+): SubscriptionAccountInfo[] =>
+    accounts.flatMap(
+        account =>
+            account.tokens?.flatMap(
+                token =>
+                    token.accounts
+                        ?.filter(
+                            tokenAccount =>
+                                tokenAccount.balance !== '0' && tokenMetadata[token.contract],
+                        )
+                        .map(tokenAccount => ({ descriptor: tokenAccount.publicKey })) || [],
+            ) || [],
+    );
 
 const findTokenAccountOwner = (
     accounts: SubscriptionAccountInfo[],
@@ -725,7 +739,8 @@ const subscribeAccounts = async (context: Context, accounts: SubscriptionAccount
     const { connect, state } = context;
     const api = await connect();
     const subscribedAccounts = state.getAccounts();
-    const tokenAccounts = extractTokenAccounts(accounts);
+    const tokenMetadata = await context.getTokenMetadata();
+    const tokenAccounts = extractTokenAccounts(accounts, tokenMetadata);
     // we have to subscribe to both system and token accounts
     const newAccounts = [...accounts, ...tokenAccounts].filter(
         account =>
@@ -733,6 +748,7 @@ const subscribeAccounts = async (context: Context, accounts: SubscriptionAccount
                 subscribedAccount => account.descriptor === subscribedAccount.descriptor,
             ),
     );
+
     await Promise.all(
         newAccounts.map(async a => {
             const abortController = new AbortController();

--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -188,6 +188,7 @@ const initialRun = [
                 isBluetoothEnabled: false,
                 showBluetoothDebugInfo: false,
                 stellarLimitedHistoryBannerClosed: false,
+                solanaLimitedHistoryBannerClosed: false,
                 hasSeenDisconnectTooltip: false,
             },
         },

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -139,6 +139,7 @@ const getInitialState = ({
             isBluetoothEnabled: false,
             showBluetoothDebugInfo: false,
             stellarLimitedHistoryBannerClosed: false,
+            solanaLimitedHistoryBannerClosed: false,
             hasSeenDisconnectTooltip: false,
         },
         torStatus: 'Disabled' as TorStatus.Disabled,

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx
@@ -16,6 +16,7 @@ import { ContextMessage } from './ContextMessage';
 import { DeviceUnavailable } from './DeviceUnavailable';
 import { EvmExplanationBanner } from './EvmExplanationBanner';
 import { ReserveBanner } from './ReserveBanner';
+import { SolanaLimitedHistoryBanner } from './SolanaLimitedHistoryBanner';
 import { StakingBanner } from './StakingBanner';
 import { StellarLimitedHistoryBanner } from './StellarLimitedHistoryBanner';
 import { TaprootBanner } from './TaprootBanner';
@@ -52,6 +53,7 @@ export const AccountBanners = ({ account }: AccountBannersProps) => {
             <EvmExplanationBanner account={account} />
             <TaprootBanner account={account} />
             {account?.networkType === 'stellar' && <StellarLimitedHistoryBanner />}
+            {account?.networkType === 'solana' && <SolanaLimitedHistoryBanner />}
             {account?.symbol && <StakingBanner account={account} />}
         </Column>
     );

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/SolanaLimitedHistoryBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/SolanaLimitedHistoryBanner.tsx
@@ -1,0 +1,39 @@
+import { setFlag } from 'src/actions/suite/suiteActions';
+import { Translation } from 'src/components/suite';
+import { useDispatch } from 'src/hooks/suite/useDispatch';
+import { useSelector } from 'src/hooks/suite/useSelector';
+import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
+
+import { BannerPoints } from './BannerPoints';
+import { CloseableBanner } from './CloseableBanner';
+
+export const SolanaLimitedHistoryBanner = () => {
+    const dispatch = useDispatch();
+    const { solanaLimitedHistoryBannerClosed } = useSelector(selectSuiteFlags);
+
+    if (solanaLimitedHistoryBannerClosed) {
+        return null;
+    }
+
+    const handleClose = () => {
+        dispatch(setFlag('solanaLimitedHistoryBannerClosed', true));
+    };
+
+    const points = [
+        <Translation
+            id="TR_SOLANA_LIMIT_HISTORY_DESCRIPTION"
+            key="TR_SOLANA_LIMIT_HISTORY_DESCRIPTION"
+        />,
+    ];
+
+    return (
+        <CloseableBanner
+            onClose={handleClose}
+            variant="info"
+            title={<Translation id="TR_SOLANA_LIMIT_HISTORY_TITLE" />}
+            hasIcon={true}
+        >
+            <BannerPoints points={points} />
+        </CloseableBanner>
+    );
+};

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -87,6 +87,7 @@ export interface Flags {
     isBluetoothEnabled: boolean;
     showBluetoothDebugInfo: boolean;
     stellarLimitedHistoryBannerClosed: boolean; // banner in account view (Overview tab) presenting limited history for Stellar
+    solanaLimitedHistoryBannerClosed: boolean; // banner in account view (Overview tab) presenting limited history for Solana
     hasSeenDisconnectTooltip: boolean; // tooltip shown when device disconnects - show only once ever
 }
 
@@ -174,6 +175,7 @@ const initialState: SuiteState = {
         isBluetoothEnabled: false,
         showBluetoothDebugInfo: false,
         stellarLimitedHistoryBannerClosed: false,
+        solanaLimitedHistoryBannerClosed: false,
         hasSeenDisconnectTooltip: false,
     },
     evmSettings: {

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9715,6 +9715,15 @@ export default defineMessages({
         defaultMessage:
             'Due to Solana network limits, you have less than a minute to confirm and send your transaction before it expires.',
     },
+    TR_SOLANA_LIMIT_HISTORY_TITLE: {
+        id: 'TR_SOLANA_LIMIT_HISTORY_TITLE',
+        defaultMessage: 'Transaction history is limited to the last 100 transactions per token',
+    },
+    TR_SOLANA_LIMIT_HISTORY_DESCRIPTION: {
+        id: 'TR_SOLANA_LIMIT_HISTORY_DESCRIPTION',
+        defaultMessage:
+            'This view shows only the most recent 100 transactions for each token. To see the full history, please use the blockchain explorer.',
+    },
     TR_GOT_IT_BUTTON: {
         id: 'TR_GOT_IT_BUTTON',
         defaultMessage: 'Got it',

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -814,7 +814,9 @@ export const isAccountOutdated = (account: Account, freshInfo: AccountInfo) => {
                 // compare last transaction signature since the total number of txs may not be fetched fully
                 freshInfo.history.txids?.[0] !== account.history.txids?.[0] ||
                 // compare last epoch
-                freshInfo.misc?.solEpoch !== account.misc?.solEpoch
+                freshInfo.misc?.solEpoch !== account.misc?.solEpoch ||
+                // compare token count (detect added/removed tokens)
+                freshInfo.tokens?.length !== account.tokens?.length
             );
         default:
             return false;

--- a/suite-native/banner-flags/src/bannerFlagsSlice.ts
+++ b/suite-native/banner-flags/src/bannerFlagsSlice.ts
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 export interface BannerFlagsState {
     isStellarLimitedHistoryBannerClosed: boolean; // banner in account view (Overview tab) presenting limited history for Stellar
+    isSolanaLimitedHistoryBannerClosed: boolean; // banner in account view (Overview tab) presenting limited history for Solana
 }
 
 export type BannerFlagsSliceRootState = {
@@ -10,6 +11,7 @@ export type BannerFlagsSliceRootState = {
 
 export const bannerFlagsInitialState: BannerFlagsState = {
     isStellarLimitedHistoryBannerClosed: false,
+    isSolanaLimitedHistoryBannerClosed: false,
 };
 
 export const bannerFlagsSlice = createSlice({
@@ -19,16 +21,25 @@ export const bannerFlagsSlice = createSlice({
         setStellarLimitedHistoryBannerClosed: state => {
             state.isStellarLimitedHistoryBannerClosed = true;
         },
+        setSolanaLimitedHistoryBannerClosed: state => {
+            state.isSolanaLimitedHistoryBannerClosed = true;
+        },
     },
 });
 
 export const bannerFlagsPersistWhitelist: Array<keyof BannerFlagsState> = [
     'isStellarLimitedHistoryBannerClosed',
+    'isSolanaLimitedHistoryBannerClosed',
 ];
 
 export const selectIsStellarLimitedHistoryBannerClosed = (state: BannerFlagsSliceRootState) =>
     state.bannerFlags.isStellarLimitedHistoryBannerClosed;
 
 export const { setStellarLimitedHistoryBannerClosed } = bannerFlagsSlice.actions;
+
+export const selectIsSolanaLimitedHistoryBannerClosed = (state: BannerFlagsSliceRootState) =>
+    state.bannerFlags.isSolanaLimitedHistoryBannerClosed;
+
+export const { setSolanaLimitedHistoryBannerClosed } = bannerFlagsSlice.actions;
 
 export const bannerFlagsReducer = bannerFlagsSlice.reducer;

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -2344,6 +2344,12 @@ export const en = {
                 'Only transactions from the past 12 months are available in this view. To explore older activity, use the blockchain explorer.',
             confirmButton: 'Got it',
         },
+        solanaLimitedHistoryBanner: {
+            title: 'Transaction history is limited to the last 100 transactions per token',
+            description:
+                'This view shows only the most recent 100 transactions for each token. To see the full history, please use the blockchain explorer.',
+            confirmButton: 'Got it',
+        },
     },
     atoms: {
         animatedDoubleView: {

--- a/suite-native/module-accounts-management/src/components/AccountBanners/SolanaLimitedHistoryBanner.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountBanners/SolanaLimitedHistoryBanner.tsx
@@ -1,0 +1,35 @@
+import { useDispatch, useSelector } from 'react-redux';
+
+import { FullAlertBox } from '@suite-native/atoms';
+import {
+    selectIsSolanaLimitedHistoryBannerClosed,
+    setSolanaLimitedHistoryBannerClosed,
+} from '@suite-native/banner-flags';
+import { useTranslate } from '@suite-native/intl';
+
+export const SolanaLimitedHistoryBanner = () => {
+    const { translate } = useTranslate();
+
+    const isClosed = useSelector(selectIsSolanaLimitedHistoryBannerClosed);
+
+    const dispatch = useDispatch();
+    const handleClose = () => {
+        dispatch(setSolanaLimitedHistoryBannerClosed());
+    };
+
+    if (isClosed) {
+        return null;
+    }
+
+    return (
+        <FullAlertBox
+            marginHorizontal="sp16"
+            title={translate('banner.solanaLimitedHistoryBanner.title')}
+            description={translate('banner.solanaLimitedHistoryBanner.description')}
+            iconName="warningCircle"
+            primaryButtonLabel={translate('banner.solanaLimitedHistoryBanner.confirmButton')}
+            onPressPrimaryButton={handleClose}
+            variant="info"
+        />
+    );
+};

--- a/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
@@ -27,6 +27,7 @@ import {
 import { TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
 import { selectHasAccountAnyTransactions } from '@suite-native/transactions';
 
+import { SolanaLimitedHistoryBanner } from './AccountBanners/SolanaLimitedHistoryBanner';
 import { AccountDetailCryptoValue } from './AccountDetailCryptoValue';
 import { AccountDetailGraph } from './AccountDetailGraph';
 import { CoinPriceCard } from './CoinPriceCard';
@@ -191,6 +192,7 @@ export const TransactionListHeader = memo(
                     )}
                     {isPriceCardDisplayed && <CoinPriceCard accountKey={accountKey} />}
                     {account.networkType === 'stellar' && <StellarLimitedHistoryBanner />}
+                    {account.networkType === 'solana' && <SolanaLimitedHistoryBanner />}
                 </VStack>
                 {hasAccountTransactions && (
                     <Box marginTop="sp52" marginHorizontal="sp32">


### PR DESCRIPTION
## Description

- Limit transaction history to the last 100 entries.
- Fetch signatures only for:
  - recognised tokens if user has >100 token accounts,
  - tokens with balance >0.
- Skip subscriptions for unrecognised or empty token accounts.
- Update `isAccountOutdated` to refresh when token count changes.
- Show a closable warning banner in Solana account view about limited history.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20292

## Screenshots:

<img width="1018" height="544" alt="image" src="https://github.com/user-attachments/assets/4f5fecfc-9eca-4b4e-80ae-0542a5c55459" />

<img width="505" height="1018" alt="image" src="https://github.com/user-attachments/assets/184e25b1-651d-47c8-bddd-5dcaa235931b" />

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/solana-limit-history-and-subscribe-filter&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/solana-limit-history-and-subscribe-filter&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/solana-limit-history-and-subscribe-filter&lookback=7)