### PR TITLE
fix(product-components): react key error

### DIFF
--- a/packages/product-components/src/components/DeviceAnimation/DeviceAnimation.tsx
+++ b/packages/product-components/src/components/DeviceAnimation/DeviceAnimation.tsx
@@ -83,7 +83,6 @@ export const DeviceAnimation = forwardRef<HTMLVideoElement, DeviceAnimationProps
         const key = `${deviceModelInFilename}_${type.toLowerCase()}_${deviceUnitColor}_${themeSuffix}`;
 
         const commonProps = {
-            key,
             loop,
             videoRef,
             onMouseOver,
@@ -94,12 +93,14 @@ export const DeviceAnimation = forwardRef<HTMLVideoElement, DeviceAnimationProps
                 {['BOOTLOADER'].includes(type) && (
                     <Video
                         src={`videos/device/trezor_${deviceModelInFilename}_${type.toLowerCase()}${themeSuffix}.webm`}
+                        key={key}
                         {...commonProps}
                     />
                 )}
                 {['SUCCESS'].includes(type) && (
                     <Video
                         src={`videos/device/trezor_${deviceModelInFilename}_${type.toLowerCase()}${themeSuffix}_frontcolor_${getFrontColor()}.webm`}
+                        key={key}
                         {...commonProps}
                     />
                 )}
@@ -107,12 +108,14 @@ export const DeviceAnimation = forwardRef<HTMLVideoElement, DeviceAnimationProps
                 {['BOOTLOADER_TWO_BUTTONS', 'NORMAL'].includes(type) && (
                     <Video
                         src={`videos/device/trezor_${DeviceModelInternal.T1B1.toLowerCase()}_${type.toLowerCase()}${themeSuffix}.webm`}
+                        key={key}
                         {...commonProps}
                     />
                 )}
                 {type === 'HOLOGRAM' && (
                     <Video
                         src={`videos/device/trezor_${deviceModelInFilename}_hologram.webm`}
+                        key={key}
                         {...commonProps}
                     />
                 )}
@@ -122,6 +125,7 @@ export const DeviceAnimation = forwardRef<HTMLVideoElement, DeviceAnimationProps
                             // if device unit color is not set, use first color available
                             deviceUnitColor ?? 1
                         }${sizeVariant ? `_${sizeVariant.toLowerCase()}` : ''}.webm`}
+                        key={key}
                         {...commonProps}
                     />
                 )}

--- a/packages/product-components/src/components/DeviceAnimation/Video.tsx
+++ b/packages/product-components/src/components/DeviceAnimation/Video.tsx
@@ -23,11 +23,10 @@ export const Video = ({ src, loop, videoRef, onMouseOver, key }: VideoProps) => 
         muted: true,
         ref: videoRef,
         onMouseOver,
-        key,
     };
 
     return (
-        <StyledVideo {...commonProps}>
+        <StyledVideo key={key} {...commonProps}>
             <source src={resolveStaticPath(src)} type="video/webm" />
         </StyledVideo>
     );


### PR DESCRIPTION
## Description

Fix noisy react error about spreading the `key` pro

## Screenshots:

<img width="562" height="402" alt="key spread" src="https://github.com/user-attachments/assets/dd06a18a-f2e8-4e82-95ef-3d8f3286dbcf" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/video-react-key-prop&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/video-react-key-prop&lookback=7)