### PR TITLE
Fix Suite Web/Desktop E2E

### DIFF
--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -1,8 +1,9 @@
-import test, { Locator, TestInfo } from '@playwright/test';
+import test, { Locator, Page, TestInfo } from '@playwright/test';
 import { isEqual, omit } from 'lodash';
 import { readdirSync } from 'node:fs';
 import path from 'node:path';
 
+import { validJws } from '@suite-common/message-system/src/__fixtures__/messageSystemActions';
 import { TradingCountryCode, regional } from '@suite-common/trading';
 import { getAccountDecimals, localizeNumber } from '@suite-common/wallet-utils';
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
@@ -157,3 +158,11 @@ export const getBigNumberFromBalance = async (locator: Locator) => {
 
     return { originalBalance, hasEllipsis };
 };
+
+/**
+ * Mocks remote message-system with an empty JWS config signed by develop key.
+ */
+export const mockRemoteMessageSystem = async (page: Page): Promise<void> =>
+    await page.route('**/config.v1.jws', async route => {
+        await route.fulfill({ status: 200, body: validJws });
+    });

--- a/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts
@@ -4,7 +4,13 @@ import { BrowserContext, Page, TestInfo, test as base } from '@playwright/test';
 import { TestAnnotationType } from '@trezor/e2e-utils';
 import { Model, SetupEmu, StartEmu, TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
 
-import { TrezorUserEnvLinkProxy, getUrl, getVideoPath, isDesktopProject } from '../common';
+import {
+    TrezorUserEnvLinkProxy,
+    getUrl,
+    getVideoPath,
+    isDesktopProject,
+    mockRemoteMessageSystem,
+} from '../common';
 import { LaunchSuiteParams, Suite, launchSuite } from '../electron';
 import { enhancePage } from './enhancePage';
 
@@ -84,6 +90,7 @@ const webSetup = async (browserContext: BrowserContext) => {
         window.Playwright = true;
     });
     await page.goto('./');
+    await mockRemoteMessageSystem(page);
 
     return page;
 };

--- a/packages/suite-desktop-core/e2e/tests/suite/db-locale-migration.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/db-locale-migration.test.ts
@@ -21,9 +21,10 @@ test.describe('Database migration', { tag: ['@group=migrations', '@webOnly'] }, 
                 priority: TestPriority.Medium,
             }),
         },
-        async ({ page }) => {
+        async ({ onboardingPage, page }) => {
             await test.step(`Load suite in old version ${migrateFromVersion}`, async () => {
                 await page.goto(`${suiteDevInstance}/${migrateFromVersion}`);
+                await onboardingPage.disableNecessaryFirmwareChecks();
                 await page.locator('[data-testid="@analytics/toggle-switch"]').click();
                 await page.locator('[data-testid="@analytics/continue-button"]').click();
                 await page.locator('[data-testid="@onboarding/exit-app-button"]').click();
@@ -39,6 +40,7 @@ test.describe('Database migration', { tag: ['@group=migrations', '@webOnly'] }, 
 
             await test.step(`Navigate to new version ${migrateToVersion} and check locale status`, async () => {
                 await page.goto(`${suiteDevInstance}/${migrateToVersion}`);
+                await onboardingPage.disableNecessaryFirmwareChecks();
 
                 await page.locator('[data-testid="@suite/menu/settings"]').click();
                 await expect(


### PR DESCRIPTION
## Description

Fix two unrelated E2E crashes caused by:
- message system interference after https://github.com/trezor/trezor-suite/pull/20533
- FW hash check interference after https://github.com/trezor/trezor-suite/pull/20535
  - (probably, not proven) downgrading tenv was necessary to fix other problems, but changed version of the device, so it went from FW hash check skipped → FW hash check performed → and in E2E it needs to be disabled always when it's done

### Cause

As for message system:
for example the `safety-checks-warning.test.ts` expects this:
<img width="624" height="95" alt="image" src="https://github.com/user-attachments/assets/623d8eff-e441-4e40-849e-8561ac4debbb" />
but gets this and fails because it cannot find [the CTA on the SafetyChecksBanner](https://github.com/trezor/trezor-suite/blob/307890a70774536167d23915178535506d87ede8/packages/suite/src/components/suite/banners/SuiteBanners/SafetyChecksBanner.tsx#L39):
<img width="1033" height="115" alt="image (1)" src="https://github.com/user-attachments/assets/dd80d992-d747-407b-9792-90543058b1b8" />

Similar case for `backup/t2t1-misc.test.ts` and `backup/t2t1-success.test.ts` which expect [NoBackupBanner](https://github.com/trezor/trezor-suite/blob/307890a70774536167d23915178535506d87ede8/packages/suite/src/components/suite/banners/SuiteBanners/NoBackupBanner.tsx)

### Notes

`page.route -> route.fulfill` is broken on playwright https://github.com/microsoft/playwright/issues/30495
(we use `onBeforeRequest` in electron-main, and it breaks it)

I tried to circumvent it [at here](https://github.com/trezor/trezor-suite/blob/e484640ea2e618d3f78e6e3104f0857520c4cf0a/packages/suite-desktop-core/e2e/support/testExtends/suiteBaseFixture.ts#L51), but it's no good, the fetch is intercepted but promise freezes pending:
```
    const encoded = encodeURIComponent(validJws);
    const redirectURL = `data:text/plain,${encoded}`;
    await suite.electronApp.evaluate(async ({ session }) => {
        session.defaultSession.webRequest.onBeforeRequest(
            { urls: ['https://data.trezor.io/config/develop/config.v1.jws'] },
            (_details, callback) => {
                callback({ redirectURL });
            },
        );
    });
```

I also tried this hack but did not finish it, the `.catch` does not suppress the error
```
/**
 * Dismiss all dismissible message system banners if any are present.
 */
export const optionallyDismissMessageSystemBanners = (page: Page) => {
    page.getByTestId(/@message-system\/.+\/dismiss/)
        .click()
        // check if any more banners are present behind the one we just dismissed
        .then(() => optionallyDismissMessageSystemBanners(page))
        // Nothing matched; suppress error.
        .catch();
};
```

---

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/e2e&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/e2e&lookback=7)