### PR TITLE
feat(suite-native): default navigation animation

### DIFF
--- a/suite-native/app/src/navigation/RootStackNavigator.tsx
+++ b/suite-native/app/src/navigation/RootStackNavigator.tsx
@@ -124,7 +124,6 @@ export const RootStackNavigator = () => {
                 name={RootStackRoutes.BootloaderMode}
                 component={BootloaderModeScreen}
             />
-
             {/* Navigation flows that start by push from bottom animation on the first screen of its stack. */}
             <RootStack.Group screenOptions={{ animation: 'slide_from_bottom' }}>
                 <RootStack.Screen

--- a/suite-native/navigation/src/config.ts
+++ b/suite-native/navigation/src/config.ts
@@ -3,5 +3,4 @@ import { NativeStackNavigationOptions } from '@react-navigation/native-stack';
 export const stackNavigationOptionsConfig: NativeStackNavigationOptions = {
     headerShown: false,
     gestureEnabled: true,
-    animation: 'slide_from_right',
 } as const;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use default animation from the react-navigation library for both OS.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19933

## Screenshots:

https://github.com/user-attachments/assets/afc88ea4-a981-4c89-a8b7-885821795b5a


https://github.com/user-attachments/assets/018a56bb-2460-4006-8738-49ef89bf37ab



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/default-navigation-animation&lookback=7)