### PR TITLE
feat(suite-native): unify connect device handlers

### DIFF
--- a/packages/suite/src/components/connection/thp/ThpAutoconnectInfoModal.tsx
+++ b/packages/suite/src/components/connection/thp/ThpAutoconnectInfoModal.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
 
-import { thpActions } from '@suite-common/thp';
+import { startThpAutoconnectThunk, thpActions } from '@suite-common/thp';
 import { Button, Card, Column, Icon, List, Modal, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { startThpAutoconnectThunk } from '../../../actions/thp/startThpAutoconnectThunk';
 import { useDevice, useDispatch } from '../../../hooks/suite';
 import { Translation } from '../../suite/Translation';
 

--- a/packages/suite/src/views/settings/SettingsDevice/ThpAutoconnect.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ThpAutoconnect.tsx
@@ -1,3 +1,4 @@
+import { startThpAutoconnectThunk } from '@suite-common/thp';
 import { Switch } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
@@ -7,7 +8,6 @@ import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 
 import { removeThpAutoconnectThunk } from '../../../actions/thp/removeThpAutoconnectThunk';
-import { startThpAutoconnectThunk } from '../../../actions/thp/startThpAutoconnectThunk';
 
 interface PinProtectionProps {
     isDeviceLocked: boolean;

--- a/suite-common/thp/src/connectThpDeviceThunk.ts
+++ b/suite-common/thp/src/connectThpDeviceThunk.ts
@@ -13,8 +13,9 @@ type ConnectThpDeviceThinkParams = {
 
 export const connectThpDeviceThunk = createThunk<void, ConnectThpDeviceThinkParams, void>(
     `${THP_PREFIX}/connectThpDeviceThunk`,
-    ({ device }, { dispatch, getState }) => {
-        if (device.thp === undefined) return;
+    ({ device }, { dispatch, getState, rejectWithValue }) => {
+        if (device.thp === undefined) return rejectWithValue('not-thp-device');
+
         const credentials = selectThpCredentials(getState());
         const isFwInstall = selectFirmware(getState()).status !== 'initial';
 

--- a/suite-common/thp/src/index.ts
+++ b/suite-common/thp/src/index.ts
@@ -3,4 +3,5 @@ export type { ThpStep } from './thpReducer';
 export { selectIsThpInProgress, selectThpStep, selectThpCredentials } from './thpSelectors';
 export { thpActions } from './thpActions';
 export { connectThpDeviceThunk } from './connectThpDeviceThunk';
+export { startThpAutoconnectThunk } from './startThpAutoconnectThunk';
 export { autoInitThpAfterDeviceConnectionThunk } from './autoInitThpAfterDeviceConnectionThunk';

--- a/suite-common/thp/src/startThpAutoconnectThunk.ts
+++ b/suite-common/thp/src/startThpAutoconnectThunk.ts
@@ -1,10 +1,9 @@
 import { createThunk } from '@suite-common/redux-utils/';
-import { thpActions } from '@suite-common/thp';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 
-import { THP_PREFIX } from './thpActions';
+import { THP_PREFIX, thpActions } from './thpActions';
 
 export const startThpAutoconnectThunk = createThunk<void, void, void>(
     `${THP_PREFIX}/startThpAutoconnectThunk`,

--- a/suite-common/thp/src/thpActions.ts
+++ b/suite-common/thp/src/thpActions.ts
@@ -7,7 +7,7 @@ export const THP_PREFIX = '@suite/thp';
 
 const invalidCode = createAction(`${THP_PREFIX}/invalid-pin-action`);
 
-const resetThpFlow = createAction(`${THP_PREFIX}/cancel-thp-flow`);
+const resetThpFlow = createAction(`${THP_PREFIX}/reset-thp-flow`);
 
 export const showAutoconnectInfo = createAction(`${THP_PREFIX}/showAutoconnectInfo`);
 

--- a/suite-native/device-manager/src/components/ConnectButton.tsx
+++ b/suite-native/device-manager/src/components/ConnectButton.tsx
@@ -3,8 +3,6 @@ import { Platform } from 'react-native';
 import { FadeInUp, FadeOutUp, LinearTransition } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/native';
-
 import { TrezorDevice } from '@suite-common/suite-types';
 import {
     selectHasRunningDiscovery,
@@ -14,15 +12,10 @@ import {
 } from '@suite-common/wallet-core';
 import { EventType, analytics } from '@suite-native/analytics';
 import { AnimatedBox, Button } from '@suite-native/atoms';
+import { useConnectDeviceHandler } from '@suite-native/device';
 import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import { IconName } from '@suite-native/icons';
 import { Translation, TxKeyPath } from '@suite-native/intl';
-import {
-    AuthorizeDeviceStackRoutes,
-    RootStackParamList,
-    RootStackRoutes,
-    StackToStackCompositeNavigationProps,
-} from '@suite-native/navigation';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { useDeviceManager } from '../hooks/useDeviceManager';
@@ -36,17 +29,10 @@ const buttonWrapperStyle = prepareNativeStyle(utils => ({
     paddingHorizontal: utils.spacings.sp16,
 }));
 
-type NavigationProp = StackToStackCompositeNavigationProps<
-    RootStackParamList,
-    RootStackRoutes.AppTabs,
-    RootStackParamList
->;
-
 export const ConnectButton = ({ onSelectDevice }: ConnectButtonProps) => {
     const { applyStyle } = useNativeStyles();
     const hasDiscovery = useSelector(selectHasRunningDiscovery);
     const isNoPhysicalDeviceConnected = useSelector(selectIsNoPhysicalDeviceConnected);
-    const navigation = useNavigation<NavigationProp>();
     const { setIsDeviceManagerVisible } = useDeviceManager();
     const isBluetoothEnabled = useFeatureFlag(FeatureFlag.IsBluetoothEnabled);
     const device = useSelector(selectSelectedDevice);
@@ -58,19 +44,15 @@ export const ConnectButton = ({ onSelectDevice }: ConnectButtonProps) => {
 
     const isConnectButtonVisible = !hasDiscovery && isNoPhysicalDeviceConnected;
 
-    const handleConnectDevice = () => {
-        const connectDeviceScreen = isOnlyBluetoothSupported
-            ? AuthorizeDeviceStackRoutes.ConnectBluetoothDevice
-            : AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice;
+    const { onConnectDevicePress } = useConnectDeviceHandler();
 
+    const handleConnectDevice = () => {
         if (device) {
             onSelectDevice(device);
         }
         setIsDeviceManagerVisible(false);
 
-        navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
-            screen: connectDeviceScreen,
-        });
+        onConnectDevicePress();
 
         analytics.report({
             type: EventType.DeviceManagerClick,

--- a/suite-native/device/src/hooks/useConnectDeviceHandler.tsx
+++ b/suite-native/device/src/hooks/useConnectDeviceHandler.tsx
@@ -1,0 +1,48 @@
+import { useCallback } from 'react';
+import { Platform } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { acquireDevice, selectIsDeviceThpRequired } from '@suite-common/wallet-core';
+import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
+import {
+    AuthorizeDeviceStackRoutes,
+    HomeStackParamList,
+    HomeStackRoutes,
+    RootStackParamList,
+    RootStackRoutes,
+    StackToStackCompositeNavigationProps,
+} from '@suite-native/navigation';
+
+type NavigationProps = StackToStackCompositeNavigationProps<
+    HomeStackParamList,
+    HomeStackRoutes.Home,
+    RootStackParamList
+>;
+
+export const useConnectDeviceHandler = () => {
+    const dispatch = useDispatch();
+
+    const navigation = useNavigation<NavigationProps>();
+
+    const isBluetoothEnabled = useFeatureFlag(FeatureFlag.IsBluetoothEnabled);
+
+    const isDeviceThpRequired = useSelector(selectIsDeviceThpRequired);
+
+    const isIosWithBluetoothEnabled = Platform.OS === 'ios' && isBluetoothEnabled;
+
+    const onConnectDevicePress = useCallback(() => {
+        if (isDeviceThpRequired) {
+            dispatch(acquireDevice({}));
+        } else {
+            navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
+                screen: isIosWithBluetoothEnabled
+                    ? AuthorizeDeviceStackRoutes.TurnOnAndUnlockDevice
+                    : AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice,
+            });
+        }
+    }, [dispatch, isDeviceThpRequired, isIosWithBluetoothEnabled, navigation]);
+
+    return { onConnectDevicePress };
+};

--- a/suite-native/device/src/index.ts
+++ b/suite-native/device/src/index.ts
@@ -1,4 +1,5 @@
 export * from './middlewares/deviceMiddleware';
+export * from './hooks/useConnectDeviceHandler';
 export * from './hooks/useHandleDeviceConnection';
 export * from './hooks/useDetectDeviceError';
 export * from './hooks/useWipeDevice';

--- a/suite-native/module-home/src/screens/HomeScreen/components/EmptyPortfolioCrossroads.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/EmptyPortfolioCrossroads.tsx
@@ -1,16 +1,14 @@
 import { Platform, View } from 'react-native';
-import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { acquireDevice, selectIsDeviceThpRequired } from '@suite-common/wallet-core';
 import { EventType, analytics } from '@suite-native/analytics';
 import { Button, Card, CenteredTitleHeader, Text, VStack } from '@suite-native/atoms';
+import { useConnectDeviceHandler } from '@suite-native/device';
 import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import { Translation } from '@suite-native/intl';
 import {
     AccountsImportStackRoutes,
-    AuthorizeDeviceStackRoutes,
     HomeStackParamList,
     HomeStackRoutes,
     RootStackParamList,
@@ -41,24 +39,17 @@ type NavigationProps = StackToStackCompositeNavigationProps<
 >;
 
 export const EmptyPortfolioCrossroads = () => {
-    const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
     const isBluetoothEnabled = useFeatureFlag(FeatureFlag.IsBluetoothEnabled);
+
     const isIosWithBluetoothEnabled = Platform.OS === 'ios' && isBluetoothEnabled;
+
     const { applyStyle } = useNativeStyles();
 
-    const isDeviceThpRequired = useSelector(selectIsDeviceThpRequired);
+    const { onConnectDevicePress } = useConnectDeviceHandler();
 
     const handleConnectDevice = () => {
-        if (isDeviceThpRequired) {
-            dispatch(acquireDevice({}));
-        } else {
-            navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
-                screen: isIosWithBluetoothEnabled
-                    ? AuthorizeDeviceStackRoutes.TurnOnAndUnlockDevice
-                    : AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice,
-            });
-        }
+        onConnectDevicePress();
         analytics.report({
             type: EventType.EmptyDashboardClick,
             payload: { action: 'connectDevice' },

--- a/suite-native/thp/package.json
+++ b/suite-native/thp/package.json
@@ -10,6 +10,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
+        "@reduxjs/toolkit": "2.8.2",
         "@suite-native/atoms": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/styles": "workspace:*",

--- a/suite-native/thp/redux.d.ts
+++ b/suite-native/thp/redux.d.ts
@@ -1,0 +1,7 @@
+import { AsyncThunkAction } from '@reduxjs/toolkit';
+
+declare module 'redux' {
+    export interface Dispatch {
+        <TThunk extends AsyncThunkAction<any, any, any>>(thunk: TThunk): ReturnType<TThunk>;
+    }
+}

--- a/suite-native/thp/src/hooks/useThpAlert.tsx
+++ b/suite-native/thp/src/hooks/useThpAlert.tsx
@@ -1,26 +1,18 @@
 import { useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
-import { thpActions } from '@suite-common/thp';
-import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { startThpAutoconnectThunk, thpActions } from '@suite-common/thp';
 import { useAlert } from '@suite-native/alerts';
 import { Box, BulletListItem, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
-import TrezorConnect from '@trezor/connect';
 
 export const useThpAlerts = () => {
     const dispatch = useDispatch();
     const { showAlert } = useAlert();
 
-    const device = useSelector(selectSelectedDevice);
-
-    const turnOnAutoconnect = useCallback(async () => {
-        const response = await TrezorConnect.thpGetCredentials({ device });
-        if (response.success) {
-            dispatch(thpActions.addCredential({ credential: response.payload }));
-        }
-        dispatch(thpActions.resetThpFlow());
-    }, [device, dispatch]);
+    const turnOnAutoconnect = useCallback(() => {
+        dispatch(startThpAutoconnectThunk());
+    }, [dispatch]);
 
     const ignoreAutoconnect = useCallback(() => {
         dispatch(thpActions.resetThpFlow());

--- a/yarn.lock
+++ b/yarn.lock
@@ -11546,6 +11546,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/thp@workspace:suite-native/thp"
   dependencies:
+    "@reduxjs/toolkit": "npm:2.8.2"
     "@suite-native/atoms": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/styles": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- https://github.com/trezor/trezor-suite/pull/21064/commits/95ba4f0edeff9fd52f5081727f251e7897717bee - clicking on `Connect device` in Dashboard and in Device switcher wasn't unified resulting in different navigation route. This PR unifies it with a reusable handler.
- https://github.com/trezor/trezor-suite/pull/21064/commits/0b7ba64aa5c5e9f24d56453fb334aba59471b42d - simple rename for action name to match the actual string
- https://github.com/trezor/trezor-suite/pull/21064/commits/48b04f6c1279caf0d41328e462366bd8a1a5e893 - auto connect functionality unification across mobile & desktop to reduce duplication. Also `connectThpDeviceThunk` will now rejectWithValue for non-thp devices



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/thp-bugs&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/thp-bugs&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/thp-bugs&lookback=7)