### PR TITLE
feat(suite-native): Mobile Sell: Legal Sheet

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -2158,7 +2158,7 @@ export const en = {
                 infoSecurity2:
                     "You're buying cryptocurrencies for your own account. You acknowledge that the provider's policies may require identity verification.",
                 infoSecurity3:
-                    " You understand that cryptocurrency transactions are final and can't be reversed or refunded. Losses due to fraud or mistakes may not be recoverable.",
+                    "You understand that cryptocurrency transactions are final and can't be reversed or refunded. Losses due to fraud or mistakes may not be recoverable.",
                 subheaderPartners: 'Verified partners by Invity',
                 infoPartners:
                     "You understand that Invity doesn't provide this service. It's governed by {companyName}’s Terms & Conditions.",
@@ -2206,6 +2206,24 @@ export const en = {
                     },
                 },
                 continueButton: "I'm ready to swap",
+            },
+            sell: {
+                title: 'Sell {symbol} with {companyName}',
+                subheaderSecurity: 'Security first with your Trezor',
+                infoSecurity1:
+                    "You're here to sell cryptocurrencies. If you were directed to this site for any other reason, contact Trezor Support before proceeding.",
+                infoSecurity2:
+                    "You're selling cryptocurrencies for your own account. You acknowledge that the provider's policies may require identity verification.",
+                infoSecurity3:
+                    "You understand that cryptocurrency transactions are final and can't be reversed or refunded. Losses due to fraud or mistakes may not be recoverable.",
+                subheaderPartners: 'Verified partners by Invity',
+                infoPartners:
+                    "You understand that Invity doesn't provide this service. It's governed by {companyName}’s Terms & Conditions.",
+                subheaderLegal: 'Legal notice',
+                infoLegal1:
+                    "You're not using this feature for gambling, fraud, or any activity that violates Invity’s or the provider's Terms of Service, or any applicable laws.",
+                infoLegal2:
+                    'You understand that cryptocurrencies are an emerging financial tool and that regulations may vary in different jurisdictions. This may put you at a higher risk of fraud, theft, or market instability.',
             },
         },
         validators: {

--- a/suite-native/module-trading/src/components/sell/SellConfirmation.tsx
+++ b/suite-native/module-trading/src/components/sell/SellConfirmation.tsx
@@ -3,18 +3,39 @@ import { AnimatedProps, FadeIn, FadeOutDown } from 'react-native-reanimated';
 import { AnimatedBox, Button } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
+import { SellLegalSheet } from './SellLegalSheet';
+import { useSellFlow } from '../../hooks/sell/useSellFlow';
+import { useSellFormContext } from '../../hooks/sell/useSellFormContext';
+
 export type ConfirmationProps = {
     enteringAnimation?: AnimatedProps<any>['entering'];
 };
 
 const CONFIRMATION_TEST_ID = '@trading/sell/continue-button';
 
-export const SellConfirmation = ({ enteringAnimation }: ConfirmationProps) => (
-    <AnimatedBox entering={enteringAnimation} exiting={FadeOutDown}>
-        <AnimatedBox entering={FadeIn}>
-            <Button onPress={() => {}} testID={CONFIRMATION_TEST_ID}>
-                <Translation id="moduleTrading.tradingScreen.buttons.continue" />
-            </Button>
+export const SellConfirmation = ({ enteringAnimation }: ConfirmationProps) => {
+    const form = useSellFormContext();
+    const { canProceed, isConsentRequested, cancelConsent, giveConsent, selectQuote } =
+        useSellFlow(form);
+
+    const [quote, sendAsset] = form.watch(['quote', 'sendAsset']);
+
+    return (
+        <AnimatedBox entering={enteringAnimation} exiting={FadeOutDown}>
+            {canProceed && (
+                <AnimatedBox entering={FadeIn}>
+                    <Button onPress={selectQuote} testID={CONFIRMATION_TEST_ID}>
+                        <Translation id="moduleTrading.tradingScreen.buttons.continue" />
+                    </Button>
+                </AnimatedBox>
+            )}
+            <SellLegalSheet
+                isVisible={isConsentRequested}
+                onConsent={giveConsent}
+                onDismiss={cancelConsent}
+                tradeProvider={quote?.exchange ?? ''}
+                sendSymbol={sendAsset?.symbol ?? ''}
+            />
         </AnimatedBox>
-    </AnimatedBox>
-);
+    );
+};

--- a/suite-native/module-trading/src/components/sell/SellLegalSheet.tsx
+++ b/suite-native/module-trading/src/components/sell/SellLegalSheet.tsx
@@ -1,0 +1,128 @@
+import { ReactNode, memo, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+
+import {
+    TradingRootState as CommonTradingRootState,
+    selectTradingProviderByNameAndTradeType,
+} from '@suite-common/trading';
+import {
+    BottomSheetModal,
+    Box,
+    BulletListItem,
+    Button,
+    Text,
+    VStack,
+    useBottomSheetModal,
+} from '@suite-native/atoms';
+import { Translation, useTranslate } from '@suite-native/intl';
+
+import { useBottomSheetBackButtonSubscription } from '../../hooks/general/useBottomSheetBackButtonSubscription';
+
+export type SellLegalSheetProps = {
+    isVisible: boolean;
+    onConsent: () => void;
+    onDismiss: () => void;
+    tradeProvider: string;
+    sendSymbol: string;
+};
+
+const CONFIRM_BUTTON_TEST_ID = '@trading/sell/confirm-button';
+
+const Subheader = ({ children }: { children: ReactNode }) => (
+    <Text variant="highlight" color="textDefault">
+        {children}
+    </Text>
+);
+
+const Info = ({ children }: { children: ReactNode }) => (
+    <BulletListItem variant="hint" color="textDefault">
+        {children}
+    </BulletListItem>
+);
+
+export const SellLegalSheet = memo(
+    ({ isVisible, onConsent, onDismiss, tradeProvider, sendSymbol }: SellLegalSheetProps) => {
+        const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
+        const { companyName } =
+            useSelector((state: CommonTradingRootState) =>
+                selectTradingProviderByNameAndTradeType(state, tradeProvider, 'sell'),
+            ) ?? {};
+        const { translate } = useTranslate();
+
+        useEffect(() => {
+            if (isVisible) {
+                openModal();
+            } else {
+                closeModal();
+            }
+        }, [closeModal, isVisible, openModal]);
+
+        useBottomSheetBackButtonSubscription(isVisible, onDismiss);
+
+        const safeCompanyName = companyName ?? tradeProvider;
+
+        return (
+            <BottomSheetModal
+                ref={bottomSheetRef}
+                title={translate('moduleTrading.legalSheet.sell.title', {
+                    companyName: safeCompanyName,
+                    symbol: sendSymbol.toUpperCase(),
+                })}
+                onDismiss={onDismiss}
+                isCloseDisplayed
+            >
+                <VStack spacing="sp12" paddingHorizontal="sp12">
+                    <VStack>
+                        <Subheader>
+                            <Translation id="moduleTrading.legalSheet.sell.subheaderSecurity" />
+                        </Subheader>
+                        <Info>
+                            <Translation id="moduleTrading.legalSheet.sell.infoSecurity1" />
+                        </Info>
+                        <Info>
+                            <Translation id="moduleTrading.legalSheet.sell.infoSecurity2" />
+                        </Info>
+                        <Info>
+                            <Translation id="moduleTrading.legalSheet.sell.infoSecurity3" />
+                        </Info>
+                    </VStack>
+                    <VStack>
+                        <Subheader>
+                            <Translation id="moduleTrading.legalSheet.sell.subheaderPartners" />
+                        </Subheader>
+                        <Info>
+                            <Translation
+                                id="moduleTrading.legalSheet.sell.infoPartners"
+                                values={{ companyName: safeCompanyName }}
+                            />
+                        </Info>
+                    </VStack>
+                    <VStack>
+                        <Subheader>
+                            <Translation id="moduleTrading.legalSheet.sell.subheaderLegal" />
+                        </Subheader>
+                        <Info>
+                            <Translation id="moduleTrading.legalSheet.sell.infoLegal1" />
+                        </Info>
+                        <Info>
+                            <Translation id="moduleTrading.legalSheet.sell.infoLegal2" />
+                        </Info>
+                    </VStack>
+                    {
+                        // Keep this condition here to simplify testing.
+                        // Otherwise, due to the way the Gorhom bottom sheet is mocked,
+                        // this button would render even when the modal is not visible,
+                        // and some tests need to target the "Continue" button on the form screen.
+                        isVisible && (
+                            <Box paddingVertical="sp20">
+                                <Button onPress={onConsent} testID={CONFIRM_BUTTON_TEST_ID}>
+                                    <Translation id="moduleTrading.tradingScreen.buttons.continue" />
+                                </Button>
+                            </Box>
+                        )
+                    }
+                </VStack>
+            </BottomSheetModal>
+        );
+    },
+);

--- a/suite-native/module-trading/src/components/sell/__tests__/SellConfirmation.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellConfirmation.comp.test.tsx
@@ -1,28 +1,28 @@
 import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
 
 import { getInitializedTradingStateWithQuotes } from '../../../__fixtures__/tradingState';
-import { BuyConfirmation } from '../BuyConfirmation';
+import { SellConfirmation } from '../SellConfirmation';
 
-jest.mock('../../../hooks/buy/useBuyFlow', () => ({
-    useBuyFlow: jest.fn(),
+jest.mock('../../../hooks/sell/useSellFlow', () => ({
+    useSellFlow: jest.fn(),
 }));
 
-jest.mock('../../../hooks/buy/useBuyFormContext', () => ({
-    useBuyFormContext: () => ({
-        watch: () => ({ exchange: 'test-provider' }),
+jest.mock('../../../hooks/sell/useSellFormContext', () => ({
+    useSellFormContext: () => ({
+        watch: () => [{ exchange: 'test-provider' }, { symbol: 'btc' }],
     }),
 }));
 
-describe('BuyConfirmation', () => {
-    const mockUseBuyFlow = require('../../../hooks/buy/useBuyFlow').useBuyFlow;
+describe('SellConfirmation', () => {
+    const mockUseSellFlow = require('../../../hooks/sell/useSellFlow').useSellFlow;
 
     const renderConfirmation = () =>
-        renderWithStoreProviderAsync(<BuyConfirmation />, {
+        renderWithStoreProviderAsync(<SellConfirmation />, {
             preloadedState: { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } },
         });
 
     it('should render continue button when canProceed is true', async () => {
-        mockUseBuyFlow.mockReturnValue({
+        mockUseSellFlow.mockReturnValue({
             canProceed: true,
             selectQuote: jest.fn(),
             isConsentRequested: false,
@@ -31,11 +31,12 @@ describe('BuyConfirmation', () => {
         });
 
         const { getByText } = await renderConfirmation();
+
         expect(getByText('Continue')).toBeTruthy();
     });
 
     it('should not render continue button when canProceed is false', async () => {
-        mockUseBuyFlow.mockReturnValue({
+        mockUseSellFlow.mockReturnValue({
             canProceed: false,
             selectQuote: jest.fn(),
             isConsentRequested: false,

--- a/suite-native/module-trading/src/components/sell/__tests__/SellLegalSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellLegalSheet.comp.test.tsx
@@ -1,0 +1,39 @@
+import { act, fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+
+import { getInitializedTradingStateWithQuotes } from '../../../__fixtures__/tradingState';
+import { SellLegalSheet, SellLegalSheetProps } from '../SellLegalSheet';
+
+describe('SellLegalSheet', () => {
+    const renderLegalSheet = (props?: Partial<SellLegalSheetProps>) =>
+        renderWithStoreProviderAsync(
+            <SellLegalSheet
+                isVisible
+                onDismiss={() => {}}
+                onConsent={() => {}}
+                tradeProvider="invity"
+                sendSymbol="usdc"
+                {...props}
+            />,
+            { preloadedState: { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } } },
+        );
+
+    it('should render text info with given tradeProviderName', async () => {
+        const { getByText } = await renderLegalSheet();
+
+        expect(getByText(/contact Trezor Support/)).toBeTruthy();
+        expect(getByText(/It's governed by Invity Finance’s Terms & Conditions./)).toBeTruthy();
+    });
+
+    it('should call onConsent callback on Continue button press and onDismiss not to be called', async () => {
+        const onConsent = jest.fn();
+        const onDismiss = jest.fn();
+        const { getByText } = await renderLegalSheet({ onConsent, onDismiss });
+
+        act(() => {
+            fireEvent.press(getByText('Continue'));
+        });
+
+        expect(onConsent).toHaveBeenCalledTimes(1);
+        expect(onDismiss).not.toHaveBeenCalled();
+    });
+});

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
@@ -1,0 +1,127 @@
+import { tradingSellActions } from '@suite-common/trading';
+import {
+    TestStore,
+    act,
+    initStore,
+    renderHookWithStoreProviderAsync,
+} from '@suite-native/test-utils';
+
+import { sellQuotes } from '../../../__fixtures__/sellQuotes';
+import { getWalletState } from '../../../__fixtures__/walletState';
+import { SellFormType } from '../../../types/sell';
+import { useSellFlow } from '../useSellFlow';
+import { useSellForm } from '../useSellForm';
+
+describe('useSellFlow', () => {
+    let store: TestStore;
+    let sellForm: SellFormType;
+
+    const renderSellForm = () => renderHookWithStoreProviderAsync(() => useSellForm(), { store });
+
+    const renderUseSellFlow = () =>
+        renderHookWithStoreProviderAsync(() => useSellFlow(sellForm), { store });
+
+    beforeEach(async () => {
+        store = await initStore({ wallet: getWalletState({ tradeType: 'sell' }) });
+
+        const { result } = await renderSellForm();
+        sellForm = result.current;
+    });
+
+    describe('canProceed', () => {
+        it('should be false when no quote is selected in form', async () => {
+            const { result } = await renderUseSellFlow();
+
+            expect(result.current.canProceed).toEqual(false);
+        });
+
+        it('should be false when quotes are being fetched', async () => {
+            act(() => {
+                sellForm.setValue('quote', sellQuotes[0]);
+                store.dispatch(tradingSellActions.setIsLoading(true));
+            });
+
+            const { result } = await renderUseSellFlow();
+
+            expect(result.current.canProceed).toEqual(false);
+        });
+
+        it('should be true when quote is selected', async () => {
+            act(() => {
+                sellForm.setValue('quote', sellQuotes[0]);
+            });
+
+            const { result } = await renderUseSellFlow();
+
+            expect(result.current.canProceed).toEqual(true);
+        });
+    });
+
+    describe('selectQuote', () => {
+        it('should do nothing when no quote is selected', async () => {
+            const { result } = await renderUseSellFlow();
+
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            expect(result.current.isConsentRequested).toEqual(false);
+        });
+
+        it('should request consent', async () => {
+            // TODO this is a temporary solution (will be changed with proper flow implementation)
+            act(() => {
+                sellForm.setValue('quote', sellQuotes[0]);
+            });
+            const { result } = await renderUseSellFlow();
+
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            expect(result.current.isConsentRequested).toEqual(true);
+        });
+    });
+
+    describe('giveConsent', () => {
+        beforeEach(() => {
+            act(() => {
+                sellForm.setValue('quote', sellQuotes[0]);
+            });
+        });
+
+        it('should resolve consent', async () => {
+            const { result } = await renderUseSellFlow();
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            act(() => {
+                result.current.giveConsent();
+            });
+
+            expect(result.current.isConsentRequested).toEqual(false);
+        });
+    });
+
+    describe('cancelConsent', () => {
+        beforeEach(() => {
+            act(() => {
+                sellForm.setValue('quote', sellQuotes[0]);
+            });
+        });
+
+        it('should resolve consent (with false value)', async () => {
+            const { result } = await renderUseSellFlow();
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            act(() => {
+                result.current.cancelConsent();
+            });
+
+            expect(result.current.isConsentRequested).toEqual(false);
+        });
+    });
+});

--- a/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
@@ -1,0 +1,48 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+
+import { selectTradingSellIsLoading } from '@suite-common/trading';
+
+import { SellFormType } from '../../types/sell';
+import { useConsent } from '../general/useConsent';
+
+type SellFlowReturn = {
+    canProceed: boolean;
+    selectQuote: () => Promise<void>;
+    isConsentRequested: boolean;
+    giveConsent: () => void;
+    cancelConsent: () => void;
+};
+
+export const useSellFlow = ({ watch }: SellFormType): SellFlowReturn => {
+    const isLoading = useSelector(selectTradingSellIsLoading);
+    const { isConsentRequested, waitForConsent, resolveConsent } = useConsent();
+
+    const candidateQuote = watch('quote');
+
+    const canProceed = !!candidateQuote && !isLoading;
+
+    const selectQuote = useCallback(async () => {
+        if (!candidateQuote) {
+            return;
+        }
+
+        await waitForConsent();
+    }, [waitForConsent, candidateQuote]);
+
+    const giveConsent = useCallback(() => {
+        resolveConsent(true);
+    }, [resolveConsent]);
+
+    const cancelConsent = useCallback(() => {
+        resolveConsent(false);
+    }, [resolveConsent]);
+
+    return {
+        canProceed,
+        selectQuote,
+        isConsentRequested,
+        giveConsent,
+        cancelConsent,
+    };
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- display continue button on sell only when user has selected quote
- display legal sheet when continue is pressed

## Related Issue

Resolve [#20840](https://github.com/trezor/trezor-suite/issues/20840)

## Screenshots:

<img width="300"  alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-29 at 15 08 16" src="https://github.com/user-attachments/assets/2e03186e-628a-435d-a60e-61f340727893" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=20840-Mobile-Sell-Legal-sheet&lookback=7)