### PR TITLE
chore(suite-native): E2Es always await userEnv disconnect

### DIFF
--- a/suite-native/app/e2e/tests/appSettingsWithDevice.test.ts
+++ b/suite-native/app/e2e/tests/appSettingsWithDevice.test.ts
@@ -40,8 +40,8 @@ conditionalDescribe(
         });
 
         afterAll(async () => {
-            await device.terminateApp();
             await disconnectTrezorUserEnv();
+            await device.terminateApp();
         });
 
         it('Coin Enabling', async () => {

--- a/suite-native/app/e2e/tests/appSettingsWithDevice.test.ts
+++ b/suite-native/app/e2e/tests/appSettingsWithDevice.test.ts
@@ -34,6 +34,7 @@ conditionalDescribe(
         });
 
         beforeEach(async () => {
+            await prepareTrezorEmulator();
             await restartApp();
             await appIsFullyLoaded();
             await wait(5000); // wait for trezor device to start communicating with the app

--- a/suite-native/app/e2e/tests/deviceOnboarding.test.ts
+++ b/suite-native/app/e2e/tests/deviceOnboarding.test.ts
@@ -60,8 +60,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device onboarding', () 
     });
 
     afterAll(async () => {
-        disconnectTrezorUserEnv();
-
+        await disconnectTrezorUserEnv();
         await device.terminateApp();
     });
 

--- a/suite-native/app/e2e/tests/deviceSettings.test.ts
+++ b/suite-native/app/e2e/tests/deviceSettings.test.ts
@@ -31,7 +31,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () =>
     });
 
     afterAll(async () => {
-        disconnectTrezorUserEnv();
+        await disconnectTrezorUserEnv();
         await device.terminateApp();
     });
 

--- a/suite-native/app/e2e/tests/invalidAccountsImport.test.ts
+++ b/suite-native/app/e2e/tests/invalidAccountsImport.test.ts
@@ -23,6 +23,7 @@ describe('Import invalid accounts', () => {
         await appIsFullyLoaded();
         await goToBtcImportXpubScreen();
     });
+
     it('Import an already imported XPUB', async () => {
         // add first account
         await onAccountImport.importAccount({

--- a/suite-native/app/e2e/tests/launchArguments.test.ts
+++ b/suite-native/app/e2e/tests/launchArguments.test.ts
@@ -29,7 +29,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Launch Arguments', () =
     });
 
     afterAll(async () => {
-        disconnectTrezorUserEnv();
+        await disconnectTrezorUserEnv();
         await device.terminateApp();
     });
 

--- a/suite-native/app/e2e/tests/onboardAndConnect.test.ts
+++ b/suite-native/app/e2e/tests/onboardAndConnect.test.ts
@@ -19,7 +19,7 @@ conditionalDescribe(
         });
 
         afterAll(async () => {
-            disconnectTrezorUserEnv();
+            await disconnectTrezorUserEnv();
             await device.terminateApp();
         });
 

--- a/suite-native/app/e2e/tests/passphraseFlow.test.ts
+++ b/suite-native/app/e2e/tests/passphraseFlow.test.ts
@@ -80,7 +80,10 @@ conditionalDescribe(device.getPlatform() === 'android', 'passphrase flow', () =>
         await onAlertSheet.skipViewOnlyMode();
     });
 
-    afterAll(disconnectTrezorUserEnv);
+    afterAll(async () => {
+        await disconnectTrezorUserEnv();
+        await device.terminateApp();
+    });
 
     // TODO #16495 - currently not working
     describe.skip('with passphrase not allowed on Trezor', () => {

--- a/suite-native/app/e2e/tests/receive.test.ts
+++ b/suite-native/app/e2e/tests/receive.test.ts
@@ -12,10 +12,17 @@ import { onTabBar } from '../pageObjects/tabBarActions';
 import { disconnectTrezorUserEnv, openApp, prepareTrezorEmulator } from '../utils';
 
 conditionalDescribe(device.getPlatform() === 'android', 'Receive', () => {
-    it('Generate device confirmed receive address.', async () => {
+    beforeAll(async () => {
         await prepareTrezorEmulator();
         await openApp({ newInstance: true, args: { preloadedState: onboardingCompleted } });
+    });
 
+    afterAll(async () => {
+        await disconnectTrezorUserEnv();
+        await device.terminateApp();
+    });
+
+    it('Generate device confirmed receive address.', async () => {
         await onCoinEnabling.waitForInitScreen();
         await onCoinEnabling.toggleNetwork('btc');
         await onCoinEnabling.clickOnConfirmButton();
@@ -32,7 +39,5 @@ conditionalDescribe(device.getPlatform() === 'android', 'Receive', () => {
         await onAccountReceive.tapShowAddressButton();
         await TrezorUserEnvLink.pressYes();
         await onAccountReceive.verifyReceiveAddress('bc1qa55m6kz3crfse5xg2rukulyap4eyp75w0puawz');
-
-        disconnectTrezorUserEnv();
     });
 });

--- a/suite-native/app/e2e/tests/send.test.ts
+++ b/suite-native/app/e2e/tests/send.test.ts
@@ -98,8 +98,9 @@ conditionalDescribe(device.getPlatform() === 'android', 'Send transaction flow.'
         await onSendOutputsForm.waitForScreen();
     });
 
-    afterAll(() => {
-        disconnectTrezorUserEnv();
+    afterAll(async () => {
+        await disconnectTrezorUserEnv();
+        await device.terminateApp();
     });
 
     it('Compose and dispatch a regtest transaction.', async () => {

--- a/suite-native/message-system/src/components/MessageSystemBannerRenderer.e2e.tsx
+++ b/suite-native/message-system/src/components/MessageSystemBannerRenderer.e2e.tsx
@@ -3,10 +3,8 @@ import { useSelector } from 'react-redux';
 import { A } from '@mobily/ts-belt';
 
 import { selectActiveBannerMessages } from '@suite-common/message-system';
-import { VStack } from '@suite-native/atoms';
+import { Box } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-
-import { MessageBanner } from './MessageBanner';
 
 const messageBannerContainerStyle = prepareNativeStyle<{ topSafeAreaInset: number }>(
     (_, { topSafeAreaInset }) => ({
@@ -16,6 +14,9 @@ const messageBannerContainerStyle = prepareNativeStyle<{ topSafeAreaInset: numbe
 
 type MessageSystemBannerRendererProps = { topSafeAreaInset: number };
 
+// This component ignores banner for message system
+/// but keeps insets to avoid layout shift in E2E tests
+// FIXME: #18775
 export const MessageSystemBannerRenderer = ({
     topSafeAreaInset,
 }: MessageSystemBannerRendererProps) => {
@@ -26,11 +27,5 @@ export const MessageSystemBannerRenderer = ({
         return null;
     }
 
-    return (
-        <VStack spacing="sp4" style={applyStyle(messageBannerContainerStyle, { topSafeAreaInset })}>
-            {activeBannerMessages.map(message => (
-                <MessageBanner key={message.id} message={message} />
-            ))}
-        </VStack>
-    );
+    return <Box style={applyStyle(messageBannerContainerStyle, { topSafeAreaInset })} />;
 };

--- a/suite-native/message-system/src/hooks/useIsMessageSystemBannerVisible.ts
+++ b/suite-native/message-system/src/hooks/useIsMessageSystemBannerVisible.ts
@@ -1,0 +1,8 @@
+import { useSelector } from 'react-redux';
+
+import { A } from '@mobily/ts-belt';
+
+import { selectActiveBannerMessages } from '@suite-common/message-system';
+
+export const useIsMessageSystemBannerVisible = () =>
+    A.isNotEmpty(useSelector(selectActiveBannerMessages));

--- a/suite-native/message-system/src/index.ts
+++ b/suite-native/message-system/src/index.ts
@@ -3,3 +3,4 @@ export * from './components/ContextMessage';
 export * from './components/MessageSystemBannerRenderer';
 export * from './components/KillswitchMessageScreen';
 export * from './messageSystemSelectors';
+export * from './hooks/useIsMessageSystemBannerVisible';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Our E2Es are now so blazing fast that even one missing await on device disconnect in one test suite can cause trouble in next test suite.


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=e2e-user-env-fix&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=e2e-user-env-fix&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=e2e-user-env-fix&lookback=7)