### PR TITLE
fix(suite-native): correct feature flag in selectIsEntropyCheckEnabledAndFailed

### DIFF
--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -234,7 +234,7 @@ export const selectHasFirmwareAuthenticityCheckHardFailed = createMemoizedSelect
 export const selectIsEntropyCheckEnabledAndFailed = createMemoizedSelector(
     [
         (state: FwAuthenticityCheckState) =>
-            selectIsFeatureEnabled(state, Feature.firmwareRevisionCheckMobile, true),
+            selectIsFeatureEnabled(state, Feature.entropyCheckMobile, true),
         selectIsEntropyCheckFailed,
     ],
     (isFeatureEnabled, isEntropyCheckFailed) => isFeatureEnabled && isEntropyCheckFailed,


### PR DESCRIPTION
## Description

Fix incorrect feature flag used in `selectIsEntropyCheckEnabledAndFailed`

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/use-Feature-entropyCheckMobile&lookback=7)