### PR TITLE
fix(suite): fix BigAmount formatting

### DIFF
--- a/packages/product-components/src/components/NumberInput/NumberInput.tsx
+++ b/packages/product-components/src/components/NumberInput/NumberInput.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react';
 import { Control, FieldValues, UseControllerProps, useController } from 'react-hook-form';
 
+import { Locale } from '@suite-common/suite-types';
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { Input, InputProps } from '@trezor/components';
 import { getLocaleSeparators } from '@trezor/utils';
@@ -70,8 +71,7 @@ export type NumberInputProps<TFieldValues extends FieldValues> = Omit<
         decimalScale?: number;
         onChange?: (value: string) => void;
         rules?: UseControllerProps['rules'];
-        // TODO: locale should be of type Locale
-        locale: string;
+        locale: Locale;
     };
 
 export const NumberInput = <TFieldValues extends FieldValues>({

--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -131,7 +131,7 @@ export const calculatePercentageOfBalance = (params: PercentageOfBalanceParams) 
     const fraction = (parseFloat(params.balance) * params.percentage) / 100;
     const maxDecimals = getAccountDecimals(params.symbol);
 
-    return localizeNumber(fraction, 'en', 0, maxDecimals);
+    return localizeNumber(fraction, 'en-US', 0, maxDecimals);
 };
 
 export const countDecimalPlaces = (value: string | number) => {

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-bitcoin.test.ts
@@ -41,13 +41,13 @@ const fiatAmount = buyQuotesBTC[0].fiatStringAmount;
 const bestBuyProvider = capitalizeFirstLetter(buyQuotesBTC[0].exchange);
 const bestBuyCryptoAmount = `${buyQuotesBTC[0].receiveStringAmount} BTC`;
 const formattedFiatWithoutSymbol = localizeNumber(fiatAmount);
-const formattedFiatAmount = `CZK ${localizeNumber(fiatAmount, 'en', 2)}`;
+const formattedFiatAmount = `CZK ${localizeNumber(fiatAmount, 'en-US', 2)}`;
 const { receiveAddress, paymentMethodName } = buyTradeBTC.trade;
 // secondOffer via Bank Transfer that matches input criteria has index 5
 const updateFiatAmount = buyQuotesBTCUpdate[5].fiatStringAmount;
 const secondOfferProvider = capitalizeFirstLetter(buyQuotesBTCUpdate[5].exchange);
 const secondOfferCryptoAmount = `${buyQuotesBTCUpdate[5].receiveStringAmount} BTC`;
-const formattedUpdateFiatAmount = `CZK ${localizeNumber(updateFiatAmount, 'en', 2)}`;
+const formattedUpdateFiatAmount = `CZK ${localizeNumber(updateFiatAmount, 'en-US', 2)}`;
 
 test.describe('Trading - Buy BTC', { tag: ['@group=trading', '@webOnly'] }, () => {
     test.beforeEach(async ({ page, tradingMock, onboardingPage, walletPage }) => {

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-ethereum.test.ts
@@ -10,7 +10,7 @@ import { expect, test } from '../../support/fixtures';
 const fiatAmount = buyQuotesEthereum[3].fiatStringAmount;
 const provider = capitalizeFirstLetter(buyQuotesEthereum[3].exchange);
 const formattedCryptoAmount = `${localizeNumber(buyQuotesEthereum[3].receiveStringAmount)} ETH`;
-const formattedFiatAmount = `CZK ${localizeNumber(fiatAmount, 'en', 2)}`;
+const formattedFiatAmount = `CZK ${localizeNumber(fiatAmount, 'en-US', 2)}`;
 const { receiveAddress, paymentMethodName } = buyTradeEthereum.trade;
 
 test.describe('Trading - Buy Ethereum', { tag: ['@group=trading', '@webOnly'] }, () => {

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
@@ -11,7 +11,7 @@ import {
 import { expect, test } from '../../support/fixtures';
 
 // Expected values based on our mocked responses
-const fiatAmount = localizeNumber(buyQuotesSolanaToken[0].fiatStringAmount, 'en', 2);
+const fiatAmount = localizeNumber(buyQuotesSolanaToken[0].fiatStringAmount, 'en-US', 2);
 const cryptoAmount = buyQuotesSolanaToken[0].receiveStringAmount;
 const provider = capitalizeFirstLetter(buyQuotesSolanaToken[0].exchange);
 const formattedCryptoAmount = `${cryptoAmount} JUP`;

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-inputs.test.ts
@@ -85,7 +85,7 @@ test.describe('Trading - Sell inputs', { tag: ['@group=trading', '@webOnly'] }, 
                             parseFloat(bitcoinBalance!) - parseFloat(resultingFee)
                         ).toString();
                         await expect(tradingPage.youPayCryptoInput).toHaveValue(
-                            localizeNumber(maxValue, 'en', 0, 8),
+                            localizeNumber(maxValue, 'en-US', 0, 8),
                         );
                     })
                     .toPass({ timeout: 15_000 });
@@ -114,7 +114,7 @@ test.describe('Trading - Sell inputs', { tag: ['@group=trading', '@webOnly'] }, 
                 const maxValue = (parseFloat(solanaBalance!) - resultingFee).toString();
                 await expect
                     .soft(tradingPage.youPayCryptoInput)
-                    .toHaveValue(localizeNumber(maxValue, 'en', 0, 9));
+                    .toHaveValue(localizeNumber(maxValue, 'en-US', 0, 9));
             });
         });
     });

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
@@ -13,7 +13,7 @@ import { formatAddress } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 // Expected values based on our mocked responses
-const fiatAmount = localizeNumber(sellQuotesSolana[0].fiatStringAmount, 'en', 2, 2);
+const fiatAmount = localizeNumber(sellQuotesSolana[0].fiatStringAmount, 'en-US', 2, 2);
 const cryptoAmount = sellQuotesSolana[0].cryptoStringAmount;
 const provider = getCompanyNameFromList(sellQuotesSolana[0].exchange, 'sellList');
 // This address belongs to second account in this wallet.

--- a/packages/suite-desktop-core/e2e/tests/wallet/coin-balance.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/coin-balance.test.ts
@@ -36,7 +36,7 @@ test.describe('Coin balance', { tag: ['@group=wallet'] }, () => {
                 );
                 const rawIncreasedBalance = originalBalance.plus(1).toString();
                 const expectedIncreasedBalance =
-                    localizeNumber(rawIncreasedBalance, 'en', 0, 8) + (hasEllipsis ? '…' : '');
+                    localizeNumber(rawIncreasedBalance, 'en-US', 0, 8) + (hasEllipsis ? '…' : '');
 
                 await trezorUserEnvLink.sendToAddressAndMineBlock({ address, btc_amount: 1 });
                 await expect(firstAccountBalanceLocator).toHaveText(expectedIncreasedBalance);

--- a/packages/suite/src/actions/settings/languageActions.ts
+++ b/packages/suite/src/actions/settings/languageActions.ts
@@ -1,6 +1,7 @@
+import type { Locale } from '@suite-common/suite-types';
+
 import { SUITE } from 'src/actions/suite/constants';
 import type { SuiteAction } from 'src/actions/suite/suiteActions';
-import type { Locale } from 'src/config/suite/languages';
 import { ensureLocale } from 'src/utils/suite/l10n';
 
 export const setLanguage = (locale: Locale): SuiteAction => ({

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -1,5 +1,6 @@
 import { createAction } from '@reduxjs/toolkit';
 
+import type { Locale } from '@suite-common/suite-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import type { TradingType } from '@suite-common/trading';
 import { deviceActions } from '@suite-common/wallet-core';
@@ -9,7 +10,6 @@ import { HandshakeElectron, desktopApi } from '@trezor/suite-desktop-api';
 
 import * as modalActions from 'src/actions/suite/modalActions';
 import type { TranslationKey } from 'src/components/suite/Translation';
-import type { Locale } from 'src/config/suite/languages';
 import { ExperimentalFeature } from 'src/constants/suite/experimental';
 import {
     AutodetectSettings,

--- a/packages/suite/src/components/suite/__tests__/NumberInput.test.tsx
+++ b/packages/suite/src/components/suite/__tests__/NumberInput.test.tsx
@@ -5,10 +5,10 @@ import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Store } from 'redux';
 
+import { Locale } from '@suite-common/suite-types';
 import { configureMockStore } from '@suite-common/test-utils';
 import { NumberInput } from '@trezor/product-components';
 
-import { Locale } from 'src/config/suite/languages';
 import suiteReducer, { SuiteState } from 'src/reducers/suite/suiteReducer';
 import { ThemeProvider } from 'src/support/suite/ThemeProvider';
 

--- a/packages/suite/src/components/wallet/BigAmountValue.tsx
+++ b/packages/suite/src/components/wallet/BigAmountValue.tsx
@@ -2,10 +2,9 @@ import { PropsWithChildren } from 'react';
 
 import styled from 'styled-components';
 
+import { Locale } from '@suite-common/suite-types';
 import { useShouldRedactNumbers } from '@suite-common/wallet-utils';
 import { typography } from '@trezor/theme';
-
-import { Locale } from 'src/config/suite/languages';
 
 import { useSelector } from '../../hooks/suite';
 import { selectLanguage } from '../../reducers/suite/suiteReducer';

--- a/packages/suite/src/components/wallet/BigAmountValue.tsx
+++ b/packages/suite/src/components/wallet/BigAmountValue.tsx
@@ -5,6 +5,8 @@ import styled from 'styled-components';
 import { useShouldRedactNumbers } from '@suite-common/wallet-utils';
 import { typography } from '@trezor/theme';
 
+import { Locale } from 'src/config/suite/languages';
+
 import { useSelector } from '../../hooks/suite';
 import { selectLanguage } from '../../reducers/suite/suiteReducer';
 import { RedactNumericalValue } from '../suite';
@@ -47,7 +49,8 @@ export const BigAmountValue = ({
     const language = useSelector(selectLanguage);
 
     // Todo: this is ugly hack, shall be refactored to some more safe alternative
-    const [whole, separator, fractional] = ['en', 'ja', 'zh'].includes(language)
+    const shouldFormatLocale: Locale[] = ['en-US', 'ja-JP', 'zh-CN', 'zh-TW'];
+    const [whole, separator, fractional] = shouldFormatLocale.includes(language)
         ? formattedStringAmount.split(/(\.)/)
         : formattedStringAmount.split(/(,)/);
 

--- a/packages/suite/src/config/suite/index.ts
+++ b/packages/suite/src/config/suite/index.ts
@@ -1,4 +1,3 @@
-import LANGUAGES from './languages';
 import SETTINGS from './settings';
 
-export { LANGUAGES, SETTINGS };
+export { SETTINGS };

--- a/packages/suite/src/hooks/guide/useGuideLoadArticle.ts
+++ b/packages/suite/src/hooks/guide/useGuideLoadArticle.ts
@@ -1,8 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import type { GuideNode } from '@suite-common/suite-types';
-
-import type { Locale } from 'src/config/suite/languages';
+import type { GuideNode, Locale } from '@suite-common/suite-types';
 
 export const loadPageMarkdownFile = async (id: string, language = 'en'): Promise<string> => {
     const file = await import(/* @vite-ignore */ `@trezor/suite-data/files/guide/${language}${id}`);

--- a/packages/suite/src/hooks/suite/useDebugLanguageShortcut.ts
+++ b/packages/suite/src/hooks/suite/useDebugLanguageShortcut.ts
@@ -1,10 +1,10 @@
 import { useCallback, useEffect } from 'react';
 
+import { LANGUAGES, Locale } from '@suite-common/suite-types';
 import { KEYBOARD_CODE } from '@trezor/components';
 
 import { setLanguage } from 'src/actions/settings/languageActions';
 import { setAutodetect } from 'src/actions/suite/suiteActions';
-import LANGUAGES, { Locale } from 'src/config/suite/languages';
 import { selectIsDebugModeActive, selectLanguage } from 'src/reducers/suite/suiteReducer';
 
 import { useDispatch } from './useDispatch';

--- a/packages/suite/src/hooks/suite/useLocales.ts
+++ b/packages/suite/src/hooks/suite/useLocales.ts
@@ -2,7 +2,8 @@ import { useEffect, useState } from 'react';
 
 import type { Locale as DateFnsLocale } from 'date-fns';
 
-import type { Locale as SuiteLocale } from 'src/config/suite/languages';
+import { Locale as SuiteLocale } from '@suite-common/suite-types';
+
 import { useSelector } from 'src/hooks/suite';
 import { selectLanguage } from 'src/reducers/suite/suiteReducer';
 

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -2,6 +2,7 @@ import { produce } from 'immer';
 
 import type { CountryCode } from '@suite-common/geolocation';
 import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
+import { Locale } from '@suite-common/suite-types';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
 import type { InvityServerEnvironment, TradingType } from '@suite-common/trading';
 import { NetworkSymbol } from '@suite-common/wallet-config';
@@ -17,7 +18,6 @@ import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
 import { versionUtils } from '@trezor/utils';
 
 import { STORAGE, SUITE } from 'src/actions/suite/constants';
-import type { Locale } from 'src/config/suite/languages';
 import { ExperimentalFeature } from 'src/constants/suite/experimental';
 import {
     hashCheckErrorScenarios,

--- a/packages/suite/src/storage/migrations/versions/25.8.0.ts
+++ b/packages/suite/src/storage/migrations/versions/25.8.0.ts
@@ -1,7 +1,7 @@
 import { createMigration } from '@suite/idb-migration-utils';
+import { LANGUAGES } from '@suite-common/suite-types';
 import { typedObjectKeys } from '@trezor/utils';
 
-import { LANGUAGES } from 'src/config/suite';
 import { SuiteDBSchema } from 'src/storage/definitions';
 
 import { updateAll } from '../utils';

--- a/packages/suite/src/support/suite/Autodetect.tsx
+++ b/packages/suite/src/support/suite/Autodetect.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect } from 'react';
 
+import { Locale } from '@suite-common/suite-types';
+
 import * as languageActions from 'src/actions/settings/languageActions';
 import { setTheme as setThemeAction } from 'src/actions/suite/suiteActions';
-import { Locale } from 'src/config/suite/languages';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { getOsTheme, watchOsTheme } from 'src/utils/suite/env';
 import { getOsLocale, watchOsLocale } from 'src/utils/suite/l10n';

--- a/packages/suite/src/support/suite/ConnectedIntlProvider.tsx
+++ b/packages/suite/src/support/suite/ConnectedIntlProvider.tsx
@@ -1,10 +1,10 @@
 import { ReactNode, useEffect, useState } from 'react';
 import { IntlProvider } from 'react-intl';
 
+import type { Locale } from '@suite-common/suite-types';
 import { isDevEnv } from '@suite-common/suite-utils';
 import enMessages from '@trezor/suite-data/files/translations/en-US.json';
 
-import type { Locale } from 'src/config/suite/languages';
 import { useSelector } from 'src/hooks/suite/useSelector';
 
 const useFetchMessages = (locale: Locale) => {

--- a/packages/suite/src/utils/suite/l10n.ts
+++ b/packages/suite/src/utils/suite/l10n.ts
@@ -1,6 +1,5 @@
+import { LANGUAGES, Locale } from '@suite-common/suite-types';
 import { getPlatformLanguages } from '@trezor/env-utils';
-
-import LANGUAGES, { Locale } from 'src/config/suite/languages';
 
 const DEFAULT_LOCALE = 'en-US';
 

--- a/packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx
@@ -1,9 +1,9 @@
+import { LANGUAGES, Locale } from '@suite-common/suite-types';
+
 import { SettingsSectionItem } from 'src/components/settings';
 import { ActionColumn, ActionSelect, TextColumn, Translation } from 'src/components/suite';
 
 import { changeLanguage } from '../../../actions/settings/deviceSettingsActions';
-import { LANGUAGES } from '../../../config/suite';
-import { Locale } from '../../../config/suite/languages';
 import { SettingsAnchor } from '../../../constants/suite/anchors';
 import { useDevice, useDispatch } from '../../../hooks/suite';
 

--- a/packages/suite/src/views/settings/SettingsGeneral/Language.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Language.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 
+import { LANGUAGES, Locale, LocaleInfo } from '@suite-common/suite-types';
 import { getPlatformLanguages } from '@trezor/env-utils';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { CROWDIN_URL } from '@trezor/urls';
@@ -9,7 +10,6 @@ import { setLanguage } from 'src/actions/settings/languageActions';
 import { setAutodetect } from 'src/actions/suite/suiteActions';
 import { SettingsSectionItem } from 'src/components/settings';
 import { ActionColumn, ActionSelect, TextColumn, Translation } from 'src/components/suite';
-import LANGUAGES, { Locale, LocaleInfo } from 'src/config/suite/languages';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { selectLanguage } from 'src/reducers/suite/suiteReducer';

--- a/suite-common/suite-types/src/index.ts
+++ b/suite-common/suite-types/src/index.ts
@@ -10,6 +10,7 @@ export * from './route';
 export * from './walletBackupType';
 export * from './sign';
 export * from './thp';
+export * from './languages';
 
 export type Selector<TReturnValue> = (state: any) => TReturnValue;
 export type SuiteCompatibleAction<TPayload> = (

--- a/suite-common/suite-types/src/languages.ts
+++ b/suite-common/suite-types/src/languages.ts
@@ -1,4 +1,4 @@
-const LANGUAGES = {
+const languages = {
     'en-US': { name: 'English', en: 'English', type: 'official' },
     'es-ES': { name: 'Español', en: 'Spanish', type: 'official' },
     'af-ZA': { name: 'Afrikaans', en: 'Afrikaans' },
@@ -34,7 +34,7 @@ const LANGUAGES = {
     'zh-TW': { name: '中文(繁體)', en: 'Chinese Traditional', type: 'community' },
 } as const;
 
-export type Locale = keyof typeof LANGUAGES;
+export type Locale = keyof typeof languages;
 
 export type LocaleInfo = {
     name: string;
@@ -42,4 +42,4 @@ export type LocaleInfo = {
     type?: 'official' | 'community';
 };
 
-export default LANGUAGES as { [code in Locale]: LocaleInfo };
+export const LANGUAGES = languages as { [code in Locale]: LocaleInfo };

--- a/suite-common/wallet-utils/src/__tests__/balanceUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/balanceUtils.test.ts
@@ -23,7 +23,7 @@ test('formatBalanceUtils', () => {
     expect(formatCoinBalance('0099999999.999999999999')).toEqual('99,999,999.9…');
     expect(formatCoinBalance('0.12345678')).toEqual('0.12345678');
     expect(formatCoinBalance('10.12345678')).toEqual('10.1234567…');
-    expect(formatCoinBalance('10000.123', 'cs')).toEqual('10\xa0000,123');
-    expect(formatCoinBalance('10000.123', 'es')).toEqual('10.000,123');
-    expect(formatCoinBalance('10000.123', 'ru')).toEqual('10\xa0000,123');
+    expect(formatCoinBalance('10000.123', 'cs-CZ')).toEqual('10\xa0000,123');
+    expect(formatCoinBalance('10000.123', 'es-ES')).toEqual('10.000,123');
+    expect(formatCoinBalance('10000.123', 'ru-RU')).toEqual('10\xa0000,123');
 });

--- a/suite-common/wallet-utils/src/__tests__/localizeNumber.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/localizeNumber.test.ts
@@ -8,9 +8,9 @@ describe('localizeNumber', () => {
         expect(localizeNumber(1.234832924423748)).toStrictEqual('1.234832924423748');
     });
 
-    it('formats with cs locale', () => {
-        expect(localizeNumber(123456789, 'cs')).toStrictEqual('123 456 789');
-        expect(localizeNumber(1.234832924423748, 'cs')).toStrictEqual('1,234832924423748');
+    it('formats with cs-CZ locale', () => {
+        expect(localizeNumber(123456789, 'cs-CZ')).toStrictEqual('123 456 789');
+        expect(localizeNumber(1.234832924423748, 'cs-CZ')).toStrictEqual('1,234832924423748');
     });
 
     it('fails with wrong values', () => {
@@ -20,19 +20,19 @@ describe('localizeNumber', () => {
     });
 
     it('formats decimals', () => {
-        expect(localizeNumber(123456789, 'en', 0, 2)).toStrictEqual('123,456,789');
-        expect(localizeNumber(123456789.101, 'en', 0, 2)).toStrictEqual('123,456,789.1');
-        expect(localizeNumber(123456789.123, 'en', 0, 2)).toStrictEqual('123,456,789.12');
+        expect(localizeNumber(123456789, 'en-US', 0, 2)).toStrictEqual('123,456,789');
+        expect(localizeNumber(123456789.101, 'en-US', 0, 2)).toStrictEqual('123,456,789.1');
+        expect(localizeNumber(123456789.123, 'en-US', 0, 2)).toStrictEqual('123,456,789.12');
 
         expect(localizeNumber(Number.MAX_SAFE_INTEGER + 1)).toStrictEqual('9,007,199,254,740,992');
         expect(localizeNumber(Number.MIN_SAFE_INTEGER - 1)).toStrictEqual('-9,007,199,254,740,992');
 
-        expect(localizeNumber(123456789, 'en', 1, 2)).toStrictEqual('123,456,789.0');
-        expect(localizeNumber(123456789.111, 'en', 1, 2)).toStrictEqual('123,456,789.11');
+        expect(localizeNumber(123456789, 'en-US', 1, 2)).toStrictEqual('123,456,789.0');
+        expect(localizeNumber(123456789.111, 'en-US', 1, 2)).toStrictEqual('123,456,789.11');
 
-        expect(localizeNumber(123456789.111, 'en', 2, 2)).toStrictEqual('123,456,789.11');
+        expect(localizeNumber(123456789.111, 'en-US', 2, 2)).toStrictEqual('123,456,789.11');
 
-        expect(() => localizeNumber(123456789, 'en', 3, 2)).toThrow();
+        expect(() => localizeNumber(123456789, 'en-US', 3, 2)).toThrow();
     });
 
     it('formats negative numbers', () => {

--- a/suite-common/wallet-utils/src/balanceUtils.ts
+++ b/suite-common/wallet-utils/src/balanceUtils.ts
@@ -8,7 +8,7 @@ export const isZero = (value: string) => {
     return valueBig.isZero();
 };
 
-export const formatCoinBalance = (value: string, locale = 'en') => {
+export const formatCoinBalance = (value: string, locale = 'en-US') => {
     const MAX_NUMBERS = 9;
     const balanceBig = new BigNumber(value);
 

--- a/suite-common/wallet-utils/src/balanceUtils.ts
+++ b/suite-common/wallet-utils/src/balanceUtils.ts
@@ -1,3 +1,4 @@
+import { Locale } from '@suite-common/suite-types';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { localizeNumber } from './localizeNumberUtils';
@@ -8,7 +9,7 @@ export const isZero = (value: string) => {
     return valueBig.isZero();
 };
 
-export const formatCoinBalance = (value: string, locale = 'en-US') => {
+export const formatCoinBalance = (value: string, locale: Locale = 'en-US') => {
     const MAX_NUMBERS = 9;
     const balanceBig = new BigNumber(value);
 

--- a/suite-common/wallet-utils/src/localizeNumberUtils.ts
+++ b/suite-common/wallet-utils/src/localizeNumberUtils.ts
@@ -1,9 +1,10 @@
+import { Locale } from '@suite-common/suite-types';
 import { getLocaleSeparators } from '@trezor/utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 export const localizeNumber = (
     value: number | string | BigNumber,
-    locale = 'en-US',
+    locale: Locale = 'en-US',
     minDecimals = 0,
     maxDecimals?: number,
 ) => {

--- a/suite-common/wallet-utils/src/localizeNumberUtils.ts
+++ b/suite-common/wallet-utils/src/localizeNumberUtils.ts
@@ -3,7 +3,7 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 export const localizeNumber = (
     value: number | string | BigNumber,
-    locale = 'en',
+    locale = 'en-US',
     minDecimals = 0,
     maxDecimals?: number,
 ) => {


### PR DESCRIPTION
Fixes big amount formatting

## Screenshots:

BEFORE
<img width="1205" height="521" alt="Screenshot 2025-08-01 at 13 01 07" src="https://github.com/user-attachments/assets/29f66d66-f44b-4ed6-a0f8-3ca0216c20e7" />

AFTER
<img width="1222" height="557" alt="Screenshot 2025-08-01 at 13 00 53" src="https://github.com/user-attachments/assets/b3d6f784-5539-4457-b46e-aa0c3d5e24d0" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/locale-big-amount-format&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/locale-big-amount-format&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/locale-big-amount-format&lookback=7)