### PR TITLE
fix(suite): correct return url params in sell trade history

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -245,7 +245,16 @@ export const useTradingSellForm = ({
         const orderId = provider.flow === 'PAYMENT_GATE' ? quote.orderId : undefined;
 
         const returnUrl = await createQuoteLink(
-            { ...quotesRequest, paymentMethod: quote.paymentMethod },
+            {
+                ...quotesRequest,
+                country: quotesRequest.country ?? quote.country,
+                fiatCurrency: quotesRequest.fiatCurrency ?? quote.fiatCurrency,
+                amountInCrypto: quotesRequest.amountInCrypto ?? quote.amountInCrypto,
+                cryptoStringAmount: quotesRequest.cryptoStringAmount ?? quote.cryptoStringAmount,
+                fiatStringAmount: quotesRequest.fiatStringAmount ?? quote.fiatStringAmount,
+                cryptoCurrency: quotesRequest.cryptoCurrency ?? quote.cryptoCurrency,
+                paymentMethod: quote.paymentMethod,
+            },
             account,
             { selectedFee, composed },
             orderId,

--- a/packages/suite/src/utils/wallet/trading/sellUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/sellUtils.ts
@@ -26,7 +26,12 @@ export const createQuoteLink = async (
     }
 
     // fees info
-    if (composedInfo.composed) {
+    if (
+        composedInfo.composed &&
+        composedInfo.composed.feePerByte &&
+        composedInfo.composed.maxFeePerGas &&
+        composedInfo.composed.maxPriorityFeePerGas
+    ) {
         hash += account.networkType === 'solana' ? '/normal' : '/custom'; // manually set fee type
         hash += `/${composedInfo.composed.feePerByte}`;
         hash += `/${composedInfo.composed.maxFeePerGas}`;


### PR DESCRIPTION
## Description

Use correct return URL params when going to partner from sell trade history.

## Related Issue

Resolve #19955 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sell-return-url-params&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sell-return-url-params&lookback=7)