### PR TITLE
fix(suite): fix amount recalculation on currency switch

### DIFF
--- a/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
@@ -60,12 +60,12 @@ export const Amount = ({ output, outputId }: AmountProps) => {
     const amountName = `outputs.${outputId}.amount` as const;
     const tokenInputName = `outputs.${outputId}.token`;
     const maxOutputId = getDefaultValue('setMaxOutputId');
-    const isSetMaxActive = maxOutputId === outputId;
+    const isSendMaxActive = maxOutputId === outputId;
     const outputError = errors.outputs ? errors.outputs[outputId] : undefined;
     const error = outputError ? outputError.amount : undefined;
 
     // corner-case: do not display "setMax" button if FormState got ANY error (setMax probably cannot be calculated)
-    const isSetMaxVisible = isSetMaxActive && !error && !Object.keys(errors).length;
+    const isSendMaxVisible = isSendMaxActive && !error && !Object.keys(errors).length;
     const maxSwitchId = `outputs.${outputId}.setMax`;
 
     const amountValue = getDefaultValue(amountName, output.amount || '');
@@ -136,13 +136,13 @@ export const Amount = ({ output, outputId }: AmountProps) => {
     const onSwitchChange = () => {
         const clearInput = network.networkType === 'solana';
 
-        setMax(outputId, isSetMaxActive, clearInput);
+        setMax(outputId, isSendMaxActive, clearInput);
         composeTransaction(amountName);
     };
 
     const sendMaxSwitch = (
         <SendMaxSwitch
-            isSetMaxActive={isSetMaxActive}
+            isSendMaxActive={isSendMaxActive}
             data-testid={maxSwitchId}
             onChange={onSwitchChange}
         />
@@ -159,10 +159,10 @@ export const Amount = ({ output, outputId }: AmountProps) => {
                     inputState={inputState}
                     locale={locale}
                     labelHoverRight={
-                        !isSetMaxVisible && (!isWithBaseCurrency || isBelowLaptop) && sendMaxSwitch
+                        !isSendMaxVisible && (!isWithBaseCurrency || isBelowLaptop) && sendMaxSwitch
                     }
                     labelRight={
-                        isSetMaxVisible && (!isWithBaseCurrency || isBelowLaptop) && sendMaxSwitch
+                        isSendMaxVisible && (!isWithBaseCurrency || isBelowLaptop) && sendMaxSwitch
                     }
                     labelLeft={
                         <Row>
@@ -198,6 +198,7 @@ export const Amount = ({ output, outputId }: AmountProps) => {
                                     <BaseCurrencyInput
                                         output={output}
                                         outputId={outputId}
+                                        isSendMaxActive={isSendMaxActive}
                                         // To fix alignment with the other input
                                         labelLeft={isBelowLaptop ? undefined : <>&nbsp;</>}
                                         labelRight={!isBelowLaptop && sendMaxSwitch}

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
@@ -18,6 +18,7 @@ import {
     getDecimalsForBaseCurrency,
     getInputState,
     isLowAnonymityWarning,
+    parseBaseCurrencyToFormattedCrypto,
     parseCryptoToFormattedBaseCurrency,
 } from '@suite-common/wallet-utils';
 import {
@@ -39,6 +40,7 @@ import { validateDecimals } from 'src/utils/suite/validation';
 type FiatInputProps = {
     output: Partial<Output>;
     outputId: number;
+    isSendMaxActive?: boolean;
     labelLeft?: React.ReactNode;
     labelHoverRight?: React.ReactNode;
     labelRight?: React.ReactNode;
@@ -47,6 +49,7 @@ type FiatInputProps = {
 export const BaseCurrencyInput = ({
     output,
     outputId,
+    isSendMaxActive,
     labelLeft,
     labelHoverRight,
     labelRight,
@@ -90,24 +93,40 @@ export const BaseCurrencyInput = ({
         isInSats: areSatsDisplayed,
     });
 
-    const recalculateFiat = (rate: number) => {
+    const recalculate = (rate: number) => {
         const cryptoValue = new BigNumber(cryptoAmountValue);
+        const fiatValue = new BigNumber(baseCurrencyValue);
+        const cryptoDecimals = token ? token.decimals : network.decimals;
 
         if (rate && !cryptoValue.isNaN() && baseCurrencyCode !== '') {
-            const formatterAmount = parseCryptoToFormattedBaseCurrency({
-                baseCurrencyCode,
-                baseCurrencyToSats: shouldSendInSats === true,
+            const baseFormatOptions = {
                 areSatsDisplayed,
-                value: cryptoValue,
                 symbol: network.symbol,
                 rate,
-            });
+            };
 
-            if (formatterAmount !== null) {
-                setValue(baseCurrencyInputName, formatterAmount, {
+            if (isSendMaxActive) {
+                const formattedAmount = parseCryptoToFormattedBaseCurrency({
+                    ...baseFormatOptions,
+                    value: cryptoValue,
+                    baseCurrencyCode,
+                    baseCurrencyToSats: shouldSendInSats === true,
+                });
+                setValue(baseCurrencyInputName, formattedAmount || '', {
                     shouldValidate: true,
                 });
-                // call compose to store draft, precomposedTx should be the same
+            } else {
+                const formattedAmount = parseBaseCurrencyToFormattedCrypto({
+                    ...baseFormatOptions,
+                    value: fiatValue,
+                    isCryptoInSats: shouldSendInSats === true,
+                    areSatsDisplayed: false,
+                    cryptoDecimals,
+                });
+                setValue(amountInputName, formattedAmount || '', {
+                    shouldValidate: true,
+                });
+
                 composeTransaction(amountInputName);
             }
         }
@@ -192,10 +211,17 @@ export const BaseCurrencyInput = ({
                 );
 
                 if (updateFiatRatesResult.meta.requestStatus === 'fulfilled') {
-                    const fiatRate = updateFiatRatesResult.payload as FiatRatesResult;
+                    // not type-safe and should be addressed in the future
+                    const fiatRates =
+                        updateFiatRatesResult.payload as PromiseSettledResult<FiatRatesResult>[];
 
-                    if (fiatRate?.rate) {
-                        recalculateFiat(fiatRate.rate);
+                    const successfulResult = fiatRates.find(
+                        (result): result is PromiseFulfilledResult<FiatRatesResult> =>
+                            result.status === 'fulfilled',
+                    );
+
+                    if (successfulResult?.value?.rate) {
+                        recalculate(successfulResult.value.rate);
                     }
                 }
             }}

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/SendMaxSwitch.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/SendMaxSwitch.tsx
@@ -3,19 +3,19 @@ import { Switch } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 
 type SendMaxSwitchProps = {
-    isSetMaxActive: boolean;
+    isSendMaxActive: boolean;
     'data-testid'?: string;
     onChange: () => void;
 };
 
 export const SendMaxSwitch = ({
-    isSetMaxActive,
+    isSendMaxActive,
     'data-testid': dataTest,
     onChange,
 }: SendMaxSwitchProps) => (
     <Switch
         labelPosition="start"
-        isChecked={isSetMaxActive}
+        isChecked={isSendMaxActive}
         data-testid={dataTest}
         size="small"
         onChange={onChange}


### PR DESCRIPTION
Fixes the amount recalculation when user switches currency.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19895

## Screenshots:
**BEFORE**
![461386807-2a954447-3833-4e54-b20b-d5af5cbf8f05](https://github.com/user-attachments/assets/53c5a13b-273d-438a-94ba-d6392256c966)

**AFTER**
https://github.com/user-attachments/assets/b3bd0a2b-8d3f-4c37-92d9-155af124a2b1





🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/currency-switch-recalculate-amount&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/currency-switch-recalculate-amount&lookback=7)