### PR TITLE
chore(message-system): disable entropyCheck for 25.8 and above

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2025-08-20T14:00:00+00:00",
-    "sequence": 105,
+    "timestamp": "2025-08-26T12:00:00+00:00",
+    "sequence": 106,
     "actions": [
         {
             "conditions": [
@@ -1774,6 +1774,44 @@
                 "feature": [
                     {
                         "domain": "security.firmware.hashCheck.otherError",
+                        "flag": false
+                    }
+                ]
+            }
+        },
+        {
+            "conditions": [
+                {
+                    "environment": {
+                        "desktop": ">=25.8.0",
+                        "mobile": "!",
+                        "web": ">=25.8.0"
+                    }
+                }
+            ],
+            "message": {
+                "id": "9534d059-f847-4694-b6ff-444504c74b4b",
+                "priority": 1,
+                "dismissible": false,
+                "variant": "info",
+                "category": "feature",
+                "content": {
+                    "en": "Placeholder",
+                    "es": "Placeholder",
+                    "cs": "Placeholder",
+                    "de": "Placeholder",
+                    "fr": "Placeholder",
+                    "it": "Placeholder",
+                    "pt": "Placeholder",
+                    "tr": "Placeholder",
+                    "ru": "Placeholder",
+                    "ja": "Placeholder",
+                    "uk": "Placeholder",
+                    "hu": "Placeholder"
+                },
+                "feature": [
+                    {
+                        "domain": "security.entropyCheck",
                         "flag": false
                     }
                 ]


### PR DESCRIPTION
## Description

Turn off entropy check for suite desktop, web from 25.8.0 and above due to false positives. 

## Screenshots:

using [the testing branch](https://github.com/trezor/trezor-suite/compare/develop...FW-check-UI-testing-branch):

simulated entropy check fail at simulated 25.8.2 :heavy_check_mark: 
[25.8.2.webm](https://github.com/user-attachments/assets/25daeb14-79a0-4c36-8f67-f7220cb4b7fe)

simulated entropy check fail at simulated 25.7.9 :x:
[25.7.9.webm](https://github.com/user-attachments/assets/7fef4b38-eafb-485c-bfc3-70ef4317f156)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/msg-system-turn-off-entropy-check&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/msg-system-turn-off-entropy-check&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/msg-system-turn-off-entropy-check&lookback=7)