### PR TITLE
Mobile swap: improve provider list

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -1963,6 +1963,7 @@ export const en = {
                 cex: 'CEX',
                 dex: 'DEX',
             },
+            noProviders: 'No offers available.',
         },
         kyc: {
             dex: 'KYC never required. DEX swaps either succeed or fail.',

--- a/suite-native/module-trading/src/__fixtures__/exchangeProviders.ts
+++ b/suite-native/module-trading/src/__fixtures__/exchangeProviders.ts
@@ -9,9 +9,9 @@ export const exchangeInvity: ExchangeProviderInfo = {
     sellTickers: ['bitcoin', 'ethereum', 'eos'] as CryptoId[],
     statusUrl: 'https://checkout.invity.io/#status/{{paymentId}}',
     supportUrl: 'https://invity.io/invest-crypto',
-    isDex: false,
+    isDex: true,
     isFixedRate: true,
-    kycPolicyType: 'noKYC',
+    kycPolicyType: 'DEX',
     addressFormats: {},
 };
 

--- a/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
@@ -118,13 +118,14 @@ export const BuyProviderPicker = () => {
             >
                 <BuyProviderPickerRight isLoading={isLoading} selectedValue={selectedValue} />
             </OverviewRow>
-            <ProviderSheet<BuyTrade>
+            <ProviderSheet
                 quotes={quotes}
                 providerInfos={providers ?? {}}
                 isVisible={isSheetVisible}
                 onClose={hideSheet}
                 onQuoteSelect={handleQuoteSelect}
                 selectedQuote={selectedValue}
+                tradingType="buy"
             />
         </>
     );

--- a/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
@@ -120,7 +120,6 @@ export const BuyProviderPicker = () => {
             </OverviewRow>
             <ProviderSheet
                 quotes={quotes}
-                providerInfos={providers ?? {}}
                 isVisible={isSheetVisible}
                 onClose={hideSheet}
                 onQuoteSelect={handleQuoteSelect}

--- a/suite-native/module-trading/src/components/exchange/ExchangeRateAndProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeRateAndProviderPicker.tsx
@@ -2,10 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { ExchangeTrade } from 'invity-api';
 
-import {
-    selectTradingExchangeIsLoading,
-    selectTradingExchangeProviders,
-} from '@suite-common/trading';
+import { selectTradingExchangeIsLoading } from '@suite-common/trading';
 
 import { ExchangeProviderPicker } from './ExchangeProviderPicker';
 import { ExchangeRatePicker } from './ExchangeRatePicker';
@@ -16,7 +13,6 @@ import { ProviderSheet } from '../general/ProviderSheet/ProviderSheet';
 
 export const ExchangeRateAndProviderPicker = () => {
     const isLoading = useSelector(selectTradingExchangeIsLoading);
-    const providers = useSelector(selectTradingExchangeProviders);
     const quotes = useSelector(selectGroupedExchangeQuotes);
 
     const form = useExchangeFormContext();
@@ -53,7 +49,6 @@ export const ExchangeRateAndProviderPicker = () => {
             />
             <ProviderSheet
                 quotes={quotes}
-                providerInfos={providers ?? {}}
                 isVisible={isSheetVisible}
                 onClose={hideSheet}
                 onQuoteSelect={handleQuoteSelect}

--- a/suite-native/module-trading/src/components/exchange/ExchangeRateAndProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeRateAndProviderPicker.tsx
@@ -51,13 +51,14 @@ export const ExchangeRateAndProviderPicker = () => {
                 selectedValue={selectedValue}
                 handleProviderPress={handleItemPress}
             />
-            <ProviderSheet<ExchangeTrade>
+            <ProviderSheet
                 quotes={quotes}
                 providerInfos={providers ?? {}}
                 isVisible={isSheetVisible}
                 onClose={hideSheet}
                 onQuoteSelect={handleQuoteSelect}
                 selectedQuote={selectedValue}
+                tradingType="exchange"
             />
         </>
     );

--- a/suite-native/module-trading/src/components/general/BottomSheetSectionList.tsx
+++ b/suite-native/module-trading/src/components/general/BottomSheetSectionList.tsx
@@ -31,6 +31,7 @@ export type TradingBottomSheetSectionListProps<T, U> = Omit<
     estimatedItemSize: number;
     noSingletonSectionHeader?: boolean;
     itemStyle?: NativeStyle<ItemRenderConfig<unknown>>;
+    SectionEmptyComponent?: ReactElement;
 };
 
 export const BottomSheetSectionList = <T, U = undefined>({
@@ -41,6 +42,7 @@ export const BottomSheetSectionList = <T, U = undefined>({
     data,
     noSingletonSectionHeader,
     itemStyle,
+    SectionEmptyComponent,
     ...rest
 }: TradingBottomSheetSectionListProps<T, U>) => {
     const {
@@ -54,6 +56,7 @@ export const BottomSheetSectionList = <T, U = undefined>({
         renderSectionHeader,
         noSingletonSectionHeader,
         itemStyle,
+        SectionEmptyComponent,
     });
 
     const listHeight = Dimensions.get('window').height * 0.9;

--- a/suite-native/module-trading/src/components/general/ProviderSheet/NoProvidersPlaceholder.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/NoProvidersPlaceholder.tsx
@@ -1,0 +1,23 @@
+import { Card, HStack, Text } from '@suite-native/atoms';
+import { Icon } from '@suite-native/icons';
+import { Translation, useTranslate } from '@suite-native/intl';
+
+export const NoProvidersPlaceholder = () => {
+    const { translate } = useTranslate();
+
+    return (
+        <Card>
+            <HStack spacing="sp8" alignItems="center">
+                <Icon
+                    name="prohibit"
+                    color="textSubdued"
+                    accessibilityLabel={translate('moduleTrading.providerSheet.noProviders')}
+                    size="large"
+                />
+                <Text variant="hint" color="textSubdued">
+                    <Translation id="moduleTrading.providerSheet.noProviders" />
+                </Text>
+            </HStack>
+        </Card>
+    );
+};

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.tsx
@@ -1,6 +1,14 @@
 import { Pressable } from 'react-native';
+import { useSelector } from 'react-redux';
 
-import { TradingProviderInfo, TradingTradeType, isBuyTrade } from '@suite-common/trading';
+import {
+    TradingProviderInfo,
+    TradingRootState,
+    TradingTradeType,
+    TradingType,
+    isBuyTrade,
+    selectTradingProviderByNameAndTradeType,
+} from '@suite-common/trading';
 import { Card, HStack, Radio, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -14,7 +22,7 @@ export type ProviderListItemProps<T extends TradingTradeType> = {
     isSelected: boolean;
     onPress: (quote: T) => void;
     quote: T;
-    provider: TradingProviderInfo;
+    tradingType: TradingType;
 };
 
 export const PROVIDER_LIST_ITEM_ESTIMATED_HEIGHT = 160 as const;
@@ -27,11 +35,16 @@ export const ProviderListItem = <T extends TradingTradeType>({
     isSelected,
     onPress,
     quote,
-    provider,
+    tradingType,
 }: ProviderListItemProps<T>) => {
     const { applyStyle } = useNativeStyles();
 
     const { toStringValue, formattedRate } = useChangeStringsExtractor(quote);
+
+    const provider =
+        useSelector((state: TradingRootState) =>
+            selectTradingProviderByNameAndTradeType(state, quote.exchange, tradingType),
+        ) ?? ({ companyName: '', logo: '' } as TradingProviderInfo);
 
     const { orderId } = quote;
     const { companyName, logo } = provider;

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.tsx
@@ -1,71 +1,25 @@
-import { ReactNode, useMemo, useState } from 'react';
-
-import {
-    TradingProviderInfo,
-    TradingTradeMapProps,
-    TradingTradeType,
-    TradingType,
-} from '@suite-common/trading';
-import { useTranslate } from '@suite-native/intl';
+import { TradingTradeMapProps, TradingTradeType, TradingType } from '@suite-common/trading';
 import { prepareNativeStyle } from '@trezor/styles';
-import { exhaustive } from '@trezor/type-utils';
 
-import { FilterItem, FilterTabs } from '../FilterTabs';
+import { useProviderFilters } from '../../../hooks/general/useProviderFilters';
+import { QuotesByCategories, QuotesCategory } from '../../../types/general';
 import { LegalGatewayContextMessage } from '../LegalGatewayContextMessage';
-import { SimpleSheetHeader } from '../SimpleSheetHeader';
 import { NoProvidersPlaceholder } from './NoProvidersPlaceholder';
 import { PROVIDER_LIST_ITEM_ESTIMATED_HEIGHT, ProviderListItem } from './ProviderListItem';
-import {
-    SectionHeaderRenderConfig,
-    SectionListData,
-    SectionListDataArray,
-} from '../../../hooks/general/useSectionList';
 import { BottomSheetSectionList } from '../BottomSheetSectionList';
-import { TradingTypeAwareContextMessage } from '../TradingTypeAwareContextMessage';
-import { CexFixedSectionHeader } from './CexFixedSectionHeader';
-import { CexFloatSectionHeader } from './CexFloatSectionHeader';
-import { DexSectionHeader } from './DexSectionHeader';
+import { ProviderSheetHandle } from './ProviderSheetHandle';
+import { ProviderSheetSectionHeader } from './ProviderSheetSectionHeader';
 
-type QuoteCategory = 'fixed' | 'float' | 'dex';
-
-export type ProvidersSheetProps<K extends TradingType, T extends TradingTradeType> = {
-    quotes: { [Q in QuoteCategory]?: T[] };
+export type ProviderSheetProps<K extends TradingType, T extends TradingTradeType> = {
+    quotes: QuotesByCategories<T>;
     isVisible: boolean;
     onClose: () => void;
     onQuoteSelect: (quote: T) => void;
     selectedQuote?: T;
-    providerInfos: { [name: string]: TradingProviderInfo };
     tradingType: K;
 };
 
-type FilterValue = 'all' | 'cex' | 'dex';
-
 const keyExtractor = <T extends TradingTradeType>(item: T) => item.orderId ?? '';
-
-const getProviderInfo = (
-    id: string | undefined,
-    providerInfos: ProvidersSheetProps<TradingType, TradingTradeType>['providerInfos'],
-) =>
-    providerInfos[id ?? ''] ?? {
-        companyName: '',
-        logo: '',
-    };
-
-const renderSectionHeader = (
-    _label: ReactNode,
-    { sectionData }: SectionHeaderRenderConfig<QuoteCategory>,
-) => {
-    switch (sectionData) {
-        case 'fixed':
-            return <CexFixedSectionHeader />;
-        case 'float':
-            return <CexFloatSectionHeader />;
-        case 'dex':
-            return <DexSectionHeader />;
-        default:
-            return exhaustive(sectionData);
-    }
-};
 
 const EMPTY_ITEM_STYLE = prepareNativeStyle(() => ({}));
 
@@ -78,99 +32,49 @@ export const ProviderSheet = <
     onClose,
     onQuoteSelect,
     selectedQuote,
-    providerInfos,
     tradingType,
-}: ProvidersSheetProps<K, T>) => {
-    const { translate } = useTranslate();
+}: ProviderSheetProps<K, T>) => {
+    const shouldShowFilters = tradingType === 'exchange';
 
-    const [selectedFilter, setSelectedFilter] = useState<FilterValue>('all');
+    const { filterItems, filteredSections, selectedFilter, setSelectedFilter } = useProviderFilters(
+        quotes,
+        shouldShowFilters,
+    );
 
     const onQuoteSelectCallback = (quote: T) => {
         onQuoteSelect(quote);
         onClose();
     };
 
-    const shouldShowFilters = tradingType === 'exchange';
-
-    const filterItems: FilterItem<FilterValue>[] = useMemo(
-        () => [
-            { label: translate('moduleTrading.providerSheet.filters.all'), value: 'all' },
-            { label: translate('moduleTrading.providerSheet.filters.cex'), value: 'cex' },
-            { label: translate('moduleTrading.providerSheet.filters.dex'), value: 'dex' },
-        ],
-        [translate],
-    );
-
-    const filteredSections: SectionListData<T, QuoteCategory> = useMemo(() => {
-        const allSections = Object.entries(quotes).map(([category, items]) => {
-            const typedCategory = category as QuoteCategory;
-
-            return {
-                key: category,
-                data: items as SectionListDataArray<T>,
-                label: '',
-                sectionData: typedCategory,
-            };
-        });
-
-        if (!shouldShowFilters || selectedFilter === 'all') {
-            return allSections;
-        }
-
-        if (selectedFilter === 'cex') {
-            return allSections.filter(
-                section => section.key === 'fixed' || section.key === 'float',
-            );
-        }
-
-        if (selectedFilter === 'dex') {
-            return allSections.filter(section => section.key === 'dex');
-        }
-
-        return allSections;
-    }, [quotes, selectedFilter, shouldShowFilters]);
-
     return (
-        <BottomSheetSectionList<T, QuoteCategory>
+        <BottomSheetSectionList<T, QuotesCategory>
             isVisible={isVisible}
             onClose={onClose}
-            renderItem={item => {
-                const provider = getProviderInfo(item.exchange, providerInfos);
-
-                return (
-                    <ProviderListItem
-                        onPress={onQuoteSelectCallback}
-                        isSelected={item.orderId === selectedQuote?.orderId}
-                        quote={item}
-                        provider={provider}
-                    />
-                );
-            }}
+            renderItem={item => (
+                <ProviderListItem
+                    onPress={onQuoteSelectCallback}
+                    isSelected={item.orderId === selectedQuote?.orderId}
+                    quote={item}
+                    tradingType={tradingType}
+                />
+            )}
             handleComponent={() => (
-                <>
-                    <SimpleSheetHeader
-                        onClose={onClose}
-                        title={translate('moduleTrading.providerSheet.title')}
-                    >
-                        {shouldShowFilters && (
-                            <FilterTabs
-                                items={filterItems}
-                                onChange={setSelectedFilter}
-                                value={selectedFilter}
-                                keyExtractor={item => item.value}
-                            />
-                        )}
-                    </SimpleSheetHeader>
-
-                    <TradingTypeAwareContextMessage marginHorizontal="sp16" marginBottom="sp4" />
-                </>
+                <ProviderSheetHandle
+                    onClose={onClose}
+                    shouldShowFilters={shouldShowFilters}
+                    filterItems={filterItems}
+                    selectedFilter={selectedFilter}
+                    setSelectedFilter={setSelectedFilter}
+                />
             )}
             ListFooterComponent={<LegalGatewayContextMessage marginVertical="sp12" />}
             data={filteredSections}
             estimatedItemSize={PROVIDER_LIST_ITEM_ESTIMATED_HEIGHT}
             keyExtractor={keyExtractor}
             extraData={selectedQuote?.orderId}
-            renderSectionHeader={renderSectionHeader}
+            renderSectionHeader={(_label, { sectionData }) => (
+                <ProviderSheetSectionHeader category={sectionData} />
+            )}
             itemStyle={EMPTY_ITEM_STYLE}
             noSingletonSectionHeader={tradingType !== 'exchange'}
             SectionEmptyComponent={<NoProvidersPlaceholder />}

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.tsx
@@ -1,6 +1,11 @@
-import { useMemo, useState } from 'react';
+import { ReactNode, useMemo, useState } from 'react';
 
-import { TradingProviderInfo, TradingTradeType } from '@suite-common/trading';
+import {
+    TradingProviderInfo,
+    TradingTradeMapProps,
+    TradingTradeType,
+    TradingType,
+} from '@suite-common/trading';
 import { useTranslate } from '@suite-native/intl';
 import { prepareNativeStyle } from '@trezor/styles';
 import { exhaustive } from '@trezor/type-utils';
@@ -8,25 +13,29 @@ import { exhaustive } from '@trezor/type-utils';
 import { FilterItem, FilterTabs } from '../FilterTabs';
 import { LegalGatewayContextMessage } from '../LegalGatewayContextMessage';
 import { SimpleSheetHeader } from '../SimpleSheetHeader';
+import { NoProvidersPlaceholder } from './NoProvidersPlaceholder';
 import { PROVIDER_LIST_ITEM_ESTIMATED_HEIGHT, ProviderListItem } from './ProviderListItem';
-import { SectionListData } from '../../../hooks/general/useSectionList';
+import {
+    SectionHeaderRenderConfig,
+    SectionListData,
+    SectionListDataArray,
+} from '../../../hooks/general/useSectionList';
 import { BottomSheetSectionList } from '../BottomSheetSectionList';
 import { TradingTypeAwareContextMessage } from '../TradingTypeAwareContextMessage';
 import { CexFixedSectionHeader } from './CexFixedSectionHeader';
 import { CexFloatSectionHeader } from './CexFloatSectionHeader';
 import { DexSectionHeader } from './DexSectionHeader';
 
-export type ProvidersSheetProps<T extends TradingTradeType> = {
-    quotes: {
-        fixed?: T[];
-        float?: T[];
-        dex?: T[];
-    };
+type QuoteCategory = 'fixed' | 'float' | 'dex';
+
+export type ProvidersSheetProps<K extends TradingType, T extends TradingTradeType> = {
+    quotes: { [Q in QuoteCategory]?: T[] };
     isVisible: boolean;
     onClose: () => void;
     onQuoteSelect: (quote: T) => void;
     selectedQuote?: T;
     providerInfos: { [name: string]: TradingProviderInfo };
+    tradingType: K;
 };
 
 type FilterValue = 'all' | 'cex' | 'dex';
@@ -35,23 +44,43 @@ const keyExtractor = <T extends TradingTradeType>(item: T) => item.orderId ?? ''
 
 const getProviderInfo = (
     id: string | undefined,
-    providerInfos: ProvidersSheetProps<TradingTradeType>['providerInfos'],
+    providerInfos: ProvidersSheetProps<TradingType, TradingTradeType>['providerInfos'],
 ) =>
     providerInfos[id ?? ''] ?? {
         companyName: '',
         logo: '',
     };
 
+const renderSectionHeader = (
+    _label: ReactNode,
+    { sectionData }: SectionHeaderRenderConfig<QuoteCategory>,
+) => {
+    switch (sectionData) {
+        case 'fixed':
+            return <CexFixedSectionHeader />;
+        case 'float':
+            return <CexFloatSectionHeader />;
+        case 'dex':
+            return <DexSectionHeader />;
+        default:
+            return exhaustive(sectionData);
+    }
+};
+
 const EMPTY_ITEM_STYLE = prepareNativeStyle(() => ({}));
 
-export const ProviderSheet = <T extends TradingTradeType>({
+export const ProviderSheet = <
+    K extends TradingType,
+    T extends TradingTradeType = TradingTradeMapProps[K],
+>({
     quotes,
     isVisible,
     onClose,
     onQuoteSelect,
     selectedQuote,
     providerInfos,
-}: ProvidersSheetProps<T>) => {
+    tradingType,
+}: ProvidersSheetProps<K, T>) => {
     const { translate } = useTranslate();
 
     const [selectedFilter, setSelectedFilter] = useState<FilterValue>('all');
@@ -61,13 +90,7 @@ export const ProviderSheet = <T extends TradingTradeType>({
         onClose();
     };
 
-    const hasFixedProviders = quotes.fixed && quotes.fixed.length > 0;
-    const hasFloatProviders = quotes.float && quotes.float.length > 0;
-    const hasDexProviders = quotes.dex && quotes.dex.length > 0;
-    const hasCexProviders = hasFixedProviders || hasFloatProviders;
-    const shouldShowFilters = hasCexProviders && hasDexProviders;
-    const shouldShowCategories =
-        [hasFixedProviders, hasFloatProviders, hasDexProviders].filter(Boolean).length > 1;
+    const shouldShowFilters = tradingType === 'exchange';
 
     const filterItems: FilterItem<FilterValue>[] = useMemo(
         () => [
@@ -78,15 +101,13 @@ export const ProviderSheet = <T extends TradingTradeType>({
         [translate],
     );
 
-    type QuoteCategory = keyof typeof quotes;
-
     const filteredSections: SectionListData<T, QuoteCategory> = useMemo(() => {
         const allSections = Object.entries(quotes).map(([category, items]) => {
             const typedCategory = category as QuoteCategory;
 
             return {
                 key: category,
-                data: items,
+                data: items as SectionListDataArray<T>,
                 label: '',
                 sectionData: typedCategory,
             };
@@ -149,23 +170,11 @@ export const ProviderSheet = <T extends TradingTradeType>({
             estimatedItemSize={PROVIDER_LIST_ITEM_ESTIMATED_HEIGHT}
             keyExtractor={keyExtractor}
             extraData={selectedQuote?.orderId}
-            renderSectionHeader={(_label, { sectionData }) => {
-                if (!shouldShowCategories) {
-                    return <></>;
-                }
-
-                switch (sectionData) {
-                    case 'fixed':
-                        return <CexFixedSectionHeader />;
-                    case 'float':
-                        return <CexFloatSectionHeader />;
-                    case 'dex':
-                        return <DexSectionHeader />;
-                    default:
-                        return exhaustive(sectionData);
-                }
-            }}
+            renderSectionHeader={renderSectionHeader}
             itemStyle={EMPTY_ITEM_STYLE}
+            noSingletonSectionHeader={tradingType !== 'exchange'}
+            SectionEmptyComponent={<NoProvidersPlaceholder />}
+            ListEmptyComponent={<NoProvidersPlaceholder />}
         />
     );
 };

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheetHandle.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheetHandle.tsx
@@ -1,0 +1,44 @@
+import { useTranslate } from '@suite-native/intl';
+
+import { FilterValue } from '../../../hooks/general/useProviderFilters';
+import { FilterItem, FilterTabs } from '../FilterTabs';
+import { SimpleSheetHeader } from '../SimpleSheetHeader';
+import { TradingTypeAwareContextMessage } from '../TradingTypeAwareContextMessage';
+
+export type ProviderSheetHandleProps = {
+    onClose: () => void;
+    shouldShowFilters: boolean;
+    filterItems: FilterItem<FilterValue>[];
+    selectedFilter: FilterValue;
+    setSelectedFilter: (value: FilterValue) => void;
+};
+
+export const ProviderSheetHandle = ({
+    filterItems,
+    selectedFilter,
+    setSelectedFilter,
+    shouldShowFilters,
+    onClose,
+}: ProviderSheetHandleProps) => {
+    const { translate } = useTranslate();
+
+    return (
+        <>
+            <SimpleSheetHeader
+                onClose={onClose}
+                title={translate('moduleTrading.providerSheet.title')}
+            >
+                {shouldShowFilters && (
+                    <FilterTabs
+                        items={filterItems}
+                        onChange={setSelectedFilter}
+                        value={selectedFilter}
+                        keyExtractor={({ value }) => value}
+                    />
+                )}
+            </SimpleSheetHeader>
+
+            <TradingTypeAwareContextMessage marginHorizontal="sp16" marginBottom="sp4" />
+        </>
+    );
+};

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheetSectionHeader.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheetSectionHeader.tsx
@@ -1,0 +1,23 @@
+import { exhaustive } from '@trezor/type-utils';
+
+import { CexFixedSectionHeader } from './CexFixedSectionHeader';
+import { CexFloatSectionHeader } from './CexFloatSectionHeader';
+import { DexSectionHeader } from './DexSectionHeader';
+import { QuotesCategory } from '../../../types/general';
+
+export type ProviderSheetSectionHeaderProps = {
+    category: QuotesCategory;
+};
+
+export const ProviderSheetSectionHeader = ({ category }: ProviderSheetSectionHeaderProps) => {
+    switch (category) {
+        case 'fixed':
+            return <CexFixedSectionHeader />;
+        case 'float':
+            return <CexFloatSectionHeader />;
+        case 'dex':
+            return <DexSectionHeader />;
+        default:
+            return exhaustive(category);
+    }
+};

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/NoProvidersPlaceholder.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/NoProvidersPlaceholder.comp.test.tsx
@@ -1,0 +1,14 @@
+import { renderWithBasicProvider } from '@suite-native/test-utils';
+
+import { NoProvidersPlaceholder } from '../NoProvidersPlaceholder';
+
+describe('NoProvidersPlaceholder', () => {
+    const renderNoProvidersPlaceholder = () => renderWithBasicProvider(<NoProvidersPlaceholder />);
+
+    it('should render text and icon with label', () => {
+        const { getByLabelText, getByText } = renderNoProvidersPlaceholder();
+
+        expect(getByText('No offers available.')).toBeOnTheScreen();
+        expect(getByLabelText('No offers available.')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.comp.test.tsx
@@ -1,4 +1,4 @@
-import { TradingProviderInfo, TradingTradeType } from '@suite-common/trading';
+import { TradingTradeType } from '@suite-common/trading';
 import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 
 import { getInitializedTradingStateWithQuotes } from '../../../../__fixtures__/tradingState';
@@ -15,12 +15,7 @@ describe('ProviderListItem', () => {
                 isSelected={false}
                 onPress={jest.fn()}
                 quote={quote}
-                provider={
-                    {
-                        companyName: '',
-                        logo: '',
-                    } as TradingProviderInfo
-                }
+                tradingType="buy"
                 {...props}
             />,
             { preloadedState },
@@ -30,26 +25,16 @@ describe('ProviderListItem', () => {
         const preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
         const quote = preloadedState.wallet.tradingNew.buy.quotes[0];
 
-        const { queryByText } = await renderProviderListItem(quote, preloadedState, {
-            provider: {
-                companyName: 'TestProvider',
-                logo: '',
-            } as TradingProviderInfo,
-        });
+        const { queryByText } = await renderProviderListItem(quote, preloadedState, {});
 
-        expect(queryByText('TestProvider')).toBeTruthy();
+        expect(queryByText('Mercuryo')).toBeTruthy();
     });
 
     it('should render trading information with formatted strings', async () => {
         const preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
         const quote = preloadedState.wallet.tradingNew.buy.quotes[0];
 
-        const { queryByText } = await renderProviderListItem(quote, preloadedState, {
-            provider: {
-                companyName: 'TestProvider',
-                logo: '',
-            } as TradingProviderInfo,
-        });
+        const { queryByText } = await renderProviderListItem(quote, preloadedState, {});
 
         expect(queryByText('Rate')).toBeTruthy();
         expect(queryByText('You get')).toBeTruthy();
@@ -57,14 +42,10 @@ describe('ProviderListItem', () => {
 
     it('should render KYC information when provider has KYC policy', async () => {
         const preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
-        const quote = preloadedState.wallet.tradingNew.buy.quotes[0];
+        const quote = preloadedState.wallet.tradingNew.exchange.quotes[2];
 
         const { queryByText } = await renderProviderListItem(quote, preloadedState, {
-            provider: {
-                companyName: 'TestProvider',
-                logo: '',
-                kycPolicyType: 'KYC-required',
-            } as TradingProviderInfo,
+            tradingType: 'exchange',
         });
 
         expect(queryByText('This provider requires to verify identity.')).toBeTruthy();
@@ -72,14 +53,10 @@ describe('ProviderListItem', () => {
 
     it('should render anonymous information for DEX providers', async () => {
         const preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
-        const quote = preloadedState.wallet.tradingNew.buy.quotes[0];
+        const quote = preloadedState.wallet.tradingNew.exchange.quotes[3];
 
         const { queryByText } = await renderProviderListItem(quote, preloadedState, {
-            provider: {
-                companyName: 'TestDEX',
-                logo: '',
-                kycPolicyType: 'DEX',
-            } as TradingProviderInfo,
+            tradingType: 'exchange',
         });
 
         expect(queryByText('Anonymous')).toBeTruthy();
@@ -92,12 +69,7 @@ describe('ProviderListItem', () => {
         const { orderId, ...quoteWithoutOrderId } = baseQuote;
         const quote = quoteWithoutOrderId as TradingTradeType;
 
-        const { queryByText } = await renderProviderListItem(quote, preloadedState, {
-            provider: {
-                companyName: 'TestProvider',
-                logo: '',
-            } as TradingProviderInfo,
-        });
+        const { queryByText } = await renderProviderListItem(quote, preloadedState, {});
 
         expect(queryByText('TestProvider')).toBeNull();
     });
@@ -106,12 +78,7 @@ describe('ProviderListItem', () => {
         const preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
         const quote = preloadedState.wallet.tradingNew.buy.quotes[0];
 
-        const { queryByText } = await renderProviderListItem(quote, preloadedState, {
-            provider: {
-                companyName: 'TestProvider',
-                logo: '',
-            } as TradingProviderInfo,
-        });
+        const { queryByText } = await renderProviderListItem(quote, preloadedState, {});
 
         expect(queryByText('This provider requires to verify identity.')).toBeTruthy();
     });

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheet.comp.test.tsx
@@ -1,0 +1,48 @@
+import { TradingTradeType, TradingType } from '@suite-common/trading';
+import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import buyQuotes from '../../../../__fixtures__/buyQuotes.json';
+import { getWalletState } from '../../../../__fixtures__/walletState';
+import { ProviderSheet, ProviderSheetProps } from '../ProviderSheet';
+
+describe('ProviderSheet', () => {
+    const renderProviderSheet = (
+        props: Partial<ProviderSheetProps<TradingType, TradingTradeType>> = {},
+        preloadedState: PreloadedState = {},
+    ) =>
+        renderWithStoreProviderAsync(
+            <ProviderSheet
+                onClose={jest.fn()}
+                isVisible={true}
+                onQuoteSelect={jest.fn()}
+                quotes={{ fixed: [] }}
+                tradingType="buy"
+                {...props}
+            />,
+            { preloadedState },
+        );
+
+    it('should render empty providers placeholder and no section header and for buy', async () => {
+        const { queryByText, getByText } = await renderProviderSheet({}, {});
+
+        expect(getByText('No offers available.')).toBeOnTheScreen();
+        expect(queryByText('Fixed-rate CEX')).toBeNull();
+    });
+
+    it('should render section header and empty placeholder for exchange', async () => {
+        const { getByText } = await renderProviderSheet({ tradingType: 'exchange' }, {});
+
+        expect(getByText('No offers available.')).toBeOnTheScreen();
+        expect(getByText('Fixed-rate CEX')).toBeOnTheScreen();
+    });
+
+    it('should render provided quotes', async () => {
+        const { queryByText, getByText } = await renderProviderSheet(
+            { quotes: { fixed: [buyQuotes[0]] } },
+            { wallet: getWalletState() },
+        );
+
+        expect(queryByText('No offers available.')).toBeNull();
+        expect(getByText('Mercuryo')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheetHandle.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheetHandle.comp.test.tsx
@@ -1,0 +1,92 @@
+import { PreloadedState, fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { ProviderSheetHandle, ProviderSheetHandleProps } from '../ProviderSheetHandle';
+
+jest.mock('@suite-common/message-system', () => {
+    const messages: Record<string, unknown> = {
+        'trading.exchange': {
+            content: { en: 'Trading exchange message' },
+        },
+    };
+
+    return {
+        ...jest.requireActual('@suite-common/message-system'),
+        selectContextMessage: (_: unknown, context: string) => messages[context],
+    };
+});
+
+describe('ProviderSheetHandle', () => {
+    const renderProviderSheetHandle = (
+        props: Partial<ProviderSheetHandleProps> = {},
+        preloadedState: PreloadedState = {},
+    ) =>
+        renderWithStoreProviderAsync(
+            <ProviderSheetHandle
+                onClose={jest.fn()}
+                shouldShowFilters={true}
+                selectedFilter="all"
+                setSelectedFilter={jest.fn()}
+                filterItems={[
+                    { label: 'All', value: 'all' },
+                    { label: 'CEX', value: 'cex' },
+                    { label: 'DEX', value: 'dex' },
+                ]}
+                {...props}
+            />,
+            { preloadedState },
+        );
+
+    it('should render component with title and filter', async () => {
+        const { getByText } = await renderProviderSheetHandle({}, {});
+
+        expect(getByText('Providers')).toBeOnTheScreen();
+        expect(getByText('All')).toBeOnTheScreen();
+        expect(getByText('CEX')).toBeOnTheScreen();
+        expect(getByText('DEX')).toBeOnTheScreen();
+    });
+
+    it('should not render filters when shouldShowFilters is false', async () => {
+        const { getByText, queryByText } = await renderProviderSheetHandle(
+            { shouldShowFilters: false },
+            {},
+        );
+
+        expect(getByText('Providers')).toBeOnTheScreen();
+        expect(queryByText('All')).toBeNull();
+        expect(queryByText('CEX')).toBeNull();
+        expect(queryByText('DEX')).toBeNull();
+    });
+
+    it('should call onClose when close button is pressed', async () => {
+        const onClose = jest.fn();
+        const { getByLabelText } = await renderProviderSheetHandle({ onClose }, {});
+
+        fireEvent.press(getByLabelText('Close'));
+
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it('should setSelectedFilter when filter item is pressed', async () => {
+        const setSelectedFilter = jest.fn();
+        const { getByText } = await renderProviderSheetHandle({ setSelectedFilter }, {});
+
+        fireEvent.press(getByText('CEX'));
+
+        expect(setSelectedFilter).toHaveBeenCalledWith('cex');
+    });
+
+    it('should display context message', async () => {
+        const { getByText } = await renderProviderSheetHandle(
+            {},
+            {
+                wallet: {
+                    tradingNew: {
+                        activeTradingType: 'exchange',
+                    },
+                },
+            },
+        );
+
+        expect(getByText('Trading exchange message')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheetSectionHeader.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheetSectionHeader.comp.test.tsx
@@ -1,0 +1,22 @@
+import { renderWithBasicProvider } from '@suite-native/test-utils';
+
+import { QuotesCategory } from '../../../../types/general';
+import {
+    ProviderSheetSectionHeader,
+    ProviderSheetSectionHeaderProps,
+} from '../ProviderSheetSectionHeader';
+
+describe('ProviderSheetSectionHeader', () => {
+    const renderProviderSheetSectionHeader = (props: ProviderSheetSectionHeaderProps) =>
+        renderWithBasicProvider(<ProviderSheetSectionHeader {...props} />);
+
+    it.each<[QuotesCategory, string]>([
+        ['fixed', 'Fixed-rate CEX'],
+        ['float', 'Floating-rate CEX'],
+        ['dex', 'DEX'],
+    ])('should render correct section based on category [%s]', (category, expectedTitle) => {
+        const { getByText } = renderProviderSheetSectionHeader({ category });
+
+        expect(getByText(expectedTitle)).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/__tests__/useProviderFilters.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useProviderFilters.test.ts
@@ -1,0 +1,108 @@
+import type { ExchangeTrade } from 'invity-api';
+
+import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
+
+import { QuotesByCategories } from '../../../types/general';
+import { useProviderFilters } from '../useProviderFilters';
+
+type UseProviderFilterProps = {
+    quotes?: QuotesByCategories<ExchangeTrade>;
+    shouldShowFilters?: boolean;
+};
+describe('useProviderFilters', () => {
+    const renderUseProviderFilters = (initialProps: UseProviderFilterProps) =>
+        renderHookWithBasicProvider(
+            ({ quotes = { fixed: [], float: [], dex: [] }, shouldShowFilters = true }) =>
+                useProviderFilters(quotes, shouldShowFilters),
+            {
+                initialProps,
+            },
+        );
+
+    it('filterItems should be stable', () => {
+        const { result, rerender } = renderUseProviderFilters({});
+
+        const initialFilterItems = result.current.filterItems;
+
+        expect(initialFilterItems).toEqual([
+            { label: 'All', value: 'all' },
+            { label: 'CEX', value: 'cex' },
+            { label: 'DEX', value: 'dex' },
+        ]);
+
+        rerender({});
+
+        expect(result.current.filterItems).toBe(initialFilterItems);
+    });
+
+    it('should return all given sections even when empty when no filter is selected ', () => {
+        const { result } = renderUseProviderFilters({
+            quotes: {
+                fixed: [],
+                float: [],
+            },
+        });
+
+        expect(result.current.filteredSections).toEqual([
+            { key: 'fixed', data: [], label: '', sectionData: 'fixed' },
+            { key: 'float', data: [], label: '', sectionData: 'float' },
+        ]);
+    });
+
+    it('should return all sections when "all" filter is selected', () => {
+        const { result } = renderUseProviderFilters({});
+
+        act(() => {
+            result.current.setSelectedFilter('all');
+        });
+
+        expect(result.current.selectedFilter).toBe('all');
+        expect(result.current.filteredSections).toEqual([
+            { key: 'fixed', data: [], label: '', sectionData: 'fixed' },
+            { key: 'float', data: [], label: '', sectionData: 'float' },
+            { key: 'dex', data: [], label: '', sectionData: 'dex' },
+        ]);
+    });
+
+    it('should return fixed and float when CEX is selected', () => {
+        const { result } = renderUseProviderFilters({});
+
+        act(() => {
+            result.current.setSelectedFilter('cex');
+        });
+
+        expect(result.current.selectedFilter).toBe('cex');
+        expect(result.current.filteredSections).toEqual([
+            { key: 'fixed', data: [], label: '', sectionData: 'fixed' },
+            { key: 'float', data: [], label: '', sectionData: 'float' },
+        ]);
+    });
+
+    it('should return dex when DEX is selected', () => {
+        const { result } = renderUseProviderFilters({});
+
+        act(() => {
+            result.current.setSelectedFilter('dex');
+        });
+
+        expect(result.current.selectedFilter).toBe('dex');
+        expect(result.current.filteredSections).toEqual([
+            { key: 'dex', data: [], label: '', sectionData: 'dex' },
+        ]);
+    });
+
+    it('should return all section when dex is selected but shouldShowFilters is false', () => {
+        const { result } = renderUseProviderFilters({ shouldShowFilters: false });
+
+        act(() => {
+            result.current.setSelectedFilter('cex');
+        });
+
+        expect(result.current.selectedFilter).toBe('cex');
+        expect(result.current.filteredSections).toEqual([
+            { key: 'fixed', data: [], label: '', sectionData: 'fixed' },
+            { key: 'float', data: [], label: '', sectionData: 'float' },
+            { key: 'dex', data: [], label: '', sectionData: 'dex' },
+        ]);
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/__tests__/useSectionList.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useSectionList.test.tsx
@@ -78,39 +78,84 @@ describe('useSectionList', () => {
             });
 
             const expectedTransformedData = [
-                ['sectionHeader', 'Section 1', 'section1', { id: 's1' }],
-                [
-                    'item',
-                    'item1',
-                    { isFirst: true, isLast: false, sectionData: { id: 's1' }, isEnabled: true },
-                ],
-                [
-                    'item',
-                    'item2',
-                    { isFirst: false, isLast: true, sectionData: { id: 's1' }, isEnabled: true },
-                ],
-                ['sectionHeader', 'Section 2', 'section2', { id: 's2' }],
-                [
-                    'item',
-                    'item3',
-                    { isFirst: true, isLast: false, sectionData: { id: 's2' }, isEnabled: true },
-                ],
-                [
-                    'item',
-                    'item4',
-                    { isFirst: false, isLast: false, sectionData: { id: 's2' }, isEnabled: true },
-                ],
-                [
-                    'item',
-                    'item5',
-                    { isFirst: false, isLast: true, sectionData: { id: 's2' }, isEnabled: true },
-                ],
-                ['sectionHeader', 'Section 3', 'section3', { id: 's3' }],
-                [
-                    'item',
-                    'item6',
-                    { isFirst: true, isLast: true, sectionData: { id: 's3' }, isEnabled: true },
-                ],
+                {
+                    type: 'sectionHeader',
+                    title: 'Section 1',
+                    key: 'section1',
+                    sectionData: { id: 's1' },
+                },
+                {
+                    type: 'item',
+                    item: 'item1',
+                    config: {
+                        isFirst: true,
+                        isLast: false,
+                        sectionData: { id: 's1' },
+                        isEnabled: true,
+                    },
+                },
+                {
+                    type: 'item',
+                    item: 'item2',
+                    config: {
+                        isFirst: false,
+                        isLast: true,
+                        sectionData: { id: 's1' },
+                        isEnabled: true,
+                    },
+                },
+                {
+                    type: 'sectionHeader',
+                    title: 'Section 2',
+                    key: 'section2',
+                    sectionData: { id: 's2' },
+                },
+                {
+                    type: 'item',
+                    item: 'item3',
+                    config: {
+                        isFirst: true,
+                        isLast: false,
+                        sectionData: { id: 's2' },
+                        isEnabled: true,
+                    },
+                },
+                {
+                    type: 'item',
+                    item: 'item4',
+                    config: {
+                        isFirst: false,
+                        isLast: false,
+                        sectionData: { id: 's2' },
+                        isEnabled: true,
+                    },
+                },
+                {
+                    type: 'item',
+                    item: 'item5',
+                    config: {
+                        isFirst: false,
+                        isLast: true,
+                        sectionData: { id: 's2' },
+                        isEnabled: true,
+                    },
+                },
+                {
+                    type: 'sectionHeader',
+                    title: 'Section 3',
+                    key: 'section3',
+                    sectionData: { id: 's3' },
+                },
+                {
+                    type: 'item',
+                    item: 'item6',
+                    config: {
+                        isFirst: true,
+                        isLast: true,
+                        sectionData: { id: 's3' },
+                        isEnabled: true,
+                    },
+                },
             ];
 
             expect(result.current.data).toEqual(expectedTransformedData);
@@ -124,26 +169,26 @@ describe('useSectionList', () => {
                 });
 
                 const expectedTransformedData = [
-                    [
-                        'item',
-                        'item1',
-                        {
+                    {
+                        type: 'item',
+                        item: 'item1',
+                        config: {
                             isFirst: true,
                             isLast: false,
                             sectionData: { id: 's1' },
                             isEnabled: true,
                         },
-                    ],
-                    [
-                        'item',
-                        'item2',
-                        {
+                    },
+                    {
+                        type: 'item',
+                        item: 'item2',
+                        config: {
                             isFirst: false,
                             isLast: true,
                             sectionData: { id: 's1' },
                             isEnabled: true,
                         },
-                    ],
+                    },
                 ];
 
                 expect(result.current.data).toEqual(expectedTransformedData);
@@ -185,18 +230,33 @@ describe('useSectionList', () => {
                 });
 
                 expect(result.current.data).toEqual([
-                    ['sectionHeader', 'Section 3', 'section3', { id: 's3' }],
-                    [
-                        'item',
-                        'item6',
-                        { isFirst: true, isLast: true, sectionData: { id: 's3' }, isEnabled: true },
-                    ],
-                    ['sectionHeader', 'Section 4', 'section4', { id: 's4' }],
-                    [
-                        'emptySection',
-                        'section4-empty-section',
-                        expect.objectContaining({ sectionData: { id: 's4' } }),
-                    ],
+                    {
+                        type: 'sectionHeader',
+                        title: 'Section 3',
+                        key: 'section3',
+                        sectionData: { id: 's3' },
+                    },
+                    {
+                        type: 'item',
+                        item: 'item6',
+                        config: {
+                            isFirst: true,
+                            isLast: true,
+                            sectionData: { id: 's3' },
+                            isEnabled: true,
+                        },
+                    },
+                    {
+                        type: 'sectionHeader',
+                        title: 'Section 4',
+                        key: 'section4',
+                        sectionData: { id: 's4' },
+                    },
+                    {
+                        type: 'emptySection',
+                        key: 'section4-empty-section',
+                        config: expect.objectContaining({ sectionData: { id: 's4' } }),
+                    },
                 ]);
             });
         });
@@ -208,27 +268,32 @@ describe('useSectionList', () => {
                 });
 
                 const expectedTransformedData = [
-                    ['sectionHeader', 'Section 1', 'section1', { id: 's1' }],
-                    [
-                        'item',
-                        'item1',
-                        {
+                    {
+                        type: 'sectionHeader',
+                        title: 'Section 1',
+                        key: 'section1',
+                        sectionData: { id: 's1' },
+                    },
+                    {
+                        type: 'item',
+                        item: 'item1',
+                        config: {
                             isFirst: true,
                             isLast: false,
                             sectionData: { id: 's1' },
                             isEnabled: true,
                         },
-                    ],
-                    [
-                        'item',
-                        'item2',
-                        {
+                    },
+                    {
+                        type: 'item',
+                        item: 'item2',
+                        config: {
                             isFirst: false,
                             isLast: true,
                             sectionData: { id: 's1' },
                             isEnabled: true,
                         },
-                    ],
+                    },
                 ];
 
                 expect(result.current.data).toEqual(expectedTransformedData);
@@ -248,7 +313,12 @@ describe('useSectionList', () => {
                 });
 
                 expect(result.current.data).toEqual([
-                    ['sectionHeader', 'Section 4', 'section4', { id: 's4' }],
+                    {
+                        type: 'sectionHeader',
+                        title: 'Section 4',
+                        key: 'section4',
+                        sectionData: { id: 's4' },
+                    },
                 ]);
             });
 
@@ -259,17 +329,22 @@ describe('useSectionList', () => {
                 });
 
                 expect(result.current.data).toEqual([
-                    ['sectionHeader', 'Section 4', 'section4', { id: 's4' }],
-                    [
-                        'emptySection',
-                        'section4-empty-section',
-                        {
+                    {
+                        type: 'sectionHeader',
+                        title: 'Section 4',
+                        key: 'section4',
+                        sectionData: { id: 's4' },
+                    },
+                    {
+                        type: 'emptySection',
+                        key: 'section4-empty-section',
+                        config: {
                             sectionData: { id: 's4' },
                             isFirst: true,
                             isLast: true,
                             isEnabled: false,
                         },
-                    ],
+                    },
                 ]);
             });
 
@@ -280,18 +355,33 @@ describe('useSectionList', () => {
                 });
 
                 expect(result.current.data).toEqual([
-                    ['sectionHeader', 'Section 3', 'section3', { id: 's3' }],
-                    [
-                        'item',
-                        'item6',
-                        { isFirst: true, isLast: true, sectionData: { id: 's3' }, isEnabled: true },
-                    ],
-                    ['sectionHeader', 'Section 4', 'section4', { id: 's4' }],
-                    [
-                        'emptySection',
-                        'section4-empty-section',
-                        expect.objectContaining({ sectionData: { id: 's4' } }),
-                    ],
+                    {
+                        type: 'sectionHeader',
+                        title: 'Section 3',
+                        key: 'section3',
+                        sectionData: { id: 's3' },
+                    },
+                    {
+                        type: 'item',
+                        item: 'item6',
+                        config: {
+                            isFirst: true,
+                            isLast: true,
+                            sectionData: { id: 's3' },
+                            isEnabled: true,
+                        },
+                    },
+                    {
+                        type: 'sectionHeader',
+                        title: 'Section 4',
+                        key: 'section4',
+                        sectionData: { id: 's4' },
+                    },
+                    {
+                        type: 'emptySection',
+                        key: 'section4-empty-section',
+                        config: expect.objectContaining({ sectionData: { id: 's4' } }),
+                    },
                 ]);
             });
         });
@@ -316,11 +406,11 @@ describe('useSectionList', () => {
             const { result } = renderUseSectionListHook({ data: [sectionWithDisabledItems] });
 
             const transformedData = result.current.data;
-            const items = transformedData.filter(item => item[0] === 'item');
+            const items = transformedData.filter(item => item.type === 'item');
 
-            expect((items[0][2] as any).isEnabled).toBe(true); // item6
-            expect((items[1][2] as any).isEnabled).toBe(false); // item7
-            expect((items[2][2] as any).isEnabled).toBe(true); // item8 (default)
+            expect((items[0] as any).config.isEnabled).toBe(true); // item6
+            expect((items[1] as any).config.isEnabled).toBe(false); // item7
+            expect((items[2] as any).config.isEnabled).toBe(true); // item8 (default)
         });
     });
 });

--- a/suite-native/module-trading/src/hooks/general/__tests__/useSectionList.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useSectionList.test.tsx
@@ -1,27 +1,32 @@
-import { ReactElement, ReactNode } from 'react';
+import { Text } from 'react-native';
 
 import { renderHookWithBasicProvider } from '@suite-native/test-utils';
 
-import { SectionHeaderRenderConfig, SectionListData, useSectionList } from '../useSectionList';
+import { UseSectionListProps, useSectionList } from '../useSectionList';
 
-const renderUseSectionListHook = (
-    data: SectionListData<any, any>,
-    noSingletonSectionHeader: boolean = false,
-    isLastItemRounded: boolean = true,
-    renderSectionHeader?: (
-        label: ReactNode,
-        config: SectionHeaderRenderConfig<any>,
-    ) => ReactElement,
+const renderUseSectionListHook = <T, U = undefined>(
+    initialProps: Partial<UseSectionListProps<T, U>>,
 ) =>
-    renderHookWithBasicProvider(() =>
-        useSectionList({
-            data,
-            renderItem: jest.fn(),
-            keyExtractor: jest.fn(),
-            noSingletonSectionHeader,
-            isLastItemRounded,
+    renderHookWithBasicProvider(
+        ({
+            data = [],
+            noSingletonSectionHeader = false,
+            isLastItemRounded = true,
             renderSectionHeader,
-        }),
+            SectionEmptyComponent,
+        }: Partial<UseSectionListProps<T, U>>) =>
+            useSectionList({
+                data,
+                renderItem: jest.fn(),
+                keyExtractor: jest.fn(),
+                noSingletonSectionHeader,
+                isLastItemRounded,
+                renderSectionHeader,
+                SectionEmptyComponent,
+            }),
+        {
+            initialProps,
+        },
     );
 
 describe('useSectionList', () => {
@@ -46,11 +51,31 @@ describe('useSectionList', () => {
         data: ['item6'],
     };
 
+    const section4 = {
+        key: 'section4',
+        label: 'Section 4',
+        sectionData: { id: 's4' },
+        data: [],
+    };
+
+    const sectionWithDisabledItems = {
+        key: 'section3',
+        label: 'Section 3',
+        sectionData: { id: 's3' },
+        data: [
+            { id: 'item6', isEnabled: true },
+            { id: 'item7', isEnabled: false },
+            { id: 'item8' }, // undefined isEnabled should default to true
+        ],
+    };
+
     const mockData = [section1, section2, section3];
 
     describe('data transformation', () => {
         it('should correctly transform data with section headers', () => {
-            const { result } = renderUseSectionListHook(mockData);
+            const { result } = renderUseSectionListHook({
+                data: mockData,
+            });
 
             const expectedTransformedData = [
                 ['sectionHeader', 'Section 1', 'section1', { id: 's1' }],
@@ -91,65 +116,204 @@ describe('useSectionList', () => {
             expect(result.current.data).toEqual(expectedTransformedData);
         });
 
-        it('should handle single section with noSingletonSectionHeader=true', () => {
-            const { result } = renderUseSectionListHook([section1], true);
+        describe('with noSingletonSectionHeader', () => {
+            it('should handle single section', () => {
+                const { result } = renderUseSectionListHook({
+                    data: [section1],
+                    noSingletonSectionHeader: true,
+                });
 
-            const expectedTransformedData = [
-                [
-                    'item',
-                    'item1',
-                    { isFirst: true, isLast: false, sectionData: { id: 's1' }, isEnabled: true },
-                ],
-                [
-                    'item',
-                    'item2',
-                    { isFirst: false, isLast: true, sectionData: { id: 's1' }, isEnabled: true },
-                ],
-            ];
+                const expectedTransformedData = [
+                    [
+                        'item',
+                        'item1',
+                        {
+                            isFirst: true,
+                            isLast: false,
+                            sectionData: { id: 's1' },
+                            isEnabled: true,
+                        },
+                    ],
+                    [
+                        'item',
+                        'item2',
+                        {
+                            isFirst: false,
+                            isLast: true,
+                            sectionData: { id: 's1' },
+                            isEnabled: true,
+                        },
+                    ],
+                ];
 
-            expect(result.current.data).toEqual(expectedTransformedData);
+                expect(result.current.data).toEqual(expectedTransformedData);
+            });
+
+            it('should handle empty data', () => {
+                const { result } = renderUseSectionListHook({
+                    data: [],
+                    noSingletonSectionHeader: true,
+                });
+
+                expect(result.current.data).toEqual([]);
+            });
+
+            it('should handle empty sections', () => {
+                const { result } = renderUseSectionListHook({
+                    data: [section4],
+                    noSingletonSectionHeader: true,
+                });
+
+                expect(result.current.data).toEqual([]);
+            });
+
+            it('should handle empty section even with renderEmptySectionContent specified', () => {
+                const { result } = renderUseSectionListHook({
+                    data: [section4],
+                    noSingletonSectionHeader: true,
+                    SectionEmptyComponent: <Text>Empty Section Placeholder</Text>,
+                });
+
+                expect(result.current.data).toEqual([]);
+            });
+
+            it('should handle multiple sections with SectionEmptyComponent specified', () => {
+                const { result } = renderUseSectionListHook({
+                    data: [section3, section4],
+                    SectionEmptyComponent: <Text>Empty Section Placeholder</Text>,
+                    noSingletonSectionHeader: true,
+                });
+
+                expect(result.current.data).toEqual([
+                    ['sectionHeader', 'Section 3', 'section3', { id: 's3' }],
+                    [
+                        'item',
+                        'item6',
+                        { isFirst: true, isLast: true, sectionData: { id: 's3' }, isEnabled: true },
+                    ],
+                    ['sectionHeader', 'Section 4', 'section4', { id: 's4' }],
+                    [
+                        'emptySection',
+                        'section4-empty-section',
+                        expect.objectContaining({ sectionData: { id: 's4' } }),
+                    ],
+                ]);
+            });
         });
 
-        it('should handle empty data', () => {
-            const { result } = renderUseSectionListHook([], true);
+        describe('without noSingletonSectionHeader', () => {
+            it('should handle single section', () => {
+                const { result } = renderUseSectionListHook({
+                    data: [section1],
+                });
 
-            expect(result.current.data).toEqual([]);
-        });
-        it('should handle empty sections', () => {
-            const { result } = renderUseSectionListHook([{ ...section1, data: [] }], true);
+                const expectedTransformedData = [
+                    ['sectionHeader', 'Section 1', 'section1', { id: 's1' }],
+                    [
+                        'item',
+                        'item1',
+                        {
+                            isFirst: true,
+                            isLast: false,
+                            sectionData: { id: 's1' },
+                            isEnabled: true,
+                        },
+                    ],
+                    [
+                        'item',
+                        'item2',
+                        {
+                            isFirst: false,
+                            isLast: true,
+                            sectionData: { id: 's1' },
+                            isEnabled: true,
+                        },
+                    ],
+                ];
 
-            expect(result.current.data).toEqual([]);
+                expect(result.current.data).toEqual(expectedTransformedData);
+            });
+
+            it('should handle empty data', () => {
+                const { result } = renderUseSectionListHook({
+                    data: [],
+                });
+
+                expect(result.current.data).toEqual([]);
+            });
+
+            it('should handle empty sections', () => {
+                const { result } = renderUseSectionListHook({
+                    data: [section4],
+                });
+
+                expect(result.current.data).toEqual([
+                    ['sectionHeader', 'Section 4', 'section4', { id: 's4' }],
+                ]);
+            });
+
+            it('should handle empty section even with SectionEmptyComponent specified', () => {
+                const { result } = renderUseSectionListHook({
+                    data: [section4],
+                    SectionEmptyComponent: <Text>Empty Section Placeholder</Text>,
+                });
+
+                expect(result.current.data).toEqual([
+                    ['sectionHeader', 'Section 4', 'section4', { id: 's4' }],
+                    [
+                        'emptySection',
+                        'section4-empty-section',
+                        {
+                            sectionData: { id: 's4' },
+                            isFirst: true,
+                            isLast: true,
+                            isEnabled: false,
+                        },
+                    ],
+                ]);
+            });
+
+            it('should handle multiple sections with SectionEmptyComponent specified', () => {
+                const { result } = renderUseSectionListHook({
+                    data: [section3, section4],
+                    SectionEmptyComponent: <Text>Empty Section Placeholder</Text>,
+                });
+
+                expect(result.current.data).toEqual([
+                    ['sectionHeader', 'Section 3', 'section3', { id: 's3' }],
+                    [
+                        'item',
+                        'item6',
+                        { isFirst: true, isLast: true, sectionData: { id: 's3' }, isEnabled: true },
+                    ],
+                    ['sectionHeader', 'Section 4', 'section4', { id: 's4' }],
+                    [
+                        'emptySection',
+                        'section4-empty-section',
+                        expect.objectContaining({ sectionData: { id: 's4' } }),
+                    ],
+                ]);
+            });
         });
     });
 
     describe('sections and items count', () => {
         it('should correctly calculate sectionsCount', () => {
-            const { result } = renderUseSectionListHook(mockData);
+            const { result } = renderUseSectionListHook({ data: mockData });
 
             expect(result.current.sectionsCount).toBe(3);
         });
 
         it('should correctly calculate itemsCount', () => {
-            const { result } = renderUseSectionListHook(mockData);
+            const { result } = renderUseSectionListHook({ data: mockData });
 
             expect(result.current.itemsCount).toBe(6);
         });
     });
 
     describe('isEnabled property handling', () => {
-        const sectionWithDisabledItems = {
-            key: 'section3',
-            label: 'Section 3',
-            sectionData: { id: 's3' },
-            data: [
-                { id: 'item6', isEnabled: true },
-                { id: 'item7', isEnabled: false },
-                { id: 'item8' }, // undefined isEnabled should default to true
-            ],
-        };
-
         it('should correctly handle items with explicit or undefined isEnabled property', () => {
-            const { result } = renderUseSectionListHook([sectionWithDisabledItems]);
+            const { result } = renderUseSectionListHook({ data: [sectionWithDisabledItems] });
 
             const transformedData = result.current.data;
             const items = transformedData.filter(item => item[0] === 'item');

--- a/suite-native/module-trading/src/hooks/general/useProviderFilters.ts
+++ b/suite-native/module-trading/src/hooks/general/useProviderFilters.ts
@@ -1,0 +1,63 @@
+import { useMemo, useState } from 'react';
+
+import { TradingTradeType } from '@suite-common/trading';
+import { useTranslate } from '@suite-native/intl';
+
+import { SectionListData, SectionListDataArray } from './useSectionList';
+import { FilterItem } from '../../components/general/FilterTabs';
+import { QuotesByCategories, QuotesCategory } from '../../types/general';
+
+export type FilterValue = 'all' | 'cex' | 'dex';
+
+export const useProviderFilters = <T extends TradingTradeType>(
+    quotes: QuotesByCategories<T>,
+    shouldShowFilters: boolean,
+) => {
+    const { translate } = useTranslate();
+    const [selectedFilter, setSelectedFilter] = useState<FilterValue>('all');
+
+    const filterItems: FilterItem<FilterValue>[] = useMemo(
+        () => [
+            { label: translate('moduleTrading.providerSheet.filters.all'), value: 'all' },
+            { label: translate('moduleTrading.providerSheet.filters.cex'), value: 'cex' },
+            { label: translate('moduleTrading.providerSheet.filters.dex'), value: 'dex' },
+        ],
+        [translate],
+    );
+
+    const filteredSections: SectionListData<T, QuotesCategory> = useMemo(() => {
+        const allSections = Object.entries(quotes).map(([category, items]) => {
+            const typedCategory = category as QuotesCategory;
+
+            return {
+                key: category,
+                data: items as SectionListDataArray<T>,
+                label: '',
+                sectionData: typedCategory,
+            };
+        });
+
+        if (!shouldShowFilters || selectedFilter === 'all') {
+            return allSections;
+        }
+
+        if (selectedFilter === 'cex') {
+            return allSections.filter(
+                section => section.key === 'fixed' || section.key === 'float',
+            );
+        }
+
+        if (selectedFilter === 'dex') {
+            return allSections.filter(section => section.key === 'dex');
+        }
+
+        return allSections;
+    }, [quotes, selectedFilter, shouldShowFilters]);
+
+    return {
+        selectedFilter,
+        setSelectedFilter,
+        filterItems,
+        filteredSections,
+    };
+};

--- a/suite-native/module-trading/src/hooks/general/useSectionList.tsx
+++ b/suite-native/module-trading/src/hooks/general/useSectionList.tsx
@@ -12,11 +12,13 @@ export type ItemRenderConfig<U> = {
     isEnabled?: boolean;
 };
 
+export type SectionListDataArray<T> = (T & { isEnabled?: boolean })[];
+
 export type SectionListData<T, U = undefined> = {
     key: string;
     label: ReactNode;
     sectionData: U;
-    data: (T & { isEnabled?: boolean })[];
+    data: SectionListDataArray<T>;
 }[];
 
 export type SectionHeaderRenderConfig<U> = {
@@ -28,12 +30,15 @@ export type ListInternalItemShape<T, U> =
     // [type, text, key, sectionData]
     | ['sectionHeader', ReactNode, string, U]
     // [type, data, config]
-    | ['item', T, ItemRenderConfig<U>];
+    | ['item', T, ItemRenderConfig<U>]
+    // [type, key, sectionData]
+    | ['emptySection', string, ItemRenderConfig<U>];
 
-type UseSectionListProps<T, U> = {
+export type UseSectionListProps<T, U> = {
     data: SectionListData<T, U>;
     renderItem: (item: T, config: ItemRenderConfig<U>) => ReactElement;
     renderSectionHeader?: (label: ReactNode, config: SectionHeaderRenderConfig<U>) => ReactElement;
+    SectionEmptyComponent?: ReactElement;
     keyExtractor: (item: T, sectionData: U) => string;
     noSingletonSectionHeader: boolean | undefined;
     isLastItemRounded?: boolean;
@@ -72,6 +77,7 @@ const defaultItemStyle = prepareNativeStyle<ItemRenderConfig<unknown>>(
 const transformToInternalFlatListData = <T, U = undefined>(
     inputData: SectionListData<T, U>,
     noSingletonSectionHeader: boolean | undefined,
+    withEmptySectionPlaceholder: boolean,
     isLastItemRounded: boolean,
 ): ListInternalItemShape<T, U>[] =>
     inputData.reduce(
@@ -91,6 +97,19 @@ const transformToInternalFlatListData = <T, U = undefined>(
 
             if (!noSingletonSectionHeader || inputData.length > 1) {
                 acc.push(['sectionHeader', label, key, sectionData]);
+
+                if (withEmptySectionPlaceholder && itemsData.length === 0) {
+                    acc.push([
+                        'emptySection',
+                        key + '-empty-section',
+                        {
+                            isFirst: true,
+                            isLast: true,
+                            sectionData,
+                            isEnabled: false,
+                        },
+                    ]);
+                }
             }
 
             acc.push(...itemsData);
@@ -111,6 +130,9 @@ const internalKeyExtractor = <T, U>(
         case 'item':
             return itemKeyExtractor(item[1], item[2].sectionData);
 
+        case 'emptySection':
+            return item[1];
+
         default:
             return exhaustive(item[0]);
     }
@@ -122,6 +144,7 @@ const renderInternalItem = <T, U>(
     renderSectionHeader:
         | ((label: ReactNode, config: SectionHeaderRenderConfig<U>) => ReactElement)
         | undefined,
+    SectionEmptyComponent: ReactElement | undefined,
     applyStyle: ReturnType<typeof useNativeStyles>['applyStyle'],
     itemStyle?: ReturnType<typeof prepareNativeStyle<ItemRenderConfig<unknown>>>,
 ): ReactElement => {
@@ -157,6 +180,22 @@ const renderInternalItem = <T, U>(
                 </AnimatedBox>
             );
 
+        case 'emptySection':
+            return (
+                <AnimatedBox
+                    entering={FadeIn}
+                    exiting={FadeOut}
+                    style={applyStyle(itemStyle ?? defaultItemStyle, {
+                        isFirst: true,
+                        isLast: true,
+                        sectionData: item[2],
+                        isEnabled: false,
+                    })}
+                >
+                    {SectionEmptyComponent}
+                </AnimatedBox>
+            );
+
         default:
             return exhaustive(item[0]);
     }
@@ -170,9 +209,11 @@ export const useSectionList = <T, U = undefined>({
     noSingletonSectionHeader,
     isLastItemRounded = true,
     itemStyle,
+    SectionEmptyComponent,
 }: UseSectionListProps<T, U>) => {
     const { applyStyle } = useNativeStyles();
     const sectionsCount = data.length;
+    const isEmptySectionPlaceholderDefined = !!SectionEmptyComponent;
 
     const itemsCount = useMemo(
         () =>
@@ -189,9 +230,10 @@ export const useSectionList = <T, U = undefined>({
             transformToInternalFlatListData<T, U>(
                 data,
                 noSingletonSectionHeader,
+                isEmptySectionPlaceholderDefined,
                 isLastItemRounded,
             ),
-        [data, noSingletonSectionHeader, isLastItemRounded],
+        [data, noSingletonSectionHeader, isLastItemRounded, isEmptySectionPlaceholderDefined],
     );
 
     return {
@@ -201,6 +243,13 @@ export const useSectionList = <T, U = undefined>({
         keyExtractor: (item: ListInternalItemShape<T, U>) =>
             internalKeyExtractor(item, keyExtractor),
         renderItem: ({ item }: { item: ListInternalItemShape<T, U> }) =>
-            renderInternalItem(item, renderItem, renderSectionHeader, applyStyle, itemStyle),
+            renderInternalItem(
+                item,
+                renderItem,
+                renderSectionHeader,
+                SectionEmptyComponent,
+                applyStyle,
+                itemStyle,
+            ),
     };
 };

--- a/suite-native/module-trading/src/hooks/general/useSectionList.tsx
+++ b/suite-native/module-trading/src/hooks/general/useSectionList.tsx
@@ -27,12 +27,22 @@ export type SectionHeaderRenderConfig<U> = {
 };
 
 export type ListInternalItemShape<T, U> =
-    // [type, text, key, sectionData]
-    | ['sectionHeader', ReactNode, string, U]
-    // [type, data, config]
-    | ['item', T, ItemRenderConfig<U>]
-    // [type, key, sectionData]
-    | ['emptySection', string, ItemRenderConfig<U>];
+    | {
+          type: 'sectionHeader';
+          title: ReactNode;
+          key: string;
+          sectionData: U;
+      }
+    | {
+          type: 'item';
+          item: T;
+          config: ItemRenderConfig<U>;
+      }
+    | {
+          type: 'emptySection';
+          key: string;
+          config: ItemRenderConfig<U>;
+      };
 
 export type UseSectionListProps<T, U> = {
     data: SectionListData<T, U>;
@@ -42,6 +52,24 @@ export type UseSectionListProps<T, U> = {
     keyExtractor: (item: T, sectionData: U) => string;
     noSingletonSectionHeader: boolean | undefined;
     isLastItemRounded?: boolean;
+    itemStyle?: ReturnType<typeof prepareNativeStyle<ItemRenderConfig<unknown>>>;
+};
+
+type TransformToInternalFlatListDataProps<T, U> = {
+    inputData: SectionListData<T, U>;
+    noSingletonSectionHeader: boolean | undefined;
+    withEmptySectionPlaceholder: boolean;
+    isLastItemRounded: boolean;
+};
+
+type RenderInternalItemProps<T, U> = {
+    item: ListInternalItemShape<T, U>;
+    renderItem: (item: T, config: ItemRenderConfig<U>) => ReactElement;
+    renderSectionHeader:
+        | ((label: ReactNode, config: SectionHeaderRenderConfig<U>) => ReactElement)
+        | undefined;
+    SectionEmptyComponent: ReactElement | undefined;
+    applyStyle: ReturnType<typeof useNativeStyles>['applyStyle'];
     itemStyle?: ReturnType<typeof prepareNativeStyle<ItemRenderConfig<unknown>>>;
 };
 
@@ -74,41 +102,46 @@ const defaultItemStyle = prepareNativeStyle<ItemRenderConfig<unknown>>(
     }),
 );
 
-const transformToInternalFlatListData = <T, U = undefined>(
-    inputData: SectionListData<T, U>,
-    noSingletonSectionHeader: boolean | undefined,
-    withEmptySectionPlaceholder: boolean,
-    isLastItemRounded: boolean,
-): ListInternalItemShape<T, U>[] =>
+const transformToInternalFlatListData = <T, U = undefined>({
+    inputData,
+    noSingletonSectionHeader,
+    withEmptySectionPlaceholder,
+    isLastItemRounded,
+}: TransformToInternalFlatListDataProps<T, U>): ListInternalItemShape<T, U>[] =>
     inputData.reduce(
         (acc, { key, label, data, sectionData }) => {
             const itemsData = data.map(
-                (item, index): ListInternalItemShape<T, U> => [
-                    'item',
+                (item, index): ListInternalItemShape<T, U> => ({
+                    type: 'item',
                     item,
-                    {
+                    config: {
                         isFirst: index === 0,
                         isLast: index === data.length - 1 && isLastItemRounded,
                         sectionData,
                         isEnabled: item.isEnabled !== undefined ? item.isEnabled : true,
                     },
-                ],
+                }),
             );
 
             if (!noSingletonSectionHeader || inputData.length > 1) {
-                acc.push(['sectionHeader', label, key, sectionData]);
+                acc.push({
+                    type: 'sectionHeader',
+                    title: label,
+                    key,
+                    sectionData,
+                });
 
                 if (withEmptySectionPlaceholder && itemsData.length === 0) {
-                    acc.push([
-                        'emptySection',
-                        key + '-empty-section',
-                        {
+                    acc.push({
+                        type: 'emptySection',
+                        key: key + '-empty-section',
+                        config: {
                             isFirst: true,
                             isLast: true,
                             sectionData,
                             isEnabled: false,
                         },
-                    ]);
+                    });
                 }
             }
 
@@ -123,33 +156,36 @@ const internalKeyExtractor = <T, U>(
     item: ListInternalItemShape<T, U>,
     itemKeyExtractor: (item: T, sectionData: U) => string,
 ) => {
-    switch (item[0]) {
+    const { type } = item;
+    switch (type) {
         case 'sectionHeader':
-            return item[2];
+            return item.key;
 
         case 'item':
-            return itemKeyExtractor(item[1], item[2].sectionData);
+            return itemKeyExtractor(item.item, item.config.sectionData);
 
         case 'emptySection':
-            return item[1];
+            return item.key;
 
         default:
-            return exhaustive(item[0]);
+            return exhaustive(type);
     }
 };
 
-const renderInternalItem = <T, U>(
-    item: ListInternalItemShape<T, U>,
-    renderItem: (item: T, config: ItemRenderConfig<U>) => ReactElement,
-    renderSectionHeader:
-        | ((label: ReactNode, config: SectionHeaderRenderConfig<U>) => ReactElement)
-        | undefined,
-    SectionEmptyComponent: ReactElement | undefined,
-    applyStyle: ReturnType<typeof useNativeStyles>['applyStyle'],
-    itemStyle?: ReturnType<typeof prepareNativeStyle<ItemRenderConfig<unknown>>>,
-): ReactElement => {
-    switch (item[0]) {
-        case 'sectionHeader':
+const renderInternalItem = <T, U>({
+    item,
+    renderItem,
+    renderSectionHeader,
+    SectionEmptyComponent,
+    applyStyle,
+    itemStyle,
+}: RenderInternalItemProps<T, U>): ReactElement => {
+    const { type } = item;
+
+    switch (type) {
+        case 'sectionHeader': {
+            const { key, sectionData, title } = item;
+
             return (
                 <AnimatedBox
                     paddingVertical={renderSectionHeader ? undefined : 'sp12'}
@@ -157,26 +193,24 @@ const renderInternalItem = <T, U>(
                     exiting={FadeOut}
                 >
                     {renderSectionHeader ? (
-                        renderSectionHeader(item[1], {
-                            sectionData: item[3],
-                            key: item[2],
-                        })
+                        renderSectionHeader(title, { sectionData, key })
                     ) : (
                         <Text variant="hint" color="textSubdued">
-                            {item[1]}
+                            {item.title}
                         </Text>
                     )}
                 </AnimatedBox>
             );
+        }
 
         case 'item':
             return (
                 <AnimatedBox
                     entering={FadeIn}
                     exiting={FadeOut}
-                    style={applyStyle(itemStyle ?? defaultItemStyle, item[2])}
+                    style={applyStyle(itemStyle ?? defaultItemStyle, item.config)}
                 >
-                    {renderItem(item[1], item[2])}
+                    {renderItem(item.item, item.config)}
                 </AnimatedBox>
             );
 
@@ -185,19 +219,14 @@ const renderInternalItem = <T, U>(
                 <AnimatedBox
                     entering={FadeIn}
                     exiting={FadeOut}
-                    style={applyStyle(itemStyle ?? defaultItemStyle, {
-                        isFirst: true,
-                        isLast: true,
-                        sectionData: item[2],
-                        isEnabled: false,
-                    })}
+                    style={applyStyle(itemStyle ?? defaultItemStyle, item.config)}
                 >
                     {SectionEmptyComponent}
                 </AnimatedBox>
             );
 
         default:
-            return exhaustive(item[0]);
+            return exhaustive(type);
     }
 };
 
@@ -227,12 +256,12 @@ export const useSectionList = <T, U = undefined>({
 
     const internalData = useMemo(
         () =>
-            transformToInternalFlatListData<T, U>(
-                data,
+            transformToInternalFlatListData<T, U>({
+                inputData: data,
+                withEmptySectionPlaceholder: isEmptySectionPlaceholderDefined,
                 noSingletonSectionHeader,
-                isEmptySectionPlaceholderDefined,
                 isLastItemRounded,
-            ),
+            }),
         [data, noSingletonSectionHeader, isLastItemRounded, isEmptySectionPlaceholderDefined],
     );
 
@@ -243,13 +272,13 @@ export const useSectionList = <T, U = undefined>({
         keyExtractor: (item: ListInternalItemShape<T, U>) =>
             internalKeyExtractor(item, keyExtractor),
         renderItem: ({ item }: { item: ListInternalItemShape<T, U> }) =>
-            renderInternalItem(
+            renderInternalItem({
                 item,
                 renderItem,
                 renderSectionHeader,
                 SectionEmptyComponent,
                 applyStyle,
                 itemStyle,
-            ),
+            }),
     };
 };

--- a/suite-native/module-trading/src/types/general.ts
+++ b/suite-native/module-trading/src/types/general.ts
@@ -40,3 +40,7 @@ export type BaseFormValues<FocusedValue extends string, Quote extends TradingTra
     generalAlert: string | undefined;
     focusedValue: FocusedValue | undefined;
 } & Record<FocusedValue, string | undefined>;
+
+export type QuotesCategory = 'fixed' | 'float' | 'dex';
+
+export type QuotesByCategories<T extends TradingTradeType> = { [Q in QuotesCategory]?: T[] };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Introduced `SectionEmptyComponent` prop to `BottomSheetSectionList` component.
- Simplified `ProviderSheet` to always display filters in exchange and never display them anywhere else.
- Simplified `ProviderSheet` to always display section headers in exchange and do not display them anywhere else, unless needed (which should never for now).

## Related Issue

Resolve #20600


## Screenshots:
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-06 at 12 15 27" src="https://github.com/user-attachments/assets/468ad976-b927-48b8-8f58-cd8912f6c43d" />
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-06 at 12 15 50" src="https://github.com/user-attachments/assets/55df07d8-3fd1-437c-ac68-18855bdcc459" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=20600-Mobile-Swap-improve-provider-list&lookback=7)