### PR TITLE
fix(suite): Show address in Sign&Verify for non-ethereum based networks

### DIFF
--- a/packages/connect/src/api/signMessage.ts
+++ b/packages/connect/src/api/signMessage.ts
@@ -61,7 +61,7 @@ export default class SignMessage extends AbstractMethod<'signMessage', PROTO.Sig
         if (code === 'ButtonRequest_Other' && name === 'sign_message') {
             return {
                 type: 'message' as const,
-                serializedPath: getSerializedPath(this.params.address_n.slice(0, 4)),
+                serializedPath: getSerializedPath(this.params.address_n),
                 coin: this.coinInfo?.shortcut ?? 'BTC',
                 message: this.payload.hex ? hexToText(this.payload.message) : this.payload.message,
             };

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/SignMessageModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/SignMessageModal.tsx
@@ -2,7 +2,12 @@ import styled from 'styled-components';
 
 import { TrezorDevice } from '@suite-common/suite-types';
 import { NetworkSymbol, getNetwork, getNetworkByEvmChainId } from '@suite-common/wallet-config';
-import { selectDeviceAccounts } from '@suite-common/wallet-core';
+import {
+    AccountsRootState,
+    selectAddressByNetworkAndPath,
+    selectDeviceAccounts,
+} from '@suite-common/wallet-core';
+import { findAccountsByAddress } from '@suite-common/wallet-utils';
 import { Card, Column, DotIndicator, H4, Modal, Row } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
 import { CoinLogo, ConfirmOnDevice } from '@trezor/product-components';
@@ -65,7 +70,14 @@ export const SignMessageModal = ({
     const network = eip712ChainId
         ? getNetworkByEvmChainId(eip712ChainId)
         : getNetwork(networkSymbol ?? 'eth');
-    const account = accounts.find(a => a.symbol === network?.symbol && a.path === serializedPath);
+
+    const address = useSelector((state: AccountsRootState) =>
+        selectAddressByNetworkAndPath(state, network, serializedPath),
+    );
+    const account =
+        network && address
+            ? findAccountsByAddress(network.symbol, address, accounts)[0]
+            : undefined;
 
     return (
         <ConnectModalBackdrop onClick={onCancel} canSwitchDevice>
@@ -116,7 +128,7 @@ export const SignMessageModal = ({
                 onCancel={onCancel}
             >
                 <Column gap={spacings.xs}>
-                    {account && (
+                    {address && (
                         <Card
                             header={
                                 <Row gap={spacings.sm}>
@@ -129,7 +141,7 @@ export const SignMessageModal = ({
                             paddingType="small"
                         >
                             <MessageText data-testid="@sign-message-modal/address">
-                                {account.descriptor}
+                                {address}
                             </MessageText>
                         </Card>
                     )}

--- a/suite-common/wallet-core/src/accounts/accountsSelectors.ts
+++ b/suite-common/wallet-core/src/accounts/accountsSelectors.ts
@@ -1,7 +1,12 @@
 import { A, F, G, pipe } from '@mobily/ts-belt';
 
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
-import { type AccountType, type Bip43Path, type NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type AccountType,
+    type Bip43Path,
+    Network,
+    type NetworkSymbol,
+} from '@suite-common/wallet-config';
 import { Account, AccountKey } from '@suite-common/wallet-types';
 import { isTestnet, isUtxoBased } from '@suite-common/wallet-utils';
 import { DeviceState, StaticSessionId } from '@trezor/connect';
@@ -278,3 +283,29 @@ export const selectSolAccountHasStaked = createMemoizedSelector([selectAccountBy
 
     return !!account.misc.solStakingAccounts?.length;
 });
+
+export const selectAddressByNetworkAndPath = createMemoizedSelector(
+    [
+        selectAccounts,
+        (_state: AccountsRootState, network?: Network) => network,
+        (_state: AccountsRootState, _network?: Network, path?: string) => path,
+    ],
+    (accounts, network, path) => {
+        if (!network || !path) return undefined;
+
+        const networkAccounts = accounts.filter(a => a.symbol === network.symbol);
+        for (const account of networkAccounts) {
+            if (account.addresses) {
+                const address = account.addresses.unused
+                    .concat(account.addresses.used)
+                    .concat(account.addresses.change)
+                    .find(a => a.path === path);
+                if (address) return address.address;
+            } else {
+                if (account.path === path) return account.descriptor;
+            }
+        }
+
+        return undefined;
+    },
+);

--- a/suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts
+++ b/suite-common/wallet-core/src/accounts/tests/accountsSelectors.test.ts
@@ -1,0 +1,139 @@
+import { networks } from '../../../../wallet-config/src/networksConfig';
+import { AccountsRootState } from '../accountsReducer';
+import { selectAddressByNetworkAndPath } from '../accountsSelectors';
+
+const mockState: AccountsRootState = {
+    wallet: {
+        accounts: [
+            {
+                deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@AC94BB9C1B08FE73BE1E3322:0',
+                index: 0,
+                backendType: undefined,
+                misc: undefined,
+                marker: undefined,
+                stellarCursor: undefined,
+                key: 'key',
+                accountType: 'normal',
+                empty: false,
+                visible: true,
+                balance: '0',
+                availableBalance: '0',
+                formattedBalance: '0',
+                tokens: [],
+                symbol: 'btc',
+                path: "m/84'/0'/0'",
+                descriptor: '1BitcoinAddress',
+                addresses: {
+                    unused: [
+                        {
+                            address: 'bc1unused',
+                            path: "m/84'/0'/0'/0/0",
+                            transfers: 0,
+                            balance: '0',
+                            sent: '0',
+                            received: '0',
+                        },
+                    ],
+                    used: [
+                        {
+                            address: 'bc1used',
+                            path: "m/84'/0'/0'/0/1",
+                            transfers: 2,
+                            balance: '0',
+                            sent: '1000000000',
+                            received: '1000000000',
+                        },
+                    ],
+                    change: [
+                        {
+                            address: 'bc1change',
+                            path: "m/84'/0'/0'/1/0",
+                            transfers: 0,
+                            balance: '0',
+                            sent: '0',
+                            received: '0',
+                        },
+                    ],
+                },
+                utxo: [],
+                history: { total: 3, unconfirmed: 0, addrTxCount: 5 },
+                metadata: {
+                    key: 'tpubDCZB6sR48s4T5Cr8qHUYSZEFCQMMHRg8AoVKVmvcAP5bRw7ArDKeoNwKAJujV3xCPkBvXH5ejSgbgyN6kREmF7sMd41NdbuHa8n1DZNxSMg',
+                },
+                networkType: 'bitcoin',
+                page: { index: 1, size: 25, total: 1 },
+                ts: 0,
+            },
+            {
+                symbol: 'eth',
+                networkType: 'ethereum',
+                descriptor: '0xEthereumAddress',
+                deviceState: '1stTestnetAddress@device_id:0',
+                key: '0xEthereumAddress-eth-deviceState',
+                accountType: 'normal',
+                index: 0,
+                path: "m/44'/60'/0'/0",
+                empty: true,
+                visible: true,
+                balance: '408873828678601000',
+                availableBalance: '408873828678601000',
+                formattedBalance: '0.408873828678601',
+                tokens: [],
+                utxo: [],
+                history: {
+                    total: 0,
+                    unconfirmed: 0,
+                },
+                metadata: {
+                    key: '1stTestnetAddress@device_id:0',
+                    1: {
+                        fileName: '',
+                        aesKey: '',
+                    },
+                },
+                page: undefined,
+                misc: { nonce: '1' },
+                marker: undefined,
+                stellarCursor: undefined,
+                ts: 0,
+            },
+        ],
+    },
+};
+
+describe(selectAddressByNetworkAndPath.name, () => {
+    it('returns unused address for BTC', () => {
+        const result = selectAddressByNetworkAndPath(mockState, networks['btc'], "m/84'/0'/0'/0/0");
+        expect(result).toBe('bc1unused');
+    });
+
+    it('returns used address for BTC', () => {
+        const result = selectAddressByNetworkAndPath(mockState, networks['btc'], "m/84'/0'/0'/0/1");
+        expect(result).toBe('bc1used');
+    });
+
+    it('returns change address for BTC', () => {
+        const result = selectAddressByNetworkAndPath(mockState, networks['btc'], "m/84'/0'/0'/1/0");
+        expect(result).toBe('bc1change');
+    });
+
+    it('returns descriptor for ETH', () => {
+        const result = selectAddressByNetworkAndPath(mockState, networks['eth'], "m/44'/60'/0'/0");
+        expect(result).toBe('0xEthereumAddress');
+    });
+
+    it('returns undefined for unknown path', () => {
+        const result = selectAddressByNetworkAndPath(mockState, networks['btc'], "m/84'/0'/0'/9/9");
+        expect(result).toBeUndefined();
+    });
+
+    it('returns undefined if network is missing', () => {
+        const result = selectAddressByNetworkAndPath(mockState, undefined, "m/84'/0'/0'/0/0");
+        expect(result).toBeUndefined();
+    });
+
+    it('returns undefined if path is missing', () => {
+        const result = selectAddressByNetworkAndPath(mockState, networks['btc'], undefined);
+        expect(result).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Finds account address correctly even when current network is not ethereum.

## Related Issue

Resolve #20249

## Screenshots:

Before:
<img width="1111" height="547" alt="address-before" src="https://github.com/user-attachments/assets/797acbd7-3d4f-422a-a1d9-b829bf2e20f8" />

After:
<img width="1120" height="721" alt="address-after" src="https://github.com/user-attachments/assets/5caa7cf9-5af5-4bc8-ba0b-018b6c15f33a" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/missing-address-sign-verify&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/missing-address-sign-verify&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/missing-address-sign-verify&lookback=7)