### PR TITLE
fix(suite-native): keep fiat value as null before loaded so skeleton is visible instead of zero

### DIFF
--- a/suite-native/assets/src/assetsSelectors.ts
+++ b/suite-native/assets/src/assetsSelectors.ts
@@ -138,18 +138,24 @@ const selectDeviceAssetsWithBalances = createMemoizedSelector(
                 (sum, { cryptoValue }) => sum.plus(new BigNumber(cryptoValue)),
                 new BigNumber(0),
             );
-            const fiatBalance = networkAccounts.reduce(
-                (sum, { fiatValue }) => (fiatValue ? sum.plus(fiatValue) : sum),
-                new BigNumber(0),
-            );
+            const fiatBalance = networkAccounts.reduce<BigNumber | null>((sum, { fiatValue }) => {
+                // If any account has null fiat data, set the network fiat to null.
+                // This prevents showing partial/incomplete values to users - we show loading state until all data is available.
+                if (sum === null) return null;
+                if (fiatValue == null) return null;
 
-            totalFiatBalance = asBaseCurrencyAmount(totalFiatBalance.plus(fiatBalance));
+                return sum.plus(fiatValue);
+            }, new BigNumber(0));
+
+            if (fiatBalance) {
+                totalFiatBalance = asBaseCurrencyAmount(totalFiatBalance.plus(fiatBalance));
+            }
 
             const asset: AssetType = {
                 symbol,
                 // For assets we should always only 8 decimals to save space
                 assetBalance: assetBalance.toFixed(8),
-                fiatBalance: asBaseCurrencyAmount(fiatBalance),
+                fiatBalance: fiatBalance ? asBaseCurrencyAmount(fiatBalance) : null,
             };
 
             return asset;


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

To be honest, I don’t know how it used to work before, but this change is relatively isolated and makes sense to me, so hopefully it didn’t break something else in an unexpected place 🙈 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20884

## Screenshots:
![Screenshot_2025-08-20-12-56-49-217_io trezor suite debug](https://github.com/user-attachments/assets/7f131f81-c39f-4304-8deb-4f5806628770)



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/null-fiat-value-skeleton&lookback=7)