### PR TITLE
Feat(suite): tooltip instead of wallet-switcher on device connect

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/suite/multiple-sessions.test.ts
@@ -64,6 +64,7 @@ test.describe('Multiple sessions', { tag: ['@group=suite'] }, () => {
             });
 
             await test.step('Take Bridge session back', async () => {
+                await dashboardPage.deviceSwitchingOpenButton.click();
                 await dashboardPage.solveIssuesButton.click();
                 await expect(page.getByTestId('@deviceStatus-connected').first()).toBeVisible();
             });

--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -16,6 +16,7 @@ const SUITE_DEVICE_UNACQUIRED = getSuiteDevice({
     type: 'unacquired',
     path: '2',
 });
+const SUITE_DEVICE_REMEMBERED = getSuiteDevice({ connected: false });
 const CONNECT_DEVICE = getConnectDevice({ path: '1' });
 
 const reducerActions = [
@@ -303,42 +304,54 @@ const selectDevice = [
     },
 ];
 
-type DeviceConnectFixture = {
+type HandleDeviceConnectFixture = {
     description: string;
     state: {
         suite: Partial<AppState['suite']>;
         device: Partial<AppState['device']>;
     };
-    device: Device;
+    newlyConnectedDevice: Device;
     expectedNextActionType: string;
 };
 
-const handleDeviceConnect: DeviceConnectFixture[] = [
+const handleDeviceConnect: HandleDeviceConnectFixture[] = [
     {
         description: `selects a newly connected device if there are none`,
-        state: {
-            device: { devices: [SUITE_DEVICE] },
-            suite: {},
-        },
-        device: CONNECT_DEVICE,
+        state: { device: {}, suite: {} },
+        newlyConnectedDevice: CONNECT_DEVICE,
         expectedNextActionType: deviceActions.selectDevice.type,
     },
     {
         description: `selects a newly connected physical device corresponding to selected remembered wallet `,
         state: {
-            device: { selectedDevice: SUITE_DEVICE },
+            device: { devices: [SUITE_DEVICE_REMEMBERED], selectedDevice: SUITE_DEVICE_REMEMBERED },
             suite: {},
         },
-        device: CONNECT_DEVICE,
+        newlyConnectedDevice: CONNECT_DEVICE,
         expectedNextActionType: deviceActions.selectDevice.type,
     },
     {
-        description: `opens the wallet switcher when newly connected physical not seen before`,
+        description: `marks device as recently connected if not seen before`,
         state: {
-            device: { selectedDevice: SUITE_DEVICE },
+            device: { devices: [SUITE_DEVICE_REMEMBERED], selectedDevice: SUITE_DEVICE_REMEMBERED },
             suite: {},
         },
-        device: { ...CONNECT_DEVICE, id: 'a-different-id' } as Device,
+        newlyConnectedDevice: { ...CONNECT_DEVICE, id: 'a-different-id' } as Device,
+        expectedNextActionType: SUITE.SET_RECENTLY_CONNECTED_DEVICE,
+    },
+    {
+        description: `opens the wallet switcher if more than one physically connected device`,
+        state: {
+            device: {
+                devices: [
+                    getSuiteDevice({ path: '777', id: 'foo', connected: true }),
+                    getSuiteDevice({ path: '888', id: 'bar', connected: true }),
+                ],
+                selectedDevice: getSuiteDevice({ path: '777', id: 'foo', connected: true }),
+            },
+            suite: {},
+        },
+        newlyConnectedDevice: CONNECT_DEVICE,
         expectedNextActionType: openSwitchDeviceDialog.pending.type,
     },
 ];

--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -6,7 +6,6 @@ import { DEVICE, Device, TRANSPORT } from '@trezor/connect';
 import { SUITE } from 'src/actions/suite/constants';
 import { AppState, TorStatus } from 'src/types/suite';
 
-import { openSwitchDeviceDialog } from '../../wallet/addWalletThunk';
 import * as suiteActions from '../suiteActions';
 
 const { getSuiteDevice, getConnectDevice } = testMocks;
@@ -338,21 +337,6 @@ const handleDeviceConnect: HandleDeviceConnectFixture[] = [
         },
         newlyConnectedDevice: { ...CONNECT_DEVICE, id: 'a-different-id' } as Device,
         expectedNextActionType: SUITE.SET_RECENTLY_CONNECTED_DEVICE,
-    },
-    {
-        description: `opens the wallet switcher if more than one physically connected device`,
-        state: {
-            device: {
-                devices: [
-                    getSuiteDevice({ path: '777', id: 'foo', connected: true }),
-                    getSuiteDevice({ path: '888', id: 'bar', connected: true }),
-                ],
-                selectedDevice: getSuiteDevice({ path: '777', id: 'foo', connected: true }),
-            },
-            suite: {},
-        },
-        newlyConnectedDevice: CONNECT_DEVICE,
-        expectedNextActionType: openSwitchDeviceDialog.pending.type,
     },
 ];
 

--- a/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
@@ -151,10 +151,7 @@ describe('Suite Actions', () => {
             const store = initStore(state);
 
             const device = f.newlyConnectedDevice;
-            const prevConnectedDevices = f.state.device.devices ?? [];
-            // ensure the device is processed into redux, as handleDeviceConnect is called afterwards and counts on it
-            await store.dispatch(deviceActions.connectDevice({ device: f.newlyConnectedDevice }));
-            await store.dispatch(handleDeviceConnect({ device, prevConnectedDevices }));
+            await store.dispatch(handleDeviceConnect(device));
             // a lot of actions may get called, and the one we are interested in may not be the last one
             expect(store.getActions().some(a => a?.type === f.expectedNextActionType)).toBe(true);
         });

--- a/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
@@ -149,7 +149,12 @@ describe('Suite Actions', () => {
         it(`handleDeviceConnect: ${f.description}`, async () => {
             const state = getInitialState(f.state.suite, f.state.device, undefined);
             const store = initStore(state);
-            await store.dispatch(handleDeviceConnect(f.device));
+
+            const device = f.newlyConnectedDevice;
+            const prevConnectedDevices = f.state.device.devices ?? [];
+            // ensure the device is processed into redux, as handleDeviceConnect is called afterwards and counts on it
+            await store.dispatch(deviceActions.connectDevice({ device: f.newlyConnectedDevice }));
+            await store.dispatch(handleDeviceConnect({ device, prevConnectedDevices }));
             // a lot of actions may get called, and the one we are interested in may not be the last one
             expect(store.getActions().some(a => a?.type === f.expectedNextActionType)).toBe(true);
         });

--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -13,6 +13,7 @@ export const SET_LANGUAGE = '@suite/set-language';
 export const SET_DEBUG_MODE = '@suite/set-debug-mode';
 export const SET_FIRMWARE_UPDATE_SOURCE = '@suite/firmware-update-source';
 export const SET_FLAG = '@suite/set-flag';
+export const SET_RECENTLY_CONNECTED_DEVICE = '@suite/set-recently-connected-device';
 export const SET_RECENTLY_DISCONNECTED_DEVICE = '@suite/set-recently-disconnected-device';
 export const ADD_DEVICE_ID_TO_SEEN_DISCONNECT_NOTIFICATION =
     '@suite/add-device-id-to-seen-disconnect-notification';

--- a/packages/suite/src/actions/suite/initAction.ts
+++ b/packages/suite/src/actions/suite/initAction.ts
@@ -18,6 +18,7 @@ import * as languageActions from 'src/actions/settings/languageActions';
 import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
 import * as modalActions from 'src/actions/suite/modalActions';
 import * as routerActions from 'src/actions/suite/routerActions';
+import { handleDeviceConnect } from 'src/actions/wallet/handleDeviceConnectThunk';
 import type { AcquiredDevice, Dispatch, GetState } from 'src/types/suite';
 
 import { SUITE } from './constants';
@@ -74,7 +75,7 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
         // see more details here: https://redux-toolkit.js.org/api/createAsyncThunk#unwrapping-result-actions
         await dispatch(
             trezorConnectActions.connectInitThunk({
-                [DEVICE.CONNECT]: (_device, prevConnectedDevices) => {
+                [DEVICE.CONNECT]: (device, prevConnectedDevices) => {
                     const previouslyConnectedUniqueDevices = prevConnectedDevices
                         .filter(device => device.connected)
                         .reduce<Map<string, AcquiredDevice>>((acc, device) => {
@@ -99,6 +100,7 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
                         return acc;
                     }, new Map<string, AcquiredDevice>());
 
+                    // open device switcher only a new device connected and there are more already
                     if (
                         uniqueConnectedDevices.size > 1 &&
                         uniqueConnectedDevices.size > previouslyConnectedUniqueDevices.size
@@ -110,7 +112,11 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
                                 },
                             }),
                         );
+
+                        return;
                     }
+                    // otherwise either automatically select, or just visually indicate new connected device
+                    dispatch(handleDeviceConnect(device));
                 },
                 [UI.INVALID_PIN_ATTEMPTS_DEPLETED]: () => {
                     dispatch(

--- a/packages/suite/src/actions/suite/initAction.ts
+++ b/packages/suite/src/actions/suite/initAction.ts
@@ -6,7 +6,6 @@ import {
     initDevices,
     periodicCheckStakeDataThunk,
     periodicFetchFiatRatesThunk,
-    selectDevices,
     updateMissingTxFiatRatesThunk,
 } from '@suite-common/wallet-core';
 import * as walletConnectActions from '@suite-common/walletconnect';
@@ -19,7 +18,7 @@ import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActi
 import * as modalActions from 'src/actions/suite/modalActions';
 import * as routerActions from 'src/actions/suite/routerActions';
 import { handleDeviceConnect } from 'src/actions/wallet/handleDeviceConnectThunk';
-import type { AcquiredDevice, Dispatch, GetState } from 'src/types/suite';
+import type { Dispatch, GetState } from 'src/types/suite';
 
 import { SUITE } from './constants';
 import { onSuiteReady, setFlag } from './suiteActions';
@@ -76,47 +75,7 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
         await dispatch(
             trezorConnectActions.connectInitThunk({
                 [DEVICE.CONNECT]: (device, prevConnectedDevices) => {
-                    const previouslyConnectedUniqueDevices = prevConnectedDevices
-                        .filter(device => device.connected)
-                        .reduce<Map<string, AcquiredDevice>>((acc, device) => {
-                            if (device.id && !acc.has(device.id)) {
-                                acc.set(device.id, device);
-                            }
-
-                            return acc;
-                        }, new Map<string, AcquiredDevice>());
-
-                    const currentConnectedDevices = selectDevices(getState()).filter(
-                        device => device.connected,
-                    );
-
-                    const uniqueConnectedDevices = currentConnectedDevices.reduce<
-                        Map<string, AcquiredDevice>
-                    >((acc, device) => {
-                        if (device.id && !acc.has(device.id)) {
-                            acc.set(device.id, device);
-                        }
-
-                        return acc;
-                    }, new Map<string, AcquiredDevice>());
-
-                    // open device switcher only a new device connected and there are more already
-                    if (
-                        uniqueConnectedDevices.size > 1 &&
-                        uniqueConnectedDevices.size > previouslyConnectedUniqueDevices.size
-                    ) {
-                        dispatch(
-                            routerActions.goto('suite-switch-device', {
-                                params: {
-                                    cancelable: true,
-                                },
-                            }),
-                        );
-
-                        return;
-                    }
-                    // otherwise either automatically select, or just visually indicate new connected device
-                    dispatch(handleDeviceConnect(device));
+                    dispatch(handleDeviceConnect({ device, prevConnectedDevices }));
                 },
                 [UI.INVALID_PIN_ATTEMPTS_DEPLETED]: () => {
                     dispatch(

--- a/packages/suite/src/actions/suite/initAction.ts
+++ b/packages/suite/src/actions/suite/initAction.ts
@@ -74,8 +74,8 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
         // see more details here: https://redux-toolkit.js.org/api/createAsyncThunk#unwrapping-result-actions
         await dispatch(
             trezorConnectActions.connectInitThunk({
-                [DEVICE.CONNECT]: (device, prevConnectedDevices) => {
-                    dispatch(handleDeviceConnect({ device, prevConnectedDevices }));
+                [DEVICE.CONNECT]: device => {
+                    dispatch(handleDeviceConnect(device));
                 },
                 [UI.INVALID_PIN_ATTEMPTS_DEPLETED]: () => {
                     dispatch(

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -50,6 +50,10 @@ export type SuiteAction =
           value: boolean;
       }
     | {
+          type: typeof SUITE.SET_RECENTLY_CONNECTED_DEVICE;
+          payload: string | null;
+      }
+    | {
           type: typeof SUITE.SET_RECENTLY_DISCONNECTED_DEVICE;
           payload: string | null;
       }
@@ -149,6 +153,10 @@ export const setFlag = (key: keyof AppState['suite']['flags'], value: boolean): 
     value,
 });
 
+export const setRecentlyConnectedDevicePath = (payload: string | null): SuiteAction => ({
+    type: SUITE.SET_RECENTLY_CONNECTED_DEVICE,
+    payload,
+});
 export const setRecentlyDisconnectedDevice = (payload: string | null): SuiteAction => ({
     type: SUITE.SET_RECENTLY_DISCONNECTED_DEVICE,
     payload,

--- a/packages/suite/src/actions/wallet/handleDeviceConnectThunk.ts
+++ b/packages/suite/src/actions/wallet/handleDeviceConnectThunk.ts
@@ -1,45 +1,22 @@
 import { createThunk } from '@suite-common/redux-utils';
-import type { AcquiredDevice, TrezorDevice } from '@suite-common/suite-types';
 import {
     DEVICE_MODULE_PREFIX,
     selectDeviceThunk,
-    selectDevices,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { Device } from '@trezor/connect';
 
 import { selectRecentlyConnectedDevice } from 'src/selectors/suite/suiteSelectors';
 
-import { openSwitchDeviceDialog } from './addWalletThunk';
 import { setRecentlyConnectedDevicePath } from '../suite/suiteActions';
-
-const getUniqueConnectedDevices = (devices: TrezorDevice[]) =>
-    devices
-        .filter(device => device.connected)
-        .reduce<Map<string, AcquiredDevice>>((acc, device) => {
-            if (device.id && !acc.has(device.id)) {
-                acc.set(device.id, device);
-            }
-
-            return acc;
-        }, new Map<string, AcquiredDevice>());
 
 // duration to visually indicate the device as recently connected
 const RECENTLY_CONNECTED_DEVICE_TIMEOUT = 5_000;
 
-type HandleDeviceConnectParams = {
-    device: Device;
-    prevConnectedDevices: TrezorDevice[];
-};
-
-export const handleDeviceConnect = createThunk<void, HandleDeviceConnectParams, void>(
+export const handleDeviceConnect = createThunk<void, Device, void>(
     `${DEVICE_MODULE_PREFIX}/handleDeviceConnect`,
-    ({ device, prevConnectedDevices }, { dispatch, getState }) => {
+    (device, { dispatch, getState }) => {
         const selectedDevice = selectSelectedDevice(getState());
-        const currentDevices = selectDevices(getState());
-
-        const prevConnectedUniqueDevices = getUniqueConnectedDevices(prevConnectedDevices);
-        const uniqueConnectedDevices = getUniqueConnectedDevices(currentDevices);
 
         // Select automatically when it is the first known device (none selected),
         // or when we connected physical device corresponding to a selected remembered wallet.
@@ -50,18 +27,11 @@ export const handleDeviceConnect = createThunk<void, HandleDeviceConnectParams, 
             return;
         }
 
-        if (
-            uniqueConnectedDevices.size > 1 &&
-            uniqueConnectedDevices.size > prevConnectedUniqueDevices.size
-        ) {
-            dispatch(openSwitchDeviceDialog());
-
-            return;
-        }
-
+        // Set the Device as recently connected to show a notification in the UI, and schedule disappearance.
         // device.path preferred because we only care about current session (not persistent),
         // and the device may initially connect as unacquired before becoming acquired.
         dispatch(setRecentlyConnectedDevicePath(device.path ?? device.id ?? null));
+
         setTimeout(() => {
             // The device may have been disconnected, and another one connected in the meantime,
             // so ensure that timeout affects only that device for which it was scheduled.

--- a/packages/suite/src/actions/wallet/handleDeviceConnectThunk.ts
+++ b/packages/suite/src/actions/wallet/handleDeviceConnectThunk.ts
@@ -1,22 +1,45 @@
 import { createThunk } from '@suite-common/redux-utils';
+import type { AcquiredDevice, TrezorDevice } from '@suite-common/suite-types';
 import {
     DEVICE_MODULE_PREFIX,
     selectDeviceThunk,
+    selectDevices,
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { Device } from '@trezor/connect';
 
 import { selectRecentlyConnectedDevice } from 'src/selectors/suite/suiteSelectors';
 
+import { openSwitchDeviceDialog } from './addWalletThunk';
 import { setRecentlyConnectedDevicePath } from '../suite/suiteActions';
+
+const getUniqueConnectedDevices = (devices: TrezorDevice[]) =>
+    devices
+        .filter(device => device.connected)
+        .reduce<Map<string, AcquiredDevice>>((acc, device) => {
+            if (device.id && !acc.has(device.id)) {
+                acc.set(device.id, device);
+            }
+
+            return acc;
+        }, new Map<string, AcquiredDevice>());
 
 // duration to visually indicate the device as recently connected
 const RECENTLY_CONNECTED_DEVICE_TIMEOUT = 5_000;
 
-export const handleDeviceConnect = createThunk(
+type HandleDeviceConnectParams = {
+    device: Device;
+    prevConnectedDevices: TrezorDevice[];
+};
+
+export const handleDeviceConnect = createThunk<void, HandleDeviceConnectParams, void>(
     `${DEVICE_MODULE_PREFIX}/handleDeviceConnect`,
-    (device: Device, { dispatch, getState }) => {
+    ({ device, prevConnectedDevices }, { dispatch, getState }) => {
         const selectedDevice = selectSelectedDevice(getState());
+        const currentDevices = selectDevices(getState());
+
+        const prevConnectedUniqueDevices = getUniqueConnectedDevices(prevConnectedDevices);
+        const uniqueConnectedDevices = getUniqueConnectedDevices(currentDevices);
 
         // Select automatically when it is the first known device (none selected),
         // or when we connected physical device corresponding to a selected remembered wallet.
@@ -27,10 +50,18 @@ export const handleDeviceConnect = createThunk(
             return;
         }
 
+        if (
+            uniqueConnectedDevices.size > 1 &&
+            uniqueConnectedDevices.size > prevConnectedUniqueDevices.size
+        ) {
+            dispatch(openSwitchDeviceDialog());
+
+            return;
+        }
+
         // device.path preferred because we only care about current session (not persistent),
         // and the device may initially connect as unacquired before becoming acquired.
         dispatch(setRecentlyConnectedDevicePath(device.path ?? device.id ?? null));
-
         setTimeout(() => {
             // The device may have been disconnected, and another one connected in the meantime,
             // so ensure that timeout affects only that device for which it was scheduled.

--- a/packages/suite/src/actions/wallet/handleDeviceConnectThunk.ts
+++ b/packages/suite/src/actions/wallet/handleDeviceConnectThunk.ts
@@ -6,20 +6,42 @@ import {
 } from '@suite-common/wallet-core';
 import { Device } from '@trezor/connect';
 
-import { openSwitchDeviceDialog } from './addWalletThunk';
+import { selectRecentlyConnectedDevice } from 'src/selectors/suite/suiteSelectors';
+
+import { setRecentlyConnectedDevicePath } from '../suite/suiteActions';
+
+// duration to visually indicate the device as recently connected
+const RECENTLY_CONNECTED_DEVICE_TIMEOUT = 5_000;
 
 export const handleDeviceConnect = createThunk(
     `${DEVICE_MODULE_PREFIX}/handleDeviceConnect`,
     (device: Device, { dispatch, getState }) => {
         const selectedDevice = selectSelectedDevice(getState());
 
-        // Select automatically when it is the first known device,
+        // Select automatically when it is the first known device (none selected),
         // or when we connected physical device corresponding to a selected remembered wallet.
-        const shouldSelectDevice = !selectedDevice || device.id === selectedDevice.id;
+        const shouldSelectDevice = selectedDevice === undefined || device.id === selectedDevice.id;
         if (shouldSelectDevice) {
             dispatch(selectDeviceThunk({ device }));
-        } else {
-            dispatch(openSwitchDeviceDialog());
+
+            return;
         }
+
+        // device.path preferred because we only care about current session (not persistent),
+        // and the device may initially connect as unacquired before becoming acquired.
+        dispatch(setRecentlyConnectedDevicePath(device.path ?? device.id ?? null));
+
+        setTimeout(() => {
+            // The device may have been disconnected, and another one connected in the meantime,
+            // so ensure that timeout affects only that device for which it was scheduled.
+            const deviceCurrent = selectRecentlyConnectedDevice(getState());
+            const deviceWhenScheduled = device;
+            if (
+                deviceCurrent?.path === deviceWhenScheduled.path ||
+                deviceCurrent?.id === deviceWhenScheduled.id
+            ) {
+                dispatch(setRecentlyConnectedDevicePath(null));
+            }
+        }, RECENTLY_CONNECTED_DEVICE_TIMEOUT);
     },
 );

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
@@ -1,12 +1,16 @@
+import { useRef } from 'react';
+
 import styled, { css } from 'styled-components';
 
 import { selectSelectedDevice } from '@suite-common/wallet-core';
-import { Icon, Tooltip } from '@trezor/components';
+import { Box, Icon, Tooltip } from '@trezor/components';
 import { focusStyleTransition, getFocusShadowStyle } from '@trezor/components/src/utils/utils';
 import { borders, spacingsPx } from '@trezor/theme';
 
-import { goto } from 'src/actions/suite/routerActions';
+import { setRecentlyConnectedDevicePath } from 'src/actions/suite/suiteActions';
+import { openSwitchDeviceDialog } from 'src/actions/wallet/addWalletThunk';
 import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
+import { selectRecentlyConnectedDevice } from 'src/selectors/suite/suiteSelectors';
 
 import { SidebarDeviceStatus } from './SidebarDeviceStatus';
 import { useResponsiveContext } from '../../../../../support/suite/ResponsiveContext';
@@ -55,51 +59,74 @@ const InnerContainer = styled.div<{ $isDisabled?: boolean }>`
     cursor: ${({ $isDisabled }) => ($isDisabled ? 'not-allowed' : 'pointer')};
 `;
 
+const RecentlyConnectedDeviceTooltipContent = () => {
+    const dispatch = useDispatch();
+
+    const recentlyConnectedDevice = useSelector(selectRecentlyConnectedDevice);
+    // deviceName must stay at initial value to prevent flickering, because the tooltip disappearing animation takes some time.
+    const deviceNameRef = useRef(recentlyConnectedDevice?.name);
+    if (deviceNameRef.current === undefined) return null;
+
+    const handleClick = () => {
+        dispatch(openSwitchDeviceDialog());
+        dispatch(setRecentlyConnectedDevicePath(null));
+    };
+
+    return (
+        <Box onClick={handleClick}>
+            {deviceNameRef.current} <Translation id="TR_CONNECTED" />
+        </Box>
+    );
+};
+
 export const DeviceSelector = () => {
     const selectedDevice = useSelector(selectSelectedDevice);
+    const recentlyConnectedDevice = useSelector(selectRecentlyConnectedDevice);
     const dispatch = useDispatch();
     const { isDiscoveryRunning } = useDiscovery();
 
     const handleSwitchDeviceClick = () => {
         if (!isDiscoveryRunning) {
-            dispatch(
-                goto('suite-switch-device', {
-                    params: {
-                        cancelable: true,
-                    },
-                }),
-            );
+            dispatch(openSwitchDeviceDialog());
+            dispatch(setRecentlyConnectedDevicePath(null));
         }
     };
 
     const { isSidebarCollapsed } = useResponsiveContext();
 
     return (
-        <Wrapper $isSidebarCollapsed={isSidebarCollapsed}>
-            <Tooltip
-                isActive={isDiscoveryRunning}
-                isFullWidth
-                placement="bottom"
-                cursor={isDiscoveryRunning ? 'not-allowed' : undefined}
-                content={<Translation id="TR_UNAVAILABLE_WHILE_LOADING" />}
-            >
-                <InnerContainer
-                    onClick={handleSwitchDeviceClick}
-                    $isDisabled={isDiscoveryRunning}
-                    tabIndex={0}
-                    data-testid="@menu/switch-device"
+        <Tooltip
+            isOpen={recentlyConnectedDevice !== undefined}
+            content={<RecentlyConnectedDeviceTooltipContent />}
+            placement="right-end"
+            hasArrow
+        >
+            <Wrapper $isSidebarCollapsed={isSidebarCollapsed}>
+                <Tooltip
+                    isActive={isDiscoveryRunning}
+                    isFullWidth
+                    placement="bottom"
+                    cursor={isDiscoveryRunning ? 'not-allowed' : undefined}
+                    content={<Translation id="TR_UNAVAILABLE_WHILE_LOADING" />}
                 >
-                    <SidebarDeviceStatus />
+                    <InnerContainer
+                        onClick={handleSwitchDeviceClick}
+                        $isDisabled={isDiscoveryRunning}
+                        tabIndex={0}
+                        data-testid="@menu/switch-device"
+                    >
+                        <SidebarDeviceStatus />
 
-                    <ExpandedSidebarOnly>
-                        {selectedDevice && selectedDevice.state && (
-                            <CaretContainer>
-                                <Icon size={20} name="caretCircleDown" />
-                            </CaretContainer>
-                        )}
-                    </ExpandedSidebarOnly>
-                </InnerContainer>
-            </Tooltip>
-        </Wrapper>
+                        <ExpandedSidebarOnly>
+                            {selectedDevice && selectedDevice.state && (
+                                <CaretContainer>
+                                    <Icon size={20} name="caretCircleDown" />
+                                </CaretContainer>
+                            )}
+                        </ExpandedSidebarOnly>
+                    </InnerContainer>
+                </Tooltip>
+            </Wrapper>
+        </Tooltip>
     );
 };

--- a/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
@@ -83,28 +83,24 @@ describe('redirectMiddleware', () => {
         it('DEVICE.CONNECT mode=initialize', () => {
             const store = initStore(getInitialState());
 
-            const action: ReturnType<typeof deviceActions.connectDevice> = {
-                type: DEVICE.CONNECT,
-                payload: {
-                    device: getConnectDevice({ mode: 'initialize' }),
-                },
-            };
+            const connectDevice = getConnectDevice({ mode: 'initialize' });
+            store.dispatch({ type: DEVICE.CONNECT, payload: { device: connectDevice } });
 
-            store.dispatch(action);
+            const device = store.getState().device.devices.find(d => d.id === connectDevice.id);
+            store.dispatch({ type: deviceActions.selectDevice.type, payload: device });
+
             expect(goto).toHaveBeenNthCalledWith(1, 'suite-start');
         });
 
         it('DEVICE.CONNECT firmware=required', () => {
             const store = initStore(getInitialState());
 
-            const action: ReturnType<typeof deviceActions.connectDevice> = {
-                type: DEVICE.CONNECT,
-                payload: {
-                    device: getConnectDevice({ mode: 'normal', firmware: 'required' }),
-                },
-            };
+            const connectDevice = getConnectDevice({ mode: 'normal', firmware: 'required' });
+            store.dispatch({ type: DEVICE.CONNECT, payload: { device: connectDevice } });
 
-            store.dispatch(action);
+            const device = store.getState().device.devices.find(d => d.id === connectDevice.id);
+            store.dispatch({ type: deviceActions.selectDevice.type, payload: device });
+
             expect(goto).toHaveBeenNthCalledWith(1, 'firmware-index');
         });
 

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -17,7 +17,6 @@ import { METADATA, ROUTER, SUITE } from 'src/actions/suite/constants';
 import { handleProtocolRequest } from 'src/actions/suite/protocolActions';
 import { goto } from 'src/actions/suite/routerActions';
 import { appChanged, setRecentlyDisconnectedDevice } from 'src/actions/suite/suiteActions';
-import { handleDeviceConnect } from 'src/actions/wallet/handleDeviceConnectThunk';
 import { Action, AppState, Dispatch } from 'src/types/suite';
 
 const isActionDeviceRelated = (action: AnyAction): boolean => {
@@ -105,10 +104,6 @@ const suite =
                         }),
                     );
                 }
-                break;
-            case DEVICE.CONNECT:
-            case DEVICE.CONNECT_UNACQUIRED:
-                api.dispatch(handleDeviceConnect(action.payload.device));
                 break;
             case DEVICE.DISCONNECT:
                 api.dispatch(handleDeviceDisconnect(action.payload));

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -127,6 +127,7 @@ export interface SuiteState {
     countryCode: CountryCode | null;
     prefillFields: PrefillFields;
     settings: SuiteSettings;
+    recentlyConnectedDeviceRef: string | null; // TODO use type DeviceRef from suite-types; currently WIP in https://github.com/trezor/trezor-suite/pull/20955
     recentlyDisconnectedDevice: string | null;
     seenDisconnectNotificationForDeviceIds: string[];
 }
@@ -210,6 +211,7 @@ const initialState: SuiteState = {
         isCoinsFilterVisible: false,
         autoEject: false,
     },
+    recentlyConnectedDeviceRef: null,
     recentlyDisconnectedDevice: null,
     seenDisconnectNotificationForDeviceIds: [],
 };
@@ -283,6 +285,9 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
                 setFlag(draft, action.key, action.value);
                 break;
 
+            case SUITE.SET_RECENTLY_CONNECTED_DEVICE:
+                draft.recentlyConnectedDeviceRef = action.payload;
+                break;
             case SUITE.SET_RECENTLY_DISCONNECTED_DEVICE:
                 draft.recentlyDisconnectedDevice = action.payload;
                 break;

--- a/packages/suite/src/selectors/suite/suiteSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteSelectors.ts
@@ -7,7 +7,7 @@ import { SUITE } from 'src/actions/suite/constants';
 import { ExperimentalFeature } from 'src/constants/suite/experimental';
 import { RouterRootState, selectRouter } from 'src/reducers/suite/routerReducer';
 import { SuiteRootState } from 'src/reducers/suite/suiteReducer';
-import { AppState, TorStatus } from 'src/types/suite';
+import { AppState, TorStatus, TrezorDevice } from 'src/types/suite';
 import { getExcludedPrerequisites, getPrerequisiteName } from 'src/utils/suite/prerequisites';
 import { getIsTorEnabled, getIsTorLoading } from 'src/utils/suite/tor';
 
@@ -104,3 +104,13 @@ export const selectIsFirmwareRevisionCheckEnabled = (state: SuiteRootState) =>
 export const selectIsAutoEjectEnabled = (state: SuiteRootState) => state.suite.settings.autoEject;
 export const selectIsTradingTermsDismissed = (state: AppState, tradingType: TradingType): boolean =>
     !!state.suite.dismissedTradingTerms?.[tradingType];
+
+// TODO use selectDeviceByDeviceRef from wallet-core; currently WIP in https://github.com/trezor/trezor-suite/pull/20955
+export const selectRecentlyConnectedDevice = (state: AppState): TrezorDevice | undefined =>
+    state.suite.recentlyConnectedDeviceRef !== null
+        ? state.device.devices.find(
+              device =>
+                  state.suite.recentlyConnectedDeviceRef === device?.id ||
+                  state.suite.recentlyConnectedDeviceRef === device.path,
+          )
+        : undefined;

--- a/suite-common/thp/src/autoInitThpAfterDeviceConnectionThunk.ts
+++ b/suite-common/thp/src/autoInitThpAfterDeviceConnectionThunk.ts
@@ -14,6 +14,7 @@ export const autoInitThpAfterDeviceConnectionThunk = createThunk<
     AutoInitThpAfterDeviceConnectionThunkParams,
     void
 >(`${THP_PREFIX}/autoInitThpAfterDeviceConnectionThunk`, ({ device }, { dispatch, getState }) => {
+    if (device.thp === undefined) return;
     const isFwInstall = selectFirmware(getState()).status !== 'initial';
 
     // This needs to be re-selected to convert Device to TrezorDevice.
@@ -22,7 +23,7 @@ export const autoInitThpAfterDeviceConnectionThunk = createThunk<
         stateDevice => stateDevice.path === device.path,
     );
     // TODO: To be fixed properly in https://github.com/trezor/trezor-suite/issues/20930
-    if (device?.thp !== undefined && !isFwInstall) {
+    if (!isFwInstall) {
         dispatch(acquireDevice({ requestedDevice: reselectedTrezorDevice }));
     }
 });

--- a/suite-common/thp/src/connectThpDeviceThunk.ts
+++ b/suite-common/thp/src/connectThpDeviceThunk.ts
@@ -14,6 +14,7 @@ type ConnectThpDeviceThinkParams = {
 export const connectThpDeviceThunk = createThunk<void, ConnectThpDeviceThinkParams, void>(
     `${THP_PREFIX}/connectThpDeviceThunk`,
     ({ device }, { dispatch, getState }) => {
+        if (device.thp === undefined) return;
         const credentials = selectThpCredentials(getState());
         const isFwInstall = selectFirmware(getState()).status !== 'initial';
 


### PR DESCRIPTION
## Description

- small change: early return from THP thunks when not THP, to prevent errors
- create a new state to track that a device has been recently connected
  - to avoid deep copying the device object, it's by ref, inspired by [#20955](https://github.com/trezor/trezor-suite/pull/20955) (WIP)
- render a tooltip for recently connected device with the model name, instead of wallet switcher
  - or should it be label? Idk we can change it later.
- autohide the tooltip after 5 s
- hide it manually when clicking
- refactor: unify the `DEVICE.CONNECT` handling, currently split between connectInitThunk hook and a middleware
  - it should be only in the  connectInitThunk hook, that's the original place firing the action, middleware = bad
- update tests
- remove the functionality that wallet switcher is opened for 2 or more physical devices → always open tooltip
  - (partially reverts [#18478](https://github.com/trezor/trezor-suite/pull/18478))

## Related Issue

Resolve #20742

## Screenshots:

### As before:

[normally connecting](https://github.com/user-attachments/assets/92012229-acde-4461-9ed9-ea83bcdf5aa7)
[connecting the same device as selected readonly](https://github.com/user-attachments/assets/00e2ec8d-3ea8-4775-80a4-9f2cb66e7780)
[multiple devices](https://github.com/user-attachments/assets/23557080-abbd-46d9-b569-1e31dcc01a74) **(updated)**



## New behavior:

[tooltip autohide](https://github.com/user-attachments/assets/cc864cce-7eaf-43a0-987f-5303dc614263)
[tooltip manual hide](https://github.com/user-attachments/assets/1cfa85c8-5076-4c80-8348-aa8643299a47)
[no collision in tooltip timing](https://github.com/user-attachments/assets/bd7e6733-fee9-49bc-901f-485cc133d064) (I connected device, tooltip appeared, quickly disconnected it and a connected a _different_ device. The timer for the first tooltip shall not close the second tooltip, it should close after its own 5 s) 

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/no-more-wallet-switcher&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/no-more-wallet-switcher&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/no-more-wallet-switcher&lookback=7)