### PR TITLE
wip: displaying tokens in the sidebar + global send

### DIFF
--- a/packages/product-components/src/components/TokenIconSet/TokenIconSet.tsx
+++ b/packages/product-components/src/components/TokenIconSet/TokenIconSet.tsx
@@ -9,6 +9,7 @@ import { Elevation, borders, mapElevationToBackground, mapElevationToBorder } fr
 export type TokenIconSetProps = {
     symbol: NetworkSymbol;
     tokens: TokenInfo[];
+    onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
 };
 
 const IconContainer = styled.div<{ $length: number }>`
@@ -37,7 +38,7 @@ const TokenIconPlaceholder = styled.div<{ $elevation: Elevation }>`
 /**
  * @param tokens - provide already sorted tokens (for example by fiat value).
  */
-export const TokenIconSet = ({ symbol, tokens }: TokenIconSetProps) => {
+export const TokenIconSet = ({ symbol, tokens, onClick }: TokenIconSetProps) => {
     const { elevation } = useElevation();
     const { length } = tokens;
 
@@ -50,7 +51,7 @@ export const TokenIconSet = ({ symbol, tokens }: TokenIconSetProps) => {
     const coingeckoId = getCoingeckoId(symbol);
 
     return (
-        <IconContainer $length={length}>
+        <IconContainer $length={length} onClick={onClick}>
             {length > 3 && <TokenIconPlaceholder $elevation={elevation} />}
             {visibleTokens.map(token => (
                 <AssetLogo

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { Account } from '@suite-common/wallet-types';
+import { Account, TokenAddress } from '@suite-common/wallet-types';
 
 import { GlobalSendReceiveModalBase } from './GlobalSendReceiveModalBase';
 import { useDevice } from '../../../../../../hooks/suite';
@@ -12,7 +12,7 @@ import { AddAccountModal } from '../../../../modals';
 
 type GlobalReceiveModalProps = {
     onCancel: () => void;
-    onSubmit: (account: Account, type: AccountItemType) => void;
+    onSubmit: (account: Account, type: AccountItemType, tokenAddress?: TokenAddress) => void;
 };
 
 export const GlobalReceiveModal = ({ onCancel, onSubmit }: GlobalReceiveModalProps) => {

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal.tsx
@@ -1,4 +1,4 @@
-import { Account } from '@suite-common/wallet-types';
+import { Account, TokenAddress } from '@suite-common/wallet-types';
 
 import { GlobalSendReceiveModalBase } from './GlobalSendReceiveModalBase';
 import { LocalAccountSearchProvider } from '../../../../../../hooks/suite/useAccountSearch';
@@ -7,7 +7,7 @@ import { Translation } from '../../../../Translation';
 
 type GlobalSendModalProps = {
     onCancel: () => void;
-    onSubmit: (account: Account, type: AccountItemType) => void;
+    onSubmit: (account: Account, type: AccountItemType, tokenAddress?: TokenAddress) => void;
 };
 
 export const GlobalSendModal = ({ onCancel, onSubmit }: GlobalSendModalProps) => (

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceive.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceive.tsx
@@ -1,7 +1,11 @@
 import { useState } from 'react';
 
+import { sendFormActions } from '@suite-common/wallet-core';
+import { TokenAddress } from '@suite-common/wallet-types';
+
+import { SUITE } from 'src/actions/suite/constants';
 import { AppNavigationTooltip } from 'src/components/suite/AppNavigation/AppNavigationTooltip';
-import { useDevice } from 'src/hooks/suite';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 
 import { useGoToWithAnalytics } from '../useGoToWithAnalytics';
 import { GlobalReceiveModal } from './GlobalReceiveModal';
@@ -10,10 +14,23 @@ import { GlobalSendReceiveButtons } from './GlobalSendReceiveButtons';
 
 export const GlobalSendReceive = () => {
     const { device } = useDevice();
+    const dispatch = useDispatch();
     const goToWithAnalytics = useGoToWithAnalytics();
     const buttonVariant = device?.connected && device?.available ? 'primary' : 'tertiary';
     const [isSendModalOpen, setIsSendModalOpen] = useState(false);
     const [isReceiveModalOpen, setIsReceiveModalOpen] = useState(false);
+
+    const prepareTokenSend = (account: Account, tokenAddress: TokenAddress) => {
+        dispatch({
+            type: SUITE.SET_SEND_FORM_PREFILL,
+            payload: tokenAddress,
+        });
+        dispatch(
+            sendFormActions.removeDraft({
+                accountKey: account.key,
+            }),
+        );
+    };
 
     return (
         <AppNavigationTooltip>
@@ -25,7 +42,10 @@ export const GlobalSendReceive = () => {
             {isSendModalOpen && (
                 <GlobalSendModal
                     onCancel={() => setIsSendModalOpen(false)}
-                    onSubmit={account => {
+                    onSubmit={(account, _, tokenAddress) => {
+                        if (tokenAddress) {
+                            prepareTokenSend(account, tokenAddress);
+                        }
                         setIsSendModalOpen(false);
                         goToWithAnalytics('wallet-send', {
                             params: {
@@ -40,7 +60,10 @@ export const GlobalSendReceive = () => {
             {isReceiveModalOpen && (
                 <GlobalReceiveModal
                     onCancel={() => setIsReceiveModalOpen(false)}
-                    onSubmit={account => {
+                    onSubmit={(account, _, tokenAddress) => {
+                        if (tokenAddress) {
+                            prepareTokenSend(account, tokenAddress);
+                        }
                         setIsReceiveModalOpen(false);
                         goToWithAnalytics('wallet-receive', {
                             params: {

--- a/packages/suite/src/components/wallet/TokenIconSetWrapper.tsx
+++ b/packages/suite/src/components/wallet/TokenIconSetWrapper.tsx
@@ -1,63 +1,54 @@
-import { selectCoinDefinitions } from '@suite-common/token-definitions';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { selectBaseCurrency, selectCurrentFiatRates } from '@suite-common/wallet-core';
-import { Account } from '@suite-common/wallet-types';
 import { TokenIconSet } from '@trezor/product-components';
 import { BigNumber } from '@trezor/utils';
 
-import { useSelector } from 'src/hooks/suite';
-import {
-    TokensWithRates,
-    enhanceTokensWithRates,
-    getTokens,
-    sortTokensWithRates,
-} from 'src/utils/wallet/tokenUtils';
+import { TokensWithRates, sortTokensWithRates } from 'src/utils/wallet/tokenUtils';
 
 type TokenIconSetWrapperProps = {
-    accounts: Account[];
+    expanded?: boolean;
     symbol: NetworkSymbol;
+    tokens?: TokensWithRates[];
+    onClick?: () => void;
 };
 
-export const TokenIconSetWrapper = ({ accounts, symbol }: TokenIconSetWrapperProps) => {
-    const baseCurrencyCode = useSelector(selectBaseCurrency);
-    const fiatRates = useSelector(selectCurrentFiatRates);
-    const coinDefinitions = useSelector(state => selectCoinDefinitions(state, symbol));
-
-    const allTokensWithRates = accounts.flatMap(account =>
-        enhanceTokensWithRates(account.tokens, baseCurrencyCode, symbol, fiatRates),
-    );
-
-    if (!allTokensWithRates.length) return null;
-
-    const tokens = getTokens({
-        tokens: allTokensWithRates,
-        symbol,
-        tokenDefinitions: coinDefinitions,
-    })?.shownWithBalance as TokensWithRates[];
+export const TokenIconSetWrapper = ({ symbol, tokens, onClick }: TokenIconSetWrapperProps) => {
+    const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+        if (!onClick) return;
+        event.stopPropagation();
+        onClick();
+    };
 
     const aggregatedTokens = Object.values(
-        tokens.reduce((acc: Record<string, TokensWithRates>, token) => {
-            const { contract, balance, fiatValue } = token;
+        tokens?.reduce((acc: Record<string, TokensWithRates>, token) => {
+            const { contract, balance } = token;
 
             if (!acc[contract]) {
                 acc[contract] = {
                     ...token,
                     balance: balance ?? '0',
-                    fiatValue: fiatValue ?? BigNumber(0),
+                    fiatValue: token.fiatValue ?? new BigNumber(0),
                 };
             } else {
                 const existingBalance = parseFloat(acc[contract].balance ?? '0');
                 const newBalance = existingBalance + parseFloat(balance ?? '0');
                 acc[contract].balance = newBalance.toString();
 
-                acc[contract].fiatValue = acc[contract].fiatValue.plus(fiatValue);
+                acc[contract].fiatValue = acc[contract].fiatValue.plus(
+                    new BigNumber(token.balance || 0).multipliedBy(token.fiatRate?.rate || 0),
+                );
             }
 
             return acc;
-        }, {}),
+        }, {}) ?? {},
     );
 
     const sortedAggregatedTokens = aggregatedTokens.sort(sortTokensWithRates);
 
-    return <TokenIconSet symbol={symbol} tokens={sortedAggregatedTokens} />;
+    return (
+        <TokenIconSet
+            symbol={symbol}
+            tokens={sortedAggregatedTokens.slice(0, 2)}
+            onClick={handleClick}
+        />
+    );
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItemContent.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItemContent.tsx
@@ -3,15 +3,20 @@ import { JSX } from 'react';
 import styled from 'styled-components';
 
 import { useFormatters } from '@suite-common/formatters';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkSymbol, getCoingeckoId } from '@suite-common/wallet-config';
 import {
     selectBaseCurrency,
     selectIsDiscreteModeActive,
     useDisplayBaseCurrency,
 } from '@suite-common/wallet-core';
-import { Account } from '@suite-common/wallet-types';
-import { BaseCurrencyAmount, isTestnet } from '@suite-common/wallet-utils';
+import { Account, TokenAddress } from '@suite-common/wallet-types';
 import {
+    BaseCurrencyAmount,
+    getContractAddressForNetworkSymbol,
+    isTestnet,
+} from '@suite-common/wallet-utils';
+import {
+    AssetLogo,
     Column,
     Row,
     SkeletonRectangle,
@@ -29,6 +34,7 @@ import {
 } from 'src/components/suite';
 import { useLoadingSkeleton, useSelector } from 'src/hooks/suite';
 import { AccountItemType } from 'src/types/wallet';
+import { TokensWithRates } from 'src/utils/wallet/tokenUtils';
 
 const AccountLabelContainer = styled.div`
     flex: 1;
@@ -46,6 +52,9 @@ type ItemContentProps = {
     formattedBalance: string;
     dataTestKey?: string;
     isFiatLoading?: boolean;
+    tokens?: TokensWithRates[];
+    isTokensExpanded?: boolean;
+    onAccountContentClick?: (tokenAddress?: TokenAddress) => void;
 };
 
 const FiatValueRenderComponent = ({ value }: { value: JSX.Element | null }) => {
@@ -95,9 +104,18 @@ export const AccountItemContent = ({
     formattedBalance,
     dataTestKey,
     isFiatLoading,
+    tokens,
+    isTokensExpanded,
+    onAccountContentClick,
 }: ItemContentProps) => {
     const discreetMode = useSelector(selectIsDiscreteModeActive);
     const { shouldAnimate } = useLoadingSkeleton();
+
+    const onTokenClick = (event: React.MouseEvent<HTMLDivElement>, tokenAddress: TokenAddress) => {
+        if (!onAccountContentClick) return;
+        event.stopPropagation();
+        onAccountContentClick(tokenAddress);
+    };
 
     const isBalanceShown = account.backendType !== 'coinjoin' || account.status !== 'initial';
 
@@ -134,6 +152,41 @@ export const AccountItemContent = ({
                     )}
                 </Column>
             )}
+            {isTokensExpanded &&
+                tokens?.map(token => (
+                    <Row
+                        key={token.contract}
+                        gap={spacings.md}
+                        margin={{ right: spacings.xxs }}
+                        justifyContent="space-between"
+                        onClick={(event: React.MouseEvent<HTMLDivElement>) => {
+                            onTokenClick(event, token.contract as TokenAddress);
+                        }}
+                    >
+                        <Row gap={spacings.xs}>
+                            <AssetLogo
+                                key={token.contract}
+                                size={20}
+                                coingeckoId={getCoingeckoId(account.symbol) ?? ''}
+                                contractAddress={getContractAddressForNetworkSymbol(
+                                    account.symbol,
+                                    token.contract,
+                                )}
+                                placeholder={token.symbol?.toUpperCase() ?? ''}
+                                placeholderWithTooltip={false}
+                            />
+                            {token.name}
+                        </Row>
+                        <Column alignItems="flex-start">
+                            <BaseCurrencyValue
+                                showLoadingSkeleton
+                                amount={token.fiatValue || ''}
+                                symbol={account.symbol}
+                                tokenAddress={token.contract as TokenAddress}
+                            />
+                        </Column>
+                    </Row>
+                ))}
         </Column>
     );
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItemContent.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItemContent.tsx
@@ -122,71 +122,84 @@ export const AccountItemContent = ({
     return (
         // Content is constant size in discreet mode, so overflow: hidden is unnecessary.
         // Though it would cut off CSS blur effect, so we may turn it off
-        <Column flex="1" overflow={discreetMode ? 'visible' : 'hidden'} gap={spacings.xxxs}>
-            <Row gap={spacings.md} margin={{ right: spacings.xxs }} justifyContent="space-between">
-                <AccountLabelContainer data-testid={`${dataTestKey}/label`}>
-                    {type === 'coin' && <AccountLabel account={account} />}
-                    {type === 'staking' && <Translation id="TR_NAV_STAKING" />}
-                    {type === 'tokens' && <Translation id="TR_NAV_TOKENS" />}
-                </AccountLabelContainer>
-                <BaseCurrency
-                    isLoading={isFiatLoading}
-                    customFiatValue={customFiatValue}
-                    symbol={account.symbol}
-                    formattedBalance={formattedBalance}
-                />
-            </Row>
-            {isBalanceShown && type !== 'tokens' && (
-                <CoinBalance
-                    data-testid="@wallet"
-                    value={formattedBalance}
-                    symbol={account.symbol}
-                />
-            )}
-            {!isBalanceShown && (
-                <Column gap={spacings.xs}>
-                    <SkeletonRectangle width="100px" height="16px" animate={shouldAnimate} />
-
-                    {!isTestnet(account.symbol) && (
+        <Column flex="1" overflow={discreetMode ? 'visible' : 'hidden'} gap={spacings.xs}>
+            <Column gap={spacings.xxxs}>
+                <Row
+                    gap={spacings.md}
+                    margin={{ right: spacings.xxs }}
+                    justifyContent="space-between"
+                >
+                    <AccountLabelContainer data-testid={`${dataTestKey}/label`}>
+                        {type === 'coin' && <AccountLabel account={account} />}
+                        {type === 'staking' && <Translation id="TR_NAV_STAKING" />}
+                        {type === 'tokens' && <Translation id="TR_NAV_TOKENS" />}
+                    </AccountLabelContainer>
+                    <BaseCurrency
+                        isLoading={isFiatLoading}
+                        customFiatValue={customFiatValue}
+                        symbol={account.symbol}
+                        formattedBalance={formattedBalance}
+                    />
+                </Row>
+                {isBalanceShown && type !== 'tokens' && (
+                    <CoinBalance
+                        data-testid="@wallet"
+                        value={formattedBalance}
+                        symbol={account.symbol}
+                    />
+                )}
+                {!isBalanceShown && (
+                    <Column gap={spacings.xs}>
                         <SkeletonRectangle width="100px" height="16px" animate={shouldAnimate} />
-                    )}
+
+                        {!isTestnet(account.symbol) && (
+                            <SkeletonRectangle
+                                width="100px"
+                                height="16px"
+                                animate={shouldAnimate}
+                            />
+                        )}
+                    </Column>
+                )}
+            </Column>
+            {isTokensExpanded && (
+                <Column gap={spacings.xs}>
+                    {tokens?.map(token => (
+                        <Row
+                            key={token.contract}
+                            gap={spacings.md}
+                            margin={{ right: spacings.xxs }}
+                            justifyContent="space-between"
+                            onClick={(event: React.MouseEvent<HTMLDivElement>) => {
+                                onTokenClick(event, token.contract as TokenAddress);
+                            }}
+                        >
+                            <Row gap={spacings.xs}>
+                                <AssetLogo
+                                    key={token.contract}
+                                    size={20}
+                                    coingeckoId={getCoingeckoId(account.symbol) ?? ''}
+                                    contractAddress={getContractAddressForNetworkSymbol(
+                                        account.symbol,
+                                        token.contract,
+                                    )}
+                                    placeholder={token.symbol?.toUpperCase() ?? ''}
+                                    placeholderWithTooltip={false}
+                                />
+                                {token.name}
+                            </Row>
+                            <Column alignItems="flex-start">
+                                <BaseCurrencyValue
+                                    showLoadingSkeleton
+                                    amount={token.balance || ''}
+                                    symbol={account.symbol}
+                                    tokenAddress={token.contract as TokenAddress}
+                                />
+                            </Column>
+                        </Row>
+                    ))}
                 </Column>
             )}
-            {isTokensExpanded &&
-                tokens?.map(token => (
-                    <Row
-                        key={token.contract}
-                        gap={spacings.md}
-                        margin={{ right: spacings.xxs }}
-                        justifyContent="space-between"
-                        onClick={(event: React.MouseEvent<HTMLDivElement>) => {
-                            onTokenClick(event, token.contract as TokenAddress);
-                        }}
-                    >
-                        <Row gap={spacings.xs}>
-                            <AssetLogo
-                                key={token.contract}
-                                size={20}
-                                coingeckoId={getCoingeckoId(account.symbol) ?? ''}
-                                contractAddress={getContractAddressForNetworkSymbol(
-                                    account.symbol,
-                                    token.contract,
-                                )}
-                                placeholder={token.symbol?.toUpperCase() ?? ''}
-                                placeholderWithTooltip={false}
-                            />
-                            {token.name}
-                        </Row>
-                        <Column alignItems="flex-start">
-                            <BaseCurrencyValue
-                                showLoadingSkeleton
-                                amount={token.fiatValue || ''}
-                                symbol={account.symbol}
-                                tokenAddress={token.contract as TokenAddress}
-                            />
-                        </Column>
-                    </Row>
-                ))}
         </Column>
     );
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItemLeft.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItemLeft.tsx
@@ -2,15 +2,19 @@ import { Column, Icon } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
 import { exhaustive } from '@trezor/type-utils';
 
+import { TokensWithRates } from 'src/utils/wallet/tokenUtils';
+
 import { Account, AccountItemType } from '../../../../../types/wallet';
 import { TokenIconSetWrapper } from '../../../TokenIconSetWrapper';
 
 const ICON_SIZE = 24;
 type AccountItemLeftProps = {
-    type: AccountItemType;
     account: Account;
+    type: AccountItemType;
+    tokens?: TokensWithRates[];
+    onClick?: () => void;
 };
-export const AccountItemLeft = ({ type, account }: AccountItemLeftProps) => {
+export const AccountItemLeft = ({ type, account, tokens, onClick }: AccountItemLeftProps) => {
     switch (type) {
         case 'coin':
             return (
@@ -21,7 +25,9 @@ export const AccountItemLeft = ({ type, account }: AccountItemLeftProps) => {
         case 'staking':
             return <Icon name="piggyBankFilled" variant="tertiary" />;
         case 'tokens':
-            return <TokenIconSetWrapper accounts={[account]} symbol={account.symbol} />;
+            return (
+                <TokenIconSetWrapper symbol={account.symbol} tokens={tokens} onClick={onClick} />
+            );
         default:
             return exhaustive(type);
     }

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow.tsx
@@ -2,8 +2,11 @@ import { forwardRef } from 'react';
 
 import styled from 'styled-components';
 
+import { TokenAddress } from '@suite-common/wallet-types';
 import { BaseCurrencyAmount } from '@suite-common/wallet-utils';
 import { spacingsPx, typography } from '@trezor/theme';
+
+import { TokensWithRates } from 'src/utils/wallet/tokenUtils';
 
 import { Left } from './AccountItem';
 import { AccountItemContent } from './AccountItemContent';
@@ -22,6 +25,10 @@ type AccountRowProps = {
     customFiatValue?: BaseCurrencyAmount;
     formattedBalance: string;
     isFiatLoading?: boolean;
+    tokens?: TokensWithRates[];
+    isTokensExpanded?: boolean;
+    onAccountContentClick?: (tokenAddress?: TokenAddress) => void;
+    onTokensClick?: () => void;
 };
 
 const Wrapper = styled(NavigationItemBase)<{
@@ -32,6 +39,7 @@ const Wrapper = styled(NavigationItemBase)<{
     background: ${({ theme, $isSelected }) => $isSelected && theme.backgroundSurfaceElevation1};
     gap: ${spacingsPx.md};
     display: flex;
+    align-items: start;
     justify-content: space-between;
     color: ${({ theme }) => theme.textSubdued};
     ${typography.hint};
@@ -48,6 +56,7 @@ export const AccountRow = forwardRef<HTMLDivElement, AccountRowProps>(
             isSelected,
             isGroup,
             isGroupSelected,
+            isTokensExpanded,
             handleHeaderClick,
             dataTestKey,
             type,
@@ -55,6 +64,9 @@ export const AccountRow = forwardRef<HTMLDivElement, AccountRowProps>(
             customFiatValue,
             formattedBalance,
             isFiatLoading,
+            tokens,
+            onTokensClick,
+            onAccountContentClick,
         },
         ref,
     ) => (
@@ -68,7 +80,12 @@ export const AccountRow = forwardRef<HTMLDivElement, AccountRowProps>(
             tabIndex={0}
         >
             <Left>
-                <AccountItemLeft type={type} account={account} />
+                <AccountItemLeft
+                    type={type}
+                    account={account}
+                    tokens={tokens ?? []}
+                    onClick={onTokensClick}
+                />
             </Left>
             <AccountItemContent
                 customFiatValue={customFiatValue}
@@ -77,6 +94,9 @@ export const AccountRow = forwardRef<HTMLDivElement, AccountRowProps>(
                 formattedBalance={formattedBalance}
                 dataTestKey={dataTestKey}
                 isFiatLoading={Boolean(isFiatLoading)}
+                tokens={tokens}
+                isTokensExpanded={isTokensExpanded}
+                onAccountContentClick={onAccountContentClick}
             />
         </Wrapper>
     ),

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/TokensAccountItem.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/TokensAccountItem.tsx
@@ -1,16 +1,18 @@
-import { Ref, forwardRef } from 'react';
+import { Ref, forwardRef, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { EnhancedTokenInfo } from '@suite-common/token-definitions';
+import { EnhancedTokenInfo, selectCoinDefinitions } from '@suite-common/token-definitions';
+import { selectBaseCurrency, selectCurrentFiatRates } from '@suite-common/wallet-core';
+import { TokenAddress } from '@suite-common/wallet-types';
 import { BaseCurrencyAmount } from '@suite-common/wallet-utils';
 import { Column, TOOLTIP_DELAY_NORMAL, Tooltip } from '@trezor/components';
-import { EventType, analytics } from '@trezor/suite-analytics';
-import { exhaustive } from '@trezor/type-utils';
 
 import { useGoToWithAnalytics } from 'src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics';
 import { NavigationItemBase } from 'src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem';
+import { useSelector } from 'src/hooks/suite';
 import { Account, AccountItemType } from 'src/types/wallet';
+import { TokensWithRates, enhanceTokensWithRates, getTokens } from 'src/utils/wallet/tokenUtils';
 
 import { AccountItemLeft } from './AccountItemLeft';
 import { AccountRow } from './AccountRow';
@@ -36,28 +38,26 @@ export const Left = styled.div`
 
 interface AccountItemProps {
     account: Account;
+    tokens: EnhancedTokenInfo[];
     // NOTE: disables the default item click behavior
     forceOnlyItemClick?: boolean;
-    type: AccountItemType;
     isSelected: boolean;
     isGroupSelected?: boolean;
     formattedBalance: string;
     customFiatValue?: BaseCurrencyAmount;
     isGroup?: boolean;
-    tokens?: EnhancedTokenInfo[];
     dataTestKey?: string;
     isFiatLoading?: boolean;
-    onClick?: (account: Account, type: AccountItemType) => void;
-    onTokensClick?: () => void;
+    onClick?: (account: Account, type: AccountItemType, tokenAddress?: TokenAddress) => void;
 }
 
 // Using `forwardRef` to be able to pass `ref` (item) TO parent (Menu/index)
-export const AccountItem = forwardRef(
+export const TokensAccountItem = forwardRef(
     (
         {
             account,
+            tokens,
             forceOnlyItemClick,
-            type,
             isSelected,
             isGroupSelected,
             formattedBalance,
@@ -65,14 +65,28 @@ export const AccountItem = forwardRef(
             isGroup,
             dataTestKey,
             isFiatLoading,
-            tokens,
             onClick,
         }: AccountItemProps,
         ref: Ref<HTMLDivElement>,
     ) => {
         const { accountType, index, symbol } = account;
+        const [isTokensExpanded, setIsTokensExpanded] = useState(false);
 
         const goToWithAnalytics = useGoToWithAnalytics(account);
+
+        const baseCurrency = useSelector(selectBaseCurrency);
+        const fiatRates = useSelector(selectCurrentFiatRates);
+        const coinDefinitions = useSelector(state => selectCoinDefinitions(state, symbol));
+
+        const allTokensWithRates = enhanceTokensWithRates(tokens, baseCurrency, symbol, fiatRates);
+
+        if (!allTokensWithRates.length) return null;
+
+        const tokensWithRates = getTokens({
+            tokens: allTokensWithRates,
+            symbol,
+            tokenDefinitions: coinDefinitions,
+        })?.shownWithBalance as TokensWithRates[];
 
         const accountRouteParams = {
             symbol,
@@ -80,54 +94,43 @@ export const AccountItem = forwardRef(
             accountType,
         };
 
-        const getRoute = () => {
-            switch (type) {
-                case 'coin':
-                    return 'wallet-index';
-                case 'staking':
-                    return 'wallet-staking';
-                case 'tokens':
-                    return 'wallet-tokens';
-                default:
-                    return exhaustive(type);
-            }
+        const handleTokensClick = () => {
+            // onClick?.(account, type);
+            setIsTokensExpanded(!isTokensExpanded);
+        };
+
+        const handleAccountContentClick = (tokenAddress?: TokenAddress) => {
+            onClick?.(account, 'tokens', tokenAddress);
         };
 
         const handleHeaderClick = () => {
-            onClick?.(account, type);
+            onClick?.(account, 'tokens');
 
             // NOTE: disable default behavior useful eg in global send modal - when picking account
             // from which to send
             if (forceOnlyItemClick) {
                 return;
             }
-            goToWithAnalytics(getRoute(), { params: accountRouteParams });
-
-            if (type === 'staking') {
-                analytics.report({
-                    type: EventType.StakingNavigate,
-                    payload: {
-                        action: 'navigate',
-                        from: 'sidebar',
-                        networkSymbol: symbol,
-                    },
-                });
-            }
+            goToWithAnalytics('wallet-tokens', { params: accountRouteParams });
         };
 
         const content = (
             <AccountRow
+                isTokensExpanded={isTokensExpanded}
                 isFiatLoading={Boolean(isFiatLoading)}
+                tokens={tokensWithRates}
                 isSelected={isSelected}
                 isGroup={isGroup}
                 isGroupSelected={isGroupSelected}
                 handleHeaderClick={handleHeaderClick}
                 dataTestKey={dataTestKey}
-                type={type}
+                type="tokens"
                 account={account}
                 ref={ref}
                 customFiatValue={customFiatValue}
                 formattedBalance={formattedBalance}
+                onAccountContentClick={handleAccountContentClick}
+                onTokensClick={handleTokensClick}
             />
         );
 
@@ -135,7 +138,7 @@ export const AccountItem = forwardRef(
             <>
                 <ExpandedSidebarOnly>{content}</ExpandedSidebarOnly>
                 <CollapsedSidebarOnly>
-                    <Column alignItems="center">
+                    <Column alignItems="start">
                         <Tooltip
                             delayShow={TOOLTIP_DELAY_NORMAL}
                             cursor="pointer"
@@ -143,8 +146,16 @@ export const AccountItem = forwardRef(
                             placement="right"
                             hasArrow
                         >
-                            <CollapsedItem $isSelected={isSelected} onClick={handleHeaderClick}>
-                                <AccountItemLeft type={type} account={account} tokens={tokens} />
+                            <CollapsedItem
+                                $isSelected={isSelected}
+                                onClick={() => handleHeaderClick()}
+                            >
+                                <AccountItemLeft
+                                    account={account}
+                                    type="tokens"
+                                    tokens={tokensWithRates}
+                                    onClick={handleTokensClick}
+                                />
                             </CollapsedItem>
                         </Tooltip>
                     </Column>
@@ -153,3 +164,5 @@ export const AccountItem = forwardRef(
         );
     },
 );
+
+TokensAccountItem.displayName = 'TokensAccountItem';

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 
+import { EnhancedTokenInfo } from '@suite-common/token-definitions';
 import { selectBaseCurrency, selectCurrentFiatRates } from '@suite-common/wallet-core';
 import {
     BASE_CURRENCY_ZERO,
@@ -15,6 +16,7 @@ import { selectRouteName } from 'src/reducers/suite/routerReducer';
 import { Account, AccountItemType } from 'src/types/wallet';
 
 import { AccountItem } from './AccountItem/AccountItem';
+import { TokensAccountItem } from './AccountItem/TokensAccountItem';
 import { useIsSidebarCollapsed } from '../../../suite/layouts/SuiteLayout/Sidebar/utils';
 
 const Section = styled.div<{ $selected?: boolean; $isSidebarCollapsed?: boolean }>`
@@ -43,7 +45,7 @@ interface AccountItemsGroupProps {
     forceOnlyItemClick?: boolean;
     selected: boolean;
     showStaking: boolean;
-    tokens?: Account['tokens'];
+    tokens?: EnhancedTokenInfo[];
     dataTestKey?: string;
     onItemClick?: (account: Account, type: AccountItemType) => void;
 }
@@ -103,18 +105,17 @@ export const AccountItemsGroup = ({
                     />
                 )}
                 {!!tokens?.length && (
-                    <AccountItem
+                    <TokensAccountItem
                         account={account}
+                        tokens={tokens}
                         forceOnlyItemClick={forceOnlyItemClick}
-                        type="tokens"
                         isSelected={selected && tokensRoutes.includes(routeName || '')}
                         formattedBalance={account.formattedBalance}
                         isGroup
                         isGroupSelected={selected}
-                        customFiatValue={tokensFiatBalance}
-                        tokens={tokens}
                         dataTestKey={`${dataTestKey}/tokens`}
                         isFiatLoading={isFiatLoading}
+                        customFiatValue={tokensFiatBalance}
                         onClick={onItemClick}
                     />
                 )}

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx
@@ -1,10 +1,14 @@
 import { selectCoinDefinitions } from '@suite-common/token-definitions';
-import { selectAccountIsStakingActive } from '@suite-common/wallet-core';
+import {
+    selectAccountIsStakingActive,
+    selectBaseCurrency,
+    selectCurrentFiatRates,
+} from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 
 import { useSelector } from 'src/hooks/suite';
 import { AccountItemType } from 'src/types/wallet';
-import { getTokens } from 'src/utils/wallet/tokenUtils';
+import { enhanceTokensWithRates, getTokens } from 'src/utils/wallet/tokenUtils';
 
 import { AccountItem } from './AccountItem/AccountItem';
 import { AccountItemsGroup } from './AccountItemsGroup';
@@ -35,6 +39,8 @@ export const AccountSection = ({
     } = account;
 
     const coinDefinitions = useSelector(state => selectCoinDefinitions(state, symbol));
+    const baseCurrency = useSelector(selectBaseCurrency);
+    const rates = useSelector(selectCurrentFiatRates);
 
     const showGroup = ['ethereum', 'solana', 'cardano'].includes(networkType);
 
@@ -43,8 +49,15 @@ export const AccountSection = ({
     );
     const isStakeShown = !hideStaking && isStakeShownStored;
 
+    const allTokensWithRates = enhanceTokensWithRates(
+        accountTokens,
+        baseCurrency,
+        account.symbol,
+        rates,
+    );
+
     const tokens = getTokens({
-        tokens: accountTokens,
+        tokens: allTokensWithRates,
         symbol: account.symbol,
         tokenDefinitions: coinDefinitions,
     });

--- a/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
@@ -228,7 +228,6 @@ export const AssetCard = ({
                         assetStakingBalance={assetStakingBalance.toString()}
                         shouldRenderStaking={shouldRenderStakingRow}
                         shouldRenderTokens={shouldRenderTokenRow}
-                        accounts={accounts}
                     />
                 )}
                 {shallDisplayBaseCurrency && (

--- a/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCardTokensAndStakingInfo.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCardTokensAndStakingInfo.tsx
@@ -1,5 +1,4 @@
 import type { NetworkSymbol } from '@suite-common/wallet-config';
-import { Account } from '@suite-common/wallet-types';
 import { Column, Divider, Icon, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -17,7 +16,6 @@ type AssetCardTokensAndStakingInfoProps = {
     assetStakingBalance: string;
     shouldRenderStaking: boolean;
     shouldRenderTokens: boolean;
-    accounts: Account[];
 };
 
 export const AssetCardTokensAndStakingInfo = ({
@@ -26,7 +24,6 @@ export const AssetCardTokensAndStakingInfo = ({
     assetStakingBalance,
     shouldRenderStaking,
     shouldRenderTokens,
-    accounts,
 }: AssetCardTokensAndStakingInfoProps) => (
     <Column>
         <Divider strokeWidth={1} margin={{ vertical: spacings.xs }} />
@@ -61,7 +58,7 @@ export const AssetCardTokensAndStakingInfo = ({
                 margin={{ horizontal: spacings.xs, bottom: spacings.xs }}
             >
                 <Row gap={spacings.xs}>
-                    <TokenIconSetWrapper accounts={accounts} symbol={symbol} />
+                    <TokenIconSetWrapper symbol={symbol} />
                     <Text typographyStyle="body" variant="tertiary">
                         <Translation id="TR_NAV_TOKENS" />
                     </Text>

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
@@ -218,9 +218,7 @@ export const AssetRow = memo(
                 )}
                 {shouldRenderTokenRow && (
                     <AssetTokenRow
-                        tokenIconSetWrapper={
-                            <TokenIconSetWrapper accounts={accounts} symbol={network.symbol} />
-                        }
+                        tokenIconSetWrapper={<TokenIconSetWrapper symbol={network.symbol} />}
                         network={network}
                         tokensDisplayFiatBalance={tokensFiatBalance.toFixed()}
                     />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In global send, it would be useful to use every single one token and be able to send / receive these tokens.

Simplest solution is to go to the tokens when page clicked or other solution can be to display all tokens there and have link to send / receive page directly

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=try-display-tokens-sidebar&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=try-display-tokens-sidebar&lookback=7)