### PR TITLE
fix(suite): wipe THP device + skipFinalReload

### DIFF
--- a/packages/connect/src/api/wipeDevice.ts
+++ b/packages/connect/src/api/wipeDevice.ts
@@ -45,7 +45,6 @@ export default class WipeDevice extends AbstractMethod<'wipeDevice'> {
             // device will require THP pairing in the next call
             // reset state and do not call GetFeatures (finalReload)
             thpState.resetState();
-            this.skipFinalReload = true;
         }
 
         return response.message;

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -428,7 +428,8 @@ export const wipeDeviceThunk = createThunk(
                 path: device.path,
             },
             // In bootloader mode we need the skip the final reload, otherwise we never get the resolution
-            skipFinalReload: isBootloaderMode,
+            // THP device will require pairing. THP state is cleared, credentials are invalid
+            skipFinalReload: isBootloaderMode || !!device.thp,
         });
 
         if (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
setting `this.skipFinalReload = true;` inside wipeDevice.run() is not effective. it is too late, this param was already used in Device.run().

the proper way is to set skipFinalReload from the deviceThunk

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-wipe-thp-device&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-wipe-thp-device&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-wipe-thp-device&lookback=7)