### PR TITLE
Feat: forget all device data

### DIFF
--- a/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
+++ b/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
@@ -109,6 +109,7 @@ const fixture: Feature[] = [
                     }),
                 ],
                 isDeviceAutoEjectEnabled: false,
+                persistentDeviceData: [],
             },
         },
         action: () => wipeDeviceThunk(),

--- a/packages/suite/src/actions/settings/__tests__/deviceSettingsActions.test.ts
+++ b/packages/suite/src/actions/settings/__tests__/deviceSettingsActions.test.ts
@@ -24,6 +24,7 @@ const getInitialState = (state: Partial<DeviceSettingsFixtureState> = {}) => ({
         devices: state.device?.devices ?? [DEVICE],
         selectedDevice: DEVICE,
         isDeviceAutoEjectEnabled: false,
+        persistentDeviceData: [],
         isConnectionModalOpen: false,
     },
     router: {},

--- a/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
@@ -68,6 +68,7 @@ const getInitialState = (state?: InitialState) => {
             devices: device ? [device] : [],
             selectedDevice: device,
             isDeviceAutoEjectEnabled: false,
+            persistentDeviceData: [],
             isConnectionModalOpen: false,
         },
         suite: {

--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -239,6 +239,7 @@ describe('Storage actions', () => {
                 device: {
                     devices: [dev1, dev2, dev2Instance1],
                     isDeviceAutoEjectEnabled: false,
+                    persistentDeviceData: [],
                     isConnectionModalOpen: false,
                     defaultConnectionMode: 'cable',
                 },
@@ -332,6 +333,7 @@ describe('Storage actions', () => {
                 device: {
                     devices: [dev1, dev2],
                     isDeviceAutoEjectEnabled: false,
+                    persistentDeviceData: [],
                     isConnectionModalOpen: false,
                     defaultConnectionMode: 'cable',
                 },
@@ -377,6 +379,7 @@ describe('Storage actions', () => {
                 device: {
                     devices: [dev1Connected],
                     isDeviceAutoEjectEnabled: false,
+                    persistentDeviceData: [],
                     isConnectionModalOpen: false,
                     defaultConnectionMode: 'cable',
                 },
@@ -416,6 +419,7 @@ describe('Storage actions', () => {
                 device: {
                     devices: [dev1],
                     isDeviceAutoEjectEnabled: false,
+                    persistentDeviceData: [],
                     isConnectionModalOpen: false,
                     defaultConnectionMode: 'cable',
                 },
@@ -468,6 +472,7 @@ describe('Storage actions', () => {
                 device: {
                     devices: [devNotRemembered],
                     isDeviceAutoEjectEnabled: false,
+                    persistentDeviceData: [],
                     isConnectionModalOpen: false,
                     defaultConnectionMode: 'cable',
                 },

--- a/packages/suite/src/actions/suite/__tests__/trezorConnectActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/trezorConnectActions.test.ts
@@ -1,6 +1,7 @@
 import { connectInitThunk } from '@suite-common/connect-init';
 import { messageSystemInitialState } from '@suite-common/message-system';
 import { testMocks } from '@suite-common/test-utils';
+import { deviceReducerInitialState } from '@suite-common/wallet-core';
 import { BLOCKCHAIN_EVENT, DEVICE_EVENT, TRANSPORT_EVENT, UI_EVENT } from '@trezor/connect';
 
 import { deviceSlice } from 'src/actions/device/deviceSlice';
@@ -19,8 +20,8 @@ const getInitialState = (suite?: Partial<SuiteState>, device?: Partial<DevicesSt
         ...suite,
     },
     device: {
+        ...deviceReducerInitialState,
         devices: device?.devices || [],
-        isDeviceAutoEjectEnabled: false,
         isConnectionModalOpen: false,
         defaultConnectionMode: 'cable' as 'cable' | 'bluetooth',
     },

--- a/packages/suite/src/actions/suite/autoEjectThunks.ts
+++ b/packages/suite/src/actions/suite/autoEjectThunks.ts
@@ -1,5 +1,4 @@
 import { createThunk } from '@suite-common/redux-utils';
-import { TrezorDevice } from '@suite-common/suite-types';
 import { forgetDisconnectedDevices, selectDevices } from '@suite-common/wallet-core';
 
 import * as storageActions from 'src/actions/suite/storageActions';
@@ -9,23 +8,20 @@ import { setAutoEject } from './suiteActions';
 
 const AUTO_EJECT_PREFIX = '@suite/autoEject';
 
-export const setAutoEjectEnabledThunk = createThunk(
+type SetAutoEjectEnabledThunkProps = { enabled: boolean };
+
+export const setAutoEjectEnabledThunk = createThunk<void, SetAutoEjectEnabledThunkProps, void>(
     `${AUTO_EJECT_PREFIX}/enableAutoEjectThunk`,
-    (
-        {
-            enabled,
-            disconnectedDevices,
-        }: {
-            enabled: boolean;
-            disconnectedDevices: TrezorDevice[];
-        },
-        { dispatch, getState },
-    ) => {
+    ({ enabled }, { dispatch, getState }) => {
         if (!enabled) {
             dispatch(setAutoEject(false));
 
             return;
         }
+
+        const devices = selectDevices(getState());
+
+        const disconnectedDevices = devices.filter(device => !device.connected && device.state);
 
         disconnectedDevices.forEach(device => {
             dispatch(forgetDisconnectedDevices({ device, forceForget: true }));

--- a/packages/suite/src/actions/suite/autoEjectThunks.ts
+++ b/packages/suite/src/actions/suite/autoEjectThunks.ts
@@ -1,5 +1,5 @@
 import { createThunk } from '@suite-common/redux-utils';
-import { forgetDisconnectedDevices, selectDevices } from '@suite-common/wallet-core';
+import { forgetAllDisconnectedDevices, selectDevices } from '@suite-common/wallet-core';
 
 import * as storageActions from 'src/actions/suite/storageActions';
 
@@ -12,27 +12,19 @@ type SetAutoEjectEnabledThunkProps = { enabled: boolean };
 
 export const setAutoEjectEnabledThunk = createThunk<void, SetAutoEjectEnabledThunkProps, void>(
     `${AUTO_EJECT_PREFIX}/enableAutoEjectThunk`,
-    ({ enabled }, { dispatch, getState }) => {
+    async ({ enabled }, { dispatch, getState }) => {
         if (!enabled) {
             dispatch(setAutoEject(false));
 
             return;
         }
 
-        const devices = selectDevices(getState());
+        // Disconnected devices are purged from local redux (awaited because the subsequent code may rely on updated deviceReducer state)
+        await dispatch(forgetAllDisconnectedDevices());
 
-        const disconnectedDevices = devices.filter(device => !device.connected && device.state);
-
-        disconnectedDevices.forEach(device => {
-            dispatch(forgetDisconnectedDevices({ device, forceForget: true }));
-        });
-
-        const allDevices = selectDevices(getState());
-        allDevices.forEach(device => {
-            if (device.features) {
-                dispatch(storageActions.forgetDevice(device));
-            }
-        });
+        // All devices, even connected ones, removed from persistent storage,
+        // which means connected device are preserved in local redux.
+        dispatch(storageActions.forgetAllDevicesThunk());
 
         dispatch(setAutoEject(true));
 

--- a/packages/suite/src/actions/suite/autoEjectThunks.ts
+++ b/packages/suite/src/actions/suite/autoEjectThunks.ts
@@ -38,8 +38,6 @@ export const setAutoEjectEnabledThunk = createThunk(
             }
         });
 
-        dispatch(storageActions.saveSuiteSettings());
-
         dispatch(setAutoEject(true));
 
         const currentDevices = selectDevices(getState());

--- a/packages/suite/src/actions/suite/autoForgetDeviceDataThunks.ts
+++ b/packages/suite/src/actions/suite/autoForgetDeviceDataThunks.ts
@@ -4,16 +4,21 @@ import {
     setAutoForgetDeviceData,
 } from '@suite-common/wallet-core';
 
+import * as storageActions from 'src/actions/suite/storageActions';
+
 import { setAutoEjectEnabledThunk } from './autoEjectThunks';
+
 const AUTO_FORGET_PREFIX = '@suite/autoForgetDeviceData';
 
 type SetAutoForgetDeviceDataThunkProps = { enabled: boolean };
 
+// TODO: move main parts of this thunk to wallet-core. The setting `autoForgetDeviceData` already lives in wallet-core.
+// But the autoEject setting lives in suiteReducer unfortunately, so that will first have to be migrated to wallet-core.
 export const setAutoForgetDeviceDataThunk = createThunk<
     void,
     SetAutoForgetDeviceDataThunkProps,
     void
->(`${AUTO_FORGET_PREFIX}/setAutoForgetDeviceDataThunk`, ({ enabled }, { dispatch }) => {
+>(`${AUTO_FORGET_PREFIX}/setAutoForgetDeviceDataThunk`, async ({ enabled }, { dispatch }) => {
     if (!enabled) {
         dispatch(setAutoForgetDeviceData(false));
 
@@ -21,9 +26,14 @@ export const setAutoForgetDeviceDataThunk = createThunk<
     }
 
     dispatch(setAutoForgetDeviceData(true));
-    dispatch(forgetAllDevicesPersistentDataThunk());
+    await dispatch(forgetAllDevicesPersistentDataThunk());
 
     // When you enable autoForget, also enable autoEject, but not the other way around, because
     // autoEject feature is a subset of autoForget feature, autoForget does not make sense without autoEject.
-    dispatch(setAutoEjectEnabledThunk({ enabled }));
+    // This also takes care of forgetting wallets (as deviceReducer `devices`) from redux as well as storage.
+    await dispatch(setAutoEjectEnabledThunk({ enabled }));
+
+    // Finally, having purged the data in Bluetooth and THP reducers, simply sync BT and THP to persistent storage.
+    dispatch(storageActions.saveKnownDevices());
+    dispatch(storageActions.saveThpCredentials());
 });

--- a/packages/suite/src/actions/suite/autoForgetDeviceDataThunks.ts
+++ b/packages/suite/src/actions/suite/autoForgetDeviceDataThunks.ts
@@ -1,0 +1,29 @@
+import { createThunk } from '@suite-common/redux-utils';
+import {
+    forgetAllDevicesPersistentDataThunk,
+    setAutoForgetDeviceData,
+} from '@suite-common/wallet-core';
+
+import { setAutoEjectEnabledThunk } from './autoEjectThunks';
+const AUTO_FORGET_PREFIX = '@suite/autoForgetDeviceData';
+
+type SetAutoForgetDeviceDataThunkProps = { enabled: boolean };
+
+export const setAutoForgetDeviceDataThunk = createThunk<
+    void,
+    SetAutoForgetDeviceDataThunkProps,
+    void
+>(`${AUTO_FORGET_PREFIX}/setAutoForgetDeviceDataThunk`, ({ enabled }, { dispatch }) => {
+    if (!enabled) {
+        dispatch(setAutoForgetDeviceData(false));
+
+        return;
+    }
+
+    dispatch(setAutoForgetDeviceData(true));
+    dispatch(forgetAllDevicesPersistentDataThunk());
+
+    // When you enable autoForget, also enable autoEject, but not the other way around, because
+    // autoEject feature is a subset of autoForget feature, autoForget does not make sense without autoEject.
+    dispatch(setAutoEjectEnabledThunk({ enabled }));
+});

--- a/packages/suite/src/actions/suite/constants/storageConstants.ts
+++ b/packages/suite/src/actions/suite/constants/storageConstants.ts
@@ -1,2 +1,6 @@
+// actions
 export const LOAD = '@storage/load' as const;
 export const ERROR = '@storage/error' as const;
+
+// prefix for thunks
+export const MODULE_PREFIX = '@suite/storage' as const;

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -1,6 +1,7 @@
 import { FieldValues } from 'react-hook-form';
 
 import { MetadataState } from '@suite-common/metadata-types';
+import { createThunk } from '@suite-common/redux-utils/';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { DefinitionType, TokenManagementAction } from '@suite-common/token-definitions';
@@ -255,6 +256,16 @@ export const forgetDevice = (device: TrezorDevice) => async (_: Dispatch, getSta
         ...accounts.map(removeAccountWithDependencies(getState)),
     ]);
 };
+
+export const forgetAllDevicesThunk = createThunk(
+    `${STORAGE.MODULE_PREFIX}/forgetAllDevices`,
+    (_, { dispatch, getState }) => {
+        const allDevices = selectDevices(getState());
+        allDevices.forEach(device => {
+            dispatch(forgetDevice(device));
+        });
+    },
+);
 
 export const saveAccounts = async (accounts: SuccessfulAccount[]) => {
     if (!(await db.isAccessible())) return;

--- a/packages/suite/src/constants/suite/anchors.ts
+++ b/packages/suite/src/constants/suite/anchors.ts
@@ -25,6 +25,7 @@ export const SettingsAnchor = {
     AutomaticUpdate: '@general-settings/automatic-update',
     AutoEject: '@general-settings/auto-eject',
     MevProtection: '@general-settings/mev-protection',
+    StoreDeviceData: '@general-settings/store-device-data',
 
     BackupFailed: '@device-settings/backup-failed',
     BackupRecoverySeed: '@device-settings/backup-recovery-seed',

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -241,6 +241,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case setBaseCurrency.type:
                 case WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS:
                 case WALLET_SETTINGS.SET_MEV_PROTECTION:
+                case WALLET_SETTINGS.AUTO_FORGET_DEVICE_DATA:
                     api.dispatch(storageActions.saveWalletSettings());
                     break;
                 case SUITE.SET_LANGUAGE:

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -22,6 +22,7 @@ import {
     selectDeviceByStaticSessionId,
     selectDevices,
     selectHistoricFiatRates,
+    selectIsAutoForgetDeviceDataEnabled,
     selectSelectedDevice,
     setBaseCurrency,
     transactionsActions,
@@ -200,7 +201,10 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 }
             }
 
+            const isAutoForgetEnabled = selectIsAutoForgetDeviceDataEnabled(api.getState());
+
             if (
+                !isAutoForgetEnabled &&
                 isAnyOf(
                     deviceActions.connectDevice, // Known device is stored
                     deviceActions.connectUnacquiredDevice, // Known device is stored
@@ -228,10 +232,11 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
             }
 
             if (
-                deviceActions.setThpCredentials.match(action) ||
-                deviceActions.connectDevice.match(action) || // To save the `connectionCounter`
-                thpActions.removeCredentials.match(action) ||
-                action.type === 'device-thp_credentials_changed'
+                !isAutoForgetEnabled &&
+                (deviceActions.setThpCredentials.match(action) ||
+                    deviceActions.connectDevice.match(action) || // To save the `connectionCounter`
+                    thpActions.removeCredentials.match(action) ||
+                    action.type === 'device-thp_credentials_changed')
             ) {
                 api.dispatch(storageActions.saveThpCredentials());
             }

--- a/packages/suite/src/reducers/backup/__tests__/backupReducer.test.ts
+++ b/packages/suite/src/reducers/backup/__tests__/backupReducer.test.ts
@@ -32,6 +32,7 @@ describe('selectBackupStatus', () => {
         device: {
             devices: [],
             isDeviceAutoEjectEnabled: false,
+            persistentDeviceData: [],
             isConnectionModalOpen: true,
             defaultConnectionMode: 'cable',
             selectedDevice: {

--- a/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
@@ -1,6 +1,10 @@
 import { TrezorDevice } from '@suite-common/suite-types';
 import { testMocks } from '@suite-common/test-utils';
-import { deviceActions } from '@suite-common/wallet-core';
+import {
+    DeviceReducerState,
+    deviceActions,
+    deviceReducerInitialState,
+} from '@suite-common/wallet-core';
 import { DEVICE } from '@trezor/connect';
 import { DeepPartial } from '@trezor/type-utils';
 
@@ -13,7 +17,7 @@ const SUITE_DEVICE = getSuiteDevice();
 type Fixture<TAction> = {
     description: string;
     actions: TAction[];
-    initialState: any;
+    initialState: DeviceReducerState;
     result: DeepPartial<TrezorDevice>[];
 };
 
@@ -23,7 +27,7 @@ const connect: Fixture<
 >[] = [
     {
         description: 'Connect device (0 connected, 0 affected)',
-        initialState: { devices: [] },
+        initialState: deviceReducerInitialState,
         actions: [
             {
                 type: DEVICE.CONNECT,
@@ -44,6 +48,7 @@ const connect: Fixture<
     {
         description: 'Connect device (1 connected, 0 affected)',
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice(undefined, {
                     device_id: 'ignored-device-id',
@@ -80,6 +85,7 @@ const connect: Fixture<
     {
         description: 'Connect device (1 connected, 1 affected)',
         initialState: {
+            ...deviceReducerInitialState,
             devices: [SUITE_DEVICE],
         },
         actions: [
@@ -102,6 +108,7 @@ const connect: Fixture<
     {
         description: 'Connect device (1 connected, 2 instances, 2 affected)',
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice({
                     instance: 1,
@@ -135,6 +142,7 @@ const connect: Fixture<
     {
         description: 'Connect device (2 connected, 1 affected)',
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice(undefined, {
                     device_id: 'ignored-device-id',
@@ -171,6 +179,7 @@ const connect: Fixture<
     {
         description: 'Connect acquired device and replace unacquired',
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice({
                     type: 'unacquired',
@@ -198,7 +207,7 @@ const connect: Fixture<
     },
     {
         description: 'Connect unacquired device',
-        initialState: { devices: [] },
+        initialState: deviceReducerInitialState,
         actions: [
             {
                 type: DEVICE.CONNECT_UNACQUIRED,
@@ -220,6 +229,7 @@ const connect: Fixture<
     {
         description: 'Connect unacquired device which already exists in reducer',
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice({
                     type: 'unacquired',
@@ -251,13 +261,12 @@ const disconnect = [
     {
         description: 'Disconnect device using path',
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice({
                     path: '1',
                 }),
             ],
-            isDeviceAutoEjectEnabled: false,
-            isConnectionModalOpen: false,
         },
         actions: [
             {
@@ -272,9 +281,8 @@ const disconnect = [
     {
         description: 'Disconnect device using device_id',
         initialState: {
+            ...deviceReducerInitialState,
             devices: [SUITE_DEVICE],
-            isDeviceAutoEjectEnabled: false,
-            isConnectionModalOpen: false,
         },
         actions: [
             {
@@ -287,6 +295,7 @@ const disconnect = [
     {
         description: 'Disconnect remembered device',
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice({
                     path: '1',
@@ -294,8 +303,6 @@ const disconnect = [
                     state: '1stTestnet@device_id:0',
                 }),
             ],
-            isDeviceAutoEjectEnabled: false,
-            isConnectionModalOpen: false,
         },
         actions: [
             {
@@ -319,6 +326,7 @@ const disconnect = [
     {
         description: 'Disconnect remembered device (2 instances)',
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice({
                     path: '1',
@@ -332,8 +340,6 @@ const disconnect = [
                     state: '1stTestnet@device_id_2:0',
                 }),
             ],
-            isDeviceAutoEjectEnabled: false,
-            isConnectionModalOpen: false,
         },
         actions: [
             {
@@ -363,6 +369,7 @@ const disconnect = [
     {
         description: 'Disconnect device (2 connected, 1 affected)',
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice(
                     {
@@ -377,8 +384,6 @@ const disconnect = [
                     path: '1',
                 }),
             ],
-            isDeviceAutoEjectEnabled: false,
-            isConnectionModalOpen: false,
         },
         actions: [
             {
@@ -401,14 +406,13 @@ const disconnect = [
     {
         description: `Disconnect unacquired device`,
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice({
                     type: 'unacquired',
                     path: '1',
                 }),
             ],
-            isDeviceAutoEjectEnabled: false,
-            isConnectionModalOpen: false,
         },
         actions: [
             {
@@ -423,11 +427,7 @@ const disconnect = [
     },
     {
         description: `Disconnect device which doesn't exists in reducer`,
-        initialState: {
-            devices: [],
-            isDeviceAutoEjectEnabled: false,
-            isConnectionModalOpen: false,
-        },
+        initialState: deviceReducerInitialState,
         actions: [
             {
                 type: DEVICE.DISCONNECT,
@@ -442,6 +442,7 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
     {
         description: `Change status available > occupied (using path)`,
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice(
                     {
@@ -480,6 +481,7 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
     {
         description: `Change unacquired (busy) THP device`,
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice({
                     type: 'unacquired',
@@ -526,7 +528,7 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
     },
     {
         description: `Change unacquired device`,
-        initialState: { devices: [] },
+        initialState: deviceReducerInitialState,
         actions: [
             {
                 type: DEVICE.CHANGED,
@@ -541,6 +543,7 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
     {
         description: `Change device (2 connected, 1 affected)`,
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice(undefined, {
                     device_id: 'ignored-device-id',
@@ -573,7 +576,10 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
     },
     {
         description: `Change device with on device with different "passphrase_protection" (shouldn't be changed)`,
-        initialState: { devices: [SUITE_DEVICE] },
+        initialState: {
+            ...deviceReducerInitialState,
+            devices: [SUITE_DEVICE],
+        },
         actions: [
             {
                 type: DEVICE.CHANGED,
@@ -598,7 +604,7 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
     },
     {
         description: `Change device which doesn't exists in reducer`,
-        initialState: { devices: [] },
+        initialState: deviceReducerInitialState,
         actions: [
             {
                 type: DEVICE.CHANGED,
@@ -610,6 +616,7 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
     {
         description: `features are not overridden when device is locked`,
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice(
                     // Reducer doesn't try to merge non-connected devices.
@@ -645,7 +652,10 @@ const selectDevice: Array<
 > = [
     {
         description: `Select device (1 connected, 1 affected)`,
-        initialState: { devices: [SUITE_DEVICE] },
+        initialState: {
+            ...deviceReducerInitialState,
+            devices: [SUITE_DEVICE],
+        },
         actions: [
             {
                 type: deviceActions.selectDevice.type,
@@ -664,6 +674,7 @@ const selectDevice: Array<
     {
         description: `Select device (2 connected, 1 affected)`,
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice(undefined, {
                     device_id: 'ignored-device-id',
@@ -694,6 +705,7 @@ const selectDevice: Array<
     {
         description: `Select device instance (2 instances, 1 affected)`,
         initialState: {
+            ...deviceReducerInitialState,
             devices: [SUITE_DEVICE, getSuiteDevice({ instance: 1 })],
         },
         actions: [
@@ -721,6 +733,7 @@ const selectDevice: Array<
     {
         description: `Select first then second instance (2 instances, 2 affected)`,
         initialState: {
+            ...deviceReducerInitialState,
             devices: [SUITE_DEVICE, getSuiteDevice({ instance: 1 })],
         },
         actions: [
@@ -751,7 +764,7 @@ const selectDevice: Array<
     },
     {
         description: `Select device (0 connected, 0 affected)`,
-        initialState: { devices: [] },
+        initialState: deviceReducerInitialState,
         actions: [
             {
                 type: deviceActions.selectDevice.type,
@@ -763,7 +776,7 @@ const selectDevice: Array<
     },
     {
         description: `Select device which doesn't exist in reducer`,
-        initialState: { devices: [] },
+        initialState: deviceReducerInitialState,
         actions: [
             {
                 type: deviceActions.selectDevice.type,
@@ -779,6 +792,7 @@ const forget: Fixture<ReturnType<typeof deviceActions.forgetDevice>>[] = [
     {
         description: `Forget multiple instances (2 connected, 5 instances, 3 affected, last instance remains with undefined state)`,
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice(undefined, {
                     device_id: 'ignored-device-id',
@@ -840,6 +854,7 @@ const forget: Fixture<ReturnType<typeof deviceActions.forgetDevice>>[] = [
     {
         description: `Forget three instances one by one (2 connected, 5 instances, 3 affected)`,
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice(undefined, {
                     device_id: 'ignored-device-id',
@@ -890,7 +905,10 @@ const forget: Fixture<ReturnType<typeof deviceActions.forgetDevice>>[] = [
     },
     {
         description: `device is unacquired`,
-        initialState: { devices: [SUITE_DEVICE] },
+        initialState: {
+            ...deviceReducerInitialState,
+            devices: [SUITE_DEVICE],
+        },
         actions: [
             {
                 type: deviceActions.forgetDevice.type,
@@ -909,7 +927,7 @@ const forget: Fixture<ReturnType<typeof deviceActions.forgetDevice>>[] = [
     },
     {
         description: `instance doesn't exist in reducer`,
-        initialState: { devices: [] },
+        initialState: deviceReducerInitialState,
         actions: [
             {
                 type: deviceActions.forgetDevice.type,
@@ -923,7 +941,10 @@ const forget: Fixture<ReturnType<typeof deviceActions.forgetDevice>>[] = [
 const remember: Fixture<ReturnType<typeof deviceActions.rememberDevice>>[] = [
     {
         description: `Remember unacquired device`,
-        initialState: { devices: [SUITE_DEVICE] },
+        initialState: {
+            ...deviceReducerInitialState,
+            devices: [SUITE_DEVICE],
+        },
         actions: [
             {
                 type: deviceActions.rememberDevice.type,
@@ -938,7 +959,10 @@ const remember: Fixture<ReturnType<typeof deviceActions.rememberDevice>>[] = [
     },
     {
         description: `Remember stateless device`,
-        initialState: { devices: [SUITE_DEVICE] },
+        initialState: {
+            ...deviceReducerInitialState,
+            devices: [SUITE_DEVICE],
+        },
         actions: [
             {
                 type: deviceActions.rememberDevice.type,
@@ -953,7 +977,10 @@ const remember: Fixture<ReturnType<typeof deviceActions.rememberDevice>>[] = [
     },
     {
         description: `Force remember device`,
-        initialState: { devices: [SUITE_DEVICE] },
+        initialState: {
+            ...deviceReducerInitialState,
+            devices: [SUITE_DEVICE],
+        },
         actions: [
             {
                 type: deviceActions.rememberDevice.type,
@@ -969,6 +996,7 @@ const remember: Fixture<ReturnType<typeof deviceActions.rememberDevice>>[] = [
     {
         description: `Remember device success`,
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice({
                     state: '1stTestnet@device_id:0',
@@ -997,6 +1025,7 @@ const remember: Fixture<ReturnType<typeof deviceActions.rememberDevice>>[] = [
     {
         description: `Remember device with multiple instances (few are stateless)`,
         initialState: {
+            ...deviceReducerInitialState,
             devices: [
                 getSuiteDevice({
                     state: '1stTestnet@device_id:0',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2849,6 +2849,46 @@ export default defineMessages({
         defaultMessage: 'Enable auto-eject?',
         id: 'TR_AUTO_EJECT_CONFIRMATION_TITLE',
     },
+    TR_DEVICE_SETTINGS_STORE_DEVICE_DATA_TITLE: {
+        id: 'TR_DEVICE_SETTINGS_STORE_DEVICE_DATA_TITLE',
+        defaultMessage: 'Store device-related data',
+    },
+    TR_DEVICE_SETTINGS_STORE_DEVICE_DATA_DESCRIPTION: {
+        id: 'TR_DEVICE_SETTINGS_STORE_DEVICE_DATA_DESCRIPTION',
+        defaultMessage:
+            'Securely stores minimal device information locally to enable advanced security features like anti-counterfeit checks and secure pairing.',
+    },
+    TR_DEVICE_SETTINGS_STORE_DEVICE_DATA_BUTTON: {
+        id: 'TR_DEVICE_SETTINGS_STORE_DEVICE_DATA_BUTTON',
+        defaultMessage: 'Change',
+    },
+    TR_STORE_DEVICE_DATA_MODAL_TITLE: {
+        id: 'TR_STORE_DEVICE_DATA_MODAL_TITLE',
+        defaultMessage: 'Store device-related data',
+    },
+    TR_STORE_DEVICE_DATA_MODAL_ENABLED: {
+        id: 'TR_STORE_DEVICE_DATA_MODAL_ENABLED',
+        defaultMessage: 'Enabled',
+    },
+    TR_STORE_DEVICE_DATA_MODAL_ENABLED_DESCRIPTION: {
+        id: 'TR_STORE_DEVICE_DATA_MODAL_ENABLED_DESCRIPTION',
+        defaultMessage:
+            'Suite locally stores and compares firmware, pairing credentials, and other device data for advanced security.',
+    },
+    TR_STORE_DEVICE_DATA_MODAL_DISABLED: {
+        id: 'TR_STORE_DEVICE_DATA_MODAL_DISABLED',
+        defaultMessage: 'Disabled',
+    },
+    TR_STORE_DEVICE_DATA_MODAL_DISABLED_DESCRIPTION: {
+        id: 'TR_STORE_DEVICE_DATA_MODAL_DISABLED_DESCRIPTION',
+        defaultMessage:
+            'No data gets stored, advanced security features are disabled. Requires secure pairing connection to be reestablished every time. For experienced users only. Use at your own risk.',
+    },
+    TR_STORE_DEVICE_DATA_MODAL_DISABLED_WARNING: {
+        id: 'TR_STORE_DEVICE_DATA_MODAL_DISABLED_WARNING',
+        defaultMessage:
+            'This will automatically eject all wallets when Trezor device is disconnected.',
+    },
     TR_LANGUAGE: {
         defaultMessage: 'Language',
         id: 'TR_LANGUAGE',
@@ -4654,6 +4694,14 @@ export default defineMessages({
     TR_EJECT_ALL_HEADING: {
         id: 'TR_EJECT_ALL_HEADING',
         defaultMessage: 'Eject all wallets on this Trezor',
+    },
+    TR_FORGET_DEVICE_HEADING: {
+        id: 'TR_FORGET_DEVICE_HEADING',
+        defaultMessage: 'Forget this device',
+    },
+    TR_FORGET_DEVICE_DESCRIPTION: {
+        id: 'TR_FORGET_DEVICE_DESCRIPTION',
+        defaultMessage: 'Removes all device-related data from Trezor Suite',
     },
     TR_VIEW_ONLY_CALL_TO_ACTION: {
         id: 'TR_VIEW_ONLY_CALL_TO_ACTION',

--- a/packages/suite/src/views/settings/SettingsGeneral/AutoEject.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/AutoEject.tsx
@@ -51,14 +51,12 @@ export const AutoEject = () => {
 
     const devices = useSelector(selectDevices);
 
-    const disconnectedDevices = devices.filter(device => !device.connected && device.state);
-    const hasAnyDisconnectedWallet = disconnectedDevices.length > 0;
+    const hasAnyDisconnectedWallet = devices.some(device => !device.connected && device.state);
 
     const toggleAutoEject = () => {
         const nextIsAutoEjectedEnabled = !isAutoEjectEnabled;
         dispatch(
             setAutoEjectEnabledThunk({
-                disconnectedDevices,
                 enabled: nextIsAutoEjectedEnabled,
             }),
         );

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -37,6 +37,7 @@ import { Language } from './Language';
 import { MevProtection } from './MevProtection';
 import { ShowApplicationLog } from './ShowApplicationLog';
 import { ShowOnTray } from './ShowOnTray';
+import { StoreDeviceData } from './StoreDeviceData';
 import { Theme } from './Theme';
 import { Tor } from './Tor';
 import { TorExternal } from './TorExternal';
@@ -115,6 +116,7 @@ export const SettingsGeneral = () => {
 
             <SettingsSection title={<Translation id="TR_PRIVACY" />} icon="lock">
                 <AutoEject />
+                <StoreDeviceData />
                 {isDesktop() && !isLinux() && <BioAuthSettings />}
             </SettingsSection>
 

--- a/packages/suite/src/views/settings/SettingsGeneral/StoreDeviceData.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/StoreDeviceData.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react';
+
+import { notificationsActions } from '@suite-common/toast-notifications';
+import { selectIsAutoForgetDeviceDataEnabled } from '@suite-common/wallet-core';
+import {
+    Banner,
+    Card,
+    Column,
+    Modal,
+    ModalProps,
+    Paragraph,
+    Radio,
+    Text,
+} from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
+import { spacings } from '@trezor/theme';
+import { EXPERIMENTAL_FEATURES_KB_URL } from '@trezor/urls';
+
+import { setAutoForgetDeviceDataThunk } from 'src/actions/suite/autoForgetDeviceDataThunks';
+import { SettingsSectionItem } from 'src/components/settings';
+import { ActionButton, ActionColumn, TextColumn, Translation } from 'src/components/suite';
+import { SettingsAnchor } from 'src/constants/suite/anchors';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
+
+export const StoreDeviceDataModal = ({ onCancel }: ModalProps) => {
+    const dispatch = useDispatch();
+
+    // The redux logic is consistent with auto-eject (enabled = should forget),
+    // but the UI here has inverted meaning (enabled = should store data)
+    const isAutoForgetDeviceDataEnabled = useSelector(selectIsAutoForgetDeviceDataEnabled);
+    const isStoreDeviceDataEnabled = !isAutoForgetDeviceDataEnabled;
+
+    const [isStoreDataEnabled, setIsStoreDataEnabled] = useState(isStoreDeviceDataEnabled);
+
+    const handleConfirmClick = () => {
+        const shouldEnableAutoForget = !isStoreDataEnabled;
+        dispatch(setAutoForgetDeviceDataThunk({ enabled: shouldEnableAutoForget }));
+
+        analytics.report({
+            type: EventType.SettingsGeneralStoreDeviceData,
+            payload: { value: isStoreDataEnabled },
+        });
+
+        dispatch(notificationsActions.addToast({ type: 'settings-applied' }));
+    };
+
+    return (
+        <Modal
+            onCancel={onCancel}
+            heading={<Translation id="TR_STORE_DEVICE_DATA_MODAL_TITLE" />}
+            variant="warning"
+            size="small"
+            bottomContent={
+                <>
+                    <Modal.Button
+                        onClick={handleConfirmClick}
+                        data-testid="@store-device-data-apply"
+                    >
+                        <Translation id="TR_CONFIRM" />
+                    </Modal.Button>
+                    <Modal.Button variant="tertiary" onClick={onCancel}>
+                        <Translation id="TR_CANCEL" />
+                    </Modal.Button>
+                </>
+            }
+        >
+            <Card margin={{ top: spacings.md }}>
+                <Column gap={spacings.xl} alignItems="flex-start">
+                    <Radio
+                        isChecked={isStoreDataEnabled}
+                        onClick={() => setIsStoreDataEnabled(true)}
+                        data-testid="@store-device-data-radio-enabled"
+                        verticalAlignment="center"
+                    >
+                        <Column alignItems="flex-start">
+                            <Text typographyStyle="highlight">
+                                <Translation id="TR_STORE_DEVICE_DATA_MODAL_ENABLED" />
+                            </Text>
+                            <Paragraph typographyStyle="hint">
+                                <Translation id="TR_STORE_DEVICE_DATA_MODAL_ENABLED_DESCRIPTION" />
+                            </Paragraph>
+                        </Column>
+                    </Radio>
+                    <Radio
+                        isChecked={!isStoreDataEnabled}
+                        onClick={() => setIsStoreDataEnabled(false)}
+                        data-testid="@store-device-data-radio-disabled"
+                        verticalAlignment="center"
+                    >
+                        <Column alignItems="flex-start">
+                            <Text typographyStyle="highlight">
+                                <Translation id="TR_STORE_DEVICE_DATA_MODAL_DISABLED" />
+                            </Text>
+                            <Paragraph typographyStyle="hint">
+                                <Translation id="TR_STORE_DEVICE_DATA_MODAL_DISABLED_DESCRIPTION" />
+                            </Paragraph>
+                        </Column>
+                    </Radio>
+                </Column>
+            </Card>
+
+            {isStoreDataEnabled ? null : (
+                <Banner icon>
+                    <Translation id="TR_STORE_DEVICE_DATA_MODAL_DISABLED_WARNING" />
+                </Banner>
+            )}
+        </Modal>
+    );
+};
+
+export const StoreDeviceData = () => {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    const handleClick = () => setIsModalOpen(true);
+    const handleModalCancel = () => setIsModalOpen(false);
+
+    // TODO remove debug check when feature is complete
+    const isDebug = useSelector(selectIsDebugModeActive);
+    if (!isDebug) return null;
+
+    return (
+        <>
+            <SettingsSectionItem anchorId={SettingsAnchor.StoreDeviceData}>
+                <TextColumn
+                    title={<Translation id="TR_DEVICE_SETTINGS_STORE_DEVICE_DATA_TITLE" />}
+                    description={
+                        <Translation id="TR_DEVICE_SETTINGS_STORE_DEVICE_DATA_DESCRIPTION" />
+                    }
+                    // TODO real link
+                    buttonLink={EXPERIMENTAL_FEATURES_KB_URL}
+                />
+                <ActionColumn>
+                    <ActionButton
+                        variant="primary"
+                        onClick={handleClick}
+                        data-testid="@settings/device/store-device-data-button"
+                    >
+                        <Translation id="TR_DEVICE_SETTINGS_STORE_DEVICE_DATA_BUTTON" />
+                    </ActionButton>
+                </ActionColumn>
+            </SettingsSectionItem>
+            {isModalOpen && <StoreDeviceDataModal onCancel={handleModalCancel} />}
+        </>
+    );
+};

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 
 import { DEFAULT_FLAGSHIP_MODEL } from '@suite-common/suite-constants';
 import * as deviceUtils from '@suite-common/suite-utils';
@@ -32,6 +32,7 @@ import { AddWalletButton } from './AddWalletButton';
 import { WalletInstance } from './WalletInstance';
 import { CardWithDevice } from '../CardWithDevice';
 import { EjectAllConfirmation } from './EjectAllConfirmation';
+import { TemporaryForgetDeviceButton } from './TemporaryForgetDeviceButton';
 
 type DeviceItemProps = {
     device: TrezorDevice;
@@ -39,7 +40,7 @@ type DeviceItemProps = {
     onCancel?: ForegroundAppProps['onCancel'];
 };
 
-const ListItem = ({ children, iconName }: { children: React.ReactNode; iconName: IconName }) => (
+const ListItem = ({ children, iconName }: { children: ReactNode; iconName: IconName }) => (
     <List.Item bulletComponent={<Icon name={iconName} variant="tertiary" size="mediumLarge" />}>
         <Paragraph typographyStyle="body" variant="tertiary" textWrap="pretty">
             {children}
@@ -95,16 +96,19 @@ export const DeviceItem = ({ device, instances, onCancel }: DeviceItemProps) => 
             onCancel={onCancel}
             device={device}
             actions={
-                instancesWithState.length > 0 && !isEjecting ? (
-                    <Tooltip content={<Translation id="TR_EJECT_ALL_HEADING" />}>
-                        <IconButton
-                            icon="eject"
-                            variant="tertiary"
-                            size="small"
-                            onClick={() => setIsEjecting(true)}
-                        />
-                    </Tooltip>
-                ) : null
+                <>
+                    {instancesWithState.length > 0 && !isEjecting ? (
+                        <Tooltip content={<Translation id="TR_EJECT_ALL_HEADING" />}>
+                            <IconButton
+                                icon="eject"
+                                variant="tertiary"
+                                size="small"
+                                onClick={() => setIsEjecting(true)}
+                            />
+                        </Tooltip>
+                    ) : null}
+                    <TemporaryForgetDeviceButton device={device} instances={instances} />
+                </>
             }
         >
             {isEjecting ? (

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/TemporaryForgetDeviceButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/TemporaryForgetDeviceButton.tsx
@@ -1,0 +1,54 @@
+import type { AcquiredDevice, TrezorDevice } from '@suite-common/suite-types';
+import { deviceActions, forgetSingleDevicePersistentDataThunk } from '@suite-common/wallet-core';
+import { IconButton, Paragraph, Tooltip } from '@trezor/components';
+import { EventType, analytics } from '@trezor/suite-analytics';
+
+import { Translation } from 'src/components/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
+
+type TemporaryForgetDeviceButtonProps = {
+    device: TrezorDevice;
+    instances: AcquiredDevice[];
+};
+
+// TODO this UI is only temporary https://github.com/trezor/trezor-suite/issues/21294
+export const TemporaryForgetDeviceButton = ({
+    device,
+    instances,
+}: TemporaryForgetDeviceButtonProps) => {
+    const dispatch = useDispatch();
+
+    // TODO remove debug check when feature is complete
+    const isDebug = useSelector(selectIsDebugModeActive);
+    if (!isDebug) return null;
+
+    const handleClick = () => {
+        dispatch(forgetSingleDevicePersistentDataThunk({ device }));
+
+        instances.forEach(instance => {
+            dispatch(deviceActions.forgetDevice({ device: instance }));
+        });
+
+        analytics.report({
+            type: EventType.SwitchDeviceForget,
+        });
+    };
+
+    return (
+        <Tooltip
+            content={
+                <div>
+                    <Paragraph typographyStyle="highlight" textWrap="balance">
+                        <Translation id="TR_FORGET_DEVICE_HEADING" />
+                    </Paragraph>
+                    <Paragraph>
+                        <Translation id="TR_FORGET_DEVICE_DESCRIPTION" />
+                    </Paragraph>
+                </div>
+            }
+        >
+            <IconButton icon="linkBreak" variant="tertiary" size="small" onClick={handleClick} />
+        </Tooltip>
+    );
+};

--- a/packages/type-utils/src/utils.ts
+++ b/packages/type-utils/src/utils.ts
@@ -1,4 +1,15 @@
 /**
+ * Pick a subset U of a union type T.
+ *
+ * Example:
+ *  ```
+ *  type T = 'a' | 'b' | 'c';
+ *  type U = UnionSubset<T, 'a' | 'c'>; // 'a' | 'c'
+ *  ```
+ */
+export type UnionSubset<T, U extends T> = U;
+
+/**
  * Make property of the object required.
  *
  * Example:

--- a/suite-common/analytics/src/events/suite/constants.ts
+++ b/suite-common/analytics/src/events/suite/constants.ts
@@ -109,6 +109,7 @@ export enum EventType {
     SettingsGeneralLabeling = 'settings/general/labeling',
     SettingsGeneralLabelingProvider = 'settings/general/labeling-provider',
     SettingsGeneralAutoEject = 'settings/general/auto-eject',
+    SettingsGeneralStoreDeviceData = 'settings/general/store-device-data',
     SettingsCoinsBackend = 'settings/coins/backend',
     SettingsCoins = 'settings/coins',
     SettingsTor = 'settings/tor',

--- a/suite-common/analytics/src/events/suite/types.ts
+++ b/suite-common/analytics/src/events/suite/types.ts
@@ -654,6 +654,12 @@ export type SuiteAnalyticsEvent =
           };
       }
     | {
+          type: EventType.SettingsGeneralStoreDeviceData;
+          payload: {
+              value: boolean;
+          };
+      }
+    | {
           type: EventType.SettingsGeneralLabelingProvider;
           payload: {
               provider:

--- a/suite-common/thp/src/thpActions.ts
+++ b/suite-common/thp/src/thpActions.ts
@@ -41,12 +41,15 @@ export const removeCredentials = createAction(
     }),
 );
 
+export const removeAllCredentials = createAction(`${THP_PREFIX}/removeAllCredentials`);
+
 export const thpActions = {
     invalidCode,
     finishThpFlow,
     addCredential,
     cancelThpFlow,
     removeCredentials,
+    removeAllCredentials,
     setLastThpCode,
     showAutoconnectInfo,
     incrementCredentialConnectionCounter,

--- a/suite-common/thp/src/thpReducer.ts
+++ b/suite-common/thp/src/thpReducer.ts
@@ -85,6 +85,9 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
                         ),
                 );
             })
+            .addCase(thpActions.removeAllCredentials, state => {
+                state.credentials = [];
+            })
             .addMatcher(isAnyOf(thpActions.finishThpFlow, thpActions.cancelThpFlow), state => {
                 state.step = null;
             })

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -68,9 +68,18 @@ const setTemporaryRememberedDevice = createAction(
 
 const forgetDevice = createAction(
     `${DEVICE_MODULE_PREFIX}/forgetDevice`,
-    (payload: { device: TrezorDevice }) => ({
-        payload,
-    }),
+    (payload: { device: TrezorDevice }) => ({ payload }),
+);
+
+// Forget persistent deviceReducer data for a device. See `forgetSingleDevicePersistentDataThunk` for all device-associated data.
+const forgetDevicePersistentData = createAction(
+    `${DEVICE_MODULE_PREFIX}/forgetDevicePersistentData`,
+    (payload: { deviceId: string }) => ({ payload }),
+);
+
+// Forget persistent deviceReducer data for all devices. See `forgetAllDevicesPersistentDataThunk` for all device-associated data.
+const forgetAllDevicesPersistentData = createAction(
+    `${DEVICE_MODULE_PREFIX}/forgetAllDevicesPersistentData`,
 );
 
 const addButtonRequest = createAction(
@@ -147,6 +156,8 @@ export const deviceActions = {
     rememberDevice,
     setTemporaryRememberedDevice,
     forgetDevice,
+    forgetDevicePersistentData,
+    forgetAllDevicesPersistentData,
     addButtonRequest,
     requestDeviceReconnect,
     selectDevice,

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -50,7 +50,7 @@ export type DeviceReducerState = {
         firmwareAuthenticity?: string[];
     };
     lastConnectedAuthenticityChecks?: KnownDevice['authenticityChecks'];
-    isDeviceAutoEjectEnabled: boolean;
+    isDeviceAutoEjectEnabled: boolean; // this is currently used only on mobile
 };
 
 export const deviceInitialState: DeviceReducerState = {

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -9,13 +9,40 @@ import { AcquiredDevice, ButtonRequest, TrezorDevice } from '@suite-common/suite
 import * as deviceUtils from '@suite-common/suite-utils';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { shouldDeviceBeRemembered } from '@suite-common/wallet-utils';
-import { Device, DeviceState, Features, KnownDevice, StaticSessionId } from '@trezor/connect';
+import {
+    Device,
+    DeviceState,
+    Features,
+    KnownDevice,
+    StaticSessionId,
+    VersionArray,
+} from '@trezor/connect';
+import { getFirmwareVersionArray } from '@trezor/device-utils';
+import { UnionSubset } from '@trezor/type-utils';
 
 import { deviceActions } from './deviceActions';
 import { PORTFOLIO_TRACKER_DEVICE_ID } from './deviceConstants';
 
+export type PersistedFeatureKey = UnionSubset<
+    keyof Features,
+    | 'device_id'
+    | 'internal_model'
+    | 'fw_vendor'
+    | 'revision'
+    | 'unit_color'
+    | 'label'
+    | 'initialized'
+>;
+export type PersistentDeviceData = Pick<Features, PersistedFeatureKey> & {
+    firmwareVersion: VersionArray | null;
+    lastConnectedBy: 'bluetooth' | 'usb' | null;
+    // TODO move devicesWithFailedEntropyCheck to this object, including persistence & migration
+    // TODO move deviceAuthenticity to this object and newly introduce persistence
+};
+
 export type DeviceReducerState = {
     devices: TrezorDevice[];
+    persistentDeviceData: PersistentDeviceData[]; // is an array since there is not a single primary id, device can be matched by various criteria
     selectedDevice?: TrezorDevice;
     deviceAuthenticity?: Record<string, StoredAuthenticateDeviceResult>;
     devicesWithFailedEntropyCheck?: (string | null)[]; // protobuf allows null values and we want to store this even if a fake device has id set to null
@@ -28,6 +55,7 @@ export type DeviceReducerState = {
 
 export const deviceInitialState: DeviceReducerState = {
     devices: [],
+    persistentDeviceData: [],
     selectedDevice: undefined,
     isDeviceAutoEjectEnabled: false,
 };
@@ -554,12 +582,40 @@ const requestDeviceReconnect = (draft: DeviceReducerState) => {
     draft.selectedDevice.reconnectRequested = true;
     draft.devices[index].reconnectRequested = true;
 };
+
+const updatePersistentDeviceData = (draft: DeviceReducerState, device: Device | TrezorDevice) => {
+    if (!device.features) return; // do not persist data for unacquired/unreadable devices
+
+    const newPersistentData: PersistentDeviceData = {
+        device_id: device.features.device_id,
+        internal_model: device.features.internal_model,
+        fw_vendor: device.features.fw_vendor,
+        revision: device.features.revision,
+        unit_color: device.features.unit_color,
+        label: device.features.label,
+        initialized: device.features.initialized,
+        lastConnectedBy: device.bluetoothProps ? 'bluetooth' : 'usb',
+        firmwareVersion: getFirmwareVersionArray(device),
+    };
+
+    const index = draft.persistentDeviceData.findIndex(d => d.device_id === device.id);
+    if (index >= 0) {
+        draft.persistentDeviceData[index] = {
+            ...draft.persistentDeviceData[index],
+            ...newPersistentData,
+        };
+    } else {
+        draft.persistentDeviceData.push(newPersistentData);
+    }
+};
+
 export const prepareDeviceReducer = createReducerWithExtraDeps(
     deviceInitialState,
     (builder, extra) => {
         builder
             .addCase(deviceActions.deviceChanged, (state, { payload }) => {
                 changeDevice(state, payload, { connected: true, available: true });
+                updatePersistentDeviceData(state, payload);
             })
             .addCase(deviceActions.setDeviceState, (state, { payload }) => {
                 setDeviceState(state, payload.device, payload.state, payload.useEmptyPassphrase);
@@ -579,6 +635,14 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(
             })
             .addCase(deviceActions.forgetDevice, (state, { payload }) => {
                 forget(state, payload.device);
+            })
+            .addCase(deviceActions.forgetDevicePersistentData, (state, { payload }) => {
+                state.persistentDeviceData = state.persistentDeviceData.filter(
+                    d => d.device_id !== payload.deviceId,
+                );
+            })
+            .addCase(deviceActions.forgetAllDevicesPersistentData, state => {
+                state.persistentDeviceData = [];
             })
             .addCase(deviceActions.addButtonRequest, (state, { payload }) => {
                 addButtonRequest(state, payload.device, payload.buttonRequest);
@@ -645,6 +709,7 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(
                 isAnyOf(deviceActions.connectDevice, deviceActions.connectUnacquiredDevice),
                 (state, { payload: { device } }) => {
                     connectDevice(state, device);
+                    updatePersistentDeviceData(state, device);
                 },
             );
     },

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -333,7 +333,7 @@ export const selectDeviceFirmwareVersionArray = createMemoizedSelector(
     device => getFirmwareVersionArray(device),
 );
 
-// todo: these are not necessarily physical, might be passphrases as well - sounds like a bug to me.
+// Selects all wallets of all physical devices. Use `selectPhysicalDevicesGrouppedById` instead to select unique devices.
 export const selectPhysicalDevices = createMemoizedSelector([selectDevices], devices =>
     pipe(
         devices,

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -173,6 +173,18 @@ export const forgetDisconnectedDevices = createThunk(
     },
 );
 
+export const forgetAllDisconnectedDevices = createThunk(
+    `${DEVICE_MODULE_PREFIX}/forgetAllDisconnectedDevices`,
+    (_, { dispatch, getState }) => {
+        const physicalDevices = selectPhysicalDevices(getState());
+        physicalDevices.forEach(device => {
+            if (!device.connected) {
+                dispatch(forgetDisconnectedDevices({ device, forceForget: true }));
+            }
+        });
+    },
+);
+
 /**
  * Called from `suiteMiddleware`
  * Keep `suite` reducer synchronized with `devices` reducer
@@ -474,6 +486,7 @@ export const wipeDeviceThunk = createThunk(
     },
 );
 
+// Note: currently used only by mobile, see `forgetAllDisconnectedDevices` for a simpler thunk
 export const toggleAutoEjectThunk = createThunk(
     `${DEVICE_MODULE_PREFIX}/toggleAutoEjectThunk`,
     (_, { dispatch, getState }) => {
@@ -484,6 +497,7 @@ export const toggleAutoEjectThunk = createThunk(
             if (!wallet.connected && wallet.remember) {
                 dispatch(deviceActions.forgetDevice({ device: wallet }));
             } else {
+                // TODO investigate why do we need to consider wallet.remember at all, when we are ejecting all wallets.
                 dispatch(
                     deviceActions.rememberDevice({
                         device: wallet,

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -495,6 +495,43 @@ export const toggleAutoEjectThunk = createThunk(
     },
 );
 
+type ForgetAllDeviceDataThunkParams = {
+    device: TrezorDevice;
+};
+
+/**
+ * This thunk is the central place to remove all persistent data related to a device.
+ */
+export const forgetSingleDevicePersistentDataThunk = createThunk(
+    `${DEVICE_MODULE_PREFIX}/forgetSingleDevicePersistentDataThunk`,
+    ({ device }: ForgetAllDeviceDataThunkParams, { dispatch }) => {
+        if (typeof device.id === 'string') {
+            dispatch(deviceActions.forgetDevicePersistentData({ deviceId: device.id }));
+        }
+        if (device.bluetoothProps !== undefined) {
+            dispatch(bluetoothActions.removeKnownDeviceAction({ id: device.bluetoothProps.id }));
+        }
+        // TODO: this works only for a connected device, as we intentionally do not link THP credentials in a remembered wallet.
+        if (device.thp !== undefined) {
+            dispatch(thpActions.removeCredentials({ credentials: device.thp.credentials }));
+        }
+    },
+);
+
+/**
+ * Helper thunk to do the same as `forgetSingleDevicePersistentDataThunk`, but for all devices.
+ * Rather than iterating through the devices, this thunk removes all data in a single swoop.
+ * This is also fully reliable for removing THP data, unlike the single device function.
+ */
+export const forgetAllDevicesPersistentDataThunk = createThunk(
+    `${DEVICE_MODULE_PREFIX}/forgetAllDevicesPersistentDataThunk`,
+    (_, { dispatch }) => {
+        dispatch(deviceActions.forgetAllDevicesPersistentData());
+        dispatch(thpActions.removeAllCredentials());
+        dispatch(bluetoothActions.knownDevicesUpdateAction({ knownDevices: [] }));
+    },
+);
+
 type FailEntropyCheckParams = {
     device: AcquiredDevice;
     error: { code?: string; error: string };

--- a/suite-common/wallet-core/src/settings/walletSettingsActions.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsActions.ts
@@ -27,6 +27,11 @@ export const toggleHideSuspiciousTransactions = createAction(
     WALLET_SETTINGS.TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS,
 );
 
+export const setAutoForgetDeviceData = createAction(
+    WALLET_SETTINGS.AUTO_FORGET_DEVICE_DATA,
+    (enabled: boolean) => ({ payload: enabled }),
+);
+
 export type ChangeCoinVisibilityAction = {
     type: typeof WALLET_SETTINGS.CHANGE_COIN_VISIBILITY;
     payload: {
@@ -54,6 +59,7 @@ export type WalletSettingsAction =
     | ReturnType<typeof changeNetworks>
     | ReturnType<typeof setBaseCurrency>
     | ReturnType<typeof toggleHideSuspiciousTransactions>
+    | ReturnType<typeof setAutoForgetDeviceData>
     | ChangeCoinVisibilityAction
     | SetHideBalanceAction
     | SetBitcoinAmountUnitsAction

--- a/suite-common/wallet-core/src/settings/walletSettingsConstants.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsConstants.ts
@@ -7,6 +7,7 @@ const TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS = '@wallet-settings/toggle-hide-suspic
 const SET_DISCREET_MODE = '@wallet-settings/set-discreet-mode';
 const CHANGE_COIN_VISIBILITY = '@wallet-settings/change-coin-visibility';
 const SET_MEV_PROTECTION = '@wallet-settings/set-mev-protection';
+const AUTO_FORGET_DEVICE_DATA = '@wallet-settings/set-auto-forget-device-data';
 
 export const WALLET_SETTINGS = {
     SET_BASE_CURRENCY,
@@ -18,4 +19,5 @@ export const WALLET_SETTINGS = {
     SET_DISCREET_MODE,
     CHANGE_COIN_VISIBILITY,
     SET_MEV_PROTECTION,
+    AUTO_FORGET_DEVICE_DATA,
 } as const;

--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
@@ -29,6 +29,7 @@ const initialState: State = {
     hideSuspiciousTransactions: false,
     bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN,
     mevProtection: true,
+    autoForgetDeviceData: false,
 };
 export const initialWalletSettingsState: State = initialState;
 
@@ -39,6 +40,7 @@ export const walletSettingsPersistedWhitelist: Array<keyof State> = [
     'hideSuspiciousTransactions',
     'bitcoinAmountUnit',
     'mevProtection',
+    'autoForgetDeviceData',
 ];
 
 export const prepareWalletSettingsReducer = createReducerWithExtraDeps(
@@ -82,6 +84,12 @@ export const prepareWalletSettingsReducer = createReducerWithExtraDeps(
         builder.addCase(WALLET_SETTINGS.TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS, state => {
             state.hideSuspiciousTransactions = !state.hideSuspiciousTransactions;
         });
+        builder.addCase(
+            WALLET_SETTINGS.AUTO_FORGET_DEVICE_DATA,
+            (state, action: ReturnType<typeof walletSettingsActions.setAutoForgetDeviceData>) => {
+                state.autoForgetDeviceData = action.payload;
+            },
+        );
     },
 );
 
@@ -95,6 +103,8 @@ export const selectIsHideSuspiciousTransactions = (state: WalletSettingsRootStat
     state.wallet.settings.hideSuspiciousTransactions;
 export const selectBitcoinAmountUnit = (state: WalletSettingsRootState) =>
     state.wallet.settings.bitcoinAmountUnit;
+export const selectIsAutoForgetDeviceDataEnabled = (state: WalletSettingsRootState) =>
+    state.wallet.settings.autoForgetDeviceData;
 
 export const selectAreSatsAmountUnit = (state: WalletSettingsRootState) => {
     const bitcoinAmountUnit = selectBitcoinAmountUnit(state);

--- a/suite-common/wallet-types/src/settings.ts
+++ b/suite-common/wallet-types/src/settings.ts
@@ -24,4 +24,5 @@ export interface WalletSettings {
     hideSuspiciousTransactions: boolean;
     bitcoinAmountUnit: PROTO.AmountUnit;
     mevProtection: boolean;
+    autoForgetDeviceData: boolean;
 }

--- a/suite-native/app/e2e/tests/deeplinkPopup.test.ts
+++ b/suite-native/app/e2e/tests/deeplinkPopup.test.ts
@@ -69,6 +69,7 @@ conditionalDescribe(device.getPlatform() === 'android', 'Deeplink connect popup.
                     },
                     device: {
                         isDeviceAutoEjectEnabled: true,
+                        persistentDeviceData: [],
                         devices: [],
                     },
                 },

--- a/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
+++ b/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
@@ -138,6 +138,7 @@ const getTestState = ({
             },
         } as TrezorDevice,
         isDeviceAutoEjectEnabled: false,
+        persistentDeviceData: [],
     },
 });
 


### PR DESCRIPTION
## Description

CR commit by commit recommended:
- small tweak: don't needlessly save auto eject settings, [see comment](https://github.com/trezor/trezor-suite/pull/21160/files#r2309809195)
- add the auto forget setting to ~suite~ **wallet-settings** and persist it
  - defined as auto forget in code for consistency with auto eject, but the UI is inverted here
  - at this point I mean persisting only the setting itself
- implement `persistentDeviceData` in wallet-core
  - add `wallet-core` thunks to forget one device and to forget all devices
  - suite `setAutoForgetDeviceDataThunk` to switch the settings and forget all device data
  - also simplify API of `setAutoEjectEnabledThunk`
- update test fixtures 
- WIP UI to forget one device and auto forget
  - [figma](https://www.figma.com/design/wGshbwWuR7shAA1i1UBqR8/View-only?node-id=5519-14145&t=A2ONQEuCikPZvn6N-0)
  - hidden behind debug mode; I did not add it to Experimental because currently it doesn't really offer anything useful (TS7 not yet released)
- implement storage synchronization of BT and THP as per `wallet.settings.autoForgetDeviceData`
  - do not persist if disabled
  - remove from storage one-time when forgotten
- refactor `autoEject` to move some code into `wallet-core`

Note that the `device.persistentDeviceData` is not yet persisted :upside_down_face: which is TODO later, because ATM it wouldn't have any use yet! The main features of this PR are:
1. prepare for future work on `persistentDeviceData`
2. enable clearing BT and THP data (currently only in debug settings, or by resetting whole suite)
3. persist BT and THP only if not disabled

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20952

### TODO

- How should we treat forgetting THP for a single device? We don't want to create a link between device and thp credentials :confused: 
- https://github.com/trezor/trezor-suite/issues/21163
- TBD: make the same issue for mobile as [#20952](https://github.com/trezor/trezor-suite/issues/20952)?

## Screenshots:

[AutoEject still works.webm](https://github.com/user-attachments/assets/4811492a-e0c9-4708-a619-4c9657a83423)
[AutoForget multiple.webm](https://github.com/user-attachments/assets/ef071e17-5aa4-46e6-90e3-9125462b446a), note that this also enables auto eject (wouldn't make sense otherwise)
[Forget a single TS7.webm](https://github.com/user-attachments/assets/e57b6199-417f-416c-a5f0-cf10bc0c4a4a) incl. BT and THP
[Disable auto forget, auto eject still active](https://github.com/user-attachments/assets/5facc584-1d61-4502-b5b8-81dfdcb362c2)


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/forget-all-device-info&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/forget-all-device-info&lookback=7)