### PR TITLE
fix(suite): Show descriptive name for wallet backup

### DIFF
--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/SelectBackupType.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/SelectBackupType.tsx
@@ -80,7 +80,6 @@ export const SelectBackupType = ({
     const deviceDefaultBackupType = useSelector(selectDeviceDefaultBackupType);
     const { isBelowTablet } = useLayoutSize();
 
-    const isDefault = deviceDefaultBackupType === selected;
     const isShamirDefault = isShamirBackupType(deviceDefaultBackupType);
     const isShamirSelected = isShamirBackupType(selected);
 
@@ -124,13 +123,7 @@ export const SelectBackupType = ({
                                 <Translation id="TR_ONBOARDING_BACKUP_TYPE" />
                             </Text>
                             <Text typographyStyle={isBelowTablet ? 'highlight' : 'titleSmall'}>
-                                <Translation
-                                    id={
-                                        isDefault
-                                            ? 'TR_ONBOARDING_BACKUP_TYPE_DEFAULT'
-                                            : typesToLabelMap[selected]
-                                    }
-                                />
+                                <Translation id={typesToLabelMap[selected]} />
                             </Text>
                         </OptionText>
                     </SelectedOption>


### PR DESCRIPTION
## Related Issue

Resolve #20287 

## Screenshots:
Before:
<img width="1200" height="555" alt="new-wallet-before" src="https://github.com/user-attachments/assets/6a95459e-3bbe-47da-9467-96663721f9ea" />

After:
<img width="1194" height="562" alt="new-wallet-after" src="https://github.com/user-attachments/assets/5650536a-da21-4780-a513-eb2dc07ce065" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/default-backup&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/default-backup&lookback=7)