### PR TITLE
t3w1 in nightly

### DIFF
--- a/.github/workflows/test-connect.yml
+++ b/.github/workflows/test-connect.yml
@@ -69,6 +69,7 @@ jobs:
     outputs:
       dailyMatrix: ${{ steps.set-matrix-daily.outputs.matrix }}
       dailyT3W1Matrix: ${{ steps.set-matrix-daily-t3w1.outputs.matrix }}
+      nightlyT3W1Matrix: ${{ steps.set-matrix-nightly-t3w1.outputs.matrix }}
       otherDevicesMatrix: ${{ steps.set-matrix-other-devices.outputs.matrix }}
       allFwsMatrix: ${{ steps.set-matrix-all-firmwares.outputs.matrix }}
       allTransportsMatrix: ${{ steps.set-matrix-all-transports.outputs.matrix }}
@@ -84,6 +85,10 @@ jobs:
       - name: Set daily T3W1 matrix
         id: set-matrix-daily-t3w1
         run: echo "matrix=$(node ./scripts/ci/connect-test-matrix-generator.js --model=T3W1 --firmware=2-latest --env=all --groups=thp --disable_cache_tx=true --transport=node-bridge)" >> $GITHUB_OUTPUT
+
+      - name: Set nightly T3W1 matrix
+        id: set-matrix-nightly-t3w1
+        run: echo "matrix=$(node ./scripts/ci/connect-test-matrix-generator.js --model=T3W1 --firmware=2-latest --env=all --groups=all --disable_cache_tx=false --transport=node-bridge)" >> $GITHUB_OUTPUT
 
       - name: Set all firmwares matrix
         id: set-matrix-all-firmwares
@@ -136,6 +141,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.dailyT3W1Matrix) }}
+
+  PR-nightly-t3w1:
+    needs: [build, set-matrix]
+    name: PR-nightly-t3w1 ${{ matrix.key }}
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository == 'trezor/trezor-suite'
+    uses: ./.github/workflows/template-connect-test-params.yml
+    with:
+      testPattern: ${{ matrix.groups.pattern }}
+      includeFilter: ${{ matrix.groups.includeFilter }}
+      testsFirmware: ${{ matrix.firmware }}
+      testDescription: ${{ matrix.env }}-${{ matrix.groups.pattern }}-${{ matrix.groups.name }}
+      disable_cache_tx: ${{ matrix.disable_cache_tx }}
+      transport: ${{ matrix.transport }}
+      testEnv: ${{ matrix.env }}
+      testFirmwareModel: ${{ matrix.model }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.set-matrix.outputs.nightlyT3W1Matrix) }}
 
   randomized-order:
     needs: [build, set-matrix]

--- a/packages/connect/e2e/__fixtures__/getAddress.ts
+++ b/packages/connect/e2e/__fixtures__/getAddress.ts
@@ -1,3 +1,10 @@
+const legacyResults = [
+    {
+        rules: ['!T3B1', '!T3T1', '!T3W1'],
+        success: false,
+    },
+];
+
 export default {
     method: 'getAddress',
     setup: {
@@ -93,6 +100,7 @@ export default {
             result: {
                 address: 'DsbjnfJrnL1orxJBCN8Kf39NjMwEktdfdWy',
             },
+            legacyResults,
         },
         {
             description: 'Decred Testnet first address',
@@ -103,6 +111,7 @@ export default {
             result: {
                 address: 'TsRQTRqf5TdEfqsnJ1gcQEDvPP363cEjr4B',
             },
+            legacyResults,
         },
         {
             description: 'Regtest P2PKH first address',

--- a/packages/connect/e2e/__fixtures__/getFeatures.ts
+++ b/packages/connect/e2e/__fixtures__/getFeatures.ts
@@ -70,14 +70,14 @@ const tests = [
                 'Capability_Shamir',
                 'Capability_ShamirGroups',
                 'Capability_PassphraseEntry',
-                'Capability_NEM',
-                'Capability_EOS',
+                // 'Capability_NEM', // discontinued starting T3B1
+                // 'Capability_EOS', // discontinued starting T3B1
             ]),
             backup_type: 'Bip39',
             sd_card_present: expect.any(Boolean),
             sd_protection: false,
             wipe_code_protection: false,
-            session_id: expect.any(String),
+            // session_id: expect.any(String), // T3W1 in this case is not paired, thus returns null, other models should return a string
             passphrase_always_on_device: false,
             flags: expect.any(Number),
             fw_vendor: expect.any(String),

--- a/packages/connect/e2e/__fixtures__/signTransactionBgold.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionBgold.ts
@@ -3,7 +3,7 @@ const { TX_CACHE } = global.TestUtils;
 const legacyResults = [
     {
         // not allowed for newer devices
-        rules: ['!T2B1', '!T3B1', '!T3T1'],
+        rules: ['!T2B1', '!T3B1', '!T3T1', '!T3W1'],
         success: false,
     },
 ];

--- a/packages/connect/e2e/__fixtures__/signTransactionDash.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionDash.ts
@@ -5,7 +5,7 @@ const { TX_CACHE } = global.TestUtils;
 const legacyResults = [
     {
         // not allowed for newer devices
-        rules: ['!T2B1', '!T3B1', '!T3T1'],
+        rules: ['!T2B1', '!T3B1', '!T3T1', '!T3W1'],
         success: false,
     },
 ];

--- a/packages/connect/e2e/__fixtures__/signTransactionDecred.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionDecred.ts
@@ -4,7 +4,7 @@ const legacyResults = [
     {
         // not allowed for lower versions
         // not allowed for newer devices
-        rules: ['<1.10.1', '<2.4.0', '!T2B1', '!T3B1', '!T3T1'],
+        rules: ['<1.10.1', '<2.4.0', '!T2B1', '!T3B1', '!T3T1', '!T3W1'],
         success: false,
     },
 ];


### PR DESCRIPTION
This PR imlements needed changes to fixtures to make them work with T3W1 model. It also adds T3W1 tests covering all the methods to nightly runs. 

example test run https://github.com/trezor/trezor-suite/actions/runs/17210500294




🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=thp-pairing-test-followup&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=thp-pairing-test-followup&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=thp-pairing-test-followup&lookback=7)