### PR TITLE
Don't open wallet switcher in fullscreen apps

### DIFF
--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -69,8 +69,7 @@ const suite =
                 setTimeout(() => {
                     const hasModalContext = state.modal.context !== '@modal/context-none';
                     const { route } = state.router;
-                    const isForegroundApp =
-                        route && !route.isFullscreenApp && !!route.isForegroundApp;
+                    const isForegroundApp = !!route?.isForegroundApp;
                     const isModalActive = hasModalContext || isForegroundApp;
 
                     if (


### PR DESCRIPTION
## Description

When device has disconnected after fw installation during onboarding and the user has never seen disconnect tooltip yet, wallet switcher was opened, effectively interrupting onboarding process. This should suppress wallet switcher during onboarding.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/wallet-switcher-fw-update&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/wallet-switcher-fw-update&lookback=7)