### PR TITLE
fix(suite-common): start discovery only if acquire is successful

### DIFF
--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -246,9 +246,7 @@ export const acquireDevice = createThunk(
                     dispatch(thpActions.resetThpFlow());
                 }
             }
-        }
-
-        if (startDiscovery) {
+        } else if (startDiscovery) {
             dispatch(
                 startDiscoveryThunk({
                     device,


### PR DESCRIPTION
Can't discover anything otherwise. I noticed this because it triggered THP pairing right after I canceled THP pairing.

TS7 connected, but THP not paired:

https://github.com/user-attachments/assets/e3c50882-6449-418e-a07a-81766ed28c0f



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/start-discovery-after-acquire&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/start-discovery-after-acquire&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/start-discovery-after-acquire&lookback=7)