### PR TITLE
`createAccount` miniclean

### DIFF
--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -621,7 +621,7 @@ export const createCoinjoinAccount =
                     unlockPath: unlockPath.payload,
                     accountType: account.accountType,
                     backendType: 'coinjoin',
-                    coin: network.symbol,
+                    symbol: network.symbol,
                 },
                 accountInfo: {
                     ...EMPTY_ACCOUNT_INFO,

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -620,6 +620,7 @@ export const createCoinjoinAccount =
                 unlockPath: unlockPath.payload,
                 accountType: account.accountType,
                 backendType: 'coinjoin',
+                status: 'initial',
                 symbol: network.symbol,
                 accountInfo: {
                     ...EMPTY_ACCOUNT_INFO,

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -615,14 +615,12 @@ export const createCoinjoinAccount =
         const coinjoinAccount = dispatch(
             accountsActions.createAccount({
                 deviceState: device!.state!.staticSessionId!,
-                discoveryItem: {
-                    index: 0,
-                    path,
-                    unlockPath: unlockPath.payload,
-                    accountType: account.accountType,
-                    backendType: 'coinjoin',
-                    symbol: network.symbol,
-                },
+                index: 0,
+                path,
+                unlockPath: unlockPath.payload,
+                accountType: account.accountType,
+                backendType: 'coinjoin',
+                symbol: network.symbol,
                 accountInfo: {
                     ...EMPTY_ACCOUNT_INFO,
                     descriptor: publicKey.payload.xpubSegwit || publicKey.payload.xpub,

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -622,8 +622,6 @@ export const createCoinjoinAccount =
                     accountType: account.accountType,
                     backendType: 'coinjoin',
                     coin: network.symbol,
-                    derivationType: 0,
-                    status: 'initial',
                 },
                 accountInfo: {
                     ...EMPTY_ACCOUNT_INFO,

--- a/suite-common/connect-popup/src/methodHooks/utils/index.ts
+++ b/suite-common/connect-popup/src/methodHooks/utils/index.ts
@@ -8,12 +8,10 @@ export const createPlaceholderAccount = (
     accountsActions.createAccount({
         // Real device state not needed, this is also better to differentiate from real accounts
         deviceState: 'placeholder@connect:0',
-        discoveryItem: {
-            index: 0,
-            path,
-            accountType: 'placeholder',
-            symbol: network.symbol,
-        },
+        index: 0,
+        path,
+        accountType: 'placeholder',
+        symbol: network.symbol,
         accountInfo: {
             path,
             descriptor: '',

--- a/suite-common/connect-popup/src/methodHooks/utils/index.ts
+++ b/suite-common/connect-popup/src/methodHooks/utils/index.ts
@@ -12,7 +12,7 @@ export const createPlaceholderAccount = (
             index: 0,
             path,
             accountType: 'placeholder',
-            coin: network.symbol,
+            symbol: network.symbol,
         },
         accountInfo: {
             path,

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -48,88 +48,84 @@ export type CreateAccountActionProps = Pick<
     error?: string;
 };
 
-const composeCreateAccountActionPayload = ({
-    deviceState,
-    path,
-    unlockPath,
-    symbol,
-    index,
-    accountType,
-    backendType,
-    accountInfo,
-    imported,
-    accountLabel,
-    visible,
-    error,
-}: CreateAccountActionProps): Account => {
-    try {
-        const { chainId } = getNetwork(symbol);
-        const { networkType } = networks[symbol];
-        const isNonEthEvm = networkType === 'ethereum' && symbol !== 'eth';
-
-        const metadataKey = isNonEthEvm
-            ? `${accountInfo.descriptor}-${chainId}`
-            : accountInfo.legacyXpub || accountInfo.descriptor;
-
-        const result: Account = {
-            deviceState,
-            accountLabel,
-            imported,
-            ...(error !== undefined ? { error, failed: true } : { failed: undefined }),
-            index,
-            path,
-            unlockPath,
-            descriptor: accountInfo.descriptor,
-            descriptorChecksum: accountInfo.descriptorChecksum,
-            key: getAccountKey(accountInfo.descriptor, symbol, deviceState),
-            accountType,
-            symbol,
-            empty: accountInfo.empty,
-            ...(backendType === 'coinjoin'
-                ? {
-                      backendType: 'coinjoin',
-                      status: 'initial',
-                  }
-                : {
-                      backendType,
-                  }),
-            visible,
-            balance: accountInfo.balance,
-            availableBalance: accountInfo.availableBalance,
-            formattedBalance: formatNetworkAmount(
-                // Ripple and Stellar `availableBalance` is reduced by reserve, use regular balance
-                isArrayMember(networkType, ['ripple', 'stellar'])
-                    ? accountInfo.balance
-                    : accountInfo.availableBalance,
-                symbol,
-            ),
-            tokens: enhanceTokens(accountInfo.tokens),
-            addresses: enhanceAddresses(accountInfo, {
-                networkType,
-                index,
-                addresses: accountInfo.addresses,
-            }),
-            utxo: enhanceUtxo(accountInfo.utxo, networkType, index),
-            history: accountInfo.history,
-            metadata: {
-                key: metadataKey,
-            },
-            ts: Date.now(),
-            ...getAccountSpecific(accountInfo, networkType),
-        };
-
-        return result;
-    } catch (error) {
-        console.error('Error creating account payload:', error);
-        throw new Error('Failed to create account payload');
-    }
-};
-
 const createAccount = createAction(
     `${ACCOUNTS_MODULE_PREFIX}/createAccount`,
-    (props: CreateAccountActionProps): { payload: Account } => ({
-        payload: composeCreateAccountActionPayload(props),
-    }),
+    ({
+        deviceState,
+        path,
+        unlockPath,
+        symbol,
+        index,
+        accountType,
+        backendType,
+        accountInfo,
+        imported,
+        accountLabel,
+        visible,
+        error,
+    }: CreateAccountActionProps): { payload: Account } => {
+        try {
+            const { chainId } = getNetwork(symbol);
+            const { networkType } = networks[symbol];
+            const isNonEthEvm = networkType === 'ethereum' && symbol !== 'eth';
+
+            const metadataKey = isNonEthEvm
+                ? `${accountInfo.descriptor}-${chainId}`
+                : accountInfo.legacyXpub || accountInfo.descriptor;
+
+            const payload: Account = {
+                deviceState,
+                accountLabel,
+                imported,
+                ...(error !== undefined ? { error, failed: true } : { failed: undefined }),
+                index,
+                path,
+                unlockPath,
+                descriptor: accountInfo.descriptor,
+                descriptorChecksum: accountInfo.descriptorChecksum,
+                key: getAccountKey(accountInfo.descriptor, symbol, deviceState),
+                accountType,
+                symbol,
+                empty: accountInfo.empty,
+                ...(backendType === 'coinjoin'
+                    ? {
+                          backendType: 'coinjoin',
+                          status: 'initial',
+                      }
+                    : {
+                          backendType,
+                      }),
+                visible,
+                balance: accountInfo.balance,
+                availableBalance: accountInfo.availableBalance,
+                formattedBalance: formatNetworkAmount(
+                    // Ripple and Stellar `availableBalance` is reduced by reserve, use regular balance
+                    isArrayMember(networkType, ['ripple', 'stellar'])
+                        ? accountInfo.balance
+                        : accountInfo.availableBalance,
+                    symbol,
+                ),
+                tokens: enhanceTokens(accountInfo.tokens),
+                addresses: enhanceAddresses(accountInfo, {
+                    networkType,
+                    index,
+                    addresses: accountInfo.addresses,
+                }),
+                utxo: enhanceUtxo(accountInfo.utxo, networkType, index),
+                history: accountInfo.history,
+                metadata: {
+                    key: metadataKey,
+                },
+                ts: Date.now(),
+                ...getAccountSpecific(accountInfo, networkType),
+            };
+
+            return { payload };
+        } catch (error) {
+            console.error('Error creating account payload:', error);
+            throw new Error('Failed to create account payload');
+        }
+    },
 );
 
 const createAccountFromAccountInfo = createAction(

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -51,9 +51,9 @@ const composeCreateAccountActionPayload = ({
     error,
 }: CreateAccountActionProps): Account => {
     try {
-        const { chainId } = getNetwork(discoveryItem.coin);
-        const { networkType } = networks[discoveryItem.coin];
-        const isNonEthEvm = networkType === 'ethereum' && discoveryItem.coin !== 'eth';
+        const { chainId } = getNetwork(discoveryItem.symbol);
+        const { networkType } = networks[discoveryItem.symbol];
+        const isNonEthEvm = networkType === 'ethereum' && discoveryItem.symbol !== 'eth';
 
         const metadataKey = isNonEthEvm
             ? `${accountInfo.descriptor}-${chainId}`
@@ -69,9 +69,9 @@ const composeCreateAccountActionPayload = ({
             unlockPath: discoveryItem.unlockPath,
             descriptor: accountInfo.descriptor,
             descriptorChecksum: accountInfo.descriptorChecksum,
-            key: getAccountKey(accountInfo.descriptor, discoveryItem.coin, deviceState),
+            key: getAccountKey(accountInfo.descriptor, discoveryItem.symbol, deviceState),
             accountType: discoveryItem.accountType,
-            symbol: discoveryItem.coin,
+            symbol: discoveryItem.symbol,
             empty: accountInfo.empty,
             ...(discoveryItem.backendType === 'coinjoin'
                 ? {
@@ -89,7 +89,7 @@ const composeCreateAccountActionPayload = ({
                 isArrayMember(networkType, ['ripple', 'stellar'])
                     ? accountInfo.balance
                     : accountInfo.availableBalance,
-                discoveryItem.coin,
+                discoveryItem.symbol,
             ),
             tokens: enhanceTokens(accountInfo.tokens),
             addresses: enhanceAddresses(accountInfo, {

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -1,7 +1,7 @@
 import { createAction } from '@reduxjs/toolkit';
 
 import { getNetwork, networks } from '@suite-common/wallet-config';
-import { Account, DiscoveryItem, SelectedAccountStatus } from '@suite-common/wallet-types';
+import { Account, SelectedAccountStatus } from '@suite-common/wallet-types';
 import {
     enhanceAddresses,
     enhanceTokens,
@@ -31,19 +31,31 @@ const removeAccount = createAction(
     }),
 );
 
-export type CreateAccountActionProps = {
-    deviceState: StaticSessionId;
-    discoveryItem: DiscoveryItem;
+export type CreateAccountActionProps = Pick<
+    Account,
+    | 'path'
+    | 'unlockPath'
+    | 'symbol'
+    | 'index'
+    | 'accountType'
+    | 'backendType'
+    | 'deviceState'
+    | 'imported'
+    | 'accountLabel'
+    | 'visible'
+> & {
     accountInfo: AccountInfo;
-    imported?: boolean;
-    accountLabel?: string;
     error?: string;
-    visible: boolean;
 };
 
 const composeCreateAccountActionPayload = ({
     deviceState,
-    discoveryItem,
+    path,
+    unlockPath,
+    symbol,
+    index,
+    accountType,
+    backendType,
     accountInfo,
     imported,
     accountLabel,
@@ -51,9 +63,9 @@ const composeCreateAccountActionPayload = ({
     error,
 }: CreateAccountActionProps): Account => {
     try {
-        const { chainId } = getNetwork(discoveryItem.symbol);
-        const { networkType } = networks[discoveryItem.symbol];
-        const isNonEthEvm = networkType === 'ethereum' && discoveryItem.symbol !== 'eth';
+        const { chainId } = getNetwork(symbol);
+        const { networkType } = networks[symbol];
+        const isNonEthEvm = networkType === 'ethereum' && symbol !== 'eth';
 
         const metadataKey = isNonEthEvm
             ? `${accountInfo.descriptor}-${chainId}`
@@ -64,22 +76,22 @@ const composeCreateAccountActionPayload = ({
             accountLabel,
             imported,
             ...(error !== undefined ? { error, failed: true } : { failed: undefined }),
-            index: discoveryItem.index,
-            path: discoveryItem.path,
-            unlockPath: discoveryItem.unlockPath,
+            index,
+            path,
+            unlockPath,
             descriptor: accountInfo.descriptor,
             descriptorChecksum: accountInfo.descriptorChecksum,
-            key: getAccountKey(accountInfo.descriptor, discoveryItem.symbol, deviceState),
-            accountType: discoveryItem.accountType,
-            symbol: discoveryItem.symbol,
+            key: getAccountKey(accountInfo.descriptor, symbol, deviceState),
+            accountType,
+            symbol,
             empty: accountInfo.empty,
-            ...(discoveryItem.backendType === 'coinjoin'
+            ...(backendType === 'coinjoin'
                 ? {
                       backendType: 'coinjoin',
                       status: 'initial',
                   }
                 : {
-                      backendType: discoveryItem.backendType,
+                      backendType,
                   }),
             visible,
             balance: accountInfo.balance,
@@ -89,15 +101,15 @@ const composeCreateAccountActionPayload = ({
                 isArrayMember(networkType, ['ripple', 'stellar'])
                     ? accountInfo.balance
                     : accountInfo.availableBalance,
-                discoveryItem.symbol,
+                symbol,
             ),
             tokens: enhanceTokens(accountInfo.tokens),
             addresses: enhanceAddresses(accountInfo, {
                 networkType,
-                index: discoveryItem.index,
+                index,
                 addresses: accountInfo.addresses,
             }),
-            utxo: enhanceUtxo(accountInfo.utxo, networkType, discoveryItem.index),
+            utxo: enhanceUtxo(accountInfo.utxo, networkType, index),
             history: accountInfo.history,
             metadata: {
                 key: metadataKey,
@@ -115,24 +127,8 @@ const composeCreateAccountActionPayload = ({
 
 const createAccount = createAction(
     `${ACCOUNTS_MODULE_PREFIX}/createAccount`,
-    ({
-        deviceState,
-        discoveryItem,
-        accountInfo,
-        imported,
-        accountLabel,
-        visible,
-        error,
-    }: CreateAccountActionProps): { payload: Account } => ({
-        payload: composeCreateAccountActionPayload({
-            deviceState,
-            discoveryItem,
-            accountInfo,
-            imported,
-            accountLabel,
-            visible,
-            error,
-        }),
+    (props: CreateAccountActionProps): { payload: Account } => ({
+        payload: composeCreateAccountActionPayload(props),
     }),
 );
 

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -76,7 +76,7 @@ const composeCreateAccountActionPayload = ({
             ...(discoveryItem.backendType === 'coinjoin'
                 ? {
                       backendType: 'coinjoin',
-                      status: discoveryItem.status,
+                      status: 'initial',
                   }
                 : {
                       backendType: discoveryItem.backendType,

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -1,7 +1,12 @@
 import { createAction } from '@reduxjs/toolkit';
 
-import { getNetwork, networks } from '@suite-common/wallet-config';
-import { Account, SelectedAccountStatus } from '@suite-common/wallet-types';
+import { getNetwork } from '@suite-common/wallet-config';
+import {
+    Account,
+    AccountBackendSpecific,
+    AccountFailureSpecific,
+    SelectedAccountStatus,
+} from '@suite-common/wallet-types';
 import {
     enhanceAddresses,
     enhanceTokens,
@@ -38,84 +43,50 @@ export type CreateAccountActionProps = Pick<
     | 'symbol'
     | 'index'
     | 'accountType'
-    | 'backendType'
     | 'deviceState'
     | 'imported'
     | 'accountLabel'
     | 'visible'
 > & {
     accountInfo: AccountInfo;
-    error?: string;
-};
+} & AccountBackendSpecific &
+    AccountFailureSpecific;
 
 const createAccount = createAction(
     `${ACCOUNTS_MODULE_PREFIX}/createAccount`,
-    ({
-        deviceState,
-        path,
-        unlockPath,
-        symbol,
-        index,
-        accountType,
-        backendType,
-        accountInfo,
-        imported,
-        accountLabel,
-        visible,
-        error,
-    }: CreateAccountActionProps): { payload: Account } => {
-        try {
-            const { chainId } = getNetwork(symbol);
-            const { networkType } = networks[symbol];
-            const isNonEthEvm = networkType === 'ethereum' && symbol !== 'eth';
+    ({ accountInfo, ...account }: CreateAccountActionProps): { payload: Account } => {
+        const { symbol, index, deviceState } = account;
+        const { descriptor, descriptorChecksum, legacyXpub } = accountInfo;
+        const { empty, balance, availableBalance, addresses, history, utxo, tokens } = accountInfo;
 
-            const metadataKey = isNonEthEvm
-                ? `${accountInfo.descriptor}-${chainId}`
-                : accountInfo.legacyXpub || accountInfo.descriptor;
+        try {
+            const { chainId, networkType } = getNetwork(symbol);
+
+            const isNonEthEvm = networkType === 'ethereum' && symbol !== 'eth';
+            const metadataKey = isNonEthEvm ? `${descriptor}-${chainId}` : legacyXpub || descriptor;
 
             const payload: Account = {
-                deviceState,
-                accountLabel,
-                imported,
-                ...(error !== undefined ? { error, failed: true } : { failed: undefined }),
-                index,
-                path,
-                unlockPath,
-                descriptor: accountInfo.descriptor,
-                descriptorChecksum: accountInfo.descriptorChecksum,
-                key: getAccountKey(accountInfo.descriptor, symbol, deviceState),
-                accountType,
-                symbol,
-                empty: accountInfo.empty,
-                ...(backendType === 'coinjoin'
-                    ? {
-                          backendType: 'coinjoin',
-                          status: 'initial',
-                      }
-                    : {
-                          backendType,
-                      }),
-                visible,
-                balance: accountInfo.balance,
-                availableBalance: accountInfo.availableBalance,
+                ...account,
+                descriptor,
+                descriptorChecksum,
+                empty,
+                balance,
+                availableBalance,
+                history,
+                key: getAccountKey(descriptor, symbol, deviceState),
                 formattedBalance: formatNetworkAmount(
                     // Ripple and Stellar `availableBalance` is reduced by reserve, use regular balance
-                    isArrayMember(networkType, ['ripple', 'stellar'])
-                        ? accountInfo.balance
-                        : accountInfo.availableBalance,
+                    isArrayMember(networkType, ['ripple', 'stellar']) ? balance : availableBalance,
                     symbol,
                 ),
-                tokens: enhanceTokens(accountInfo.tokens),
+                tokens: enhanceTokens(tokens),
                 addresses: enhanceAddresses(accountInfo, {
                     networkType,
                     index,
-                    addresses: accountInfo.addresses,
+                    addresses,
                 }),
-                utxo: enhanceUtxo(accountInfo.utxo, networkType, index),
-                history: accountInfo.history,
-                metadata: {
-                    key: metadataKey,
-                },
+                utxo: enhanceUtxo(utxo, networkType, index),
+                metadata: { key: metadataKey },
                 ts: Date.now(),
                 ...getAccountSpecific(accountInfo, networkType),
             };

--- a/suite-common/wallet-core/src/accounts/tests/accountsReducer.test.ts
+++ b/suite-common/wallet-core/src/accounts/tests/accountsReducer.test.ts
@@ -45,7 +45,7 @@ describe('Account Reducer', () => {
                     index: 0,
                     path: testBip43Path,
                     accountType: 'normal',
-                    coin: 'btc',
+                    symbol: 'btc',
                 },
                 accountInfo: {
                     descriptor: 'XPUB',

--- a/suite-common/wallet-core/src/accounts/tests/accountsReducer.test.ts
+++ b/suite-common/wallet-core/src/accounts/tests/accountsReducer.test.ts
@@ -41,12 +41,10 @@ describe('Account Reducer', () => {
         store.dispatch(
             accountsActions.createAccount({
                 deviceState: '1stTestnetAddress@device_id:0',
-                discoveryItem: {
-                    index: 0,
-                    path: testBip43Path,
-                    accountType: 'normal',
-                    symbol: 'btc',
-                },
+                index: 0,
+                path: testBip43Path,
+                accountType: 'normal',
+                symbol: 'btc',
                 accountInfo: {
                     descriptor: 'XPUB',
                     path: testBip43Path,

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -205,7 +205,7 @@ const transformProgressEventData = (
         accountInfo,
         // first normal account is always visible on web & desktop
         visible: response.failed || !response.empty || (accountType === 'normal' && index === 0),
-        error: response.failed ? response.error : undefined,
+        ...(!response.failed ? { failed: undefined } : { failed: true, error: response.error }),
     };
 
     const discoveryPayload: DiscoveryStatus = {

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -2,7 +2,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import { AcquiredDevice, AuthorizedDevice, TrezorDevice } from '@suite-common/suite-types';
 import { getNewInstanceNumber } from '@suite-common/suite-utils';
 import { Bip43Path, TrezorConnectBackendType } from '@suite-common/wallet-config';
-import { DiscoveryItem, DiscoveryStatus } from '@suite-common/wallet-types';
+import { DiscoveryStatus } from '@suite-common/wallet-types';
 import { shouldDeviceBeRemembered } from '@suite-common/wallet-utils';
 import TrezorConnect, {
     AccountInfo,
@@ -185,14 +185,6 @@ const transformProgressEventData = (
 ) => {
     const { index, symbol, type: accountType, path, backendType } = response;
 
-    const discoveryItem: DiscoveryItem = {
-        symbol,
-        index,
-        accountType,
-        path: path as Bip43Path,
-        backendType: backendType as TrezorConnectBackendType | undefined,
-    };
-
     const accountInfo: AccountInfo = !response.failed
         ? response
         : {
@@ -205,7 +197,11 @@ const transformProgressEventData = (
 
     const accountPayload: CreateAccountActionProps = {
         deviceState,
-        discoveryItem,
+        symbol,
+        index,
+        accountType,
+        path: path as Bip43Path,
+        backendType: backendType as TrezorConnectBackendType | undefined,
         accountInfo,
         // first normal account is always visible on web & desktop
         visible: response.failed || !response.empty || (accountType === 'normal' && index === 0),

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -183,10 +183,10 @@ const transformProgressEventData = (
     deviceState: StaticSessionId,
     discovery: DiscoveryStatus,
 ) => {
-    const { index, symbol: coin, type: accountType, path, backendType } = response;
+    const { index, symbol, type: accountType, path, backendType } = response;
 
     const discoveryItem: DiscoveryItem = {
-        coin,
+        symbol,
         index,
         accountType,
         path: path as Bip43Path,
@@ -196,7 +196,7 @@ const transformProgressEventData = (
     const accountInfo: AccountInfo = !response.failed
         ? response
         : {
-              descriptor: `failed:${index}:${coin}:${accountType}`,
+              descriptor: `failed:${index}:${symbol}:${accountType}`,
               balance: '0',
               availableBalance: '0',
               empty: true,

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -103,7 +103,9 @@ export type AccountBackendSpecific =
           syncing?: boolean;
       };
 
-type AccountFailureSpecific = { failed: true; error: string } | { failed?: false };
+export type AccountFailureSpecific =
+    | { failed: true; error: string }
+    | { failed?: false; error?: undefined };
 
 export type AccountKey = string; // <AccountDescriptor>-<NetworkSymbol>-<DeviceStaticSessionId>
 export type AccountDescriptor = string & Branded<'AccountDescriptor'>; // Descriptor or xpub/zpub/..

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -1,4 +1,3 @@
-import { Bip43Path } from '@suite-common/wallet-config';
 import type { DeviceUniquePath } from '@trezor/connect';
 import { BundleProgress, StaticSessionId } from '@trezor/connect';
 
@@ -57,11 +56,7 @@ export type DiscoveryStatus = CommonDiscoveryStatus &
 
 export type Discovery = Record<DeviceUniquePath, DiscoveryStatus>;
 
-export type DiscoveryItem = {
-    path: Bip43Path;
-    unlockPath?: Account['unlockPath'];
-    coin: Account['symbol'];
-    index: number;
-    accountType: Account['accountType'];
-    backendType?: Account['backendType'];
-};
+export type DiscoveryItem = Pick<
+    Account,
+    'path' | 'unlockPath' | 'symbol' | 'index' | 'accountType' | 'backendType'
+>;

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -2,7 +2,7 @@ import { Bip43Path } from '@suite-common/wallet-config';
 import type { DeviceUniquePath } from '@trezor/connect';
 import { BundleProgress, StaticSessionId } from '@trezor/connect';
 
-import { Account, AccountBackendSpecific } from './account';
+import { Account } from './account';
 
 type CommonDiscoveryStatus = {
     isAddingHiddenWallet?: boolean; // to control visibility of special loader
@@ -58,18 +58,10 @@ export type DiscoveryStatus = CommonDiscoveryStatus &
 export type Discovery = Record<DeviceUniquePath, DiscoveryStatus>;
 
 export type DiscoveryItem = {
-    // @trezor/connect
     path: Bip43Path;
     unlockPath?: Account['unlockPath'];
     coin: Account['symbol'];
-    identity?: string;
-    details?: 'basic' | 'tokens' | 'tokenBalances' | 'txids' | 'txs';
-    pageSize?: number;
-    suppressBackupWarning?: boolean;
-    // Useful to skip additional getFeatures call which is redundant in discovery
-    skipFinalReload?: boolean;
-    // wallet
     index: number;
     accountType: Account['accountType'];
-    derivationType?: 0 | 1 | 2;
-} & AccountBackendSpecific;
+    backendType?: Account['backendType'];
+};

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -1,8 +1,6 @@
 import type { DeviceUniquePath } from '@trezor/connect';
 import { BundleProgress, StaticSessionId } from '@trezor/connect';
 
-import { Account } from './account';
-
 type CommonDiscoveryStatus = {
     isAddingHiddenWallet?: boolean; // to control visibility of special loader
     isAddingExistingWallet?: boolean; // to control visibility of special loader
@@ -55,8 +53,3 @@ export type DiscoveryStatus = CommonDiscoveryStatus &
     );
 
 export type Discovery = Record<DeviceUniquePath, DiscoveryStatus>;
-
-export type DiscoveryItem = Pick<
-    Account,
-    'path' | 'unlockPath' | 'symbol' | 'index' | 'accountType' | 'backendType'
->;

--- a/suite-native/module-accounts-import/src/accountsImportThunks.ts
+++ b/suite-native/module-accounts-import/src/accountsImportThunks.ts
@@ -61,12 +61,10 @@ export const importAccountThunk = createThunk(
             dispatch(
                 accountsActions.createAccount({
                     deviceState,
-                    discoveryItem: {
-                        index: deviceNetworkAccounts.length, // indexed from 0
-                        path: (accountInfo?.path ?? '') as Bip43Path,
-                        accountType,
-                        symbol,
-                    },
+                    index: deviceNetworkAccounts.length, // indexed from 0
+                    path: (accountInfo?.path ?? '') as Bip43Path,
+                    accountType,
+                    symbol,
                     accountInfo,
                     imported,
                     accountLabel,

--- a/suite-native/module-accounts-import/src/accountsImportThunks.ts
+++ b/suite-native/module-accounts-import/src/accountsImportThunks.ts
@@ -65,7 +65,7 @@ export const importAccountThunk = createThunk(
                         index: deviceNetworkAccounts.length, // indexed from 0
                         path: (accountInfo?.path ?? '') as Bip43Path,
                         accountType,
-                        coin: symbol,
+                        symbol,
                     },
                     accountInfo,
                     imported,


### PR DESCRIPTION
## Description

**Pure refactoring**. After discovery was rewritten, there's no reason to keep `DiscoveryItem` and all the related logic when creating an account.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/create-account-miniclean&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/create-account-miniclean&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/create-account-miniclean&lookback=7)