### PR TITLE
Refactor e2e trading soft asserts payloads

### DIFF
--- a/packages/suite-desktop-core/e2e/support/mocks/tradingMock.ts
+++ b/packages/suite-desktop-core/e2e/support/mocks/tradingMock.ts
@@ -135,4 +135,25 @@ export class TradingMock {
             );
         }
     };
+
+    @step()
+    async routeDummyProviderSupportPage() {
+        await this.page.route(/https:\/\/example\.org\/orders\/.*/, async route => {
+            const html = `
+            <!DOCTYPE html>
+            <html>
+            <head><title>Provider Support</title></head>
+            <body>
+                <h1>Provider Support Page</h1>
+                <p>Order ID: ${route.request().url().split('/').pop()}</p>
+            </body>
+            </html>
+        `;
+            await route.fulfill({
+                status: 200,
+                contentType: 'text/html',
+                body: html,
+            });
+        });
+    }
 }

--- a/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
@@ -263,7 +263,7 @@ export class TradingPage {
         amount: string,
         cryptoCurrency: string = 'bitcoin',
         wantCrypto: boolean = false,
-        fiatCurrencyCode: BaseCurrencyCode = 'czk',
+        fiatCurrencyCode: BaseCurrencyCode = 'usd',
         country: TradingCountryCode = 'CZ',
     ) {
         const inputField = wantCrypto ? this.youPayCryptoInput : this.youPayFiatInput;
@@ -273,7 +273,7 @@ export class TradingPage {
         const quotesRequestPromise = this.page.waitForRequest(invityEndpoint.buyQuotes);
         const quotesResponsePromise = this.page.waitForResponse(invityEndpoint.buyQuotes);
         await inputField.fill(amount);
-        await expect(quotesRequestPromise).toHavePayload({
+        await expect.soft(quotesRequestPromise).toHavePayload({
             wantCrypto,
             fiatCurrency: fiatCurrencyCode.toUpperCase(),
             receiveCurrency: cryptoCurrency,
@@ -289,7 +289,7 @@ export class TradingPage {
     async fillSellForm(
         amount: string,
         cryptoCurrency: string = 'bitcoin',
-        fiatCurrencyCode: BaseCurrencyCode = 'eur',
+        fiatCurrencyCode: BaseCurrencyCode = 'usd',
         country: TradingCountryCode = 'CZ',
     ) {
         await this.selectCountryOfResidence(country);
@@ -299,7 +299,7 @@ export class TradingPage {
             this.page.getByText(messages['AMOUNT_IS_NOT_ENOUGH'].defaultMessage),
             'Insufficient funds in the account to run sell flow test. Please contact the "tech_qa" Slack group immediately.',
         ).toBeHidden();
-        await expect(quoteRequestPromise).toHavePayload({
+        await expect.soft(quoteRequestPromise).toHavePayload({
             amountInCrypto: true,
             cryptoCurrency,
             fiatCurrency: fiatCurrencyCode.toUpperCase(),
@@ -348,7 +348,7 @@ export class TradingPage {
         const quotesResponsePromise = this.page.waitForResponse(invityEndpoint.swapQuotes);
         await expect(this.bestOfferAmount).toHaveText(/0 \w+/);
         await this.youPayCryptoInput.fill(params.amount);
-        await expect(quotesRequestPromise).toHavePayload({
+        await expect.soft(quotesRequestPromise).toHavePayload({
             receive: params.receiveNetwork,
             send: params.sendCurrency,
             sendStringAmount: params.amount,

--- a/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
@@ -236,8 +236,10 @@ export class TradingPage {
         if (currentCurrency === currencyCode.toUpperCase()) {
             return;
         }
-        await this.youPayCurrencyDropdown.click();
-        await this.youPayCurrencyOption(currencyCode).click();
+        await this.page.selectDropdownOptionWithRetry(
+            this.youPayCurrencyDropdown,
+            this.youPayCurrencyOption(currencyCode),
+        );
     }
 
     @step()
@@ -263,11 +265,16 @@ export class TradingPage {
         amount: string,
         cryptoCurrency: string = 'bitcoin',
         wantCrypto: boolean = false,
-        fiatCurrencyCode: BaseCurrencyCode = 'usd',
+        fiatCurrencyCode: BaseCurrencyCode = 'czk',
         country: TradingCountryCode = 'CZ',
     ) {
         const inputField = wantCrypto ? this.youPayCryptoInput : this.youPayFiatInput;
         await expect(inputField).not.toHaveValue('');
+        if (wantCrypto) {
+            // The desired value is already set due to sideeffect of mocked response,
+            // We clear it so we can intercept and verify request payload that is triggered by filling value.
+            await inputField.fill('');
+        }
         await this.selectCountryOfResidence(country);
         await this.selectFiatCurrency(fiatCurrencyCode);
         const quotesRequestPromise = this.page.waitForRequest(invityEndpoint.buyQuotes);
@@ -289,10 +296,11 @@ export class TradingPage {
     async fillSellForm(
         amount: string,
         cryptoCurrency: string = 'bitcoin',
-        fiatCurrencyCode: BaseCurrencyCode = 'usd',
+        fiatCurrencyCode: BaseCurrencyCode = 'eur',
         country: TradingCountryCode = 'CZ',
     ) {
         await this.selectCountryOfResidence(country);
+        await this.selectFiatCurrency(fiatCurrencyCode);
         const quoteRequestPromise = this.page.waitForRequest(invityEndpoint.sellQuotes);
         await this.youPayCryptoInput.fill(amount);
         await expect(

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-bitcoin.test.ts
@@ -119,10 +119,10 @@ test.describe('Trading - Buy BTC', { tag: ['@group=trading', '@webOnly'] }, () =
             const tradeRequestPromise = page.waitForRequest(invityEndpoint.buyTrade);
             const watchRequestPromise = page.waitForRequest(invityEndpoint.buyWatch);
             await tradingPage.finishTransactionButton.click();
-            await expect(tradeRequestPromise).toHavePayload(invityRequest.buyTradeBTCPayload, {
+            await expect.soft(tradeRequestPromise).toHavePayload(invityRequest.buyTradeBTCPayload, {
                 omit: ['returnUrl', 'trade.orderId', 'trade.paymentId'],
             });
-            await expect(watchRequestPromise).toHavePayload(invityRequest.buyWatchPayload, {
+            await expect.soft(watchRequestPromise).toHavePayload(invityRequest.buyWatchPayload, {
                 omit: ['partnerData', 'orderId', 'paymentId'],
             });
             await expect(tradingPage.transactionDetailStatus).toHaveText(

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
@@ -15,7 +15,7 @@ const fiatAmount = localizeNumber(buyQuotesSolanaToken[0].fiatStringAmount, 'en-
 const cryptoAmount = buyQuotesSolanaToken[0].receiveStringAmount;
 const provider = capitalizeFirstLetter(buyQuotesSolanaToken[0].exchange);
 const formattedCryptoAmount = `${cryptoAmount} JUP`;
-const formattedFiatAmount = `CZK ${fiatAmount}`;
+const formattedFiatAmount = `USD ${fiatAmount}`;
 const { receiveAddress, paymentMethodName } = buyTradeSolanaToken.trade;
 
 test.describe('Trading - Buy Solana', { tag: ['@group=trading', '@webOnly'] }, () => {
@@ -59,9 +59,11 @@ test.describe('Trading - Buy Solana', { tag: ['@group=trading', '@webOnly'] }, (
             await expect(tradingPage.confirmationPaymentMethod).toHaveText(paymentMethodName);
             const tradeRequestPromise = page.waitForRequest(invityEndpoint.buyTrade);
             await tradingPage.finishTransactionButton.click();
-            await expect(tradeRequestPromise).toHavePayload(invityRequest.buyTradeSolanaPayload, {
-                omit: ['returnUrl', 'trade.orderId', 'trade.paymentId'],
-            });
+            await expect
+                .soft(tradeRequestPromise)
+                .toHavePayload(invityRequest.buyTradeSolanaPayload, {
+                    omit: ['returnUrl', 'trade.orderId', 'trade.paymentId'],
+                });
         });
 
         await tradingPage.waitForRedirectCompletion();

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
@@ -15,7 +15,7 @@ const fiatAmount = localizeNumber(buyQuotesSolanaToken[0].fiatStringAmount, 'en-
 const cryptoAmount = buyQuotesSolanaToken[0].receiveStringAmount;
 const provider = capitalizeFirstLetter(buyQuotesSolanaToken[0].exchange);
 const formattedCryptoAmount = `${cryptoAmount} JUP`;
-const formattedFiatAmount = `USD ${fiatAmount}`;
+const formattedFiatAmount = `CZK ${fiatAmount}`;
 const { receiveAddress, paymentMethodName } = buyTradeSolanaToken.trade;
 
 test.describe('Trading - Buy Solana', { tag: ['@group=trading', '@webOnly'] }, () => {

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
@@ -62,7 +62,7 @@ test.describe('Trading - Sell BTC', { tag: ['@group=trading', '@webOnly'] }, () 
             await tradingPage.sellBestOfferButton.click();
             const tradeRequestPromise = page.waitForRequest(invityEndpoint.sellTrade);
             await tradingPage.termsConfirmButton.click();
-            await expect(tradeRequestPromise).toHavePayload(invityRequest.sellTradePayload, {
+            await expect.soft(tradeRequestPromise).toHavePayload(invityRequest.sellTradePayload, {
                 omit: ['returnUrl', 'trade.orderId', 'trade.paymentId', 'trade.refundAddress'],
             });
         });

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
@@ -154,7 +154,7 @@ test.describe('Trading - Sell Solana', { tag: ['@group=trading', '@webOnly'] }, 
             await tradingPage.selectThisQuoteButton.nth(1).click();
             const sellTradePromise = page.waitForRequest(invityEndpoint.sellTrade);
             await tradingPage.termsConfirmButton.click();
-            await expect(sellTradePromise).toHavePayload(
+            await expect.soft(sellTradePromise).toHavePayload(
                 {
                     // the second chosen offer via Bank Transfer that matches input criteria has index 3
                     trade: sellQuotesSolana[3],

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
@@ -40,6 +40,7 @@ test.describe('Trading - Swap coins', { tag: ['@group=trading', '@webOnly'] }, (
                 });
                 await tradingMock.routeSwapTrade(swapTradeSolanaBTC);
                 await tradingMock.routeSolanaSendRequests();
+                await tradingMock.routeDummyProviderSupportPage();
                 await page.route(invityEndpoint.swapWatch, async route => {
                     await route.fulfill({ json: { status: 'SENDING', sendAddress } });
                 });


### PR DESCRIPTION
Minor fixes:
- changes payload asserts to soft to make troubleshooting easier and run the whole test to see how the problems in payload have impact on flow
- made Trading test more resilient to functionality changes in selecting default currency (I have added test todo for that area into my pair programming list)
- start mocking partner site to solve 3rd party instabilities

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-e2e-trading-soft-asserts-payloads&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-e2e-trading-soft-asserts-payloads&lookback=7)