### PR TITLE
Mobile Exchange: clear send asset on device change

### DIFF
--- a/suite-native/module-trading/src/__fixtures__/walletState.ts
+++ b/suite-native/module-trading/src/__fixtures__/walletState.ts
@@ -34,5 +34,9 @@ export const getWalletState = ({
         historic: {},
         lastWeek: {},
     } as FiatRatesState,
-    accounts: [getBtcAccount(), getEthAccount()] as Account[],
+    accounts: [
+        getBtcAccount('btc-account-1'),
+        getBtcAccount('btc-account-2'),
+        getEthAccount(),
+    ] as Account[],
 });

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -29,6 +29,7 @@ import { buyFormValidationSchema } from '../../utils/buy/buyFormValidationSchema
 import { truncateDecimals } from '../../utils/general/amountUtils';
 import { getSymbolFromTradeableAsset } from '../../utils/general/tradeableAssetUtils';
 import { useContextForTradingForm } from '../general/form/useContextForTradingForm';
+import { useReceiveAccountChangeEffect } from '../general/form/useReceiveAccountChangeEffect';
 
 const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: BuyFormType) => {
     const dispatch = useDispatch();
@@ -98,14 +99,6 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: 
 
         return unsubscribe;
     }, [dispatch, setValue, watch]);
-};
-
-const useReceiveAccountChangeEffect = ({ setValue }: BuyFormType) => {
-    const selectedReceiveAccount = useSelector(selectBuySelectedReceiveAccount);
-
-    useEffect(() => {
-        setValue('receiveAccount', selectedReceiveAccount);
-    }, [setValue, selectedReceiveAccount]);
 };
 
 const useBuyQuotesChangeEffect = ({ getValues, setValue }: BuyFormType) => {
@@ -233,9 +226,10 @@ export const useBuyForm = (): BuyFormType => {
         validation: buyFormValidationSchema,
         context,
     });
+    const { setValue } = form;
 
     useAmountAndCurrencyFieldsChangeEffect(form);
-    useReceiveAccountChangeEffect(form);
+    useReceiveAccountChangeEffect(setValue, selectBuySelectedReceiveAccount);
     useBuyQuotesChangeEffect(form);
     useBuyQuoteChangeEffect(form);
     useValidations(form, limits);

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
@@ -25,6 +25,7 @@ import { ExchangeFormType, ExchangeFormValues } from '../../types/exchange';
 import { exchangeFormValidationSchema } from '../../utils/exchange/exchangeFormValidationSchema';
 import { getSymbolFromTradeableAsset } from '../../utils/general/tradeableAssetUtils';
 import { useContextForTradingForm } from '../general/form/useContextForTradingForm';
+import { useReceiveAccountChangeEffect } from '../general/form/useReceiveAccountChangeEffect';
 import { useSendAccountAssetBalance } from '../general/form/useSendAccountAssetBalance';
 import { useSendAccountChangeEffect } from '../general/form/useSendAccountChangeEffect';
 
@@ -98,14 +99,6 @@ const useExchangeQuoteChangeEffect = ({ watch, setValue }: ExchangeFormType) => 
     }, [selectedQuote, isAmountInSats, symbol, setValue]);
 };
 
-const useReceiveAccountChangeEffect = ({ setValue }: ExchangeFormType) => {
-    const receiveAccount = useSelector(selectExchangeSelectedReceiveAccount);
-
-    useEffect(() => {
-        setValue('receiveAccount', receiveAccount);
-    }, [receiveAccount, setValue]);
-};
-
 const useValidations = (
     { trigger, setValue }: ExchangeFormType,
     limits: TradingExchangeAmountLimitProps | undefined,
@@ -136,11 +129,12 @@ export const useExchangeForm = () => {
         validation: exchangeFormValidationSchema,
         context,
     });
+    const { setValue } = form;
 
     useExchangeQuotesChangeEffect(form);
     useExchangeQuoteChangeEffect(form);
-    useSendAccountChangeEffect(form.setValue, selectExchangeSelectedSendAccount);
-    useReceiveAccountChangeEffect(form);
+    useSendAccountChangeEffect(setValue, selectExchangeSelectedSendAccount);
+    useReceiveAccountChangeEffect(setValue, selectExchangeSelectedReceiveAccount);
     useSendAccountAssetBalance(form, setBalance, setSendSymbol);
     useValidations(form, limits);
 

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
@@ -26,6 +26,7 @@ import { exchangeFormValidationSchema } from '../../utils/exchange/exchangeFormV
 import { getSymbolFromTradeableAsset } from '../../utils/general/tradeableAssetUtils';
 import { useContextForTradingForm } from '../general/form/useContextForTradingForm';
 import { useSendAccountAssetBalance } from '../general/form/useSendAccountAssetBalance';
+import { useSendAccountChangeEffect } from '../general/form/useSendAccountChangeEffect';
 
 const useExchangeQuotesChangeEffect = ({ getValues, setValue }: ExchangeFormType) => {
     const providers = useSelector(selectTradingExchangeProviders);
@@ -97,14 +98,6 @@ const useExchangeQuoteChangeEffect = ({ watch, setValue }: ExchangeFormType) => 
     }, [selectedQuote, isAmountInSats, symbol, setValue]);
 };
 
-const useSendAccountChangeEffect = ({ setValue }: ExchangeFormType) => {
-    const sendAccount = useSelector(selectExchangeSelectedSendAccount);
-
-    useEffect(() => {
-        setValue('sendAccount', sendAccount);
-    }, [sendAccount, setValue]);
-};
-
 const useReceiveAccountChangeEffect = ({ setValue }: ExchangeFormType) => {
     const receiveAccount = useSelector(selectExchangeSelectedReceiveAccount);
 
@@ -146,7 +139,7 @@ export const useExchangeForm = () => {
 
     useExchangeQuotesChangeEffect(form);
     useExchangeQuoteChangeEffect(form);
-    useSendAccountChangeEffect(form);
+    useSendAccountChangeEffect(form.setValue, selectExchangeSelectedSendAccount);
     useReceiveAccountChangeEffect(form);
     useSendAccountAssetBalance(form, setBalance, setSendSymbol);
     useValidations(form, limits);

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useReceiveAccountChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useReceiveAccountChangeEffect.test.ts
@@ -1,0 +1,51 @@
+import { tradingExchangeActions } from '@suite-common/trading';
+import {
+    TestStore,
+    act,
+    initStore,
+    renderHookWithStoreProviderAsync,
+} from '@suite-native/test-utils';
+
+import { getBtcAccount } from '../../../../__fixtures__/account';
+import { getWalletState } from '../../../../__fixtures__/walletState';
+import { selectExchangeSelectedReceiveAccount } from '../../../../selectors/exchangeSelectors';
+import { useReceiveAccountChangeEffect } from '../useReceiveAccountChangeEffect';
+
+describe('useReceiveAccountChangeEffect', () => {
+    let store: TestStore;
+    let setValue: jest.Mock;
+
+    const renderUseReceiveAccountChangeEffect = () =>
+        renderHookWithStoreProviderAsync(
+            () => useReceiveAccountChangeEffect(setValue, selectExchangeSelectedReceiveAccount),
+            { store },
+        );
+
+    beforeEach(async () => {
+        const preloadState = { wallet: getWalletState({ tradeType: 'exchange' }) };
+        store = await initStore(preloadState);
+        setValue = jest.fn();
+    });
+
+    it('should set receiveAccount based on store value', async () => {
+        await renderUseReceiveAccountChangeEffect();
+
+        expect(setValue).toHaveBeenCalledTimes(1);
+        expect(setValue).toHaveBeenCalledWith('receiveAccount', undefined);
+    });
+
+    it('should set receiveAccount on change', async () => {
+        await renderUseReceiveAccountChangeEffect();
+
+        setValue.mockClear();
+        act(() => {
+            store.dispatch(tradingExchangeActions.setReceiveAccountKey('btc-account-1'));
+        });
+
+        expect(setValue).toHaveBeenCalledTimes(1);
+        expect(setValue).toHaveBeenCalledWith('receiveAccount', {
+            account: getBtcAccount('btc-account-1'),
+            address: undefined,
+        });
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useSendAccountChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useSendAccountChangeEffect.test.ts
@@ -1,0 +1,82 @@
+import { tradingExchangeActions } from '@suite-common/trading';
+import {
+    TestStore,
+    act,
+    initStore,
+    renderHookWithStoreProviderAsync,
+} from '@suite-native/test-utils';
+
+import { getBtcAccount } from '../../../../__fixtures__/account';
+import { getWalletState } from '../../../../__fixtures__/walletState';
+import { selectExchangeSelectedSendAccount } from '../../../../selectors/exchangeSelectors';
+import { useSendAccountChangeEffect } from '../useSendAccountChangeEffect';
+
+describe('useSendAccountChangeEffect', () => {
+    let store: TestStore;
+    let setValue: jest.Mock;
+
+    const renderUseSendAccountChangeEffect = () =>
+        renderHookWithStoreProviderAsync(
+            () => {
+                useSendAccountChangeEffect(setValue, selectExchangeSelectedSendAccount);
+            },
+            { store },
+        );
+
+    beforeEach(async () => {
+        const preloadState = { wallet: getWalletState({ tradeType: 'exchange' }) };
+        store = await initStore(preloadState);
+        setValue = jest.fn();
+    });
+
+    it('should set sendAccount and sendAsset to undefined initially', async () => {
+        await renderUseSendAccountChangeEffect();
+
+        expect(setValue).toHaveBeenCalledTimes(2);
+        expect(setValue).toHaveBeenCalledWith('sendAccount', undefined);
+        expect(setValue).toHaveBeenCalledWith('sendAsset', undefined);
+    });
+
+    it('should set sendAccount when account is changed in store', async () => {
+        await renderUseSendAccountChangeEffect();
+
+        setValue.mockClear();
+        act(() => {
+            store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
+        });
+
+        expect(setValue).toHaveBeenCalledTimes(1);
+        expect(setValue).toHaveBeenCalledWith('sendAccount', getBtcAccount('btc-account-1'));
+    });
+
+    it('should set sendAsset to undefined when no trading account is selected', async () => {
+        await renderUseSendAccountChangeEffect();
+        act(() => {
+            store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
+        });
+
+        setValue.mockClear();
+        act(() => {
+            store.dispatch(tradingExchangeActions.setTradingAccountKey(undefined));
+        });
+
+        expect(setValue).toHaveBeenCalledTimes(2);
+        expect(setValue).toHaveBeenCalledWith('sendAccount', undefined);
+        expect(setValue).toHaveBeenCalledWith('sendAsset', undefined);
+    });
+
+    it('should not change sendAsset when trading account key changed', async () => {
+        await renderUseSendAccountChangeEffect();
+        act(() => {
+            store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
+        });
+
+        setValue.mockClear();
+        act(() => {
+            store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-2'));
+        });
+
+        expect(setValue).toHaveBeenCalledTimes(1);
+        expect(setValue).toHaveBeenCalledWith('sendAccount', getBtcAccount('btc-account-2'));
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/form/useReceiveAccountChangeEffect.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useReceiveAccountChangeEffect.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+
+import type { AccountsRootState } from '@suite-common/wallet-core';
+
+import type { TradingRootState } from '../../../reducers';
+import type { ReceiveAccount } from '../../../types/general';
+
+// Lame version of `UseFormReturn<{receiveAccount: ReceiveAccount | undefined}>['setValue']`,
+// but TS likes this one more.
+type FormSetValue = (key: 'receiveAccount', value: ReceiveAccount | undefined) => void;
+
+type ReceiveAccountSelector = (
+    state: TradingRootState & AccountsRootState,
+) => ReceiveAccount | undefined;
+
+export const useReceiveAccountChangeEffect = (
+    setValue: FormSetValue,
+    selectReceiveAccount: ReceiveAccountSelector,
+) => {
+    const receiveAccount = useSelector(selectReceiveAccount);
+
+    useEffect(() => {
+        setValue('receiveAccount', receiveAccount);
+    }, [receiveAccount, setValue]);
+};

--- a/suite-native/module-trading/src/hooks/general/form/useSendAccountChangeEffect.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useSendAccountChangeEffect.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+
+import type { AccountsRootState } from '@suite-common/wallet-core';
+import type { Account } from '@suite-common/wallet-types';
+
+import type { TradingRootState } from '../../../reducers';
+import type { FormWithSendAccountValues } from '../../../types/general';
+
+// Lame version of `UseFormReturn<FormWithSendAssetValues>['setValue']`, but TS likes this one more.
+type FormSetValue = ((
+    key: 'sendAccount',
+    value: FormWithSendAccountValues['sendAccount'],
+) => void) &
+    ((key: 'sendAsset', value: FormWithSendAccountValues['sendAsset']) => void);
+
+type SendAccountSelector = (state: TradingRootState & AccountsRootState) => Account | undefined;
+
+export const useSendAccountChangeEffect = (
+    setValue: FormSetValue,
+    selectSendAccount: SendAccountSelector,
+) => {
+    const sendAccount = useSelector(selectSendAccount);
+
+    useEffect(() => {
+        setValue('sendAccount', sendAccount);
+        if (!sendAccount) {
+            setValue('sendAsset', undefined);
+        }
+    }, [sendAccount, setValue]);
+};

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
@@ -1,8 +1,6 @@
 import { SellFiatTrade } from 'invity-api';
 
-import { TrezorDevice } from '@suite-common/suite-types';
 import { tradingSellActions } from '@suite-common/trading';
-import { deviceActions } from '@suite-common/wallet-core';
 import { EventType, analytics } from '@suite-native/analytics';
 import { Form, useField } from '@suite-native/forms';
 import {
@@ -448,25 +446,6 @@ describe('useSellForm', () => {
                 expect(result.current.getValues('generalAlert')).toBeUndefined();
             });
         });
-    });
-
-    it('should clear sendAsset on device change', async () => {
-        const { result } = await renderUseSellForm();
-        act(() => {
-            result.current.setValue('sendAsset', btcAsset);
-        });
-
-        act(() => {
-            store.dispatch(
-                deviceActions.selectDevice({
-                    name: 'TEST_DEVICE',
-                    state: { staticSessionId: 'TEST_DEVICE_SESSION_ID' },
-                    id: 'TEST_DEVICE_ID',
-                } as unknown as TrezorDevice),
-            );
-        });
-
-        expect(result.current.getValues('sendAsset')).toEqual(undefined);
     });
 
     describe('on quotes change', () => {

--- a/suite-native/module-trading/src/hooks/sell/useSellForm.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellForm.ts
@@ -10,11 +10,7 @@ import {
     selectValidTradingSellQuotes,
 } from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';
-import {
-    WalletSettingsRootState,
-    selectIsAmountInSats,
-    selectSelectedDevice,
-} from '@suite-common/wallet-core';
+import { WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 import { EventType, analytics } from '@suite-native/analytics';
 import { useForm } from '@suite-native/forms';
@@ -33,23 +29,7 @@ import { getSymbolFromTradeableAsset } from '../../utils/general/tradeableAssetU
 import { sellFormValidationSchema } from '../../utils/sell/sellFormValidationSchema';
 import { useContextForTradingForm } from '../general/form/useContextForTradingForm';
 import { useSendAccountAssetBalance } from '../general/form/useSendAccountAssetBalance';
-
-const useSendAccountChangeEffect = ({ setValue }: SellFormType) => {
-    const sendAccount = useSelector(selectSellSelectedSendAccount);
-
-    useEffect(() => {
-        setValue('sendAccount', sendAccount);
-    }, [sendAccount, setValue]);
-};
-
-const useSelectedDeviceChangeEffect = ({ setValue }: SellFormType) => {
-    const selectedDevice = useSelector(selectSelectedDevice);
-    const unqDeviceIdentifier = selectedDevice?.state?.staticSessionId;
-
-    useEffect(() => {
-        setValue('sendAsset', undefined, { shouldValidate: true });
-    }, [unqDeviceIdentifier, setValue]);
-};
+import { useSendAccountChangeEffect } from '../general/form/useSendAccountChangeEffect';
 
 const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: SellFormType) => {
     const dispatch = useDispatch();
@@ -232,8 +212,7 @@ export const useSellForm = (): SellFormType => {
         context,
     });
 
-    useSendAccountChangeEffect(form);
-    useSelectedDeviceChangeEffect(form);
+    useSendAccountChangeEffect(form.setValue, selectSellSelectedSendAccount);
     useAmountAndCurrencyFieldsChangeEffect(form);
     useSendAccountAssetBalance(form, setBalance, setSendSymbol);
     useSellQuotesChangeEffect(form);

--- a/suite-native/module-trading/src/reducers/__tests__/tradingSlice.test.ts
+++ b/suite-native/module-trading/src/reducers/__tests__/tradingSlice.test.ts
@@ -352,14 +352,16 @@ describe('tradingSlice', () => {
             expect(state.buy.tradingAccountKey).toBeUndefined();
         });
 
-        it('should clear exchange.receiveAccountKey', () => {
+        it('should clear exchange.receiveAccountKey and exchange.tradingAccountKey', () => {
             const actions = [
                 tradingExchangeActions.setReceiveAccountKey('account-key'),
+                tradingExchangeActions.setTradingAccountKey('account-key'),
                 deviceActions.selectDevice({ name: 'TEST_DEVICE' } as TrezorDevice),
             ];
 
             const state = actions.reduce(tradingReducer, undefined) as TradingState;
             expect(state.exchange.receiveAccountKey).toBeUndefined();
+            expect(state.exchange.tradingAccountKey).toBeUndefined();
         });
 
         it('should clear sell.tradingAccountKey', () => {

--- a/suite-native/module-trading/src/reducers/tradingSlice.ts
+++ b/suite-native/module-trading/src/reducers/tradingSlice.ts
@@ -95,6 +95,7 @@ export const tradingSlice = createSliceWithExtraDeps({
             .addCase(deviceActions.selectDevice, state => {
                 state.buy.tradingAccountKey = undefined;
                 state.buy.receiveAddress = undefined;
+                state.exchange.tradingAccountKey = undefined;
                 state.exchange.receiveAccountKey = undefined;
                 state.exchange.receiveAddress = undefined;
                 state.sell.tradingAccountKey = undefined;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- clear sendAsset when sendAccount becomes undefined
- share sendAccount reaction logic between exchange and sell
- share receiveAccount reaction logic between buy and exchange

## Related Issue

Resolve #21002

## Screenshots:

https://github.com/user-attachments/assets/02659799-aab4-42ce-aaed-1532a5366742




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=21002-Trade-Swap-Clear-send-asset-on-device-change&lookback=7)