### PR TITLE
EVM balance when pending txs

### DIFF
--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -387,16 +387,8 @@ export const transformAccountInfo = (payload: BlockbookAccountInfo): AccountInfo
     const unconfirmedBalance = new BigNumber(payload.unconfirmedBalance);
 
     let availableBalance = payload.balance;
-    if (!unconfirmedBalance.isNaN()) {
-        if (!isEVM) {
+    if (!unconfirmedBalance.isNaN() && !isEVM) {
             availableBalance = unconfirmedBalance.plus(payload.balance).toString();
-        } else if (isEVM && unconfirmedBalance.lt(0)) {
-            // if unconfirmed balance is positive it means that address has pending receive transaction
-            // this address cannot use this balance yet so it should not be visible
-            // however, for negative it has to be applied, otherwise it would not be possible to e.g. bump fee
-            // (when tx is pending the balance is still on the account)
-            availableBalance = unconfirmedBalance.plus(payload.balance).toString();
-        }
     }
     const empty =
         payload.txs === 0 &&

--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -17,7 +17,14 @@ import type {
 } from '@trezor/blockchain-link-types/src/blockbook';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { Addresses, enhanceVinVout, filterTargets, sumVinVout, transformTarget } from './utils';
+import {
+    Addresses,
+    enhanceVinVout,
+    filterShadowedPendingTxsByNonce,
+    filterTargets,
+    sumVinVout,
+    transformTarget,
+} from './utils';
 
 export const transformServerInfo = (payload: ServerInfo) => ({
     name: payload.name,
@@ -388,12 +395,21 @@ export const transformAccountInfo = (payload: BlockbookAccountInfo): AccountInfo
 
     let availableBalance = payload.balance;
     if (!unconfirmedBalance.isNaN() && !isEVM) {
-            availableBalance = unconfirmedBalance.plus(payload.balance).toString();
+        availableBalance = unconfirmedBalance.plus(payload.balance).toString();
     }
     const empty =
         payload.txs === 0 &&
         payload.unconfirmedTxs === 0 &&
         new BigNumber(availableBalance).isZero();
+
+    const unfilteredTransactions = payload.transactions
+        ? payload.transactions.map(t => transformTransaction(t, addresses ?? descriptor))
+        : undefined;
+
+    const transactions =
+        isEVM && unfilteredTransactions
+            ? filterShadowedPendingTxsByNonce(unfilteredTransactions, descriptor.toLowerCase())
+            : unfilteredTransactions;
 
     return {
         descriptor,
@@ -410,9 +426,7 @@ export const transformAccountInfo = (payload: BlockbookAccountInfo): AccountInfo
                     ? payload.txs - payload.nonTokenTxs
                     : undefined,
             unconfirmed: payload.unconfirmedTxs,
-            transactions: payload.transactions
-                ? payload.transactions.map(t => transformTransaction(t, addresses ?? descriptor))
-                : undefined,
+            transactions,
         },
         misc,
         page,

--- a/packages/blockchain-link-utils/src/tests/fixtures/utils.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/utils.ts
@@ -1,3 +1,5 @@
+import type { Transaction } from '@trezor/blockchain-link-types';
+
 export const filterTargets = [
     {
         description: 'addresses as string',
@@ -81,3 +83,126 @@ export const unsortedTxs = [
 ];
 
 export const sortedTxs = [...'abcdefghij'].map(txid => ({ txid }));
+
+const me = '0x9ea3721b5bf3b64b4418c38b603154d2d597fae3';
+const other = '0x1111111111111111111111111111111111111111';
+
+const makeEthTx = (p: {
+    txid: string;
+    status?: number; // -1 pending, 0 failed, 1 mined
+    nonce?: number;
+    type?: Transaction['type']; // 'sent' | 'self' | 'recv' | ...
+    from?: string; // vin[0].addresses[0]
+}): Transaction => {
+    const tx = {
+        txid: p.txid,
+        type: p.type ?? 'sent',
+        blockTime: 0,
+        blockHeight: -1,
+        amount: '0',
+        fee: '0',
+        targets: [],
+        details: {
+            vin: [
+                {
+                    n: 0,
+                    isAddress: true,
+                    addresses: [(p.from ?? me).toLowerCase()],
+                },
+            ],
+            vout: [],
+            size: 0,
+            totalInput: '0',
+            totalOutput: '0',
+        },
+        ethereumSpecific: {
+            status: p.status ?? -1,
+            nonce: p.nonce,
+        } as Transaction['ethereumSpecific'],
+    } satisfies Partial<Transaction>;
+
+    return tx as unknown as Transaction;
+};
+
+export const filterShadowedPendingTxsByNonce = [
+    {
+        description: 'drops pending outgoing when mined with same nonce exists (same sender)',
+        input: [
+            makeEthTx({ txid: 'pending-394', status: -1, nonce: 394, type: 'sent', from: me }),
+            makeEthTx({ txid: 'pending-393', status: -1, nonce: 393, type: 'sent', from: me }),
+            makeEthTx({ txid: 'mined-394', status: 1, nonce: 394, type: 'sent', from: me }),
+        ],
+        lowerCasedDescriptor: me,
+        expectedTxids: ['mined-394'],
+    },
+    {
+        description: 'keeps pending when mined has different nonce (same sender)',
+        input: [
+            makeEthTx({ txid: 'pending-396', status: -1, nonce: 396, type: 'sent', from: me }),
+            makeEthTx({ txid: 'mined-395', status: 1, nonce: 395, type: 'sent', from: me }),
+            makeEthTx({ txid: 'mined-394', status: 1, nonce: 394, type: 'sent', from: me }),
+        ],
+        lowerCasedDescriptor: me,
+        expectedTxids: ['pending-396', 'mined-395', 'mined-394'],
+    },
+    {
+        description: 'keeps pending when mined has different nonce (different sender)',
+        input: [
+            makeEthTx({
+                txid: 'pending-other-10',
+                status: -1,
+                nonce: 10,
+                type: 'recv',
+                from: other,
+            }),
+            makeEthTx({ txid: 'mined-me-10', status: 1, nonce: 10, type: 'sent', from: me }),
+            makeEthTx({ txid: 'mined-me-9', status: 1, nonce: 9, type: 'sent', from: me }),
+        ],
+        lowerCasedDescriptor: me,
+        expectedTxids: ['pending-other-10', 'mined-me-10', 'mined-me-9'],
+    },
+    {
+        description: 'keeps pending if there is no non-pending with same nonce',
+        input: [makeEthTx({ txid: 'only-pending-7', status: -1, nonce: 7, from: me })],
+        lowerCasedDescriptor: me,
+        expectedTxids: ['only-pending-7'],
+    },
+    {
+        description: 'handles nonce = 0 (falsy) correctly',
+        input: [
+            makeEthTx({ txid: 'pending-0', status: -1, nonce: 0, from: me }),
+            makeEthTx({ txid: 'mined-0', status: 1, nonce: 0, from: me }),
+        ],
+        lowerCasedDescriptor: me,
+        expectedTxids: ['mined-0'],
+    },
+    {
+        description: 'self behaves like sent (outgoing) for stínění',
+        input: [
+            makeEthTx({ txid: 'pending-self-33', status: -1, nonce: 33, type: 'self', from: me }),
+            makeEthTx({ txid: 'mined-self-33', status: 1, nonce: 33, type: 'self', from: me }),
+        ],
+        lowerCasedDescriptor: me,
+        expectedTxids: ['mined-self-33'],
+    },
+    {
+        description: 'failed (status=0) can shadow pending',
+        input: [
+            makeEthTx({ txid: 'pending-8', status: -1, nonce: 8, from: me }),
+            makeEthTx({ txid: 'failed-8', status: 0, nonce: 8, from: me }),
+        ],
+        lowerCasedDescriptor: me,
+        expectedTxids: ['failed-8'],
+    },
+    {
+        description: 'handles more pending txs at oncecorrectly',
+        input: [
+            makeEthTx({ txid: 'pending-8', status: -1, nonce: 8, from: me }),
+            makeEthTx({ txid: 'pending-8', status: -1, nonce: 8, from: me }),
+            makeEthTx({ txid: 'pending-9', status: -1, nonce: 9, from: me }),
+            makeEthTx({ txid: 'mined-8', status: 1, nonce: 8, from: me }),
+        ],
+        lowerCasedDescriptor: me,
+        expectedTxids: ['mined-8', 'pending-9'],
+    },
+];

--- a/packages/blockchain-link-utils/src/tests/utils.test.ts
+++ b/packages/blockchain-link-utils/src/tests/utils.test.ts
@@ -1,4 +1,4 @@
-import { filterTargets, sortTxsFromLatest } from '../utils';
+import { filterShadowedPendingTxsByNonce, filterTargets, sortTxsFromLatest } from '../utils';
 import * as fixtures from './fixtures/utils';
 
 describe('blockbook/utils', () => {
@@ -14,5 +14,14 @@ describe('blockbook/utils', () => {
 
     it('sortTxsFromLatest', () => {
         expect(sortTxsFromLatest(fixtures.unsortedTxs as any)).toMatchObject(fixtures.sortedTxs);
+    });
+
+    describe('filterShadowedPendingTxsByNonce', () => {
+        fixtures.filterShadowedPendingTxsByNonce.forEach(f => {
+            it(f.description, () => {
+                const out = filterShadowedPendingTxsByNonce(f.input, f.lowerCasedDescriptor);
+                expect(out.map(tx => tx.txid).sort()).toEqual(f.expectedTxids.sort());
+            });
+        });
     });
 });

--- a/packages/blockchain-link-utils/src/utils.ts
+++ b/packages/blockchain-link-utils/src/utils.ts
@@ -45,6 +45,7 @@ export const transformTarget = (target: VinVout, incoming: VinVout[]) => ({
     coinbase: target.coinbase,
     isAccountTarget: incoming.includes(target) ? true : undefined,
 });
+
 const adjustHeight = ({ blockHeight }: { blockHeight?: number }) =>
     blockHeight === undefined || blockHeight <= 0 ? Number.MAX_SAFE_INTEGER : blockHeight;
 
@@ -75,4 +76,39 @@ export const formatTokenSymbol = (symbol: string) => {
     const isTokenSymbolLong = upperCasedSymbol.length > 7;
 
     return isTokenSymbolLong ? `${upperCasedSymbol.slice(0, 7)}...` : upperCasedSymbol;
+};
+
+const isOutgoing = (lowerCasedDescriptor: string, tx: Transaction) =>
+    tx.details?.vin?.[0]?.addresses?.[0]?.toLowerCase() === lowerCasedDescriptor;
+
+export const filterShadowedPendingTxsByNonce = (
+    txs: Transaction[],
+    lowerCasedDescriptor: string,
+) => {
+    // txs should come sorted by nonce
+    const myLatestMinedTx = txs.find(
+        tx =>
+            isOutgoing(lowerCasedDescriptor, tx) &&
+            tx.ethereumSpecific &&
+            (tx.ethereumSpecific.status === 0 || tx.ethereumSpecific.status === 1) &&
+            Number.isInteger(tx.ethereumSpecific.nonce),
+    );
+
+    if (!myLatestMinedTx?.ethereumSpecific) return txs;
+
+    const latestMinedNonce = myLatestMinedTx.ethereumSpecific.nonce;
+
+    return txs.filter(tx => {
+        const es = tx.ethereumSpecific;
+        if (!es) return true;
+
+        const isOutgoingTx = isOutgoing(lowerCasedDescriptor, tx);
+        const isPending = es.status === -1;
+
+        if (isOutgoingTx && isPending && es.nonce <= latestMinedNonce) {
+            return false;
+        }
+
+        return true;
+    });
 };

--- a/packages/blockchain-link/tests/unit/fixtures/getAccountInfo-blockbook.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/getAccountInfo-blockbook.ts
@@ -525,7 +525,7 @@ const fixtures: {
         },
     },
     {
-        description: 'ETH send receive tx',
+        description: 'ETH send receive tx, balance no change',
         params: {
             descriptor: '0xFc6B5d6af8A13258f7CbD0D39E11b35e01a32F93',
         },
@@ -546,7 +546,7 @@ const fixtures: {
             descriptor: '0xFc6B5d6af8A13258f7CbD0D39E11b35e01a32F93',
             empty: false,
             balance: '100',
-            availableBalance: '99',
+            availableBalance: '100',
             history: {},
             misc: {
                 nonce: '100',

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -163,7 +163,7 @@ const updateAccount = createAction(
                     visible: account.visible || !accountInfo.empty,
                     formattedBalance: formatNetworkAmount(
                         // Ripple and Stellar `availableBalance` is reduced by reserve, use regular balance
-                        account.networkType === 'ripple' || account.networkType === 'stellar'
+                        ['ripple', 'stellar'].includes(account.networkType)
                             ? accountInfo.balance
                             : accountInfo.availableBalance,
                         account.symbol,


### PR DESCRIPTION
## Description

- do not change EVM balance until tx is mined
- discard pending tx if mined tx with same nonce already exists
  - I agree it should be handled on Blockbook but on all accounts after new txs it would have to check if there is anything in mempool, too performance heavy. Pending txs from mempool are droppped after 1 hour - 2 days

## Related Issue

Resolve #13614
Resolve #15823 (no really needed anymore)
Does not solve https://github.com/trezor/trezor-suite/issues/20595
Resolve [#8439](https://github.com/trezor/trezor-suite/issues/8439)

one of cases https://satoshilabs.slack.com/archives/CKZHV2G13/p1756239926134719

## Screenshots:
Whole balance sent, pending tx, low fee

<img width="1415" height="798" alt="Screenshot 2025-08-28 at 10 10 46" src="https://github.com/user-attachments/assets/2910d3c5-93a1-4543-8107-72fedb1e6d07" />

Whole balance sent from rabby with normal fee
<img width="399" height="230" alt="Screenshot 2025-08-28 at 10 10 54" src="https://github.com/user-attachments/assets/c74f4eb1-a4d5-4e12-8827-3f38334d9385" />

Pending tx is filtered
<img width="1408" height="601" alt="Screenshot 2025-08-28 at 10 11 00" src="https://github.com/user-attachments/assets/432dc583-6537-4ea0-a110-f069954f4642" />

but still available on blockbook
<img width="774" height="921" alt="Screenshot 2025-08-28 at 10 12 35" src="https://github.com/user-attachments/assets/aae8ce0c-8a52-42b2-9e3e-1caef4a73c55" />

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/evm-negative-balances&lookback=7)