### PR TITLE
ci(suite-native): notify about nightly e2e failure

### DIFF
--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -23,7 +23,8 @@ on:
 jobs:
   run_android_e2e_tests:
     runs-on: ubuntu-latest
-
+    outputs:
+      is_failure: ${{ steps.aggregate-result.outputs.is_failure }}
     strategy:
       fail-fast: false
       matrix:
@@ -154,3 +155,21 @@ jobs:
         with:
           name: failed-android-tests-${{ matrix.TEST_GROUP }}
           path: suite-native/app/artifacts
+
+      - name: Set failure flag for Slack webhook
+        id: aggregate-result
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        run: echo "is_failure=true" >> $GITHUB_ENV
+
+  notify_scheduled_failure_to_slack:
+    if: ${{ needs.run_android_e2e_tests.outputs.is_failure == 'true' }}
+    runs-on: ubuntu-latest
+    needs: run_android_e2e_tests
+    steps:
+      - name: Notify scheduled job failure to Slack
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_MOBILE_E2E_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "Scheduled run of mobile Android E2E tests failed!"

--- a/.github/workflows/test-suite-native-e2e-android-t3w1.yml
+++ b/.github/workflows/test-suite-native-e2e-android-t3w1.yml
@@ -11,7 +11,9 @@ on:
   #     - "suite-native/**"
   #     - "suite-common/**"
   #     - "packages/connect/**"
-  #     - ".github/workflows/test-suite-native-e2e-android.yml"
+  #     - ".github/workflows/test-suite-native-e2e-android-t3w1.yml"
+  #     - ".github/workflows/template-suite-native-e2e-android.yml"
+  #     - ".github/workflows/template-suite-native-prepare-test-app-android.yml"
   #     - "!**.md"
   # push:
   #   branches:

--- a/.github/workflows/test-suite-native-e2e-android.yml
+++ b/.github/workflows/test-suite-native-e2e-android.yml
@@ -12,6 +12,8 @@ on:
       - "suite-common/**"
       - "packages/connect/**"
       - ".github/workflows/test-suite-native-e2e-android.yml"
+      - ".github/workflows/template-suite-native-e2e-android.yml"
+      - ".github/workflows/template-suite-native-prepare-test-app-android.yml"
       - "!**.md"
   push:
     branches:


### PR DESCRIPTION
Extend android e2e pipeline to notify to slack channel in case of nightly tests failure.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/native/notify-nightly-failure&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/native/notify-nightly-failure&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ci/native/notify-nightly-failure&lookback=7)