### PR TITLE
fix(suite): don't show wallet-switcher when connecting physical over a view-only device

### DIFF
--- a/packages/suite/src/actions/wallet/handleDeviceConnectThunk.ts
+++ b/packages/suite/src/actions/wallet/handleDeviceConnectThunk.ts
@@ -8,14 +8,23 @@ import { Device } from '@trezor/connect';
 
 import { openSwitchDeviceDialog } from './addWalletThunk';
 
+/**
+ * Triggered by @trezor/connect events DEVICE.CONNECT or DEVICE.CONNECT_UNACQUIRED.
+ * @param device physical device that was just now connected (raw Connect device, not yet enriched to TrezorDevice type)
+ */
 export const handleDeviceConnect = createThunk(
     `${DEVICE_MODULE_PREFIX}/handleDeviceConnect`,
     (device: Device, { dispatch, getState }) => {
         const selectedDevice = selectSelectedDevice(getState());
 
-        // Select automatically when it is the first known device,
-        // or when we connected physical device corresponding to a selected remembered wallet.
-        const shouldSelectDevice = !selectedDevice || device.id === selectedDevice.id;
+        const shouldSelectDevice =
+            // Select automatically when it is the first encountered device,
+            !selectedDevice ||
+            // or when we connected physical device corresponding to a selected remembered wallet,
+            device.id === selectedDevice.id ||
+            // or when currently selected device is remembered, and a different device is physically connected.
+            !selectedDevice.connected;
+
         if (shouldSelectDevice) {
             dispatch(selectDeviceThunk({ device }));
         } else {

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -297,11 +297,18 @@ const sortDevices = (devices: TrezorDevice[]) =>
         if (a.id === b.id) {
             return 0;
         }
+
+        // NOTE: ensure that a is at the end
         if (a.id === PORTFOLIO_TRACKER_DEVICE_ID) {
             return 1;
         }
 
-        return -1;
+        // NOTE: ensure that b is at the end
+        if (b.id === PORTFOLIO_TRACKER_DEVICE_ID) {
+            return -1;
+        }
+
+        return 0;
     });
 
 export const initDevices = createThunk(


### PR DESCRIPTION
## Description

When selected device is remembered wallet, and you connect physical device, select that device automatically instead of opening wallet-switcher.

:thought_balloon: from UX perspective this IMO makes sense, because physically connecting a device is an act of users' will, that they want to interact with it, so if we focus this device it's nothing unexpected.

See screenshot description for the complex situation that this solves.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20158 a bit differently

## Screenshots:

- Refresh suite with two remembered devices T1B1 and T2T1, and only the T1B1 is now physically selected.
- When refreshing Suite, it only knows two remembered device (not connected).
- T2T1 starts selected only because it's the first in the list, though in this case it's the "wrong" one (see [initDevices](https://github.com/trezor/trezor-suite/blob/db326423a3c40a824342332c7fd62f6e3648053f/suite-common/wallet-core/src/device/deviceThunks.ts#L322))
- It isn't until a bit later that TrezorConnect emits DEVICE.CONNECT on the T1B1
  - (which has been physically connected the whole time)
- And the T1B1 **now** gets automatically selected **instead** wallet-switcher
- When connecting _also_ the T2T1, you get wallet-switcher 

[Screencast from 2025-08-08 14-33-16.webm](https://github.com/user-attachments/assets/15cda1b8-3185-4f8b-9aa6-15c203f44258)


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/wallet-switcher&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/wallet-switcher&lookback=7)