### PR TITLE
fix(suite, suite-common): better determine THP capability

### DIFF
--- a/packages/suite/src/views/onboarding/steps/FirmwareStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/FirmwareStep.tsx
@@ -50,7 +50,7 @@ export const FirmwareStep = () => {
     //
     // This is an ugly hack to do so using the effect.
     useEffect(() => {
-        if (status === 'done' && device?.thp?.properties !== undefined) {
+        if (status === 'done' && device?.thp !== undefined) {
             goToNextStepAndResetReducer();
         }
     }, [status, goToNextStepAndResetReducer, device]);

--- a/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
@@ -97,7 +97,7 @@ export const SettingsDevice = () => {
     const isBluetoothDevice = device.features?.capabilities.includes('Capability_BLE');
     const isBluetoothConnectedDevice = device?.bluetoothProps?.id !== undefined;
 
-    const isThpDevice = device?.thp?.properties !== undefined;
+    const isThpDevice = device?.thp !== undefined;
 
     return (
         <SettingsLayout>

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -233,7 +233,7 @@ export const acquireDevice = createThunk(
                         error: response.payload.error,
                     }),
                 );
-                if (device?.thp?.properties !== undefined) {
+                if (device?.thp !== undefined) {
                     dispatch(thpActions.resetThpFlow());
                 }
             }


### PR DESCRIPTION
Determine whether a device supports THP by looking at `device.thp`, not `device.thp.properties`. The properties can reset so they are not reliable.

How to reproduce the bug:
- connect TS7 that is not THP paired
- cancel pairing on Trezor
- click "Try again"
- cancel on Trezor again - **the modal won't close** 
<img width="580" height="386" alt="Screenshot 2025-08-25 at 18 37 13" src="https://github.com/user-attachments/assets/9e95638a-a12d-4edb-86bc-4f147464d335" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-properties&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-properties&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/thp-properties&lookback=7)