### PR TITLE
fix(suite-common): update unacquired THP device

### DIFF
--- a/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
@@ -557,6 +557,53 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
         ],
     },
     {
+        description: `Change unacquired (busy) THP device`,
+        initialState: {
+            devices: [
+                getSuiteDevice({
+                    type: 'unacquired',
+                    path: '2',
+                    status: 'busy',
+                }),
+                getSuiteDevice(undefined, {
+                    device_id: 'ignored-device-id',
+                }),
+            ],
+        },
+        actions: [
+            {
+                type: DEVICE.CHANGED,
+                payload: getConnectDevice({
+                    type: 'unacquired',
+                    path: '2',
+                    thp: {
+                        channel: '00',
+                        credentials: [],
+                        expectedResponses: [],
+                        recvBit: 0,
+                        recvNonce: 0,
+                        sendBit: 0,
+                        sendNonce: 0,
+                    },
+                }),
+            },
+        ],
+        result: [
+            {
+                status: undefined,
+                thp: {
+                    channel: '00',
+                },
+            },
+            {
+                status: 'available',
+                features: {
+                    device_id: 'ignored-device-id',
+                },
+            },
+        ],
+    },
+    {
         description: `Change unacquired device`,
         initialState: { devices: [] },
         actions: [

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -175,6 +175,8 @@ const getConnectDevice = (dev?: Partial<StringPath<Device>>, feat?: Partial<Feat
             label: 'Unacquired device',
             name: 'name of unacquired device',
             transportSessionOwner: 'another app name',
+            thp: dev.thp,
+            status: dev.status,
         };
     }
 

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -246,8 +246,18 @@ const changeDevice = (
     device: Device | TrezorDevice,
     extended: Partial<AcquiredDevice>,
 ) => {
-    // change only acquired devices
-    if (!device.features) return;
+    // change only acquired and THP devices
+    if (!device.features) {
+        if (device.thp) {
+            const affectedDevice = draft.devices.find(d => !d.features && d.path === device.path);
+            if (affectedDevice) {
+                affectedDevice.status = device.status;
+                affectedDevice.thp = device.thp;
+            }
+        }
+
+        return;
+    }
 
     // this is not nice - during passphrase/discovery refactor, I made a decision that we are not going to update device.state in reducer
     // in any other case than as a result of device authorization (passphrase+discovery). But later we realized that we need to update device.state.sessionId


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Related to `Device.status = 'busy'` https://github.com/trezor/trezor-suite/pull/20260

unacquired Device.busy may be changed to Device.thp once its stops being busy


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/unacquired-device-changes&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/unacquired-device-changes&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/unacquired-device-changes&lookback=7)