### PR TITLE
chore(suite-native): downgrade android resource class back to default to lower costs

### DIFF
--- a/suite-native/app/eas.json
+++ b/suite-native/app/eas.json
@@ -21,8 +21,7 @@
                 "distribution": "store"
             },
             "android": {
-                "distribution": "internal",
-                "resourceClass": "large"
+                "distribution": "internal"
             }
         },
         "preview": {
@@ -48,8 +47,7 @@
             },
             "autoIncrement": true,
             "android": {
-                "credentialsSource": "remote",
-                "resourceClass": "large"
+                "credentialsSource": "remote"
             },
             "ios": {
                 "credentialsSource": "remote"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- With "large" we pay `$2` per build, default "medium" cost `1$` per build
- We have the default for preview builds and not experiencing any issue with it.


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/downgrade-android-resource-class&lookback=7)