### PR TITLE
fix(suite): hide bioauth known error from console logging

### DIFF
--- a/packages/suite/src/actions/suite/bioAuthThunks.ts
+++ b/packages/suite/src/actions/suite/bioAuthThunks.ts
@@ -102,12 +102,12 @@ export const requestBioAuthChangeThunk = createThunk(
             };
         } catch (error) {
             dispatch(bioAuthActions.bioAuthValidated(null));
-            console.error(error);
 
             if (KNOWN_ERROR_MESSAGES.some(message => String(error).includes(message))) {
                 // NOTE: known error message
                 return;
             }
+            console.error(error);
             dispatch(
                 notificationsActions.addToast({
                     type: 'error',
@@ -150,12 +150,12 @@ export const requestBioAuthValidationThunk = createThunk(
             }
         } catch (error) {
             dispatch(bioAuthActions.bioAuthValidated(null));
-            console.error(error);
 
             if (KNOWN_ERROR_MESSAGES.some(message => String(error).includes(message))) {
                 // NOTE: known error message
                 return;
             }
+            console.error(error);
 
             dispatch(
                 notificationsActions.addToast({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hides the console.error for expected error in bio auth

## Related Issue

Resolve https://satoshilabs.sentry.io/issues/6809755420/?project=5193825&query=release%3A%2225.8.1.desktop.codesign.8d8960b8635e8bd37befb571a7f0108f0177db69%22&referrer=release-issue-stream

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=hide-known-error-from-console-bioauth&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=hide-known-error-from-console-bioauth&lookback=7)