### PR TITLE
chore(transport-bluetooth): add commentary to forgetDevice

### DIFF
--- a/packages/transport-bluetooth/src/client/types.ts
+++ b/packages/transport-bluetooth/src/client/types.ts
@@ -98,6 +98,9 @@ export interface BluetoothIpcApi {
     stopScan(): Promise<IpcResponse>;
     connectDevice(id: string): Promise<IpcResponse>;
     disconnectDevice(id: string): Promise<IpcResponse>;
+    /**
+     * Forget device by its Bluetooth Id. Supported only on Windows.
+     */
     forgetDevice(id: string): Promise<IpcResponse>;
     on: TypedManagerEvents['on'];
     off: TypedManagerEvents['off'];


### PR DESCRIPTION
Add commentary that `forgetDevice` is supported only on Windows, because that is not clear until you [open implementation](https://github.com/trezor/trezor-suite/blob/712bf2a2de9a3a610d0f2baecc70c742b19040a1/packages/transport-bluetooth/src/server/methods/forget_device.rs)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/BluetoothIpcApi-forgetDevice-comment&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/BluetoothIpcApi-forgetDevice-comment&lookback=7)