### PR TITLE
passphrase duplicate refactoring

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseDuplicateModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseDuplicateModal.tsx
@@ -1,17 +1,15 @@
 import {
     cancelDiscoveryThunk,
     runDiscoveryThunk,
-    selectDeviceThunk,
-    selectDevices,
-    selectDiscovery,
     startDiscoveryThunk,
+    switchToDuplicatedWallet,
 } from '@suite-common/wallet-core';
 import { DiscoveryStatus } from '@suite-common/wallet-types';
 import { Button, Column, H3, Text, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
-import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 import { TrezorDevice } from 'src/types/suite';
 import { CardWithDevice } from 'src/views/suite/SwitchDevice/CardWithDevice';
 import { SwitchDeviceModal } from 'src/views/suite/SwitchDevice/SwitchDeviceModal';
@@ -29,24 +27,11 @@ export const PassphraseDuplicateModal = ({
 }: PassphraseDuplicateModalProps) => {
     const { isLocked } = useDevice();
     const dispatch = useDispatch();
-    const discoveries = useSelector(selectDiscovery);
 
     const isDeviceLocked = isLocked();
-    const devices = useSelector(selectDevices);
 
-    const duplicateDevice = devices
-        .filter(d => d.state?.staticSessionId)
-        .find(
-            d =>
-                d.state!.staticSessionId?.split(':')[0] ===
-                discovery.duplicateDeviceStaticSessionId.split(':')[0],
-        );
-    const switchToDuplicateWallet = () => {
-        // if the last selected device is the same as the duplicate passphrase, do nothing, otherwise select it
-        if (duplicateDevice) {
-            dispatch(selectDeviceThunk({ device: duplicateDevice }));
-        }
-        dispatch(cancelDiscoveryThunk(device));
+    const handleDuplicateDevicePassphrase = () => {
+        dispatch(switchToDuplicatedWallet());
     };
 
     const onTryDifferentPassphrase = () => {
@@ -68,9 +53,6 @@ export const PassphraseDuplicateModal = ({
                 ...discovery,
             }),
         );
-
-        const nextDiscovery = discoveries?.[device.path];
-        if (!nextDiscovery) return;
 
         dispatch(runDiscoveryThunk(device));
     };
@@ -94,7 +76,7 @@ export const PassphraseDuplicateModal = ({
                         >
                             <Button
                                 variant="primary"
-                                onClick={switchToDuplicateWallet}
+                                onClick={handleDuplicateDevicePassphrase}
                                 isDisabled={isDeviceLocked}
                                 isFullWidth
                             >

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -27,7 +27,6 @@ import TrezorConnect, {
     Response as ConnectResponse,
     DEVICE,
     Device,
-    StaticSessionId,
 } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { getEnvironment } from '@trezor/env-utils';
@@ -37,14 +36,13 @@ import { isChanged } from '@trezor/utils';
 import { DEVICE_MODULE_PREFIX, deviceActions } from './deviceActions';
 import { PORTFOLIO_TRACKER_DEVICE_ID, portfolioTrackerDevice } from './deviceConstants';
 import {
-    selectDeviceByBaseStaticSessionId,
     selectDeviceById,
     selectDevices,
     selectPhysicalDevices,
     selectSelectedDevice,
 } from './deviceSelectors';
 import { selectAccountByKey } from '../accounts/accountsSelectors';
-import { cancelDiscoveryThunk, startDiscoveryThunk } from '../discovery/discoveryThunks';
+import { startDiscoveryThunk } from '../discovery/discoveryThunks';
 
 type SelectDeviceThunkParams = {
     device: Device | TrezorDevice | undefined;
@@ -248,39 +246,6 @@ export const acquireDevice = createThunk(
                 }),
             );
         }
-    },
-);
-
-export const switchDuplicatedDevice = createThunk(
-    `${DEVICE_MODULE_PREFIX}/switchDuplicatedDevice`,
-    async (passphraseDuplicateStaticSessionId: StaticSessionId, { dispatch, getState, extra }) => {
-        const {
-            actions: { onModalCancel },
-        } = extra;
-        // close modal
-        dispatch(onModalCancel());
-
-        const device = selectDeviceByBaseStaticSessionId(
-            getState(),
-            passphraseDuplicateStaticSessionId,
-        );
-
-        if (!device) {
-            console.error('switchDuplicatedDevice: Device not found');
-
-            return;
-        }
-
-        dispatch(cancelDiscoveryThunk(device));
-
-        // release session from authorizeDevice
-        await TrezorConnect.getFeatures({
-            device,
-            keepSession: false,
-        });
-
-        // switch to existing wallet
-        dispatch(selectDeviceThunk({ device }));
     },
 );
 

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -388,13 +388,12 @@ export const runDiscoveryThunk = createThunk(
                         deviceStateResponse.payload._state.staticSessionId!.split(':')[0],
                 );
 
-            if (isAddingHiddenWallet && duplicate) {
+            if (isAddingHiddenWallet && duplicate?.state?.staticSessionId) {
                 dispatch(
                     discoveryActions.updateDiscovery(
                         {
                             status: 'passphrase-duplicate',
-                            duplicateDeviceStaticSessionId:
-                                deviceStateResponse.payload._state.staticSessionId,
+                            duplicateDeviceStaticSessionId: duplicate.state.staticSessionId,
                         },
                         device.path,
                     ),
@@ -834,5 +833,28 @@ export const restartDiscoveryThunk = createThunk(
             // if no staticSessionId available yet it means we failed sooner, for example during pin input
             dispatch(startDiscoveryThunk({ device }));
         }
+    },
+);
+
+export const switchToDuplicatedWallet = createThunk(
+    `${DISCOVERY_MODULE_PREFIX}/switchToDuplicatedWallet`,
+    (_, { dispatch, getState }) => {
+        const device = selectSelectedDevice(getState());
+        if (!device) return;
+
+        const discovery = selectDiscoveryByDevicePath(getState(), device.path);
+
+        if (discovery?.status !== 'passphrase-duplicate') return;
+
+        dispatch(cancelDiscoveryThunk(device));
+
+        const duplicatedDevice = selectDeviceByStaticSessionId(
+            getState(),
+            discovery.duplicateDeviceStaticSessionId,
+        );
+
+        if (!duplicatedDevice) return;
+        // Switch to the duplicated wallet
+        dispatch(selectDeviceThunk({ device: duplicatedDevice }));
     },
 );

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -8,7 +8,7 @@ type CommonDiscoveryStatus = {
     isAddingHiddenWallet?: boolean; // to control visibility of special loader
     isAddingExistingWallet?: boolean; // to control visibility of special loader
     isAddingHiddenWalletWithRespectToSettings?: boolean;
-    hasLoadedAnyNonEmptyAccount?: boolean; // NOTE: used to indicate the the disocovery started loading actual accounts
+    hasLoadedAnyNonEmptyAccount?: boolean; // NOTE: used to indicate the the discovery started loading actual accounts
     emptyWallet?: boolean;
     passphraseOnDevice?: boolean;
     startTimestamp?: number;

--- a/suite-native/device-authorization/src/deviceAuthorizationSlice.ts
+++ b/suite-native/device-authorization/src/deviceAuthorizationSlice.ts
@@ -111,16 +111,6 @@ export const selectPassphraseError = (
     }
 };
 
-export const selectPassphraseDuplicateStaticSessionId = (
-    state: DiscoveryRootState & DeviceRootState,
-) => {
-    const discovery = selectDiscoveryByDevicePath(state, state.device.selectedDevice?.path);
-
-    return discovery?.status === 'passphrase-duplicate'
-        ? discovery.duplicateDeviceStaticSessionId
-        : null;
-};
-
 export const selectHasVerificationCancelledError = (
     state: DiscoveryRootState & DeviceRootState,
 ) => {

--- a/suite-native/module-authorize-device/src/components/passphrase/PassphraseDuplicateAlert.tsx
+++ b/suite-native/module-authorize-device/src/components/passphrase/PassphraseDuplicateAlert.tsx
@@ -42,15 +42,13 @@ export const PassphraseDuplicateAlert = ({ children }: { children: React.ReactNo
         ({ duplicateStaticSessionId }: { duplicateStaticSessionId: StaticSessionId }) => {
             // Not all passphrase errors have device property, but we know this one does
             // based on condition in `./passphraseSlice`. This if is just to keep TS happy.
-            if (duplicateStaticSessionId) {
-                dispatch(switchDuplicatedDevice(duplicateStaticSessionId));
-                navigation.navigate(RootStackRoutes.AppTabs, {
-                    screen: AppTabsRoutes.HomeStack,
-                    params: {
-                        screen: HomeStackRoutes.Home,
-                    },
-                });
-            }
+            dispatch(switchDuplicatedDevice(duplicateStaticSessionId));
+            navigation.navigate(RootStackRoutes.AppTabs, {
+                screen: AppTabsRoutes.HomeStack,
+                params: {
+                    screen: HomeStackRoutes.Home,
+                },
+            });
         },
         [dispatch, navigation],
     );

--- a/suite-native/module-authorize-device/src/components/passphrase/PassphraseDuplicateAlert.tsx
+++ b/suite-native/module-authorize-device/src/components/passphrase/PassphraseDuplicateAlert.tsx
@@ -1,12 +1,11 @@
 import { useCallback, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { switchDuplicatedDevice } from '@suite-common/wallet-core';
+import { switchToDuplicatedWallet } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { EventType, analytics } from '@suite-native/analytics';
-import { selectPassphraseDuplicateStaticSessionId } from '@suite-native/device-authorization';
 import { useTranslate } from '@suite-native/intl';
 import {
     AppTabsRoutes,
@@ -17,7 +16,6 @@ import {
     RootStackRoutes,
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
-import { StaticSessionId } from '@trezor/connect';
 
 type NavigationProp = StackToStackCompositeNavigationProps<
     AuthorizeDeviceStackParamList,
@@ -28,45 +26,31 @@ type NavigationProp = StackToStackCompositeNavigationProps<
 export const PassphraseDuplicateAlert = ({ children }: { children: React.ReactNode }) => {
     const dispatch = useDispatch();
 
-    const passphraseDuplicateStaticSessionId = useSelector(
-        selectPassphraseDuplicateStaticSessionId,
-    );
-
     const { translate } = useTranslate();
 
     const navigation = useNavigation<NavigationProp>();
-
     const { showAlert } = useAlert();
 
-    const handleDuplicateDevicePassphrase = useCallback(
-        ({ duplicateStaticSessionId }: { duplicateStaticSessionId: StaticSessionId }) => {
-            // Not all passphrase errors have device property, but we know this one does
-            // based on condition in `./passphraseSlice`. This if is just to keep TS happy.
-            dispatch(switchDuplicatedDevice(duplicateStaticSessionId));
-            navigation.navigate(RootStackRoutes.AppTabs, {
-                screen: AppTabsRoutes.HomeStack,
-                params: {
-                    screen: HomeStackRoutes.Home,
-                },
-            });
-        },
-        [dispatch, navigation],
-    );
+    const handleDuplicateDevicePassphrase = useCallback(() => {
+        dispatch(switchToDuplicatedWallet());
+
+        navigation.navigate(RootStackRoutes.AppTabs, {
+            screen: AppTabsRoutes.HomeStack,
+            params: {
+                screen: HomeStackRoutes.Home,
+            },
+        });
+    }, [dispatch, navigation]);
 
     useEffect(() => {
-        if (passphraseDuplicateStaticSessionId) {
-            analytics.report({ type: EventType.PassphraseDuplicate });
-            showAlert({
-                title: translate('modulePassphrase.passphraseMismatch.title'),
-                description: translate('modulePassphrase.passphraseMismatch.subtitle'),
-                primaryButtonTitle: translate('modulePassphrase.passphraseMismatch.button'),
-                onPressPrimaryButton: () =>
-                    handleDuplicateDevicePassphrase({
-                        duplicateStaticSessionId: passphraseDuplicateStaticSessionId,
-                    }),
-            });
-        }
-    }, [handleDuplicateDevicePassphrase, passphraseDuplicateStaticSessionId, showAlert, translate]);
+        analytics.report({ type: EventType.PassphraseDuplicate });
+        showAlert({
+            title: translate('modulePassphrase.passphraseMismatch.title'),
+            description: translate('modulePassphrase.passphraseMismatch.subtitle'),
+            primaryButtonTitle: translate('modulePassphrase.passphraseMismatch.button'),
+            onPressPrimaryButton: () => handleDuplicateDevicePassphrase(),
+        });
+    }, [handleDuplicateDevicePassphrase, showAlert, translate]);
 
     return children ?? null;
 };


### PR DESCRIPTION
This PR should only remove useless code in "passphrase duplicate" handling while keeping the same functionality. It affects both desktop and mobile


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=discovery-meow&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=discovery-meow&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=discovery-meow&lookback=7)