### PR TITLE
Feat e2e native reporter - workflow

### DIFF
--- a/.github/workflows/test-suite-native-e2e-manual-reporter.yml
+++ b/.github/workflows/test-suite-native-e2e-manual-reporter.yml
@@ -1,5 +1,5 @@
-name: "[Test] Release Suite Sanity test publisher"
-# Runs Playwright reporter, creating manual regressions release suite in GitHub"
+name: "[Test] Release Suite Native Sanity test publisher"
+# Runs Native reporter, creating manual regressions release suite in GitHub"
 
 on:
   workflow_dispatch:
@@ -8,14 +8,13 @@ on:
         description: "(optional) Run the publisher for specific tests. Can be multiple tests' filenames separated by whitespace. Ex: test1.test.ts test2.test.ts"
         required: false
         default: ""
-  workflow_call:
 
 concurrency:
   group: manual-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
-  run-e2e-suite-manual-tests:
+  run_android_e2e_tests:
     if: github.repository == 'trezor/trezor-suite'
     runs-on: ubuntu-latest
 
@@ -27,18 +26,28 @@ jobs:
           app-id: ${{ secrets.TREZOR_BOT_APP_ID }}
           private-key: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
 
-      - name: Checkout
+      - name: Checkout project
         uses: actions/checkout@v4
         with:
-          submodules: true
-          ref: ${{ github.sha }}
-          fetch-depth: 2
+          submodules: "true"
 
-      - name: Setup Node.js
+      - name: Install node and yarn
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           cache: yarn
+
+      - name: Load node modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node_modules/${{ github.ref }}/${{github.run_id}}
+
+      - name: Install Yarn dependencies
+        run: |
+          echo -e "\nenableScripts: false" >> .yarnrc.yml
+          echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
+          yarn install
 
       - name: Extract Release Build
         id: extract_branch
@@ -46,13 +55,7 @@ jobs:
         run: |
           echo "release_build=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}-${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
-      - name: Install PW Dependencies
-        shell: bash
-        run: |
-          echo "Installing Playwright dependencies"
-          yarn workspaces focus @trezor/suite-desktop-core
-
-      - name: Run Playwright Reporter
+      - name: Run Detox Reporter
         shell: bash
         env:
           GITHUB_ACTION: true
@@ -60,5 +63,5 @@ jobs:
           GITHUB_REPORTER_VERBOSE: true
           RELEASE_BUILD: ${{ env.release_build }}
         run: |
-          echo "Starting Playwright Reporter for manual regression suite"
-          yarn workspace @trezor/suite-desktop-core github:report:manual ${{ inputs.testFilter }}
+          echo "Starting Detox Reporter for manual regression suite"
+          yarn workspace @suite-native/app github:report:manual ${{ inputs.testFilter }}

--- a/suite-native/app/.detoxrc.js
+++ b/suite-native/app/.detoxrc.js
@@ -64,5 +64,25 @@ module.exports = {
             device: 'emulator',
             app: 'android.release',
         },
+        // Configuration for publishing manual tests
+        'reporter.only': {
+            device: 'emulator', // does not need device
+            app: 'android.debug', // does not need app
+            testRunner: {
+                args: {
+                    $0: 'jest',
+                    config: 'e2e/jest.config.js',
+                    maxWorkers: 1,
+                },
+            },
+            artifacts: false,
+            behavior: {
+                init: {
+                    exposeGlobals: false,
+                    reinstallApp: false,
+                },
+                launchApp: 'manual',
+            },
+        },
     },
 };

--- a/suite-native/app/e2e/jest.config.js
+++ b/suite-native/app/e2e/jest.config.js
@@ -19,7 +19,6 @@ module.exports = {
     reporters: [
         'detox/runners/jest/reporter',
         ['jest-junit', { outputDirectory: './reports', outputName: 'junit-report.xml' }],
-        // '<rootDir>/e2e/support/reporter/index.js',
     ],
     testEnvironment: 'detox/runners/jest/testEnvironment',
     verbose: true,

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -18,7 +18,7 @@
         "prebuild:clean": "expo prebuild --clean",
         "build:e2e": "npx detox build --configuration",
         "test:e2e": "npx detox test --configuration ",
-        "report:manual": "npx detox test ./e2e/tests/manual/currencyChange.test.ts --configuration android.emu.debug",
+        "github:report:manual": "npx detox test --configuration reporter.only --reporters ./e2e/support/reporter/index.js --testPathPattern /manual/",
         "start:e2e": "NODE_ENV=test RN_SRC_EXT=e2e.ts,e2e.tsx expo start --dev-client",
         "reverse-ports": "adb reverse tcp:8081 tcp:8081 && adb reverse tcp:21325 tcp:21325 && adb reverse tcp:19121 tcp:19121"
     },


### PR DESCRIPTION
adds workflow for Suite native Sanity test publisher.
I need to merge it to test it :(
reporter added on package script level
filters and targets only manual tests by folder

next steps: debug, document, introduce to automated tests in release pipeline

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-e2e-native-reporter&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-e2e-native-reporter&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat-e2e-native-reporter&lookback=7)