### PR TITLE
fix(e2e-suite): Disable temporarly trading tests on web canary workflow

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -23,9 +23,13 @@ inputs:
     default: "false"
     required: false
   additional-grep:
-    description: "Additional grep for PW tests. Use regexp groups with positive or negative lookahead. Example: (?=.*@webOnly)"
-    default: ""
+    description: "Extra include grep (regex), passed to --grep, does not work for negative lookahead."
     required: false
+    default: ""
+  additional-grep-invert:
+    description: "Exclude grep (regex), passed to --grep-invert"
+    required: false
+    default: ""
   currents-project-id:
     description: "Currents project ID for reporting"
     required: true
@@ -126,7 +130,8 @@ runs:
           --pwc-cancel-after-failures ${{ inputs.fail-fast }} \
           --forbid-only \
           $REPORTER_OPT \
-          --grep="${{ inputs.additional-grep }}"
+          --grep="${{ inputs.additional-grep }}" \
+          --grep-invert="${{ inputs.additional-grep-invert }}"
 
     - name: Extract and Upload Logs
       if: ${{ !cancelled() }}

--- a/.github/workflows/test-suite-desktop-e2e-fw-canary.yml
+++ b/.github/workflows/test-suite-desktop-e2e-fw-canary.yml
@@ -66,7 +66,7 @@ jobs:
           containers: "trezor-user-env-unix bitcoin-regtest electrum-regtest"
           workspace-dependencies: "@trezor/suite-desktop"
           test-group: ${{ matrix.TEST_GROUP }}
-          additional-grep: "(?!.*@specificFirmware)"
+          additional-grep-invert: "@specificFirmware"
           fail-fast: false
           currents-project-id: "4ytF0E"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}

--- a/.github/workflows/test-suite-desktop-e2e-pr.yml
+++ b/.github/workflows/test-suite-desktop-e2e-pr.yml
@@ -126,7 +126,7 @@ jobs:
           containers: "trezor-user-env-unix bitcoin-regtest electrum-regtest"
           workspace-dependencies: "@trezor/suite-desktop"
           test-group: ${{ matrix.TEST_GROUP }}
-          additional-grep: "(?!.*@nightlyOnly)"
+          additional-grep-invert: "@nightlyOnly"
           fail-fast: 7
           currents-project-id: "4ytF0E"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}

--- a/.github/workflows/test-suite-desktop-e2e-release.yml
+++ b/.github/workflows/test-suite-desktop-e2e-release.yml
@@ -78,7 +78,7 @@ jobs:
           containers: "trezor-user-env-unix bitcoin-regtest electrum-regtest"
           workspace-dependencies: "@trezor/suite-desktop"
           test-group: ${{ matrix.TEST_GROUP }}
-          additional-grep: "(?!.*@nightlyOnly)"
+          additional-grep-invert: "@nightlyOnly"
           fail-fast: false
           currents-project-id: "4ytF0E"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}

--- a/.github/workflows/test-suite-web-e2e-fw-canary.yml
+++ b/.github/workflows/test-suite-web-e2e-fw-canary.yml
@@ -61,7 +61,7 @@ jobs:
           containers: "trezor-user-env-unix bitcoin-regtest electrum-regtest"
           test-group: ${{ matrix.TEST_GROUP }}
           fail-fast: false
-          additional-grep: "(?!.*@specificFirmware)"
+          additional-grep-invert: "@specificFirmware|@group=trading"
           currents-project-id: "Og0NOQ"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}
           currents-tags: "fw-canary"

--- a/.github/workflows/test-suite-web-e2e-pr.yml
+++ b/.github/workflows/test-suite-web-e2e-pr.yml
@@ -129,7 +129,8 @@ jobs:
           project: "web"
           containers: "trezor-user-env-unix bitcoin-regtest electrum-regtest"
           test-group: ${{ matrix.TEST_GROUP }}
-          additional-grep: "(?=.*@webOnly)(?!.*@nightlyOnly)"
+          additional-grep: "@webOnly"
+          additional-grep-invert: "@nightlyOnly"
           fail-fast: 7
           currents-project-id: "Og0NOQ"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}

--- a/.github/workflows/test-suite-web-e2e-release.yml
+++ b/.github/workflows/test-suite-web-e2e-release.yml
@@ -70,7 +70,7 @@ jobs:
           project: "web"
           containers: "trezor-user-env-unix bitcoin-regtest electrum-regtest"
           test-group: ${{ matrix.TEST_GROUP }}
-          additional-grep: "(?!.*@nightlyOnly)"
+          additional-grep-invert: "@nightlyOnly"
           fail-fast: false
           currents-project-id: "Og0NOQ"
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}


### PR DESCRIPTION
- disables Trading tests on web canary pipeline - there is bug (incomplete SLIP 24 feature) and we are not able to use run wide tagging due to Currents bug (been reported). So this is temporary solution until  currents fix it.
- fixes grep param on action run-e2e-tests.yaml by introducing grep-invert param. It was not correctly working as you can see on this run where we have both tag fw-canary and customFirmware and you see in results a test that should have been excluded. Note: customFirmware serves as tag for a test that work with specific firmware and doesn't make sense to run it on fw-canary run

<img width="1573" height="771" alt="image" src="https://github.com/user-attachments/assets/48553f0e-64bc-4fcd-ac6b-80fef70dad96" />

I have tested the greps locally.
Here is [fw-canary](https://github.com/trezor/trezor-suite/actions/runs/17072284822/job/48404883550) web run - all passed, no trading tests run, no customFirmware run

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-disable-trading-canary&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-disable-trading-canary&lookback=7)