### PR TITLE
feat(suite): simplify approval modal layout

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
@@ -183,14 +183,16 @@ export const TransactionReviewModalBodyInner = ({
         isTrading: !!precomposedForm.trading?.activeSection,
     });
 
-    const actionTranslation = getTransactionReviewModalActionTranslation({
-        stakeType,
-        precomposedForm,
-        tradingToken,
-        isBumpFeeRbfAction,
-        isCancelRbfAction,
-        isSending,
-    });
+    const actionTranslation = (source: 'heading' | 'button') =>
+        getTransactionReviewModalActionTranslation({
+            stakeType,
+            precomposedForm,
+            tradingToken,
+            isBumpFeeRbfAction,
+            isCancelRbfAction,
+            isSending,
+            source,
+        });
 
     const isBroadcastEnabled = options.includes('broadcast');
 
@@ -223,7 +225,9 @@ export const TransactionReviewModalBodyInner = ({
             <Modal.ModalBase
                 heading={
                     <Translation
-                        {...(areDetailsVisible ? { id: 'TR_DETAIL' } : actionTranslation)}
+                        {...(areDetailsVisible
+                            ? { id: 'TR_DETAIL' }
+                            : actionTranslation('heading'))}
                     />
                 }
                 onBackClick={areDetailsVisible ? () => setAreDetailsVisible(false) : undefined}
@@ -259,7 +263,7 @@ export const TransactionReviewModalBodyInner = ({
                         handleTryAgain={handleTryAgain}
                         txInfoState={txInfoState}
                         areDetailsVisible={areDetailsVisible}
-                        actionTranslation={actionTranslation}
+                        actionTranslation={actionTranslation('button')}
                         isTxExpired={isTxExpired}
                         hasTxExpired={hasTxExpired}
                         stakeType={stakeType || undefined}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
@@ -6,30 +6,30 @@ import styled from 'styled-components';
 import {
     TradingExchangeType,
     invityAPI,
-    parseCryptoId,
     tradingExchangeActions,
     useTradingInfo,
 } from '@suite-common/trading';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
 import {
     Badge,
-    Card,
+    Box,
     CollapsibleBox,
     Column,
-    Divider,
     Modal,
     Paragraph,
-    Radio,
+    RadioCard,
     Row,
     Text,
 } from '@trezor/components';
-import { spacings } from '@trezor/theme';
+import { CoinLogo } from '@trezor/product-components';
+import { borders, spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite/Translation';
 import { AccountLabeling } from 'src/components/suite/labeling';
 import { Fees } from 'src/components/wallet/Fees/Fees';
-import { useDispatch } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 import { TradingExchangeApprovalType } from 'src/types/trading/tradingForm';
 import { getProvidersInfoProps } from 'src/utils/wallet/trading/tradingTypingUtils';
 import { TradingCoinLogo } from 'src/views/wallet/trading/common/TradingCoinLogo';
@@ -77,6 +77,8 @@ export const ApproveModal = ({
         trigger,
     } = context;
 
+    const isDebug = useSelector(selectIsDebugModeActive);
+
     const { cryptoIdToSymbolAndContractAddress, cryptoIdToCoinSymbol } = useTradingInfo();
 
     const [approvalType, setApprovalType] = useState<DexApprovalType>('MINIMAL');
@@ -97,20 +99,10 @@ export const ApproveModal = ({
 
     const providerName = exchangeInfo?.providerInfos[quoteExchange]?.companyName || quoteExchange;
 
-    const isFullApproval = !(Number(selectedQuote.preapprovedStringAmount) > 0);
-
     if (!selectedQuote.send) return null;
-
-    const isToken = parseCryptoId(selectedQuote.send)?.contractAddress !== undefined;
 
     const translationValues = {
         value: selectedQuote.approvalStringAmount,
-        send: cryptoIdToCoinSymbol(selectedQuote.send),
-        provider: providerName,
-    };
-
-    const preapprovedTranslationValues = {
-        value: selectedQuote.preapprovedStringAmount,
         send: cryptoIdToCoinSymbol(selectedQuote.send),
         provider: providerName,
     };
@@ -167,7 +159,12 @@ export const ApproveModal = ({
             onCancel={onCancel}
             variant="primary"
             size="small"
-            heading={<Translation id="TR_EXCHANGE_APPROVAL_APPROVE_TOKEN_SPENDING" />}
+            heading={
+                <Translation
+                    id="TR_EXCHANGE_APPROVAL_APPROVE_TOKEN_SPENDING"
+                    values={{ displaySymbol }}
+                />
+            }
             bottomContent={
                 <>
                     {selectedQuote.status === 'APPROVAL_REQ' && (
@@ -177,7 +174,7 @@ export const ApproveModal = ({
                             isDisabled={!device?.connected}
                             onClick={confirmAndSend}
                         >
-                            <Translation id="TR_EXCHANGE_CONFIRM_ON_TREZOR_SEND" />
+                            <Translation id="TR_CONTINUE" />
                         </Modal.Button>
                     )}
 
@@ -186,153 +183,128 @@ export const ApproveModal = ({
                     </Modal.Button>
                 </>
             }
+            description={
+                <Row margin={{ top: spacings.xs }} gap={spacings.xxs}>
+                    <CoinLogo size={20} symbol={account.symbol} />
+                    <AccountLabeling
+                        account={account}
+                        showAccountTypeBadge
+                        accountTypeBadgeSize="small"
+                    />
+                </Row>
+            }
         >
             <Column gap={spacings.sm}>
-                <Card>
-                    <Row gap={spacings.sm}>
-                        <TradingCoinLogo cryptoId={selectedQuote.send} size={24} />
-                        <Column>
-                            <Translation
-                                id="TR_EXCHANGE_APPROVAL_APPROVE_TOKEN"
-                                values={{ displaySymbol }}
-                            />
-                            <Paragraph typographyStyle="label" variant="default" align="start">
-                                <AccountLabeling
-                                    account={account}
-                                    showAccountTypeBadge={true}
-                                    accountTypeBadgeSize="small"
+                <Box padding={spacings.sm} borderWidth={borders.widths.large} borderRadius="12px">
+                    <Column gap={spacings.sm}>
+                        <Text>
+                            <Translation id="TR_EXCHANGE_APPROVAL_PROVIDER" />
+                        </Text>
+                        <Row gap={spacings.xs}>
+                            {provider?.logo && (
+                                <Icon src={invityAPI.getProviderLogoUrl(provider.logo)} alt="" />
+                            )}
+                            <Column>
+                                {provider?.companyName && <Text>{provider.companyName}</Text>}
+                                <Text typographyStyle="hint" variant="tertiary">
+                                    {contractAddress}
+                                </Text>
+                            </Column>
+                        </Row>
+                    </Column>
+                </Box>
+
+                <Box borderWidth={borders.widths.large} padding={spacings.sm} borderRadius="12px">
+                    <Column gap={spacings.sm}>
+                        <Text>
+                            <Translation id="TR_EXCHANGE_APPROVAL_SET_LIMIT" />
+                        </Text>
+                        <RadioCard
+                            isActive={approvalType === 'INFINITE'}
+                            onClick={() => selectApprovalValue('INFINITE')}
+                        >
+                            <Row>
+                                <TradingCoinLogo
+                                    cryptoId={selectedQuote.send}
+                                    size={20}
+                                    margin={{ right: spacings.xxs }}
+                                />
+                                <Text>
+                                    <Translation id="TR_EXCHANGE_APPROVAL_VALUE_INFINITE" />
+                                </Text>
+                            </Row>
+                            <Paragraph
+                                margin={{ top: spacings.xxs }}
+                                typographyStyle="hint"
+                                variant="tertiary"
+                            >
+                                <Translation
+                                    id="TR_EXCHANGE_APPROVAL_VALUE_INFINITE_INFO"
+                                    values={translationValues}
                                 />
                             </Paragraph>
-                        </Column>
-                    </Row>
-
-                    <Divider />
-
-                    <Row gap={spacings.sm}>
-                        {provider?.logo && (
-                            <Icon src={invityAPI.getProviderLogoUrl(provider.logo)} alt="" />
-                        )}
-
-                        {provider?.companyName}
-                    </Row>
-                </Card>
-
-                <CollapsibleBox
-                    heading={
-                        <Row gap={spacings.sm}>
-                            <Translation id="TR_EXCHANGE_APPROVAL_LIMIT" />
-                            {approvalType === 'MINIMAL' && (
-                                <Badge variant="primary">
-                                    <Translation id="TR_EXCHANGE_APPROVAL_LIMIT_MINIMAL" />
-                                </Badge>
-                            )}
-                            {approvalType === 'INFINITE' && (
-                                <Badge variant="warning">
-                                    <Translation id="TR_EXCHANGE_APPROVAL_LIMIT_INFINITE" />
-                                </Badge>
-                            )}
-                        </Row>
-                    }
-                >
-                    <Column gap={spacings.md}>
-                        <Card>
-                            <Radio
-                                isChecked={approvalType === 'MINIMAL'}
-                                onClick={() => selectApprovalValue('MINIMAL')}
-                                verticalAlignment="center"
-                                isDisabled={isFormLoading || isConfirmButtonLoading}
+                        </RadioCard>
+                        <RadioCard
+                            isActive={approvalType === 'MINIMAL'}
+                            onClick={() => selectApprovalValue('MINIMAL')}
+                        >
+                            <Row>
+                                <TradingCoinLogo
+                                    cryptoId={selectedQuote.send}
+                                    size={20}
+                                    margin={{ right: spacings.xxs }}
+                                />
+                                <Text>
+                                    <Translation
+                                        id="TR_EXCHANGE_APPROVAL_VALUE_MINIMAL"
+                                        values={translationValues}
+                                    />
+                                </Text>
+                            </Row>
+                            <Paragraph
+                                margin={{ top: spacings.xxs }}
+                                typographyStyle="hint"
+                                variant="tertiary"
                             >
-                                <Column alignItems="flex-start">
-                                    <Text typographyStyle="highlight">
-                                        <Translation
-                                            id="TR_EXCHANGE_APPROVAL_VALUE_MINIMAL"
-                                            values={translationValues}
-                                        />
-                                    </Text>
-                                    <Paragraph typographyStyle="hint">
-                                        <Translation
-                                            id="TR_EXCHANGE_APPROVAL_VALUE_MINIMAL_INFO"
-                                            values={translationValues}
-                                        />
-                                    </Paragraph>
-                                </Column>
-                            </Radio>
-                        </Card>
-                        <Card>
-                            <Radio
-                                isChecked={approvalType === 'INFINITE'}
-                                onClick={() => selectApprovalValue('INFINITE')}
-                                verticalAlignment="center"
-                                isDisabled={isFormLoading || isConfirmButtonLoading}
-                            >
-                                <Column alignItems="flex-start">
-                                    <Text typographyStyle="highlight">
-                                        <Translation
-                                            id="TR_EXCHANGE_APPROVAL_VALUE_INFINITE"
-                                            values={translationValues}
-                                        />
-                                    </Text>
-                                    <Paragraph typographyStyle="hint">
-                                        <Translation
-                                            id="TR_EXCHANGE_APPROVAL_VALUE_INFINITE_INFO"
-                                            values={translationValues}
-                                        />
-                                    </Paragraph>
-                                </Column>
-                            </Radio>
-                        </Card>
-
-                        {isToken && !isFullApproval && (
-                            <Card>
-                                <Radio
-                                    isChecked={approvalType === 'ZERO'}
-                                    onClick={() => selectApprovalValue('ZERO')}
-                                    verticalAlignment="center"
-                                    isDisabled={isFormLoading || isConfirmButtonLoading}
-                                >
-                                    <Column alignItems="flex-start">
-                                        <Text typographyStyle="highlight">
-                                            <Translation
-                                                id="TR_EXCHANGE_APPROVAL_VALUE_ZERO"
-                                                values={preapprovedTranslationValues}
-                                            />
-                                        </Text>
-                                        <Paragraph typographyStyle="hint">
-                                            <Translation
-                                                id="TR_EXCHANGE_APPROVAL_VALUE_ZERO_INFO"
-                                                values={preapprovedTranslationValues}
-                                            />
-                                        </Paragraph>
-                                    </Column>
-                                </Radio>
-                            </Card>
-                        )}
-
-                        {dexTx.data && (
+                                <Translation
+                                    id="TR_EXCHANGE_APPROVAL_VALUE_MINIMAL_INFO"
+                                    values={translationValues}
+                                />
+                            </Paragraph>
+                        </RadioCard>
+                        {isDebug && dexTx.data ? (
                             <CollapsibleBox
-                                heading={<Translation id="TR_EXCHANGE_APPROVAL_DATA" />}
+                                heading={
+                                    <Row gap={spacings.xs}>
+                                        <Translation id="TR_EXCHANGE_APPROVAL_DATA" />
+                                        <Badge variant="warning" size="small">
+                                            <Translation id="TR_DEBUG_ONLY" />
+                                        </Badge>
+                                    </Row>
+                                }
                             >
                                 <BreakableValue>{dexTx.data}</BreakableValue>
                             </CollapsibleBox>
-                        )}
+                        ) : null}
                     </Column>
-                </CollapsibleBox>
+                </Box>
 
-                <Divider margin={{ top: spacings.xxs, bottom: spacings.xxs }} />
-
-                <Fees
-                    control={control}
-                    feeInfo={feeInfo}
-                    account={account}
-                    composedLevels={composedLevels}
-                    errors={errors}
-                    isDirty={isDirty}
-                    register={register}
-                    setValue={setValue}
-                    getValues={getValues}
-                    changeFeeLevel={changeFeeLevel}
-                    trigger={trigger}
-                />
+                <Box padding={spacings.sm} borderWidth={borders.widths.large} borderRadius="12px">
+                    <Fees
+                        label="TR_TX_FEE"
+                        control={control}
+                        feeInfo={feeInfo}
+                        account={account}
+                        composedLevels={composedLevels}
+                        errors={errors}
+                        isDirty={isDirty}
+                        register={register}
+                        setValue={setValue}
+                        getValues={getValues}
+                        changeFeeLevel={changeFeeLevel}
+                        trigger={trigger}
+                    />
+                </Box>
             </Column>
         </Modal>
     );

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -539,7 +539,7 @@ export default defineMessages({
         id: 'TR_EXCHANGE_APPROVAL_ERROR',
     },
     TR_EXCHANGE_APPROVAL_APPROVE_TOKEN_SPENDING: {
-        defaultMessage: 'Approve token spending',
+        defaultMessage: 'Set {displaySymbol} spending',
         id: 'TR_EXCHANGE_APPROVAL_APPROVE_TOKEN_SPENDING',
     },
     TR_EXCHANGE_APPROVAL_APPROVE_TOKEN: {
@@ -607,21 +607,21 @@ export default defineMessages({
         id: 'TR_EXCHANGE_APPROVAL_VALUE',
     },
     TR_EXCHANGE_APPROVAL_VALUE_MINIMAL: {
-        defaultMessage: 'Necessary value of {value} {send}',
+        defaultMessage: '{value} {send}',
         id: 'TR_EXCHANGE_APPROVAL_VALUE_MINIMAL',
     },
     TR_EXCHANGE_APPROVAL_VALUE_MINIMAL_INFO: {
         defaultMessage:
-            'Approve only the exact amount required for this swap. You will need to pay an additional fee if you want to make a similar swap again.',
+            "Approve only the amount needed for this swap. This helps reduce risk, but you'll need to approve again (and pay a fee) for future swaps.",
         id: 'TR_EXCHANGE_APPROVAL_VALUE_MINIMAL_INFO',
     },
     TR_EXCHANGE_APPROVAL_VALUE_INFINITE: {
-        defaultMessage: 'Infinite value',
+        defaultMessage: 'Unlimited',
         id: 'TR_EXCHANGE_APPROVAL_VALUE_INFINITE',
     },
     TR_EXCHANGE_APPROVAL_VALUE_INFINITE_INFO: {
         defaultMessage:
-            'Create a single approval transaction to simplify multiple exchanges of {send} with {provider}. This saves on fees but carries a risk to your funds in the unlikely case of a flaw in {provider}’s contract.',
+            'Approve unlimited {send} to skip future approval requests and reduce fees. Only use this option if you trust {provider}, as it will have access to all your {send}.',
         id: 'TR_EXCHANGE_APPROVAL_VALUE_INFINITE_INFO',
     },
     TR_EXCHANGE_APPROVAL_VALUE_ZERO: {
@@ -640,6 +640,14 @@ export default defineMessages({
     TR_EXCHANGE_APPROVAL_NOT_REQUIRED: {
         defaultMessage: 'No approval transaction needed for {send}.',
         id: 'TR_EXCHANGE_APPROVAL_NOT_REQUIRED',
+    },
+    TR_EXCHANGE_APPROVAL_PROVIDER: {
+        defaultMessage: 'Provider',
+        id: 'TR_EXCHANGE_APPROVAL_PROVIDER',
+    },
+    TR_EXCHANGE_APPROVAL_SET_LIMIT: {
+        defaultMessage: 'Set limit',
+        id: 'TR_EXCHANGE_APPROVAL_SET_LIMIT',
     },
     TR_EXCHANGE_SWAP_SEND_TO: {
         defaultMessage: '{provider} contract address',
@@ -1564,12 +1572,20 @@ export default defineMessages({
         id: 'TR_TRADING_SWAP_UNAVAILABLE',
     },
     TR_TRADING_APPROVE_TOKEN: {
-        defaultMessage: 'Approve {tokenSymbol}',
+        defaultMessage: 'Approve {tokenSymbol} spending',
         id: 'TR_TRADING_APPROVE_TOKEN',
     },
+    TR_TRADING_APPROVE_TOKEN_BUTTON: {
+        defaultMessage: 'Approve {tokenSymbol}',
+        id: 'TR_TRADING_APPROVE_TOKEN_BUTTON',
+    },
     TR_TRADING_REVOKE_TOKEN: {
-        defaultMessage: 'Revoke {tokenSymbol}',
+        defaultMessage: 'Revoke {tokenSymbol} spending',
         id: 'TR_TRADING_REVOKE_TOKEN',
+    },
+    TR_TRADING_REVOKE_TOKEN_BUTTON: {
+        defaultMessage: 'Revoke {tokenSymbol}',
+        id: 'TR_TRADING_REVOKE_TOKEN_BUTTON',
     },
     TR_TRADING_TRANS_ID: {
         defaultMessage: 'Trans. ID:',

--- a/packages/suite/src/utils/suite/transactionReview.ts
+++ b/packages/suite/src/utils/suite/transactionReview.ts
@@ -10,6 +10,7 @@ interface GetTransactionReviewModalActionTranslationParams {
     isBumpFeeRbfAction: boolean;
     isCancelRbfAction: boolean;
     isSending?: boolean;
+    source: 'heading' | 'button';
 }
 
 export const getTransactionReviewModalActionTranslation = ({
@@ -19,6 +20,7 @@ export const getTransactionReviewModalActionTranslation = ({
     isBumpFeeRbfAction,
     isCancelRbfAction,
     isSending,
+    source,
 }: GetTransactionReviewModalActionTranslationParams): ExtendedMessageDescriptor => {
     switch (stakeType) {
         case 'stake':
@@ -40,12 +42,18 @@ export const getTransactionReviewModalActionTranslation = ({
         switch (transactionPurpose) {
             case 'approval':
                 return {
-                    id: 'TR_TRADING_APPROVE_TOKEN',
+                    id:
+                        source === 'heading'
+                            ? 'TR_TRADING_APPROVE_TOKEN'
+                            : 'TR_TRADING_APPROVE_TOKEN_BUTTON',
                     values: { tokenSymbol: tradingToken?.symbol?.toUpperCase() },
                 };
             case 'revoke':
                 return {
-                    id: 'TR_TRADING_REVOKE_TOKEN',
+                    id:
+                        source === 'heading'
+                            ? 'TR_TRADING_REVOKE_TOKEN'
+                            : 'TR_TRADING_REVOKE_TOKEN_BUTTON',
                     values: { tokenSymbol: tradingToken?.symbol?.toUpperCase() },
                 };
             default:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR implements the updated Approval modal according to the [Figma](https://www.figma.com/design/nsDtvR2N5TmuK1QCefRdvP/Trading--Final-?node-id=4230-2212&t=fsNTebgxEYdgeCr2-4) design. **Title** and **button text** in `TransactionReviewModal` were also updated.

## Related Issue

Resolve #20272 

## Screenshots:
|debug mode|no debug mode|
|------------|----------------|
|<img width="603" height="976" alt="Screenshot 2025-08-04 at 16 57 45" src="https://github.com/user-attachments/assets/d006c586-57cf-4670-b852-3145f30d35b4" />|<img width="609" height="770" alt="image" src="https://github.com/user-attachments/assets/7fd1fd0a-848f-4d9a-a5ef-1e3747962568" />|

Updated **title** and submit **button text**
<img width="612" height="780" alt="Screenshot 2025-08-04 at 17 00 36" src="https://github.com/user-attachments/assets/ec170dca-7b13-4db6-8df8-23a845d80bee" />

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/approve-modal-improvements&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/approve-modal-improvements&lookback=7)