### PR TITLE
Chore: deduplicate screen names

### DIFF
--- a/suite-native/device-manager/src/components/ConnectButton.tsx
+++ b/suite-native/device-manager/src/components/ConnectButton.tsx
@@ -61,7 +61,7 @@ export const ConnectButton = ({ onSelectDevice }: ConnectButtonProps) => {
     const handleConnectDevice = () => {
         const connectDeviceScreen = isOnlyBluetoothSupported
             ? AuthorizeDeviceStackRoutes.ConnectBluetoothDevice
-            : AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice;
+            : AuthorizeDeviceStackRoutes.ConnectAndUnlockDeviceAuthorize;
 
         if (device) {
             onSelectDevice(device);

--- a/suite-native/device/src/hooks/useDetectDeviceError.tsx
+++ b/suite-native/device/src/hooks/useDetectDeviceError.tsx
@@ -243,7 +243,7 @@ export const useDetectDeviceError = () => {
                 onPressPrimaryButton: () => {
                     handleDisconnect();
                     navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
-                        screen: AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice,
+                        screen: AuthorizeDeviceStackRoutes.ConnectAndUnlockDeviceAuthorize,
                     });
                 },
                 secondaryButtonTitle: (

--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -84,7 +84,7 @@ export const useHandleDeviceConnection = () => {
     );
 
     const isDeviceOnboardingConnectAndUnlockScreenFocused = useNavigationRouteMatch(
-        DeviceOnboardingStackRoutes.ConnectAndUnlockDevice,
+        DeviceOnboardingStackRoutes.ConnectAndUnlockDeviceOnboarding,
     );
 
     const lastRoute = useNavigationState(state => state?.routes.at(-1)?.name);
@@ -204,7 +204,7 @@ export const useHandleDeviceConnection = () => {
 
             if (isDeviceOnboardingStackFocused) {
                 navigation.navigate(RootStackRoutes.DeviceOnboardingStack, {
-                    screen: DeviceOnboardingStackRoutes.ConnectAndUnlockDevice,
+                    screen: DeviceOnboardingStackRoutes.ConnectAndUnlockDeviceOnboarding,
                 });
 
                 return;

--- a/suite-native/module-authorize-device/src/navigation/AuthorizeDeviceStackNavigator.tsx
+++ b/suite-native/module-authorize-device/src/navigation/AuthorizeDeviceStackNavigator.tsx
@@ -59,7 +59,7 @@ export const AuthorizeDeviceStackNavigator = () => {
                             component={RemoveBluetoothDeviceScreen}
                         />
                         <AuthorizeDeviceStack.Screen
-                            name={AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice}
+                            name={AuthorizeDeviceStackRoutes.ConnectAndUnlockDeviceAuthorize}
                             component={ConnectAndUnlockDeviceScreen}
                             options={{ animationTypeForReplace: 'pop' }}
                         />

--- a/suite-native/module-authorize-device/src/screens/connect/ConnectAndUnlockDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/ConnectAndUnlockDeviceScreen.tsx
@@ -21,7 +21,7 @@ export const ConnectAndUnlockDeviceScreen = ({
     navigation,
 }: StackToStackCompositeScreenProps<
     AuthorizeDeviceStackParamList,
-    AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice,
+    AuthorizeDeviceStackRoutes.ConnectAndUnlockDeviceAuthorize,
     RootStackParamList
 >) => {
     const isBluetoothEnabled = useFeatureFlag(FeatureFlag.IsBluetoothEnabled);

--- a/suite-native/module-authorize-device/src/screens/connect/TurnOnAndUnlockDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/TurnOnAndUnlockDeviceScreen.tsx
@@ -41,7 +41,7 @@ export const TurnOnAndUnlockDeviceScreen = () => {
     const unknownNearbyDevices = useSelector(selectUnknownNearbyBluetoothDevices);
 
     const navigateToConnectAndUnlockDeviceScreen = () => {
-        navigation.replace(AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice);
+        navigation.replace(AuthorizeDeviceStackRoutes.ConnectAndUnlockDeviceAuthorize);
     };
 
     const navigateToRemoveBluetoothDeviceScreen = useCallback(() => {

--- a/suite-native/module-device-onboarding/src/navigation/DeviceOnboardingStackNavigator.tsx
+++ b/suite-native/module-device-onboarding/src/navigation/DeviceOnboardingStackNavigator.tsx
@@ -34,7 +34,7 @@ export const DeviceOnboardingStackNavigator = () => (
         screenOptions={stackNavigationOptionsConfig}
     >
         <DeviceOnboardingStack.Screen
-            name={DeviceOnboardingStackRoutes.ConnectAndUnlockDevice}
+            name={DeviceOnboardingStackRoutes.ConnectAndUnlockDeviceOnboarding}
             component={ConnectAndUnlockDeviceScreen}
             options={{
                 gestureEnabled: false,

--- a/suite-native/module-device-settings/src/hooks/useDeviceConnectionGuard.ts
+++ b/suite-native/module-device-settings/src/hooks/useDeviceConnectionGuard.ts
@@ -26,7 +26,7 @@ export const useDeviceConnectionGuard = () => {
 
     const redirectToConnectAndUnlockScreen = useCallback(() => {
         navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
-            screen: AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice,
+            screen: AuthorizeDeviceStackRoutes.ConnectAndUnlockDeviceAuthorize,
             params: {
                 onCancelNavigationTarget: {
                     name: RootStackRoutes.DeviceSettingsStack,

--- a/suite-native/module-home/src/screens/HomeScreen/components/EmptyPortfolioCrossroads.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/EmptyPortfolioCrossroads.tsx
@@ -49,7 +49,7 @@ export const EmptyPortfolioCrossroads = () => {
         navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
             screen: isIosWithBluetoothEnabled
                 ? AuthorizeDeviceStackRoutes.TurnOnAndUnlockDevice
-                : AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice,
+                : AuthorizeDeviceStackRoutes.ConnectAndUnlockDeviceAuthorize,
         });
         analytics.report({
             type: EventType.EmptyDashboardClick,

--- a/suite-native/module-send/src/components/SendFeesForm.tsx
+++ b/suite-native/module-send/src/components/SendFeesForm.tsx
@@ -230,7 +230,7 @@ export const SendFeesForm = ({ accountKey, tokenContract }: SendFormProps) => {
 
         // In case that view only device is not connected, show connect screen first.
         navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
-            screen: AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice,
+            screen: AuthorizeDeviceStackRoutes.ConnectAndUnlockDeviceAuthorize,
             params: {
                 // If user cancels, navigate back to the send fees screen.
                 onCancelNavigationTarget: {

--- a/suite-native/module-send/src/hooks/useShowDeviceDisconnectedAlert.tsx
+++ b/suite-native/module-send/src/hooks/useShowDeviceDisconnectedAlert.tsx
@@ -25,7 +25,7 @@ export const useShowDeviceDisconnectedAlert = () => {
 
     const handleReconnect = () => {
         navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
-            screen: AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice,
+            screen: AuthorizeDeviceStackRoutes.ConnectAndUnlockDeviceAuthorize,
             params: {
                 // If user cancels the re-connecting process, redirect him to the Home screen.
                 onCancelNavigationTarget: {

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -132,7 +132,7 @@ export type OnboardingStackParamList = {
 };
 
 export type DeviceOnboardingStackParamList = {
-    [DeviceOnboardingStackRoutes.ConnectAndUnlockDevice]: undefined;
+    [DeviceOnboardingStackRoutes.ConnectAndUnlockDeviceOnboarding]: undefined;
     [DeviceOnboardingStackRoutes.UninitializedDeviceLanding]: undefined;
     [DeviceOnboardingStackRoutes.SuspiciousDevice]: {
         suspicionCause: DeviceSuspicionCause;
@@ -256,7 +256,7 @@ export type DeviceAuthenticityStackParamList = {
 };
 
 export type AuthorizeDeviceStackParamList = {
-    [AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice]:
+    [AuthorizeDeviceStackRoutes.ConnectAndUnlockDeviceAuthorize]:
         | { onCancelNavigationTarget: NavigateParameters<RootStackParamList> }
         | undefined;
     [AuthorizeDeviceStackRoutes.TurnOnAndUnlockDevice]: undefined;

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -40,7 +40,7 @@ export enum OnboardingStackRoutes {
 }
 
 export enum DeviceOnboardingStackRoutes {
-    ConnectAndUnlockDevice = 'ConnectAndUnlockDevice',
+    ConnectAndUnlockDeviceOnboarding = 'ConnectAndUnlockDeviceOnboarding',
     UninitializedDeviceLanding = 'UninitializedDeviceLanding',
     SuspiciousDevice = 'SuspiciousDevice',
     SecurityCheck = 'SecurityCheck',
@@ -122,7 +122,7 @@ export enum DeviceNameStackRoutes {
 }
 
 export enum AuthorizeDeviceStackRoutes {
-    ConnectAndUnlockDevice = 'ConnectAndUnlockDevice',
+    ConnectAndUnlockDeviceAuthorize = 'ConnectAndUnlockDeviceAuthorize',
     TurnOnAndUnlockDevice = 'TurnOnAndUnlockDevice',
     ConnectBluetoothDevice = 'ConnectBluetoothDevice',
     RemoveBluetoothDevice = 'RemoveBluetoothDevice',

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -44,10 +44,10 @@ export enum DeviceOnboardingStackRoutes {
     UninitializedDeviceLanding = 'UninitializedDeviceLanding',
     SuspiciousDevice = 'SuspiciousDevice',
     SecurityCheck = 'SecurityCheck',
-    FirmwareInstallation = 'FirmwareInstallation',
-    DeviceAuthenticity = 'DeviceAuthenticity ',
+    FirmwareInstallation = 'FirmwareInstallation', // FIXME
+    DeviceAuthenticity = 'DeviceAuthenticity ', // FIXME
     DeviceAuthenticitySuccess = 'DeviceAuthenticitySuccess',
-    ConfirmFirmwareUpdate = 'ConfirmFirmwareUpdate',
+    ConfirmFirmwareUpdate = 'ConfirmFirmwareUpdate', // FIXME
     DeviceTutorial = 'DeviceTutorial',
     CreateOrRecoverCrossroads = 'CreateOrRecoverCrossroads',
     CreateWalletLoading = 'CreateWalletLoading',
@@ -73,24 +73,24 @@ export enum DeviceSettingsStackRoutes {
     PinProtection = 'PinProtection',
     DevicePinProtectionStack = 'DevicePinProtectionStack',
     FirmwareUpdateStack = 'FirmwareUpdateStack',
-    DeviceAuthenticity = 'DeviceAuthenticity',
+    DeviceAuthenticity = 'DeviceAuthenticity', // FIXME
     DeviceAuthenticityStack = 'DeviceAuthenticityStack',
-    ContinueOnTrezor = 'ContinueOnTrezor',
+    ContinueOnTrezor = 'ContinueOnTrezor', // FIXME
     WipeDeviceStack = 'WipeDeviceStack',
     DeviceNameStack = 'DeviceNameStack',
     DeviceCheckBackupStack = 'DeviceCheckBackupStack',
 }
 
 export enum DevicePinProtectionStackRoutes {
-    ContinueOnTrezor = 'ContinueOnTrezor',
+    ContinueOnTrezor = 'ContinueOnTrezor', // FIXME
     EnterCurrentPin = 'EnterCurrentPin',
     EnterNewPin = 'EnterNewPin',
     ConfirmNewPin = 'ConfirmNewPin',
 }
 
 export enum FirmwareUpdateStackRoutes {
-    ConfirmFirmwareUpdate = 'ConfirmFirmwareUpdate',
-    FirmwareInstallation = 'FirmwareInstallation',
+    ConfirmFirmwareUpdate = 'ConfirmFirmwareUpdate', // FIXME
+    FirmwareInstallation = 'FirmwareInstallation', // FIXME
 }
 
 export enum DeviceCheckBackupStackRoutes {
@@ -110,14 +110,14 @@ export enum DeviceAuthenticityStackRoutes {
 
 export enum WipeDeviceStackRoutes {
     WipeDevice = 'WipeDevice',
-    ContinueOnTrezor = 'ContinueOnTrezor',
+    ContinueOnTrezor = 'ContinueOnTrezor', // FIXME
     WipeDeviceLoadingScreen = 'WipeDeviceLoadingScreen',
     FactoryReset = 'FactoryReset',
 }
 
 export enum DeviceNameStackRoutes {
     DeviceName = 'DeviceName',
-    ContinueOnTrezor = 'ContinueOnTrezor',
+    ContinueOnTrezor = 'ContinueOnTrezor', // FIXME
     DeviceNameLoadingScreen = 'DeviceNameLoadingScreen',
 }
 
@@ -157,7 +157,7 @@ export enum AccountsStackRoutes {
 }
 
 export enum ReceiveStackRoutes {
-    ReceiveAccounts = 'ReceiveAccounts',
+    ReceiveAccounts = 'ReceiveAccounts', // FIXME
     ReceiveAccount = 'ReceiveAccount',
 }
 
@@ -191,7 +191,7 @@ export enum SettingsStackRoutes {
 
 export enum TradingStackRoutes {
     Trading = 'Trading',
-    ReceiveAccounts = 'ReceiveAccounts',
+    ReceiveAccounts = 'ReceiveAccounts', // FIXME
     TradingHistory = 'TradingHistory',
     TradingExchangePreview = 'TradingExchangePreview',
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Deduplicate screen names. Reusing a screen name can cause incorrect navigation and makes analytics harder to interpret (it becomes almost impossible to distinguish between duplicated screens; the only workaround is to check them in combination with the previous screen).

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/deduplicate-screen-names&lookback=7)