### PR TITLE
Device busy view

### DIFF
--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -68,8 +68,13 @@ interface ReconnectDevicePromptProps {
 export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePromptProps) => {
     const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
     const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
-    const { showManualReconnectPrompt, status, reconnectEvent, buttonEvent } =
-        useFirmwareDesktopUpdate();
+    const {
+        showManualReconnectPrompt,
+        status,
+        reconnectEvent,
+        buttonEvent,
+        deviceIsWaitingForConfirmationToConnectToHost,
+    } = useFirmwareDesktopUpdate();
     const { device } = useDevice();
 
     const eventDevice = usePreviousDefined(buttonEvent?.device || device);
@@ -94,12 +99,12 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
 
     const rebootPhase = getRebootPhase();
     const isRebootDone = rebootPhase === 'done';
-    const deviceModelInternal = device?.features?.internal_model;
     const isAbortable =
         onClose !== undefined && isManualRebootRequired && rebootPhase == 'waiting-for-reboot';
     const showWebUsbButton = rebootPhase === 'disconnected' && isWebUsbTransport;
-
     const toNormal = reconnectEvent?.target === 'normal' && reconnectEvent.method === 'manual';
+    const showConfirmOnDevice =
+        (!isManualRebootRequired && !isRebootDone) || deviceIsWaitingForConfirmationToConnectToHost;
 
     const getHeading = () => {
         if (isRebootDone) {
@@ -142,12 +147,12 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
 
     return (
         <Modal.Backdrop onClick={isAbortable ? onClose : undefined}>
-            {!isManualRebootRequired && !isRebootDone && (
+            {showConfirmOnDevice && (
                 <ConfirmOnDevicePill
                     title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
-                    deviceModelInternal={deviceModelInternal}
-                    deviceUnitColor={device?.features?.unit_color}
-                    isConfirmed={!buttonEvent}
+                    deviceModelInternal={eventDevice?.features?.internal_model}
+                    deviceUnitColor={eventDevice?.features?.unit_color}
+                    isConfirmed={!buttonEvent && !deviceIsWaitingForConfirmationToConnectToHost}
                 />
             )}
             <Modal.ModalBase

--- a/packages/suite/src/components/suite/PrerequisitesGuide/BannerAndTroubleshooting.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/BannerAndTroubleshooting.tsx
@@ -30,7 +30,6 @@ const getComponent = (prerequisite: PrerequisiteType | null) => {
         case 'device-disconnected':
             return <DeviceConnect />;
         case 'device-unacquired':
-        case 'device-busy':
             return <DeviceAcquire />;
         case 'device-thp-locked':
             return <DeviceTrezorHostProtocolPair />;

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
@@ -15,6 +15,7 @@ import messages from 'src/support/messages';
 import { TrezorDevice } from 'src/types/suite';
 
 interface ConfirmActionProps {
+    cancelable?: boolean;
     device: TrezorDevice;
     title?: TranslationKey;
     onCancel?: () => void;
@@ -25,10 +26,14 @@ export const ConfirmActionModal = ({
     title,
     device,
     onCancel,
+    cancelable = true,
     enableBackdropClick = true,
 }: ConfirmActionProps) => {
     const intl = useIntl();
     const handleCancel = () => {
+        if (!cancelable) {
+            return;
+        }
         TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
         onCancel?.();
     };
@@ -43,7 +48,7 @@ export const ConfirmActionModal = ({
                 title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
                 deviceModelInternal={getDeviceInternalModel(device)}
                 deviceUnitColor={getDeviceColorVariant(device)}
-                onCancel={handleCancel}
+                onCancel={cancelable ? handleCancel : undefined}
             />
             <Modal.ModalBase size="tiny">
                 <Column alignItems="center" gap={16}>

--- a/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
+++ b/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
@@ -141,13 +141,17 @@ export const useFirmwareInstallation = (
     // To instruct user to reboot to bootloader manually, UI.FIRMWARE_DISCONNECT event is emitted first,
     // and UI.FIRMWARE_RECONNECT is emitted after the device disconnects.
     const showManualReconnectPrompt = reconnectEvent?.method === 'manual';
+    const deviceIsWaitingForConfirmationToConnectToHost =
+        reconnectEvent?.method === 'auto' && reconnectEvent.target === 'bootloader';
 
     const showReconnectPrompt =
         shouldShowReconnectPrompt({
             buttonEvent,
             firmwareStatus: firmware.status,
             originalDevice,
-        }) || showManualReconnectPrompt;
+        }) ||
+        showManualReconnectPrompt ||
+        deviceIsWaitingForConfirmationToConnectToHost;
 
     const deviceWillBeWiped = determineIfDeviceWillBeWiped(
         originalDevice,
@@ -255,5 +259,6 @@ export const useFirmwareInstallation = (
         reconnectEvent,
         buttonEvent,
         progressEvent,
+        deviceIsWaitingForConfirmationToConnectToHost,
     };
 };


### PR DESCRIPTION
WIP from @szymonlesisz to be completed.

Resolve https://github.com/trezor/trezor-suite/issues/20942


## What's done here
- added device-busy state to the "Connect" initial screen - displays hint that device may be in bootloader mode and requests restart
- added Hint to the "device selector banner"  that also displays hint to restart the device when busy
- adds a modal to the update process in onboarding that pops up when you need to click "Connect to host"
- same modal to the update when done through settings

## What this does
Adds the modal to when the device says during FW update `Connect to host` this pops a modal that prompts user to focus on the device.

## Questions
- is the copy correct?
- shoudn't the modals be more specific and tell the user what exactly he should click in what state the device is?

## TODO:
- is the hack around modal in onboarding okayish?
- update the modals texts?

cc @komret 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/device-busy-view&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/device-busy-view&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/device-busy-view&lookback=7)