### PR TITLE
feat(suite): add cardano staking info modals

### DIFF
--- a/packages/suite/src/components/suite/StakingProcess/StakingInfo.tsx
+++ b/packages/suite/src/components/suite/StakingProcess/StakingInfo.tsx
@@ -3,7 +3,11 @@ import { useSelector } from 'react-redux';
 
 import { getDaysToAddToPool } from '@suite-common/staking';
 import { NetworkSymbol, NetworkType, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
-import { SOLANA_EPOCH_DAYS } from '@suite-common/wallet-constants';
+import {
+    CARDANO_ACTIVATION_PERIOD_DAYS,
+    CARDANO_EPOCH_DAYS,
+    SOLANA_EPOCH_DAYS,
+} from '@suite-common/wallet-constants';
 import {
     AccountsRootState,
     StakeRootState,
@@ -66,6 +70,23 @@ const getInfoRowsData = (
                     <Translation
                         id="TR_STAKE_EARN_REWARDS_EVERY"
                         values={{ days: SOLANA_EPOCH_DAYS }}
+                    />
+                ),
+            };
+        case 'cardano':
+            return {
+                payoutDays: (
+                    <Translation
+                        id="TR_STAKE_APPROXIMATE_DAYS"
+                        values={{ count: CARDANO_ACTIVATION_PERIOD_DAYS }}
+                    />
+                ),
+                rewardsPeriodHeading: <Translation id="TR_STAKE_ENTER_ACTIVATION_PERIOD" />,
+                rewardsPeriodSubheading: <Translation id="TR_STAKE_TIME_TO_START_EARNING" />,
+                rewardsEarningHeading: (
+                    <Translation
+                        id="TR_STAKE_EARN_REWARDS_EVERY"
+                        values={{ days: CARDANO_EPOCH_DAYS }}
                     />
                 ),
             };

--- a/packages/suite/src/components/suite/StakingProcess/UnstakingInfo.tsx
+++ b/packages/suite/src/components/suite/StakingProcess/UnstakingInfo.tsx
@@ -51,6 +51,17 @@ const getInfoRowsData = (
                     />
                 ),
             };
+        case 'cardano':
+            return {
+                readyForClaimDays: <Translation id="TR_STAKE_INSTANTLY" />,
+                deactivatePeriodHeading: <Translation id="TR_STAKE_RECEIVE_DEPOSIT_IN_ACCOUNT" />,
+                deactivatePeriodSubheading: (
+                    <Translation
+                        id="TR_STAKE_YOUR_DEPOSIT_IS_RETURNED"
+                        values={{ networkDisplaySymbol: getNetworkDisplaySymbol(accountSymbol) }}
+                    />
+                ),
+            };
         default:
             return null;
     }
@@ -67,6 +78,8 @@ export const UnstakingInfo = ({ isExpanded }: UnstakingInfoProps) => {
         useSelector((state: StakeRootState) => selectValidatorsQueue(state, account?.symbol)) || {};
 
     if (!account) return null;
+
+    const isCardano = account.networkType === 'cardano';
 
     const daysToUnstake = getUnstakingPeriodInDays({
         networkType: account.networkType,
@@ -109,6 +122,7 @@ export const UnstakingInfo = ({ isExpanded }: UnstakingInfoProps) => {
                 text: <Translation id="TR_TRADING_NETWORK_FEE" />,
                 isBadge: true,
             },
+            isHidden: isCardano,
         },
         {
             heading: (
@@ -117,8 +131,11 @@ export const UnstakingInfo = ({ isExpanded }: UnstakingInfoProps) => {
                     values={{ networkDisplaySymbol: displaySymbol }}
                 />
             ),
+            isHidden: isCardano,
         },
     ];
+
+    const visibleInfoRows = infoRows.filter(row => !row.isHidden);
 
     return (
         <BulletList
@@ -127,7 +144,7 @@ export const UnstakingInfo = ({ isExpanded }: UnstakingInfoProps) => {
             bulletSize="small"
             titleGap={spacings.xxs}
         >
-            {infoRows.map(({ heading, content, subheading }, index) => (
+            {visibleInfoRows.map(({ heading, content, subheading }, index) => (
                 <InfoRow key={index} {...{ heading, subheading, content, isExpanded }} />
             ))}
         </BulletList>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeInANutshellModal/StakeInANutshellModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeInANutshellModal/StakeInANutshellModal.tsx
@@ -33,26 +33,47 @@ interface StakingDetails {
     translationId: TranslationKey;
 }
 
-const getStakingDetails = (networkType: NetworkType): StakingDetails[] => [
-    {
-        id: 0,
-        icon: 'lockSimple',
-        translationId: 'TR_STAKE_STAKED_AMOUNT_LOCKED',
-    },
-    {
-        id: 1,
-        icon: 'handCoins',
-        translationId: 'TR_STAKE_REWARDS_EARN',
-    },
-    {
-        id: 2,
-        icon: 'arrowBendDoubleUpLeft',
-        translationId:
-            networkType === 'ethereum'
-                ? 'TR_STAKE_ETH_UNSTAKING_TAKES'
-                : 'TR_STAKE_SOL_UNSTAKING_TAKES',
-    },
-];
+const getStakingDetails = (networkType: NetworkType): StakingDetails[] => {
+    if (networkType === 'cardano')
+        return [
+            {
+                id: 0,
+                icon: 'wallet',
+                translationId: 'TR_STAKE_YOUR_FUNDS_STAY_ACCESSIBLE',
+            },
+            {
+                id: 1,
+                icon: 'piggyBank',
+                translationId: 'TR_STAKE_ALL_YOUR_FUNDS_IS_STAKED',
+            },
+            {
+                id: 2,
+                icon: 'scroll',
+                translationId: 'TR_STAKE_RETURNABLE_DEPOSIT_IS_REQUIRED',
+            },
+        ];
+
+    return [
+        {
+            id: 0,
+            icon: 'lockSimple',
+            translationId: 'TR_STAKE_STAKED_AMOUNT_LOCKED',
+        },
+        {
+            id: 1,
+            icon: 'handCoins',
+            translationId: 'TR_STAKE_REWARDS_EARN',
+        },
+        {
+            id: 2,
+            icon: 'arrowBendDoubleUpLeft',
+            translationId:
+                networkType === 'ethereum'
+                    ? 'TR_STAKE_ETH_UNSTAKING_TAKES'
+                    : 'TR_STAKE_SOL_UNSTAKING_TAKES',
+        },
+    ];
+};
 
 interface StakeInANutshellModalProps {
     onCancel: () => void;
@@ -64,6 +85,8 @@ export const StakeInANutshellModal = ({ onCancel }: StakeInANutshellModalProps) 
     const { validatorWithdrawTime, validatorExitTime } = useSelector(state =>
         selectValidatorsQueueData(state, account?.symbol),
     );
+
+    const isCardano = account?.networkType === 'cardano';
 
     const unstakingPeriod = getUnstakingPeriodInDays({
         networkType: account?.networkType,
@@ -108,7 +131,9 @@ export const StakeInANutshellModal = ({ onCancel }: StakeInANutshellModalProps) 
             heading: <Translation id="TR_STAKE_UNSTAKING_PROCESS" />,
             badge: (
                 <>
-                    <Translation id="TR_TX_CONFIRMATIONS" values={{ confirmationsCount: 2 }} />{' '}
+                    {!isCardano && (
+                        <Translation id="TR_TX_CONFIRMATIONS" values={{ confirmationsCount: 2 }} />
+                    )}{' '}
                     <Translation id="TR_TX_FEE" />
                 </>
             ),

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeForm.tsx
@@ -7,6 +7,7 @@ import { useStakeFormContext } from 'src/hooks/wallet/useStakeForm';
 import { ConfirmStakeModal } from './ConfirmStakeModal';
 import { StakeAvailableBalance } from './StakeAvailableBalance';
 import { StakeInputs } from './StakeInputs';
+import { StakeRegistrationDepositCard } from './StakeRegistrationDepositCard';
 
 export const StakeForm = () => {
     const {
@@ -26,7 +27,9 @@ export const StakeForm = () => {
         trigger,
     } = useStakeFormContext();
 
-    const { formattedBalance, symbol } = account;
+    const { formattedBalance, symbol, networkType } = account;
+
+    const isCardanoNetwork = networkType === 'cardano';
 
     return (
         <>
@@ -39,9 +42,18 @@ export const StakeForm = () => {
             )}
 
             <Column gap={spacings.xxl} margin={{ bottom: spacings.lg }}>
-                <StakeAvailableBalance formattedBalance={formattedBalance} symbol={symbol} />
+                {isCardanoNetwork ? (
+                    <StakeRegistrationDepositCard account={account} />
+                ) : (
+                    <>
+                        <StakeAvailableBalance
+                            formattedBalance={formattedBalance}
+                            symbol={symbol}
+                        />
 
-                <StakeInputs />
+                        <StakeInputs />
+                    </>
+                )}
 
                 <Fees
                     control={control}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeRegistrationDepositCard.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeRegistrationDepositCard.tsx
@@ -1,0 +1,57 @@
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { CARDANO_STAKING_REGISTRATION_DEPOSIT } from '@suite-common/wallet-constants';
+import { Account } from '@suite-common/wallet-types';
+import { Banner, Card, Paragraph, Row } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
+import { Translation } from 'src/components/suite/Translation';
+
+type StakeRegistrationDepositCardProps = {
+    account: Account;
+};
+
+export const StakeRegistrationDepositCard = ({ account }: StakeRegistrationDepositCardProps) => {
+    const { symbol } = account;
+
+    return (
+        <Card paddingType="small" flex="1">
+            <Row gap={spacings.lg} justifyContent="space-between" margin={{ bottom: spacings.md }}>
+                <Paragraph typographyStyle="body">
+                    <Translation id="AMOUNT" />
+                </Paragraph>
+                <Paragraph typographyStyle="highlight">
+                    <Translation id="TR_STAKE_ENTIRE_BALANCE" />
+                </Paragraph>
+            </Row>
+            <Row gap={spacings.lg} justifyContent="space-between">
+                <Paragraph typographyStyle="body">
+                    <Translation id="TR_STAKE_REGISTRATION_DEPOSIT" />
+                </Paragraph>
+                <Paragraph typographyStyle="highlight">
+                    {CARDANO_STAKING_REGISTRATION_DEPOSIT} {getNetworkDisplaySymbol(symbol)}
+                </Paragraph>
+            </Row>
+            <Row gap={spacings.lg} justifyContent="space-between" margin={{ bottom: spacings.md }}>
+                <Paragraph variant="tertiary" typographyStyle="hint">
+                    <Translation id="TR_STAKE_RETURNED_TO_ACCOUNT_WHEN_UNSTAKE" />
+                </Paragraph>
+                <Paragraph variant="tertiary" typographyStyle="hint">
+                    ≈
+                    <BaseCurrencyValue
+                        amount={CARDANO_STAKING_REGISTRATION_DEPOSIT}
+                        symbol={symbol}
+                    />
+                </Paragraph>
+            </Row>
+            <Banner variant="info">
+                <Translation
+                    id="TR_STAKE_FUNDS_WARNING"
+                    values={{
+                        networkDisplaySymbol: getNetworkDisplaySymbol(symbol),
+                    }}
+                />
+            </Banner>
+        </Card>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/EverstakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/EverstakeModal.tsx
@@ -90,7 +90,12 @@ export const EverstakeModal = ({ onCancel }: EverstakeModalProps) => {
     return (
         <Modal
             heading={<Translation id="TR_STAKE_NETWORK" values={{ symbol: displaySymbol }} />}
-            description={<Translation id="TR_STAKE_YOUR_FUNDS_MAINTAINED" />}
+            description={
+                <Translation
+                    id="TR_STAKE_YOUR_FUNDS_MAINTAINED"
+                    values={{ networkDisplaySymbol: displaySymbol }}
+                />
+            }
             onCancel={onCancelClick}
             size="small"
             bottomContent={

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9437,6 +9437,73 @@ export default defineMessages({
         id: 'TR_STAKE_NETWORK_SEE_MONEY_DANCE_DESC',
         defaultMessage: 'Earn ~{apyPercent}% <t>APY</t> by staking your {symbol} with Trezor.',
     },
+    TR_STAKE_EARN_APY_BY_STAKING: {
+        id: 'TR_STAKE_EARN_APY_BY_STAKING',
+        defaultMessage: 'Earn ~{apyPercent}% APY by staking your {symbol}',
+    },
+    TR_STAKE_FULL_BALANCE_AND_EARN: {
+        id: 'TR_STAKE_FULL_BALANCE_AND_EARN',
+        defaultMessage:
+            'Stake your full balance and earn around {amount} {symbol}/year at the current APY. Your {symbol} stay in your account, ready to use anytime—while helping secure the network.',
+    },
+    TR_STAKE_KEEP_EARNING: {
+        id: 'TR_STAKE_KEEP_EARNING',
+        defaultMessage: 'Keep earning',
+    },
+    TR_STAKE_APY_INFO: {
+        id: 'TR_STAKE_APY_INFO',
+        defaultMessage:
+            'APY (Annual Percentage Yield) is your yearly return on staked funds, with compounding.',
+    },
+    TR_STAKE_USE_ANYTIME: {
+        id: 'TR_STAKE_USE_ANYTIME',
+        defaultMessage: 'Use anytime',
+    },
+    TR_STAKE_SEND_SWAP_SPEND_ANYTIME: {
+        id: 'TR_STAKE_SEND_SWAP_SPEND_ANYTIME',
+        defaultMessage: 'Send, swap, or spend your {symbol} whenever you want—even while staking.',
+    },
+    TR_STAKE_GET_MORE: {
+        id: 'TR_STAKE_GET_MORE',
+        defaultMessage: 'Get more',
+    },
+    TR_STAKE_CLAIM_REWARDS_TO_GROW: {
+        id: 'TR_STAKE_CLAIM_REWARDS_TO_GROW',
+        defaultMessage: 'Claim rewards to grow your stake and earn even more.',
+    },
+    TR_STAKE_YOUR_FUNDS_STAY_ACCESSIBLE: {
+        id: 'TR_STAKE_YOUR_FUNDS_STAY_ACCESSIBLE',
+        defaultMessage: 'Your {networkDisplaySymbol} stays accessible to you at all times.',
+    },
+    TR_STAKE_ALL_YOUR_FUNDS_IS_STAKED: {
+        id: 'TR_STAKE_ALL_YOUR_FUNDS_IS_STAKED',
+        defaultMessage: 'All your available {networkDisplaySymbol} is staked.',
+    },
+    TR_STAKE_RETURNABLE_DEPOSIT_IS_REQUIRED: {
+        id: 'TR_STAKE_RETURNABLE_DEPOSIT_IS_REQUIRED',
+        defaultMessage:
+            'A returnable deposit of 2 {networkDisplaySymbol} is required to register your staking key.',
+    },
+    TR_STAKE_ENTER_ACTIVATION_PERIOD: {
+        id: 'TR_STAKE_ENTER_ACTIVATION_PERIOD',
+        defaultMessage: 'Enter activation period',
+    },
+    TR_STAKE_INSTANTLY: {
+        id: 'TR_STAKE_INSTANTLY',
+        defaultMessage: 'Instantly',
+    },
+    TR_STAKE_RECEIVE_DEPOSIT_IN_ACCOUNT: {
+        id: 'TR_STAKE_RECEIVE_DEPOSIT_IN_ACCOUNT',
+        defaultMessage: 'Receive deposit in account',
+    },
+    TR_STAKE_YOUR_DEPOSIT_IS_RETURNED: {
+        id: 'TR_STAKE_YOUR_DEPOSIT_IS_RETURNED',
+        defaultMessage: 'Your deposit of 2 {networkDisplaySymbol} is returned',
+    },
+    TR_STAKE_TIME_TO_START_EARNING: {
+        id: 'TR_STAKE_TIME_TO_START_EARNING',
+        defaultMessage: 'Time it takes before you start earning rewards',
+    },
     TR_STAKE_APY_APPROX: {
         id: 'TR_STAKE_APY_APPROX',
         defaultMessage: '~{apyPercent}% APY',
@@ -9840,7 +9907,8 @@ export default defineMessages({
     },
     TR_STAKE_YOUR_FUNDS_MAINTAINED: {
         id: 'TR_STAKE_YOUR_FUNDS_MAINTAINED',
-        defaultMessage: 'Your staked funds are maintained by Everstake.',
+        defaultMessage:
+            'Your {networkDisplaySymbol} stay in your wallet. Everstake handles the stake.',
     },
     TR_STAKE_EVERSTAKE_MANAGES: {
         id: 'TR_STAKE_EVERSTAKE_MANAGES',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -8131,6 +8131,23 @@ export default defineMessages({
         id: 'TR_STAKE_DEREGISTERED',
         defaultMessage: 'Deregistration of a stake address',
     },
+    TR_STAKE_ENTIRE_BALANCE: {
+        id: 'TR_STAKE_ENTIRE_BALANCE',
+        defaultMessage: 'Entire balance',
+    },
+    TR_STAKE_REGISTRATION_DEPOSIT: {
+        id: 'TR_STAKE_REGISTRATION_DEPOSIT',
+        defaultMessage: 'Registration deposit',
+    },
+    TR_STAKE_RETURNED_TO_ACCOUNT_WHEN_UNSTAKE: {
+        id: 'TR_STAKE_RETURNED_TO_ACCOUNT_WHEN_UNSTAKE',
+        defaultMessage: 'Returned to account when you unstake',
+    },
+    TR_STAKE_FUNDS_WARNING: {
+        id: 'TR_STAKE_FUNDS_WARNING',
+        defaultMessage:
+            'Your {networkDisplaySymbol} stays in your account while staked—you can send, swap, or spend it anytime.',
+    },
     TR_ERROR_CARDANO_DELEGATE: {
         id: 'TR_ERROR_CARDANO_DELEGATE',
         defaultMessage: "Amount isn't enough",

--- a/packages/suite/src/views/wallet/staking/WalletStaking.tsx
+++ b/packages/suite/src/views/wallet/staking/WalletStaking.tsx
@@ -3,13 +3,16 @@ import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 import { Translation } from 'src/components/suite';
 import { AccountExceptionLayout, WalletLayout } from 'src/components/wallet';
 import { useSelector } from 'src/hooks/suite';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 
 import { CardanoStakingDashboard } from './components/CardanoStakingDashboard';
+import { NewCardanoStakingDashboard } from './components/CardanoStakingDashboard/NewCardanoStakingDashboard';
 import { EthStakingDashboard } from './components/EthStakingDashboard/components/EthStakingDashboard';
 import { SolStakingDashboard } from './components/SolStakingDashboard/SolStakingDashboard';
 
 export const WalletStaking = () => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const isDebugModeActive = useSelector(selectIsDebugModeActive);
 
     if (selectedAccount.status !== 'loaded') {
         return <WalletLayout title="TR_NAV_STAKING" account={selectedAccount} />;
@@ -18,7 +21,11 @@ export const WalletStaking = () => {
     if (hasNetworkFeatures(selectedAccount.account, 'staking')) {
         switch (selectedAccount.account.networkType) {
             case 'cardano':
-                return <CardanoStakingDashboard selectedAccount={selectedAccount} />;
+                return isDebugModeActive ? (
+                    <NewCardanoStakingDashboard selectedAccount={selectedAccount} />
+                ) : (
+                    <CardanoStakingDashboard selectedAccount={selectedAccount} />
+                );
             case 'ethereum':
                 return <EthStakingDashboard selectedAccount={selectedAccount} />;
             case 'solana':

--- a/packages/suite/src/views/wallet/staking/components/CardanoStakingDashboard/NewCardanoStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/CardanoStakingDashboard/NewCardanoStakingDashboard.tsx
@@ -1,0 +1,32 @@
+import { selectAccountIsStakingActive } from '@suite-common/wallet-core';
+import { SelectedAccountLoaded } from '@suite-common/wallet-types';
+import { Column } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
+import { useSelector } from 'src/hooks/suite';
+
+import { StakingDashboard } from '../StakingDashboard/StakingDashboard';
+import { EmptyStakingCard } from '../StakingDashboard/components/EmptyStakingCard';
+
+interface NewCardanoStakingDashboardProps {
+    selectedAccount: SelectedAccountLoaded;
+}
+
+export const NewCardanoStakingDashboard = ({
+    selectedAccount,
+}: NewCardanoStakingDashboardProps) => {
+    const { account } = selectedAccount;
+
+    const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
+
+    return (
+        <StakingDashboard
+            selectedAccount={selectedAccount}
+            dashboard={
+                <Column alignItems="normal" gap={spacings.xxxxl}>
+                    {!isStakingActive && <EmptyStakingCard />}
+                </Column>
+            }
+        />
+    );
+};

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
@@ -43,6 +43,8 @@ export const EmptyStakingCard = () => {
     const isDeviceConnected = device?.connected && device?.available;
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
+    const isCardano = account?.networkType === 'cardano';
+
     const apy = useSelector(state => selectPoolStatsApyData(state, account?.symbol));
     const stakingData = getStakingDataForNetwork(account);
 
@@ -91,18 +93,43 @@ export const EmptyStakingCard = () => {
             },
             {
                 id: 1,
-                icon: 'lockLaminatedOpen' as const,
-                title: <Translation id="TR_STAKING_CARD_LOCK_IN_TITLE" />,
-                text: <Translation id="TR_STAKING_CARD_LOCK_IN_TEXT" />,
+                icon: isCardano ? ('wallet' as const) : ('lockLaminatedOpen' as const),
+                title: (
+                    <Translation
+                        id={isCardano ? 'TR_STAKE_USE_ANYTIME' : 'TR_STAKING_CARD_LOCK_IN_TITLE'}
+                    />
+                ),
+                text: (
+                    <Translation
+                        id={
+                            isCardano
+                                ? 'TR_STAKE_SEND_SWAP_SPEND_ANYTIME'
+                                : 'TR_STAKING_CARD_LOCK_IN_TEXT'
+                        }
+                        values={{ symbol: displaySymbol }}
+                    />
+                ),
             },
             {
                 id: 2,
-                icon: 'everstakeLogo' as const,
-                title: <Translation id="TR_STAKING_CARD_RESTAKE_TITLE" />,
-                text: <Translation id="TR_STAKING_CARD_RESTAKE_TEXT" />,
+                icon: isCardano ? ('handCoins' as const) : ('everstakeLogo' as const),
+                title: (
+                    <Translation
+                        id={isCardano ? 'TR_STAKE_GET_MORE' : 'TR_STAKING_CARD_RESTAKE_TITLE'}
+                    />
+                ),
+                text: (
+                    <Translation
+                        id={
+                            isCardano
+                                ? 'TR_STAKE_CLAIM_REWARDS_TO_GROW'
+                                : 'TR_STAKING_CARD_RESTAKE_TEXT'
+                        }
+                    />
+                ),
             },
         ],
-        [],
+        [isCardano, displaySymbol],
     );
 
     const openStakeInANutshellModal = () => {

--- a/suite-common/wallet-constants/src/cardanoStakingConstants.ts
+++ b/suite-common/wallet-constants/src/cardanoStakingConstants.ts
@@ -1,4 +1,14 @@
+import { BigNumber } from '@trezor/utils';
+
 export const BACKUP_CARDANO_APY = 4.5;
 export const ESTIMATED_YEARLY_REWARD_RATE = 2.22;
 export const CARDANO_ACTIVATION_PERIOD_DAYS = 10;
 export const CARDANO_EPOCH_DAYS = 5;
+
+export const CARDANO_STAKING_REGISTRATION_DEPOSIT = '2';
+export const MIN_CARDANO_AMOUNT_FOR_STAKING = new BigNumber(2);
+export const MAX_CARDANO_AMOUNT_FOR_STAKING = new BigNumber(72_000_000);
+export const MIN_CARDANO_FOR_WITHDRAWALS = new BigNumber(2);
+export const MIN_CARDANO_BALANCE_FOR_STAKING = MIN_CARDANO_AMOUNT_FOR_STAKING.plus(
+    MIN_CARDANO_FOR_WITHDRAWALS,
+);

--- a/suite-common/wallet-constants/src/cardanoStakingConstants.ts
+++ b/suite-common/wallet-constants/src/cardanoStakingConstants.ts
@@ -1,0 +1,4 @@
+export const BACKUP_CARDANO_APY = 4.5;
+export const ESTIMATED_YEARLY_REWARD_RATE = 2.22;
+export const CARDANO_ACTIVATION_PERIOD_DAYS = 10;
+export const CARDANO_EPOCH_DAYS = 5;

--- a/suite-common/wallet-constants/src/index.ts
+++ b/suite-common/wallet-constants/src/index.ts
@@ -3,4 +3,5 @@ export * from './sendForm';
 export * from './discovery';
 export * from './ethereumStakingConstants';
 export * from './solanaStakingConstants';
+export * from './cardanoStakingConstants';
 export * from './stakingConstants';

--- a/suite-common/wallet-core/src/stake/stakeSelectors.ts
+++ b/suite-common/wallet-core/src/stake/stakeSelectors.ts
@@ -1,6 +1,14 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { BACKUP_APY, BACKUP_ETH_APY, BACKUP_SOL_APY } from '@suite-common/wallet-constants';
-import { isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
+import {
+    BACKUP_APY,
+    BACKUP_CARDANO_APY,
+    BACKUP_ETH_APY,
+    BACKUP_SOL_APY,
+} from '@suite-common/wallet-constants';
+import {
+    isSupportedCardanoStakingNetworkSymbol,
+    isSupportedSolStakingNetworkSymbol,
+} from '@suite-common/wallet-utils';
 
 import { StakeRootState } from './stakeReducer';
 
@@ -19,6 +27,10 @@ export const selectPoolStatsApyData = (state: StakeRootState, symbol?: NetworkSy
 
     if (isSupportedSolStakingNetworkSymbol(symbol)) {
         return data?.[symbol]?.stakingInfo?.data?.apy || BACKUP_SOL_APY;
+    }
+
+    if (isSupportedCardanoStakingNetworkSymbol(symbol)) {
+        return BACKUP_CARDANO_APY;
     }
 
     return data?.[symbol]?.poolStats?.data.ethApy || BACKUP_ETH_APY;

--- a/suite-common/wallet-types/src/cardanoStaking.ts
+++ b/suite-common/wallet-types/src/cardanoStaking.ts
@@ -61,3 +61,7 @@ export type CardanoStaking = {
     calculateFeeAndDeposit: (action: CardanoAction) => Promise<void>;
     error?: string;
 };
+
+export const supportedCardanoNetworkSymbols = ['ada', 'tada'] as const;
+
+export type SupportedCardanoNetworkSymbols = (typeof supportedCardanoNetworkSymbols)[number];

--- a/suite-common/wallet-utils/src/cardanoStakingUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoStakingUtils.ts
@@ -1,0 +1,12 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    SupportedCardanoNetworkSymbols,
+    supportedCardanoNetworkSymbols,
+} from '@suite-common/wallet-types';
+import { isArrayMember } from '@trezor/utils';
+
+export function isSupportedCardanoStakingNetworkSymbol(
+    symbol: NetworkSymbol,
+): symbol is SupportedCardanoNetworkSymbols {
+    return isArrayMember(symbol, supportedCardanoNetworkSymbols);
+}

--- a/suite-common/wallet-utils/src/index.ts
+++ b/suite-common/wallet-utils/src/index.ts
@@ -30,3 +30,4 @@ export * from './baseCurrency';
 export * from './filterAndCategorizeUtxosUtils';
 export * from './hooks/useExcludedUtxos';
 export * from './hooks/useFilteredUtxos';
+export * from './cardanoStakingUtils';

--- a/suite-common/wallet-utils/src/stakingUtils.ts
+++ b/suite-common/wallet-utils/src/stakingUtils.ts
@@ -1,7 +1,11 @@
 import { NetworkSymbol, NetworkType } from '@suite-common/wallet-config';
 import {
+    MAX_CARDANO_AMOUNT_FOR_STAKING,
     MAX_ETH_AMOUNT_FOR_STAKING,
     MAX_SOL_AMOUNT_FOR_STAKING,
+    MIN_CARDANO_AMOUNT_FOR_STAKING,
+    MIN_CARDANO_BALANCE_FOR_STAKING,
+    MIN_CARDANO_FOR_WITHDRAWALS,
     MIN_ETH_AMOUNT_FOR_STAKING,
     MIN_ETH_BALANCE_FOR_STAKING,
     MIN_ETH_FOR_WITHDRAWALS,
@@ -80,6 +84,13 @@ export const getStakingLimitsByNetwork = (account: Account) => {
                 MAX_AMOUNT_FOR_STAKING: MAX_SOL_AMOUNT_FOR_STAKING,
                 MIN_FOR_WITHDRAWALS: MIN_SOL_FOR_WITHDRAWALS,
                 MIN_BALANCE_FOR_STAKING: MIN_SOL_BALANCE_FOR_STAKING,
+            };
+        case 'cardano':
+            return {
+                MIN_AMOUNT_FOR_STAKING: MIN_CARDANO_AMOUNT_FOR_STAKING,
+                MAX_AMOUNT_FOR_STAKING: MAX_CARDANO_AMOUNT_FOR_STAKING,
+                MIN_FOR_WITHDRAWALS: MIN_CARDANO_FOR_WITHDRAWALS,
+                MIN_BALANCE_FOR_STAKING: MIN_CARDANO_BALANCE_FOR_STAKING,
             };
         default:
             throw new Error(`Unsupported network type: ${account.networkType}`);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Created Cardano staking dashboard
- Refactored components for the empty staking flow to support Cardano
- Hid the new Cardano dashboard under the debug mode flag
- Cardano stake modal 

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="2414" height="1026" alt="image" src="https://github.com/user-attachments/assets/215afb0a-3a05-4ac5-96b0-1605a2ce1530" />
<img width="856" height="1278" alt="image" src="https://github.com/user-attachments/assets/734c8c94-2ec4-4c1c-b547-2b0596c8cead" />
<img width="1282" height="956" alt="image" src="https://github.com/user-attachments/assets/d0a38b49-77c5-46e2-a054-4ce567c04421" />
<img width="1940" height="1106" alt="image" src="https://github.com/user-attachments/assets/998edf36-7e21-4e03-8316-cadebe4ea9df" />



