### PR TITLE
fix(suite): remove background for OnboardingLayout

### DIFF
--- a/packages/suite/src/components/onboarding/OnboardingLayout.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingLayout.tsx
@@ -27,7 +27,6 @@ const Wrapper = styled.div`
     height: 100%;
     flex-direction: column;
     align-items: center;
-    background: ${({ theme }) => theme.backgroundSurfaceElevation2};
 `;
 
 const Body = styled.div`
@@ -61,9 +60,6 @@ const Header = styled.div`
     align-items: center;
     flex-direction: column;
     max-width: ${MAX_ONBOARDING_WIDTH}px;
-    background: ${({ theme }) => theme.backgroundSurfaceElevation2};
-    box-shadow: 0 ${spacingsPx.md} ${spacingsPx.sm} ${spacingsPx.xxs}
-        ${({ theme }) => theme.backgroundSurfaceElevation2};
     margin-bottom: ${spacingsPx.md};
     z-index: ${zIndices.base};
 


### PR DESCRIPTION
## Description

Remove background in OnboardingLayout for consistency with the rest of the app

## Screenshots

| Before | After |
|-|-|
|<img width="1290" height="1056" alt="Screenshot 2025-08-28 at 16 19 55" src="https://github.com/user-attachments/assets/0f90cbb7-f118-44a7-a116-738827f8709d" />|<img width="1290" height="1056" alt="Screenshot 2025-08-28 at 16 20 19" src="https://github.com/user-attachments/assets/34fa8f46-5e4d-406d-a047-3db71413e97c" />|


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=onboardinglayout-background&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=onboardinglayout-background&lookback=7)