### PR TITLE
Mobile Exchange: amount badge does not respect sats

### DIFF
--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountBadge.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountBadge.tsx
@@ -1,14 +1,17 @@
 import { useSelector } from 'react-redux';
 
+import { invariant } from '@suite-common/suite-utils';
 import { selectTradingExchangeIsLoading } from '@suite-common/trading';
 import { FiatRatesRootState, WalletSettingsRootState } from '@suite-common/wallet-core';
 import { Badge } from '@suite-native/atoms';
 import { useField } from '@suite-native/forms';
 
 import { useExchangeFormContext } from '../../../hooks/exchange/useExchangeFormContext';
+import { useConvertFormValueToBaseUnit } from '../../../hooks/general/useConvertFormValueToBaseUnit';
 import { TradingRootState } from '../../../reducers';
 import { selectAmountInBaseFiatCurrency } from '../../../selectors/commonSelectors';
 import { TradeableAsset } from '../../../types/general';
+import { getSymbolFromTradeableAsset } from '../../../utils/general/tradeableAssetUtils';
 import { FiatAmountBadge } from '../../general/FiatAmountBadge';
 
 type ExchangeSendFiatAmountBadgeProps = {
@@ -17,9 +20,16 @@ type ExchangeSendFiatAmountBadgeProps = {
 };
 
 const ExchangeSendFiatAmountBadge = ({ amount, asset }: ExchangeSendFiatAmountBadgeProps) => {
+    const { convertStrToBaseUnit } = useConvertFormValueToBaseUnit();
+    const symbol = getSymbolFromTradeableAsset(asset);
+    invariant(symbol, 'Asset symbol is undefined');
+
+    const convertedAmount = convertStrToBaseUnit(amount, symbol);
+    invariant(convertedAmount, 'Amount could not be converted to base unit');
+
     const fiatAmount = useSelector(
         (state: FiatRatesRootState & WalletSettingsRootState & TradingRootState) =>
-            selectAmountInBaseFiatCurrency(state, asset, amount),
+            selectAmountInBaseFiatCurrency(state, asset, convertedAmount),
     );
 
     return <FiatAmountBadge amount={fiatAmount} />;

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountBadge.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountBadge.comp.test.tsx
@@ -5,6 +5,7 @@ import {
     renderHookWithStoreProviderAsync,
     renderWithStoreProviderAsync,
 } from '@suite-native/test-utils';
+import { PROTO } from '@trezor/connect';
 
 import { btcAsset } from '../../../../__fixtures__/tradeableAssets';
 import { getWalletState } from '../../../../__fixtures__/walletState';
@@ -15,8 +16,8 @@ import { ExchangeSendAmountBadge } from '../ExchangeSendAmountBadge';
 describe('ExchangeSendAmountBadge', () => {
     let form: ExchangeFormType;
 
-    const getPreloadedState = (): PreloadedState => ({
-        wallet: getWalletState(),
+    const getPreloadedState = (bitcoinAmountUnit = PROTO.AmountUnit.BITCOIN): PreloadedState => ({
+        wallet: getWalletState({ tradeType: 'exchange', bitcoinAmountUnit }),
     });
 
     const renderForm = () => renderHookWithStoreProviderAsync(() => useExchangeForm());
@@ -101,6 +102,18 @@ describe('ExchangeSendAmountBadge', () => {
 
             expect(queryByText('VALIDATION_ERROR')).toBeNull();
             expect(getByText('$1.00')).toBeOnTheScreen();
+        });
+
+        it('should display correct value when using sats', async () => {
+            act(() => {
+                form.setValue('sendCryptoAmount', '1234567123456');
+            });
+
+            const { getByText } = await renderExchangeSendAmountBadge(
+                getPreloadedState(PROTO.AmountUnit.SATOSHI),
+            );
+
+            expect(getByText('$12.35')).toBeOnTheScreen();
         });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fixes bug where value displayed above amount input in Exchange is wrongly converting sats unit to fiat.

## Related Issue

Resolve #21049


## Screenshots:
<img width="316" height="168" alt="Screenshot 2025-08-27 at 13 56 42" src="https://github.com/user-attachments/assets/91bbee35-4d71-4c0c-a884-3dfe27599f0e" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=21049-Mobile-Swap-amount-badge-does-not-respect-sats&lookback=7)