### PR TITLE
Fix `selectEnabledSupportedNetworks` memoization

### DIFF
--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -34,13 +34,15 @@ type CompoundRootState = AccountsRootState &
     WalletSettingsRootState;
 const createMemoizedSelector = createWeakMapSelector.withTypes<CompoundRootState>();
 
-const selectEnabledSupportedNetworks = (state: CompoundRootState) => {
-    const enabledNetworks = selectEnabledNetworks(state);
-    const device = selectSelectedDevice(state);
-    const deviceNetworks = selectSupportedNetworkByDevice(device);
+const selectEnabledSupportedNetworks = createMemoizedSelector(
+    [selectEnabledNetworks, selectSelectedDevice],
+    (enabledNetworks, device) => {
+        const deviceNetworks = selectSupportedNetworkByDevice(device);
+        const supportedNetworks = enabledNetworks.filter(n => deviceNetworks.includes(n));
 
-    return enabledNetworks.filter(network => deviceNetworks.includes(network));
-};
+        return returnStableArrayIfEmpty(supportedNetworks);
+    },
+);
 
 /**
  * Listable accounts are visible, enabled in settings, supported by the device and conventionally sorted.


### PR DESCRIPTION
## Description

Recently I've added `selectEnabledSupportedNetworks` selector, used as an input selector in `selectAllAccountsToList`, which then printed console warnings because it wasn't properly memoized (it returned different array references for the same inputs). This should fix it.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/memoized-rediscover-selector&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/memoized-rediscover-selector&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/memoized-rediscover-selector&lookback=7)