### PR TITLE
fix(connect-explorer-theme): z-index for dropdown on mobile

### DIFF
--- a/packages/connect-explorer-theme/css/styles.css
+++ b/packages/connect-explorer-theme/css/styles.css
@@ -41,14 +41,15 @@ summary {
 
 @media (max-width: 767px) {
     .nextra-sidebar-container {
-        @apply nx-fixed nx-pt-[calc(var(--nextra-navbar-height))] nx-top-0 nx-w-full nx-bottom-0 nx-z-[15] nx-overscroll-contain nx-bg-white dark:nx-bg-dark;
+        @apply nx-fixed nx-pt-[calc(var(--nextra-navbar-height))] nx-top-0 nx-w-full nx-bottom-0 nx-z-[1] nx-overscroll-contain nx-bg-white dark:nx-bg-dark;
         transition: transform 0.8s cubic-bezier(0.52, 0.16, 0.04, 1);
         will-change: transform, opacity;
         contain: layout style;
         backface-visibility: hidden;
 
         & > .nextra-scrollbar {
-            mask-image: linear-gradient(to bottom, transparent, #000 20px),
+            mask-image:
+                linear-gradient(to bottom, transparent, #000 20px),
                 linear-gradient(to left, #000 10px, transparent 10px);
         }
     }
@@ -103,7 +104,8 @@ article details > summary {
 @media (min-width: 768px) {
     .nextra-toc > .div,
     .nextra-sidebar-container {
-        mask-image: linear-gradient(to bottom, transparent, #000 20px),
+        mask-image:
+            linear-gradient(to bottom, transparent, #000 20px),
             linear-gradient(to left, #000 10px, transparent 10px);
     }
 }

--- a/packages/connect-explorer-theme/src/components/sidebar.tsx
+++ b/packages/connect-explorer-theme/src/components/sidebar.tsx
@@ -114,7 +114,7 @@ export function Sidebar({
                 className={cn(
                     'motion-reduce:nx-transition-none [transition:background-color_1.5s_ease]',
                     menu
-                        ? 'nx-fixed nx-inset-0 nx-z-10 nx-bg-black/80 dark:nx-bg-black/60'
+                        ? 'nx-fixed nx-inset-0 nx-bg-black/80 dark:nx-bg-black/60'
                         : 'nx-bg-transparent',
                 )}
                 onClick={() => setMenu(false)}


### PR DESCRIPTION
## Description

Tiny fix of z-index so dropdown for coin selection works properly in mobile layout. 

<img width="552" height="602" alt="Screenshot 2025-08-14 at 17 26 37" src="https://github.com/user-attachments/assets/60a92455-72b8-45fa-b014-8f9d891c68b4" />
