### PR TITLE
fix(suite): fix adding devices to app state, there shouldn't be any u…

### DIFF
--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -322,6 +322,7 @@ export const selectDeviceFirmwareVersionArray = createMemoizedSelector(
     device => getFirmwareVersionArray(device),
 );
 
+// todo: these are not necessarily physical, might be passphrases as well - sounds like a bug to me.
 export const selectPhysicalDevices = createMemoizedSelector([selectDevices], devices =>
     pipe(
         devices,

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -22,7 +22,6 @@ import {
     selectDeviceByStaticSessionId,
     selectDevices,
     selectIsDeviceAutoEjectEnabled,
-    selectPhysicalDevices,
     selectSelectedDevice,
     selectStandardWalletDevice,
 } from '../device/deviceSelectors';
@@ -100,20 +99,18 @@ const applyDeviceStatesThunk = createThunk(
                 return;
             }
 
+            const devicesByPathWithoutState = devicesByPath.filter(d => !d.state?.staticSessionId);
             // sanity check that there is no 2 devices sharing the same path. this shouldn't happen, the only way that comes to my mind
             // is when you would create a copy of device and store it in redux before authorizing it (this is actually the old way of doing things)
             // todo: this sanity check could be moved somewhere higher.
-            // if (devicesByPath.length !== 1) {
-            //     throw new Error('exactly one device should be found by path');
-            // }
+            if (devicesByPathWithoutState.length !== 1 && devicesByPathWithoutState.length !== 0) {
+                throw new Error('there must be either one or zero physical devices without state');
+            }
             const device = devicesByPath[0];
 
             assertDeviceIsAcquired(device);
             assertStaticSessionId(newDeviceState);
             const { staticSessionId } = newDeviceState;
-
-            const physicalDevices = selectPhysicalDevices(getState());
-            const devicesWithoutState = physicalDevices.filter(d => !d.state?.staticSessionId);
 
             // user was adding a hidden wallet but he might have input empty passphrase -> this is defacto standard wallet
             let useEmptyPassphrase = !isAddingHiddenWallet; // set to reasonable default
@@ -141,7 +138,7 @@ const applyDeviceStatesThunk = createThunk(
             }
 
             // now we expect that there is exactly one device without state - meaning that we want to update its state
-            if (devicesWithoutState.length === 1) {
+            if (devicesByPathWithoutState.length === 1) {
                 dispatch(
                     deviceActions.setDeviceState({
                         device,


### PR DESCRIPTION
1. connect 2 physical devices
2. standard wallet to the first selected device gets created automatically

observe bug: there are 3 device instances in redux, but there should only be 2

before:
<img width="1331" height="712" alt="image" src="https://github.com/user-attachments/assets/711751de-0217-480e-8bac-8a712f758ed9" />

after:
<img width="916" height="687" alt="image" src="https://github.com/user-attachments/assets/bf4bee35-c300-4890-afb2-9b9a98150de5" />

this probably did not cause any issues in the UI thanks to filtering on the UI layer but of course having fuzzy data is always a recipe for disaster

## QA 
please focus testing passphrase flow with multiple physical devices connected

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-adding-devices-to-app-state&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-adding-devices-to-app-state&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-adding-devices-to-app-state&lookback=7)