### PR TITLE
Don't show staking dashboard to bitcoin users

### DIFF
--- a/packages/suite/src/views/dashboard/index.tsx
+++ b/packages/suite/src/views/dashboard/index.tsx
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 
 import { Context } from '@suite-common/message-system';
-import { selectHasBitcoinOnlyFirmware } from '@suite-common/wallet-core';
+import { getNetworkType } from '@suite-common/wallet-config';
+import { selectEnabledNetworks } from '@suite-common/wallet-core';
 import { Column } from '@trezor/components';
 import { spacings, spacingsPx } from '@trezor/theme';
 
@@ -27,7 +28,10 @@ export const Dashboard = () => {
     useLayout('Home', <PageHeader />);
     useNotificationForDisconnectedDevice();
 
-    const hasBitcoinOnlyFirmware = useSelector(selectHasBitcoinOnlyFirmware);
+    const enabledNetworks = useSelector(selectEnabledNetworks);
+    const hasNonBitcoinNetwork = enabledNetworks
+        .map(getNetworkType)
+        .some(networkType => networkType !== 'bitcoin');
 
     return (
         <Column gap={spacings.xxxxl} data-testid="@dashboard/index">
@@ -38,7 +42,7 @@ export const Dashboard = () => {
             </Container>
             <DashboardPromoBanner />
             <AssetsView />
-            {!hasBitcoinOnlyFirmware && <StakingDashboard />}
+            {hasNonBitcoinNetwork && <StakingDashboard />}
             <DashboardFooter />
         </Column>
     );


### PR DESCRIPTION
## Description

Users with only Bitcoin (or bitcoin-like coins) enabled shouldn't be harassed by staking section on dashboard.

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/hide-staking-dashboard&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/hide-staking-dashboard&lookback=7)