### PR TITLE
fix(suite): setting device.useDeviceState fixes

### DIFF
--- a/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
+++ b/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
@@ -3,12 +3,7 @@ import assert from 'assert';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { testMocks } from '@suite-common/test-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import {
-    ConnectDeviceSettings,
-    deviceActions,
-    prepareDeviceReducer,
-    wipeDeviceThunk,
-} from '@suite-common/wallet-core';
+import { deviceActions, prepareDeviceReducer, wipeDeviceThunk } from '@suite-common/wallet-core';
 import { Response } from '@trezor/connect';
 
 import suiteReducer from 'src/reducers/suite/suiteReducer';
@@ -39,10 +34,6 @@ type Feature = {
     };
 };
 
-const SUITE_SETTINGS: ConnectDeviceSettings = {
-    defaultWalletLoading: 'standard',
-};
-
 const fixture: Feature[] = [
     {
         description: 'Wipe device',
@@ -69,7 +60,6 @@ const fixture: Feature[] = [
                             available: false,
                             features: { ...deviceChange.features, device_id: 'device-id' },
                         },
-                        settings: SUITE_SETTINGS,
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
                 {
@@ -82,7 +72,6 @@ const fixture: Feature[] = [
                             available: true,
                             features: { ...deviceChange.features, device_id: 'new-device-id' },
                         },
-                        settings: SUITE_SETTINGS,
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
                 {
@@ -145,7 +134,6 @@ const fixture: Feature[] = [
                             available: false,
                             features: { ...deviceChange.features, device_id: 'device-id' },
                         },
-                        settings: SUITE_SETTINGS,
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
                 {
@@ -159,8 +147,8 @@ const fixture: Feature[] = [
                             instance: 1,
                             state: { staticSessionId: '1stTestnetAddress@device_1_id:0' },
                             features: { ...deviceChange.features, device_id: 'device-id' },
+                            useEmptyPassphrase: true,
                         },
-                        settings: SUITE_SETTINGS,
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
                 {
@@ -174,8 +162,8 @@ const fixture: Feature[] = [
                             instance: 2,
                             state: { staticSessionId: '1stTestnetAddress@device_2_id:0' },
                             features: { ...deviceChange.features, device_id: 'device-id' },
+                            useEmptyPassphrase: true,
                         },
-                        settings: SUITE_SETTINGS,
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
                 {
@@ -188,7 +176,6 @@ const fixture: Feature[] = [
                             available: true,
                             features: { ...deviceChange.features, device_id: 'new-device-id' },
                         },
-                        settings: SUITE_SETTINGS,
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
                 {
@@ -203,7 +190,6 @@ const fixture: Feature[] = [
                             state: { staticSessionId: '1stTestnetAddress@device_1_id:0' },
                             features: { ...deviceChange.features, device_id: 'new-device-id' },
                         },
-                        settings: SUITE_SETTINGS,
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
                 {
@@ -218,7 +204,6 @@ const fixture: Feature[] = [
                             state: { staticSessionId: '1stTestnetAddress@device_2_id:0' },
                             features: { ...deviceChange.features, device_id: 'new-device-id' },
                         },
-                        settings: SUITE_SETTINGS,
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
                 {

--- a/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
@@ -4,7 +4,6 @@ import { connectInitThunk } from '@suite-common/connect-init';
 import { prepareFirmwareReducer } from '@suite-common/firmware';
 import { testMocks } from '@suite-common/test-utils';
 import {
-    ConnectDeviceSettings,
     acquireDevice,
     deviceActions,
     forgetDisconnectedDevices,
@@ -109,10 +108,6 @@ const initStore = (state: State) => {
     });
 
     return store;
-};
-
-const SUITE_SETTINGS: ConnectDeviceSettings = {
-    defaultWalletLoading: 'standard',
 };
 
 describe('Suite Actions', () => {
@@ -234,9 +229,7 @@ describe('Suite Actions', () => {
     // just for coverage
     it('misc', () => {
         const SUITE_DEVICE = getSuiteDevice({ path: '1' });
-        expect(
-            deviceActions.forgetDevice({ device: SUITE_DEVICE, settings: SUITE_SETTINGS }),
-        ).toMatchObject({
+        expect(deviceActions.forgetDevice({ device: SUITE_DEVICE })).toMatchObject({
             type: deviceActions.forgetDevice.type,
         });
         expect(suiteActions.setDebugMode({ showDebugMenu: true })).toMatchObject({

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -18,7 +18,6 @@ import {
 import { cloneObject } from '@trezor/utils';
 
 import { selectCoinjoinAccountByKey } from 'src/reducers/wallet/coinjoinReducer';
-import { selectSuiteSettings } from 'src/selectors/suite/suiteSelectors';
 import { db } from 'src/storage';
 import type { PreloadStoreAction } from 'src/support/suite/preloadStore';
 import type { AppState, Dispatch, GetState, TrezorDevice } from 'src/types/suite';
@@ -545,12 +544,11 @@ export const removeDatabase = () => async (dispatch: Dispatch, getState: GetStat
     if (!(await db.isAccessible())) return;
 
     const devices = selectDevices(getState());
-    const settings = selectSuiteSettings(getState());
 
     const rememberedDevices = devices.filter(d => d.remember);
     // forget all remembered devices
     rememberedDevices.forEach(d => {
-        dispatch(deviceActions.forgetDevice({ device: d, settings }));
+        dispatch(deviceActions.forgetDevice({ device: d }));
     });
     await db.removeDatabase();
     dispatch(

--- a/packages/suite/src/actions/wallet/signVerifyActions.ts
+++ b/packages/suite/src/actions/wallet/signVerifyActions.ts
@@ -17,7 +17,7 @@ type StateParams = {
     device: TrezorDevice;
     account: Account;
     coin: Account['symbol'];
-    useEmptyPassphrase: boolean;
+    useEmptyPassphrase?: boolean;
     chunkify?: boolean;
 };
 

--- a/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
@@ -87,7 +87,6 @@ describe('redirectMiddleware', () => {
                 type: DEVICE.CONNECT,
                 payload: {
                     device: getConnectDevice({ mode: 'initialize' }),
-                    settings: { defaultWalletLoading: 'standard' },
                 },
             };
 
@@ -102,7 +101,6 @@ describe('redirectMiddleware', () => {
                 type: DEVICE.CONNECT,
                 payload: {
                     device: getConnectDevice({ mode: 'normal', firmware: 'required' }),
-                    settings: { defaultWalletLoading: 'standard' },
                 },
             };
 

--- a/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
@@ -1,6 +1,6 @@
 import { TrezorDevice } from '@suite-common/suite-types';
 import { testMocks } from '@suite-common/test-utils';
-import { ConnectDeviceSettings, deviceActions } from '@suite-common/wallet-core';
+import { deviceActions } from '@suite-common/wallet-core';
 import { DEVICE } from '@trezor/connect';
 import { DeepPartial } from '@trezor/type-utils';
 
@@ -17,10 +17,6 @@ type Fixture<TAction> = {
     result: DeepPartial<TrezorDevice>[];
 };
 
-const SUITE_SETTINGS: ConnectDeviceSettings = {
-    defaultWalletLoading: 'standard',
-};
-
 const connect: Fixture<
     | ReturnType<typeof deviceActions.connectDevice>
     | ReturnType<typeof deviceActions.connectUnacquiredDevice>
@@ -35,9 +31,6 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
-                    settings: {
-                        defaultWalletLoading: 'standard',
-                    },
                 },
             },
         ],
@@ -64,9 +57,6 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
-                    settings: {
-                        defaultWalletLoading: 'standard',
-                    },
                 },
             },
         ],
@@ -99,9 +89,6 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
-                    settings: {
-                        defaultWalletLoading: 'standard',
-                    },
                 },
             },
         ],
@@ -129,9 +116,6 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
-                    settings: {
-                        defaultWalletLoading: 'standard',
-                    },
                 },
             },
         ],
@@ -165,9 +149,6 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
-                    settings: {
-                        defaultWalletLoading: 'standard',
-                    },
                 },
             },
         ],
@@ -204,9 +185,6 @@ const connect: Fixture<
                     device: getConnectDevice({
                         path: '1',
                     }),
-                    settings: {
-                        defaultWalletLoading: 'standard',
-                    },
                 },
             },
         ],
@@ -215,58 +193,6 @@ const connect: Fixture<
                 type: 'acquired',
                 path: '1',
                 connected: true,
-            },
-        ],
-    },
-    {
-        description:
-            'Connect device with different "passphrase_protection" (create new missing instance)',
-        initialState: {
-            devices: [
-                getSuiteDevice(
-                    {
-                        useEmptyPassphrase: false,
-                        instance: 1,
-                    },
-                    {
-                        passphrase_protection: true,
-                    },
-                ),
-            ],
-        },
-        actions: [
-            {
-                type: DEVICE.CONNECT,
-                payload: {
-                    device: getConnectDevice({
-                        path: '1',
-                    }),
-                    settings: {
-                        defaultWalletLoading: 'standard',
-                    },
-                },
-            },
-        ],
-        result: [
-            {
-                type: 'acquired',
-                path: '1',
-                connected: true,
-                available: false,
-                instance: 1,
-                features: {
-                    passphrase_protection: false,
-                },
-            },
-            {
-                type: 'acquired',
-                path: '1',
-                instance: undefined,
-                connected: true,
-                available: true,
-                features: {
-                    passphrase_protection: false,
-                },
             },
         ],
     },
@@ -281,9 +207,6 @@ const connect: Fixture<
                         type: 'unacquired',
                         path: '1',
                     }),
-                    settings: {
-                        defaultWalletLoading: 'standard',
-                    },
                 },
             },
         ],
@@ -312,9 +235,6 @@ const connect: Fixture<
                         type: 'unacquired',
                         path: '1',
                     }),
-                    settings: {
-                        defaultWalletLoading: 'standard',
-                    },
                 },
             },
         ],
@@ -826,18 +746,16 @@ const forget: Fixture<ReturnType<typeof deviceActions.forgetDevice>>[] = [
                 type: deviceActions.forgetDevice.type,
                 payload: {
                     device: getSuiteDevice({ instance: 1 }),
-                    settings: SUITE_SETTINGS,
                 },
             },
             {
                 type: deviceActions.forgetDevice.type,
-                payload: { device: SUITE_DEVICE, settings: SUITE_SETTINGS },
+                payload: { device: SUITE_DEVICE },
             },
             {
                 type: deviceActions.forgetDevice.type,
                 payload: {
                     device: getSuiteDevice({ connected: true, instance: 3 }),
-                    settings: SUITE_SETTINGS,
                 },
             },
         ],
@@ -847,17 +765,18 @@ const forget: Fixture<ReturnType<typeof deviceActions.forgetDevice>>[] = [
                 features: {
                     device_id: 'ignored-device-id',
                 },
+                useEmptyPassphrase: undefined,
             },
             {
                 instance: 1,
                 features: {
                     device_id: 'ignored-device-id',
                 },
+                useEmptyPassphrase: undefined,
             },
             {
                 ...getSuiteDevice({ connected: true, instance: 3 }),
                 state: undefined,
-                useEmptyPassphrase: true,
             },
         ],
     },
@@ -882,7 +801,7 @@ const forget: Fixture<ReturnType<typeof deviceActions.forgetDevice>>[] = [
         actions: [
             {
                 type: deviceActions.forgetDevice.type,
-                payload: { device: getSuiteDevice({ instance: 3 }), settings: SUITE_SETTINGS },
+                payload: { device: getSuiteDevice({ instance: 3 }) },
             },
             {
                 type: deviceActions.forgetDevice.type,
@@ -890,12 +809,11 @@ const forget: Fixture<ReturnType<typeof deviceActions.forgetDevice>>[] = [
                     device: getSuiteDevice(undefined, {
                         device_id: 'ignored-device-id',
                     }),
-                    settings: SUITE_SETTINGS,
                 },
             },
             {
                 type: deviceActions.forgetDevice.type,
-                payload: { device: SUITE_DEVICE, settings: SUITE_SETTINGS },
+                payload: { device: SUITE_DEVICE },
             },
         ],
         result: [
@@ -923,7 +841,6 @@ const forget: Fixture<ReturnType<typeof deviceActions.forgetDevice>>[] = [
                     device: getSuiteDevice({
                         type: 'unacquired',
                     }),
-                    settings: SUITE_SETTINGS,
                 },
             },
         ],
@@ -939,7 +856,7 @@ const forget: Fixture<ReturnType<typeof deviceActions.forgetDevice>>[] = [
         actions: [
             {
                 type: deviceActions.forgetDevice.type,
-                payload: { device: SUITE_DEVICE, settings: SUITE_SETTINGS },
+                payload: { device: SUITE_DEVICE },
             },
         ],
         result: [],

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectAllConfirmation.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectAllConfirmation.tsx
@@ -5,8 +5,7 @@ import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
-import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectSuiteSettings } from 'src/selectors/suite/suiteSelectors';
+import { useDispatch } from 'src/hooks/suite';
 
 type EjectAllConfirmationProps = {
     onCancel: () => void;
@@ -16,11 +15,9 @@ type EjectAllConfirmationProps = {
 export const EjectAllConfirmation = ({ onCancel, instances }: EjectAllConfirmationProps) => {
     const dispatch = useDispatch();
 
-    const settings = useSelector(selectSuiteSettings);
-
     const handleEjectAll = () => {
         instances.forEach(instance => {
-            dispatch(deviceActions.forgetDevice({ device: instance, settings }));
+            dispatch(deviceActions.forgetDevice({ device: instance }));
         });
 
         analytics.report({

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectConfirmation.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectConfirmation.tsx
@@ -7,8 +7,7 @@ import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
-import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectSuiteSettings } from 'src/selectors/suite/suiteSelectors';
+import { useDispatch } from 'src/hooks/suite';
 
 type EjectConfirmationProps = {
     onCancel: MouseEventHandler<HTMLButtonElement> | undefined;
@@ -19,10 +18,8 @@ type EjectConfirmationProps = {
 export const EjectConfirmation = ({ onClick, onCancel, instance }: EjectConfirmationProps) => {
     const dispatch = useDispatch();
 
-    const settings = useSelector(selectSuiteSettings);
-
     const handleEject = () => {
-        dispatch(deviceActions.forgetDevice({ device: instance, settings }));
+        dispatch(deviceActions.forgetDevice({ device: instance }));
 
         analytics.report({
             type: EventType.SwitchDeviceEject,

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -134,7 +134,7 @@ export const WalletInstance = ({
                         >
                             <Row justifyContent="space-between">
                                 <Row gap={spacings.xxs}>
-                                    {!instance.useEmptyPassphrase && (
+                                    {instance.useEmptyPassphrase === false && (
                                         <Tooltip
                                             content={
                                                 <Translation id="TR_WALLET_PASSPHRASE_WALLET" />

--- a/suite-common/bluetooth/tests/bluetoothReducer.test.ts
+++ b/suite-common/bluetooth/tests/bluetoothReducer.test.ts
@@ -151,7 +151,6 @@ describe('bluetoothReducer', () => {
         store.dispatch(
             deviceActions.connectDevice({
                 device: trezorDevice as Device,
-                settings: { defaultWalletLoading: 'passphrase' },
             }),
         );
         expect(store.getState().bluetooth.knownDevices).toEqual([nearbyDevice]);

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -27,7 +27,7 @@ export type ButtonRequest = Omit<DeviceEvent['payload'], 'device' | 'code'> & {
 };
 
 export interface ExtendedDevice {
-    useEmptyPassphrase: boolean;
+    useEmptyPassphrase?: boolean;
     remember?: boolean; // device should be remembered
     forceRemember?: true; // device was forced to be remembered
     temporaryRemember?: boolean; // device should be remembered only for fw update or this session
@@ -57,6 +57,7 @@ export type UnreadableDevice = UnreadableDeviceBase & ExtendedDevice;
 export type TrezorDevice = AcquiredDevice | UnknownDevice | UnreadableDevice;
 
 export type AuthorizedDevice = AcquiredDevice & {
+    useEmptyPassphrase: boolean;
     state: Required<DeviceState>;
     instance: number;
     walletNumber: number;

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -231,7 +231,7 @@ const getSuiteDevice = (
     const device = getConnectDevice(dev, { bootloader_mode, ...feat });
     if (device.type === 'acquired') {
         return {
-            useEmptyPassphrase: true,
+            useEmptyPassphrase: dev?.state ? true : undefined,
             remember: false,
             connected: false,
             available: false,

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -1,18 +1,12 @@
 import { createAction } from '@reduxjs/toolkit';
 
 import { ButtonRequest, ThpSuiteCredentials, TrezorDevice } from '@suite-common/suite-types';
-import { WalletType } from '@suite-common/wallet-types';
 import { DEVICE, Device, DeviceState, StaticSessionId } from '@trezor/connect';
 
 export const DEVICE_MODULE_PREFIX = '@suite/device';
 
-export type ConnectDeviceSettings = {
-    defaultWalletLoading: WalletType;
-};
-
 export type DeviceConnectActionPayload = {
     device: Device;
-    settings: ConnectDeviceSettings;
 };
 
 const connectDevice = createAction(DEVICE.CONNECT, (payload: DeviceConnectActionPayload) => ({
@@ -69,7 +63,7 @@ const setTemporaryRememberedDevice = createAction(
 
 const forgetDevice = createAction(
     `${DEVICE_MODULE_PREFIX}/forgetDevice`,
-    (payload: { device: TrezorDevice; settings: ConnectDeviceSettings }) => ({
+    (payload: { device: TrezorDevice }) => ({
         payload,
     }),
 );

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -10,9 +10,8 @@ import * as deviceUtils from '@suite-common/suite-utils';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { shouldDeviceBeRemembered } from '@suite-common/wallet-utils';
 import { Device, DeviceState, Features, KnownDevice, StaticSessionId } from '@trezor/connect';
-import { isNative } from '@trezor/env-utils';
 
-import { ConnectDeviceSettings, deviceActions } from './deviceActions';
+import { deviceActions } from './deviceActions';
 import { PORTFOLIO_TRACKER_DEVICE_ID } from './deviceConstants';
 
 export type DeviceReducerState = {
@@ -102,32 +101,13 @@ const merge = (
     },
 });
 
-const getShouldUseEmptyPassphrase = (
-    device: Device | TrezorDevice,
-    deviceInstance: number | undefined,
-    settings: ConnectDeviceSettings,
-): boolean => {
-    if (!device.features) return false;
-
-    if (isNative() && (!deviceInstance || deviceInstance === 1)) {
-        // On mobile, if device has instance === 1, we always want to use empty passphrase since we
-        // connect & authorize standard wallet by default. Other instances will have `usePassphraseProtection` set same way as web/desktop app.
-        return true;
-    }
-
-    return !device.features.passphrase_protection || settings.defaultWalletLoading === 'standard';
-};
 /**
  * Action handler: DEVICE.CONNECT + DEVICE.CONNECT_UNACQUIRED
  * @param {DeviceReducerState} draft
  * @param {Device} device
  * @returns
  */
-const connectDevice = (
-    draft: DeviceReducerState,
-    device: Device,
-    settings: ConnectDeviceSettings,
-) => {
+const connectDevice = (draft: DeviceReducerState, device: Device) => {
     const currentTime = new Date().getTime();
 
     const deviceCommonFields = {
@@ -154,7 +134,6 @@ const connectDevice = (
             ...device,
             ...deviceCommonFields,
             available: false,
-            useEmptyPassphrase: true,
         });
 
         return;
@@ -184,13 +163,11 @@ const connectDevice = (
         ? deviceUtils.getNewInstanceNumber(draft.devices, device) || 1
         : undefined;
 
-    const useEmptyPassphrase = getShouldUseEmptyPassphrase(device, deviceInstance, settings);
-
     const newDevice: TrezorDevice = {
         ...device,
         ...deviceCommonFields,
         state: device._state,
-        useEmptyPassphrase,
+        useEmptyPassphrase: undefined,
         remember: shouldDeviceBeRemembered({
             isDeviceAutoEjectEnabled: draft.isDeviceAutoEjectEnabled,
             device,
@@ -205,7 +182,7 @@ const connectDevice = (
         const changedDevices = affectedDevices.map(d => {
             // change availability according to "passphrase_protection" field
             if (
-                !d.useEmptyPassphrase &&
+                d.useEmptyPassphrase === true &&
                 isUnlocked(device.features) &&
                 !features.passphrase_protection
             ) {
@@ -215,12 +192,6 @@ const connectDevice = (
             return merge(d, { ...device, connected: true, available: true });
         });
 
-        // affected device with current "passphrase_protection" does not exists
-        // basically it means that the "standard" device without "useEmptyPassphrase" was forgotten or never created (removed from reducer)
-        // automatically create new "standard" instance
-        if (!changedDevices.find(d => d.available)) {
-            changedDevices.push(newDevice);
-        }
         // fill draft with affectedDevices values
         changedDevices.forEach(d => draft.devices.push(d));
     } else {
@@ -491,11 +462,7 @@ const setTemporaryRememberedDevice = (
  * @param {TrezorDevice} device
  * @returns
  */
-const forget = (
-    draft: DeviceReducerState,
-    device: TrezorDevice,
-    settings: ConnectDeviceSettings,
-) => {
+const forget = (draft: DeviceReducerState, device: TrezorDevice) => {
     // only acquired devices
     if (!device || !device.features) return;
     const index = deviceUtils.findInstanceIndex(draft.devices, device);
@@ -506,11 +473,7 @@ const forget = (
         draft.devices[index].state = undefined;
         draft.devices[index].walletNumber = undefined;
 
-        draft.devices[index].useEmptyPassphrase = getShouldUseEmptyPassphrase(
-            device,
-            undefined,
-            settings,
-        );
+        draft.devices[index].useEmptyPassphrase = undefined;
 
         // set remember to false to make it disappear after device is disconnected
         draft.devices[index].remember = false;
@@ -600,7 +563,7 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
             setTemporaryRememberedDevice(state, payload.device, payload.temporaryRemember);
         })
         .addCase(deviceActions.forgetDevice, (state, { payload }) => {
-            forget(state, payload.device, payload.settings);
+            forget(state, payload.device);
         })
         .addCase(deviceActions.addButtonRequest, (state, { payload }) => {
             addButtonRequest(state, payload.device, payload.buttonRequest);
@@ -650,8 +613,8 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
         })
         .addMatcher(
             isAnyOf(deviceActions.connectDevice, deviceActions.connectUnacquiredDevice),
-            (state, { payload: { device, settings } }) => {
-                connectDevice(state, device, settings);
+            (state, { payload: { device } }) => {
+                connectDevice(state, device);
             },
         );
 });

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -481,3 +481,7 @@ export const selectDeviceDefaultBackupType = createMemoizedSelector(
         return deviceModel ? defaultBackupTypeMap[deviceModel] : 'shamir-single';
     },
 );
+
+export const selectStandardWalletDevice = createMemoizedSelector([selectDevices], devices =>
+    devices.find(device => device.useEmptyPassphrase),
+);

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -359,7 +359,7 @@ export const selectRememberedStandardWalletsCount = createMemoizedSelector(
     [selectPhysicalDevices],
     devices =>
         returnStableArrayIfEmpty(
-            devices.filter(device => device.remember && device.useEmptyPassphrase),
+            devices.filter(device => device.remember && device.useEmptyPassphrase === true),
         ).length,
 );
 
@@ -367,7 +367,7 @@ export const selectRememberedHiddenWalletsCount = createMemoizedSelector(
     [selectPhysicalDevices],
     devices =>
         returnStableArrayIfEmpty(
-            devices.filter(device => device.remember && !device.useEmptyPassphrase),
+            devices.filter(device => device.remember && device.useEmptyPassphrase === false),
         ).length,
 );
 

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -34,7 +34,7 @@ import { getEnvironment } from '@trezor/env-utils';
 import { exhaustive } from '@trezor/type-utils';
 import { isChanged } from '@trezor/utils';
 
-import { ConnectDeviceSettings, DEVICE_MODULE_PREFIX, deviceActions } from './deviceActions';
+import { DEVICE_MODULE_PREFIX, deviceActions } from './deviceActions';
 import { PORTFOLIO_TRACKER_DEVICE_ID, portfolioTrackerDevice } from './deviceConstants';
 import {
     selectDeviceByBaseStaticSessionId,
@@ -156,15 +156,10 @@ export const handleDeviceDisconnect = createThunk(
  */
 export const forgetDisconnectedDevices = createThunk(
     `${DEVICE_MODULE_PREFIX}/forgetDisconnectedDevices`,
-    (
-        params: { device: Device | TrezorDevice; forceForget?: boolean },
-        { dispatch, getState, extra },
-    ) => {
+    (params: { device: Device | TrezorDevice; forceForget?: boolean }, { dispatch, getState }) => {
         const { device, forceForget = false } = params;
         const devices = selectDevices(getState());
         const deviceInstances = devices.filter(d => d.id === device.id);
-
-        const settings = extra.selectors.selectSuiteSettings(getState());
 
         deviceInstances.forEach(d => {
             if (
@@ -176,7 +171,7 @@ export const forgetDisconnectedDevices = createThunk(
                     !d.state ||
                     d.mode !== 'normal')
             ) {
-                dispatch(deviceActions.forgetDevice({ device: d, settings }));
+                dispatch(deviceActions.forgetDevice({ device: d }));
             }
         });
     },
@@ -227,6 +222,7 @@ export const acquireDevice = createThunk(
 
         const response = await TrezorConnect.getFeatures({
             device,
+            // todo: it shouldn't be needed I think - getFeatures is not touching device.state, is it?
             useEmptyPassphrase: true,
         });
 
@@ -432,19 +428,16 @@ type DeviceConnectThunksParams = {
 
 export const deviceConnectThunks = createThunk<void, DeviceConnectThunksParams, void>(
     `${DEVICE_MODULE_PREFIX}/deviceConnectThunk`,
-    ({ type, device }, { dispatch, getState, extra }) => {
-        const settings = extra.selectors.selectSuiteSettings(getState());
-
+    ({ type, device }, { dispatch }) => {
         switch (type) {
             case DEVICE.CONNECT:
-                dispatch(deviceActions.connectDevice({ device, settings }));
+                dispatch(deviceActions.connectDevice({ device }));
                 dispatch(connectThpDeviceThunk({ device }));
                 break;
             case DEVICE.CONNECT_UNACQUIRED:
                 dispatch(
                     deviceActions.connectUnacquiredDevice({
                         device,
-                        settings,
                     }),
                 );
                 dispatch(autoInitThpAfterDeviceConnectionThunk({ device }));
@@ -492,11 +485,10 @@ export const wipeDeviceThunk = createThunk(
             }
             const newDevice = selectSelectedDevice(getState());
             const newDevices = selectDevices(getState());
-            const settings = extra.selectors.selectSuiteSettings(getState());
 
             deviceInstances.push(...getDeviceInstances(newDevice!, newDevices));
             deviceInstances.forEach(d => {
-                dispatch(deviceActions.forgetDevice({ device: d, settings }));
+                dispatch(deviceActions.forgetDevice({ device: d }));
             });
             dispatch(notificationsActions.addToast({ type: 'device-wiped' }));
 
@@ -524,11 +516,7 @@ export const toggleAutoEjectThunk = createThunk(
 
         physicalDevices.forEach(wallet => {
             if (!wallet.connected && wallet.remember) {
-                const settings: ConnectDeviceSettings = {
-                    defaultWalletLoading: 'standard',
-                };
-
-                dispatch(deviceActions.forgetDevice({ device: wallet, settings }));
+                dispatch(deviceActions.forgetDevice({ device: wallet }));
             } else {
                 dispatch(
                     deviceActions.rememberDevice({

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -507,14 +507,6 @@ export const runDiscoveryThunk = createThunk(
             const allAccountsEmpty = result.payload.nonempty === 0;
             // there is at least one account with balance - passphrase is not empty
             if (!allAccountsEmpty) {
-                await dispatch(
-                    applyDeviceStatesThunk({
-                        newDeviceState: deviceStateResponse.payload._state,
-                        isAddingHiddenWallet,
-                        devicePath: device.path,
-                    }),
-                );
-
                 dispatch(
                     completeDiscoveryThunk({
                         staticSessionId: deviceStateResponse.payload._state.staticSessionId,
@@ -522,6 +514,7 @@ export const runDiscoveryThunk = createThunk(
                     }),
                 );
 
+                // finish here, device state was applied from bundle progress handler
                 return;
             }
 

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -120,6 +120,8 @@ const applyDeviceStatesThunk = createThunk(
                     deviceActions.setDeviceState({
                         device,
                         state: newDeviceState,
+                        // todo: this is incorrect, it should not depend on user's input but on
+                        // discovery actual result (empty passphrase entered on device)
                         useEmptyPassphrase: !isAddingHiddenWallet,
                     }),
                 );
@@ -132,6 +134,8 @@ const applyDeviceStatesThunk = createThunk(
                             ...device,
                             metadata: {},
                             instance: getNewInstanceNumber(selectDevices(getState()), device),
+                            // todo: this is incorrect, it should not depend on user's input but on
+                            // discovery actual result (empty passphrase entered on device)
                             useEmptyPassphrase: !isAddingHiddenWallet,
                             remember: shouldDeviceBeRemembered({
                                 isDeviceAutoEjectEnabled,

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -24,6 +24,7 @@ import {
     selectIsDeviceAutoEjectEnabled,
     selectPhysicalDevices,
     selectSelectedDevice,
+    selectStandardWalletDevice,
 } from '../device/deviceSelectors';
 import { selectDeviceThunk } from '../device/deviceThunks';
 import { selectAccountsToBeForgotten, selectDiscoveryAccountsParam } from '../selectors';
@@ -114,15 +115,38 @@ const applyDeviceStatesThunk = createThunk(
             const physicalDevices = selectPhysicalDevices(getState());
             const devicesWithoutState = physicalDevices.filter(d => !d.state?.staticSessionId);
 
+            // user was adding a hidden wallet but he might have input empty passphrase -> this is defacto standard wallet
+            let useEmptyPassphrase = !isAddingHiddenWallet; // set to reasonable default
+            if (isAddingHiddenWallet) {
+                let emptyPassphraseDeviceState = selectStandardWalletDevice(getState())?.state;
+
+                // no cache hit, query device
+                if (!emptyPassphraseDeviceState) {
+                    const res = await TrezorConnect.getDeviceState({
+                        device,
+                        useEmptyPassphrase: true,
+                    });
+                    if (res.success) {
+                        emptyPassphraseDeviceState = res.payload._state;
+                    }
+
+                    // todo: how to handle error?
+                }
+
+                if (emptyPassphraseDeviceState) {
+                    useEmptyPassphrase =
+                        emptyPassphraseDeviceState!.staticSessionId?.split(':')[0] ===
+                        staticSessionId.split(':')[0];
+                }
+            }
+
             // now we expect that there is exactly one device without state - meaning that we want to update its state
             if (devicesWithoutState.length === 1) {
                 dispatch(
                     deviceActions.setDeviceState({
                         device,
                         state: newDeviceState,
-                        // todo: this is incorrect, it should not depend on user's input but on
-                        // discovery actual result (empty passphrase entered on device)
-                        useEmptyPassphrase: !isAddingHiddenWallet,
+                        useEmptyPassphrase,
                     }),
                 );
             } else {
@@ -134,9 +158,7 @@ const applyDeviceStatesThunk = createThunk(
                             ...device,
                             metadata: {},
                             instance: getNewInstanceNumber(selectDevices(getState()), device),
-                            // todo: this is incorrect, it should not depend on user's input but on
-                            // discovery actual result (empty passphrase entered on device)
-                            useEmptyPassphrase: !isAddingHiddenWallet,
+                            useEmptyPassphrase,
                             remember: shouldDeviceBeRemembered({
                                 isDeviceAutoEjectEnabled,
                                 device,

--- a/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
@@ -99,6 +99,7 @@ export const DeviceItemContent = React.memo(
             (isPortfolioTrackerDevice ? device?.name : device?.label) ??
             translate('deviceManager.defaultHeader');
 
+        // todo: only makes sense device is already authorized (has state)
         const walletNameLabel = device?.useEmptyPassphrase ? (
             <Translation id="deviceManager.wallet.standard" />
         ) : (

--- a/suite-native/device-manager/src/components/WalletItem.tsx
+++ b/suite-native/device-manager/src/components/WalletItem.tsx
@@ -30,6 +30,10 @@ export const WalletItem = ({ onPress, deviceState, isSelectable = true }: Wallet
 
     const showAsSelected = isSelected && isSelectable;
 
+    if (!device?.state?.staticSessionId) {
+        console.warn('device is not authorized, this will yield unexpected wallet type');
+    }
+
     return (
         <WalletItemBase
             variant={device.useEmptyPassphrase ? 'standard' : 'passphrase'}

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -1,7 +1,6 @@
 import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
 import { createThunk } from '@suite-common/redux-utils';
 import {
-    ConnectDeviceSettings,
     deviceActions,
     failEntropyCheckThunk,
     selectDevicePath,
@@ -35,11 +34,7 @@ export const setTemporaryRememberedDeviceThunk = createThunk(
 
         // if the device is not connected and it was remembered only temporarily, we need to forget it
         if (!device.connected && device.temporaryRemember && !temporaryRemember) {
-            const settings: ConnectDeviceSettings = {
-                defaultWalletLoading: 'standard',
-            };
-
-            dispatch(deviceActions.forgetDevice({ device, settings }));
+            dispatch(deviceActions.forgetDevice({ device }));
         }
 
         return;

--- a/suite-native/module-connect-popup/src/components/AddressConfirmation.tsx
+++ b/suite-native/module-connect-popup/src/components/AddressConfirmation.tsx
@@ -15,6 +15,7 @@ export const AddressConfirmation = () => {
     const popupCall = useSelector(selectConnectPopupCall);
     const device = useSelector(selectSelectedDevice);
     const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
+    // todo: only makes sense if device is already authorized (has state)
     const passphraseWalletLabel = device?.useEmptyPassphrase ? (
         <Translation id="deviceManager.wallet.standard" />
     ) : (

--- a/suite-native/module-settings/src/components/EjectWallets/WalletRememberModeIconButton.tsx
+++ b/suite-native/module-settings/src/components/EjectWallets/WalletRememberModeIconButton.tsx
@@ -3,7 +3,6 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { TrezorDevice } from '@suite-common/suite-types';
 import {
-    ConnectDeviceSettings,
     deviceActions,
     selectIsDeviceAutoEjectEnabled,
     toggleRememberDevice,
@@ -21,10 +20,6 @@ export const WalletRememberModeIconButton = ({ device }: { device: TrezorDevice 
     const { showToast } = useToast();
 
     const handleEjectWallet = () => {
-        const settings: ConnectDeviceSettings = {
-            defaultWalletLoading: 'standard',
-        };
-
         analytics.report({
             type: EventType.AutoEjectChange,
             payload: { enabled: !device.remember, origin: 'settingsToggle' },
@@ -41,7 +36,7 @@ export const WalletRememberModeIconButton = ({ device }: { device: TrezorDevice 
                 });
             }
         } else {
-            dispatch(deviceActions.forgetDevice({ device, settings }));
+            dispatch(deviceActions.forgetDevice({ device }));
             showToast({
                 variant: 'default',
                 message: <Translation id="moduleSettings.viewOnly.autoEject.toast.walletEjected" />,

--- a/suite-native/module-settings/src/components/EjectWallets/WalletRow.tsx
+++ b/suite-native/module-settings/src/components/EjectWallets/WalletRow.tsx
@@ -24,6 +24,7 @@ export const WalletRow = ({ device }: WalletRowProps) => {
     const { applyStyle } = useNativeStyles();
     const hasDiscovery = useSelector(selectHasRunningDiscovery);
 
+    // todo: only makes sense if device is already authorized (has state)
     const walletNameLabel = device.useEmptyPassphrase ? (
         <Translation id="moduleSettings.viewOnly.wallet.standard" />
     ) : (
@@ -38,6 +39,7 @@ export const WalletRow = ({ device }: WalletRowProps) => {
     return (
         <HStack key={device.instance} style={applyStyle(walletRowStyle)}>
             <HStack spacing="sp12" alignItems="center">
+                {/* // todo: only makes sense if device is already authorized (has state) */}
                 <Icon name={device.useEmptyPassphrase ? 'wallet' : 'password'} size="mediumLarge" />
                 <Text variant="callout">{walletNameLabel}</Text>
             </HStack>


### PR DESCRIPTION
resolve #19801

## QA notes 

I made couple of changes, so please check:
- #19801
- passphrase flow did not break, wallets are named and numbered correctly...

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=use-device-state&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=use-device-state&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=use-device-state&lookback=7)