### PR TITLE
feat(suite-native): hide unssuported actions

### DIFF
--- a/suite-native/device-manager/src/components/DeviceManagerContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerContent.tsx
@@ -8,6 +8,7 @@ import {
     PORTFOLIO_TRACKER_DEVICE_ID,
     selectDeviceThunk,
     selectHasRunningDiscovery,
+    selectIsDeviceInitialized,
     selectIsPortfolioTrackerDevice,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
@@ -50,6 +51,8 @@ export const DeviceManagerContent = () => {
 
     const hasDiscovery = useSelector(selectHasRunningDiscovery);
     const device = useSelector(selectSelectedDevice);
+    const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
+
     const { setIsDeviceManagerVisible } = useDeviceManager();
 
     const toggleIsChangeDeviceRequested = () =>
@@ -81,7 +84,8 @@ export const DeviceManagerContent = () => {
     const scrollViewTopOffset = insets.top + utils.spacings.sp24 + HEADER_HEIGHT;
     const scrollViewMaxHeight = CONTENT_MAX_HEIGHT - scrollViewTopOffset;
 
-    const isAddHiddenWalletButtonVisible = !hasDiscovery && device?.connected;
+    const isAddHiddenWalletButtonVisible =
+        !hasDiscovery && device?.connected && isDeviceInitialized;
 
     return (
         <DeviceManagerModal

--- a/suite-native/module-device-settings/src/components/DeviceInfo.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceInfo.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { selectHasRunningDiscovery, selectIsDeviceInitialized } from '@suite-common/wallet-core';
 import { HStack, IconButton, Text, VStack } from '@suite-native/atoms';
 import { DeviceImage } from '@suite-native/device';
 import { useIsMultiline } from '@suite-native/helpers';
@@ -35,6 +35,7 @@ export const DeviceInfo = ({ deviceModel, deviceName }: DeviceInfoProps) => {
     const navigation = useNavigation<NavigationProp>();
     const { applyStyle } = useNativeStyles();
     const { onTextLayout, isMultiline } = useIsMultiline();
+    const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
 
     const navigateToDeviceNameStack = () => {
         navigation.navigate(DeviceSettingsStackRoutes.DeviceNameStack, {
@@ -51,14 +52,16 @@ export const DeviceInfo = ({ deviceModel, deviceName }: DeviceInfoProps) => {
                 <Text style={applyStyle(textStyle)} variant="titleMedium" onLayout={onTextLayout}>
                     {name}
                 </Text>
-                <IconButton
-                    onPress={navigateToDeviceNameStack}
-                    isLoading={isDiscoveryRunning}
-                    testID="@device-name/change-button"
-                    size="extraSmall"
-                    iconName="pencilSimpleLine"
-                    colorScheme="tertiaryElevation0"
-                />
+                {isDeviceInitialized && (
+                    <IconButton
+                        onPress={navigateToDeviceNameStack}
+                        isLoading={isDiscoveryRunning}
+                        testID="@device-name/change-button"
+                        size="extraSmall"
+                        iconName="pencilSimpleLine"
+                        colorScheme="tertiaryElevation0"
+                    />
+                )}
             </HStack>
         </VStack>
     );

--- a/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
@@ -5,7 +5,9 @@ import {
     selectDeviceLabel,
     selectDeviceModel,
     selectDeviceName,
+    selectIsDeviceBackupUnfinished,
     selectIsDeviceConnectedViaBluetooth,
+    selectIsDeviceInitialized,
 } from '@suite-common/wallet-core';
 import { TitledSection, VStack } from '@suite-native/atoms';
 import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
@@ -28,7 +30,11 @@ export const DeviceSettingsModalScreen = () => {
     const deviceName = useSelector(selectDeviceName);
     const deviceLabel = useSelector(selectDeviceLabel);
     const isDeviceConnectedViaBluetooth = useSelector(selectIsDeviceConnectedViaBluetooth);
+    const isDeviceBackupUnfinished = useSelector(selectIsDeviceBackupUnfinished);
+    const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
     const isCheckBackupsEnabled = useFeatureFlag(FeatureFlag.IsCheckBackupsEnabled);
+    const isCheckBackupAvailable =
+        isCheckBackupsEnabled && !isDeviceBackupUnfinished && isDeviceInitialized;
 
     if (!deviceModel || !deviceName) {
         return null;
@@ -41,13 +47,13 @@ export const DeviceSettingsModalScreen = () => {
                 <TitledSection
                     title={<Translation id="moduleDeviceSettings.sectionTitles.general" />}
                 >
-                    <DevicePinProtectionCard />
+                    {isDeviceInitialized && <DevicePinProtectionCard />}
                     <DeviceFirmwareCard />
                 </TitledSection>
                 <TitledSection
                     title={<Translation id="moduleDeviceSettings.sectionTitles.security" />}
                 >
-                    {isCheckBackupsEnabled && <DeviceCheckBackupCard />}
+                    {isCheckBackupAvailable && <DeviceCheckBackupCard />}
                     {SUPPORTS_DEVICE_AUTHENTICITY_CHECK[deviceModel] && <DeviceAuthenticityCard />}
                 </TitledSection>
                 {isDeviceConnectedViaBluetooth && <DeviceBluetoothCard />}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

hide pin protection, labeling, check backup and passphrase actions if the device is not initialized

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20278

## Screenshots:


https://github.com/user-attachments/assets/d794303a-68a5-48a1-8e8c-f415e06eaa6a




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/settings-options-uninilize&lookback=7)