### PR TITLE
refactor(common): rename selectIsDeviceConnectedViaBluetooth to selectIsBluetoothDevice

### DIFF
--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -132,7 +132,7 @@ export const selectIsDeviceConnected = createMemoizedSelector(
     device => !!device?.connected,
 );
 
-export const selectIsDeviceConnectedViaBluetooth = createMemoizedSelector(
+export const selectIsBluetoothDevice = createMemoizedSelector(
     [selectSelectedDevice],
     device => !!device?.bluetoothProps,
 );

--- a/suite-native/device/src/components/ConnectorImage.tsx
+++ b/suite-native/device/src/components/ConnectorImage.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { selectIsDeviceConnectedViaBluetooth } from '@suite-common/wallet-core';
+import { selectIsBluetoothDevice } from '@suite-common/wallet-core';
 import { Box, Image } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
@@ -18,9 +18,9 @@ export type ConnectorImageProps = {
 export const ConnectorImage = ({ maxHeight }: ConnectorImageProps) => {
     const { applyStyle } = useNativeStyles();
 
-    const isDeviceConnectedViaBluetooth = useSelector(selectIsDeviceConnectedViaBluetooth);
+    const isBluetoothDevice = useSelector(selectIsBluetoothDevice);
 
-    if (!isDeviceConnectedViaBluetooth) {
+    if (!isBluetoothDevice) {
         return (
             <Image
                 source={require('../assets/connector.webp')}

--- a/suite-native/firmware/src/hooks/useFirmware.tsx
+++ b/suite-native/firmware/src/hooks/useFirmware.tsx
@@ -6,7 +6,7 @@ import {
     UseFirmwareInstallationParams,
     useFirmwareInstallation,
 } from '@suite-common/firmware';
-import { selectIsDeviceConnectedViaBluetooth } from '@suite-common/wallet-core';
+import { selectIsBluetoothDevice } from '@suite-common/wallet-core';
 import { TxKeyPath, useTranslate } from '@suite-native/intl';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { setPriorityMode } from '@trezor/react-native-usb';
@@ -45,9 +45,7 @@ export const useFirmware = (
 
     // When the device is restarted after FW installation via Bluetooth, this flag changes to false
     // for a moment which triggers firmwareUpdate again. => Use ref to prevent this.
-    const isDeviceConnectedViaBluetoothRef = useRef(
-        useSelector(selectIsDeviceConnectedViaBluetooth),
-    );
+    const isBluetoothDeviceRef = useRef(useSelector(selectIsBluetoothDevice));
 
     const setIsFirmwareInstallationRunning = useCallback(
         (isRunning: boolean) => {
@@ -82,7 +80,7 @@ export const useFirmware = (
     }, [progress, status, setMayBeStuckedTimeout, resetMayBeStuckedTimeout]);
 
     const firmwareUpdate = useCallback(async () => {
-        if (!isDeviceConnectedViaBluetoothRef.current) {
+        if (!isBluetoothDeviceRef.current) {
             setPriorityMode(true);
         }
         const result = await firmwareUpdateCommon({ ignoreBaseUrl: true })
@@ -96,7 +94,7 @@ export const useFirmware = (
             })
             .then(({ connectResponse }) => connectResponse)
             .finally(() => {
-                if (!isDeviceConnectedViaBluetoothRef.current) {
+                if (!isBluetoothDeviceRef.current) {
                     setPriorityMode(false);
                 }
                 resetMayBeStuckedTimeout();

--- a/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
@@ -5,8 +5,8 @@ import {
     selectDeviceLabel,
     selectDeviceModel,
     selectDeviceName,
+    selectIsBluetoothDevice,
     selectIsDeviceBackupUnfinished,
-    selectIsDeviceConnectedViaBluetooth,
     selectIsDeviceInitialized,
 } from '@suite-common/wallet-core';
 import { TitledSection, VStack } from '@suite-native/atoms';
@@ -28,7 +28,7 @@ export const DeviceSettingsModalScreen = () => {
     const deviceModel = useSelector(selectDeviceModel);
     const deviceName = useSelector(selectDeviceName);
     const deviceLabel = useSelector(selectDeviceLabel);
-    const isDeviceConnectedViaBluetooth = useSelector(selectIsDeviceConnectedViaBluetooth);
+    const isBluetoothDevice = useSelector(selectIsBluetoothDevice);
     const isDeviceBackupUnfinished = useSelector(selectIsDeviceBackupUnfinished);
     const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
     const isCheckBackupAvailable = isDeviceInitialized && !isDeviceBackupUnfinished;
@@ -46,7 +46,7 @@ export const DeviceSettingsModalScreen = () => {
                 >
                     {isDeviceInitialized && <DevicePinProtectionCard />}
                     <DeviceFirmwareCard />
-                    {isDeviceConnectedViaBluetooth && <DeviceBluetoothCard />}
+                    {isBluetoothDevice && <DeviceBluetoothCard />}
                 </TitledSection>
                 <TitledSection
                     title={<Translation id="moduleDeviceSettings.sectionTitles.security" />}

--- a/suite-native/module-home/src/screens/HomeScreen/components/AutoEjectAnimation.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/AutoEjectAnimation.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-import { selectIsDeviceConnectedViaBluetooth } from '@suite-common/wallet-core';
+import { selectIsBluetoothDevice } from '@suite-common/wallet-core';
 import { LottieAnimation } from '@suite-native/atoms';
 
 import autoEjectCableLottie from '../../../assets/auto-eject-cable-lottie.json';
 import autoEjectWirelessLottie from '../../../assets/auto-eject-wireless-lottie.json';
 
 export const AutoEjectAnimation = () => {
-    const isDeviceConnectedViaBluetooth = useSelector(selectIsDeviceConnectedViaBluetooth);
+    const isBluetoothDevice = useSelector(selectIsBluetoothDevice);
 
     return (
         <LottieAnimation
-            source={isDeviceConnectedViaBluetooth ? autoEjectWirelessLottie : autoEjectCableLottie}
+            source={isBluetoothDevice ? autoEjectWirelessLottie : autoEjectCableLottie}
         />
     );
 };


### PR DESCRIPTION
The previous name was misleading as the selector returns `true` even if the device is disconnected.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/common/is-bluetooth-device&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/common/is-bluetooth-device&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/common/is-bluetooth-device&lookback=7)