### PR TITLE
chore(suite-native): fill in missing translations

### DIFF
--- a/suite-native/accounts/src/components/AccountsSearchForm.tsx
+++ b/suite-native/accounts/src/components/AccountsSearchForm.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import Animated, { FadeIn, FadeOut, SlideInLeft, SlideOutLeft } from 'react-native-reanimated';
 
 import { Box, HStack, SearchInput, TextButton } from '@suite-native/atoms';
+import { Translation, useTranslate } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type AccountsSearchFormProps = {
@@ -24,6 +25,7 @@ const cancelButtonContainerStyle = prepareNativeStyle(() => ({
 }));
 
 export const AccountsSearchForm = ({ onPressCancel, onInputChange }: AccountsSearchFormProps) => {
+    const { translate } = useTranslate();
     const { applyStyle } = useNativeStyles();
 
     const [inputText, setInputText] = useState('');
@@ -55,14 +57,16 @@ export const AccountsSearchForm = ({ onPressCancel, onInputChange }: AccountsSea
                     style={applyStyle(searchFormInputStyle)}
                 >
                     <SearchInput
-                        placeholder="Search assets"
+                        placeholder={translate('accounts.searchForm.placeholder')}
                         onChange={setInputText}
                         maxLength={MAX_SEARCH_VALUE_LENGTH}
                     />
                 </Animated.View>
 
                 <Box style={applyStyle(cancelButtonContainerStyle)}>
-                    <TextButton onPress={onPressCancel}>Cancel</TextButton>
+                    <TextButton onPress={onPressCancel}>
+                        <Translation id="generic.buttons.cancel" />
+                    </TextButton>
                 </Box>
             </HStack>
         </Animated.View>

--- a/suite-native/atoms/src/TrezorSuiteLiteHeader.tsx
+++ b/suite-native/atoms/src/TrezorSuiteLiteHeader.tsx
@@ -11,20 +11,6 @@ export const TrezorSuiteLiteHeader = ({
     textVariant = 'titleSmall',
 }: TrezorSuiteLiteHeaderProps) => (
     <Text variant={textVariant} color="textSecondaryHighlight" textAlign="center">
-        <Translation
-            id="generic.header"
-            values={{
-                green: chunks => (
-                    <Text variant={textVariant} color="textSecondaryHighlight">
-                        {chunks}
-                    </Text>
-                ),
-                grey: chunks => (
-                    <Text variant={textVariant} color="textSubdued">
-                        {chunks}
-                    </Text>
-                ),
-            }}
-        />
+        <Translation id="generic.trezorSuiteLite" />
     </Text>
 );

--- a/suite-native/bluetooth/src/components/BluetoothDeviceCard.tsx
+++ b/suite-native/bluetooth/src/components/BluetoothDeviceCard.tsx
@@ -49,7 +49,10 @@ export const BluetoothDeviceCard = ({
             <Box alignItems="center">
                 <Text variant="titleSmall">{modelConfig.name}</Text>
                 <Text variant="hint" color="textSubdued">
-                    {modelConfig.colors[deviceColor] ?? 'Unknown'} • {device.name}
+                    {modelConfig.colors[deviceColor] ?? (
+                        <Translation id="bluetooth.deviceCard.unknownColor" />
+                    )}{' '}
+                    • {device.name}
                 </Text>
             </Box>
             <Button

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -7,7 +7,6 @@ export const en = {
     generic: {
         trezorSuite: 'Trezor Suite',
         trezorSuiteLite: 'Trezor Suite Lite',
-        header: '<grey>About</grey> <green>Trezor Suite Lite</green>',
         buttons: {
             back: 'Back',
             cancel: 'Cancel',
@@ -136,6 +135,9 @@ export const en = {
         accountLabelFieldHint: {
             letterCount: '{current} / {max} letters',
         },
+        searchForm: {
+            placeholder: 'Search assets',
+        },
     },
     accountList: {
         numberOfTokens: '+{numberOfTokens, plural, one{1 Token} other{# Tokens}}',
@@ -187,6 +189,7 @@ export const en = {
         deviceCard: {
             connect: { actionButton: 'Connect' },
             remove: { actionButton: 'Pair again' },
+            unknownColor: 'Unknown',
         },
     },
     moduleAccountImport: {
@@ -227,6 +230,10 @@ export const en = {
                     address: 'Address is not valid',
                 },
             },
+            scanButton: {
+                xpub: 'Scan public key (XPUB)',
+                address: 'Scan receive address',
+            },
             hintBottomSheet: {
                 title: {
                     xpub: 'Where is my public key (XPUB)?',
@@ -237,6 +244,13 @@ export const en = {
                     address:
                         'To view the receive address of your account, open the Trezor Suite desktop app, plugin your Trezor device, select <emphasized>Accounts</emphasized>, choose <emphasized>Receive</emphasized>, and click on <emphasized>Show full address</emphasized>.',
                 },
+            },
+        },
+        accountImportLoaderScreen: {
+            loaderState: {
+                balances: 'Retrieving Balances',
+                assets: 'Confirming assets',
+                transactions: 'Checking transactions',
             },
         },
     },
@@ -1502,6 +1516,12 @@ export const en = {
                 title: 'Rename coin',
                 coinLabel: 'Coin label',
             },
+            removeAccountAlert: {
+                title: 'Do you really want to remove this coin from {trezorSuiteLiteHeader}?',
+                description:
+                    'Your coins remain intact and safe. Import this coin again using your public key (XPUB) or receive address at any time.',
+                primaryButton: 'Remove coin',
+            },
         },
         accountDetailContentScreen: {
             coinPriceCard: {
@@ -1579,6 +1599,36 @@ export const en = {
             stakeRegistration: 'Registration of a stake address',
             stakeDeregistration: 'Deregistration of a stake address',
         },
+        TransactionDetailScreen: {
+            inputsSheet: {
+                inputs: 'Inputs {inputsCount}',
+                outputs: 'Outputs {outputsCount}',
+                internalTransfers: 'Internal transfers',
+                tokenTransfers: 'Token transfers',
+            },
+            valuesSheet: {
+                today: 'Today {percentageDifference}',
+                transaction: 'Transaction',
+                input: 'Input',
+                fee: 'Output',
+                total: 'Total',
+            },
+            parametersSheet: {
+                confirmations: 'Confirmations',
+                feeRate: 'Fee rate',
+                rbf: 'RBF',
+                lockTime: 'Lock time',
+                broadcast: 'Broadcast',
+                transactionId: 'Transaction ID',
+                transactionIdCopied: 'Transaction ID copied',
+            },
+            addressesSheet: {
+                from: 'From {count}',
+                to: 'To {count}',
+                copied: 'Address copied to clipboard',
+            },
+            unknownTarget: 'Target or Origin of transaction is unknown.',
+        },
     },
     device: {
         title: {
@@ -1630,12 +1680,23 @@ export const en = {
         goToAccessories: 'Get swag for your device @ Trezor Shop',
     },
     qrCode: {
+        scanner: 'QR code scanner',
         addressCopied: 'Address copied',
         copyButton: 'Copy',
         shareButton: 'Share',
         qrCodeHint: 'Point the camera directly at the QR code',
         pickImageButton: 'Upload from gallery',
         pickImageError: 'QR code not found in the image.',
+        cautionWarning: {
+            title: 'Handle your public key (XPUB) with caution',
+            subtitle:
+                'Sharing your public key (XPUB) with a third party gives them the ability to view your transaction history.',
+        },
+        deniedWarning: {
+            title: 'Camera access denied.',
+            description: 'Please allow camera access in your device settings.',
+            grantPermissionButton: 'Grant permission',
+        },
     },
     graph: {
         retrievingData: 'Retrieving data...',
@@ -2194,6 +2255,7 @@ export const en = {
             },
             timeAt: '{date} at {time}',
             status: {
+                badge: 'Trade status badge',
                 loginRequest: 'Pending',
                 requesting: 'Requesting',
                 submitted: 'Submitted',
@@ -2295,6 +2357,13 @@ export const en = {
                 inputLabel: 'Slippage',
                 outOfRangeError: 'Slippage must be between 0.01% and 50%',
             },
+        },
+    },
+    notifications: {
+        transaction: {
+            incoming: 'Incoming transaction',
+            confirmed: 'Received transaction',
+            sending: 'Sending transaction',
         },
     },
     firmware: {

--- a/suite-native/module-accounts-import/src/components/AccountImportLoader.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportLoader.tsx
@@ -7,6 +7,7 @@ import Animated, {
 } from 'react-native-reanimated';
 
 import { Box, Spinner, SpinnerLoadingState, Text } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 const LINE_VISIBILITY_DURATION = 1000;
@@ -81,7 +82,7 @@ export const AccountImportLoader = ({ loadingState, onComplete }: AccountImportL
                             setLineHeight1(event.nativeEvent.layout.y);
                         }}
                     >
-                        Retrieving Balances
+                        <Translation id="moduleAccountImport.accountImportLoaderScreen.loaderState.balances" />
                     </Text>
                     <Text
                         variant="titleSmall"
@@ -90,7 +91,7 @@ export const AccountImportLoader = ({ loadingState, onComplete }: AccountImportL
                             setLineHeight2(event.nativeEvent.layout.y);
                         }}
                     >
-                        Confirming assets
+                        <Translation id="moduleAccountImport.accountImportLoaderScreen.loaderState.assets" />
                     </Text>
                     <Text
                         variant="titleSmall"
@@ -99,7 +100,7 @@ export const AccountImportLoader = ({ loadingState, onComplete }: AccountImportL
                             setLineHeight3(event.nativeEvent.layout.y);
                         }}
                     >
-                        Checking transactions
+                        <Translation id="moduleAccountImport.accountImportLoaderScreen.loaderState.transactions" />
                     </Text>
                 </Animated.View>
             </Box>

--- a/suite-native/module-accounts-import/src/components/XpubImportSection.tsx
+++ b/suite-native/module-accounts-import/src/components/XpubImportSection.tsx
@@ -1,5 +1,6 @@
 import { type NetworkSymbol, type NetworkType, getNetworkType } from '@suite-common/wallet-config';
 import { Box, Button } from '@suite-native/atoms';
+import { Translation, TxKeyPath } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { QrWithLaser } from './QRWithLaser';
@@ -17,20 +18,20 @@ const importSectionWrapperStyle = prepareNativeStyle(_ => ({
     width: '100%',
 }));
 
-export const networkTypeToTitleMap: Record<NetworkType, string> = {
-    bitcoin: 'Scan public key (XPUB)',
-    cardano: 'Scan public key (XPUB)',
-    ethereum: 'Scan receive address',
-    ripple: 'Scan receive address',
-    solana: 'Scan receive address',
-    stellar: 'Scan receive address',
+export const networkTypeToTitleTxKeyMap: Record<NetworkType, TxKeyPath> = {
+    bitcoin: 'moduleAccountImport.xpubScanScreen.scanButton.xpub',
+    cardano: 'moduleAccountImport.xpubScanScreen.scanButton.xpub',
+    ethereum: 'moduleAccountImport.xpubScanScreen.scanButton.address',
+    ripple: 'moduleAccountImport.xpubScanScreen.scanButton.address',
+    solana: 'moduleAccountImport.xpubScanScreen.scanButton.address',
+    stellar: 'moduleAccountImport.xpubScanScreen.scanButton.address',
 };
 
 export const XpubImportSection = ({ onRequestCamera, symbol }: XpubImportSectionProps) => {
     const { applyStyle } = useNativeStyles();
 
     const networkType = getNetworkType(symbol);
-    const buttonTitle = networkTypeToTitleMap[networkType];
+    const buttonTitleTxKey = networkTypeToTitleTxKeyMap[networkType];
 
     return (
         <Box style={applyStyle(importSectionWrapperStyle)}>
@@ -38,7 +39,7 @@ export const XpubImportSection = ({ onRequestCamera, symbol }: XpubImportSection
                 <QrWithLaser />
             </Box>
             <Button size="large" onPress={onRequestCamera}>
-                {buttonTitle}
+                <Translation id={buttonTitleTxKey} />
             </Button>
         </Box>
     );

--- a/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
@@ -30,7 +30,7 @@ import { AccountImportScreenHeader } from '../components/AccountImportScreenHead
 import { DevXpub } from '../components/DevXpub';
 import { XpubHint } from '../components/XpubHint';
 import { XpubHintBottomSheet } from '../components/XpubHintBottomSheet';
-import { XpubImportSection, networkTypeToTitleMap } from '../components/XpubImportSection';
+import { XpubImportSection, networkTypeToTitleTxKeyMap } from '../components/XpubImportSection';
 
 const FORM_BUTTON_FADE_IN_DURATION = 200;
 
@@ -204,7 +204,7 @@ export const XpubScanScreen = ({
                                     onPress={onXpubFormSubmit}
                                     size="large"
                                 >
-                                    Confirm
+                                    <Translation id="generic.buttons.confirm" />
                                 </Button>
                             </Animated.View>
                         )}
@@ -220,7 +220,7 @@ export const XpubScanScreen = ({
                 handleClose={closeXpubHint}
             />
             <ScanQRBottomSheet
-                title={networkTypeToTitleMap[networkType]}
+                title={<Translation id={networkTypeToTitleTxKeyMap[networkType]} />}
                 onCodeScanned={handleBarCodeScanned}
                 ref={scannerRef}
                 onClose={closeScanner}

--- a/suite-native/module-accounts-management/src/components/AccountRenameForm.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountRenameForm.tsx
@@ -15,7 +15,7 @@ import {
 } from '@suite-native/accounts';
 import { Box, Button, InputType, VStack } from '@suite-native/atoms';
 import { Form, TextInputField } from '@suite-native/forms';
-import { useTranslate } from '@suite-native/intl';
+import { Translation, useTranslate } from '@suite-native/intl';
 
 type AccountRenameFormProps = {
     accountKey: string;
@@ -82,7 +82,7 @@ export const AccountRenameForm = ({ accountKey, onSubmit }: AccountRenameFormPro
                         isDisabled={!isValid}
                         testID="@account-detail/settings/account-rename/confirm-button"
                     >
-                        Confirm
+                        <Translation id="generic.buttons.confirm" />
                     </Button>
                 </VStack>
             </Form>

--- a/suite-native/module-accounts-management/src/components/AccountSettingsRemoveCoinButton.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountSettingsRemoveCoinButton.tsx
@@ -4,6 +4,7 @@ import { AccountsRootState, accountsActions, selectAccountByKey } from '@suite-c
 import { AccountKey } from '@suite-common/wallet-types';
 import { useAlert } from '@suite-native/alerts';
 import { Button, TrezorSuiteLiteHeader } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
 import { useNavigateToInitialScreen } from '@suite-native/navigation';
 
 type AccountSettingsRemoveCoinButtonProps = {
@@ -32,16 +33,20 @@ export const AccountSettingsRemoveCoinButton = ({
         showAlert({
             pictogramVariant: 'critical',
             title: (
-                <>
-                    Do you really want to remove this coin from <TrezorSuiteLiteHeader />?
-                </>
+                <Translation
+                    id="moduleAccountManagement.accountSettingsScreen.removeAccountAlert.title"
+                    values={{ trezorSuiteLiteHeader: <TrezorSuiteLiteHeader /> }}
+                />
             ),
-            description:
-                'Your coins remain intact and safe. Import this coin again using your public key (XPUB) or receive address at any time.',
-            primaryButtonTitle: 'Remove coin',
+            description: (
+                <Translation id="moduleAccountManagement.accountSettingsScreen.removeAccountAlert.description" />
+            ),
+            primaryButtonTitle: (
+                <Translation id="moduleAccountManagement.accountSettingsScreen.removeAccountAlert.primaryButton" />
+            ),
             primaryButtonVariant: 'redBold',
             onPressPrimaryButton: handleRemoveAccount,
-            secondaryButtonTitle: 'Cancel',
+            secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
             secondaryButtonVariant: 'redElevation0',
             onPressSecondaryButton: () => hideAlert(),
         });
@@ -54,7 +59,7 @@ export const AccountSettingsRemoveCoinButton = ({
             colorScheme="redElevation0"
             testID="@account-detail/settings/remove-coin-button"
         >
-            Remove coin
+            <Translation id="moduleAccountManagement.accountSettingsScreen.removeAccountAlert.primaryButton" />
         </Button>
     );
 };

--- a/suite-native/module-trading/src/components/history/TradeStatusBadge.tsx
+++ b/suite-native/module-trading/src/components/history/TradeStatusBadge.tsx
@@ -1,7 +1,7 @@
 import { TradingTransactionStatus } from '@suite-common/trading';
 import { Badge, BadgeVariant } from '@suite-native/atoms';
 import { IconName } from '@suite-native/icons';
-import { Translation } from '@suite-native/intl';
+import { Translation, useTranslate } from '@suite-native/intl';
 import { exhaustive } from '@trezor/type-utils';
 
 export type TransactionStatusProps = {
@@ -98,6 +98,7 @@ const getLabel = (status: TradingTransactionStatus) => {
 };
 
 export const TradeStatusBadge = ({ status }: TransactionStatusProps) => {
+    const { translate } = useTranslate();
     if (!status) {
         return null;
     }
@@ -108,7 +109,7 @@ export const TradeStatusBadge = ({ status }: TransactionStatusProps) => {
             size="small"
             variant={getBadgeVariant(status)}
             icon={getBadgeIconName(status)}
-            accessibilityHint="Trade status badge"
+            accessibilityHint={translate('moduleTrading.tradeHistory.status.badge')}
         />
     );
 };

--- a/suite-native/notifications/src/components/TransactionNotification.tsx
+++ b/suite-native/notifications/src/components/TransactionNotification.tsx
@@ -19,6 +19,7 @@ import {
 } from '@suite-common/wallet-core';
 import { TransactionType } from '@suite-common/wallet-types';
 import { Icon } from '@suite-native/icons';
+import { TxKeyPath, useTranslate } from '@suite-native/intl';
 import {
     RootStackParamList,
     RootStackRoutes,
@@ -35,7 +36,7 @@ type TransactionNotificationProps = {
 };
 
 type TransactionTypeProperties = {
-    title?: string;
+    titleTxKey?: TxKeyPath;
     prefix?: string;
     transactionType: TransactionType;
     isIconAnimated: boolean;
@@ -43,19 +44,19 @@ type TransactionTypeProperties = {
 
 const transactionTypeToContentMap = {
     'tx-received': {
-        title: 'Incoming transaction',
+        titleTxKey: 'notifications.transaction.incoming',
         prefix: 'from',
         transactionType: 'recv',
         isIconAnimated: true,
     },
     'tx-confirmed': {
-        title: 'Received transaction',
+        titleTxKey: 'notifications.transaction.confirmed',
         prefix: 'from',
         transactionType: 'recv',
         isIconAnimated: false,
     },
     'tx-sent': {
-        title: 'Sending transaction',
+        titleTxKey: 'notifications.transaction.sending',
         prefix: 'to',
         transactionType: 'sent',
         isIconAnimated: true,
@@ -66,6 +67,7 @@ export const TransactionNotification = ({
     notificationId,
     isHiddenAutomatically = true,
 }: TransactionNotificationProps) => {
+    const { translate } = useTranslate();
     const navigation =
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AppTabs>>();
     const dispatch = useDispatch();
@@ -95,7 +97,7 @@ export const TransactionNotification = ({
 
     if (!accountKey || !notification || !transactionTargetAddress) return null;
 
-    const { title, prefix, transactionType, isIconAnimated } =
+    const { titleTxKey, prefix, transactionType, isIconAnimated } =
         transactionTypeToContentMap[notification.type];
 
     const navigateToTransactionDetail = () => {
@@ -111,7 +113,7 @@ export const TransactionNotification = ({
             isHiddenAutomatically={isHiddenAutomatically}
             onHide={handleRemoveNotification}
             onPress={navigateToTransactionDetail}
-            title={title}
+            title={translate(titleTxKey)}
             description={
                 <TransactionNotificationDescription
                     amount={transaction?.amount ?? null}

--- a/suite-native/qr-code/src/components/CameraPermissionError.tsx
+++ b/suite-native/qr-code/src/components/CameraPermissionError.tsx
@@ -1,6 +1,7 @@
 import { Linking } from 'react-native';
 
 import { Box, Button, Text } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 const permissionTextContainerStyle = prepareNativeStyle(({ spacings }) => ({
@@ -20,14 +21,18 @@ export const CameraPermissionError = () => {
 
     return (
         <Box style={applyStyle(permissionTextContainerStyle)}>
-            <Text textAlign="center">Camera access denied.</Text>
-            <Text textAlign="center">Please allow camera access in your device settings.</Text>
+            <Text textAlign="center">
+                <Translation id="qrCode.deniedWarning.title" />
+            </Text>
+            <Text textAlign="center">
+                <Translation id="qrCode.deniedWarning.description" />
+            </Text>
 
             <Button
                 onPress={navigateToSystemSettings}
                 style={applyStyle(grantPermissionButtonStyle)}
             >
-                Grant permission
+                <Translation id="qrCode.deniedWarning.grantPermissionButton" />
             </Button>
         </Box>
     );

--- a/suite-native/qr-code/src/components/QRCodeScanner.tsx
+++ b/suite-native/qr-code/src/components/QRCodeScanner.tsx
@@ -5,7 +5,7 @@ import { BarcodeScanningResult, CameraView, PermissionStatus } from 'expo-camera
 
 import { Box, HStack, Loader, Text, VStack } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
-import { Translation } from '@suite-native/intl';
+import { Translation, useTranslate } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { nativeSpacings } from '@trezor/theme';
 
@@ -29,6 +29,7 @@ const cameraStyle = prepareNativeStyle(() => ({
 }));
 
 export const QRCodeScanner = ({ onCodeScanned }: QRCodeScannerProps) => {
+    const { translate } = useTranslate();
     const { applyStyle } = useNativeStyles();
     const { cameraPermissionStatus } = useCameraPermission();
 
@@ -85,7 +86,7 @@ export const QRCodeScanner = ({ onCodeScanned }: QRCodeScannerProps) => {
                             barcodeScannerSettings={{
                                 barcodeTypes: ['qr'],
                             }}
-                            accessibilityLabel="QR code scanner"
+                            accessibilityLabel={translate('qrCode.scanner')}
                         />
                     </Box>
                 </VStack>

--- a/suite-native/qr-code/src/components/XpubQRCodeWarningOverlay.tsx
+++ b/suite-native/qr-code/src/components/XpubQRCodeWarningOverlay.tsx
@@ -1,4 +1,5 @@
 import { Box, PictogramTitleHeader } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 const overlayStyle = prepareNativeStyle(utils => ({
@@ -14,9 +15,8 @@ export const XpubOverlayWarning = () => {
         <Box style={applyStyle(overlayStyle)}>
             <PictogramTitleHeader
                 variant="warning"
-                title="Handle your public key (XPUB) with caution"
-                subtitle="Sharing your public key (XPUB) with a third party gives them the ability to
-                        view your transaction history."
+                title={<Translation id="qrCode.cautionWarning.title" />}
+                subtitle={<Translation id="qrCode.cautionWarning.subtitle" />}
             />
         </Box>
     );

--- a/suite-native/transactions/src/components/TransactionDetail/NetworkTransactionDetailSummary.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/NetworkTransactionDetailSummary.tsx
@@ -9,6 +9,7 @@ import {
 } from '@suite-common/wallet-core';
 import { AccountKey } from '@suite-common/wallet-types';
 import { Box, ErrorMessage, VStack } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { TransactionDetailAddressesSection } from './TransactionDetailAddressesSection';
@@ -75,7 +76,13 @@ export const NetworkTransactionDetailSummary = ({
     );
 
     if (!transaction) {
-        return <ErrorMessage errorMessage="Target or Origin of transaction is unknown." />;
+        return (
+            <ErrorMessage
+                errorMessage={
+                    <Translation id="transactions.TransactionDetailScreen.unknownTarget" />
+                }
+            />
+        );
     }
 
     return (

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailAddressesSection.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailAddressesSection.tsx
@@ -6,11 +6,11 @@ import { TokenAddress } from '@suite-common/wallet-types';
 import { Box, CardDivider, Text, VStack } from '@suite-native/atoms';
 import { AccountAddressFormatter } from '@suite-native/formatters';
 import { CryptoIconWithNetwork } from '@suite-native/icons';
-import { Translation } from '@suite-native/intl';
+import { Translation, TxKeyPath } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { ChangeAddressesHeader } from './ChangeAddressesHeader';
-import { formatAddressLabel } from './TransactionDetailAddressesSheet';
+import { formatAddressesCount } from './TransactionDetailAddressesSheet';
 import { SummaryRow } from './TransactionSummaryRow';
 import { VinVoutAddress } from '../../types';
 
@@ -85,7 +85,10 @@ export const TransactionDetailAddressesSection = ({
         [addresses],
     );
 
-    const formattedTitle = formatAddressLabel(addressesType, targetAddresses.length);
+    const titleTxKey: TxKeyPath =
+        addressesType === 'inputs'
+            ? 'transactions.TransactionDetailScreen.addressesSheet.from'
+            : 'transactions.TransactionDetailScreen.addressesSheet.to';
 
     const isShowMoreButtonVisible = addresses.length > 2;
     const hiddenAddressesCount = targetAddresses.length - 2;
@@ -97,7 +100,10 @@ export const TransactionDetailAddressesSection = ({
                 <Box flexDirection="row" justifyContent="space-between" alignItems="center">
                     <Box>
                         <Text color="textSubdued" variant="hint">
-                            {formattedTitle}
+                            <Translation
+                                id={titleTxKey}
+                                values={{ count: formatAddressesCount(targetAddresses.length) }}
+                            />
                         </Text>
                         {targetAddresses.slice(0, 2).map(({ address }) => (
                             <AccountAddressFormatter

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailAddressesSheet.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailAddressesSheet.tsx
@@ -19,6 +19,7 @@ import {
 } from '@suite-native/atoms';
 import { useCopyToClipboard } from '@suite-native/helpers';
 import { Icon } from '@suite-native/icons';
+import { Translation, useTranslate } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { ChangeAddressesHeader } from './ChangeAddressesHeader';
@@ -40,20 +41,24 @@ const copyContainerStyle = prepareNativeStyle(utils => ({
     marginHorizontal: utils.spacings.sp8,
 }));
 
-export const formatAddressLabel = (addressType: AddressesType, count: number) => {
-    const labelPrefix = addressType === 'inputs' ? 'From' : 'To';
+export const formatAddressesCount = (count: number) => {
     if (count > 1) {
-        return `${labelPrefix} · ${count}`;
+        return `· ${count}`;
     }
 
-    return labelPrefix;
+    return '';
 };
 
 const AddressRow = ({ address }: { address: string }) => {
+    const { translate } = useTranslate();
     const { applyStyle } = useNativeStyles();
     const copyToClipboard = useCopyToClipboard();
 
-    const handleCopy = () => copyToClipboard(address, 'Address copied to clipboard');
+    const handleCopy = () =>
+        copyToClipboard(
+            address,
+            translate('transactions.TransactionDetailScreen.addressesSheet.copied'),
+        );
 
     return (
         <Box flex={1} flexDirection="row" justifyContent="space-between" alignItems="flex-start">
@@ -120,8 +125,18 @@ export const TransactionDetailAddressesSheet = ({
                 <Toggle
                     isToggled={displayedAddressesType === 'outputs'}
                     onToggle={toggleAddresses}
-                    leftLabel={formatAddressLabel('inputs', inputAddresses.length)}
-                    rightLabel={formatAddressLabel('outputs', outputAddresses.length)}
+                    leftLabel={
+                        <Translation
+                            id="transactions.TransactionDetailScreen.addressesSheet.from"
+                            values={{ count: formatAddressesCount(inputAddresses.length) }}
+                        />
+                    }
+                    rightLabel={
+                        <Translation
+                            id="transactions.TransactionDetailScreen.addressesSheet.to"
+                            values={{ count: formatAddressesCount(outputAddresses.length) }}
+                        />
+                    }
                 />
                 <Box marginVertical="sp16">
                     <VStack spacing="sp16">
@@ -136,7 +151,7 @@ export const TransactionDetailAddressesSheet = ({
                     </VStack>
                     <Box marginTop="sp24" paddingHorizontal="sp8">
                         <Button size="large" onPress={onClose}>
-                            Close
+                            <Translation id="generic.buttons.close" />
                         </Button>
                     </Box>
                 </Box>

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailInputsSheet.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailInputsSheet.tsx
@@ -7,7 +7,7 @@ import { TransactionsRootState } from '@suite-common/wallet-core';
 import { AccountKey } from '@suite-common/wallet-types';
 import { Box, Text, VStack } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
-import { useTranslate } from '@suite-native/intl';
+import { Translation, useTranslate } from '@suite-native/intl';
 
 import { TransactionDetailInputsSheetSection } from './TransactionDetailInputsSheetSection';
 import { TransactionDetailSheet } from './TransactionDetailSheet';
@@ -27,7 +27,10 @@ const InputsOutputsHeader = ({ inputsCount, outputsCount }: InputsOutputsHeaderP
     <Box flexDirection="row" justifyContent="space-between" marginBottom="sp16">
         <Box flex={1} flexDirection="row" alignItems="center" paddingLeft="sp8">
             <Text variant="hint" color="textSubdued">
-                Inputs · {inputsCount}
+                <Translation
+                    id="transactions.TransactionDetailScreen.inputsSheet.inputs"
+                    values={{ inputsCount: `· ${inputsCount}` }}
+                />
             </Text>
             <Box marginLeft="sp8">
                 <Icon name="arrowLineDown" color="iconSubdued" size="medium" />
@@ -36,7 +39,10 @@ const InputsOutputsHeader = ({ inputsCount, outputsCount }: InputsOutputsHeaderP
 
         <Box flex={1} flexDirection="row" alignItems="center" paddingLeft="sp24">
             <Text variant="hint" color="textSubdued">
-                Outputs · {outputsCount}
+                <Translation
+                    id="transactions.TransactionDetailScreen.inputsSheet.outputs"
+                    values={{ outputsCount: `· ${outputsCount}` }}
+                />
             </Text>
             <Box marginLeft="sp8">
                 <Icon name="arrowLineUp" color="iconSubdued" size="medium" />
@@ -89,12 +95,16 @@ export const TransactionDetailInputsSheet = ({
                 />
 
                 <TransactionDetailInputsSheetSection
-                    header="Internal Transfers"
+                    header={
+                        <Translation id="transactions.TransactionDetailScreen.inputsSheet.internalTransfers" />
+                    }
                     transfers={internalTransfers}
                 />
 
                 <TransactionDetailInputsSheetSection
-                    header="Token Transfers"
+                    header={
+                        <Translation id="transactions.TransactionDetailScreen.inputsSheet.tokenTransfers" />
+                    }
                     transfers={tokenTransfers}
                 />
             </VStack>

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailParametersSheet.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailParametersSheet.tsx
@@ -76,7 +76,11 @@ export const TransactionDetailParametersSheet = ({
     const displayedParameters = networkTypeToDisplayedParametersMap[networkType];
     const parametersCardIsDisplayed = displayedParameters.length !== 0;
 
-    const handleClickCopy = () => copyToClipboard(transaction.txid, 'Transaction ID copied');
+    const handleClickCopy = () =>
+        copyToClipboard(
+            transaction.txid,
+            translate('transactions.TransactionDetailScreen.parametersSheet.transactionIdCopied'),
+        );
 
     return (
         <TransactionDetailSheet
@@ -87,7 +91,11 @@ export const TransactionDetailParametersSheet = ({
         >
             <VStack>
                 <Card>
-                    <TransactionDetailRow title="Transaction ID">
+                    <TransactionDetailRow
+                        title={translate(
+                            'transactions.TransactionDetailScreen.parametersSheet.transactionId',
+                        )}
+                    >
                         <Box
                             flexDirection="row"
                             alignItems="center"
@@ -107,7 +115,11 @@ export const TransactionDetailParametersSheet = ({
                             </Box>
                         </Box>
                     </TransactionDetailRow>
-                    <TransactionDetailRow title="Confirmations">
+                    <TransactionDetailRow
+                        title={translate(
+                            'transactions.TransactionDetailScreen.parametersSheet.confirmations',
+                        )}
+                    >
                         <Text>
                             <ConfirmationsCount txid={transaction.txid} accountKey={accountKey} />
                         </Text>
@@ -124,22 +136,38 @@ export const TransactionDetailParametersSheet = ({
                                 <EthereumParameters transaction={transaction} />
                             )}
                         {displayedParameters.includes('feeRate') && (
-                            <TransactionDetailRow title="Fee rate">
+                            <TransactionDetailRow
+                                title={translate(
+                                    'transactions.TransactionDetailScreen.parametersSheet.feeRate',
+                                )}
+                            >
                                 <FeeFormatter transaction={transaction} />
                             </TransactionDetailRow>
                         )}
                         {transaction.symbol === 'btc' && (
-                            <TransactionDetailRow title="RBF">
+                            <TransactionDetailRow
+                                title={translate(
+                                    'transactions.TransactionDetailScreen.parametersSheet.rbf',
+                                )}
+                            >
                                 {getEnabledTitle(!!transaction.rbf)}
                             </TransactionDetailRow>
                         )}
                         {displayedParameters.includes('broadcast') && (
-                            <TransactionDetailRow title="Broadcast">
+                            <TransactionDetailRow
+                                title={translate(
+                                    'transactions.TransactionDetailScreen.parametersSheet.broadcast',
+                                )}
+                            >
                                 {getEnabledTitle(!!transaction.blockHeight)}
                             </TransactionDetailRow>
                         )}
                         {displayedParameters.includes('lockTime') && (
-                            <TransactionDetailRow title="Locktime">
+                            <TransactionDetailRow
+                                title={translate(
+                                    'transactions.TransactionDetailScreen.parametersSheet.lockTime',
+                                )}
+                            >
                                 {getEnabledTitle(!!transaction.lockTime)}
                             </TransactionDetailRow>
                         )}

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailSheet.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailSheet.tsx
@@ -4,6 +4,7 @@ import { TouchableOpacity } from 'react-native-gesture-handler';
 import { EventType, analytics } from '@suite-native/analytics';
 import { BottomSheetModal, Box, Button, Text, useBottomSheetModal } from '@suite-native/atoms/src';
 import { Icon, IconName } from '@suite-native/icons';
+import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles/src';
 
 type TransactionDetailSheetProps = {
@@ -84,7 +85,7 @@ export const TransactionDetailSheet = ({
                     {children}
                     <Box paddingHorizontal="sp8" marginTop="sp24">
                         <Button size="large" onPress={closeModal}>
-                            Close
+                            <Translation id="generic.buttons.close" />
                         </Button>
                     </Box>
                 </Box>

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailValuesSheet.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailValuesSheet.tsx
@@ -17,7 +17,7 @@ import {
     CryptoToFiatAmountFormatter,
     PercentageDifferenceFormatter,
 } from '@suite-native/formatters';
-import { useTranslate } from '@suite-native/intl';
+import { Translation, useTranslate } from '@suite-native/intl';
 
 import { TransactionDetailSheet } from './TransactionDetailSheet';
 
@@ -59,11 +59,17 @@ const TodayHeaderCell = ({ cryptoValue, symbol, historicRate }: TodayHeaderCellP
 
     return (
         <Text variant="hint" color="textSubdued">
-            Today{' '}
-            <PercentageDifferenceFormatter
-                oldValue={fiatTotalHistoryNumeric}
-                newValue={fiatTotalActualNumeric}
-                variant="hint"
+            <Translation
+                id="transactions.TransactionDetailScreen.valuesSheet.today"
+                values={{
+                    percentageDifference: (
+                        <PercentageDifferenceFormatter
+                            oldValue={fiatTotalHistoryNumeric}
+                            newValue={fiatTotalActualNumeric}
+                            variant="hint"
+                        />
+                    ),
+                }}
             />
         </Text>
     );
@@ -98,7 +104,9 @@ export const TransactionDetailValuesSheet = ({
                     <Table>
                         <Tr>
                             <Th />
-                            <Th>Transaction</Th>
+                            <Th>
+                                <Translation id="transactions.TransactionDetailScreen.valuesSheet.transaction" />
+                            </Th>
                             <Th>
                                 <TodayHeaderCell
                                     cryptoValue={transaction.amount}
@@ -109,7 +117,9 @@ export const TransactionDetailValuesSheet = ({
                         </Tr>
 
                         <Tr>
-                            <Th>Input</Th>
+                            <Th>
+                                <Translation id="transactions.TransactionDetailScreen.valuesSheet.input" />
+                            </Th>
                             <Td>
                                 <CryptoToFiatAmountFormatter
                                     variant="hint"
@@ -132,7 +142,9 @@ export const TransactionDetailValuesSheet = ({
                             </Td>
                         </Tr>
                         <Tr>
-                            <Th>Fee</Th>
+                            <Th>
+                                <Translation id="transactions.TransactionDetailScreen.valuesSheet.fee" />
+                            </Th>
                             <Td>
                                 <CryptoToFiatAmountFormatter
                                     variant="hint"
@@ -155,7 +167,9 @@ export const TransactionDetailValuesSheet = ({
                             </Td>
                         </Tr>
                         <Tr>
-                            <Th>Total</Th>
+                            <Th>
+                                <Translation id="transactions.TransactionDetailScreen.valuesSheet.total" />
+                            </Th>
                             <Td>
                                 <CryptoToFiatAmountFormatter
                                     variant="hint"


### PR DESCRIPTION
## Description
- [script](https://gist.github.com/PeKne/fe0fa1d8c70d088d2d748d09b043cefb) for printing out all the potentially translatable strings was created
  - this script uses babel parser to convert the code to the abstract syntax tree (in JSON format), then only JSX strings and general string literals were printed
- I went through all the string and replaced those that are user facing

## Related Issue

Resolve #21103 

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/fill-in-missing-translations&lookback=7)