### PR TITLE
Fix/schedule action reject

### DIFF
--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -266,7 +266,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
                 return readResult;
             },
-            { signal, timeout },
+            { signal, graceful: true, timeout },
         );
     }
 
@@ -333,7 +333,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
                 return sendResult;
             },
-            { signal, timeout },
+            { signal, graceful: true, timeout },
         );
     }
 
@@ -391,7 +391,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
                 return message;
             },
-            { signal, timeout },
+            { signal, graceful: true, timeout },
         );
     }
 

--- a/packages/transport/src/utils/readWithExpectedHeaders.ts
+++ b/packages/transport/src/utils/readWithExpectedHeaders.ts
@@ -72,6 +72,7 @@ export function readWithExpectedHeaders<T extends Receiver>(receiver: T, options
                 readAndAssert(receiver, expectedHeaders, { ...options, signal: attemptSignal }),
             {
                 signal: options?.signal,
+                graceful: true,
                 attempts: options?.attempts || Infinity,
                 timeout: options?.timeout,
                 attemptFailureHandler: error => {

--- a/packages/transport/tests/readWithExpectedHeaders.test.ts
+++ b/packages/transport/tests/readWithExpectedHeaders.test.ts
@@ -14,7 +14,7 @@ describe('readWithExpectedHeaders', () => {
             new Promise<any>((resolve, reject) => {
                 const listener = () => {
                     signal.removeEventListener('abort', listener);
-                    reject(new Error('Aborted'));
+                    reject(new Error('Aborted by signal in API'));
                 };
                 signal?.addEventListener('abort', listener);
 
@@ -35,10 +35,9 @@ describe('readWithExpectedHeaders', () => {
         });
 
         const resultPromise = read([Buffer.alloc(3)]);
-
+        await new Promise(resolve => setTimeout(resolve, 1));
         abortController.abort();
-        // error thrown from scheduleAction
-        await expect(() => resultPromise).rejects.toThrow('Aborted by signal');
+        await expect(() => resultPromise).rejects.toThrow('Aborted by signal in API');
     });
 
     it('read timeout', async () => {

--- a/packages/transport/tests/thp.test.ts
+++ b/packages/transport/tests/thp.test.ts
@@ -33,11 +33,14 @@ describe('thp', () => {
             const abortController = new AbortController();
             let attempt = 0;
             const apiRead = jest.fn(
-                () =>
+                signal =>
                     new Promise<any>(resolve => {
                         if (++attempt < 5) {
                             resolve({ success: true, payload: Buffer.alloc(32) });
                         } else {
+                            signal?.addEventListener('abort', () => {
+                                resolve({ success: false, message: 'Aborted by signal in API' });
+                            });
                             abortController.abort();
                         }
                     }),
@@ -53,7 +56,7 @@ describe('thp', () => {
             });
 
             expect(apiRead).toHaveBeenCalledTimes(5);
-            expect(result).toMatchObject({ success: false, message: 'Aborted by signal' });
+            expect(result).toMatchObject({ success: false, message: 'Aborted by signal in API' });
         });
 
         it('api write failed', async () => {

--- a/packages/utils/src/scheduleAction.ts
+++ b/packages/utils/src/scheduleAction.ts
@@ -18,20 +18,28 @@ export type ScheduleActionParams = {
     attemptFailureHandler?: (error: Error) => Error | void; // break attemptLoop if `Error` is set
 } & AttemptParams; // Ignored when attempts is AttemptParams[]
 
+export const SCHEDULE_ACTION_ABORTED_ERROR_MESSAGE = 'Aborted by signal' as const;
+export class RejectWhenAbortedError extends Error {
+    constructor() {
+        super(SCHEDULE_ACTION_ABORTED_ERROR_MESSAGE);
+    }
+}
+
 const isArray = (
     attempts: ScheduleActionParams['attempts'],
 ): attempts is readonly AttemptParams[] => Array.isArray(attempts);
 
 const resolveAfterMs = (ms: number | undefined, clear: AbortSignal) =>
     new Promise<void>((resolve, reject) => {
-        if (clear.aborted) return reject();
+        const errorSignal = new RejectWhenAbortedError();
+        if (clear.aborted) return reject(errorSignal);
         if (ms === undefined) return resolve();
         // eslint-disable-next-line prefer-const
         let timeout: TimerId;
         const onClear = () => {
             clearTimeout(timeout);
             clear.removeEventListener('abort', onClear);
-            reject();
+            reject(errorSignal);
         };
         timeout = setTimeout(() => {
             clear.removeEventListener('abort', onClear);
@@ -42,13 +50,14 @@ const resolveAfterMs = (ms: number | undefined, clear: AbortSignal) =>
 
 const rejectAfterMs = (ms: number, reason: Error, clear: AbortSignal) =>
     new Promise<never>((_, reject) => {
-        if (clear.aborted) return reject();
+        const errorSignal = new RejectWhenAbortedError();
+        if (clear.aborted) return reject(errorSignal);
         // eslint-disable-next-line prefer-const
         let timeout: TimerId | undefined;
         const onClear = () => {
             clearTimeout(timeout);
             clear.removeEventListener('abort', onClear);
-            reject();
+            reject(errorSignal);
         };
         timeout = setTimeout(() => {
             clear.removeEventListener('abort', onClear);
@@ -60,14 +69,6 @@ const rejectAfterMs = (ms: number, reason: Error, clear: AbortSignal) =>
 const maybeRejectAfterMs = (ms: number | undefined, reason: Error, clear: AbortSignal) =>
     ms === undefined ? [] : [rejectAfterMs(ms, reason, clear)];
 
-export const SCHEDULE_ACTION_ABORTED_ERROR_MESSAGE = 'Aborted by signal' as const;
-
-export class RejectWhenAbortedError extends Error {
-    constructor() {
-        super(SCHEDULE_ACTION_ABORTED_ERROR_MESSAGE);
-    }
-}
-
 const rejectWhenAborted = (signal: AbortSignal | undefined, clear: AbortSignal) =>
     new Promise<never>((_, reject) => {
         const errorSignal = new RejectWhenAbortedError();
@@ -78,7 +79,7 @@ const rejectWhenAborted = (signal: AbortSignal | undefined, clear: AbortSignal) 
         const onClear = () => {
             signal?.removeEventListener('abort', onAbort);
             clear.removeEventListener('abort', onClear);
-            reject();
+            reject(errorSignal);
         };
         clear.addEventListener('abort', onClear);
     });
@@ -121,7 +122,9 @@ const attemptLoop = async <T>(
         }
     }
 
-    return clear.aborted ? Promise.reject() : attempt(attempts - 1, clear);
+    return clear.aborted
+        ? Promise.reject(new RejectWhenAbortedError())
+        : attempt(attempts - 1, clear);
 };
 
 export const SCHEDULE_ACTION_TIMEOUT_ERROR_MESSAGE = 'Aborted by timeout' as const;

--- a/packages/utils/src/scheduleAction.ts
+++ b/packages/utils/src/scheduleAction.ts
@@ -14,6 +14,7 @@ export type ScheduleActionParams = {
         | number // How many attempts before failure (default = one, or infinite when deadline is set)
         | readonly AttemptParams[]; // Array of timeouts and gaps for every attempt (length = attempt count)
     signal?: AbortSignal;
+    graceful?: boolean; // Abort signalling will not throw immediately but let the action handle it instead (default = false)
     attemptFailureHandler?: (error: Error) => Error | void; // break attemptLoop if `Error` is set
 } & AttemptParams; // Ignored when attempts is AttemptParams[]
 
@@ -153,13 +154,28 @@ export const scheduleAction = async <T>(
     const getParams = isArray(attempts)
         ? (attempt: number) => attempts[attempt]
         : () => ({ timeout, gap });
-
     const errorDeadline = new ScheduleActionDeadlineError();
     const errorTimeout = new ScheduleActionTimeoutError();
 
+    const graceful = params.graceful && signal;
+    const actionAborter = new AbortController();
+    if (graceful) {
+        if (signal.aborted) {
+            actionAborter.abort();
+        } else {
+            const onAbort = () => {
+                signal.removeEventListener('abort', onAbort);
+                clear.removeEventListener('abort', onAbort);
+                actionAborter.abort();
+            };
+            signal.addEventListener('abort', onAbort);
+            clear.addEventListener('abort', onAbort);
+        }
+    }
+
     try {
         return await Promise.race([
-            rejectWhenAborted(signal, clear),
+            ...(graceful ? [] : [rejectWhenAborted(signal, clear)]),
             ...maybeRejectAfterMs(deadlineMs, errorDeadline, clear),
             resolveAfterMs(delay, clear).then(() =>
                 attemptLoop(
@@ -176,7 +192,7 @@ export const scheduleAction = async <T>(
                             ? Promise.reject(errorHandlerResult)
                             : resolveAfterMs(getParams(attempt).gap ?? 0, clear);
                     },
-                    clear,
+                    graceful ? actionAborter.signal : clear,
                 ),
             ),
         ]);

--- a/packages/utils/tests/scheduleAction.test.ts
+++ b/packages/utils/tests/scheduleAction.test.ts
@@ -239,6 +239,34 @@ describe('scheduleAction', () => {
         expect(checkListeners()).toBeUndefined();
     });
 
+    it("don't reject after abort (graceful: true)", async () => {
+        let ctrl = new AbortController();
+        const action = (sig?: AbortSignal) =>
+            new Promise(resolve => {
+                sig?.addEventListener('abort', () => {
+                    setTimeout(() => resolve({ success: false }), 1000);
+                });
+            });
+
+        let resultPromise = scheduleAction(action, {
+            signal: ctrl.signal,
+        });
+        new Promise(resolve => setTimeout(resolve, 1));
+        ctrl.abort();
+        await expect(() => resultPromise).rejects.toThrow(ERR_SIGNAL);
+
+        ctrl = new AbortController();
+        resultPromise = scheduleAction(action, {
+            signal: ctrl.signal,
+            graceful: true,
+            timeout: 2000,
+        });
+        await new Promise(resolve => setTimeout(resolve, 1));
+        ctrl.abort();
+        const result = await resultPromise;
+        expect(result).toEqual({ success: false });
+    });
+
     it('variable timeouts', async () => {
         const TIMEOUTS = [50, 150, 100];
         const MARGIN = 10;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
should fix `NodeUsbTransport`  https://github.com/trezor/trezor-suite/issues/20774 and probably https://github.com/trezor/trezor-suite/issues/20954 app crashing on macos

`scheduleAction` rejects immediately when signal is aborted but in some scenarios (transport call/send/receive) we want to wait for the inner action to fail gracefully as reaction on signal.abort.

`NodeUsbTransport` abort process is async and we need to wait for usb.device.reset() to finish before another read/write




log from premature rejection:
```

@trezor/connect handleMessage ui-request_thp_pairing

@trezor/transport usb: device.transferIn ## here: transport.read

Core handleMessage popup-closed ## transport read abort

Core Cleanup...

@trezor/transport usb: abortableMethod onAbort start

@trezor/transport usb: resetDevice: device.reset

DeviceCommands Sending Cancel {} ## premature transport.send because scheduleAction was rejected immediately

@trezor/transport sendThpMessage attempt 0 start

@trezor/transport usb: device.transferOut

@trezor/transport usb: abortableMethod method() aborted: true Error: transferIn error: Error: LIBUSB_TRANSFER_NO_DEVICE

@trezor/transport usb: device.transferOut done.

@trezor/transport sendThpMessage success: true

@trezor/transport sendThpMessage read ThpAck

@trezor/transport usb: device.transferIn
  console.error
@trezor/transport usb: resetDevice: device.reset error: reset error: Error: LIBUSB_ERROR_NOT_FOUND

@trezor/transport usb: abortableMethod onAbort done
  console.error
@trezor/transport usb: device.transferIn error Error: Aborted by signal
  console.error
@trezor/transport transport: abstract api: unknown error Error: Aborted by signal ## here: actual transport read end

@trezor/transport usb: device.transferIn done. status: ok, byteLength: 64.

@trezor/transport sendThpMessage done

@trezor/transport receiveThpMessage start 4,128

@trezor/transport readAndAssert start

@trezor/transport usb: device.transferIn

@trezor/transport usb: device.transferIn done. status: ok, byteLength: 64.

@trezor/transport readAndAssert done

@trezor/transport receiveThpMessage send ThpAck

@trezor/transport usb: device.transferOut

@trezor/transport usb: device.transferOut done.

@trezor/transport receiveThpMessage done

DeviceCommands Received Failure { code: 'Failure_ActionCancelled', message: 'Cancelled' }
```

log after the fix:
```
@trezor/connect handleMessage ui-request_thp_pairing

@trezor/transport usb: device.transferIn ## here: transport.read

Core handleMessage popup-closed ## transport read abort

@trezor/transport usb: abortableMethod onAbort start

@trezor/transport usb: resetDevice: device.reset

Core Cleanup...

@trezor/transport usb: resetDevice: device.reset done

@trezor/transport usb: abortableMethod onAbort done ## here: transport read end
  console.error
@trezor/transport usb: device.transferIn error Error: Aborted by signal
  console.error
@trezor/transport transport: abstract api: unknown error Error: Aborted by signal
DeviceCommands Sending Cancel {} ## now it is safe to send/call

@trezor/transport sendThpMessage attempt 0 start
```



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/schedule-action-reject&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/schedule-action-reject&lookback=7)