### PR TITLE
feat(suite-native): use Device.modelName as THP host name on iOS

### DIFF
--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -42,7 +42,8 @@ export const extraDependencies: ExtraDependencies = mergeDeepObject(extraDepende
             params: undefined,
         }),
         selectThpSettings: state => ({
-            hostName: Device.deviceName,
+            // On iOS 16 and newer, deviceName is set to "iPhone" without the correct entitlement.
+            hostName: Platform.OS === 'ios' ? Device.modelName : Device.deviceName,
             pairingMethods: ['CodeEntry', 'NFC'],
             staticKey: state.thp?.staticKey,
             knownCredentials: state.thp?.credentials,


### PR DESCRIPTION
## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20990


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/connect-ios-hostname&lookback=7)