### PR TITLE
Hide floating header in device switcher

### DIFF
--- a/packages/suite/src/components/suite/bluetooth/BluetoothConnect.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothConnect.tsx
@@ -25,6 +25,7 @@ import { bluetoothStopScanningThunk } from '../../../actions/bluetooth/bluetooth
 import { setBluetoothListOpen } from '../../../actions/bluetooth/desktopBluetoothReducer';
 import { closeModalApp } from '../../../actions/suite/routerActions';
 import { useDispatch, useSelector } from '../../../hooks/suite';
+import { Translation } from '../Translation';
 
 const SCAN_TIMEOUT = 30_000;
 const UNPAIRED_DEVICES_LAST_UPDATED_LIMIT = 30_000;
@@ -186,7 +187,10 @@ export const BluetoothConnect = ({ uiMode }: BluetoothConnectProps) => {
     }
 
     if (nearbyDevices === null || waitingForFirstUpdate) {
-        return <BluetoothLoading onClose={onClose} />;
+        const floatingHeader =
+            uiMode === 'card' ? undefined : <Translation id="TR_CONNECT_VIA_BLUETOOTH" />;
+
+        return <BluetoothLoading floatingHeader={floatingHeader} onClose={onClose} />;
     }
 
     return (

--- a/packages/suite/src/components/suite/bluetooth/BluetoothLoading.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothLoading.tsx
@@ -1,16 +1,19 @@
+import { ReactNode } from 'react';
+
 import { Card, Spinner } from '@trezor/components';
 
 import { BluetoothDialogCard } from './BluetoothDialogCard';
 import { Translation } from '../Translation';
 
 type BluetoothLoadingProps = {
+    floatingHeader?: ReactNode;
     onClose: () => void;
 };
 
-export const BluetoothLoading = ({ onClose }: BluetoothLoadingProps) => (
+export const BluetoothLoading = ({ floatingHeader, onClose }: BluetoothLoadingProps) => (
     <BluetoothDialogCard
         cardHeader={<Translation id="TR_LOADING" />}
-        floatingHeader={<Translation id="TR_CONNECT_VIA_BLUETOOTH" />}
+        floatingHeader={floatingHeader}
         headerOnClose={onClose}
     >
         <Card>


### PR DESCRIPTION
The header was meant only for the welcome screen.

## Screenshots:
before:
<img width="379" height="264" alt="Screenshot 2025-08-15 at 18 18 21" src="https://github.com/user-attachments/assets/6e3d3303-d0b5-43dd-9499-25983ac4389e" />

after:
<img width="389" height="199" alt="Screenshot 2025-08-15 at 18 19 11" src="https://github.com/user-attachments/assets/f5fbea61-4b85-4b35-9fb2-525676268aae" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/floating-header&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/floating-header&lookback=7)