### PR TITLE
fix(suite): in the global send / receive do not display staking among…

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AccountList.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AccountList.tsx
@@ -12,9 +12,12 @@ const ScrollContainer = styled.div`
     overflow: hidden auto;
 `;
 
-type AccountListProps = { onSubmit: (account: Account, type: AccountItemType) => void };
+type AccountListProps = {
+    hideStaking?: boolean;
+    onSubmit: (account: Account, type: AccountItemType) => void;
+};
 
-export const AccountList = ({ onSubmit }: AccountListProps) => {
+export const AccountList = ({ hideStaking, onSubmit }: AccountListProps) => {
     const { scrollElementRef, onScroll, ShadowTop, ShadowBottom, ShadowContainer } =
         useScrollShadow();
 
@@ -27,7 +30,7 @@ export const AccountList = ({ onSubmit }: AccountListProps) => {
         <ShadowContainer>
             <ShadowTop backgroundColor={shadowColor} />
             <ScrollContainer ref={scrollElementRef} onScroll={onScroll}>
-                <AccountsList forceOnlyItemClick onItemClick={onSubmit} />
+                <AccountsList forceOnlyItemClick hideStaking={hideStaking} onItemClick={onSubmit} />
             </ScrollContainer>
             <ShadowBottom backgroundColor={shadowColor} />
         </ShadowContainer>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveModalBase.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveModalBase.tsx
@@ -37,7 +37,7 @@ export const GlobalSendReceiveModalBase = ({
                     {additionalAction}
                 </Row>
                 <ElevationContext baseElevation={-1}>
-                    <AccountList onSubmit={onSubmit} />
+                    <AccountList hideStaking onSubmit={onSubmit} />
                 </ElevationContext>
             </Column>
         </Modal>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx
@@ -12,6 +12,7 @@ import { AccountItemsGroup } from './AccountItemsGroup';
 interface AccountSectionProps {
     account: Account;
     forceOnlyItemClick?: boolean;
+    hideStaking?: boolean;
     selected: boolean;
     onItemClick?: (account: Account, type: AccountItemType) => void;
 }
@@ -19,6 +20,7 @@ interface AccountSectionProps {
 export const AccountSection = ({
     account,
     forceOnlyItemClick,
+    hideStaking,
     selected,
     onItemClick,
 }: AccountSectionProps) => {
@@ -36,7 +38,10 @@ export const AccountSection = ({
 
     const showGroup = ['ethereum', 'solana', 'cardano'].includes(networkType);
 
-    const isStakeShown = useSelector(state => selectAccountIsStakingActive(state, account.key));
+    const isStakeShownStored = useSelector(state =>
+        selectAccountIsStakingActive(state, account.key),
+    );
+    const isStakeShown = !hideStaking && isStakeShownStored;
 
     const tokens = getTokens({
         tokens: accountTokens,

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -21,6 +21,7 @@ import { useIsSidebarCollapsed } from '../../../suite/layouts/SuiteLayout/Sideba
 
 interface AccountListProps {
     forceOnlyItemClick?: boolean;
+    hideStaking?: boolean;
     onItemClick?: (account: Account, type: AccountItemType) => void;
 }
 
@@ -28,6 +29,7 @@ type AccountsProps = {
     accounts: Account[];
     coinjoinIsPreloading?: boolean;
     discoveryInProgress?: boolean;
+    hideStaking?: boolean;
     type: AccountType;
     // NOTE: this is to disable completely default click behavior of the item
     forceOnlyItemClick?: boolean;
@@ -37,6 +39,7 @@ type AccountsProps = {
 const Accounts = ({
     accounts,
     forceOnlyItemClick,
+    hideStaking,
     coinjoinIsPreloading,
     discoveryInProgress,
     type,
@@ -62,6 +65,7 @@ const Accounts = ({
                     <AccountSection
                         key={account.key}
                         forceOnlyItemClick={forceOnlyItemClick}
+                        hideStaking={hideStaking}
                         account={{
                             ...account,
                             accountLabel: accountLabels[account.key],
@@ -76,7 +80,11 @@ const Accounts = ({
     );
 };
 
-export const AccountsList = ({ forceOnlyItemClick, onItemClick }: AccountListProps) => {
+export const AccountsList = ({
+    forceOnlyItemClick,
+    hideStaking,
+    onItemClick,
+}: AccountListProps) => {
     const device = useSelector(selectSelectedDevice);
     const accounts = useSelector(selectAllAccountsToList);
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
@@ -155,11 +163,11 @@ export const AccountsList = ({ forceOnlyItemClick, onItemClick }: AccountListPro
                         hasBalance={groupHasBalance}
                         keepOpen={hideLabel || keepOpen(type)}
                     >
-                        <Accounts {...accountProps} />
+                        <Accounts hideStaking={hideStaking} {...accountProps} />
                     </AccountGroup>
                 </ExpandedSidebarOnly>
                 <CollapsedSidebarOnly>
-                    <Accounts {...accountProps} />
+                    <Accounts hideStaking={hideStaking} {...accountProps} />
                 </CollapsedSidebarOnly>
             </>
         );


### PR DESCRIPTION
… the accounts

<!--- Provide a general summary of your changes in the Title above -->

## Description

Hide "stakings" from the accounts menu in global send / receive modal, where you pick from or to which account to send funds.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


<img width="898" height="705" alt="Screenshot 2025-08-08 at 12 35 22 PM" src="https://github.com/user-attachments/assets/fb2365b0-9c61-482c-9216-7b22b6123a76" />
<img width="689" height="625" alt="Screenshot 2025-08-08 at 12 35 09 PM" src="https://github.com/user-attachments/assets/57e1bbb1-68be-49f5-a066-318541ea08e7" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=remove-staking-from-global-send&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=remove-staking-from-global-send&lookback=7)