### PR TITLE
prevent `rejectionHandled` in `discoverAccounts`

### DIFF
--- a/packages/connect/src/api/discoverAccounts.ts
+++ b/packages/connect/src/api/discoverAccounts.ts
@@ -251,10 +251,12 @@ export default class DiscoverAccounts extends AbstractMethod<'discoverAccounts',
         }
 
         let descPromise = this.getDescriptor(coinInfo, bip43, derivation, offset + index);
+        descPromise.catch(() => {});
         while (true) {
             try {
                 const { descriptor, ...descRest } = await descPromise;
                 descPromise = this.getDescriptor(coinInfo, bip43, derivation, offset + index + 1);
+                descPromise.catch(() => {});
 
                 const info = await blockchain.getAccountInfo({ descriptor, details, pageSize });
 
@@ -283,7 +285,6 @@ export default class DiscoverAccounts extends AbstractMethod<'discoverAccounts',
                     return { nonempty: index - skip };
                 }
             } catch (err) {
-                descPromise.catch(() => {});
                 const path = substituteBip43Path(bip43, offset + index);
                 const { message: error, code } = err;
                 const failed = true;


### PR DESCRIPTION
## Description

Despite the behavior being exactly as expected, `discoverAccounts` sometimes sent `PromiseRejectionHandledWarning` to Sentry because of late addition of error handler. Adding it immediately (even if not needed) seems to fix it.

## Related Issue

Should resolve [this Sentry issue](https://satoshilabs.sentry.io/issues/6677308640/)


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/rejection-handled&lookback=7)