### PR TITLE
chore(suite): display meaningful approve/revoke notifications

### DIFF
--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -198,6 +198,37 @@ export const NotificationRenderer = ({
                     }}
                 />
             );
+        case 'tx-revoked':
+            return (
+                <TransactionRenderer
+                    render={render}
+                    notification={notification}
+                    icon="arrowUp"
+                    variant="success"
+                    message="TOAST_TX_REVOKED"
+                    messageValues={{
+                        tokenSymbol: notification.tokenSymbol,
+                    }}
+                />
+            );
+        case 'tx-approved':
+            return (
+                <TransactionRenderer
+                    render={render}
+                    notification={notification}
+                    icon="arrowUp"
+                    variant="success"
+                    message={
+                        notification.isInfiniteApproval
+                            ? 'TOAST_TX_APPROVED_MAX'
+                            : 'TOAST_TX_APPROVED'
+                    }
+                    messageValues={{
+                        amount: notification.formattedAmount,
+                        tokenSymbol: notification.tokenSymbol,
+                    }}
+                />
+            );
         case 'tx-sent':
             return (
                 <TransactionRenderer

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
@@ -30,7 +30,14 @@ import { getTxAnchor } from 'src/utils/suite/anchor';
 
 type TransactionRendererProps = NotificationViewProps &
     NotificationRendererProps<
-        'tx-sent' | 'tx-received' | 'tx-confirmed' | 'tx-staked' | 'tx-unstaked' | 'tx-claimed'
+        | 'tx-sent'
+        | 'tx-received'
+        | 'tx-confirmed'
+        | 'tx-staked'
+        | 'tx-unstaked'
+        | 'tx-claimed'
+        | 'tx-approved'
+        | 'tx-revoked'
     >;
 
 export const TransactionRenderer = ({ render: View, ...props }: TransactionRendererProps) => {
@@ -95,6 +102,7 @@ export const TransactionRenderer = ({ render: View, ...props }: TransactionRende
         <View
             {...props}
             messageValues={{
+                ...props.messageValues,
                 amount: <HiddenPlaceholder>{formattedAmount}</HiddenPlaceholder>,
                 account: (
                     <AccountLabeling

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4079,6 +4079,18 @@ export default defineMessages({
         id: 'TOAST_COPY_TO_CLIPBOARD',
         defaultMessage: 'Copied',
     },
+    TOAST_TX_REVOKED: {
+        id: 'TOAST_TX_REVOKED',
+        defaultMessage: 'Revoke transaction of {tokenSymbol} was broadcasted',
+    },
+    TOAST_TX_APPROVED: {
+        id: 'TOAST_TX_APPROVED',
+        defaultMessage: 'Approve transaction of {amount} {tokenSymbol} was broadcasted',
+    },
+    TOAST_TX_APPROVED_MAX: {
+        id: 'TOAST_TX_APPROVED_MAX',
+        defaultMessage: 'Approve transaction of unlimited {tokenSymbol} was broadcasted',
+    },
     TOAST_TX_SENT: {
         id: 'TOAST_TX_SENT',
         defaultMessage: '{amount} sent from {account}',

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -23,6 +23,17 @@ type SentTransactionNotification = {
     type: 'tx-sent';
 } & TransactionNotificationPayload;
 
+type RevokeTransactionNotification = {
+    type: 'tx-revoked';
+    tokenSymbol?: string;
+} & TransactionNotificationPayload;
+
+type ApproveTransactionNotification = {
+    type: 'tx-approved';
+    tokenSymbol?: string;
+    isInfiniteApproval: boolean;
+} & TransactionNotificationPayload;
+
 type ReceivedTransactionNotification = {
     type: 'tx-received' | 'tx-confirmed';
 } & TransactionNotificationPayload;
@@ -78,6 +89,8 @@ export type ToastPayload = (
               | 'sign-transaction-timeout';
       }
     | SentTransactionNotification
+    | ApproveTransactionNotification
+    | RevokeTransactionNotification
     | {
           type: 'raw-tx-sent';
           txid: string;

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -2,6 +2,7 @@ import { G } from '@mobily/ts-belt';
 import { isRejected } from '@reduxjs/toolkit';
 
 import { ActionsFromAsyncThunk, createThunk } from '@suite-common/redux-utils';
+import { UINT256_MAX } from '@suite-common/suite-constants';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import {
@@ -16,14 +17,17 @@ import {
     PrecomposedTransactionFinalCardano,
 } from '@suite-common/wallet-types';
 import {
+    asAmountSubunit,
     convertAmountSubunitsToUnits,
     convertAmountUnitsToSubunits,
     formatNetworkAmount,
     getAccountDecimals,
     getAreSatoshisUsed,
+    getEvmApprovalTxData,
     getPendingAccount,
     hasNetworkFeatures,
     isCardanoTx,
+    subunitsToUnits,
     tryGetAccountIdentity,
 } from '@suite-common/wallet-utils';
 import { BlockbookTransaction } from '@trezor/blockchain-link-types';
@@ -333,28 +337,59 @@ export const pushSendFormTransactionThunk = createThunk<
             : '0';
 
         const areSatoshisUsed = getAreSatoshisUsed(bitcoinAmountUnit, selectedAccount);
-
-        // get total amount without fee OR token amount
-        const formattedAmount = token
-            ? `${convertAmountSubunitsToUnits(
-                  precomposedTransaction.totalSpent,
-                  token.decimals,
-              )} ${token.symbol!.toUpperCase()}`
-            : formatNetworkAmount(spentWithoutFee, selectedAccount.symbol, true, areSatoshisUsed);
+        const evmApprovalData = getEvmApprovalTxData(precomposedForm?.ethereumDataHex);
 
         if (isSuccessfullyPushedTransaction(pushTxResponse)) {
             const { txid } = pushTxResponse.payload;
 
-            dispatch(
-                notificationsActions.addToast({
-                    type: 'tx-sent',
-                    formattedAmount,
-                    device,
-                    descriptor: selectedAccount.descriptor,
-                    symbol: selectedAccount.symbol,
-                    txid,
-                }),
-            );
+            if (evmApprovalData && token) {
+                const isInfiniteApproval = new BigNumber(evmApprovalData.amount).eq(UINT256_MAX);
+                const amount = subunitsToUnits({
+                    value: asAmountSubunit(new BigNumber(evmApprovalData.amount)),
+                    decimals: token.decimals,
+                }).toString();
+
+                dispatch(
+                    notificationsActions.addToast({
+                        type: evmApprovalData.type === 'approval' ? 'tx-approved' : 'tx-revoked',
+                        isInfiniteApproval,
+                        formattedAmount: amount,
+                        tokenSymbol: token.symbol?.toUpperCase(),
+                        device,
+                        descriptor: selectedAccount.descriptor,
+                        symbol: selectedAccount.symbol,
+                        txid,
+                    }),
+                );
+            } else {
+                const amount = token
+                    ? subunitsToUnits({
+                          value: asAmountSubunit(new BigNumber(precomposedTransaction.totalSpent)),
+                          decimals: token.decimals,
+                      })
+                    : null;
+
+                // get total amount without fee OR token amount
+                const formattedAmount =
+                    token && amount
+                        ? `${amount} ${token.symbol?.toUpperCase()}`
+                        : formatNetworkAmount(
+                              spentWithoutFee,
+                              selectedAccount.symbol,
+                              true,
+                              areSatoshisUsed,
+                          );
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'tx-sent',
+                        formattedAmount,
+                        device,
+                        descriptor: selectedAccount.descriptor,
+                        symbol: selectedAccount.symbol,
+                        txid,
+                    }),
+                );
+            }
 
             dispatch(
                 synchronizeSentTransactionThunk({


### PR DESCRIPTION
## Description

This PR brings meaningful content to approve/revoke tx notifications.

## Related Issue

Resolve #14937

## Screenshots:
|Approve|Revoke|
|--------|--------|
|<img width="440" height="104" alt="Screenshot 2025-08-07 at 18 41 42" src="https://github.com/user-attachments/assets/4a608d28-b657-441c-ae3a-6c2f01f75a33" />|<img width="432" height="78" alt="Screenshot 2025-08-07 at 19 08 45" src="https://github.com/user-attachments/assets/d100f8ca-0e6f-4ca6-9956-fa87027ac9d3" />|
|<img width="423" height="86" alt="Screenshot 2025-08-20 at 12 01 35" src="https://github.com/user-attachments/assets/8ef52868-7b1d-4b6d-85b3-437793805a87" />|




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/approve-notification-text&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/approve-notification-text&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/approve-notification-text&lookback=7)