### PR TITLE
fix(suite): Change BackupStatus to inProgress

### DIFF
--- a/packages/suite/src/actions/backup/__tests__/backupActions.test.ts
+++ b/packages/suite/src/actions/backup/__tests__/backupActions.test.ts
@@ -76,8 +76,8 @@ describe('Backup Actions', () => {
             payload: undefined,
         });
         expect(store.getActions().shift()).toEqual({
-            type: BACKUP.SET_STATUS,
-            payload: 'in-progress',
+            type: BACKUP.SET_IN_PROGRESS,
+            payload: true,
         });
         expect(store.getActions().shift()).toEqual({ type: SUITE.LOCK_DEVICE, payload: true });
         expect(store.getActions().shift()).toEqual({ type: SUITE.LOCK_DEVICE, payload: false });
@@ -115,8 +115,8 @@ describe('Backup Actions', () => {
             payload: undefined,
         });
         expect(store.getActions().shift()).toEqual({
-            type: BACKUP.SET_STATUS,
-            payload: 'in-progress',
+            type: BACKUP.SET_IN_PROGRESS,
+            payload: true,
         });
         expect(store.getActions().shift()).toEqual({ type: SUITE.LOCK_DEVICE, payload: true });
         expect(store.getActions().shift()).toEqual({ type: SUITE.LOCK_DEVICE, payload: false });

--- a/packages/suite/src/actions/backup/backupActions.ts
+++ b/packages/suite/src/actions/backup/backupActions.ts
@@ -18,7 +18,7 @@ export type BackupStatus = 'initial' | 'in-progress' | 'finished' | 'error';
 export type BackupAction =
     | { type: typeof BACKUP.RESET_REDUCER }
     | { type: typeof BACKUP.TOGGLE_CHECKBOX_BY_KEY; payload: ConfirmKey }
-    | { type: typeof BACKUP.SET_STATUS; payload: BackupStatus }
+    | { type: typeof BACKUP.SET_IN_PROGRESS; payload: boolean }
     | { type: typeof BACKUP.SET_ERROR; payload: string };
 
 export const toggleCheckboxByKey = (key: ConfirmKey): BackupAction => ({
@@ -26,9 +26,9 @@ export const toggleCheckboxByKey = (key: ConfirmKey): BackupAction => ({
     payload: key,
 });
 
-export const setStatus = (status: BackupStatus): BackupAction => ({
-    type: BACKUP.SET_STATUS,
-    payload: status,
+export const setInProgress = (in_progress: boolean): BackupAction => ({
+    type: BACKUP.SET_IN_PROGRESS,
+    payload: in_progress,
 });
 
 export const setError = (error: string): BackupAction => ({
@@ -54,8 +54,8 @@ export const backupDevice =
         }
 
         dispatch({
-            type: BACKUP.SET_STATUS,
-            payload: 'in-progress',
+            type: BACKUP.SET_IN_PROGRESS,
+            payload: true,
         });
 
         const result = await TrezorConnect.backupDevice({
@@ -90,8 +90,8 @@ export const backupDevice =
                 dispatch(notificationsActions.addToast({ type: 'backup-success' }));
             }
             dispatch({
-                type: BACKUP.SET_STATUS,
-                payload: 'finished',
+                type: BACKUP.SET_IN_PROGRESS,
+                payload: false,
             });
             analytics.report({
                 type: EventType.CreateBackup,

--- a/packages/suite/src/actions/backup/constants/backup.ts
+++ b/packages/suite/src/actions/backup/constants/backup.ts
@@ -1,4 +1,4 @@
 export const TOGGLE_CHECKBOX_BY_KEY = '@backup/toggle-checkbox-by-key' as const;
-export const SET_STATUS = '@backup/set-status' as const;
+export const SET_IN_PROGRESS = '@backup/set-in-progress' as const;
 export const SET_ERROR = '@backup/set-error' as const;
 export const RESET_REDUCER = '@backup/reset-reducer' as const;

--- a/packages/suite/src/reducers/backup/__tests__/backupReducer.test.ts
+++ b/packages/suite/src/reducers/backup/__tests__/backupReducer.test.ts
@@ -1,0 +1,69 @@
+import type { DeviceRootState } from '@suite-common/wallet-core';
+import { BackupAvailability } from '@trezor/protobuf/src/messages';
+
+import { selectBackupStatus } from '../backupReducer';
+import type { BackupRootState, BackupState } from '../backupReducer';
+
+describe('selectBackupStatus', () => {
+    const baseBackup: BackupState = {
+        userConfirmed: [],
+        inProgress: false,
+        error: undefined,
+    };
+
+    const errorBackup: BackupState = {
+        userConfirmed: [],
+        inProgress: false,
+        error: 'error message',
+    };
+
+    const inProgressBackup: BackupState = {
+        userConfirmed: [],
+        inProgress: true,
+        error: undefined,
+    };
+
+    const getState = (
+        backup: BackupState,
+        backup_availability: BackupAvailability,
+    ): BackupRootState & DeviceRootState => ({
+        backup: { ...baseBackup, ...backup },
+        device: {
+            devices: [],
+            isDeviceAutoEjectEnabled: false,
+            isConnectionModalOpen: true,
+            selectedDevice: {
+                features: { backup_availability },
+            } as any,
+        },
+    });
+
+    it('returns "finished" if backup_availability is Available regardless of backup state', () => {
+        [baseBackup, errorBackup, inProgressBackup].forEach(backup => {
+            const state = getState(backup, 'Available');
+            expect(selectBackupStatus(state)).toBe('finished');
+        });
+    });
+
+    it('returns "finished" if backup_availability is NotAvailable regardless of backup state', () => {
+        [baseBackup, errorBackup, inProgressBackup].forEach(backup => {
+            const state = getState(backup, 'NotAvailable');
+            expect(selectBackupStatus(state)).toBe('finished');
+        });
+    });
+
+    it('returns "error" if backup.error is set', () => {
+        const state = getState(errorBackup, 'Required');
+        expect(selectBackupStatus(state)).toBe('error');
+    });
+
+    it('returns "in-progress" if backup.inProgress is true', () => {
+        const state = getState(inProgressBackup, 'Required');
+        expect(selectBackupStatus(state)).toBe('in-progress');
+    });
+
+    it('returns "initial" if none of the above', () => {
+        const state = getState(baseBackup, 'Required');
+        expect(selectBackupStatus(state)).toBe('initial');
+    });
+});

--- a/packages/suite/src/reducers/backup/backupReducer.ts
+++ b/packages/suite/src/reducers/backup/backupReducer.ts
@@ -1,5 +1,7 @@
 import { produce } from 'immer';
 
+import { DeviceRootState } from '@suite-common/wallet-core';
+
 import { BackupStatus, ConfirmKey } from 'src/actions/backup/backupActions';
 import { BACKUP } from 'src/actions/backup/constants';
 import { Action } from 'src/types/suite';
@@ -10,13 +12,13 @@ export interface BackupRootState {
 
 export interface BackupState {
     userConfirmed: ConfirmKey[];
-    status: BackupStatus;
+    inProgress: boolean;
     error?: string;
 }
 
 const initialState: BackupState = {
     userConfirmed: [],
-    status: 'initial',
+    inProgress: false,
 };
 
 const handleToggleCheckboxByKey = (draft: BackupState, key: ConfirmKey) => {
@@ -37,11 +39,11 @@ const backup = (state: BackupState = initialState, action: Action) =>
             case BACKUP.TOGGLE_CHECKBOX_BY_KEY:
                 handleToggleCheckboxByKey(draft, action.payload);
                 break;
-            case BACKUP.SET_STATUS:
-                draft.status = action.payload;
+            case BACKUP.SET_IN_PROGRESS:
+                draft.inProgress = action.payload;
                 break;
             case BACKUP.SET_ERROR:
-                draft.status = 'error';
+                draft.inProgress = false;
                 draft.error = action.payload;
                 break;
             case BACKUP.RESET_REDUCER:
@@ -52,5 +54,13 @@ const backup = (state: BackupState = initialState, action: Action) =>
     });
 
 export const selectBackup = (state: BackupRootState) => state.backup;
+export const selectBackupStatus = (state: BackupRootState & DeviceRootState): BackupStatus => {
+    const backup_availability = state.device.selectedDevice?.features?.backup_availability;
+    if (backup_availability === 'Available' || backup_availability === 'NotAvailable')
+        return 'finished';
+    else if (state.backup.error !== undefined) return 'error';
+    else if (state.backup.inProgress) return 'in-progress';
+    else return 'initial';
+};
 
 export default backup;

--- a/packages/suite/src/views/backup/Backup.tsx
+++ b/packages/suite/src/views/backup/Backup.tsx
@@ -13,7 +13,7 @@ import { BackupStep1Initial } from './BackupStep1Initial';
 import { BackupStep2InProgress } from './BackupStep2InProgress';
 import { BackupStep3Finished } from './BackupStep3Finished';
 import { BackupStepError } from './BackupStepError';
-import { selectBackup } from '../../reducers/backup/backupReducer';
+import { selectBackup, selectBackupStatus } from '../../reducers/backup/backupReducer';
 
 const getEdgeCaseModalHeading = (unfinishedBackup: boolean) => {
     if (unfinishedBackup) {
@@ -29,6 +29,7 @@ export const Backup = ({
 }: ForegroundAppProps): NonNullable<ReactNode> /* NonNullable return type is required here to prevent default return from switch-case */ => {
     const device = useSelector(selectSelectedDevice);
     const backup = useSelector(selectBackup);
+    const backupStatus = useSelector(selectBackupStatus);
 
     const isDeviceUnavailable = !isDeviceAcquired(device) || !device.connected;
 
@@ -51,7 +52,7 @@ export const Backup = ({
         with backup finished or failed. Either way, there is no way.
     */
     if (
-        backup.status !== 'finished' &&
+        backupStatus !== 'finished' &&
         !backup.error &&
         device.features.backup_availability !== 'Required' &&
         device.features.unfinished_backup !== null
@@ -84,11 +85,11 @@ export const Backup = ({
         );
     }
 
-    switch (backup.status) {
+    switch (backupStatus) {
         case 'initial':
             return <BackupStep1Initial onCancel={onCancel} backup={backup} />;
         case 'in-progress':
-            return <BackupStep2InProgress onCancel={onCancel} backup={backup} />;
+            return <BackupStep2InProgress onCancel={onCancel} />;
         case 'finished':
             return <BackupStep3Finished onCancel={onCancel} backup={backup} />;
         case 'error':

--- a/packages/suite/src/views/backup/BackupStep1Initial.tsx
+++ b/packages/suite/src/views/backup/BackupStep1Initial.tsx
@@ -42,7 +42,7 @@ export const BackupStep1Initial = ({
             variant="primary"
             data-testid="@backup"
             heading={<Translation id="TR_CREATE_BACKUP" />}
-            description={<BackupStepDescription backupStatus={backup.status} />}
+            description={<BackupStepDescription />}
             bottomContent={
                 <>
                     <Modal.Button

--- a/packages/suite/src/views/backup/BackupStep2InProgress.tsx
+++ b/packages/suite/src/views/backup/BackupStep2InProgress.tsx
@@ -3,21 +3,14 @@ import { Modal } from '@trezor/components';
 import { Loading } from 'src/components/suite';
 
 import { BackupStepDescription } from './BackupStepDescription';
-import { BackupState } from '../../reducers/backup/backupReducer';
 
-export const BackupStep2InProgress = ({
-    onCancel,
-    backup,
-}: {
-    onCancel: () => void;
-    backup: BackupState;
-}) => (
+export const BackupStep2InProgress = ({ onCancel }: { onCancel: () => void }) => (
     <Modal
         onCancel={onCancel}
         variant="primary"
         data-testid="@backup"
         heading={null}
-        description={<BackupStepDescription backupStatus={backup.status} />}
+        description={<BackupStepDescription />}
     >
         <Loading />
     </Modal>

--- a/packages/suite/src/views/backup/BackupStep3Finished.tsx
+++ b/packages/suite/src/views/backup/BackupStep3Finished.tsx
@@ -23,7 +23,7 @@ export const BackupStep3Finished = ({
             variant="primary"
             data-testid="@backup"
             heading={<Translation id="TR_BACKUP_CREATED" />}
-            description={<BackupStepDescription backupStatus={backup.status} />}
+            description={<BackupStepDescription />}
             bottomContent={
                 <Modal.Button
                     isDisabled={!continueEnabled}

--- a/packages/suite/src/views/backup/BackupStepDescription.tsx
+++ b/packages/suite/src/views/backup/BackupStepDescription.tsx
@@ -1,9 +1,12 @@
-import { BackupStatus } from '../../actions/backup/backupActions';
+import { useSelector } from 'src/hooks/suite';
+import { selectBackupStatus } from 'src/reducers/backup/backupReducer';
+
 import { Translation } from '../../components/suite';
 
 const nonErrorBackupStatuses = ['initial', 'in-progress', 'finished'] as const;
 
-export const BackupStepDescription = ({ backupStatus }: { backupStatus: BackupStatus }) => {
+export const BackupStepDescription = () => {
+    const backupStatus = useSelector(selectBackupStatus);
     const currentProgressBarStep = nonErrorBackupStatuses.some(status => status === backupStatus)
         ? nonErrorBackupStatuses.findIndex(s => s === backupStatus) + 1
         : undefined;

--- a/packages/suite/src/views/onboarding/steps/Backup.tsx
+++ b/packages/suite/src/views/onboarding/steps/Backup.tsx
@@ -20,6 +20,7 @@ import {
 import { Translation } from 'src/components/suite';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectBackup, selectBackupStatus } from 'src/reducers/backup/backupReducer';
 import { selectIsActionAbortable, selectIsDeviceLocked } from 'src/selectors/suite/suiteSelectors';
 import { canContinue } from 'src/utils/backup';
 
@@ -30,7 +31,8 @@ const StyledImage = styled(Image)`
 
 export const BackupStep = () => {
     const [showSkipConfirmation, setShowSkipConfirmation] = useState(false);
-    const backup = useSelector(state => state.backup);
+    const backup = useSelector(selectBackup);
+    const backupStatus = useSelector(selectBackupStatus);
     const device = useSelector(selectSelectedDevice);
     const isDeviceLocked = useSelector(selectIsDeviceLocked);
     const isActionAbortable = useSelector(selectIsActionAbortable);
@@ -67,7 +69,7 @@ export const BackupStep = () => {
             {showSkipConfirmation && (
                 <SkipStepConfirmation onCancel={() => setShowSkipConfirmation(false)} />
             )}
-            {backup.status === 'initial' && (
+            {backupStatus === 'initial' && (
                 <OnboardingStepBox
                     image="BACKUP"
                     heading={<Translation id="TR_CREATE_BACKUP" />}
@@ -95,7 +97,7 @@ export const BackupStep = () => {
                     </OptionsWrapper>
                 </OnboardingStepBox>
             )}
-            {backup.status === 'in-progress' && (
+            {backupStatus === 'in-progress' && (
                 <OnboardingStepBox
                     image="BACKUP"
                     heading={<Translation id="TR_CREATE_BACKUP" />}
@@ -105,7 +107,7 @@ export const BackupStep = () => {
                 />
             )}
 
-            {backup.status === 'finished' && (
+            {backupStatus === 'finished' && (
                 <OnboardingStepBox
                     image="BACKUP"
                     heading={<Translation id="TR_BACKUP_CREATED" />}
@@ -121,7 +123,7 @@ export const BackupStep = () => {
                     }
                 />
             )}
-            {backup.status === 'error' && (
+            {backupStatus === 'error' && (
                 <OnboardingStepBox
                     image="BACKUP"
                     heading={<Translation id="TOAST_BACKUP_FAILED" />}


### PR DESCRIPTION
Now we construct BackupState also from device features.

## Description

Changed BackupState to contain `inProgress` instead of `backupStatus`. Then we construct `backupStatus` from BackupState and DeviceState:
- If BackupState has error set, status is `error`
- If `inProgress`, status is `in-progress`
- If `backup_availability` from DeviceState is `Required`, then we don't have backup => `initial`
- `finished` otherwise

## Related Issue

Resolve #14655


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/backup-state&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/backup-state&lookback=7)