### PR TITLE
fix(suite): make sure that the positional params of the modal routes …

### DIFF
--- a/packages/suite/src/utils/suite/__tests__/router.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/router.test.ts
@@ -79,7 +79,6 @@ describe('router', () => {
                 }),
             ).toEqual('/accounts#/btc/0/normal');
             expect(
-                // @ts-expect-error: invalid params
                 getRoute('wallet-index', {
                     accountIndex: 1,
                     symbol: 'btc',
@@ -87,7 +86,6 @@ describe('router', () => {
             ).toEqual('/accounts#/btc/1');
             // route shouldn't have params
             expect(
-                // @ts-expect-error: invalid params
                 getRoute('onboarding-index', {
                     symbol: 'btc',
                 }),

--- a/packages/suite/src/utils/suite/router.ts
+++ b/packages/suite/src/utils/suite/router.ts
@@ -1,3 +1,4 @@
+import { modalAppParams } from '@suite-common/suite-config';
 import { Route } from '@suite-common/suite-types';
 import { getNetworkOptional, isAccountOfNetwork } from '@suite-common/wallet-config';
 import { WalletParams as CommonWalletParams } from '@suite-common/wallet-types';
@@ -76,27 +77,29 @@ const parseParamValue = <T>(value: string, defaultValue?: T) => {
 };
 
 export type ModalAppParams = {
-    cancelable: boolean;
-    variant?: string;
+    [key in (typeof modalAppParams)[number]]: string | boolean | undefined;
+};
+
+const modalAppParamsDefaultValues: ModalAppParams = {
+    cancelable: true,
+    variant: undefined,
 };
 
 const validateModalAppParams = (url: string, params?: Route['params']): ModalAppParams | null => {
     const [, hash] = stripPrefixedURL(url).split('#');
-    if (!hash) return null;
-    const splitted = hash.split('/').filter(p => p.length > 0);
-    if (splitted.length === 0) return null;
-
-    const defaults: ModalAppParams = { cancelable: true };
-
-    if (params === undefined) return defaults;
+    const splitted = hash?.split('/').filter(p => p.length > 0);
+    if (!splitted || splitted.length === 0) return modalAppParamsDefaultValues;
 
     return {
-        ...defaults,
+        ...modalAppParamsDefaultValues,
         ...Object.fromEntries(
-            params.map((param, index) => [
+            params?.map((param, index) => [
                 param,
-                parseParamValue(splitted[index], defaults[param as keyof ModalAppParams]),
-            ]),
+                parseParamValue(
+                    splitted[index],
+                    modalAppParamsDefaultValues[param as keyof ModalAppParams],
+                ),
+            ]) ?? [],
         ),
     } as ModalAppParams;
 };
@@ -137,7 +140,9 @@ export const getAppWithParams = (url: string): RouterAppWithParams => {
 };
 
 export type WalletParams = CommonWalletParams;
-export type RouteParams = WalletParams | ModalAppParams;
+export type RouteParams = {
+    [K in keyof (WalletParams & ModalAppParams)]?: (WalletParams & ModalAppParams)[K];
+};
 
 export const getRoute = (name: Route['name'], params?: RouteParams) => {
     const route = findRouteByName(name);

--- a/suite-common/suite-config/src/routes.ts
+++ b/suite-common/suite-config/src/routes.ts
@@ -4,8 +4,8 @@
 // 3. implement validation function in @suite-utils/router:getAppWithParams
 // 4. add params types to RouteParamsTypes (@suite-constants/routes)
 
-const walletParams = ['symbol', 'accountIndex', 'accountType'] as const;
-const modalAppParams = ['cancelable', 'variant'] as const;
+export const walletParams = ['symbol', 'accountIndex', 'accountType'] as const;
+export const modalAppParams = ['cancelable', 'variant'] as const;
 
 export const routes = [
     {


### PR DESCRIPTION
…are populated with defaults

<!--- Provide a general summary of your changes in the Title above -->

## Description

Funny thing. If there were no params at all, the default `cancelable: true` hasn't been applied. There had to be something behind `#` in the URL.

Previous, before `26f46e39451b8331ed57f7c14136e3ac43fbbacc` that `SwitchDevice` modal didn't even cared about `cancelable=true/false` in its props, so it just worked as cancelable always.

So by "fixing" the switch device modal to care for `cancelable` prop, we broke other cases that relied on cancelable swich device modal and didn't pass the parameter explicitly in `goto()`

So from now on, you are forced by the TS to provide the default param values even if these are undefined.

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/20480

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=20480-fixed-no-default-params-routes&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=20480-fixed-no-default-params-routes&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=20480-fixed-no-default-params-routes&lookback=7)