### PR TITLE
fix(components): props leaking into html img

### DIFF
--- a/packages/components/src/components/Image/Image.tsx
+++ b/packages/components/src/components/Image/Image.tsx
@@ -2,6 +2,8 @@ import { ImgHTMLAttributes } from 'react';
 
 import styled from 'styled-components';
 
+import { isArrayMember, typedObjectEntries } from '@trezor/utils';
+
 import { PNG_IMAGES, PngImage, SVG_IMAGES, SvgImage } from './images';
 import {
     FrameProps,
@@ -78,21 +80,29 @@ export type ImageProps = AllowedFrameProps &
           }
     ) & { isFilterActive?: boolean };
 
+const getImageHTMLProps = (
+    imageProps: Omit<ImageProps, 'image' | 'imageSrc' | 'isFilterActive'>,
+): ImageHTMLProps =>
+    typedObjectEntries(imageProps).reduce<ImageHTMLProps>(
+        (imageHTMLProps, [propKey, propValue]) => {
+            if (!isArrayMember(propKey, allowedImageFrameProps)) {
+                imageHTMLProps[propKey] = propValue;
+            }
+
+            return imageHTMLProps;
+        },
+        {},
+    );
+
 export const Image = ({ image, imageSrc, isFilterActive = true, ...rest }: ImageProps) => {
     const frameProps = pickAndPrepareFrameProps(rest, allowedImageFrameProps);
-    const imageProps = Object.entries(rest).reduce((props, [propKey, propValue]) => {
-        if (!(propKey in frameProps)) {
-            props[propKey as keyof ImageHTMLProps] = propValue;
-        }
-
-        return props;
-    }, {} as ImageHTMLProps);
+    const imageHTMLProps = getImageHTMLProps(rest);
     const sourceProps = image ? getSourceProps(image) : { src: imageSrc };
 
     return (
         <StyledImage
             {...sourceProps}
-            {...imageProps}
+            {...imageHTMLProps}
             {...frameProps}
             $isFilterActive={isFilterActive}
         />


### PR DESCRIPTION
## Description

[Fix this react error](https://satoshilabs.sentry.io/issues/6770100269/?environment=develop&project=5193825&query=is%3Aunresolved&referrer=issue-stream) (only emitted on develop) and tidy up the code a little bit.

This is more than a minor annoyance – I found that in Sentry, this react error absorbs other errors into its stack trace.
For example on Device Compromised modal, it eats up FW authenticity check errors ([example](https://satoshilabs.sentry.io/issues/6770100269/events/cb3520f221ac488f971d25ed3dd1a9b1/?project=5193825)) :facepalm:  



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/image-props&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/image-props&lookback=7)