### PR TITLE
chore(suite): replace placeholder with TS5

### DIFF
--- a/packages/suite/src/components/connection/DeviceConnectionAnimation.tsx
+++ b/packages/suite/src/components/connection/DeviceConnectionAnimation.tsx
@@ -1,6 +1,6 @@
 import styled, { keyframes } from 'styled-components';
 
-import { DeviceModelInternal } from '@trezor/device-utils';
+import { DEFAULT_FLAGSHIP_MODEL } from '@suite-common/suite-constants';
 
 import { ConnectorImage } from './ConnectorImage';
 import { DeviceImage } from './DeviceImage';
@@ -46,7 +46,7 @@ export const CableConnectionAnimation = ({
 }: CableConnectionAnimationProps) => (
     <Wrapper>
         <DeviceWrapper>
-            <DeviceImage size="large" deviceModel={DeviceModelInternal.T3W1} />
+            <DeviceImage size="large" deviceModel={DEFAULT_FLAGSHIP_MODEL} />
         </DeviceWrapper>
         {!isBluetooth && (
             <CableWrapper>

--- a/packages/suite/src/components/connection/DeviceImage.tsx
+++ b/packages/suite/src/components/connection/DeviceImage.tsx
@@ -5,9 +5,10 @@ import { Image, PNG_IMAGES, PNG_PATH } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 // component taken from native part of app, edit for desktop & web usage only for one model
-type SupportedDeviceModels = DeviceModelInternal.T3W1;
+type SupportedDeviceModels = DeviceModelInternal.T3W1 | DeviceModelInternal.T3T1;
 
 const deviceImageMap: Record<SupportedDeviceModels, string> = {
+    [DeviceModelInternal.T3T1]: resolveStaticPath(`${PNG_PATH}/${PNG_IMAGES.TREZOR_T3T1_LARGE_2x}`),
     [DeviceModelInternal.T3W1]: resolveStaticPath(`${PNG_PATH}/${PNG_IMAGES.TREZOR_T3W1_LARGE_2x}`),
 };
 


### PR DESCRIPTION
## Description

Changed connection modal image from placeholder to TS5.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21133

## Screenshots:
**BEFORE**
<img width="1720" height="1047" alt="483211310-6117e23e-1575-46c5-9d2c-b9c7ea397ee7" src="https://github.com/user-attachments/assets/9e8d4395-2623-4d2a-b99f-3e3c81abef39" />

**AFTER**
<img width="1611" height="1014" alt="Screenshot 2025-08-28 at 23 04 00" src="https://github.com/user-attachments/assets/307f8aeb-e26c-4d9a-925c-4984aeb6198d" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/change-placeholder&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/change-placeholder&lookback=7)