### PR TITLE
chore(storage): save device only when state changes

### DIFF
--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -187,15 +187,22 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 );
             }
 
-            if (deviceActions.updateSelectedDevice.match(action)) {
+            if (
+                deviceActions.addAuthorizedDevice.match(action) ||
+                deviceActions.setDeviceState.match(action)
+            ) {
+                const device =
+                    'device' in action.payload
+                        ? action.payload.device
+                        : selectSelectedDevice(api.getState());
                 const isAutoEjectEnabled = selectIsAutoEjectEnabled(api.getState());
 
                 if (
-                    isDeviceRemembered(action.payload) &&
-                    action.payload?.mode === 'normal' &&
+                    isDeviceRemembered(device) &&
+                    device?.mode === 'normal' &&
                     !isAutoEjectEnabled
                 ) {
-                    storageActions.saveDevice(action.payload);
+                    storageActions.saveDevice(device);
                 }
             }
 


### PR DESCRIPTION
This might be an unnecessary optimization but I still wanted to discuss it - at the moment, we write device into indexxed db anytime there is updateSelectedDevice action fired which is fired based on these conditions https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/middlewares/suite/suiteMiddleware.ts#L23 and in my opinion it might be happening too often.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=optimize-device-saving&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=optimize-device-saving&lookback=7)