### PR TITLE
feat(connect): add `Method_Unsupported` error

### DIFF
--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -68,7 +68,7 @@ const impl = new TrezorConnectDynamic<
         // Handle desktop errors
         if (
             impl.getTargetType() === 'core-in-suite-desktop' &&
-            errorCode === 'Desktop_ConnectionMissing'
+            (errorCode === 'Desktop_ConnectionMissing' || errorCode === 'Method_Unsupported')
         ) {
             await impl.switchTarget('iframe');
 

--- a/packages/connect/src/constants/errors.ts
+++ b/packages/connect/src/constants/errors.ts
@@ -23,6 +23,7 @@ export const ERROR_CODES = {
     Method_Discovery_BundleException: '', // thrown by getAccountInfo method
     Method_Override: 'override', // inner "error", it's more like a interruption
     Method_NoResponse: 'Call resolved without response', // thrown by npm index(es), call to Core resolved without response, should not happen
+    Method_Unsupported: 'Unsupported method', // 3rd party called a method unknown by current version
 
     Backend_NotSupported: 'BlockchainLink settings not found in coins.json', // thrown by methods which using backends, blockchainLink not defined for this coin
     Backend_WorkerMissing: '', // thrown by BlockchainLink class, worker not specified

--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -25,6 +25,7 @@ export const useConnectPopupDesktop = () => {
             if (desktopApi.available && (await desktopApi.connectPopupEnabled())) {
                 desktopApi.on('connect-popup/call', async params => {
                     await queuePopupCall();
+                    const deferred = getPopupCallDeferred(true);
                     dispatch(
                         connectPopupCallThunk({
                             method: params.method as keyof typeof TrezorConnect,
@@ -41,7 +42,7 @@ export const useConnectPopupDesktop = () => {
                             },
                         }),
                     );
-                    const response = await getPopupCallDeferred(true).promise;
+                    const response = await deferred.promise;
                     desktopApi.connectPopupResponse({ ...response, id: params.id });
                 });
                 desktopApi.on('connect-popup/cancel', params => {

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -31,6 +31,8 @@ export const connectPopupCallThunkInner = createThunk<
     `${CONNECT_POPUP_MODULE}/callThunk`,
     async ({ method, payload, source }, { dispatch, getState, extra }) => {
         try {
+            if (!TrezorConnect[method]) throw TypedError('Method_Unsupported');
+
             // @ts-expect-error: method is dynamic
             const methodInfo = await TrezorConnect[method]({
                 ...payload,
@@ -147,7 +149,10 @@ export const connectPopupCallThunkInner = createThunk<
             if (error?.error === 'switching-device') {
                 // Do nothing, call will be restarted after device switch
                 return;
-            } else if (error?.code === 'Method_Cancel') {
+            } else if (
+                error?.code === 'Method_Cancel' ||
+                error?.code === 'Method_Unsupported' // handled by fallback mechanism in connect-web
+            ) {
                 dispatch(connectPopupActions.finishCall());
             } else {
                 dispatch(connectPopupActions.setError(serializeError(error)));


### PR DESCRIPTION
## Description

Adds new error `Method_Unsupported` for cases where Connect in Suite is outdated and doesn't support a newer method that the 3rd party wants to call. 
It's handled silently, by falling back to Connect Popup on web.  

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-connect-unsupported-method&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-connect-unsupported-method&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-connect-unsupported-method&lookback=7)