### PR TITLE
Fix/allow undefined when no fw updates

### DIFF
--- a/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
+++ b/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
@@ -537,7 +537,7 @@ describe('onCallFirmwareUpdate', () => {
                 params: {},
                 context,
             }),
-        ).rejects.toThrow('Device missing features');
+        ).rejects.toThrow('device.firmwareReleaseMessage is not set');
 
         await deviceList.dispose();
     });

--- a/packages/connect/src/data/__tests__/firmwareInfo.test.ts
+++ b/packages/connect/src/data/__tests__/firmwareInfo.test.ts
@@ -42,7 +42,7 @@ describe('data/firmwareInfo', () => {
                 features,
                 FirmwareType.Universal,
             );
-            expect(firmwareReleaseConfigInfo.release.version).toEqual([2, 1, 1]);
+            expect(firmwareReleaseConfigInfo?.release.version).toEqual([2, 1, 1]);
         });
     });
 });

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -149,7 +149,7 @@ export const getReleaseConfig = (features: Features, firmwareType: FirmwareType)
     }
     const deviceMessageRelease = firmwareReleaseConfig[internal_model];
     if (!deviceMessageRelease) {
-        throw new Error(`No firmware release config found for device model ${internal_model}`);
+        return;
     }
 
     return deviceMessageRelease[firmwareType];
@@ -489,12 +489,12 @@ export const getReleaseInfo = ({
 export const getFirmwareReleaseConfigInfo = (features: Features, firmwareType: FirmwareType) => {
     const deviceMessageRelease = getReleaseConfig(features, firmwareType);
     if (!deviceMessageRelease) {
-        throw new Error('Missing Firmware release config release for device');
+        return;
     }
 
     const { release, conditions, firmware_type } = deviceMessageRelease;
     if (!release) {
-        throw new Error('Missing Firmware release for device');
+        return;
     }
 
     const currentVersion = getCurrentVersion(features);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We want to allow device models with no FW release to be supported instead of throwing error, so if device model does not have firmware release config we ignore except for essential that is FW update.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/allow-undefined-when-no-fw-updates&lookback=7)