### PR TITLE
Fix: unsigned env should use dev key also in prod app

### DIFF
--- a/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
+++ b/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
@@ -1,7 +1,7 @@
 import { decode, verify } from 'jws';
 
 import { FirmwareReleaseConfig } from '@trezor/device-utils';
-import { getJWSPublicKey } from '@trezor/env-utils';
+import { getFirmwareReleaseJwsPublicKey } from '@trezor/env-utils';
 
 import { firmwareReleaseConfigAssets } from './assetUtils';
 import { FirmwareUpdateSource, getOnlineFirmwareBaseUrl } from '../data/firmwareInfo';
@@ -102,7 +102,7 @@ export const getFirmwareReleaseConfig = async () => {
     }
 
     const useProductionKey = ['test-signed', 'production'].includes(env) || finalSource === 'local';
-    const publicKey = getJWSPublicKey('firmware-release', useProductionKey);
+    const publicKey = getFirmwareReleaseJwsPublicKey(useProductionKey);
 
     verifyJwsSignature(finalJws, publicKey);
     // Only decode the JWS if we haven't already assigned the payload
@@ -122,7 +122,7 @@ export const getOnlyLocalFirmwareReleaseConfig = (): {
 } => {
     const localJws = firmwareReleaseConfigAssets.jws;
     // For local-only, we always use the production signing key.
-    const publicKey = getJWSPublicKey('firmware-release', true);
+    const publicKey = getFirmwareReleaseJwsPublicKey(true);
 
     verifyJwsSignature(localJws, publicKey);
     const config = decodeJwsPayload(localJws);

--- a/packages/env-utils/src/envUtils.native.ts
+++ b/packages/env-utils/src/envUtils.native.ts
@@ -4,7 +4,7 @@ import Constants from 'expo-constants';
 import { getLocales } from 'expo-localization';
 
 import { firmwareConfigPublicKey, publicKey } from './jws';
-import { EnvUtils, JWSPublicKeyUse } from './types';
+import { EnvUtils } from './types';
 
 const isWeb = () => false;
 
@@ -79,15 +79,10 @@ const getOsNameWeb = () => '';
 
 const getOsFamily = (): 'Linux' => 'Linux';
 
-export const getJWSPublicKey = (use: JWSPublicKeyUse, useCodeSignKey = false) => {
-    if (['message-system', 'token-definitions'].includes(use)) {
-        return isCodesignBuild() ? publicKey.codesign : publicKey.dev;
-    }
+export const getJWSPublicKey = () => (isCodesignBuild() ? publicKey.codesign : publicKey.dev);
 
-    return isCodesignBuild() || useCodeSignKey
-        ? firmwareConfigPublicKey.codesign
-        : firmwareConfigPublicKey.dev;
-};
+export const getFirmwareReleaseJwsPublicKey = (useCodeSignKey = false) =>
+    useCodeSignKey ? firmwareConfigPublicKey.codesign : firmwareConfigPublicKey.dev;
 
 export const envUtils: EnvUtils = {
     isWeb,
@@ -123,4 +118,5 @@ export const envUtils: EnvUtils = {
     getOsNameWeb,
     getOsFamily,
     getJWSPublicKey,
+    getFirmwareReleaseJwsPublicKey,
 };

--- a/packages/env-utils/src/envUtils.ts
+++ b/packages/env-utils/src/envUtils.ts
@@ -1,7 +1,7 @@
 import { UAParser } from 'ua-parser-js';
 
 import { firmwareConfigPublicKey, publicKey } from './jws';
-import { EnvUtils, Environment, JWSPublicKeyUse } from './types';
+import { EnvUtils, Environment } from './types';
 
 export const isWeb = () => process.env.SUITE_TYPE === 'web';
 
@@ -143,15 +143,10 @@ const getOsFamily = () => {
 
 const getDeviceType = () => getUserAgentParser().getDevice().type;
 
-export const getJWSPublicKey = (use: JWSPublicKeyUse, useCodeSignKey = false) => {
-    if (['message-system', 'token-definitions'].includes(use)) {
-        return isCodesignBuild() ? publicKey.codesign : publicKey.dev;
-    }
+export const getJWSPublicKey = () => (isCodesignBuild() ? publicKey.codesign : publicKey.dev);
 
-    return isCodesignBuild() || useCodeSignKey
-        ? firmwareConfigPublicKey.codesign
-        : firmwareConfigPublicKey.dev;
-};
+export const getFirmwareReleaseJwsPublicKey = (useCodeSignKey: boolean) =>
+    useCodeSignKey ? firmwareConfigPublicKey.codesign : firmwareConfigPublicKey.dev;
 
 export const envUtils: EnvUtils = {
     isWeb,
@@ -187,4 +182,5 @@ export const envUtils: EnvUtils = {
     getOsNameWeb,
     getOsFamily,
     getJWSPublicKey,
+    getFirmwareReleaseJwsPublicKey,
 };

--- a/packages/env-utils/src/index.ts
+++ b/packages/env-utils/src/index.ts
@@ -36,4 +36,5 @@ export const {
     getOsNameWeb,
     getOsFamily,
     getJWSPublicKey,
+    getFirmwareReleaseJwsPublicKey,
 } = envUtils;

--- a/packages/env-utils/src/types.ts
+++ b/packages/env-utils/src/types.ts
@@ -1,7 +1,5 @@
 export type Environment = 'desktop' | 'web' | 'mobile';
 
-export type JWSPublicKeyUse = 'message-system' | 'firmware-release' | 'token-definitions';
-
 export interface EnvUtils {
     isWeb: () => boolean;
     isDesktop: () => boolean;
@@ -35,5 +33,6 @@ export interface EnvUtils {
     getOsName: () => '' | 'android' | 'linux' | 'windows' | 'macos' | 'chromeos' | 'ios';
     getOsNameWeb: () => string | undefined;
     getOsFamily: () => 'Windows' | 'MacOS' | 'Linux';
-    getJWSPublicKey: (use: JWSPublicKeyUse, useCodeSignKey?: boolean) => string;
+    getJWSPublicKey: () => string;
+    getFirmwareReleaseJwsPublicKey: (useCodeSignKey: boolean) => string;
 }

--- a/suite-common/message-system/src/messageSystemThunks.ts
+++ b/suite-common/message-system/src/messageSystemThunks.ts
@@ -87,7 +87,7 @@ export const fetchConfigThunk = createThunk(
                     throw Error(`Wrong algorithm in JWS config header: ${algorithmInHeader}`);
                 }
 
-                const authenticityPublicKey = getJWSPublicKey('message-system');
+                const authenticityPublicKey = getJWSPublicKey();
 
                 if (!authenticityPublicKey) {
                     throw Error('JWS public key is not defined!');

--- a/suite-common/token-definitions/src/tokenDefinitionsUtils.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsUtils.ts
@@ -143,7 +143,7 @@ export const fetchTokenDefinitions = async (
         throw Error(`Wrong algorithm in JWS config header: ${algorithmInHeader}`);
     }
 
-    const authenticityPublicKey = getJWSPublicKey('token-definitions');
+    const authenticityPublicKey = getJWSPublicKey();
 
     if (G.isNullable(authenticityPublicKey)) {
         throw Error('Public key check token definitions authenticity was not found.');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When firmware source `unsigned` and codesignbuild it should still use the development key for verification of firmware release config JWS signature.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/unsigned-env-should-be-unsigned-also-in-prod-app&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/unsigned-env-should-be-unsigned-also-in-prod-app&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/unsigned-env-should-be-unsigned-also-in-prod-app&lookback=7)