### PR TITLE
fix(suite): incorrect trading account selected in receive step

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.ts
@@ -6,6 +6,9 @@ import {
     cryptoIdToSymbol,
     getUnusedAddressFromAccount,
     parseCryptoId,
+    selectTradingActiveSection,
+    selectTradingBuyReceiveAccountKey,
+    selectTradingExchangeAccountKey,
 } from '@suite-common/trading';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
@@ -67,7 +70,14 @@ const useTradingVerifyAccount = ({
     cryptoId,
     nonSuiteAccount,
 }: TradingVerifyAccountProps): TradingVerifyAccountReturnProps => {
+    const activeSection = useSelector(selectTradingActiveSection);
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const selectedAccountKey =
+        useSelector(
+            activeSection === 'exchange'
+                ? selectTradingExchangeAccountKey
+                : selectTradingBuyReceiveAccountKey,
+        ) || selectedAccount.account?.key;
     const accounts = useSelector(state => state.wallet.accounts);
     const isDebug = useSelector(selectIsDebugModeActive);
     const device = useSelector(selectSelectedDevice);
@@ -114,13 +124,13 @@ const useTradingVerifyAccount = ({
             ),
         [device, suiteReceiveAccounts, isSupportedNetwork, nonSuiteAccount],
     );
+
     const preselectedAccount = useMemo(
         () =>
             selectAccountOptions.find(
-                accountOption =>
-                    accountOption.account?.descriptor === selectedAccount.account?.descriptor,
+                accountOption => accountOption.account?.key === selectedAccountKey,
             ) ?? selectAccountOptions[0],
-        [selectAccountOptions, selectedAccount],
+        [selectAccountOptions, selectedAccountKey],
     );
 
     const { address } = methods.getValues();

--- a/suite-common/wallet-utils/src/__tests__/filterReceiveAccounts.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/filterReceiveAccounts.test.ts
@@ -85,8 +85,12 @@ describe('filter receive accounts', () => {
         expect(runFilterReceiveAccouns({})).toEqual(filteredAccounts);
     });
 
-    it('returns only non-debug accounts when debug mode is off', () => {
-        const filteredAccounts = [getWalletAccount({ symbol: 'eth', accountType: 'normal' })];
+    it('returns non-debug + non-empty accounts when debug mode is off', () => {
+        const filteredAccounts = [
+            getWalletAccount({ symbol: 'eth', accountType: 'normal' }),
+            getWalletAccount({ symbol: 'eth', accountType: 'ledger' }),
+            getWalletAccount({ symbol: 'eth', accountType: 'legacy' }),
+        ];
 
         expect(runFilterReceiveAccouns({ isDebug: false })).toEqual(filteredAccounts);
     });

--- a/suite-common/wallet-utils/src/filterReceiveAccounts.ts
+++ b/suite-common/wallet-utils/src/filterReceiveAccounts.ts
@@ -32,9 +32,11 @@ export const filterReceiveAccounts = ({
 }: FilterReceiveAccountsProps): Account[] => {
     const isSameDevice = (account: Account) => account.deviceState === deviceState;
     const isSameNetwork = (account: Account) => account.symbol === symbol;
-    const shouldDisplayDebugOnly = (account: Account) =>
-        isDebug || !isDebugOnlyAccountType(account.accountType, account.symbol);
     const isNotEmptyAccount = (account: Account) => !account.empty;
+    const shouldDisplayDebugOnly = (account: Account) =>
+        isDebug ||
+        !isDebugOnlyAccountType(account.accountType, account.symbol) ||
+        isNotEmptyAccount;
     const isVisibleAccount = (account: Account) => account.visible;
     const isFirstNormalAccount = (account: Account) =>
         account.accountType === 'normal' && account.index === 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- fix missing non empty ledger account when debug mode not active
- fix selecting receive account
  - it should try to receive the same account as send account

## Related Issue

Resolve #20718

## Screenshots:

https://github.com/user-attachments/assets/50e7dd7a-11fd-469a-86a7-d402aff3e384


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/receive-account-trading&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/receive-account-trading&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/receive-account-trading&lookback=7)