### PR TITLE
feat(suite): enable trezor connect by default

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/analytics/toggle.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/analytics/toggle.test.ts
@@ -103,7 +103,8 @@ test.describe('Analytics Toggle - Enabling and Disabling', { tag: ['@group=other
         await expect(settingsPage.analyticsSwitch.locator('input')).toBeChecked();
 
         await analyticsSection.continueButton.click(); // Click the button and trigger the request
-        await analytics.waitForAnalyticsRequests(2);
+        // 3 requests are expected: "suite/ready", "analytics/enable", and "connect-popup/init"
+        await analytics.waitForAnalyticsRequests(3);
 
         // assert that more than 1 event was fired and it was "suite/ready" and "analytics/enable" for sure
         expect(analytics.requests.length).toBeGreaterThan(1);

--- a/packages/suite-desktop-core/src/index.d.ts
+++ b/packages/suite-desktop-core/src/index.d.ts
@@ -136,7 +136,7 @@ declare type TraySettings = {
 };
 
 declare type ConnectSettings = {
-    enableWs: boolean;
+    disableWs: boolean;
     autoStartDontAskAgain: boolean;
     hasUsedConnectWs: boolean;
 };

--- a/packages/suite-desktop-core/src/libs/store.ts
+++ b/packages/suite-desktop-core/src/libs/store.ts
@@ -103,7 +103,7 @@ export class Store {
 
     public getConnectSettings() {
         return this.store.get('connectSettings', {
-            enableWs: false,
+            disableWs: false,
             autoStartDontAskAgain: false,
             hasUsedConnectWs: false,
         });

--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -6,7 +6,6 @@ import { validateIpcMessage } from '@trezor/ipc-proxy';
 import { restartApp } from '../libs/app-utils';
 import { exposeConnectWs } from '../libs/connect-ws';
 import { createHttpReceiver } from '../libs/http-receiver';
-import { hasSwitch } from '../libs/process-switches';
 import { app, ipcMain } from '../typed-electron';
 
 import type { ModuleInitBackground } from './index';
@@ -74,8 +73,7 @@ export const initBackground: ModuleInitBackground = ({
             }
         });
 
-        const connectPopupEnabled = () =>
-            hasSwitch('expose-connect-ws') || store.getConnectSettings().enableWs;
+        const connectPopupEnabled = () => !store.getConnectSettings().disableWs;
         ipcMain.handle('connect-popup/enabled', ipcEvent => {
             validateIpcMessage(ipcEvent);
 
@@ -84,7 +82,7 @@ export const initBackground: ModuleInitBackground = ({
         ipcMain.handle('connect-popup/set-enabled', (ipcEvent, enabled: boolean) => {
             validateIpcMessage(ipcEvent);
 
-            store.setConnectSettings({ enableWs: enabled });
+            store.setConnectSettings({ disableWs: !enabled });
             restartApp();
         });
         if (connectPopupEnabled()) {

--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -13,7 +13,6 @@ export type ExperimentalFeature =
     | 'password-manager'
     | 'tor-external'
     | 'nft-section'
-    | 'trezor-connect-ws'
     | 'biometric-authentication';
 
 export type ExperimentalFeatureConfig = {
@@ -58,14 +57,6 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
     'nft-section': {
         title: 'TR_EXPERIMENTAL_NFT_SECTION',
         description: 'TR_EXPERIMENTAL_NFT_SECTION_DESCRIPTION',
-    },
-    'trezor-connect-ws': {
-        title: 'TR_EXPERIMENTAL_TREZORCONNECT_WS',
-        description: 'TR_EXPERIMENTAL_TREZORCONNECT_WS_DESCRIPTION',
-        isDisabled: () => !isDesktop(),
-        onToggle: async ({ newValue }) => {
-            await desktopApi.connectPopupSetEnabled(newValue);
-        },
     },
     'biometric-authentication': {
         title: 'TR_BIO_AUTH',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -10447,19 +10447,6 @@ export default defineMessages({
         id: 'TR_QUIT_NOW',
         defaultMessage: 'Quit now',
     },
-    TR_EXPERIMENTAL_TREZORCONNECT_WS: {
-        id: 'TR_EXPERIMENTAL_TREZORCONNECT_WS',
-        defaultMessage: 'Trezor Connect',
-    },
-    TR_EXPERIMENTAL_TREZORCONNECT_WS_DESCRIPTION: {
-        id: 'TR_EXPERIMENTAL_TREZORCONNECT_WS_DESCRIPTION',
-        defaultMessage:
-            'Connect with third-party apps directly from Trezor Suite for a smoother, more integrated experience. Enabling this feature will restart the app.',
-    },
-    TR_EXPERIMENTAL_WALLETCONNECT_DESCRIPTION: {
-        id: 'TR_EXPERIMENTAL_WALLETCONNECT_DESCRIPTION',
-        defaultMessage: 'Use WalletConnect to connect your Trezor to Ethereum or Solana dApps.',
-    },
     TR_SWITCH_ACCOUNT: {
         id: 'TR_SWITCH_ACCOUNT',
         defaultMessage: 'Switch account',

--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -12,14 +12,12 @@ import TrezorConnect from '@trezor/connect';
 import { EventTypeShared, analytics } from '@trezor/suite-analytics';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
-import { SUITE } from 'src/actions/suite/constants';
 import { openModal } from 'src/actions/suite/modalActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const useConnectPopupDesktop = () => {
     const dispatch = useDispatch();
     const popupCall = useSelector(selectConnectPopupCall);
-    const experimentalFeatures = useSelector(state => state.suite.settings.experimental);
     const initialized = useRef(false);
 
     useEffect(() => {
@@ -62,20 +60,6 @@ export const useConnectPopupDesktop = () => {
                     analytics.report({
                         type: EventTypeShared.ConnectPopupInit,
                     });
-
-                    // Update experimental features value
-                    // TODO: remove this when out of experimental
-                    if (!experimentalFeatures?.includes('trezor-connect-ws')) {
-                        dispatch({
-                            type: SUITE.SET_EXPERIMENTAL_FEATURES,
-                            payload: {
-                                enabledFeatures: [
-                                    ...(experimentalFeatures ?? []),
-                                    'trezor-connect-ws',
-                                ],
-                            },
-                        });
-                    }
                 }
             }
         };
@@ -88,7 +72,7 @@ export const useConnectPopupDesktop = () => {
                 desktopApi.removeAllListeners('app/auto-start/popup-request');
             }
         };
-    }, [dispatch, experimentalFeatures]);
+    }, [dispatch]);
 
     // App focus control
     const [currentlyOngoing, setCurrentlyOngoing] = useState(false);

--- a/packages/suite/src/views/settings/SettingsConnectedApps/SettingsConnectedApps.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/SettingsConnectedApps.tsx
@@ -6,8 +6,7 @@ import { spacings } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite';
-import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectHasExperimentalFeature } from 'src/reducers/suite/suiteReducer';
+import { useDispatch } from 'src/hooks/suite';
 
 import { ConnectPermissions } from './ConnectPermissions';
 import { WalletConnectButton } from './WalletConnectButton';
@@ -15,7 +14,6 @@ import { WalletConnectList } from './WalletConnectList';
 
 export const SettingsConnectedApps = () => {
     const dispatch = useDispatch();
-    const connectFeatureFlag = useSelector(selectHasExperimentalFeature('trezor-connect-ws'));
 
     const tabs = [
         {
@@ -30,7 +28,7 @@ export const SettingsConnectedApps = () => {
             icon: 'trezorLogo' as const,
             title: <Translation id="TR_TREZOR_CONNECT" />,
             component: <ConnectPermissions />,
-            isEnabled: connectFeatureFlag && isDesktop(),
+            isEnabled: isDesktop(),
         },
     ].filter(tab => tab.isEnabled);
     const [activeItemdId, setActiveItemId] = useState(tabs[0]?.id ?? 0);

--- a/packages/suite/src/views/settings/SettingsDebug/ConnectPopup.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/ConnectPopup.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+import { Switch } from '@trezor/components';
+import { desktopApi } from '@trezor/suite-desktop-api';
+
+import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
+
+export const ConnectPopup = () => {
+    const [isEnabled, setIsEnabled] = useState(false);
+
+    useEffect(() => {
+        if (desktopApi.available) {
+            desktopApi.connectPopupEnabled().then(enabled => setIsEnabled(enabled));
+        }
+    }, []);
+
+    const handleOnChange = async () => {
+        if (desktopApi.available) {
+            const newState = !isEnabled;
+            setIsEnabled(newState);
+            await desktopApi.connectPopupSetEnabled(newState);
+        }
+    };
+
+    return (
+        <SectionItem>
+            <TextColumn
+                title="Connect Popup"
+                description="Enable communication between Connect in 3rd party apps and Trezor Suite. Toggling restarts the application."
+            />
+            <ActionColumn>
+                <Switch isChecked={isEnabled} onChange={handleOnChange} />
+            </ActionColumn>
+        </SectionItem>
+    );
+};

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -11,6 +11,7 @@ import { Backends } from './Backends';
 import { Bluetooth } from './Bluetooth';
 import { CheckFirmwareAuthenticity } from './CheckFirmwareAuthenticity';
 import { CoinjoinApi } from './CoinjoinApi';
+import { ConnectPopup } from './ConnectPopup';
 import { DeviceAuthenticity } from './DeviceAuthenticity';
 import { Devkit } from './Devkit';
 import { GithubIssue } from './GithubIssue';
@@ -94,6 +95,7 @@ export const SettingsDebug = () => {
             </SettingsSection>
             <SettingsSection title="TrezorConnect">
                 <TrezorConnectLogs />
+                {isDesktop() && <ConnectPopup />}
             </SettingsSection>
         </SettingsLayout>
     );


### PR DESCRIPTION
## Description

Move Trezor Connect out of experimental features and enable it by default. 

Add a debug setting to opt-out for testing purposes.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-connect-launch&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-connect-launch&lookback=7)