### PR TITLE
20908 mobile swap display country of residence picker

### DIFF
--- a/suite-native/module-trading/src/components/buy/BuyCountryOfResidencePicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyCountryOfResidencePicker.tsx
@@ -1,79 +1,12 @@
-import { useCallback } from 'react';
-
-import { TradingCountryOption } from '@suite-common/trading';
-import { EventType, analytics } from '@suite-native/analytics';
-import { HStack, Text } from '@suite-native/atoms';
-import { useTranslate } from '@suite-native/intl';
-
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
-import { useSheetControls } from '../../hooks/general/useSheetControls';
-import { CountrySheet } from '../general/CountrySheet/CountrySheet';
-import { OverviewRow } from '../general/OverviewRow';
+import { CountryOfResidencePicker } from '../general/CountrySheet/CountryOfResidencePicker';
 
 const COUNTRY_PICKER_TEST_ID = '@trading/buy/country';
 
 export const BuyCountryOfResidencePicker = () => {
-    const { translate } = useTranslate();
     const form = useBuyFormContext();
-    const { isSheetVisible, hideSheet, showSheet, setSelectedValue, selectedValue } =
-        useSheetControls(form, 'country');
-
-    const handleCountrySelect = useCallback(
-        (country: TradingCountryOption) => {
-            setSelectedValue(country);
-
-            if (selectedValue === country) return;
-
-            analytics.report({
-                type: EventType.TradingParameterChanged,
-                payload: {
-                    type: 'buy',
-                    parameter: 'country',
-                },
-            });
-        },
-        [selectedValue, setSelectedValue],
-    );
 
     return (
-        <>
-            <OverviewRow
-                title={translate('moduleTrading.tradingScreen.countryOfResidence')}
-                onPress={showSheet}
-                testID={COUNTRY_PICKER_TEST_ID}
-            >
-                {selectedValue ? (
-                    <HStack>
-                        <Text
-                            color="textSubdued"
-                            variant="body"
-                            accessibilityLabel={translate(
-                                'moduleTrading.tradingScreen.selectedCountryOfResidence',
-                            )}
-                            testID={COUNTRY_PICKER_TEST_ID + '/value'}
-                        >
-                            {selectedValue.label}
-                        </Text>
-                    </HStack>
-                ) : (
-                    <Text
-                        color="textDisabled"
-                        variant="body"
-                        accessibilityLabel={translate(
-                            'moduleTrading.tradingScreen.noCountryOfResidence',
-                        )}
-                        testID={COUNTRY_PICKER_TEST_ID + '/value'}
-                    >
-                        {translate('moduleTrading.notSelected')}
-                    </Text>
-                )}
-            </OverviewRow>
-            <CountrySheet
-                isVisible={isSheetVisible}
-                onClose={hideSheet}
-                onCountrySelect={handleCountrySelect}
-                selectedCountryId={selectedValue?.value}
-            />
-        </>
+        <CountryOfResidencePicker testID={COUNTRY_PICKER_TEST_ID} form={form} tradingType="buy" />
     );
 };

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyCountryOfResidencePicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyCountryOfResidencePicker.comp.test.tsx
@@ -1,69 +1,55 @@
+import { EventType, analytics } from '@suite-native/analytics';
 import { Form } from '@suite-native/forms';
 import {
-    fireEvent,
+    act,
     renderHookWithStoreProviderAsync,
     renderWithBasicProvider,
+    userEvent,
 } from '@suite-native/test-utils';
 
 import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { useListDataFilter } from '../../../hooks/general/useListDataFilter';
+import { BuyFormType } from '../../../types/buy';
 import { BuyCountryOfResidencePicker } from '../BuyCountryOfResidencePicker';
 
-let mockUseListDataFilter: typeof useListDataFilter;
-
-jest.mock('../../../hooks/general/useListDataFilter', () => ({
-    ...jest.requireActual('../../../hooks/general/useListDataFilter'),
-    useListDataFilter: (rawData: unknown[], filterCallback: (i: unknown, f: string) => boolean) =>
-        mockUseListDataFilter(rawData, filterCallback),
-}));
-
 describe('BuyCountryOfResidencePicker', () => {
-    beforeEach(() => {
-        mockUseListDataFilter = jest.requireActual(
-            '../../../hooks/general/useListDataFilter',
-        ).useListDataFilter;
-    });
+    let form: BuyFormType;
 
-    const renderCountryOfResidencePicker = async () => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm());
+    const renderBuyForm = () => renderHookWithStoreProviderAsync(() => useBuyForm());
 
-        return renderWithBasicProvider(
-            <Form form={result.current}>
-                <BuyCountryOfResidencePicker />
-            </Form>,
-        );
-    };
-
-    it('should display "Not selected" when in default state', async () => {
-        const { getByLabelText } = await renderCountryOfResidencePicker();
-
-        expect(getByLabelText('No country of residence selected')).toHaveTextContent(
-            'Not selected',
-        );
-    });
-
-    it('should allow to select country', async () => {
-        const { getByText, getByLabelText } = await renderCountryOfResidencePicker();
-
-        // select country
-        fireEvent.press(getByText('Country of residence'));
-        fireEvent.press(getByText(/Algeria/));
-
-        expect(getByLabelText('Selected country of residence')).toHaveTextContent('🇩🇿 Algeria');
-    });
-
-    it('should display empty component when filtered data is empty', async () => {
-        mockUseListDataFilter = () => ({
-            filteredData: [],
-            setFilterValue: jest.fn(),
-            filterValue: 'test-key',
+    const renderCountryOfResidencePicker = () =>
+        renderWithBasicProvider(<BuyCountryOfResidencePicker />, {
+            wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
-        const { getByText } = await renderCountryOfResidencePicker();
-        fireEvent.press(getByText('Country of residence'));
 
-        expect(getByText('Country not found')).toBeTruthy();
-        expect(
-            getByText('Check the spelling or browse the list to select an option.'),
-        ).toBeTruthy();
+    beforeEach(async () => {
+        const { result } = await renderBuyForm();
+        form = result.current;
+    });
+
+    it('should use selected country from form', () => {
+        act(() => {
+            form.setValue('country', { value: 'US', label: 'United States' });
+        });
+
+        const { getByTestId } = renderCountryOfResidencePicker();
+
+        expect(getByTestId('@trading/buy/country/value')).toHaveTextContent('United States');
+    });
+
+    it('should call analytics on country change', async () => {
+        const reportSpy = jest.spyOn(analytics, 'report');
+
+        const { getByText } = renderCountryOfResidencePicker();
+
+        await userEvent.press(getByText('Country of residence'));
+        await userEvent.press(getByText(/Algeria/));
+
+        expect(reportSpy).toHaveBeenCalledWith({
+            type: EventType.TradingParameterChanged,
+            payload: {
+                type: 'buy',
+                parameter: 'country',
+            },
+        });
     });
 });

--- a/suite-native/module-trading/src/components/general/CountrySheet/CountryOfResidencePicker.tsx
+++ b/suite-native/module-trading/src/components/general/CountrySheet/CountryOfResidencePicker.tsx
@@ -1,0 +1,92 @@
+import { useCallback } from 'react';
+
+import { TradingType } from '@suite-common/trading';
+import { EventType, analytics } from '@suite-native/analytics';
+import { HStack, Text } from '@suite-native/atoms';
+import type { UseFormReturn } from '@suite-native/forms';
+import { useTranslate } from '@suite-native/intl';
+
+import { useSheetControls } from '../../../hooks/general/useSheetControls';
+import { BuyFormType, BuyFormValues } from '../../../types/buy';
+import { SellFormType, SellFormValues } from '../../../types/sell';
+import { OverviewRow } from '../OverviewRow';
+import { CountrySheet } from './CountrySheet';
+
+export type CountryOfResidencePickerProps<Form extends BuyFormType | SellFormType> = {
+    testID: string;
+    form: Form;
+    tradingType: TradingType;
+};
+
+const reportCountryChange = (type: TradingType) => {
+    analytics.report({
+        type: EventType.TradingParameterChanged,
+        payload: {
+            type,
+            parameter: 'country',
+        },
+    });
+};
+
+export const CountryOfResidencePicker = <Form extends BuyFormType | SellFormType>({
+    form,
+    testID,
+    tradingType,
+}: CountryOfResidencePickerProps<Form>) => {
+    const { translate } = useTranslate();
+    const { isSheetVisible, hideSheet, showSheet, setSelectedValue, selectedValue } =
+        useSheetControls(form as UseFormReturn<BuyFormValues | SellFormValues>, 'country');
+
+    const handleCountrySelect = useCallback(
+        (country: typeof selectedValue) => {
+            setSelectedValue(country);
+
+            if (selectedValue?.value !== country?.value) {
+                reportCountryChange(tradingType);
+            }
+        },
+        [selectedValue, setSelectedValue, tradingType],
+    );
+
+    return (
+        <>
+            <OverviewRow
+                title={translate('moduleTrading.tradingScreen.countryOfResidence')}
+                onPress={showSheet}
+                testID={testID}
+            >
+                {selectedValue ? (
+                    <HStack>
+                        <Text
+                            color="textSubdued"
+                            variant="body"
+                            accessibilityLabel={translate(
+                                'moduleTrading.tradingScreen.selectedCountryOfResidence',
+                            )}
+                            testID={testID + '/value'}
+                        >
+                            {selectedValue.label}
+                        </Text>
+                    </HStack>
+                ) : (
+                    <Text
+                        color="textDisabled"
+                        variant="body"
+                        accessibilityLabel={translate(
+                            'moduleTrading.tradingScreen.noCountryOfResidence',
+                        )}
+                        testID={testID + '/value'}
+                    >
+                        {translate('moduleTrading.notSelected')}
+                    </Text>
+                )}
+            </OverviewRow>
+            <CountrySheet
+                isVisible={isSheetVisible}
+                onClose={hideSheet}
+                onCountrySelect={handleCountrySelect}
+                selectedCountryId={selectedValue?.value}
+            />
+        </>
+    );
+};

--- a/suite-native/module-trading/src/components/general/CountrySheet/__tests__/CountryOfResidencePicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/CountrySheet/__tests__/CountryOfResidencePicker.comp.test.tsx
@@ -1,0 +1,102 @@
+import { analytics } from '@suite-common/analytics';
+import {
+    renderHookWithStoreProviderAsync,
+    renderWithBasicProvider,
+    userEvent,
+} from '@suite-native/test-utils';
+
+import { useBuyForm } from '../../../../hooks/buy/useBuyForm';
+import { useListDataFilter } from '../../../../hooks/general/useListDataFilter';
+import { BuyFormType } from '../../../../types/buy';
+import {
+    CountryOfResidencePicker,
+    CountryOfResidencePickerProps,
+} from '../CountryOfResidencePicker';
+
+let mockUseListDataFilter: typeof useListDataFilter;
+
+jest.mock('../../../../hooks/general/useListDataFilter', () => ({
+    ...jest.requireActual('../../../../hooks/general/useListDataFilter'),
+    useListDataFilter: (rawData: unknown[], filterCallback: (i: unknown, f: string) => boolean) =>
+        mockUseListDataFilter(rawData, filterCallback),
+}));
+
+describe('CountryOfResidencePicker', () => {
+    beforeEach(() => {
+        mockUseListDataFilter = jest.requireActual(
+            '../../../../hooks/general/useListDataFilter',
+        ).useListDataFilter;
+    });
+
+    const renderCountryOfResidencePicker = async (
+        props: Partial<CountryOfResidencePickerProps<BuyFormType>> = {},
+    ) => {
+        const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm());
+
+        return renderWithBasicProvider(
+            <CountryOfResidencePicker
+                form={result.current}
+                testID="TEST_ID"
+                tradingType="buy"
+                {...props}
+            />,
+        );
+    };
+
+    it('should display "Not selected" when in default state', async () => {
+        const { getByLabelText } = await renderCountryOfResidencePicker();
+
+        expect(getByLabelText('No country of residence selected')).toHaveTextContent(
+            'Not selected',
+        );
+    });
+
+    it('should allow to select country', async () => {
+        const { getByText, getByLabelText } = await renderCountryOfResidencePicker();
+
+        // select country
+        await userEvent.press(getByText('Country of residence'));
+        await userEvent.press(getByText(/Algeria/));
+
+        expect(getByLabelText('Selected country of residence')).toHaveTextContent('🇩🇿 Algeria');
+    });
+
+    it('should display empty component when filtered data is empty', async () => {
+        mockUseListDataFilter = () => ({
+            filteredData: [],
+            setFilterValue: jest.fn(),
+            filterValue: 'test-key',
+        });
+        const { getByText } = await renderCountryOfResidencePicker();
+        await userEvent.press(getByText('Country of residence'));
+
+        expect(getByText('Country not found')).toBeTruthy();
+        expect(
+            getByText('Check the spelling or browse the list to select an option.'),
+        ).toBeTruthy();
+    });
+
+    it('should report to analytics after country changed', async () => {
+        const reportSpy = jest.spyOn(analytics, 'report');
+        const { getByText } = await renderCountryOfResidencePicker();
+
+        await userEvent.press(getByText('Country of residence'));
+        await userEvent.press(getByText(/Algeria/));
+
+        expect(reportSpy).toHaveBeenCalled();
+    });
+
+    it('should not report to analytics when user selects already selected country', async () => {
+        const reportSpy = jest.spyOn(analytics, 'report');
+        const { getByText, getAllByText } = await renderCountryOfResidencePicker();
+
+        await userEvent.press(getByText('Country of residence'));
+        await userEvent.press(getByText(/Algeria/));
+        reportSpy.mockClear();
+
+        await userEvent.press(getAllByText(/Algeria/)[0]);
+        await userEvent.press(getAllByText(/Algeria/)[1]);
+
+        expect(reportSpy).not.toHaveBeenCalled();
+    });
+});

--- a/suite-native/module-trading/src/components/sell/SellForm.tsx
+++ b/suite-native/module-trading/src/components/sell/SellForm.tsx
@@ -6,6 +6,7 @@ import { AnimatedBox, VStack } from '@suite-native/atoms';
 import { SellAlert } from './SellAlert';
 import { SellCard } from './SellCard';
 import { SellConfirmation } from './SellConfirmation';
+import { SellPaymentCard } from './payment/SellPaymentCard';
 import { useFocusedValueWatch } from '../../hooks/general/useFocusedValueWatch';
 import { useMountedRecentlyFlag } from '../../hooks/general/useMountedRecentlyFlag';
 import { useSellFormContext } from '../../hooks/sell/useSellFormContext';
@@ -56,7 +57,13 @@ const SellFormMemoized = memo(
                     {isAmountInputActive ? (
                         <AmountEditingDoneButton testID={AMOUNT_EDITING_DONE_BUTTON_TEST_ID} />
                     ) : (
-                        <SellConfirmation enteringAnimation={enteringAnimation} />
+                        <>
+                            <SellPaymentCard
+                                shouldAnimateEntering={shouldAnimateEntering}
+                                isFormMountedRecently={isFormMountedRecently}
+                            />
+                            <SellConfirmation enteringAnimation={enteringAnimation} />
+                        </>
                     )}
                 </VStack>
             </AnimatedBox>

--- a/suite-native/module-trading/src/components/sell/__tests__/SellForm.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellForm.comp.test.tsx
@@ -29,8 +29,8 @@ describe('SellForm', () => {
         const { result } = await renderFormHook({});
         const { getByText, getByLabelText } = await renderSellForm({}, result.current);
 
-        expect(getByText('You pay')).toBeTruthy();
-        expect(getByText('You get')).toBeTruthy();
+        expect(getByText('You pay')).toBeOnTheScreen();
+        expect(getByText('You get')).toBeOnTheScreen();
         expect(getByLabelText('Select coin')).toHaveTextContent(/Select coin/);
     });
 
@@ -46,10 +46,10 @@ describe('SellForm', () => {
         it('should render with default values', async () => {
             const { getByLabelText, getByText } = await renderSellForm(preloadedState, form);
 
-            expect(getByText('You pay')).toBeTruthy();
-
-            expect(getByLabelText('Select fiat currency')).toBeTruthy();
+            expect(getByText('You pay')).toBeOnTheScreen();
+            expect(getByLabelText('Select fiat currency')).toBeOnTheScreen();
             expect(getByLabelText('Select coin')).toHaveTextContent(/Select coin/);
+            expect(getByText('Country of residence')).toBeOnTheScreen();
         });
 
         it('should render only SellCard and Done when amount input is active', async () => {
@@ -58,10 +58,11 @@ describe('SellForm', () => {
             });
             const { queryByText, getByText } = await renderSellForm(preloadedState, form);
 
-            expect(getByText('You pay')).toBeTruthy();
-            expect(getByText('You get')).toBeTruthy();
+            expect(getByText('You pay')).toBeOnTheScreen();
+            expect(getByText('You get')).toBeOnTheScreen();
 
             expect(queryByText('Continue')).toBeNull();
+            expect(queryByText('Country of residence')).toBeNull();
         });
     });
 });

--- a/suite-native/module-trading/src/components/sell/payment/SellCountryOfResidencePicker.tsx
+++ b/suite-native/module-trading/src/components/sell/payment/SellCountryOfResidencePicker.tsx
@@ -1,0 +1,12 @@
+import { useSellFormContext } from '../../../hooks/sell/useSellFormContext';
+import { CountryOfResidencePicker } from '../../general/CountrySheet/CountryOfResidencePicker';
+
+const COUNTRY_PICKER_TEST_ID = '@trading/sell/country';
+
+export const SellCountryOfResidencePicker = () => {
+    const form = useSellFormContext();
+
+    return (
+        <CountryOfResidencePicker testID={COUNTRY_PICKER_TEST_ID} form={form} tradingType="sell" />
+    );
+};

--- a/suite-native/module-trading/src/components/sell/payment/SellPaymentCard.tsx
+++ b/suite-native/module-trading/src/components/sell/payment/SellPaymentCard.tsx
@@ -1,0 +1,44 @@
+import { Platform } from 'react-native';
+import { FadeIn, FadeInDown, FadeOutUp, StretchInY, StretchOutY } from 'react-native-reanimated';
+
+import { AnimatedBox, Card } from '@suite-native/atoms';
+
+import { SellCountryOfResidencePicker } from './SellCountryOfResidencePicker';
+
+export type SellPaymentCardProps = {
+    isFormMountedRecently?: boolean;
+    shouldAnimateEntering?: boolean;
+};
+
+const getEnteringAnimation = (isFormMountedRecently?: boolean, shouldAnimateEntering?: boolean) => {
+    // on android fade animation looks ugly on view with shadows, better to skip the initial one
+    // and use stretch animation instead for the rest of the time
+    if (Platform.OS === 'android') {
+        return isFormMountedRecently ? undefined : StretchInY;
+    }
+
+    if (isFormMountedRecently) {
+        return shouldAnimateEntering ? FadeIn : undefined;
+    }
+
+    return FadeInDown;
+};
+
+// on android fade animation looks ugly on view with shadows, better to use stretch one here
+const getExitingAnimation = () => (Platform.OS === 'android' ? StretchOutY : FadeOutUp);
+
+export const SellPaymentCard = ({
+    shouldAnimateEntering,
+    isFormMountedRecently,
+}: SellPaymentCardProps) => {
+    const enteringAnimation = getEnteringAnimation(isFormMountedRecently, shouldAnimateEntering);
+    const exitingAnimation = getExitingAnimation();
+
+    return (
+        <AnimatedBox entering={enteringAnimation} exiting={exitingAnimation}>
+            <Card noPadding>
+                <SellCountryOfResidencePicker />
+            </Card>
+        </AnimatedBox>
+    );
+};

--- a/suite-native/module-trading/src/components/sell/payment/__tests__/SellCountryOfResidencePicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/payment/__tests__/SellCountryOfResidencePicker.comp.test.tsx
@@ -1,0 +1,55 @@
+import { EventType, analytics } from '@suite-native/analytics';
+import { Form } from '@suite-native/forms';
+import {
+    act,
+    renderHookWithStoreProviderAsync,
+    renderWithBasicProvider,
+    userEvent,
+} from '@suite-native/test-utils';
+
+import { useSellForm } from '../../../../hooks/sell/useSellForm';
+import { SellFormType } from '../../../../types/sell';
+import { SellCountryOfResidencePicker } from '../SellCountryOfResidencePicker';
+
+describe('SellCountryOfResidencePicker', () => {
+    let form: SellFormType;
+
+    const renderSellForm = () => renderHookWithStoreProviderAsync(() => useSellForm());
+
+    const renderCountryOfResidencePicker = () =>
+        renderWithBasicProvider(<SellCountryOfResidencePicker />, {
+            wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+        });
+
+    beforeEach(async () => {
+        const { result } = await renderSellForm();
+        form = result.current;
+    });
+
+    it('should use selected country from form', () => {
+        act(() => {
+            form.setValue('country', { value: 'US', label: 'United States' });
+        });
+
+        const { getByTestId } = renderCountryOfResidencePicker();
+
+        expect(getByTestId('@trading/sell/country/value')).toHaveTextContent('United States');
+    });
+
+    it('should call analytics on country change', async () => {
+        const reportSpy = jest.spyOn(analytics, 'report');
+
+        const { getByText } = renderCountryOfResidencePicker();
+
+        await userEvent.press(getByText('Country of residence'));
+        await userEvent.press(getByText(/Algeria/));
+
+        expect(reportSpy).toHaveBeenCalledWith({
+            type: EventType.TradingParameterChanged,
+            payload: {
+                type: 'sell',
+                parameter: 'country',
+            },
+        });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Displays country of residence picker on trading sell tab

<!--- Describe your changes in detail -->

## Related Issue

Resolve [#20908](https://github.com/trezor/trezor-suite/issues/20908)

## Screenshots:

<img width="250" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-20 at 17 40 09" src="https://github.com/user-attachments/assets/1b29cbb7-b0c2-48c3-9d2e-54119fe048d8" />
<img width="250" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-20 at 17 40 31" src="https://github.com/user-attachments/assets/df895aea-aa63-49cc-b4a2-22a9eaf9c9ff" />
<img width="250"  alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-20 at 17 40 41" src="https://github.com/user-attachments/assets/7a41f1b8-35e5-4ee9-a3c4-40966aae71d6" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=20908-Mobile-Swap-Display-country-of-residence-picker&lookback=7)