### PR TITLE
fix(suite): Remove misleading fee in advanced transaction speedup

### DIFF
--- a/packages/suite/src/components/wallet/Fees/CustomFee/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee/CustomFee.tsx
@@ -57,6 +57,7 @@ type CustomFeeProps<TFieldValues extends FormState> = {
     getValues: UseFormGetValues<TFieldValues>;
     trigger: UseFormTrigger<TFieldValues>;
     transactionInfo?: PrecomposedTransaction | PrecomposedTransactionCardano;
+    showCurrentFee: boolean;
 };
 
 export const CustomFee = <TFieldValues extends FormState>({
@@ -66,6 +67,7 @@ export const CustomFee = <TFieldValues extends FormState>({
     register,
     control,
     transactionInfo,
+    showCurrentFee,
     ...props
 }: CustomFeeProps<TFieldValues>) => {
     const { translationString } = useTranslation();
@@ -102,7 +104,13 @@ export const CustomFee = <TFieldValues extends FormState>({
         <>
             <Column gap={spacings.xs}>
                 <CustomFeeTooLowBanner feePerUnitValue={feePerUnitValue} feeInfo={feeInfo} />
-                <CurrentFee networkType={networkType} networkSymbol={symbol} feeInfo={feeInfo} />
+                {showCurrentFee && (
+                    <CurrentFee
+                        networkType={networkType}
+                        networkSymbol={symbol}
+                        feeInfo={feeInfo}
+                    />
+                )}
                 {networkType === 'ethereum' ? (
                     <CustomFeeEthereum
                         {...props}

--- a/packages/suite/src/components/wallet/Fees/Fees.tsx
+++ b/packages/suite/src/components/wallet/Fees/Fees.tsx
@@ -258,6 +258,7 @@ export const Fees = <TFieldValues extends FormState>({
                     setValue={setValue}
                     transactionInfo={transactionInfo}
                     trigger={trigger}
+                    showCurrentFee={!rbfForm}
                 />
             )}
             {error && (


### PR DESCRIPTION
Adds a new switch to disable `Current fee:` and turns it of when speeding up transaction.

## Related Issue

Resolve #19930

## Screenshots:
<img width="985" height="432" alt="speedup" src="https://github.com/user-attachments/assets/cded5e61-1c42-4852-8a27-eff6080c7d2d" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/misleading-fee-speedup&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/misleading-fee-speedup&lookback=7)