### PR TITLE
fix(e2e): expect correct device status selector

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/suite/initial-run.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/initial-run.test.ts
@@ -40,11 +40,12 @@ test.describe('Suite initial run', { tag: ['@group=suite'] }, () => {
 
     test('Once user passed trough, skips initial run and shows connect-device modal', async ({
         page,
-        dashboardPage,
         onboardingPage,
     }) => {
         await onboardingPage.completeOnboarding();
         await page.reload();
-        await expect(dashboardPage.deviceSwitchingOpenButton).toContainText('Connected');
+        await expect(page.getByTestId('@deviceStatus-connected').first()).toBeVisible({
+            timeout: 30_000,
+        });
     });
 });

--- a/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
@@ -58,12 +58,14 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
             });
 
             await test.step('After reloading inactive suite session does not take Bridge session back', async () => {
-                await expect(dashboardPage.deviceStatusOnSwitchDevice).toHaveText('Disconnected');
+                await expect(page.getByTestId('@deviceStatus-disconnected').first()).toBeVisible({
+                    timeout: 30_000,
+                });
             });
 
             await test.step('Take Bridge session back', async () => {
                 await dashboardPage.solveIssuesButton.click();
-                await expect(dashboardPage.deviceStatusOnSwitchDevice).toHaveText('Connected');
+                await expect(page.getByTestId('@deviceStatus-connected').first()).toBeVisible();
             });
         },
     );


### PR DESCRIPTION
## Description

Reason:

`@menu/switch-device` is the container, and it contains either `@deviceStatus-connected` or `@deviceStatus-disconnected`

But depending on timing, when you load suite it most usually **first** shows Disconnected, then Connected.
So if you await the container and expect it to contain Connected, you'll be disappointed because the element is found, but at the time, it contains different text (for a fraction of second, but it fails the test).

:point_right: Need to await the Connected element.

Also, there may be multiple devices with remembered wallets. That's why I use `.first()` because `toBeVisible` is strict and fails otherwise ( :thought_balloon: could it happen that the first one is _not_ visible but the 2nd one is, and we should expect that one? Idk, this works)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/e2e-device-status-assertions&lookback=7)