### PR TITLE
fix(connect): onCallFirmwareUpdate bluetooth and device-disconnect race condition

### DIFF
--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -180,6 +180,66 @@ const waitForReconnectedDevice = async (
     return reconnectedDevice;
 };
 
+const getRebootMethod = async ({
+    deviceList,
+    device,
+    log,
+}: {
+    deviceList: DeviceList;
+    device: Device;
+    log: Log;
+}) => {
+    let method: ReconnectParams['method'] = 'wait';
+
+    // not a bluetooth device
+    if (!device.bluetoothProps) {
+        return method;
+    }
+
+    const ctrl = new AbortController();
+    // device disconnected before it was requested to disconnect by the BT api. see: UI.FIRMWARE_DISCONNECT
+    const disconnectedPromise = new Promise<void>(resolve => {
+        const handleDisconnect = () => {
+            log.info(`waitForBluetoothReboot device-disconnected. aborted: ${ctrl.signal.aborted}`);
+            if (!ctrl.signal.aborted) {
+                ctrl.abort();
+                method = 'auto'; // do not wait for disconnection
+            }
+
+            resolve();
+        };
+        deviceList.once('device-disconnect', handleDisconnect);
+        ctrl.signal.addEventListener('abort', () => {
+            deviceList.off('device-disconnect', handleDisconnect);
+            resolve();
+        });
+    });
+
+    // close device
+    await device.release();
+
+    // wait T3W1 countdown after FW installation
+    const restartPromise = new Promise<void>(resolve => {
+        resolveAfter(4000).then(() => {
+            log.info(`waitForBluetoothReboot restartPromise. aborted: ${ctrl.signal.aborted}`);
+            if (!ctrl.signal.aborted) {
+                ctrl.abort();
+                // request ui (suite) to disconnect the device
+                postMessage(
+                    createUiMessage(UI.FIRMWARE_DISCONNECT, {
+                        device: device.toMessageObject(),
+                    }),
+                );
+            }
+            resolve();
+        });
+    });
+
+    await Promise.race([disconnectedPromise, restartPromise]);
+
+    return method;
+};
+
 const getInstallationParams = (device: Device, params: Params) => {
     const btcOnly = params.btcOnly ?? device.firmwareType === FirmwareType.BitcoinOnly;
 
@@ -517,21 +577,10 @@ export const onCallFirmwareUpdate = async ({
         });
     }
 
-    if (device.bluetoothProps) {
-        // close device
-        await device.release();
-        // T3W1 countdown after FW installation
-        await resolveAfter(4000);
-        // request ui (suite) to disconnect the device
-        postMessage(
-            createUiMessage(UI.FIRMWARE_DISCONNECT, {
-                device: device.toMessageObject(),
-            }),
-        );
-    }
+    const method = await getRebootMethod({ deviceList, device, log });
 
     reconnectedDevice = await waitForReconnectedDevice(
-        { bootloader: false, method: 'wait' },
+        { bootloader: false, method },
         { ...context, device: reconnectedDevice },
     );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix for the issue mentioned here: https://github.com/trezor/trezor-suite/pull/20920

after successful FW update device reboots from bootloader to normal mode. 

suite expects that device gets disconnected **or** waits 4 seconds (countdown on device) a tries to force disconnection via suite > bluetoothIpc (UI.FIRMWARE_DISCONNECT)

in case 1, we dont expect antoher device-disconnect event so we should use `method = 'auto'` of `waitForReconnectedDevice`

in case 2 or not bluetooth device (default) we expect disconnection so is  `method = 'wait'`

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/thp-fw-update-reboot&lookback=7)