### PR TITLE
Analytics - Approve/Revoke

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
@@ -22,6 +22,7 @@ import {
     Text,
 } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { borders, spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite/Translation';
@@ -29,6 +30,7 @@ import { AccountLabeling } from 'src/components/suite/labeling';
 import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { useTradingExchangeCryptoAndProviderInfo } from 'src/hooks/wallet/trading/form/useTradingExchangeCryptoAndProviderInfo';
 import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 import { TradingExchangeApprovalType } from 'src/types/trading/tradingForm';
 import { getProvidersInfoProps } from 'src/utils/wallet/trading/tradingTypingUtils';
@@ -78,6 +80,8 @@ export const ApproveModal = ({
         fetchFeesAndCompose,
     } = context;
 
+    const cryptoInfo = useTradingExchangeCryptoAndProviderInfo();
+
     const isDebug = useSelector(selectIsDebugModeActive);
 
     const { cryptoIdToSymbolAndContractAddress, cryptoIdToCoinSymbol } = useTradingInfo();
@@ -105,6 +109,17 @@ export const ApproveModal = ({
     const selectApprovalValue = async (type: DexApprovalType) => {
         if (!selectedQuote.receiveAddress || approvalType === type) {
             return;
+        }
+
+        if (['MINIMAL', 'INFINITE'].includes(type)) {
+            analytics.report({
+                type: EventType.TradingExchangeApproval,
+                payload: {
+                    type: 'approve-modal',
+                    action: type === 'MINIMAL' ? 'limit-exact' : 'limit-unlimited',
+                    ...cryptoInfo,
+                },
+            });
         }
 
         setIsConfirmButtonLoading(true);
@@ -140,10 +155,32 @@ export const ApproveModal = ({
     };
 
     const confirmAndSend = async () => {
+        analytics.report({
+            type: EventType.TradingExchangeApproval,
+            payload: {
+                type: 'approve-modal',
+                action: 'continue',
+                ...cryptoInfo,
+            },
+        });
+
         setIsConfirmButtonLoading(true);
         await sendTransaction();
         setIsConfirmButtonLoading(false);
         onCancel(true);
+    };
+
+    const onClose = (isSubmitting?: boolean) => {
+        analytics.report({
+            type: EventType.TradingExchangeApproval,
+            payload: {
+                type: 'approve-modal',
+                action: 'cancel',
+                ...cryptoInfo,
+            },
+        });
+
+        onCancel(isSubmitting);
     };
 
     const { coinSymbol, contractAddress } = cryptoIdToSymbolAndContractAddress(selectedQuote.send);
@@ -157,7 +194,7 @@ export const ApproveModal = ({
 
     return (
         <Modal
-            onCancel={() => onCancel()}
+            onCancel={() => onClose()}
             variant="primary"
             size="small"
             heading={
@@ -179,7 +216,7 @@ export const ApproveModal = ({
                         </Modal.Button>
                     )}
 
-                    <Modal.Button size="medium" variant="tertiary" onClick={() => onCancel()}>
+                    <Modal.Button size="medium" variant="tertiary" onClick={() => onClose()}>
                         <Translation id="TR_CANCEL" />
                     </Modal.Button>
                 </>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal.tsx
@@ -17,6 +17,7 @@ import {
     Text,
 } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { borders, spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite/Translation';
@@ -24,6 +25,7 @@ import { AccountLabeling } from 'src/components/suite/labeling';
 import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { useTradingExchangeCryptoAndProviderInfo } from 'src/hooks/wallet/trading/form/useTradingExchangeCryptoAndProviderInfo';
 import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 import { getProvidersInfoProps } from 'src/utils/wallet/trading/tradingTypingUtils';
 import { tokenSupportsIncreasingAllowance } from 'src/utils/wallet/trading/tradingUtils';
@@ -64,6 +66,8 @@ export const RevokeModal = ({ onCancel }: RevokeModalProps) => {
         trigger,
     } = context;
 
+    const cryptoInfo = useTradingExchangeCryptoAndProviderInfo();
+
     const isDebug = useSelector(selectIsDebugModeActive);
 
     const { cryptoIdToSymbolAndContractAddress } = useTradingInfo();
@@ -75,10 +79,32 @@ export const RevokeModal = ({ onCancel }: RevokeModalProps) => {
     }
 
     const confirmAndSend = async () => {
+        analytics.report({
+            type: EventType.TradingExchangeApproval,
+            payload: {
+                type: 'revoke-modal',
+                action: 'continue',
+                ...cryptoInfo,
+            },
+        });
+
         setIsConfirmButtonLoading(true);
         await sendTransaction();
         setIsConfirmButtonLoading(false);
         onCancel(true);
+    };
+
+    const onClose = (isSubmitting?: boolean) => {
+        analytics.report({
+            type: EventType.TradingExchangeApproval,
+            payload: {
+                type: 'revoke-modal',
+                action: 'cancel',
+                ...cryptoInfo,
+            },
+        });
+
+        onCancel(isSubmitting);
     };
 
     const { coinSymbol, contractAddress } = cryptoIdToSymbolAndContractAddress(selectedQuote.send);
@@ -93,7 +119,7 @@ export const RevokeModal = ({ onCancel }: RevokeModalProps) => {
 
     return (
         <Modal
-            onCancel={() => onCancel()}
+            onCancel={() => onClose()}
             variant="primary"
             size="small"
             heading={
@@ -113,7 +139,7 @@ export const RevokeModal = ({ onCancel }: RevokeModalProps) => {
                         <Translation id="TR_CONTINUE" />
                     </Modal.Button>
 
-                    <Modal.Button size="medium" variant="tertiary" onClick={() => onCancel()}>
+                    <Modal.Button size="medium" variant="tertiary" onClick={() => onClose()}>
                         <Translation id="TR_CANCEL" />
                     </Modal.Button>
                 </>

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeCryptoAndProviderInfo.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeCryptoAndProviderInfo.ts
@@ -1,0 +1,48 @@
+import { useMemo } from 'react';
+
+import { TradingExchangeType } from '@suite-common/trading';
+
+import { getTradingCryptoInfo } from 'src/utils/wallet/trading/tradingUtils';
+
+import { useTradingFormContext } from './useTradingCommonForm';
+
+export const useTradingExchangeCryptoAndProviderInfo = () => {
+    const { selectedQuote, preselectedQuote, exchangeInfo, getValues } =
+        useTradingFormContext<TradingExchangeType>();
+    const { sendCryptoSelect, receiveCryptoSelect, selectedFee } = getValues();
+
+    const cryptoInfo = useMemo(() => {
+        const {
+            label: sendCryptoLabel,
+            networkSymbol: sendCryptoNetworkSymbol,
+            contractAddress: sendCryptoContractAddress,
+        } = getTradingCryptoInfo(sendCryptoSelect);
+
+        const {
+            label: receiveCryptoLabel,
+            networkSymbol: receiveCryptoNetworkSymbol,
+            contractAddress: receiveCryptoContractAddress,
+        } = getTradingCryptoInfo(receiveCryptoSelect);
+
+        return {
+            sendCryptoLabel,
+            sendCryptoNetworkSymbol,
+            sendCryptoContractAddress,
+            receiveCryptoLabel,
+            receiveCryptoNetworkSymbol,
+            receiveCryptoContractAddress,
+        };
+    }, [sendCryptoSelect, receiveCryptoSelect]);
+
+    const providerName = useMemo(() => {
+        const quoteExchange = preselectedQuote?.exchange ?? selectedQuote?.exchange;
+
+        return quoteExchange && exchangeInfo?.providerInfos[quoteExchange]?.companyName;
+    }, [selectedQuote, preselectedQuote, exchangeInfo]);
+
+    return {
+        ...cryptoInfo,
+        providerName,
+        selectedFee,
+    };
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
@@ -6,12 +6,14 @@ import styled, { DefaultTheme, keyframes } from 'styled-components';
 import { TradingExchangeType, tradingExchangeActions, useTradingInfo } from '@suite-common/trading';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Banner, Button, Column, Icon, Paragraph, Row } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
 import { TxAddress } from 'src/components/suite/copy/TxAddress';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { useTradingExchangeCryptoAndProviderInfo } from 'src/hooks/wallet/trading/form/useTradingExchangeCryptoAndProviderInfo';
 import { useTradingExchangeWatchApproval } from 'src/hooks/wallet/trading/form/useTradingExchangeWatchApproval';
 import { TradingExchangeApprovalType } from 'src/types/trading/tradingForm';
 import { tokenSupportsIncreasingAllowance } from 'src/utils/wallet/trading/tradingUtils';
@@ -84,6 +86,8 @@ export const TradingFormApproval = ({
         },
         account,
     } = context;
+
+    const cryptoInfo = useTradingExchangeCryptoAndProviderInfo();
 
     const currentQuoteStatus = selectedQuote?.status;
     const previousQuoteStatus = usePrevious(currentQuoteStatus);
@@ -183,6 +187,15 @@ export const TradingFormApproval = ({
             return;
         }
 
+        analytics.report({
+            type: EventType.TradingExchangeApproval,
+            payload: {
+                type: 'exchange-form',
+                action: 'approve',
+                ...cryptoInfo,
+            },
+        });
+
         setApprovalType('APPROVE');
         setIsApproveButtonLoading(true);
 
@@ -197,6 +210,15 @@ export const TradingFormApproval = ({
             return;
         }
 
+        analytics.report({
+            type: EventType.TradingExchangeApproval,
+            payload: {
+                type: 'exchange-form',
+                action: 'revoke',
+                ...cryptoInfo,
+            },
+        });
+
         setApprovalType('REVOKE');
         setIsRevokeButtonLoading(true);
 
@@ -210,6 +232,15 @@ export const TradingFormApproval = ({
         if (!selectedQuote || !selectedQuote.receiveAddress) {
             return;
         }
+
+        analytics.report({
+            type: EventType.TradingExchangeApproval,
+            payload: {
+                type: 'exchange-form',
+                action: 'swap',
+                ...cryptoInfo,
+            },
+        });
 
         setIsSwapButtonLoading(true);
 
@@ -229,6 +260,15 @@ export const TradingFormApproval = ({
     };
 
     const onRefreshClick = async () => {
+        analytics.report({
+            type: EventType.TradingExchangeApproval,
+            payload: {
+                type: 'exchange-form',
+                action: 'refresh',
+                ...cryptoInfo,
+            },
+        });
+
         setIsRefreshButtonLoading(true);
 
         resetSelectedOffer();

--- a/suite-common/analytics/src/events/suite/constants.ts
+++ b/suite-common/analytics/src/events/suite/constants.ts
@@ -58,6 +58,7 @@ export enum EventType {
     TradingSell = 'trade/sell',
     TradingStatus = 'trade/status',
     TradingConfirmTrade = 'trade/confirm-trade',
+    TradingExchangeApproval = 'trade/approval',
 
     StakingNavigate = 'staking/navigate',
     StakingStake = 'staking/stake',

--- a/suite-common/analytics/src/events/suite/types.ts
+++ b/suite-common/analytics/src/events/suite/types.ts
@@ -341,6 +341,60 @@ export type SuiteAnalyticsEvent =
           };
       }
     | {
+          type: EventType.TradingExchangeApproval;
+          payload: {
+              type: 'exchange-form';
+              action: 'approve' | 'revoke' | 'swap' | 'refresh';
+
+              sendCryptoLabel?: string;
+              sendCryptoNetworkSymbol?: string;
+              sendCryptoContractAddress?: string;
+
+              receiveCryptoLabel?: string;
+              receiveCryptoNetworkSymbol?: string;
+              receiveCryptoContractAddress?: string;
+
+              selectedFee?: string;
+              exchangeName?: string;
+          };
+      }
+    | {
+          type: EventType.TradingExchangeApproval;
+          payload: {
+              type: 'approve-modal';
+              action: 'continue' | 'cancel' | 'limit-exact' | 'limit-unlimited';
+
+              sendCryptoLabel?: string;
+              sendCryptoNetworkSymbol?: string;
+              sendCryptoContractAddress?: string;
+
+              receiveCryptoLabel?: string;
+              receiveCryptoNetworkSymbol?: string;
+              receiveCryptoContractAddress?: string;
+
+              selectedFee?: string;
+              exchangeName?: string;
+          };
+      }
+    | {
+          type: EventType.TradingExchangeApproval;
+          payload: {
+              type: 'revoke-modal';
+              action: 'continue' | 'cancel';
+
+              sendCryptoLabel?: string;
+              sendCryptoNetworkSymbol?: string;
+              sendCryptoContractAddress?: string;
+
+              receiveCryptoLabel?: string;
+              receiveCryptoNetworkSymbol?: string;
+              receiveCryptoContractAddress?: string;
+
+              selectedFee?: string;
+              exchangeName?: string;
+          };
+      }
+    | {
           type: EventType.StakingNavigate;
           payload: {
               action: 'navigate' | 'cancel';


### PR DESCRIPTION
## Description

Added analytics for approve/revoke EVM DEX transactions.

- exchange form
  - click on `Set & approve spending` button
  - click on `Increase approval` button
  - click on `Revoke approval` button
  - click on `Revoke previous approval` button
  - click on `Swap` button
- approve modal
  - changing approval limit buttons
  - `Continue` button
  - `Cancel` button
- revoke modal
  - `Continue` button
  - `Cancel` button

## Related Issue

Resolve #20989 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/analytics-approval&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/analytics-approval&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/analytics-approval&lookback=7)