### PR TITLE
chore(message-system): disable entropyCheck also for mobile 25.8

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1821,6 +1821,44 @@
             "conditions": [
                 {
                     "environment": {
+                        "desktop": "!",
+                        "mobile": ">=25.8.0",
+                        "web": "!"
+                    }
+                }
+            ],
+            "message": {
+                "id": "1a93ebf0-489a-4317-9839-3018fc38a4c0",
+                "priority": 1,
+                "dismissible": false,
+                "variant": "info",
+                "category": "feature",
+                "content": {
+                    "en": "Placeholder",
+                    "es": "Placeholder",
+                    "cs": "Placeholder",
+                    "de": "Placeholder",
+                    "fr": "Placeholder",
+                    "it": "Placeholder",
+                    "pt": "Placeholder",
+                    "tr": "Placeholder",
+                    "ru": "Placeholder",
+                    "ja": "Placeholder",
+                    "uk": "Placeholder",
+                    "hu": "Placeholder"
+                },
+                "feature": [
+                    {
+                        "domain": "security.entropyCheck.mobile",
+                        "flag": false
+                    }
+                ]
+            }
+        },
+        {
+            "conditions": [
+                {
+                    "environment": {
                         "desktop": ">=25.8.1",
                         "mobile": "!",
                         "web": "*"


### PR DESCRIPTION
Followup to #21026 to also target mobile – the evidence points to connect so it will probably be a problem too for upcoming mobile version.

## Screenshots

using [the testing branch](https://github.com/trezor/trezor-suite/compare/develop...FW-check-UI-testing-branch):

simulated entropy check fail at new message system config :heavy_check_mark: 
[new msg system.webm](https://github.com/user-attachments/assets/90168886-0aa3-4a1c-beed-f2981a7feedb) (I successfully finished backup check, but had to end the video to rewind it)

simulated entropy check fail at previous message system config :x:
[old msg system.webm](https://github.com/user-attachments/assets/535deb0f-2b07-425d-9d78-0d29f0a494c3)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/amend-message-system-also-for-mobile&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/amend-message-system-also-for-mobile&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/amend-message-system-also-for-mobile&lookback=7)