### PR TITLE
fix: Show 0 decimal places for Fiat BaseCurrency in the Account List

### DIFF
--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -19,6 +19,7 @@
         "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
+        "@trezor/utils": "workspace:*",
         "@trezor/utxo-lib": "workspace:*"
     },
     "devDependencies": {

--- a/packages/blockchain-link-types/src/baseCurrency.ts
+++ b/packages/blockchain-link-types/src/baseCurrency.ts
@@ -1,3 +1,5 @@
+import { typedObjectKeys } from '@trezor/utils';
+
 export const fiatBaseCurrencies = {
     usd: { code: 'usd', label: 'United States Dollar' },
     eur: { code: 'eur', label: 'Euro' },
@@ -49,6 +51,8 @@ export const valuablesBaseCurrencies = {
     xag: { code: 'xag', label: 'Silver' },
     xau: { code: 'xau', label: 'Gold' },
 } as const;
+
+export const valuablesBaseCurrencyCodes = typedObjectKeys(valuablesBaseCurrencies);
 
 export const baseCurrencies = {
     ...fiatBaseCurrencies,

--- a/packages/blockchain-link-types/tsconfig.json
+++ b/packages/blockchain-link-types/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../utils" },
         { "path": "../utxo-lib" },
         { "path": "../type-utils" }
     ]

--- a/packages/blockchain-link-types/tsconfig.lib.json
+++ b/packages/blockchain-link-types/tsconfig.lib.json
@@ -6,6 +6,9 @@
     "include": ["./src"],
     "references": [
         {
+            "path": "../utils"
+        },
+        {
             "path": "../utxo-lib"
         },
         {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItemContent.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItemContent.tsx
@@ -5,12 +5,14 @@ import styled from 'styled-components';
 import { useFormatters } from '@suite-common/formatters';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import {
+    selectAreSatsAmountUnit,
     selectBaseCurrency,
     selectIsDiscreteModeActive,
     useDisplayBaseCurrency,
 } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import { BaseCurrencyAmount, isTestnet } from '@suite-common/wallet-utils';
+import { valuablesBaseCurrencyCodes } from '@trezor/blockchain-link-types';
 import {
     Column,
     Row,
@@ -19,6 +21,7 @@ import {
     TruncateWithTooltip,
 } from '@trezor/components';
 import { spacings } from '@trezor/theme';
+import { isArrayMember } from '@trezor/utils';
 
 import {
     AccountLabel,
@@ -72,17 +75,49 @@ const BaseCurrency = ({
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const { shouldAnimate } = useLoadingSkeleton();
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(symbol);
+    const isBtcAmountInSats = useSelector(selectAreSatsAmountUnit);
+
+    // This is special case, here is Account list we have a little space, so we never show
+    // decimal places for fiat currencies (fiat always have 2 or 3 decimal places),
+    // where subunits are insignificant (little value).
+    //
+    // But we want to show decimal places for crypto (BTC) base currencies as they usually
+    // have very significant subunits.
+    const isBitcoinInSats = baseCurrencyCode === 'btc' && isBtcAmountInSats;
+
+    const forceZeroDecimalPlaces =
+        !isBitcoinInSats && !isArrayMember(baseCurrencyCode, valuablesBaseCurrencyCodes);
 
     return shallDisplayBaseCurrency && customFiatValue !== undefined ? (
         <HiddenPlaceholder>
             {isLoading ? (
                 <SkeletonRectangle animate={shouldAnimate} />
             ) : (
-                <BaseCurrencyAmountFormatter value={customFiatValue} currency={baseCurrencyCode} />
+                <BaseCurrencyAmountFormatter
+                    value={customFiatValue}
+                    currency={baseCurrencyCode}
+                    {...(forceZeroDecimalPlaces
+                        ? {
+                              minimumFractionDigits: 0,
+                              maximumFractionDigits: 0,
+                          }
+                        : {})}
+                />
             )}
         </HiddenPlaceholder>
     ) : (
-        <BaseCurrencyValue amount={formattedBalance} symbol={symbol}>
+        <BaseCurrencyValue
+            amount={formattedBalance}
+            symbol={symbol}
+            fiatAmountFormatterOptions={
+                forceZeroDecimalPlaces
+                    ? {
+                          minimumFractionDigits: 0,
+                          maximumFractionDigits: 0,
+                      }
+                    : undefined
+            }
+        >
             {FiatValueRenderComponent}
         </BaseCurrencyValue>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -11801,6 +11801,7 @@ __metadata:
   resolution: "@trezor/blockchain-link-types@workspace:packages/blockchain-link-types"
   dependencies:
     "@trezor/type-utils": "workspace:*"
+    "@trezor/utils": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
     tsx: "npm:^4.20.3"
   peerDependencies:


### PR DESCRIPTION
<img width="450" height="213" alt="image" src="https://github.com/user-attachments/assets/d884a51f-359c-4e42-93d2-0c79f794a16f" />


```
    // This is special case, here is Account list we have a little space, so we never show
    // decimal places for fiat currencies (fiat always have 2 or 3 decimal places),
    // where subunits are insignificant (little value).
    //
    // But we want to show decimal places for crypto (BTC) base currencies as they usually
    // have very significant subunits.
```    

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=decimal_places_big_fiat&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=decimal_places_big_fiat&lookback=7)