### PR TITLE
test(connect): use only local firmware release config

### DIFF
--- a/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
+++ b/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
@@ -225,7 +225,7 @@ const setupTest = () => {
 
 describe('onCallFirmwareUpdate', () => {
     beforeAll(async () => {
-        await DataManager.load(parseConnectSettings({}));
+        await DataManager.load(parseConnectSettings({}), true, true);
     });
     beforeEach(() => {
         if (!ASSETS_BASE_URL) {

--- a/packages/connect/src/data/__tests__/DataManager.test.ts
+++ b/packages/connect/src/data/__tests__/DataManager.test.ts
@@ -31,7 +31,7 @@ const settings = {
 describe('data/DataManager', () => {
     beforeEach(async () => {
         try {
-            await DataManager.load(settings, false);
+            await DataManager.load(settings, false, true);
         } catch (err) {
             // eslint-disable-next-line jest/no-standalone-expect
             expect(err).toBe(undefined);

--- a/packages/connect/src/data/__tests__/firmwareInfo.test.ts
+++ b/packages/connect/src/data/__tests__/firmwareInfo.test.ts
@@ -28,7 +28,7 @@ describe('data/firmwareInfo', () => {
     });
     describe('getFirmwareReleaseConfigInfo', () => {
         beforeAll(async () => {
-            await DataManager.load(parseConnectSettings({}));
+            await DataManager.load(parseConnectSettings({}), true, true);
         });
         it('should offer latest compatible relase when latest one is not compatible', () => {
             const features = getDeviceFeatures({

--- a/packages/connect/src/device/__tests__/DeviceList.test.ts
+++ b/packages/connect/src/device/__tests__/DeviceList.test.ts
@@ -22,9 +22,13 @@ const waitForNthEventOfType = (
 describe('DeviceList', () => {
     beforeAll(async () => {
         // todo: I don't get it. If we pass empty messages: {} (see getDeviceListParams), tests behave differently.
-        await DataManager.load({
-            ...parseConnectSettings({}),
-        });
+        await DataManager.load(
+            {
+                ...parseConnectSettings({}),
+            },
+            true,
+            true,
+        );
     });
 
     let list: DeviceList;

--- a/packages/connect/src/device/__tests__/handshakeWorkflow.test.ts
+++ b/packages/connect/src/device/__tests__/handshakeWorkflow.test.ts
@@ -49,6 +49,7 @@ describe('workflow/handshake', () => {
                 ...parseConnectSettings({}),
             },
             true,
+            true,
         );
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There is no need to use remote FW release config in tests and it might make it more unpredictable and flaky, so for tests using it only local.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/use-only-local-fw-release-config-in-tests&lookback=7)