### PR TITLE
feat(suite): allow adding the next account (sequential indices)

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
@@ -3,7 +3,6 @@ import { useCallback } from 'react';
 import { Network, NetworkAccount } from '@suite-common/wallet-config';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { UnavailableCapability } from '@trezor/connect';
-import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { Translation } from 'src/components/suite';
 import { useAccountSearch, useSelector } from 'src/hooks/suite';
@@ -18,7 +17,7 @@ const verifyAvailability = ({
     unavailableCapability,
 }: {
     emptyAccounts: Account[];
-    account: Account;
+    account?: Account;
     unavailableCapability?: UnavailableCapability;
 }) => {
     if (unavailableCapability === 'no-support') {
@@ -37,66 +36,69 @@ const verifyAvailability = ({
         // discovery failed?
         return 'MODAL_ADD_ACCOUNT_NO_ACCOUNT';
     }
-    if (emptyAccounts.length === 0) {
-        return 'MODAL_ADD_ACCOUNT_NO_EMPTY_ACCOUNT';
-    }
-    if (emptyAccounts.length > 1) {
-        // prev account is empty, do not add another
-        return 'MODAL_ADD_ACCOUNT_PREVIOUS_EMPTY';
-    }
-    if (account.index === 0 && account.empty && account.accountType === 'normal') {
-        // current (first normal) account is empty, do not add another
-        return 'MODAL_ADD_ACCOUNT_PREVIOUS_EMPTY';
-    }
-    if (account.index >= 10) {
-        return 'MODAL_ADD_ACCOUNT_LIMIT_EXCEEDED';
+
+    if (account.networkType !== 'ethereum') {
+        if (emptyAccounts.length === 0) {
+            return 'MODAL_ADD_ACCOUNT_NO_EMPTY_ACCOUNT';
+        }
+        if (emptyAccounts.length > 1) {
+            // prev account is empty, do not add another
+            return 'MODAL_ADD_ACCOUNT_PREVIOUS_EMPTY';
+        }
+        if (account.index === 0 && account.empty && account.accountType === 'normal') {
+            // current (first normal) account is empty, do not add another
+            return 'MODAL_ADD_ACCOUNT_PREVIOUS_EMPTY';
+        }
     }
 };
 
 interface AddAccountButtonProps {
     network: Network;
     selectedAccount?: NetworkAccount;
-    emptyAccounts: Account[];
+    scopedAccounts: Account[];
     onEnableAccount: (account: Account) => void;
+    onAddNewAccount: () => void;
 }
 
 const AddDefaultAccountButton = ({
-    emptyAccounts,
+    scopedAccounts,
     onEnableAccount,
+    onAddNewAccount,
     network,
     selectedAccount,
 }: AddAccountButtonProps) => {
-    const defaultAccount = emptyAccounts[emptyAccounts.length - 1];
+    const defaultAccount = scopedAccounts.at(-1);
     const device = useSelector(selectSelectedDevice);
 
     const { setCoinFilter, setSearchString, coinFilter } = useAccountSearch();
 
     const handleClick = useCallback(() => {
-        const { accountType: type, path, symbol } = defaultAccount;
-        onEnableAccount(defaultAccount);
-        // reset search string in account search box
-        setSearchString(undefined);
-        if (coinFilter && coinFilter !== symbol) {
-            // if coinFilter is active then reset it only if added account doesn't belong to selected/filtered coin
-            setCoinFilter(undefined);
+        if (defaultAccount) {
+            onEnableAccount(defaultAccount);
+            // reset search string in account search box
+            setSearchString(undefined);
+            if (coinFilter && coinFilter !== defaultAccount.symbol) {
+                // if coinFilter is active then reset it only if added account doesn't belong to selected/filtered coin
+                setCoinFilter(undefined);
+            }
+        } else {
+            onAddNewAccount();
         }
-        // just to log that account was added manually.
-        analytics.report({
-            type: EventType.AccountsNewAccount,
-            payload: {
-                type,
-                path,
-                symbol,
-            },
-        });
-    }, [defaultAccount, onEnableAccount, setSearchString, setCoinFilter, coinFilter]);
+    }, [
+        defaultAccount,
+        onEnableAccount,
+        setSearchString,
+        coinFilter,
+        onAddNewAccount,
+        setCoinFilter,
+    ]);
 
     const unavailableCapability = selectedAccount?.accountType
         ? device?.unavailableCapabilities?.[selectedAccount?.accountType]
         : undefined;
 
     const disabledMessage = verifyAvailability({
-        emptyAccounts,
+        emptyAccounts: scopedAccounts.filter(account => account.empty),
         account: defaultAccount,
         unavailableCapability,
     });
@@ -113,8 +115,9 @@ const AddDefaultAccountButton = ({
 export const AddAccountButton = ({
     network,
     selectedAccount,
-    emptyAccounts,
+    scopedAccounts,
     onEnableAccount,
+    onAddNewAccount,
 }: AddAccountButtonProps) => {
     switch (selectedAccount?.accountType) {
         case 'coinjoin':
@@ -124,8 +127,9 @@ export const AddAccountButton = ({
                 <AddDefaultAccountButton
                     network={network}
                     selectedAccount={selectedAccount}
-                    emptyAccounts={emptyAccounts}
+                    scopedAccounts={scopedAccounts}
                     onEnableAccount={onEnableAccount}
+                    onAddNewAccount={onAddNewAccount}
                 />
             );
     }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -2,12 +2,14 @@ import { useState } from 'react';
 
 import styled from 'styled-components';
 
+import { notificationsActions } from '@suite-common/toast-notifications';
 import { Network, NetworkAccount, NetworkSymbol, networks } from '@suite-common/wallet-config';
 import {
     accountsActions,
     changeCoinVisibility,
     selectEnabledNetworks,
 } from '@suite-common/wallet-core';
+import { prepareNewAccountPayload } from '@suite-common/wallet-utils';
 import { CollapsibleBox, Modal, Tooltip } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { spacings, spacingsPx } from '@trezor/theme';
@@ -93,15 +95,17 @@ export const AddAccountModal = ({
 
     // Collect all empty accounts related to selected device and selected accountType
     const currentType = selectedAccount?.accountType ?? 'normal';
-    const emptyAccounts = selectedNetwork
-        ? accounts.filter(
-              a =>
-                  a.deviceState === device.state?.staticSessionId &&
-                  a.symbol === selectedNetwork.symbol &&
-                  a.accountType === currentType &&
-                  a.empty,
-          )
+    const scopedAccounts = selectedNetwork
+        ? accounts
+              .filter(
+                  a =>
+                      a.deviceState === device.state?.staticSessionId &&
+                      a.symbol === selectedNetwork.symbol &&
+                      a.accountType === currentType,
+              )
+              .toSorted((a, b) => a.index - b.index)
         : [];
+    const emptyAccounts = selectedNetwork ? scopedAccounts.filter(a => a.empty) : [];
 
     const filterNetworksBySymbol = (networks: Network[], symbol?: NetworkSymbol) =>
         symbol ? networks.filter(network => network.symbol === symbol) : networks;
@@ -176,9 +180,36 @@ export const AddAccountModal = ({
             }
         }
     };
-    const addAccount = (account: Account) => {
+
+    const enableAccount = async (account: Account) => {
         onCancel();
-        dispatch(accountsActions.changeAccountVisibility(account));
+        if (account.visible) {
+            const newAccount = await prepareNewAccountPayload({
+                accountType: account.accountType,
+                networkSymbol: account.symbol,
+                index: account.index + 1,
+                backendType: account.backendType != 'coinjoin' ? account.backendType : undefined,
+                selectedAccount,
+                accountTypes,
+                deviceState: device.state?.staticSessionId,
+            });
+
+            if (newAccount instanceof Error) {
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'discovery-error',
+                        error: newAccount.message,
+                    }),
+                );
+
+                return;
+            }
+
+            dispatch(accountsActions.createAccount(newAccount));
+        } else {
+            dispatch(accountsActions.changeAccountVisibility(account));
+        }
+
         onAddAccount?.(account);
         if (app === 'wallet' && !noRedirect) {
             // redirect to account only if added from "wallet" app
@@ -191,6 +222,37 @@ export const AddAccountModal = ({
                     },
                 }),
             );
+        }
+    };
+
+    const addNewAccount = async () => {
+        if (selectedNetwork) {
+            const account = selectedNetwork.accountTypes[currentType];
+
+            if (account) {
+                const newAccount = await prepareNewAccountPayload({
+                    accountType: account.accountType,
+                    networkSymbol: selectedNetwork.symbol,
+                    index: 0,
+                    backendType:
+                        account.backendType != 'coinjoin' ? account.backendType : undefined,
+                    selectedAccount,
+                    accountTypes,
+                    deviceState: device.state?.staticSessionId,
+                });
+                if (newAccount instanceof Error) {
+                    dispatch(
+                        notificationsActions.addToast({
+                            type: 'discovery-error',
+                            error: newAccount.message,
+                        }),
+                    );
+
+                    return;
+                }
+
+                dispatch(accountsActions.createAccount(newAccount));
+            }
         }
     };
 
@@ -311,8 +373,9 @@ export const AddAccountModal = ({
                     <AddAccountButton
                         network={selectedNetwork}
                         selectedAccount={selectedAccount}
-                        emptyAccounts={emptyAccounts}
-                        onEnableAccount={addAccount}
+                        scopedAccounts={scopedAccounts}
+                        onEnableAccount={enableAccount}
+                        onAddNewAccount={addNewAccount}
                     />
                 ) : (
                     <Modal.Button onClick={enableNetwork}>

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -3,10 +3,12 @@ import {
     type AccountType,
     type Bip43Path,
     type Bip43PathTemplate,
+    type NetworkAccount,
     type NetworkFeature,
     type NetworkSymbol,
     type NetworkSymbolExtended,
     type NetworkType,
+    type TrezorConnectBackendType,
     getNetwork,
     getNetworkDisplaySymbol,
     networkSymbolCollection,
@@ -26,7 +28,7 @@ import {
 } from '@suite-common/wallet-types';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { formatTokenSymbol } from '@trezor/blockchain-link-utils';
-import {
+import TrezorConnect, {
     AccountAddress,
     AccountAddresses,
     AccountInfo,
@@ -38,6 +40,7 @@ import {
     TokenInfo,
     TokenTransfer,
 } from '@trezor/connect';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { exhaustive } from '@trezor/type-utils';
 import { HELP_CENTER_ADDRESSES_URL, HELP_CENTER_TAPROOT_URL } from '@trezor/urls';
 import { arrayDistinct, bufferUtils } from '@trezor/utils';
@@ -1228,5 +1231,58 @@ export const parseAccountKey = (accountKey: AccountKey) => {
         accountDescriptor: accountDescriptor as AccountDescriptor,
         networkSymbol: networkSymbol as NetworkSymbol,
         deviceStaticSessionId: deviceStaticSessionId as StaticSessionId,
+    };
+};
+
+export const prepareNewAccountPayload = async ({
+    accountType,
+    networkSymbol,
+    index,
+    backendType,
+    selectedAccount,
+    accountTypes,
+    deviceState,
+}: {
+    accountType: AccountType;
+    networkSymbol: NetworkSymbol;
+    index: number;
+    backendType?: TrezorConnectBackendType;
+    selectedAccount?: NetworkAccount;
+    accountTypes?: NetworkAccount[];
+    deviceState?: StaticSessionId;
+}) => {
+    const networkAccount =
+        selectedAccount ?? accountTypes?.find(v => v.accountType === accountType);
+
+    const newPath = networkAccount?.bip43Path.replace('i', String(index));
+
+    if (!newPath || !deviceState) return new Error('Missing path');
+
+    const res = await TrezorConnect.getAccountInfo({
+        path: newPath,
+        coin: networkSymbol,
+    });
+
+    if (!res.success) return new Error(res.payload.error);
+
+    // just to log that account was added manually.
+    analytics.report({
+        type: EventType.AccountsNewAccount,
+        payload: {
+            type: accountType,
+            path: newPath,
+            symbol: networkSymbol,
+        },
+    });
+
+    return {
+        accountInfo: res.payload,
+        visible: true,
+        deviceState,
+        symbol: networkSymbol,
+        index,
+        accountType,
+        path: newPath as Bip43Path,
+        backendType,
     };
 };


### PR DESCRIPTION
## Description

When the user chooses to add another account, discovery now targets the immediate next index (N+1) for the selected network.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15417
Resolve https://github.com/trezor/trezor-suite/issues/5659

## Video:

https://github.com/user-attachments/assets/942ad793-466b-4a47-82c4-c502b4276c93

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/discovery-next-account&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/discovery-next-account&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/discovery-next-account&lookback=7)