### PR TITLE
fix(suite-native): allow bluetooth connect for ble devices only

### DIFF
--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -192,6 +192,11 @@ export const selectHasDevicePassphraseEntryCapability = createMemoizedSelector(
     capabilities => !!capabilities?.includes('Capability_PassphraseEntry'),
 );
 
+export const selectHasDeviceBluetoothCapability = createMemoizedSelector(
+    [selectDeviceCapabilities],
+    capabilities => !!capabilities?.includes('Capability_BLE'),
+);
+
 export const selectDeviceStatus = createMemoizedSelector(
     [selectSelectedDevice],
     device => device && getStatus(device),

--- a/suite-native/module-authorize-device/src/screens/connect/ConnectAndUnlockDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/ConnectAndUnlockDeviceScreen.tsx
@@ -3,7 +3,11 @@ import { useSelector } from 'react-redux';
 
 import { useIsFocused } from '@react-navigation/native';
 
-import { selectIsDeviceAuthorized, selectIsDeviceConnected } from '@suite-common/wallet-core';
+import {
+    selectHasDeviceBluetoothCapability,
+    selectIsDeviceAuthorized,
+    selectIsDeviceConnected,
+} from '@suite-common/wallet-core';
 import { ConnectAndUnlockDeviceScreenContent } from '@suite-native/device';
 import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import {
@@ -24,8 +28,9 @@ export const ConnectAndUnlockDeviceScreen = ({
     AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice,
     RootStackParamList
 >) => {
-    const isBluetoothEnabled = useFeatureFlag(FeatureFlag.IsBluetoothEnabled);
+    const isBluetoothFeatureFlagEnabled = useFeatureFlag(FeatureFlag.IsBluetoothEnabled);
 
+    const isBluetoothDevice = useSelector(selectHasDeviceBluetoothCapability);
     const isDeviceAuthorized = useSelector(selectIsDeviceAuthorized);
     const isFocused = useIsFocused();
     const isDeviceConnected = useSelector(selectIsDeviceConnected);
@@ -55,6 +60,8 @@ export const ConnectAndUnlockDeviceScreen = ({
         }
     }, [isDeviceAuthorized, isDeviceConnected, isFocused, navigateBack]);
 
+    const isBluetoothConnectionAvailable = isBluetoothFeatureFlagEnabled && isBluetoothDevice;
+
     return (
         <Screen
             header={
@@ -69,7 +76,9 @@ export const ConnectAndUnlockDeviceScreen = ({
         >
             <ConnectAndUnlockDeviceScreenContent
                 onConnectViaBluetooth={
-                    isBluetoothEnabled ? navigateToTurnOnAndUnlockDeviceScreen : undefined
+                    isBluetoothConnectionAvailable
+                        ? navigateToTurnOnAndUnlockDeviceScreen
+                        : undefined
                 }
             />
         </Screen>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve #20871

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/connect-via-bluetooth-button&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/connect-via-bluetooth-button&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/connect-via-bluetooth-button&lookback=7)