### PR TITLE
fix(suite-native): render passphrase input form immediately

### DIFF
--- a/suite-native/module-authorize-device/src/navigation/PassphraseStackNavigator.tsx
+++ b/suite-native/module-authorize-device/src/navigation/PassphraseStackNavigator.tsx
@@ -67,7 +67,7 @@ export const PassphraseStackNavigator = () => {
                 />
             )}
 
-            {passphraseState === 'starting' && (
+            {['starting', 'enter-passphrase'].includes(passphraseState) && (
                 <PassphraseStack.Screen
                     name={AuthorizeDeviceStackRoutes.PassphraseForm}
                     component={PassphraseFormScreen}


### PR DESCRIPTION
this should fix #20964

One thing I am not certain about - I am getting this warning now

```
 WARN  Found screens with the same name nested inside one another. Check:

AuthorizeDeviceStack > PassphraseForm, AuthorizeDeviceStack > PassphraseForm > PassphraseForm
```



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-native-passphrase-form&lookback=7)