### PR TITLE
Fix/bt scan filter

### DIFF
--- a/packages/transport-bluetooth/src/server/adapter_manager.rs
+++ b/packages/transport-bluetooth/src/server/adapter_manager.rs
@@ -2,7 +2,7 @@ use btleplug::{
     api::{Central, CentralEvent, CentralState, Manager as _, Peripheral as _},
     platform::{Adapter, Manager, Peripheral, PeripheralId},
 };
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use futures::StreamExt;
 use log::info;
 use std::{
@@ -22,11 +22,19 @@ use crate::server::{
 };
 
 #[derive(Clone)]
+pub struct ServicelessDevice {
+    update_count: u128,
+    timestamp: u128,
+}
+
+#[derive(Clone)]
 pub struct AdapterManager {
     manager: Manager,
     adapter: Arc<Mutex<Option<Adapter>>>,
     adapter_state: Arc<Mutex<AdapterState>>,
     manager_state: Arc<Mutex<ManagerState>>,
+    discovered_id: DashSet<String>,
+    serviceless_peripherals: DashMap<String, ServicelessDevice>,
 }
 
 struct ManagerState {
@@ -54,6 +62,12 @@ pub enum AdapterError {
     #[error("PeripheralNotFound")]
     PeripheralNotFound,
 
+    #[error("PeripheralDiscovered")]
+    PeripheralDiscovered,
+
+    #[error("Peripheral create error")]
+    PeripheralNotCreated,
+
     #[error("Btleplug error: {0}")]
     BtleplugError(#[from] btleplug::Error),
 }
@@ -76,6 +90,8 @@ impl AdapterManager {
             adapter,
             adapter_state,
             manager_state,
+            discovered_id: DashSet::new(),
+            serviceless_peripherals: DashMap::new(),
         })
     }
 
@@ -265,18 +281,25 @@ impl AdapterManager {
     }
 
     async fn add_device(&self, id: &PeripheralId) -> Result<TrezorDevice, AdapterError> {
+        let state = self.manager_state.lock().await;
+        if state.peripherals.contains_key(&id.to_string()) {
+            return Err(AdapterError::PeripheralDiscovered);
+        }
+        drop(state);
+
         let id = id.to_string();
         let peripheral = self.get_peripheral_or_die(&id).await?;
         let is_known = self.is_known_peripheral(&id).await;
         let device = match TrezorDevice::new(peripheral, is_known).await {
             Ok(device) => device,
             Err(_) => {
-                return Err(AdapterError::AdapterMissing);
+                return Err(AdapterError::PeripheralNotCreated);
             }
         };
 
         let state = self.manager_state.lock().await;
         state.peripherals.insert(device.get_id(), device.clone());
+        self.discovered_id.insert(device.get_id());
 
         Ok(device)
     }
@@ -332,6 +355,7 @@ impl AdapterManager {
 
         // notify about each removed device
         for id in removed.iter() {
+            self.discovered_id.remove(id);
             self.dispatch_notification(NotificationEvent::DeviceRemoved { id: id.clone() })
                 .await;
         }
@@ -339,8 +363,16 @@ impl AdapterManager {
         Ok(devices)
     }
 
+    fn is_discovered(&self, id: &PeripheralId) -> bool {
+        self.discovered_id.contains(&id.to_string())
+    }
+
     // get TrezorDevice from AdapterManager or None
     async fn get_device(&self, id: &PeripheralId) -> Option<TrezorDevice> {
+        if !self.is_discovered(&id) {
+            return None;
+        }
+
         let state = self.manager_state.lock().await;
         if let Some(device) = state.peripherals.get(&id.to_string()) {
             return Some(device.clone());
@@ -390,6 +422,61 @@ impl AdapterManager {
         devices
     }
 
+    async fn add_serviceless_device(
+        &self,
+        id: &PeripheralId,
+        update_count: u128,
+    ) -> Result<(), AdapterError> {
+        let peripheral = self.get_peripheral_or_die(&id.to_string()).await?;
+        if let Ok(Some(props)) = peripheral.properties().await {
+            if let Some(_name) = props.local_name {
+                let device = ServicelessDevice {
+                    update_count,
+                    timestamp: utils::get_timestamp(),
+                };
+
+                self.serviceless_peripherals
+                    .insert(id.to_string(), device.clone());
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn update_serviceless_device(&self, id: &PeripheralId) -> Result<(), AdapterError> {
+        let device = self.serviceless_peripherals.get(&id.to_string());
+        if device.is_none() {
+            return Ok(());
+        }
+
+        let update_count = device.unwrap().update_count;
+        self.serviceless_peripherals.remove(&id.to_string());
+        if self.is_discovered(&id) {
+            return Ok(());
+        }
+
+        let peripheral = self.get_peripheral_or_die(&id.to_string()).await?;
+        if peripheral.services().len() == 0 {
+            let _ = peripheral.discover_services().await;
+        }
+
+        let adapter = self.get_adapter_or_die().await?;
+        if let Some(_device) = utils::scan_filter(&adapter, &id).await {
+            if let Ok(_device) = self.add_device(&id).await {
+                let devices = self.get_devices().await;
+                self.dispatch_notification(NotificationEvent::DeviceDiscovered {
+                    id: id.to_string(),
+                    devices,
+                })
+                .await;
+            }
+        } else if update_count < 1000 && peripheral.services().len() == 0 {
+            let _ = self.add_serviceless_device(&id, update_count + 1).await;
+        }
+
+        Ok(())
+    }
+
     async fn start_events_stream(&self) -> Result<(), AdapterError> {
         let adapter = self.get_adapter_or_die().await?;
         // linux this will start scanning after adp.events subscription
@@ -419,6 +506,8 @@ impl AdapterManager {
                                         .await;
                                 }
                             }
+                        } else {
+                            let _ = self_ref.add_serviceless_device(&id, 0).await;
                         }
                     }
                     CentralEvent::DeviceUpdated(id) => {
@@ -442,6 +531,8 @@ impl AdapterManager {
                                     })
                                     .await;
                             }
+                        } else {
+                            let _ = self_ref.update_serviceless_device(&id).await;
                         }
                     }
                     CentralEvent::DeviceDisconnected(id) => {
@@ -499,6 +590,18 @@ impl AdapterManager {
                                     .await;
                             }
                         }
+                    }
+                    CentralEvent::ManufacturerDataAdvertisement {
+                        id,
+                        manufacturer_data: _,
+                    } => {
+                        // log is useful but noisy
+                        // info!("ManufacturerDataAdvertisement: {:?} : {:?}", id, manufacturer_data);
+                        let _ = self_ref.update_serviceless_device(&id).await;
+                    }
+                    CentralEvent::ServicesAdvertisement { id, services: _ } => {
+                        // info!("ServicesAdvertisement: {:?} : {:?}", id, services);
+                        let _ = self_ref.update_serviceless_device(&id).await;
                     }
                     _ => {}
                 }

--- a/packages/transport-bluetooth/src/server/methods/start_scan.rs
+++ b/packages/transport-bluetooth/src/server/methods/start_scan.rs
@@ -7,7 +7,6 @@ use tokio::time::{sleep, Duration};
 
 use crate::server::{
     adapter_manager::{AdapterError, AdapterManager},
-    device::SERVICE_UUID,
     types::{
         AbortProcess, AdapterState, ChannelMessage, MethodResult, NotificationEvent,
         WsResponsePayload,
@@ -19,20 +18,7 @@ async fn start_scanning(adapter: &Adapter) -> Result<(), AdapterError> {
     // stop previous process just to be sure
     stop_scanning(adapter).await;
 
-    // workaround for windows
-    #[allow(unused_mut)]
-    let mut filter = ScanFilter {
-        services: vec![SERVICE_UUID],
-    };
-    #[cfg(target_os = "windows")]
-    {
-        // TODO: windows use default ScanFilter
-        // ScanFilter doesn't work correctly on windows https://github.com/deviceplug/btleplug/issues/249
-        // TODO: i believe i have a fix for that in btleplug
-        filter = ScanFilter::default();
-    }
-
-    if let Err(err) = adapter.start_scan(filter).await {
+    if let Err(err) = adapter.start_scan(ScanFilter::default()).await {
         info!("Start scan error {err}");
         return Err(err.into());
     }

--- a/packages/transport-bluetooth/src/server/platform/mod.rs
+++ b/packages/transport-bluetooth/src/server/platform/mod.rs
@@ -1,7 +1,9 @@
 use btleplug::platform::Peripheral;
 
 pub trait PlatformDevice {
-    async fn is_paired(peripheral: &Peripheral) -> Result<bool, Box<dyn std::error::Error + Send + Sync>>;
+    async fn is_paired(
+        peripheral: &Peripheral,
+    ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>>;
 
     fn get_address(peripheral: Peripheral) -> String;
 }

--- a/packages/transport-bluetooth/src/server/utils.rs
+++ b/packages/transport-bluetooth/src/server/utils.rs
@@ -20,16 +20,6 @@ pub async fn scan_filter(adapter: &Adapter, id: &PeripheralId) -> Option<Periphe
         if service.is_some() {
             return Some(peripheral);
         }
-
-        // 2 types of advertisements:
-        // Primary Advertisement: basic data like flags, manufacturer-specific but lack of services and local_name
-        // Scan Response: additional details like services and local_name
-        // advertisements may be received in unexpected order
-        // linux / mac: props.services is empty. try by name
-        let name = props.local_name.unwrap_or("".to_string());
-        if name.contains("Trezor") {
-            return Some(peripheral);
-        }
     };
 
     None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Problem:
peripheral sends 2 types of advertisements:
1, Primary Advertisement: basic data like flags, manufacturer-specific but lack of services and local_name
2. Scan Response: additional details like services and local_name

advertisements may be received in unexpected order


some macos are having problem with receiving/update peripheral services and advertisement data @martykan even tried it natively with swift - looks like it's some system cache bug.

from now server is listening for all the devices and stores the devices without discovered services as `ServicelessDevice`
each time this devices sends an update it tries to rediscover services again and in case of success emits `DeviceDiscovered` event

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bt-scan-filter&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-scan-filter&lookback=7)