### PR TITLE
chore(suite): remove unused url implementation

### DIFF
--- a/packages/suite/src/views/wallet/transactions/CoinjoinExplanation/CoinjoinExplanation.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinExplanation/CoinjoinExplanation.tsx
@@ -1,13 +1,10 @@
-import { darken } from 'polished';
 import styled from 'styled-components';
 
 import { Card, Icon, variables } from '@trezor/components';
 import { mediaQueries } from '@trezor/styles';
 import { spacings, spacingsPx, typography } from '@trezor/theme';
-import { HELP_CENTER_COINJOIN_URL } from '@trezor/urls';
 
 import { Translation } from 'src/components/suite';
-import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
 
 import { CoinjoinProcessStep, CoinjoinProcessStepProps } from './CoinjoinProcessStep';
 
@@ -41,36 +38,6 @@ const Steps = styled(Card)`
     }
 `;
 
-const StyledLearnMoreButton = styled(LearnMoreButton)`
-    margin: 0 auto;
-    color: ${({ theme }) => theme.textSubdued};
-
-    button {
-        background: #d9d9d9;
-    }
-
-    path {
-        fill: ${({ theme }) => theme.iconSubdued};
-    }
-
-    button:hover,
-    button:focus {
-        background: ${({ theme }) => darken(theme.legacy.HOVER_DARKEN_FILTER, '#d9d9d9')};
-    }
-
-    ${mediaQueries.dark_theme} {
-        button {
-            background: ${({ theme }) => theme.backgroundSurfaceElevation0};
-        }
-
-        button:hover,
-        button:focus {
-            background: ${({ theme }) =>
-                darken(theme.legacy.HOVER_DARKEN_FILTER, theme.backgroundSurfaceElevation0)};
-        }
-    }
-`;
-
 const STEPS: Array<Omit<CoinjoinProcessStepProps, 'number'>> = [
     {
         image: 'COINS',
@@ -101,7 +68,5 @@ export const CoinjoinExplanation = () => (
                 <CoinjoinProcessStep number={index + 1} key={step.image} {...step} />
             ))}
         </Steps>
-
-        <StyledLearnMoreButton url={HELP_CENTER_COINJOIN_URL} />
     </Container>
 );

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -83,8 +83,6 @@ export const HELP_CENTER_QR_CODE_URL: Url =
     'https://trezor.io/guides/trezor-suite/trezor-suite-desktop/qr-codes-in-trezor-suite';
 export const HELP_CENTER_ADDRESSES_URL: Url =
     'https://trezor.io/guides/trezor-suite/trezor-suite-desktop/addresses-transaction-history';
-export const HELP_CENTER_COINJOIN_URL: Url =
-    'https://trezor.io/learn/advanced/Blockchain-architecture-technologies/what-is-coinjoin';
 export const HELP_CENTER_TAPROOT_URL: Url =
     'https://trezor.io/learn/advanced/standards-proposals/what-is-taproot';
 export const HELP_CENTER_UDEV_URL: Url = 'https://trezor.io/guides/trezorctl/udev-rules';

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -39,11 +39,7 @@ import {
     TokenTransfer,
 } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
-import {
-    HELP_CENTER_ADDRESSES_URL,
-    HELP_CENTER_COINJOIN_URL,
-    HELP_CENTER_TAPROOT_URL,
-} from '@trezor/urls';
+import { HELP_CENTER_ADDRESSES_URL, HELP_CENTER_TAPROOT_URL } from '@trezor/urls';
 import { arrayDistinct, bufferUtils } from '@trezor/utils';
 import { BigNumber, BigNumberValue } from '@trezor/utils/src/bigNumber';
 
@@ -285,8 +281,6 @@ export const getAccountTypeUrl = (path: string) => {
     switch (bip43) {
         case 'bip86':
             return HELP_CENTER_TAPROOT_URL;
-        case 'slip25':
-            return HELP_CENTER_COINJOIN_URL;
         case 'shelley':
             return undefined;
         default:


### PR DESCRIPTION
tests [detected](https://github.com/trezor/trezor-suite/actions/runs/16895646473/job/47864775032#step:5:103) unused url so I removed it along with its implementation. 

can somebody confirm that it was removed and is not going to be replaced by anything? cc @pavelmario 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=remove-unused-url-implementation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=remove-unused-url-implementation&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=remove-unused-url-implementation&lookback=7)