### PR TITLE
fix(e2e-suite): asserts of emulator display handles different whitespaces gracefuly

### DIFF
--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -166,3 +166,54 @@ export const mockRemoteMessageSystem = async (page: Page): Promise<void> =>
     await page.route('**/config.v1.jws', async route => {
         await route.fulfill({ status: 200, body: validJws });
     });
+
+export const normalizeWhitespace = (obj: any): any => {
+    if (typeof obj === 'string') {
+        // Normalize whitespace: \u00A0 is non-breaking space, \u0020 is regular space.
+        return obj.replace(/[\u00A0\u0020]/g, ' ');
+    }
+    if (Array.isArray(obj)) {
+        return obj.map(normalizeWhitespace);
+    }
+    if (obj && typeof obj === 'object') {
+        const result: any = {};
+        for (const [key, value] of Object.entries(obj)) {
+            result[key] = normalizeWhitespace(value);
+        }
+
+        return result;
+    }
+
+    return obj;
+};
+
+export const analyzeObject = (obj: any): any => {
+    const padding = 3; // Padding for character codes
+    const analyzeText = (text: string) => {
+        const chars = Array.from(text);
+        const paddedChars = chars.map(char => char.padStart(padding, ' '));
+        const paddedCodes = chars.map(char => char.charCodeAt(0).toString().padStart(padding, ' '));
+
+        return {
+            chars: `${paddedChars.join(' ')}`,
+            codes: `${paddedCodes.join(' ')}`,
+        };
+    };
+
+    if (typeof obj === 'string') {
+        return analyzeText(obj);
+    }
+    if (Array.isArray(obj)) {
+        return obj.map(analyzeObject);
+    }
+    if (obj && typeof obj === 'object') {
+        const result: any = {};
+        for (const [key, value] of Object.entries(obj)) {
+            result[key] = analyzeObject(value);
+        }
+
+        return result;
+    }
+
+    return obj;
+};

--- a/packages/suite-desktop-core/e2e/support/pageObjects/devicePrompt.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/devicePrompt.ts
@@ -1,6 +1,6 @@
 import { Locator, Page, expect } from '@playwright/test';
 
-import { TrezorUserEnvLinkProxy, step } from '../common';
+import { TrezorUserEnvLinkProxy, analyzeObject, step } from '../common';
 
 export class DevicePrompt {
     readonly confirmOnDevicePrompt: Locator;
@@ -130,12 +130,25 @@ export class DevicePrompt {
         return textsArray.map(removeWhitespaces).join('');
     }
 
+    @step()
+    async getAnalyzedDisplayContent() {
+        const debugState = await this.getDisplayContent();
+
+        return analyzeObject({
+            header: debugState.header,
+            body: debugState.body,
+            footer: debugState.footer,
+        });
+    }
+
     // Serves to quickly get the text from the device display and end the test
     @step()
     async debugThrowJSONFromDisplay() {
         const debugState = await TrezorUserEnvLinkProxy.getDebugState();
         const json = JSON.parse(debugState.tokens.join(''));
-        throw new Error(`Debug JSON: ${JSON.stringify(json, null, 2)}`);
+        throw new Error(
+            `Debug JSON: ${JSON.stringify(json, null, 2)} \n\nCharacter analysis: ${JSON.stringify(await this.getAnalyzedDisplayContent(), null, 2)}`,
+        );
     }
 
     @step()

--- a/packages/suite-desktop-core/e2e/support/testExtends/customMatchers.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/customMatchers.ts
@@ -2,7 +2,7 @@ import { Locator, Request, expect as baseExpect, test } from '@playwright/test';
 import { diff } from 'jest-diff';
 import { isEqual } from 'lodash';
 
-import { formatAddress, isEqualWithOmit } from '../common';
+import { formatAddress, isEqualWithOmit, normalizeWhitespace } from '../common';
 import { DevicePrompt } from '../pageObjects/devicePrompt';
 
 type LineFormats = 'fourTetragrams' | 'fullLine';
@@ -37,11 +37,14 @@ const compareDisplayContent = async (
     errorMessage: string,
 ) => {
     await test.step(`expected object: ${JSON.stringify(expectedContent)}`, () => {});
-    const content = await devicePrompt.getDisplayContent();
+    const contentRaw = await devicePrompt.getDisplayContent();
+    const content = normalizeWhitespace(contentRaw);
+    const debugInfo = JSON.stringify(await devicePrompt.getAnalyzedDisplayContent(), null, 2);
 
     return {
         pass: isEqual(expectedContent, content),
-        message: () => `${errorMessage}. Diff:\n${diff(expectedContent, content)}`,
+        message: () =>
+            `${errorMessage}. Diff:\n${diff(expectedContent, content)}\n\nAnalysis:\n${debugInfo}`,
     };
 };
 


### PR DESCRIPTION
adds extra debug logging that shows character codes
I have ran both nightly and canary workflows and all passed

Extra logging:
```
Error: expect Emulator display to match. Diff:
    - Expected
    + Received

      Object {
        "body": Array [
          Array [
            "Gas limit",
          ],
          Array [
    -       "26000x units",
    +       "26000 units",
          ],
          Array [
            " ",
          ],
          Array [
            "Max fee per gas",
          ],
          Array [
            "2.67674454 Gwei",
          ],
          Array [
            " ",
          ],
          Array [
            "Max priority fee",
          ],
          Array [
            "1.375641927 Gwei",
          ],
        ],
        "header": Object {
          "title": "Fee info",
        },
      }
    Analysis:
    {
      "header": {
        "title": {
          "chars": "  F   e   e       i   n   f   o",
          "codes": " 70 101 101  32 105 110 102 111"
        }
      },
      "body": [
        [
          {
            "chars": "  G   a   s       l   i   m   i   t",
            "codes": " 71  97 115  32 108 105 109 105 116"
          }
        ],
        [
          {
            "chars": "  2   6   0   0   0       u   n   i   t   s",
            "codes": " 50  54  48  48  48  32 117 110 105 116 115"
          }
        ],
        [
          {
            "chars": "   ",
            "codes": " 32"
          }
        ],
        [
          {
            "chars": "  M   a   x       f   e   e       p   e   r       g   a   s",
            "codes": " 77  97 120  32 102 101 101  32 112 101 114  32 103  97 115"
          }
        ],
        [
          {
            "chars": "  2   .   6   7   6   7   4   4   5   4       G   w   e   i",
            "codes": " 50  46  54  55  54  55  52  52  53  52  32  71 119 101 105"
          }
        ],
        [
          {
            "chars": "   ",
            "codes": " 32"
          }
        ],
        [
          {
            "chars": "  M   a   x       p   r   i   o   r   i   t   y       f   e   e",
            "codes": " 77  97 120  32 112 114 105 111 114 105 116 121  32 102 101 101"
          }
        ],
        [
          {
            "chars": "  1   .   3   7   5   6   4   1   9   2   7       G   w   e   i",
            "codes": " 49  46  51  55  53  54  52  49  57  50  55  32  71 119 101 105"
          }
        ]
      ]
    }

       97 |         await test.step('Verify Fee Info on emulator', async () => {
       98 |             await tradingPage.fees.openFeeInfoOnEmulator();
    >  99 |             await expect(devicePrompt).toDisplayOnEmulator({
          |                                        ^
      100 |                 header: { title: 'Fee info' },
      101 |                 body: [
      102 |                     ['Gas limit'],
        at /home/mcihlar/git/trezor-suite/packages/suite-desktop-core/e2e/tests/wallet/send-eth.test.ts:99:40
        at /home/mcihlar/git/trezor-suite/packages/suite-desktop-core/e2e/tests/wallet/send-eth.test.ts:97:9
```

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-canary&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-canary&lookback=7)