### PR TITLE
fix(suite-native): check backup test works again

### DIFF
--- a/suite-native/app/e2e/tests/deviceSettings.test.ts
+++ b/suite-native/app/e2e/tests/deviceSettings.test.ts
@@ -16,10 +16,11 @@ import {
     restartApp,
 } from '../utils';
 
+const defaultEmulatorOptions: PrepareTrezorEmulatorProps = { seed: MNEMONICS.mnemonic_all };
+
 conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () => {
     beforeAll(async () => {
-        const emulatorOptions: PrepareTrezorEmulatorProps = { seed: MNEMONICS.mnemonic_all };
-        await prepareTrezorEmulator(emulatorOptions);
+        await prepareTrezorEmulator(defaultEmulatorOptions);
         await openApp({ newInstance: true, args: { preloadedState: onboardingCompleted } });
 
         await onCoinEnabling.waitForInitScreen();
@@ -34,7 +35,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () =>
 
     describe('Tests with T3T1 device model', () => {
         beforeEach(async () => {
-            await prepareTrezorEmulator();
+            await prepareTrezorEmulator(defaultEmulatorOptions);
             await restartApp();
             await appIsFullyLoaded();
 
@@ -123,13 +124,8 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () =>
     });
 
     describe('Tests with FW update required', () => {
-        const emulatorOptions: PrepareTrezorEmulatorProps = {
-            seed: MNEMONICS.mnemonic_all,
-            version: '2.8.9',
-        };
-
         beforeEach(async () => {
-            await prepareTrezorEmulator(emulatorOptions);
+            await prepareTrezorEmulator({ ...defaultEmulatorOptions, version: '2.8.9' });
             await restartApp({ args: { isFirmwareUpdateEnabled: true } });
             await appIsFullyLoaded();
 
@@ -150,13 +146,8 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () =>
     });
 
     describe('Tests with T1B1 device model', () => {
-        const emulatorOptions: PrepareTrezorEmulatorProps = {
-            seed: MNEMONICS.mnemonic_all,
-            model: 'T1B1',
-        };
-
         beforeEach(async () => {
-            await prepareTrezorEmulator(emulatorOptions);
+            await prepareTrezorEmulator({ ...defaultEmulatorOptions, model: 'T1B1' });
             await restartApp();
             await appIsFullyLoaded();
 


### PR DESCRIPTION
## Description
Fixes `Tests with T3T1 device model - Device Check Backup` test. This test was failing due to initalizing device with calling `prepareTrezorEmulator()` with no arguments, instead initializing the device with the all seed as expected.

💡 I am still not very happy about the structure of the tests. But let's revisit this matter with soon planned e2e test launch arguments refactor. 


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/check-backup-e2e-test&lookback=7)