### PR TITLE
Trading - Approval States + Revoke Modal

### DIFF
--- a/packages/suite-data/files/translations/en-US.json
+++ b/packages/suite-data/files/translations/en-US.json
@@ -969,7 +969,7 @@
   "TR_EXCHANGE_APPROVAL_DATA": "Approval transaction data",
   "TR_EXCHANGE_APPROVAL_ERROR": "Failed to load approval status",
   "TR_EXCHANGE_APPROVAL_FORM_APPROVAL_REVOKED": "Approval revoked",
-  "TR_EXCHANGE_APPROVAL_FORM_APPROVE_BUTTON": "Approve",
+  "TR_EXCHANGE_APPROVAL_FORM_APPROVE_BUTTON": "Set & approve spending",
   "TR_EXCHANGE_APPROVAL_FORM_PENDING_PREFIX": "Transaction with ID",
   "TR_EXCHANGE_APPROVAL_FORM_PENDING_SUFFIX": "is being processed",
   "TR_EXCHANGE_APPROVAL_FORM_READY_TO_SWAP": "Ready to swap",

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { DexApprovalType, ExchangeTrade } from 'invity-api';
 import styled from 'styled-components';
@@ -46,7 +46,7 @@ const Icon = styled.img`
 
 type ApproveModalProps = {
     setApprovalType: (approvalType: TradingExchangeApprovalType) => void;
-    onCancel: () => void;
+    onCancel: (isSubmitting?: boolean) => void;
 };
 
 export const ApproveModal = ({
@@ -84,12 +84,6 @@ export const ApproveModal = ({
 
     const [approvalType, setApprovalType] = useState<DexApprovalType>('MINIMAL');
     const [isConfirmButtonLoading, setIsConfirmButtonLoading] = useState<boolean>(false);
-
-    useEffect(() => {
-        if (selectedQuote?.status !== 'APPROVAL_REQ') {
-            onCancel();
-        }
-    }, [selectedQuote?.status, onCancel]);
 
     if (!selectedQuote) return null;
 
@@ -149,6 +143,7 @@ export const ApproveModal = ({
         setIsConfirmButtonLoading(true);
         await sendTransaction();
         setIsConfirmButtonLoading(false);
+        onCancel(true);
     };
 
     const { coinSymbol, contractAddress } = cryptoIdToSymbolAndContractAddress(selectedQuote.send);
@@ -162,7 +157,7 @@ export const ApproveModal = ({
 
     return (
         <Modal
-            onCancel={onCancel}
+            onCancel={() => onCancel()}
             variant="primary"
             size="small"
             heading={
@@ -184,7 +179,7 @@ export const ApproveModal = ({
                         </Modal.Button>
                     )}
 
-                    <Modal.Button size="medium" variant="tertiary" onClick={onCancel}>
+                    <Modal.Button size="medium" variant="tertiary" onClick={() => onCancel()}>
                         <Translation id="TR_CANCEL" />
                     </Modal.Button>
                 </>
@@ -201,7 +196,11 @@ export const ApproveModal = ({
             }
         >
             <Column gap={spacings.sm}>
-                <Box padding={spacings.sm} borderWidth={borders.widths.large} borderRadius="12px">
+                <Box
+                    padding={spacings.sm}
+                    borderWidth={borders.widths.large}
+                    borderRadius={borders.radii.sm}
+                >
                     <Column gap={spacings.sm}>
                         <Text>
                             <Translation id="TR_EXCHANGE_APPROVAL_PROVIDER" />
@@ -220,7 +219,11 @@ export const ApproveModal = ({
                     </Column>
                 </Box>
 
-                <Box borderWidth={borders.widths.large} padding={spacings.sm} borderRadius="12px">
+                <Box
+                    borderWidth={borders.widths.large}
+                    padding={spacings.sm}
+                    borderRadius={borders.radii.sm}
+                >
                     <Column gap={spacings.sm}>
                         <Text>
                             <Translation id="TR_EXCHANGE_APPROVAL_SET_LIMIT" />
@@ -297,7 +300,11 @@ export const ApproveModal = ({
                     </Column>
                 </Box>
 
-                <Box padding={spacings.sm} borderWidth={borders.widths.large} borderRadius="12px">
+                <Box
+                    padding={spacings.sm}
+                    borderWidth={borders.widths.large}
+                    borderRadius={borders.radii.sm}
+                >
                     <Fees
                         label="TR_TX_FEE"
                         control={control}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal.tsx
@@ -1,0 +1,236 @@
+import { useState } from 'react';
+
+import styled from 'styled-components';
+
+import { TradingExchangeType, invityAPI, useTradingInfo } from '@suite-common/trading';
+import { getDisplaySymbol } from '@suite-common/wallet-config';
+import {
+    Badge,
+    Banner,
+    Box,
+    CollapsibleBox,
+    Column,
+    Divider,
+    Icon,
+    Modal,
+    Row,
+    Text,
+} from '@trezor/components';
+import { CoinLogo } from '@trezor/product-components';
+import { borders, spacings } from '@trezor/theme';
+
+import { Translation } from 'src/components/suite/Translation';
+import { AccountLabeling } from 'src/components/suite/labeling';
+import { Fees } from 'src/components/wallet/Fees/Fees';
+import { useSelector } from 'src/hooks/suite';
+import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
+import { getProvidersInfoProps } from 'src/utils/wallet/trading/tradingTypingUtils';
+import { tokenSupportsIncreasingAllowance } from 'src/utils/wallet/trading/tradingUtils';
+import { TradingCoinLogo } from 'src/views/wallet/trading/common/TradingCoinLogo';
+
+const BreakableValue = styled.span`
+    word-break: break-all;
+`;
+
+const CustomIcon = styled.img`
+    flex: none;
+    width: 24px;
+    height: 24px;
+`;
+
+type RevokeModalProps = {
+    onCancel: (isSubmitting?: boolean) => void;
+};
+
+export const RevokeModal = ({ onCancel }: RevokeModalProps) => {
+    const context = useTradingFormContext<TradingExchangeType>();
+    const {
+        form: {
+            state: { isFormLoading },
+        },
+        device,
+        account,
+        selectedQuote,
+        sendTransaction,
+        control,
+        feeInfo,
+        composedLevels,
+        formState: { errors, isDirty },
+        register,
+        setValue,
+        getValues,
+        changeFeeLevel,
+        trigger,
+    } = context;
+
+    const isDebug = useSelector(selectIsDebugModeActive);
+
+    const { cryptoIdToSymbolAndContractAddress } = useTradingInfo();
+
+    const [isConfirmButtonLoading, setIsConfirmButtonLoading] = useState<boolean>(false);
+
+    if (!selectedQuote?.exchange || !selectedQuote?.dexTx || !selectedQuote?.send) {
+        return null;
+    }
+
+    const confirmAndSend = async () => {
+        setIsConfirmButtonLoading(true);
+        await sendTransaction();
+        setIsConfirmButtonLoading(false);
+        onCancel(true);
+    };
+
+    const { coinSymbol, contractAddress } = cryptoIdToSymbolAndContractAddress(selectedQuote.send);
+    const displaySymbol = coinSymbol && getDisplaySymbol(coinSymbol, contractAddress);
+    const isIncreasingAllowanceSupported = tokenSupportsIncreasingAllowance(contractAddress);
+
+    const providers = getProvidersInfoProps(context);
+    const provider =
+        selectedQuote && selectedQuote.exchange && providers
+            ? providers[selectedQuote.exchange]
+            : undefined;
+
+    return (
+        <Modal
+            onCancel={() => onCancel()}
+            variant="primary"
+            size="small"
+            heading={
+                <Translation
+                    id="TR_EXCHANGE_APPROVAL_REVOKE_TOKEN_SPENDING"
+                    values={{ displaySymbol }}
+                />
+            }
+            bottomContent={
+                <>
+                    <Modal.Button
+                        size="medium"
+                        isLoading={isFormLoading || isConfirmButtonLoading}
+                        isDisabled={!device?.connected}
+                        onClick={confirmAndSend}
+                    >
+                        <Translation id="TR_CONTINUE" />
+                    </Modal.Button>
+
+                    <Modal.Button size="medium" variant="tertiary" onClick={() => onCancel()}>
+                        <Translation id="TR_CANCEL" />
+                    </Modal.Button>
+                </>
+            }
+            description={
+                <Row margin={{ top: spacings.xs }} gap={spacings.xxs}>
+                    <CoinLogo size={20} symbol={account.symbol} />
+                    <AccountLabeling
+                        account={account}
+                        showAccountTypeBadge
+                        accountTypeBadgeSize="small"
+                    />
+                </Row>
+            }
+        >
+            <Column gap={spacings.sm}>
+                {!isIncreasingAllowanceSupported && (
+                    <Banner variant="info" icon="info">
+                        <Translation
+                            id="TR_EXCHANGE_APPROVAL_MODAL_REVOKE_BANNER"
+                            values={{ displaySymbol }}
+                        />
+                    </Banner>
+                )}
+
+                <Box
+                    borderWidth={borders.widths.large}
+                    padding={spacings.sm}
+                    borderRadius={borders.radii.sm}
+                >
+                    <Column gap={spacings.sm}>
+                        <Column gap={spacings.sm}>
+                            <Text>
+                                <Translation id="TR_EXCHANGE_APPROVAL_PROVIDER" />
+                            </Text>
+                            <Row gap={spacings.xs}>
+                                {provider?.logo && (
+                                    <CustomIcon
+                                        src={invityAPI.getProviderLogoUrl(provider.logo)}
+                                        alt={provider.logo}
+                                    />
+                                )}
+                                <Column>
+                                    {provider?.companyName && <Text>{provider.companyName}</Text>}
+                                    <Text typographyStyle="hint" variant="tertiary">
+                                        {contractAddress}
+                                    </Text>
+                                </Column>
+                            </Row>
+                        </Column>
+
+                        <Divider margin={{ top: 0, bottom: 0 }} />
+
+                        <Row alignItems="flex-start" gap={spacings.xxxxl}>
+                            <Column gap={spacings.sm} flex="1" overflow="hidden">
+                                <Text>
+                                    <Translation id="TR_EXCHANGE_APPROVAL_CURRENT_LIMIT" />
+                                </Text>
+                                <Row gap={spacings.sm}>
+                                    <TradingCoinLogo cryptoId={selectedQuote.send} size={24} />
+                                    {selectedQuote.preapprovedStringAmount} {displaySymbol}
+                                </Row>
+                            </Column>
+
+                            <Column alignSelf="center">
+                                <Icon name="arrowRight" />
+                            </Column>
+
+                            <Column gap={spacings.sm} flex="1">
+                                <Text>
+                                    <Translation id="TR_EXCHANGE_APPROVAL_NEW_LIMIT" />
+                                </Text>
+                                <Row gap={spacings.sm}>
+                                    <TradingCoinLogo cryptoId={selectedQuote.send} size={24} />0{' '}
+                                    {displaySymbol}
+                                </Row>
+                            </Column>
+                        </Row>
+
+                        {isDebug && selectedQuote.dexTx.data ? (
+                            <CollapsibleBox
+                                heading={
+                                    <Row gap={spacings.xs}>
+                                        <Translation id="TR_EXCHANGE_APPROVAL_DATA" />
+                                        <Badge variant="warning" size="small">
+                                            <Translation id="TR_DEBUG_ONLY" />
+                                        </Badge>
+                                    </Row>
+                                }
+                            >
+                                <BreakableValue>{selectedQuote.dexTx.data}</BreakableValue>
+                            </CollapsibleBox>
+                        ) : null}
+                    </Column>
+                </Box>
+
+                <Box
+                    padding={spacings.sm}
+                    borderWidth={borders.widths.large}
+                    borderRadius={borders.radii.sm}
+                >
+                    <Fees
+                        label="TR_TX_FEE"
+                        control={control}
+                        feeInfo={feeInfo}
+                        account={account}
+                        composedLevels={composedLevels}
+                        errors={errors}
+                        isDirty={isDirty}
+                        register={register}
+                        setValue={setValue}
+                        getValues={getValues}
+                        changeFeeLevel={changeFeeLevel}
+                        trigger={trigger}
+                    />
+                </Box>
+            </Column>
+        </Modal>
+    );
+};

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -718,15 +718,14 @@ export const useTradingExchangeForm = ({
     const revokeApproval = async (trade: ExchangeTrade) => {
         if (!trade.receiveAddress) return false;
 
-        const approvalType: DexApprovalType = 'ZERO';
+        setApprovalInitiated(true);
 
+        const approvalType: DexApprovalType = 'ZERO';
         const updatedTrade: ExchangeTrade = {
             ...trade,
             approvalType,
-            status: 'CONFIRM',
+            status: trade.status === 'APPROVAL_REQ' ? 'APPROVAL_REQ' : 'CONFIRM',
         };
-
-        setApprovalInitiated(true);
 
         dispatch(tradingExchangeActions.saveSelectedQuote(updatedTrade));
 
@@ -735,11 +734,7 @@ export const useTradingExchangeForm = ({
             receiveAddress: trade.receiveAddress,
         });
 
-        if (!newTrade) {
-            return false;
-        }
-
-        return await sendTransaction();
+        return !!newTrade;
     };
 
     const fetchApprovalStatus = async (trade?: ExchangeTrade) => {
@@ -764,6 +759,11 @@ export const useTradingExchangeForm = ({
         await handleChange();
     };
 
+    const fetchFeesAndCompose = async () => {
+        await dispatch(updateFeeInfoThunk({ networkSymbol: account.symbol })).unwrap();
+        composeRequest();
+    };
+
     useEffect(() => {
         if (isPreviousRouteFromTradeSection && tradingAccountKey !== selectedAccount.account?.key) {
             setShouldUseTradingAccountKey(true);
@@ -780,11 +780,6 @@ export const useTradingExchangeForm = ({
         selectedAccount.account?.key,
         tradingAccountKey,
     ]);
-
-    const fetchFeesAndCompose = async () => {
-        await dispatch(updateFeeInfoThunk({ networkSymbol: account.symbol })).unwrap();
-        composeRequest();
-    };
 
     useEffect(() => {
         dispatch(tradingThunks.loadInitialDataThunk({ activeSection: type }));

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -534,77 +534,59 @@ export default defineMessages({
         defaultMessage: '{providerName}’s address',
         id: 'TR_EXCHANGE_SEND_TO',
     },
-    TR_EXCHANGE_APPROVAL_ERROR: {
-        defaultMessage: 'Failed to load approval status',
-        id: 'TR_EXCHANGE_APPROVAL_ERROR',
-    },
     TR_EXCHANGE_APPROVAL_APPROVE_TOKEN_SPENDING: {
         defaultMessage: 'Set {displaySymbol} spending',
         id: 'TR_EXCHANGE_APPROVAL_APPROVE_TOKEN_SPENDING',
     },
-    TR_EXCHANGE_APPROVAL_APPROVE_TOKEN: {
-        defaultMessage: 'Approve {displaySymbol}',
-        id: 'TR_EXCHANGE_APPROVAL_APPROVE_TOKEN',
-    },
-    TR_EXCHANGE_APPROVAL_LIMIT: {
-        defaultMessage: 'Approval limit',
-        id: 'TR_EXCHANGE_APPROVAL_LIMIT',
-    },
-    TR_EXCHANGE_APPROVAL_LIMIT_MINIMAL: {
-        defaultMessage: 'Minimum',
-        id: 'TR_EXCHANGE_APPROVAL_LIMIT_MINIMAL',
-    },
-    TR_EXCHANGE_APPROVAL_LIMIT_INFINITE: {
-        defaultMessage: 'Unlimited',
-        id: 'TR_EXCHANGE_APPROVAL_LIMIT_INFINITE',
-    },
-    TR_EXCHANGE_APPROVAL_FORM_REQUIRED: {
-        defaultMessage: 'Approval is required',
-        id: 'TR_EXCHANGE_APPROVAL_FORM_REQUIRED',
-    },
-    TR_EXCHANGE_APPROVAL_FORM_PENDING_PREFIX: {
-        defaultMessage: 'Transaction with ID',
-        id: 'TR_EXCHANGE_APPROVAL_FORM_PENDING_PREFIX',
-    },
-    TR_EXCHANGE_APPROVAL_FORM_PENDING_SUFFIX: {
-        defaultMessage: 'is being processed',
-        id: 'TR_EXCHANGE_APPROVAL_FORM_PENDING_SUFFIX',
-    },
-    TR_EXCHANGE_APPROVAL_FORM_READY_TO_SWAP: {
-        defaultMessage: 'Ready to swap',
-        id: 'TR_EXCHANGE_APPROVAL_FORM_READY_TO_SWAP',
-    },
-    TR_EXCHANGE_APPROVAL_FORM_APPROVAL_REVOKED: {
-        defaultMessage: 'Approval revoked',
-        id: 'TR_EXCHANGE_APPROVAL_FORM_APPROVAL_REVOKED',
-    },
-    TR_EXCHANGE_APPROVAL_FORM_TITLE: {
-        defaultMessage: 'Contract approval',
-        id: 'TR_EXCHANGE_APPROVAL_FORM_TITLE',
+    TR_EXCHANGE_APPROVAL_REVOKE_TOKEN_SPENDING: {
+        defaultMessage: 'Revoke {displaySymbol} spending',
+        id: 'TR_EXCHANGE_APPROVAL_REVOKE_TOKEN_SPENDING',
     },
     TR_EXCHANGE_APPROVAL_FORM_APPROVE_BUTTON: {
-        defaultMessage: 'Approve',
+        defaultMessage: 'Set & approve spending',
         id: 'TR_EXCHANGE_APPROVAL_FORM_APPROVE_BUTTON',
     },
     TR_EXCHANGE_APPROVAL_FORM_REVOKE_BUTTON: {
         defaultMessage: 'Revoke approval',
         id: 'TR_EXCHANGE_APPROVAL_FORM_REVOKE_BUTTON',
     },
+    TR_EXCHANGE_APPROVAL_FORM_INCREASE_BUTTON: {
+        defaultMessage: 'Increase approval',
+        id: 'TR_EXCHANGE_APPROVAL_FORM_INCREASE_BUTTON',
+    },
     TR_EXCHANGE_APPROVAL_FORM_REFRESH_BUTTON: {
         defaultMessage: 'Refresh',
         id: 'TR_EXCHANGE_APPROVAL_FORM_REFRESH_BUTTON',
     },
-    TR_EXCHANGE_APPROVAL_FORM_TX_PROCESSED: {
-        defaultMessage: 'The approval transaction has been processed successfully.',
-        id: 'TR_EXCHANGE_APPROVAL_FORM_TX_PROCESSED',
+    TR_EXCHANGE_APPROVAL_FORM_REVOKE_BANNER: {
+        defaultMessage:
+            'The approved amount is too low. To increase it, first revoke the current approval, then set a higher limit.',
+        id: 'TR_EXCHANGE_APPROVAL_FORM_REVOKE_BANNER',
     },
-    TR_EXCHANGE_APPROVAL_SEND_TO: {
-        defaultMessage: '{send} contract',
-        id: 'TR_EXCHANGE_APPROVAL_SEND_TO',
+    TR_EXCHANGE_APPROVAL_MODAL_REVOKE_BANNER: {
+        defaultMessage:
+            "{displaySymbol} doesn't support increasing limits. You need to revoke the current approval before setting a higher one.",
+        id: 'TR_EXCHANGE_APPROVAL_MODAL_REVOKE_BANNER',
     },
-    TR_EXCHANGE_APPROVAL_VALUE: {
-        defaultMessage: 'Approval value',
-        id: 'TR_EXCHANGE_APPROVAL_VALUE',
+    TR_EXCHANGE_APPROVAL_FORM_CONFIRMING_APPROVAL: {
+        defaultMessage: 'Confirming approval...',
+        id: 'TR_EXCHANGE_APPROVAL_FORM_CONFIRMING_APPROVAL',
+    },
+    TR_EXCHANGE_APPROVAL_FORM_REVOKING_APPROVAL: {
+        defaultMessage: 'Revoking approval...',
+        id: 'TR_EXCHANGE_APPROVAL_FORM_REVOKING_APPROVAL',
+    },
+    TR_EXCHANGE_APPROVAL_FORM_TRANSACTION_ID: {
+        defaultMessage: 'Transaction ID:',
+        id: 'TR_EXCHANGE_APPROVAL_FORM_TRANSACTION_ID',
+    },
+    TR_EXCHANGE_APPROVAL_CURRENT_LIMIT: {
+        defaultMessage: 'Current limit',
+        id: 'TR_EXCHANGE_APPROVAL_CURRENT_LIMIT',
+    },
+    TR_EXCHANGE_APPROVAL_NEW_LIMIT: {
+        defaultMessage: 'New limit',
+        id: 'TR_EXCHANGE_APPROVAL_NEW_LIMIT',
     },
     TR_EXCHANGE_APPROVAL_VALUE_MINIMAL: {
         defaultMessage: '{value} {send}',
@@ -624,22 +606,9 @@ export default defineMessages({
             'Approve unlimited {send} to skip future approval requests and reduce fees. Only use this option if you trust {provider}, as it will have access to all your {send}.',
         id: 'TR_EXCHANGE_APPROVAL_VALUE_INFINITE_INFO',
     },
-    TR_EXCHANGE_APPROVAL_VALUE_ZERO: {
-        defaultMessage: 'Revoke previous approval of {value} {send}',
-        id: 'TR_EXCHANGE_APPROVAL_VALUE_ZERO',
-    },
-    TR_EXCHANGE_APPROVAL_VALUE_ZERO_INFO: {
-        defaultMessage:
-            'Perform a transaction that will remove previous approval of contract with {provider}.',
-        id: 'TR_EXCHANGE_APPROVAL_VALUE_ZERO_INFO',
-    },
     TR_EXCHANGE_APPROVAL_DATA: {
         defaultMessage: 'Approval transaction data',
         id: 'TR_EXCHANGE_APPROVAL_DATA',
-    },
-    TR_EXCHANGE_APPROVAL_NOT_REQUIRED: {
-        defaultMessage: 'No approval transaction needed for {send}.',
-        id: 'TR_EXCHANGE_APPROVAL_NOT_REQUIRED',
     },
     TR_EXCHANGE_APPROVAL_PROVIDER: {
         defaultMessage: 'Provider',

--- a/packages/suite/src/utils/wallet/trading/tradingUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/tradingUtils.ts
@@ -392,3 +392,12 @@ export const getTradeTypeByRoute = (
         return 'exchange';
     }
 };
+
+export const tokenSupportsIncreasingAllowance = (contractAddress?: string) => {
+    const ethereumUsdtContractAddress = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
+
+    return (
+        contractAddress &&
+        contractAddress.trim().toLowerCase() !== ethereumUsdtContractAddress.toLowerCase()
+    );
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
@@ -1,11 +1,11 @@
-import { ReactNode, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { usePrevious } from 'react-use';
 
 import styled, { DefaultTheme, keyframes } from 'styled-components';
 
-import { TradingExchangeType, tradingExchangeActions } from '@suite-common/trading';
+import { TradingExchangeType, tradingExchangeActions, useTradingInfo } from '@suite-common/trading';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
-import { Button, Card, Column, Icon, IconVariant, Paragraph, Row } from '@trezor/components';
+import { Banner, Button, Column, Icon, Paragraph, Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
@@ -14,6 +14,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingExchangeWatchApproval } from 'src/hooks/wallet/trading/form/useTradingExchangeWatchApproval';
 import { TradingExchangeApprovalType } from 'src/types/trading/tradingForm';
+import { tokenSupportsIncreasingAllowance } from 'src/utils/wallet/trading/tradingUtils';
 
 const TextButton = styled.div<{ $disabled: boolean }>`
     color: ${({ theme, $disabled }) =>
@@ -26,15 +27,6 @@ const TextButton = styled.div<{ $disabled: boolean }>`
     }
 `;
 
-const IconWrapper = styled.div`
-    background-color: inherit;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transform: translateY(2px);
-`;
-
 const loadingAnimation = keyframes`
     from {
         transform: rotate(0deg);
@@ -44,47 +36,22 @@ const loadingAnimation = keyframes`
     }
 `;
 
-const LoadingIconWrapper = styled.div`
+const IconWrapper = styled.div`
+    background-color: inherit;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transform: translateY(2px);
+
     animation: ${loadingAnimation} 1s linear infinite;
 `;
-
-type IconProps = { variant?: IconVariant };
-
-const IconCheck = ({ variant }: IconProps) => (
-    <Icon name="checkCircle" size="mediumLarge" variant={variant} />
-);
-
-const IconPending = ({ variant }: IconProps) => (
-    <Icon name="clock" size="mediumLarge" variant={variant} />
-);
-
-const IconLoading = ({ variant }: IconProps) => (
-    <LoadingIconWrapper>
-        <Icon name="spinnerGap" size="mediumLarge" variant={variant} />
-    </LoadingIconWrapper>
-);
-
-const IconCircle = ({ variant }: IconProps) => (
-    <Icon name="circle" size="mediumLarge" variant={variant} />
-);
-
-const IconError = ({ variant }: IconProps) => (
-    <Icon name="xCircle" size="mediumLarge" variant={variant} />
-);
-
-const ApprovalStep = ({ label, icon }: { label: ReactNode; icon: ReactNode }) => (
-    <Row gap={spacings.sm} alignItems="flex-start">
-        <IconWrapper>{icon}</IconWrapper>
-        <Paragraph typographyStyle="body" variant="tertiary" align="start">
-            {label}
-        </Paragraph>
-    </Row>
-);
 
 type ApprovalStep = 'REQUIRED' | 'APPROVED' | 'LOADING' | 'ERROR';
 
 interface TradingFormApprovalProps {
     openApproveModal: () => void;
+    openRevokeModal: () => void;
     approvalType: TradingExchangeApprovalType;
     setApprovalType: (approvalType: TradingExchangeApprovalType) => void;
     isManuallyApproved: boolean;
@@ -93,9 +60,9 @@ interface TradingFormApprovalProps {
 
 export const TradingFormApproval = ({
     openApproveModal,
+    openRevokeModal,
     approvalType,
     setApprovalType,
-    isManuallyApproved,
     setIsManuallyApproved,
 }: TradingFormApprovalProps) => {
     const dispatch = useDispatch();
@@ -133,6 +100,8 @@ export const TradingFormApproval = ({
         selectedQuote,
         watchApproval,
     });
+
+    const { cryptoIdToSymbolAndContractAddress } = useTradingInfo();
 
     useEffect(() => {
         if (currentQuoteStatus === 'ERROR') {
@@ -220,7 +189,6 @@ export const TradingFormApproval = ({
         await approveTransaction(selectedQuote);
 
         setIsApproveButtonLoading(false);
-
         openApproveModal();
     };
 
@@ -235,6 +203,7 @@ export const TradingFormApproval = ({
         await revokeApproval(selectedQuote);
 
         setIsRevokeButtonLoading(false);
+        openRevokeModal();
     };
 
     const onProceedToSwapClick = async () => {
@@ -292,124 +261,85 @@ export const TradingFormApproval = ({
     const isRefreshButtonDisabled =
         isRefreshButtonLoading || isFormLoading || isScheduledQuotesRefresh || isDiscoveryRunning;
 
+    const isApprovalTxPreApproved =
+        selectedQuote?.preapprovedStringAmount && selectedQuote.preapprovedStringAmount !== '0';
+
+    const { contractAddress } = cryptoIdToSymbolAndContractAddress(selectedQuote?.send);
+    const isIncreasingAllowanceSupported = tokenSupportsIncreasingAllowance(contractAddress);
+
     return (
         <Column gap={spacings.md} alignItems="center">
-            <Card paddingType="none" margin={{ bottom: spacings.md }}>
-                <Column
-                    margin={{ horizontal: spacings.xxs, vertical: spacings.xxs }}
-                    gap={spacings.xxs}
-                >
-                    <Paragraph
-                        typographyStyle="label"
-                        variant="tertiary"
-                        align="start"
-                        margin={{ vertical: spacings.xxs, horizontal: spacings.sm }}
-                    >
-                        <Translation id="TR_EXCHANGE_APPROVAL_FORM_TITLE" />
-                    </Paragraph>
-
-                    <Card>
-                        <Column gap={spacings.sm}>
-                            {approvalStep === 'REQUIRED' && (
+            {approvalStep === 'REQUIRED' && (
+                <>
+                    {isApprovalTxPreApproved ? (
+                        <>
+                            {!isIncreasingAllowanceSupported ? (
                                 <>
-                                    <ApprovalStep
-                                        label={
-                                            <Translation id="TR_EXCHANGE_APPROVAL_FORM_REQUIRED" />
-                                        }
-                                        icon={<IconPending variant="tertiary" />}
-                                    />
+                                    <Button
+                                        onClick={onRevokeApprovalClick}
+                                        variant="primary"
+                                        isFullWidth
+                                        isLoading={isRevokeButtonLoading}
+                                        isDisabled={isRevokeButtonDisabled}
+                                    >
+                                        <Translation id="TR_EXCHANGE_APPROVAL_FORM_REVOKE_BUTTON" />
+                                    </Button>
 
-                                    <ApprovalStep
-                                        label={
-                                            <Translation id="TR_EXCHANGE_APPROVAL_FORM_READY_TO_SWAP" />
+                                    <Banner variant="warning" icon="warning">
+                                        <Translation id="TR_EXCHANGE_APPROVAL_FORM_REVOKE_BANNER" />
+                                    </Banner>
+                                </>
+                            ) : (
+                                <>
+                                    <Button
+                                        onClick={onApproveTransactionClick}
+                                        variant="primary"
+                                        isFullWidth
+                                        isLoading={
+                                            isApproveButtonLoading ||
+                                            isRevokeButtonLoading ||
+                                            (preselectedQuote && isFormLoading)
                                         }
-                                        icon={<IconCircle variant="tertiary" />}
-                                    />
+                                        isDisabled={
+                                            isApproveButtonDisabled || isRevokeButtonDisabled
+                                        }
+                                    >
+                                        <Translation id="TR_EXCHANGE_APPROVAL_FORM_INCREASE_BUTTON" />
+                                    </Button>
+
+                                    <TextButton
+                                        onClick={() =>
+                                            isRevokeButtonDisabled ||
+                                            isRevokeButtonLoading ||
+                                            isApproveButtonDisabled ||
+                                            isApproveButtonLoading
+                                                ? null
+                                                : onRevokeApprovalClick()
+                                        }
+                                        $disabled={
+                                            isRevokeButtonDisabled || isApproveButtonDisabled
+                                        }
+                                    >
+                                        <Translation id="TR_EXCHANGE_APPROVAL_FORM_REVOKE_BUTTON" />
+                                    </TextButton>
                                 </>
                             )}
-
-                            {approvalStep === 'LOADING' && (
-                                <>
-                                    <ApprovalStep
-                                        label={
-                                            <Column>
-                                                <Translation id="TR_EXCHANGE_APPROVAL_FORM_PENDING_PREFIX" />
-                                                {selectedQuote?.approvalSendTxHash && (
-                                                    <TxAddress
-                                                        variant="primary"
-                                                        typographyStyle="body"
-                                                        txAddress={selectedQuote.approvalSendTxHash}
-                                                        account={account}
-                                                        shouldAllowCopy={false}
-                                                    />
-                                                )}
-                                                <Translation id="TR_EXCHANGE_APPROVAL_FORM_PENDING_SUFFIX" />
-                                            </Column>
-                                        }
-                                        icon={<IconLoading variant="tertiary" />}
-                                    />
-
-                                    <ApprovalStep
-                                        label={
-                                            <Translation
-                                                id={
-                                                    approvalType === 'APPROVE'
-                                                        ? 'TR_EXCHANGE_APPROVAL_FORM_READY_TO_SWAP'
-                                                        : 'TR_EXCHANGE_APPROVAL_FORM_APPROVAL_REVOKED'
-                                                }
-                                            />
-                                        }
-                                        icon={<IconCircle variant="tertiary" />}
-                                    />
-                                </>
-                            )}
-
-                            {approvalStep === 'APPROVED' && (
-                                <>
-                                    {isManuallyApproved && (
-                                        <ApprovalStep
-                                            label={
-                                                <Translation id="TR_EXCHANGE_APPROVAL_FORM_TX_PROCESSED" />
-                                            }
-                                            icon={<IconCheck variant="primary" />}
-                                        />
-                                    )}
-
-                                    <ApprovalStep
-                                        label={
-                                            <Translation id="TR_EXCHANGE_APPROVAL_FORM_READY_TO_SWAP" />
-                                        }
-                                        icon={<IconCheck variant="primary" />}
-                                    />
-                                </>
-                            )}
-
-                            {(!approvalStep || approvalStep === 'ERROR') && (
-                                <ApprovalStep
-                                    label={<Translation id="TR_EXCHANGE_APPROVAL_ERROR" />}
-                                    icon={<IconError variant="destructive" />}
-                                />
-                            )}
-                        </Column>
-                    </Card>
-                </Column>
-            </Card>
-
-            {(approvalStep === 'REQUIRED' ||
-                (approvalStep === 'LOADING' && approvalType === 'REVOKE')) && (
-                <Button
-                    onClick={onApproveTransactionClick}
-                    variant="primary"
-                    isFullWidth
-                    isLoading={isApproveButtonLoading}
-                    isDisabled={isApproveButtonDisabled}
-                >
-                    <Translation id="TR_EXCHANGE_APPROVAL_FORM_APPROVE_BUTTON" />
-                </Button>
+                        </>
+                    ) : (
+                        <Button
+                            onClick={onApproveTransactionClick}
+                            variant="primary"
+                            isFullWidth
+                            isLoading={isApproveButtonLoading}
+                            isDisabled={isApproveButtonDisabled}
+                        >
+                            <Translation id="TR_EXCHANGE_APPROVAL_FORM_APPROVE_BUTTON" />
+                        </Button>
+                    )}
+                </>
             )}
 
-            {(approvalStep === 'APPROVED' ||
-                (approvalStep === 'LOADING' && approvalType === 'APPROVE')) && (
+            {approvalStep === 'APPROVED' && (
                 <>
                     <Button
                         onClick={onProceedToSwapClick}
@@ -441,6 +371,12 @@ export const TradingFormApproval = ({
                 </>
             )}
 
+            {approvalStep === 'LOADING' && (
+                <Button variant="primary" isFullWidth isDisabled={true}>
+                    <Translation id="TR_TRADING_SWAP" />
+                </Button>
+            )}
+
             {(!approvalStep || approvalStep === 'ERROR') && (
                 <Button
                     onClick={onRefreshClick}
@@ -451,6 +387,42 @@ export const TradingFormApproval = ({
                 >
                     <Translation id="TR_EXCHANGE_APPROVAL_FORM_REFRESH_BUTTON" />
                 </Button>
+            )}
+
+            {approvalStep === 'LOADING' && (
+                <Column alignItems="flex-start">
+                    <Row alignItems="flex-start" gap={spacings.sm}>
+                        <IconWrapper>
+                            <Icon name="spinnerGap" size="mediumLarge" />
+                        </IconWrapper>
+
+                        <Column>
+                            <Paragraph typographyStyle="body" variant="tertiary" align="start">
+                                <Translation
+                                    id={
+                                        approvalType === 'APPROVE'
+                                            ? 'TR_EXCHANGE_APPROVAL_FORM_CONFIRMING_APPROVAL'
+                                            : 'TR_EXCHANGE_APPROVAL_FORM_REVOKING_APPROVAL'
+                                    }
+                                />
+                            </Paragraph>
+
+                            <Paragraph typographyStyle="body" variant="tertiary" align="start">
+                                <Translation id="TR_EXCHANGE_APPROVAL_FORM_TRANSACTION_ID" />
+                            </Paragraph>
+
+                            {selectedQuote?.approvalSendTxHash && (
+                                <TxAddress
+                                    variant="primary"
+                                    typographyStyle="body"
+                                    txAddress={selectedQuote.approvalSendTxHash}
+                                    account={account}
+                                    shouldAllowCopy={false}
+                                />
+                            )}
+                        </Column>
+                    </Row>
+                </Column>
             )}
         </Column>
     );

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -23,6 +23,7 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { Translation } from 'src/components/suite';
 import { ApproveModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal';
+import { RevokeModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingDeviceDisconnected } from 'src/hooks/wallet/trading/form/common/useTradingDeviceDisconnected';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
@@ -69,6 +70,7 @@ export const TradingFormOffer = () => {
 
     const [isCompareLoading, setIsCompareLoading] = useState<boolean>(false);
     const [isApproveModalOpen, setIsApproveModalOpen] = useState(false);
+    const [isRevokeModalOpen, setIsRevokeModalOpen] = useState(false);
     const [isManuallyApproved, setIsManuallyApproved] = useState(false);
 
     const context = useTradingFormContext();
@@ -201,16 +203,48 @@ export const TradingFormOffer = () => {
         setIsApproveModalOpen(true);
     };
 
-    const onCloseApproveModal = async () => {
+    const onCloseApproveModal = async (isSubmitting = false) => {
         setIsApproveModalOpen(false);
 
         if (isTradingExchangeContext(context)) {
+            if (isSubmitting) return;
             if (context.selectedQuote?.receiveAddress) {
                 await context.confirmApproval({
                     trade: { ...context.selectedQuote, approvalType: undefined },
                     receiveAddress: context.selectedQuote.receiveAddress,
                 });
             }
+
+            context.setValue('ethereumDataHex', '');
+            await context.fetchFeesAndCompose();
+        }
+    };
+
+    const onOpenRevokeModal = async () => {
+        if (isTradingExchangeContext(context)) {
+            if (context.selectedQuote?.dexTx) {
+                context.setValue('ethereumDataHex', context.selectedQuote?.dexTx.data);
+                context.setValue(TRADING_FORM_OUTPUT_ADDRESS, context.selectedQuote?.dexTx.to);
+            }
+
+            await context.fetchFeesAndCompose();
+        }
+
+        setIsRevokeModalOpen(true);
+    };
+
+    const onCloseRevokeModal = async (isSubmitting = false) => {
+        setIsRevokeModalOpen(false);
+
+        if (isTradingExchangeContext(context)) {
+            if (isSubmitting) return;
+            if (context.selectedQuote?.receiveAddress) {
+                await context.confirmApproval({
+                    trade: { ...context.selectedQuote, approvalType: undefined },
+                    receiveAddress: context.selectedQuote?.receiveAddress,
+                });
+            }
+
             context.setValue('ethereumDataHex', '');
             await context.fetchFeesAndCompose();
         }
@@ -343,6 +377,7 @@ export const TradingFormOffer = () => {
             {requiresTokenApproval && bestScoredQuote && !isLoading ? (
                 <TradingFormApproval
                     openApproveModal={onOpenApproveModal}
+                    openRevokeModal={onOpenRevokeModal}
                     approvalType={approvalType}
                     setApprovalType={setApprovalType}
                     isManuallyApproved={isManuallyApproved}
@@ -369,6 +404,8 @@ export const TradingFormOffer = () => {
             {isApproveModalOpen && (
                 <ApproveModal onCancel={onCloseApproveModal} setApprovalType={setApprovalType} />
             )}
+
+            {isRevokeModalOpen && <RevokeModal onCancel={onCloseRevokeModal} />}
         </Column>
     );
 };


### PR DESCRIPTION
## Description

- updated approval states according to [Figma](https://www.figma.com/design/nsDtvR2N5TmuK1QCefRdvP/Trading--Final-?node-id=4236-8452&t=fsNTebgxEYdgeCr2-4)
- added a new revoke modal
- for USDT tokens, the user cannot increase approval and must revoke the pre-approved amount first
- for other tokens, the user can either increase current approval or revoke previous approval

## Related Issue

Resolve #20385 
Resolve #20386 
Resolve #19220

## Screenshots:

<img width="100%" alt="01-approve" src="https://github.com/user-attachments/assets/67ea9554-63ca-4ff0-9750-f7b73b897e3f" />

<img width="100%" alt="02-confirming-approval" src="https://github.com/user-attachments/assets/f8130d21-6dc8-4caf-99b8-6be1b6b03215" />

Token is pre-approved but the user wants to swap a higher amount.

<img width="100%" alt="03-increase-approval" src="https://github.com/user-attachments/assets/73ec1ef0-43c0-413b-bbc3-9f7a1a90ba64" />

For USDT tokens, user cannot increase approval and must revoke pre-approved amount first.

<img width="100%" alt="06-revoke-approval" src="https://github.com/user-attachments/assets/9e36e303-efe4-4b25-ad9f-ae84fec46960" />

<img width="100%" alt="07-revoke-modal" src="https://github.com/user-attachments/assets/c4b887af-531f-44d9-bc6d-fe5624ec60b6" />

<img width="100%" alt="05-revoking-approval" src="https://github.com/user-attachments/assets/0d31645f-18b5-4b15-87ef-b5fb3d213f21" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/approval-states&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/approval-states&lookback=7)