### PR TITLE
Trading - don't refresh quotes when app is inactive

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingInitializer.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingInitializer.ts
@@ -6,8 +6,9 @@ import {
 } from '@suite-common/trading';
 import { useTimer } from '@trezor/react-utils';
 
-import { useDevice, useDispatch } from 'src/hooks/suite';
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { useServerEnvironment } from 'src/hooks/wallet/trading/useServerEnviroment';
+import { selectIsWindowVisible } from 'src/reducers/suite/windowReducer';
 import { UseTradingCommonProps, UseTradingCommonReturnProps } from 'src/types/trading/trading';
 
 export const useTradingInitializer = ({
@@ -19,6 +20,8 @@ export const useTradingInitializer = ({
     const timer = useTimer();
     const { account } = selectedAccount;
     const { device } = useDevice();
+
+    const isWindowVisible = useSelector(selectIsWindowVisible);
 
     const checkQuotesTimer = useCallback(
         (callback: () => Promise<void>) => {
@@ -35,13 +38,16 @@ export const useTradingInitializer = ({
                     return;
                 }
 
-                if (timer.timeSpent.seconds === INVITY_API_RELOAD_QUOTES_AFTER_SECONDS) {
+                if (
+                    isWindowVisible &&
+                    timer.timeSpent.seconds >= INVITY_API_RELOAD_QUOTES_AFTER_SECONDS
+                ) {
                     dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
                     callback();
                 }
             }
         },
-        [timer, pageType, isLoading, dispatch],
+        [timer, isWindowVisible, pageType, isLoading, dispatch],
     );
 
     useServerEnvironment();


### PR DESCRIPTION
## Description

When the user leaves the Suite browser tab, don't refresh quotes. The timer still runs in the background and once the user is inactive for too long, upon opening Suite again, the quotes will refresh.

## Related Issue

Resolve #20384 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/quotes-refresh&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/quotes-refresh&lookback=7)