### PR TITLE
ci(github): fix tests connect otherDevicesMatrix

### DIFF
--- a/.github/workflows/test-connect.yml
+++ b/.github/workflows/test-connect.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Set other devices matrix
         id: set-matrix-other-devices
-        run: echo "otherDevicesMatrix=$(node ./scripts/ci/connect-test-matrix-generator.js --model=all --firmware=2-main --env=node --groups=api --disable_cache_tx=true)" >> $GITHUB_OUTPUT
+        run: echo "otherDevicesMatrix=$(node ./scripts/ci/connect-test-matrix-generator.js --model=all --firmware=2-main --env=node --groups=api --disable_cache_tx=true --transport=all)" >> $GITHUB_OUTPUT
 
       - name: Set all transports matrix
         id: set-matrix-all-transports


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding missing mandatory flat for script `/scripts/ci/connect-test-matrix-generator.j` in `otherDevicesMatrix`.

Since tests in CI are complaining about it like https://github.com/trezor/trezor-suite/actions/runs/16764380504 :


```
[Test] connect core e2e
Error when evaluating 'strategy' for job 'all-models-api'. .github/workflows/test-connect.yml (Line: 172, Col: 15): Error from function 'fromJson': empty input, .github/workflows/test-connect.yml (Line: 172, Col: 15): Unexpected value ''

```


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/fix-test-connect-otherDevicesMatrix&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/fix-test-connect-otherDevicesMatrix&lookback=7)