### PR TITLE
refactor(suite): extract suiteReducer selectors

### DIFF
--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/Available.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/Available.tsx
@@ -6,7 +6,7 @@ import { download } from 'src/actions/suite/desktopUpdateActions';
 import { setFlag } from 'src/actions/suite/suiteActions';
 import { MarkdownWithComponents, Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 import { getVersionName } from './getVersionName';
 

--- a/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
+++ b/packages/suite/src/actions/bluetooth/initBluetoothThunk.ts
@@ -3,6 +3,8 @@ import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { BluetoothDevice, bluetoothIpc } from '@trezor/transport-bluetooth';
 
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
+
 import {
     DesktopBluetoothDevice,
     fromBluetoothDevice,
@@ -12,7 +14,6 @@ import { bluetoothConnectDeviceThunk } from './bluetoothConnectDeviceThunk';
 import { bluetoothStartScanningThunk } from './bluetoothStartScanningThunk';
 import { selectConnectingDevices } from './desktopBluetoothSelectors';
 import { remapKnownDevicesForLinux } from './remapKnownDevicesForLinux';
-import { selectSuiteFlags } from '../../reducers/suite/suiteReducer';
 
 export const initBluetoothThunk = createThunk<void, void, void>(
     `${BLUETOOTH_PREFIX}/initBluetoothThunk`,

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -7,9 +7,8 @@ import TrezorConnect, { ERRORS } from '@trezor/connect';
 
 import * as modalActions from 'src/actions/suite/modalActions';
 import * as DEVICE from 'src/constants/suite/device';
+import { selectIsEntropyCheckEnabled } from 'src/selectors/suite/suiteSelectors';
 import { Dispatch, GetState } from 'src/types/suite';
-
-import { selectIsEntropyCheckEnabled } from '../../reducers/suite/suiteReducer';
 
 export const applySettings =
     (params: Parameters<typeof TrezorConnect.applySettings>[0]) =>

--- a/packages/suite/src/actions/suite/routerActions.ts
+++ b/packages/suite/src/actions/suite/routerActions.ts
@@ -7,7 +7,7 @@ import { ROUTER } from 'src/actions/suite/constants';
 import * as suiteActions from 'src/actions/suite/suiteActions';
 import type { AnchorType } from 'src/constants/suite/anchors';
 import { RouterAppWithParams, SettingsBackRoute } from 'src/constants/suite/routes';
-import { selectIsRouterLocked, selectIsRouterOrUiLocked } from 'src/reducers/suite/suiteReducer';
+import { selectIsRouterLocked, selectIsRouterOrUiLocked } from 'src/selectors/suite/suiteSelectors';
 import { getLocation, navigate } from 'src/support/suite/navigationService';
 import { Dispatch, GetState } from 'src/types/suite';
 import {

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -18,6 +18,7 @@ import {
 import { cloneObject } from '@trezor/utils';
 
 import { selectCoinjoinAccountByKey } from 'src/reducers/wallet/coinjoinReducer';
+import { selectSuiteSettings } from 'src/selectors/suite/suiteSelectors';
 import { db } from 'src/storage';
 import type { PreloadStoreAction } from 'src/support/suite/preloadStore';
 import type { AppState, Dispatch, GetState, TrezorDevice } from 'src/types/suite';
@@ -27,7 +28,6 @@ import { serializeCoinjoinAccount, serializeDevice } from 'src/utils/suite/stora
 import { deviceGraphDataFilterFn } from 'src/utils/wallet/graph';
 
 import { STORAGE } from './constants';
-import { selectSuiteSettings } from '../../reducers/suite/suiteReducer';
 import { DesktopBluetoothDevice } from '../bluetooth/DesktopBluetoothDevice';
 
 export type StorageAction = NonNullable<PreloadStoreAction>;

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -11,12 +11,8 @@ import { HandshakeElectron, desktopApi } from '@trezor/suite-desktop-api';
 import * as modalActions from 'src/actions/suite/modalActions';
 import type { TranslationKey } from 'src/components/suite/Translation';
 import { ExperimentalFeature } from 'src/constants/suite/experimental';
-import {
-    AutodetectSettings,
-    DebugModeOptions,
-    EvmSettings,
-    selectTorState,
-} from 'src/reducers/suite/suiteReducer';
+import { AutodetectSettings, DebugModeOptions, EvmSettings } from 'src/reducers/suite/suiteReducer';
+import { selectTorState } from 'src/selectors/suite/suiteSelectors';
 import { TorStatus } from 'src/types/suite';
 import type { AppState, Dispatch, GetState, TorBootstrap } from 'src/types/suite';
 import { isOnionUrl } from 'src/utils/suite/tor';

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -19,7 +19,6 @@ import TrezorConnect from '@trezor/connect';
 import { promiseAllSequence } from '@trezor/utils';
 
 import { openModal } from 'src/actions/suite/modalActions';
-import { selectIsDeviceLocked } from 'src/reducers/suite/suiteReducer';
 import {
     selectCoinjoinAccountByKey,
     selectCoinjoinAccounts,
@@ -32,6 +31,7 @@ import {
     selectSessionByAccountKey,
     selectWeightedAnonymityByAccountKey,
 } from 'src/reducers/wallet/coinjoinReducer';
+import { selectIsDeviceLocked } from 'src/selectors/suite/suiteSelectors';
 import { COORDINATOR_FEE_RATE_MULTIPLIER, CoinjoinService } from 'src/services/coinjoin';
 import type { CoinjoinSymbol } from 'src/services/coinjoin';
 import { Dispatch, GetState } from 'src/types/suite';

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -19,13 +19,13 @@ import { getOsName } from '@trezor/env-utils';
 import { arrayDistinct, arrayToDictionary, promiseAllSequence } from '@trezor/utils';
 
 import { onCancel as closeModal, openModal } from 'src/actions/suite/modalActions';
-import { selectAddressDisplayType, selectIsDeviceLocked } from 'src/reducers/suite/suiteReducer';
 import {
     selectCoinjoinAccounts,
     selectRoundsDurationInHours,
     selectRoundsLeftByAccountKey,
     selectRoundsNeededByAccountKey,
 } from 'src/reducers/wallet/coinjoinReducer';
+import { selectAddressDisplayType, selectIsDeviceLocked } from 'src/selectors/suite/suiteSelectors';
 import type { CoinjoinSymbol } from 'src/services/coinjoin';
 import { CoinjoinService, getCoinjoinConfig } from 'src/services/coinjoin';
 import { Dispatch, GetState } from 'src/types/suite';

--- a/packages/suite/src/actions/wallet/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/receiveActions.ts
@@ -6,7 +6,7 @@ import { EventType, analytics } from '@trezor/suite-analytics';
 
 import * as modalActions from 'src/actions/suite/modalActions';
 import { RECEIVE } from 'src/actions/wallet/constants';
-import { selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
+import { selectAddressDisplayType } from 'src/selectors/suite/suiteSelectors';
 import { Dispatch, GetState } from 'src/types/suite';
 
 export type ReceiveAction =

--- a/packages/suite/src/actions/wallet/signVerifyActions.ts
+++ b/packages/suite/src/actions/wallet/signVerifyActions.ts
@@ -3,7 +3,7 @@ import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
 import TrezorConnect, { Success, Unsuccessful } from '@trezor/connect';
 
-import { selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
+import { selectAddressDisplayType } from 'src/selectors/suite/suiteSelectors';
 import type { Dispatch, GetState, TrezorDevice } from 'src/types/suite';
 import type { Account } from 'src/types/wallet';
 

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -31,7 +31,7 @@ import { calculateTotalGasCost, getAccountIdentity } from '@suite-common/wallet-
 import TrezorConnect, { FeeLevel } from '@trezor/connect';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
-import { selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
+import { selectAddressDisplayType } from 'src/selectors/suite/suiteSelectors';
 import { Dispatch, GetState } from 'src/types/suite';
 
 const calculateStakingTransaction = (

--- a/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
@@ -36,7 +36,7 @@ import TrezorConnect, { FeeLevel } from '@trezor/connect';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
+import { selectAddressDisplayType } from 'src/selectors/suite/suiteSelectors';
 import { Dispatch, GetState } from 'src/types/suite';
 
 const calculateTransaction = (

--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -18,11 +18,11 @@ import {
     SkipStepConfirmation,
 } from 'src/components/onboarding';
 import { useDevice, useOnboarding, useSelector } from 'src/hooks/suite';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 
 import { PrerequisitesGuide, Translation } from '../suite';
 import { FirmwareButtonsRow } from './Buttons/FirmwareButtonsRow';
 import { FirmwareSwitchWarning } from './FirmwareSwitchWarning';
-import { selectIsDebugModeActive } from '../../reducers/suite/suiteReducer';
 
 const Description = styled.div`
     align-items: center;

--- a/packages/suite/src/components/firmware/FirmwareInstallationStandalone.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInstallationStandalone.tsx
@@ -7,7 +7,7 @@ import { spacings } from '@trezor/theme';
 import { FirmwareOffer, FirmwareProgressBar, ReconnectDevicePrompt } from 'src/components/firmware';
 import { Translation } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite/useSelector';
-import { selectHasTransportOfType } from 'src/reducers/suite/suiteReducer';
+import { selectHasTransportOfType } from 'src/selectors/suite/suiteSelectors';
 
 type FirmwareInstallationStandaloneProps = {
     // If true, information about new version is not shown, because we don't know anything about it

--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -14,7 +14,7 @@ import { spacings } from '@trezor/theme';
 import { Translation, WebUsbButton } from 'src/components/suite';
 import { DeviceConfirmImage } from 'src/components/suite/DeviceConfirmImage';
 import { useDevice, useSelector } from 'src/hooks/suite';
-import { selectHasTransportOfType } from 'src/reducers/suite/suiteReducer';
+import { selectHasTransportOfType } from 'src/selectors/suite/suiteSelectors';
 
 const RebootDeviceGraphics = ({
     device,

--- a/packages/suite/src/components/guide/GuideArticle.tsx
+++ b/packages/suite/src/components/guide/GuideArticle.tsx
@@ -6,7 +6,7 @@ import { GuideContent, GuideHeader, GuideMarkdown, GuideViewWrapper } from 'src/
 import { Translation } from 'src/components/suite';
 import { useGuideLoadArticle } from 'src/hooks/guide';
 import { useSelector } from 'src/hooks/suite';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 
 const ArticleWrapper = styled.div`
     padding-bottom: ${spacingsPx.xxl};

--- a/packages/suite/src/components/guide/GuideCategory.tsx
+++ b/packages/suite/src/components/guide/GuideCategory.tsx
@@ -12,7 +12,7 @@ import {
 } from 'src/components/guide';
 import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import { getNodeTitle } from 'src/utils/suite/guide';
 
 const Section = styled.div`

--- a/packages/suite/src/components/guide/GuideNode.tsx
+++ b/packages/suite/src/components/guide/GuideNode.tsx
@@ -10,7 +10,7 @@ import { borders, spacings } from '@trezor/theme';
 
 import { openNode } from 'src/actions/suite/guideActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import { getNodeTitle } from 'src/utils/suite/guide';
 
 const NodeButton = styled.button`

--- a/packages/suite/src/components/guide/HeaderBreadcrumb.tsx
+++ b/packages/suite/src/components/guide/HeaderBreadcrumb.tsx
@@ -10,7 +10,7 @@ import { Translation } from 'src/components/suite';
 // importing directly, otherwise unit tests fail, seems to be a styled-components issue
 import { TrezorLink } from 'src/components/suite/TrezorLink';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import { findAncestorNodes, getNodeTitle } from 'src/utils/suite/guide';
 
 const BreadcrumbWrapper = styled.span`

--- a/packages/suite/src/components/onboarding/OnboardingProgressBar.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingProgressBar.tsx
@@ -6,9 +6,9 @@ import { Icon, variables } from '@trezor/components';
 import { spacingsPx, typography } from '@trezor/theme';
 
 import { useDevice, useOnboarding, useSelector } from 'src/hooks/suite';
+import { selectIsDeviceAuthenticityCheckEnabled } from 'src/selectors/suite/suiteSelectors';
 
 import { stepCategories } from '../../config/onboarding/steps';
-import { selectIsDeviceAuthenticityCheckEnabled } from '../../reducers/suite/suiteReducer';
 import { isStepCategoryUsed } from '../../utils/onboarding/steps';
 import { Translation } from '../suite';
 

--- a/packages/suite/src/components/settings/DeviceBanner.tsx
+++ b/packages/suite/src/components/settings/DeviceBanner.tsx
@@ -8,7 +8,7 @@ import { spacings } from '@trezor/theme';
 
 import { WebUsbButton } from 'src/components/suite/WebUsbButton';
 import { useDevice, useSelector } from 'src/hooks/suite';
-import { selectHasTransportOfType } from 'src/reducers/suite/suiteReducer';
+import { selectHasTransportOfType } from 'src/selectors/suite/suiteSelectors';
 
 import { AcquireDeviceButton } from '../suite/AcquireDeviceButton';
 

--- a/packages/suite/src/components/settings/SettingsLayout.tsx
+++ b/packages/suite/src/components/settings/SettingsLayout.tsx
@@ -11,7 +11,7 @@ import {
     SubpageNavigation,
 } from 'src/components/suite/layouts/SuiteLayout';
 import { useDiscovery, useDispatch, useLayout, useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 import { AccountHeaderProvider } from 'src/support/suite/AccountHeaderProvider';
 import { SettingsLoading } from 'src/views/settings/SettingsLoader';
 

--- a/packages/suite/src/components/suite/Address.tsx
+++ b/packages/suite/src/components/suite/Address.tsx
@@ -5,7 +5,7 @@ import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { useSelector } from 'src/hooks/suite';
-import { selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
+import { selectAddressDisplayType } from 'src/selectors/suite/suiteSelectors';
 
 const TRUNCATION_PLACEHOLDER = ' ... ';
 

--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -19,7 +19,7 @@ import { spacings } from '@trezor/theme';
 import { HiddenPlaceholder, Sign } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import { BlurUrls } from 'src/views/wallet/tokens/common/BlurUrls';
 
 import { RedactNumericalValue } from './RedactNumericalValue';

--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -11,10 +11,12 @@ import { useWindowVisibility } from 'src/hooks/suite/useWindowVisibility';
 import {
     selectIsEntropyCheckEnabledAndFailed,
     selectIsFirmwareAuthenticityCheckEnabledAndHardFailed,
+} from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
+import {
     selectIsLoggedOut,
     selectIsTransportInitialized,
     selectPrerequisite,
-} from 'src/reducers/suite/suiteReducer';
+} from 'src/selectors/suite/suiteSelectors';
 import type { AppState } from 'src/types/suite';
 import { Onboarding } from 'src/views/onboarding';
 import { SuiteStart } from 'src/views/start/SuiteStart';

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceConnect.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceConnect.tsx
@@ -15,10 +15,10 @@ import {
     TROUBLESHOOTING_TIP_USB,
 } from 'src/components/suite/troubleshooting/tips';
 import { useBridgeDesktopApi } from 'src/hooks/suite/useBridgeDesktopApi';
+import { selectHasTransportOfType, selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 import { selectConnectingDevices } from '../../../actions/bluetooth/desktopBluetoothSelectors';
 import { useSelector } from '../../../hooks/suite';
-import { selectHasTransportOfType, selectSuiteFlags } from '../../../reducers/suite/suiteReducer';
 import {
     TroubleshootingTipsItem,
     TroubleshootingTipsWithSections,

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUsedElsewhere.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUsedElsewhere.tsx
@@ -8,8 +8,8 @@ import {
     TROUBLESHOOTING_TIP_RECONNECT,
 } from 'src/components/suite/troubleshooting/tips';
 import { useDevice, useSelector } from 'src/hooks/suite';
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
-import { selectSuiteFlags } from '../../../reducers/suite/suiteReducer';
 import { AcquireDeviceButton } from '../AcquireDeviceButton';
 
 export const DeviceUsedElsewhere = () => {

--- a/packages/suite/src/components/suite/PrerequisitesGuide/PrerequisitesGuide.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/PrerequisitesGuide.tsx
@@ -22,7 +22,7 @@ import { spacings } from '@trezor/theme';
 import { goto } from 'src/actions/suite/routerActions';
 import { ConnectDevicePrompt, Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectPrerequisite } from 'src/reducers/suite/suiteReducer';
+import { selectPrerequisite } from 'src/selectors/suite/suiteSelectors';
 
 import { DeviceAcquire } from './DeviceAcquire';
 import { DeviceBootloader } from './DeviceBootloader';

--- a/packages/suite/src/components/suite/PrerequisitesGuide/Transport.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/Transport.tsx
@@ -8,10 +8,10 @@ import {
     TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE,
     TROUBLESHOOTING_TIP_WEBUSB_ENVIRONMENT,
 } from 'src/components/suite/troubleshooting/tips';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 
 import { useSelector } from '../../../hooks/suite';
 import { useBridgeDesktopApi } from '../../../hooks/suite/useBridgeDesktopApi';
-import { selectIsDebugModeActive } from '../../../reducers/suite/suiteReducer';
 import { TroubleshootingTipsItem } from '../troubleshooting/TroubleshootingTips';
 
 const tipItems: TroubleshootingTipsItem[] = [

--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
@@ -8,7 +8,7 @@ import {
     selectFirmwareHashCheckErrorIfEnabled,
     selectFirmwareRevisionCheckErrorIfEnabled,
     selectIsEntropyCheckEnabledAndFailed,
-} from 'src/reducers/suite/suiteReducer';
+} from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
 
 import { SecurityCheckFail } from './SecurityCheckFail';
 import { hardFailureChecklistItems, softFailureChecklistItems } from './checklistItems';

--- a/packages/suite/src/components/suite/Ticker/TrendTicker.tsx
+++ b/packages/suite/src/components/suite/Ticker/TrendTicker.tsx
@@ -9,7 +9,7 @@ import { spacingsPx, typography } from '@trezor/theme';
 
 import { BaseCurrencyValue } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 
 import { NoRatesTooltip } from './NoRatesTooltip';
 

--- a/packages/suite/src/components/suite/TorLoader/TorLoader.tsx
+++ b/packages/suite/src/components/suite/TorLoader/TorLoader.tsx
@@ -17,7 +17,7 @@ import { toggleTor, updateTorStatus } from 'src/actions/suite/suiteActions';
 import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectModalType } from 'src/reducers/suite/modalReducer';
-import { selectTorState } from 'src/reducers/suite/suiteReducer';
+import { selectTorState } from 'src/selectors/suite/suiteSelectors';
 import { TorStatus } from 'src/types/suite';
 
 type TorLoadingScreenProps = {

--- a/packages/suite/src/components/suite/banners/MessageSystemBanner.tsx
+++ b/packages/suite/src/components/suite/banners/MessageSystemBanner.tsx
@@ -6,7 +6,7 @@ import { Banner, BannerProps, Row, Banner as WarningComponent } from '@trezor/co
 
 import { goto } from 'src/actions/suite/routerActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectLanguage, selectTorState } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage, selectTorState } from 'src/selectors/suite/suiteSelectors';
 import { getTorUrlIfAvailable } from 'src/utils/suite/tor';
 
 type MessageSystemBannerProps = {

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareAuthenticityCheckBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareAuthenticityCheckBanner.tsx
@@ -11,7 +11,7 @@ import { useSelector } from 'src/hooks/suite';
 import {
     selectFirmwareHashCheckErrorIfEnabled,
     selectFirmwareRevisionCheckErrorIfEnabled,
-} from 'src/reducers/suite/suiteReducer';
+} from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
 
 const revisionCheckMessages: Record<
     Exclude<FirmwareRevisionCheckError, SkippedRevisionCheckError>,

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
@@ -15,8 +15,8 @@ import { useSelector } from 'src/hooks/suite';
 import {
     selectFirmwareHashCheckErrorIfEnabled,
     selectFirmwareRevisionCheckErrorIfEnabled,
-    selectTransportOfType,
-} from 'src/reducers/suite/suiteReducer';
+} from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
+import { selectTransportOfType } from 'src/selectors/suite/suiteSelectors';
 
 import { MessageSystemBanner } from '../MessageSystemBanner';
 import { BridgeDeprecated } from './BridgeDeprecatedBanner';

--- a/packages/suite/src/components/suite/bluetooth/BluetoothDeviceComponent.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDeviceComponent.tsx
@@ -3,10 +3,11 @@ import { models } from '@trezor/device-utils';
 import { RotateDeviceImage } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
+
 import { BluetoothDebugInfo } from './BluetoothDebugInfo';
 import { DesktopBluetoothDevice } from '../../../actions/bluetooth/DesktopBluetoothDevice';
 import { useSelector } from '../../../hooks/suite';
-import { selectSuiteFlags } from '../../../reducers/suite/suiteReducer';
 
 type BluetoothDeviceProps = {
     device: DesktopBluetoothDevice;

--- a/packages/suite/src/components/suite/copy/TxAddress.tsx
+++ b/packages/suite/src/components/suite/copy/TxAddress.tsx
@@ -11,7 +11,7 @@ import { openModal } from 'src/actions/suite/modalActions';
 import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
 import { TrezorLink } from 'src/components/suite/TrezorLink';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
+import { selectAddressDisplayType } from 'src/selectors/suite/suiteSelectors';
 
 type DisplayMode = 'copy' | 'modal' | 'static';
 

--- a/packages/suite/src/components/suite/layouts/LoggedOutSidebar.tsx
+++ b/packages/suite/src/components/suite/layouts/LoggedOutSidebar.tsx
@@ -4,9 +4,10 @@ import { Route } from '@suite-common/suite-types';
 import { Column, ElevationUp, useElevation } from '@trezor/components';
 import { Elevation, mapElevationToBackground, mapElevationToBorder } from '@trezor/theme';
 
+import { selectIsInitialRun } from 'src/selectors/suite/suiteSelectors';
+
 import { SIDEBAR_MIN_WIDTH } from './SuiteLayout/Sidebar/Sidebar';
 import { useSelector } from '../../../hooks/suite';
-import { selectIsInitialRun } from '../../../reducers/suite/suiteReducer';
 import { TrafficLightOffset } from '../TrafficLightOffset';
 import { Nav, SETTINGS_ROUTES } from './SuiteLayout/Sidebar/Navigation';
 import { NavItem } from './SuiteLayout/Sidebar/NavigationItem';

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/SettingsName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/SettingsName.tsx
@@ -8,7 +8,7 @@ import { spacingsPx } from '@trezor/theme';
 import { setDebugMode } from 'src/actions/suite/suiteActions';
 import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 
 import { HeaderHeading } from './BasicName';
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/DebugAndExperimental.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/DebugAndExperimental.tsx
@@ -6,7 +6,7 @@ import { spacings } from '@trezor/theme';
 import { goto } from 'src/actions/suite/routerActions';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 
 import { QuickActionButton } from './QuickActionButton';
 import { TooltipRow } from './TooltipRow';

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Tor.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Tor.tsx
@@ -14,11 +14,11 @@ import { spacings } from '@trezor/theme';
 import { goto } from 'src/actions/suite/routerActions';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectTorState } from 'src/selectors/suite/suiteSelectors';
 import { TorStatus } from 'src/types/suite';
 
 import { QuickActionButton } from './QuickActionButton';
 import { TooltipRow } from './TooltipRow';
-import { selectTorState } from '../../../../../../reducers/suite/suiteReducer';
 import { Translation, TranslationKey } from '../../../../Translation';
 
 const torStatusTranslationMap: Record<TorStatus, TranslationKey> = {

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -32,7 +32,7 @@ import { QrCode } from 'src/components/suite/QrCode';
 import { useGuideOpenNode } from 'src/hooks/guide';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
-import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
+import { selectIsActionAbortable } from 'src/selectors/suite/suiteSelectors';
 import { ThunkAction } from 'src/types/suite';
 import { DESTINATION_TAG_GUIDE_PATH } from 'src/views/wallet/send/Options/MiscNetworkOptions/DestinationTag';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
@@ -32,7 +32,7 @@ import * as modalActions from 'src/actions/suite/modalActions';
 import { ConnectModalBackdrop } from 'src/components/suite/ConnectModalBackdrop';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
+import { selectIsActionAbortable } from 'src/selectors/suite/suiteSelectors';
 import { getTransactionReviewModalActionTranslation } from 'src/utils/suite/transactionReview';
 
 import { TransactionReviewModalBottomContent } from './TransactionReviewOutputList/TransactionReviewModalBottomContent';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx
@@ -14,7 +14,7 @@ import { createCoinjoinAccount } from 'src/actions/wallet/coinjoinAccountActions
 import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectModalType } from 'src/reducers/suite/modalReducer';
-import { selectTorState } from 'src/reducers/suite/suiteReducer';
+import { selectTorState } from 'src/selectors/suite/suiteSelectors';
 import { Account } from 'src/types/wallet';
 
 import { AddButton } from './AddButton';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -17,8 +17,8 @@ import { goto } from 'src/actions/suite/routerActions';
 import { CoinList, Translation } from 'src/components/suite';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 import { selectIsPublic } from 'src/reducers/wallet/coinjoinReducer';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 import { TrezorDevice } from 'src/types/suite';
 import { Account } from 'src/types/wallet';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
@@ -22,7 +22,7 @@ import { useBackendsForm, useDefaultUrls } from 'src/hooks/settings/backends';
 import { useExplorerForm } from 'src/hooks/settings/useExplorerForm';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectModalType } from 'src/reducers/suite/modalReducer';
-import { selectTorState } from 'src/reducers/suite/suiteReducer';
+import { selectTorState } from 'src/selectors/suite/suiteSelectors';
 
 import { BackendTypeSelect } from './CustomBackends/BackendTypeSelect';
 import ConnectionInfo from './CustomBackends/ConnectionInfo';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
@@ -29,7 +29,7 @@ import { AccountLabeling } from 'src/components/suite/labeling';
 import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 import { TradingExchangeApprovalType } from 'src/types/trading/tradingForm';
 import { getProvidersInfoProps } from 'src/utils/wallet/trading/tradingTypingUtils';
 import { TradingCoinLogo } from 'src/views/wallet/trading/common/TradingCoinLogo';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceModal.tsx
@@ -8,7 +8,7 @@ import { spacings } from '@trezor/theme';
 import { onCancel, openModal } from 'src/actions/suite/modalActions';
 import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 
 const items: Array<{ icon: IconName; text: TranslationKey }> = [
     { icon: 'shieldCheck', text: 'TR_DEVICE_AUTHENTICITY_ITEM_1' },

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RequestEnableTorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RequestEnableTorModal.tsx
@@ -7,7 +7,7 @@ import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
-import { selectTorState } from 'src/reducers/suite/suiteReducer';
+import { selectTorState } from 'src/selectors/suite/suiteSelectors';
 
 type RequestEnableTorModalProps = {
     decision: Extract<UserContextPayload, { type: 'request-enable-tor' }>['decision'];

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeInputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeInputs.tsx
@@ -11,7 +11,7 @@ import { BigNumber } from '@trezor/utils';
 import { BaseCurrencyValue, Translation } from 'src/components/suite';
 import { useSelector, useTranslation } from 'src/hooks/suite';
 import { useStakeFormContext } from 'src/hooks/wallet/useStakeForm';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import { CRYPTO_INPUT, FIAT_INPUT } from 'src/types/wallet/stakeForms';
 import { validateStakingMax } from 'src/utils/suite/staking';
 import {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeInputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeInputs.tsx
@@ -10,7 +10,7 @@ import { spacings } from '@trezor/theme';
 import { BaseCurrencyValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
 import { useSelector, useTranslation } from 'src/hooks/suite';
 import { useUnstakeFormContext } from 'src/hooks/wallet/useUnstakeForm';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import { FIAT_INPUT, OUTPUT_AMOUNT } from 'src/types/wallet/stakeForms';
 import {
     validateCryptoLimits,

--- a/packages/suite/src/components/suite/troubleshooting/tips/BridgeTip.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/BridgeTip.tsx
@@ -7,7 +7,7 @@ import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
 import { useBridgeDesktopApi } from 'src/hooks/suite/useBridgeDesktopApi';
 import { useOpenSuiteDesktop } from 'src/hooks/suite/useOpenSuiteDesktop';
-import { selectTransportOfType } from 'src/reducers/suite/suiteReducer';
+import { selectTransportOfType } from 'src/selectors/suite/suiteSelectors';
 
 export const Wrapper = styled.div`
     a {

--- a/packages/suite/src/components/wallet/BigAmountValue.tsx
+++ b/packages/suite/src/components/wallet/BigAmountValue.tsx
@@ -6,8 +6,9 @@ import { Locale } from '@suite-common/suite-types';
 import { useShouldRedactNumbers } from '@suite-common/wallet-utils';
 import { typography } from '@trezor/theme';
 
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
+
 import { useSelector } from '../../hooks/suite';
-import { selectLanguage } from '../../reducers/suite/suiteReducer';
 import { RedactNumericalValue } from '../suite';
 
 const ValueWrapper = styled.div`

--- a/packages/suite/src/components/wallet/CoinjoinAccountDiscoveryProgress/CoinjoinAccountDiscoveryProgress.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinAccountDiscoveryProgress/CoinjoinAccountDiscoveryProgress.tsx
@@ -17,7 +17,7 @@ import { spacings } from '@trezor/theme';
 import { Translation } from 'src/components/suite';
 import { useCoinjoinAccountLoadingProgress } from 'src/hooks/coinjoin';
 import { useSelector } from 'src/hooks/suite';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 
 import { RotatingFacts } from './RotatingFacts';
 

--- a/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeEthereum.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeEthereum.tsx
@@ -10,7 +10,7 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { Translation } from 'src/components/suite';
 import { InputError } from 'src/components/wallet';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import { validateDecimals } from 'src/utils/suite/validation';
 
 import { CustomFeeBasicProps, FEE_LIMIT, FEE_PER_UNIT } from './CustomFee';

--- a/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeMisc.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CustomFeeMisc.tsx
@@ -7,7 +7,7 @@ import { Text } from '@trezor/components';
 import { NumberInput } from '@trezor/product-components';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import { validateDecimals } from 'src/utils/suite/validation';
 
 import { CustomFeeBasicProps, FEE_LIMIT, FEE_PER_UNIT } from './CustomFee';

--- a/packages/suite/src/components/wallet/Fees/StandardFee/EthereumFeeCards.tsx
+++ b/packages/suite/src/components/wallet/Fees/StandardFee/EthereumFeeCards.tsx
@@ -9,7 +9,7 @@ import { spacings } from '@trezor/theme';
 
 import { BaseCurrencyValue, Translation } from 'src/components/suite';
 import { useLocales, useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 
 import { FeeOptionType, getFeeLevelTranslationId } from '../Fees';
 import { FeeCard } from './FeeCard';

--- a/packages/suite/src/components/wallet/Pagination.tsx
+++ b/packages/suite/src/components/wallet/Pagination.tsx
@@ -8,7 +8,7 @@ import { borders, spacings, spacingsPx, typography } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite/Translation';
 import { useSelector } from 'src/hooks/suite';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 
 const Wrapper = styled.div<{ $hasPages?: boolean }>`
     display: flex;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ContextMessage.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ContextMessage.tsx
@@ -9,7 +9,7 @@ import { Banner, Row } from '@trezor/components';
 
 import { goto } from 'src/actions/suite/routerActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectLanguage, selectTorState } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage, selectTorState } from 'src/selectors/suite/suiteSelectors';
 import { getTorUrlIfAvailable } from 'src/utils/suite/tor';
 
 type ContextMessageProps = {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/SolanaLimitedHistoryBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/SolanaLimitedHistoryBanner.tsx
@@ -2,7 +2,7 @@ import { setFlag } from 'src/actions/suite/suiteActions';
 import { Translation } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { useSelector } from 'src/hooks/suite/useSelector';
-import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 import { BannerPoints } from './BannerPoints';
 import { CloseableBanner } from './CloseableBanner';

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -19,7 +19,7 @@ import { goto } from 'src/actions/suite/routerActions';
 import { setFlag } from 'src/actions/suite/suiteActions';
 import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 interface StakingBannerProps {
     account: Account;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StellarLimitedHistoryBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StellarLimitedHistoryBanner.tsx
@@ -2,7 +2,7 @@ import { setFlag } from 'src/actions/suite/suiteActions';
 import { Translation } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { useSelector } from 'src/hooks/suite/useSelector';
-import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 import { BannerPoints } from './BannerPoints';
 import { CloseableBanner } from './CloseableBanner';

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/TaprootBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/TaprootBanner.tsx
@@ -6,11 +6,11 @@ import { setFlag } from 'src/actions/suite/suiteActions';
 import { Translation } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { useSelector } from 'src/hooks/suite/useSelector';
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 import { Account } from 'src/types/wallet';
 
 import { BannerPoints } from './BannerPoints';
 import { CloseableBanner } from './CloseableBanner';
-import { selectSuiteFlags } from '../../../../reducers/suite/suiteReducer';
 
 interface TaprootBannerProps {
     account?: Account;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/TorDisconnected.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/TorDisconnected.tsx
@@ -4,8 +4,8 @@ import { toggleTor } from 'src/actions/suite/suiteActions';
 import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectModalType } from 'src/reducers/suite/modalReducer';
-import { selectTorState } from 'src/reducers/suite/suiteReducer';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
+import { selectTorState } from 'src/selectors/suite/suiteSelectors';
 
 export const TorDisconnected = () => {
     const account = useSelector(selectSelectedAccount);

--- a/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
@@ -6,8 +6,8 @@ import { Translation } from 'src/components/suite/Translation';
 import { NavigationItem, SubpageNavigation } from 'src/components/suite/layouts/SuiteLayout';
 import { useGoToWithAnalytics } from 'src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics';
 import { useSelector } from 'src/hooks/suite';
-import { selectHasExperimentalFeature } from 'src/reducers/suite/suiteReducer';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
+import { selectHasExperimentalFeature } from 'src/selectors/suite/suiteSelectors';
 import { WalletParams } from 'src/types/wallet';
 
 export const AccountNavigation = () => {

--- a/packages/suite/src/hooks/coinjoin/useCoinjoinSessionBlockers.ts
+++ b/packages/suite/src/hooks/coinjoin/useCoinjoinSessionBlockers.ts
@@ -1,8 +1,8 @@
 import { Feature, selectFeatureMessageContent } from '@suite-common/message-system';
 
 import { useSelector, useTranslation } from 'src/hooks/suite';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
 import { selectCoinjoinSessionBlockerByAccountKey } from 'src/reducers/wallet/coinjoinReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 
 export const useCoinjoinSessionBlockers = (
     accountKey: string,

--- a/packages/suite/src/hooks/settings/useNetworkSupport.ts
+++ b/packages/suite/src/hooks/settings/useNetworkSupport.ts
@@ -4,7 +4,7 @@ import { DeviceModelInternal, hasBitcoinOnlyFirmware } from '@trezor/device-util
 import { arrayPartition } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 
 export const useNetworkSupport = () => {
     const device = useSelector(selectSelectedDevice);

--- a/packages/suite/src/hooks/suite/useDebugLanguageShortcut.ts
+++ b/packages/suite/src/hooks/suite/useDebugLanguageShortcut.ts
@@ -5,7 +5,7 @@ import { KEYBOARD_CODE } from '@trezor/components';
 
 import { setLanguage } from 'src/actions/settings/languageActions';
 import { setAutodetect } from 'src/actions/suite/suiteActions';
-import { selectIsDebugModeActive, selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectIsDebugModeActive, selectLanguage } from 'src/selectors/suite/suiteSelectors';
 
 import { useDispatch } from './useDispatch';
 import { useSelector } from './useSelector';

--- a/packages/suite/src/hooks/suite/useDevice.ts
+++ b/packages/suite/src/hooks/suite/useDevice.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 
-import { selectIsDeviceOrUiLocked } from 'src/reducers/suite/suiteReducer';
+import { selectIsDeviceOrUiLocked } from 'src/selectors/suite/suiteSelectors';
 
 import { useSelector } from './useSelector';
 

--- a/packages/suite/src/hooks/suite/useDisplayMode.ts
+++ b/packages/suite/src/hooks/suite/useDisplayMode.ts
@@ -1,8 +1,8 @@
 import { selectDeviceUnavailableCapabilities } from '@suite-common/wallet-core';
 import { AddressDisplayOptions, ReviewOutput, StakeType } from '@suite-common/wallet-types';
 
-import { selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
+import { selectAddressDisplayType } from 'src/selectors/suite/suiteSelectors';
 import { DisplayMode } from 'src/types/suite';
 
 import { useSelector } from './useSelector';

--- a/packages/suite/src/hooks/suite/useExternalLink.ts
+++ b/packages/suite/src/hooks/suite/useExternalLink.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { useSelector } from 'src/hooks/suite';
-import { selectTorState } from 'src/reducers/suite/suiteReducer';
+import { selectTorState } from 'src/selectors/suite/suiteSelectors';
 import { getTorUrlIfAvailable } from 'src/utils/suite/tor';
 
 /**

--- a/packages/suite/src/hooks/suite/useFormattersConfig.ts
+++ b/packages/suite/src/hooks/suite/useFormattersConfig.ts
@@ -2,7 +2,7 @@ import { FormatterProviderConfig } from '@suite-common/formatters';
 import { selectLocalCurrency } from '@suite-common/wallet-core';
 
 import { useSelector } from 'src/hooks/suite/useSelector';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 
 export const useFormattersConfig = (): FormatterProviderConfig => {
     const locale = useSelector(selectLanguage);

--- a/packages/suite/src/hooks/suite/useLocales.ts
+++ b/packages/suite/src/hooks/suite/useLocales.ts
@@ -5,7 +5,7 @@ import type { Locale as DateFnsLocale } from 'date-fns';
 import { Locale as SuiteLocale } from '@suite-common/suite-types';
 
 import { useSelector } from 'src/hooks/suite';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 
 const getDateFnsLocale = (locale: SuiteLocale): DateFnsLocale['code'] => {
     const localeMap: Record<SuiteLocale, DateFnsLocale['code']> = {

--- a/packages/suite/src/hooks/suite/useMessageSystemStaking.ts
+++ b/packages/suite/src/hooks/suite/useMessageSystemStaking.ts
@@ -5,7 +5,7 @@ import {
 } from '@suite-common/message-system';
 import { NetworkSymbol, StakingNetworkSymbol } from '@suite-common/wallet-config';
 
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 
 import { useSelector } from './useSelector';
 

--- a/packages/suite/src/hooks/suite/useMessageSystemTrading.ts
+++ b/packages/suite/src/hooks/suite/useMessageSystemTrading.ts
@@ -5,7 +5,7 @@ import {
 } from '@suite-common/message-system';
 import { TradingType } from '@suite-common/trading';
 
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 
 import { useSelector } from './useSelector';
 

--- a/packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts
+++ b/packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts
@@ -4,7 +4,7 @@ import { useWindowFocus } from '@trezor/react-utils';
 import { SUITE_BRIDGE_DEEPLINK, SUITE_URL } from '@trezor/urls';
 
 import { useSelector } from 'src/hooks/suite';
-import { selectHasTransportOfType } from 'src/reducers/suite/suiteReducer';
+import { selectHasTransportOfType } from 'src/selectors/suite/suiteSelectors';
 
 export const useOpenSuiteDesktop = () => {
     const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
@@ -20,7 +20,7 @@ import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { useCompose } from 'src/hooks/wallet/form/useCompose';
 import { useFees } from 'src/hooks/wallet/form/useFees';
-import { selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
+import { selectAddressDisplayType } from 'src/selectors/suite/suiteSelectors';
 import {
     TradingSellExchangeFormProps,
     TradingUseComposeTransactionProps,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -38,7 +38,7 @@ import { useTradingBuyFormRedirectValues } from 'src/hooks/wallet/trading/form/u
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { useFormDraft } from 'src/hooks/wallet/useFormDraft';
 import { useTradingNavigation } from 'src/hooks/wallet/useTradingNavigation';
-import { selectIsTradingTermsDismissed } from 'src/reducers/suite/suiteReducer';
+import { selectIsTradingTermsDismissed } from 'src/selectors/suite/suiteSelectors';
 import { Dispatch } from 'src/types/suite';
 import { UseTradingFormProps } from 'src/types/trading/trading';
 import {

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.ts
@@ -18,7 +18,7 @@ import { selectLocalCurrency } from '@suite-common/wallet-core';
 import { isArrayMember, typedObjectValues } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
-import { selectTorState } from 'src/reducers/suite/suiteReducer';
+import { selectTorState } from 'src/selectors/suite/suiteSelectors';
 import { TradingBuyFormDefaultValuesProps } from 'src/types/trading/tradingForm';
 import { Account } from 'src/types/wallet';
 import { buildTradingFiatOption } from 'src/utils/wallet/trading/tradingUtils';

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -54,7 +54,7 @@ import { useTradingNavigation } from 'src/hooks/wallet/useTradingNavigation';
 import {
     selectIsDebugModeActive,
     selectIsTradingTermsDismissed,
-} from 'src/reducers/suite/suiteReducer';
+} from 'src/selectors/suite/suiteSelectors';
 import { Dispatch } from 'src/types/suite';
 import { UseTradingFormProps } from 'src/types/trading/trading';
 import {

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -50,7 +50,7 @@ import { useTradingNavigation } from 'src/hooks/wallet/useTradingNavigation';
 import {
     selectIsDebugModeActive,
     selectIsTradingTermsDismissed,
-} from 'src/reducers/suite/suiteReducer';
+} from 'src/selectors/suite/suiteSelectors';
 import {
     TradingAccountOptionsGroupOptionProps,
     UseTradingFormProps,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellFormDefaultValues.ts
@@ -17,7 +17,7 @@ import { isArrayMember, typedObjectValues } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
 import { useTradingBuildAccountGroups } from 'src/hooks/wallet/trading/form/common/useTradingBuildAccountGroups';
-import { selectTorState } from 'src/reducers/suite/suiteReducer';
+import { selectTorState } from 'src/selectors/suite/suiteSelectors';
 import { TradingSellFormDefaultValuesProps } from 'src/types/trading/tradingForm';
 import { Account } from 'src/types/wallet';
 import {

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.ts
@@ -15,7 +15,7 @@ import { openModal } from 'src/actions/suite/modalActions';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useAccountAddressDictionary } from 'src/hooks/wallet/useAccounts';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 import {
     TradingAccountType,
     TradingGetTranslationIdsProps,

--- a/packages/suite/src/hooks/wallet/useCardanoStaking.ts
+++ b/packages/suite/src/hooks/wallet/useCardanoStaking.ts
@@ -21,7 +21,7 @@ import trezorConnect, { PROTO } from '@trezor/connect';
 
 import { setPendingStakeTx } from 'src/actions/wallet/cardanoStakingActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsDeviceLocked } from 'src/reducers/suite/suiteReducer';
+import { selectIsDeviceLocked } from 'src/selectors/suite/suiteSelectors';
 import { AppState } from 'src/types/suite';
 import { ActionAvailability, CardanoStaking } from 'src/types/wallet/cardanoStaking';
 

--- a/packages/suite/src/middlewares/suite/messageSystemMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/messageSystemMiddleware.ts
@@ -10,7 +10,7 @@ import { changeNetworks, deviceActions, selectSelectedDevice } from '@suite-comm
 import { DEVICE, TRANSPORT } from '@trezor/connect';
 
 import { SUITE } from 'src/actions/suite/constants';
-import { selectActiveTransports } from 'src/reducers/suite/suiteReducer';
+import { selectActiveTransports } from 'src/selectors/suite/suiteSelectors';
 import { getIsTorEnabled } from 'src/utils/suite/tor';
 
 // actions which can affect message system messages

--- a/packages/suite/src/middlewares/suite/redirectMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/redirectMiddleware.ts
@@ -3,7 +3,7 @@ import { MiddlewareAPI } from 'redux';
 import { deviceActions, selectDevices, selectSelectedDevice } from '@suite-common/wallet-core';
 
 import * as routerActions from 'src/actions/suite/routerActions';
-import { selectIsRouterLocked } from 'src/reducers/suite/suiteReducer';
+import { selectIsRouterLocked } from 'src/selectors/suite/suiteSelectors';
 import { Action, AppState, Dispatch, TrezorDevice } from 'src/types/suite';
 
 const handleDeviceRedirect = (dispatch: Dispatch, state: AppState, device?: TrezorDevice) => {

--- a/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
@@ -29,13 +29,13 @@ import {
     SESSION_TX_BROADCASTED,
     SET_DEBUG_SETTINGS,
 } from 'src/actions/wallet/constants/coinjoinConstants';
-import { selectIsDeviceOrUiLocked, selectTorState } from 'src/reducers/suite/suiteReducer';
 import {
     selectCoinjoinAccountByKey,
     selectCoinjoinSessionBlockerByAccountKey,
     selectIsAccountWithSessionInCriticalPhaseByAccountKey,
     selectIsAnySessionInCriticalPhase,
 } from 'src/reducers/wallet/coinjoinReducer';
+import { selectIsDeviceOrUiLocked, selectTorState } from 'src/selectors/suite/suiteSelectors';
 import { CoinjoinService } from 'src/services/coinjoin';
 import type { Action, AppState, Dispatch } from 'src/types/suite';
 import { CoinjoinConfig } from 'src/types/wallet/coinjoin';

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -12,7 +12,7 @@ import {
 } from '@suite-common/wallet-core';
 
 import { SUITE } from 'src/actions/suite/constants';
-import { selectIsDeviceLocked } from 'src/reducers/suite/suiteReducer';
+import { selectIsDeviceLocked } from 'src/selectors/suite/suiteSelectors';
 
 // todo: this is crazy. needs some consideration
 export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -35,7 +35,7 @@ import * as metadataActions from 'src/actions/suite/metadataActions';
 import * as storageActions from 'src/actions/suite/storageActions';
 import { FORM_DRAFT, GRAPH } from 'src/actions/wallet/constants';
 import * as COINJOIN from 'src/actions/wallet/constants/coinjoinConstants';
-import { selectIsAutoEjectEnabled } from 'src/reducers/suite/suiteReducer';
+import { selectIsAutoEjectEnabled } from 'src/selectors/suite/suiteSelectors';
 import { db } from 'src/storage';
 import type { AppState, Dispatch, Action as SuiteAction } from 'src/types/suite';
 import type { WalletAction } from 'src/types/wallet';

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -1,38 +1,20 @@
 import { produce } from 'immer';
 
 import type { CountryCode } from '@suite-common/geolocation';
-import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
 import { Locale } from '@suite-common/suite-types';
-import { isDeviceAcquired } from '@suite-common/suite-utils';
 import type { InvityServerEnvironment, TradingType } from '@suite-common/trading';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import {
-    DeviceRootState,
-    selectIsEntropyCheckFailed,
-    selectSelectedDevice,
-} from '@suite-common/wallet-core';
 import { AddressDisplayOptions, WalletType } from '@suite-common/wallet-types';
 import { ConnectSettings, InstallerInfo, TRANSPORT, TransportInfo } from '@trezor/connect';
 import { isWeb } from '@trezor/env-utils';
 import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
-import { versionUtils } from '@trezor/utils';
 
 import { STORAGE, SUITE } from 'src/actions/suite/constants';
 import { ExperimentalFeature } from 'src/constants/suite/experimental';
-import {
-    hashCheckErrorScenarios,
-    isSkippedHashCheckError,
-    isSkippedRevisionCheckError,
-    revisionCheckErrorScenarios,
-} from 'src/constants/suite/firmware';
 import { SIDEBAR_WIDTH_NUMERIC } from 'src/constants/suite/layout';
-import { Action, AppState, TorBootstrap, TorStatus } from 'src/types/suite';
+import { Action, TorBootstrap, TorStatus } from 'src/types/suite';
 import type { OAuthServerEnvironment } from 'src/types/suite/metadata';
 import { ensureLocale } from 'src/utils/suite/l10n';
-import { getExcludedPrerequisites, getPrerequisiteName } from 'src/utils/suite/prerequisites';
-import { getIsTorEnabled, getIsTorLoading } from 'src/utils/suite/tor';
-
-import { RouterRootState, selectRouter } from './routerReducer';
 
 export interface SuiteRootState {
     suite: SuiteState;
@@ -433,223 +415,5 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
             // no default
         }
     });
-
-export const selectTorState = (state: SuiteRootState) => {
-    const { torStatus, torBootstrap } = state.suite;
-
-    return {
-        torStatus,
-        isTorEnabled: getIsTorEnabled(torStatus),
-        isTorLoading: getIsTorLoading(torStatus),
-        isTorError: torStatus === TorStatus.Error,
-        isTorDisabling: torStatus === TorStatus.Disabling,
-        isTorDisabled: torStatus === TorStatus.Disabled,
-        isTorEnabling: torStatus === TorStatus.Enabling,
-        torBootstrap,
-    };
-};
-
-// TODO: use this selector in all places where we need to check if debug mode is active
-export const selectIsDebugModeActive = (state: SuiteRootState) =>
-    state.suite.settings.debug.showDebugMenu;
-
-export const selectLanguage = (state: SuiteRootState) => state.suite.settings.language;
-
-export const selectAddressDisplayType = (state: SuiteRootState) =>
-    state.suite.settings.addressDisplayType;
-
-export const selectIsDeviceLocked = (state: SuiteRootState) =>
-    !!state.suite.locks[SUITE.LOCK_TYPE.DEVICE];
-
-export const selectIsDeviceOrUiLocked = (state: SuiteRootState) =>
-    !!state.suite.locks[SUITE.LOCK_TYPE.DEVICE] || !!state.suite.locks[SUITE.LOCK_TYPE.UI];
-
-export const selectIsRouterLocked = (state: SuiteRootState) =>
-    !!state.suite.locks[SUITE.LOCK_TYPE.ROUTER];
-
-export const selectIsRouterOrUiLocked = (state: SuiteRootState) =>
-    !!state.suite.locks[SUITE.LOCK_TYPE.ROUTER] || !!state.suite.locks[SUITE.LOCK_TYPE.UI];
-
-export const selectIsTransportInitialized = (state: SuiteRootState) => !!state.suite.transport;
-
-export const selectActiveTransports = (state: SuiteRootState) =>
-    state.suite.transport?.transports ?? [];
-
-export const selectHasActiveTransport = (state: SuiteRootState) =>
-    !!state.suite.transport?.transports.length;
-
-export const selectHasTransportOfType = (type: TransportInfo['type']) => (state: SuiteRootState) =>
-    state.suite.transport?.transports.some(t => t.type === type) ?? false;
-
-export const selectTransportOfType = (type: TransportInfo['type']) => (state: SuiteRootState) =>
-    state.suite.transport?.transports.find(t => t.type === type);
-
-export const selectUdevInstaller = (state: SuiteRootState) => state.suite.transport?.udev;
-
-export const selectIsActionAbortable = (state: SuiteRootState) => {
-    const bridge = state.suite.transport?.transports.find(t => t.type === 'BridgeTransport');
-
-    // TODO abortable actions should be decided based on specific device's transport
-    return !bridge || versionUtils.isNewerOrEqual(bridge.version as string, '2.0.31');
-};
-
-export const selectPrerequisite = (state: SuiteRootState & RouterRootState & DeviceRootState) => {
-    const { transport } = state.suite;
-    const device = selectSelectedDevice(state);
-    const router = selectRouter(state);
-
-    const excluded = getExcludedPrerequisites(router);
-    const prerequisite = getPrerequisiteName({ router, device, transport });
-
-    if (prerequisite === undefined) return;
-
-    if (excluded.includes(prerequisite)) {
-        return;
-    }
-
-    return prerequisite;
-};
-
-export const selectIsTEXDashboardPromoBannerShown = (state: SuiteRootState) =>
-    state.suite.flags.showTEXDashboardPromoBanner;
-
-export const selectIsSettingsDesktopAppPromoBannerShown = (state: SuiteRootState) =>
-    state.suite.flags.showSettingsDesktopAppPromoBanner;
-
-export const selectIsUnhideTokenModalShown = (state: SuiteRootState) =>
-    state.suite.flags.showUnhideTokenModal;
-
-export const selectIsCopyAddressModalShown = (state: SuiteRootState) =>
-    state.suite.flags.showCopyAddressModal;
-
-export const selectIsInitialRun = (state: SuiteRootState) => state.suite.flags.initialRun;
-
-export const selectIsLoggedOut = (state: SuiteRootState & DeviceRootState) =>
-    selectIsInitialRun(state) || state.device?.selectedDevice?.mode !== 'normal';
-
-export const selectSuiteFlags = (state: SuiteRootState) => state.suite.flags;
-
-export const selectSuiteSettings = (state: SuiteRootState) => ({
-    defaultWalletLoading: state.suite.settings.defaultWalletLoading,
-});
-
-export const selectHasExperimentalFeature =
-    (feature: ExperimentalFeature) => (state: SuiteRootState) =>
-        state.suite.settings.experimental?.includes(feature) ?? false;
-
-export const selectIsDeviceAuthenticityCheckEnabled = (state: SuiteRootState) =>
-    state.suite.settings.enabledSecurityChecks.deviceAuthenticity;
-export const selectIsEntropyCheckEnabled = (state: SuiteRootState) =>
-    state.suite.settings.enabledSecurityChecks.entropy;
-export const selectIsFirmwareHashCheckEnabled = (state: SuiteRootState) =>
-    state.suite.settings.enabledSecurityChecks.firmwareHash;
-export const selectIsFirmwareRevisionCheckEnabled = (state: SuiteRootState) =>
-    state.suite.settings.enabledSecurityChecks.firmwareRevision;
-export const selectIsAutoEjectEnabled = (state: SuiteRootState) => state.suite.settings.autoEject;
-
-/**
- * Get firmware revision check error, or null if check was successful / skipped.
- */
-export const selectFirmwareRevisionCheckError = (state: AppState) => {
-    const device = selectSelectedDevice(state);
-    if (!isDeviceAcquired(device) || !device.authenticityChecks) return null;
-    const checkResult = device.authenticityChecks.firmwareRevision;
-
-    // null means not performed, then don't consider it failed
-    if (!checkResult || checkResult.success) return null;
-
-    if (isSkippedRevisionCheckError(checkResult.error)) return null;
-
-    return checkResult.error;
-};
-
-export const selectFirmwareRevisionCheckErrorIfEnabled = (state: AppState) => {
-    const revisionCheckError = selectFirmwareRevisionCheckError(state);
-    if (revisionCheckError === null) return null;
-
-    const isFirmwareRevisionCheckDisabled =
-        !state.suite.settings.enabledSecurityChecks.firmwareRevision;
-    if (isFirmwareRevisionCheckDisabled) return null;
-
-    const isDisabledByMessageSystem = selectIsFeatureDisabled(state, Feature.firmwareRevisionCheck);
-    if (isDisabledByMessageSystem) return null;
-
-    return revisionCheckError;
-};
-
-/**
- * Get firmware hash check error, or null if check was successful / skipped.
- */
-export const selectFirmwareHashCheckError = (state: AppState) => {
-    const device = selectSelectedDevice(state);
-    if (!isDeviceAcquired(device) || !device.authenticityChecks) return null;
-    const checkResult = device.authenticityChecks.firmwareHash;
-
-    // null means not performed, then don't consider it failed
-    if (!checkResult || checkResult.success) return null;
-
-    if (isSkippedHashCheckError(checkResult.error)) return null;
-
-    return checkResult.error;
-};
-
-export const selectFirmwareHashCheckErrorIfEnabled = (state: AppState) => {
-    const hashCheckError = selectFirmwareHashCheckError(state);
-    if (hashCheckError === null) return null;
-
-    const isFirmwareHashCheckDisabled = !state.suite.settings.enabledSecurityChecks.firmwareHash;
-    if (isFirmwareHashCheckDisabled) return null;
-
-    const isDisabledByMessageSystem = selectIsFeatureDisabled(state, Feature.firmwareHashCheck);
-    if (isDisabledByMessageSystem) return null;
-
-    if (
-        hashCheckError === 'other-error' &&
-        selectIsFeatureDisabled(state, Feature.firmwareHashCheckOtherError)
-    ) {
-        return null;
-    }
-
-    if (
-        hashCheckError === 'takes-too-long' &&
-        selectIsFeatureDisabled(state, Feature.firmwareHashCheckTimeout)
-    ) {
-        return null;
-    }
-
-    return hashCheckError;
-};
-
-/**
- * Determine hard failure of either of firmware authenticity checks to block access to device.
- */
-export const selectIsFirmwareAuthenticityCheckEnabledAndHardFailed = (state: AppState) => {
-    const revisionError = selectFirmwareRevisionCheckErrorIfEnabled(state);
-    const isRevisionHardError =
-        revisionError !== null && revisionCheckErrorScenarios[revisionError].type === 'hardModal';
-
-    const hashError = selectFirmwareHashCheckErrorIfEnabled(state);
-    const isHashHardError =
-        hashError !== null && hashCheckErrorScenarios[hashError].type === 'hardModal';
-
-    return isRevisionHardError || isHashHardError;
-};
-
-/**
- * Return true if entropy check has failed and is not disabled via settings nor message system.
- */
-export const selectIsEntropyCheckEnabledAndFailed = (state: AppState) => {
-    const isEntropyCheckEnabled = selectIsEntropyCheckEnabled(state);
-    const isEntropyCheckDisabledByMessageSystem = selectIsFeatureDisabled(
-        state,
-        Feature.entropyCheck,
-    );
-    const isEntropyCheckFailed = selectIsEntropyCheckFailed(state);
-
-    return isEntropyCheckEnabled && !isEntropyCheckDisabledByMessageSystem && isEntropyCheckFailed;
-};
-
-export const selectIsTradingTermsDismissed = (state: AppState, tradingType: TradingType): boolean =>
-    !!state.suite.dismissedTradingTerms?.[tradingType];
 
 export default suiteReducer;

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -21,11 +21,8 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { STORAGE } from 'src/actions/suite/constants';
 import { COINJOIN } from 'src/actions/wallet/constants';
-import {
-    SuiteRootState,
-    selectIsDeviceOrUiLocked,
-    selectTorState,
-} from 'src/reducers/suite/suiteReducer';
+import { SuiteRootState } from 'src/reducers/suite/suiteReducer';
+import { selectIsDeviceOrUiLocked, selectTorState } from 'src/selectors/suite/suiteSelectors';
 import {
     CLIENT_STATUS_FALLBACK,
     DEFAULT_TARGET_ANONYMITY,

--- a/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
@@ -1,0 +1,115 @@
+import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
+import { isDeviceAcquired } from '@suite-common/suite-utils';
+import { selectIsEntropyCheckFailed, selectSelectedDevice } from '@suite-common/wallet-core';
+
+import {
+    hashCheckErrorScenarios,
+    isSkippedHashCheckError,
+    isSkippedRevisionCheckError,
+    revisionCheckErrorScenarios,
+} from 'src/constants/suite/firmware';
+import { AppState } from 'src/types/suite';
+
+import { selectIsEntropyCheckEnabled } from './suiteSelectors';
+
+/**
+ * Get firmware revision check error, or null if check was successful / skipped.
+ */
+export const selectFirmwareRevisionCheckError = (state: AppState) => {
+    const device = selectSelectedDevice(state);
+    if (!isDeviceAcquired(device) || !device.authenticityChecks) return null;
+    const checkResult = device.authenticityChecks.firmwareRevision;
+
+    // null means not performed, then don't consider it failed
+    if (!checkResult || checkResult.success) return null;
+
+    if (isSkippedRevisionCheckError(checkResult.error)) return null;
+
+    return checkResult.error;
+};
+
+export const selectFirmwareRevisionCheckErrorIfEnabled = (state: AppState) => {
+    const revisionCheckError = selectFirmwareRevisionCheckError(state);
+    if (revisionCheckError === null) return null;
+
+    const isFirmwareRevisionCheckDisabled =
+        !state.suite.settings.enabledSecurityChecks.firmwareRevision;
+    if (isFirmwareRevisionCheckDisabled) return null;
+
+    const isDisabledByMessageSystem = selectIsFeatureDisabled(state, Feature.firmwareRevisionCheck);
+    if (isDisabledByMessageSystem) return null;
+
+    return revisionCheckError;
+};
+
+/**
+ * Get firmware hash check error, or null if check was successful / skipped.
+ */
+export const selectFirmwareHashCheckError = (state: AppState) => {
+    const device = selectSelectedDevice(state);
+    if (!isDeviceAcquired(device) || !device.authenticityChecks) return null;
+    const checkResult = device.authenticityChecks.firmwareHash;
+
+    // null means not performed, then don't consider it failed
+    if (!checkResult || checkResult.success) return null;
+
+    if (isSkippedHashCheckError(checkResult.error)) return null;
+
+    return checkResult.error;
+};
+
+export const selectFirmwareHashCheckErrorIfEnabled = (state: AppState) => {
+    const hashCheckError = selectFirmwareHashCheckError(state);
+    if (hashCheckError === null) return null;
+
+    const isFirmwareHashCheckDisabled = !state.suite.settings.enabledSecurityChecks.firmwareHash;
+    if (isFirmwareHashCheckDisabled) return null;
+
+    const isDisabledByMessageSystem = selectIsFeatureDisabled(state, Feature.firmwareHashCheck);
+    if (isDisabledByMessageSystem) return null;
+
+    if (
+        hashCheckError === 'other-error' &&
+        selectIsFeatureDisabled(state, Feature.firmwareHashCheckOtherError)
+    ) {
+        return null;
+    }
+
+    if (
+        hashCheckError === 'takes-too-long' &&
+        selectIsFeatureDisabled(state, Feature.firmwareHashCheckTimeout)
+    ) {
+        return null;
+    }
+
+    return hashCheckError;
+};
+
+/**
+ * Determine hard failure of either of firmware authenticity checks to block access to device.
+ */
+export const selectIsFirmwareAuthenticityCheckEnabledAndHardFailed = (state: AppState) => {
+    const revisionError = selectFirmwareRevisionCheckErrorIfEnabled(state);
+    const isRevisionHardError =
+        revisionError !== null && revisionCheckErrorScenarios[revisionError].type === 'hardModal';
+
+    const hashError = selectFirmwareHashCheckErrorIfEnabled(state);
+    const isHashHardError =
+        hashError !== null && hashCheckErrorScenarios[hashError].type === 'hardModal';
+
+    return isRevisionHardError || isHashHardError;
+};
+
+/**
+ * Return true if entropy check has failed and is not disabled via settings nor message system.
+ */
+export const selectIsEntropyCheckEnabledAndFailed = (state: AppState) => {
+    const isEntropyCheckEnabled = selectIsEntropyCheckEnabled(state);
+    const isEntropyCheckDisabledByMessageSystem = selectIsFeatureDisabled(
+        state,
+        Feature.entropyCheck,
+    );
+    const isEntropyCheckFailed = selectIsEntropyCheckFailed(state);
+
+    return isEntropyCheckEnabled && !isEntropyCheckDisabledByMessageSystem && isEntropyCheckFailed;
+};

--- a/packages/suite/src/selectors/suite/suiteSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteSelectors.ts
@@ -1,0 +1,106 @@
+import type { TradingType } from '@suite-common/trading';
+import { DeviceRootState, selectSelectedDevice } from '@suite-common/wallet-core';
+import { TransportInfo } from '@trezor/connect';
+import { versionUtils } from '@trezor/utils';
+
+import { SUITE } from 'src/actions/suite/constants';
+import { ExperimentalFeature } from 'src/constants/suite/experimental';
+import { RouterRootState, selectRouter } from 'src/reducers/suite/routerReducer';
+import { SuiteRootState } from 'src/reducers/suite/suiteReducer';
+import { AppState, TorStatus } from 'src/types/suite';
+import { getExcludedPrerequisites, getPrerequisiteName } from 'src/utils/suite/prerequisites';
+import { getIsTorEnabled, getIsTorLoading } from 'src/utils/suite/tor';
+
+export const selectTorState = (state: SuiteRootState) => {
+    const { torStatus, torBootstrap } = state.suite;
+
+    return {
+        torStatus,
+        isTorEnabled: getIsTorEnabled(torStatus),
+        isTorLoading: getIsTorLoading(torStatus),
+        isTorError: torStatus === TorStatus.Error,
+        isTorDisabling: torStatus === TorStatus.Disabling,
+        isTorDisabled: torStatus === TorStatus.Disabled,
+        isTorEnabling: torStatus === TorStatus.Enabling,
+        torBootstrap,
+    };
+};
+
+// TODO: use this selector in all places where we need to check if debug mode is active
+export const selectIsDebugModeActive = (state: SuiteRootState) =>
+    state.suite.settings.debug.showDebugMenu;
+export const selectLanguage = (state: SuiteRootState) => state.suite.settings.language;
+export const selectAddressDisplayType = (state: SuiteRootState) =>
+    state.suite.settings.addressDisplayType;
+export const selectIsDeviceLocked = (state: SuiteRootState) =>
+    !!state.suite.locks[SUITE.LOCK_TYPE.DEVICE];
+export const selectIsDeviceOrUiLocked = (state: SuiteRootState) =>
+    !!state.suite.locks[SUITE.LOCK_TYPE.DEVICE] || !!state.suite.locks[SUITE.LOCK_TYPE.UI];
+export const selectIsRouterLocked = (state: SuiteRootState) =>
+    !!state.suite.locks[SUITE.LOCK_TYPE.ROUTER];
+export const selectIsRouterOrUiLocked = (state: SuiteRootState) =>
+    !!state.suite.locks[SUITE.LOCK_TYPE.ROUTER] || !!state.suite.locks[SUITE.LOCK_TYPE.UI];
+export const selectIsTransportInitialized = (state: SuiteRootState) => !!state.suite.transport;
+export const selectActiveTransports = (state: SuiteRootState) =>
+    state.suite.transport?.transports ?? [];
+export const selectHasActiveTransport = (state: SuiteRootState) =>
+    !!state.suite.transport?.transports.length;
+export const selectHasTransportOfType = (type: TransportInfo['type']) => (state: SuiteRootState) =>
+    state.suite.transport?.transports.some(t => t.type === type) ?? false;
+export const selectTransportOfType = (type: TransportInfo['type']) => (state: SuiteRootState) =>
+    state.suite.transport?.transports.find(t => t.type === type);
+export const selectUdevInstaller = (state: SuiteRootState) => state.suite.transport?.udev;
+
+export const selectIsActionAbortable = (state: SuiteRootState) => {
+    const bridge = state.suite.transport?.transports.find(t => t.type === 'BridgeTransport');
+
+    // TODO abortable actions should be decided based on specific device's transport
+    return !bridge || versionUtils.isNewerOrEqual(bridge.version as string, '2.0.31');
+};
+
+export const selectPrerequisite = (state: SuiteRootState & RouterRootState & DeviceRootState) => {
+    const { transport } = state.suite;
+    const device = selectSelectedDevice(state);
+    const router = selectRouter(state);
+
+    const excluded = getExcludedPrerequisites(router);
+    const prerequisite = getPrerequisiteName({ router, device, transport });
+
+    if (prerequisite === undefined) return;
+
+    if (excluded.includes(prerequisite)) {
+        return;
+    }
+
+    return prerequisite;
+};
+
+export const selectIsTEXDashboardPromoBannerShown = (state: SuiteRootState) =>
+    state.suite.flags.showTEXDashboardPromoBanner;
+export const selectIsSettingsDesktopAppPromoBannerShown = (state: SuiteRootState) =>
+    state.suite.flags.showSettingsDesktopAppPromoBanner;
+export const selectIsUnhideTokenModalShown = (state: SuiteRootState) =>
+    state.suite.flags.showUnhideTokenModal;
+export const selectIsCopyAddressModalShown = (state: SuiteRootState) =>
+    state.suite.flags.showCopyAddressModal;
+export const selectIsInitialRun = (state: SuiteRootState) => state.suite.flags.initialRun;
+export const selectIsLoggedOut = (state: SuiteRootState & DeviceRootState) =>
+    selectIsInitialRun(state) || state.device?.selectedDevice?.mode !== 'normal';
+export const selectSuiteFlags = (state: SuiteRootState) => state.suite.flags;
+export const selectSuiteSettings = (state: SuiteRootState) => ({
+    defaultWalletLoading: state.suite.settings.defaultWalletLoading,
+});
+export const selectHasExperimentalFeature =
+    (feature: ExperimentalFeature) => (state: SuiteRootState) =>
+        state.suite.settings.experimental?.includes(feature) ?? false;
+export const selectIsDeviceAuthenticityCheckEnabled = (state: SuiteRootState) =>
+    state.suite.settings.enabledSecurityChecks.deviceAuthenticity;
+export const selectIsEntropyCheckEnabled = (state: SuiteRootState) =>
+    state.suite.settings.enabledSecurityChecks.entropy;
+export const selectIsFirmwareHashCheckEnabled = (state: SuiteRootState) =>
+    state.suite.settings.enabledSecurityChecks.firmwareHash;
+export const selectIsFirmwareRevisionCheckEnabled = (state: SuiteRootState) =>
+    state.suite.settings.enabledSecurityChecks.firmwareRevision;
+export const selectIsAutoEjectEnabled = (state: SuiteRootState) => state.suite.settings.autoEject;
+export const selectIsTradingTermsDismissed = (state: AppState, tradingType: TradingType): boolean =>
+    !!state.suite.dismissedTradingTerms?.[tradingType];

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -24,13 +24,13 @@ import { StorageLoadAction } from 'src/actions/suite/storageActions';
 import * as cardanoStakingActions from 'src/actions/wallet/cardanoStakingActions';
 import { reportCheckFail } from 'src/components/suite/SecurityCheck/useReportDeviceCompromised';
 import { selectIsWindowVisible } from 'src/reducers/suite/windowReducer';
+import { selectSuiteSettings } from 'src/selectors/suite/suiteSelectors';
 import { fixLoadedCoinjoinAccount } from 'src/utils/wallet/coinjoinUtils';
 
 import { forgetBluetoothDeviceThunk } from '../actions/bluetooth/bluetoothEraseBondsThunk';
 import * as suiteActions from '../actions/suite/suiteActions';
 import { FW_HASH_CHECK_DEFAULT_TIMEOUTS } from '../constants/suite/firmware';
 import type { BioAuthState } from '../reducers/bioAuth';
-import { selectSuiteSettings } from '../reducers/suite/suiteReducer';
 import { AppState, TrezorDevice } from '../types/suite';
 
 const connectSrc = '../';

--- a/packages/suite/src/support/suite/useTor.tsx
+++ b/packages/suite/src/support/suite/useTor.tsx
@@ -10,7 +10,7 @@ import {
     updateTorStatus,
 } from 'src/actions/suite/suiteActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectTorState } from 'src/reducers/suite/suiteReducer';
+import { selectTorState } from 'src/selectors/suite/suiteSelectors';
 import { TorStatus } from 'src/types/suite';
 import { getIsTorDomain } from 'src/utils/suite/tor';
 

--- a/packages/suite/src/views/backup/BackupStep1Initial.tsx
+++ b/packages/suite/src/views/backup/BackupStep1Initial.tsx
@@ -6,7 +6,7 @@ import { ConfirmKey, backupDevice } from 'src/actions/backup/backupActions';
 import { PreBackupCheckboxes } from 'src/components/backup';
 import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsDeviceLocked } from 'src/reducers/suite/suiteReducer';
+import { selectIsDeviceLocked } from 'src/selectors/suite/suiteSelectors';
 
 import { BackupStepDescription } from './BackupStepDescription';
 import { BackupState } from '../../reducers/backup/backupReducer';

--- a/packages/suite/src/views/dashboard/AssetsView/AssetCoinLogo.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetCoinLogo.tsx
@@ -9,7 +9,7 @@ import { Row, SkeletonCircle, Tooltip } from '@trezor/components';
 import { AssetShareIndicator } from '@trezor/product-components';
 
 import { useSelector } from 'src/hooks/suite';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 
 type AssetCoinLogoProps = {
     symbol: NetworkSymbol;

--- a/packages/suite/src/views/dashboard/DashboardPassphraseBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPassphraseBanner.tsx
@@ -13,7 +13,7 @@ import { setFlag } from 'src/actions/suite/suiteActions';
 import { Translation } from 'src/components/suite';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
-import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 import { bannerAnimationConfig } from './banner-animations';
 

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx
@@ -4,10 +4,10 @@ import { Feature, selectFeatureConfig } from '@suite-common/message-system';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { useSelector } from 'src/hooks/suite';
+import { selectIsTEXDashboardPromoBannerShown } from 'src/selectors/suite/suiteSelectors';
 
 import { TrezorExpertBanner } from './TrezorExpertBanner';
 import { isDashboardBannerType } from './dashboardBannerTypes';
-import { selectIsTEXDashboardPromoBannerShown } from '../../../reducers/suite/suiteReducer';
 
 export const DashboardPromoBanner = () => {
     const [isVisible, setIsVisible] = useState(true);

--- a/packages/suite/src/views/dashboard/StakeEthCard/StakeEthCard.tsx
+++ b/packages/suite/src/views/dashboard/StakeEthCard/StakeEthCard.tsx
@@ -15,7 +15,7 @@ import { setFlag } from 'src/actions/suite/suiteActions';
 import { DashboardSection } from 'src/components/dashboard';
 import { StakingFeature, Translation } from 'src/components/suite';
 import { useDevice, useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
-import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 import { StakeEthCardFooter } from './StakeEthCardFooter/StakeEthCardFooter';
 

--- a/packages/suite/src/views/onboarding/UnexpectedState/index.tsx
+++ b/packages/suite/src/views/onboarding/UnexpectedState/index.tsx
@@ -6,7 +6,7 @@ import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { PrerequisitesGuide } from 'src/components/suite';
 import { useOnboarding, useSelector } from 'src/hooks/suite';
-import { selectPrerequisite } from 'src/reducers/suite/suiteReducer';
+import { selectPrerequisite } from 'src/selectors/suite/suiteSelectors';
 
 import { DeviceDifferent } from './DeviceDifferent';
 import { ShowPinMatrix } from './ShowPinMatrix';

--- a/packages/suite/src/views/onboarding/steps/Backup.tsx
+++ b/packages/suite/src/views/onboarding/steps/Backup.tsx
@@ -20,7 +20,7 @@ import {
 import { Translation } from 'src/components/suite';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsActionAbortable, selectIsDeviceLocked } from 'src/reducers/suite/suiteReducer';
+import { selectIsActionAbortable, selectIsDeviceLocked } from 'src/selectors/suite/suiteSelectors';
 import { canContinue } from 'src/utils/backup';
 
 // eslint-disable-next-line local-rules/no-override-ds-component

--- a/packages/suite/src/views/onboarding/steps/DeviceTutorial.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceTutorial.tsx
@@ -17,7 +17,7 @@ import { OnboardingStepBox } from 'src/components/onboarding';
 import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectOnboardingTutorialStatus } from 'src/reducers/onboarding/onboardingReducer';
-import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
+import { selectIsActionAbortable } from 'src/selectors/suite/suiteSelectors';
 import messages from 'src/support/messages';
 
 const StyledOnboardingStepBox = styled(OnboardingStepBox)`

--- a/packages/suite/src/views/onboarding/steps/Final.tsx
+++ b/packages/suite/src/views/onboarding/steps/Final.tsx
@@ -22,7 +22,7 @@ import { HomescreenGallery, Translation } from 'src/components/suite';
 import { ChangeDeviceLabelForm } from 'src/components/suite/ChangeDeviceLabelForm';
 import { useDevice, useDispatch, useOnboarding, useSelector } from 'src/hooks/suite';
 import { useChangeDeviceLabel } from 'src/hooks/suite/useChangeDeviceLabel';
-import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
+import { selectIsActionAbortable } from 'src/selectors/suite/suiteSelectors';
 import { isHomescreenSupportedOnDevice } from 'src/utils/suite/homescreen';
 
 const Content = styled.div`

--- a/packages/suite/src/views/onboarding/steps/FirmwareInstallation.tsx
+++ b/packages/suite/src/views/onboarding/steps/FirmwareInstallation.tsx
@@ -8,7 +8,10 @@ import { FirmwareOffer, FirmwareProgressBar, ReconnectDevicePrompt } from 'src/c
 import { OnboardingStepBox } from 'src/components/onboarding';
 import { Translation, WebUsbButton } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite/useSelector';
-import { selectHasTransportOfType, selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
+import {
+    selectHasTransportOfType,
+    selectIsActionAbortable,
+} from 'src/selectors/suite/suiteSelectors';
 
 const SelectDevice = styled.div`
     display: flex;

--- a/packages/suite/src/views/onboarding/steps/Pin.tsx
+++ b/packages/suite/src/views/onboarding/steps/Pin.tsx
@@ -14,7 +14,7 @@ import {
 } from 'src/components/onboarding';
 import { PinMatrix, Translation } from 'src/components/suite';
 import { useDispatch, useOnboarding, useSelector } from 'src/hooks/suite';
-import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
+import { selectIsActionAbortable } from 'src/selectors/suite/suiteSelectors';
 
 const SetPinStep = () => {
     const [showSkipConfirmation, setShowSkipConfirmation] = useState(false);

--- a/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
@@ -9,7 +9,7 @@ import { OnboardingButtonCta } from 'src/components/onboarding';
 import { SelectRecoveryType, SelectRecoveryWord, SelectWordCount } from 'src/components/recovery';
 import { Translation } from 'src/components/suite';
 import { useDispatch, useRecovery, useSelector } from 'src/hooks/suite';
-import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
+import { selectIsActionAbortable } from 'src/selectors/suite/suiteSelectors';
 import { pickByDeviceModel } from 'src/utils/device/modelUtils';
 
 import RecoveryStepBox from './RecoveryStepBox';

--- a/packages/suite/src/views/onboarding/steps/ResetDevice.tsx
+++ b/packages/suite/src/views/onboarding/steps/ResetDevice.tsx
@@ -12,7 +12,7 @@ import { OnboardingButtonBack, OnboardingStepBox, OptionsWrapper } from 'src/com
 import { Translation } from 'src/components/suite';
 import * as STEP from 'src/constants/onboarding/steps';
 import { useDevice, useDispatch, useOnboarding, useSelector } from 'src/hooks/suite';
-import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
+import { selectIsActionAbortable } from 'src/selectors/suite/suiteSelectors';
 
 import { SelectBackupType, isShamirBackupType } from './SelectBackupType/SelectBackupType';
 

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
@@ -13,7 +13,7 @@ import { DeviceAuthenticationExplainer, Translation } from 'src/components/suite
 import { SecurityCheckFail } from 'src/components/suite/SecurityCheck/SecurityCheckFail';
 import { AuthenticateDeviceSupportButton } from 'src/components/suite/SecurityCheck/deviceCompromisedCtas';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 
 const StyledCard = styled(CollapsibleOnboardingCard)`
     padding: ${spacingsPx.md};

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
@@ -33,7 +33,7 @@ import { SecurityCheckLayout } from 'src/components/suite/SecurityCheck/Security
 import { ContactSupport } from 'src/components/suite/SecurityCheck/deviceCompromisedCtas';
 import { useDispatch, useLayoutSize, useOnboarding, useSelector } from 'src/hooks/suite';
 import { selectIsOnboardingActive } from 'src/reducers/onboarding/onboardingReducer';
-import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 import { DeviceAuthenticity } from './DeviceAuthenticity';
 import { SecurityChecklist } from './SecurityChecklist';

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -23,10 +23,10 @@ import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanner
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { useDevice, useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 import { isCoinjoinSupportedSymbol } from 'src/utils/wallet/coinjoinUtils';
 
 import { FirmwareTypeSuggestion } from './FirmwareTypeSuggestion';
-import { selectSuiteFlags } from '../../../reducers/suite/suiteReducer';
 
 const DiscoveryButtonWrapper = styled.div`
     margin-top: ${spacingsPx.xl};

--- a/packages/suite/src/views/settings/SettingsDebug/Bluetooth.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Bluetooth.tsx
@@ -4,11 +4,11 @@ import { Checkbox } from '@trezor/components';
 
 import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 import { disposeBluetoothThunk } from '../../../actions/bluetooth/disposeBluetoothThunk';
 import { initBluetoothThunk } from '../../../actions/bluetooth/initBluetoothThunk';
 import { setFlag } from '../../../actions/suite/suiteActions';
-import { selectSuiteFlags } from '../../../reducers/suite/suiteReducer';
 
 export const Bluetooth = () => {
     const { isBluetoothEnabled } = useSelector(selectSuiteFlags);

--- a/packages/suite/src/views/settings/SettingsDebug/CheckFirmwareAuthenticity.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/CheckFirmwareAuthenticity.tsx
@@ -7,7 +7,7 @@ import {
     selectIsEntropyCheckEnabled,
     selectIsFirmwareHashCheckEnabled,
     selectIsFirmwareRevisionCheckEnabled,
-} from 'src/reducers/suite/suiteReducer';
+} from 'src/selectors/suite/suiteSelectors';
 
 export const CheckFirmwareAuthenticity = () => {
     const dispatch = useDispatch();

--- a/packages/suite/src/views/settings/SettingsDebug/GithubIssue.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/GithubIssue.tsx
@@ -1,6 +1,6 @@
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { useDevice, useSelector } from 'src/hooks/suite';
-import { selectActiveTransports } from 'src/reducers/suite/suiteReducer';
+import { selectActiveTransports } from 'src/selectors/suite/suiteSelectors';
 import { openGithubIssue } from 'src/services/github';
 
 export const GithubIssue = () => {

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -5,7 +5,7 @@ import { SettingsLayout, SettingsSection } from 'src/components/settings';
 import { Translation } from 'src/components/suite';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useSelector } from 'src/hooks/suite';
-import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 import { Backends } from './Backends';
 import { Bluetooth } from './Bluetooth';

--- a/packages/suite/src/views/settings/SettingsDebug/ShowBluetoothDebugInfo.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/ShowBluetoothDebugInfo.tsx
@@ -2,9 +2,9 @@ import { Checkbox } from '@trezor/components';
 
 import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 import { setFlag } from '../../../actions/suite/suiteActions';
-import { selectSuiteFlags } from '../../../reducers/suite/suiteReducer';
 
 export const ShowBluetoothDebugInfo = () => {
     const { isBluetoothEnabled, showBluetoothDebugInfo } = useSelector(selectSuiteFlags);

--- a/packages/suite/src/views/settings/SettingsDebug/Transport.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Transport.tsx
@@ -8,7 +8,8 @@ import { ArrayElement } from '@trezor/type-utils';
 import { setDebugMode } from 'src/actions/suite/suiteActions';
 import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { DebugModeOptions, selectActiveTransports } from 'src/reducers/suite/suiteReducer';
+import { DebugModeOptions } from 'src/reducers/suite/suiteReducer';
+import { selectActiveTransports } from 'src/selectors/suite/suiteSelectors';
 
 type Transport = ArrayElement<NonNullable<DebugModeOptions['transports']>>;
 

--- a/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
@@ -2,7 +2,7 @@ import { Checkbox } from '@trezor/components';
 
 import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
-import { selectTransportOfType } from 'src/reducers/suite/suiteReducer';
+import { selectTransportOfType } from 'src/selectors/suite/suiteSelectors';
 
 import { useBridgeDesktopApi } from '../../../hooks/suite/useBridgeDesktopApi';
 

--- a/packages/suite/src/views/settings/SettingsDevice/DeviceAuthenticityOptOut.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/DeviceAuthenticityOptOut.tsx
@@ -10,7 +10,7 @@ import {
     Translation,
 } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsDeviceAuthenticityCheckEnabled } from 'src/reducers/suite/suiteReducer';
+import { selectIsDeviceAuthenticityCheckEnabled } from 'src/selectors/suite/suiteSelectors';
 
 export const DeviceAuthenticityOptOut = () => {
     const dispatch = useDispatch();

--- a/packages/suite/src/views/settings/SettingsDevice/FirmwareAuthenticityChecks.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/FirmwareAuthenticityChecks.tsx
@@ -13,7 +13,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 import {
     selectIsFirmwareHashCheckEnabled,
     selectIsFirmwareRevisionCheckEnabled,
-} from 'src/reducers/suite/suiteReducer';
+} from 'src/selectors/suite/suiteSelectors';
 
 export const FirmwareAuthenticityChecks = () => {
     const dispatch = useDispatch();

--- a/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
@@ -7,7 +7,7 @@ import { DeviceBanner, SettingsLayout, SettingsSection } from 'src/components/se
 import { Translation } from 'src/components/suite';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useDevice, useSelector } from 'src/hooks/suite';
-import { selectHasActiveTransport, selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
+import { selectHasActiveTransport, selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 import type { TrezorDevice } from 'src/types/suite';
 import { isRecoveryInProgress } from 'src/utils/device/isRecoveryInProgress';
 

--- a/packages/suite/src/views/settings/SettingsGeneral/AutoEject.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/AutoEject.tsx
@@ -9,7 +9,7 @@ import { SettingsSectionItem } from 'src/components/settings';
 import { ActionColumn, TextColumn, Translation } from 'src/components/suite';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsAutoEjectEnabled } from 'src/reducers/suite/suiteReducer';
+import { selectIsAutoEjectEnabled } from 'src/selectors/suite/suiteSelectors';
 
 const AutoEjectConfirmationModal = ({
     onCancel,

--- a/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
@@ -13,7 +13,7 @@ import { ActionColumn, SectionItem, TextColumn, Translation } from 'src/componen
 import { EXPERIMENTAL_FEATURES, ExperimentalFeature } from 'src/constants/suite/experimental';
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { selectIsBioAuthAvailable } from 'src/reducers/bioAuth';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 
 type FeatureLineProps = {
     feature: ExperimentalFeature;

--- a/packages/suite/src/views/settings/SettingsGeneral/Language.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Language.tsx
@@ -12,7 +12,7 @@ import { SettingsSectionItem } from 'src/components/settings';
 import { ActionColumn, ActionSelect, TextColumn, Translation } from 'src/components/suite';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import { getOsLocale } from 'src/utils/suite/l10n';
 
 const onlyOfficial = (locale: [string, LocaleInfo]): locale is [Locale, LocaleInfo] =>

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -12,7 +12,7 @@ import {
     selectHasExperimentalFeature,
     selectIsSettingsDesktopAppPromoBannerShown,
     selectTorState,
-} from 'src/reducers/suite/suiteReducer';
+} from 'src/selectors/suite/suiteSelectors';
 import { TorStatus } from 'src/types/suite';
 
 import { AddressDisplay } from './AddressDisplay';

--- a/packages/suite/src/views/settings/SettingsGeneral/Theme.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Theme.tsx
@@ -7,7 +7,7 @@ import { SettingsSectionItem } from 'src/components/settings';
 import { ActionColumn, ActionSelect, TextColumn, Translation } from 'src/components/suite';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 import { getOsTheme } from 'src/utils/suite/env';
 
 type ThemeColorVariantWithSystem = ThemeColorVariant | 'system';

--- a/packages/suite/src/views/settings/SettingsGeneral/TorExternal.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/TorExternal.tsx
@@ -7,7 +7,7 @@ import { SettingsSectionItem } from 'src/components/settings';
 import { ActionColumn, ActionSelect, TextColumn, Translation } from 'src/components/suite';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useSelector } from 'src/hooks/suite';
-import { selectTorState } from 'src/reducers/suite/suiteReducer';
+import { selectTorState } from 'src/selectors/suite/suiteSelectors';
 
 const options = [
     {

--- a/packages/suite/src/views/start/StartContent.tsx
+++ b/packages/suite/src/views/start/StartContent.tsx
@@ -1,6 +1,6 @@
 import { PrerequisitesGuide } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
-import { selectPrerequisite } from 'src/reducers/suite/suiteReducer';
+import { selectPrerequisite } from 'src/selectors/suite/suiteSelectors';
 
 import { ModalSwitcher } from '../../components/suite/modals/ModalSwitcher/ModalSwitcher';
 import { SecurityCheck } from '../onboarding/steps/SecurityCheck/SecurityCheck';

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
@@ -21,7 +21,7 @@ import { spacings } from '@trezor/theme';
 import { closeModalApp, goto } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
-import { selectIsDeviceOrUiLocked } from 'src/reducers/suite/suiteReducer';
+import { selectIsDeviceOrUiLocked } from 'src/selectors/suite/suiteSelectors';
 import { AcquiredDevice, ForegroundAppProps, TrezorDevice } from 'src/types/suite';
 
 interface AddWalletButtonProps {

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceHeader.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceHeader.tsx
@@ -9,7 +9,7 @@ import { Translation, WebUsbButton } from 'src/components/suite';
 import { WebUsbIconButton } from 'src/components/suite/WebUsbButton';
 import { DeviceStatus } from 'src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus';
 import { useSelector } from 'src/hooks/suite';
-import { selectHasTransportOfType } from 'src/reducers/suite/suiteReducer';
+import { selectHasTransportOfType } from 'src/selectors/suite/suiteSelectors';
 import { ForegroundAppProps, TrezorDevice } from 'src/types/suite';
 
 type DeviceHeaderProps = {

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectAllConfirmation.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectAllConfirmation.tsx
@@ -6,8 +6,7 @@ import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-
-import { selectSuiteSettings } from '../../../../reducers/suite/suiteReducer';
+import { selectSuiteSettings } from 'src/selectors/suite/suiteSelectors';
 
 type EjectAllConfirmationProps = {
     onCancel: () => void;

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectConfirmation.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectConfirmation.tsx
@@ -8,8 +8,7 @@ import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-
-import { selectSuiteSettings } from '../../../../reducers/suite/suiteReducer';
+import { selectSuiteSettings } from 'src/selectors/suite/suiteSelectors';
 
 type EjectConfirmationProps = {
     onCancel: MouseEventHandler<HTMLButtonElement> | undefined;

--- a/packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx
@@ -4,6 +4,7 @@ import { Button, Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 import { ForegroundAppProps } from 'src/types/suite';
 
 import { DeviceItem } from './DeviceItem/DeviceItem';
@@ -11,7 +12,6 @@ import { SwitchDeviceModal } from './SwitchDeviceModal';
 import { setBluetoothListOpen } from '../../../actions/bluetooth/desktopBluetoothReducer';
 import { selectIsBluetoothListOpen } from '../../../actions/bluetooth/desktopBluetoothSelectors';
 import { BluetoothConnect } from '../../../components/suite/bluetooth/BluetoothConnect';
-import { selectSuiteFlags } from '../../../reducers/suite/suiteReducer';
 
 export const SwitchDevice = ({ cancelable, onCancel }: ForegroundAppProps) => {
     const { isBluetoothEnabled } = useSelector(selectSuiteFlags);

--- a/packages/suite/src/views/suite/bridge/index.tsx
+++ b/packages/suite/src/views/suite/bridge/index.tsx
@@ -9,7 +9,7 @@ import {
     selectHasActiveTransport,
     selectHasTransportOfType,
     selectTransportOfType,
-} from 'src/reducers/suite/suiteReducer';
+} from 'src/selectors/suite/suiteSelectors';
 
 // it actually changes to "Install suite desktop"
 export const BridgeUnavailable = () => {

--- a/packages/suite/src/views/suite/udev/index.tsx
+++ b/packages/suite/src/views/suite/udev/index.tsx
@@ -6,7 +6,7 @@ import { DATA_URL, HELP_CENTER_UDEV_URL } from '@trezor/urls';
 
 import { Translation } from 'src/components/suite';
 import { useExternalLink, useSelector } from 'src/hooks/suite';
-import { selectUdevInstaller } from 'src/reducers/suite/suiteReducer';
+import { selectUdevInstaller } from 'src/selectors/suite/suiteSelectors';
 import type { ForegroundAppProps } from 'src/types/suite';
 
 type Installer = {

--- a/packages/suite/src/views/wallet/details/CoinjoinLogs.tsx
+++ b/packages/suite/src/views/wallet/details/CoinjoinLogs.tsx
@@ -3,7 +3,7 @@ import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { ActionButton, ActionColumn, TextColumn, Translation } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite/useSelector';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 
 export const CoinjoinLogs = () => {
     const isDebug = useSelector(selectIsDebugModeActive);

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -24,7 +24,7 @@ import { TranslationKey } from 'src/components/suite/Translation';
 import { AccountTypeDescription } from 'src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription';
 import { WalletLayout } from 'src/components/wallet';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/reducers/suite/suiteReducer';
+import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
 
 import { CoinjoinLogs } from './CoinjoinLogs';
 import { CoinjoinSetup } from './CoinjoinSetup/CoinjoinSetup';

--- a/packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx
+++ b/packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx
@@ -37,7 +37,7 @@ import {
     TrezorLink,
 } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsCopyAddressModalShown } from 'src/reducers/suite/suiteReducer';
+import { selectIsCopyAddressModalShown } from 'src/selectors/suite/suiteSelectors';
 import { getTokenAddressTranslationId } from 'src/utils/wallet/tokenUtils';
 
 import { DropdownRow } from '../../tokens/DropdownRow';

--- a/packages/suite/src/views/wallet/receive/Receive.tsx
+++ b/packages/suite/src/views/wallet/receive/Receive.tsx
@@ -5,7 +5,7 @@ import { spacings } from '@trezor/theme';
 import { ConfirmEvmExplanationModal } from 'src/components/suite/modals';
 import { WalletLayout, WalletSubpageHeading } from 'src/components/wallet';
 import { useDevice, useSelector } from 'src/hooks/suite';
-import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/reducers/suite/suiteReducer';
+import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
 
 import { CoinjoinReceiveWarning } from './components/CoinjoinReceiveWarning';
 import { ConnectDeviceReceivePromo } from './components/ConnectDevicePromo';

--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
@@ -22,7 +22,7 @@ import { spacings } from '@trezor/theme';
 import { showAddress } from 'src/actions/wallet/receiveActions';
 import { ReadMoreLink, Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite/';
-import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/reducers/suite/suiteReducer';
+import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
 import { AppState } from 'src/types/suite';
 
 const FreshAddressWrapper = styled.div`

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -21,7 +21,7 @@ import { showAddress } from 'src/actions/wallet/receiveActions';
 import { FormattedCryptoAmount, MetadataLabeling, Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite/';
 import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
-import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/reducers/suite/suiteReducer';
+import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
 import { AppState } from 'src/types/suite';
 import { MetadataAddPayload } from 'src/types/suite/metadata';
 

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/Locktime/LocktimeBlockHeight.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/Locktime/LocktimeBlockHeight.tsx
@@ -10,7 +10,7 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { Translation } from 'src/components/suite';
 import { useSelector, useTranslation } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 
 export const inputName = 'bitcoinLocktimeBlockHeight';
 

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
@@ -20,7 +20,7 @@ import { BaseCurrencyValue, Translation } from 'src/components/suite';
 import { useLayoutSize, useSelector, useTranslation } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import {
     validateDecimals,
     validateInteger,

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
@@ -27,7 +27,7 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { useTranslation } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import { validateDecimals } from 'src/utils/suite/validation';
 
 type FiatInputProps = {

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
@@ -51,7 +51,7 @@ import {
 import { TokenAddressRow } from 'src/components/suite/copy/TokenAddressRow';
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
-import { selectIsCopyAddressModalShown } from 'src/reducers/suite/suiteReducer';
+import { selectIsCopyAddressModalShown } from 'src/selectors/suite/suiteSelectors';
 import {
     enhanceTokensWithRates,
     getTokenAddressTranslationId,

--- a/packages/suite/src/views/wallet/tokens/TokensNavigation.tsx
+++ b/packages/suite/src/views/wallet/tokens/TokensNavigation.tsx
@@ -12,7 +12,7 @@ import { goto } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { selectRouteName } from 'src/reducers/suite/routerReducer';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 import { GetTokensOutputType, getTokens } from 'src/utils/wallet/tokenUtils';
 
 import { TranslationKey } from '../../../components/suite/Translation';

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -60,7 +60,7 @@ import {
 import {
     selectIsCopyAddressModalShown,
     selectIsUnhideTokenModalShown,
-} from 'src/reducers/suite/suiteReducer';
+} from 'src/selectors/suite/suiteSelectors';
 import { formatTokenSymbol, getTokenAddressTranslationId } from 'src/utils/wallet/tokenUtils';
 
 import { BlurUrls } from '../BlurUrls';

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputCryptoAmount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputCryptoAmount.tsx
@@ -18,7 +18,7 @@ import { useDidUpdate } from '@trezor/react-utils';
 import { useSelector, useTranslation } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import {
     TradingAccountOptionsGroupOptionProps,
     TradingCryptoListProps,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
@@ -13,7 +13,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { useSelector, useTranslation } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import {
     TradingAllFormProps,
     TradingFormInputFiatCryptoProps,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOfferFiatAmount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOfferFiatAmount.tsx
@@ -2,7 +2,7 @@ import { Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { useSelector } from 'src/hooks/suite';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import { TradingFormInputCurrency } from 'src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency';
 
 interface TradingFormOfferFiatAmountProps {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOfferOTC.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOfferOTC.tsx
@@ -19,7 +19,7 @@ import { Translation, TrezorLink } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { useFiatFromCryptoValue } from 'src/hooks/suite/useFiatFromCryptoValue';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
-import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import {
     isTradingBuyContext,
     isTradingSellContext,

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
@@ -21,7 +21,7 @@ import { spacings } from '@trezor/theme';
 
 import { setFlag } from 'src/actions/suite/suiteActions';
 import { Translation } from 'src/components/suite';
-import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 const options = [
     {


### PR DESCRIPTION
## Description

`suiteReducer` file is very long, because it contains a complex reducer and a lot of selectors
→ extract to selectors files, like it has been done in most `suite-common/wallet-core` reducers.

I have creates `suiteSelectors.ts`, but also `suiteAuthenticityChecksSelectors.ts` because they are long boilerplate, depend on the former, and are kind of a self-contained topic.

### Notes

:information_source:  The reasoning in wallet-core was not just splitting files, but also circular dependencies. There might be some here, but who knows :shrug: 

:thought_balloon: I know that this is not an ideal solution. The `suite` package is a yuuge monolith that should be split into subpackages sorted by concern, not into the grand directories like "selectors" and "reducers"  and "actions"  (sorted by technology instead of concern). But that'd be a long road ahead. This is low hanging fruit, kinda.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/extract-suite-selectors&lookback=7)