### PR TITLE
fix(suite): close modal by clicking on ModalBackdrop

### DIFF
--- a/packages/suite/src/components/suite/TrafficLightOffset.tsx
+++ b/packages/suite/src/components/suite/TrafficLightOffset.tsx
@@ -24,8 +24,6 @@ const FixForNotBeingAbleToDragWindow = styled.div`
 
 const Container = styled.div<{ $offset: number }>`
     ${({ $offset }) => `padding-top: ${$offset}px;`}
-    width: 100%;
-    height: 100%;
 `;
 
 // See: https://github.com/electron/electron/issues/5678


### PR DESCRIPTION
Fixes ability to close modal by clicking on Modal Backdrop.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20730

## Screenshots:
**BEFORE**

https://github.com/user-attachments/assets/a696c44f-6397-4cf9-ad54-125a4e04d30e

**AFTER**

https://github.com/user-attachments/assets/7b253f47-bbf4-4477-8ff7-761941451415



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/close-wallet-switcher-by-clicking-on-the-background&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/close-wallet-switcher-by-clicking-on-the-background&lookback=7)