### PR TITLE
fix(suite-native): use ios_from_right as default navigation animation

### DIFF
--- a/suite-native/navigation/src/config.ts
+++ b/suite-native/navigation/src/config.ts
@@ -3,4 +3,5 @@ import { NativeStackNavigationOptions } from '@react-navigation/native-stack';
 export const stackNavigationOptionsConfig: NativeStackNavigationOptions = {
     headerShown: false,
     gestureEnabled: true,
+    animation: 'ios_from_right',
 } as const;


### PR DESCRIPTION
Changed to `ios_from_right` since the default Android animation looks really weird in some contexts. Change approved by Sheny.

https://github.com/user-attachments/assets/abeaef31-5eec-4072-8ed5-87d13637b0f5

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19933.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/navigation-animation&lookback=7)