### PR TITLE
test(suite-native): optimize device settings e2e

### DIFF
--- a/suite-native/app/e2e/pageObjects/deviceSettingsActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceSettingsActions.ts
@@ -2,10 +2,12 @@ import { MNEMONICS, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { scrollUntilVisible, waitForElementByIdToBeVisible } from '../utils';
 
-const insertAllSeed = async () => {
-    for (let i = 0; i < MNEMONICS.mnemonic_all.length; i++) {
-        await TrezorUserEnvLink.inputEmu('all');
-    }
+const insertSeed = async (seed: string = MNEMONICS.mnemonic_immune) => {
+    const seedWords = seed.split(' ');
+
+    await seedWords.forEach(async word => {
+        await TrezorUserEnvLink.inputEmu(word);
+    });
 };
 
 export const redirectToDeviceAuthenticityScreenButton = element(
@@ -19,7 +21,7 @@ class DeviceSettingsActions {
             .withTimeout(10000);
     }
 
-    async waitForHomescreenAndUninitializedTitle() {
+    async waitForHomeScreenAndUninitializedTitle() {
         await waitFor(element(by.id('@screen/Home')))
             .toBeVisible()
             .withTimeout(10000);
@@ -169,7 +171,12 @@ class DeviceSettingsActions {
         await TrezorUserEnvLink.pressYes();
         await TrezorUserEnvLink.selectNumOfWordsEmu(12);
         await TrezorUserEnvLink.pressYes();
-        await insertAllSeed();
+        await insertSeed();
+        await TrezorUserEnvLink.pressYes();
+
+        await waitFor(element(by.text('Your backup is valid')))
+            .toBeVisible()
+            .withTimeout(10000);
     }
 }
 

--- a/suite-native/app/e2e/tests/deviceSettings.test.ts
+++ b/suite-native/app/e2e/tests/deviceSettings.test.ts
@@ -1,5 +1,5 @@
 import { conditionalDescribe } from '@suite-common/test-utils';
-import { MNEMONICS, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { onboardingCompleted } from '../fixtures/onboardingCompleted';
 import { onAlertSheet } from '../pageObjects/alertSheetActions';
@@ -8,7 +8,6 @@ import { onDeviceAuthenticitySuccess } from '../pageObjects/deviceAuthenticitySu
 import { onDeviceManager } from '../pageObjects/deviceManagerActions';
 import { onDeviceSettings } from '../pageObjects/deviceSettingsActions';
 import {
-    PrepareTrezorEmulatorProps,
     appIsFullyLoaded,
     disconnectTrezorUserEnv,
     openApp,
@@ -16,11 +15,9 @@ import {
     restartApp,
 } from '../utils';
 
-const defaultEmulatorOptions: PrepareTrezorEmulatorProps = { seed: MNEMONICS.mnemonic_all };
-
 conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () => {
     beforeAll(async () => {
-        await prepareTrezorEmulator(defaultEmulatorOptions);
+        await prepareTrezorEmulator();
         await openApp({ newInstance: true, args: { preloadedState: onboardingCompleted } });
 
         await onCoinEnabling.waitForInitScreen();
@@ -33,9 +30,13 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () =>
         await device.terminateApp();
     });
 
+    afterEach(async () => {
+        await TrezorUserEnvLink.stopEmu();
+    });
+
     describe('Tests with T3T1 device model', () => {
         beforeEach(async () => {
-            await prepareTrezorEmulator(defaultEmulatorOptions);
+            await prepareTrezorEmulator();
             await restartApp();
             await appIsFullyLoaded();
 
@@ -109,23 +110,19 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () =>
             await onDeviceSettings.confirmStepperItems(1);
             await TrezorUserEnvLink.pressYes();
 
-            await onDeviceSettings.waitForHomescreenAndUninitializedTitle();
+            await onDeviceSettings.waitForHomeScreenAndUninitializedTitle();
         });
 
         test('Device Check Backup', async () => {
             await onDeviceSettings.tapDeviceCheckBackupButton();
 
             await onDeviceSettings.passCheckBackupFlow();
-
-            await waitFor(element(by.text('Your backup is valid')))
-                .toBeVisible()
-                .withTimeout(10000);
         });
     });
 
     describe('Tests with FW update required', () => {
         beforeEach(async () => {
-            await prepareTrezorEmulator({ ...defaultEmulatorOptions, version: '2.8.9' });
+            await prepareTrezorEmulator({ version: '2.8.9' });
             await restartApp({ args: { isFirmwareUpdateEnabled: true } });
             await appIsFullyLoaded();
 
@@ -139,15 +136,12 @@ conditionalDescribe(device.getPlatform() === 'android', 'Device settings', () =>
             await onDeviceSettings.tapCheckBackupButtonFromFirmwareUpdate();
 
             await onDeviceSettings.passCheckBackupFlow();
-            await waitFor(element(by.text('Your backup is valid')))
-                .toBeVisible()
-                .withTimeout(10000);
         });
     });
 
     describe('Tests with T1B1 device model', () => {
         beforeEach(async () => {
-            await prepareTrezorEmulator({ ...defaultEmulatorOptions, model: 'T1B1' });
+            await prepareTrezorEmulator({ model: 'T1B1' });
             await restartApp();
             await appIsFullyLoaded();
 


### PR DESCRIPTION
## Description
Device settings E2E were using `all` seed that has many accounts, and discovery might take more than 30s. This PR uses `immune` seed with a single BTC account, so the discovery is basically instant. **The device settings test are way shorter now and not flaky anymore due to unfinished discovery.**


## Screenshots:

<img width="910" height="772" alt="Screenshot 2025-08-27 at 7 13 11 AM" src="https://github.com/user-attachments/assets/5279bf74-e738-4697-8292-5ad0db9a3ac6" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native/optimize-device-settings-e2e&lookback=7)