### PR TITLE
fix(suite): Sort transactions before exporting

### DIFF
--- a/packages/suite/src/actions/wallet/exportTransactionsActions.ts
+++ b/packages/suite/src/actions/wallet/exportTransactionsActions.ts
@@ -68,6 +68,9 @@ export const exportTransactionsThunk = createThunk(
                 ? advancedSearchTransactions(transactions, accountMetadata, searchQuery)
                 : transactions;
 
+        // getAccountTransactions doesn't guarantee transactions will be sorted
+        filteredTransaction.sort((t1, t2) => (t2.blockTime || 0) - (t1.blockTime || 0));
+
         // Prepare data in right format
         const data = await formatData(
             {


### PR DESCRIPTION
Sorts transactions before exporting.

## Related Issue

Resolve #5718 


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/export-transaction-order&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/export-transaction-order&lookback=7)