### PR TITLE
chore(suite-common): dont fetch fiat rates for 0 balance tokens

### DIFF
--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts
@@ -24,6 +24,7 @@ import {
     roundTimestampToNearestPastHour,
 } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
+import { BigNumber } from '@trezor/utils';
 
 import { MAX_AGE } from './fiatRatesConstants';
 import { FiatRatesRootState } from './fiatRatesTypes';
@@ -103,13 +104,15 @@ export const selectTickerFromAccounts = (
             {
                 symbol: account.symbol,
             } as TickerId,
-            ...(account.tokens || []).map(
-                token =>
-                    ({
-                        symbol: account.symbol,
-                        tokenAddress: token.contract,
-                    }) as TickerId,
-            ),
+            ...(account.tokens || [])
+                .filter(token => new BigNumber(token.balance ?? '0').gt(0))
+                .map(
+                    token =>
+                        ({
+                            symbol: account.symbol,
+                            tokenAddress: token.contract,
+                        }) as TickerId,
+                ),
         ]),
         A.flat,
         A.filter(


### PR DESCRIPTION
## Description

Fiat rates are only fetched for token with balance > 0

## Related Issue

Resolve #21063

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/dont-fetch-fiat-rate-for-zero-balance&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/dont-fetch-fiat-rate-for-zero-balance&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/dont-fetch-fiat-rate-for-zero-balance&lookback=7)