### PR TITLE
fix(suite): fallback to device in reconnect device prompt

### DIFF
--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -2,6 +2,7 @@ import * as semver from 'semver';
 
 import { useFirmwareInstallation } from '@suite-common/firmware';
 import { TranslationKey } from '@suite-common/intl-types';
+import { TrezorDevice } from '@suite-common/suite-types';
 import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
 import { BulletList, Column, DeviceAnimation, H2, Modal, Paragraph } from '@trezor/components';
 import { Device } from '@trezor/connect';
@@ -18,7 +19,7 @@ const RebootDeviceGraphics = ({
     device,
     isManualRebootRequired,
 }: {
-    device?: Device;
+    device?: Device | TrezorDevice;
     isManualRebootRequired: boolean;
 }) => {
     if (!isManualRebootRequired) {
@@ -68,7 +69,7 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
     const { showManualReconnectPrompt, status, reconnectEvent, buttonEvent } =
         useFirmwareInstallation();
     const { device } = useDevice();
-    const eventDevice = buttonEvent?.device;
+    const eventDevice = buttonEvent?.device || device;
 
     const isManualRebootRequired =
         // Automatic reboot isn't supported:


### PR DESCRIPTION
buttonEvent not available on old fws

<!--- Provide a general summary of your changes in the Title above -->

## Description

- fix old reboot to bootloader flow
- introduced new util `usePreviousDefined` for caching defined value

## Related Issue

Resolve https://satoshilabs.slack.com/archives/CKZHV2G13/p1754051208136669

## Screenshots:
<img width="517" height="582" alt="Screenshot 2025-08-04 at 13 49 49" src="https://github.com/user-attachments/assets/3a31971c-74b0-4874-96cd-cd0469592121" />

because of this, there is `usePreviousDefined`
<img width="516" height="621" alt="Screenshot 2025-08-04 at 14 04 26" src="https://github.com/user-attachments/assets/5a26c956-5e5f-402d-95bd-4fb9763dc4e1" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/2.1.5-device&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/2.1.5-device&lookback=7)