### PR TITLE
chore(connect): unify handshake cancel timeouts

### DIFF
--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -8,7 +8,6 @@ import { resolveAfter, scheduleAction, versionUtils } from '@trezor/utils';
 
 import { ERRORS } from '../constants';
 import { Device } from './Device';
-import { DataManager } from '../data/DataManager';
 import { DEVICE } from '../events';
 import { initLog } from '../utils/debug';
 
@@ -63,10 +62,6 @@ const error = (error: Error) => ({ success: false as const, error });
 const nestedError = (cause: Error) => error(ERRORS.nestError(cause));
 const fail = (msg: string) =>
     error(isErrorWithoutDeviceInteraction(msg) ? new ERRORS.TransportError(msg) : new Error(msg));
-
-const getFeaturesTimeout = () =>
-    // Due to performance issues in suite-native during app start, original timeout is not sufficient.
-    DataManager.getSettings('env') === 'react-native' ? 20_000 : 3_000;
 
 export interface TypedCallProvider {
     typedCall: Messages.TypedCall;
@@ -190,7 +185,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
             // transport response is pending endlessly, calling any other message will end up with "device call in progress"
             // set the timeout for this call so whenever it happens "unacquired device" will be created instead
             // next time device should be called together with "Initialize" (calling "acquireDevice" from the UI)
-            const timeout = name === 'GetFeatures' ? getFeaturesTimeout() : undefined;
+            const timeout = name === 'GetFeatures' ? 3_000 : undefined;
 
             const callPromise = this.call(name, data, { timeout });
 

--- a/packages/connect/src/device/workflow/handshake.ts
+++ b/packages/connect/src/device/workflow/handshake.ts
@@ -3,13 +3,10 @@ import { TRANSPORT_ERROR } from '@trezor/transport';
 import { resolveAfter, versionUtils } from '@trezor/utils';
 
 import { TypedError } from '../../constants/errors';
-import { DataManager } from '../../data/DataManager';
 import { WorkflowContext } from '../../types/workflow';
 import { Log } from '../../utils/debug';
 
 const CANCEL_TIMEOUT = 1_000;
-// Due to performance issues in suite-native during app start, original timeout is not sufficient.
-const CANCEL_TIMEOUT_REACT_NATIVE = 20_000;
 const ATTEMPTS_LIMIT = 10;
 
 type Context = {
@@ -36,15 +33,12 @@ export const handshakeCancel = async ({ device, logger, signal }: Context) => {
         return;
     }
 
-    const isNative = DataManager.getSettings('env') === 'react-native';
-    const cancelTimeout = isNative ? CANCEL_TIMEOUT_REACT_NATIVE : CANCEL_TIMEOUT;
-
     logger?.debug('handshake Cancel start');
 
     // send could fail on T1 bootloader when device has erase/wipe button request displayed
     const send = await device
         .getCurrentSession()
-        .send('Cancel', {}, { signal, timeout: cancelTimeout });
+        .send('Cancel', {}, { signal, timeout: CANCEL_TIMEOUT });
 
     if (!send.success) {
         logger?.debug(`handshake Cancel send error ${send.error}`);
@@ -60,7 +54,7 @@ export const handshakeCancel = async ({ device, logger, signal }: Context) => {
 
         const result = await device.getCurrentSession().receive({
             signal,
-            timeout: cancelTimeout,
+            timeout: CANCEL_TIMEOUT,
         });
 
         // Older T1 don't respond to Cancel message which seems to be recoverable only by reacquiring


### PR DESCRIPTION
No need for different timeouts anymore because of https://github.com/trezor/trezor-suite/pull/19574.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/connect/handshake-timeout&lookback=7)