### PR TITLE
fix(suite): removed duplicated zn-TW language

### DIFF
--- a/packages/suite/src/components/wallet/BigAmountValue.tsx
+++ b/packages/suite/src/components/wallet/BigAmountValue.tsx
@@ -48,7 +48,7 @@ export const BigAmountValue = ({
     const language = useSelector(selectLanguage);
 
     // Todo: this is ugly hack, shall be refactored to some more safe alternative
-    const shouldFormatLocale: Locale[] = ['en-US', 'ja-JP', 'zh-CN', 'zh-TW'];
+    const shouldFormatLocale: Locale[] = ['en-US', 'ja-JP', 'zh-CN'];
     const [whole, separator, fractional] = shouldFormatLocale.includes(language)
         ? formattedStringAmount.split(/(\.)/)
         : formattedStringAmount.split(/(,)/);

--- a/packages/suite/src/hooks/suite/useLocales.ts
+++ b/packages/suite/src/hooks/suite/useLocales.ts
@@ -41,7 +41,6 @@ const getDateFnsLocale = (locale: SuiteLocale): DateFnsLocale['code'] => {
         'uk-UA': 'uk',
         'vi-VN': 'vi',
         'zh-CN': 'zhCN',
-        'zh-TW': 'zhTW',
         ww: 'zhTW',
     };
 

--- a/suite-common/suite-types/src/languages.ts
+++ b/suite-common/suite-types/src/languages.ts
@@ -31,8 +31,7 @@ const languages = {
     'uk-UA': { name: 'Українська', en: 'Ukrainian', type: 'community' },
     'vi-VN': { name: 'Tiếng Việt', en: 'Vietnamese' },
     'zh-CN': { name: '中文(简体)', en: 'Chinese Simplified', type: 'community' },
-    'zh-TW': { name: '中文(繁體)', en: 'Chinese Traditional', type: 'community' },
-    ww: { name: '臺語', en: 'Hokkien', type: 'community' },
+    ww: { name: '臺語', en: 'Taiwanese Mandarin', type: 'community' },
 } as const;
 
 export type Locale = keyof typeof languages;


### PR DESCRIPTION
Removed duplicated `zn-TW` that we introduced when we were debugging changing auto-generate translation files.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/chinese-locales&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/chinese-locales&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/chinese-locales&lookback=7)