### PR TITLE
fix(suite-common): keep firmwareUpdateSource when reset fw reducer

### DIFF
--- a/suite-common/firmware/src/firmwareReducer.ts
+++ b/suite-common/firmware/src/firmwareReducer.ts
@@ -84,6 +84,7 @@ export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, (
         })
         .addCase(firmwareActions.resetReducer, state => ({
             ...initialState,
+            firmwareUpdateSource: state.firmwareUpdateSource,
             useDevkit: state.useDevkit,
         }))
         .addCase(firmwareActions.toggleUseDevkit, (state, { payload }) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There was an issue that when opening the FW update modal and closing it the firmware reducer is reset and it was clearing the `firmwareUpdateSource` in the reducer to `production` although it actually was set to any other env.

Now when reseting it also keeps the real `firmwareUpdateSource`.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/keep-firmwareUpdateSource-when-reset-reducer&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/keep-firmwareUpdateSource-when-reset-reducer&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/keep-firmwareUpdateSource-when-reset-reducer&lookback=7)