### PR TITLE
docs: update 'export DISPLAY=:0' in step env variable

### DIFF
--- a/docs/tests/e2e-playwright-suite.md
+++ b/docs/tests/e2e-playwright-suite.md
@@ -24,7 +24,7 @@ _(in case of Linux with X11 support, skip to step 6.)_
 1. Run Docker and go to Preferences -> Resources -> Advanced and increase RAM to at least 4GB. Otherwise, the app during tests does not even load.
 1. In the terminal window, set two environment variables:
     - ``export HOSTNAME=`hostname` ``
-    - `export DISPLAY=${HOSTNAME}:0`
+    - `export DISPLAY=:0`
 1. In terminal window, navigate to `trezor-user-env` repo root and run `./run.sh`.
 1. In workspace `packages/suite-desktop-core` create a `.env` file according to the `.example.env`
 


### PR DESCRIPTION
## Description

When the hostname is omitted (**:0**), X11 client, will try to connect to the X server using the most efficient method for the local machine, which is a **Unix domain socket**. This is a fast, secure, and direct method of communication between processes on the same system.
