### PR TITLE
Fix/thp sync after send

### DIFF
--- a/packages/connect/e2e/tests/device/thpPairing.test.ts
+++ b/packages/connect/e2e/tests/device/thpPairing.test.ts
@@ -169,4 +169,103 @@ describe('THP pairing', () => {
         });
         expect(address).toMatchObject({ success: true });
     });
+
+    it('ThpPairing cancelled', async () => {
+        const device = await waitForDevice({
+            pairingMethods: ['CodeEntry'],
+            knownCredentials: [],
+        });
+
+        const ERR = new Error('Unexpected success');
+        let result;
+
+        // 1. reject pairing tag request from host
+        TrezorConnect.on('ui-request_thp_pairing', () => {
+            TrezorConnect.cancel('Custom cancel');
+        });
+        result = await TrezorConnect.getFeatures({ device });
+        if (result.success) throw ERR;
+        expect(result.payload.error).toMatch('Custom cancel');
+
+        // 2. reject pairing tag request from Trezor
+        TrezorConnect.removeAllListeners('ui-request_thp_pairing');
+        TrezorConnect.on('ui-request_thp_pairing', () => {
+            controller.send({ type: 'emulator-press-no' });
+        });
+        result = await TrezorConnect.getFeatures({ device });
+        if (result.success) throw ERR;
+        expect(result.payload.error).toMatch('Cancelled');
+
+        // 3. reject pairing confirmation from Trezor
+        TrezorConnect.removeAllListeners('ui-button');
+        TrezorConnect.on('ui-button', () => {
+            controller.send({ type: 'emulator-press-no' });
+        });
+        result = await TrezorConnect.getFeatures({ device });
+        if (result.success) throw ERR;
+        expect(result.payload.error).toMatch('Cancelled');
+
+        // 3. reject pairing confirmation from host
+        TrezorConnect.removeAllListeners('ui-button');
+        TrezorConnect.on('ui-button', () => {
+            TrezorConnect.cancel('Custom canceled');
+        });
+        result = await TrezorConnect.getFeatures({ device });
+        if (result.success) throw ERR;
+        expect(result.payload.error).toMatch('Custom canceled');
+
+        // check if pairing is still responsive
+        TrezorConnect.removeAllListeners('ui-button');
+        TrezorConnect.removeAllListeners('ui-request_thp_pairing');
+        TrezorConnect.on('ui-button', () => {
+            controller.send({ type: 'emulator-press-yes' });
+        });
+        TrezorConnect.on('ui-request_thp_pairing', async ({ nfcData, ...rest }) => {
+            const state = await controller.getPairingInfo(rest.device.thp!.channel, nfcData);
+            TrezorConnect.uiResponse({
+                type: 'ui-receive_thp_pairing_tag',
+                payload: { source: 'code-entry', tag: state.code_entry_code },
+            });
+        });
+        result = await TrezorConnect.getFeatures({ device });
+        expect(result).toMatchObject({ success: true });
+
+        // 4. reject ButtonRequest from host
+        TrezorConnect.removeAllListeners('ui-button');
+        TrezorConnect.on('ui-button', () => {
+            TrezorConnect.cancel('Custom canceled');
+        });
+        result = await TrezorConnect.getAddress({
+            device,
+            path: "m/44'/0'/0'/1/1",
+            showOnTrezor: true,
+        });
+        if (result.success) throw ERR;
+        expect(result.payload.error).toMatch('Custom canceled');
+
+        // 4. reject ButtonRequest from Trezor
+        TrezorConnect.removeAllListeners('ui-button');
+        TrezorConnect.on('ui-button', () => {
+            controller.send({ type: 'emulator-press-no' });
+        });
+        result = await TrezorConnect.getAddress({
+            device,
+            path: "m/44'/0'/0'/1/1",
+            showOnTrezor: true,
+        });
+        if (result.success) throw ERR;
+        expect(result.payload.error).toMatch('Cancelled');
+
+        // and finally check if device is still responsive
+        TrezorConnect.removeAllListeners('ui-button');
+        TrezorConnect.on('ui-button', () => {
+            controller.send({ type: 'emulator-press-yes' });
+        });
+        result = await TrezorConnect.getAddress({
+            device,
+            path: "m/44'/0'/0'/1/1",
+            showOnTrezor: true,
+        });
+        expect(result).toMatchObject({ success: true });
+    });
 });

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -439,7 +439,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     async interrupt(reason: Error) {
-        await abortThpWorkflow(this);
+        await abortThpWorkflow(this, () => this.runAbort?.abort(reason));
         await this.currentSession?.abort(reason);
 
         // reject inner defer

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -206,14 +206,9 @@ export class DeviceCurrentSession implements TypedCallProvider {
                         // ignore whatever happens
                     }
                 } else {
+                    // transport is currently in "call-read" state, update sync bit
                     this.device.getThpState()?.sync('send', 'Cancel');
-                    await this.transport.send({
-                        name: 'Cancel',
-                        data: {},
-                        session: this.session,
-                        protocol: this.device.protocol,
-                        thpState: this.device.getThpState(),
-                    });
+                    await this.send('Cancel', {});
                 }
             }
 

--- a/packages/connect/src/device/thp/thpCall.ts
+++ b/packages/connect/src/device/thp/thpCall.ts
@@ -86,7 +86,7 @@ export const thpCall = async <T extends MessageKey>(
     return result.payload as ThpCallResponse[T];
 };
 
-export const abortThpWorkflow = async (device: Device) => {
+export const abortThpWorkflow = async (device: Device, abort?: () => any) => {
     const thpState = device.getThpState();
     if (!thpState || !device.currentRun) {
         return Promise.resolve(); // not a THP device
@@ -104,6 +104,10 @@ export const abortThpWorkflow = async (device: Device) => {
     } else if (thpState.cancelablePromise) {
         thpState.sync('send', 'Cancel');
         await device.getCurrentSession().send('Cancel', {});
+        // abort current run and wait for the result
+        if (abort) {
+            abort();
+        }
         await device.currentRun;
     }
 };

--- a/packages/protocol/src/protocol-thp/decode.ts
+++ b/packages/protocol/src/protocol-thp/decode.ts
@@ -198,8 +198,6 @@ export const decodeSendAck = (decodedMessage: MessageV2) => {
     if (magic === THP_READ_ACK_HEADER_BYTE) {
         return decodeReadAck();
     }
-
-    throw new Error('Unexpected send response: ' + magic);
 };
 
 // Decode protocol-v2 message from thp receive process

--- a/packages/protocol/tests/protocol-thp/protocol-thp.test.ts
+++ b/packages/protocol/tests/protocol-thp/protocol-thp.test.ts
@@ -96,15 +96,14 @@ describe('protocol-thp', () => {
     });
 
     it('decodeSendAck', () => {
-        const thpError2 = decodeSendAck(decodeV2(Buffer.from('42122200050270303cfa', 'hex')));
-        expect(thpError2.type).toBe('ThpError');
+        const thpError = decodeSendAck(decodeV2(Buffer.from('42122200050270303cfa', 'hex')));
+        expect(thpError?.type).toBe('ThpError');
 
         const ack = decodeSendAck(decodeV2(Buffer.from('2812340004e98c8599', 'hex')));
-        expect(ack.type).toBe('ThpAck');
+        expect(ack?.type).toBe('ThpAck');
 
-        expect(() => decodeSendAck(decodeV2(Buffer.from('40ffff0004f9215951', 'hex')))).toThrow(
-            'Unexpected send response',
-        );
+        const unexpected = decodeSendAck(decodeV2(Buffer.from('40ffff0004f9215951', 'hex')));
+        expect(unexpected).toBe(undefined);
 
         expect(() => decodeSendAck(decodeV2(Buffer.from('40ffff000499999999', 'hex')))).toThrow(
             'Invalid CRC',

--- a/packages/transport/src/thp/send.ts
+++ b/packages/transport/src/thp/send.ts
@@ -94,7 +94,7 @@ export const sendThpMessage = async ({
         // parse and check the result
         const decodedResult = protocolThp.decodeSendAck(protocolV2.decode(result.payload));
         // fail on ThpError
-        if (decodedResult.type === 'ThpError') {
+        if (decodedResult?.type === 'ThpError') {
             const { code, message } = decodedResult.message;
 
             return error({ error: code, message });

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -320,6 +320,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                         signal,
                         logger: this.logger,
                     });
+                    thpState?.sync('send', name);
                 } else {
                     sendResult = await sendChunks(chunks, apiWrite);
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. ThpState was unsynchronized after Cancelling ButtonRequest, its because of missing line (probably during rebases)   `thpState?.sync('send', name);` in `AbstractApiTransport` for the reference the same line is present in `BridgeTransport`. while doint the tests i also noticed that `abortThpWorkflow` didnt reject/abort pending `device.currentRun` promise and hungs forever.

2. remove error from `decodeSendAck` - function which reads ThpAck after send, related to https://github.com/trezor/trezor-firmware/pull/5578#issuecomment-3208001837 (FW will also ignore unexpected messages)

3. complex tests of ThpState lifecycle when Cancel is called

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-sync-after-send&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-sync-after-send&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/thp-sync-after-send&lookback=7)