### PR TITLE
feat(suite): receive disabled when backup failed

### DIFF
--- a/packages/suite/src/hooks/suite/useReceiveDisabled.tsx
+++ b/packages/suite/src/hooks/suite/useReceiveDisabled.tsx
@@ -1,0 +1,41 @@
+import { FC, PropsWithChildren, ReactNode } from 'react';
+
+import { selectIsDeviceBackupUnfinished } from '@suite-common/wallet-core';
+import { Tooltip } from '@trezor/components';
+
+import { Translation } from 'src/components/suite';
+import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
+
+import { useSelector } from './useSelector';
+
+export const useReceiveDisabled = () => {
+    const isAuthenticityCheckFailed = useSelector(
+        selectIsFirmwareAuthenticityCheckEnabledAndHardFailed,
+    );
+    const isDeviceBackupUnfinished = useSelector(selectIsDeviceBackupUnfinished);
+
+    const isReceiveDisabled: boolean = isAuthenticityCheckFailed || isDeviceBackupUnfinished;
+
+    const getTooltipContent = (): ReactNode => {
+        if (isAuthenticityCheckFailed) {
+            return <Translation id="TR_RECEIVE_ADDRESS_SECURITY_CHECK_FAILED" />;
+        }
+        if (isDeviceBackupUnfinished) {
+            return <Translation id="TR_RECEIVE_ADDRESS_FAILED_BACKUP" />;
+        }
+
+        return null;
+    };
+    const tooltipContent = getTooltipContent();
+
+    const ReceiveDisabledWrapper: FC<PropsWithChildren> =
+        tooltipContent !== null
+            ? ({ children }) => <Tooltip content={tooltipContent}>{children}</Tooltip>
+            : ({ children }) => children;
+
+    return {
+        isReceiveDisabled,
+        ReceiveDisabledWrapper,
+        receiveDisabledTooltipContent: tooltipContent,
+    };
+};

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2612,6 +2612,10 @@ export default defineMessages({
         defaultMessage: 'Wallet backup failed. Wipe your Trezor and start the setup process again.',
         id: 'TR_FAILED_BACKUP',
     },
+    TR_RECEIVE_ADDRESS_FAILED_BACKUP: {
+        defaultMessage: 'Wallet backup failed. Sending funds to this wallet is not secure.',
+        id: 'TR_RECEIVE_ADDRESS_FAILED_BACKUP',
+    },
     TR_FIAT_RATES_NOT_AVAILABLE: {
         defaultMessage: 'Rate not available.',
         id: 'TR_FIAT_RATES_NOT_AVAILABLE',

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -3,16 +3,7 @@ import { ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { getAccountTypeTech } from '@suite-common/wallet-utils';
-import {
-    Button,
-    Card,
-    Column,
-    InfoItem,
-    Paragraph,
-    Row,
-    Tooltip,
-    variables,
-} from '@trezor/components';
+import { Button, Card, Column, InfoItem, Paragraph, Row, variables } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { HELP_CENTER_BIP32_URL, HELP_CENTER_XPUB_URL, Url } from '@trezor/urls';
 
@@ -24,7 +15,7 @@ import { TranslationKey } from 'src/components/suite/Translation';
 import { AccountTypeDescription } from 'src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription';
 import { WalletLayout } from 'src/components/wallet';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
+import { useReceiveDisabled } from 'src/hooks/suite/useReceiveDisabled';
 
 import { CoinjoinLogs } from './CoinjoinLogs';
 import { CoinjoinSetup } from './CoinjoinSetup/CoinjoinSetup';
@@ -69,14 +60,9 @@ const DetailsRow = ({ title, description, learnMoreUrl, children }: DetailsRowPr
 
 const Details = () => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
-    const isAuthenticityCheckFailed = useSelector(
-        selectIsFirmwareAuthenticityCheckEnabledAndHardFailed,
-    );
-    const dispatch = useDispatch();
+    const { isReceiveDisabled, ReceiveDisabledWrapper } = useReceiveDisabled();
 
-    const tooltipContent = isAuthenticityCheckFailed ? (
-        <Translation id="TR_RECEIVE_ADDRESS_SECURITY_CHECK_FAILED" />
-    ) : null;
+    const dispatch = useDispatch();
 
     const { device, isLocked } = useDevice();
 
@@ -86,7 +72,7 @@ const Details = () => {
 
     const { account } = selectedAccount;
     const locked = isLocked(true);
-    const disabled = locked || isAuthenticityCheckFailed;
+    const disabled = locked || isReceiveDisabled;
 
     const accountTypeTech = getAccountTypeTech(account.path);
 
@@ -147,7 +133,7 @@ const Details = () => {
                                 description={<Translation id="TR_ACCOUNT_DETAILS_XPUB" />}
                                 learnMoreUrl={HELP_CENTER_XPUB_URL}
                             >
-                                <Tooltip content={tooltipContent}>
+                                <ReceiveDisabledWrapper>
                                     <Button
                                         variant="tertiary"
                                         data-testid="@wallets/details/show-xpub-button"
@@ -159,7 +145,7 @@ const Details = () => {
                                     >
                                         <Translation id="TR_ACCOUNT_DETAILS_XPUB_BUTTON" />
                                     </Button>
-                                </Tooltip>
+                                </ReceiveDisabledWrapper>
                             </DetailsRow>
                         )
                     ) : (

--- a/packages/suite/src/views/wallet/receive/Receive.tsx
+++ b/packages/suite/src/views/wallet/receive/Receive.tsx
@@ -5,7 +5,7 @@ import { spacings } from '@trezor/theme';
 import { ConfirmEvmExplanationModal } from 'src/components/suite/modals';
 import { WalletLayout, WalletSubpageHeading } from 'src/components/wallet';
 import { useDevice, useSelector } from 'src/hooks/suite';
-import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
+import { useReceiveDisabled } from 'src/hooks/suite/useReceiveDisabled';
 
 import { CoinjoinReceiveWarning } from './components/CoinjoinReceiveWarning';
 import { ConnectDeviceReceivePromo } from './components/ConnectDevicePromo';
@@ -20,9 +20,7 @@ export const Receive = () => {
     const receive = useSelector(state => state.wallet.receive);
     const device = useSelector(selectSelectedDevice);
 
-    const isAuthenticityCheckFailed = useSelector(
-        selectIsFirmwareAuthenticityCheckEnabledAndHardFailed,
-    );
+    const { isReceiveDisabled } = useReceiveDisabled();
 
     const { account } = selectedAccount;
 
@@ -42,8 +40,9 @@ export const Receive = () => {
     const showCexWarning = account?.accountType === 'coinjoin' && !isCoinjoinReceiveWarningHidden;
 
     const isDeviceConnected = device.connected && device.available;
-    // FW check hard failure is persisted for view-only → severe banner is shown & Receive button disabled, so this weaker banner is superfluous
-    const isConnectDevicePromoDisplayed = !isDeviceConnected && !isAuthenticityCheckFailed;
+    // FW check hard failure or backup check failure is persisted for view-only
+    // → severe banner is shown & Receive button disabled, so this weaker banner is superfluous
+    const isConnectDevicePromoDisplayed = !isDeviceConnected && !isReceiveDisabled;
 
     return (
         <WalletLayout title="TR_NAV_RECEIVE" isSubpage account={selectedAccount}>

--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
@@ -22,7 +22,7 @@ import { spacings } from '@trezor/theme';
 import { showAddress } from 'src/actions/wallet/receiveActions';
 import { ReadMoreLink, Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite/';
-import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
+import { useReceiveDisabled } from 'src/hooks/suite/useReceiveDisabled';
 import { AppState } from 'src/types/suite';
 
 const FreshAddressWrapper = styled.div`
@@ -93,9 +93,7 @@ export const FreshAddress = ({
     const isAccountUtxoBased = useSelector((state: AccountsRootState) =>
         selectIsAccountUtxoBased(state, account?.key ?? ''),
     );
-    const isAuthenticityCheckFailed = useSelector(
-        selectIsFirmwareAuthenticityCheckEnabledAndHardFailed,
-    );
+    const { isReceiveDisabled, receiveDisabledTooltipContent } = useReceiveDisabled();
     const dispatch = useDispatch();
 
     const firstFreshAddress = useMemo(() => {
@@ -127,8 +125,8 @@ export const FreshAddress = ({
         if (!firstFreshAddress) {
             return <Translation id="RECEIVE_ADDRESS_LIMIT_REACHED" />;
         }
-        if (isAuthenticityCheckFailed) {
-            return <Translation id="TR_RECEIVE_ADDRESS_SECURITY_CHECK_FAILED" />;
+        if (receiveDisabledTooltipContent !== null) {
+            return receiveDisabledTooltipContent;
         }
 
         return null;
@@ -138,11 +136,7 @@ export const FreshAddress = ({
         'data-testid': '@wallet/receive/reveal-address-button',
         onClick: handleAddressReveal,
         isDisabled:
-            disabled ||
-            locked ||
-            coinjoinDisallowReveal ||
-            !firstFreshAddress ||
-            isAuthenticityCheckFailed,
+            disabled || locked || coinjoinDisallowReveal || !firstFreshAddress || isReceiveDisabled,
         isLoading: locked,
     };
 

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -4,24 +4,15 @@ import styled from 'styled-components';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
-import {
-    Button,
-    Card,
-    Column,
-    GradientOverlay,
-    Row,
-    Table,
-    Text,
-    Tooltip,
-} from '@trezor/components';
+import { Button, Card, Column, GradientOverlay, Row, Table, Text } from '@trezor/components';
 import { AccountAddress } from '@trezor/connect';
 import { spacings } from '@trezor/theme';
 
 import { showAddress } from 'src/actions/wallet/receiveActions';
 import { FormattedCryptoAmount, MetadataLabeling, Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite/';
+import { useReceiveDisabled } from 'src/hooks/suite/useReceiveDisabled';
 import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
-import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
 import { AppState } from 'src/types/suite';
 import { MetadataAddPayload } from 'src/types/suite/metadata';
 
@@ -49,18 +40,13 @@ type ItemProps = {
 };
 
 const Item = ({ addr, locked, symbol, onClick, metadataPayload, index }: ItemProps) => {
-    const isAuthenticityCheckFailed = useSelector(
-        selectIsFirmwareAuthenticityCheckEnabledAndHardFailed,
-    );
+    const { isReceiveDisabled, ReceiveDisabledWrapper } = useReceiveDisabled();
     const [isHovered, setIsHovered] = useState(false);
 
     const amount = formatNetworkAmount(addr.received || '0', symbol);
     const fresh = !addr.transfers;
     const address = addr.address.substring(0, 20);
-    const isDisabled = locked || isAuthenticityCheckFailed;
-    const tooltipContent = isAuthenticityCheckFailed ? (
-        <Translation id="TR_RECEIVE_ADDRESS_SECURITY_CHECK_FAILED" />
-    ) : null;
+    const isDisabled = locked || isReceiveDisabled;
 
     return (
         <Table.Row onHover={setIsHovered}>
@@ -83,7 +69,7 @@ const Item = ({ addr, locked, symbol, onClick, metadataPayload, index }: ItemPro
             </Table.Cell>
             <Table.Cell align="end">
                 <AddressActions $isVisible={isHovered}>
-                    <Tooltip content={tooltipContent}>
+                    <ReceiveDisabledWrapper>
                         <Button
                             data-testid={`@wallet/receive/reveal-address-button/${index}`}
                             variant="tertiary"
@@ -94,7 +80,7 @@ const Item = ({ addr, locked, symbol, onClick, metadataPayload, index }: ItemPro
                         >
                             <Translation id="TR_REVEAL_ADDRESS" />
                         </Button>
-                    </Tooltip>
+                    </ReceiveDisabledWrapper>
                 </AddressActions>
             </Table.Cell>
 

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -82,7 +82,7 @@ export const selectIsDeviceBackupRequired = createMemoizedSelector(
 
 export const selectIsDeviceBackupUnfinished = createMemoizedSelector(
     [selectDeviceFeatures],
-    features => features?.unfinished_backup,
+    features => features?.unfinished_backup === true,
 );
 
 export const selectDeviceButtonRequests = createMemoizedSelector(


### PR DESCRIPTION
## Description

Disabled receive (fresh address, used address, xpub) also when backup failed, similarly to device compromised.
Extract the common logic into a hook.

## Related Issue

Resolve #18638

## Screenshots:

As before: receive disabled when device compromised
[device compromised.webm](https://github.com/user-attachments/assets/12ae9a71-53e6-4c9a-9bed-b7e2b2256591)

New behavior: receive disabled when backup failed
[backup failed.webm](https://github.com/user-attachments/assets/62bbb14b-bbc8-4bc0-9615-fef53d9f05b9)

and even after device disconnected
[Screencast from 2025-08-06 16-39-58.webm](https://github.com/user-attachments/assets/8301096a-587d-4f7c-a720-44af293d6679)

---

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/receive-disabled-when-backup-failed&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/receive-disabled-when-backup-failed&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/receive-disabled-when-backup-failed&lookback=7)