### PR TITLE
fix(e2e): fixes partner site mocking and fee tests

### DIFF
--- a/packages/suite-desktop-core/e2e/fixtures/invity/swap/list.json
+++ b/packages/suite-desktop-core/e2e/fixtures/invity/swap/list.json
@@ -5909,7 +5909,7 @@
         ],
         "supportUrl": "https://help.sideshift.ai/en/",
         "kycPolicyType": "KYC-yesrefund",
-        "statusUrl": "https://example.org/orders/{{orderId}}",
+        "statusUrl": "https://mocked.partner.site/orders/{{orderId}}",
         "kycPolicy": "KYC requested in exceptional cases. KYC may be required for refunds. 🤝",
         "isRefundRequired": true
     },
@@ -6342,7 +6342,7 @@
         ],
         "supportUrl": "https://help.sideshift.ai/en/",
         "kycPolicyType": "KYC-yesrefund",
-        "statusUrl": "https://example.org/orders/{{orderId}}",
+        "statusUrl": "https://mocked.partner.site/orders/{{orderId}}",
         "kycPolicy": "KYC requested in exceptional cases. KYC may be required for refunds. 🤝",
         "isRefundRequired": true
     },

--- a/packages/suite-desktop-core/e2e/fixtures/invity/swap/trade-solana-btc.json
+++ b/packages/suite-desktop-core/e2e/fixtures/invity/swap/trade-solana-btc.json
@@ -4,7 +4,7 @@
     "orderId": "1061e2d760262e1de932",
     "quoteId": "5d7e2530-cb13-4fd1-80d7-aec23fcb67d4",
     "status": "CONFIRM",
-    "statusUrl": "https://example.org/orders/1061e2d760262e1de932",
+    "statusUrl": "https://mocked.partner.site/orders/1061e2d760262e1de932",
     "exchange": "sideshiftfr",
     "send": "solana",
     "receive": "bitcoin",

--- a/packages/suite-desktop-core/e2e/support/mocks/tradingMock.ts
+++ b/packages/suite-desktop-core/e2e/support/mocks/tradingMock.ts
@@ -138,13 +138,13 @@ export class TradingMock {
 
     @step()
     async routeDummyProviderSupportPage() {
-        await this.page.route(/https:\/\/example\.org\/orders\/.*/, async route => {
+        await this.page.context().route('https://mocked.partner.site/orders/*', async route => {
             const html = `
             <!DOCTYPE html>
             <html>
-            <head><title>Provider Support</title></head>
+            <head><title>Mocked Provider Support</title></head>
             <body>
-                <h1>Provider Support Page</h1>
+                <h1>Mocked Provider Support Page</h1>
                 <p>Order ID: ${route.request().url().split('/').pop()}</p>
             </body>
             </html>

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-coins.test.ts
@@ -131,15 +131,12 @@ test.describe('Trading - Swap coins', { tag: ['@group=trading', '@webOnly'] }, (
         });
 
         await test.step('Verify button opens provider support page in new tab', async () => {
-            // There was minor instability, so we are adding retry to this step group
-            await expect(async () => {
-                const partnerPagePromise = page.context().waitForEvent('page', { timeout: 5_000 });
-                await page.getByRole('link', { name: 'Go to provider support' }).click();
-                const partnerTab = await partnerPagePromise;
-                // Mocked data have URL changed to https://example.org/orders/{{orderId}} for stability reasons
-                await expect(partnerTab).toHaveURL(/https:\/\/example\.org\/orders\//);
-                await partnerTab.close();
-            }).toPass({ timeout: 20_000 });
+            const partnerPagePromise = page.context().waitForEvent('page');
+            await page.getByRole('link', { name: 'Go to provider support' }).click();
+            const partnerTab = await partnerPagePromise;
+            // Mocked data have URL changed to https://mocked.partner.site/orders/{{orderId}} for stability reasons
+            await expect(partnerTab).toHaveURL(/https:\/\/mocked\.partner\.site\/orders\//);
+            await partnerTab.close();
         });
 
         // Statuses: SENDING -> CONVERTING -> CONFIRMING -> SUCCESS

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-fees-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-fees-bitcoin.test.ts
@@ -24,7 +24,7 @@ test.describe('Trading - Swap fees Bitcoin', { tag: ['@group=trading', '@webOnly
         },
     );
 
-    test('Swap custom fees for Bitcoin', async ({ tradingPage, devicePrompt }) => {
+    test('Swap custom fees for Bitcoin', async ({ page, tradingPage, devicePrompt }) => {
         let feeRate: string;
         await test.step('Fill in a Swap form', async () => {
             await tradingPage.fees.switchModeButton('custom').click();
@@ -44,6 +44,7 @@ test.describe('Trading - Swap fees Bitcoin', { tag: ['@group=trading', '@webOnly
             await tradingPage.swapBestOfferButton.click();
             await tradingPage.confirmTrade('Ethereum #1');
             await tradingPage.finishTransactionButton.click();
+            await page.waitForTimeout(3000); // wait for compound data to be ready
             await tradingPage.openConfirmAndSendModal();
             await expect(devicePrompt.headerParagraph).toContainText('Bitcoin #1');
             await devicePrompt.waitForPromptAndClick();

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-fees-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-fees-ethereum.test.ts
@@ -35,7 +35,7 @@ test.describe('Trading - Swap fees', { tag: ['@group=trading', '@webOnly'] }, ()
         },
     );
 
-    test('Swap custom fees for Ethereum', async ({ tradingPage, devicePrompt }) => {
+    test('Swap custom fees for Ethereum', async ({ page, tradingPage, devicePrompt }) => {
         await test.step('Fill in a Swap form', async () => {
             await tradingPage.fees.switchModeButton('custom').click();
             await tradingPage.fees.ethereumFeeLimit.fill(gasLimit);
@@ -55,6 +55,7 @@ test.describe('Trading - Swap fees', { tag: ['@group=trading', '@webOnly'] }, ()
             await tradingPage.swapBestOfferButton.click();
             await tradingPage.confirmTrade('Bitcoin #1');
             await tradingPage.finishTransactionButton.click();
+            await page.waitForTimeout(3000); // wait for compound data to be ready
             await tradingPage.openConfirmAndSendModal();
             await expect(devicePrompt.headerParagraph).toContainText('Ethereum #1');
             await devicePrompt.waitForPromptAndClick();


### PR DESCRIPTION
- partner site had already been mocked but there was an error in mock implementation. It was called on page objects instead of page.context object. The difference is that the first does not work on a new tab that got open.

- There is race condition in swap flows. Normal user cannot hit it but fast automation does. I had added fixed wait since there is nothing to grab on. I will explore whether we can create some kind of awaiter for state in redux. And I also asked devs whether the button is enabled only after the data is ready. 

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-stabilize-tests&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-stabilize-tests&lookback=7)