### PR TITLE
chore(suite): remove unneeded DeviceConnectActionPayload type

### DIFF
--- a/suite-common/bluetooth/src/bluetoothReducer.ts
+++ b/suite-common/bluetooth/src/bluetoothReducer.ts
@@ -1,11 +1,12 @@
 import { AnyAction, Draft } from '@reduxjs/toolkit';
 
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
-import { DeviceConnectActionPayload, deviceActions } from '@suite-common/wallet-core';
+import { deviceActions } from '@suite-common/wallet-core';
 
 import { bluetoothActions } from './bluetoothActions';
 import { deserializeBluetoothDeviceSerialization } from './deserializeBluetoothDeviceSerialization';
 import { BluetoothAdapterStatus, BluetoothDeviceCommon, BluetoothScanStatus } from './types';
+import { Device } from '@trezor/connect';
 
 export type BluetoothState<T extends BluetoothDeviceCommon> = {
     adapterStatus: BluetoothAdapterStatus;
@@ -99,14 +100,7 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
                 action =>
                     action.type === deviceActions.connectDevice.type ||
                     action.type === deviceActions.connectUnacquiredDevice.type,
-                (
-                    state,
-                    {
-                        payload: {
-                            device: { bluetoothProps },
-                        },
-                    }: { payload: DeviceConnectActionPayload },
-                ) => {
+                (state, { payload: { bluetoothProps } }: { payload: Device }) => {
                     if (bluetoothProps === undefined) {
                         return;
                     }

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -5,11 +5,7 @@ import { DEVICE, Device, DeviceState, StaticSessionId } from '@trezor/connect';
 
 export const DEVICE_MODULE_PREFIX = '@suite/device';
 
-export type DeviceConnectActionPayload = {
-    device: Device;
-};
-
-const connectDevice = createAction(DEVICE.CONNECT, (payload: DeviceConnectActionPayload) => ({
+const connectDevice = createAction(DEVICE.CONNECT, (payload: Device) => ({
     payload,
 }));
 
@@ -18,10 +14,9 @@ const createDeviceInstance = createAction(
     (payload: { device: TrezorDevice }) => ({ payload }),
 );
 
-const connectUnacquiredDevice = createAction(
-    DEVICE.CONNECT_UNACQUIRED,
-    (payload: DeviceConnectActionPayload) => ({ payload }),
-);
+const connectUnacquiredDevice = createAction(DEVICE.CONNECT_UNACQUIRED, (payload: Device) => ({
+    payload,
+}));
 
 const deviceChanged = createAction(DEVICE.CHANGED, (payload: Device) => ({
     payload,


### PR DESCRIPTION
this type makes no sense anymore, it just complicates stuff since event handlers for DEVICE.CHANGE and DEVICE.CONNECT  had to have different signatures

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=remove-unneeded-payload-type&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=remove-unneeded-payload-type&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=remove-unneeded-payload-type&lookback=7)