### PR TITLE
chore(wallet-core): fix typo in react version

### DIFF
--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -35,7 +35,7 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "date-fns": "^4.1.0",
-        "react": "18.2.0",
+        "react": "19.0.0",
         "react-hook-form": "^7.62.0",
         "react-redux": "^9.2.0",
         "web3-utils": "^4.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9971,7 +9971,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     date-fns: "npm:^4.1.0"
-    react: "npm:18.2.0"
+    react: "npm:19.0.0"
     react-hook-form: "npm:^7.62.0"
     react-redux: "npm:^9.2.0"
     web3-utils: "npm:^4.3.1"


### PR DESCRIPTION
Specify consistent react version everywhere (19.0.0)
In wallet-core we have 18.2.0

But it's no harm, the 18.2.0 did not actually install :shrug: 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=wallet-core-fix-typo-react-version&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=wallet-core-fix-typo-react-version&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=wallet-core-fix-typo-react-version&lookback=7)