### PR TITLE
fix(suite): close the trezors ui window right when the passphrase is …

### DIFF
--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -703,9 +703,32 @@ export const runAdditionalDiscoveryThunk = createThunk(
 
         TrezorConnect.on<DiscoverAccountsProgress>(UI.BUNDLE_PROGRESS, onBundleProgress);
 
-        const result = await TrezorConnect.discoverAccounts({
-            device,
+        // NOTE: prepare the device to the corresponding state eg. insert the passphrase
+        const stateResult = await TrezorConnect.getDeviceState({
+            device: {
+                path: device.path,
+                instance: device.instance,
+                state: device.state.staticSessionId,
+            },
             useEmptyPassphrase: device.useEmptyPassphrase,
+        });
+
+        if (stateResult.success) {
+            dispatch(
+                applyDeviceStatesThunk({
+                    newDeviceState: stateResult.payload._state,
+                    isAddingHiddenWallet: !device.useEmptyPassphrase,
+                    devicePath: device.path,
+                }),
+            );
+        }
+
+        // NOTE: keep here the previous device as default to prevent TS from screeming
+        const updatedDevice = selectDeviceByStaticSessionId(getState(), staticSessionId) ?? device;
+
+        const result = await TrezorConnect.discoverAccounts({
+            device: updatedDevice,
+            useEmptyPassphrase: updatedDevice.useEmptyPassphrase,
             accounts: accountsParam,
         });
 
@@ -721,14 +744,14 @@ export const runAdditionalDiscoveryThunk = createThunk(
                         error: result.payload.error,
                         errorCode: result.payload.code,
                     },
-                    device.path,
+                    updatedDevice.path,
                 ),
             );
 
             return;
         }
 
-        dispatch(discoveryActions.updateDiscovery({ status: 'complete' }, device.path));
+        dispatch(discoveryActions.updateDiscovery({ status: 'complete' }, updatedDevice.path));
     },
 );
 


### PR DESCRIPTION
…confirmed when discovery requests it dynamically

<!--- Provide a general summary of your changes in the Title above -->

## Description

This is IMHO a better solution. 

Here, I recognize that the additional discovery requested a passphrase and when this check passes, I manually hide the window. The weakness is that theoretically, there can be another window request and this can hide it. But the likelihood is small, and you see the dispatches in the console.

Second possible solution is to hide modal "as it renders" based on some state of the discovery. Guess that would require another flag in the discovery to make it reliable like "discovery requested passphrase dynamically" and there would be a condition that if discovery progresses, hide this modal without waiting for hte "window close" event.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20045#issuecomment-3149631542

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=20045-passphrase-confirmation-stuck&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=20045-passphrase-confirmation-stuck&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=20045-passphrase-confirmation-stuck&lookback=7)