### PR TITLE
chore(suite-native): don't remember unacquired devices

### DIFF
--- a/suite-common/wallet-utils/src/deviceUtils.ts
+++ b/suite-common/wallet-utils/src/deviceUtils.ts
@@ -22,6 +22,8 @@ export const shouldDeviceBeRemembered = ({
 
     if (device.mode !== 'normal') return false;
 
+    if (device.type !== 'acquired') return false;
+
     return !isDeviceAutoEjectEnabled;
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- if device isn't acquired, we probably shouldn't remember it

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/unacquired-devices-not-remembered&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/unacquired-devices-not-remembered&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/unacquired-devices-not-remembered&lookback=7)