### PR TITLE
ci: fix bluetooth binary commit message

### DIFF
--- a/.github/workflows/build-transport-bluetooth-binary.yml
+++ b/.github/workflows/build-transport-bluetooth-binary.yml
@@ -48,8 +48,8 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ steps.trezor-bot-token.outputs.token }}
-          title: "chore:(transport-bluetooth) update binaries"
-          commit-message: "chore:(transport-bluetooth) update binaries"
+          title: "chore(transport-bluetooth): update binaries"
+          commit-message: "chore(transport-bluetooth): update binaries"
           committer: ${{ steps.trezor-bot-token.outputs.app-slug }}[bot] <208941332+${{ steps.trezor-bot-token.outputs.app-slug }}[bot]@users.noreply.github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           branch: transport-bluetooth-binaries-update-${{ github.sha }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
CI build commit message typo, automated PR is failing with error

https://github.com/trezor/trezor-suite/pull/20909

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bt-workflow&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-workflow&lookback=7)