### PR TITLE
fix(discovery): fix wallet duplication

### DIFF
--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -302,6 +302,7 @@ export const runDiscoveryThunk = createThunk(
 
             const { isAddingHiddenWallet } = discovery;
 
+            assertDeviceIsAcquired(device);
             if (isAddingHiddenWallet && device.features && !device.features.passphrase_protection) {
                 dispatch(
                     discoveryActions.updateDiscovery(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Without this assertion, it was possible to create wallets for an `acquired` device, which resulted in wallet duplication in some cases

-  reverse of https://github.com/trezor/trezor-suite/commit/e759b6bd5c81eec5eb22852a91ab98f735f60a7a

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20685, https://github.com/trezor/trezor-suite/issues/20685 

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/wallet-duplication&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/wallet-duplication&lookback=7)