### PR TITLE
Fix/bluetooth process

### DIFF
--- a/packages/suite-desktop-core/src/libs/processes/BaseProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/BaseProcess.ts
@@ -20,6 +20,7 @@ export type Options = {
     startupCooldown?: number;
     stopKillWait?: number;
     autoRestart?: number;
+    env?: Record<string, string | undefined>;
 };
 
 const defaultOptions: Options = {
@@ -125,7 +126,7 @@ export abstract class BaseProcess {
             !app.isPackaged ? system : '',
         );
         const processPath = path.join(processDir, `${this.processName}${ext}`);
-        const processEnv = { ...process.env };
+        const processEnv = { ...process.env, ...this.options.env };
         // library search path for macOS
         processEnv.DYLD_LIBRARY_PATH = processEnv.DYLD_LIBRARY_PATH
             ? `${processEnv.DYLD_LIBRARY_PATH}:${processDir}`

--- a/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
@@ -7,7 +7,9 @@ export class BluetoothProcess extends BaseProcess {
     private readonly port;
 
     constructor(port = 21327) {
-        super('bluetooth', 'trezor-bluetooth');
+        super('bluetooth', 'trezor-bluetooth', {
+            autoRestart: 0,
+        });
         this.port = port;
     }
 
@@ -37,13 +39,10 @@ export class BluetoothProcess extends BaseProcess {
             });
             this.logger.debug(this.logTopic, `Checking status (${resp.status})`);
             if (resp.status === 200) {
-                const data = await resp.json();
-                if (data?.version) {
-                    return {
-                        service: true,
-                        process: true,
-                    };
-                }
+                return {
+                    service: true,
+                    process: true,
+                };
             }
         } catch (err) {
             this.logger.debug(this.logTopic, `Status error: ${err.message}`);

--- a/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
@@ -9,6 +9,12 @@ export class BluetoothProcess extends BaseProcess {
     constructor(port = 21327) {
         super('bluetooth', 'trezor-bluetooth', {
             autoRestart: 0,
+            env: {
+                // https://github.com/electron/electron/blob/ab2a4fd836d539194bc5cde5f0d665eddeb6a134/docs/api/environment-variables.md?plain=1#L190
+                // Electron sometimes modifies the value of XDG_CURRENT_DESKTOP
+                XDG_CURRENT_DESKTOP:
+                    process.env.ORIGINAL_XDG_CURRENT_DESKTOP || process.env.XDG_CURRENT_DESKTOP,
+            },
         });
         this.port = port;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`BluetoothProcess` - disable autorestart + fix `status` method (there no data in the response)

`BaseProcess` - pass `XDG_CURRENT_DESKTOP` to the process if electron modifies it 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bluetooth-process&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bluetooth-process&lookback=7)