### PR TITLE
Change csv delimiter to ","

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/metadata/output-labeling.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/output-labeling.test.ts
@@ -98,7 +98,7 @@ test.describe('Metadata - Output labeling', { tag: ['@group=metadata', '@webOnly
             const download = await page.waitForEvent('download');
             const downloadPath = await download.path();
             const fileContent = fs.readFileSync(downloadPath, 'utf8');
-            const expectedSubstr = '1PmVvr5DNVYJygtDT7J312qmxpa5pceu9E;submitted by button';
+            const expectedSubstr = '1PmVvr5DNVYJygtDT7J312qmxpa5pceu9E,submitted by button';
             expect(fileContent).toContain(expectedSubstr);
             expect(typeof fileContent).toBe('string');
         },

--- a/packages/suite/src/utils/wallet/__tests__/exportTransactionsUtils.test.ts
+++ b/packages/suite/src/utils/wallet/__tests__/exportTransactionsUtils.test.ts
@@ -1,0 +1,13 @@
+import { sanitizeCsvValue } from '../exportTransactionsUtils';
+
+describe(sanitizeCsvValue.name, () => {
+    test.each([
+        ['simplevalue', 'simplevalue'],
+        ['value,with,commas', '"value,with,commas"'],
+        ['value"with"quotes', 'value"with"quotes'],
+        ['commas,"and",quotes', '"commas,""and"",quotes"'],
+        ['a,"b","c",d', '"a,""b"",""c"",d"'],
+    ])('sanitizes "%s" to "%s"', (input, expected) => {
+        expect(sanitizeCsvValue(input)).toBe(expected);
+    });
+});

--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -291,7 +291,7 @@ const prepareContent = (
         .filter(record => record !== null) as Fields[];
 };
 
-const sanitizeCsvValue = (value: string) => {
+export const sanitizeCsvValue = (value: string) => {
     if (value.indexOf(CSV_SEPARATOR) !== -1) {
         return `"${value.replace(/"/g, '""')}"`;
     }

--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -55,7 +55,7 @@ type Fields = {
 };
 
 const CSV_NEWLINE = '\n';
-const CSV_SEPARATOR = ';';
+const CSV_SEPARATOR = ',';
 
 // Docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/format
 const dateFormat = {


### PR DESCRIPTION
Changes CSV delimiter to `,`. Also adds few unit tests for `sanitizeCsvValue`.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/12995

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/change-csv-delimeter&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/change-csv-delimeter&lookback=7)