### PR TITLE
fix(suite): make sure that the order isnt changed when there isnt a p…

### DIFF
--- a/packages/suite/src/actions/suite/initAction.ts
+++ b/packages/suite/src/actions/suite/initAction.ts
@@ -18,7 +18,7 @@ import * as languageActions from 'src/actions/settings/languageActions';
 import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
 import * as modalActions from 'src/actions/suite/modalActions';
 import * as routerActions from 'src/actions/suite/routerActions';
-import type { Dispatch, GetState } from 'src/types/suite';
+import type { AcquiredDevice, Dispatch, GetState } from 'src/types/suite';
 
 import { SUITE } from './constants';
 import { onSuiteReady, setFlag } from './suiteActions';
@@ -75,16 +75,33 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
         await dispatch(
             trezorConnectActions.connectInitThunk({
                 [DEVICE.CONNECT]: (_device, prevConnectedDevices) => {
-                    const previouslyConnectedDevices = prevConnectedDevices.filter(
-                        device => device.connected,
-                    );
+                    const previouslyConnectedUniqueDevices = prevConnectedDevices
+                        .filter(device => device.connected)
+                        .reduce<Map<string, AcquiredDevice>>((acc, device) => {
+                            if (device.id && !acc.has(device.id)) {
+                                acc.set(device.id, device);
+                            }
+
+                            return acc;
+                        }, new Map<string, AcquiredDevice>());
+
                     const currentConnectedDevices = selectDevices(getState()).filter(
                         device => device.connected,
                     );
 
+                    const uniqueConnectedDevices = currentConnectedDevices.reduce<
+                        Map<string, AcquiredDevice>
+                    >((acc, device) => {
+                        if (device.id && !acc.has(device.id)) {
+                            acc.set(device.id, device);
+                        }
+
+                        return acc;
+                    }, new Map<string, AcquiredDevice>());
+
                     if (
-                        currentConnectedDevices.length > 1 &&
-                        currentConnectedDevices.length > previouslyConnectedDevices.length
+                        uniqueConnectedDevices.size > 1 &&
+                        uniqueConnectedDevices.size > previouslyConnectedUniqueDevices.size
                     ) {
                         dispatch(
                             routerActions.goto('suite-switch-device', {

--- a/suite-common/wallet-core/src/device/deviceThunks.test.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.test.ts
@@ -1,0 +1,62 @@
+import type { TrezorDevice } from '@suite-common/suite-types';
+
+import { PORTFOLIO_TRACKER_DEVICE_ID, portfolioTrackerDevice } from './deviceConstants';
+import { sortDevices } from './deviceThunks';
+
+describe('deviceThunks', () => {
+    describe('sortDevices', () => {
+        const baseAcquired: TrezorDevice = {
+            ...portfolioTrackerDevice,
+            type: 'acquired',
+        } as TrezorDevice;
+
+        const createTestDevice = (id: string, ts: number): TrezorDevice =>
+            ({
+                ...baseAcquired,
+                id,
+                ts,
+            }) as TrezorDevice;
+
+        it('sorts by timestamp desc when no portfolio tracker devices are present', () => {
+            const input = [
+                createTestDevice('a', 1),
+                createTestDevice('b', 3),
+                createTestDevice('c', 2),
+            ];
+
+            const result = sortDevices(input);
+
+            expect(result.map(d => d.id)).toEqual(['b', 'c', 'a']);
+        });
+
+        it('moves portfolio tracker devices to the end while preserving timestamp order', () => {
+            const pt = PORTFOLIO_TRACKER_DEVICE_ID;
+            const input = [
+                createTestDevice('x', 4),
+                createTestDevice(pt, 10),
+                createTestDevice('y', 3),
+                createTestDevice(pt, 2),
+                createTestDevice('z', 8),
+            ];
+
+            const result = sortDevices(input);
+
+            expect(result.slice(0, 3).map(d => d.id)).toEqual(['z', 'x', 'y']);
+            expect(result.slice(3).map(d => d.id)).toEqual([pt, pt]);
+            expect(result.slice(3).map(d => d.ts)).toEqual([10, 2]);
+        });
+
+        it('does not mutate the input array', () => {
+            const input = [
+                createTestDevice('a', 1),
+                createTestDevice(PORTFOLIO_TRACKER_DEVICE_ID, 5),
+                createTestDevice('b', 3),
+            ];
+            const original = [...input];
+
+            void sortDevices(input);
+
+            expect(input).toEqual(original);
+        });
+    });
+});

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -292,17 +292,17 @@ export const switchDuplicatedDevice = createThunk(
 );
 
 // Sort devices by timestamp and put Portfolio Tracker device at the end.
-const sortDevices = (devices: TrezorDevice[]) =>
-    sortByTimestamp([...devices]).sort((a, b) => {
-        if (a.id === b.id) {
-            return 0;
-        }
-        if (a.id === PORTFOLIO_TRACKER_DEVICE_ID) {
-            return 1;
-        }
+export const sortDevices = (devices: TrezorDevice[]) => {
+    const sortedDevicesByTimestamp = sortByTimestamp([...devices]);
 
-        return -1;
-    });
+    const containsPortfolioTrackerDevices = sortedDevicesByTimestamp.filter(
+        device => device.id === PORTFOLIO_TRACKER_DEVICE_ID,
+    );
+
+    return sortedDevicesByTimestamp
+        .filter(device => device.id !== PORTFOLIO_TRACKER_DEVICE_ID)
+        .concat(containsPortfolioTrackerDevices);
+};
 
 export const initDevices = createThunk(
     `${DEVICE_MODULE_PREFIX}/initDevices`,


### PR DESCRIPTION
…ortfolio tracker device

<!--- Provide a general summary of your changes in the Title above -->

## Description

Problem: the sorting was wrong, when there was multiple devices it order was switched `(likely missed a branch like b.id === portfolioTrackerId) return -1`

Replaced with explicit puting to the end.

This may fix bug: https://github.com/trezor/trezor-suite/issues/20659

And also similar bugs when device swithcer opens completley needleslly (eg. when the disconnected device is first in the list)

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/20659


Also fixes bug when the device switcher is opened wrongly coz there is always first device selected when there are 2 devices

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=wrongly-sorted-initial-devices&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=wrongly-sorted-initial-devices&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=wrongly-sorted-initial-devices&lookback=7)