### PR TITLE
fix(connect): cloneObject bottleneck in coinInfo

### DIFF
--- a/packages/connect/src/data/coinInfo.ts
+++ b/packages/connect/src/data/coinInfo.ts
@@ -15,48 +15,46 @@ const ethereumNetworks: EthereumNetworkInfo[] = [];
 const miscNetworks: MiscNetworkInfo[] = [];
 
 export const getBitcoinNetwork = (pathOrName: DerivationPath) => {
-    const networks = cloneObject(bitcoinNetworks);
     if (typeof pathOrName === 'string') {
         const name = pathOrName.toLowerCase();
 
-        return networks.find(
+        return bitcoinNetworks.find(
             n =>
                 n.name.toLowerCase() === name ||
                 n.shortcut.toLowerCase() === name ||
                 n.label.toLowerCase() === name,
-        );
+        ) as Readonly<BitcoinNetworkInfo>;
     }
     const slip44 = fromHardened(pathOrName[1]);
 
-    return networks.find(n => n.slip44 === slip44);
+    return bitcoinNetworks.find(n => n.slip44 === slip44) as Readonly<BitcoinNetworkInfo>;
 };
 
 export const getEthereumNetwork = (pathOrNetworkSymbol: DerivationPath) => {
-    const networks = cloneObject(ethereumNetworks);
-
     if (typeof pathOrNetworkSymbol === 'string') {
         const networkSymbol = pathOrNetworkSymbol.toLowerCase();
 
-        return networks.find(network => network.shortcut.toLowerCase() === networkSymbol);
+        return ethereumNetworks.find(
+            network => network.shortcut.toLowerCase() === networkSymbol,
+        ) as Readonly<EthereumNetworkInfo>;
     }
 
     const slip44 = fromHardened(pathOrNetworkSymbol[1]);
 
-    return networks.find(n => n.slip44 === slip44);
+    return ethereumNetworks.find(n => n.slip44 === slip44) as Readonly<EthereumNetworkInfo>;
 };
 
 export const getMiscNetwork = (pathOrName: DerivationPath) => {
-    const networks = cloneObject(miscNetworks);
     if (typeof pathOrName === 'string') {
         const name = pathOrName.toLowerCase();
 
-        return networks.find(
+        return miscNetworks.find(
             n => n.name.toLowerCase() === name || n.shortcut.toLowerCase() === name,
-        );
+        ) as Readonly<MiscNetworkInfo>;
     }
     const slip44 = fromHardened(pathOrName[1]);
 
-    return networks.find(n => n.slip44 === slip44);
+    return miscNetworks.find(n => n.slip44 === slip44) as Readonly<MiscNetworkInfo>;
 };
 
 /*


### PR DESCRIPTION
## Description

Found this performance issue when troubleshooting lags in Suite mobile. The extra `cloneObject` is expensive due to the size of `coins.json` and causes extra garbage collector runs whenever it's used.

<img width="1048" height="377" alt="Screenshot 2025-08-07 at 13 54 24" src="https://github.com/user-attachments/assets/b490058e-a7b5-4161-b436-c907bc6d1738" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-cloneobject-optimization&lookback=7)