### PR TITLE
fix(suite): handle connect unacquired device

### DIFF
--- a/packages/suite/src/actions/suite/initAction.ts
+++ b/packages/suite/src/actions/suite/initAction.ts
@@ -77,6 +77,9 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
                 [DEVICE.CONNECT]: device => {
                     dispatch(handleDeviceConnect(device));
                 },
+                [DEVICE.CONNECT_UNACQUIRED]: device => {
+                    dispatch(handleDeviceConnect(device));
+                },
                 [UI.INVALID_PIN_ATTEMPTS_DEPLETED]: () => {
                     dispatch(
                         modalActions.openModal({


### PR DESCRIPTION
## Description

Hotfix for #20997

Fixes connection of THP device, which always starts as unaquired.


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-unacquired&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-unacquired&lookback=7)