### PR TITLE
fix(suite): open wallet-switcher on device connect if other devices

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/settings/without-device.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/without-device.test.ts
@@ -8,8 +8,14 @@ test.describe(
             await onboardingPage.completeOnboarding();
         });
 
-        test('Settings navigation', async ({ page, walletPage, trezorUserEnvLink }) => {
+        test('Settings navigation', async ({
+            page,
+            walletPage,
+            trezorUserEnvLink,
+            emulatorStartConf,
+        }) => {
             await test.step('Go to send form and verify Trezor disconnected warning', async () => {
+                await trezorUserEnvLink.startEmu({ ...emulatorStartConf, wipe: false });
                 await walletPage.openAccount();
                 await page.getByTestId('@wallet/menu/wallet-send').click();
                 await trezorUserEnvLink.stopEmu();
@@ -25,7 +31,7 @@ test.describe(
             });
 
             await test.step('Reconnect trezor and verify warning is gone', async () => {
-                await trezorUserEnvLink.startEmu();
+                await trezorUserEnvLink.startEmu({ ...emulatorStartConf, wipe: false });
                 await page.getByTestId('@suite/menu/suite-index').click();
                 await walletPage.openAccount();
                 await page.getByTestId('@wallet/menu/wallet-send').click();

--- a/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
@@ -58,8 +58,6 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
             });
 
             await test.step('After reloading inactive suite session does not take Bridge session back', async () => {
-                await expect(dashboardPage.deviceStatus).toHaveText('Disconnected');
-                await dashboardPage.deviceSwitchingOpenButton.click();
                 await expect(dashboardPage.deviceStatusOnSwitchDevice).toHaveText('Disconnected');
             });
 

--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -1,11 +1,12 @@
 import { testMocks } from '@suite-common/test-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { deviceActions } from '@suite-common/wallet-core';
-import { DEVICE, TRANSPORT } from '@trezor/connect';
+import { DEVICE, Device, TRANSPORT } from '@trezor/connect';
 
 import { SUITE } from 'src/actions/suite/constants';
-import { TorStatus } from 'src/types/suite';
+import { AppState, TorStatus } from 'src/types/suite';
 
+import { openSwitchDeviceDialog } from '../../wallet/addWalletThunk';
 import * as suiteActions from '../suiteActions';
 
 const { getSuiteDevice, getConnectDevice } = testMocks;
@@ -302,23 +303,43 @@ const selectDevice = [
     },
 ];
 
-const handleDeviceConnect = [
+type DeviceConnectFixture = {
+    description: string;
+    state: {
+        suite: Partial<AppState['suite']>;
+        device: Partial<AppState['device']>;
+    };
+    device: Device;
+    expectedNextActionType: string;
+};
+
+const handleDeviceConnect: DeviceConnectFixture[] = [
     {
-        description: `select connected device`,
+        description: `selects a newly connected device if there are none`,
         state: {
             device: { devices: [SUITE_DEVICE] },
             suite: {},
         },
         device: CONNECT_DEVICE,
-        result: deviceActions.selectDevice.type,
+        expectedNextActionType: deviceActions.selectDevice.type,
     },
     {
-        description: `ignore`,
+        description: `selects a newly connected physical device corresponding to selected remembered wallet `,
         state: {
             device: { selectedDevice: SUITE_DEVICE },
             suite: {},
         },
         device: CONNECT_DEVICE,
+        expectedNextActionType: deviceActions.selectDevice.type,
+    },
+    {
+        description: `opens the wallet switcher when newly connected physical not seen before`,
+        state: {
+            device: { selectedDevice: SUITE_DEVICE },
+            suite: {},
+        },
+        device: { ...CONNECT_DEVICE, id: 'a-different-id' } as Device,
+        expectedNextActionType: openSwitchDeviceDialog.pending.type,
     },
 ];
 

--- a/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
@@ -8,7 +8,6 @@ import {
     acquireDevice,
     deviceActions,
     forgetDisconnectedDevices,
-    handleDeviceConnect,
     handleDeviceDisconnect,
     observeSelectedDevice,
     prepareDeviceReducer,
@@ -16,6 +15,7 @@ import {
 } from '@suite-common/wallet-core';
 import { DEVICE } from '@trezor/connect';
 
+import { handleDeviceConnect } from 'src/actions/wallet/handleDeviceConnectThunk';
 import modalReducer from 'src/reducers/suite/modalReducer';
 import routerReducer from 'src/reducers/suite/routerReducer';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
@@ -155,12 +155,8 @@ describe('Suite Actions', () => {
             const state = getInitialState(f.state.suite, f.state.device, undefined);
             const store = initStore(state);
             await store.dispatch(handleDeviceConnect(f.device));
-            if (!f.result) {
-                expect(filterThunkActionTypes(store.getActions()).length).toEqual(0);
-            } else {
-                const action = filterThunkActionTypes(store.getActions()).pop();
-                expect(action?.type).toEqual(f.result);
-            }
+            // a lot of actions may get called, and the one we are interested in may not be the last one
+            expect(store.getActions().some(a => a?.type === f.expectedNextActionType)).toBe(true);
         });
     });
 

--- a/packages/suite/src/actions/wallet/handleDeviceConnectThunk.ts
+++ b/packages/suite/src/actions/wallet/handleDeviceConnectThunk.ts
@@ -1,0 +1,25 @@
+import { createThunk } from '@suite-common/redux-utils';
+import {
+    DEVICE_MODULE_PREFIX,
+    selectDeviceThunk,
+    selectSelectedDevice,
+} from '@suite-common/wallet-core';
+import { Device } from '@trezor/connect';
+
+import { openSwitchDeviceDialog } from './addWalletThunk';
+
+export const handleDeviceConnect = createThunk(
+    `${DEVICE_MODULE_PREFIX}/handleDeviceConnect`,
+    (device: Device, { dispatch, getState }) => {
+        const selectedDevice = selectSelectedDevice(getState());
+
+        // Select automatically when it is the first known device,
+        // or when we connected physical device corresponding to a selected remembered wallet.
+        const shouldSelectDevice = !selectedDevice || device.id === selectedDevice.id;
+        if (shouldSelectDevice) {
+            dispatch(selectDeviceThunk({ device }));
+        } else {
+            dispatch(openSwitchDeviceDialog());
+        }
+    },
+);

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -7,7 +7,6 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     deviceActions,
     forgetDisconnectedDevices,
-    handleDeviceConnect,
     handleDeviceDisconnect,
     observeSelectedDevice,
     restartDiscoveryThunk,
@@ -18,6 +17,7 @@ import { METADATA, ROUTER, SUITE } from 'src/actions/suite/constants';
 import { handleProtocolRequest } from 'src/actions/suite/protocolActions';
 import { goto } from 'src/actions/suite/routerActions';
 import { appChanged, setRecentlyDisconnectedDevice } from 'src/actions/suite/suiteActions';
+import { handleDeviceConnect } from 'src/actions/wallet/handleDeviceConnectThunk';
 import { Action, AppState, Dispatch } from 'src/types/suite';
 
 const isActionDeviceRelated = (action: AnyAction): boolean => {

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -109,23 +109,6 @@ export type CreateDeviceInstanceError = {
  * Triggered by `@trezor/connect DEVICE_EVENT`
  * @param {Device} device
  */
-export const handleDeviceConnect = createThunk(
-    `${DEVICE_MODULE_PREFIX}/handleDeviceConnect`,
-    (device: Device, { dispatch, getState }) => {
-        const selectedDevice = selectSelectedDevice(getState());
-
-        if (!selectedDevice) {
-            dispatch(selectDeviceThunk({ device }));
-        } else {
-            // TODO: show some nice notification/tooltip in DeviceMenu
-        }
-    },
-);
-
-/**
- * Triggered by `@trezor/connect DEVICE_EVENT`
- * @param {Device} device
- */
 export const handleDeviceDisconnect = createThunk(
     `${DEVICE_MODULE_PREFIX}/handleDeviceDisconnect`,
     (device: Device | TrezorDevice, { dispatch, getState, extra }) => {


### PR DESCRIPTION
## Description

Open wallet switcher when a device is physically connected.

## Related Issue

Resolve #20158

## Screenshots:

When device is connected:

With no known device, it gets autoselected and wallet-switcher does not open (as before)

[autoselect when no device.webm](https://github.com/user-attachments/assets/3837da69-26c6-4951-8435-eddd7c7b739c)

With a device already (view-only or connected), the wallet switcher opens 

[wallet switcher opens when other device.webm](https://github.com/user-attachments/assets/84b4bfec-68dc-4a1f-be53-b71bdf8183a3)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/open-wallet-switcher-on-device-connect&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/open-wallet-switcher-on-device-connect&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/open-wallet-switcher-on-device-connect&lookback=7)