### PR TITLE
fix: make type-utils a dev dep

### DIFF
--- a/packages/transport-native-bluetooth/package.json
+++ b/packages/transport-native-bluetooth/package.json
@@ -11,7 +11,9 @@
     },
     "dependencies": {
         "@trezor/transport": "workspace:*",
-        "@trezor/type-utils": "workspace:*",
         "react-native-ble-plx": "3.5.0"
+    },
+    "devDependencies": {
+        "@trezor/type-utils": "workspace:*"
     }
 }

--- a/packages/transport-native-bluetooth/src/api/bluetoothManager.ts
+++ b/packages/transport-native-bluetooth/src/api/bluetoothManager.ts
@@ -12,7 +12,7 @@ import {
 
 import { EventEmitter } from 'events';
 
-import { IntervalId } from '@trezor/type-utils';
+import type { IntervalId } from '@trezor/type-utils';
 
 import { BluetoothDevice, DeviceConnectionStatusChangeEvent } from './types';
 


### PR DESCRIPTION
## Description

* Only used for type information
* can be moved to dev dependencies

## Related Issue

 None
 
## Screenshots:

None