### PR TITLE
feat(connect-popup): thp error message

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -166,6 +166,9 @@ export const handleUIAffectingMessage = (message: CoreEventMessage) => {
         case UI_REQUEST.INVALID_PASSPHRASE:
             view.initInvalidPassphraseView(message.payload);
             break;
+        case UI_REQUEST.REQUEST_THP_PAIRING:
+            showView('thp-pairing');
+            break;
         // no default
     }
 };

--- a/packages/connect-popup/src/static/popup.css
+++ b/packages/connect-popup/src/static/popup.css
@@ -2544,3 +2544,9 @@ section > div .divider span:after {
 .iframe-failure .cancel {
     margin-top: 16px;
 }
+
+.thp-pairing {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}

--- a/packages/connect-popup/src/static/popup.html
+++ b/packages/connect-popup/src/static/popup.html
@@ -117,6 +117,8 @@
             <%= require('./views/confirm-output.html') %>
             <!-- Passphrase on device -->
             <%= require('./views/passphrase-on-device.html') %>
+            <!-- THP pairing -->
+            <%= require('./views/thp-pairing.html') %>
 
             <!-- Iframe not loading failure start-->
             <!-- moved into @trezor/connect-ui -->

--- a/packages/connect-popup/src/static/views/thp-pairing.html
+++ b/packages/connect-popup/src/static/views/thp-pairing.html
@@ -1,0 +1,14 @@
+<div class="thp-pairing">
+    <h3>Your Trezor is not supported by Connect Popup</h3>
+    <p>
+        For enhanced security, Trezor Safe 7 and later devices are not supported by Connect Popup.
+    </p>
+    <p>
+        To connect to third party apps, please install
+        <a href="https://suite.trezor.io" target="_blank">Trezor Suite</a>. Ensure that the app you
+        are connecting to supports the latest version of Trezor Connect.
+    </p>
+
+    <button class="confirm submit" tabindex="4" onclick="window.closeWindow();">Close</button>
+</div>
+<!-- Seedless: END -->


### PR DESCRIPTION
## Description

Display an error message for THP pairing in Connect Popup, at least until we figure out what to do product-wise. 

## Screenshots:

<img width="548" height="396" alt="Screenshot 2025-08-18 at 14 35 51" src="https://github.com/user-attachments/assets/cceb6a75-1f74-4eb3-8319-eca7a144b56d" />
