### PR TITLE
Feat/fiat rates in trading

### DIFF
--- a/packages/suite-data/files/translations/en-US.json
+++ b/packages/suite-data/files/translations/en-US.json
@@ -1019,7 +1019,7 @@
   "TR_EXCHANGE_DETAIL_SUCCESS_BUTTON": "Make another Swap",
   "TR_EXCHANGE_DETAIL_SUCCESS_TEXT": "Your transaction was successful.",
   "TR_EXCHANGE_DETAIL_SUCCESS_TITLE": "Swap successful",
-  "TR_EXCHANGE_DEX": "Decentralized exchange offer",
+  "TR_EXCHANGE_DEX": "DEX",
   "TR_EXCHANGE_EXTRA_FIELD": "{extraFieldName}",
   "TR_EXCHANGE_EXTRA_FIELD_INVALID": "{extraFieldName} is invalid",
   "TR_EXCHANGE_EXTRA_FIELD_QUESTION_TOOLTIP": "{extraFieldDescription}",

--- a/packages/suite/src/components/suite/BaseCurrencyValue.tsx
+++ b/packages/suite/src/components/suite/BaseCurrencyValue.tsx
@@ -5,7 +5,8 @@ import styled from 'styled-components';
 
 import { useFormatters } from '@suite-common/formatters';
 import { selectIsSpecificCoinDefinitionKnown } from '@suite-common/token-definitions';
-import { TokenAddress } from '@suite-common/wallet-types';
+import { CONTRACT_ADDRESS_FOR_NATIVE_TOKEN } from '@suite-common/trading';
+import { RateTypeWithoutHistoric, TokenAddress } from '@suite-common/wallet-types';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-utils';
 import { SkeletonRectangle } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
@@ -38,6 +39,7 @@ type BaseCurrencyValueProps = UseFiatFromCryptoValueParams & {
     showLoadingSkeleton?: boolean;
     className?: string;
     isLoading?: boolean;
+    rateType?: RateTypeWithoutHistoric;
 };
 
 /**
@@ -69,14 +71,17 @@ export const BaseCurrencyValue = ({
     shouldConvert = true,
     showLoadingSkeleton,
     isLoading,
+    rateType,
 }: BaseCurrencyValueProps) => {
     const { shouldAnimate } = useLoadingSkeleton();
+    const isNativeToken = !tokenAddress || tokenAddress === CONTRACT_ADDRESS_FOR_NATIVE_TOKEN;
     const { baseCurrencyCode, fiatAmount, rate, currentRate } = useFiatFromCryptoValue({
         amount,
         symbol,
-        tokenAddress,
+        tokenAddress: isNativeToken ? undefined : tokenAddress,
         historicRate,
         useHistoricRate,
+        rateType,
     });
 
     const { BaseCurrencyAmountFormatter } = useFormatters();

--- a/packages/suite/src/hooks/suite/useFiatFromCryptoValue.ts
+++ b/packages/suite/src/hooks/suite/useFiatFromCryptoValue.ts
@@ -1,6 +1,6 @@
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectFiatRatesByFiatRateKey } from '@suite-common/wallet-core';
-import { TokenAddress } from '@suite-common/wallet-types';
+import { RateTypeWithoutHistoric, TokenAddress } from '@suite-common/wallet-types';
 import { AmountUnit, getFiatRateKey, toFiatCurrency } from '@suite-common/wallet-utils';
 
 import { useSelector } from 'src/hooks/suite';
@@ -9,6 +9,7 @@ interface CommonOwnProps {
     amount: string | AmountUnit; // Todo: remove `string` only for back compatibility
     symbol: NetworkSymbol;
     tokenAddress?: TokenAddress;
+    rateType?: RateTypeWithoutHistoric;
 }
 
 export interface UseFiatFromCryptoValueParams extends CommonOwnProps {
@@ -22,11 +23,14 @@ export const useFiatFromCryptoValue = ({
     tokenAddress,
     historicRate,
     useHistoricRate,
+    rateType,
 }: UseFiatFromCryptoValueParams) => {
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const fiatRateKey = getFiatRateKey(symbol, baseCurrencyCode, tokenAddress);
 
-    const currentRate = useSelector(state => selectFiatRatesByFiatRateKey(state, fiatRateKey));
+    const currentRate = useSelector(state =>
+        selectFiatRatesByFiatRateKey(state, fiatRateKey, rateType),
+    );
 
     const rate = useHistoricRate ? historicRate : currentRate?.rate;
     const fiatAmount = rate ? toFiatCurrency({ amount, rate }) : null;

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.ts
@@ -1,9 +1,13 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
-import { FiatCurrencyCode } from 'invity-api';
+import { CryptoId, FiatCurrencyCode } from 'invity-api';
 
-import { cryptoIdToSymbol, mapTestnetSymbol } from '@suite-common/trading';
-import { NetworkSymbol, networks } from '@suite-common/wallet-config';
+import {
+    cryptoIdToNetworkAndContractAddress,
+    isCryptoIdForNativeToken,
+    mapTestnetSymbol,
+} from '@suite-common/trading';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import {
     selectBaseCurrency,
     selectFiatRatesByFiatRateKey,
@@ -18,12 +22,11 @@ import {
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
-import { TradingAccountOptionsGroupOptionProps } from 'src/types/trading/trading';
-import { getTradingNetworkDecimals } from 'src/utils/wallet/trading/tradingUtils';
 
 interface TradingBalanceProps {
-    sendCryptoSelect?: TradingAccountOptionsGroupOptionProps;
     fiatCurrency?: FiatCurrencyCode;
+    cryptoId?: CryptoId;
+    amount?: string;
 }
 
 interface TradingBalanceReturnProps {
@@ -41,28 +44,37 @@ interface TradingBalanceReturnProps {
 }
 
 export const useTradingFiatValues = ({
-    sendCryptoSelect,
+    cryptoId,
     fiatCurrency,
+    amount,
 }: TradingBalanceProps): TradingBalanceReturnProps | null => {
     const dispatch = useDispatch();
-    const defaultCryptoSymbol = 'btc';
-    const symbol = sendCryptoSelect
-        ? (cryptoIdToSymbol(sendCryptoSelect.value) ?? defaultCryptoSymbol)
-        : defaultCryptoSymbol;
-    const tokenAddressTyped = (sendCryptoSelect?.contractAddress ?? undefined) as
-        | TokenAddress
-        | undefined;
+
+    const isNativeToken = cryptoId && isCryptoIdForNativeToken(cryptoId);
+
+    const { network, contractAddress, symbol } = useMemo(() => {
+        const defaultCryptoSymbol = 'btc';
+        const assetInfo = cryptoId && cryptoIdToNetworkAndContractAddress(cryptoId);
+
+        return {
+            network: assetInfo?.network,
+            contractAddress: isNativeToken
+                ? undefined
+                : (assetInfo?.contractAddress as TokenAddress | undefined),
+            symbol: assetInfo?.network?.symbol ?? defaultCryptoSymbol,
+        };
+    }, [cryptoId, isNativeToken]);
+
     const symbolForFiat = mapTestnetSymbol(symbol);
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const fiatRateKey = getFiatRateKey(
         symbolForFiat,
         fiatCurrency ?? baseCurrencyCode,
-        tokenAddressTyped,
+        contractAddress,
     );
-    const fiatRate = useSelector(state => selectFiatRatesByFiatRateKey(state, fiatRateKey));
-    const balance = sendCryptoSelect?.balance;
 
-    const network = networks[symbol];
+    const fiatRate = useSelector(state => selectFiatRatesByFiatRateKey(state, fiatRateKey));
+
     const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
 
     const fiatRatesUpdater = useCallback(
@@ -71,18 +83,20 @@ export const useTradingFiatValues = ({
             currentTokenAddress?: TokenAddress,
         ): Promise<FiatRatesResult | null> => {
             if (!value) return null;
+            const tokenAddress = currentTokenAddress ?? contractAddress;
 
             const updateFiatRatesResult = await dispatch(
                 updateFiatRatesThunk({
                     tickers: [
                         {
                             symbol,
-                            tokenAddress: currentTokenAddress ?? tokenAddressTyped,
+                            tokenAddress: isNativeToken ? undefined : tokenAddress,
                         },
                     ],
                     baseCurrencyCode: value,
                     rateType: 'current',
                     fetchAttemptTimestamp: Date.now() as Timestamp,
+                    skipCache: true,
                 }),
             );
 
@@ -90,34 +104,30 @@ export const useTradingFiatValues = ({
 
             return updateFiatRatesResult.payload as FiatRatesResult;
         },
-        [dispatch, symbol, tokenAddressTyped],
+        [contractAddress, dispatch, symbol, isNativeToken],
     );
 
-    // update rates on mount
     useEffect(() => {
+        if (!fiatCurrency) return;
+
         fiatRatesUpdater(fiatCurrency);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [fiatCurrency, fiatRatesUpdater]);
 
-    if (!balance || !fiatCurrency) return null;
+    if (!amount || !fiatCurrency || !network) return null;
 
-    const decimals = getTradingNetworkDecimals({
-        sendCryptoSelect,
-        network,
-    });
     const formattedBalance = shouldSendInSats
-        ? convertAmountUnitsToSubunits(balance, decimals)
-        : balance;
-    const fiatValue = toFiatCurrency({ amount: balance, rate: fiatRate?.rate })?.toFixed(2) ?? null;
+        ? convertAmountUnitsToSubunits(amount, network.decimals)
+        : amount;
+    const fiatValue = toFiatCurrency({ amount, rate: fiatRate?.rate })?.toFixed(2) ?? null;
 
     return {
         fiatValue,
         fiatRate,
-        accountBalance: balance,
+        accountBalance: amount,
         formattedBalance,
         symbol,
-        networkDecimals: decimals,
-        tokenAddress: tokenAddressTyped,
+        networkDecimals: network.decimals,
+        tokenAddress: contractAddress,
         fiatRatesUpdater,
     };
 };

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -82,7 +82,8 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
         ? isZero(tokenData.balance || '0')
         : isZero(account.formattedBalance);
     const tradingFiatValues = useTradingFiatValues({
-        sendCryptoSelect,
+        cryptoId: sendCryptoSelect?.value,
+        amount: sendCryptoSelect?.balance,
         fiatCurrency: getValues().outputs?.[0]?.currency?.value as FiatCurrencyCode,
     });
     const networkDecimals = getTradingNetworkDecimals({

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 
-import type { BuyTrade, BuyTradeResponse, CryptoId } from 'invity-api';
+import type { BuyTrade, BuyTradeResponse, CryptoId, FiatCurrencyCode } from 'invity-api';
 import useDebounce from 'react-use/lib/useDebounce';
 
 import {
@@ -48,6 +48,7 @@ import {
 import { createQuoteLink, createTxLink } from 'src/utils/wallet/trading/buyUtils';
 import { getTradingCryptoInfo } from 'src/utils/wallet/trading/tradingUtils';
 
+import { useTradingFiatValues } from './common/useTradingFiatValues';
 import { useTradingInitializer } from './common/useTradingInitializer';
 
 export const useTradingBuyForm = ({
@@ -81,6 +82,19 @@ export const useTradingBuyForm = ({
 
     const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
     const isPreviousRouteFromTradeSection = useTradingPreviousRoute(type);
+
+    const fiatTradingValuesParams = selectedQuote
+        ? {
+              cryptoId: selectedQuote.receiveCurrency,
+              amount: selectedQuote.receiveAmount?.toString(),
+              fiatCurrency: selectedQuote.fiatCurrency as FiatCurrencyCode | undefined,
+          }
+        : {
+              cryptoId: quotesRequest?.receiveCurrency,
+              amount: quotesRequest?.cryptoStringAmount,
+              fiatCurrency: quotesRequest?.fiatCurrency as FiatCurrencyCode | undefined,
+          };
+    useTradingFiatValues(fiatTradingValuesParams);
 
     const {
         defaultValues,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -96,7 +96,8 @@ export const useTradingExchangeForm = ({
     const verifiedAddress = useSelector(selectTradingVerifiedAddress);
     const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const exchangeInfo = useSelector(selectTradingExchangeInfo);
-    const { selectedFee, composed } = useSelector(selectTradingComposedTransactionInfo);
+    const composedTransactionInfo = useSelector(selectTradingComposedTransactionInfo);
+    const { selectedFee, composed } = composedTransactionInfo;
 
     const isPreviousRouteFromTradeSection = useTradingPreviousRoute(type);
 
@@ -176,9 +177,17 @@ export const useTradingExchangeForm = ({
     const { rateType, exchangeType, sendCryptoSelect, receiveCryptoSelect } = getValues();
     const output = values.outputs?.[0];
     const fiatValues = useTradingFiatValues({
-        sendCryptoSelect,
+        cryptoId: sendCryptoSelect?.value,
+        amount: sendCryptoSelect?.balance,
         fiatCurrency: output?.currency?.value as FiatCurrencyCode,
     });
+
+    useTradingFiatValues({
+        cryptoId: receiveCryptoSelect?.value,
+        amount: receiveCryptoSelect?.balance,
+        fiatCurrency: output?.currency?.value as FiatCurrencyCode,
+    });
+
     const fiatOfBestScoredQuote = quotes?.[0]?.sendStringAmount
         ? (toFiatCurrency({
               amount: quotes?.[0]?.sendStringAmount,
@@ -868,6 +877,7 @@ export const useTradingExchangeForm = ({
         isFetchingApprovalStatus,
         setReceiveAccount,
         composeRequest,
+        composedTransactionInfo,
         changeFeeLevel,
         setAmountLimits,
         goToOffers,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -106,7 +106,9 @@ export const useTradingSellForm = ({
         selectIsTradingTermsDismissed(state, type),
     );
 
-    const { selectedFee, composed } = useSelector(selectTradingComposedTransactionInfo);
+    const composedTransactionInfo = useSelector(selectTradingComposedTransactionInfo);
+    const { selectedFee, composed } = composedTransactionInfo;
+
     const { navigateToSellForm, navigateToSellOffers, navigateToSellConfirm } =
         useTradingNavigation(account);
 
@@ -597,6 +599,7 @@ export const useTradingSellForm = ({
         quotesRequest,
         quotes: quotesByPaymentMethod,
         composedLevels,
+        composedTransactionInfo,
         localCurrencyOption,
         feeInfo,
         isComposing,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -736,7 +736,7 @@ export default defineMessages({
         id: 'TR_EXCHANGE_FLOAT',
     },
     TR_EXCHANGE_DEX: {
-        defaultMessage: 'Decentralized exchange offer',
+        defaultMessage: 'DEX',
         id: 'TR_EXCHANGE_DEX',
     },
     TR_TRADING_EXCHANGE_FIXED_OFFERS_HEADING: {
@@ -1260,10 +1260,6 @@ export default defineMessages({
         defaultMessage: 'You get',
         id: 'TR_TRADING_YOU_GET',
     },
-    TR_TRADING_YOU_RECEIVE: {
-        defaultMessage: 'You receive',
-        id: 'TR_TRADING_YOU_RECEIVE',
-    },
     TR_TRADING_COUNTRY: {
         defaultMessage: 'Country of residence',
         id: 'TR_TRADING_COUNTRY',
@@ -1442,10 +1438,6 @@ export default defineMessages({
         defaultMessage: 'KYC is never required. Exceptional cases are automatically refunded.',
         id: 'TR_TRADING_KYC_NO_KYC',
     },
-    TR_TRADING_KYC_DEX: {
-        defaultMessage: 'KYC is never required. DEX swaps either succeed or fail.',
-        id: 'TR_TRADING_KYC_DEX',
-    },
     TR_TRADING_DCA_HEADING: {
         defaultMessage: 'Invest with Invity, secure with Trezor',
         id: 'TR_TRADING_DCA_HEADING',
@@ -1585,6 +1577,10 @@ export default defineMessages({
     TR_TRADING_PROVIDER: {
         defaultMessage: 'Provider',
         id: 'TR_TRADING_PROVIDER',
+    },
+    TR_TRADING_EXCHANGE_TYPE: {
+        defaultMessage: 'Exchange type',
+        id: 'TR_TRADING_EXCHANGE_TYPE',
     },
     TR_ADDRESS_MODAL_CLIPBOARD: {
         defaultMessage: 'Copy address',

--- a/packages/suite/src/types/trading/trading.ts
+++ b/packages/suite/src/types/trading/trading.ts
@@ -185,6 +185,7 @@ export interface TradingGetCryptoQuoteAmountProps {
     sendCurrency: CryptoId | string | undefined;
     receiveAmount: string;
     receiveCurrency: CryptoId | undefined;
+    networkFee?: string | undefined;
 }
 
 export interface TradingGetPaymentMethodProps {

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -17,15 +17,18 @@ import type {
     TradingBuyFormProps,
     TradingBuyInfoSelector,
     TradingBuyType,
+    TradingComposedTransactionInfo,
     TradingCountryOption,
     TradingExchangeFormProps,
     TradingExchangeInfoSelector,
+    TradingExchangeStepType,
     TradingExchangeType,
     TradingFiatCurrencyOption,
     TradingPaymentMethodListProps,
     TradingPaymentMethodType,
     TradingSellFormProps,
     TradingSellInfoSelector,
+    TradingSellStepType,
     TradingSellType,
     TradingTradeType,
     TradingTransactionBuy,
@@ -149,6 +152,7 @@ export interface TradingSellFormContextProps
     sellInfo?: TradingSellInfoSelector;
     localCurrencyOption: { label: string; value: string };
     composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
+    composedTransactionInfo: TradingComposedTransactionInfo;
     quotesRequest: SellFiatTradeQuoteRequest | undefined;
     feeInfo: FeeInfo;
     quotes: SellFiatTrade[];
@@ -198,6 +202,7 @@ export interface TradingExchangeFormContextProps
     defaultCurrency: TradingFiatCurrencyOption;
     amountLimits?: CryptoAmountLimitProps;
     composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
+    composedTransactionInfo: TradingComposedTransactionInfo;
     quotes: ExchangeTrade[];
     cexQuotes: ExchangeTrade[];
     dexQuotes: ExchangeTrade[];
@@ -367,4 +372,5 @@ export interface TradingOfferExchangeProps
 export interface TradingSelectedOfferInfoProps extends TradingOfferCommonProps {
     selectedAccount?: Account;
     transactionId?: string;
+    formStep?: TradingExchangeStepType | TradingSellStepType;
 }

--- a/packages/suite/src/utils/wallet/trading/__tests__/tradingUtils.test.ts
+++ b/packages/suite/src/utils/wallet/trading/__tests__/tradingUtils.test.ts
@@ -227,8 +227,8 @@ describe('trading utils', () => {
             inputLabel: 'TR_TRADING_SWAP_AMOUNT',
             offerLabel: 'TR_TRADING_YOU_GET',
             labelComparatorOffer: 'TR_TRADING_YOU_WILL_GET',
-            sendLabel: 'TR_TRADING_SWAP',
-            receiveLabel: 'TR_TRADING_YOU_RECEIVE',
+            sendLabel: 'TR_TRADING_YOU_PAY',
+            receiveLabel: 'TR_TRADING_YOU_GET',
         });
     });
 

--- a/packages/suite/src/utils/wallet/trading/tradingTypingUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/tradingTypingUtils.ts
@@ -57,6 +57,7 @@ export const getCryptoQuoteAmountProps = (
 
     if (isTradingSellContext(context)) {
         const amountInCrypto = context.quotesRequest?.amountInCrypto;
+        const networkFee = context.composedTransactionInfo?.composed?.fee;
         const quote = quoteInput as SellFiatTrade;
 
         if (!quote || !context.quotesRequest) return null;
@@ -67,10 +68,12 @@ export const getCryptoQuoteAmountProps = (
             sendCurrency: quote?.fiatCurrency,
             receiveAmount: quote?.cryptoStringAmount ?? '',
             receiveCurrency: quote?.cryptoCurrency,
+            networkFee,
         };
     }
 
     const quote = quoteInput as ExchangeTrade;
+    const networkFee = context.composedTransactionInfo?.composed?.fee;
 
     return {
         amountInCrypto: false,
@@ -78,6 +81,7 @@ export const getCryptoQuoteAmountProps = (
         sendCurrency: quote?.send,
         receiveAmount: quote?.receiveStringAmount ?? '',
         receiveCurrency: quote?.receive,
+        networkFee,
     };
 };
 

--- a/packages/suite/src/utils/wallet/trading/tradingUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/tradingUtils.ts
@@ -289,8 +289,6 @@ export const tradingGetAmountLabels = ({
     const youPay = 'TR_TRADING_YOU_PAY';
     const youWillGet = 'TR_TRADING_YOU_WILL_GET';
     const youWillPay = 'TR_TRADING_YOU_WILL_PAY';
-    const youReceive = 'TR_TRADING_YOU_RECEIVE';
-    const exchange = 'TR_TRADING_SWAP';
     const exchangeAmount = 'TR_TRADING_SWAP_AMOUNT';
 
     if (type === 'exchange') {
@@ -298,8 +296,8 @@ export const tradingGetAmountLabels = ({
             inputLabel: exchangeAmount,
             offerLabel: youGet,
             labelComparatorOffer: youWillGet,
-            sendLabel: exchange,
-            receiveLabel: youReceive,
+            sendLabel: youPay,
+            receiveLabel: youGet,
         };
     }
 

--- a/packages/suite/src/views/wallet/trading/common/TradingBalance.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingBalance.tsx
@@ -47,6 +47,7 @@ export const TradingBalance = ({
         amount: stringBalance || '',
         symbol,
         tokenAddress,
+        rateType: 'current',
     });
 
     if (showOnlyAmount) {
@@ -54,10 +55,9 @@ export const TradingBalance = ({
 
         return (
             <Text variant="tertiary" typographyStyle="label">
-                &asymp;{' '}
                 {!amountInCrypto ? (
                     <HiddenPlaceholder>
-                        {formattedBalance} {balanceCurrency}
+                        &asymp; {formattedBalance} {balanceCurrency}
                     </HiddenPlaceholder>
                 ) : (
                     stringBalance &&
@@ -67,6 +67,8 @@ export const TradingBalance = ({
                             amount={stringBalance}
                             symbol={symbol}
                             tokenAddress={tokenAddress}
+                            rateType="current"
+                            showApproximationIndicator
                         />
                     )
                 )}
@@ -88,6 +90,7 @@ export const TradingBalance = ({
                         amount={stringBalance}
                         symbol={symbol}
                         tokenAddress={tokenAddress}
+                        rateType="current"
                     />
                 </>
             )}

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuy.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuy.tsx
@@ -4,7 +4,7 @@ import { usePrevious } from 'react-use';
 import { BuyTradeStatus } from 'invity-api';
 import styled from 'styled-components';
 
-import type { TradingBuyType } from '@suite-common/trading';
+import { type TradingBuyType, selectTradingComposedTransactionInfo } from '@suite-common/trading';
 import { selectAccounts } from '@suite-common/wallet-core';
 import { Card, Column } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
@@ -51,6 +51,7 @@ export const TradingDetailBuy = () => {
     const tradeStatus = trade?.data?.status;
     const previousTradeStatus = usePrevious(tradeStatus);
     const tradeStatusStep = getTradeStatusStep(tradeStatus);
+    const composedTransaction = useSelector(selectTradingComposedTransactionInfo);
 
     const exchange = trade?.data?.exchange;
     const provider =
@@ -64,6 +65,7 @@ export const TradingDetailBuy = () => {
         sendCurrency: trade?.data?.fiatCurrency,
         receiveAmount: trade?.data?.receiveStringAmount ?? '',
         receiveCurrency: trade?.data?.receiveCurrency,
+        networkFee: composedTransaction?.composed?.fee,
     };
 
     const receiveAccount = accounts.find(account => account.key === trade?.receiveAccountKey);

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
@@ -4,7 +4,11 @@ import { usePrevious } from 'react-use';
 import { ExchangeTradeStatus } from 'invity-api';
 import styled from 'styled-components';
 
-import { type TradingExchangeType } from '@suite-common/trading';
+import {
+    type TradingExchangeType,
+    selectTradingComposedTransactionInfo,
+    selectTradingExchangeFormStep,
+} from '@suite-common/trading';
 import { selectAccounts } from '@suite-common/wallet-core';
 import { Card, Column, InfoItem } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
@@ -58,6 +62,8 @@ export const TradingDetailExchange = () => {
     const tradeStatus = trade?.data?.status || 'CONFIRMING';
     const previousTradeStatus = usePrevious(tradeStatus);
     const tradeStatusStep = getTradeStatusStep(tradeStatus);
+    const formStep = useSelector(selectTradingExchangeFormStep);
+    const composedTransaction = useSelector(selectTradingComposedTransactionInfo);
 
     const exchange = trade?.data?.exchange;
     const provider =
@@ -70,6 +76,7 @@ export const TradingDetailExchange = () => {
         sendCurrency: trade?.data?.send,
         receiveAmount: trade?.data?.receiveStringAmount ?? '',
         receiveCurrency: trade?.data?.receive,
+        networkFee: composedTransaction?.composed?.fee,
     };
 
     useEffect(() => {
@@ -154,6 +161,7 @@ export const TradingDetailExchange = () => {
             </Column>
             <Card>
                 <TradingSelectedOfferInfo
+                    formStep={formStep}
                     account={sendAccount}
                     selectedAccount={receiveAccount}
                     selectedQuote={trade.data}

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSell.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSell.tsx
@@ -4,7 +4,11 @@ import { usePrevious } from 'react-use';
 import { SellTradeStatus } from 'invity-api';
 import styled from 'styled-components';
 
-import type { TradingSellType } from '@suite-common/trading';
+import {
+    type TradingSellType,
+    selectTradingComposedTransactionInfo,
+    selectTradingSellFormStep,
+} from '@suite-common/trading';
 import { selectAccounts } from '@suite-common/wallet-core';
 import { Card, Column } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
@@ -44,6 +48,8 @@ export const TradingDetailSell = () => {
     const tradeStatus = trade?.data?.status || 'PENDING';
     const previousTradeStatus = usePrevious(tradeStatus);
     const tradeStatusStep = getTradeStatusStep(tradeStatus);
+    const formStep = useSelector(selectTradingSellFormStep);
+    const composedTransaction = useSelector(selectTradingComposedTransactionInfo);
 
     const exchange = trade?.data?.exchange;
     const provider =
@@ -57,6 +63,7 @@ export const TradingDetailSell = () => {
         sendCurrency: trade?.data?.fiatCurrency,
         receiveAmount: trade?.data?.cryptoStringAmount ?? '',
         receiveCurrency: trade?.data?.cryptoCurrency,
+        networkFee: composedTransaction?.composed?.fee,
     };
 
     const sendAccount = accounts.find(account => account.key === trade?.sendAccountKey);
@@ -128,6 +135,7 @@ export const TradingDetailSell = () => {
                     transactionId={trade.key}
                     type="sell"
                     quoteAmounts={quoteAmounts}
+                    formStep={formStep}
                 />
             </Card>
         </Wrapper>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAccount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAccount.tsx
@@ -53,7 +53,8 @@ export const TradingFormInputAccount = <
         | TradingAccountOptionsGroupOptionProps
         | undefined;
     const fiatValues = useTradingFiatValues({
-        sendCryptoSelect: selectedOption,
+        amount: selectedOption?.balance,
+        cryptoId: selectedOption?.value,
         fiatCurrency: getValues().outputs?.[0]?.currency?.value as FiatCurrencyCode,
     });
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInputs.tsx
@@ -9,6 +9,7 @@ import {
     type TradingBuyFormProps,
     type TradingExchangeFormProps,
     type TradingSellFormProps,
+    cryptoIdToNetworkAndContractAddress,
 } from '@suite-common/trading';
 import { TokenAddress } from '@suite-common/wallet-types';
 import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
@@ -17,6 +18,7 @@ import { hasBitcoinOnlyFirmware } from '@trezor/device-utils/src/firmwareUtils';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
+import { ExperimentWrapper } from 'src/components/suite/Experiment/ExperimentWrapper';
 import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { TradingUseFormActionsReturnProps } from 'src/types/trading/tradingForm';
@@ -209,14 +211,28 @@ export const TradingFormInputs = () => {
                                     />
                                 ))}
                             </Row>
-                            <TradingBalance
-                                balance={outputAmount}
-                                displaySymbol={sendCryptoSelect?.value}
-                                symbol={account.symbol}
-                                tokenAddress={tokenAddress}
-                                showOnlyAmount
-                                amountInCrypto={amountInCrypto}
-                                sendCryptoSelect={sendCryptoSelect}
+                            <ExperimentWrapper
+                                id="tradingFiatValues"
+                                components={[
+                                    {
+                                        variant: 'A',
+                                        element: <></>,
+                                    },
+                                    {
+                                        variant: 'B',
+                                        element: (
+                                            <TradingBalance
+                                                balance={outputAmount}
+                                                displaySymbol={sendCryptoSelect?.value}
+                                                symbol={account.symbol}
+                                                tokenAddress={tokenAddress}
+                                                showOnlyAmount
+                                                amountInCrypto={amountInCrypto}
+                                                sendCryptoSelect={sendCryptoSelect}
+                                            />
+                                        ),
+                                    },
+                                ]}
                             />
                         </Row>
                     )}
@@ -248,8 +264,11 @@ export const TradingFormInputs = () => {
     }
 
     const { buyInfo, device } = context;
-    const { currencySelect, cryptoSelect } = context.getValues();
+    const { currencySelect, cryptoSelect, amountInCrypto, cryptoInput } = context.getValues();
     const supportedCryptoCurrencies = buyInfo?.supportedCryptoCurrencies;
+
+    const tokenAddress = (cryptoSelect.contractAddress as TokenAddress | null) ?? undefined;
+    const { network } = cryptoIdToNetworkAndContractAddress(cryptoSelect.value);
 
     return (
         <>
@@ -260,14 +279,45 @@ export const TradingFormInputs = () => {
                 methods={{ ...context }}
                 isDisabled={hasBitcoinOnlyFirmware(device)}
             />
-            <TradingFormInputFiatCrypto<TradingBuyFormProps>
-                cryptoInputName={TRADING_FORM_CRYPTO_INPUT}
-                fiatInputName={TRADING_FORM_FIAT_INPUT}
-                cryptoSelectName={TRADING_FORM_CRYPTO_CURRENCY_SELECT}
-                currencySelectLabel={currencySelect.label}
-                cryptoCurrencyLabel={cryptoSelect.value}
-                methods={{ ...context }}
-            />
+            <Column gap={spacings.xs}>
+                <TradingFormInputFiatCrypto<TradingBuyFormProps>
+                    cryptoInputName={TRADING_FORM_CRYPTO_INPUT}
+                    fiatInputName={TRADING_FORM_FIAT_INPUT}
+                    cryptoSelectName={TRADING_FORM_CRYPTO_CURRENCY_SELECT}
+                    currencySelectLabel={currencySelect.label}
+                    cryptoCurrencyLabel={cryptoSelect.value}
+                    methods={{ ...context }}
+                />
+
+                {amountInCrypto && (
+                    <ExperimentWrapper
+                        id="tradingFiatValues"
+                        components={[
+                            {
+                                variant: 'A',
+                                element: <></>,
+                            },
+                            {
+                                variant: 'B',
+                                element: network?.symbol ? (
+                                    <Row justifyContent="end">
+                                        <TradingBalance
+                                            balance={cryptoInput}
+                                            displaySymbol={cryptoSelect?.label}
+                                            symbol={network?.symbol}
+                                            tokenAddress={tokenAddress}
+                                            showOnlyAmount
+                                            amountInCrypto={amountInCrypto}
+                                        />
+                                    </Row>
+                                ) : (
+                                    <></>
+                                ),
+                            },
+                        ]}
+                    />
+                )}
+            </Column>
             <TradingFormInputPaymentMethod label="TR_TRADING_PAYMENT_METHOD" />
             <TradingFormInputCountry label="TR_TRADING_COUNTRY" />
             <TradingFormFeesDisclamer />

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -22,6 +22,7 @@ import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { Translation } from 'src/components/suite';
+import { ExperimentWrapper } from 'src/components/suite/Experiment/ExperimentWrapper';
 import { ApproveModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal';
 import { RevokeModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -271,7 +272,7 @@ export const TradingFormOffer = () => {
     const selectedAssetCryptoId =
         !state.isLoadingOrInvalid && receiveCurrency
             ? receiveCurrency
-            : (selectedCrypto?.value as CryptoId);
+            : (selectedCrypto?.value as CryptoId | undefined);
 
     return (
         <Column gap={spacings.lg}>
@@ -297,14 +298,25 @@ export const TradingFormOffer = () => {
                     />
                 )}
                 {isTradingExchangeContext(context) && contractAddress && network && (
-                    <Paragraph typographyStyle="label" variant="tertiary">
-                        <Translation
-                            id="TR_TRADING_ON_NETWORK_CHAIN"
-                            values={{
-                                networkName: network,
-                            }}
-                        />
-                    </Paragraph>
+                    <ExperimentWrapper
+                        id="tradingFiatValues"
+                        components={[
+                            {
+                                variant: 'A',
+                                element: (
+                                    <Paragraph typographyStyle="label" variant="tertiary">
+                                        <Translation
+                                            id="TR_TRADING_ON_NETWORK_CHAIN"
+                                            values={{
+                                                networkName: network,
+                                            }}
+                                        />
+                                    </Paragraph>
+                                ),
+                            },
+                            { variant: 'B', element: <></> },
+                        ]}
+                    />
                 )}
             </Column>
             <Column gap={spacings.xxs}>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOfferCryptoAmount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOfferCryptoAmount.tsx
@@ -1,41 +1,76 @@
 import { CryptoId } from 'invity-api';
 
-import { useTradingInfo } from '@suite-common/trading';
-import { Row, Text } from '@trezor/components';
+import { cryptoIdToNetwork, useTradingInfo } from '@suite-common/trading';
+import { TokenAddress } from '@suite-common/wallet-types';
+import { Column, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
+import { BigNumber } from '@trezor/utils';
 
-import { FormattedCryptoAmount } from 'src/components/suite';
+import { BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
+import { ExperimentWrapper } from 'src/components/suite/Experiment/ExperimentWrapper';
 import { TradingCoinLogo } from 'src/views/wallet/trading/common/TradingCoinLogo';
 
 interface TradingCryptoAmountProps {
     amount: string | number;
-    cryptoId: CryptoId;
+    cryptoId: CryptoId | undefined;
 }
 
 export const TradingFormOfferCryptoAmount = ({ amount, cryptoId }: TradingCryptoAmountProps) => {
     const { cryptoIdToSymbolAndContractAddress } = useTradingInfo();
     const { coinSymbol, contractAddress } = cryptoIdToSymbolAndContractAddress(cryptoId);
+    const network = cryptoId && cryptoIdToNetwork(cryptoId);
 
     if (!coinSymbol) {
         return;
     }
 
+    const hasAmount = amount && new BigNumber(amount).gt(0);
+
     return (
-        <Row gap={spacings.sm}>
-            <TradingCoinLogo cryptoId={cryptoId} />
-            <Text
-                data-testid="@trading/best-offer/amount"
-                typographyStyle="titleMedium"
-                ellipsisLineCount={2}
-            >
-                <FormattedCryptoAmount
-                    value={amount}
-                    symbol={coinSymbol}
-                    contractAddress={contractAddress}
-                    isRawString
-                    isBalance={false}
-                />
-            </Text>
-        </Row>
+        <Column alignItems="start">
+            <Row gap={spacings.xs} alignItems="center">
+                {cryptoId && <TradingCoinLogo cryptoId={cryptoId} />}
+                <Text
+                    data-testid="@trading/best-offer/amount"
+                    typographyStyle="titleMedium"
+                    ellipsisLineCount={2}
+                >
+                    <FormattedCryptoAmount
+                        value={amount}
+                        symbol={coinSymbol}
+                        contractAddress={contractAddress}
+                        isRawString
+                        isBalance={false}
+                    />
+                </Text>
+            </Row>
+            <ExperimentWrapper
+                id="tradingFiatValues"
+                components={[
+                    { variant: 'A', element: <></> },
+                    {
+                        variant: 'B',
+                        element:
+                            hasAmount && network ? (
+                                <Text
+                                    typographyStyle="hint"
+                                    variant="tertiary"
+                                    margin={{ left: spacings.xxl }}
+                                >
+                                    <BaseCurrencyValue
+                                        amount={amount.toString()}
+                                        tokenAddress={contractAddress as TokenAddress}
+                                        symbol={network.symbol}
+                                        rateType="current"
+                                        showApproximationIndicator
+                                    />
+                                </Text>
+                            ) : (
+                                <></>
+                            ),
+                    },
+                ]}
+            />
+        </Column>
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOfferOTC.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOfferOTC.tsx
@@ -65,6 +65,7 @@ export const TradingFormOfferOTC = () => {
         amount: cryptoAmount || '0',
         symbol: network?.symbol || 'btc',
         tokenAddress: contractAddress as TokenAddress | undefined,
+        rateType: 'current',
     });
 
     const fiatAmount = amountInCrypto ? fiatAmountConverted : fiatInput;

--- a/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingExchangeHeaderSummary.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingExchangeHeaderSummary.tsx
@@ -73,6 +73,7 @@ export const TradingExchangeHeaderSummary = ({
                                 disableHiddenPlaceholder
                                 amount={feeAmount}
                                 symbol={symbol}
+                                rateType="current"
                             />
                         ),
                     }}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoExchangeType.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoExchangeType.tsx
@@ -1,7 +1,7 @@
 import { ExchangeTrade } from 'invity-api';
 
 import type { TradingTradeType } from '@suite-common/trading';
-import { Row, Text, Tooltip } from '@trezor/components';
+import { InfoItem, Text, Tooltip } from '@trezor/components';
 
 import { Translation } from 'src/components/suite';
 import { TradingExchangeProvidersInfoProps } from 'src/types/trading/trading';
@@ -21,8 +21,8 @@ export const TradingInfoExchangeType = ({
         providers && exchangeQuote.exchange ? providers[exchangeQuote.exchange] : undefined;
 
     return (
-        <Row justifyContent="center" flex="auto">
-            <Text data-testid="@trading/offer/info/exchange-type" variant="tertiary">
+        <InfoItem label={<Translation id="TR_TRADING_EXCHANGE_TYPE" />} direction="row">
+            <Text data-testid="@trading/offer/info/exchange-type">
                 {provider?.isFixedRate && !exchangeQuote.isDex && (
                     <Tooltip content={<Translation id="TR_EXCHANGE_FIXED_OFFERS_INFO" />} hasIcon>
                         <Translation id="TR_EXCHANGE_FIXED" />
@@ -35,6 +35,6 @@ export const TradingInfoExchangeType = ({
                 )}
                 {exchangeQuote.isDex && <Translation id="TR_EXCHANGE_DEX" />}
             </Text>
-        </Row>
+        </InfoItem>
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoFee.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoFee.tsx
@@ -1,0 +1,23 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { AmountUnit } from '@suite-common/wallet-utils';
+import { InfoItem } from '@trezor/components';
+
+import { BaseCurrencyValue, Translation } from 'src/components/suite';
+
+interface TradingInfoFeeProps {
+    symbol: NetworkSymbol | undefined;
+    amount: AmountUnit | undefined;
+}
+
+export const TradingInfoFee = ({ symbol, amount }: TradingInfoFeeProps) => (
+    <InfoItem label={<Translation id="TR_TRADING_NETWORK_FEE" />} direction="row">
+        {amount && symbol && (
+            <BaseCurrencyValue
+                disableHiddenPlaceholder
+                amount={amount}
+                symbol={symbol}
+                showApproximationIndicator
+            />
+        )}
+    </InfoItem>
+);

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
@@ -1,13 +1,20 @@
 import { CryptoId } from 'invity-api';
 
-import { type TradingType } from '@suite-common/trading';
-import { Account } from '@suite-common/wallet-types';
+import {
+    TradingExchangeStepType,
+    TradingSellStepType,
+    type TradingType,
+    cryptoIdToNetworkSymbolAndContractAddress,
+} from '@suite-common/trading';
+import { Account, TokenAddress } from '@suite-common/wallet-types';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-utils';
-import { Column, InfoItem, Row, Text } from '@trezor/components';
-import { spacings } from '@trezor/theme';
+import { Box, Column, InfoItem, Row, Text } from '@trezor/components';
+import { borders, spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils';
 
-import { AccountLabel, Translation } from 'src/components/suite';
+import { AccountLabel, BaseCurrencyValue, Translation } from 'src/components/suite';
+import { ExperimentWrapper } from 'src/components/suite/Experiment/ExperimentWrapper';
+import { useTranslation } from 'src/hooks/suite';
 import { TradingPayGetLabelType } from 'src/types/trading/trading';
 import { TradingCoinLogo } from 'src/views/wallet/trading/common/TradingCoinLogo';
 import { TradingCryptoAmount } from 'src/views/wallet/trading/common/TradingCryptoAmount';
@@ -20,6 +27,7 @@ interface TradingInfoItemProps {
     currency?: CryptoId;
     amount?: string;
     isReceive?: boolean;
+    formStep?: TradingExchangeStepType | TradingSellStepType;
 }
 
 export const TradingInfoItem = ({
@@ -29,21 +37,27 @@ export const TradingInfoItem = ({
     label,
     currency,
     amount,
-}: TradingInfoItemProps) => (
-    <InfoItem label={<Translation id={label} />} direction="row">
-        {type === 'exchange' || isReceive ? (
-            <Column alignItems="flex-end" gap={spacings.xxxs}>
-                <Row gap={spacings.xs}>
-                    {currency && (
-                        <>
-                            <TradingCoinLogo cryptoId={currency} size={20} />
-                            <TradingCryptoAmount amount={amount} cryptoId={currency} />
-                        </>
-                    )}
-                </Row>
-                {account && (
-                    <Text variant="tertiary" typographyStyle="label" as="div">
-                        <Row gap={spacings.xxs}>
+    formStep,
+}: TradingInfoItemProps) => {
+    const { translationString } = useTranslation();
+    const currencyInfo = currency && cryptoIdToNetworkSymbolAndContractAddress(currency);
+    const accountLabelPrefix = translationString(isReceive ? 'TR_TO' : 'TR_FROM').toLowerCase();
+
+    const shouldShowAccountLabel =
+        ((formStep && ['SEND_TRANSACTION', 'SIGN_DATA'].includes(formStep)) || !isReceive) &&
+        account &&
+        type !== 'sell';
+
+    return type === 'exchange' || isReceive ? (
+        <Column width="100%">
+            <Row justifyContent="space-between">
+                <Text variant="tertiary" typographyStyle="hint">
+                    <Translation id={label} />
+                </Text>
+                {shouldShowAccountLabel && (
+                    <Text variant="tertiary" typographyStyle="hint" as="div">
+                        <Row>
+                            {accountLabelPrefix}&nbsp;
                             <AccountLabel
                                 account={account}
                                 showAccountTypeBadge
@@ -52,8 +66,51 @@ export const TradingInfoItem = ({
                         </Row>
                     </Text>
                 )}
-            </Column>
-        ) : (
+            </Row>
+            <Box
+                margin={{ top: spacings.xs }}
+                borderWidth={borders.widths.medium}
+                borderRadius={borders.radii.sm}
+                padding={spacings.md}
+            >
+                {amount && currency && (
+                    <Row gap={spacings.xs} alignItems="start">
+                        <TradingCoinLogo cryptoId={currency} size={24} />
+                        <Column>
+                            <TradingCryptoAmount amount={amount} cryptoId={currency} />
+                            <ExperimentWrapper
+                                id="tradingFiatValues"
+                                components={[
+                                    { variant: 'A', element: <></> },
+                                    {
+                                        variant: 'B',
+                                        element: currencyInfo?.symbol ? (
+                                            <Text variant="tertiary" typographyStyle="hint">
+                                                <BaseCurrencyValue
+                                                    amount={amount}
+                                                    symbol={currencyInfo.symbol}
+                                                    rateType="current"
+                                                    tokenAddress={
+                                                        currencyInfo.contractAddress as
+                                                            | TokenAddress
+                                                            | undefined
+                                                    }
+                                                    showApproximationIndicator
+                                                />
+                                            </Text>
+                                        ) : (
+                                            <></>
+                                        ),
+                                    },
+                                ]}
+                            />
+                        </Column>
+                    </Row>
+                )}
+            </Box>
+        </Column>
+    ) : (
+        <InfoItem label={<Translation id={label} />} direction="row">
             <Row data-testid="@trading/form/info/fiat-amount">
                 <TradingFiatAmount
                     amount={
@@ -64,6 +121,6 @@ export const TradingInfoItem = ({
                     currency={currency}
                 />
             </Row>
-        )}
-    </InfoItem>
-);
+        </InfoItem>
+    );
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
@@ -67,8 +67,9 @@ export const TradingOfferExchange = ({
                     <Fragment key={index}>{step.isActive && step.component}</Fragment>
                 ))}
             </Card>
-            <Card>
+            <Card paddingType="large">
                 <TradingSelectedOfferInfo
+                    formStep={formStep}
                     account={account}
                     selectedAccount={tradingVerifyAccount.selectedAccountOption?.account}
                     selectedQuote={selectedQuote}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSell.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSell.tsx
@@ -50,7 +50,11 @@ export const TradingOfferSell = (props: TradingOfferSellProps) => {
                 ))}
             </Card>
             <Card>
-                <TradingSelectedOfferInfo {...props} selectedAccount={sendAccount} />
+                <TradingSelectedOfferInfo
+                    {...props}
+                    selectedAccount={sendAccount}
+                    formStep={formStep}
+                />
             </Card>
         </>
     );

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo.tsx
@@ -1,18 +1,21 @@
 import { CryptoId } from 'invity-api';
 
-import { Column, Divider } from '@trezor/components';
+import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
+import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
+import { BigNumber } from '@trezor/utils';
 
 import { TradingExchangeProvidersInfoProps } from 'src/types/trading/trading';
 import { TradingSelectedOfferInfoProps } from 'src/types/trading/tradingForm';
 import { tradingGetAmountLabels } from 'src/utils/wallet/trading/tradingUtils';
 import { TradingInfoExchangeType } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoExchangeType';
-import { TradingInfoHeader } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoHeader';
 import { TradingInfoItem } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem';
 import { TradingInfoPaymentMethod } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoPaymentMethod';
 import { TradingInfoProvider } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoProvider';
 import { TradingTransactionId } from 'src/views/wallet/trading/common/TradingTransactionId';
 import { TradingUtilsKyc } from 'src/views/wallet/trading/common/TradingUtils/TradingUtilsKyc';
+
+import { TradingInfoFee } from './TradingInfo/TradingInfoFee';
 
 export const TradingSelectedOfferInfo = ({
     account,
@@ -24,51 +27,63 @@ export const TradingSelectedOfferInfo = ({
     transactionId,
     paymentMethod,
     paymentMethodName,
+    formStep,
 }: TradingSelectedOfferInfoProps) => {
     const { exchange } = selectedQuote;
 
-    const amountLabels = tradingGetAmountLabels({ type, amountInCrypto: true });
+    const amountInCrypto = quoteAmounts?.amountInCrypto ?? true;
+
+    const amountLabels = tradingGetAmountLabels({ type, amountInCrypto });
+
+    const tradedAssets = [
+        <TradingInfoItem
+            key={amountLabels.sendLabel}
+            account={account}
+            type={type}
+            label={amountLabels.sendLabel}
+            currency={quoteAmounts?.sendCurrency as CryptoId}
+            amount={quoteAmounts?.sendAmount}
+            formStep={formStep}
+        />,
+        <TradingInfoItem
+            key={amountLabels.receiveLabel}
+            account={selectedAccount}
+            type={type}
+            label={amountLabels.receiveLabel}
+            currency={quoteAmounts?.receiveCurrency}
+            amount={quoteAmounts?.receiveAmount}
+            formStep={formStep}
+            isReceive
+        />,
+    ];
+
+    const fee =
+        quoteAmounts?.networkFee && account?.symbol
+            ? subunitsToUnits({
+                  value: asAmountSubunit(new BigNumber(quoteAmounts.networkFee)),
+                  symbol: account.symbol,
+              })
+            : undefined;
 
     return (
         <Column gap={spacings.xl} data-testid="@trading/form/info">
-            {type !== 'exchange' && quoteAmounts?.receiveCurrency && (
-                <>
-                    <TradingInfoHeader receiveCurrency={quoteAmounts.receiveCurrency} />
-                    <Divider margin={{}} />
-                </>
-            )}
-            <TradingInfoItem
-                account={account}
-                type={type}
-                label={amountLabels.sendLabel}
-                currency={quoteAmounts?.sendCurrency as CryptoId}
-                amount={quoteAmounts?.sendAmount}
-            />
-            <TradingInfoItem
-                account={selectedAccount}
-                type={type}
-                label={amountLabels.receiveLabel}
-                currency={quoteAmounts?.receiveCurrency}
-                amount={quoteAmounts?.receiveAmount}
-                isReceive
-            />
-            <Divider margin={{}} />
-            {type === 'exchange' && (
-                <>
+            <Column gap={spacings.sm}>
+                {type === 'sell' ? [...tradedAssets.reverse()] : tradedAssets}
+                {fee && <TradingInfoFee symbol={account?.symbol} amount={fee} />}
+                <TradingInfoProvider providers={providers} exchange={exchange} />
+                {type === 'exchange' && (
                     <TradingInfoExchangeType
                         selectedQuote={selectedQuote}
                         providers={providers as TradingExchangeProvidersInfoProps}
                     />
-                    <Divider margin={{}} />
-                </>
-            )}
-            <TradingInfoProvider providers={providers} exchange={exchange} />
-            {paymentMethod && (
-                <TradingInfoPaymentMethod
-                    paymentMethod={paymentMethod}
-                    paymentMethodName={paymentMethodName}
-                />
-            )}
+                )}
+                {paymentMethod && (
+                    <TradingInfoPaymentMethod
+                        paymentMethod={paymentMethod}
+                        paymentMethodName={paymentMethodName}
+                    />
+                )}
+            </Column>
             {type === 'exchange' && (
                 <TradingUtilsKyc
                     exchange={exchange}

--- a/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsKyc.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsKyc.tsx
@@ -35,8 +35,6 @@ const getKycPolicy = (kycPolicyType: ExchangeKYCType | undefined) => {
     if (kycPolicyType === KYC_NO_KYC) {
         return <Translation id="TR_TRADING_KYC_NO_KYC" />;
     }
-
-    return <Translation id="TR_TRADING_KYC_DEX" />;
 };
 
 export const TradingUtilsKyc = ({

--- a/suite-common/fiat-services/src/coingecko.ts
+++ b/suite-common/fiat-services/src/coingecko.ts
@@ -1,4 +1,4 @@
-import { networks } from '@suite-common/wallet-config';
+import { getNetwork, networks } from '@suite-common/wallet-config';
 import { HistoricRates, TickerId } from '@suite-common/wallet-types';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { parseAsset } from '@trezor/blockchain-link-utils/src/blockfrost';
@@ -15,11 +15,15 @@ interface HistoricalResponse extends HistoricRates {
     symbol: string;
 }
 
+interface FetchCurrentFiatRatesOptions {
+    skipCache?: boolean;
+}
+
 const rateLimiter = new RateLimiter(1_000, 15_000);
 
-const fetchCoinGecko = async (url: string) => {
+const fetchCoinGecko = async (url: string, init?: RequestInit) => {
     try {
-        const res = await rateLimiter.limit(signal => fetchUrl(url, { signal }));
+        const res = await rateLimiter.limit(signal => fetchUrl(url, { signal, ...init }));
         if (!res.ok) {
             console.warn(`Coingecko: Fiat rates failed to fetch: ${res.status}`);
 
@@ -40,7 +44,7 @@ const fetchCoinGecko = async (url: string) => {
  * @returns
  */
 const buildCoinUrls = (ticker: TickerId) => {
-    const { coingeckoId } = networks[ticker.symbol];
+    const { coingeckoId, settlementLayer } = getNetwork(ticker.symbol);
     if (!coingeckoId) {
         console.error('buildCoinUrls: cannot find coingecko asset platform id for ', ticker);
 
@@ -48,6 +52,10 @@ const buildCoinUrls = (ticker: TickerId) => {
     }
 
     const baseUrl = `${COINGECKO_API_BASE_URL}/coins/${coingeckoId}`;
+
+    if (settlementLayer && !ticker.tokenAddress) {
+        return [`${COINGECKO_API_BASE_URL}/coins/${networks[settlementLayer].coingeckoId}`];
+    }
 
     if (!ticker.tokenAddress) {
         return [baseUrl];
@@ -80,16 +88,21 @@ const buildCoinUrls = (ticker: TickerId) => {
  * @param {TickerId} ticker
  * @returns
  */
-export const fetchCurrentFiatRates = async (ticker: TickerId) => {
+export const fetchCurrentFiatRates = async (
+    ticker: TickerId,
+    options?: FetchCurrentFiatRatesOptions,
+) => {
     const coinUrls = buildCoinUrls(ticker);
     if (!coinUrls || coinUrls.length === 0) return null;
 
     const urlParams =
         'tickers=false&market_data=true&community_data=false&developer_data=false&sparkline=false&localization=false';
 
+    const headers = options?.skipCache ? { 'X-Bypass-Cache': '1' } : undefined;
+
     for (const coinUrl of coinUrls) {
         const url = `${coinUrl}?${urlParams}`;
-        const rates = await fetchCoinGecko(url);
+        const rates = await fetchCoinGecko(url, { headers });
 
         if (rates) {
             return {

--- a/suite-common/fiat-services/src/rates.ts
+++ b/suite-common/fiat-services/src/rates.ts
@@ -28,6 +28,7 @@ type FiatRatesParams = {
     ticker: TickerId;
     localCurrency: BaseCurrencyCode;
     isElectrumBackend: boolean;
+    skipCache?: boolean;
 };
 
 const getConnectFiatRatesForTimestamp = async (
@@ -73,11 +74,14 @@ export const fetchCurrentFiatRates = ({
     ticker,
     localCurrency,
     isElectrumBackend,
+    skipCache,
 }: FiatRatesParams): Promise<FiatRatesResult | null> =>
     parallelRequestsCache.cache(
         ['fetchCurrentFiatRates', ticker.symbol, ticker.tokenAddress, localCurrency],
         async () => {
-            if (isBlockbookBasedNetwork(ticker.symbol)) {
+            // If skipCache is true, skip Blockbook support check and fetch fiat rates
+            // directly from Coingecko to ensure up-to-date values.
+            if (isBlockbookBasedNetwork(ticker.symbol) && !skipCache) {
                 if (!isElectrumBackend) {
                     const { success, payload } = await scheduleAction(
                         () =>
@@ -129,7 +133,9 @@ export const fetchCurrentFiatRates = ({
                     };
             }
 
-            const coingeckoResponse = await coingeckoService.fetchCurrentFiatRates(ticker);
+            const coingeckoResponse = await coingeckoService.fetchCurrentFiatRates(ticker, {
+                skipCache,
+            });
 
             if (!coingeckoResponse) {
                 return null;

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -122,6 +122,7 @@ export type ContextDomain = FunctionContextReturnValues;
 
 export const Experiment = {
     tradingFeedbackForm: '092db279-98dc-418e-bbfa-ef70716fb211',
+    tradingFiatValues: 'b73df44d-37ed-4b66-aba1-5c4164493bae',
 } as const;
 
 export type ExperimentKey = keyof typeof Experiment;

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -102,6 +102,7 @@ type UpdateCurrentFiatRatesThunkPayload = {
     fetchAttemptTimestamp: Timestamp;
     rateType: RateTypeWithoutHistoric;
     forceFetchToken?: boolean;
+    skipCache?: boolean;
 };
 
 export const updateFiatRatesThunk = createThunk<
@@ -110,7 +111,10 @@ export const updateFiatRatesThunk = createThunk<
     void
 >(
     `${FIAT_RATES_MODULE_PREFIX}/updateFiatRates`,
-    async ({ tickers, baseCurrencyCode, rateType, forceFetchToken }, { getState }) => {
+    async (
+        { tickers, baseCurrencyCode, rateType, forceFetchToken, skipCache = false },
+        { getState },
+    ) => {
         const fetchRate = async (ticker: TickerId) => {
             if (isTestnet(ticker.symbol)) {
                 throw new Error('Testnet');
@@ -140,6 +144,7 @@ export const updateFiatRatesThunk = createThunk<
                             ticker,
                             localCurrency: baseCurrencyCode,
                             isElectrumBackend,
+                            skipCache,
                         });
                     case 'lastWeek':
                         return fetchLastWeekFiatRates({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR implements small redesign of trading offer section and showing of up to date fiat values for trading. Showing of fiat values is part of `tradingFiatValues` experiment and to test this PR locally you'll have to update config with values below and `FORCE_LOCAL_JWS` variable [here](https://github.com/trezor/trezor-suite/blob/develop/suite-common/message-system/src/messageSystemThunks.ts#L27). Also, fiat value of network fee is now shown in the offer section.

### Experiment
```
        {
            "conditions": [
                {
                    "environment": {
                        "desktop": "*",
                        "mobile": "*",
                        "web": "*"
                    }
                }
            ],
            "experiment": {
                "id": "b73df44d-37ed-4b66-aba1-5c4164493bae",
                "groups": [
                    {
                        "variant": "A",
                        "percentage": 0
                    },
                    {
                        "variant": "B",
                        "percentage": 100
                    }
                ]
            }
        }
```


## Related Issue

Resolve #19948

## Screenshots:
<details>
  <summary><h3>Exchange</h3></summary>
<img width="1463" height="873" alt="swap-1" src="https://github.com/user-attachments/assets/c33ab676-0bec-41bf-b191-7caa19dc16f3" />
<img width="1459" height="873" alt="swap-2" src="https://github.com/user-attachments/assets/818cdff0-5fdf-448c-8c41-6d91d6455809" />
<img width="1463" height="872" alt="swap-3" src="https://github.com/user-attachments/assets/75f48c6e-7901-440b-892c-f9ca90226420" />
</details>

<details>
   <summary><h3>Sell</h3></summary>
<img width="1509" height="970" alt="sell-1" src="https://github.com/user-attachments/assets/ecd48d22-f2be-42ca-9166-eb5c698a3d40" />
<img width="1510" height="973" alt="sell-2" src="https://github.com/user-attachments/assets/9acad5f3-8114-4354-9a3e-af540010406f" />
<img width="1510" height="967" alt="sell-3" src="https://github.com/user-attachments/assets/771dede5-e9a6-4d49-8a91-f9cd95d94f95" />
</details>

<details>
   <summary><h3>Buy</h3></summary>
<img width="1448" height="895" alt="buy-1" src="https://github.com/user-attachments/assets/177f4f61-9acf-4a42-9bbf-6162b3651295" />
<img width="1448" height="890" alt="buy-2" src="https://github.com/user-attachments/assets/dbdc39f9-4838-4bd4-9890-27391ac07748" />
<img width="1442" height="891" alt="buy-3" src="https://github.com/user-attachments/assets/a8942119-7a4f-44f0-8f34-929899fc97e8" />
</details>

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/fiat-rates-in-trading&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/fiat-rates-in-trading&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/fiat-rates-in-trading&lookback=7)