### PR TITLE
fix(suite): do not remove drafts on account change, fix state switch

### DIFF
--- a/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
@@ -70,6 +70,7 @@ const initStore = ({ send, fees, selectedAccount, coinjoin, bitcoinAmountUnit }:
                 settings: { bitcoinAmountUnit, enabledNetworks: ['thol'] },
             },
             suite: { settings: { language: 'en' } },
+            router: { route: { name: 'wallet-send' } },
         },
     });
 
@@ -255,6 +256,7 @@ describe('useSendForm hook', () => {
                     // validate action result
                     actionCallback(callback, a);
                 });
+
                 unmount();
             },
             TEST_TIMEOUT,

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -360,6 +360,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [draft]);
 
+    // update composedLevels when feeInfo changes
     useEffect(() => {
         composeDraft(getValues());
     }, [composeDraft, getValues]);

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -226,7 +226,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
 
     const resetContext = useCallback(() => {
         setComposedLevels(undefined);
-        dispatch(removeSendFormDraftThunk()); // reset draft;
+        dispatch(removeSendFormDraftThunk());
         setState(getStateFromProps({ selectedAccount, localCurrency, online, metadataEnabled }));
     }, [dispatch, setComposedLevels, selectedAccount, localCurrency, online, metadataEnabled]);
 
@@ -283,13 +283,6 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
             }
         }
     }, [getValues, composedLevels, dispatch, resetContext, selectedAccount.account]);
-
-    // reset on account change
-    useEffect(() => {
-        if (state.account.key !== selectedAccount.account.key) {
-            resetContext();
-        }
-    }, [state.account.key, selectedAccount.account.key, resetContext]);
 
     const protocol = useSelector(state => state.protocol);
 
@@ -367,7 +360,6 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [draft]);
 
-    // update composedLevels when feeInfo changes
     useEffect(() => {
         composeDraft(getValues());
     }, [composeDraft, getValues]);

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -22,7 +22,6 @@ import {
     selectDevices,
     selectHistoricFiatRates,
     selectSelectedDevice,
-    sendFormActions,
     setBaseCurrency,
     transactionsActions,
     updateTxsFiatRatesThunk,
@@ -33,7 +32,7 @@ import { walletConnectActions } from '@suite-common/walletconnect';
 import { METADATA, STORAGE, SUITE } from 'src/actions/suite/constants';
 import * as metadataActions from 'src/actions/suite/metadataActions';
 import * as storageActions from 'src/actions/suite/storageActions';
-import { FORM_DRAFT, GRAPH } from 'src/actions/wallet/constants';
+import { GRAPH } from 'src/actions/wallet/constants';
 import * as COINJOIN from 'src/actions/wallet/constants/coinjoinConstants';
 import { selectIsAutoEjectEnabled } from 'src/selectors/suite/suiteSelectors';
 import { db } from 'src/storage';
@@ -211,19 +210,6 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 api.dispatch(storageActions.saveKnownDevices());
             }
 
-            if (sendFormActions.storeDraft.match(action)) {
-                const device = selectSelectedDevice(api.getState());
-                const { formState, accountKey } = action.payload;
-                // save drafts for remembered device
-                if (isDeviceRemembered(device)) {
-                    storageActions.saveDraft(formState, accountKey);
-                }
-            }
-
-            if (sendFormActions.removeDraft.match(action)) {
-                storageActions.removeDraft(action.payload.accountKey);
-            }
-
             if (
                 isAnyOf(
                     connectPopupActions.rememberAppPermissions,
@@ -328,17 +314,6 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     }
                     break;
                 }
-                case FORM_DRAFT.STORE_DRAFT: {
-                    const device = selectSelectedDevice(api.getState());
-                    // save drafts for remembered device
-                    if (isDeviceRemembered(device)) {
-                        storageActions.saveFormDraft(action.key, action.formDraft);
-                    }
-                    break;
-                }
-                case FORM_DRAFT.REMOVE_DRAFT:
-                    storageActions.removeFormDraft(action.key);
-                    break;
 
                 case deviceActions.setEntropyCheckFail.type:
                     api.dispatch(storageActions.saveEntropyCheckFail());

--- a/packages/suite/src/views/wallet/send/index.tsx
+++ b/packages/suite/src/views/wallet/send/index.tsx
@@ -71,7 +71,6 @@ const SendLoaded = ({ children, selectedAccount }: SendLoadedProps) => {
     const sendContextValues = useSendForm({ ...props, selectedAccount });
 
     const { symbol } = selectedAccount.account;
-
     if (props.sendRaw) {
         return (
             <WalletLayout title="TR_NAV_SEND" isSubpage account={selectedAccount}>
@@ -111,8 +110,10 @@ const SendLoaded = ({ children, selectedAccount }: SendLoadedProps) => {
 
 const Send = ({ children }: SendProps) => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const currentRoute = useSelector(state => state.router.route?.name);
 
-    if (selectedAccount.status !== 'loaded') {
+    // alone selectedAccount.status is not enough, currently there is a race-condition that needs to be fixed in send form
+    if (selectedAccount.status !== 'loaded' || currentRoute !== 'wallet-send') {
         return <WalletLayout title="TR_NAV_SEND" account={selectedAccount} />;
     }
 


### PR DESCRIPTION
Currently there is a deeply rooted race-condition in the send form that would require a refactor. (and we don't want to break things now 😅) - but I was able to fix it in this [file](https://github.com/trezor/trezor-suite/blob/1d99a9268cf6285f93a241523e19b44b128e52dc/packages/suite/src/views/wallet/send/index.tsx).

The race condition is "fixed" by debounce function (I tried to invalidate the debounce request, but that helped only partially). 

**Changes**:
- do not save drafts to DB
- persist send form drafts across different coins
- race-condition fix in wallet/send/index

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20359

## Screenshots:
**BEFORE**

https://github.com/user-attachments/assets/66e9ef7b-3564-4ee7-881d-c132ae32c54b


**AFTER**

https://github.com/user-attachments/assets/8fb0df9a-1834-46fe-9672-29d20835530e




🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/incorrect-send-form-state-persistency&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/incorrect-send-form-state-persistency&lookback=7)