### PR TITLE
fix(suite): TxAddress action icons should take same space as on hover

### DIFF
--- a/packages/suite/src/components/suite/copy/TxAddress.tsx
+++ b/packages/suite/src/components/suite/copy/TxAddress.tsx
@@ -16,16 +16,14 @@ import { selectAddressDisplayType } from 'src/selectors/suite/suiteSelectors';
 type DisplayMode = 'copy' | 'modal' | 'static';
 
 const IconWrapper = styled.div`
-    display: none;
+    display: block;
     padding: 1px;
     border-radius: 2px;
+    opacity: 0;
+    transition: 250ms ease;
     margin-left: 4px;
     background-color: ${({ theme }) => theme.iconSubdued};
     height: 14px;
-
-    &:hover {
-        opacity: 0.7;
-    }
 `;
 
 const onHoverTextOverflowContainerHover = css`
@@ -35,7 +33,11 @@ const onHoverTextOverflowContainerHover = css`
     z-index: 3;
 
     ${IconWrapper} {
-        display: block;
+        opacity: 1;
+
+        &:hover {
+            opacity: 0.7;
+        }
     }
 `;
 


### PR DESCRIPTION
Fixes "jumping" TX details modals.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20678

## Screenshots:
**BEFORE**

https://github.com/user-attachments/assets/c23a3d96-f131-4d35-a967-529ab2a314ff

**AFTER**

https://github.com/user-attachments/assets/1d890ba2-dd28-4b59-8ec6-9dee9f621882





🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tx-address-actions-spacing&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tx-address-actions-spacing&lookback=7)