### PR TITLE
feat(suite): New unsupported asset message next to graph

### DIFF
--- a/packages/suite/src/components/dashboard/DashboardSection.tsx
+++ b/packages/suite/src/components/dashboard/DashboardSection.tsx
@@ -8,11 +8,12 @@ import {
     useState,
 } from 'react';
 
-import { Column, H3, IconButton, Paragraph, Row } from '@trezor/components';
+import { Box, Column, H3, IconButton, Paragraph, Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 type DashboardSectionProps = HTMLAttributes<HTMLDivElement> & {
     heading: ReactElement;
+    subheading?: ReactElement;
     text?: ReactNode;
     actions?: ReactElement;
     collapsible?: boolean;
@@ -25,6 +26,7 @@ export const DashboardSection = forwardRef(
     (
         {
             heading,
+            subheading,
             text,
             actions,
             collapsible = false,
@@ -46,22 +48,25 @@ export const DashboardSection = forwardRef(
             <div ref={ref} {...rest}>
                 <Column data-testid={dataTestId} gap={spacings.md}>
                     <Column width="100%" gap={spacings.xs}>
-                        <Row as="header" justifyContent="space-between">
-                            {heading && (
-                                <H3>
-                                    <Row as="span">{heading}</Row>
-                                </H3>
-                            )}
-                            {actions && <div>{actions}</div>}
-                            {collapsible && (
+                        <Box>
+                    <Row as="header" justifyContent="space-between">
+                        {heading && (
+                            <H3>
+                                <Row as="span">{heading}</Row>
+                            </H3>
+                        )}
+
+                        {actions && <div>{actions}</div>}
+                    {collapsible && (
                                 <IconButton
                                     icon={collapsed ? 'caretDown' : 'caretUp'}
                                     size="small"
                                     variant="tertiary"
                                     onClick={() => setCollapsed(prev => !prev)}
                                 ></IconButton>
-                            )}
-                        </Row>
+                            )}</Row>
+                    {subheading}
+                </Box>
                         {text && <Paragraph variant="tertiary">{text}</Paragraph>}
                     </Column>
                     {!collapsed && children}

--- a/packages/suite/src/components/dashboard/DashboardSection.tsx
+++ b/packages/suite/src/components/dashboard/DashboardSection.tsx
@@ -49,24 +49,25 @@ export const DashboardSection = forwardRef(
                 <Column data-testid={dataTestId} gap={spacings.md}>
                     <Column width="100%" gap={spacings.xs}>
                         <Box>
-                    <Row as="header" justifyContent="space-between">
-                        {heading && (
-                            <H3>
-                                <Row as="span">{heading}</Row>
-                            </H3>
-                        )}
+                            <Row as="header" justifyContent="space-between">
+                                {heading && (
+                                    <H3>
+                                        <Row as="span">{heading}</Row>
+                                    </H3>
+                                )}
 
-                        {actions && <div>{actions}</div>}
-                    {collapsible && (
-                                <IconButton
-                                    icon={collapsed ? 'caretDown' : 'caretUp'}
-                                    size="small"
-                                    variant="tertiary"
-                                    onClick={() => setCollapsed(prev => !prev)}
-                                ></IconButton>
-                            )}</Row>
-                    {subheading}
-                </Box>
+                                {actions && <div>{actions}</div>}
+                                {collapsible && (
+                                    <IconButton
+                                        icon={collapsed ? 'caretDown' : 'caretUp'}
+                                        size="small"
+                                        variant="tertiary"
+                                        onClick={() => setCollapsed(prev => !prev)}
+                                    ></IconButton>
+                                )}
+                            </Row>
+                            {subheading}
+                        </Box>
                         {text && <Paragraph variant="tertiary">{text}</Paragraph>}
                     </Column>
                     {!collapsed && children}

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6454,10 +6454,10 @@ export default defineMessages({
         id: 'TR_LABELING_REMOVE_OUTPUT',
         defaultMessage: 'Remove label',
     },
-    TR_GRAPH_MISSING_DATA: {
-        id: 'TR_GRAPH_MISSING_DATA',
+    TR_GRAPH_MISSING_DATA_INFO: {
+        id: 'TR_GRAPH_MISSING_DATA_INFO',
         defaultMessage:
-            "XRP, XLM, SOL, and all token amounts are in the portfolio balance but aren't currently supported in graph view.",
+            'and all related accounts are reflected in the balance but not in the graph',
     },
     METADATA_PROVIDER_NOT_FOUND_ERROR: {
         id: 'METADATA_PROVIDER_NOT_FOUND_ERROR',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6454,10 +6454,20 @@ export default defineMessages({
         id: 'TR_LABELING_REMOVE_OUTPUT',
         defaultMessage: 'Remove label',
     },
-    TR_GRAPH_MISSING_DATA_INFO: {
-        id: 'TR_GRAPH_MISSING_DATA_INFO',
+    TR_GRAPH_MISSING_DATA_WITH_TOKENS: {
+        id: 'TR_GRAPH_MISSING_DATA_WITH_TOKENS',
         defaultMessage:
-            "and all token amounts are included in the portfolio balance, but aren't currently supported in graph view.",
+            "{networks} and all token amounts are included in the portfolio balance, but aren't currently supported in graph view.",
+    },
+    TR_GRAPH_MISSING_DATA_NETWORKS: {
+        id: 'TR_GRAPH_MISSING_DATA_NETWORKS',
+        defaultMessage:
+            "{networks} are included in the portfolio balance, but aren't currently supported in graph view.",
+    },
+    TR_GRAPH_MISSING_DATA_TOKENS: {
+        id: 'TR_GRAPH_MISSING_DATA_TOKENS',
+        defaultMessage:
+            "All token amounts are included in the portfolio balance, but aren't currently supported in graph view.",
     },
     METADATA_PROVIDER_NOT_FOUND_ERROR: {
         id: 'METADATA_PROVIDER_NOT_FOUND_ERROR',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6457,7 +6457,7 @@ export default defineMessages({
     TR_GRAPH_MISSING_DATA_INFO: {
         id: 'TR_GRAPH_MISSING_DATA_INFO',
         defaultMessage:
-            'and all related accounts are reflected in the balance but not in the graph',
+            "and all token amounts are included in the portfolio balance, but aren't currently supported in graph view.",
     },
     METADATA_PROVIDER_NOT_FOUND_ERROR: {
         id: 'METADATA_PROVIDER_NOT_FOUND_ERROR',

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -6,8 +6,7 @@ import {
     selectCurrentFiatRates,
 } from '@suite-common/wallet-core';
 import { isAccountFailed } from '@suite-common/wallet-utils';
-import { Card, Column, Dropdown, Switch, Tooltip } from '@trezor/components';
-import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
+import { Card, Column, Dropdown, Switch } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { goto } from 'src/actions/suite/routerActions';
@@ -22,6 +21,7 @@ import { DashboardGraph } from './DashboardGraph';
 import { EmptyWallet } from './EmptyWallet';
 import { PortfolioCardException } from './PortfolioCardException';
 import { PortfolioCardHeader } from './PortfolioCardHeader';
+import { UnsupportedAssetsMessage, useUnsupportedAssetsMessage } from './UnsupportedAssetsMessage';
 
 export const PortfolioCard = memo(() => {
     const currentFiatRates = useSelector(selectCurrentFiatRates);
@@ -68,19 +68,18 @@ export const PortfolioCard = memo(() => {
     const isWalletError = discoveryStatus?.status === 'exception';
     const showGraphControls =
         !isWalletEmpty && !isWalletLoading && !isWalletError && !dashboardGraphHidden;
-
-    const showMissingDataTooltip =
-        showGraphControls &&
-        !hasBitcoinOnlyFirmware(device) &&
-        !!accounts.some(
-            account =>
-                account.history &&
-                (account.tokens?.length ||
-                    ['ripple', 'solana', 'stellar'].includes(account.networkType)),
-        );
+    const { affectedAssets } = useUnsupportedAssetsMessage({
+        showGraphControls,
+        device,
+        accounts,
+    });
 
     const goToReceive = () => dispatch(goto('wallet-receive'));
-    const heading = <Translation id="TR_MY_PORTFOLIO" />;
+    const heading = (
+        <>
+            <Translation id="TR_MY_PORTFOLIO" />
+        </>
+    );
     const header =
         discovery && discoveryStatus?.status === 'exception' ? null : (
             <PortfolioCardHeader
@@ -98,15 +97,8 @@ export const PortfolioCard = memo(() => {
 
     return (
         <DashboardSection
-            heading={
-                showMissingDataTooltip ? (
-                    <Tooltip hasIcon content={<Translation id="TR_GRAPH_MISSING_DATA" />}>
-                        {heading}
-                    </Tooltip>
-                ) : (
-                    heading
-                )
-            }
+            heading={heading}
+            subheading={<UnsupportedAssetsMessage affectedAssets={affectedAssets} />}
             actions={
                 !isWalletEmpty && !isWalletLoading && !isWalletError ? (
                     <Dropdown

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -21,7 +21,7 @@ import { DashboardGraph } from './DashboardGraph';
 import { EmptyWallet } from './EmptyWallet';
 import { PortfolioCardException } from './PortfolioCardException';
 import { PortfolioCardHeader } from './PortfolioCardHeader';
-import { UnsupportedAssetsMessage, useUnsupportedAssetsMessage } from './UnsupportedAssetsMessage';
+import { UnsupportedAssetsMessage, useUnsupportedNetworkMessage } from './UnsupportedAssetsMessage';
 
 export const PortfolioCard = memo(() => {
     const currentFiatRates = useSelector(selectCurrentFiatRates);
@@ -68,18 +68,15 @@ export const PortfolioCard = memo(() => {
     const isWalletError = discoveryStatus?.status === 'exception';
     const showGraphControls =
         !isWalletEmpty && !isWalletLoading && !isWalletError && !dashboardGraphHidden;
-    const { affectedAssets } = useUnsupportedAssetsMessage({
+    const { affectedNetworks, hasTokens, showMissingDataTooltip } = useUnsupportedNetworkMessage({
         showGraphControls,
         device,
         accounts,
     });
 
     const goToReceive = () => dispatch(goto('wallet-receive'));
-    const heading = (
-        <>
-            <Translation id="TR_MY_PORTFOLIO" />
-        </>
-    );
+    const heading = <Translation id="TR_MY_PORTFOLIO" />;
+
     const header =
         discovery && discoveryStatus?.status === 'exception' ? null : (
             <PortfolioCardHeader
@@ -98,7 +95,14 @@ export const PortfolioCard = memo(() => {
     return (
         <DashboardSection
             heading={heading}
-            subheading={<UnsupportedAssetsMessage affectedAssets={affectedAssets} />}
+            subheading={
+                showMissingDataTooltip ? (
+                    <UnsupportedAssetsMessage
+                        affectedNetworks={affectedNetworks}
+                        hasTokens={hasTokens}
+                    />
+                ) : undefined
+            }
             actions={
                 !isWalletEmpty && !isWalletLoading && !isWalletError ? (
                     <Dropdown

--- a/packages/suite/src/views/dashboard/PortfolioCard/UnsupportedAssetsMessage.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/UnsupportedAssetsMessage.tsx
@@ -1,0 +1,64 @@
+import styled from 'styled-components';
+
+import { TrezorDevice } from '@suite-common/suite-types';
+import { Account } from '@suite-common/wallet-types';
+import { Text } from '@trezor/components';
+import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
+
+import { Translation } from '../../../components/suite';
+
+const Asset = styled.span`
+    display: inline-block;
+
+    &::first-letter {
+        text-transform: capitalize;
+    }
+`;
+
+const UNSUPPORTED_NETWORKS = ['ripple', 'solana', 'stellar'];
+
+export const useUnsupportedAssetsMessage = ({
+    showGraphControls,
+    device,
+    accounts,
+}: {
+    showGraphControls: boolean;
+    device?: TrezorDevice;
+    accounts: Account[];
+}) => {
+    const affectedAccounts =
+        showGraphControls &&
+        !hasBitcoinOnlyFirmware(device) &&
+        accounts
+            .filter(
+                account =>
+                    account.history &&
+                    (account.tokens?.length || UNSUPPORTED_NETWORKS.includes(account.networkType)),
+            )
+            .map(({ networkType }) => networkType);
+
+    const affectedAssets = [...new Set(affectedAccounts || [])];
+    const showMissingDataTooltip = affectedAssets.length > 0;
+
+    return { affectedAssets, showMissingDataTooltip };
+};
+
+type UnsupportedAssetsMessageProps = {
+    affectedAssets: string[];
+};
+
+export const UnsupportedAssetsMessage = ({ affectedAssets }: UnsupportedAssetsMessageProps) => {
+    if (affectedAssets.length === 0) return null;
+
+    return (
+        <Text variant="tertiary" typographyStyle="hint">
+            {affectedAssets.map((asset, index) => (
+                <>
+                    <Asset key={asset}>{asset}</Asset>
+                    {affectedAssets.length - 1 > index ? ', ' : ''}
+                </>
+            ))}{' '}
+            <Translation id="TR_GRAPH_MISSING_DATA_INFO" />
+        </Text>
+    );
+};

--- a/packages/suite/src/views/dashboard/PortfolioCard/UnsupportedAssetsMessage.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/UnsupportedAssetsMessage.tsx
@@ -1,23 +1,14 @@
-import styled from 'styled-components';
-
 import { TrezorDevice } from '@suite-common/suite-types';
+import { getNetworkFeatures } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 import { Text } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 
 import { Translation } from '../../../components/suite';
 
-const Asset = styled.span`
-    display: inline-block;
-
-    &::first-letter {
-        text-transform: capitalize;
-    }
-`;
-
 const UNSUPPORTED_NETWORKS = ['ripple', 'solana', 'stellar'];
 
-export const useUnsupportedAssetsMessage = ({
+export const useUnsupportedNetworkMessage = ({
     showGraphControls,
     device,
     accounts,
@@ -26,39 +17,71 @@ export const useUnsupportedAssetsMessage = ({
     device?: TrezorDevice;
     accounts: Account[];
 }) => {
+    const hasAnyAccountWithTokens = (accounts: Account[]): boolean =>
+        accounts.some(account => {
+            const features = getNetworkFeatures(account.symbol);
+
+            return features?.includes('tokens') ?? false;
+        });
+
     const affectedAccounts =
         showGraphControls &&
         !hasBitcoinOnlyFirmware(device) &&
         accounts
             .filter(
-                account =>
-                    account.history &&
-                    (account.tokens?.length || UNSUPPORTED_NETWORKS.includes(account.networkType)),
+                account => account.history && UNSUPPORTED_NETWORKS.includes(account.networkType),
             )
             .map(({ networkType }) => networkType);
 
-    const affectedAssets = [...new Set(affectedAccounts || [])];
-    const showMissingDataTooltip = affectedAssets.length > 0;
+    const affectedNetworks = [...new Set(affectedAccounts || [])];
+    const hasTokens = hasAnyAccountWithTokens(accounts);
+    const showMissingDataTooltip = affectedNetworks.length > 0 || hasTokens;
 
-    return { affectedAssets, showMissingDataTooltip };
+    return { affectedNetworks, showMissingDataTooltip, hasTokens };
+};
+
+type MessageProps = {
+    affectedNetworks: string[];
+    hasTokens: boolean;
+};
+
+const capitalizeFirstLetter = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
+
+const Message = ({ affectedNetworks, hasTokens }: MessageProps) => {
+    const hasNetworks = affectedNetworks.length > 0;
+    const networksString = affectedNetworks
+        .map(network => capitalizeFirstLetter(network))
+        .join(', ');
+
+    if (hasNetworks && hasTokens) {
+        return (
+            <Translation
+                id="TR_GRAPH_MISSING_DATA_WITH_TOKENS"
+                values={{ networks: networksString }}
+            />
+        );
+    } else if (hasNetworks) {
+        return (
+            <Translation
+                id="TR_GRAPH_MISSING_DATA_NETWORKS"
+                values={{ networks: networksString }}
+            />
+        );
+    } else {
+        return <Translation id="TR_GRAPH_MISSING_DATA_TOKENS" />;
+    }
 };
 
 type UnsupportedAssetsMessageProps = {
-    affectedAssets: string[];
+    affectedNetworks: string[];
+    hasTokens: boolean;
 };
 
-export const UnsupportedAssetsMessage = ({ affectedAssets }: UnsupportedAssetsMessageProps) => {
-    if (affectedAssets.length === 0) return null;
-
-    return (
-        <Text variant="tertiary" typographyStyle="hint">
-            {affectedAssets.map((asset, index) => (
-                <>
-                    <Asset key={asset}>{asset}</Asset>
-                    {affectedAssets.length - 1 > index ? ', ' : ''}
-                </>
-            ))}{' '}
-            <Translation id="TR_GRAPH_MISSING_DATA_INFO" />
-        </Text>
-    );
-};
+export const UnsupportedAssetsMessage = ({
+    affectedNetworks,
+    hasTokens,
+}: UnsupportedAssetsMessageProps) => (
+    <Text variant="tertiary" typographyStyle="hint">
+        <Message affectedNetworks={affectedNetworks} hasTokens={hasTokens} />
+    </Text>
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

**BTC + XRP (tokens)**

<img width="1301" height="659" alt="Screenshot 2025-09-02 at 13 31 47" src="https://github.com/user-attachments/assets/143f9455-74bb-48a5-a4bd-cfe8940d1473" />

**BTC + SOL (tokens) + XRP (tokens)**

<img width="1291" height="663" alt="Screenshot 2025-09-02 at 13 32 22" src="https://github.com/user-attachments/assets/68cf74a0-d502-4e42-b3e7-2127fa01ed5b" />

**BTC + XLM (no tokens)**

<img width="1296" height="664" alt="Screenshot 2025-09-02 at 13 33 07" src="https://github.com/user-attachments/assets/e61c097a-6170-4b23-b4f1-fca82558e104" />

**BTC + SOL (tokens) + XRP (tokens) + XLM (no tokens)**

<img width="1307" height="921" alt="Screenshot 2025-09-02 at 13 33 46" src="https://github.com/user-attachments/assets/1221290c-ffeb-45d2-ac35-d72ca9cb0fdf" />

**BTC**

<img width="1290" height="638" alt="Screenshot 2025-09-02 at 13 34 03" src="https://github.com/user-attachments/assets/481faaee-04c5-40fb-b2ad-e1810855066d" />





## Related Issue

Resolve #20720

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=new-graph-unsupported-message&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=new-graph-unsupported-message&lookback=7)