### PR TITLE
feat(transport-bluetooth): use write with response

### DIFF
--- a/packages/transport-bluetooth/src/client/bluetooth-api.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-api.ts
@@ -8,13 +8,11 @@ import { PathInternal } from '@trezor/transport/src/types';
 import { readMessageBuffer } from '@trezor/transport/src/utils/readMessageBuffer';
 
 import { TrezorBluetooth } from './trezor-bluetooth';
-import { BluetoothDevice } from './types';
+import { BluetoothDevice, TrezorBluetoothSettings } from './types';
 
 // implementation of @trezor/transport/src/api/abstract
 
-type BluetoothApiParams = AbstractApiConstructorParams & {
-    url: string;
-};
+type BluetoothApiParams = AbstractApiConstructorParams & TrezorBluetoothSettings;
 
 export class BluetoothApi extends AbstractApi {
     chunkSize = 244;
@@ -24,7 +22,7 @@ export class BluetoothApi extends AbstractApi {
     constructor(options: BluetoothApiParams) {
         super(options);
 
-        this.api = new TrezorBluetooth({ url: options.url, logger: options.logger });
+        this.api = new TrezorBluetooth(options);
     }
 
     private devicesToDescriptors(devices: BluetoothDevice[]) {

--- a/packages/transport-bluetooth/src/client/transport.ts
+++ b/packages/transport-bluetooth/src/client/transport.ts
@@ -2,12 +2,11 @@ import { AbstractTransportParams } from '@trezor/transport/src/transports/abstra
 import { AbstractApiTransport } from '@trezor/transport/src/transports/abstractApi';
 
 import { BluetoothApi } from './bluetooth-api';
+import { TrezorBluetoothSettings } from './types';
 
 // implementation of @trezor/transport/src/transports/abstractApi
 
-type BluetoothTransportParams = Omit<AbstractTransportParams, 'api'> & {
-    url: string;
-};
+type BluetoothTransportParams = Omit<AbstractTransportParams, 'api'> & TrezorBluetoothSettings;
 
 export class BluetoothTransport extends AbstractApiTransport {
     public name = 'BluetoothTransport' as const;
@@ -15,9 +14,9 @@ export class BluetoothTransport extends AbstractApiTransport {
     private wsApi: BluetoothApi;
 
     constructor(params: BluetoothTransportParams) {
-        const { url, logger, ...rest } = params;
+        const { url, logger, writeWithResponse, writeWithDelay, ...rest } = params;
 
-        const api = new BluetoothApi({ url, logger });
+        const api = new BluetoothApi({ url, logger, writeWithResponse, writeWithDelay });
         api.on('transport-interface-error', ({ error }) => {
             this.emit('transport-error', error);
         });

--- a/packages/transport-bluetooth/src/client/trezor-bluetooth.ts
+++ b/packages/transport-bluetooth/src/client/trezor-bluetooth.ts
@@ -1,3 +1,4 @@
+import { resolveAfter } from '@trezor/utils';
 import { WebsocketClient } from '@trezor/websocket-client';
 
 import {
@@ -67,8 +68,42 @@ export class TrezorBluetooth extends WebsocketClient<NotificationEvent> {
         return this.sendMessage({ method: 'connect_device', params }, { timeout: wsTimeout });
     }
 
-    write(params: WriteParams) {
-        const withResponse = false;
+    private writeBuffer: Record<string, { bytes: number; lastWrite: number } | undefined> = {};
+
+    private async write(params: WriteParams) {
+        const writeBuffer = this.writeBuffer[params.id];
+        if (!writeBuffer) {
+            throw new Error('Device not opened');
+        }
+
+        // MacOS and Windows writeWithoutResponse sends packets faster than Trezor is able to process or just loose packets and doesn't send them at all (macos)
+        // we need to use throttle it to make sure that they are received and processed correctly
+        // NOTE: the faster it sends the longer it waits when withResponse is used
+        const MIN_PACKETS = 8;
+        const MAX_PACKETS = 16;
+        const PACKET_SIZE = 244;
+        const WITH_RESPONSE_BYTES = PACKET_SIZE * MAX_PACKETS;
+        let withResponse = false;
+        const lastWrite = Date.now() - writeBuffer.lastWrite;
+        // windows: use delay between packets. do not use writeWithResponse - it takes too long
+        if (this.settings.writeWithDelay && lastWrite < MIN_PACKETS) {
+            const wait =
+                MIN_PACKETS -
+                lastWrite +
+                Math.floor(MIN_PACKETS * ((writeBuffer.bytes / WITH_RESPONSE_BYTES) % 1));
+            await resolveAfter(wait);
+        }
+
+        // macos: use writeWithResponse occasionally (first few packets and every 16-nth)
+        if (this.settings.writeWithResponse) {
+            const sent = writeBuffer.bytes / PACKET_SIZE;
+            if (sent <= MIN_PACKETS || sent % WITH_RESPONSE_BYTES === 0) {
+                withResponse = true;
+            }
+        }
+
+        writeBuffer.lastWrite = Date.now();
+        writeBuffer.bytes += params.data.length;
 
         return this.sendMessage({ method: 'write', params: { ...params, withResponse } });
     }
@@ -92,6 +127,17 @@ export class TrezorBluetooth extends WebsocketClient<NotificationEvent> {
 
         if (method === 'write') {
             return this.write(params);
+        }
+
+        if (method === 'open_device') {
+            this.writeBuffer[params] = {
+                bytes: 0,
+                lastWrite: 0,
+            };
+        }
+
+        if (method === 'close_device') {
+            delete this.writeBuffer[params];
         }
 
         return this.sendMessage({ method, params });

--- a/packages/transport-bluetooth/src/client/types.ts
+++ b/packages/transport-bluetooth/src/client/types.ts
@@ -7,6 +7,8 @@ export interface TrezorBluetoothSettings {
     url: string;
     logger?: Logger;
     timeout?: number;
+    writeWithResponse?: boolean;
+    writeWithDelay?: boolean;
 }
 
 export type BluetoothInfo = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We need to dynamically change bluetooth write params when we are sending big messages like for example FW update.
briefly explanation:
- `WriteWithoutResponse` (default - fast) sends the message but doesnt guarantee the delivery, we dont know if bluetooth central (adapter) really send it and is it safe to send another chunk.
- `WriteWithResponse` (slower) - sends the message and waits for delivery confirmation (ACK sent by bluetooth peripheral)


Those params behaves differently on each OS:
- linux: `WriteWithoutResponse` works as expected and doesnt need any workaroud.
- macos: `WriteWithoutResponse` sends the message immediately (~1ms) - after a while it keep loosing the packets when  the OS buffer is full. Additionally i've fixed one bug in [btleblug dependency](https://github.com/deviceplug/btleplug/pull/441) - hopefully it will be merged soon.
- windows: `WriteWithoutResponse` is also very fast and it is clogging the OS buffer (loosing packets) yet `WriteWithResponse` is deadly slow

To optimize FW update process we need custom approach.

- for macos use `WriteWithResponse`  on first 8 packets and then on each 16nth packet.
- for windows `WriteWithoutResponse` but throttle it and use delay if sending speed it too fast

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/bt-write-without-response&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/bt-write-without-response&lookback=7)