### PR TITLE
Mobile Swap: make sure FiatCurrencies uses correct trade type context

### DIFF
--- a/suite-native/module-trading/src/__fixtures__/tradingState.ts
+++ b/suite-native/module-trading/src/__fixtures__/tradingState.ts
@@ -95,7 +95,7 @@ export const getInitializedSellState = () =>
                 ['mercuryo']: sellMercuryo,
                 ['cexdirect']: sellCexdirect,
             },
-            supportedFiatCurrencies: ['usd', 'eur', 'czk'] as FiatCurrencyCode[],
+            supportedFiatCurrencies: ['usd', 'eur', 'pln'] as FiatCurrencyCode[],
             supportedCryptoCurrencies: [
                 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
                 'ethereum',

--- a/suite-native/module-trading/src/components/buy/BuyFiatCurrencyPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFiatCurrencyPicker.tsx
@@ -1,10 +1,10 @@
 import { HStack } from '@suite-native/atoms';
 
 import { BuyFiatAmountInput } from './BuyFiatAmountInput';
+import { BuyFiatCurrencySheet } from './BuyFiatCurrencySheet';
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
 import { useSheetControls } from '../../hooks/general/useSheetControls';
 import { FiatCurrencyButton } from '../general/FiatCurrencyButton';
-import { FiatCurrencySheet } from '../general/FiatCurrencySheet/FiatCurrencySheet';
 
 const FIAT_CURRENCY_PICKER_TEST_ID = '@trading/buy/fiat-button';
 
@@ -23,7 +23,7 @@ export const BuyFiatCurrencyPicker = () => {
                 />
                 <BuyFiatAmountInput />
             </HStack>
-            <FiatCurrencySheet
+            <BuyFiatCurrencySheet
                 isVisible={isSheetVisible}
                 onClose={hideSheet}
                 onFiatSelect={setSelectedValue}

--- a/suite-native/module-trading/src/components/buy/BuyFiatCurrencySheet.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFiatCurrencySheet.tsx
@@ -1,0 +1,15 @@
+import { useSelector } from 'react-redux';
+
+import { selectBuySupportedFiatCurrenciesList } from '../../selectors/buySelectors';
+import {
+    FiatCurrencySheet,
+    FiatCurrencySheetProps,
+} from '../general/FiatCurrencySheet/FiatCurrencySheet';
+
+export type BuyFiatCurrencySheetProps = Omit<FiatCurrencySheetProps, 'supportedFiatCurrencies'>;
+
+export const BuyFiatCurrencySheet = (props: BuyFiatCurrencySheetProps) => {
+    const supportedCurrencies = useSelector(selectBuySupportedFiatCurrenciesList);
+
+    return <FiatCurrencySheet {...props} supportedFiatCurrencies={supportedCurrencies} />;
+};

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencySheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencySheet.comp.test.tsx
@@ -1,0 +1,20 @@
+import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { getWalletState } from '../../../__fixtures__/walletState';
+import { BuyFiatCurrencySheet } from '../BuyFiatCurrencySheet';
+
+describe('BuyFiatCurrencySheet', () => {
+    const renderBuyFiatCurrencySheet = () =>
+        renderWithStoreProviderAsync(
+            <BuyFiatCurrencySheet onFiatSelect={jest.fn()} onClose={jest.fn()} isVisible={true} />,
+            { preloadedState: { wallet: getWalletState({ tradeType: 'buy' }) } },
+        );
+
+    it('should render items based on buy state', async () => {
+        const { getByText } = await renderBuyFiatCurrencySheet();
+
+        expect(getByText('USD')).toBeOnTheScreen();
+        expect(getByText('EUR')).toBeOnTheScreen();
+        expect(getByText('CZK')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencySheet.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencySheet.tsx
@@ -15,13 +15,15 @@ export type FiatCurrencySheetProps = {
     isVisible: boolean;
     onClose: () => void;
     onFiatSelect: (currency: FiatCurrencyCode) => void;
+    supportedFiatCurrencies: FiatCurrencyItem[];
 };
 
 const keyExtractor = (item: FiatCurrencyItem) => item.value;
 
 export const FiatCurrencySheet = memo(
-    ({ isVisible, onClose, onFiatSelect }: FiatCurrencySheetProps) => {
-        const { filteredData, filterValue, setFilterValue } = useFiatCurrencyFilteredData();
+    ({ isVisible, onClose, onFiatSelect, supportedFiatCurrencies }: FiatCurrencySheetProps) => {
+        const { filteredData, filterValue, setFilterValue } =
+            useFiatCurrencyFilteredData(supportedFiatCurrencies);
         const { translate } = useTranslate();
 
         // we need to keep stable callback reference, otherwise header will be re-mounted on every keystroke

--- a/suite-native/module-trading/src/components/sell/fiat/SellFiatCurrencyPicker.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/SellFiatCurrencyPicker.tsx
@@ -1,10 +1,10 @@
 import { HStack } from '@suite-native/atoms';
 
 import { SellFiatAmountInput } from './SellFiatAmountInput';
+import { SellFiatCurrencySheet } from './SellFiatCurrencySheet';
 import { useSheetControls } from '../../../hooks/general/useSheetControls';
 import { useSellFormContext } from '../../../hooks/sell/useSellFormContext';
 import { FiatCurrencyButton } from '../../general/FiatCurrencyButton';
-import { FiatCurrencySheet } from '../../general/FiatCurrencySheet/FiatCurrencySheet';
 
 const FIAT_CURRENCY_PICKER_TEST_ID = '@trading/sell/fiat-button';
 
@@ -23,7 +23,7 @@ export const SellFiatCurrencyPicker = () => {
                 />
                 <SellFiatAmountInput />
             </HStack>
-            <FiatCurrencySheet
+            <SellFiatCurrencySheet
                 isVisible={isSheetVisible}
                 onClose={hideSheet}
                 onFiatSelect={setSelectedValue}

--- a/suite-native/module-trading/src/components/sell/fiat/SellFiatCurrencySheet.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/SellFiatCurrencySheet.tsx
@@ -1,0 +1,15 @@
+import { useSelector } from 'react-redux';
+
+import { selectSellSupportedFiatCurrenciesList } from '../../../selectors/sellSelectors';
+import {
+    FiatCurrencySheet,
+    FiatCurrencySheetProps,
+} from '../../general/FiatCurrencySheet/FiatCurrencySheet';
+
+export type SellFiatCurrencySheetProps = Omit<FiatCurrencySheetProps, 'supportedFiatCurrencies'>;
+
+export const SellFiatCurrencySheet = (props: SellFiatCurrencySheetProps) => {
+    const supportedCurrencies = useSelector(selectSellSupportedFiatCurrenciesList);
+
+    return <FiatCurrencySheet {...props} supportedFiatCurrencies={supportedCurrencies} />;
+};

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencyPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencyPicker.test.tsx
@@ -6,7 +6,7 @@ import {
     renderWithStoreProviderAsync,
 } from '@suite-native/test-utils';
 
-import { getInitializedTradingState } from '../../../../__fixtures__/tradingState';
+import { getWalletState } from '../../../../__fixtures__/walletState';
 import { useListDataFilter } from '../../../../hooks/general/useListDataFilter';
 import { useSellForm } from '../../../../hooks/sell/useSellForm';
 import { SellFiatCurrencyPicker } from '../SellFiatCurrencyPicker';
@@ -27,7 +27,7 @@ describe('SellFiatCurrencyPicker', () => {
     });
 
     const renderFiatCurrencyPicker = async () => {
-        const preloadedState = { wallet: { tradingNew: getInitializedTradingState() } };
+        const preloadedState = { wallet: getWalletState({ tradeType: 'sell' }) };
         const { result } = await renderHookWithStoreProviderAsync(() => useSellForm(), {
             preloadedState,
         });
@@ -52,12 +52,12 @@ describe('SellFiatCurrencyPicker', () => {
         const { getByText, getByLabelText } = await renderFiatCurrencyPicker();
 
         fireEvent.press(getByLabelText('Select fiat currency'));
-        fireEvent.press(getByText('CZK'));
+        fireEvent.press(getByText('PLN'));
 
         // wait for validators to run
         await act(() => Promise.resolve());
 
-        expect(getByLabelText('Select fiat currency')).toHaveTextContent(/CZK/);
+        expect(getByLabelText('Select fiat currency')).toHaveTextContent(/PLN/);
     });
 
     it('should display empty component when filtered data is empty', async () => {

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencySheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencySheet.comp.test.tsx
@@ -1,0 +1,20 @@
+import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { getWalletState } from '../../../../__fixtures__/walletState';
+import { SellFiatCurrencySheet } from '../SellFiatCurrencySheet';
+
+describe('SellFiatCurrencySheet', () => {
+    const renderSellFiatCurrencySheet = () =>
+        renderWithStoreProviderAsync(
+            <SellFiatCurrencySheet onFiatSelect={jest.fn()} onClose={jest.fn()} isVisible={true} />,
+            { preloadedState: { wallet: getWalletState({ tradeType: 'sell' }) } },
+        );
+
+    it('should render items based on Sell state', async () => {
+        const { getByText } = await renderSellFiatCurrencySheet();
+
+        expect(getByText('USD')).toBeOnTheScreen();
+        expect(getByText('EUR')).toBeOnTheScreen();
+        expect(getByText('PLN')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/__tests__/useFiatCurrencyFilteredData.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useFiatCurrencyFilteredData.test.ts
@@ -1,16 +1,32 @@
-import { act, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
 
-import { getInitializedTradingState } from '../../../__fixtures__/tradingState';
+import { FiatCurrencyItem } from '../../../types/general';
 import { useFiatCurrencyFilteredData } from '../useFiatCurrencyFilteredData';
+
+const supportedFiatCurrencies: FiatCurrencyItem[] = [
+    {
+        displayValue: 'USD',
+        label: 'United States Dollar',
+        value: 'usd',
+    },
+    {
+        displayValue: 'EUR',
+        label: 'Euro',
+        value: 'eur',
+    },
+    {
+        displayValue: 'CZK',
+        label: 'Czech Koruna',
+        value: 'czk',
+    },
+];
 
 describe('useFiatCurrencyFilteredData', () => {
     const renderUseFiatCurrencyFilteredData = () =>
-        renderHookWithStoreProviderAsync(() => useFiatCurrencyFilteredData(), {
-            preloadedState: { wallet: { tradingNew: getInitializedTradingState() } },
-        });
+        renderHookWithBasicProvider(() => useFiatCurrencyFilteredData(supportedFiatCurrencies));
 
-    it('should return section list data structure', async () => {
-        const { result } = await renderUseFiatCurrencyFilteredData();
+    it('should return section list data structure', () => {
+        const { result } = renderUseFiatCurrencyFilteredData();
 
         expect(result.current.filteredData).toEqual([
             {
@@ -38,8 +54,8 @@ describe('useFiatCurrencyFilteredData', () => {
         ]);
     });
 
-    it('should filter by label case-insensitive', async () => {
-        const { result } = await renderUseFiatCurrencyFilteredData();
+    it('should filter by label case-insensitive', () => {
+        const { result } = renderUseFiatCurrencyFilteredData();
 
         act(() => {
             result.current.setFilterValue('unITed');
@@ -50,8 +66,8 @@ describe('useFiatCurrencyFilteredData', () => {
         ]);
     });
 
-    it('should filter by value case-insensitive', async () => {
-        const { result } = await renderUseFiatCurrencyFilteredData();
+    it('should filter by value case-insensitive', () => {
+        const { result } = renderUseFiatCurrencyFilteredData();
 
         act(() => {
             result.current.setFilterValue('uSd');
@@ -62,8 +78,8 @@ describe('useFiatCurrencyFilteredData', () => {
         ]);
     });
 
-    it('should return current filter value', async () => {
-        const { result } = await renderUseFiatCurrencyFilteredData();
+    it('should return current filter value', () => {
+        const { result } = renderUseFiatCurrencyFilteredData();
 
         act(() => {
             result.current.setFilterValue('usd');

--- a/suite-native/module-trading/src/hooks/general/useFiatCurrencyFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/general/useFiatCurrencyFilteredData.ts
@@ -1,21 +1,18 @@
 import { ReactNode, useMemo } from 'react';
-import { useSelector } from 'react-redux';
 
 import { useListDataFilter } from './useListDataFilter';
-import { selectBuySupportedFiatCurrenciesList } from '../../selectors/buySelectors';
 import { FiatCurrencyItem } from '../../types/general';
 
 const filterCallback = ({ label, value }: FiatCurrencyItem, filterValue: string): boolean =>
     label.toLowerCase().includes(filterValue.toLowerCase()) ||
     value.toLowerCase().includes(filterValue.toLowerCase());
 
-export const useFiatCurrencyFilteredData = () => {
-    const supportedCurrencies = useSelector(selectBuySupportedFiatCurrenciesList);
+export const useFiatCurrencyFilteredData = (supportedFiatCurrencies: FiatCurrencyItem[]) => {
     const {
         filteredData: data,
         filterValue,
         setFilterValue,
-    } = useListDataFilter(supportedCurrencies, filterCallback);
+    } = useListDataFilter(supportedFiatCurrencies, filterCallback);
 
     const filteredData = useMemo(
         () => [


### PR DESCRIPTION

## Description

- Use correct list of supported fiat currencies from stata for buy/sell

## Related Issue

Resolve [#20507](https://github.com/trezor/trezor-suite/issues/20507)



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=20507-Mobile-Sell-make-sure-FiatCurrencies-uses-correct-trade-type-context&lookback=7)