### PR TITLE
fix(suite-native): fix wrong fee validation 

### DIFF
--- a/suite-native/transaction-management/src/hooks/useFeesForm.ts
+++ b/suite-native/transaction-management/src/hooks/useFeesForm.ts
@@ -1,6 +1,5 @@
 import { useSelector } from 'react-redux';
 
-import { getNetworkType } from '@suite-common/wallet-config';
 import {
     AccountsRootState,
     FeesRootState,
@@ -41,8 +40,6 @@ export const useFeesForm = ({
         symbol: account?.symbol,
     });
 
-    const networkType = account?.symbol ? getNetworkType(account.symbol) : undefined;
-
     const minimalFeeLimit =
         'estimatedFeeLimit' in feeLevels.normal ? feeLevels.normal.estimatedFeeLimit : undefined;
 
@@ -57,7 +54,7 @@ export const useFeesForm = ({
         },
         context: {
             networkFeeInfo,
-            networkType,
+            symbol: account?.symbol,
             minimalFeeLimit,
         },
     });


### PR DESCRIPTION
After rebase one file was not updated to follow the change of fees and used networkType instead of networkSymbol. This caused validations on decimals to fail. This PR fixes it.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/fees-validation&lookback=7)