### PR TITLE
chore(module-authorization-device): simplify selectPassphraseError

### DIFF
--- a/suite-native/device-authorization/src/deviceAuthorizationSlice.ts
+++ b/suite-native/device-authorization/src/deviceAuthorizationSlice.ts
@@ -90,25 +90,15 @@ export const selectInputPassphraseOnDevice = (state: DeviceAuthorizationRootStat
 export const selectCheckPassphraseOnDevice = (state: DeviceAuthorizationRootState) =>
     state.deviceAuthorization.checkPassphraseOnDevice;
 
-export const selectPassphraseError = (
+export const selectHasPassphraseError = (
     state: DiscoveryRootState & DeviceRootState & DeviceAuthorizationState,
 ) => {
     const discovery = selectDiscoveryByDevicePath(state, state.device.selectedDevice?.path);
 
-    if (!discovery || !discovery.isAddingHiddenWallet) {
-        return null;
-    }
-
-    switch (discovery.status) {
-        case 'failed':
-            return 'action-failed';
-        case 'cancelled':
-            return 'action-cancelled';
-        case 'passphrase-mismatch':
-            return 'passphrase-mismatch';
-        default:
-            return null;
-    }
+    return (
+        discovery?.isAddingExistingWallet &&
+        ['failed', 'cancelled', 'passphrase-mismatch'].includes(discovery.status)
+    );
 };
 
 export const selectHasVerificationCancelledError = (

--- a/suite-native/module-authorize-device/src/useRedirectOnPassphraseCompletion.ts
+++ b/suite-native/module-authorize-device/src/useRedirectOnPassphraseCompletion.ts
@@ -11,9 +11,9 @@ import {
 } from '@suite-common/wallet-core';
 import { EventType, analytics } from '@suite-native/analytics';
 import {
+    selectHasPassphraseError,
     selectHasVerificationCancelledError,
     selectPassphraseDiscoveryCompleted,
-    selectPassphraseError,
 } from '@suite-native/device-authorization';
 import { useNavigateToInitialScreen } from '@suite-native/navigation';
 
@@ -21,7 +21,7 @@ export const useRedirectOnPassphraseCompletion = () => {
     const device = useSelector(selectSelectedDevice);
 
     const passphraseDiscoveryCompleted = useSelector(selectPassphraseDiscoveryCompleted);
-    const hasPassphraseError = useSelector(selectPassphraseError);
+    const hasPassphraseError = useSelector(selectHasPassphraseError);
     const hasVerificationCancelledError = useSelector(selectHasVerificationCancelledError);
 
     const dispatch = useDispatch();


### PR DESCRIPTION
selectPassphraseError returns some string that are not used anywhere. Simplified

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=selectHasPassphraseError&lookback=7)