### PR TITLE
refactor(e2e): Introruces awaited expects for Redux store

### DIFF
--- a/packages/suite-desktop-core/e2e/support/testExtends/enhancePage.ts
+++ b/packages/suite-desktop-core/e2e/support/testExtends/enhancePage.ts
@@ -1,4 +1,5 @@
 import { Locator, Page, expect, test } from '@playwright/test';
+import { get } from 'lodash';
 
 declare module '@playwright/test' {
     interface Page {
@@ -7,6 +8,15 @@ declare module '@playwright/test' {
         // Methods
         discoveryShouldFinish(): Promise<void>;
         selectDropdownOptionWithRetry(dropdown: Locator, option: Locator): Promise<void>;
+        expectReduxObjectNotToBeEmpty(
+            objectPath: string,
+            options?: { timeout?: number },
+        ): Promise<void>;
+        expectReduxObjectToEqual(
+            objectPath: string,
+            expectedValue: any,
+            options?: { timeout?: number },
+        ): Promise<void>;
     }
 }
 
@@ -38,6 +48,35 @@ export const enhancePage = (page: Page): Page => {
                 await expect(option).toBeVisible({ timeout: 2000 });
                 await option.click({ timeout: 2000 });
             }).toPass({ timeout: 10_000 });
+        });
+    };
+
+    page.expectReduxObjectNotToBeEmpty = async function (
+        objectPath: string,
+        options = { timeout: 5000 },
+    ) {
+        await test.step('Expect Redux object not to be empty', async () => {
+            await expect(async () => {
+                const state = await page.evaluate(() => window.store.getState());
+                const testedObject = get(state, objectPath);
+                expect(testedObject).toBeDefined();
+                expect(testedObject).not.toBeNull();
+                expect(testedObject).not.toEqual({});
+            }).toPass({ timeout: options.timeout });
+        });
+    };
+
+    page.expectReduxObjectToEqual = async function (
+        objectPath: string,
+        expectedValue: any,
+        options = { timeout: 5000 },
+    ) {
+        await test.step('Expect Redux object to equal', async () => {
+            await expect(async () => {
+                const state = await page.evaluate(() => window.store.getState());
+                const testedObject = get(state, objectPath);
+                expect(testedObject).toStrictEqual(expectedValue);
+            }).toPass({ timeout: options.timeout });
         });
     };
 

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-fees-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-fees-bitcoin.test.ts
@@ -44,7 +44,7 @@ test.describe('Trading - Swap fees Bitcoin', { tag: ['@group=trading', '@webOnly
             await tradingPage.swapBestOfferButton.click();
             await tradingPage.confirmTrade('Ethereum #1');
             await tradingPage.finishTransactionButton.click();
-            await page.waitForTimeout(3000); // wait for compound data to be ready
+            await page.expectReduxObjectNotToBeEmpty('wallet.tradingNew.composedTransactionInfo');
             await tradingPage.openConfirmAndSendModal();
             await expect(devicePrompt.headerParagraph).toContainText('Bitcoin #1');
             await devicePrompt.waitForPromptAndClick();

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-fees-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-fees-ethereum.test.ts
@@ -55,7 +55,7 @@ test.describe('Trading - Swap fees', { tag: ['@group=trading', '@webOnly'] }, ()
             await tradingPage.swapBestOfferButton.click();
             await tradingPage.confirmTrade('Bitcoin #1');
             await tradingPage.finishTransactionButton.click();
-            await page.waitForTimeout(3000); // wait for compound data to be ready
+            await page.expectReduxObjectNotToBeEmpty('wallet.tradingNew.composedTransactionInfo');
             await tradingPage.openConfirmAndSendModal();
             await expect(devicePrompt.headerParagraph).toContainText('Ethereum #1');
             await devicePrompt.waitForPromptAndClick();


### PR DESCRIPTION
eliminates set of page.waitForTimeout
Here is example where retry occured
<img width="458" height="684" alt="image" src="https://github.com/user-attachments/assets/b2e674a8-ca06-4e5c-ae06-a17cea4e4f2f" />

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-stabilize-tests&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-stabilize-tests&lookback=7)