### PR TITLE
chore(connect): removing unecessary TODO comment

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -691,8 +691,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
             return;
         }
 
-        // TODO(karliatto): We get bundled relase here, if it is not present it will try to get the it online inside `checkFirmwareRevision`
-        // by using `getReleaseByVersion` that checks the bundled and if not found then it tries to find it online.
         const release = getReleaseAsset(
             this.features.internal_model,
             firmwareVersion,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When I wrote this comment I thought that we could use utility that gets firmware revision from local or remote but I realized there is actual value in knowing if it is from remote or not since the error is different and some errors are retry-able  and other are not.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/remove-comment-since-I-realized-it-does-not-make-sense&lookback=7)