### PR TITLE
native send form can pre-fill invalid feePerUnit decimals

### DIFF
--- a/suite-native/module-send/src/components/SendFeesForm.tsx
+++ b/suite-native/module-send/src/components/SendFeesForm.tsx
@@ -49,6 +49,7 @@ import {
     selectFeeLevels,
 } from '../sendFormSlice';
 import { NativeSupportedFeeLevel } from '../types';
+import { getFeeValue } from '../utils';
 
 type SendFormProps = {
     accountKey: AccountKey;
@@ -93,16 +94,20 @@ export const SendFeesForm = ({ accountKey, tokenContract }: SendFormProps) => {
 
     const normalFee = feeLevels.normal as PrecomposedTransactionFinal; // user is not allowed to enter this screen if normal fee is not final
 
+    const trimmedFeePerUnit = getFeeValue({
+        feeRate: formDraft?.feePerUnit,
+        symbol: account?.symbol,
+    });
     const form = useForm<SendFeesFormValues>({
         validation: sendFeesFormValidationSchema,
         defaultValues: {
             feeLevel: formDraft?.selectedFee as NativeSupportedFeeLevel,
-            customFeePerUnit: formDraft?.feePerUnit,
+            customFeePerUnit: trimmedFeePerUnit,
             customFeeLimit: normalFee?.feeLimit,
         },
         context: {
             networkFeeInfo,
-            networkType,
+            symbol: account?.symbol,
             minimalFeeLimit,
         },
     });

--- a/suite-native/module-send/src/sendFeesFormSchema.ts
+++ b/suite-native/module-send/src/sendFeesFormSchema.ts
@@ -1,13 +1,14 @@
 import { yup } from '@suite-common/validators';
-import { NetworkType } from '@suite-common/wallet-config';
+import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { FeeInfo } from '@suite-common/wallet-types';
 import { isDecimalsValid } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { NativeSupportedFeeLevel } from './types';
+import { getFeeDecimals } from './utils';
 
 type SendFeesFormContext = {
-    networkType?: NetworkType;
+    symbol?: NetworkSymbol;
     networkFeeInfo?: FeeInfo;
     minimalFeeLimit?: string;
 };
@@ -30,17 +31,17 @@ export const sendFeesFormValidationSchema = yup.object({
             (value, { options: { context } }: yup.TestContext<SendFeesFormContext>) => {
                 if (!value) return true;
 
-                const { networkFeeInfo, networkType } = context!;
+                const { networkFeeInfo, symbol } = context!;
+
+                if (!symbol) return false;
+
+                const { networkType } = getNetwork(symbol);
+
                 if (!networkFeeInfo || !networkType) return false;
 
-                if (networkType !== 'bitcoin' && networkType !== 'ethereum') return true;
+                const maxDecimals = getFeeDecimals({ symbol });
 
-                let maxDecimals = 0;
-                if (networkType === 'bitcoin') {
-                    maxDecimals = 2;
-                } else if (networkType === 'ethereum') {
-                    maxDecimals = 9;
-                }
+                if (maxDecimals === null) return true;
 
                 return isDecimalsValid(value, maxDecimals);
             },
@@ -80,7 +81,10 @@ export const sendFeesFormValidationSchema = yup.object({
             'fee-limit-too-low',
             'Value is too low.',
             (value, { options: { context } }: yup.TestContext<SendFeesFormContext>) => {
-                const { networkType, minimalFeeLimit } = context!;
+                const { symbol, minimalFeeLimit } = context!;
+                if (!symbol) return true;
+
+                const { networkType } = getNetwork(symbol);
 
                 // Fee limit is used only for Ethereum, pass this validation for other networks.
                 if (networkType !== 'ethereum') return true;

--- a/suite-native/module-send/src/utils.ts
+++ b/suite-native/module-send/src/utils.ts
@@ -1,6 +1,8 @@
+import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { FormState, TokenAddress } from '@suite-common/wallet-types';
 import { Utxo } from '@trezor/blockchain-link-types';
 import { FeeLevel } from '@trezor/connect';
+import { BigNumber } from '@trezor/utils';
 
 import { SendOutputFieldName, SendOutputsFormValues } from './sendOutputsFormSchema';
 
@@ -40,3 +42,40 @@ export const constructFormDraft = ({
 
 export const isSameUtxo = (utxo1: Utxo, utxo2: Utxo): boolean =>
     utxo1.txid === utxo2.txid && utxo1.vout === utxo2.vout;
+
+export const getFeeDecimals = ({ symbol }: { symbol: NetworkSymbol }) => {
+    const network = getNetwork(symbol);
+
+    switch (network.networkType) {
+        case 'ethereum': {
+            return 9;
+        }
+
+        case 'bitcoin': {
+            return 2;
+        }
+
+        default:
+            return null;
+    }
+};
+
+export const getFeeValue = ({
+    feeRate,
+    symbol,
+}: {
+    feeRate: string | undefined;
+    symbol: NetworkSymbol | undefined;
+}) => {
+    if (!feeRate || !symbol) {
+        return undefined;
+    }
+
+    const decimals = getFeeDecimals({ symbol });
+
+    if (decimals !== null) {
+        return new BigNumber(feeRate).decimalPlaces(decimals, 1 /*ROUND_DOWN*/).toFixed();
+    }
+
+    return feeRate;
+};


### PR DESCRIPTION
We didn't previously make sure we pre-fill fee data with correct max amount of decimals than what we later validate. It caused issues at least with Litecoin, where we pre-filed 3 decimals, but fee form validation rejected this because 2 decimals were expected. Unless user set custom fee with less decimals, he then wasn't allowed to send LTC

This fix introduces sanitising for the form before we insert pre-filed data. 


https://github.com/user-attachments/assets/0f355802-a47e-4a72-b8b5-6d8de28e9bfe

Resolve #20734


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/send-fees-form-decimal-validation&lookback=7)