### PR TITLE
test(suite-native): fix device settings element text matching

### DIFF
--- a/suite-native/app/e2e/tests/deviceSettings.test.ts
+++ b/suite-native/app/e2e/tests/deviceSettings.test.ts
@@ -94,7 +94,9 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () =>
 
             await onDeviceSettings.waitForSettingsScreen();
 
-            expect(element(by.label('new name'))).toBeVisible();
+            await waitFor(element(by.text('new name')))
+                .toBeVisible()
+                .withTimeout(10000);
         });
 
         test('Wipe device', async () => {
@@ -114,7 +116,9 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () =>
 
             await onDeviceSettings.passCheckBackupFlow();
 
-            expect(element(by.label('Your backup is valid'))).toBeVisible();
+            await waitFor(element(by.text('Your backup is valid')))
+                .toBeVisible()
+                .withTimeout(10000);
         });
     });
 
@@ -139,8 +143,9 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () =>
             await onDeviceSettings.tapCheckBackupButtonFromFirmwareUpdate();
 
             await onDeviceSettings.passCheckBackupFlow();
-
-            expect(element(by.label('Your backup is valid'))).toBeVisible();
+            await waitFor(element(by.text('Your backup is valid')))
+                .toBeVisible()
+                .withTimeout(10000);
         });
     });
 
@@ -162,9 +167,9 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () =>
         test('Device Check Backup with unsupported Device Model', async () => {
             await onDeviceSettings.tapDeviceCheckBackupButton();
 
-            expect(
-                element(by.label('To check your backup, use the web application.')),
-            ).toBeVisible();
+            await waitFor(element(by.text('To check your backup, use the web application.')))
+                .toBeVisible()
+                .withTimeout(10000);
         });
     });
 });


### PR DESCRIPTION
## Description
The end-to-end device settings tests were performing text matching without waiting for the screen content to render, which caused some tests to be unreliable. This fix addresses this issue.



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native/fix-device-settings-e2e-text-match&lookback=7)