### PR TITLE
chore(suite): display swap notifications with correct content

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coin-to-token.test.ts
@@ -17,7 +17,7 @@ const formattedSendAmount = `${localizeNumber(sendAmount)} SOL`;
 const formattedReceiveAmount = `${localizeNumber(swapQuotesSolanaUSDC[0].receiveStringAmount)} USDC`;
 const { sendAddress, receiveAddress, receive: usdcMint } = swapTradeSolanaUSDC;
 const formattedSendAddress = formatAddress(sendAddress);
-const toastText = `${formattedSendAmount} sent from Solana #1`;
+const toastText = `Swap transaction of ${formattedSendAmount} (Solana #1) to ${formattedReceiveAmount} (Ethereum #1) was broadcasted`;
 
 test.describe('Trading - Swap coin to token', { tag: ['@group=trading', '@webOnly'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
@@ -90,7 +90,7 @@ test.describe('Trading - Swap coin to token', { tag: ['@group=trading', '@webOnl
         // Thanks to our mocked responses, the crypto is actually not send.
         await test.step('Send crypto to provider', async () => {
             await devicePrompt.sendButton.click();
-            await expect(page.getByTestId('@toast/tx-sent')).toContainText(toastText);
+            await expect(page.getByTestId('@toast/tx-exchange')).toContainText(toastText);
             await expect(tradingPage.transactionDetailStatus).toHaveText(
                 messages['TR_EXCHANGE_DETAIL_SUCCESS_TITLE'].defaultMessage,
             );

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-token-to-coin.test.ts
@@ -17,7 +17,7 @@ const formattedSendAmount = `${localizeNumber(sendAmount)} USDT`;
 const formattedReceiveAmount = `${localizeNumber(swapQuotesTetherBTC[2].receiveStringAmount!)} BTC`;
 const { sendAddress, receiveAddress, send: tetherMint } = swapTradeTetherBTC;
 const formattedSendAddress = formatAddress(sendAddress);
-const toastText = `${formattedSendAmount} sent from Solana #1`;
+const toastText = `Swap transaction of ${formattedSendAmount} (Solana #1) to ${formattedReceiveAmount} (Bitcoin #1) was broadcasted`;
 
 test.describe('Trading - Swap token to coin', { tag: ['@group=trading', '@webOnly'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
@@ -87,7 +87,7 @@ test.describe('Trading - Swap token to coin', { tag: ['@group=trading', '@webOnl
         // Thanks to our mocked responses, the crypto is actually not send.
         await test.step('Send crypto to provider', async () => {
             await devicePrompt.sendButton.click();
-            await expect(page.getByTestId('@toast/tx-sent')).toContainText(toastText);
+            await expect(page.getByTestId('@toast/tx-exchange')).toContainText(toastText);
             await expect(tradingPage.transactionDetailStatus).toHaveText(
                 messages['TR_EXCHANGE_DETAIL_SUCCESS_TITLE'].defaultMessage,
             );

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-tokens.test.ts
@@ -17,7 +17,7 @@ const formattedSendAmount = `${localizeNumber(sendAmount)} USDT`;
 const formattedReceiveAmount = `${localizeNumber(swapQuotesSolanaTokens[0].receiveStringAmount!)} USDC`;
 const { sendAddress, receiveAddress, send: tetherMint, receive: usdcMint } = swapTradeSolanaTokens;
 const formattedSendAddress = formatAddress(sendAddress);
-const toastText = `${formattedSendAmount} sent from Solana #1`;
+const toastText = `Swap transaction of ${formattedSendAmount} (Solana #1) to ${formattedReceiveAmount} (Solana #1) was broadcasted`;
 
 test.describe('Trading - Swap tokens', { tag: ['@group=trading', '@webOnly'] }, () => {
     test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
@@ -87,7 +87,7 @@ test.describe('Trading - Swap tokens', { tag: ['@group=trading', '@webOnly'] }, 
         // Thanks to our mocked responses, the crypto is actually not send.
         await test.step('Send crypto to provider', async () => {
             await devicePrompt.sendButton.click();
-            await expect(page.getByTestId('@toast/tx-sent')).toContainText(toastText);
+            await expect(page.getByTestId('@toast/tx-exchange')).toContainText(toastText);
             await expect(tradingPage.transactionDetailStatus).toHaveText(
                 messages['TR_EXCHANGE_DETAIL_SUCCESS_TITLE'].defaultMessage,
             );

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
 
 import {
     DeviceRootState,
@@ -17,6 +16,8 @@ import {
 } from '@suite-common/wallet-utils';
 import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
+
+import { useSelector } from 'src/hooks/suite';
 
 import { ExpiredTxValidity } from '../../UserContextModal/TxDetailModal/ExpiredTxValidity';
 import { ReplaceByFeeFailedOriginalTxConfirmed } from '../../UserContextModal/TxDetailModal/ReplaceByFeeFailedOriginalTxConfirmed';
@@ -116,7 +117,6 @@ export const TransactionReviewModalContent = ({
                 outputs={outputs}
                 buttonRequestsCount={buttonRequestsCount}
                 isRbfAction={isBumpFeeRbfAction}
-                tradingFormState={precomposedForm?.trading}
                 reviewStep={reviewStep}
                 isSending={isSending}
                 stakeType={stakeType || undefined}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 import { DeviceRootState, selectSendFormReviewLastButtonCode } from '@suite-common/wallet-core';
 import type {
     FormState,
-    FormStateTrading,
     GeneralPrecomposedTransactionFinal,
     StakeFormState,
 } from '@suite-common/wallet-types';
@@ -31,7 +30,6 @@ export type TransactionReviewOutputListProps = {
     outputs: ReviewOutput[];
     buttonRequestsCount: number;
     isRbfAction: boolean;
-    tradingFormState: FormStateTrading | undefined;
     reviewStep: number;
     onTryAgain: (close: boolean) => void;
     isSending?: boolean;
@@ -66,7 +64,6 @@ export const TransactionReviewOutputList = ({
     outputs,
     buttonRequestsCount,
     isRbfAction,
-    tradingFormState,
     stakeType,
     deadline,
     reviewStep,
@@ -91,6 +88,8 @@ export const TransactionReviewOutputList = ({
         lastButtonRequestCode,
     });
 
+    const { trading } = precomposedForm;
+
     const isFirstStep = buttonRequestsCount <= 1;
 
     const isStaking = stakeType;
@@ -103,8 +102,6 @@ export const TransactionReviewOutputList = ({
     const summaryIndex = outputs.findIndex(
         ({ type }) => !['address', 'amount', 'opreturn'].includes(type),
     );
-    const isSLIP24Active =
-        !!tradingFormState && 'send' in tradingFormState && 'receive' in tradingFormState;
 
     useEffect(() => {
         if (reviewStep === outputs.length || signedTx) {
@@ -119,7 +116,7 @@ export const TransactionReviewOutputList = ({
         isFirstOutputAddress &&
         isFirstStep &&
         !isStaking &&
-        !tradingFormState &&
+        !trading &&
         !isInternalTransfer &&
         !signedTx
     ) {
@@ -163,7 +160,7 @@ export const TransactionReviewOutputList = ({
                                 })}
                                 account={account}
                                 isRbf={isRbfAction}
-                                isTrading={!!tradingFormState}
+                                isTrading={!!trading}
                                 stakeType={stakeType}
                                 evmTxType={getEvmTransactionTextSignature(
                                     precomposedForm.ethereumDataHex,
@@ -189,7 +186,6 @@ export const TransactionReviewOutputList = ({
                             precomposedForm={precomposedForm}
                             stakeType={stakeType}
                             isRbf={isRbfAction}
-                            isSLIP24Active={isSLIP24Active}
                         />
                     </Column>
                 </Wrapper>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
@@ -33,7 +33,6 @@ const getLines = (
     precomposedForm: FormState | StakeFormState,
     isRbfAction?: boolean,
     stakeType?: StakeType,
-    isSLIP24Active?: boolean,
 ): OutputElementLine[] => {
     const isUpdatedSendFlow = getIsUpdatedSendFlow(device);
     const isUpdatedEthereumSendFlow = getIsUpdatedEthereumSendFlow(device, networkType, stakeType);
@@ -58,7 +57,7 @@ const getLines = (
         .minus(precomposedTx.fee)
         .toString();
 
-    if (isSLIP24Active) {
+    if (precomposedForm.trading?.isSlip24Active) {
         return [
             {
                 id: 'fee',
@@ -125,7 +124,6 @@ export type TransactionReviewTotalOutputProps = {
     precomposedTx: GeneralPrecomposedTransactionFinal;
     precomposedForm: FormState | StakeFormState;
     account: Account;
-    isSLIP24Active: boolean;
     isRbf: boolean;
     stakeType?: StakeType;
 };
@@ -136,7 +134,6 @@ export const TransactionReviewTotalOutput = ({
     precomposedTx,
     precomposedForm,
     stakeType,
-    isSLIP24Active,
     isRbf,
 }: TransactionReviewTotalOutputProps) => {
     const device = useSelector(selectSelectedDevice);
@@ -146,20 +143,12 @@ export const TransactionReviewTotalOutput = ({
     }
 
     const { networkType, symbol } = account;
-    const lines = getLines(
-        device,
-        networkType,
-        precomposedTx,
-        precomposedForm,
-        isRbf,
-        stakeType,
-        isSLIP24Active,
-    );
+    const lines = getLines(device, networkType, precomposedTx, precomposedForm, isRbf, stakeType);
 
     return (
         <TransactionReviewOutputElement
             title={
-                isSLIP24Active ? (
+                precomposedForm.trading?.isSlip24Active ? (
                     <Translation id="TR_SUMMARY" />
                 ) : (
                     <Translation id="TR_TOTAL_INCLUDING_FEE" />

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/ExchangeInfoRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/ExchangeInfoRenderer.tsx
@@ -1,0 +1,61 @@
+import { selectTradingCoinSymbolByCryptoId } from '@suite-common/trading';
+import { selectAccountByKey } from '@suite-common/wallet-core';
+
+import {
+    HiddenPlaceholder,
+    NotificationRendererProps,
+    NotificationViewProps,
+} from 'src/components/suite';
+import { useDefaultAccountLabel } from 'src/hooks/suite';
+import { useSelector } from 'src/hooks/suite/useSelector';
+
+type ExchangeInfoRendererProps = Omit<NotificationViewProps, 'messageValues'> &
+    NotificationRendererProps<'tx-exchange'>;
+
+export const ExchangeInfoRenderer = ({ render: View, ...props }: ExchangeInfoRendererProps) => {
+    const { getDefaultAccountLabel } = useDefaultAccountLabel();
+
+    const { send, receive } = props.notification.metadata;
+
+    const sendSymbol = useSelector(state =>
+        selectTradingCoinSymbolByCryptoId(state, send.cryptoId),
+    );
+    const receiveSymbol = useSelector(state =>
+        selectTradingCoinSymbolByCryptoId(state, receive.cryptoId),
+    );
+
+    const sendAccount = useSelector(state => selectAccountByKey(state, send.accountKey));
+    const receiveAccount = useSelector(state => selectAccountByKey(state, receive.accountKey));
+
+    const sendAccountLabel = sendAccount
+        ? (sendAccount.accountLabel ??
+          getDefaultAccountLabel({
+              accountType: sendAccount.accountType,
+              symbol: sendAccount.symbol,
+              index: sendAccount.index,
+          }))
+        : undefined;
+
+    const receiveAccountLabel = receiveAccount
+        ? (receiveAccount.accountLabel ??
+          getDefaultAccountLabel({
+              accountType: receiveAccount.accountType,
+              symbol: receiveAccount.symbol,
+              index: receiveAccount.index,
+          }))
+        : undefined;
+
+    return (
+        <View
+            {...props}
+            messageValues={{
+                sendAmount: <HiddenPlaceholder>{send.amount}</HiddenPlaceholder>,
+                sendAsset: sendSymbol,
+                sendAccount: sendAccountLabel,
+                receiveAmount: <HiddenPlaceholder>{receive.amount}</HiddenPlaceholder>,
+                receiveAsset: receiveSymbol,
+                receiveAccount: receiveAccountLabel,
+            }}
+        />
+    );
+};

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -13,6 +13,7 @@ import type { ExtendedMessageDescriptor } from 'src/types/suite';
 import { ActionRenderer } from './ActionRenderer';
 import { AutoEjectRenderer } from './AutoEjectRenderer';
 import { CoinProtocolRenderer } from './CoinProtocolRenderer';
+import { ExchangeInfoRenderer } from './ExchangeInfoRenderer';
 import { TransactionRenderer } from './TransactionRenderer';
 
 const simple = (
@@ -229,6 +230,17 @@ export const NotificationRenderer = ({
                     }}
                 />
             );
+        case 'tx-exchange': {
+            return (
+                <ExchangeInfoRenderer
+                    render={render}
+                    notification={notification}
+                    icon="arrowUp"
+                    variant="success"
+                    message="TOAST_TX_EXCHANGE_BROADCASTED"
+                />
+            );
+        }
         case 'tx-sent':
             return (
                 <TransactionRenderer

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4116,6 +4116,11 @@ export default defineMessages({
         id: 'TOAST_TX_SENT',
         defaultMessage: '{amount} sent from {account}',
     },
+    TOAST_TX_EXCHANGE_BROADCASTED: {
+        id: 'TOAST_TX_EXCHANGE_BROADCASTED',
+        defaultMessage:
+            'Swap transaction of {sendAmount} {sendAsset} ({sendAccount}) to {receiveAmount} {receiveAsset} ({receiveAccount}) was broadcasted',
+    },
     TOAST_RAW_TX_SENT: {
         id: 'TOAST_RAW_TX_SENT',
         defaultMessage: 'Transaction sent. Tx ID: {txid}',

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -2,6 +2,7 @@ import { TranslationKey } from '@suite-common/intl-types';
 import { DesktopAppUpdateState, Protocol } from '@suite-common/suite-constants';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { FormStateTradingExchange } from '@suite-common/wallet-types';
 import { DEVICE } from '@trezor/connect';
 
 export type NotificationId = number;
@@ -32,6 +33,11 @@ type ApproveTransactionNotification = {
     type: 'tx-approved';
     tokenSymbol?: string;
     isInfiniteApproval: boolean;
+} & TransactionNotificationPayload;
+
+type ExchangeTransactionNotification = {
+    type: 'tx-exchange';
+    metadata: FormStateTradingExchange;
 } & TransactionNotificationPayload;
 
 type ReceivedTransactionNotification = {
@@ -91,6 +97,7 @@ export type ToastPayload = (
     | SentTransactionNotification
     | ApproveTransactionNotification
     | RevokeTransactionNotification
+    | ExchangeTransactionNotification
     | {
           type: 'raw-tx-sent';
           txid: string;

--- a/suite-common/trading/src/__tests__/utils.test.ts
+++ b/suite-common/trading/src/__tests__/utils.test.ts
@@ -384,6 +384,7 @@ describe('getTradingFormState', () => {
         it('should return default state when required fields are missing', () => {
             const incompleteTrade = {
                 exchange: 'test-exchange',
+                isSlip24Active: false,
                 // Missing required fields
             } as SellFiatTrade;
 
@@ -395,10 +396,12 @@ describe('getTradingFormState', () => {
                 activeSection,
                 trade: incompleteTrade,
                 providers,
+                sendAccountKey: '',
             });
 
             expect(result).toEqual({
                 activeSection: 'sell',
+                isSlip24Active: false,
             });
         });
 
@@ -415,10 +418,12 @@ describe('getTradingFormState', () => {
                 activeSection,
                 trade,
                 providers: {},
+                sendAccountKey: '',
             });
 
             expect(result).toEqual({
                 activeSection: 'sell',
+                isSlip24Active: false,
             });
         });
 
@@ -439,10 +444,13 @@ describe('getTradingFormState', () => {
                 activeSection,
                 trade,
                 providers,
+                sendAccountKey: '',
+                isSlip24Active: false,
             });
 
             expect(result).toEqual({
                 activeSection: 'sell',
+                isSlip24Active: false,
             });
         });
 
@@ -464,12 +472,16 @@ describe('getTradingFormState', () => {
                 trade,
                 providers,
                 isSlip24Active: true,
+                sendAccountKey: '',
             });
 
             expect(result).toEqual({
                 activeSection: 'sell',
+                isSlip24Active: true,
                 recipientName: 'Test Exchange',
                 send: {
+                    accountKey: '',
+                    cryptoId: 'bitcoin',
                     symbol: 'btc',
                     contractAddress: undefined,
                     amount: '0.025',
@@ -499,15 +511,19 @@ describe('getTradingFormState', () => {
                 trade,
                 providers,
                 isSlip24Active: true,
+                sendAccountKey: '',
             });
 
             expect(result).toEqual({
                 activeSection: 'sell',
                 recipientName: 'Test Exchange',
+                isSlip24Active: true,
                 send: {
+                    accountKey: '',
                     symbol: 'eth',
                     contractAddress: '0x123456789',
                     amount: '100',
+                    cryptoId: 'ethereum--0x123456789',
                 },
                 receive: {
                     amount: '500',
@@ -535,10 +551,12 @@ describe('getTradingFormState', () => {
                 trade: incompleteTrade,
                 providers,
                 isSlip24Active: true,
+                sendAccountKey: '',
             });
 
             expect(result).toEqual({
                 activeSection: 'exchange',
+                isSlip24Active: true,
             });
         });
 
@@ -556,10 +574,12 @@ describe('getTradingFormState', () => {
                 trade,
                 providers: {},
                 isSlip24Active: true,
+                sendAccountKey: '',
             });
 
             expect(result).toEqual({
                 activeSection: 'exchange',
+                isSlip24Active: true,
             });
         });
 
@@ -581,10 +601,12 @@ describe('getTradingFormState', () => {
                 trade,
                 providers,
                 isSlip24Active: true,
+                sendAccountKey: '',
             });
 
             expect(result).toEqual({
                 activeSection: 'exchange',
+                isSlip24Active: true,
             });
         });
 
@@ -606,10 +628,12 @@ describe('getTradingFormState', () => {
                 trade,
                 providers,
                 isSlip24Active: true,
+                sendAccountKey: '',
             });
 
             expect(result).toEqual({
                 activeSection: 'exchange',
+                isSlip24Active: true,
             });
         });
 
@@ -631,17 +655,24 @@ describe('getTradingFormState', () => {
                 trade,
                 providers,
                 isSlip24Active: true,
+                sendAccountKey: '',
+                receiveAccountKey: '',
             });
 
             expect(result).toEqual({
                 activeSection: 'exchange',
                 recipientName: 'Test Exchange',
+                isSlip24Active: true,
                 send: {
+                    accountKey: '',
+                    cryptoId: 'bitcoin',
                     symbol: 'btc',
                     contractAddress: undefined,
                     amount: '0.025',
                 },
                 receive: {
+                    accountKey: '',
+                    cryptoId: 'ethereum',
                     symbol: 'eth',
                     contractAddress: undefined,
                     amount: '1',
@@ -667,17 +698,24 @@ describe('getTradingFormState', () => {
                 trade,
                 providers,
                 isSlip24Active: true,
+                sendAccountKey: '',
+                receiveAccountKey: '',
             });
 
             expect(result).toEqual({
                 activeSection: 'exchange',
                 recipientName: 'Test Exchange',
+                isSlip24Active: true,
                 send: {
+                    accountKey: '',
+                    cryptoId: 'ethereum--0xsend456',
                     symbol: 'eth',
                     contractAddress: '0xsend456',
                     amount: '50',
                 },
                 receive: {
+                    accountKey: '',
+                    cryptoId: 'ethereum--0xreceive123',
                     symbol: 'eth',
                     contractAddress: '0xreceive123',
                     amount: '100',
@@ -701,10 +739,12 @@ describe('getTradingFormState', () => {
                 trade,
                 providers: undefined,
                 isSlip24Active: true,
+                sendAccountKey: '',
             });
 
             expect(result).toEqual({
                 activeSection: 'sell',
+                isSlip24Active: true,
             });
         });
 
@@ -722,10 +762,12 @@ describe('getTradingFormState', () => {
                 trade,
                 providers: { 'test-exchange': mockProvider },
                 isSlip24Active: true,
+                sendAccountKey: '',
             });
 
             expect(result).toEqual({
                 activeSection: 'sell',
+                isSlip24Active: true,
             });
         });
 
@@ -747,10 +789,12 @@ describe('getTradingFormState', () => {
                 trade,
                 providers,
                 isSlip24Active: true,
+                sendAccountKey: '',
             });
 
             expect(result).toEqual({
                 activeSection: 'sell',
+                isSlip24Active: true,
             });
         });
     });

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -627,10 +627,12 @@ export const selectTradingVerifiedAddress = (state: TradingRootState) =>
 export const selectTradingIsSlip24Allowed = createMemoizedSelectorWithDeviceAndAccounts(
     [
         state => selectDeviceUnavailableCapabilities(state),
-        (_: TradingRootState, account: Account) => account,
-        (_: TradingRootState, __: Account, isSlip24Active: boolean) => isSlip24Active,
+        (_: TradingRootState, account: Account | undefined) => account,
+        (_: TradingRootState, __: Account | undefined, isSlip24Active: boolean) => isSlip24Active,
     ],
     (unavailableCapabilities, account, isSlip24Active) => {
+        if (!account) return false;
+
         const isFirmwareVersionSlip24Compatible = !unavailableCapabilities?.['slip24'];
         // TODO: slip24 - can be removed when slip24 is enabled for all networks
         const supportedNetworks: NetworkType[] = ['bitcoin', 'ethereum'];

--- a/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
@@ -141,6 +141,7 @@ describe('recomposeAndSignTxThunk', () => {
         });
         const tradingFormState = {
             activeSection: 'exchange' as const,
+            isSlip24Active: false,
         };
 
         const mockSignAndPushSendFormTransaction = jest.fn();

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -13,6 +13,7 @@ import {
     asAmountSubunit,
     isApprovalFlowSupported,
     isEvmApprovalTx,
+    isExchangeTradingForm,
     subunitsToUnits,
 } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
@@ -52,16 +53,6 @@ export type RecomposeAndSignTxThunkProps = {
         paymentRequests,
     }: TradingSignAndPushSendFormTransactionProps) => Promise<TradingFulfillValue>;
 };
-
-const getTradingFormStateAccordingRestriction = (
-    tradingFormState: FormStateTrading,
-    isPaymentRequestsAllowed: boolean,
-): FormStateTrading =>
-    isPaymentRequestsAllowed
-        ? tradingFormState
-        : {
-              activeSection: tradingFormState.activeSection,
-          };
 
 /**
  * This thunk is particularly useful for scenarios where transaction details (e.g., fees, outputs) need to be recalculated
@@ -124,10 +115,6 @@ export const recomposeAndSignTxThunk = createThunk<
             !ethereumDataHex ||
             (isApprovalFlowSupported(device) && isEvmApprovalTx(ethereumDataHex));
 
-        const restrictedTradingFormState = getTradingFormStateAccordingRestriction(
-            tradingFormState,
-            isPaymentRequestsAllowed,
-        );
         // prepare the fee levels, set custom values from composed
         // WORKAROUND: sendFormEthereumActions and sendFormRippleActions use form outputs instead of composed transaction data
         const formState: FormState = {
@@ -152,7 +139,7 @@ export const recomposeAndSignTxThunk = createThunk<
             ethereumDataHex,
             ethereumAdjustGasLimit,
             selectedUtxos: [],
-            trading: restrictedTradingFormState,
+            trading: tradingFormState,
         };
 
         // prepare form state for composeAction
@@ -250,12 +237,12 @@ export const recomposeAndSignTxThunk = createThunk<
         const formStateUpdated: FormState = {
             ...formState,
             trading: {
-                ...restrictedTradingFormState,
-                ...('send' in restrictedTradingFormState
+                ...tradingFormState,
+                ...(isPaymentRequestsAllowed && isExchangeTradingForm(tradingFormState)
                     ? {
                           send: {
-                              ...restrictedTradingFormState.send,
-                              amount: formattedMaxAmount ?? restrictedTradingFormState.send.amount,
+                              ...tradingFormState.send,
+                              amount: formattedMaxAmount ?? tradingFormState.send.amount,
                           },
                       }
                     : {}),
@@ -265,7 +252,7 @@ export const recomposeAndSignTxThunk = createThunk<
         const paymentRequests = isPaymentRequestsAllowed
             ? await dispatch(
                   tradingThunks.createPaymentRequestsThunk({
-                      type: restrictedTradingFormState.activeSection,
+                      type: tradingFormState.activeSection,
                       account,
                       composedLevels: precomposedToSign,
                       formattedMaxAmount,

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -9,16 +9,19 @@ import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { tradingActions } from '../../reducers/tradingReducer';
 import {
     selectTradingExchangeAccountKey,
+    selectTradingExchangeProviders,
     selectTradingExchangeReceiveAccountKey,
     selectTradingExchangeSelectedQuote,
 } from '../../selectors/tradingSelectors';
 import { TradingSendRejectedProps } from '../../types';
+import { getTradingFormState } from '../../utils';
 import { RecomposeAndSignTxThunkProps } from '../common/recomposeAndSignTxThunk';
 
 export type SendDexTransactionThunkProps = {
     account: Account;
     returnUrl: string;
     setMaxOutputId?: number | undefined;
+    isSlip24Active?: boolean;
 
     nextStep: () => void;
     processResponseData: (response: ExchangeTrade) => void;
@@ -39,6 +42,7 @@ export const sendDexTransactionThunk = createThunk<
             account,
             returnUrl,
             setMaxOutputId,
+            isSlip24Active,
             nextStep,
             processResponseData,
             triggerAnalyticsTradeConfirmation,
@@ -49,6 +53,7 @@ export const sendDexTransactionThunk = createThunk<
         const selectedQuote = selectTradingExchangeSelectedQuote(getState());
         const sendAccountKey = selectTradingExchangeAccountKey(getState());
         const receiveAccountKey = selectTradingExchangeReceiveAccountKey(getState());
+        const providers = selectTradingExchangeProviders(getState());
 
         if (
             !selectedQuote ||
@@ -61,6 +66,15 @@ export const sendDexTransactionThunk = createThunk<
                 error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
             });
         }
+
+        const tradingFormState = getTradingFormState({
+            activeSection: 'exchange',
+            providers,
+            trade: selectedQuote,
+            isSlip24Active,
+            sendAccountKey: account.key,
+            receiveAccountKey,
+        });
 
         // after discussion with 1inch, adjust the gas limit by the factor of 1.25
         // swap can use different swap paths when mining tx than when estimating tx
@@ -76,9 +90,7 @@ export const sendDexTransactionThunk = createThunk<
                 ethereumAdjustGasLimit: selectedQuote.status === 'CONFIRM' ? '1.25' : undefined,
                 setMaxOutputId,
                 signAndPushSendFormTransaction,
-                tradingFormState: {
-                    activeSection: 'exchange',
-                },
+                tradingFormState,
             }),
         );
 

--- a/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
@@ -70,6 +70,7 @@ export const sendTransactionThunk = createThunk<
                         triggerAnalyticsTradeConfirmation,
                         processResponseData,
                         signAndPushSendFormTransaction,
+                        isSlip24Active,
                     }),
                 ).unwrap();
 
@@ -96,6 +97,8 @@ export const sendTransactionThunk = createThunk<
             providers,
             trade: selectedTrade,
             isSlip24Active,
+            sendAccountKey: account.key,
+            receiveAccountKey,
         });
 
         const sendStringAmount = shouldSendInSats
@@ -103,7 +106,6 @@ export const sendTransactionThunk = createThunk<
             : selectedTrade.sendStringAmount;
         const sendPaymentExtraId =
             selectedTrade.partnerPaymentExtraId || trade?.partnerPaymentExtraId;
-
         const recomposeAndSignTx = await dispatch(
             tradingThunks.recomposeAndSignTxThunk({
                 account,

--- a/suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts
@@ -73,6 +73,7 @@ export const sendSellTransactionThunk = createThunk(
             providers,
             trade: selectedTrade,
             isSlip24Active,
+            sendAccountKey: account.key,
         });
         const cryptoStringAmount = shouldSendInSats
             ? convertAmountUnitsToSubunits(selectedTrade.cryptoStringAmount, decimals)

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -318,13 +318,17 @@ type TradingGetFormStateExchangeProps = {
 type TradingGetFormStateProps = {
     providers: Record<string, ExchangeProviderInfo | SellProviderInfo> | undefined;
     isSlip24Active?: boolean;
+    sendAccountKey: string | undefined;
+    receiveAccountKey?: string | undefined;
 } & (TradingGetFormStateSellProps | TradingGetFormStateExchangeProps);
 
 export const getTradingFormState = ({
     activeSection,
     trade,
     providers,
-    isSlip24Active,
+    isSlip24Active = false,
+    sendAccountKey,
+    receiveAccountKey,
 }: TradingGetFormStateProps): FormStateTrading => {
     const provider = trade?.exchange ? providers?.[trade.exchange] : undefined;
 
@@ -333,6 +337,7 @@ export const getTradingFormState = ({
         case 'sell': {
             const defaultState = {
                 activeSection,
+                isSlip24Active,
             };
 
             if (
@@ -353,9 +358,12 @@ export const getTradingFormState = ({
             }
 
             return {
+                isSlip24Active,
                 activeSection,
                 recipientName: provider.companyName,
                 send: {
+                    cryptoId: trade.cryptoCurrency,
+                    accountKey: sendAccountKey,
                     symbol: networkData.network.symbol,
                     contractAddress: networkData.contractAddress,
                     amount: trade.cryptoStringAmount,
@@ -369,6 +377,7 @@ export const getTradingFormState = ({
         case 'exchange': {
             const defaultState = {
                 activeSection,
+                isSlip24Active,
             };
 
             if (
@@ -392,12 +401,17 @@ export const getTradingFormState = ({
             return {
                 activeSection,
                 recipientName: provider.companyName,
+                isSlip24Active,
                 send: {
+                    cryptoId: trade.send,
+                    accountKey: sendAccountKey,
                     symbol: sendNetworkData.network.symbol,
                     contractAddress: sendNetworkData.contractAddress,
                     amount: trade.sendStringAmount,
                 },
                 receive: {
+                    cryptoId: trade.receive,
+                    accountKey: receiveAccountKey,
                     symbol: receiveNetworkData.network.symbol,
                     contractAddress: receiveNetworkData.contractAddress,
                     amount: trade.receiveStringAmount,

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -29,6 +29,7 @@ import {
     getPendingAccount,
     hasNetworkFeatures,
     isCardanoTx,
+    isExchangeTradingForm,
     subunitsToUnits,
     tryGetAccountIdentity,
 } from '@suite-common/wallet-utils';
@@ -367,6 +368,18 @@ export const pushSendFormTransactionThunk = createThunk<
                         isInfiniteApproval,
                         formattedAmount: amount,
                         tokenSymbol: token.symbol?.toUpperCase(),
+                        device,
+                        descriptor: selectedAccount.descriptor,
+                        symbol: selectedAccount.symbol,
+                        txid,
+                    }),
+                );
+            } else if (isExchangeTradingForm(precomposedForm?.trading)) {
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'tx-exchange',
+                        metadata: precomposedForm.trading,
+                        formattedAmount: precomposedForm.trading.send.amount,
                         device,
                         descriptor: selectedAccount.descriptor,
                         symbol: selectedAccount.symbol,

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -1,3 +1,5 @@
+import { CryptoId } from 'invity-api';
+
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountUtxo, FeeLevel } from '@trezor/connect';
 
@@ -14,6 +16,8 @@ export type FormOptions =
 export type UtxoSorting = 'newestFirst' | 'oldestFirst' | 'smallestFirst' | 'largestFirst';
 
 export type FormStateTradingCryptoCurrency = {
+    cryptoId: CryptoId | undefined;
+    accountKey: string | undefined;
     symbol: NetworkSymbol;
     contractAddress?: string;
     amount: string;
@@ -24,13 +28,15 @@ export type FormStateTradingFiatCurrency = {
     fiatCurrency: string;
 };
 
-type FormStateTradingDefault = {
+export type FormStateTradingDefault = {
     activeSection: 'sell' | 'exchange';
+    isSlip24Active: boolean;
 };
 
 type FormStateTradingCommon = {
     recipientName: string;
     send: FormStateTradingCryptoCurrency;
+    isSlip24Active: boolean;
 };
 
 type FormStateTradingSell = {
@@ -38,7 +44,7 @@ type FormStateTradingSell = {
     receive: FormStateTradingFiatCurrency;
 } & FormStateTradingCommon;
 
-type FormStateTradingExchange = {
+export type FormStateTradingExchange = {
     activeSection: 'exchange';
     receive: FormStateTradingCryptoCurrency;
 } & FormStateTradingCommon;

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -21,6 +21,7 @@ import { getShortFingerprint, isCardanoTx } from './cardanoUtils';
 import { isApprovalFlowSupported as isApprovalSupported } from './deviceUtils';
 import { getEvmApprovalTxData, isEvmApprovalTx } from './ethUtils';
 import { getStakeType } from './ethereumStakingUtils';
+import { isExchangeTradingForm } from './sendFormUtils';
 import { isRbfBumpFeeTransaction } from './transactionUtils';
 
 export const getTransactionReviewOutputState = (
@@ -369,7 +370,7 @@ const constructNewFlow = ({
                 }
             }
         });
-    } else if (trading && 'send' in trading && 'receive' in trading) {
+    } else if (precomposedForm.trading?.isSlip24Active && isExchangeTradingForm(trading)) {
         outputs.push({ type: 'recipient_name', value: trading.recipientName });
         outputs.push({
             type: 'traded_assets',

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -25,6 +25,8 @@ import type {
     ExternalOutput,
     FeeInfo,
     FormState,
+    FormStateTrading,
+    FormStateTradingExchange,
     GeneralPrecomposedTransactionFinal,
     Output,
     RbfTransactionParams,
@@ -675,3 +677,7 @@ export const getMevProtectedTxData = (
 
     return isMevProtectionEnabled ? hex : { hex, disableAlternativeRPC: true };
 };
+
+export const isExchangeTradingForm = (
+    form: FormStateTrading | undefined,
+): form is FormStateTradingExchange => form?.activeSection === 'exchange';

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -6,6 +6,7 @@ import {
     TradingSellType,
     TradingSignAndPushSendFormTransactionProps,
     selectTradingExchangeProviders,
+    selectTradingExchangeReceiveAccountKey,
     selectTradingExchangeSelectedQuote,
     selectTradingSellProviders,
     selectTradingSellSelectedQuote,
@@ -108,6 +109,11 @@ export const composeTradingTransactionThunk = createThunk(
                     ? (selectTradingExchangeProviders(getState()) ?? {})
                     : (selectTradingSellProviders(getState()) ?? {});
 
+            const receiveAccountKey =
+                tradeType === 'exchange'
+                    ? selectTradingExchangeReceiveAccountKey(getState())
+                    : undefined;
+
             if (!selectedQuote) {
                 return rejectWithValue('No selected quote found');
             }
@@ -121,6 +127,8 @@ export const composeTradingTransactionThunk = createThunk(
                 providers,
                 feeLevel: { label: selectedFeeLevel, feePerUnit: '' },
                 isSlip24Active,
+                sendAccountKey: account.key,
+                receiveAccountKey,
             });
 
             const response = await dispatch(

--- a/suite-native/module-trading/src/utils/__tests__/tradingFormUtils.test.ts
+++ b/suite-native/module-trading/src/utils/__tests__/tradingFormUtils.test.ts
@@ -6,6 +6,7 @@ import { createFormStateForSendForm } from '../tradingFormUtils';
 
 describe('createFormStateForSendForm', () => {
     describe('createTradingFormState', () => {
+        const sendAccountKey = '';
         it('should create FormState for exchange quote (swap)', () => {
             const exchangeQuote: ExchangeTrade = {
                 exchange: 'sideshiftfr',
@@ -30,6 +31,7 @@ describe('createFormStateForSendForm', () => {
                 quote: exchangeQuote,
                 feeLevel,
                 providers,
+                sendAccountKey,
             });
 
             expect(formState.outputs).toHaveLength(1);
@@ -71,7 +73,11 @@ describe('createFormStateForSendForm', () => {
             } as SellFiatTrade;
 
             const providers = { invity: sellInvity };
-            const formState = createFormStateForSendForm({ quote: sellQuote, providers });
+            const formState = createFormStateForSendForm({
+                quote: sellQuote,
+                providers,
+                sendAccountKey,
+            });
 
             expect(formState.outputs).toHaveLength(1);
             expect(formState.outputs[0]).toEqual({
@@ -99,7 +105,11 @@ describe('createFormStateForSendForm', () => {
             };
 
             const providers = { invity: exchangeInvity };
-            const formState = createFormStateForSendForm({ quote: tokenQuote, providers });
+            const formState = createFormStateForSendForm({
+                quote: tokenQuote,
+                providers,
+                sendAccountKey,
+            });
 
             expect(formState.outputs[0].token).toBe('0x0987654321123456789012345678901234567890');
             expect(formState.outputs[0].address).toBe('0x1234567890123456789012345678901234567890');
@@ -121,7 +131,11 @@ describe('createFormStateForSendForm', () => {
             };
 
             const providers = { changelly: exchangeInvity };
-            const formState = createFormStateForSendForm({ quote: xrpQuote, providers });
+            const formState = createFormStateForSendForm({
+                quote: xrpQuote,
+                providers,
+                sendAccountKey,
+            });
 
             expect(formState.destinationTag).toBe('12345');
         });
@@ -154,6 +168,7 @@ describe('createFormStateForSendForm', () => {
                 quote,
                 extraField: customExtraField,
                 providers,
+                sendAccountKey,
             });
 
             expect(formState.destinationTag).toBe('custom-tag-123');
@@ -170,7 +185,11 @@ describe('createFormStateForSendForm', () => {
 
             const providers = { test: exchangeInvity };
             expect(() =>
-                createFormStateForSendForm({ quote: invalidQuote as any, providers }),
+                createFormStateForSendForm({
+                    quote: invalidQuote as any,
+                    providers,
+                    sendAccountKey,
+                }),
             ).toThrow('Invalid quote type: must be ExchangeTrade or SellFiatTrade');
         });
 
@@ -188,7 +207,7 @@ describe('createFormStateForSendForm', () => {
             };
 
             const providers = { test: exchangeInvity };
-            const formState = createFormStateForSendForm({ quote, providers });
+            const formState = createFormStateForSendForm({ quote, providers, sendAccountKey });
 
             expect(formState.selectedFee).toBe('normal');
             expect(formState.feePerUnit).toBe('');

--- a/suite-native/module-trading/src/utils/tradingFormUtils.ts
+++ b/suite-native/module-trading/src/utils/tradingFormUtils.ts
@@ -14,6 +14,16 @@ import {
 import { FormState, FormStateTrading } from '@suite-common/wallet-types';
 import { FeeLevel } from '@trezor/connect';
 
+interface CreateFormStateForSendFormParams {
+    quote: ExchangeTrade | SellFiatTrade;
+    providers: Record<string, ExchangeProviderInfo> | { [name: string]: SellProviderInfo };
+    feeLevel?: Pick<FeeLevel, 'label' | 'feePerUnit' | 'feeLimit'>;
+    extraField?: string;
+    isSlip24Active?: boolean;
+    sendAccountKey: string | undefined;
+    receiveAccountKey?: string | undefined;
+}
+
 /**
  * Creates a FormState for transactions from exchange or sell quotes
  */
@@ -23,13 +33,9 @@ export const createFormStateForSendForm = ({
     feeLevel = { label: 'normal', feePerUnit: '' },
     extraField,
     isSlip24Active = false,
-}: {
-    quote: ExchangeTrade | SellFiatTrade;
-    providers: Record<string, ExchangeProviderInfo> | { [name: string]: SellProviderInfo };
-    feeLevel?: Pick<FeeLevel, 'label' | 'feePerUnit' | 'feeLimit'>;
-    extraField?: string;
-    isSlip24Active?: boolean;
-}): FormState => {
+    sendAccountKey,
+    receiveAccountKey,
+}: CreateFormStateForSendFormParams): FormState => {
     if (!isExchangeTrade(quote) && !isSellFiatTrade(quote)) {
         throw new Error('Invalid quote type: must be ExchangeTrade or SellFiatTrade');
     }
@@ -65,6 +71,8 @@ export const createFormStateForSendForm = ({
             providers: exchangeProviders,
             trade: exchangeQuote,
             isSlip24Active,
+            sendAccountKey,
+            receiveAccountKey,
         });
     } else {
         // Sell quote (crypto to fiat)
@@ -87,6 +95,8 @@ export const createFormStateForSendForm = ({
             providers: sellProviders,
             trade: sellQuote,
             isSlip24Active,
+            sendAccountKey,
+            receiveAccountKey,
         });
     }
     const formState: FormState = {


### PR DESCRIPTION
## Description

Swap notifications now display info about the swap including tokens, amounts and accounts.

## Related Issue

Resolve #14940

## Screenshots:
<img width="434" height="73" alt="Screenshot 2025-08-20 at 18 53 24" src="https://github.com/user-attachments/assets/7460fcf8-890f-4cb7-8110-67970102ae30" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/improve-swap-notification&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/improve-swap-notification&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/improve-swap-notification&lookback=7)