### PR TITLE
feat(suite): add Done button for UnpairedBluetoothDeviceNeedsManualOsRemovalModal

### DIFF
--- a/packages/suite/src/components/suite/bluetooth/UnpairedBluetoothDeviceNeedsManualOsRemovalModal.tsx
+++ b/packages/suite/src/components/suite/bluetooth/UnpairedBluetoothDeviceNeedsManualOsRemovalModal.tsx
@@ -63,7 +63,7 @@ export const UnpairedBluetoothDeviceNeedsManualOsRemovalModal = () => {
                         <Translation id="TR_BLUETOOTH_OPEN_BLUETOOTH_SETTINGS" />
                     </Modal.Button>
                     <Modal.Button variant="tertiary" onClick={onCancel}>
-                        <Translation id="TR_CANCEL" />
+                        <Translation id="TR_DONE" />
                     </Modal.Button>
                 </>
             }

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4430,6 +4430,10 @@ export default defineMessages({
         id: 'TR_CANCEL',
         defaultMessage: 'Cancel',
     },
+    TR_DONE: {
+        id: 'TR_DONE',
+        defaultMessage: 'Done',
+    },
     TR_CANCELLED: {
         id: 'TR_CANCELLED',
         defaultMessage: 'Canceled',


### PR DESCRIPTION
## Description

Replace the "Cancel" button with "Done" button in `UnpairedBluetoothDeviceNeedsManualOsRemovalModal`, because after user is sent to user settings, removes the device in settings manually _and returns to Suite_, it is otherwise not clear what to do at this point.
The button does the same thing as Cancel, but its copy makes it clear "now I should click this to proceed" 

## Screenshots:

<img width="708" height="406" alt="image" src="https://github.com/user-attachments/assets/33246adb-25c6-47e1-aea7-e7b68a60862a" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/done-button-UnpairedBluetoothDeviceNeedsManualOsRemovalModal&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/done-button-UnpairedBluetoothDeviceNeedsManualOsRemovalModal&lookback=7)