### PR TITLE
Fix multiple standard wallets

### DIFF
--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -699,7 +699,7 @@ export const runAdditionalDiscoveryThunk = createThunk(
         TrezorConnect.on<DiscoverAccountsProgress>(UI.BUNDLE_PROGRESS, onBundleProgress);
 
         // NOTE: prepare the device to the corresponding state eg. insert the passphrase
-        const stateResult = await TrezorConnect.getDeviceState({
+        const deviceStateResponse = await TrezorConnect.getDeviceState({
             device: {
                 path: device.path,
                 instance: device.instance,
@@ -708,12 +708,13 @@ export const runAdditionalDiscoveryThunk = createThunk(
             useEmptyPassphrase: device.useEmptyPassphrase,
         });
 
-        if (stateResult.success) {
+        if (deviceStateResponse.success) {
+            assertStaticSessionId(deviceStateResponse.payload._state);
             dispatch(
-                applyDeviceStatesThunk({
-                    newDeviceState: stateResult.payload._state,
-                    isAddingHiddenWallet: !device.useEmptyPassphrase,
-                    devicePath: device.path,
+                deviceActions.setDeviceState({
+                    device,
+                    state: deviceStateResponse.payload._state,
+                    useEmptyPassphrase: device.useEmptyPassphrase,
                 }),
             );
         }


### PR DESCRIPTION
## Description

Should fix the issue with multiple standard wallets from one device while preserving the merit of #20550.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/multiple-standard-wallets&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/multiple-standard-wallets&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/multiple-standard-wallets&lookback=7)