### PR TITLE
fix(suite): crashing on the list of device languages display

### DIFF
--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -106,7 +106,7 @@ export type KnownDevice = BaseDevice & {
     features: PROTO.Features;
     thp?: ThpStateSerialized;
     unavailableCapabilities: UnavailableCapabilities;
-    availableTranslations: Record<string, string>;
+    availableTranslations: string[];
     authenticityChecks: {
         firmwareRevision: FirmwareRevisionCheckResult | null;
         firmwareHash: FirmwareHashCheckResult | null;

--- a/packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx
@@ -23,12 +23,10 @@ export const ChangeLanguage = ({ isDeviceLocked }: ChangeLanguageProps) => {
 
     const isSupportedDevice = device?.features?.capabilities?.includes('Capability_Translations');
 
-    const deviceSupportedTranslations = Object.keys(device?.availableTranslations ?? {}).map(
-        it => ({
-            value: it,
-            label: `${LANGUAGES[it as Locale].name} (beta)`,
-        }),
-    );
+    const deviceSupportedTranslations = (device?.availableTranslations ?? []).map(it => ({
+        value: it,
+        label: `${LANGUAGES[it as Locale].name} (beta)`,
+    }));
 
     if (isSupportedDevice !== true || deviceSupportedTranslations.length === 0) {
         return null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-but-device-available-languages&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-but-device-available-languages&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-but-device-available-languages&lookback=7)