### PR TITLE
fix(suite-native): propagate manufacturer data changes to nearby devices

### DIFF
--- a/packages/transport-native-bluetooth/src/api/bluetoothManager.ts
+++ b/packages/transport-native-bluetooth/src/api/bluetoothManager.ts
@@ -46,6 +46,15 @@ const errorLog = (...args: any[]) => {
     console.error('BluetoothManager', ...args);
 };
 
+const toBluetoothDevice = (device: Device): BluetoothDevice => ({
+    id: device.id,
+    name: device.name ?? 'Unknown',
+    // @suite-common utils expect the Bluetooth company identifier (first two bytes) to be trimmed
+    manufacturerData: Array.from(Buffer.from(device.manufacturerData ?? '', 'base64')).slice(2),
+    lastUpdatedTimestamp: Date.now(),
+    connectionStatus: { type: 'disconnected' },
+});
+
 class BluetoothManager {
     private bleManager: BleManager | null = null;
     private eventEmitter: EventEmitter = new EventEmitter();
@@ -115,27 +124,19 @@ class BluetoothManager {
             }
             if (scannedDevice) {
                 debugLog(`Scanned device ${scannedDevice}`);
+                const nearbyDevice = toBluetoothDevice(scannedDevice);
                 const nearbyDeviceIndex = this.nearbyDevices.findIndex(
-                    d => d.id === scannedDevice.id,
+                    d => d.id === nearbyDevice.id,
                 );
                 if (nearbyDeviceIndex >= 0) {
-                    this.nearbyDevices[nearbyDeviceIndex] = {
-                        ...this.nearbyDevices[nearbyDeviceIndex],
-                        lastUpdatedTimestamp: Date.now(),
-                    };
+                    const oldNearbyDevice = this.nearbyDevices[nearbyDeviceIndex];
+                    nearbyDevice.connectionStatus = oldNearbyDevice.connectionStatus;
+                    this.nearbyDevices[nearbyDeviceIndex] = nearbyDevice;
+                    if (nearbyDevice.manufacturerData[0] !== oldNearbyDevice.manufacturerData[0]) {
+                        this.emitNearbyDevicesChange();
+                    }
                 } else {
-                    const manufacturerDataBytes = Buffer.from(
-                        scannedDevice.manufacturerData ?? '',
-                        'base64',
-                    );
-                    this.nearbyDevices.unshift({
-                        id: scannedDevice.id,
-                        name: scannedDevice.name ?? 'Unknown',
-                        // Bluetooth company identifier is not expected to be present
-                        manufacturerData: Array.from(manufacturerDataBytes).slice(2),
-                        lastUpdatedTimestamp: Date.now(),
-                        connectionStatus: { type: 'disconnected' },
-                    });
+                    this.nearbyDevices.unshift(nearbyDevice);
                     this.emitNearbyDevicesChange();
                 }
             }

--- a/suite-native/bluetooth/src/__tests__/selectors.test.ts
+++ b/suite-native/bluetooth/src/__tests__/selectors.test.ts
@@ -108,17 +108,24 @@ describe('selectNearbyBluetoothDevices', () => {
 
 describe('selectNearbyPairableBluetoothDevices', () => {
     test.each([
-        ['null nearby devices', null, []],
-        ['empty nearby devices', [], []],
-        ['non-pairable nearby device', [knownDevice], []],
-        ['pairable nearby device', [pairableDevice], [pairableDevice]],
-        ['several nearby devices', [unknownDevice, knownDevice, pairableDevice], [pairableDevice]],
-    ])('returns correct value for %s', (_, nearbyDevices, expectedDevices) => {
+        ['null nearby devices', null, [], []],
+        ['empty nearby devices', [], [], []],
+        ['non-pairable nearby device', [knownDevice], [], []],
+        ['pairable nearby device', [pairableDevice], [], [pairableDevice]],
+        ['pairable known device', [pairableDevice], [pairableDevice], []],
+        [
+            'several nearby devices',
+            [unknownDevice, knownDevice, pairableDevice],
+            [],
+            [pairableDevice],
+        ],
+    ])('returns correct value for %s', (_, nearbyDevices, knownDevices, expectedDevices) => {
         expect(
             selectNearbyPairableBluetoothDevices({
                 bluetooth: {
                     ...initialState,
                     nearbyDevices,
+                    knownDevices,
                 },
             }),
         ).toStrictEqual(expectedDevices);

--- a/suite-native/bluetooth/src/selectors.ts
+++ b/suite-native/bluetooth/src/selectors.ts
@@ -29,10 +29,12 @@ export const selectNearbyBluetoothDevices = createMemoizedSelector(
 );
 
 export const selectNearbyPairableBluetoothDevices = createMemoizedSelector(
-    [selectNearbyBluetoothDevices],
-    nearbyBluetoothDevices =>
+    [selectNearbyBluetoothDevices, selectKnownBluetoothDevices],
+    (nearbyBluetoothDevices, knownBluetoothDevices) =>
         nearbyBluetoothDevices.filter(
-            ({ manufacturerData }) => manufacturerData.filterPolicy?.pairing === true,
+            ({ id, manufacturerData }) =>
+                knownBluetoothDevices.every(knownDevice => knownDevice.id !== id) &&
+                manufacturerData.filterPolicy?.pairing === true,
         ),
 );
 


### PR DESCRIPTION
- When manufacturer data changes, e.g. if pairing is enabled/disabled, it's propagated to nearby devices.
- Any known device is not considered to be pairable again (mistakenly removed in the previous change).

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/bluetooth-nearby-devices&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/bluetooth-nearby-devices&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/bluetooth-nearby-devices&lookback=7)