### PR TITLE
fix(suite): Allow utf-8 in OP_RETURN

### DIFF
--- a/packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx
@@ -60,7 +60,7 @@ export const OpReturn = ({ outputId }: { outputId: number }) => {
 
     const { ref: asciiRef, ...asciiField } = register(inputAsciiName, {
         onChange: event => {
-            setValue(inputHexName, Buffer.from(event.target.value, 'ascii').toString('hex'), {
+            setValue(inputHexName, Buffer.from(event.target.value, 'utf-8').toString('hex'), {
                 shouldValidate: true,
             });
             composeTransaction(inputAsciiName);
@@ -79,7 +79,7 @@ export const OpReturn = ({ outputId }: { outputId: number }) => {
     useEffect(() => {
         setValue(
             inputAsciiName,
-            hexValue && !hexError ? Buffer.from(hexValue, 'hex').toString('ascii') : '',
+            hexValue && !hexError ? Buffer.from(hexValue, 'hex').toString('utf-8') : '',
         );
     }, [inputAsciiName, hexValue, hexError, setValue]);
 


### PR DESCRIPTION
Changed the OP_RETURN human readable format field to accept utf-8.

## Related Issue

Resolve #20633 

## Screenshots:
<img width="1452" height="740" alt="op-return" src="https://github.com/user-attachments/assets/a402a888-bccc-417c-b6f5-34834011db25" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/op-return-utf-8&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/op-return-utf-8&lookback=7)