### PR TITLE
fix(suite): sats interfering in send form fiat input

### DIFF
--- a/packages/suite/src/hooks/wallet/useSendFormFields.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormFields.ts
@@ -154,7 +154,7 @@ export const useSendFormFields = ({
                     cryptoDecimals,
                     rate: fiatRate,
                     isCryptoInSats: shouldSendInSats === true,
-                    areSatsDisplayed,
+                    areSatsDisplayed: baseCurrencyCode === 'btc' && areSatsDisplayed,
                     value: new BigNumber(fiat),
                 });
             };


### PR DESCRIPTION
## Description

The `parseBaseCurrencyToFormattedCrypto` pure function does not know what is the base currency, and it passed an argument if it should convert the base currency amount to sats.

Currently it mistakenly divides by 1e8 **any fiat amount** in send form when sats are on :scream_cat:
When you enter 3 USD, it thinks it's like 3 "USD sat" and converts it to 3e-8 USD :see_no_evil: 
Of course, that must be done **only** if base currency === btc!  

## Related Issue

Resolve #20594

## Screenshots:

with lang CZ, base currency: USD, btc unit: sats

[Screencast from 2025-08-07 13-00-22.webm](https://github.com/user-attachments/assets/b5a270cd-ec89-42f1-a9b8-24928e843cd2)

with lang CZ, base currency: BTC, btc unit: sats

[Screencast from 2025-08-07 13-01-42.webm](https://github.com/user-attachments/assets/2839d73b-6cc3-486d-8899-cd00542e6027)
