### PR TITLE
fix(suite): walletconnect deeplink cold-start

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal.tsx
@@ -473,6 +473,7 @@ export const TxSimulationModal = () => {
                                                                     explorer?.queryString
                                                                 }
                                                                 shouldAllowCopy
+                                                                typographyStyle="label"
                                                             />
                                                         ),
                                                     },
@@ -493,10 +494,16 @@ export const TxSimulationModal = () => {
                                                                 vertical: spacings.sm,
                                                             }}
                                                             alignItems="center"
-                                                            justifyContent="space-between"
+                                                            justifyContent="flex-start"
                                                         >
-                                                            <Text>{item.label}</Text>
-                                                            <Text>{item.value}</Text>
+                                                            <Text flex="1">{item.label}</Text>
+                                                            <Text
+                                                                flex="2"
+                                                                wordBreak="break-all"
+                                                                typographyStyle="label"
+                                                            >
+                                                                {item.value}
+                                                            </Text>
                                                         </Row>
                                                     ) : null,
                                                 )}

--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -419,7 +419,12 @@ export const walletConnectInitThunk = createThunk(
 
 export const walletConnectPairThunk = createThunk<void, { uri: string }>(
     `${WALLETCONNECT_MODULE}/walletConnectPairThunk`,
-    async ({ uri }) => {
+    async ({ uri }, { dispatch }) => {
+        if (!walletKit) {
+            // May happen when Suite cold-starts from deeplink
+            await dispatch(walletConnectInitThunk());
+        }
+
         try {
             await walletKit.pair({ uri });
             analytics.report({


### PR DESCRIPTION
## Description

Fixes an issue with WalletConnect when Suite is started from a deeplink, which starts the pairing before WalletKit is initialized. 

Also includes a UI clean up for TX simulation details.

## Screenshots:

| Before | After |
| - | - |
|<img width="719" height="863" alt="Screenshot 2025-08-27 at 15 59 59" src="https://github.com/user-attachments/assets/d31b8ee0-605e-44dd-81cb-f2a43c6119f7" />|<img width="719" height="863" alt="Screenshot 2025-08-27 at 15 49 08" src="https://github.com/user-attachments/assets/c0d532ba-39bb-429e-864d-e11a26aec3f7" />|


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/walletconnect-deeplink&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/walletconnect-deeplink&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/walletconnect-deeplink&lookback=7)