### PR TITLE
fix(suite): no view details in toast at all in trading

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
@@ -46,6 +46,7 @@ import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useFees } from 'src/hooks/wallet/form/useFees';
 import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
+import { getTokenAddressTranslationId } from 'src/utils/wallet/tokenUtils';
 
 const TxSimulationAsset = ({
     assetDiff,
@@ -455,7 +456,11 @@ export const TxSimulationModal = () => {
                                                     },
                                                     {
                                                         label: (
-                                                            <Translation id="TR_CONTRACT_ADDRESS" />
+                                                            <Translation
+                                                                id={getTokenAddressTranslationId(
+                                                                    network.networkType,
+                                                                )}
+                                                            />
                                                         ),
                                                         value: (
                                                             <TxAddress

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
@@ -57,28 +57,25 @@ export const TransactionRenderer = ({ render: View, ...props }: TransactionRende
     const destinationRoute = isStakeTypeTx(tx?.ethereumSpecific?.parsedData?.methodId)
         ? 'wallet-staking'
         : 'wallet-index';
+    const isTradingRoute = !!routeName?.includes('wallet-trading');
 
     const handleTransactionClick = () => {
-        const isTradingRoute = !!routeName?.includes('wallet-trading');
-
-        if (!isTradingRoute) {
-            const deviceToSelect = accountDevice || device;
-            if (deviceToSelect?.id !== currentDevice?.id) {
-                dispatch(selectDeviceThunk({ device: deviceToSelect }));
-            }
-
-            const txAnchor = getTxAnchor(tx?.txid);
-            dispatch(
-                goto(destinationRoute, {
-                    params: {
-                        accountIndex: account.index,
-                        accountType: account.accountType,
-                        symbol: account.symbol,
-                    },
-                    anchor: txAnchor,
-                }),
-            );
+        const deviceToSelect = accountDevice || device;
+        if (deviceToSelect?.id !== currentDevice?.id) {
+            dispatch(selectDeviceThunk({ device: deviceToSelect }));
         }
+
+        const txAnchor = getTxAnchor(tx?.txid);
+        dispatch(
+            goto(destinationRoute, {
+                params: {
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                    symbol: account.symbol,
+                },
+                anchor: txAnchor,
+            }),
+        );
 
         if (tx?.txid) {
             dispatch(
@@ -109,7 +106,7 @@ export const TransactionRenderer = ({ render: View, ...props }: TransactionRende
                 confirmations,
             }}
             action={
-                tx
+                tx && !isTradingRoute
                     ? {
                           onClick: handleTransactionClick,
                           label: 'TOAST_TX_BUTTON',

--- a/packages/suite/src/components/wallet/InputError.tsx
+++ b/packages/suite/src/components/wallet/InputError.tsx
@@ -18,10 +18,10 @@ export const InputError = ({ buttonProps, learnMoreUrl, message }: InputErrorPro
     <Row gap={spacings.xs} justifyContent="space-between" flex="1">
         <Row gap={spacings.xs}>
             <Paragraph>{message}</Paragraph>
-            {learnMoreUrl && <LearnMoreButton url={learnMoreUrl} />}
+            {learnMoreUrl && <LearnMoreButton url={learnMoreUrl} textWrap={false} />}
         </Row>
         {buttonProps?.text && (
-            <Button size="tiny" variant="tertiary" onClick={buttonProps.onClick}>
+            <Button size="tiny" variant="tertiary" onClick={buttonProps.onClick} textWrap={false}>
                 {buttonProps.text}
             </Button>
         )}

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7092,13 +7092,17 @@ export default defineMessages({
         id: 'TR_CONTRACT_ADDRESS',
         defaultMessage: 'Contract address',
     },
+    TR_TOKEN_ADDRESS: {
+        id: 'TR_TOKEN_ADDRESS',
+        defaultMessage: 'Token address',
+    },
     TR_POLICY_ID_ADDRESS: {
         id: 'TR_POLICY_ID_ADDRESS',
-        defaultMessage: 'Policy ID:',
+        defaultMessage: 'Policy ID',
     },
     TR_FINGERPRINT_ADDRESS: {
         id: 'TR_FINGERPRINT_ADDRESS',
-        defaultMessage: 'Fingerprint:',
+        defaultMessage: 'Fingerprint',
     },
     TR_ANALYZE_IN_EXPLORER: {
         id: 'TR_ANALYZE_IN_EXPLORER',

--- a/packages/suite/src/utils/wallet/tokenUtils.ts
+++ b/packages/suite/src/utils/wallet/tokenUtils.ts
@@ -4,7 +4,7 @@ import {
     TokenDefinitionsState,
     isTokenDefinitionKnown,
 } from '@suite-common/token-definitions';
-import { NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
+import { NetworkSymbol, NetworkType, getNetworkFeatures } from '@suite-common/wallet-config';
 import { Account, Rate, RatesByKey, TokenAddress } from '@suite-common/wallet-types';
 import {
     getFiatRateKey,
@@ -181,4 +181,15 @@ export const hasVisibleTokens = (
         currentTokens.shownWithBalance.length + currentTokens.shownWithoutBalance.length;
 
     return visibleTokenCount > 0;
+};
+
+export const getTokenAddressTranslationId = (networkType: NetworkType) => {
+    switch (networkType) {
+        case 'solana':
+            return 'TR_TOKEN_ADDRESS';
+        case 'cardano':
+            return 'TR_POLICY_ID_ADDRESS';
+        default:
+            return 'TR_CONTRACT_ADDRESS';
+    }
 };

--- a/packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx
+++ b/packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx
@@ -38,6 +38,7 @@ import {
 } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectIsCopyAddressModalShown } from 'src/reducers/suite/suiteReducer';
+import { getTokenAddressTranslationId } from 'src/utils/wallet/tokenUtils';
 
 import { DropdownRow } from '../../tokens/DropdownRow';
 import { BlurUrls } from '../../tokens/common/BlurUrls';
@@ -97,10 +98,11 @@ const NftsRow = ({
                                         <InfoItem
                                             typographyStyle="label"
                                             label={
-                                                <>
-                                                    <Translation id="TR_CONTRACT_ADDRESS" />
-                                                    {': '}
-                                                </>
+                                                <Translation
+                                                    id={getTokenAddressTranslationId(
+                                                        network.networkType,
+                                                    )}
+                                                />
                                             }
                                             gap={spacings.zero}
                                         >

--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
@@ -178,7 +178,7 @@ export const FreshAddress = ({
                     )}
                 </Tooltip>
             </Row>
-            {account.networkType === 'ethereum' && (
+            {account.networkType === 'ethereum' && account.symbol !== 'eth' && (
                 <Banner icon variant="info" margin={{ top: spacings.xxl }}>
                     <H4>
                         <Translation

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
@@ -54,6 +54,7 @@ import { useSendFormContext } from 'src/hooks/wallet';
 import { selectIsCopyAddressModalShown } from 'src/reducers/suite/suiteReducer';
 import {
     enhanceTokensWithRates,
+    getTokenAddressTranslationId,
     getTokens,
     sortTokensWithRates,
 } from 'src/utils/wallet/tokenUtils';
@@ -367,14 +368,11 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
                                 <Row justifyContent="flex-start">
                                     <Text variant="tertiary" typographyStyle="hint">
                                         <Row gap={spacings.xxs}>
-                                            {account.networkType === 'cardano' ? (
-                                                <Translation id="TR_POLICY_ID_ADDRESS" />
-                                            ) : (
-                                                <>
-                                                    <Translation id="TR_CONTRACT_ADDRESS" />
-                                                    {': '}
-                                                </>
-                                            )}
+                                            <Translation
+                                                id={getTokenAddressTranslationId(
+                                                    account.networkType,
+                                                )}
+                                            />
                                             <TokenAddressRow
                                                 typographyStyle="hint"
                                                 variant="tertiary"

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -61,7 +61,7 @@ import {
     selectIsCopyAddressModalShown,
     selectIsUnhideTokenModalShown,
 } from 'src/reducers/suite/suiteReducer';
-import { formatTokenSymbol } from 'src/utils/wallet/tokenUtils';
+import { formatTokenSymbol, getTokenAddressTranslationId } from 'src/utils/wallet/tokenUtils';
 
 import { BlurUrls } from '../BlurUrls';
 
@@ -257,10 +257,11 @@ export const TokenRow = ({
                                 <Column maxWidth={200} gap={spacings.md}>
                                     <TokenAddressItem
                                         label={
-                                            <>
-                                                <Translation id="TR_CONTRACT_ADDRESS" />
-                                                {': '}
-                                            </>
+                                            <Translation
+                                                id={getTokenAddressTranslationId(
+                                                    network.networkType,
+                                                )}
+                                            />
                                         }
                                         address={token.contract}
                                         type="contract"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- `View details` button deleted from toasts in trading as it can break the trading loading flow 🤷 
- Solana token address is now named correctly
- no weird ethereum/evm info in ethereum accounts
- fixed buttons under input

## Related Issue

Resolve  #19056
Resolve #19587
Resolve #19355
Resolve #19873

## Screenshots:

<img width="1117" height="328" alt="Screenshot 2025-08-06 at 9 29 00" src="https://github.com/user-attachments/assets/cfbb1f07-2013-46a1-8a7f-9aa124751f09" />
<img width="1120" height="841" alt="Screenshot 2025-08-06 at 9 29 05" src="https://github.com/user-attachments/assets/a8b8285b-b979-4b13-939b-41607e74ac49" />
<img width="732" height="453" alt="Screenshot 2025-08-06 at 9 29 16" src="https://github.com/user-attachments/assets/2911e977-96ec-4fb3-9fff-8601dd7bc160" />
<img width="982" height="941" alt="Screenshot 2025-08-06 at 9 29 57" src="https://github.com/user-attachments/assets/20f1b6f4-cc38-4d39-9d0b-6b3565bbf45a" />
<img width="866" height="972" alt="Screenshot 2025-08-06 at 9 30 42" src="https://github.com/user-attachments/assets/78de807c-15c6-4834-9aa3-18afe954f141" />
