### PR TITLE
feat(suite): debug settings forget all BT devices

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/BluetoothEnabledCheckbox.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/BluetoothEnabledCheckbox.tsx
@@ -10,7 +10,7 @@ import { disposeBluetoothThunk } from '../../../actions/bluetooth/disposeBluetoo
 import { initBluetoothThunk } from '../../../actions/bluetooth/initBluetoothThunk';
 import { setFlag } from '../../../actions/suite/suiteActions';
 
-export const Bluetooth = () => {
+export const BluetoothEnabledCheckbox = () => {
     const { isBluetoothEnabled } = useSelector(selectSuiteFlags);
     const dispatch = useDispatch();
     const [isLoading, setIsLoading] = useState(false);

--- a/packages/suite/src/views/settings/SettingsDebug/ForgetBluetoothDevices.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/ForgetBluetoothDevices.tsx
@@ -1,0 +1,34 @@
+import { bluetoothActions } from '@suite-common/bluetooth';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import { Button } from '@trezor/components';
+import { desktopApi } from '@trezor/suite-desktop-api';
+
+import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
+import { useDispatch } from 'src/hooks/suite';
+
+export const ForgetAllDevicesButton = () => {
+    const dispatch = useDispatch();
+
+    const handleForgetButtonClick = () => {
+        dispatch(bluetoothActions.knownDevicesUpdateAction({ knownDevices: [] }));
+        dispatch(notificationsActions.addToast({ type: 'clear-storage' }));
+    };
+    const handleOpenSettingsButtonClick = () => desktopApi.openSystemSettings('bluetooth');
+
+    return (
+        <SectionItem>
+            <TextColumn
+                title="Forget all known Bluetooth devices"
+                description="Forgets devices persisted in Suite. In order to fully remove, go to system settings and manually remove the device there."
+            />
+            <ActionColumn>
+                <Button onClick={handleForgetButtonClick} size="small" variant="destructive">
+                    Forget in Suite
+                </Button>
+                <Button onClick={handleOpenSettingsButtonClick} size="small" variant="tertiary">
+                    Open system settings
+                </Button>
+            </ActionColumn>
+        </SectionItem>
+    );
+};

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -8,13 +8,14 @@ import { useSelector } from 'src/hooks/suite';
 import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 import { Backends } from './Backends';
-import { Bluetooth } from './Bluetooth';
+import { BluetoothEnabledCheckbox } from './BluetoothEnabledCheckbox';
 import { CheckFirmwareAuthenticity } from './CheckFirmwareAuthenticity';
 import { CoinjoinApi } from './CoinjoinApi';
 import { ConnectPopup } from './ConnectPopup';
 import { DeviceAuthenticity } from './DeviceAuthenticity';
 import { Devkit } from './Devkit';
 import { FirmwareUpdate } from './FirmwareUpdate';
+import { ForgetAllDevicesButton } from './ForgetBluetoothDevices';
 import { GithubIssue } from './GithubIssue';
 import { InvityApi } from './InvityApi';
 import { MessageSystemDebugInfo } from './MessageSystemDebugInfo';
@@ -89,8 +90,9 @@ export const SettingsDebug = () => {
             </SettingsSection>
             {isDesktop() && (
                 <SettingsSection title={<Translation id="TR_BLUETOOTH" />}>
-                    <Bluetooth />
+                    <BluetoothEnabledCheckbox />
                     <ShowBluetoothDebugInfo />
+                    <ForgetAllDevicesButton />
                 </SettingsSection>
             )}
             <SettingsSection title="Trezor Host Protocol">


### PR DESCRIPTION
## Description

Add a button to debug settings to clear all known BT devices.
I've found it to be useful (I was resetting whole storage a lot to do this). 

## Screenshots:

<img width="1174" height="256" alt="image" src="https://github.com/user-attachments/assets/ed62388f-0c2b-4c77-8cad-a114a7a3a7ae" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-bt-debug-clear-devices&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-bt-debug-clear-devices&lookback=7)