### PR TITLE
fix(suite): add ConnectionGlobalModal to onboarding

### DIFF
--- a/packages/suite/src/views/onboarding/index.tsx
+++ b/packages/suite/src/views/onboarding/index.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { exhaustive } from '@trezor/type-utils';
 
 import { MODAL } from 'src/actions/suite/constants';
+import { ConnectionGlobalModal } from 'src/components/connection/ConnectionGlobalModal';
 import { OnboardingLayout } from 'src/components/onboarding';
 import { ReduxModal } from 'src/components/suite/modals/ReduxModal/ReduxModal';
 import * as STEP from 'src/constants/onboarding/steps';
@@ -71,6 +72,7 @@ export const Onboarding = () => {
     return (
         <OnboardingLayout>
             {allowedModal && <ReduxModal {...allowedModal} />}
+            <ConnectionGlobalModal />
 
             <UnexpectedState>
                 <StepComponent />


### PR DESCRIPTION
## Description

If we get to a state where the device disconnects during onboarding flow, it's not possible to show the connection modal again. For example this "Connect" button wouldn't do anything. 

## Screenshots:

<img width="1100" height="655" alt="Screenshot 2025-08-28 at 16 18 20" src="https://github.com/user-attachments/assets/be16871d-e5a4-4f91-bbbc-dfb49c324eb5" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/device-connection-modal-in-onboarding&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/device-connection-modal-in-onboarding&lookback=7)