### PR TITLE
fix(suite): don't redirect back to provider when not necessary

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -384,6 +384,14 @@ export const useTradingSellForm = ({
             });
 
             navigateToSellConfirm();
+
+            // empty quoteId means the partner requests login first, requestTrade to get login screen
+            if (
+                (sellInfo && sellUtils.needToRegisterOrVerifyBankAccount({ quote, sellInfo })) ||
+                !quote.quoteId
+            ) {
+                doSellTrade(quote);
+            }
         };
 
         const onCancel = () => {
@@ -555,22 +563,6 @@ export const useTradingSellForm = ({
             isComposing,
         ],
     );
-
-    useDebounce(() => {
-        // empty quoteId means the partner requests login first, requestTrade to get login screen
-        if (
-            selectedQuote &&
-            pageType === 'confirm' &&
-            (!selectedQuote.quoteId ||
-                (sellInfo &&
-                    sellUtils.needToRegisterOrVerifyBankAccount({
-                        quote: selectedQuote,
-                        sellInfo,
-                    })))
-        ) {
-            doSellTrade(selectedQuote);
-        }
-    }, 50);
 
     useEffect(() => {
         if (!quotesRequest && isNotFormPage) {


### PR DESCRIPTION
## Description

This PR fixes an issue where user with a lot of tokens would be stuck in infinite redirect loop between the Suite and provider when selling tokens.

### Root cause 

`useDebounce` would be called after the redirect back from the provider while `sellInfo` was still `undefined` and therefore `trade` request was not fired so the flow stopped [here](https://github.com/trezor/trezor-suite/blob/d17806cd044adf12476fb410745860461ca9574f/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts#L274-L276) because `commonFunctions` availability depends on availability of `sellInfo`.

This however happened only for users with not many assets.

For users with a lot of different assets `sellInfo` managed to load before it got to the `useDebounce` that made the flow continue and `trade` request was fired with outdated data causing the redirect.

### Result

Now, `doSellTrade` is fired only when user submits the form. After the redirect from the provider back to the app, we don't call `doSellTrade` again and instead just use already setup subscription to the trade changes via `useTradingWatchTrade`

## Related Issue

Resolve #20670

---

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sell-infinite-redirect&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sell-infinite-redirect&lookback=7)