### PR TITLE
Feat: suite desktop bluetooth binaries

### DIFF
--- a/packages/suite-desktop/electron-builder-config.js
+++ b/packages/suite-desktop/electron-builder-config.js
@@ -3,6 +3,15 @@ const { suiteVersion } = require('../suite/package.json');
 
 const isCodesignBuild = process.env.IS_CODESIGN_BUILD === 'true';
 
+const filterExtraResources = resources =>
+    resources.filter(r => {
+        if (r.to.includes('bluetooth')) {
+            return !!process.env.BLUETOOTH;
+        }
+
+        return true;
+    });
+
 // to be able to use patterns like ${author} and ${arch}
 module.exports = {
     // distingush between dev and prod builds
@@ -82,7 +91,7 @@ module.exports = {
     },
     mac: {
         files: ['entitlements.mac.inherit.plist'],
-        extraResources: [
+        extraResources: filterExtraResources([
             {
                 from: 'build/static/bin/bridge/mac-${arch}',
                 to: 'bin/bridge',
@@ -95,7 +104,14 @@ module.exports = {
                 from: 'build/static/bin/coinjoin/mac-${arch}',
                 to: 'bin/coinjoin',
             },
-        ],
+            {
+                from: 'build/static/bin/bluetooth/mac-${arch}',
+                to: 'bin/bluetooth',
+            },
+        ]),
+        binaries: process.env.BLUETOOTH
+            ? ['Contents/Resources/bin/bluetooth/trezor-bluetooth']
+            : undefined,
         icon: 'build/static/images/desktop/512x512.icns',
         artifactName: 'Trezor-Suite-${version}-mac-${arch}.${ext}',
         hardenedRuntime: true,
@@ -115,7 +131,7 @@ module.exports = {
         target: ['dmg', 'zip'],
     },
     win: {
-        extraResources: [
+        extraResources: filterExtraResources([
             {
                 from: 'build/static/bin/bridge/win-${arch}',
                 to: 'bin/bridge',
@@ -132,7 +148,11 @@ module.exports = {
                 from: 'build/static/bin/win_hello.node',
                 to: 'bin/win_hello.node',
             },
-        ],
+            {
+                from: 'build/static/bin/bluetooth/win-${arch}',
+                to: 'bin/bluetooth',
+            },
+        ]),
         icon: 'build/static/images/desktop/512x512.png',
         artifactName: 'Trezor-Suite-${version}-win-${arch}.${ext}',
         target: ['nsis'],
@@ -143,7 +163,7 @@ module.exports = {
         },
     },
     linux: {
-        extraResources: [
+        extraResources: filterExtraResources([
             {
                 from: 'build/static/bin/bridge/linux-${arch}',
                 to: 'bin/bridge',
@@ -160,7 +180,11 @@ module.exports = {
                 from: 'build/static/bin/coinjoin/linux-${arch}',
                 to: 'bin/coinjoin',
             },
-        ],
+            {
+                from: 'build/static/bin/bluetooth/linux-${arch}',
+                to: 'bin/bluetooth',
+            },
+        ]),
         icon: 'build/static/images/desktop/512x512.png',
         artifactName: 'Trezor-Suite-${version}-linux-${arch}.${ext}',
         executableName: 'trezor-suite',

--- a/packages/suite-desktop/electron-builder-config.js
+++ b/packages/suite-desktop/electron-builder-config.js
@@ -104,9 +104,9 @@ module.exports = {
         entitlements: 'entitlements.mac.inherit.plist',
         entitlementsInherit: 'entitlements.mac.inherit.plist',
         extendInfo: {
+            NSBluetoothAlwaysUsageDescription:
+                'Allow Trezor Suite to use Bluetooth to securely connect and communicate with your Trezor device.',
             // Delete those keys from Info.plist, Electron adds them by default but Trezor Suite does not need these permissions
-            NSBluetoothAlwaysUsageDescription: undefined,
-            NSBluetoothPeripheralUsageDescription: undefined,
             NSMicrophoneUsageDescription: undefined,
             // Replace default "This app needs access to the camera" message with our own
             NSCameraUsageDescription:

--- a/packages/suite-desktop/entitlements.mac.inherit.plist
+++ b/packages/suite-desktop/entitlements.mac.inherit.plist
@@ -10,5 +10,7 @@
     <true/>
     <key>com.apple.security.device.camera</key>
     <true/>
+    <key>com.apple.security.device.bluetooth</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. adding bluetooth to mac entitlements, not sure what to do with `entitlements.mac.inherit.plist` should it be cloned to `entitlements-bluetooth.mac.inherit.plist`  and used conditionally? what do you think @martykan 

2. conditionally adding bluetooth binaries to extraResources of electron builder

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-desktop-bluetooth&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-desktop-bluetooth&lookback=7)