### PR TITLE
fix(suite-native): fees footer radius

### DIFF
--- a/suite-native/transaction-management/src/components/fees/FeesFooter.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeesFooter.tsx
@@ -43,6 +43,7 @@ const cardStyle = prepareNativeStyle(utils => ({
     backgroundColor: utils.colors.backgroundSurfaceElevationNegative,
     borderColor: utils.colors.borderElevation0,
     borderWidth: utils.borders.widths.small,
+    borderRadius: utils.borders.radii.r20,
     ...utils.boxShadows.none,
 }));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- fix border radius in fees footer wrapper to match the radius of the button a little better

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
Before:
![Screenshot_2025-08-19-16-40-21-32_f0e0ef16e89dc3099c9d2ea44a0bcfa0](https://github.com/user-attachments/assets/05892b04-ddd4-4a0b-832d-eaaf89468167)


After: 
![Screenshot_2025-08-19-16-42-27-54_f0e0ef16e89dc3099c9d2ea44a0bcfa0](https://github.com/user-attachments/assets/60cc2a5c-0c4e-4f63-95a0-85dcfb897622)


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/fees-footer-radius&lookback=7)