### PR TITLE
fix(suite): format sats as integer, not to cryptoDecimals

### DIFF
--- a/suite-common/wallet-utils/src/baseCurrency.ts
+++ b/suite-common/wallet-utils/src/baseCurrency.ts
@@ -143,5 +143,7 @@ export const parseBaseCurrencyToFormattedCrypto = ({
         : cryptoAmount;
 
     // 4. We have to return this correctly rounded as this value is used in the NumberInput
-    return valueToDisplay?.toFixed(cryptoDecimals) ?? null;
+    const finalValueDecimals = isCryptoInSats ? 0 : cryptoDecimals; // round units, not subunits
+
+    return valueToDisplay?.toFixed(finalValueDecimals) ?? null;
 };


### PR DESCRIPTION
## Description

When crypto is calculated from fiat, it is rounded to cryptoDecimals, e.g. 8 for BTC.
But when the crypto is sat, it should not be rounded to 8 decimals, but 0 decimals.

## Related Issue

Resolve #20594

## Screenshots:

[Screencast from 2025-08-08 15-42-49.webm](https://github.com/user-attachments/assets/11ae5c11-dd7b-4476-8b2d-785741d2eda4)



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/rounding-sendform&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/rounding-sendform&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/rounding-sendform&lookback=7)