### PR TITLE
Fix(suite): THP modals

### DIFF
--- a/packages/suite/src/components/suite/DeviceConfirmImage.tsx
+++ b/packages/suite/src/components/suite/DeviceConfirmImage.tsx
@@ -1,17 +1,14 @@
 import { getDeviceInternalModel } from '@suite-common/suite-utils';
 import { Image, ImageKey, ImageProps } from '@trezor/components';
 import { Device } from '@trezor/connect';
+import { DeviceModelInternal } from '@trezor/device-utils';
 
 type DeviceConfirmImageProps = Omit<ImageProps, 'image'> & {
     device: Pick<Device, 'features' | 'thp'>;
 };
 
 export const DeviceConfirmImage = ({ device }: DeviceConfirmImageProps) => {
-    const deviceModelInternal = getDeviceInternalModel(device);
-
-    if (!deviceModelInternal) {
-        return null;
-    }
+    const deviceModelInternal = getDeviceInternalModel(device) ?? DeviceModelInternal.UNKNOWN;
 
     const imgName: ImageKey = `DEVICE_CONFIRM_TREZOR_${deviceModelInternal}`;
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
@@ -24,9 +24,15 @@ interface ConfirmActionProps {
     device: TrezorDevice;
     title?: TranslationKey;
     onCancel?: () => void;
+    enableBackdropClick?: boolean;
 }
 
-export const ConfirmActionModal = ({ title, device, onCancel }: ConfirmActionProps) => {
+export const ConfirmActionModal = ({
+    title,
+    device,
+    onCancel,
+    enableBackdropClick = true,
+}: ConfirmActionProps) => {
     const intl = useIntl();
     const handleCancel = () => {
         TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
@@ -35,7 +41,7 @@ export const ConfirmActionModal = ({ title, device, onCancel }: ConfirmActionPro
 
     return (
         <ConnectModalBackdrop
-            onClick={onCancel}
+            onClick={enableBackdropClick ? onCancel : undefined}
             data-testid="@suite/modal/confirm-action-on-device"
             canSwitchDevice
         >

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ThpPairingPinEntryModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ThpPairingPinEntryModal.tsx
@@ -22,6 +22,7 @@ export const ThpPairingPinEntryModal = () => {
     return (
         <Modal
             onCancel={onCancel}
+            isBackdropCancelable={false}
             size="small"
             data-testid="@modal/thp-paring"
             heading={<Translation id="TR_THP_ENTER_ONE_TIME_CODE" />}

--- a/packages/suite/src/components/thp/ThpAutoconnectionModal.tsx
+++ b/packages/suite/src/components/thp/ThpAutoconnectionModal.tsx
@@ -20,6 +20,7 @@ export const ThpAutoconnectionModal = ({ device }: ThpAutoconnectionModalProps) 
             device={device}
             title="TR_THP_SECURELY_AUTOCONNECT_WITH_TREZOR"
             onCancel={onCancel}
+            enableBackdropClick={false}
         />
     );
 };

--- a/packages/suite/src/components/thp/ThpConnectionModal.tsx
+++ b/packages/suite/src/components/thp/ThpConnectionModal.tsx
@@ -15,6 +15,7 @@ export const ThpConnectionModal = ({ device }: ThpConnectionModalProps) => {
             device={device}
             title="TR_THP_SECURELY_CONNECT_WITH_TREZOR"
             onCancel={onCancel}
+            enableBackdropClick={false}
         />
     );
 };

--- a/packages/suite/src/components/thp/ThpConnectionModal.tsx
+++ b/packages/suite/src/components/thp/ThpConnectionModal.tsx
@@ -1,5 +1,8 @@
 import { TrezorDevice } from '@suite-common/suite-types';
+import { thpActions } from '@suite-common/thp';
 import TrezorConnect from '@trezor/connect';
+
+import { useDispatch } from 'src/hooks/suite';
 
 import { ConfirmActionModal } from '../suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal';
 
@@ -8,7 +11,12 @@ type ThpConnectionModalProps = {
 };
 
 export const ThpConnectionModal = ({ device }: ThpConnectionModalProps) => {
-    const onCancel = () => TrezorConnect.cancel();
+    const dispatch = useDispatch();
+
+    const onCancel = () => {
+        TrezorConnect.cancel();
+        dispatch(thpActions.resetThpFlow());
+    };
 
     return (
         <ConfirmActionModal


### PR DESCRIPTION
## Description

Small fixes for THP modals:
- make background **not** cancellable
- fix cancelling from suite-side on `ThpConnectionModal`
- fix `ThpConnectionModal` missing device image

## Related Issue

Resolve #19614
Resolve #20911
Resolve #20912

## Screenshots:

Concerning #20912:

Before:
<img width="628" height="462" alt="Image" src="https://github.com/user-attachments/assets/c41cfceb-7fbb-4453-ac5e-93592f7d694e" />

After:
<img width="636" height="587" alt="Image" src="https://github.com/user-attachments/assets/15638a44-34a3-4290-9d89-28f1b9e5d3d2" />

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-modals&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-modals&lookback=7)