### PR TITLE
fix(product-components): react error passsing key as prop

### DIFF
--- a/packages/product-components/src/components/DeviceAnimation/DeviceAnimation.tsx
+++ b/packages/product-components/src/components/DeviceAnimation/DeviceAnimation.tsx
@@ -80,7 +80,7 @@ export const DeviceAnimation = forwardRef<HTMLVideoElement, DeviceAnimationProps
 
         // Key is used to force re-render of the video element. When `src` of the inner <source> tag
         // changes, the video element does not re-render. This is a workaround.
-        const key = `${deviceModelInFilename}_${type.toLowerCase()}_${deviceUnitColor}_${themeSuffix}`;
+        const rerenderKey = `${deviceModelInFilename}_${type.toLowerCase()}_${deviceUnitColor}_${themeSuffix}`;
 
         const commonProps = {
             loop,
@@ -93,14 +93,14 @@ export const DeviceAnimation = forwardRef<HTMLVideoElement, DeviceAnimationProps
                 {['BOOTLOADER'].includes(type) && (
                     <Video
                         src={`videos/device/trezor_${deviceModelInFilename}_${type.toLowerCase()}${themeSuffix}.webm`}
-                        key={key}
+                        rerenderKey={rerenderKey}
                         {...commonProps}
                     />
                 )}
                 {['SUCCESS'].includes(type) && (
                     <Video
                         src={`videos/device/trezor_${deviceModelInFilename}_${type.toLowerCase()}${themeSuffix}_frontcolor_${getFrontColor()}.webm`}
-                        key={key}
+                        rerenderKey={rerenderKey}
                         {...commonProps}
                     />
                 )}
@@ -108,14 +108,14 @@ export const DeviceAnimation = forwardRef<HTMLVideoElement, DeviceAnimationProps
                 {['BOOTLOADER_TWO_BUTTONS', 'NORMAL'].includes(type) && (
                     <Video
                         src={`videos/device/trezor_${DeviceModelInternal.T1B1.toLowerCase()}_${type.toLowerCase()}${themeSuffix}.webm`}
-                        key={key}
+                        rerenderKey={rerenderKey}
                         {...commonProps}
                     />
                 )}
                 {type === 'HOLOGRAM' && (
                     <Video
                         src={`videos/device/trezor_${deviceModelInFilename}_hologram.webm`}
-                        key={key}
+                        rerenderKey={rerenderKey}
                         {...commonProps}
                     />
                 )}
@@ -125,7 +125,7 @@ export const DeviceAnimation = forwardRef<HTMLVideoElement, DeviceAnimationProps
                             // if device unit color is not set, use first color available
                             deviceUnitColor ?? 1
                         }${sizeVariant ? `_${sizeVariant.toLowerCase()}` : ''}.webm`}
-                        key={key}
+                        rerenderKey={rerenderKey}
                         {...commonProps}
                     />
                 )}

--- a/packages/product-components/src/components/DeviceAnimation/Video.tsx
+++ b/packages/product-components/src/components/DeviceAnimation/Video.tsx
@@ -13,10 +13,10 @@ type VideoProps = {
     loop: boolean;
     videoRef: React.Ref<HTMLVideoElement>;
     onMouseOver?: MouseEventHandler<HTMLVideoElement>;
-    key: string;
+    rerenderKey: string;
 };
 
-export const Video = ({ src, loop, videoRef, onMouseOver, key }: VideoProps) => {
+export const Video = ({ src, loop, videoRef, onMouseOver, rerenderKey }: VideoProps) => {
     const commonProps = {
         loop,
         autoPlay: true,
@@ -26,7 +26,7 @@ export const Video = ({ src, loop, videoRef, onMouseOver, key }: VideoProps) => 
     };
 
     return (
-        <StyledVideo key={key} {...commonProps}>
+        <StyledVideo key={rerenderKey} {...commonProps}>
             <source src={resolveStaticPath(src)} type="video/webm" />
         </StyledVideo>
     );


### PR DESCRIPTION
## Description

Followup to #21155: rename the prop because `key` prop passed from `DeviceAnimation` is apparently not available to be consumed by `Video` 

## Screenshots:

<img width="498" height="69" alt="image" src="https://github.com/user-attachments/assets/0333dbc3-2cf8-405a-b4c6-06bab65418cc" />

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/video-key-prop-rename&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/video-key-prop-rename&lookback=7)