### PR TITLE
Fix e2e stabilize ci

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
@@ -473,16 +473,6 @@ export class TradingPage {
     }
 
     @step()
-    async waitForSellRedirectCompletion() {
-        await expect(this.page.getByText('Buy & sell')).toBeHidden();
-        //TODO: Workaround because of bug #19743, device switcher should not be opened
-        await Promise.all([
-            expect(this.page.getByText('Buy & sell')).toBeVisible({ timeout: 30_000 }),
-            this.page.getByTestId('@switch-device/cancel-button').click({ timeout: 30_000 }),
-        ]);
-    }
-
-    @step()
     async verifyBuyFormOpened(cryptoName: RegExp) {
         await expect(this.accountDropdown).toHaveText(cryptoName);
         await expect(this.page.getByText('You buy')).toBeVisible();

--- a/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
@@ -483,20 +483,20 @@ export class TradingPage {
     }
 
     @step()
-    async verifyBuyFormOpened(cryptoName: string) {
-        await expect(this.accountDropdown).toContainText(cryptoName);
+    async verifyBuyFormOpened(cryptoName: RegExp) {
+        await expect(this.accountDropdown).toHaveText(cryptoName);
         await expect(this.page.getByText('You buy')).toBeVisible();
     }
 
     @step()
-    async verifySellFormOpened(cryptoName: string) {
-        await expect(this.accountDropdown).toContainText(cryptoName);
+    async verifySellFormOpened(cryptoName: RegExp) {
+        await expect(this.accountDropdown).toHaveText(cryptoName);
         await expect(this.page.getByText('You sell')).toBeVisible();
     }
 
     @step()
-    async verifySwapFormOpened(cryptoName: string) {
-        await expect(this.swapFromAccountInput).toContainText(cryptoName);
+    async verifySwapFormOpened(cryptoName: RegExp) {
+        await expect(this.swapFromAccountInput).toHaveText(cryptoName);
         await expect(this.page.getByText('Swap amount')).toBeVisible();
     }
 

--- a/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-cardano.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/passphrase/passphrase-cardano.test.ts
@@ -25,8 +25,6 @@ test.describe('Passphrase with cardano', { tag: ['@group=passphrase'] }, () => {
                 await trezorUserEnvLink.stopEmu();
                 await expect(page.getByTestId('@deviceStatus-disconnected')).toBeVisible();
                 await trezorUserEnvLink.startEmu({ model: emulatorStartConf.model, wipe: false });
-                //TODO: Workaround because of bug #19743, device switcher should not be opened
-                await dashboardPage.deviceSwitchingCloseButton.click();
                 await expect(page.getByTestId('@deviceStatus-connected')).toBeVisible();
             });
         }

--- a/packages/suite-desktop-core/e2e/tests/trading/navigation.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/navigation.test.ts
@@ -3,7 +3,7 @@ import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('Trading - Navigation', { tag: ['@group=trading'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
-    test.beforeEach(async ({ page, onboardingPage, dashboardPage, settingsPage }) => {
+    test.beforeEach(async ({ onboardingPage, dashboardPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
         await settingsPage.changeNetworks({
             enableNetworks: ['eth', 'ltc'],

--- a/packages/suite-desktop-core/e2e/tests/trading/navigation.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/navigation.test.ts
@@ -5,11 +5,9 @@ test.describe('Trading - Navigation', { tag: ['@group=trading'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
     test.beforeEach(async ({ page, onboardingPage, dashboardPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
-        await settingsPage.navigateTo('coins');
-        await settingsPage.coins.enableNetwork('ltc');
-        await settingsPage.coins.enableNetwork('eth');
-        await settingsPage.coins.activateCoinsButton.click();
-        await page.discoveryShouldFinish();
+        await settingsPage.changeNetworks({
+            enableNetworks: ['eth', 'ltc'],
+        });
         await dashboardPage.deviceSwitchingOpenButton.click();
         await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
     });
@@ -26,33 +24,34 @@ test.describe('Trading - Navigation', { tag: ['@group=trading'] }, () => {
             await test.step('Buy from dashboard asset card', async () => {
                 await dashboardPage.navigateTo();
                 await page.getByTestId('@dashboard/asset/btc/buy-button').click();
-                await tradingPage.verifyBuyFormOpened('BTC');
-                await page.getByTestId(`@account-menu/filter-accounts`).click();
-                await walletPage.walletFilter('btc').click();
+                await tradingPage.verifyBuyFormOpened(/BTC/);
             });
 
             await test.step('Buy from account trade section', async () => {
                 await walletPage.openAccount({ symbol: 'btc' });
                 await page.getByTestId('@trading/menu/wallet-trading-buy').click();
-                await tradingPage.verifyBuyFormOpened('BTC');
+                await tradingPage.verifyBuyFormOpened(/BTC/);
             });
 
             await test.step('Buy from global header', async () => {
                 await dashboardPage.navigateTo();
+                const isBuyButtonUnderDropDown = await walletPage.walletExtraDropDown.isVisible();
+                if (isBuyButtonUnderDropDown) {
+                    await walletPage.walletExtraDropDown.click();
+                }
                 await walletPage.openTradingGlobalButton.click();
-                await tradingPage.verifyBuyFormOpened('BTC');
+                await tradingPage.verifyBuyFormOpened(/BTC|ETH|LTC/);
             });
 
             await test.step('Buy from empty account', async () => {
-                await walletPage.walletFilter('btc').click();
                 await walletPage.openAccount({ symbol: 'ltc' });
                 await page.getByTestId('@accounts/empty-account/buy').click();
-                await tradingPage.verifyBuyFormOpened('LTC');
+                await tradingPage.verifyBuyFormOpened(/LTC/);
             });
 
             await test.step('Buy from token', async () => {
                 await walletPage.openBuyTradingOfToken('eth', 'TrueUSD');
-                await tradingPage.verifyBuyFormOpened('TrueUSD');
+                await tradingPage.verifyBuyFormOpened(/TrueUSD/);
             });
 
             // SELL
@@ -60,7 +59,7 @@ test.describe('Trading - Navigation', { tag: ['@group=trading'] }, () => {
             await test.step('Sell from account trade section', async () => {
                 await walletPage.openAccount({ symbol: 'btc' });
                 await page.getByTestId('@trading/menu/wallet-trading-sell').click();
-                await tradingPage.verifySellFormOpened('BTC');
+                await tradingPage.verifySellFormOpened(/BTC/);
             });
 
             await test.step('Sell from token', async () => {
@@ -68,7 +67,7 @@ test.describe('Trading - Navigation', { tag: ['@group=trading'] }, () => {
                 // We cannot reproduce it manually, so we are using retry workaround to stabilize automation
                 await expect(async () => {
                     await walletPage.openSellTradingOfToken('eth', 'USD Coin');
-                    await tradingPage.verifySellFormOpened('USD Coin');
+                    await tradingPage.verifySellFormOpened(/USD Coin/);
                 }).toPass({ timeout: 15_000 });
             });
 
@@ -76,18 +75,18 @@ test.describe('Trading - Navigation', { tag: ['@group=trading'] }, () => {
             await test.step('Swap from Global header', async () => {
                 await dashboardPage.navigateTo();
                 await walletPage.openSwapGlobalButton.click();
-                await tradingPage.verifySwapFormOpened('BTC');
+                await tradingPage.verifySwapFormOpened(/BTC|ETH|LTC/);
             });
 
             await test.step('Swap from account trade section', async () => {
                 await walletPage.openAccount({ symbol: 'btc' });
                 await page.getByTestId('@trading/menu/wallet-trading-exchange').click();
-                await tradingPage.verifySwapFormOpened('BTC');
+                await tradingPage.verifySwapFormOpened(/BTC/);
             });
 
             await test.step('Swap from token', async () => {
                 await walletPage.openSwapTradingOfToken('eth', 'USD Coin');
-                await tradingPage.verifySwapFormOpened('USD Coin');
+                await tradingPage.verifySwapFormOpened(/USD Coin/);
             });
         },
     );

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
@@ -67,7 +67,7 @@ test.describe('Trading - Sell BTC', { tag: ['@group=trading', '@webOnly'] }, () 
             });
         });
 
-        await tradingPage.waitForSellRedirectCompletion();
+        await tradingPage.waitForRedirectCompletion();
 
         await test.step('Verify all confirmation values', async () => {
             await expect(tradingPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);
@@ -140,7 +140,7 @@ test.describe('Trading - Sell BTC', { tag: ['@group=trading', '@webOnly'] }, () 
                     await tradingPage.termsConfirmButton.click();
                 });
 
-                await tradingPage.waitForSellRedirectCompletion();
+                await tradingPage.waitForRedirectCompletion();
 
                 await test.step('Initiate send and verify Fee', async () => {
                     await tradingPage.initiateSendConfirmation();

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum-token.test.ts
@@ -59,7 +59,7 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=trading', '@webOnly'] }
             await tradingPage.termsConfirmButton.click();
         });
 
-        await tradingPage.waitForSellRedirectCompletion();
+        await tradingPage.waitForRedirectCompletion();
 
         await test.step('Verify all confirmation values', async () => {
             await expect(tradingPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum.test.ts
@@ -81,7 +81,7 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=trading', '@webOnly'] }
             await tradingPage.termsConfirmButton.click();
         });
 
-        await tradingPage.waitForSellRedirectCompletion();
+        await tradingPage.waitForRedirectCompletion();
 
         await test.step('Verify all confirmation values', async () => {
             await expect(tradingPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
@@ -77,7 +77,7 @@ test.describe('Trading - Sell Solana', { tag: ['@group=trading', '@webOnly'] }, 
             await tradingPage.termsConfirmButton.click();
         });
 
-        await tradingPage.waitForSellRedirectCompletion();
+        await tradingPage.waitForRedirectCompletion();
 
         await test.step('Verify all confirmation values', async () => {
             await expect(tradingPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);


### PR DESCRIPTION
- makes trading navigation test more resilient
- removes workaround from passphrase-cardano.test.ts. Previously we had to close device switcher, no longer needed -> that started failing test.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-stabilize-ci&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-stabilize-ci&lookback=7)