### PR TITLE
feat(suite): created deviceSlice, open BT connection mode from wallet switcher

### DIFF
--- a/packages/suite/src/actions/device/deviceSelectors.ts
+++ b/packages/suite/src/actions/device/deviceSelectors.ts
@@ -1,0 +1,7 @@
+import { DesktopDeviceRootState } from './deviceSlice';
+
+export const selectIsConnectionModalOpen = (state: DesktopDeviceRootState) =>
+    state.device.isConnectionModalOpen;
+
+export const selectDeviceDefaultConnectionMode = (state: DesktopDeviceRootState) =>
+    state.device.defaultConnectionMode;

--- a/packages/suite/src/actions/device/deviceSlice.ts
+++ b/packages/suite/src/actions/device/deviceSlice.ts
@@ -45,8 +45,9 @@ export const deviceSlice = createSliceWithExtraDeps({
         builder
             .addMatcher(
                 isAnyOf(deviceActions.connectDevice, deviceActions.connectUnacquiredDevice),
-                state => {
+                (state, action) => {
                     state.isConnectionModalOpen = false;
+                    commonReducer(state, action as AnyAction);
                 },
             )
             .addDefaultCase((state, action) => {

--- a/packages/suite/src/actions/device/deviceSlice.ts
+++ b/packages/suite/src/actions/device/deviceSlice.ts
@@ -1,0 +1,58 @@
+import { PayloadAction, isAnyOf } from '@reduxjs/toolkit';
+
+import { AnyAction, createSliceWithExtraDeps } from '@suite-common/redux-utils';
+import {
+    DeviceReducerState,
+    deviceInitialState as commonInitialState,
+    deviceActions,
+    prepareDeviceReducer,
+} from '@suite-common/wallet-core';
+
+type ConnectionMode = 'cable' | 'bluetooth';
+
+export type DesktopDeviceState = DeviceReducerState & {
+    isConnectionModalOpen: boolean;
+    defaultConnectionMode: ConnectionMode;
+};
+
+export const initialState: DesktopDeviceState = {
+    ...commonInitialState,
+    isConnectionModalOpen: false,
+    defaultConnectionMode: 'cable',
+};
+
+export type DesktopDeviceRootState = {
+    device: DesktopDeviceState;
+};
+
+export const deviceSlice = createSliceWithExtraDeps({
+    name: 'device',
+    initialState,
+    reducers: {
+        toggleConnectionModal: state => {
+            state.isConnectionModalOpen = !state.isConnectionModalOpen;
+        },
+        setConnectionModal: (state, { payload }: PayloadAction<boolean>) => {
+            state.isConnectionModalOpen = payload;
+        },
+        setConnectionMode: (state, { payload }: PayloadAction<ConnectionMode>) => {
+            state.defaultConnectionMode = payload;
+        },
+    },
+    extraReducers: (builder, extra) => {
+        const commonReducer = prepareDeviceReducer(extra);
+
+        builder
+            .addMatcher(
+                isAnyOf(deviceActions.connectDevice, deviceActions.connectUnacquiredDevice),
+                state => {
+                    state.isConnectionModalOpen = false;
+                },
+            )
+            .addDefaultCase((state, action) => {
+                commonReducer(state, action as AnyAction);
+            });
+    },
+});
+
+export const { toggleConnectionModal, setConnectionModal, setConnectionMode } = deviceSlice.actions;

--- a/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
+++ b/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
@@ -109,7 +109,6 @@ const fixture: Feature[] = [
                     }),
                 ],
                 isDeviceAutoEjectEnabled: false,
-                isConnectionModalOpen: false,
             },
         },
         action: () => wipeDeviceThunk(),

--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -3,7 +3,6 @@ import '@suite-common/test-utils/src/globalOverrides';
 import {
     changeCoinVisibility,
     deviceActions,
-    prepareDeviceReducer,
     prepareDiscoveryReducer,
     prepareSendFormReducer,
     selectDevices,
@@ -13,6 +12,7 @@ import {
 import * as discoveryActions from '@suite-common/wallet-core';
 import { getAccountIdentifier, getAccountTransactions } from '@suite-common/wallet-utils';
 
+import { deviceSlice } from 'src/actions/device/deviceSlice';
 import { SETTINGS } from 'src/config/suite';
 import storageMiddleware from 'src/middlewares/wallet/storageMiddleware';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
@@ -30,7 +30,7 @@ import * as suiteActions from '../suiteActions';
 const { getSuiteDevice, getWalletAccount, getWalletTransaction } = testMocks;
 
 const discoveryReducer = prepareDiscoveryReducer(extraDependencies);
-const deviceReducer = prepareDeviceReducer(extraDependencies);
+const deviceReducer = deviceSlice.prepareReducer(extraDependencies);
 const sendFormReducer = prepareSendFormReducer(extraDependencies);
 const walletSettingsReducer = discoveryActions.prepareWalletSettingsReducer(extraDependencies);
 
@@ -240,6 +240,7 @@ describe('Storage actions', () => {
                     devices: [dev1, dev2, dev2Instance1],
                     isDeviceAutoEjectEnabled: false,
                     isConnectionModalOpen: false,
+                    defaultConnectionMode: 'cable',
                 },
                 wallet: {
                     accounts: [acc1, acc2],
@@ -332,6 +333,7 @@ describe('Storage actions', () => {
                     devices: [dev1, dev2],
                     isDeviceAutoEjectEnabled: false,
                     isConnectionModalOpen: false,
+                    defaultConnectionMode: 'cable',
                 },
                 wallet: {
                     accounts: [acc1, acc2],
@@ -376,6 +378,7 @@ describe('Storage actions', () => {
                     devices: [dev1Connected],
                     isDeviceAutoEjectEnabled: false,
                     isConnectionModalOpen: false,
+                    defaultConnectionMode: 'cable',
                 },
                 wallet: {
                     accounts: [acc1],
@@ -414,6 +417,7 @@ describe('Storage actions', () => {
                     devices: [dev1],
                     isDeviceAutoEjectEnabled: false,
                     isConnectionModalOpen: false,
+                    defaultConnectionMode: 'cable',
                 },
                 wallet: {
                     accounts: [acc1, accLtc],
@@ -465,6 +469,7 @@ describe('Storage actions', () => {
                     devices: [devNotRemembered],
                     isDeviceAutoEjectEnabled: false,
                     isConnectionModalOpen: false,
+                    defaultConnectionMode: 'cable',
                 },
             }),
         );

--- a/packages/suite/src/actions/suite/__tests__/trezorConnectActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/trezorConnectActions.test.ts
@@ -1,15 +1,15 @@
 import { connectInitThunk } from '@suite-common/connect-init';
 import { messageSystemInitialState } from '@suite-common/message-system';
 import { testMocks } from '@suite-common/test-utils';
-import { prepareDeviceReducer } from '@suite-common/wallet-core';
 import { BLOCKCHAIN_EVENT, DEVICE_EVENT, TRANSPORT_EVENT, UI_EVENT } from '@trezor/connect';
 
+import { deviceSlice } from 'src/actions/device/deviceSlice';
 import { SUITE } from 'src/actions/suite/constants';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
 import { extraDependencies } from 'src/support/extraDependencies';
 import { configureStore } from 'src/support/tests/configureStore';
 
-const deviceReducer = prepareDeviceReducer(extraDependencies);
+const deviceReducer = deviceSlice.prepareReducer(extraDependencies);
 
 type SuiteState = ReturnType<typeof suiteReducer>;
 type DevicesState = ReturnType<typeof deviceReducer>;
@@ -22,6 +22,7 @@ const getInitialState = (suite?: Partial<SuiteState>, device?: Partial<DevicesSt
         devices: device?.devices || [],
         isDeviceAutoEjectEnabled: false,
         isConnectionModalOpen: false,
+        defaultConnectionMode: 'cable' as 'cable' | 'bluetooth',
     },
     wallet: {
         settings: {

--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -19,6 +19,8 @@ import { bluetoothConnectDeviceThunk } from 'src/actions/bluetooth/bluetoothConn
 import { bluetoothDisconnectDeviceThunk } from 'src/actions/bluetooth/bluetoothDisconnectDeviceThunk';
 import { bluetoothStartScanningThunk } from 'src/actions/bluetooth/bluetoothStartScanningThunk';
 import { bluetoothStopScanningThunk } from 'src/actions/bluetooth/bluetoothStopScanningThunk';
+import { selectDeviceDefaultConnectionMode } from 'src/actions/device/deviceSelectors';
+import { setConnectionMode } from 'src/actions/device/deviceSlice';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
@@ -62,12 +64,14 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
     const { isBluetoothEnabled } = useSelector(selectSuiteFlags);
     const bluetoothAdapterStatus = useSelector(selectAdapterStatus);
 
-    const [isBluetoothMode, setIsBluetoothMode] = useState(false);
+    const defaultConnectionMode = useSelector(selectDeviceDefaultConnectionMode);
+
+    const isBluetoothMode = defaultConnectionMode === 'bluetooth';
 
     const bluetoothMode = isBluetoothMode && isBluetoothEnabled && isDesktop();
 
     const toggleBluetoothMode = () => {
-        setIsBluetoothMode(!isBluetoothMode);
+        dispatch(setConnectionMode(bluetoothMode ? 'cable' : 'bluetooth'));
     };
 
     const toggleShowHints = () => {

--- a/packages/suite/src/components/connection/ConnectionGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectionGlobalModal.tsx
@@ -1,11 +1,9 @@
 import { selectThpStep } from '@suite-common/thp';
-import {
-    deviceActions,
-    selectIsConnectionModalOpen,
-    selectSelectedDevice,
-} from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { exhaustive } from '@trezor/type-utils';
 
+import { selectIsConnectionModalOpen } from 'src/actions/device/deviceSelectors';
+import { toggleConnectionModal as toggleConnectionModalAction } from 'src/actions/device/deviceSlice';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { ConnectDeviceGlobalModal } from './ConnectDeviceGlobalModal';
@@ -22,7 +20,7 @@ export const ConnectionGlobalModal = () => {
     const thpStep = useSelector(selectThpStep);
 
     const toggleConnectionModal = () => {
-        dispatch(deviceActions.toggleConnectionModal());
+        dispatch(toggleConnectionModalAction());
     };
 
     // handle THP modals first if we have a device and thpStep

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -1,11 +1,11 @@
 import { fireEvent, screen } from '@testing-library/react';
 
 import { AnalyticsState } from '@suite-common/analytics';
-import { DeviceReducerState } from '@suite-common/wallet-core';
 import { TransportInfo } from '@trezor/connect';
 import * as envUtils from '@trezor/env-utils';
 import { DeepPartial } from '@trezor/type-utils';
 
+import { DesktopDeviceState } from 'src/actions/device/deviceSlice';
 import { AppState } from 'src/reducers/store';
 import { RouterState } from 'src/reducers/suite/routerReducer';
 import { SuiteState } from 'src/reducers/suite/suiteReducer';
@@ -60,7 +60,7 @@ type GetInitialStateProps = {
     suite?: Partial<SuiteState>;
     router?: Partial<RouterState>;
     // I am not happy about `DeepPartial` here, but it would be hell to fix all the fixtures
-    device?: DeepPartial<DeviceReducerState>;
+    device?: DeepPartial<DesktopDeviceState>;
     analytics?: Partial<AnalyticsState>;
 };
 
@@ -72,7 +72,7 @@ const getInitialState = ({
 }: GetInitialStateProps = {}): AppState => ({
     ...initialAppState,
     router: { ...initialAppState.router, ...router } as unknown as RouterState,
-    device: { ...initialAppState.device, ...device } as DeviceReducerState,
+    device: { ...initialAppState.device, ...device } as DesktopDeviceState,
     analytics: { ...initialAppState.analytics, ...analytics },
 
     suite: {

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceConnect.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceConnect.tsx
@@ -1,6 +1,6 @@
-import { deviceActions } from '@suite-common/wallet-core';
 import { Button } from '@trezor/components';
 
+import { toggleConnectionModal } from 'src/actions/device/deviceSlice';
 import { Translation, WebUsbButton } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectHasTransportOfType } from 'src/selectors/suite/suiteSelectors';
@@ -14,7 +14,7 @@ export const DeviceConnect = () => {
     }
 
     return (
-        <Button onClick={() => dispatch(deviceActions.toggleConnectionModal())}>
+        <Button onClick={() => dispatch(toggleConnectionModal())}>
             <Translation id="TR_CONNECT" />
         </Button>
     );

--- a/packages/suite/src/components/suite/bluetooth/UnpairedBluetoothDeviceNeedsManualOsRemovalModal.tsx
+++ b/packages/suite/src/components/suite/bluetooth/UnpairedBluetoothDeviceNeedsManualOsRemovalModal.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 
-import { deviceActions } from '@suite-common/wallet-core';
 import { Banner, Column, H3, Modal, Paragraph, Spinner } from '@trezor/components';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { spacings } from '@trezor/theme';
 
+import { toggleConnectionModal } from 'src/actions/device/deviceSlice';
 import { Translation } from 'src/components/suite';
 
 import { setBluetoothDeviceNeedsManualOsRemoval } from '../../../actions/bluetooth/desktopBluetoothReducer';
@@ -31,7 +31,7 @@ export const UnpairedBluetoothDeviceNeedsManualOsRemovalModal = () => {
 
     const onCancel = () => {
         dispatch(setBluetoothDeviceNeedsManualOsRemoval({ needsManualRemoval: false }));
-        dispatch(deviceActions.toggleConnectionModal());
+        dispatch(toggleConnectionModal());
     };
 
     if (isUnpairingDevice) {

--- a/packages/suite/src/reducers/backup/__tests__/backupReducer.test.ts
+++ b/packages/suite/src/reducers/backup/__tests__/backupReducer.test.ts
@@ -1,5 +1,6 @@
-import type { DeviceRootState } from '@suite-common/wallet-core';
 import { BackupAvailability } from '@trezor/protobuf/src/messages';
+
+import type { DesktopDeviceRootState } from 'src/actions/device/deviceSlice';
 
 import { selectBackupStatus } from '../backupReducer';
 import type { BackupRootState, BackupState } from '../backupReducer';
@@ -26,12 +27,13 @@ describe('selectBackupStatus', () => {
     const getState = (
         backup: BackupState,
         backup_availability: BackupAvailability,
-    ): BackupRootState & DeviceRootState => ({
+    ): BackupRootState & DesktopDeviceRootState => ({
         backup: { ...baseBackup, ...backup },
         device: {
             devices: [],
             isDeviceAutoEjectEnabled: false,
             isConnectionModalOpen: true,
+            defaultConnectionMode: 'cable',
             selectedDevice: {
                 features: { backup_availability },
             } as any,

--- a/packages/suite/src/reducers/suite/index.ts
+++ b/packages/suite/src/reducers/suite/index.ts
@@ -3,9 +3,9 @@ import { prepareConnectPopupReducer } from '@suite-common/connect-popup';
 import { logsSlice } from '@suite-common/logger';
 import { prepareMessageSystemReducer } from '@suite-common/message-system';
 import { notificationsReducer } from '@suite-common/toast-notifications';
-import { prepareDeviceReducer } from '@suite-common/wallet-core';
 import { prepareWalletConnectReducer } from '@suite-common/walletconnect';
 
+import { deviceSlice } from 'src/actions/device/deviceSlice';
 import { extraDependencies } from 'src/support/extraDependencies';
 
 import desktopUpdate from './desktopUpdateReducer';
@@ -20,7 +20,7 @@ import window from './windowReducer';
 const analytics = prepareAnalyticsReducer(extraDependencies);
 // Type annotation as a workaround for type-check error "The inferred type of 'default' cannot be named..."
 const messageSystem = prepareMessageSystemReducer(extraDependencies);
-const device = prepareDeviceReducer(extraDependencies);
+const device = deviceSlice.prepareReducer(extraDependencies);
 const connectPopupReducer = prepareConnectPopupReducer(extraDependencies);
 const walletConnectReducer = prepareWalletConnectReducer(extraDependencies);
 

--- a/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
+++ b/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
@@ -2,8 +2,8 @@ import { FirmwareUpdateState } from '@suite-common/firmware';
 import { messageSystemInitialState } from '@suite-common/message-system';
 import { MetadataState } from '@suite-common/metadata-types';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { deviceReducerInitialState } from '@suite-common/wallet-core';
 
+import { initialState } from 'src/actions/device/deviceSlice';
 import { BackupState } from 'src/reducers/backup/backupReducer';
 import { OnboardingState } from 'src/reducers/onboarding/onboardingReducer';
 import { AppState } from 'src/reducers/store';
@@ -15,7 +15,7 @@ import WalletReducers from 'src/reducers/wallet';
 
 export const initialAppState: AppState = {
     suite: suiteInitialState,
-    device: deviceReducerInitialState,
+    device: initialState,
     bluetooth: {
         unpairedDeviceNeedsManualOsRemoval: false,
         isBluetoothListOpen: false,

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -21,6 +21,7 @@ import { BlockchainEvent, DEVICE, DeviceEvent, TransportEvent, UiEvent } from '@
 import { FilterOutFromUnionByTypeProperty } from '@trezor/type-utils';
 
 import type { BackupAction } from 'src/actions/backup/backupActions';
+import { deviceSlice } from 'src/actions/device/deviceSlice';
 import type { OnboardingAction } from 'src/actions/onboarding/onboardingActions';
 import type { RecoveryAction } from 'src/actions/recovery/recoveryActions';
 import { BioAuthAction } from 'src/actions/suite/bioAuthActions';
@@ -82,6 +83,9 @@ type BluetoothAction = ReturnType<(typeof bluetoothActions)[keyof typeof bluetoo
 type BluetoothActionDesktop = ReturnType<
     (typeof bluetoothSlice.actions)[keyof typeof bluetoothSlice.actions]
 >;
+type DeviceActionDesktop = ReturnType<
+    (typeof deviceSlice.actions)[keyof typeof deviceSlice.actions]
+>;
 type ThpAction = ReturnType<(typeof thpActions)[keyof typeof thpActions]>;
 type GeolocationAction = ReturnType<(typeof geolocationActions)[keyof typeof geolocationActions]>;
 type FeeAction = ReturnType<(typeof feesActions)[keyof typeof feesActions]>;
@@ -113,6 +117,7 @@ export type Action =
     | ReturnType<typeof addLog>
     | BluetoothAction
     | BluetoothActionDesktop
+    | DeviceActionDesktop
     | ThpAction
     | GeolocationAction
     | BioAuthAction

--- a/packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx
@@ -1,8 +1,9 @@
 import * as deviceUtils from '@suite-common/suite-utils';
-import { deviceActions, selectDevices } from '@suite-common/wallet-core';
+import { selectDevices } from '@suite-common/wallet-core';
 import { Button, Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
+import { setConnectionMode, toggleConnectionModal } from 'src/actions/device/deviceSlice';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 import { ForegroundAppProps } from 'src/types/suite';
@@ -23,7 +24,8 @@ export const SwitchDevice = ({ cancelable, onCancel }: ForegroundAppProps) => {
     });
 
     const openDeviceConnectionModal = () => {
-        dispatch(deviceActions.toggleConnectionModal());
+        dispatch(setConnectionMode('bluetooth'));
+        dispatch(toggleConnectionModal());
         onCancel();
     };
 

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -128,8 +128,6 @@ const toggleIsDeviceAutoEjectEnabled = createAction(
     `${DEVICE_MODULE_PREFIX}/toggleAutoEjectDevices`,
 );
 
-const toggleConnectionModal = createAction(`${DEVICE_MODULE_PREFIX}/toggleConnectionModal`);
-
 const setDiscovered = createAction(
     `${DEVICE_MODULE_PREFIX}/setDiscovered`,
     (staticSessionId: StaticSessionId, success: boolean) => ({
@@ -138,7 +136,6 @@ const setDiscovered = createAction(
 );
 
 export const deviceActions = {
-    toggleConnectionModal,
     connectDevice,
     createDeviceInstance,
     connectUnacquiredDevice,

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -554,7 +554,6 @@ const requestDeviceReconnect = (draft: DeviceReducerState) => {
     draft.selectedDevice.reconnectRequested = true;
     draft.devices[index].reconnectRequested = true;
 };
-
 export const prepareDeviceReducer = createReducerWithExtraDeps(
     deviceInitialState,
     (builder, extra) => {

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -24,17 +24,15 @@ export type DeviceReducerState = {
     };
     lastConnectedAuthenticityChecks?: KnownDevice['authenticityChecks'];
     isDeviceAutoEjectEnabled: boolean;
-    isConnectionModalOpen: boolean;
 };
 
-const initialState: DeviceReducerState = {
+export const deviceInitialState: DeviceReducerState = {
     devices: [],
     selectedDevice: undefined,
     isDeviceAutoEjectEnabled: false,
-    isConnectionModalOpen: false,
 };
 
-export const deviceReducerInitialState = initialState;
+export const deviceReducerInitialState = deviceInitialState;
 
 export type DeviceRootState = {
     device: DeviceReducerState;
@@ -111,7 +109,6 @@ const merge = (
  */
 const connectDevice = (draft: DeviceReducerState, device: Device) => {
     const currentTime = new Date().getTime();
-    draft.isConnectionModalOpen = false;
 
     const deviceCommonFields = {
         connected: true,
@@ -558,98 +555,98 @@ const requestDeviceReconnect = (draft: DeviceReducerState) => {
     draft.devices[index].reconnectRequested = true;
 };
 
-export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (builder, extra) => {
-    builder
-        .addCase(deviceActions.deviceChanged, (state, { payload }) => {
-            changeDevice(state, payload, { connected: true, available: true });
-        })
-        .addCase(deviceActions.setDeviceState, (state, { payload }) => {
-            setDeviceState(state, payload.device, payload.state, payload.useEmptyPassphrase);
-        })
-        .addCase(deviceActions.addAuthorizedDevice, (state, { payload }) => {
-            addAuthorizedDevice(state, payload.device);
-        })
+export const prepareDeviceReducer = createReducerWithExtraDeps(
+    deviceInitialState,
+    (builder, extra) => {
+        builder
+            .addCase(deviceActions.deviceChanged, (state, { payload }) => {
+                changeDevice(state, payload, { connected: true, available: true });
+            })
+            .addCase(deviceActions.setDeviceState, (state, { payload }) => {
+                setDeviceState(state, payload.device, payload.state, payload.useEmptyPassphrase);
+            })
+            .addCase(deviceActions.addAuthorizedDevice, (state, { payload }) => {
+                addAuthorizedDevice(state, payload.device);
+            })
 
-        .addCase(deviceActions.deviceDisconnect, (state, { payload }) => {
-            disconnectDevice(state, payload);
-        })
-        .addCase(deviceActions.rememberDevice, (state, { payload }) => {
-            remember(state, payload.device, payload.remember, payload.forceRemember);
-        })
-        .addCase(deviceActions.setTemporaryRememberedDevice, (state, { payload }) => {
-            setTemporaryRememberedDevice(state, payload.device, payload.temporaryRemember);
-        })
-        .addCase(deviceActions.forgetDevice, (state, { payload }) => {
-            forget(state, payload.device);
-        })
-        .addCase(deviceActions.addButtonRequest, (state, { payload }) => {
-            addButtonRequest(state, payload.device, payload.buttonRequest);
-        })
-        .addCase(deviceActions.removeButtonRequests, (state, { payload }) => {
-            removeButtonRequests(state, payload.device, payload.buttonRequestCode);
-        })
-        .addCase(deviceActions.requestDeviceReconnect, state => {
-            requestDeviceReconnect(state);
-        })
-        .addCase(deviceActions.selectDevice, (state, { payload }) => {
-            updateTimestamp(state, payload);
-            state.selectedDevice = payload;
-        })
-        .addCase(deviceActions.updateSelectedDevice, (state, { payload }) => {
-            state.selectedDevice = payload;
-        })
-        .addCase(deviceAuthenticityActions.result, (state, { payload }) => {
-            setDeviceAuthenticity(state, payload.device, payload.result);
-        })
-        .addCase(deviceActions.dismissFirmwareAuthenticityCheck, (state, { payload }) => {
-            if (!state.dismissedSecurityChecks) {
-                state.dismissedSecurityChecks = {};
-            }
-            if (!state.dismissedSecurityChecks.firmwareAuthenticity) {
-                state.dismissedSecurityChecks.firmwareAuthenticity = [];
-            }
-            state.dismissedSecurityChecks.firmwareAuthenticity.unshift(payload);
-        })
-        .addCase(extra.actionTypes.setDeviceMetadata, extra.reducers.setDeviceMetadataReducer)
-        .addCase(
-            extra.actionTypes.setDeviceMetadataPasswords,
-            extra.reducers.setDeviceMetadataPasswordsReducer,
-        )
-        .addCase(extra.actionTypes.storageLoad, extra.reducers.storageLoadDevices)
-        .addCase(deviceActions.setEntropyCheckFail, (state, { payload }) => {
-            if (!state.devicesWithFailedEntropyCheck) {
-                state.devicesWithFailedEntropyCheck = [];
-            }
-            state.devicesWithFailedEntropyCheck.push(payload);
-        })
-        .addCase(deviceActions.createDeviceInstance, (state, { payload }) => {
-            createInstance(state, payload.device);
-        })
-        .addCase(
-            deviceActions.setLocalFirstStorageSecret,
-            (state, { payload: { device, evoluKeys } }) => {
-                if (!device.features) return;
-                const index = deviceUtils.findInstanceIndex(state.devices, device);
-                if (!state.devices[index]) return;
-                state.devices[index].localFirstStorageSecret = { evoluKeys };
-            },
-        )
-        .addCase(deviceActions.toggleIsDeviceAutoEjectEnabled, state => {
-            state.isDeviceAutoEjectEnabled = !state.isDeviceAutoEjectEnabled;
-        })
-        .addCase(deviceActions.toggleConnectionModal, state => {
-            state.isConnectionModalOpen = !state.isConnectionModalOpen;
-        })
-        .addCase(deviceActions.setDiscovered, (state, { payload }) => {
-            const device = state.devices.find(
-                d => d.state?.staticSessionId === payload.staticSessionId,
+            .addCase(deviceActions.deviceDisconnect, (state, { payload }) => {
+                disconnectDevice(state, payload);
+            })
+            .addCase(deviceActions.rememberDevice, (state, { payload }) => {
+                remember(state, payload.device, payload.remember, payload.forceRemember);
+            })
+            .addCase(deviceActions.setTemporaryRememberedDevice, (state, { payload }) => {
+                setTemporaryRememberedDevice(state, payload.device, payload.temporaryRemember);
+            })
+            .addCase(deviceActions.forgetDevice, (state, { payload }) => {
+                forget(state, payload.device);
+            })
+            .addCase(deviceActions.addButtonRequest, (state, { payload }) => {
+                addButtonRequest(state, payload.device, payload.buttonRequest);
+            })
+            .addCase(deviceActions.removeButtonRequests, (state, { payload }) => {
+                removeButtonRequests(state, payload.device, payload.buttonRequestCode);
+            })
+            .addCase(deviceActions.requestDeviceReconnect, state => {
+                requestDeviceReconnect(state);
+            })
+            .addCase(deviceActions.selectDevice, (state, { payload }) => {
+                updateTimestamp(state, payload);
+                state.selectedDevice = payload;
+            })
+            .addCase(deviceActions.updateSelectedDevice, (state, { payload }) => {
+                state.selectedDevice = payload;
+            })
+            .addCase(deviceAuthenticityActions.result, (state, { payload }) => {
+                setDeviceAuthenticity(state, payload.device, payload.result);
+            })
+            .addCase(deviceActions.dismissFirmwareAuthenticityCheck, (state, { payload }) => {
+                if (!state.dismissedSecurityChecks) {
+                    state.dismissedSecurityChecks = {};
+                }
+                if (!state.dismissedSecurityChecks.firmwareAuthenticity) {
+                    state.dismissedSecurityChecks.firmwareAuthenticity = [];
+                }
+                state.dismissedSecurityChecks.firmwareAuthenticity.unshift(payload);
+            })
+            .addCase(extra.actionTypes.setDeviceMetadata, extra.reducers.setDeviceMetadataReducer)
+            .addCase(
+                extra.actionTypes.setDeviceMetadataPasswords,
+                extra.reducers.setDeviceMetadataPasswordsReducer,
+            )
+            .addCase(extra.actionTypes.storageLoad, extra.reducers.storageLoadDevices)
+            .addCase(deviceActions.setEntropyCheckFail, (state, { payload }) => {
+                if (!state.devicesWithFailedEntropyCheck) {
+                    state.devicesWithFailedEntropyCheck = [];
+                }
+                state.devicesWithFailedEntropyCheck.push(payload);
+            })
+            .addCase(deviceActions.createDeviceInstance, (state, { payload }) => {
+                createInstance(state, payload.device);
+            })
+            .addCase(
+                deviceActions.setLocalFirstStorageSecret,
+                (state, { payload: { device, evoluKeys } }) => {
+                    if (!device.features) return;
+                    const index = deviceUtils.findInstanceIndex(state.devices, device);
+                    if (!state.devices[index]) return;
+                    state.devices[index].localFirstStorageSecret = { evoluKeys };
+                },
+            )
+            .addCase(deviceActions.toggleIsDeviceAutoEjectEnabled, state => {
+                state.isDeviceAutoEjectEnabled = !state.isDeviceAutoEjectEnabled;
+            })
+            .addCase(deviceActions.setDiscovered, (state, { payload }) => {
+                const device = state.devices.find(
+                    d => d.state?.staticSessionId === payload.staticSessionId,
+                );
+                if (device) device.discovered = payload.success;
+            })
+            .addMatcher(
+                isAnyOf(deviceActions.connectDevice, deviceActions.connectUnacquiredDevice),
+                (state, { payload: { device } }) => {
+                    connectDevice(state, device);
+                },
             );
-            if (device) device.discovered = payload.success;
-        })
-        .addMatcher(
-            isAnyOf(deviceActions.connectDevice, deviceActions.connectUnacquiredDevice),
-            (state, { payload: { device } }) => {
-                connectDevice(state, device);
-            },
-        );
-});
+    },
+);

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -30,8 +30,6 @@ export const selectDevicesCount = (state: DeviceRootState) => state.device?.devi
 export const selectSelectedDevice = (state: DeviceRootState) => state.device.selectedDevice;
 export const selectIsDeviceAutoEjectEnabled = (state: DeviceRootState) =>
     state.device.isDeviceAutoEjectEnabled;
-export const selectIsConnectionModalOpen = (state: DeviceRootState) =>
-    state.device.isConnectionModalOpen;
 
 // Derived selectors
 export const selectIsPendingTransportEvent = createMemoizedSelector(

--- a/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
+++ b/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
@@ -138,7 +138,6 @@ const getTestState = ({
             },
         } as TrezorDevice,
         isDeviceAutoEjectEnabled: false,
-        isConnectionModalOpen: false,
     },
 });
 


### PR DESCRIPTION
**changes:** 
- created `deviceSlice` for web & desktop to separate non-common state.
- `ConnectionModal` opens in BT mode by default when opened from Wallet Switcher

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21129 & https://github.com/trezor/trezor-suite/issues/21130



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/move-connection-modal-state&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/move-connection-modal-state&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/move-connection-modal-state&lookback=7)