### PR TITLE
test(connect): disable t3w1 from tests

### DIFF
--- a/.github/workflows/test-connect.yml
+++ b/.github/workflows/test-connect.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Set other devices matrix
         id: set-matrix-other-devices
-        run: echo "otherDevicesMatrix=$(node ./scripts/ci/connect-test-matrix-generator.js --model=all --firmware=2-main --env=node --groups=api --disable_cache_tx=true --transport=all)" >> $GITHUB_OUTPUT
+        run: echo "otherDevicesMatrix=$(node ./scripts/ci/connect-test-matrix-generator.js --model=T2T1,T2B1,T3B1,T3T1 --firmware=2-main --env=node --groups=api --disable_cache_tx=true --transport=all)" >> $GITHUB_OUTPUT
 
       - name: Set all transports matrix
         id: set-matrix-all-transports


### PR DESCRIPTION
I hope I am going to revert this commit very soon but we are not ready yet to support T3W1 i tests 

https://github.com/trezor/trezor-suite/actions/runs/16895529868/job/47864491071#step:17:312

<img width="336" height="525" alt="image" src="https://github.com/user-attachments/assets/d19cfdb8-8851-4659-96be-dc3727437077" />


https://github.com/trezor/trezor-suite/actions/runs/16906447249

<img width="296" height="387" alt="image" src="https://github.com/user-attachments/assets/0209f8ed-b42c-4fff-bba8-3900e0a88eb8" />

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=t3w1-out&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=t3w1-out&lookback=7)