### PR TITLE
chore(suite): rename FirmwareUpdate to FirmwareUpdateEnvironmentSelect

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/FirmwareUpdateEnvironmentSelect.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/FirmwareUpdateEnvironmentSelect.tsx
@@ -10,7 +10,7 @@ const StyledActionSelect = styled(ActionSelect)`
     min-width: 256px;
 `;
 
-export const FirmwareUpdate = () => {
+export const FirmwareUpdateEnvironmentSelect = () => {
     const firmwareUpdateSource = useSelector(selectFirmwareUpdateSource);
     const dispatch = useDispatch();
 

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -14,7 +14,7 @@ import { CoinjoinApi } from './CoinjoinApi';
 import { ConnectPopup } from './ConnectPopup';
 import { DeviceAuthenticity } from './DeviceAuthenticity';
 import { Devkit } from './Devkit';
-import { FirmwareUpdate } from './FirmwareUpdate';
+import { FirmwareUpdateEnvironmentSelect } from './FirmwareUpdateEnvironmentSelect';
 import { ForgetAllDevicesButton } from './ForgetBluetoothDevices';
 import { GithubIssue } from './GithubIssue';
 import { InvityApi } from './InvityApi';
@@ -104,7 +104,7 @@ export const SettingsDebug = () => {
                 {isDesktop() && <ConnectPopup />}
             </SettingsSection>
             <SettingsSection title="Firmware update source">
-                <FirmwareUpdate />
+                <FirmwareUpdateEnvironmentSelect />
             </SettingsSection>
             <LocalFirstStorageSettings />
         </SettingsLayout>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The name of the component `FirmwareUpdate.txs` was confusing to what it does, using name `FirmwareUpdateEnvironmentSelect.tsx` as the same component in native `suite-native/module-dev-utils/src/components/FirmwareUpdateEnvironmentSelect.tsx` makes more sense.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/rename-component-to-make-more-sense&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/rename-component-to-make-more-sense&lookback=7)