### PR TITLE
chore(suite-common): do not refetch fiat rates when app is not visible

### DIFF
--- a/packages/suite/src/actions/suite/__tests__/initAction.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/initAction.test.ts
@@ -25,6 +25,7 @@ import {
 } from '@suite-common/wallet-core';
 import { walletConnectInitThunk } from '@suite-common/walletconnect';
 import TrezorConnect from '@trezor/connect';
+import { initialBreakpointFlags } from '@trezor/theme';
 
 import { ROUTER, SUITE } from 'src/actions/suite/constants';
 import { init } from 'src/actions/suite/initAction';
@@ -33,6 +34,7 @@ import metadataReducer from 'src/reducers/suite/metadataReducer';
 import modalReducer from 'src/reducers/suite/modalReducer';
 import routerReducer from 'src/reducers/suite/routerReducer';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
+import windowReducer from 'src/reducers/suite/windowReducer';
 import walletReducers from 'src/reducers/wallet';
 import { extraDependencies } from 'src/support/extraDependencies';
 import { setLocation, setNavigate } from 'src/support/suite/navigationService';
@@ -67,6 +69,7 @@ const getInitialState = (initialRun?: boolean) => ({
     device: deviceReducer(undefined, EMPTY_ACTION),
     metadata: metadataReducer(undefined, EMPTY_ACTION),
     firmware: { firmwareUpdateSource: 'production' },
+    window: windowReducer({ ...initialBreakpointFlags, isVisible: true }, EMPTY_ACTION),
 });
 
 type Fixture = {

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -259,11 +259,22 @@ type PeriodicFetchFiatRatesThunkPayload = {
 
 export const periodicFetchFiatRatesThunk = createThunk(
     `${FIAT_RATES_MODULE_PREFIX}/periodicFetchFiatRates`,
-    async ({ rateType, localCurrency }: PeriodicFetchFiatRatesThunkPayload, { dispatch }) => {
+    async (
+        { rateType, localCurrency }: PeriodicFetchFiatRatesThunkPayload,
+        { dispatch, getState, extra },
+    ) => {
+        const {
+            selectors: { selectIsWindowVisible },
+        } = extra;
+        const isWindowVisible = selectIsWindowVisible(getState());
+
         if (ratesTimeouts[rateType]) {
             clearTimeout(ratesTimeouts[rateType]!);
         }
-        await dispatch(fetchFiatRatesThunk({ rateType, localCurrency }));
+
+        if (isWindowVisible) {
+            await dispatch(fetchFiatRatesThunk({ rateType, localCurrency }));
+        }
         ratesTimeouts[rateType] = setTimeout(() => {
             dispatch(periodicFetchFiatRatesThunk({ rateType, localCurrency }));
         }, REFETCH_INTERVAL[rateType]);


### PR DESCRIPTION
## Description

Fiat rates are refetched periodically only when app is visible.

## Related Issue

Resolve #21061



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/dont-refresh-rates-when-app-minimized&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/dont-refresh-rates-when-app-minimized&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/dont-refresh-rates-when-app-minimized&lookback=7)