### PR TITLE
feat(suite):  getComputerName and use it in THP pairing

### DIFF
--- a/packages/suite-desktop-core/src/libs/info.ts
+++ b/packages/suite-desktop-core/src/libs/info.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process';
 import { app } from 'electron';
 import os from 'os';
 
@@ -49,4 +50,21 @@ export const getComputerInfo = () => {
         `- Cores: ${cpu.cores} @ ${cpu.speedGHz} GHz`,
         `- RAM: ${bytesToHumanReadable(os.totalmem())}`,
     ];
+};
+
+export const getComputerName = () => {
+    let name;
+    switch (process.platform) {
+        case 'win32':
+            name = process.env.COMPUTERNAME;
+            break;
+        case 'darwin':
+            name = execSync('scutil --get ComputerName').toString().trim();
+            break;
+        case 'linux':
+            name = execSync('hostnamectl --pretty').toString().trim();
+            break;
+    }
+
+    return name || os.hostname();
 };

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -6,6 +6,7 @@ import { parseElectrumUrl } from '@trezor/utils';
 
 import { getStoredFirmwares } from './firmware';
 import { APP_NAME } from '../libs/constants';
+import { getComputerName } from '../libs/info';
 import { PowerSaveBlocker } from '../libs/power-save-blocker';
 
 import { MainThreadEmitter, ModuleInit, ModuleInitBackground } from './index';
@@ -65,7 +66,8 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
                     const localFirmwares = await getStoredFirmwares();
                     if (settings.thp) {
                         // upgrade THP hostName with codesign (dev/local) suffix
-                        settings.thp.hostName = APP_NAME;
+                        settings.thp.appName = APP_NAME;
+                        settings.thp.hostName = getComputerName();
                     }
                     if (localFirmwares.success) {
                         settings.localFirmwares = localFirmwares.payload;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Following https://github.com/trezor/trezor-suite/pull/20750

we need to pass appName + hostName in THP pairing

im using some snippent [found on SO](https://stackoverflow.com/a/75309339)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-machine-name&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-machine-name&lookback=7)