### PR TITLE
fix traffic light offset wrapper

### DIFF
--- a/packages/suite/src/components/suite/TrafficLightOffset.tsx
+++ b/packages/suite/src/components/suite/TrafficLightOffset.tsx
@@ -9,6 +9,7 @@ type Props = {
     children?: React.ReactNode;
     offset?: number;
     isVisible?: boolean;
+    expand?: boolean;
 };
 
 const FixForNotBeingAbleToDragWindow = styled.div`
@@ -22,8 +23,13 @@ const FixForNotBeingAbleToDragWindow = styled.div`
     width: 100%;
 `;
 
-const Container = styled.div<{ $offset: number }>`
+const Container = styled.div<{ $offset: number; $expand?: boolean }>`
     ${({ $offset }) => `padding-top: ${$offset}px;`}
+
+    ${({ $expand }) =>
+        $expand &&
+        `height: 100%;
+    width: 100%;`}
 `;
 
 // See: https://github.com/electron/electron/issues/5678
@@ -38,11 +44,20 @@ export const TrafficLightDraggableWindowHeader = ({ children, isVisible = true }
 };
 
 // on Mac in desktop app we don't use window bar and close/maximize/minimize icons are positioned directly in the app
-export const TrafficLightOffset = ({ children, offset = 35, isVisible = true }: Props) => {
+export const TrafficLightOffset = ({
+    children,
+    offset = 35,
+    isVisible = true,
+    expand = true,
+}: Props) => {
     const isMac = isMacOs();
     const isDesktopApp = isDesktop();
 
     if (!isVisible || !isMac || !isDesktopApp) return children;
 
-    return <Container $offset={offset}>{children}</Container>;
+    return (
+        <Container $offset={offset} $expand={expand}>
+            {children}
+        </Container>
+    );
 };

--- a/packages/suite/src/views/suite/SwitchDevice/SwitchDeviceModal.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/SwitchDeviceModal.tsx
@@ -43,7 +43,7 @@ export const SwitchDeviceModal = ({
             alignment={{ x: 'start', y: 'start' }}
             padding={spacings.xs}
         >
-            <TrafficLightOffset>
+            <TrafficLightOffset expand={false}>
                 <Container data-testid={`${dataTest}/switch-device`}>
                     <Column alignItems="flex-start" gap={spacings.md} flex="1">
                         <motion.div


### PR DESCRIPTION
Improvement fix for https://github.com/trezor/trezor-suite/pull/20779 since it broke sidebar.

## Screenshots:
BEFORE
<img width="2090" height="1178" alt="Screenshot 2025-08-19 at 13 55 42" src="https://github.com/user-attachments/assets/1f46bdde-55da-4501-ab04-959ef25e3a1e" />
AFTER
<img width="1744" height="1072" alt="Screenshot 2025-08-19 at 13 56 00" src="https://github.com/user-attachments/assets/9b709d3d-b1c8-47fb-b024-52b27e3b8fbb" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trafficlight-offset-expand-prop&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trafficlight-offset-expand-prop&lookback=7)