### PR TITLE
Fix double text bio auth

### DIFF
--- a/packages/suite/src/actions/suite/bioAuthThunks.ts
+++ b/packages/suite/src/actions/suite/bioAuthThunks.ts
@@ -57,7 +57,7 @@ export const bioAuthWindowFocusThunk = createThunk(
     },
 );
 
-const KNOWN_ERROR_MESSAGES = new Set(['Authentication canceled.']);
+const KNOWN_ERROR_MESSAGES = ['Authentication canceled.'];
 
 export const requestBioAuthChangeThunk = createThunk(
     `${BIO_AUTH_PREFIX}/requestBioAuthChangeThunk`,
@@ -104,7 +104,7 @@ export const requestBioAuthChangeThunk = createThunk(
             dispatch(bioAuthActions.bioAuthValidated(null));
             console.error(error);
 
-            if (KNOWN_ERROR_MESSAGES.has(String(error))) {
+            if (KNOWN_ERROR_MESSAGES.some(message => String(error).includes(message))) {
                 // NOTE: known error message
                 return;
             }
@@ -152,7 +152,7 @@ export const requestBioAuthValidationThunk = createThunk(
             dispatch(bioAuthActions.bioAuthValidated(null));
             console.error(error);
 
-            if (KNOWN_ERROR_MESSAGES.has(String(error))) {
+            if (KNOWN_ERROR_MESSAGES.some(message => String(error).includes(message))) {
                 // NOTE: known error message
                 return;
             }

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1761,7 +1761,7 @@ export default defineMessages({
         id: 'TR_BIO_AUTH_FAILED',
     },
     TR_BIO_AUTH_SYSTEM_MESSAGE_MAC: {
-        defaultMessage: 'verify your identity. Touch ID or enter your password to allow this',
+        defaultMessage: 'verify your identity',
         id: 'TR_BIO_AUTH_SYSTEM_MESSAGE_MAC',
     },
     TR_BIO_AUTH_SYSTEM_MESSAGE_WIN: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- fixes double same text in the mac trigger bio auth window
- fixes problem when there was an error notification when user cancels the bio auth

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
<img width="304" height="329" alt="Screenshot 2025-08-08 at 12 47 38" src="https://github.com/user-attachments/assets/5d4c00ef-ed34-428d-93ac-2644aed0d8ff" />

After:
<img width="432" height="438" alt="Screenshot 2025-08-08 at 12 58 14 PM" src="https://github.com/user-attachments/assets/fb74c01a-b853-48e9-ac86-67e51831f2fd" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-double-text-bio-auth&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-double-text-bio-auth&lookback=7)