### PR TITLE
Fix `<TextButton />` prop propagation

### DIFF
--- a/packages/components/src/components/buttons/TextButton/TextButton.tsx
+++ b/packages/components/src/components/buttons/TextButton/TextButton.tsx
@@ -104,9 +104,10 @@ export const TextButton = ({
     isLoading = false,
     children,
     variant = 'primary',
+    margin,
     ...rest
 }: TextButtonProps) => {
-    const frameProps = pickAndPrepareFrameProps(rest, allowedButtonFrameProps);
+    const frameProps = pickAndPrepareFrameProps({ margin, ...rest }, allowedButtonFrameProps);
     const theme = useTheme();
     const IconComponent = getIcon({
         icon,


### PR DESCRIPTION
## Description

Because of `{...rest}` spread in `<TextButtonContainer />`, `margin="[object Object]"` sometimes appeared in DOM, printing a warning. First I tried not to pass the `rest` at all and leave only `frameProps` there, but it broke the tests because (at least) `data-testid` and `onClick` were missing as well. So I defensively omit `margin` in particular which seems to be fine.

What do you think @jvaclavik?


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/button-margin-prop&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/button-margin-prop&lookback=7)