### PR TITLE
fix(connect): missing reference to postMessage in getRebootMethod

### DIFF
--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -184,10 +184,12 @@ const getRebootMethod = async ({
     deviceList,
     device,
     log,
+    postMessage,
 }: {
     deviceList: DeviceList;
     device: Device;
     log: Log;
+    postMessage: PostMessage;
 }) => {
     let method: ReconnectParams['method'] = 'wait';
 
@@ -577,7 +579,7 @@ export const onCallFirmwareUpdate = async ({
         });
     }
 
-    const method = await getRebootMethod({ deviceList, device, log });
+    const method = await getRebootMethod({ deviceList, device, log, postMessage });
 
     reconnectedDevice = await waitForReconnectedDevice(
         { bootloader: false, method },


### PR DESCRIPTION
## Description

Pass missing reference to postMessage in getRebootMethod in FW update process. 

This was causing an error at the end of the install process when waiting for the device to reboot. 

TypeScript didn't notice because postMessage exists in Window context on the web.


## Related Issue

Resolve #21122, resolve #20796

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-postmessage-getrebootmethod&lookback=7)