### PR TITLE
core(codeowners): change code-owner roles

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -50,7 +50,7 @@
 
 /packages/icons @trezor/suite-mobile
 
-/suite-common/message-system @tomasklim @matejkriz
+/suite-common/message-system @tomasklim @matejkriz @MiroslavProchazka @pavelmario
 
 /suite-common/token-definitions @tomasklim
 
@@ -80,7 +80,7 @@
 
 /packages/theme @trezor/suite-engagement
 
-/packages/urls @marekrjpolak
+/packages/urls @marekrjpolak @pavelmario
 
 /packages/utils @karliatto
 
@@ -90,11 +90,11 @@
 
 /packages/styles @trezor/suite-engagement
 
-/packages/suite/src/support/messages.ts @MiroslavProchazka
+/packages/suite/src/support/messages.ts @pavelmario
 
 /suite-common/graph @trezor/suite-mobile
 
-/packages/connect/src/data/deviceAuthenticityConfig.ts @tsusanka
+/packages/connect/src/data/deviceAuthenticityConfig.ts @tsusanka @MiroslavProchazka
 
 /packages/schema-utils @martykan
 


### PR DESCRIPTION
This pull request updates the `CODEOWNERS` file to reflect changes in team and individual ownership for several files and packages. The updates assign additional owners to ensure better coverage and responsibility distribution.

Ownership updates:

* Added `@MiroslavProchazka` and `@pavelmario` as owners for `/suite-common/message-system`
* Added `@pavelmario` as an owner for `/packages/urls`
* Changed the owner of `/packages/suite/src/support/messages.ts` to `@pavelmario`
* Added `@MiroslavProchazka` as an owner for `/packages/connect/src/data/deviceAuthenticityConfig.ts`

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=change-codeowners-to-pavel&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=change-codeowners-to-pavel&lookback=7)