### PR TITLE
fix(suite): show check for updates after disabling eap

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/VersionWithUpdate.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/VersionWithUpdate.tsx
@@ -139,11 +139,12 @@ export const VersionWithUpdate = () => {
                             <Translation id="SETTINGS_UPDATE_CHECKING" />
                         </ActionButton>
                     )}
-                    {desktopUpdateState.state === UpdateState.NotAvailable && (
-                        <ActionButton onClick={checkForUpdates} variant="primary">
-                            <Translation id="SETTINGS_UPDATE_CHECK" />
-                        </ActionButton>
-                    )}
+                    {desktopUpdateState.state === UpdateState.NotAvailable ||
+                        (desktopUpdateState.state === UpdateState.EarlyAccessDisable && (
+                            <ActionButton onClick={checkForUpdates} variant="primary">
+                                <Translation id="SETTINGS_UPDATE_CHECK" />
+                            </ActionButton>
+                        ))}
                     {desktopUpdateState.state === UpdateState.Available && (
                         <ActionButton onClick={maximizeUpdateModal} variant="primary">
                             <Translation id="SETTINGS_UPDATE_AVAILABLE" />


### PR DESCRIPTION
Shows `Check for updates` button immediately after disabling EAP.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/14944

## Screenshots:
<img width="821" height="276" alt="Screenshot 2025-08-08 at 1 00 19" src="https://github.com/user-attachments/assets/2669c862-a1cf-433a-ae0e-72cb3b73c8ea" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/check-for-updates-button-disappears-after-disabling-eap&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/check-for-updates-button-disappears-after-disabling-eap&lookback=7)