### PR TITLE
feat(suite-native): distribute adhoc builds for ios via testflight to simplify testing flow

### DIFF
--- a/.github/workflows/build-suite-native-adhoc.yml
+++ b/.github/workflows/build-suite-native-adhoc.yml
@@ -42,10 +42,22 @@ jobs:
         run: |
           yarn workspaces focus @suite-native/app
           npx patch-package # Apply global patches.
-      - name: Trigger adhoc build
+      - name: Trigger adhoc build Android
+        if: ${{ github.event.inputs.PLATFORM == 'android' || github.event.inputs.PLATFORM == 'all' }}
         run: |
           yarn native:adhoc \
-            -p ${{ github.event.inputs.PLATFORM }} \
+            -p android \
+            --non-interactive \
+            --no-wait \
+            --freeze-credentials \
+            --message ${{ github.sha }} \
+            2>&1 | sed -E 's/UDID: [A-Za-z0-9-]+/UDID: [REDACTED]/g' # remove UDIDs from output
+      - name: Trigger adhoc build iOS
+        if: ${{ github.event.inputs.PLATFORM == 'ios' || github.event.inputs.PLATFORM == 'all' }}
+        run: |
+          yarn native:adhoc \
+            -p ios \
+            --auto-submit \
             --non-interactive \
             --no-wait \
             --freeze-credentials \

--- a/suite-native/app/eas.json
+++ b/suite-native/app/eas.json
@@ -41,7 +41,10 @@
                 "EXPO_PUBLIC_FF_IS_DEVICE_CONNECT_ENABLED": "true",
                 "EXPO_PUBLIC_FF_IS_BLUETOOTH_ENABLED": "true"
             },
-            "developmentClient": false
+            "developmentClient": false,
+            "ios": {
+                "distribution": "store"
+            }
         },
         "production": {
             "extends": "base",
@@ -73,7 +76,14 @@
         "develop": {
             "ios": {
                 "bundleIdentifier": "io.trezor.suite.develop",
-                "ascAppId": "1631884497",
+                "ascAppId": "1632206646",
+                "appleTeamId": "C3P22XVH2C"
+            }
+        },
+        "adhoc": {
+            "ios": {
+                "bundleIdentifier": "io.trezor.suite.preview",
+                "ascAppId": "6739429089",
                 "appleTeamId": "C3P22XVH2C"
             }
         },


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

It would be easier for us to distribute ad-hoc build on ios via testflight, so we don't have to register each device in provisioning profiles and we can install even older builds.

- ios build https://expo.dev/accounts/trezorcompany-develop/projects/trezor-suite-preview/builds/ac9d9886-cc0e-4f6b-a892-0f2b4bd6f750
- ios submission https://expo.dev/accounts/trezorcompany-develop/projects/trezor-suite-preview/submissions/0e58b727-8d14-465b-ab65-e2f4c90eec8f

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21030



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/distribute-adhoc-ios-to-testflight&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/distribute-adhoc-ios-to-testflight&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/distribute-adhoc-ios-to-testflight&lookback=7)