### PR TITLE
fix(connect): remove call to method.confirmation since it might use m…

### DIFF
--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -38,7 +38,6 @@ export interface MethodInfo {
     name: string;
     requiredPermissions: MethodPermission[];
     info: string;
-    confirmation?: UiRequestConfirmation['payload'];
     precomposed?: PrecomposeResultFinal;
 }
 
@@ -354,7 +353,8 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
             name: this.name,
             requiredPermissions: this.requiredPermissions,
             info: this.info,
-            confirmation: this.confirmation,
+            // confirmation can't be accessed here - it might use method.device which is not assigned yet
+            // confirmation: this.confirmation,
             precomposed: undefined, // will be filled in only if method.payloadToPrecomposed is implemented and both __info and __precompose param are sent
             // this could be used for more. it could tell clients what are min firmware versions (firmwareRange) and much more
         };


### PR DESCRIPTION
…ethod.device which is not defined at that moment

it would crash on methods like this - https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/api/wipeDevice.ts#L21

found while debugging tests in #19900 which are still failing :( (on something else) 

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-method-info&lookback=7)