### PR TITLE
fix(connect): wrong comment to old naming

### DIFF
--- a/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
+++ b/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
@@ -545,7 +545,7 @@ describe('onCallFirmwareUpdate', () => {
                 params: {},
                 context,
             }),
-        ).rejects.toThrow('device.firmwareReleaseMessage is not set');
+        ).rejects.toThrow('device.firmwareReleaseConfigInfo is not set');
 
         await deviceList.dispose();
     });

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -255,7 +255,7 @@ const getBinaryHelper = async ({
     }
 
     if (!device.firmwareReleaseConfigInfo) {
-        throw ERRORS.TypedError('Runtime', 'device.firmwareReleaseMessage is not set');
+        throw ERRORS.TypedError('Runtime', 'device.firmwareReleaseConfigInfo is not set');
     }
     const deviceModel = device.features?.internal_model;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This name was the old one, fixing it to use the current one.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/typo-in-error&lookback=7)