### PR TITLE
chore: start using selectedDevice by reference

### DIFF
--- a/packages/suite/src/actions/backup/__tests__/backupActions.test.ts
+++ b/packages/suite/src/actions/backup/__tests__/backupActions.test.ts
@@ -11,7 +11,7 @@ import { BACKUP } from 'src/actions/backup/constants';
 import { SUITE } from 'src/actions/suite/constants';
 import { configureStore } from 'src/support/tests/configureStore';
 
-const getInitialState = (override: any) => {
+const getInitialState = (override: any = {}) => {
     const defaults = {
         suite: {
             locks: [3],
@@ -19,15 +19,19 @@ const getInitialState = (override: any) => {
         },
         // doesnt affect anything, just needed for TrezorConnect.init action
         device: {
-            selectedDevice: {
-                connected: true,
-                type: 'acquired',
-                features: {
-                    major_version: 2,
-                    internal_model: DeviceModelInternal.T2T1,
+            selectedDevice: 'device_id',
+            devices: [
+                {
+                    id: 'device_id',
+                    connected: true,
+                    type: 'acquired',
+                    features: {
+                        device_id: 'device_id',
+                        major_version: 2,
+                        internal_model: DeviceModelInternal.T2T1,
+                    },
                 },
-            },
-            devices: [],
+            ],
         },
         wallet: {
             settings: {
@@ -57,7 +61,7 @@ describe('Backup Actions', () => {
     it('backup success', async () => {
         testMocks.setTrezorConnectFixtures({ success: true });
 
-        const state = getInitialState({});
+        const state = getInitialState();
         const store = mockStore(state);
         await store.dispatch(connectInitThunk());
 

--- a/packages/suite/src/actions/firmware/__fixtures__/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/__fixtures__/firmwareActions.ts
@@ -5,10 +5,15 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 
 const { getSuiteDevice, getFirmwareReleaseConfigInfo } = testMocks;
 
-const bootloaderDevice = getSuiteDevice({ mode: 'bootloader', connected: true });
+const deviceId = 'device_id';
+const bootloaderDevice = getSuiteDevice(
+    { mode: 'bootloader', connected: true },
+    { device_id: deviceId },
+);
 const bootloaderDeviceNeedsIntermediary = {
     ...getSuiteDevice(
         {
+            path: 'a',
             mode: 'bootloader',
             connected: true,
             firmwareReleaseConfigInfo: {
@@ -22,12 +27,13 @@ const bootloaderDeviceNeedsIntermediary = {
                 },
             },
         },
-        { major_version: 1, internal_model: DeviceModelInternal.T1B1 },
+        { major_version: 1, internal_model: DeviceModelInternal.T1B1, device_id: deviceId },
     ),
 };
 const bootloaderDeviceNoIntermediaryT1 = {
     ...getSuiteDevice(
         {
+            path: 'a',
             mode: 'bootloader',
             connected: true,
             firmwareReleaseConfigInfo: {
@@ -43,7 +49,7 @@ const firmwareUpdateResponsePayload = {
     versionCheck: true,
 };
 
-export const actions = [
+export const fixtures = [
     {
         description: 'Success T2T1',
         action: () => firmwareUpdate({ firmwareType: FirmwareType.Universal }),
@@ -56,7 +62,7 @@ export const actions = [
         initialState: {
             device: {
                 devices: [bootloaderDevice],
-                selectedDevice: bootloaderDevice,
+                selectedDevice: deviceId,
             },
             suite: {},
         },
@@ -82,7 +88,7 @@ export const actions = [
         initialState: {
             device: {
                 devices: [bootloaderDevice],
-                selectedDevice: bootloaderDevice,
+                selectedDevice: deviceId,
             },
             suite: {},
         },
@@ -107,7 +113,7 @@ export const actions = [
         },
         initialState: {
             device: {
-                selectedDevice: bootloaderDeviceNeedsIntermediary,
+                selectedDevice: bootloaderDeviceNeedsIntermediary.path,
                 devices: [bootloaderDeviceNeedsIntermediary],
             },
             suite: {},
@@ -136,7 +142,7 @@ export const actions = [
         },
         initialState: {
             device: {
-                selectedDevice: bootloaderDeviceNoIntermediaryT1,
+                selectedDevice: bootloaderDeviceNoIntermediaryT1.path,
                 devices: [bootloaderDeviceNoIntermediaryT1],
             },
             suite: {},
@@ -172,7 +178,7 @@ export const actions = [
         action: () => firmwareUpdate({ firmwareType: FirmwareType.Universal }),
         initialState: {
             device: {
-                selectedDevice: bootloaderDevice,
+                selectedDevice: deviceId,
                 devices: [bootloaderDevice],
             },
             suite: {},
@@ -209,7 +215,7 @@ export const actions = [
         action: () => firmwareUpdate({ firmwareType: FirmwareType.Universal }),
         initialState: {
             device: {
-                selectedDevice: bootloaderDevice,
+                selectedDevice: deviceId,
                 devices: [bootloaderDevice],
             },
             suite: {},

--- a/packages/suite/src/actions/firmware/__tests__/firmwareActions.test.ts
+++ b/packages/suite/src/actions/firmware/__tests__/firmwareActions.test.ts
@@ -1,13 +1,12 @@
 import { prepareFirmwareReducer } from '@suite-common/firmware';
 import { testMocks } from '@suite-common/test-utils';
 import { DeviceReducerState } from '@suite-common/wallet-core';
-import { DeviceModelInternal } from '@trezor/device-utils';
 
 import suiteReducer from 'src/reducers/suite/suiteReducer';
 import { extraDependencies } from 'src/support/extraDependencies';
 import { configureStore, filterThunkActionTypes } from 'src/support/tests/configureStore';
 
-import { actions, reducerActions } from '../__fixtures__/firmwareActions';
+import { fixtures, reducerActions } from '../__fixtures__/firmwareActions';
 
 const firmwareReducer = prepareFirmwareReducer(extraDependencies);
 
@@ -36,14 +35,8 @@ const getInitialState = (override?: InitialState): any => {
         },
         firmware: firmwareReducer(undefined, { type: 'foo' } as any),
         device: {
-            selectedDevice: {
-                connected: true,
-                type: 'acquired',
-                features: {
-                    major_version: 2,
-                    internal_model: DeviceModelInternal.T2T1,
-                },
-            },
+            selectedDevice: device?.devices?.[0]?.features?.device_id,
+            devices: [],
             ...device,
         },
         analytics: {
@@ -77,7 +70,7 @@ describe('Firmware Actions', () => {
         jest.clearAllMocks();
     });
 
-    actions.forEach(f => {
+    fixtures.forEach(f => {
         it(f.description, async () => {
             // set fixtures
             testMocks.setTrezorConnectFixtures(f.mocks?.connect);

--- a/packages/suite/src/actions/onboarding/__tests__/onboardingActions.test.ts
+++ b/packages/suite/src/actions/onboarding/__tests__/onboardingActions.test.ts
@@ -34,7 +34,10 @@ const getInitialState = (custom?: any) => {
             ...suiteReducer(undefined, {} as Action),
             ...suite,
         },
-        device: {},
+        device: {
+            devices: [],
+            selectedDevice: undefined,
+        },
     };
 };
 

--- a/packages/suite/src/actions/recovery/__tests__/recoveryActions.test.ts
+++ b/packages/suite/src/actions/recovery/__tests__/recoveryActions.test.ts
@@ -5,18 +5,23 @@ import recoveryReducer from 'src/reducers/recovery/recoveryReducer';
 import { configureStore } from 'src/support/tests/configureStore';
 import { Action } from 'src/types/suite';
 
+const device = {
+    state: {
+        staticSessionId: 'static-session-id',
+    },
+    features: {
+        major_version: 2,
+        internal_model: DeviceModelInternal.T2T1,
+    },
+};
 const getInitialState = (custom?: any): any => ({
     suite: {
         flags: {},
         locks: [],
     },
     device: {
-        selectedDevice: {
-            features: {
-                major_version: 2,
-                internal_model: DeviceModelInternal.T2T1,
-            },
-        },
+        selectedDevice: device.state.staticSessionId,
+        devices: [device],
     },
     recovery: {
         ...recoveryReducer(undefined, {} as Action),

--- a/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
+++ b/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
@@ -63,18 +63,6 @@ const fixture: Feature[] = [
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,
                 {
-                    type: deviceActions.forgetDevice.type,
-                    payload: {
-                        device: {
-                            ...deviceChange,
-                            id: 'new-device-id',
-                            connected: true,
-                            available: true,
-                            features: { ...deviceChange.features, device_id: 'new-device-id' },
-                        },
-                    },
-                } satisfies ReturnType<typeof deviceActions.forgetDevice>,
-                {
                     type: notificationsActions.addToast.type,
                     payload: { type: 'device-wiped', context: 'toast', id: expect.any(Number) },
                 } satisfies ReturnType<typeof notificationsActions.addToast>,
@@ -163,46 +151,6 @@ const fixture: Feature[] = [
                             state: { staticSessionId: '1stTestnetAddress@device_2_id:0' },
                             features: { ...deviceChange.features, device_id: 'device-id' },
                             useEmptyPassphrase: true,
-                        },
-                    },
-                } satisfies ReturnType<typeof deviceActions.forgetDevice>,
-                {
-                    type: deviceActions.forgetDevice.type,
-                    payload: {
-                        device: {
-                            ...deviceChange,
-                            id: 'new-device-id',
-                            connected: true,
-                            available: true,
-                            features: { ...deviceChange.features, device_id: 'new-device-id' },
-                        },
-                    },
-                } satisfies ReturnType<typeof deviceActions.forgetDevice>,
-                {
-                    type: deviceActions.forgetDevice.type,
-                    payload: {
-                        device: {
-                            ...deviceChange,
-                            id: 'new-device-id',
-                            connected: true,
-                            available: true,
-                            instance: 1,
-                            state: { staticSessionId: '1stTestnetAddress@device_1_id:0' },
-                            features: { ...deviceChange.features, device_id: 'new-device-id' },
-                        },
-                    },
-                } satisfies ReturnType<typeof deviceActions.forgetDevice>,
-                {
-                    type: deviceActions.forgetDevice.type,
-                    payload: {
-                        device: {
-                            ...deviceChange,
-                            id: 'new-device-id',
-                            connected: true,
-                            available: true,
-                            instance: 2,
-                            state: { staticSessionId: '1stTestnetAddress@device_2_id:0' },
-                            features: { ...deviceChange.features, device_id: 'new-device-id' },
                         },
                     },
                 } satisfies ReturnType<typeof deviceActions.forgetDevice>,

--- a/packages/suite/src/actions/settings/__tests__/deviceSettingsActions.test.ts
+++ b/packages/suite/src/actions/settings/__tests__/deviceSettingsActions.test.ts
@@ -22,7 +22,7 @@ const getInitialState = (state: Partial<DeviceSettingsFixtureState> = {}) => ({
     },
     device: {
         devices: state.device?.devices ?? [DEVICE],
-        selectedDevice: DEVICE,
+        selectedDevice: DEVICE.id!,
         isDeviceAutoEjectEnabled: false,
     },
     router: {},

--- a/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
@@ -644,7 +644,7 @@ const disposeMetadataKeys: Fixture<(typeof metadataActions)['disposeMetadataKeys
         description: 'keys',
         initialState: {
             device: {
-                state: '1stTestnetAddress@device_id:0',
+                state: { staticSessionId: '1stTestnetAddress@device_id:0' },
                 metadata: { 1: { fileName: 'foo', aesKey: 'bar' } },
             },
             accounts: [
@@ -662,7 +662,9 @@ const disposeMetadataKeys: Fixture<(typeof metadataActions)['disposeMetadataKeys
         },
         params: [] as const,
         result: {
-            device: { selectedDevice: { state: '1stTestnetAddress@device_id:0', metadata: {} } },
+            device: {
+                selectedDevice: '1stTestnetAddress@device_id:0',
+            },
             wallet: {
                 accounts: [
                     {

--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -1,7 +1,7 @@
 import { testMocks } from '@suite-common/test-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { deviceActions } from '@suite-common/wallet-core';
-import { DEVICE, Device, TRANSPORT } from '@trezor/connect';
+import { Device, TRANSPORT } from '@trezor/connect';
 
 import { SUITE } from 'src/actions/suite/constants';
 import { AppState, TorStatus } from 'src/types/suite';
@@ -326,7 +326,7 @@ const handleDeviceConnect: DeviceConnectFixture[] = [
     {
         description: `selects a newly connected physical device corresponding to selected remembered wallet `,
         state: {
-            device: { selectedDevice: SUITE_DEVICE },
+            device: { selectedDevice: SUITE_DEVICE.path, devices: [SUITE_DEVICE] },
             suite: {},
         },
         device: CONNECT_DEVICE,
@@ -335,7 +335,7 @@ const handleDeviceConnect: DeviceConnectFixture[] = [
     {
         description: `opens the wallet switcher when newly connected physical not seen before`,
         state: {
-            device: { selectedDevice: SUITE_DEVICE },
+            device: { selectedDevice: SUITE_DEVICE.path, devices: [SUITE_DEVICE] },
             suite: {},
         },
         device: { ...CONNECT_DEVICE, id: 'a-different-id' } as Device,
@@ -346,14 +346,19 @@ const handleDeviceConnect: DeviceConnectFixture[] = [
 const handleDeviceDisconnect = [
     {
         description: `no selected device in reducer`,
-        state: {},
+        state: {
+            device: {
+                devices: [],
+                selectedDevice: undefined,
+            },
+        },
         device: CONNECT_DEVICE,
     },
     {
         description: `disconnect not selected device`,
         state: {
             suite: {},
-            device: { selectedDevice: SUITE_DEVICE },
+            device: { selectedDevice: SUITE_DEVICE.path, devices: [SUITE_DEVICE] },
         },
         device: getConnectDevice({
             path: '2',
@@ -364,12 +369,13 @@ const handleDeviceDisconnect = [
         state: {
             suite: {},
             device: {
-                selectedDevice: SUITE_DEVICE,
+                selectedDevice: SUITE_DEVICE.path,
                 devices: [SUITE_DEVICE],
             },
         },
         device: CONNECT_DEVICE,
         result: {
+            type: undefined,
             payload: undefined,
         },
     },
@@ -378,7 +384,7 @@ const handleDeviceDisconnect = [
         state: {
             suite: {},
             device: {
-                selectedDevice: SUITE_DEVICE,
+                selectedDevice: '1stTestnetAddress@device_b_id:0',
                 devices: [
                     getSuiteDevice({
                         path: '1',
@@ -389,46 +395,13 @@ const handleDeviceDisconnect = [
             },
         },
         device: CONNECT_DEVICE,
-    },
-    {
-        description: `disconnected selected device (3 instances: 2 remembered, 1 stateless which will be removed, no action)`,
-        state: {
-            suite: {},
-            device: {
-                selectedDevice: SUITE_DEVICE,
-                devices: [
-                    SUITE_DEVICE,
-                    getSuiteDevice({
-                        path: '1',
-                        state: '1stTestnetAddress@device_a_id:0',
-                        instance: 2,
-                        remember: true,
-                    }),
-                    getSuiteDevice({
-                        path: '1',
-                        state: '1stTestnetAddress@device_b_id:0',
-                        instance: 1,
-                        remember: true,
-                    }),
-                ],
-            },
-        },
-        device: CONNECT_DEVICE,
-        result: {
-            type: deviceActions.selectDevice.type,
-            payload: getSuiteDevice({
-                state: '1stTestnetAddress@device_b_id:0',
-                instance: 1,
-                remember: true,
-            }),
-        },
     },
     {
         description: `switch to first unacquired device`,
         state: {
             suite: {},
             device: {
-                selectedDevice: SUITE_DEVICE,
+                selectedDevice: SUITE_DEVICE.path,
                 devices: [
                     SUITE_DEVICE,
                     getSuiteDevice({
@@ -458,12 +431,13 @@ const handleDeviceDisconnect = [
             }),
         },
     },
+
     {
         description: `switch to first connected device`,
         state: {
             suite: {},
             device: {
-                selectedDevice: SUITE_DEVICE,
+                selectedDevice: SUITE_DEVICE.path,
                 devices: [
                     getSuiteDevice(
                         {
@@ -510,12 +484,13 @@ const handleDeviceDisconnect = [
             ),
         },
     },
+
     {
         description: `switch to recently used device`,
         state: {
             suite: {},
             device: {
-                selectedDevice: SUITE_DEVICE,
+                selectedDevice: SUITE_DEVICE.path,
                 devices: [
                     getSuiteDevice(
                         {
@@ -568,7 +543,7 @@ const forgetDisconnectedDevices = [
         state: {
             suite: {},
             device: {
-                selectedDevice: SUITE_DEVICE_UNACQUIRED,
+                selectedDevice: SUITE_DEVICE_UNACQUIRED.path,
                 devices: [SUITE_DEVICE_UNACQUIRED],
             },
         },
@@ -582,7 +557,7 @@ const forgetDisconnectedDevices = [
         state: {
             suite: {},
             device: {
-                selectedDevice: SUITE_DEVICE,
+                selectedDevice: SUITE_DEVICE.path,
                 devices: [
                     SUITE_DEVICE,
                     getSuiteDevice({
@@ -603,7 +578,7 @@ const forgetDisconnectedDevices = [
         state: {
             suite: {},
             device: {
-                selectedDevice: SUITE_DEVICE,
+                selectedDevice: SUITE_DEVICE.path,
                 devices: [
                     SUITE_DEVICE,
                     getSuiteDevice({
@@ -634,7 +609,7 @@ const forgetDisconnectedDevices = [
         state: {
             suite: {},
             device: {
-                selectedDevice: SUITE_DEVICE,
+                selectedDevice: SUITE_DEVICE.path,
                 devices: [
                     getSuiteDevice({
                         path: '1',
@@ -650,78 +625,13 @@ const forgetDisconnectedDevices = [
     },
 ];
 
-const observeSelectedDevice = [
-    {
-        description: `ignored action`,
-        state: {},
-        action: {
-            type: 'foo',
-        },
-        changed: false,
-    },
-    {
-        description: `no selected device in reducer`,
-        state: {},
-        action: {
-            type: DEVICE.CONNECT,
-        },
-        changed: false,
-    },
-    {
-        description: `device not changed`,
-        action: {
-            type: DEVICE.CONNECT,
-        },
-        state: {
-            suite: {},
-            device: {
-                selectedDevice: SUITE_DEVICE,
-                devices: [SUITE_DEVICE],
-            },
-        },
-        changed: false,
-    },
-    {
-        description: `device is changed`,
-        action: {
-            type: DEVICE.CONNECT,
-        },
-        state: {
-            suite: {},
-            device: {
-                selectedDevice: SUITE_DEVICE,
-                devices: [
-                    getSuiteDevice({
-                        connected: true,
-                    }),
-                ],
-            },
-        },
-        result: deviceActions.updateSelectedDevice.type,
-        changed: true,
-    },
-    {
-        description: `device is changed (missing in reducer)`,
-        action: {
-            type: DEVICE.CONNECT,
-        },
-        state: {
-            suite: {},
-            device: {
-                selectedDevice: SUITE_DEVICE,
-                devices: [],
-            },
-        },
-        changed: true,
-    },
-];
-
 const acquireDevice = [
     {
         description: `success`,
         state: {
             device: {
-                selectedDevice: SUITE_DEVICE,
+                devices: [SUITE_DEVICE],
+                selectedDevice: SUITE_DEVICE.path,
             },
         },
         result: '@suite/device/removeButtonRequests',
@@ -738,7 +648,8 @@ const acquireDevice = [
         description: `with TrezorConnect error`,
         state: {
             device: {
-                selectedDevice: SUITE_DEVICE,
+                selectedDevice: SUITE_DEVICE.path,
+                devices: [SUITE_DEVICE],
             },
         },
         getFeatures: {
@@ -762,6 +673,5 @@ export default {
     handleDeviceConnect,
     handleDeviceDisconnect,
     forgetDisconnectedDevices,
-    observeSelectedDevice,
     acquireDevice,
 };

--- a/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
@@ -66,7 +66,8 @@ const getInitialState = (state?: InitialState) => {
         metadata: metadataReducer(metadata, initAction),
         device: {
             devices: device ? [device] : [],
-            selectedDevice: device,
+            selectedDevice:
+                device?.state?.staticSessionId || device?.features?.device_id || device?.path,
             isDeviceAutoEjectEnabled: false,
         },
         suite: {

--- a/packages/suite/src/actions/suite/__tests__/protocolActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/protocolActions.test.ts
@@ -15,7 +15,8 @@ const getInitialState = (state?: ProtocolState) => ({
         ...state,
     },
     device: {
-        device: undefined,
+        devices: [],
+        selectedDevice: undefined,
     },
 });
 

--- a/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
@@ -8,7 +8,6 @@ import {
     deviceActions,
     forgetDisconnectedDevices,
     handleDeviceDisconnect,
-    observeSelectedDevice,
     prepareDeviceReducer,
     selectDeviceThunk,
 } from '@suite-common/wallet-core';
@@ -188,21 +187,6 @@ describe('Suite Actions', () => {
             actions.forEach((a, i) => {
                 expect(a.payload.device).toMatchObject(f.result[i]);
             });
-        });
-    });
-
-    fixtures.observeSelectedDevice.forEach(f => {
-        it(`observeSelectedDevice: ${f.description}`, () => {
-            const state = getInitialState(f.state.suite, f.state.device);
-            const store = initStore(state);
-            const changed = store.dispatch(observeSelectedDevice());
-            expect(changed).toEqual(f.changed);
-            if (!f.result) {
-                expect(filterThunkActionTypes(store.getActions()).length).toEqual(0);
-            } else {
-                const action = filterThunkActionTypes(store.getActions()).pop();
-                expect(action?.type).toEqual(f.result);
-            }
         });
     });
 

--- a/packages/suite/src/actions/wallet/__fixtures__/publicKeyActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/publicKeyActions.ts
@@ -87,8 +87,8 @@ export default [
         description: 'Show public key, device not connected',
         initialState: {
             device: {
-                selectedDevice: getSuiteDevice({ connected: false }),
-                devices: [],
+                selectedDevice: 'a',
+                devices: [getSuiteDevice({ connected: false, id: 'a' }, { device_id: 'a' })],
             },
         },
         mocks: {},

--- a/packages/suite/src/actions/wallet/__fixtures__/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/receiveActions.ts
@@ -157,7 +157,10 @@ export default [
                 settings: { debug: {} },
             },
             device: {
-                selectedDevice: testMocks.getSuiteDevice({ connected: false }),
+                selectedDevice: testMocks.getSuiteDevice({ connected: false }, { device_id: 'a' })
+                    .features?.device_id,
+
+                devices: [testMocks.getSuiteDevice({ connected: false }, { device_id: 'a' })],
             },
         },
         mocks: {},

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
@@ -35,7 +35,10 @@ const rootReducer = combineReducers({
         () => ({}),
     ),
     messageSystem: prepareMessageSystemReducer(extraDependencies),
-    device: createReducer({ devices: [DEVICE], selectedDevice: DEVICE }, () => ({})),
+    device: createReducer(
+        { devices: [DEVICE], selectedDevice: DEVICE.state?.staticSessionId },
+        () => ({}),
+    ),
     modal: () => ({}),
     wallet: combineReducers({
         coinjoin: coinjoinReducer,

--- a/packages/suite/src/actions/wallet/__tests__/publicKeyActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/publicKeyActions.test.ts
@@ -49,7 +49,7 @@ const device = testMocks.getSuiteDevice({
 });
 
 const rootReducer = combineReducers({
-    device: createReducer({ devices: [device], selectedDevice: device }, () => {}),
+    device: createReducer({ devices: [device], selectedDevice: device.id }, () => {}),
     wallet: combineReducers({
         selectedAccount: createReducer(
             {

--- a/packages/suite/src/actions/wallet/__tests__/receiveActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/receiveActions.test.ts
@@ -87,6 +87,11 @@ interface InitialState {
     modal: ModalState;
 }
 
+const device = getSuiteDevice(
+    { id: 'a', available: true, connected: true, state: 'b@c:0' },
+    { device_id: 'a' },
+);
+
 const getInitialState = (state: Partial<InitialState> | undefined) => ({
     suite: {
         ...suiteReducer(undefined, { type: 'foo' } as any),
@@ -112,7 +117,8 @@ const getInitialState = (state: Partial<InitialState> | undefined) => ({
     },
     device: {
         ...deviceReducer(undefined, { type: 'foo' } as any),
-        selectedDevice: getSuiteDevice({ available: true, connected: true }),
+        selectedDevice: device.state?.staticSessionId,
+        devices: [device],
         ...state?.device,
     },
     messageSystem: messageSystemInitialState,

--- a/packages/suite/src/actions/wallet/__tests__/signVerifyActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/signVerifyActions.test.ts
@@ -10,13 +10,18 @@ const SIGNATURE = 'SIGNATURE';
 
 const { getSuiteDevice } = testMocks;
 
+const device = getSuiteDevice({ connected: true, available: true, state: 'a@b:0' });
+
 describe('Sign/Verify actions', () => {
     let store: any;
 
     beforeEach(() => {
         store = configureStore()({
             wallet: { selectedAccount: { account: { symbol: 'btc', networkType: 'bitcoin' } } },
-            device: { selectedDevice: getSuiteDevice({ connected: true, available: true }) },
+            device: {
+                selectedDevice: device.state!.staticSessionId!,
+                devices: [device],
+            },
             suite: { settings: { addressDisplayType: 'chunked' } },
         });
     });

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -197,10 +197,14 @@ describe(`${Preloader.name} component`, () => {
 
     it('Unacquired device', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                transportSessionOwner: 'foo',
-                type: 'unacquired',
-            },
+            devices: [
+                {
+                    transportSessionOwner: 'foo',
+                    type: 'unacquired',
+                    path: 'a',
+                },
+            ],
+            selectedDevice: 'a',
         };
 
         const store = initStore(
@@ -222,11 +226,15 @@ describe(`${Preloader.name} component`, () => {
 
     it('Unreadable device: webusb HID', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                type: 'unreadable',
-                error: 'unable to open device',
-                hid: true,
-            },
+            devices: [
+                {
+                    path: 'a',
+                    type: 'unreadable',
+                    error: 'unable to open device',
+                    hid: true,
+                },
+            ],
+            selectedDevice: 'a',
         };
 
         const store = initStore(
@@ -249,10 +257,14 @@ describe(`${Preloader.name} component`, () => {
         jest.spyOn(envUtils, 'isLinux').mockImplementation(() => true);
 
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                type: 'unreadable',
-                error: 'LIBUSB_ERROR_ACCESS',
-            },
+            devices: [
+                {
+                    path: 'a',
+                    type: 'unreadable',
+                    error: 'LIBUSB_ERROR_ACCESS',
+                },
+            ],
+            selectedDevice: 'a',
         };
 
         const store = initStore(
@@ -276,10 +288,14 @@ describe(`${Preloader.name} component`, () => {
         jest.spyOn(envUtils, 'isLinux').mockImplementation(() => false);
 
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                type: 'unreadable',
-                error: 'LIBUSB_ERROR_ACCESS',
-            },
+            devices: [
+                {
+                    type: 'unreadable',
+                    error: 'LIBUSB_ERROR_ACCESS',
+                    path: 'a',
+                },
+            ],
+            selectedDevice: 'a',
         };
 
         const store = initStore(
@@ -300,10 +316,14 @@ describe(`${Preloader.name} component`, () => {
 
     it('Unreadable device: unknown error', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                type: 'unreadable',
-                error: 'Unexpected error',
-            },
+            devices: [
+                {
+                    path: 'a',
+                    type: 'unreadable',
+                    error: 'Unexpected error',
+                },
+            ],
+            selectedDevice: 'a',
         };
 
         const store = initStore(
@@ -324,10 +344,14 @@ describe(`${Preloader.name} component`, () => {
 
     it('Unknown device (should never happen)', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                transportSessionOwner: 'foo',
-                features: undefined,
-            },
+            devices: [
+                {
+                    transportSessionOwner: 'foo',
+                    path: 'a',
+                    features: undefined,
+                },
+            ],
+            selectedDevice: 'a',
         };
 
         const store = initStore(
@@ -349,11 +373,15 @@ describe(`${Preloader.name} component`, () => {
 
     it('Seedless device', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                mode: 'seedless',
-                features: {},
-                authenticityChecks: {},
-            },
+            devices: [
+                {
+                    mode: 'seedless',
+                    features: {},
+                    authenticityChecks: {},
+                    path: 'a',
+                },
+            ],
+            selectedDevice: 'a',
         };
 
         const store = initStore(
@@ -376,10 +404,14 @@ describe(`${Preloader.name} component`, () => {
 
     it('Recovery mode device', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                features: { recovery_status: 'Recovery' },
-                authenticityChecks: {},
-            },
+            devices: [
+                {
+                    id: 'a',
+                    features: { device_id: 'a', recovery_status: 'Recovery' },
+                    authenticityChecks: {},
+                },
+            ],
+            selectedDevice: 'a',
         };
 
         const store = initStore(
@@ -401,11 +433,15 @@ describe(`${Preloader.name} component`, () => {
 
     it('Not initialized device', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                mode: 'initialize',
-                features: {},
-                authenticityChecks: {},
-            },
+            devices: [
+                {
+                    id: 'a',
+                    mode: 'initialize',
+                    features: { device_id: 'a' },
+                    authenticityChecks: {},
+                },
+            ],
+            selectedDevice: 'a',
         };
 
         const store = initStore(
@@ -427,11 +463,15 @@ describe(`${Preloader.name} component`, () => {
 
     it('Bootloader device with installed firmware', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                mode: 'bootloader',
-                features: { firmware_present: true },
-                authenticityChecks: {},
-            },
+            devices: [
+                {
+                    mode: 'bootloader',
+                    features: { firmware_present: true },
+                    authenticityChecks: {},
+                    path: 'a',
+                },
+            ],
+            selectedDevice: 'a',
         };
 
         const store = initStore(
@@ -453,11 +493,15 @@ describe(`${Preloader.name} component`, () => {
 
     it('Bootloader device without firmware', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                mode: 'bootloader',
-                features: { firmware_present: false },
-                authenticityChecks: {},
-            },
+            devices: [
+                {
+                    path: 'a',
+                    mode: 'bootloader',
+                    features: { firmware_present: false },
+                    authenticityChecks: {},
+                },
+            ],
+            selectedDevice: 'a',
         };
 
         const store = initStore(
@@ -495,11 +539,17 @@ describe(`${Preloader.name} component`, () => {
 
     it('Required FW update device', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                firmware: 'required',
-                features: {},
-                authenticityChecks: {},
-            },
+            devices: [
+                {
+                    firmware: 'required',
+                    id: 'a',
+                    authenticityChecks: {},
+                    features: {
+                        device_id: 'a',
+                    },
+                },
+            ],
+            selectedDevice: 'a',
         };
 
         const store = initStore(

--- a/packages/suite/src/components/suite/Preloader/__tests__/selectShouldDisplayDeviceCompromised.test.ts
+++ b/packages/suite/src/components/suite/Preloader/__tests__/selectShouldDisplayDeviceCompromised.test.ts
@@ -34,11 +34,16 @@ const fixtures: Fixture[] = [
             router: { route: { app: 'dashboard' } },
             messageSystem: messageSystemInitialState,
             device: {
-                selectedDevice: {
-                    features: {},
-                    id: 'deviceId',
-                    authenticityChecks: authenticityChecksSuccess,
-                },
+                devices: [
+                    {
+                        features: {
+                            device_id: 'deviceId',
+                        },
+                        id: 'deviceId',
+                        authenticityChecks: authenticityChecksSuccess,
+                    },
+                ],
+                selectedDevice: 'deviceId',
             },
             suite: suiteAllSettingsEnabled,
         },
@@ -50,11 +55,14 @@ const fixtures: Fixture[] = [
             router: { route: { app: 'settings' } },
             messageSystem: messageSystemInitialState,
             device: {
-                selectedDevice: {
-                    features: {},
-                    id: 'deviceId',
-                    authenticityChecks: authenticityChecksFail,
-                },
+                devices: [
+                    {
+                        features: { device_id: 'deviceId' },
+                        id: 'deviceId',
+                        authenticityChecks: authenticityChecksFail,
+                    },
+                ],
+                selectedDevice: 'deviceId',
             },
             suite: suiteAllSettingsEnabled,
         },
@@ -66,11 +74,14 @@ const fixtures: Fixture[] = [
             router: { route: { app: 'dashboard' } },
             messageSystem: messageSystemInitialState,
             device: {
-                selectedDevice: {
-                    features: {},
-                    id: 'deviceId',
-                    authenticityChecks: authenticityChecksFail,
-                },
+                devices: [
+                    {
+                        features: { device_id: 'deviceId' },
+                        id: 'deviceId',
+                        authenticityChecks: authenticityChecksFail,
+                    },
+                ],
+                selectedDevice: 'deviceId',
             },
             suite: suiteAllSettingsEnabled,
         },
@@ -83,11 +94,15 @@ const fixtures: Fixture[] = [
             messageSystem: messageSystemInitialState,
             device: {
                 dismissedSecurityChecks: { firmwareAuthenticity: ['deviceId'] },
-                selectedDevice: {
-                    features: {},
-                    id: 'deviceId',
-                    authenticityChecks: authenticityChecksFail,
-                },
+
+                devices: [
+                    {
+                        features: { device_id: 'deviceId' },
+                        id: 'deviceId',
+                        authenticityChecks: authenticityChecksFail,
+                    },
+                ],
+                selectedDevice: 'deviceId',
             },
             suite: suiteAllSettingsEnabled,
         },
@@ -99,14 +114,17 @@ const fixtures: Fixture[] = [
             router: { route: { app: 'dashboard' } },
             messageSystem: messageSystemInitialState,
             device: {
-                selectedDevice: {
-                    features: {},
-                    id: 'deviceId',
-                    authenticityChecks: {
-                        firmwareRevision: { success: false, error: 'revision-mismatch' },
-                        firmwareHash: { success: true },
+                devices: [
+                    {
+                        features: { device_id: 'deviceId' },
+                        id: 'deviceId',
+                        authenticityChecks: {
+                            firmwareRevision: { success: false, error: 'revision-mismatch' },
+                            firmwareHash: { success: true },
+                        },
                     },
-                },
+                ],
+                selectedDevice: 'deviceId',
             },
             suite: {
                 settings: {
@@ -127,11 +145,14 @@ const fixtures: Fixture[] = [
             messageSystem: messageSystemInitialState,
             device: {
                 devicesWithFailedEntropyCheck: ['deviceId'],
-                selectedDevice: {
-                    features: {},
-                    id: 'deviceId',
-                    authenticityChecks: authenticityChecksSuccess,
-                },
+                devices: [
+                    {
+                        features: { device_id: 'deviceId' },
+                        id: 'deviceId',
+                        authenticityChecks: authenticityChecksSuccess,
+                    },
+                ],
+                selectedDevice: 'deviceId',
             },
             suite: suiteAllSettingsEnabled,
         },
@@ -144,11 +165,14 @@ const fixtures: Fixture[] = [
             messageSystem: messageSystemInitialState,
             device: {
                 devicesWithFailedEntropyCheck: ['deviceId'],
-                selectedDevice: {
-                    features: {},
-                    id: 'deviceId',
-                    authenticityChecks: authenticityChecksSuccess,
-                },
+                devices: [
+                    {
+                        features: { device_id: 'deviceId' },
+                        id: 'deviceId',
+                        authenticityChecks: authenticityChecksSuccess,
+                    },
+                ],
+                selectedDevice: 'deviceId',
             },
             suite: { settings: { enabledSecurityChecks: { entropy: false } } },
         },

--- a/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
@@ -34,54 +34,70 @@ const deviceCompromisedFixtures: Array<{
     {
         description: 'Failed entropy check',
         device: {
+            devices: [{ id: 'deviceId' }],
             devicesWithFailedEntropyCheck: ['deviceId'],
-            selectedDevice: {
-                id: 'deviceId',
-            },
+            selectedDevice: 'deviceId',
         },
         result: 'TR_DEVICE_COMPROMISED_ENTROPY_CHECK_TEXT',
     },
     {
         description: 'Failed firmware hash check',
         device: {
-            selectedDevice: {
-                authenticityChecks: {
-                    firmwareHash: {
-                        error: 'hash-mismatch',
+            devices: [
+                {
+                    id: 'a',
+                    path: 'a',
+                    authenticityChecks: {
+                        firmwareHash: {
+                            error: 'hash-mismatch',
+                        },
                     },
+                    features: { device_id: 'a' },
                 },
-                features: {},
-            },
+            ],
+            selectedDevice: 'a',
         },
         result: 'TR_DEVICE_COMPROMISED_FW_HASH_CHECK_TEXT',
     },
     {
         description: 'Firmware hash check other-error (1st occurrence)',
         device: {
-            selectedDevice: {
-                connected: true,
-                authenticityChecks: {
-                    firmwareHash: {
-                        error: 'other-error',
+            selectedDevice: 'deviceId',
+            devices: [
+                {
+                    id: 'deviceId',
+                    connected: true,
+                    authenticityChecks: {
+                        firmwareHash: {
+                            error: 'other-error',
+                        },
+                    },
+                    features: {
+                        device_id: 'deviceId',
                     },
                 },
-                features: {},
-            },
+            ],
         },
         result: 'TR_FAILED_VERIFY_DEVICE_TEXT',
     },
     {
         description: 'Firmware hash check other-error (2nd occurrence)',
         device: {
-            selectedDevice: {
-                connected: true,
-                authenticityChecks: {
-                    firmwareHash: {
-                        error: 'other-error',
+            devices: [
+                {
+                    id: 'deviceId',
+                    connected: true,
+                    authenticityChecks: {
+                        firmwareHash: {
+                            error: 'other-error',
+                        },
+                    },
+                    features: {
+                        device_id: 'deviceId',
                     },
                 },
-                features: {},
-            },
+            ],
+            selectedDevice: 'deviceId',
             lastConnectedAuthenticityChecks: {
                 firmwareHash: {
                     error: 'other-error',
@@ -93,14 +109,21 @@ const deviceCompromisedFixtures: Array<{
     {
         description: 'Failed firmware revision check',
         device: {
-            selectedDevice: {
-                authenticityChecks: {
-                    firmwareRevision: {
-                        error: 'revision-mismatch',
+            devices: [
+                {
+                    id: 'deviceId',
+                    connected: true,
+                    authenticityChecks: {
+                        firmwareRevision: {
+                            error: 'revision-mismatch',
+                        },
+                    },
+                    features: {
+                        device_id: 'deviceId',
                     },
                 },
-                features: {},
-            },
+            ],
+            selectedDevice: 'deviceId',
         },
         result: 'TR_DEVICE_COMPROMISED_FW_REVISION_CHECK_TEXT',
     },

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -270,7 +270,10 @@ export const getRootReducer = (selectedAccount = BTC_ACCOUNT, fees = DEFAULT_FEE
             },
             () => ({}),
         ),
-        device: createReducer({ selectedDevice: DEVICE, devices: [DEVICE] }, () => {}),
+        device: createReducer(
+            { selectedDevice: DEVICE.state!.staticSessionId!, devices: [DEVICE] },
+            () => {},
+        ),
         wallet: combineReducers({
             send: sendFormReducer,
             accounts: createReducer(

--- a/packages/suite/src/middlewares/suite/__tests__/buttonRequestMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/buttonRequestMiddleware.test.ts
@@ -15,7 +15,7 @@ import { Action, Dispatch } from 'src/types/suite';
 
 const { getSuiteDevice } = testMocks;
 
-const device = getSuiteDevice();
+const device = getSuiteDevice({ state: 'a@b:0' });
 
 const getInitialState = () => ({
     router: routerReducer(undefined, { type: 'foo' } as any),
@@ -29,7 +29,7 @@ const getInitialState = () => ({
     },
     device: {
         devices: [device],
-        selectedDevice: device,
+        selectedDevice: device.state!.staticSessionId!,
     },
     messageSystem: messageSystemInitialState,
     firmware: { firmwareUpdateSource: 'production' },

--- a/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
@@ -109,19 +109,20 @@ describe('redirectMiddleware', () => {
         });
 
         it('SUITE.SELECT_DEVICE reset wallet params', () => {
+            const device = getSuiteDevice(
+                {
+                    path: '2',
+                },
+                {
+                    device_id: 'previous-device',
+                },
+            );
             const store = initStore(
                 getInitialState(
                     undefined,
                     {
-                        devices: [],
-                        selectedDevice: getSuiteDevice(
-                            {
-                                path: '2',
-                            },
-                            {
-                                device_id: 'previous-device',
-                            },
-                        ),
+                        devices: [device],
+                        selectedDevice: device.features!.device_id!,
                     },
                     {
                         app: 'wallet',

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -10,6 +10,7 @@ import {
     handleDeviceDisconnect,
     observeSelectedDevice,
     restartDiscoveryThunk,
+    selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { DEVICE } from '@trezor/connect';
 
@@ -85,6 +86,11 @@ const suite =
             }
         }
 
+        let prevSelectedDevice;
+        if (isActionDeviceRelated(action)) {
+            prevSelectedDevice = selectSelectedDevice(api.getState());
+        }
+
         // pass action to reducers
         next(action);
 
@@ -123,9 +129,9 @@ const suite =
             default:
                 break;
         }
+
         if (isActionDeviceRelated(action)) {
-            // keep suite reducer synchronized with other reducers (selected device)
-            api.dispatch(observeSelectedDevice());
+            api.dispatch(observeSelectedDevice(prevSelectedDevice));
         }
 
         return action;

--- a/packages/suite/src/middlewares/wallet/__fixtures__/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/__fixtures__/coinjoinMiddleware.ts
@@ -61,7 +61,7 @@ const COINJOIN_ACCOUNT_B = {
 const DEFAULT_STATE = {
     device: {
         devices: [DEVICE_A, DEVICE_B],
-        selectedDevice: DEVICE_A,
+        selectedDevice: DEVICE_A.state.staticSessionId,
     },
     suite: {
         torStatus: 'Enabled',

--- a/packages/suite/src/middlewares/wallet/__tests__/walletMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/walletMiddleware.test.ts
@@ -43,7 +43,8 @@ const getInitialState = ({ router, accounts, settings, selectedAccount, send }: 
     },
     suite: {},
     device: {
-        device: true, // device is irrelevant in this test
+        devices: [],
+        selectedDevice: undefined,
     },
     wallet: {
         accounts: accounts || accountsReducer(undefined, { type: 'foo' } as any),

--- a/packages/suite/src/selectors/suite/suiteSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteSelectors.ts
@@ -85,7 +85,7 @@ export const selectIsCopyAddressModalShown = (state: SuiteRootState) =>
     state.suite.flags.showCopyAddressModal;
 export const selectIsInitialRun = (state: SuiteRootState) => state.suite.flags.initialRun;
 export const selectIsLoggedOut = (state: SuiteRootState & DeviceRootState) =>
-    selectIsInitialRun(state) || state.device?.selectedDevice?.mode !== 'normal';
+    selectIsInitialRun(state) || selectSelectedDevice(state)?.mode !== 'normal';
 export const selectSuiteFlags = (state: SuiteRootState) => state.suite.flags;
 export const selectSuiteSettings = (state: SuiteRootState) => ({
     defaultWalletLoading: state.suite.settings.defaultWalletLoading,

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -13,6 +13,7 @@ import {
     ExplorerConfig,
     FiatRatesState,
     TransactionsState,
+    selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { buildHistoricRatesFromStorage, getAccountKey } from '@suite-common/wallet-utils';
 import { StaticSessionId } from '@trezor/connect';
@@ -67,7 +68,7 @@ export const extraDependencies: ExtraDependencies = {
         selectDebugSettings: (state: AppState) => state.suite.settings.debug,
         // FW binaries on desktop are stored in "*/static/connect/data/firmware/*/*.bin" (see "connect-common" package)
         selectDesktopBinDir: (state: AppState) => state.desktop?.paths?.binDir,
-        selectDevice: (state: AppState) => state.device.selectedDevice,
+        selectDevice: (state: AppState) => selectSelectedDevice(state),
         selectLanguage: (state: AppState) => state.suite.settings.language,
         selectMetadata: (state: AppState) => state.metadata,
         selectRouterApp: (state: AppState) => state.router.app,

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -3,8 +3,10 @@ import {
     DeviceButtonRequest,
     DeviceEvent,
     DeviceState,
+    DeviceUniquePath,
     KnownDevice,
     PROTO,
+    StaticSessionId,
     UnknownDevice as UnknownDeviceBase,
     UnreadableDevice as UnreadableDeviceBase,
 } from '@trezor/connect';
@@ -67,3 +69,6 @@ export type AuthorizedDevice = AcquiredDevice & {
  * used when saving device to storage
  */
 export type DeviceWithEmptyPath = Omit<AcquiredDevice, 'path'> & { path: '' };
+
+type DeviceId = string;
+export type DeviceRef = StaticSessionId | DeviceId | DeviceUniquePath;

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -1,5 +1,5 @@
 import { AnyAction } from '@suite-common/redux-utils';
-import { AcquiredDevice, TrezorDevice } from '@suite-common/suite-types';
+import { AcquiredDevice, DeviceRef, TrezorDevice } from '@suite-common/suite-types';
 import { DEVICE, Device, DeviceEvent, KnownDevice, UnavailableCapability } from '@trezor/connect';
 import { DeviceModelInternal, getNarrowedDeviceModelInternal } from '@trezor/device-utils';
 import { exhaustive } from '@trezor/type-utils';
@@ -454,3 +454,19 @@ export const getDeviceInternalModel = (device: Pick<Device, 'features' | 'thp'>)
 
 export const getDeviceColorVariant = (device: Pick<Device, 'features' | 'thp'>) =>
     device.features?.unit_color ?? device.thp?.properties?.model_variant;
+
+export const getDeviceRef = (device: TrezorDevice): DeviceRef => {
+    if (device.state?.staticSessionId) {
+        return device.state?.staticSessionId;
+    }
+
+    if (device.id) {
+        return device.id;
+    }
+
+    if (device.path) {
+        return device.path;
+    }
+
+    throw new Error('Device does not have a valid reference');
+};

--- a/suite-common/thp/tests/autoInitThpAfterDeviceConnectionThunk.test.ts
+++ b/suite-common/thp/tests/autoInitThpAfterDeviceConnectionThunk.test.ts
@@ -22,6 +22,7 @@ const device = testMocks.getSuiteDevice({
         recvNonce: 0,
         expectedResponses: [],
     },
+    path: 'a',
 }) as Device;
 const initialThpState: ThpState = { step: null, lastThpCode: undefined, credentials: [] };
 const initialFirmwareState: FirmwareUpdateState = {
@@ -82,7 +83,7 @@ const createStore = ({ isFirmwareInstallation, isDeviceSelected }: CreateStorePa
                 : initialFirmwareState,
             device: {
                 devices: [device],
-                selectedDevice: isDeviceSelected ? device : undefined,
+                selectedDevice: isDeviceSelected ? device.path! : undefined,
             },
         },
     });

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -271,11 +271,14 @@ describe('tradingSelectors', () => {
                 },
             },
             device: {
-                selectedDevice: {
-                    state: {
-                        staticSessionId: 'staticSessionId' as StaticSessionId,
+                devices: [
+                    {
+                        state: {
+                            staticSessionId: 'staticSessionId' as StaticSessionId,
+                        },
                     },
-                },
+                ],
+                selectedDevice: 'staticSessionId',
             },
         }) as unknown as TradingRootStateWithDeviceAndAccounts;
 

--- a/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
@@ -1,10 +1,8 @@
 import { combineReducers, createReducer } from '@reduxjs/toolkit';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { TrezorDevice } from '@suite-common/suite-types';
 import { configureMockStore, extraDependenciesMock, testMocks } from '@suite-common/test-utils';
 import {
-    DeviceReducerState,
     composeSendFormTransactionFeeLevelsThunk,
     prepareDeviceReducer,
 } from '@suite-common/wallet-core';
@@ -101,16 +99,6 @@ describe('recomposeAndSignTxThunk', () => {
         const account = accountBtc as Account;
         const device = testMocks.getSuiteDevice();
 
-        const deviceState: Partial<DeviceReducerState> = {
-            selectedDevice: {
-                features: {
-                    major_version: 2,
-                    minor_version: 8,
-                    patch_version: 11,
-                },
-            } as TrezorDevice,
-        };
-
         const store = configureMockStore({
             extra: {},
             reducer: combineReducers({
@@ -132,10 +120,7 @@ describe('recomposeAndSignTxThunk', () => {
                 },
                 device: {
                     devices: [device],
-                    selectedDevice: {
-                        ...device,
-                        ...deviceState.selectedDevice,
-                    },
+                    selectedDevice: device.features?.device_id,
                 },
             },
         });

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -5,7 +5,7 @@ import {
     deviceAuthenticityActions,
 } from '@suite-common/device-authenticity';
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
-import { AcquiredDevice, ButtonRequest, TrezorDevice } from '@suite-common/suite-types';
+import { AcquiredDevice, ButtonRequest, DeviceRef, TrezorDevice } from '@suite-common/suite-types';
 import * as deviceUtils from '@suite-common/suite-utils';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { shouldDeviceBeRemembered } from '@suite-common/wallet-utils';
@@ -16,7 +16,12 @@ import { PORTFOLIO_TRACKER_DEVICE_ID } from './deviceConstants';
 
 export type DeviceReducerState = {
     devices: TrezorDevice[];
-    selectedDevice?: TrezorDevice;
+    /**
+     * StaticSessionId  - authorized device
+     * DeviceId         - unauthorized device
+     * DeviceUniquePath - unacquired device or device in bootloader mode
+     */
+    selectedDevice?: DeviceRef;
     deviceAuthenticity?: Record<string, StoredAuthenticateDeviceResult>;
     devicesWithFailedEntropyCheck?: (string | null)[]; // protobuf allows null values and we want to store this even if a fake device has id set to null
     dismissedSecurityChecks?: {
@@ -363,6 +368,8 @@ const disconnectDevice = (draft: DeviceReducerState, device: TrezorDevice) => {
         }
     });
 
+    //
+
     if (isDeviceAcquired(device)) {
         draft.lastConnectedAuthenticityChecks = device.authenticityChecks;
     }
@@ -544,11 +551,14 @@ export const setDeviceAuthenticity = (
 // called after successful wipeDevice
 const requestDeviceReconnect = (draft: DeviceReducerState) => {
     // only acquired devices
-    if (!draft.selectedDevice?.features) return;
-    const index = deviceUtils.findInstanceIndex(draft.devices, draft.selectedDevice);
-    if (!draft.devices[index]) return;
-    draft.selectedDevice.reconnectRequested = true;
-    draft.devices[index].reconnectRequested = true;
+    const selectedDevice = draft.devices.find(
+        device =>
+            draft.selectedDevice === device.state?.staticSessionId ||
+            draft.selectedDevice === device.id,
+    );
+    if (!selectedDevice?.features) return;
+    // todo: test!
+    selectedDevice.reconnectRequested = true;
 };
 
 export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (builder, extra) => {
@@ -562,7 +572,6 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
         .addCase(deviceActions.addAuthorizedDevice, (state, { payload }) => {
             addAuthorizedDevice(state, payload.device);
         })
-
         .addCase(deviceActions.deviceDisconnect, (state, { payload }) => {
             disconnectDevice(state, payload);
         })
@@ -586,10 +595,7 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
         })
         .addCase(deviceActions.selectDevice, (state, { payload }) => {
             updateTimestamp(state, payload);
-            state.selectedDevice = payload;
-        })
-        .addCase(deviceActions.updateSelectedDevice, (state, { payload }) => {
-            state.selectedDevice = payload;
+            state.selectedDevice = payload ? deviceUtils.getDeviceRef(payload) : undefined;
         })
         .addCase(deviceAuthenticityActions.result, (state, { payload }) => {
             setDeviceAuthenticity(state, payload.device, payload.result);

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -1,7 +1,7 @@
 import { A, pipe } from '@mobily/ts-belt';
 
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
-import { BackupType, TrezorDevice } from '@suite-common/suite-types';
+import { BackupType, DeviceRef, TrezorDevice } from '@suite-common/suite-types';
 import * as deviceUtils from '@suite-common/suite-utils';
 import { getDeviceInstances, getFwUpdateVersion, getStatus } from '@suite-common/suite-utils';
 import { networkSymbolCollection } from '@suite-common/wallet-config';
@@ -20,9 +20,22 @@ import { DeviceRootState } from './deviceReducer';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<DeviceRootState>();
 
-export const selectDevices = (state: DeviceRootState) => state.device?.devices;
-export const selectDevicesCount = (state: DeviceRootState) => state.device?.devices?.length;
-export const selectSelectedDevice = (state: DeviceRootState) => state.device.selectedDevice;
+export const selectDevices = (state: DeviceRootState) => state.device.devices;
+export const selectDevicesCount = (state: DeviceRootState) => state.device.devices.length;
+
+export const selectDeviceByDeviceRef = (state: DeviceRootState, deviceRef: DeviceRef) =>
+    state.device.devices.find(
+        device =>
+            deviceRef === device.state?.staticSessionId ||
+            deviceRef === device?.id ||
+            deviceRef === device.path,
+    );
+
+export const selectSelectedDevice = (state: DeviceRootState) =>
+    state.device.selectedDevice
+        ? selectDeviceByDeviceRef(state, state.device.selectedDevice)
+        : undefined;
+
 export const selectIsDeviceAutoEjectEnabled = (state: DeviceRootState) =>
     state.device.isDeviceAutoEjectEnabled;
 

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -1,12 +1,7 @@
 import { bluetoothActions } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
-import { AcquiredDevice, TrezorDevice } from '@suite-common/suite-types';
-import {
-    getDeviceInstances,
-    getFirstDeviceInstance,
-    getSelectedDevice,
-    sortByTimestamp,
-} from '@suite-common/suite-utils';
+import { AcquiredDevice, DeviceRef, TrezorDevice } from '@suite-common/suite-types';
+import { getDeviceInstances, sortByTimestamp } from '@suite-common/suite-utils';
 import {
     autoInitThpAfterDeviceConnectionThunk,
     connectThpDeviceThunk,
@@ -36,6 +31,7 @@ import { isChanged } from '@trezor/utils';
 import { DEVICE_MODULE_PREFIX, deviceActions } from './deviceActions';
 import { PORTFOLIO_TRACKER_DEVICE_ID, portfolioTrackerDevice } from './deviceConstants';
 import {
+    selectDeviceByDeviceRef,
     selectDeviceById,
     selectDevices,
     selectPhysicalDevices,
@@ -46,6 +42,43 @@ import { startDiscoveryThunk } from '../discovery/discoveryThunks';
 
 type SelectDeviceThunkParams = {
     device: Device | TrezorDevice | undefined;
+};
+
+/**
+ * @param {(TrezorDevice)} device
+ * @param {TrezorDevice[]} devices
+ * @returns {TrezorDevice | undefined }
+ */
+const getSelectedDevice = (
+    device: Device | TrezorDevice,
+    devices: TrezorDevice[],
+): TrezorDevice | undefined => {
+    // selected device is not acquired
+
+    if ('ts' in device) {
+        const { path, instance } = device;
+
+        return devices.find(d => {
+            if ((!d.features || d.mode === 'bootloader') && d.path === path) {
+                return true;
+            }
+            if (d.instance === instance && d.features && d.id === device.id) {
+                return true;
+            }
+
+            // special case we need to use after wipe device (which changes device_id)
+            if (d.instance === instance && d.path.length > 0 && d.path === device.path) {
+                return true;
+            }
+
+            return false;
+        });
+    } else {
+        const instances = devices.filter(d => d.path === device.path);
+
+        return sortByTimestamp(instances)[0];
+    }
+    // todo: maybe select by staticSessionId || device_id || path
 };
 
 /**
@@ -60,18 +93,7 @@ export const selectDeviceThunk = createThunk<void, SelectDeviceThunkParams, void
         const devices = selectDevices(getState());
 
         if (device) {
-            // "ts" is one of the field which distinguish Device from TrezorDevice
-            // (device from connect doesn't have timestamp but suite device has)
-            if ('ts' in device) {
-                // requested device is a @suite TrezorDevice type. get exact instance from reducer
-                payload = getSelectedDevice(device, devices);
-            } else {
-                // requested device is a @trezor/connect Device type
-                // find all instances and select recently used
-                const instances = devices.filter(d => d.path === device.path);
-
-                payload = sortByTimestamp(instances)[0];
-            }
+            payload = getSelectedDevice(device, devices);
         }
 
         dispatch(deviceActions.selectDevice(payload));
@@ -109,37 +131,70 @@ export const handleDeviceDisconnect = createThunk(
             selectors: { selectRouterApp },
         } = extra;
 
-        const selectedDevice = selectSelectedDevice(getState());
-        const routerApp = selectRouterApp(getState());
-        const devices = selectDevices(getState());
-        if (!selectedDevice) return;
-        if (selectedDevice.path !== device.path) return;
+        // eslint-disable-next-line no-restricted-syntax
+        const selectedDevice = getState().device.selectedDevice as DeviceRef;
+        // no device was selected
+        if (!selectedDevice) {
+            return;
+        }
+
+        // the device that got disconnected or forgotten was not selected
+        if (
+            selectedDevice !== device.path &&
+            selectedDevice !== device?.id &&
+            // @ts-expect-error todo: typing
+            selectedDevice !== device?.state?.staticSessionId
+        ) {
+            return;
+        }
+
+        // at this point, we know that the device that got disconnected was also the selected one
 
         /**
          * Under normal circumstances, after device is disconnected we want suite to select another existing device (either remembered or physically connected)
          * This is not the case in firmware update and onboarding; In this case we simply wan't suite.device to be empty until user reconnects a device again
          */
+        const routerApp = selectRouterApp(getState());
         if (['onboarding', 'firmware', 'firmware-type'].includes(routerApp)) {
             dispatch(selectDeviceThunk({ device: undefined }));
 
             return;
         }
 
-        // selected device is disconnected, decide what to do next
-        // device is still present in reducer (remembered or candidate to remember)
-        const devicePresent = getSelectedDevice(selectedDevice, devices);
-        const deviceInstances = getDeviceInstances(selectedDevice, devices);
+        const devices = selectDevices(getState());
+
+        const devicePresent = selectDeviceByDeviceRef(
+            getState(),
+            selectedDevice.split(':')[0].split('@')[1], // use device_id only
+        );
+
+        // try to select another wallet instance of the same physical device
+        const deviceInstances = !devicePresent
+            ? []
+            : getDeviceInstances(devicePresent, devices).filter(
+                  d => d.id !== selectedDevice && d.state !== devicePresent.state,
+              );
         if (deviceInstances.length > 0) {
-            // if selected device is gone from reducer, switch to first instance
-            if (!devicePresent) {
-                dispatch(selectDeviceThunk({ device: deviceInstances[0] }));
-            }
+            dispatch(
+                selectDeviceThunk({
+                    device: deviceInstances[deviceInstances.length - 1],
+                }),
+            );
 
             return;
         }
-
-        const available = getFirstDeviceInstance(devices);
-        dispatch(selectDeviceThunk({ device: available[0] }));
+        // else select another physical device
+        const physicalDevices = selectPhysicalDevices(getState());
+        if (physicalDevices.length > 0) {
+            dispatch(
+                selectDeviceThunk({
+                    device: sortByTimestamp(physicalDevices)[0],
+                }),
+            );
+        } else {
+            // clear selectedDevice field
+            dispatch(selectDeviceThunk({ device: undefined }));
+        }
     },
 );
 
@@ -175,23 +230,16 @@ export const forgetDisconnectedDevices = createThunk(
  * Called from `suiteMiddleware`
  * Keep `suite` reducer synchronized with `devices` reducer
  */
-export const observeSelectedDevice = () => (dispatch: any, getState: any) => {
-    const devices = selectDevices(getState());
-
-    const selectedDevice = selectSelectedDevice(getState());
-
-    if (!selectedDevice) return false;
-
-    const deviceFromReducer = getSelectedDevice(selectedDevice, devices);
-    if (!deviceFromReducer) return true;
-
-    const changed = isChanged(selectedDevice, deviceFromReducer);
-    if (changed) {
-        dispatch(deviceActions.updateSelectedDevice(deviceFromReducer));
-    }
-
-    return changed;
-};
+export const observeSelectedDevice =
+    (prevSelectedDevice?: TrezorDevice) => (dispatch: any, getState: any) => {
+        const nextSelectedDevice = selectSelectedDevice(getState());
+        if (!nextSelectedDevice) return;
+        // todo: and this could be a performance issue, but I need to figure out a save way how to get rid of updateSelectedDevice or how to fire it in a different way
+        const changed = isChanged(prevSelectedDevice || undefined, nextSelectedDevice);
+        if (changed) {
+            dispatch(deviceActions.updateSelectedDevice(nextSelectedDevice));
+        }
+    };
 
 /**
  * Called from <AcquireDevice /> component
@@ -418,7 +466,6 @@ export const wipeDeviceThunk = createThunk(
         const devices = selectDevices(getState());
         // collect devices with old "device.id" to be removed (see description below)
         const deviceInstances = getDeviceInstances(device, devices);
-
         const result = await TrezorConnect.wipeDevice({
             device: {
                 path: device.path,
@@ -445,10 +492,7 @@ export const wipeDeviceThunk = createThunk(
                     extra.thunks.forgetBluetoothDevice({ bluetoothId: device.bluetoothProps.id }),
                 );
             }
-            const newDevice = selectSelectedDevice(getState());
-            const newDevices = selectDevices(getState());
 
-            deviceInstances.push(...getDeviceInstances(newDevice!, newDevices));
             deviceInstances.forEach(d => {
                 dispatch(deviceActions.forgetDevice({ device: d }));
             });

--- a/suite-native/device-authorization/src/deviceAuthorizationSlice.ts
+++ b/suite-native/device-authorization/src/deviceAuthorizationSlice.ts
@@ -4,6 +4,7 @@ import {
     DeviceRootState,
     DiscoveryRootState,
     selectDiscoveryByDevicePath,
+    selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { UI } from '@trezor/connect';
 
@@ -93,7 +94,9 @@ export const selectCheckPassphraseOnDevice = (state: DeviceAuthorizationRootStat
 export const selectHasPassphraseError = (
     state: DiscoveryRootState & DeviceRootState & DeviceAuthorizationState,
 ) => {
-    const discovery = selectDiscoveryByDevicePath(state, state.device.selectedDevice?.path);
+    // todo: optimize
+    const selectedDevice = selectSelectedDevice(state);
+    const discovery = selectDiscoveryByDevicePath(state, selectedDevice?.path);
 
     return (
         discovery?.isAddingExistingWallet &&
@@ -104,13 +107,15 @@ export const selectHasPassphraseError = (
 export const selectHasVerificationCancelledError = (
     state: DiscoveryRootState & DeviceRootState,
 ) => {
-    const discovery = selectDiscoveryByDevicePath(state, state.device.selectedDevice?.path);
+    const selectedDevice = selectSelectedDevice(state);
+    const discovery = selectDiscoveryByDevicePath(state, selectedDevice?.path);
 
     return discovery?.status === 'cancelled';
 };
 
 export const selectHasPassphraseMismatchError = (state: DiscoveryRootState & DeviceRootState) => {
-    const discovery = selectDiscoveryByDevicePath(state, state.device.selectedDevice?.path);
+    const selectedDevice = selectSelectedDevice(state);
+    const discovery = selectDiscoveryByDevicePath(state, selectedDevice?.path);
 
     return discovery?.status === 'passphrase-mismatch';
 };
@@ -118,7 +123,8 @@ export const selectHasPassphraseMismatchError = (state: DiscoveryRootState & Dev
 export const selectIsCreatingNewPassphraseWallet = (
     state: DiscoveryRootState & DeviceRootState,
 ) => {
-    const discovery = selectDiscoveryByDevicePath(state, state.device.selectedDevice?.path);
+    const selectedDevice = selectSelectedDevice(state);
+    const discovery = selectDiscoveryByDevicePath(state, selectedDevice?.path);
 
     return discovery?.isAddingHiddenWallet;
 };
@@ -126,11 +132,12 @@ export const selectIsCreatingNewPassphraseWallet = (
 export const isPassphraseDeviceLoadingDone = (
     state: DiscoveryRootState & DeviceRootState & DeviceAuthorizationRootState,
 ) => {
-    if (!state.device.selectedDevice?.state) {
+    const selectedDevice = selectSelectedDevice(state);
+    if (!selectedDevice?.state) {
         return false;
     }
 
-    const discovery = selectDiscoveryByDevicePath(state, state.device.selectedDevice?.path);
+    const discovery = selectDiscoveryByDevicePath(state, selectedDevice?.path);
 
     if (!discovery || !discovery.isAddingHiddenWallet) {
         return false;
@@ -140,7 +147,8 @@ export const isPassphraseDeviceLoadingDone = (
 };
 
 export const selectPassphraseDeviceNotEmpty = (state: DiscoveryRootState & DeviceRootState) => {
-    const discovery = selectDiscoveryByDevicePath(state, state.device.selectedDevice?.path);
+    const selectedDevice = selectSelectedDevice(state);
+    const discovery = selectDiscoveryByDevicePath(state, selectedDevice?.path);
 
     if (!discovery || !discovery.isAddingHiddenWallet) {
         return null;
@@ -157,7 +165,8 @@ export const selectPassphraseDeviceNotEmpty = (state: DiscoveryRootState & Devic
 };
 
 export const selectPassphraseDiscoveryCompleted = (state: DiscoveryRootState & DeviceRootState) => {
-    const discovery = selectDiscoveryByDevicePath(state, state.device.selectedDevice?.path);
+    const selectedDevice = selectSelectedDevice(state);
+    const discovery = selectDiscoveryByDevicePath(state, selectedDevice?.path);
 
     if (!discovery || !discovery.isAddingHiddenWallet) {
         return null;

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -13,6 +13,7 @@ import {
     selectDeviceThunk,
     selectDiscoveryByDevicePath,
     selectIsDeviceForceRemembered,
+    selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { EventType, analytics } from '@suite-native/analytics';
 import { clearAndUnlockDeviceAccessQueue } from '@suite-native/device-mutex';
@@ -57,6 +58,11 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
             if (discovery?.status === 'complete' && action.payload.mode === 'normal') {
                 dispatch(setShouldShowAutoEjectAlert(true));
             }
+        }
+
+        let prevSelectedDevice;
+        if (isActionDeviceRelated(action)) {
+            prevSelectedDevice = selectSelectedDevice(getState());
         }
 
         /* The `next` function has to be executed here, because the further dispatched actions of this middleware
@@ -138,7 +144,7 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
         }
 
         if (isActionDeviceRelated(action)) {
-            dispatch(observeSelectedDevice());
+            dispatch(observeSelectedDevice(prevSelectedDevice));
         }
 
         return action;

--- a/suite-native/module-home/src/screens/HomeScreen/components/__tests__/EmptyHomeRenderer.comp.test.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/__tests__/EmptyHomeRenderer.comp.test.tsx
@@ -36,8 +36,8 @@ describe('EmptyHomeRenderer', () => {
         await renderEmptyHomeRenderer({
             featureFlags: { isDeviceConnectEnabled: false },
             device: {
-                selectedDevice: { type: 'acquired' },
-                devices: [{ id: 'device_id' }],
+                selectedDevice: 'a',
+                devices: [{ type: 'acquired', path: 'a' }, { id: 'device_id' }],
             },
         });
 
@@ -49,11 +49,19 @@ describe('EmptyHomeRenderer', () => {
             await renderEmptyHomeRenderer({
                 featureFlags: { isDeviceConnectEnabled: true },
                 device: {
-                    selectedDevice: {
-                        connected: true,
-                        features: { initialized: false, internal_model: DeviceModelInternal.T3B1 },
-                    },
-                    devices: [{ id: 'device_id' }],
+                    selectedDevice: 'a',
+                    devices: [
+                        {
+                            id: 'a',
+                            connected: true,
+                            features: {
+                                device_id: 'a',
+                                initialized: false,
+                                internal_model: DeviceModelInternal.T3B1,
+                            },
+                        },
+                        { id: 'device_id' },
+                    ],
                 },
             });
 
@@ -64,11 +72,19 @@ describe('EmptyHomeRenderer', () => {
             await renderEmptyHomeRenderer({
                 featureFlags: { isDeviceConnectEnabled: true },
                 device: {
-                    selectedDevice: {
-                        connected: true,
-                        features: { initialized: false, internal_model: DeviceModelInternal.T1B1 },
-                    },
-                    devices: [{ id: 'device_id' }],
+                    selectedDevice: 'a',
+                    devices: [
+                        {
+                            id: 'a',
+                            connected: true,
+                            features: {
+                                initialized: false,
+                                internal_model: DeviceModelInternal.T1B1,
+                                device_id: 'a',
+                            },
+                        },
+                        { id: 'device_id' },
+                    ],
                 },
             });
 
@@ -79,11 +95,7 @@ describe('EmptyHomeRenderer', () => {
             await renderEmptyHomeRenderer({
                 featureFlags: { isDeviceConnectEnabled: true },
                 device: {
-                    selectedDevice: {
-                        connected: false,
-                        features: { initialized: true },
-                        state: {},
-                    },
+                    selectedDevice: 'PORTFOLIO_TRACKER_DEVICE_ID',
                     devices: [{ id: PORTFOLIO_TRACKER_DEVICE_ID }],
                 },
             });
@@ -95,12 +107,16 @@ describe('EmptyHomeRenderer', () => {
             await renderEmptyHomeRenderer({
                 featureFlags: { isDeviceConnectEnabled: true },
                 device: {
-                    selectedDevice: {
-                        connected: false,
-                        features: { initialized: true },
-                        state: undefined,
-                    },
-                    devices: [{ id: 'device_id' }],
+                    selectedDevice: 'a',
+                    devices: [
+                        {
+                            connected: false,
+                            features: { initialized: true, device_id: 'a' },
+                            state: undefined,
+                            id: 'a',
+                        },
+                        { id: 'device_id' },
+                    ],
                 },
             });
 
@@ -112,12 +128,16 @@ describe('EmptyHomeRenderer', () => {
         await renderEmptyHomeRenderer({
             featureFlags: { isDeviceConnectEnabled: true },
             device: {
-                selectedDevice: {
-                    connected: true,
-                    features: { initialized: true },
-                    state: {},
-                },
-                devices: [{ id: 'device_id' }],
+                selectedDevice: 'a',
+                devices: [
+                    {
+                        connected: true,
+                        features: { initialized: true, device_id: 'a' },
+                        state: {},
+                        id: 'a',
+                    },
+                    { id: 'device_id' },
+                ],
             },
         });
 

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyTradeableAssetPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyTradeableAssetPicker.comp.test.tsx
@@ -20,7 +20,10 @@ describe('BuyTradeableAssetPicker', () => {
 
     const initPreloadedStore = (firmwareType: FirmwareType) =>
         initStore({
-            device: { selectedDevice: { firmwareType } },
+            device: {
+                selectedDevice: 'a',
+                devices: [{ firmwareType, path: 'a' }],
+            },
             wallet: { tradingNew: getInitializedTradingState() },
         });
 

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeTradeableAssetPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeTradeableAssetPicker.comp.test.tsx
@@ -19,7 +19,7 @@ describe('ExchangeTradeableAssetPicker', () => {
 
     const initPreloadedStore = (firmwareType: FirmwareType) =>
         initStore({
-            device: { selectedDevice: { firmwareType } },
+            device: { devices: [{ firmwareType, path: 'a' }], selectedDevice: 'a' },
             wallet: { tradingNew: getInitializedTradingState() },
         });
 

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountList.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountList.comp.test.tsx
@@ -20,14 +20,17 @@ import { AccountList, AccountsListProps, keyExtractor } from '../AccountList';
 const accounts = fixturesAccounts as Account[];
 const defaultPreloadedState = {
     device: {
-        selectedDevice: {
-            state: {
-                staticSessionId: 'staticSessionId' as StaticSessionId,
+        devices: [
+            {
+                state: {
+                    staticSessionId: 'staticSessionId' as StaticSessionId,
+                },
+                connected: true,
+                available: true,
+                remember: true,
             },
-            connected: true,
-            available: true,
-            remember: true,
-        },
+        ],
+        selectedDevice: 'staticSessionId',
     },
     wallet: { accounts },
 };

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/NoAccountsComponent.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/NoAccountsComponent.comp.test.tsx
@@ -13,11 +13,15 @@ describe('NoAccountsComponent', () => {
         renderWithStoreProviderAsync(<NoAccountsComponent isBottomRounded />, {
             preloadedState: {
                 device: {
-                    selectedDevice: {
-                        remember: true,
-                        connected: isConnected,
-                        id,
-                    },
+                    devices: [
+                        {
+                            remember: true,
+                            connected: isConnected,
+                            id,
+                            state: { staticSessionId: 'a@b:1' },
+                        },
+                    ],
+                    selectedDevice: id || 'a@b:1',
                 },
             },
         });

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailTransactionInfo.comp.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailTransactionInfo.comp.test.tsx
@@ -14,14 +14,17 @@ import {
 const accounts = fixturesAccounts as Account[];
 const getPreloadedState = (trades: TradingTransaction[]): PreloadedState => ({
     device: {
-        selectedDevice: {
-            state: {
-                staticSessionId: 'staticSessionId' as StaticSessionId,
+        devices: [
+            {
+                state: {
+                    staticSessionId: 'staticSessionId' as StaticSessionId,
+                },
+                connected: true,
+                available: true,
+                remember: true,
             },
-            connected: true,
-            available: true,
-            remember: true,
-        },
+        ],
+        selectedDevice: 'staticSessionId',
     },
     wallet: {
         accounts,

--- a/suite-native/module-trading/src/hooks/general/__tests__/useAllTradesReloadTimer.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useAllTradesReloadTimer.test.ts
@@ -70,9 +70,12 @@ describe('useAllTradesReloadTimer', () => {
                 ],
             },
             device: {
-                selectedDevice: {
-                    state: { staticSessionId: 'device1@test:123' },
-                },
+                devices: [
+                    {
+                        state: { staticSessionId: 'device1@test:123' },
+                    },
+                ],
+                selectedDevice: 'device1@test:123',
             },
         };
 

--- a/suite-native/module-trading/src/hooks/general/__tests__/useReceiveAccountsListData.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useReceiveAccountsListData.test.tsx
@@ -9,11 +9,14 @@ import { ReceiveAccountsListMode, useReceiveAccountsListData } from '../useRecei
 describe('useReceiveAccountsListData', () => {
     const defaultPreloadedState = {
         device: {
-            selectedDevice: {
-                state: {
-                    staticSessionId: 'staticSessionId' as StaticSessionId,
+            devices: [
+                {
+                    state: {
+                        staticSessionId: 'staticSessionId' as StaticSessionId,
+                    },
                 },
-            },
+            ],
+            selectedDevice: 'staticSessionId',
         },
         wallet: { accounts: accounts as Account[] },
     };
@@ -152,11 +155,14 @@ describe('useReceiveAccountsListData', () => {
         it('should not display not visible accounts', async () => {
             const preloadedState = {
                 device: {
-                    selectedDevice: {
-                        state: {
-                            staticSessionId: 'staticSessionId' as StaticSessionId,
+                    devices: [
+                        {
+                            state: {
+                                staticSessionId: 'staticSessionId' as StaticSessionId,
+                            },
                         },
-                    },
+                    ],
+                    selectedDevice: 'staticSessionId',
                 },
                 wallet: {
                     accounts: [

--- a/suite-native/module-trading/src/hooks/general/__tests__/useWatchAllTrades.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useWatchAllTrades.test.ts
@@ -78,9 +78,12 @@ describe('useWatchAllTrades', () => {
                 ],
             },
             device: {
-                selectedDevice: {
-                    state: { staticSessionId: 'device1@test:123' },
-                },
+                devices: [
+                    {
+                        state: { staticSessionId: 'device1@test:123' },
+                    },
+                ],
+                selectedDevice: 'device1@test:123',
             },
         };
 

--- a/suite-native/module-trading/src/screens/__tests__/TradingHistoryScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingHistoryScreen.comp.test.tsx
@@ -47,11 +47,14 @@ const getPreloadedState = (): PreloadedState => ({
         accounts: fixturesAccounts as Account[],
     },
     device: {
-        selectedDevice: {
-            state: {
-                staticSessionId: 'staticSessionId' as StaticSessionId,
+        devices: [
+            {
+                state: {
+                    staticSessionId: 'staticSessionId' as StaticSessionId,
+                },
             },
-        },
+        ],
+        selectedDevice: 'staticSessionId',
     },
 });
 

--- a/suite-native/module-trading/src/screens/__tests__/TradingReceiveAccountsPickerScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingReceiveAccountsPickerScreen.comp.test.tsx
@@ -27,14 +27,17 @@ jest.mock('@react-navigation/native', () => ({
 
 const getPreloadedState = (preloadedAccounts: Account[]): PreloadedState => ({
     device: {
-        selectedDevice: {
-            state: {
-                staticSessionId: 'staticSessionId' as StaticSessionId,
+        devices: [
+            {
+                state: {
+                    staticSessionId: 'staticSessionId' as StaticSessionId,
+                },
+                connected: true,
+                available: true,
+                remember: true,
             },
-            connected: true,
-            available: true,
-            remember: true,
-        },
+        ],
+        selectedDevice: 'staticSessionId',
     },
     wallet: {
         accounts: preloadedAccounts,

--- a/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
@@ -340,7 +340,10 @@ describe('commonSelectors', () => {
                     settings: { localCurrency: 'usd', enabledNetworks: ['btc'] },
                     transactions: { transactions: {} },
                 },
-                device: { selectedDevice: { state: { staticSessionId: testDeviceState } } },
+                device: {
+                    devices: [{ state: { staticSessionId: testDeviceState } }],
+                    selectedDevice: testDeviceState,
+                },
                 tokenDefinitions: {},
                 fiat: { rates: {}, current: 'usd' },
             } as any;
@@ -378,7 +381,10 @@ describe('commonSelectors', () => {
                     accounts: [zeroBalanceAccount],
                     settings: { localCurrency: 'usd', enabledNetworks: ['btc'] },
                 },
-                device: { selectedDevice: { state: { staticSessionId: testDeviceState } } },
+                device: {
+                    selectedDevice: testDeviceState,
+                    devices: [{ state: { staticSessionId: testDeviceState } }],
+                },
                 tokenDefinitions: {},
                 fiat: { rates: {}, current: 'usd' },
             } as any;
@@ -428,7 +434,10 @@ describe('commonSelectors', () => {
                     settings: { localCurrency: 'usd', enabledNetworks: ['eth'] },
                     transactions: { transactions: {} },
                 },
-                device: { selectedDevice: { state: { staticSessionId: testDeviceState } } },
+                device: {
+                    selectedDevice: testDeviceState,
+                    devices: [{ state: { staticSessionId: testDeviceState } }],
+                },
                 tokenDefinitions: {
                     eth: {
                         coin: {
@@ -487,7 +496,10 @@ describe('commonSelectors', () => {
                     settings: { localCurrency: 'usd', enabledNetworks: ['eth'] },
                     transactions: { transactions: {} },
                 },
-                device: { selectedDevice: { state: { staticSessionId: testDeviceState } } },
+                device: {
+                    selectedDevice: testDeviceState,
+                    devices: [{ state: { staticSessionId: testDeviceState } }],
+                },
                 tokenDefinitions: {
                     eth: {
                         coin: {
@@ -542,7 +554,10 @@ describe('commonSelectors', () => {
                     settings: { localCurrency: 'usd', enabledNetworks: ['eth'] },
                     transactions: { transactions: {} },
                 },
-                device: { selectedDevice: { state: { staticSessionId: testDeviceState } } },
+                device: {
+                    selectedDevice: testDeviceState,
+                    devices: [{ state: { staticSessionId: testDeviceState } }],
+                },
                 tokenDefinitions: {
                     eth: {
                         coin: {
@@ -595,7 +610,10 @@ describe('commonSelectors', () => {
                     settings: { localCurrency: 'usd', enabledNetworks: ['eth'] },
                     transactions: { transactions: {} },
                 },
-                device: { selectedDevice: { state: { staticSessionId: testDeviceState } } },
+                device: {
+                    selectedDevice: testDeviceState,
+                    devices: [{ state: { staticSessionId: testDeviceState } }],
+                },
                 tokenDefinitions: {}, // No token definitions
                 fiat: { rates: {}, current: 'usd' },
             } as any;
@@ -628,7 +646,10 @@ describe('commonSelectors', () => {
                     settings: { localCurrency: 'usd', enabledNetworks: ['btc'] },
                     transactions: { transactions: {} },
                 },
-                device: { selectedDevice: { state: { staticSessionId: testDeviceState } } },
+                device: {
+                    selectedDevice: testDeviceState,
+                    devices: [{ state: { staticSessionId: testDeviceState } }],
+                },
                 tokenDefinitions: {},
                 fiat: { rates: {}, current: 'usd' },
             } as any;
@@ -659,7 +680,10 @@ describe('commonSelectors', () => {
                     settings: { localCurrency: 'usd', enabledNetworks: ['btc'] },
                     transactions: { transactions: {} },
                 },
-                device: { selectedDevice: { state: { staticSessionId: testDeviceState } } },
+                device: {
+                    selectedDevice: testDeviceState,
+                    devices: [{ state: { staticSessionId: testDeviceState } }],
+                },
                 tokenDefinitions: {},
                 fiat: { rates: {}, current: 'usd' },
             } as any;

--- a/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
+++ b/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
@@ -131,12 +131,7 @@ const getTestState = ({
                 },
             } as TrezorDevice,
         ],
-        selectedDevice: {
-            state: {
-                sessionId: '1',
-                staticSessionId: staticStateString,
-            },
-        } as TrezorDevice,
+        selectedDevice: staticStateString,
         isDeviceAutoEjectEnabled: false,
     },
 });


### PR DESCRIPTION
storing selectedDevice by reference instead of doing full copy. 
This could bring some code clarity and maybe also some performance optimization 

<img width="1283" height="1043" alt="image" src="https://github.com/user-attachments/assets/e4080525-4eaa-45e1-bddc-eb79fa6cba39" />


### QA  notes:

- affects both desktop and mobile
- affects passphrase 
- wipe device should forget wallet and accounts correctly
- removing wallets should correctly switch to a remaining wallet
- reloading with a wallet selected should work

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=device-reference-2&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=device-reference-2&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=device-reference-2&lookback=7)