### PR TITLE
chore(connect): optimize cache local data

### DIFF
--- a/packages/connect/src/data/DataManager.ts
+++ b/packages/connect/src/data/DataManager.ts
@@ -5,6 +5,7 @@ import coins from '@trezor/connect-common/files/coins.json';
 import {
     ConditionalRelease,
     DeviceModelInternal,
+    FirmwareReleaseConfig,
     FirmwareType,
     IntermediaryReleaseConfig,
     ReleasesConfig,
@@ -36,6 +37,7 @@ export class DataManager {
     private static firmwareIntermediaryReleasesConfig:
         | Record<keyof typeof DeviceModelInternal, IntermediaryReleaseConfig[]>
         | undefined;
+    private static localFirmwareReleaseConfig: FirmwareReleaseConfig;
 
     static async load(
         settings: ConnectSettings,
@@ -58,13 +60,22 @@ export class DataManager {
             ...this.assets.coinsEth,
         });
 
+        this.prepareLocalFirmwareReleaseData();
         await this.loadFirmwareRelaseConfig(onlyLocalFirmwareConfig);
+    }
+
+    static prepareLocalFirmwareReleaseData() {
+        const { config } = getOnlyLocalFirmwareReleaseConfig();
+        this.setLocalFirmwareReleaseConfig(config);
     }
 
     static async loadFirmwareRelaseConfig(onlyLocal: boolean): Promise<void> {
         let firmwareRelaseConfig;
         if (onlyLocal) {
-            firmwareRelaseConfig = getOnlyLocalFirmwareReleaseConfig();
+            firmwareRelaseConfig = {
+                config: this.getLocalFirmwareReleaseConfig(),
+                isRemote: false,
+            };
         } else {
             firmwareRelaseConfig = await getFirmwareReleaseConfig();
         }
@@ -94,6 +105,13 @@ export class DataManager {
     }
     static getLocalFirmwares(): LocalFirmwares {
         return this.localFirmwares;
+    }
+
+    static setLocalFirmwareReleaseConfig(localFirmwareReleaseConfig: FirmwareReleaseConfig) {
+        this.localFirmwareReleaseConfig = localFirmwareReleaseConfig;
+    }
+    static getLocalFirmwareReleaseConfig(): FirmwareReleaseConfig {
+        return this.localFirmwareReleaseConfig;
     }
 
     static setFirmwareReleaseConfig(releaseConfig: ReleasesConfig): void {

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -14,7 +14,6 @@ import { Features, FirmwareReleaseConfigInfo, FirmwareType } from '../types';
 import { DataManager } from './DataManager';
 import { getReleaseAsset, getReleasesAssetByDeviceModelAndFirmwareType } from '../utils/assetUtils';
 import { httpRequest } from '../utils/assets';
-import { getOnlyLocalFirmwareReleaseConfig } from '../utils/firmwareReleaseConfigUtils';
 import {
     buildIntermediaryFirmwareFileName,
     buildLocalFirmwareFileName,
@@ -82,7 +81,7 @@ const getBundledFirmwareVersion = (
     deviceModel: DeviceModelInternal,
     firmwareType: FirmwareType,
 ) => {
-    const { config: localFirmwareReleaseConfig } = getOnlyLocalFirmwareReleaseConfig();
+    const localFirmwareReleaseConfig = DataManager.getLocalFirmwareReleaseConfig();
     const modelReleases = localFirmwareReleaseConfig.releases[deviceModel];
     const bundledRelease = modelReleases?.[firmwareType];
     if (!bundledRelease) {
@@ -288,7 +287,7 @@ export const initializeFirmwareConfig = async (
     }
 
     // We had some issue getting remote so we use local data.
-    const { config: localFirmwareReleaseConfig } = getOnlyLocalFirmwareReleaseConfig();
+    const localFirmwareReleaseConfig = DataManager.getLocalFirmwareReleaseConfig();
     const localReleases = createLocalFirmwareConfig(localFirmwareReleaseConfig);
 
     return {

--- a/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
+++ b/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
@@ -76,6 +76,7 @@ export const getFirmwareReleaseConfig = async () => {
 
     let finalJws = remoteJws;
     let finalSource = initialSource;
+    let config;
 
     if (initialSource === 'remote') {
         try {
@@ -91,6 +92,9 @@ export const getFirmwareReleaseConfig = async () => {
             if (localPayload.sequence >= remotePayload.sequence) {
                 finalJws = firmwareReleaseConfigAssets.jws;
                 finalSource = 'local';
+                config = localPayload;
+            } else {
+                config = remotePayload;
             }
         } catch (error) {
             console.error(`Error comparing remote/local JWS: ${error}. Using remote as is.`);
@@ -101,7 +105,10 @@ export const getFirmwareReleaseConfig = async () => {
     const publicKey = getJWSPublicKey('firmware-release', useProductionKey);
 
     verifyJwsSignature(finalJws, publicKey);
-    const config = decodeJwsPayload(finalJws);
+    // Only decode the JWS if we haven't already assigned the payload
+    if (!config) {
+        config = decodeJwsPayload(finalJws);
+    }
 
     return {
         config,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds couple of performance improvements to performance in the firmware release config decoding and verification. 

* Now the firmware release configs are only verified 2 times for each of them (local and remote) by caching data.
* Avoid unnecessary decode of firmware release config.

This should be a performance improvement specially in mobile since verify JWS function is very inefficient in that environment. Further improvemnts could be made by using a native library for mobile jWS verification.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/optimize-local-data-cache&lookback=7)