### PR TITLE
Feat: update calculate firmware hash to support TS7

### DIFF
--- a/packages/connect/src/api/firmware/__tests__/calculateFirmwareHash.test.ts
+++ b/packages/connect/src/api/firmware/__tests__/calculateFirmwareHash.test.ts
@@ -1,3 +1,5 @@
+import { DeviceModelInternal } from '@trezor/device-utils';
+
 import { calculateFirmwareHash } from '../calculateFirmwareHash';
 
 // NOTE: for unit test purposes create "firmware with empty bytes"
@@ -5,15 +7,31 @@ import { calculateFirmwareHash } from '../calculateFirmwareHash';
 const bin = Buffer.from('ff', 'hex');
 
 describe('firmware/calculateFirmwareHash', () => {
+    it('T1B1 without internal_model', () => {
+        expect(
+            calculateFirmwareHash(
+                // @ts-expect-error - Testing some might be real case when T1B1 does not report interna_model
+                undefined,
+                bin,
+                Buffer.from('0123456789abcdef'),
+            ),
+        ).toStrictEqual({
+            hash: 'f5f1097835c9a7c45486230b4f40389a85a4442b5c2c7766e7ca8ef22bf84bd1',
+            challenge: '30313233343536373839616263646566',
+        });
+    });
+
     it('T1B1 with challenge', () => {
-        expect(calculateFirmwareHash(1, bin, Buffer.from('0123456789abcdef'))).toStrictEqual({
+        expect(
+            calculateFirmwareHash(DeviceModelInternal.T1B1, bin, Buffer.from('0123456789abcdef')),
+        ).toStrictEqual({
             hash: 'f5f1097835c9a7c45486230b4f40389a85a4442b5c2c7766e7ca8ef22bf84bd1',
             challenge: '30313233343536373839616263646566',
         });
     });
 
     it('T1B1 without challenge', () => {
-        expect(calculateFirmwareHash(1, bin)).toStrictEqual({
+        expect(calculateFirmwareHash(DeviceModelInternal.T1B1, bin)).toStrictEqual({
             hash: 'a184d460adaac3c059bf2240521b5ff89a6aa6c2a765165d28bee7f4cb9af051',
             challenge: '',
         });
@@ -21,28 +39,53 @@ describe('firmware/calculateFirmwareHash', () => {
 
     // T2T1 results from https://github.com/trezor/trezor-firmware/blob/main/core/tests/test_trezor.utils.py
     it('T2T1 with challenge', () => {
-        expect(calculateFirmwareHash(2, bin, Buffer.from('0123456789abcdef'))).toStrictEqual({
+        expect(
+            calculateFirmwareHash(DeviceModelInternal.T2T1, bin, Buffer.from('0123456789abcdef')),
+        ).toStrictEqual({
             hash: 'a0934098a680db076ddf7ee22745f119d8fda4601048f05fdb66a64eddc0cfed',
             challenge: '30313233343536373839616263646566',
         });
     });
 
     it('T2T1 without challenge', () => {
-        expect(calculateFirmwareHash(2, bin)).toStrictEqual({
+        expect(calculateFirmwareHash(DeviceModelInternal.T2T1, bin)).toStrictEqual({
             hash: 'd2db90a76a5636a7004ec3b48e71a955e0cbb2cb5a6fd7ae9fbef846bc166c8c',
+            challenge: '',
+        });
+    });
+
+    it('T3W1 with challenge', () => {
+        expect(
+            calculateFirmwareHash(DeviceModelInternal.T3W1, bin, Buffer.from('0123456789abcdef')),
+        ).toStrictEqual({
+            hash: '9fb271f171cb9b6a915bac9b62ad80d2319f52dbae7501ddb1d7db43fdfae86f',
+            challenge: '30313233343536373839616263646566',
+        });
+    });
+
+    it('T3W1 without challenge', () => {
+        expect(calculateFirmwareHash(DeviceModelInternal.T3W1, bin)).toStrictEqual({
+            hash: '6f64d60f29dadd23f0383c51a0c595b4a4d7da952a1f3c7a03de149f1f7a394c',
             challenge: '',
         });
     });
 
     // just for coverage
     it('no padding', () => {
-        expect(calculateFirmwareHash(2, Buffer.alloc(13 * 128 * 1024).fill(bin))).toStrictEqual({
+        expect(
+            calculateFirmwareHash(
+                DeviceModelInternal.T2T1,
+                Buffer.alloc(13 * 128 * 1024).fill(bin),
+            ),
+        ).toStrictEqual({
             hash: 'd2db90a76a5636a7004ec3b48e71a955e0cbb2cb5a6fd7ae9fbef846bc166c8c',
             challenge: '',
         });
     });
 
-    it('Firmware too big', () => {
-        expect(() => calculateFirmwareHash(2, Buffer.alloc(100000000))).toThrow('Firmware too big');
+    it('T2T1, Firmware too big', () => {
+        expect(() =>
+            calculateFirmwareHash(DeviceModelInternal.T2T1, Buffer.alloc(100000000)),
+        ).toThrow('Firmware too big');
     });
 });

--- a/packages/connect/src/api/firmware/calculateFirmwareHash.ts
+++ b/packages/connect/src/api/firmware/calculateFirmwareHash.ts
@@ -1,10 +1,35 @@
 import { blake2sHex } from 'blakejs';
 
-const SIZE_T1 = (7 * 128 + 64) * 1024;
-const SIZE_TT = 13 * 128 * 1024;
+import { DeviceModelInternal } from '@trezor/device-utils';
 
-export const calculateFirmwareHash = (major_version: number, fw: ArrayBuffer, key?: Buffer) => {
-    const size = major_version === 1 ? SIZE_T1 : SIZE_TT;
+// Size values are taken from
+// https://github.com/trezor/trezor-firmware/blob/56f9490c01b40e99d94fe5d8a283955800d86562/core/embed/models/T3T1/memory.h#L62
+// and the calculation reflects the internal memory layout.
+// We keep size values expanded even though the result is the same for all core models except T3W1.
+const SIZE_T1B1 = (7 * 128 + 64) * 1024; // 960 kB
+const SIZE_T2T1 = 13 * 128 * 1024; // 1664 kB
+const SIZE_T2B1 = 13 * 128 * 1024; // 1664 kB
+const SIZE_T3B1 = 208 * 8 * 1024; // 1664 kB
+const SIZE_T3T1 = 208 * 8 * 1024; // 1664 kB
+const SIZE_T3W1 = 417 * 8 * 1024; // 3336 kB
+
+const firmwareSizeMap: Partial<Record<DeviceModelInternal, number>> = {
+    [DeviceModelInternal.T1B1]: SIZE_T1B1,
+    [DeviceModelInternal.T2T1]: SIZE_T2T1,
+    [DeviceModelInternal.T2B1]: SIZE_T2B1,
+    [DeviceModelInternal.T3B1]: SIZE_T3B1,
+    [DeviceModelInternal.T3T1]: SIZE_T3T1,
+    [DeviceModelInternal.T3W1]: SIZE_T3W1,
+};
+
+export const calculateFirmwareHash = (
+    internal_model: DeviceModelInternal,
+    fw: ArrayBuffer,
+    key?: Buffer,
+) => {
+    // Default is SIZE_T1B1 since some old T1 do not report internal_model.
+    const size = firmwareSizeMap[internal_model] ?? SIZE_T1B1;
+
     const padding = size - fw.byteLength;
     if (padding < 0) {
         throw new Error('Firmware too big');

--- a/packages/connect/src/device/workflow/checkFirmwareHash.ts
+++ b/packages/connect/src/device/workflow/checkFirmwareHash.ts
@@ -76,7 +76,7 @@ export const checkFirmwareHash = async ({
 
     const strippedBinary = stripFwHeaders(firmwareBinary.binary);
     const { hash: expectedHash, challenge } = calculateFirmwareHash(
-        device.features.major_version,
+        device.features.internal_model,
         strippedBinary,
         randomBytes(32),
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is updating `calculateFirmwareHash` to work with TS7.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/update-calculateFirmwareHash-to-support-ts7&lookback=7)