### PR TITLE
feat(suite): put the global send/receive to the settings

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveButtons.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveButtons.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { selectHasBitcoinOnlyFirmware } from '@suite-common/wallet-core';
 import { ButtonGroup, ButtonVariant } from '@trezor/components';
 
-import { selectHasExperimentalFeature } from 'src/selectors/suite/suiteSelectors';
+import { ExperimentalFeatureFlag } from 'src/support/suite/ExperimentalFeatureFlag';
 
 import { Translation } from '../../../../Translation';
 import { HeaderActionButton } from '../HeaderActionButton';
@@ -18,38 +18,35 @@ export const GlobalSendReceiveButtons = ({
     setIsReceiveModalOpen,
     variant,
 }: GlobalSendReceiveButtonsProps) => {
-    const experimentalFeatures = useSelector(selectHasExperimentalFeature('global-send-receive'));
     const btcOnlyFw = useSelector(selectHasBitcoinOnlyFirmware);
 
-    if (!experimentalFeatures && !btcOnlyFw) {
-        return null;
-    }
-
     return (
-        <ButtonGroup size="small">
-            <HeaderActionButton
-                key="wallet-send"
-                icon="arrowUp"
-                onClick={() => {
-                    setIsSendModalOpen(true);
-                }}
-                data-testid="@wallet/menu/wallet-global-send"
-                variant={variant}
-            >
-                <Translation id="TR_NAV_SEND" />
-            </HeaderActionButton>
+        <ExperimentalFeatureFlag feature="global-send-receive" featureFlagDisabled={btcOnlyFw}>
+            <ButtonGroup size="small">
+                <HeaderActionButton
+                    key="wallet-send"
+                    icon="arrowUp"
+                    onClick={() => {
+                        setIsSendModalOpen(true);
+                    }}
+                    data-testid="@wallet/menu/wallet-global-send"
+                    variant={variant}
+                >
+                    <Translation id="TR_NAV_SEND" />
+                </HeaderActionButton>
 
-            <HeaderActionButton
-                key="wallet-receive"
-                icon="arrowDown"
-                onClick={() => {
-                    setIsReceiveModalOpen(true);
-                }}
-                data-testid="@wallet/menu/wallet-global-receive"
-                variant={variant}
-            >
-                <Translation id="TR_NAV_RECEIVE" />
-            </HeaderActionButton>
-        </ButtonGroup>
+                <HeaderActionButton
+                    key="wallet-receive"
+                    icon="arrowDown"
+                    onClick={() => {
+                        setIsReceiveModalOpen(true);
+                    }}
+                    data-testid="@wallet/menu/wallet-global-receive"
+                    variant={variant}
+                >
+                    <Translation id="TR_NAV_RECEIVE" />
+                </HeaderActionButton>
+            </ButtonGroup>
+        </ExperimentalFeatureFlag>
     );
 };

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveButtons.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveButtons.tsx
@@ -1,4 +1,9 @@
+import { useSelector } from 'react-redux';
+
+import { selectHasBitcoinOnlyFirmware } from '@suite-common/wallet-core';
 import { ButtonGroup, ButtonVariant } from '@trezor/components';
+
+import { selectHasExperimentalFeature } from 'src/selectors/suite/suiteSelectors';
 
 import { Translation } from '../../../../Translation';
 import { HeaderActionButton } from '../HeaderActionButton';
@@ -12,30 +17,39 @@ export const GlobalSendReceiveButtons = ({
     setIsSendModalOpen,
     setIsReceiveModalOpen,
     variant,
-}: GlobalSendReceiveButtonsProps) => (
-    <ButtonGroup size="small">
-        <HeaderActionButton
-            key="wallet-send"
-            icon="arrowUp"
-            onClick={() => {
-                setIsSendModalOpen(true);
-            }}
-            data-testid="@wallet/menu/wallet-global-send"
-            variant={variant}
-        >
-            <Translation id="TR_NAV_SEND" />
-        </HeaderActionButton>
+}: GlobalSendReceiveButtonsProps) => {
+    const experimentalFeatures = useSelector(selectHasExperimentalFeature('global-send-receive'));
+    const btcOnlyFw = useSelector(selectHasBitcoinOnlyFirmware);
 
-        <HeaderActionButton
-            key="wallet-receive"
-            icon="arrowDown"
-            onClick={() => {
-                setIsReceiveModalOpen(true);
-            }}
-            data-testid="@wallet/menu/wallet-global-receive"
-            variant={variant}
-        >
-            <Translation id="TR_NAV_RECEIVE" />
-        </HeaderActionButton>
-    </ButtonGroup>
-);
+    if (!experimentalFeatures && !btcOnlyFw) {
+        return null;
+    }
+
+    return (
+        <ButtonGroup size="small">
+            <HeaderActionButton
+                key="wallet-send"
+                icon="arrowUp"
+                onClick={() => {
+                    setIsSendModalOpen(true);
+                }}
+                data-testid="@wallet/menu/wallet-global-send"
+                variant={variant}
+            >
+                <Translation id="TR_NAV_SEND" />
+            </HeaderActionButton>
+
+            <HeaderActionButton
+                key="wallet-receive"
+                icon="arrowDown"
+                onClick={() => {
+                    setIsReceiveModalOpen(true);
+                }}
+                data-testid="@wallet/menu/wallet-global-receive"
+                variant={variant}
+            >
+                <Translation id="TR_NAV_RECEIVE" />
+            </HeaderActionButton>
+        </ButtonGroup>
+    );
+};

--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -13,7 +13,8 @@ export type ExperimentalFeature =
     | 'password-manager'
     | 'tor-external'
     | 'nft-section'
-    | 'biometric-authentication';
+    | 'biometric-authentication'
+    | 'global-send-receive';
 
 export type ExperimentalFeatureConfig = {
     title: TranslationKey;
@@ -74,5 +75,9 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
                 throw new Error('Could not change bio auth');
             }
         },
+    },
+    'global-send-receive': {
+        title: 'TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE',
+        description: 'TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION',
     },
 };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5280,6 +5280,14 @@ export default defineMessages({
         defaultMessage:
             'For experienced users only. Use at your own risk. These features are in testing, may be unstable, and might not have long-term support.',
     },
+    TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE: {
+        id: 'TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE',
+        defaultMessage: 'Global send/receive',
+    },
+    TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION: {
+        id: 'TR_EXPERIMENTAL_GLOBAL_SEND_RECEIVE_DESCRIPTION',
+        defaultMessage: 'Send and receive transactions from the dashboard directly to any account.',
+    },
     TR_GO_TO_EXP_FEATURE: {
         id: 'TR_GO_TO_EXP_FEATURE',
         defaultMessage: 'Open',

--- a/packages/suite/src/support/suite/ExperimentalFeatureFlag.tsx
+++ b/packages/suite/src/support/suite/ExperimentalFeatureFlag.tsx
@@ -1,0 +1,27 @@
+import { memo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { ExperimentalFeature } from 'src/constants/suite/experimental';
+import { selectHasExperimentalFeature } from 'src/selectors/suite/suiteSelectors';
+
+export const ExperimentalFeatureFlag = memo(
+    ({
+        children,
+        feature,
+        featureFlagDisabled,
+    }: {
+        children: React.ReactNode;
+        feature: ExperimentalFeature;
+        featureFlagDisabled?: boolean;
+    }) => {
+        const experimentalFeatures = useSelector(selectHasExperimentalFeature(feature));
+
+        if (featureFlagDisabled) {
+            return children;
+        }
+
+        return experimentalFeatures ? children : null;
+    },
+);
+
+ExperimentalFeatureFlag.displayName = 'ExperimentalFeatureFlag';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Put the global send / receive behind the Experimental flag but have it enabled for btc only firmwares
## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20967

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=20967-global-send-experiment&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=20967-global-send-experiment&lookback=7)