### PR TITLE
Move advanced bitcoin options to dropdown menu

### DIFF
--- a/packages/components/src/components/Flex/Flex.tsx
+++ b/packages/components/src/components/Flex/Flex.tsx
@@ -184,7 +184,7 @@ export type FlexProps = AllowedFrameProps & {
     /** @deprecated Use only is case of absolute desperation. Prefer keep it according to elevation. */
     dividerColor?: string;
     className?: string;
-    onClick?: () => void;
+    onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
     'data-testid'?: string;
     as?: string;
 };

--- a/packages/components/src/components/Menu/Menu.tsx
+++ b/packages/components/src/components/Menu/Menu.tsx
@@ -43,6 +43,7 @@ export type DropdownMenuItemProps = {
     iconRight?: IconName;
     isDisabled?: boolean;
     isHidden?: boolean;
+    closeOnClick?: boolean;
     'data-testid'?: string;
 };
 
@@ -119,7 +120,7 @@ export const Menu = forwardRef<HTMLUListElement, MenuProps>(
 
                     const focusedItem = visibleItems[focusedItemIndex];
 
-                    onClose?.();
+                    if (focusedItem.closeOnClick !== false) onClose?.();
                     focusedItem?.onClick?.();
                 }
             };
@@ -188,7 +189,7 @@ export const Menu = forwardRef<HTMLUListElement, MenuProps>(
                                         data-testid={item['data-testid']}
                                         {...item}
                                         onClick={() => {
-                                            onClose?.();
+                                            if (item.closeOnClick !== false) onClose?.();
                                             item.onClick?.();
                                         }}
                                         key={index}

--- a/packages/components/src/components/form/Switch/Switch.tsx
+++ b/packages/components/src/components/form/Switch/Switch.tsx
@@ -115,13 +115,13 @@ export const Switch = ({
             gap={mapSizeToLabelContainerGap(size)}
             isReversed={labelPosition === 'start'}
             margin={margin}
+            onClick={handleContainerClick}
         >
             <Container
                 // @ts-expect-error - needed for playwright retry-ability
                 disabled={isDisabled}
                 $isChecked={isChecked}
                 $isDisabled={isDisabled}
-                onClick={handleContainerClick}
                 data-testid={dataTest}
             >
                 <Box

--- a/packages/components/src/components/form/Switch/Switch.tsx
+++ b/packages/components/src/components/form/Switch/Switch.tsx
@@ -18,7 +18,7 @@ type AllowedFrameProps = Pick<FrameProps, (typeof allowedSwitchFrameProps)[numbe
 export type SwitchProps = AllowedFrameProps & {
     isChecked: boolean;
     label?: ReactNode;
-    onChange: (isChecked: boolean) => void;
+    onChange?: (isChecked: boolean) => void;
     isDisabled?: boolean;
     size?: SwitchSize;
     'data-testid'?: string;
@@ -98,7 +98,7 @@ export const Switch = ({
 
     const handleChange = () => {
         if (isDisabled) return;
-        onChange(!isChecked);
+        onChange?.(!isChecked);
     };
 
     const handleContainerClick = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/trading/tradingPage.ts
@@ -100,7 +100,6 @@ export class TradingPage {
     readonly finishTransactionButton: Locator;
     readonly confirmOnTrezorAndSend: Locator;
     // Swap
-    readonly broadcastButton: Locator;
     readonly sendAddressInput: Locator;
     readonly sendAmountInput: Locator;
     readonly sendButton: Locator;
@@ -188,7 +187,6 @@ export class TradingPage {
             '@trading/offer/confirm-on-trezor-and-send',
         );
         // Swap
-        this.broadcastButton = this.page.getByTestId('broadcast-button');
         this.sendAddressInput = this.page.getByTestId('outputs.0.address');
         this.sendAmountInput = this.page.getByTestId('outputs.0.amount');
         this.sendButton = this.page.getByTestId('@send/review-button');

--- a/packages/suite-desktop-core/e2e/tests/wallet/send-doge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/send-doge.test.ts
@@ -43,7 +43,8 @@ test.describe('Doge Send', { tag: ['@group=wallet', '@snapshot'] }, () => {
         });
 
         await test.step('Fill amount over MAX_SAFE_INTEGER and send', async () => {
-            await tradingPage.broadcastButton.click();
+            await page.getByTestId('@send/header-dropdown').click();
+            await page.getByTestId('@send/header-dropdown/broadcast').click();
             await tradingPage.sendAddressInput.fill(recipientAddress);
             await tradingPage.sendAmountInput.fill(sendAmount);
             await tradingPage.sendButton.click();

--- a/packages/suite-desktop-core/e2e/tests/wallet/send-form-ltc.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/send-form-ltc.test.ts
@@ -31,7 +31,8 @@ test.describe('LTC send form with mocked blockbook', { tag: ['@group=wallet'] },
     }) => {
         await walletPage.openAccount({ symbol: 'ltc', type: 'normal', atIndex: 0 });
         await walletPage.openSendFormButton.click();
-        await tradingPage.broadcastButton.click();
+        await page.getByTestId('@send/header-dropdown').click();
+        await page.getByTestId('@send/header-dropdown/broadcast').click();
         await tradingPage.sendAddressInput.fill('ltc1q0lqwsyygg9frql6ujjfhevfculsxwledvv6yzc');
         await page.getByTestId('outputs.0.setMax').click();
         await tradingPage.sendButton.click();

--- a/packages/suite-desktop-core/e2e/tests/wallet/send-form-regtest.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/send-form-regtest.test.ts
@@ -45,7 +45,8 @@ test.describe('Send form for bitcoin', { tag: ['@group=wallet'] }, () => {
         await tradingPage.sendAddressInput.fill(ADDRESS_INDEX_1);
 
         // add locktime
-        await page.getByTestId('add-locktime-button').click();
+        await page.getByTestId('@send/header-dropdown').click();
+        await page.getByTestId('@send/header-dropdown/locktime').click();
         await page.getByTestId('locktime-option/input').click();
         await page.getByTestId('locktime-option/option/block').click();
         await page.getByTestId('locktime-blockheight-input').fill('1000');

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/BitcoinOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/BitcoinOptions.tsx
@@ -2,20 +2,16 @@ import { useWatch } from 'react-hook-form';
 
 import styled from 'styled-components';
 
-import { selectNetworkBlockchainInfo } from '@suite-common/wallet-core';
-import { datetimeToLocktime } from '@suite-common/wallet-utils';
 import { Button, Tooltip, variables } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 
 import { OpenGuideFromTooltip } from 'src/components/guide';
 import { Translation } from 'src/components/suite';
-import { useSelector } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 
 import { OnOffSwitcher } from '../OnOffSwitcher';
 import { CoinControl } from './CoinControl/CoinControl';
 import { Locktime } from './Locktime/Locktime';
-import { canLocktimeTxBeBroadcast } from './Locktime/canLocktimeTxBeBroadcast';
 
 const Wrapper = styled.div`
     display: flex;
@@ -72,8 +68,6 @@ export const BitcoinOptions = () => {
         setDraftSaveRequest,
         resetDefaultValue,
         setValue,
-        watch,
-        network,
     } = useSendFormContext();
 
     const options = useWatch({
@@ -96,75 +90,10 @@ export const BitcoinOptions = () => {
         setDraftSaveRequest(true);
     };
 
-    const blockchain = useSelector(state => selectNetworkBlockchainInfo(state, network.symbol));
-
-    const [locktimeBlockHeight, locktimeDatetime] = watch([
-        'bitcoinLocktimeBlockHeight',
-        'bitcoinLocktimeDatetime',
-    ]);
-
-    const canLocktimeBeBroadcast = canLocktimeTxBeBroadcast({
-        locktimeBlockHeight: Number(locktimeBlockHeight),
-        locktimeDatetime: datetimeToLocktime(locktimeDatetime),
-        currentBlockHeight: blockchain.blockHeight,
-    });
-
     return (
         <Wrapper>
             <Row>
                 <Left>
-                    {!locktimeEnabled && (
-                        <Tooltip
-                            addon={
-                                <OpenGuideFromTooltip id="/3_send-and-receive/transactions-in-depth/locktime.md" />
-                            }
-                            content={<Translation id="LOCKTIME_ADD_TOOLTIP" />}
-                            cursor="pointer"
-                        >
-                            <StyledButton
-                                variant="tertiary"
-                                size="small"
-                                icon="calendar"
-                                onClick={() => {
-                                    // open additional form
-                                    toggleOption('bitcoinLocktime');
-                                    composeTransaction();
-                                }}
-                                data-testid="add-locktime-button"
-                            >
-                                <Translation id="LOCKTIME_ADD" />
-                            </StyledButton>
-                        </Tooltip>
-                    )}
-                    <Tooltip
-                        content={
-                            <Translation
-                                id={
-                                    canLocktimeBeBroadcast
-                                        ? 'BROADCAST_TOOLTIP'
-                                        : 'BROADCAST_TOOLTIP_DISABLED_LOCKTIME'
-                                }
-                            />
-                        }
-                    >
-                        <StyledButton
-                            variant="tertiary"
-                            size="small"
-                            icon="broadcast"
-                            onClick={() => {
-                                toggleOption('broadcast');
-                                composeTransaction();
-                            }}
-                            data-testid="broadcast-button"
-                            isDisabled={!canLocktimeBeBroadcast}
-                        >
-                            <Inline>
-                                <Translation id="BROADCAST" />
-                                <OnOffSwitcher isOn={broadcastEnabled} />
-                            </Inline>
-                        </StyledButton>
-                    </Tooltip>
-
                     {!utxoSelectionEnabled && (
                         <Tooltip
                             addon={

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/Locktime/Locktime.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/Locktime/Locktime.tsx
@@ -2,9 +2,10 @@ import { useEffect, useState } from 'react';
 
 import { selectBlockchainHeightBySymbol } from '@suite-common/wallet-core';
 import { datetimeToLocktime } from '@suite-common/wallet-utils';
-import { Card, IconButton, Row, Select } from '@trezor/components';
+import { Card, IconButton, Row, Select, Tooltip } from '@trezor/components';
 
-import { TextColumn } from 'src/components/suite';
+import { OpenGuideFromTooltip } from 'src/components/guide';
+import { TextColumn, Translation } from 'src/components/suite';
 import { useSelector, useTranslation } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 
@@ -99,7 +100,17 @@ export const Locktime = ({ close }: LocktimeProps) => {
         <Card>
             <Row justifyContent="space-between" alignItems="start">
                 <TextColumn
-                    title={translationString('LOCKTIME_ADD')}
+                    title={
+                        <Tooltip
+                            addon={
+                                <OpenGuideFromTooltip id="/3_send-and-receive/transactions-in-depth/locktime.md" />
+                            }
+                            content={<Translation id="LOCKTIME_ADD_TOOLTIP" />}
+                            hasIcon
+                        >
+                            <Translation id="LOCKTIME_ADD" />
+                        </Tooltip>
+                    }
                     description={translationString('LOCKTIME_DESCRIPTION')}
                 />
                 <IconButton icon="x" size="small" variant="tertiary" onClick={close} />

--- a/packages/suite/src/views/wallet/send/SendHeader.tsx
+++ b/packages/suite/src/views/wallet/send/SendHeader.tsx
@@ -1,7 +1,9 @@
+import { useWatch } from 'react-hook-form';
+
 import styled from 'styled-components';
 
 import { sendFormActions } from '@suite-common/wallet-core';
-import { Button, Dropdown, DropdownMenuItemProps } from '@trezor/components';
+import { Button, Dropdown, DropdownMenuItemProps, Switch, Text } from '@trezor/components';
 import { FADE_IN } from '@trezor/components/src/config/animations';
 
 import { Translation } from 'src/components/suite';
@@ -20,16 +22,34 @@ export const SendHeader = () => {
     const { device } = useDevice();
     const {
         outputs,
+        control,
         account: { networkType },
         formState: { isDirty },
+        toggleOption,
 
         addOpReturn,
         resetContext,
         loadTransaction,
     } = useSendFormContext();
 
+    const enabledFormOptions = useWatch({
+        name: 'options',
+        defaultValue: [],
+        control,
+    });
+
     const opreturnOutput = (outputs || []).find(o => o.type === 'opreturn');
+    const locktimeEnabled = enabledFormOptions.includes('bitcoinLocktime');
+    const broadcastEnabled = enabledFormOptions.includes('broadcast');
     const options: Array<DropdownMenuItemProps> = [
+        {
+            'data-testid': '@send/header-dropdown/import',
+            onClick: () => {
+                loadTransaction();
+            },
+            label: <Translation id="IMPORT_CSV" />,
+            isHidden: networkType !== 'bitcoin',
+        },
         {
             'data-testid': '@send/header-dropdown/opreturn',
             onClick: addOpReturn,
@@ -38,11 +58,36 @@ export const SendHeader = () => {
             isHidden: networkType !== 'bitcoin',
         },
         {
-            'data-testid': '@send/header-dropdown/import',
+            'data-testid': '@send/header-dropdown/locktime',
             onClick: () => {
-                loadTransaction();
+                toggleOption('bitcoinLocktime');
+                if (broadcastEnabled) toggleOption('broadcast');
             },
-            label: <Translation id="IMPORT_CSV" />,
+            label: <Translation id="LOCKTIME_ADD" />,
+            isDisabled: !!locktimeEnabled,
+            isHidden: networkType !== 'bitcoin',
+        },
+        {
+            'data-testid': '@send/header-dropdown/broadcast',
+            onClick: () => toggleOption('broadcast'),
+            closeOnClick: false,
+            label: (
+                <Switch
+                    isDisabled={!!locktimeEnabled}
+                    isChecked={broadcastEnabled}
+                    labelPosition="start"
+                    label={
+                        <Text
+                            typographyStyle="hint"
+                            variant={locktimeEnabled ? 'disabled' : 'default'}
+                            textWrap="nowrap"
+                        >
+                            <Translation id="BROADCAST" />
+                        </Text>
+                    }
+                />
+            ),
+            isDisabled: !!locktimeEnabled,
             isHidden: networkType !== 'bitcoin',
         },
         {


### PR DESCRIPTION
Moved broadcast and locktime to advanced menu. 

## Description
* Added `dontCloseOnClick` to `MenuItems` (useful for having switch in menu)
* Allowed not passing `onChange` to `Switch`
* Fixed `Switch`'s `handleContainerClick` to catch clicks on label
* Moved Locktime + Broadcast to dropdown menu.

## Related Issue

Resolve #20094

## Screenshots

Before:
<img width="1789" height="750" alt="advanced-before" src="https://github.com/user-attachments/assets/0e69c576-548f-41a2-9dc1-1bb1a86add4b" />

After:
<img width="1780" height="740" alt="advanced-after" src="https://github.com/user-attachments/assets/bec1b61a-a65d-4d7d-bd97-3801480de45c" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/advanced-bitcoin-options&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/advanced-bitcoin-options&lookback=7)