### PR TITLE
feat(suite): show only real nearBy devices in BT list

### DIFF
--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -19,6 +19,10 @@ import { bluetoothConnectDeviceThunk } from 'src/actions/bluetooth/bluetoothConn
 import { bluetoothDisconnectDeviceThunk } from 'src/actions/bluetooth/bluetoothDisconnectDeviceThunk';
 import { bluetoothStartScanningThunk } from 'src/actions/bluetooth/bluetoothStartScanningThunk';
 import { bluetoothStopScanningThunk } from 'src/actions/bluetooth/bluetoothStopScanningThunk';
+import {
+    selectIsUnpairingDevice,
+    selectUnpairedDeviceNeedsManualOsRemoval,
+} from 'src/actions/bluetooth/desktopBluetoothSelectors';
 import { selectDeviceDefaultConnectionMode } from 'src/actions/device/deviceSelectors';
 import { setConnectionMode } from 'src/actions/device/deviceSlice';
 import { Translation } from 'src/components/suite/Translation';
@@ -61,6 +65,9 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
     const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
     const [shouldPairAgain, setShouldPairAgain] = useState(false);
 
+    const wasBluetoothDeviceWiped = useSelector(selectUnpairedDeviceNeedsManualOsRemoval);
+    const isUnpairingDevice = useSelector(selectIsUnpairingDevice);
+
     const { isBluetoothEnabled } = useSelector(selectSuiteFlags);
     const bluetoothAdapterStatus = useSelector(selectAdapterStatus);
 
@@ -96,11 +103,7 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
             // If the device is connected or paired (it may have been paired in the OS system directly)
             // => do not filter it based isDeviceUnresponsiveForTooLong
 
-            return (
-                it.connected ||
-                it.paired ||
-                knownDevices.some(knownDevice => knownDevice.id === it.id)
-            );
+            return it.connected;
         }
 
         return true;
@@ -178,6 +181,8 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
             setSelectedDeviceId(null);
         }
     };
+
+    if (wasBluetoothDeviceWiped || isUnpairingDevice) return null;
 
     if (showHints) {
         return (


### PR DESCRIPTION
Make the BT co/re-connect better and do not show not nearBy devices even if they're paired, connected or known.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/old-nearby-devices&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/old-nearby-devices&lookback=7)