### PR TITLE
chore(connect): suppress warning for recoverDevice when uninitialized

### DIFF
--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -40,6 +40,8 @@ const allowedCallsBeforeInitialize: Messages.MessageKey[] = [
     'RebootToBootloader',
     'FirmwareErase',
     'FirmwareUpload',
+    // Wallet recovery may also be called before Initialize
+    'RecoveryDevice',
     // There are other, which are allowed by firmware (ApplySettings,...) but we do not use them this way in connect.
 ];
 


### PR DESCRIPTION
## Description

Recover device is another call that may be called before initialization, so suppress warning that is thrown ([sentry event](https://satoshilabs.sentry.io/issues/6750472866/events/ee2613e86af54fd1a433a8047fc2eebe/))

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/recoverDevice-suppress-warning&lookback=7)