### PR TITLE
fix(suite): banner did not display correct localization

### DIFF
--- a/packages/suite/src/components/suite/banners/MessageSystemBanner.tsx
+++ b/packages/suite/src/components/suite/banners/MessageSystemBanner.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { messageSystemActions } from '@suite-common/message-system';
+import { messageSystemActions, resolveMessageContent } from '@suite-common/message-system';
 import { Message } from '@suite-common/suite-types';
 import { Banner, BannerProps, Row, Banner as WarningComponent } from '@trezor/components';
 
@@ -41,7 +41,7 @@ export const MessageSystemBanner = ({ message, margin, width }: MessageSystemBan
         }
 
         return {
-            label: label[language] || label.en,
+            label: resolveMessageContent(label, language) || label.en,
             onClick: onClick!,
             'data-testid': `@message-system/${id}/cta`,
         };
@@ -84,7 +84,7 @@ export const MessageSystemBanner = ({ message, margin, width }: MessageSystemBan
             margin={margin}
             width={width}
         >
-            {content[language] || content.en}
+            {resolveMessageContent(content, language) || content.en}
         </Banner>
     );
 };

--- a/suite-common/message-system/src/__fixtures__/messageSystemUtils.ts
+++ b/suite-common/message-system/src/__fixtures__/messageSystemUtils.ts
@@ -2070,7 +2070,6 @@ export const validateExperiments = [
 ];
 
 const localizedMessages: Localization = {
-    'en-GB': 'This is a message in English-GB.',
     en: 'This is a message in English.',
     cs: 'Toto je zpráva v češtině.',
     de: 'Dies ist eine Nachricht auf Deutsch.',
@@ -2097,8 +2096,8 @@ export const resolveMessageContentFixture: Array<{
     {
         description: 'resolveMessageContent - case 1',
         message: localizedMessages,
-        language: 'en-GB',
-        result: 'This is a message in English-GB.',
+        language: 'en',
+        result: 'This is a message in English.',
     },
     {
         description: 'resolveMessageContent - case 2',


### PR DESCRIPTION
## Description

Normalize the banner locale to a two-letter code via `resolveMessageContent`, since the banner used full locales (e.g. "en-US") while the message system expects xx keys.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19994


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/message-system-banner-localization&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/message-system-banner-localization&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/message-system-banner-localization&lookback=7)