### PR TITLE
chore(message-system): bump sequence number

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2025-08-26T12:00:00+00:00",
-    "sequence": 106,
+    "timestamp": "2025-08-27T08:30:00+00:00",
+    "sequence": 107,
     "actions": [
         {
             "conditions": [


### PR DESCRIPTION
## Description

Bump sequence number, which was omitted in https://github.com/trezor/trezor-suite/pull/21027

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bump-msg-system-sequence&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bump-msg-system-sequence&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/bump-msg-system-sequence&lookback=7)