### PR TITLE
chore(firmware-authenticity): do not Sentry report if device not connected

### DIFF
--- a/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
+++ b/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
@@ -35,9 +35,13 @@ const useReportRevisionCheck = () => {
     const errorType = isError ? revisionCheck.error : null;
     const errorPayload = isError ? revisionCheck.errorPayload : null;
 
+    const shouldReport =
+        device?.connected === true &&
+        errorType !== null &&
+        revisionCheckErrorScenarios[errorType].shouldReport;
+
     useEffect(() => {
-        if (errorType === null) return;
-        if (revisionCheckErrorScenarios[errorType].shouldReport) {
+        if (shouldReport) {
             dispatch(
                 reportSecurityCheckThunk({
                     level: 'error',
@@ -47,7 +51,7 @@ const useReportRevisionCheck = () => {
                 }),
             );
         }
-    }, [dispatch, commonData, errorType, errorPayload]);
+    }, [dispatch, commonData, errorType, errorPayload, shouldReport]);
 };
 
 const useReportHashCheck = () => {
@@ -61,23 +65,28 @@ const useReportHashCheck = () => {
     const errorPayload = isError ? hashCheck.errorPayload : null;
     const attemptCount = isError ? hashCheck.attemptCount : null;
 
-    useEffect(() => {
-        if (errorType === null) return;
-        if (!hashCheckErrorScenarios[errorType].shouldReport) return;
-        const willBeRetried =
-            isArrayMember(errorType, FIRMWARE.HASH_CHECK_RETRIABLE_ERRORS) &&
-            (attemptCount ?? 0) < FIRMWARE.HASH_CHECK_MAX_ATTEMPTS;
-        if (willBeRetried) return;
+    const shouldReport =
+        device?.connected === true &&
+        errorType !== null &&
+        hashCheckErrorScenarios[errorType].shouldReport;
 
-        dispatch(
-            reportSecurityCheckThunk({
-                level: 'error',
-                checkType: 'Firmware hash',
-                contextData: { ...commonData, errorType, attemptCount },
-                payload: errorPayload,
-            }),
-        );
-    }, [dispatch, commonData, errorType, errorPayload, attemptCount]);
+    useEffect(() => {
+        if (shouldReport) {
+            const willBeRetried =
+                isArrayMember(errorType, FIRMWARE.HASH_CHECK_RETRIABLE_ERRORS) &&
+                (attemptCount ?? 0) < FIRMWARE.HASH_CHECK_MAX_ATTEMPTS;
+            if (willBeRetried) return;
+
+            dispatch(
+                reportSecurityCheckThunk({
+                    level: 'error',
+                    checkType: 'Firmware hash',
+                    contextData: { ...commonData, errorType, attemptCount },
+                    payload: errorPayload,
+                }),
+            );
+        }
+    }, [dispatch, commonData, errorType, errorPayload, attemptCount, shouldReport]);
 
     // success bears warning if it needed retries, so we report the previous error payload, see Device.ts in connect
     const isHashCheckSuccess = hashCheck && hashCheck.success;


### PR DESCRIPTION
## Description

Do not report firmware authenticity checks to sentry if device is not connected.

:information_source:  FYI all check error types that are not `skipped` and are `isConclusive` in [scenariosConfig](https://github.com/trezor/trezor-suite/blob/9acad6ca5bf5a330b6655ed6ac89de8a3a8c52a7/suite-common/firmware-authenticity/src/scenariosConfig.ts) are persisted for remembered wallet, so that the DeviceCompromised modal and banner show up everytime – until, theoretically, you reconnect device and the checks pass, though that's unlikely.

## Screenshots:

N/A

I tested that
Sentry is sent for
- `shouldReport: true` errors at a connected device
Sentry is not sent for
- `shouldReport: true` errors at a disconnected device
- `shouldReport: false` errors
- success

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/no-sentry-if-device-not-connected&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/no-sentry-if-device-not-connected&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/no-sentry-if-device-not-connected&lookback=7)