### PR TITLE
feat(connect): add `getThpCredentials` method

### DIFF
--- a/packages/connect/e2e/tests/device/thpPairing.test.ts
+++ b/packages/connect/e2e/tests/device/thpPairing.test.ts
@@ -28,8 +28,8 @@ describe('THP pairing', () => {
 
         return new Promise<Device>((resolve, reject) => {
             const onDeviceConnected = (device: Device) => {
-                TrezorConnect.removeAllListeners('device-connect');
-                TrezorConnect.removeAllListeners('device-connect_unacquired');
+                TrezorConnect.off('device-connect', onDeviceConnected);
+                TrezorConnect.off('device-connect_unacquired', onDeviceConnected);
                 if (device.type === 'unreadable') {
                     reject(new Error('Device unreadable'));
                 } else {
@@ -84,5 +84,89 @@ describe('THP pairing', () => {
 
         // TODO: expect(device.type).toEqual('unreadable');
         expect(device.type).toEqual('unacquired');
+    });
+
+    it('ThpPairing with credentials (autoconnect: false)', async () => {
+        const device = await waitForDevice({
+            pairingMethods: ['CodeEntry'],
+            knownCredentials: [
+                {
+                    trezor_static_public_key:
+                        'f60b84cdb80a2139f80489c811dc129937a4f4f75ca7710c7570c5085f1ffe68',
+                    credential:
+                        '0a1c0a0974657374733a65326510001a0d5472657a6f72436f6e6e656374122098822d64a482198c9654295ee690f7bf0e8ecf1aac50473b0e805c5614a3bef9',
+                    autoconnect: false,
+                },
+            ],
+        });
+
+        const pairingSpy = typeof jest !== 'undefined' ? jest.fn() : jasmine.createSpy('pairing');
+        TrezorConnect.on('ui-request_thp_pairing', pairingSpy);
+
+        const address = await TrezorConnect.getAddress({
+            device,
+            path: "m/44'/0'/0'/1/1",
+            showOnTrezor: true,
+        });
+        expect(address).toMatchObject({ success: true });
+        expect(pairingSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it('ThpPairing with credentials (autoconnect: true)', async () => {
+        const device = await waitForDevice({ pairingMethods: ['CodeEntry'] });
+
+        const credentialsSpy =
+            typeof jest !== 'undefined' ? jest.fn() : jasmine.createSpy('credentials');
+        TrezorConnect.on('device-thp_credentials_changed', credentialsSpy);
+
+        TrezorConnect.on('ui-request_thp_pairing', async ({ nfcData }) => {
+            const state = await controller.getPairingInfo(device.thp!.channel, nfcData);
+            TrezorConnect.uiResponse({
+                type: 'ui-receive_thp_pairing_tag',
+                payload: { source: 'code-entry', tag: state.code_entry_code },
+            });
+        });
+
+        // start pairing
+        await TrezorConnect.getFeatures({ device });
+        // autoconnect: false credentials obtained
+        expect(credentialsSpy).toHaveBeenCalledTimes(1);
+
+        // generate autoconnect credentials
+        await TrezorConnect.thpGetCredentials({ device });
+        // autoconnect: true credentials obtained
+        expect(credentialsSpy).toHaveBeenCalledTimes(2);
+
+        // expect no pairing or button request from now on
+        TrezorConnect.removeAllListeners('ui-request_thp_pairing');
+        TrezorConnect.removeAllListeners('ui-button');
+
+        // restart the device
+        await controller.stopEmu();
+        await new Promise<void>(resolve => {
+            const onDeviceDisconnected = () => {
+                TrezorConnect.off('device-disconnect', onDeviceDisconnected);
+                resolve();
+            };
+            TrezorConnect.on('device-disconnect', onDeviceDisconnected);
+        });
+        await controller.startEmu({
+            model: 'T3W1',
+            version: '2-main',
+        });
+        await new Promise<void>(resolve => {
+            const onDeviceConnected = () => {
+                TrezorConnect.off('device-connect', onDeviceConnected);
+                resolve();
+            };
+            TrezorConnect.on('device-connect', onDeviceConnected);
+        });
+
+        const address = await TrezorConnect.getAddress({
+            device,
+            path: "m/44'/0'/0'/1/1",
+            showOnTrezor: false,
+        });
+        expect(address).toMatchObject({ success: true });
     });
 });

--- a/packages/connect/src/api/index.ts
+++ b/packages/connect/src/api/index.ts
@@ -57,6 +57,8 @@ export { default as setProxy } from './setProxy';
 export { default as signMessage } from './signMessage';
 export { default as signTransaction } from './signTransaction';
 export { default as unlockPath } from './unlockPath';
+export { default as thpGetCredentials } from './thpGetCredentials';
+export { default as thpRemoveCredentials } from './thpRemoveCredentials';
 // export { default as uiResponse } from './uiResponse';
 export { default as verifyMessage } from './verifyMessage';
 export { default as wipeDevice } from './wipeDevice';

--- a/packages/connect/src/api/thpGetCredentials.ts
+++ b/packages/connect/src/api/thpGetCredentials.ts
@@ -1,0 +1,36 @@
+// import { Assert } from '@trezor/schema-utils';
+import { ERRORS } from '../constants';
+import { AbstractMethod } from '../core/AbstractMethod';
+import { DataManager } from '../data/DataManager';
+import { getThpCredentials } from '../device/thp';
+import { DEVICE, UI } from '../events';
+
+export default class ThpGetCredentials extends AbstractMethod<'thpGetCredentials'> {
+    init() {
+        this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
+        this.requiredPermissions = ['management'];
+        this.useDeviceState = false;
+        this.skipFinalReload = true;
+    }
+
+    async run() {
+        const thpState = this.device.getThpState();
+        if (!thpState?.handshakeCredentials) {
+            throw ERRORS.TypedError('Device_ThpStateMissing');
+        }
+
+        const credentials = await getThpCredentials(this.device, true);
+        thpState.setPairingCredentials([credentials]);
+
+        // update values in DataManager
+        DataManager.getSettings('thp')?.knownCredentials?.push(credentials);
+
+        // emit change event to host, store new credentials in DataManager
+        this.device.emit(DEVICE.THP_CREDENTIALS_CHANGED, {
+            credentials,
+            staticKey: thpState.handshakeCredentials.staticKey.toString('hex'),
+        });
+
+        return credentials;
+    }
+}

--- a/packages/connect/src/api/thpRemoveCredentials.ts
+++ b/packages/connect/src/api/thpRemoveCredentials.ts
@@ -1,0 +1,44 @@
+import { ERRORS } from '../constants';
+import { AbstractMethod } from '../core/AbstractMethod';
+import { DataManager } from '../data/DataManager';
+import { UI } from '../events';
+
+export default class ThpRemoveCredentials extends AbstractMethod<'thpRemoveCredentials'> {
+    init() {
+        this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
+        this.requiredPermissions = ['management'];
+        this.useDeviceState = false;
+        this.skipFinalReload = true;
+    }
+
+    run() {
+        const thpState = this.device.getThpState();
+        if (!thpState) {
+            throw ERRORS.TypedError('Device_ThpStateMissing');
+        }
+
+        const knownCredentials = DataManager.getSettings('thp')?.knownCredentials;
+        if (knownCredentials) {
+            const toRemoveCredentials = (
+                this.payload.credentials || thpState.pairingCredentials
+            ).map(c => c.credential);
+
+            const index = knownCredentials.findIndex(({ credential }) =>
+                toRemoveCredentials.includes(credential),
+            );
+
+            if (index >= 0) {
+                knownCredentials.splice(index, 1); // remove credential from DataManager
+            }
+        }
+
+        // should we change Device to unacquired?
+        // should @trezor/connect remember that this device is requested not to be remembered?
+        // this will work after device disconnection
+
+        thpState.resetState(); // reset device state
+
+        // followup: increase credentials counter on Trezor (not implemented in firmware yet)
+        return Promise.resolve({ message: 'Success' });
+    }
+}

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -258,6 +258,10 @@ export const factory = <
 
     setProxy: params => call({ ...params, method: 'setProxy' }),
 
+    thpGetCredentials: params => call({ ...params, method: 'thpGetCredentials' }),
+
+    thpRemoveCredentials: params => call({ ...params, method: 'thpRemoveCredentials' }),
+
     dispose,
 
     cancel,

--- a/packages/connect/src/types/api/index.ts
+++ b/packages/connect/src/types/api/index.ts
@@ -82,6 +82,8 @@ import { stellarSignTransaction } from './stellarSignTransaction';
 import { tezosGetAddress } from './tezosGetAddress';
 import { tezosGetPublicKey } from './tezosGetPublicKey';
 import { tezosSignTransaction } from './tezosSignTransaction';
+import { thpGetCredentials } from './thpGetCredentials';
+import { thpRemoveCredentials } from './thpRemoveCredentials';
 import { uiResponse } from './uiResponse';
 import { unlockPath } from './unlockPath';
 import { verifyMessage } from './verifyMessage';
@@ -251,6 +253,12 @@ export interface TrezorConnect {
 
     // todo: link docs
     getSettings: typeof getSettings;
+
+    // https://connect.trezor.io/9/methods/device/thpGetCredentials/
+    thpGetCredentials: typeof thpGetCredentials;
+
+    // https://connect.trezor.io/9/methods/device/thpRemoveCredentials/
+    thpRemoveCredentials: typeof thpRemoveCredentials;
 
     // https://connect.trezor.io/9/methods/other/init/
     init: typeof init;

--- a/packages/connect/src/types/api/thpGetCredentials.ts
+++ b/packages/connect/src/types/api/thpGetCredentials.ts
@@ -1,0 +1,5 @@
+import type { ThpCredentials } from '@trezor/protocol';
+
+import type { CommonParams, Response } from '../params';
+
+export declare function thpGetCredentials(params?: CommonParams): Response<ThpCredentials>;

--- a/packages/connect/src/types/api/thpRemoveCredentials.ts
+++ b/packages/connect/src/types/api/thpRemoveCredentials.ts
@@ -1,0 +1,8 @@
+import type { ThpCredentials } from '@trezor/protocol';
+
+import type { PROTO } from '../../constants';
+import type { CommonParams, Response } from '../params';
+
+export declare function thpRemoveCredentials(
+    params: CommonParams & { credentials?: ThpCredentials[] },
+): Response<PROTO.Success>;

--- a/packages/trezor-user-env-link/src/types.ts
+++ b/packages/trezor-user-env-link/src/types.ts
@@ -1,4 +1,4 @@
 /** device model as expected by trezor-user-env */
-export type Model = 'T1B1' | 'T2T1' | 'T3B1' | 'T3T1';
+export type Model = 'T1B1' | 'T2T1' | 'T3B1' | 'T3T1' | 'T3W1';
 
 export type Firmwares = Record<Model, string[]>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

adding 2 new methods for create and remove THP credentials (autoconnect = true)

1. `thpGetCredentials` creates THP credentials with `autoconnect` flag - if suite use those credentials there will be no interaction (connection confirmation)
1. `thpRemoveCredentials`  removes THP credentials from the memory (thp settings) - this action doesn't use the device (yet) as trezor does not store the credentials, may in the future there will be possibility to ivalidate all THP credentials at once but it is not possible to do it individually 

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-thp-credentials&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-thp-credentials&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connect-thp-credentials&lookback=7)