### PR TITLE
fix(suite-native): avoid conflict between group e2e test artifacts

### DIFF
--- a/.github/workflows/test-suite-native-e2e-android.yml
+++ b/.github/workflows/test-suite-native-e2e-android.yml
@@ -302,5 +302,5 @@ jobs:
         if: ${{failure()}}
         uses: actions/upload-artifact@v4
         with:
-          name: failed-android-tests
+          name: failed-android-tests-${{ matrix.TEST_GROUP }}
           path: suite-native/app/artifacts


### PR DESCRIPTION
## Description
- if there were multiple e2e test groups failing, only the one first to fail stored the artifacts. The others group file names were conflicting, so it failed (see the screenshot). This PR fixes that:

<img width="1668" height="462" alt="Screenshot 2025-08-20 at 2 32 31 PM" src="https://github.com/user-attachments/assets/102c1986-48a1-4d1a-80a0-1c1e4322f930" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/avoid-conflict-between-e2e-artifacts&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/avoid-conflict-between-e2e-artifacts&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/avoid-conflict-between-e2e-artifacts&lookback=7)