### PR TITLE
fix: rates of undefined

### DIFF
--- a/suite-common/graph/src/graphDataFetching.ts
+++ b/suite-common/graph/src/graphDataFetching.ts
@@ -505,7 +505,7 @@ export const getMultipleAccountBalanceHistoryWithFiat = async ({
 
     const coinsFiatRates: Record<CoinKey, FiatRatesItem[]> = D.fromPairs(
         // Some coins might not have fiat rates, so we need to filter them out
-        pairs.filter(([, res]) => res?.[0].rates?.[baseCurrencyCode] !== -1),
+        pairs.filter(([, res]) => res?.[0]?.rates?.[baseCurrencyCode] !== -1),
     );
 
     if (A.length(accountsWithBalanceHistoryFlattened) === 1) {

--- a/suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts
+++ b/suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts
@@ -44,9 +44,9 @@ export const useDayCoinPriceChange = (symbol?: NetworkSymbol | null) => {
             if (!timestampedFiatRates) return;
 
             const [yesterday, today] = timestampedFiatRates.tickers;
-            setYesterdayValue(yesterday.rates[fiatCurrencyCode] ?? null);
+            setYesterdayValue(yesterday?.rates[fiatCurrencyCode] ?? null);
 
-            const currentRate = today.rates[fiatCurrencyCode];
+            const currentRate = today?.rates[fiatCurrencyCode];
             setCurrentValue(
                 currentRate !== undefined ? asBaseCurrencyAmount(new BigNumber(currentRate)) : null,
             );


### PR DESCRIPTION
Hotfix: Sometimes object for tha rates can be undefined in graph or  in useDayCoinPriceChange


in sentry [here](https://satoshilabs.sentry.io/issues/6796202557/?project=4504214699245568&query=is%3Aunresolved%20ty%20%27rates%27%20of%20undefined&referrer=issue-stream) and [here](https://satoshilabs.sentry.io/issues/6161761797/?project=4504214699245568&query=is%3Aunresolved%20ty%20%27rates%27%20of%20undefined&referrer=issue-stream)

## Related Issue

Resolve #16242




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/undefined-rates&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/undefined-rates&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/undefined-rates&lookback=7)