### PR TITLE
feat(suite-native): show only pairable devices on the Turn on & unlock screen

### DIFF
--- a/suite-native/bluetooth/jest.config.js
+++ b/suite-native/bluetooth/jest.config.js
@@ -1,0 +1,5 @@
+const { ...baseConfig } = require('../../jest.config.native');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-native/bluetooth/src/__tests__/selectors.test.ts
+++ b/suite-native/bluetooth/src/__tests__/selectors.test.ts
@@ -1,0 +1,150 @@
+import { prepareInitialState } from '@suite-common/bluetooth';
+import { DeviceModelInternal } from '@trezor/device-utils';
+
+import { NativeBluetoothState } from '../bluetoothSlice';
+import {
+    selectHasKnownBluetoothDevices,
+    selectKnownConnectableBluetoothDevices,
+    selectNearbyBluetoothDevices,
+    selectNearbyPairableBluetoothDevices,
+} from '../selectors';
+import { BluetoothDevice } from '../types';
+
+const initialState: NativeBluetoothState = {
+    ...prepareInitialState<BluetoothDevice>(),
+    permissionStatus: 'granted',
+};
+
+const unknownDevice: BluetoothDevice = {
+    id: '4de11222-cef9-43fa-aee2-ffa77c697a29',
+    name: 'Disconnected TS7',
+    connectionStatus: { type: 'disconnected' },
+    lastUpdatedTimestamp: Date.now(),
+    manufacturerData: {
+        deviceModel: DeviceModelInternal.UNKNOWN,
+        deviceColor: 0,
+    },
+};
+
+const knownDevice: BluetoothDevice = {
+    id: '7a39820f-6387-4251-b066-46ed70d37d3f',
+    name: 'Disconnected TS7',
+    connectionStatus: { type: 'disconnected' },
+    lastUpdatedTimestamp: Date.now(),
+    manufacturerData: {
+        deviceModel: DeviceModelInternal.T3W1,
+        deviceColor: 1,
+        filterPolicy: {
+            pairing: false,
+            connected: false,
+            bond_memory_full: false,
+        },
+    },
+};
+const knownConnectingDevice: BluetoothDevice = {
+    ...knownDevice,
+    connectionStatus: { type: 'connecting' },
+};
+const knownPairableDevice: BluetoothDevice = {
+    ...knownDevice,
+    manufacturerData: {
+        ...knownDevice.manufacturerData,
+        filterPolicy: {
+            pairing: true,
+            connected: false,
+            bond_memory_full: false,
+        },
+    },
+};
+
+const pairableDevice: BluetoothDevice = {
+    id: '653ab4bc-d0b5-47d7-ab5d-ad834e4956f5',
+    name: 'Pairable TS7',
+    connectionStatus: { type: 'disconnected' },
+    lastUpdatedTimestamp: Date.now(),
+    manufacturerData: {
+        deviceModel: DeviceModelInternal.T3W1,
+        deviceColor: 1,
+        filterPolicy: {
+            pairing: true,
+            connected: false,
+            bond_memory_full: false,
+        },
+    },
+};
+
+describe('selectHasKnownBluetoothDevices', () => {
+    test.each([
+        ['empty known devices', [], false],
+        ['non-empty known devices', [knownDevice], true],
+    ])('returns correct value for %s', (_, knownDevices, expectedValue) => {
+        expect(
+            selectHasKnownBluetoothDevices({
+                bluetooth: {
+                    ...initialState,
+                    knownDevices,
+                },
+            }),
+        ).toStrictEqual(expectedValue);
+    });
+});
+
+describe('selectNearbyBluetoothDevices', () => {
+    test.each([
+        ['null nearby devices', null, []],
+        ['empty nearby devices', [], []],
+        ['non-empty nearby devices', [knownDevice, pairableDevice], [knownDevice, pairableDevice]],
+    ])('returns correct value for %s', (_, nearbyDevices, expectedDevices) => {
+        expect(
+            selectNearbyBluetoothDevices({
+                bluetooth: {
+                    ...initialState,
+                    nearbyDevices,
+                },
+            }),
+        ).toStrictEqual(expectedDevices);
+    });
+});
+
+describe('selectNearbyPairableBluetoothDevices', () => {
+    test.each([
+        ['null nearby devices', null, []],
+        ['empty nearby devices', [], []],
+        ['non-pairable nearby device', [knownDevice], []],
+        ['pairable nearby device', [pairableDevice], [pairableDevice]],
+        ['several nearby devices', [unknownDevice, knownDevice, pairableDevice], [pairableDevice]],
+    ])('returns correct value for %s', (_, nearbyDevices, expectedDevices) => {
+        expect(
+            selectNearbyPairableBluetoothDevices({
+                bluetooth: {
+                    ...initialState,
+                    nearbyDevices,
+                },
+            }),
+        ).toStrictEqual(expectedDevices);
+    });
+});
+
+describe('selectKnownConnectableBluetoothDevices', () => {
+    test.each([
+        ['null nearby devices', null, [knownDevice], []],
+        ['empty nearby devices', [], [knownDevice], []],
+        ['no known devices', [knownDevice], [], []],
+        [
+            'one known device',
+            [pairableDevice, knownDevice, knownConnectingDevice, knownPairableDevice],
+            [knownDevice],
+            [knownDevice],
+        ],
+    ])('returns correct value for %s', (_, nearbyDevices, knownDevices, expectedDevices) => {
+        expect(
+            selectKnownConnectableBluetoothDevices({
+                bluetooth: {
+                    ...initialState,
+                    nearbyDevices,
+                    knownDevices,
+                },
+            }),
+        ).toStrictEqual(expectedDevices);
+    });
+});

--- a/suite-native/bluetooth/src/bluetoothSlice.ts
+++ b/suite-native/bluetooth/src/bluetoothSlice.ts
@@ -11,7 +11,7 @@ import { bluetoothManager } from '@trezor/transport-native-bluetooth';
 
 import { BluetoothDevice, BluetoothPermissionStatus } from './types';
 
-type NativeBluetoothState = BluetoothState<BluetoothDevice> & {
+export type NativeBluetoothState = BluetoothState<BluetoothDevice> & {
     permissionStatus: BluetoothPermissionStatus;
 };
 

--- a/suite-native/bluetooth/src/selectors.ts
+++ b/suite-native/bluetooth/src/selectors.ts
@@ -28,22 +28,21 @@ export const selectNearbyBluetoothDevices = createMemoizedSelector(
     nearbyDevices => nearbyDevices ?? [],
 );
 
-export const selectUnknownNearbyBluetoothDevices = createMemoizedSelector(
-    [selectNearbyBluetoothDevices, selectKnownBluetoothDevices],
-    (nearbyBluetoothDevices, knownBluetoothDevices) =>
-        nearbyBluetoothDevices.filter(nearbyDevice =>
-            knownBluetoothDevices.every(knownDevice => nearbyDevice.id !== knownDevice.id),
+export const selectNearbyPairableBluetoothDevices = createMemoizedSelector(
+    [selectNearbyBluetoothDevices],
+    nearbyBluetoothDevices =>
+        nearbyBluetoothDevices.filter(
+            ({ manufacturerData }) => manufacturerData.filterPolicy?.pairing === true,
         ),
 );
 
 export const selectKnownConnectableBluetoothDevices = createMemoizedSelector(
     [selectNearbyBluetoothDevices, selectKnownBluetoothDevices],
     (nearbyBluetoothDevices, knownBluetoothDevices) =>
-        nearbyBluetoothDevices.filter(nearbyDevice =>
-            knownBluetoothDevices.some(
-                knownDevice =>
-                    nearbyDevice.id === knownDevice.id &&
-                    knownDevice.connectionStatus.type === 'disconnected',
-            ),
+        nearbyBluetoothDevices.filter(
+            ({ id, manufacturerData, connectionStatus }) =>
+                knownBluetoothDevices.some(knownDevice => knownDevice.id === id) &&
+                manufacturerData.filterPolicy?.pairing !== true &&
+                connectionStatus.type === 'disconnected',
         ),
 );

--- a/suite-native/module-authorize-device/src/screens/connect/ConnectBluetoothDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/ConnectBluetoothDeviceScreen.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 import {
     BluetoothDeviceList,
     selectNearbyBluetoothDevices,
-    selectUnknownNearbyBluetoothDevices,
+    selectNearbyPairableBluetoothDevices,
     useBluetoothDevice,
 } from '@suite-native/bluetooth';
 import {
@@ -28,7 +28,7 @@ export const ConnectBluetoothDeviceScreen = () => {
     const navigation = useNavigation<NavigationProps>();
 
     const nearbyBluetoothDevices = useSelector(selectNearbyBluetoothDevices);
-    const unknownNearbyBluetoothDevices = useSelector(selectUnknownNearbyBluetoothDevices);
+    const nearbyPairableBluetoothDevices = useSelector(selectNearbyPairableBluetoothDevices);
 
     useEffect(() => {
         if (nearbyBluetoothDevices.length === 0) {
@@ -40,7 +40,7 @@ export const ConnectBluetoothDeviceScreen = () => {
         <Screen header={<BluetoothDeviceScreenHeader />}>
             <BluetoothDeviceList
                 variant="connect"
-                devices={unknownNearbyBluetoothDevices}
+                devices={nearbyPairableBluetoothDevices}
                 onDeviceButtonPress={connectBluetoothDevice}
             />
         </Screen>

--- a/suite-native/module-authorize-device/src/screens/connect/TurnOnAndUnlockDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/TurnOnAndUnlockDeviceScreen.tsx
@@ -7,7 +7,7 @@ import { useAlert } from '@suite-native/alerts';
 import {
     selectBluetoothAdapterStatus,
     selectHasKnownBluetoothDevices,
-    selectUnknownNearbyBluetoothDevices,
+    selectNearbyPairableBluetoothDevices,
     useBluetoothManager,
 } from '@suite-native/bluetooth';
 import { TurnOnAndUnlockDeviceScreenContent } from '@suite-native/device';
@@ -37,7 +37,7 @@ export const TurnOnAndUnlockDeviceScreen = () => {
 
     const bluetoothAdapterStatus = useSelector(selectBluetoothAdapterStatus);
     const hasKnownBluetoothDevices = useSelector(selectHasKnownBluetoothDevices);
-    const unknownNearbyBluetoothDevices = useSelector(selectUnknownNearbyBluetoothDevices);
+    const nearbyPairableBluetoothDevices = useSelector(selectNearbyPairableBluetoothDevices);
 
     const navigateToConnectAndUnlockDeviceScreen = () => {
         navigation.replace(AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice);
@@ -91,11 +91,11 @@ export const TurnOnAndUnlockDeviceScreen = () => {
     );
 
     useEffect(() => {
-        if (unknownNearbyBluetoothDevices.length > 0) {
+        if (nearbyPairableBluetoothDevices.length > 0) {
             hideAlert();
             navigation.navigate(AuthorizeDeviceStackRoutes.ConnectBluetoothDevice);
         }
-    }, [unknownNearbyBluetoothDevices, hideAlert, navigation]);
+    }, [nearbyPairableBluetoothDevices, hideAlert, navigation]);
 
     useBluetoothManager();
 


### PR DESCRIPTION
This prevents zombie devices to be shown on the screen. However, if you wipe Suite but the device remains paired, you have to remove it from OS BT settings to be able to connect it again.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/bluetooth-selectors&lookback=7)