### PR TITLE
fix(suite): on selecting factory-reset device goto manual check before onboarding

### DIFF
--- a/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
@@ -97,13 +97,14 @@ export const NeedsAttentionBanner = ({
 
     const onSolveIssueClick = (): void => {
         switch (deviceStatus) {
-            // wiped device - should pass through Manual Device Check before starting onboarding
-            case 'initialize':
+            // If onboarding is pending, then it should pass through Manual Device Check.
+            case 'initialize': // Wiped device with firmware present.
+            case 'bootloader': // Fresh or factory-reset device? Can also be initalized device manually put into BL,
+                // but we cannot tell (device.features.initialized is null)
                 selectDevice();
                 dispatch(goto('suite-start'));
                 break;
 
-            case 'bootloader': // device without firmware or in the bootloader mode
             case 'seedless':
             case 'firmware-required':
             case 'unavailable':


### PR DESCRIPTION
## Description

Followup to #20353: fix also for fresh | factory-reset device.

## Related Issue

Resolve #15052

## Screenshots:

[Wiped with FW](https://github.com/user-attachments/assets/a66b905c-6b3a-4aed-8bee-9aa0b4eac52b)
[Wiped without FW](https://github.com/user-attachments/assets/ada5e2d7-d43e-4563-b20e-96aa0a762197)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/security-check-for-factory-reset-device&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/security-check-for-factory-reset-device&lookback=7)