### PR TITLE
test(suite-native): fix setup when running locally on mac

### DIFF
--- a/suite-native/app/e2e/utils.ts
+++ b/suite-native/app/e2e/utils.ts
@@ -149,8 +149,8 @@ export const prepareTrezorEmulator = async ({
         const modelSupportedFirmwares = TrezorUserEnvLink?.firmwares?.[model] || [];
 
         const fwVersion =
-            version && modelSupportedFirmwares.includes(version) ? version : '2-latest';
-
+            (version && modelSupportedFirmwares.find(v => v.replace('-arm', '') === version)) ||
+            '2-latest';
         await TrezorUserEnvLink.disconnect();
         await TrezorUserEnvLink.connect();
         // start with latest officially released firmware (necessary to pass the firmware checks)


### PR DESCRIPTION
when I run suite-native tests locally on mac-arm, this test https://github.com/trezor/trezor-suite/blob/develop/suite-native/app/e2e/tests/deviceSettings.test.ts#L141 always fails because it would run the latest emu and not the request one.

since on mac-arm fw versions reported by tenv are suffixed with -arm
<img width="429" height="151" alt="image" src="https://github.com/user-attachments/assets/7dc4a573-a59e-4c90-85e8-8b1d107819a0" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=native-fix-setup&lookback=7)