### PR TITLE
chore(suite-common): split thp finish actions

### DIFF
--- a/packages/suite/src/actions/thp/removeThpAutoconnectThunk.ts
+++ b/packages/suite/src/actions/thp/removeThpAutoconnectThunk.ts
@@ -46,7 +46,7 @@ export const removeThpAutoconnectThunk = createThunk<
                 notificationsActions.addToast({ type: 'error', error: response.payload.error }),
             );
         }
-        dispatch(thpActions.resetThpFlow());
+        dispatch(thpActions.finishThpFlow());
 
         return fulfillWithValue(response);
     },

--- a/packages/suite/src/components/connection/thp/ThpAutoconnectInfoModal.tsx
+++ b/packages/suite/src/components/connection/thp/ThpAutoconnectInfoModal.tsx
@@ -19,7 +19,7 @@ export const ThpAutoconnectInfoModal = () => {
     };
 
     const onCancel = () => {
-        dispatch(thpActions.resetThpFlow());
+        dispatch(thpActions.finishThpFlow());
     };
 
     return (

--- a/packages/suite/src/components/connection/thp/ThpAutoconnectionModal.tsx
+++ b/packages/suite/src/components/connection/thp/ThpAutoconnectionModal.tsx
@@ -12,7 +12,7 @@ export const ThpAutoconnectionModal = ({ device }: ThpAutoconnectionModalProps) 
     const dispatch = useDispatch();
 
     const onCancel = () => {
-        dispatch(thpActions.resetThpFlow());
+        dispatch(thpActions.finishThpFlow());
     };
 
     return (

--- a/packages/suite/src/components/connection/thp/ThpConnectionModal.tsx
+++ b/packages/suite/src/components/connection/thp/ThpConnectionModal.tsx
@@ -15,7 +15,7 @@ export const ThpConnectionModal = ({ device }: ThpConnectionModalProps) => {
 
     const onCancel = () => {
         TrezorConnect.cancel();
-        dispatch(thpActions.resetThpFlow());
+        dispatch(thpActions.finishThpFlow());
     };
 
     return (

--- a/packages/suite/src/components/connection/thp/ThpPairingFailedModal.tsx
+++ b/packages/suite/src/components/connection/thp/ThpPairingFailedModal.tsx
@@ -22,7 +22,7 @@ export const ThpPairingFailedModal = () => {
     };
 
     const onCancel = () => {
-        dispatch(thpActions.resetThpFlow());
+        dispatch(thpActions.finishThpFlow());
     };
 
     return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ThpPairingPinEntryModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ThpPairingPinEntryModal.tsx
@@ -16,7 +16,7 @@ export const ThpPairingPinEntryModal = () => {
 
     const onCancel = () => {
         TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
-        dispatch(thpActions.resetThpFlow());
+        dispatch(thpActions.finishThpFlow());
     };
 
     return (

--- a/suite-common/thp/src/connectThpDeviceThunk.ts
+++ b/suite-common/thp/src/connectThpDeviceThunk.ts
@@ -13,9 +13,7 @@ type ConnectThpDeviceThinkParams = {
 
 export const connectThpDeviceThunk = createThunk<void, ConnectThpDeviceThinkParams, void>(
     `${THP_PREFIX}/connectThpDeviceThunk`,
-    ({ device }, { dispatch, getState, rejectWithValue }) => {
-        if (device.thp === undefined) return rejectWithValue('not-thp-device');
-
+    ({ device }, { dispatch, getState }) => {
         const credentials = selectThpCredentials(getState());
         const isFwInstall = selectFirmware(getState()).status !== 'initial';
 
@@ -45,10 +43,10 @@ export const connectThpDeviceThunk = createThunk<void, ConnectThpDeviceThinkPara
             dispatch(
                 shallShowAutoConnectDialog
                     ? thpActions.showAutoconnectInfo()
-                    : thpActions.resetThpFlow(),
+                    : thpActions.finishThpFlow(),
             );
         } else {
-            dispatch(thpActions.resetThpFlow());
+            dispatch(thpActions.finishThpFlow());
         }
     },
 );

--- a/suite-common/thp/src/startThpAutoconnectThunk.ts
+++ b/suite-common/thp/src/startThpAutoconnectThunk.ts
@@ -23,6 +23,6 @@ export const startThpAutoconnectThunk = createThunk<void, void, void>(
                 notificationsActions.addToast({ type: 'error', error: response.payload.error }),
             );
         }
-        dispatch(thpActions.resetThpFlow());
+        dispatch(thpActions.finishThpFlow());
     },
 );

--- a/suite-common/thp/src/thpActions.ts
+++ b/suite-common/thp/src/thpActions.ts
@@ -7,7 +7,9 @@ export const THP_PREFIX = '@suite/thp';
 
 const invalidCode = createAction(`${THP_PREFIX}/invalid-pin-action`);
 
-const resetThpFlow = createAction(`${THP_PREFIX}/reset-thp-flow`);
+const finishThpFlow = createAction(`${THP_PREFIX}/finish-thp-flow`);
+
+const cancelThpFlow = createAction(`${THP_PREFIX}/cancel-thp-flow`);
 
 export const showAutoconnectInfo = createAction(`${THP_PREFIX}/showAutoconnectInfo`);
 
@@ -41,8 +43,9 @@ export const removeCredentials = createAction(
 
 export const thpActions = {
     invalidCode,
-    resetThpFlow,
+    finishThpFlow,
     addCredential,
+    cancelThpFlow,
     removeCredentials,
     setLastThpCode,
     showAutoconnectInfo,

--- a/suite-common/thp/src/thpReducer.ts
+++ b/suite-common/thp/src/thpReducer.ts
@@ -1,4 +1,4 @@
-import { AnyAction } from '@reduxjs/toolkit';
+import { AnyAction, isAnyOf } from '@reduxjs/toolkit';
 
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { ThpSuiteCredentials } from '@suite-common/suite-types';
@@ -55,9 +55,6 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
     initialState,
     (builder, extra) =>
         builder
-            .addCase(thpActions.resetThpFlow, state => {
-                state.step = null;
-            })
             .addCase(thpActions.invalidCode, state => {
                 state.step = 'CodeInvalid';
             })
@@ -87,6 +84,9 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
                                 stateCredential.credential === payloadCredential.credential,
                         ),
                 );
+            })
+            .addMatcher(isAnyOf(thpActions.finishThpFlow, thpActions.cancelThpFlow), state => {
+                state.step = null;
             })
             .addMatcher(
                 action => action.type === UI.REQUEST_THP_PAIRING,

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -234,7 +234,7 @@ export const acquireDevice = createThunk(
                     }),
                 );
                 if (device?.thp !== undefined) {
-                    dispatch(thpActions.resetThpFlow());
+                    dispatch(thpActions.cancelThpFlow());
                 }
             }
         } else if (startDiscovery) {
@@ -395,7 +395,9 @@ export const deviceConnectThunks = createThunk<void, DeviceConnectThunksParams, 
         switch (type) {
             case DEVICE.CONNECT:
                 dispatch(deviceActions.connectDevice({ device }));
-                dispatch(connectThpDeviceThunk({ device }));
+                if (device.thp !== undefined) {
+                    dispatch(connectThpDeviceThunk({ device }));
+                }
                 break;
             case DEVICE.CONNECT_UNACQUIRED:
                 dispatch(

--- a/suite-native/thp/src/hooks/useThpAlert.tsx
+++ b/suite-native/thp/src/hooks/useThpAlert.tsx
@@ -15,7 +15,7 @@ export const useThpAlerts = () => {
     }, [dispatch]);
 
     const ignoreAutoconnect = useCallback(() => {
-        dispatch(thpActions.resetThpFlow());
+        dispatch(thpActions.finishThpFlow());
     }, [dispatch]);
 
     const showThpAutoconnectAlert = useCallback(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- separate thp actions for success / finish so we can use them for redirecting. No change in app behavior.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/split-thp-actions&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/split-thp-actions&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/split-thp-actions&lookback=7)