### PR TITLE
fix(suite): make sure that tokens from global send go to tokens page

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceive.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceive.tsx
@@ -25,9 +25,10 @@ export const GlobalSendReceive = () => {
             {isSendModalOpen && (
                 <GlobalSendModal
                     onCancel={() => setIsSendModalOpen(false)}
-                    onSubmit={account => {
+                    onSubmit={(account, type) => {
                         setIsSendModalOpen(false);
-                        goToWithAnalytics('wallet-send', {
+
+                        goToWithAnalytics(type === 'tokens' ? 'wallet-tokens' : 'wallet-send', {
                             params: {
                                 symbol: account.symbol,
                                 accountIndex: account.index,
@@ -40,9 +41,10 @@ export const GlobalSendReceive = () => {
             {isReceiveModalOpen && (
                 <GlobalReceiveModal
                     onCancel={() => setIsReceiveModalOpen(false)}
-                    onSubmit={account => {
+                    onSubmit={(account, type) => {
                         setIsReceiveModalOpen(false);
-                        goToWithAnalytics('wallet-receive', {
+
+                        goToWithAnalytics(type === 'tokens' ? 'wallet-tokens' : 'wallet-receive', {
                             params: {
                                 symbol: account.symbol,
                                 accountIndex: account.index,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Clicking on token it went to receive / send the base coin, not to the tokens page

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-to-tokens-from-global-send&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-to-tokens-from-global-send&lookback=7)