### PR TITLE
fix(protocol): do not reset ThpState.properties

### DIFF
--- a/packages/protocol/src/protocol-thp/ThpState.ts
+++ b/packages/protocol/src/protocol-thp/ThpState.ts
@@ -287,7 +287,6 @@ export class ThpState {
     resetState() {
         this._phase = 'handshake';
         this._isPaired = false;
-        this._properties = undefined;
         this._pairingTagPromise = undefined;
         this._cancelablePromise = false;
         this._handshakeCredentials = undefined;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
uninteded bug added during the review https://github.com/trezor/trezor-suite/pull/20183#discussion_r2267504240

ThpState.properties should not be cleared


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-properties-reset&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-properties-reset&lookback=7)