### PR TITLE
fix(e2e): fixed expected string

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/staking/staking-form.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/staking/staking-form.test.ts
@@ -112,7 +112,9 @@ test.describe('ETH staking form', { tag: ['@group=staking'] }, () => {
                     await page.getByRole('button', { name: 'Max' }).click();
                     await expect
                         .soft(stakingSection.withdrawalWarning)
-                        .toHaveText('We’ve left 0.03 ETH out so you can pay for withdrawal fees.');
+                        .toHaveText(
+                            'We’ve left 0.03 ETH in your account so you can pay for withdrawal fees.',
+                        );
                     const expectedMax = new BigNumber(ethereumStakingBalance!)
                         .minus(WITHDRAWAL_BUFFER)
                         .minus(MOCKED_FEE_AMOUNT);


### PR DESCRIPTION
Crowdin sync did break tests (althrough the CI actions did not run on that PR) - so here is a fix

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/e2e-crowdin-sync&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/e2e-crowdin-sync&lookback=7)