### PR TITLE
fix(suite): Translate hex value to human readable correctly

### DIFF
--- a/packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import styled from 'styled-components';
 
 import { formInputsMaxLength } from '@suite-common/validators';
@@ -37,12 +39,11 @@ const Space = styled.div`
 export const OpReturn = ({ outputId }: { outputId: number }) => {
     const {
         register,
-        outputs,
-        getDefaultValue,
         setValue,
         formState: { errors },
         composeTransaction,
         removeOpReturn,
+        watch,
     } = useSendFormContext();
 
     const { translationString } = useTranslation();
@@ -50,8 +51,8 @@ export const OpReturn = ({ outputId }: { outputId: number }) => {
     const inputAsciiName = `outputs.${outputId}.dataAscii` as const;
     const inputHexName = `outputs.${outputId}.dataHex` as const;
 
-    const asciiValue = getDefaultValue(inputAsciiName, outputs[outputId].dataAscii || '');
-    const hexValue = getDefaultValue(inputHexName, outputs[outputId].dataHex || '');
+    const asciiValue = watch(inputAsciiName);
+    const hexValue = watch(inputHexName);
 
     const outputError = errors.outputs ? errors.outputs[outputId] : undefined;
     const asciiError = outputError ? outputError.dataAscii : undefined;
@@ -66,20 +67,21 @@ export const OpReturn = ({ outputId }: { outputId: number }) => {
         },
         required: translationString('DATA_NOT_SET'),
     });
+
     const { ref: hexRef, ...hexField } = register(inputHexName, {
-        onChange: event => {
-            setValue(
-                inputAsciiName,
-                !hexError ? Buffer.from(event.target.value, 'hex').toString('ascii') : '',
-            );
-            composeTransaction(inputHexName);
-        },
         required: translationString('DATA_NOT_SET'),
         validate: (value = '') => {
             if (!isHexValid(value)) return translationString('DATA_NOT_VALID_HEX');
             if (value.length > 80 * 2) return translationString('DATA_HEX_TOO_BIG');
         },
     });
+
+    useEffect(() => {
+        setValue(
+            inputAsciiName,
+            hexValue && !hexError ? Buffer.from(hexValue, 'hex').toString('ascii') : '',
+        );
+    }, [inputAsciiName, hexValue, hexError, setValue]);
 
     return (
         <div>


### PR DESCRIPTION
Moved changing logic from `onChange` to `watch`+`useEffect` to run **after** validation.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve #20848

## Screenshots:
Before:
<img width="1474" height="616" alt="image" src="https://github.com/user-attachments/assets/fbefaa96-2e90-436e-828f-4aa8b428ad5b" />
after:
<img width="893" height="321" alt="image" src="https://github.com/user-attachments/assets/43f48431-c828-414b-b891-4b414aee079e" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/op-return-hex-value&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/op-return-hex-value&lookback=7)