### PR TITLE
fix(suite): make sure that app doesnt crash when signing and verifyin…

### DIFF
--- a/packages/suite/src/views/wallet/sign-verify/index.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/index.tsx
@@ -109,9 +109,9 @@ const SignVerify = () => {
 
     // Empty accountTypes means there is only 'normal' accountType and therefore the signatures are same.
     const signFormatsDiffer =
-        selectedAccount.account!.networkType === 'bitcoin' &&
-        selectedAccount.account!.accountType !== 'legacy' &&
-        Object.keys(selectedAccount.network!.accountTypes).length >= 1;
+        selectedAccount.account?.networkType === 'bitcoin' &&
+        selectedAccount.account?.accountType !== 'legacy' &&
+        Object.keys(selectedAccount.network?.accountTypes ?? {}).length >= 1;
 
     return (
         <WalletLayout title="TR_NAV_SIGN_VERIFY" isSubpage account={selectedAccount}>


### PR DESCRIPTION
…g an unloaded account

Weirdly, we simply trusted that the account will be there even for cases when the account isn't yet properly loaded. I looked at the code and I think like if the account isn't loaded, this condition may be false and this may appera in a sec.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve  https://satoshilabs.sentry.io/issues/6809207371/?project=5193825&query=release%3A%2225.8.1.desktop.codesign.8d8960b8635e8bd37befb571a7f0108f0177db69%22&referrer=release-issue-stream

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=undefined-account-error&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=undefined-account-error&lookback=7)