### PR TITLE
fix(suite-web): set thp.hostName = browser name

### DIFF
--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -81,7 +81,7 @@ export const extraDependencies: ExtraDependencies = {
             state.suite.settings.debug.invityServerEnvironment,
         selectIsViewOnlyByDefaultEnabled: (_: AppState) => true,
         selectThpSettings: (state: AppState) => ({
-            hostName: 'Trezor Suite', // NOTE: this is displayed on Trezor. not the same as manifest.appName
+            appName: 'Trezor Suite', // NOTE: this is displayed on Trezor. not the same as manifest.appName
             pairingMethods: ['CodeEntry'],
             staticKey: state.thp?.staticKey,
             knownCredentials: state.thp?.credentials,

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -24,9 +24,9 @@ import TrezorConnect, {
     UI_EVENT,
     UI_REQUEST,
 } from '@trezor/connect';
-import { isDesktop } from '@trezor/env-utils';
+import { getBrowserName, isDesktop, isWeb } from '@trezor/env-utils';
 import { DATA_URL } from '@trezor/urls';
-import { getSynchronize } from '@trezor/utils';
+import { capitalizeFirstLetter, getSynchronize } from '@trezor/utils';
 
 import { blacklist } from './blacklist';
 import { cardanoConnectPatch } from './cardanoConnectPatch';
@@ -178,6 +178,11 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
         };
 
         const { transports, showConnectLogs } = selectDebugSettings(getState());
+        const thp = selectThpSettings(getState());
+        // desktop thp appName/hostName enhanced in ./packages/suite-desktop-core/src/modules/trezor-connect.ts
+        if (isWeb()) {
+            thp.hostName = capitalizeFirstLetter(getBrowserName());
+        }
 
         try {
             await TrezorConnect.init({
@@ -185,7 +190,7 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
                 binFilesBaseUrl,
                 pendingTransportEvent: selectIsPendingTransportEvent(getState()),
                 transports,
-                thp: selectThpSettings(getState()),
+                thp,
                 debug: showConnectLogs,
                 firmwareHashCheckTimeouts,
                 firmwareUpdateSource: getFirmwareUpdateSource(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix shared extraDependencies `hostName` > `appName` 
"Allow Trezor Suite on Trezor Suite" bug

add browser name as `thp.hostName` in suite-web




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-web-thp-hostname&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-web-thp-hostname&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-web-thp-hostname&lookback=7)