### PR TITLE
feat(suite-native): Mobile Swap: reload quotes on trading account change

### DIFF
--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeQuotes.test.ts
@@ -213,6 +213,7 @@ describe('useExchangeQuotes', () => {
         ['sendAsset', usdcAsset],
         ['receiveAsset', usdtAsset],
         ['sendCryptoAmount', '0.2'],
+        ['sendAccount', getBtcAccount('btc-account-2')],
     ])('should refetch quotes on %s value change', async (field, value) => {
         const store = await getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.ts
@@ -23,6 +23,7 @@ type ShouldFetchExchangeQuotesRef = {
     sendAsset: string | undefined;
     receiveAsset: string | undefined;
     sendCryptoAmount: string | undefined;
+    accountDescriptor: string | undefined;
 };
 
 type PromiseType = {
@@ -35,6 +36,7 @@ const defaultState = {
     sendAsset: undefined,
     receiveAsset: undefined,
     sendCryptoAmount: undefined,
+    accountDescriptor: undefined,
 } as const;
 
 const useShouldFetchExchangeQuotes = (
@@ -53,10 +55,11 @@ const useShouldFetchExchangeQuotes = (
         };
     }
 
-    const [sendAsset, receiveAsset, sendCryptoAmount] = watch([
+    const [sendAsset, receiveAsset, sendCryptoAmount, sendAccount] = watch([
         'sendAsset',
         'receiveAsset',
         'sendCryptoAmount',
+        'sendAccount',
     ]);
 
     const isFetchAllowed =
@@ -65,7 +68,8 @@ const useShouldFetchExchangeQuotes = (
     if (
         sendAsset?.cryptoId === prevState.current.sendAsset &&
         receiveAsset?.cryptoId === prevState.current.receiveAsset &&
-        sendCryptoAmount === prevState.current.sendCryptoAmount
+        sendCryptoAmount === prevState.current.sendCryptoAmount &&
+        sendAccount?.descriptor === prevState.current.accountDescriptor
     ) {
         return {
             isFetchAllowed,
@@ -77,6 +81,7 @@ const useShouldFetchExchangeQuotes = (
         sendAsset: sendAsset?.cryptoId,
         receiveAsset: receiveAsset?.cryptoId,
         sendCryptoAmount,
+        accountDescriptor: sendAccount?.descriptor,
     };
 
     return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

reload quotes when trading account descriptor has changed

## Related Issue

Resolve [#20901](https://github.com/trezor/trezor-suite/issues/20901)



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=20901--Mobile-Swap-reload-quotes-on-trading-account-change&lookback=7)