### PR TITLE
fix(trading): add hashes for eip712 signing on t1b1

### DIFF
--- a/packages/connect-plugin-ethereum/package.json
+++ b/packages/connect-plugin-ethereum/package.json
@@ -19,7 +19,13 @@
     ],
     "sideEffects": false,
     "publishConfig": {
-        "main": "lib/index.js"
+        "main": "lib/index.js",
+        "exports": {
+            ".": {
+                "import": "./libESM/index.js",
+                "require": "./lib/index.js"
+            }
+        }
     },
     "main": "src/index.ts",
     "files": [
@@ -27,12 +33,6 @@
         "libESM",
         "!**/*.map"
     ],
-    "exports": {
-        ".": {
-            "import": "./libESM/index.js",
-            "require": "./lib/index.js"
-        }
-    },
     "peerDependencies": {
         "@metamask/eth-sig-util": "^8.2.0",
         "tslib": "^2.6.2"

--- a/packages/connect-plugin-stellar/package.json
+++ b/packages/connect-plugin-stellar/package.json
@@ -20,12 +20,12 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "publishConfig": {
-        "main": "lib/index.js"
-    },
-    "exports": {
-        ".": {
-            "import": "./libESM/index.js",
-            "require": "./lib/index.js"
+        "main": "lib/index.js",
+        "exports": {
+            ".": {
+                "import": "./libESM/index.js",
+                "require": "./lib/index.js"
+            }
         }
     },
     "files": [

--- a/suite-common/trading/package.json
+++ b/suite-common/trading/package.json
@@ -19,6 +19,7 @@
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/address-validator": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/connect-plugin-ethereum": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/react-utils": "workspace:*",
         "@trezor/utils": "workspace:*",

--- a/suite-common/trading/src/thunks/exchange/__tests__/signDataAndConfirmThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/signDataAndConfirmThunk.test.ts
@@ -16,6 +16,11 @@ import { initialState, prepareTradingReducer } from '../../../reducers/tradingRe
 
 const tradingReducer = prepareTradingReducer(extraDependenciesMock);
 
+jest.mock('@trezor/connect-plugin-ethereum', () => ({
+    ...jest.requireActual('@trezor/connect-plugin-ethereum'),
+    transformTypedData: jest.fn().mockReturnValue({ domain_separator_hash: '', message_hash: '' }),
+}));
+
 describe('signDataAndConfirmThunk', () => {
     afterEach(() => {
         jest.clearAllMocks();

--- a/suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts
@@ -6,6 +6,7 @@ import TrezorConnect, {
     EthereumSignTypedDataMessage,
     EthereumSignTypedDataTypes,
 } from '@trezor/connect';
+import { transformTypedData } from '@trezor/connect-plugin-ethereum';
 
 import { exchangeThunks } from '../';
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
@@ -71,11 +72,27 @@ export const signDataAndConfirmThunk = createThunk(
         const typedData = selectedQuote?.signData
             .data as EthereumSignTypedDataMessage<EthereumSignTypedDataTypes>;
 
+        let hashes;
+        try {
+            hashes = transformTypedData(typedData as any, true);
+        } catch (error) {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'sign-message-error',
+                    error: error.message,
+                }),
+            );
+
+            return;
+        }
+
         dispatch(tradingActions.setModalAccountKey(account.key));
         const result = await TrezorConnect.ethereumSignTypedData({
             path: account.path,
-            metamask_v4_compat: false,
+            metamask_v4_compat: true,
             data: typedData,
+            domain_separator_hash: hashes.domain_separator_hash,
+            message_hash: hashes.message_hash || undefined,
             device: {
                 path: device?.path,
                 instance: device?.instance,

--- a/suite-common/trading/tsconfig.json
+++ b/suite-common/trading/tsconfig.json
@@ -11,6 +11,9 @@
             "path": "../../packages/address-validator"
         },
         { "path": "../../packages/connect" },
+        {
+            "path": "../../packages/connect-plugin-ethereum"
+        },
         { "path": "../../packages/env-utils" },
         { "path": "../../packages/react-utils" },
         { "path": "../../packages/utils" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9892,6 +9892,7 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/address-validator": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/connect-plugin-ethereum": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/react-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
@@ -12157,7 +12158,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/connect-plugin-ethereum@workspace:packages/connect-plugin-ethereum":
+"@trezor/connect-plugin-ethereum@workspace:*, @trezor/connect-plugin-ethereum@workspace:packages/connect-plugin-ethereum":
   version: 0.0.0-use.local
   resolution: "@trezor/connect-plugin-ethereum@workspace:packages/connect-plugin-ethereum"
   dependencies:


### PR DESCRIPTION
## Description

Add missing hashes for EIP-712 signing on T1B1


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-trading-eip712-t1b1&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-trading-eip712-t1b1&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-trading-eip712-t1b1&lookback=7)