### PR TITLE
fix(suite-native): account asset name in My Assets

### DIFF
--- a/suite-native/module-trading/src/__fixtures__/account.ts
+++ b/suite-native/module-trading/src/__fixtures__/account.ts
@@ -95,3 +95,41 @@ export const getEthAccount = (key = 'eth-account-1') =>
             total: 8,
         },
     }) as unknown as Account;
+
+export const getBaseAccount = (key = 'base-account-1') =>
+    ({
+        key,
+        deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@448CCE89D32A733A1632F345:0',
+        accountLabel: 'Base #1',
+        index: 0,
+        path: "m/44'/60'/0'/0/0",
+        descriptor: '0x73d0385F4d8E00C5e6504C6030F47BF6212736A8',
+        accountType: 'normal',
+        symbol: 'base',
+        empty: false,
+        backendType: 'blockbook',
+        visible: true,
+        balance: '1000000000000000000',
+        availableBalance: '1000000000000000000',
+        formattedBalance: '1',
+        tokens: [],
+        history: {
+            total: 0,
+            unconfirmed: 0,
+            tokens: 0,
+        },
+        metadata: {
+            key: '0x73d0385F4d8E00C5e6504C6030F47BF6212736A8',
+        },
+        ts: 1750315198255,
+        networkType: 'ethereum',
+        misc: {
+            nonce: '0',
+            addressAliases: {},
+        },
+        page: {
+            index: 1,
+            size: 1,
+            total: 1,
+        },
+    }) as unknown as Account;

--- a/suite-native/module-trading/src/__fixtures__/walletState.ts
+++ b/suite-native/module-trading/src/__fixtures__/walletState.ts
@@ -3,17 +3,19 @@ import { FiatRatesState } from '@suite-common/wallet-core';
 import { Account, RatesByKey, type WalletSettings } from '@suite-common/wallet-types';
 import { PROTO } from '@trezor/connect';
 
-import { getBtcAccount, getEthAccount } from './account';
+import { getBaseAccount, getBtcAccount, getEthAccount } from './account';
 import { getInitializedTradingState } from './tradingState';
 
 type GetWalletStateParams = {
     bitcoinAmountUnit?: PROTO.AmountUnit;
     tradeType?: TradingType;
+    deviceState?: string;
 };
 
 export const getWalletState = ({
     bitcoinAmountUnit = PROTO.AmountUnit.BITCOIN,
     tradeType = 'buy',
+    deviceState,
 }: GetWalletStateParams = {}) => ({
     tradingNew: getInitializedTradingState(tradeType),
     settings: {
@@ -35,8 +37,9 @@ export const getWalletState = ({
         lastWeek: {},
     } as FiatRatesState,
     accounts: [
-        getBtcAccount('btc-account-1'),
-        getBtcAccount('btc-account-2'),
-        getEthAccount(),
+        { ...getBtcAccount('btc-account-1'), ...(deviceState && { deviceState }) },
+        { ...getBtcAccount('btc-account-2'), ...(deviceState && { deviceState }) },
+        { ...getEthAccount(), ...(deviceState && { deviceState }) },
+        { ...getBaseAccount(), ...(deviceState && { deviceState }) },
     ] as Account[],
 });

--- a/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
@@ -680,5 +680,25 @@ describe('commonSelectors', () => {
             );
             expect(result[0].data[0].symbol).toBe('btc');
         });
+
+        it('should use network display symbol name for account asset name', () => {
+            const testDeviceState = 'test-device';
+
+            const stateWithDevice = {
+                wallet: getWalletState({ tradeType: 'exchange', deviceState: testDeviceState }),
+                device: { selectedDevice: { state: { staticSessionId: testDeviceState } } },
+                tokenDefinitions: {},
+                fiat: { rates: {}, current: 'usd' },
+            } as any;
+
+            const result = selectAccountsWithTokensToSellSectionListByTradingType(
+                stateWithDevice,
+                'exchange',
+            );
+
+            const accountAsset = result[1].data[0];
+            expect(accountAsset.symbol).toBe('base');
+            expect(accountAsset.name).toBe('Base Ethereum');
+        });
     });
 });

--- a/suite-native/module-trading/src/selectors/commonSelectors.ts
+++ b/suite-native/module-trading/src/selectors/commonSelectors.ts
@@ -18,7 +18,7 @@ import {
     selectTradingSellSellCryptoIds,
     toTokenCryptoId,
 } from '@suite-common/trading';
-import { getNetwork } from '@suite-common/wallet-config';
+import { getNetwork, getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import {
     AccountsRootState,
     DeviceRootState,
@@ -235,7 +235,7 @@ export const selectAccountsWithTokensToSellSectionListByTradingType =
 
                     const accountAsset = {
                         symbol: account.symbol,
-                        name: account.accountLabel || '',
+                        name: getNetworkDisplaySymbolName(account.symbol),
                         balance: account.formattedBalance,
                         fiatBalance: getAccountFiatBalance({
                             account,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve #20965 

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=20965-mobile-swap-trading-my-assets-shows-account-label-instead-of-native-coin-name&lookback=7)