### PR TITLE
feat(connect): firmware update via BluetoothTransport

### DIFF
--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -452,6 +452,18 @@ export const onCallFirmwareUpdate = async ({
             'onCallFirmwareUpdate',
             'waiting for disconnected event after rebootToBootloader...',
         );
+
+        if (device.bluetoothProps) {
+            // close device
+            await device.release();
+            // request ui (suite) to disconnect the device
+            postMessage(
+                createUiMessage(UI.FIRMWARE_DISCONNECT, {
+                    device: device.toMessageObject(),
+                }),
+            );
+        }
+
         await disconnectedPromise;
 
         // This delay is crucial see https://github.com/trezor/trezor-firmware/issues/1983
@@ -503,6 +515,19 @@ export const onCallFirmwareUpdate = async ({
             firmwareUploadRequest: { payload: stripped },
             updateFlowType,
         });
+    }
+
+    if (device.bluetoothProps) {
+        // close device
+        await device.release();
+        // T3W1 countdown after FW installation
+        await resolveAfter(4000);
+        // request ui (suite) to disconnect the device
+        postMessage(
+            createUiMessage(UI.FIRMWARE_DISCONNECT, {
+                device: device.toMessageObject(),
+            }),
+        );
     }
 
     reconnectedDevice = await waitForReconnectedDevice(

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -1,6 +1,7 @@
 import { MiddlewareAPI } from 'redux';
 
 import TrezorConnect, { UI } from '@trezor/connect';
+import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
 import { goto } from 'src/actions/suite/routerActions';
 import { Action, AppState, Dispatch } from 'src/types/suite';
@@ -20,6 +21,14 @@ const buttonRequest =
                 }),
             );
             TrezorConnect.cancel('Device_Unreadable');
+        }
+
+        if (action.type === UI.FIRMWARE_DISCONNECT && action.payload.device.bluetoothProps) {
+            const { id } = action.payload.device.bluetoothProps;
+            bluetoothIpc
+                .disconnectDevice(id)
+                .then(() => bluetoothIpc.startScan()) // restart scanning
+                .catch(() => {});
         }
 
         // firmware bug https://github.com/trezor/trezor-firmware/issues/35


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
last missing piece for @yanascz + bt-mobile implementation.

After the reboot from/to bootloader device stays connected to bluetooth, to keep current flow we need to request the UI (suite) to disconnect the device and then auto reconnect it.


**Note**: current FW build [have a bug](https://github.com/trezor/trezor-firmware/issues/5584) - this is why in `feat/bt-thp` the second condition needs to be commented out to work properly

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/bt-fw-update&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/bt-fw-update&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/bt-fw-update&lookback=7)