### PR TITLE
chore(suite): remove leftover firwareUpdateSource setting

### DIFF
--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -11,7 +11,6 @@ export const BIO_AUTH_WINDOW_FOCUS = '@suite/bio-auth-window-focus';
 export const TOGGLE_BIO_AUTH_VALIDATION_REQUESTED = '@suite/toggle-bio-auth-validation-requested';
 export const SET_LANGUAGE = '@suite/set-language';
 export const SET_DEBUG_MODE = '@suite/set-debug-mode';
-export const SET_FIRMWARE_UPDATE_SOURCE = '@suite/firmware-update-source';
 export const SET_FLAG = '@suite/set-flag';
 export const SET_RECENTLY_CONNECTED_DEVICE = '@suite/set-recently-connected-device';
 export const SET_RECENTLY_DISCONNECTED_DEVICE = '@suite/set-recently-disconnected-device';

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -5,7 +5,6 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import type { TradingType } from '@suite-common/trading';
 import { deviceActions } from '@suite-common/wallet-core';
 import { getCustomBackends } from '@suite-common/wallet-utils';
-import { FirmwareUpdateSource } from '@trezor/connect/src/data/firmwareInfo';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { HandshakeElectron, desktopApi } from '@trezor/suite-desktop-api';
 
@@ -31,7 +30,6 @@ export type SuiteAction =
       }
     | { type: typeof SUITE.SET_DEBUG_MODE; payload: Partial<DebugModeOptions> }
     | { type: typeof SUITE.ONLINE_STATUS; payload: boolean }
-    | { type: typeof SUITE.SET_FIRMWARE_UPDATE_SOURCE; payload: FirmwareUpdateSource }
     | { type: typeof SUITE.TOR_STATUS; payload: TorStatus }
     | { type: typeof SUITE.TOR_BOOTSTRAP; payload: TorBootstrap | null }
     | { type: typeof SUITE.ONION_LINKS; payload: boolean }

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -244,7 +244,6 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case SUITE.SET_LANGUAGE:
                 case SUITE.SET_FLAG:
                 case SUITE.SET_DEBUG_MODE:
-                case SUITE.SET_FIRMWARE_UPDATE_SOURCE:
                 case SUITE.SET_EXPERIMENTAL_FEATURES:
                 case SUITE.ONION_LINKS:
                 case SUITE.SET_THEME:

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -6,7 +6,6 @@ import type { InvityServerEnvironment, TradingType } from '@suite-common/trading
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { AddressDisplayOptions, WalletType } from '@suite-common/wallet-types';
 import { ConnectSettings, InstallerInfo, TRANSPORT, TransportInfo } from '@trezor/connect';
-import { FirmwareUpdateSource } from '@trezor/connect/src/data/firmwareInfo';
 import { isWeb } from '@trezor/env-utils';
 import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
 
@@ -94,7 +93,6 @@ export interface SuiteSettings {
     isCoinjoinReceiveWarningHidden: boolean;
     isDesktopSuitePromoHidden: boolean;
     debug: DebugModeOptions;
-    firmwareUpdateSource: FirmwareUpdateSource;
     autodetect: AutodetectSettings;
     enabledSecurityChecks: {
         deviceAuthenticity: boolean;
@@ -200,7 +198,6 @@ const initialState: SuiteState = {
             isUnlockedBootloaderAllowed: false,
             showConnectLogs: false,
         },
-        firmwareUpdateSource: 'production',
         autodetect: {
             language: true,
             theme: true,
@@ -296,10 +293,6 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
                     ...draft.seenDisconnectNotificationForDeviceIds,
                     action.payload.deviceId,
                 ];
-                break;
-
-            case SUITE.SET_FIRMWARE_UPDATE_SOURCE:
-                draft.settings.firmwareUpdateSource = action.payload;
                 break;
 
             case SUITE.EVM_CONFIRM_EXPLANATION_MODAL:


### PR DESCRIPTION
This seems to be a leftover?

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-leftover-setting&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-leftover-setting&lookback=7)