### PR TITLE
feat(e2e-suite): new staking form tests - inputs and limits

### DIFF
--- a/packages/product-components/src/components/InputWithOptions/InputWithOptions.tsx
+++ b/packages/product-components/src/components/InputWithOptions/InputWithOptions.tsx
@@ -46,6 +46,7 @@ export const InputWithOptions = <TFieldValues extends FieldValues>({
     const labelRight =
         canSwitchInputs && switchTranslation != null ? (
             <TextButton
+                data-testid={`${dataTest}/switch-inputs`}
                 size="small"
                 onClick={() => setAmountInCrypto(prevValue => !prevValue)}
                 type="button"

--- a/packages/suite-desktop-core/e2e/support/mocks/eth-endpoints.ts
+++ b/packages/suite-desktop-core/e2e/support/mocks/eth-endpoints.ts
@@ -96,4 +96,47 @@ export const fixtures = [
         default: true,
         response: [],
     },
+    {
+        method: 'getCurrentFiatRates',
+        default: true,
+        response: {
+            data: {
+                ts: 1752167345,
+                rates: {
+                    usd: 0.5,
+                },
+            },
+        },
+    },
+    {
+        method: 'getFiatRatesForTimestamps',
+        default: true,
+        response: ({ params }: any) => {
+            if (params.token && params.timestamps.length > 0) {
+                return {
+                    data: {
+                        tickers: params.timestamps.map((ts: number) => ({
+                            ts,
+                            rates: {
+                                usd: 0.5,
+                            },
+                        })),
+                    },
+                };
+            }
+
+            if (params.timestamps.length > 0) {
+                return {
+                    data: {
+                        tickers: params.timestamps.map((ts: number) => ({
+                            ts,
+                            rates: {
+                                usd: 2000,
+                            },
+                        })),
+                    },
+                };
+            }
+        },
+    },
 ];

--- a/packages/suite-desktop-core/e2e/support/pageObjects/stakingSection.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/stakingSection.ts
@@ -16,6 +16,7 @@ export class StakingSection {
     readonly unstakeToClaimButton: Locator;
     readonly availableBalanceWithSymbol: Locator;
     readonly cryptoInput: Locator;
+    readonly fiatInput: Locator;
     readonly unstakeButton: Locator;
     readonly speedUpButton: Locator;
     readonly pendingTransactionText: Locator;
@@ -40,6 +41,13 @@ export class StakingSection {
     readonly claimButton: Locator;
     readonly claimModalAmount: Locator;
     readonly claimModalButton: Locator;
+    readonly fractionButton = (amount: '10%' | '25%' | '50%' | 'Max') =>
+        this.page.getByRole('button', { name: amount });
+    readonly cryptoInputBottomText: Locator;
+    readonly switchInputs: Locator;
+    readonly withdrawalWarning: Locator;
+    readonly fiatTicker: Locator;
+    readonly cryptoTicker: Locator;
 
     constructor(private readonly page: Page) {
         this.stakingTabButton = this.page.getByTestId('@wallet/menu/staking');
@@ -54,6 +62,7 @@ export class StakingSection {
             '@staking/available-balance-with-symbol',
         );
         this.cryptoInput = this.page.getByTestId('@staking/form/crypto-input');
+        this.fiatInput = this.page.getByTestId('@staking/form/fiat-input');
         this.unstakeButton = this.page
             .getByTestId('@modal')
             .getByRole('button', { name: 'Unstake' });
@@ -92,6 +101,13 @@ export class StakingSection {
         this.claimModalButton = this.page
             .getByTestId('@staking/claim-modal')
             .getByRole('button', { name: 'Claim', exact: true });
+        this.cryptoInputBottomText = this.page.getByTestId(
+            '@staking/form/crypto-input/bottom-text',
+        );
+        this.switchInputs = this.page.getByTestId('@staking/form/switch-inputs');
+        this.withdrawalWarning = this.page.getByTestId('@staking/form/withdrawal-warning');
+        this.fiatTicker = this.page.getByTestId('@staking/form/fiat-input/input-addon');
+        this.cryptoTicker = this.page.getByTestId('@staking/form/crypto-input/input-addon');
     }
 
     async expectProgressIndicatorsToMatchPhase(

--- a/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
@@ -57,9 +57,6 @@ export class TradingPage {
     readonly youPayFiatCryptoSwitchButton: Locator;
     readonly youPayCryptoInput: Locator;
     readonly cryptoInputBottomText: Locator;
-    readonly youPayFractionButton = (amount: '10%' | '25%' | '50%' | 'Max') =>
-        this.page.getByRole('button', { name: amount });
-
     readonly countryOfResidenceDropdown: Locator;
     readonly countryOfResidenceOption = (countryCode: string) =>
         this.page.getByTestId(`@trading/form/country-select/option/${countryCode}`);

--- a/packages/suite-desktop-core/e2e/tests/staking/initial-stake.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/staking/initial-stake.test.ts
@@ -96,10 +96,12 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                     footer: 'Tap to continue',
                 });
                 await devicePrompt.waitForPromptAndClick();
-                await expect(devicePrompt.outputValueOf('amount')).toHaveText(
+                await expect(devicePrompt.cryptoAmountWithSymbolOf('amount')).toHaveText(
                     '0.100204158497493752 ETH',
                 );
-                await expect(devicePrompt.outputValueOf('fee')).toHaveText('0.000290278609719 ETH');
+                await expect(devicePrompt.cryptoAmountWithSymbolOf('fee')).toHaveText(
+                    '0.000290278609719 ETH',
+                );
 
                 await expect(devicePrompt).toDisplayOnEmulator({
                     header: { title: 'Stake' },

--- a/packages/suite-desktop-core/e2e/tests/staking/stake-more.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/staking/stake-more.test.ts
@@ -89,10 +89,12 @@ test.describe('ETH staking', { tag: ['@group=staking'] }, () => {
                     footer: 'Tap to continue',
                 });
                 await devicePrompt.waitForPromptAndClick();
-                await expect(devicePrompt.outputValueOf('amount')).toHaveText(
+                await expect(devicePrompt.cryptoAmountWithSymbolOf('amount')).toHaveText(
                     '0.100204158497493752 ETH',
                 );
-                await expect(devicePrompt.outputValueOf('fee')).toHaveText('0.000290278609719 ETH');
+                await expect(devicePrompt.cryptoAmountWithSymbolOf('fee')).toHaveText(
+                    '0.000290278609719 ETH',
+                );
 
                 await expect(devicePrompt).toDisplayOnEmulator({
                     header: { title: 'Stake' },

--- a/packages/suite-desktop-core/e2e/tests/staking/staking-form.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/staking/staking-form.test.ts
@@ -1,0 +1,140 @@
+import { localizeNumber } from '@suite-common/wallet-utils';
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+import messages from '@trezor/suite/src/support/messages';
+import { BigNumber } from '@trezor/utils';
+
+import { calculatePercentageOfBalance } from '../../support/common';
+import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
+
+let ethereumStakingBalance: string | null;
+const MOCKED_FEE_AMOUNT = 0.000290278609719;
+const WITHDRAWAL_BUFFER = 0.03;
+
+test.describe('ETH staking form', { tag: ['@group=staking'] }, () => {
+    test.use({
+        emulatorSetupConf: {
+            mnemonic: 'access juice claim special truth ugly swarm rabbit hair man error bar',
+        },
+    });
+    test.beforeEach(
+        async ({ page, dashboardPage, onboardingPage, settingsPage, blockbookMock }) => {
+            await onboardingPage.completeOnboarding();
+            await settingsPage.navigateTo('coins');
+            await blockbookMock.start('eth');
+
+            await settingsPage.coins.disableNetwork('btc');
+            await settingsPage.coins.enableNetwork('eth');
+            await settingsPage.coins.openNetworkAdvanceSettings('eth');
+            await settingsPage.coins.changeBackend('blockbook', blockbookMock.url);
+
+            await dashboardPage.dashboardMenuButton.click();
+            await page.discoveryShouldFinish();
+        },
+    );
+
+    test(
+        'Staking form % inputs and limits',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use staking form functions.',
+                category: TestCategory.ETH,
+                priority: TestPriority.Medium,
+                stream: TestStream.Trends,
+            }),
+        },
+        async ({ page, walletPage, stakingSection }) => {
+            await test.step('Identify possible staking balance', async () => {
+                await walletPage.openAccount({ symbol: 'eth', type: 'normal', atIndex: 0 });
+                ethereumStakingBalance = await walletPage.topPanelBalance.textContent();
+                if (!ethereumStakingBalance) {
+                    throw new Error('Ethereum staking balance is undefined or null');
+                }
+                ethereumStakingBalance = ethereumStakingBalance?.replace(/,/g, '');
+                await stakingSection.stakingTabButton.click();
+                await stakingSection.stakeMoreButton.click();
+            });
+
+            await test.step('Check limits for staking', async () => {
+                await test.step('Below minimum', async () => {
+                    await stakingSection.cryptoInput.fill('0.00000001');
+
+                    await expect
+                        .soft(stakingSection.cryptoInputBottomText)
+                        .toHaveText('Minimum is 0.1 ETH', { timeout: 15_000 });
+                });
+
+                await test.step('Too many decimal digits', async () => {
+                    await stakingSection.cryptoInput.fill('0.0000000000000000001');
+                    await expect
+                        .soft(stakingSection.cryptoInputBottomText)
+                        .toHaveText('Maximum 18 decimals allowed', { timeout: 15_000 });
+                });
+
+                await test.step('Not enough funds', async () => {
+                    await stakingSection.cryptoInput.fill('4000');
+                    await expect
+                        .soft(stakingSection.cryptoInputBottomText)
+                        .toHaveText(messages['AMOUNT_IS_NOT_ENOUGH'].defaultMessage, {
+                            timeout: 15_000,
+                        });
+                });
+
+                await test.step('Clear input and set minimum', async () => {
+                    await stakingSection.cryptoInput.clear();
+                    await expect
+                        .soft(stakingSection.cryptoInputBottomText)
+                        .toHaveText(messages['AMOUNT_IS_NOT_SET'].defaultMessage, {
+                            timeout: 15_000,
+                        });
+
+                    await stakingSection.cryptoInput.fill('0.1');
+                    await expect
+                        .soft(stakingSection.cryptoInputBottomText)
+                        .toBeHidden({ timeout: 15_000 });
+                });
+            });
+
+            await test.step('Try all % inputs for Eth staking', async () => {
+                for (const percentage of [10, 25, 50]) {
+                    await test.step(`${percentage}% of ETH balance`, async () => {
+                        await page.getByRole('button', { name: percentage + '%' }).click();
+                        const expectedValue = calculatePercentageOfBalance({
+                            percentage,
+                            balance: ethereumStakingBalance!,
+                            symbol: 'eth',
+                        });
+                        await expect.soft(stakingSection.cryptoInput).toHaveValue(expectedValue);
+                    });
+                }
+
+                await test.step('Max of ETH balance', async () => {
+                    await page.getByRole('button', { name: 'Max' }).click();
+                    await expect
+                        .soft(stakingSection.withdrawalWarning)
+                        .toHaveText('We’ve left 0.03 ETH out so you can pay for withdrawal fees.');
+                    const expectedMax = new BigNumber(ethereumStakingBalance!)
+                        .minus(WITHDRAWAL_BUFFER)
+                        .minus(MOCKED_FEE_AMOUNT);
+                    const formattedExpectedMax = localizeNumber(
+                        expectedMax.decimalPlaces(18, BigNumber.ROUND_UP),
+                    );
+                    await expect.soft(stakingSection.cryptoInput).toHaveValue(formattedExpectedMax);
+                });
+            });
+
+            await test.step('Switch to Fiat and back', async () => {
+                const cryptoValue = 500;
+                const ratioToFiat = 0.5; // Mocked ratio for testing
+                const fiatValue = cryptoValue * ratioToFiat;
+                await stakingSection.cryptoInput.fill(cryptoValue.toString());
+                await stakingSection.switchInputs.click();
+                await expect.soft(stakingSection.fiatInput).toHaveValue(fiatValue.toString());
+                await expect.soft(stakingSection.fiatTicker).toHaveText('USD');
+                await stakingSection.switchInputs.click();
+                await expect.soft(stakingSection.cryptoInput).toHaveValue(cryptoValue.toString());
+                await expect.soft(stakingSection.cryptoTicker).toHaveText('ETH');
+            });
+        },
+    );
+});

--- a/packages/suite-desktop-core/e2e/tests/staking/unstake.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/staking/unstake.test.ts
@@ -72,8 +72,12 @@ test.describe('ETH unstaking and claim', { tag: ['@group=staking'] }, () => {
                     footer: 'Tap to continue',
                 });
                 await devicePrompt.waitForPromptAndClick();
-                await expect(devicePrompt.outputValueOf('amount')).toHaveText('3,234 ETH');
-                await expect(devicePrompt.outputValueOf('fee')).toHaveText('0.000290278609719 ETH');
+                await expect(devicePrompt.cryptoAmountWithSymbolOf('amount')).toHaveText(
+                    '3,234 ETH',
+                );
+                await expect(devicePrompt.cryptoAmountWithSymbolOf('fee')).toHaveText(
+                    '0.000290278609719 ETH',
+                );
                 await expect(devicePrompt).toDisplayOnEmulator({
                     header: { title: 'Unstake' },
                     body: [
@@ -181,8 +185,12 @@ test.describe('ETH unstaking and claim', { tag: ['@group=staking'] }, () => {
                     footer: 'Tap to continue',
                 });
                 await devicePrompt.waitForPromptAndClick();
-                await expect(devicePrompt.outputValueOf('amount')).toHaveText('3,234 ETH');
-                await expect(devicePrompt.outputValueOf('fee')).toHaveText('0.000290278609719 ETH');
+                await expect(devicePrompt.cryptoAmountWithSymbolOf('amount')).toHaveText(
+                    '3,234 ETH',
+                );
+                await expect(devicePrompt.cryptoAmountWithSymbolOf('fee')).toHaveText(
+                    '0.000290278609719 ETH',
+                );
                 await expect(devicePrompt).toDisplayOnEmulator({
                     header: { title: 'Claim' },
                     body: [['Maximum fee'], splitStringByDisplayLimit('0.000290278609719 ETH')],

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeInputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeInputs.tsx
@@ -209,7 +209,7 @@ export const StakeInputs = () => {
                 ]}
             />
             {shouldShowAmountForWithdrawalWarning && (
-                <Banner variant="info" width="100%">
+                <Banner data-testid="@staking/form/withdrawal-warning" variant="info" width="100%">
                     <Translation
                         id={
                             isLessAmountForWithdrawalWarningShown


### PR DESCRIPTION
New test covering various functions of staking form
- limits and error handling
- % inputs
- fiat switch

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-e2e-staking-limits&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-e2e-staking-limits&lookback=7)