### PR TITLE
fix(suite): onboarding stuck on SecurityCheck

### DIFF
--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
@@ -26,6 +26,7 @@ import {
 } from '@trezor/urls';
 
 import { goto } from 'src/actions/suite/routerActions';
+import * as routerActions from 'src/actions/suite/routerActions';
 import { Hologram, OnboardingButtonSkip } from 'src/components/onboarding';
 import { Translation, TrezorLink } from 'src/components/suite';
 import { SecurityCheckFail } from 'src/components/suite/SecurityCheck/SecurityCheckFail';
@@ -144,6 +145,8 @@ const SecurityCheckContent = ({
             rerun();
         } else if (isOnboardingActive) {
             goToNextStep('firmware');
+            // ensure that we are not stuck in the 'start' FullscreenApp
+            dispatch(routerActions.goto('onboarding-index'));
         } else {
             dispatch(goto('onboarding-index'));
         }


### PR DESCRIPTION
## Description

Idk how to reproduce it, but somehow I got `selectIsOnboardingActive` true even when it rly wasn't, and then  only the elseif with `goToNextStep('firmware')` was fired, so the router stayed on `/start` (which is fullscreen app, preventing rendering of anything else).

:point_right: set up my trezor CTA did not do anything :scream:

## Screenshots:

green button was stuck:

<img width="866" height="557" alt="Screenshot from 2025-08-18 13-10-16" src="https://github.com/user-attachments/assets/25480fc1-c359-4982-b3f6-6d6154065420" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/onboarding-stuck&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/onboarding-stuck&lookback=7)