### PR TITLE
fix(suite-native): device settings ble card

### DIFF
--- a/suite-native/module-device-settings/src/components/DeviceBluetoothCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceBluetoothCard.tsx
@@ -46,9 +46,7 @@ export const DeviceBluetoothCard = () => {
             primaryButtonTitle: (
                 <Translation id="moduleDeviceSettings.bluetooth.unpairTrezorButton" />
             ),
-            primaryButtonVariant: 'redBold',
             secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
-            secondaryButtonVariant: 'redElevation0',
             onPressPrimaryButton: unpairTrezor,
         });
     };
@@ -59,7 +57,6 @@ export const DeviceBluetoothCard = () => {
             subtitle={<Translation id="moduleDeviceSettings.bluetooth.content" />}
             icon="bluetoothSlash"
             onPress={showInfoAlert}
-            variant="danger"
         />
     );
 };

--- a/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
@@ -46,6 +46,7 @@ export const DeviceSettingsModalScreen = () => {
                 >
                     {isDeviceInitialized && <DevicePinProtectionCard />}
                     <DeviceFirmwareCard />
+                    {isDeviceConnectedViaBluetooth && <DeviceBluetoothCard />}
                 </TitledSection>
                 <TitledSection
                     title={<Translation id="moduleDeviceSettings.sectionTitles.security" />}
@@ -56,7 +57,6 @@ export const DeviceSettingsModalScreen = () => {
                 <TitledSection
                     title={<Translation id="moduleDeviceSettings.sectionTitles.dangerZone" />}
                 >
-                    {isDeviceConnectedViaBluetooth && <DeviceBluetoothCard />}
                     <WipeDeviceCard />
                 </TitledSection>
             </VStack>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Tweak design of device settings unpair card based on this design: 
https://www.figma.com/design/yl2g0XLU9iIgJsrxSOqkS9/Bluetooth---THP--Final-?node-id=2315-28774&m=dev


## Screenshots:
<img width="324" height="667" alt="image" src="https://github.com/user-attachments/assets/306f985e-e796-40f1-b289-2279bfd0e20b" />
<img width="331" height="670" alt="image" src="https://github.com/user-attachments/assets/0778917a-f22c-4c92-b57d-2454ed0a5ce7" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-settings-unpair-card&lookback=7)