### PR TITLE
fix(suite): make sure that clicking on the add wallet won't cause 'ac…

### DIFF
--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
@@ -18,7 +18,7 @@ import {
 import { CardButton } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
-import { closeModalApp } from 'src/actions/suite/routerActions';
+import { closeModalApp, goto } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { selectIsDeviceOrUiLocked } from 'src/reducers/suite/suiteReducer';
@@ -62,6 +62,7 @@ export const AddWalletButton = ({ device, instances, onCancel }: AddWalletButton
                 isAddingHiddenWalletWithRespectToSettings,
             }),
         );
+        dispatch(goto('suite-index'));
     };
 
     const ExpandedPassphraseContainer = () => (


### PR DESCRIPTION
…count doesnt exist'

<!--- Provide a general summary of your changes in the Title above -->

## Description

There's a problem that when the discovery is started basically a new device is selected that doesn't have such accounts.

So for every case, redirect to `/` that's dashboard to prevent any 404

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/20514

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=20514-add-wallet-account-doesnt-exist&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=20514-add-wallet-account-doesnt-exist&lookback=7)