### PR TITLE
fix(suite): remember previous device for bootloader reconnect

### DIFF
--- a/packages/react-utils/src/hooks/usePreviousDefined.ts
+++ b/packages/react-utils/src/hooks/usePreviousDefined.ts
@@ -1,0 +1,13 @@
+import { useEffect, useRef } from 'react';
+
+export const usePreviousDefined = <T>(value: T | undefined): T | undefined => {
+    const ref = useRef<T>(value);
+
+    useEffect(() => {
+        if (value !== undefined) {
+            ref.current = value;
+        }
+    }, [value]);
+
+    return ref.current;
+};

--- a/packages/react-utils/src/index.ts
+++ b/packages/react-utils/src/index.ts
@@ -8,4 +8,5 @@ export { useTimer } from './hooks/useTimer';
 export { useWindowFocus } from './hooks/useWindowFocus';
 export { useClickCooldown } from './hooks/useClickCooldown';
 export { useAsyncClickHandler } from './hooks/useAsyncClickHandler';
+export { usePreviousDefined } from './hooks/usePreviousDefined';
 export type { Timer } from './hooks/useTimer';

--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -8,6 +8,7 @@ import { BulletList, Column, DeviceAnimation, H2, Modal, Paragraph } from '@trez
 import { Device } from '@trezor/connect';
 import { DeviceModelInternal, getFirmwareVersion } from '@trezor/device-utils';
 import { ConfirmOnDevice } from '@trezor/product-components';
+import { usePreviousDefined } from '@trezor/react-utils';
 import { spacings } from '@trezor/theme';
 
 import { Translation, WebUsbButton } from 'src/components/suite';
@@ -69,7 +70,8 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
     const { showManualReconnectPrompt, status, reconnectEvent, buttonEvent } =
         useFirmwareInstallation();
     const { device } = useDevice();
-    const eventDevice = buttonEvent?.device || device;
+
+    const eventDevice = usePreviousDefined(buttonEvent?.device || device);
 
     const isManualRebootRequired =
         // Automatic reboot isn't supported:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- push forgotten commit in #20552
- introduced new method to remember device connected before disconnect to bootloader

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="536" height="678" alt="Screenshot 2025-08-05 at 15 22 20" src="https://github.com/user-attachments/assets/bc28ffd6-b2e1-410b-abe1-e8b73488fe7e" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/2.1.5-fw-second-try&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/2.1.5-fw-second-try&lookback=7)