### PR TITLE
Mobile Exchange: form interactions

### DIFF
--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
@@ -1,6 +1,7 @@
 import { ExchangeTrade } from 'invity-api';
 
 import { tradingExchangeActions } from '@suite-common/trading';
+import { EventType, analytics } from '@suite-native/analytics';
 import {
     PreloadedState,
     TestStore,
@@ -14,6 +15,7 @@ import { getBtcAccount } from '../../../__fixtures__/account';
 import { exchangeQuotes } from '../../../__fixtures__/exchangeQuotes';
 import { btcAsset, usdcAsset } from '../../../__fixtures__/tradeableAssets';
 import { getWalletState } from '../../../__fixtures__/walletState';
+import { exchangeActions } from '../../../reducers';
 import { ExchangeFormType } from '../../../types/exchange';
 import { clearExchangeFormQuoteData, useExchangeForm } from '../useExchangeForm';
 
@@ -101,7 +103,7 @@ describe('useExchangeForm', () => {
             expect(result.current.getValues('receiveCryptoAmount')).toBe('0.00089537');
         });
 
-        it('should sets receiveCryptoAmount in sats when using BTC and amount in sats', async () => {
+        it('should set receiveCryptoAmount in sats when using BTC and amount in sats', async () => {
             store = await getInitializedStore(PROTO.AmountUnit.SATOSHI);
             const { result } = await renderUseExchangeForm();
             act(() => {
@@ -203,6 +205,50 @@ describe('useExchangeForm', () => {
         });
     });
 
+    describe('sendAsset', () => {
+        it('should clear crypto amount on change', async () => {
+            const { result } = await renderUseExchangeForm();
+            act(() => {
+                result.current.setValue('sendAsset', btcAsset);
+                result.current.setValue('sendCryptoAmount', '100');
+            });
+
+            act(() => {
+                result.current.setValue('sendAsset', usdcAsset);
+            });
+
+            expect(result.current.getValues('sendCryptoAmount')).toBeUndefined();
+        });
+
+        it('should report change to analytics', async () => {
+            const reportSpy = jest.spyOn(analytics, 'report');
+            const { result } = await renderUseExchangeForm();
+
+            act(() => {
+                result.current.setValue('sendAsset', btcAsset);
+            });
+
+            expect(reportSpy).toHaveBeenCalledWith({
+                type: EventType.TradingParameterChanged,
+                payload: {
+                    type: 'exchange',
+                    parameter: 'cryptoFrom',
+                },
+            });
+        });
+
+        it('should dispatch sendAssetChanged action', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const { result } = await renderUseExchangeForm();
+
+            act(() => {
+                result.current.setValue('sendAsset', btcAsset);
+            });
+
+            expect(dispatchSpy).toHaveBeenCalledWith(exchangeActions.sendAssetChanged());
+        });
+    });
+
     describe('receiveAccount', () => {
         it('should be undefined by default', async () => {
             const { result } = await renderUseExchangeForm();
@@ -225,6 +271,36 @@ describe('useExchangeForm', () => {
         });
     });
 
+    describe('receiveAsset', () => {
+        it('should report change to analytics', async () => {
+            const reportSpy = jest.spyOn(analytics, 'report');
+            const { result } = await renderUseExchangeForm();
+
+            act(() => {
+                result.current.setValue('receiveAsset', btcAsset);
+            });
+
+            expect(reportSpy).toHaveBeenCalledWith({
+                type: EventType.TradingParameterChanged,
+                payload: {
+                    type: 'exchange',
+                    parameter: 'cryptoTo',
+                },
+            });
+        });
+
+        it('should dispatch receiveAssetChanged action', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const { result } = await renderUseExchangeForm();
+
+            act(() => {
+                result.current.setValue('receiveAsset', btcAsset);
+            });
+
+            expect(dispatchSpy).toHaveBeenCalledWith(exchangeActions.receiveAssetChanged());
+        });
+    });
+
     describe('validations', () => {
         it.each([
             ['0.00001', 'Minimum is 0.0001 BTC'],
@@ -234,8 +310,15 @@ describe('useExchangeForm', () => {
             const { result } = await renderUseExchangeForm();
 
             act(() => {
-                store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
                 result.current.setValue('sendAsset', btcAsset);
+                store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(
+                    tradingExchangeActions.setAmountLimits({
+                        minCrypto: '0.0001',
+                        maxCrypto: '50',
+                        currency: 'BTC',
+                    }),
+                );
                 result.current.setValue('sendCryptoAmount', amount);
             });
 
@@ -256,8 +339,15 @@ describe('useExchangeForm', () => {
             const { result } = await renderUseExchangeForm();
 
             act(() => {
-                store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
                 result.current.setValue('sendAsset', btcAsset);
+                store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
+                store.dispatch(
+                    tradingExchangeActions.setAmountLimits({
+                        minCrypto: '0.0001',
+                        maxCrypto: '50',
+                        currency: 'BTC',
+                    }),
+                );
                 result.current.setValue('sendCryptoAmount', amount);
             });
 

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
@@ -18,7 +18,9 @@ import { ExchangeFormType } from '../../../types/exchange';
 import { clearExchangeFormQuoteData, useExchangeForm } from '../useExchangeForm';
 
 describe('useExchangeForm', () => {
-    const renderUseExchangeForm = (store: TestStore) =>
+    let store: TestStore;
+
+    const renderUseExchangeForm = () =>
         renderHookWithStoreProviderAsync(() => useExchangeForm(), { store });
 
     const getInitializedStore = async (bitcoinAmountUnit = PROTO.AmountUnit.BITCOIN) => {
@@ -32,10 +34,13 @@ describe('useExchangeForm', () => {
         return await initStore(preloadedState);
     };
 
+    beforeEach(async () => {
+        store = await getInitializedStore();
+    });
+
     describe('on quotes change', () => {
         it('should select fixed quote with best rate', async () => {
-            const store = await getInitializedStore();
-            const { result } = await renderUseExchangeForm(store);
+            const { result } = await renderUseExchangeForm();
             act(() => {
                 store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
             });
@@ -48,8 +53,7 @@ describe('useExchangeForm', () => {
         });
 
         it('should select floating quote when fixed is not available', async () => {
-            const store = await getInitializedStore();
-            const { result } = await renderUseExchangeForm(store);
+            const { result } = await renderUseExchangeForm();
             act(() => {
                 store.dispatch(
                     tradingExchangeActions.saveQuotes([exchangeQuotes[2], exchangeQuotes[3]]),
@@ -64,8 +68,7 @@ describe('useExchangeForm', () => {
         });
 
         it('should select dex quote when no other quotes are available', async () => {
-            const store = await getInitializedStore();
-            const { result } = await renderUseExchangeForm(store);
+            const { result } = await renderUseExchangeForm();
             act(() => {
                 store.dispatch(tradingExchangeActions.saveQuotes([exchangeQuotes[3]]));
             });
@@ -78,8 +81,7 @@ describe('useExchangeForm', () => {
         });
 
         it('should set quote to undefined when no quotes are available', async () => {
-            const store = await getInitializedStore();
-            const { result } = await renderUseExchangeForm(store);
+            const { result } = await renderUseExchangeForm();
             act(() => {
                 store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
             });
@@ -91,8 +93,7 @@ describe('useExchangeForm', () => {
         });
 
         it('should set receiveCryptoAmount based on selected quote', async () => {
-            const store = await getInitializedStore();
-            const { result } = await renderUseExchangeForm(store);
+            const { result } = await renderUseExchangeForm();
             act(() => {
                 store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
             });
@@ -101,8 +102,8 @@ describe('useExchangeForm', () => {
         });
 
         it('should sets receiveCryptoAmount in sats when using BTC and amount in sats', async () => {
-            const store = await getInitializedStore(PROTO.AmountUnit.SATOSHI);
-            const { result } = await renderUseExchangeForm(store);
+            store = await getInitializedStore(PROTO.AmountUnit.SATOSHI);
+            const { result } = await renderUseExchangeForm();
             act(() => {
                 result.current.setValue('receiveAsset', btcAsset);
                 store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
@@ -112,12 +113,10 @@ describe('useExchangeForm', () => {
         });
 
         describe('when quote is selected and new quotes are fetched', () => {
-            let store: TestStore;
             let form: ExchangeFormType;
 
             beforeEach(async () => {
-                store = await getInitializedStore();
-                const { result } = await renderUseExchangeForm(store);
+                const { result } = await renderUseExchangeForm();
                 form = result.current;
 
                 act(() => {
@@ -188,15 +187,13 @@ describe('useExchangeForm', () => {
 
     describe('sendAccount', () => {
         it('should be undefined by default', async () => {
-            const store = await getInitializedStore();
-            const { result } = await renderUseExchangeForm(store);
+            const { result } = await renderUseExchangeForm();
 
             expect(result.current.getValues('sendAccount')).toBeUndefined();
         });
 
         it('should update sendAccount value when account in redux store is changed', async () => {
-            const store = await getInitializedStore();
-            const { result } = await renderUseExchangeForm(store);
+            const { result } = await renderUseExchangeForm();
 
             act(() => {
                 store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
@@ -208,15 +205,13 @@ describe('useExchangeForm', () => {
 
     describe('receiveAccount', () => {
         it('should be undefined by default', async () => {
-            const store = await getInitializedStore();
-            const { result } = await renderUseExchangeForm(store);
+            const { result } = await renderUseExchangeForm();
 
             expect(result.current.getValues('receiveAccount')).toBeUndefined();
         });
 
         it('should update receiveAccount value when account in redux store is changed', async () => {
-            const store = await getInitializedStore();
-            const { result } = await renderUseExchangeForm(store);
+            const { result } = await renderUseExchangeForm();
 
             act(() => {
                 store.dispatch(tradingExchangeActions.setReceiveAccountKey('btc-account-1'));
@@ -236,8 +231,7 @@ describe('useExchangeForm', () => {
             ['100', 'Maximum is 50 BTC'],
             ['1', 'Insufficient balance'],
         ])('should display error for crypto amount %s BTC', async (amount, expectedValue) => {
-            const store = await getInitializedStore();
-            const { result } = await renderUseExchangeForm(store);
+            const { result } = await renderUseExchangeForm();
 
             act(() => {
                 store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
@@ -258,8 +252,8 @@ describe('useExchangeForm', () => {
             ['10000000000', 'Maximum is 5000000000 sat'],
             ['10000000', 'Insufficient balance'],
         ])('should display error for crypto amount %s SATS', async (amount, expectedValue) => {
-            const store = await getInitializedStore(PROTO.AmountUnit.SATOSHI);
-            const { result } = await renderUseExchangeForm(store);
+            store = await getInitializedStore(PROTO.AmountUnit.SATOSHI);
+            const { result } = await renderUseExchangeForm();
 
             act(() => {
                 store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
@@ -276,8 +270,8 @@ describe('useExchangeForm', () => {
         });
 
         it('should correctly compute balance with SATS', async () => {
-            const store = await getInitializedStore(PROTO.AmountUnit.SATOSHI);
-            const { result } = await renderUseExchangeForm(store);
+            store = await getInitializedStore(PROTO.AmountUnit.SATOSHI);
+            const { result } = await renderUseExchangeForm();
 
             act(() => {
                 store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
@@ -296,8 +290,7 @@ describe('useExchangeForm', () => {
             ['1', false],
             ['2', true],
         ])('should use correct balance for USDC and amount %s', async (amount, expectedInvalid) => {
-            const store = await getInitializedStore();
-            const { result } = await renderUseExchangeForm(store);
+            const { result } = await renderUseExchangeForm();
 
             act(() => {
                 store.dispatch(tradingExchangeActions.setTradingAccountKey('eth-account-1'));
@@ -313,13 +306,12 @@ describe('useExchangeForm', () => {
         });
 
         it('should trigger validation once limits are loaded', async () => {
-            const store = await getInitializedStore();
             act(() => {
                 store.dispatch(tradingExchangeActions.setAmountLimits(undefined));
                 store.dispatch(tradingExchangeActions.setTradingAccountKey('btc-account-1'));
             });
 
-            const { result } = await renderUseExchangeForm(store);
+            const { result } = await renderUseExchangeForm();
 
             act(() => {
                 result.current.setValue('sendAsset', btcAsset);
@@ -344,8 +336,7 @@ describe('useExchangeForm', () => {
 
         describe('generalAlert', () => {
             it('should be undefined by default', async () => {
-                const store = await getInitializedStore();
-                const { result } = await renderUseExchangeForm(store);
+                const { result } = await renderUseExchangeForm();
 
                 act(() => {
                     store.dispatch(tradingExchangeActions.saveQuotes([] as ExchangeTrade[]));
@@ -356,8 +347,7 @@ describe('useExchangeForm', () => {
             });
 
             it('should be set when empty quotes are fetched and no limits are set', async () => {
-                const store = await getInitializedStore();
-                const { result } = await renderUseExchangeForm(store);
+                const { result } = await renderUseExchangeForm();
 
                 act(() => {
                     store.dispatch(
@@ -377,8 +367,7 @@ describe('useExchangeForm', () => {
             });
 
             it('should be undefined when empty quotes are fetched and limits are set', async () => {
-                const store = await getInitializedStore();
-                const { result } = await renderUseExchangeForm(store);
+                const { result } = await renderUseExchangeForm();
 
                 act(() => {
                     store.dispatch(
@@ -401,8 +390,7 @@ describe('useExchangeForm', () => {
             });
 
             it('should be undefined once quotes are fetched', async () => {
-                const store = await getInitializedStore();
-                const { result } = await renderUseExchangeForm(store);
+                const { result } = await renderUseExchangeForm();
 
                 act(() => {
                     store.dispatch(
@@ -420,8 +408,7 @@ describe('useExchangeForm', () => {
             });
 
             it('should be cleared once quotes are fetched', async () => {
-                const store = await getInitializedStore();
-                const { result } = await renderUseExchangeForm(store);
+                const { result } = await renderUseExchangeForm();
 
                 act(() => {
                     store.dispatch(
@@ -446,8 +433,7 @@ describe('useExchangeForm', () => {
 
     describe('clearExchangeFormQuoteData', () => {
         it('should clear quote, sendCryptoAmount, receiveCryptoAmount and generalAlert data', async () => {
-            const store = await getInitializedStore();
-            const { result } = await renderUseExchangeForm(store);
+            const { result } = await renderUseExchangeForm();
 
             act(() => {
                 result.current.setValue('quote', exchangeQuotes[0] as ExchangeTrade);

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeQuotes.test.ts
@@ -13,7 +13,7 @@ import { PROTO } from '@trezor/connect';
 
 import { getBtcAccount, getEthAccount } from '../../../__fixtures__/account';
 import { exchangeQuotes } from '../../../__fixtures__/exchangeQuotes';
-import { btcAsset, ethAsset, usdcAsset, usdtAsset } from '../../../__fixtures__/tradeableAssets';
+import { btcAsset, ethAsset, usdtAsset } from '../../../__fixtures__/tradeableAssets';
 import { getInitializedTradingState } from '../../../__fixtures__/tradingState';
 import { ExchangeFormValues } from '../../../types/exchange';
 import { useExchangeForm } from '../useExchangeForm';
@@ -210,7 +210,6 @@ describe('useExchangeQuotes', () => {
     });
 
     it.each<[keyof ExchangeFormValues, ExchangeFormValues[keyof ExchangeFormValues]]>([
-        ['sendAsset', usdcAsset],
         ['receiveAsset', usdtAsset],
         ['sendCryptoAmount', '0.2'],
         ['sendAccount', getBtcAccount('btc-account-2')],

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
@@ -1,7 +1,7 @@
-import { useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
-import { ExchangeTrade } from 'invity-api';
+import { CryptoId, ExchangeTrade } from 'invity-api';
 
 import {
     TradingExchangeAmountLimitProps,
@@ -11,9 +11,11 @@ import {
 import { getNetwork } from '@suite-common/wallet-config';
 import { WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
+import { EventType, analytics } from '@suite-native/analytics';
 import { useForm } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 
+import { exchangeActions } from '../../reducers';
 import {
     selectExchangeAmountLimits,
     selectExchangeQuotes,
@@ -86,7 +88,7 @@ const useExchangeQuoteChangeEffect = ({ watch, setValue }: ExchangeFormType) => 
     useEffect(() => {
         const amount = selectedQuote?.receiveStringAmount;
         if (!amount) {
-            setValue('receiveCryptoAmount', undefined);
+            setValue('receiveCryptoAmount', undefined, { shouldValidate: true });
 
             return;
         }
@@ -95,8 +97,58 @@ const useExchangeQuoteChangeEffect = ({ watch, setValue }: ExchangeFormType) => 
             isAmountInSats && amount && symbol
                 ? convertAmountUnitsToSubunits(amount, getNetwork(symbol).decimals)
                 : amount;
-        setValue('receiveCryptoAmount', value);
+        setValue('receiveCryptoAmount', value, { shouldValidate: true });
     }, [selectedQuote, isAmountInSats, symbol, setValue]);
+};
+
+const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, watch }: ExchangeFormType) => {
+    const dispatch = useDispatch();
+    const prevSendCryptoId = useRef<CryptoId | undefined>(undefined);
+    const prevReceiveCryptoId = useRef<CryptoId | undefined>(undefined);
+
+    useEffect(() => {
+        const { unsubscribe } = watch(({ sendAsset, receiveAsset }, { name }) => {
+            switch (name) {
+                case 'sendAsset':
+                    if (sendAsset?.cryptoId !== prevSendCryptoId.current) {
+                        analytics.report({
+                            type: EventType.TradingParameterChanged,
+                            payload: {
+                                type: 'exchange',
+                                parameter: 'cryptoFrom',
+                            },
+                        });
+
+                        prevSendCryptoId.current = sendAsset?.cryptoId as CryptoId | undefined;
+                        setValue('sendCryptoAmount', undefined, { shouldValidate: true });
+                        dispatch(exchangeActions.sendAssetChanged());
+                    }
+                    break;
+
+                case 'receiveAsset':
+                    if (receiveAsset?.cryptoId !== prevReceiveCryptoId.current) {
+                        analytics.report({
+                            type: EventType.TradingParameterChanged,
+                            payload: {
+                                type: 'exchange',
+                                parameter: 'cryptoTo',
+                            },
+                        });
+
+                        prevReceiveCryptoId.current = receiveAsset?.cryptoId as
+                            | CryptoId
+                            | undefined;
+                        dispatch(exchangeActions.receiveAssetChanged());
+                    }
+                    break;
+
+                default:
+                // do nothing
+            }
+        });
+
+        return unsubscribe;
+    }, [setValue, watch, dispatch]);
 };
 
 const useValidations = (
@@ -135,6 +187,7 @@ export const useExchangeForm = () => {
     useExchangeQuoteChangeEffect(form);
     useSendAccountChangeEffect(setValue, selectExchangeSelectedSendAccount);
     useReceiveAccountChangeEffect(setValue, selectExchangeSelectedReceiveAccount);
+    useAmountAndCurrencyFieldsChangeEffect(form);
     useSendAccountAssetBalance(form, setBalance, setSendSymbol);
     useValidations(form, limits);
 

--- a/suite-native/module-trading/src/reducers/__tests__/exchangeSlice.test.ts
+++ b/suite-native/module-trading/src/reducers/__tests__/exchangeSlice.test.ts
@@ -85,4 +85,52 @@ describe('exchangeSlice', () => {
             expect(state.quotesRequest).toBeUndefined();
         });
     });
+
+    describe('sendAssetChanged', () => {
+        it('should clear amount limits and quotes request data', () => {
+            const prevState: TradingExchangeState = {
+                ...exchangeInitialState,
+                amountLimits: {
+                    currency: 'BTC',
+                    minCrypto: '0.001',
+                    maxCrypto: '10',
+                },
+                quotesRequest: {
+                    send: 'bitcoin' as CryptoId,
+                    receive: 'ethereum' as CryptoId,
+                },
+            };
+
+            const state = exchangeReducer(prevState, exchangeActions.sendAssetChanged());
+
+            expect(state.amountLimits).toBeUndefined();
+            expect(state.quotesRequest).toBeUndefined();
+        });
+    });
+
+    describe('receiveAssetChanged', () => {
+        it('should clear amount limits, quotes request and receive account info', () => {
+            const prevState: TradingExchangeState = {
+                ...exchangeInitialState,
+                amountLimits: {
+                    currency: 'BTC',
+                    minCrypto: '0.001',
+                    maxCrypto: '10',
+                },
+                quotesRequest: {
+                    send: 'bitcoin' as CryptoId,
+                    receive: 'ethereum' as CryptoId,
+                },
+                receiveAccountKey: 'account-key1',
+                receiveAddress: { address: 'bc1qxyz' } as Address,
+            };
+
+            const state = exchangeReducer(prevState, exchangeActions.receiveAssetChanged());
+
+            expect(state.amountLimits).toBeUndefined();
+            expect(state.quotesRequest).toBeUndefined();
+            expect(state.receiveAccountKey).toBeUndefined();
+            expect(state.receiveAddress).toBeUndefined();
+        });
+    });
 });

--- a/suite-native/module-trading/src/reducers/exchangeSlice.ts
+++ b/suite-native/module-trading/src/reducers/exchangeSlice.ts
@@ -37,6 +37,16 @@ const exchangeSlice = createSlice({
             state.quotesRequest = undefined;
             state.quotes = [];
         },
+        sendAssetChanged: state => {
+            state.amountLimits = undefined;
+            state.quotesRequest = undefined;
+        },
+        receiveAssetChanged: state => {
+            state.amountLimits = undefined;
+            state.quotesRequest = undefined;
+            state.receiveAccountKey = undefined;
+            state.receiveAddress = undefined;
+        },
     },
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When send asset is changed:
- clear send amount

When receive asset is changed:
- clear receive account and address

Should resolve all remaining issues with missing clearing of trading forms.

## Related Issue
Resolve #21001

## Screenshots:

https://github.com/user-attachments/assets/863cfb4d-682f-4e72-b111-f4f5203a93b9




🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mobile-trade-exchange-form-interactions&lookback=7)