### PR TITLE
fix(suite): align approval flow outputs highlighting

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
@@ -20,6 +20,7 @@ import {
 import {
     getStakeType,
     getTxValidityTimeoutInMs,
+    isEvmApprovalTx,
     isRbfBumpFeeTransaction,
     isRbfCancelTransaction,
 } from '@suite-common/wallet-utils';
@@ -110,6 +111,8 @@ export const TransactionReviewModalBodyInner = ({
     const isActionAbortable = useSelector(selectIsActionAbortable);
     const tradingToken = useSelector(selectTradingComposedTransactionInfo).composed?.token;
 
+    const isApprovalTx = isEvmApprovalTx(precomposedForm.ethereumDataHex);
+
     const totalRecipients = outputs.filter(({ type }) => type === 'address').length;
     const hasOpReturn = outputs.some(output => output.type === 'opreturn');
 
@@ -140,14 +143,22 @@ export const TransactionReviewModalBodyInner = ({
                 reviewStep === 1 &&
                 totalRecipients === 1 && // Currently we only support going bak for =1
                 lastButtonRequestCode === 'ButtonRequest_ConfirmOutput' &&
-                !hasOpReturn
+                !hasOpReturn &&
+                !isApprovalTx
             ) {
                 setReviewStep(prev => prev - 1);
             } else {
                 setReviewStep(prev => prev + 1);
             }
         }
-    }, [buttonRequestsCount, lastButtonRequestCode, reviewStep, totalRecipients, hasOpReturn]);
+    }, [
+        buttonRequestsCount,
+        lastButtonRequestCode,
+        reviewStep,
+        totalRecipients,
+        hasOpReturn,
+        isApprovalTx,
+    ]);
 
     const isInternalTransfer = useSelector(state =>
         selectIsTxOutputInternal(state, account?.symbol, outputs[0]),

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -58,8 +58,6 @@ const SectionHeading = ({ output, index }: { output: ReviewOutput; index: number
     </H4>
 );
 
-const TOTAL_STEPS_PER_RECIPIENT = 2; // 1 for address, 1 for amount
-
 export const TransactionReviewOutputList = ({
     account,
     precomposedTx,
@@ -86,11 +84,8 @@ export const TransactionReviewOutputList = ({
         selectSendFormReviewLastButtonCode(state, symbol),
     );
 
-    const totalRecipients = outputs.filter(({ type }) => type === 'address').length;
-    const hasOpReturn = outputs.some(output => output.type === 'opreturn');
-
     const reviewState = getTransactionReviewState({
-        index: totalRecipients * TOTAL_STEPS_PER_RECIPIENT + (hasOpReturn ? 1 : 0),
+        index: outputs.length,
         currentStep: reviewStep,
         hasSignedTx: !!signedTx,
         lastButtonRequestCode,


### PR DESCRIPTION
## Description

This PR fixes confirmation steps highlighting in tx review modal for approve/revoke flow.

## Related Issue

Resolve #20404

## Screenshots:

https://github.com/user-attachments/assets/35966be6-7798-4619-82e5-9fd6ce8b710d

https://github.com/user-attachments/assets/58061421-bd3d-4aba-a88c-2915a85ecaa3



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/token-approval-tx-flow&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/token-approval-tx-flow&lookback=7)