### PR TITLE
Refactor: unify FW authenticity check selectors

### DIFF
--- a/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
@@ -1,36 +1,24 @@
 import {
-    hashCheckErrorScenarios,
+    isHardHashCheckError,
+    isHardRevisionCheckError,
     isSkippedHashCheckError,
     isSkippedRevisionCheckError,
-    revisionCheckErrorScenarios,
 } from '@suite-common/firmware-authenticity';
 import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
-import { isDeviceAcquired } from '@suite-common/suite-utils';
-import { selectIsEntropyCheckFailed, selectSelectedDevice } from '@suite-common/wallet-core';
+import {
+    selectFirmwareHashCheckError,
+    selectFirmwareRevisionCheckError,
+    selectIsEntropyCheckFailed,
+} from '@suite-common/wallet-core';
 
 import { AppState } from 'src/types/suite';
 
 import { selectIsEntropyCheckEnabled } from './suiteSelectors';
 
-/**
- * Get firmware revision check error, or null if check was successful / skipped.
- */
-export const selectFirmwareRevisionCheckError = (state: AppState) => {
-    const device = selectSelectedDevice(state);
-    if (!isDeviceAcquired(device) || !device.authenticityChecks) return null;
-    const checkResult = device.authenticityChecks.firmwareRevision;
-
-    // null means not performed, then don't consider it failed
-    if (!checkResult || checkResult.success) return null;
-
-    if (isSkippedRevisionCheckError(checkResult.error)) return null;
-
-    return checkResult.error;
-};
-
 export const selectFirmwareRevisionCheckErrorIfEnabled = (state: AppState) => {
     const revisionCheckError = selectFirmwareRevisionCheckError(state);
     if (revisionCheckError === null) return null;
+    if (isSkippedRevisionCheckError(revisionCheckError)) return null;
 
     const isFirmwareRevisionCheckDisabled =
         !state.suite.settings.enabledSecurityChecks.firmwareRevision;
@@ -42,25 +30,10 @@ export const selectFirmwareRevisionCheckErrorIfEnabled = (state: AppState) => {
     return revisionCheckError;
 };
 
-/**
- * Get firmware hash check error, or null if check was successful / skipped.
- */
-export const selectFirmwareHashCheckError = (state: AppState) => {
-    const device = selectSelectedDevice(state);
-    if (!isDeviceAcquired(device) || !device.authenticityChecks) return null;
-    const checkResult = device.authenticityChecks.firmwareHash;
-
-    // null means not performed, then don't consider it failed
-    if (!checkResult || checkResult.success) return null;
-
-    if (isSkippedHashCheckError(checkResult.error)) return null;
-
-    return checkResult.error;
-};
-
 export const selectFirmwareHashCheckErrorIfEnabled = (state: AppState) => {
     const hashCheckError = selectFirmwareHashCheckError(state);
     if (hashCheckError === null) return null;
+    if (isSkippedHashCheckError(hashCheckError)) return null;
 
     const isFirmwareHashCheckDisabled = !state.suite.settings.enabledSecurityChecks.firmwareHash;
     if (isFirmwareHashCheckDisabled) return null;
@@ -90,14 +63,9 @@ export const selectFirmwareHashCheckErrorIfEnabled = (state: AppState) => {
  */
 export const selectIsFirmwareAuthenticityCheckEnabledAndHardFailed = (state: AppState) => {
     const revisionError = selectFirmwareRevisionCheckErrorIfEnabled(state);
-    const isRevisionHardError =
-        revisionError !== null && revisionCheckErrorScenarios[revisionError].type === 'hardModal';
-
     const hashError = selectFirmwareHashCheckErrorIfEnabled(state);
-    const isHashHardError =
-        hashError !== null && hashCheckErrorScenarios[hashError].type === 'hardModal';
 
-    return isRevisionHardError || isHashHardError;
+    return isHardRevisionCheckError(revisionError) || isHardHashCheckError(hashError);
 };
 
 /**

--- a/suite-common/firmware-authenticity/src/utils.ts
+++ b/suite-common/firmware-authenticity/src/utils.ts
@@ -3,6 +3,12 @@ import type { FilterPropertiesByType } from '@trezor/type-utils';
 
 import { hashCheckErrorScenarios, revisionCheckErrorScenarios } from './scenariosConfig';
 
+export const isHardRevisionCheckError = (error: FirmwareRevisionCheckError | null) =>
+    error !== null && revisionCheckErrorScenarios[error].type === 'hardModal';
+
+export const isHardHashCheckError = (error: FirmwareHashCheckError | null) =>
+    error !== null && hashCheckErrorScenarios[error].type === 'hardModal';
+
 export type SkippedRevisionCheckError = keyof FilterPropertiesByType<
     typeof revisionCheckErrorScenarios,
     { type: 'skipped' }

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -515,3 +515,31 @@ export const selectDeviceDefaultBackupType = createMemoizedSelector(
 export const selectStandardWalletDevice = createMemoizedSelector([selectDevices], devices =>
     devices.find(device => device.useEmptyPassphrase),
 );
+
+/**
+ * Get firmware revision check error, or null if check was successful / skipped.
+ */
+export const selectFirmwareRevisionCheckError = (state: DeviceRootState) => {
+    const device = selectSelectedDevice(state);
+    if (!deviceUtils.isDeviceAcquired(device) || !device.authenticityChecks) return null;
+    const checkResult = device.authenticityChecks.firmwareRevision;
+
+    // null means not performed, then don't consider it failed
+    if (!checkResult || checkResult.success) return null;
+
+    return checkResult.error;
+};
+
+/**
+ * Get firmware hash check error, or null if check was successful / skipped.
+ */
+export const selectFirmwareHashCheckError = (state: DeviceRootState) => {
+    const device = selectSelectedDevice(state);
+    if (!deviceUtils.isDeviceAcquired(device) || !device.authenticityChecks) return null;
+    const checkResult = device.authenticityChecks.firmwareHash;
+
+    // null means not performed, then don't consider it failed
+    if (!checkResult || checkResult.success) return null;
+
+    return checkResult.error;
+};

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -1,13 +1,16 @@
 import { A, G, pipe } from '@mobily/ts-belt';
 
-import { revisionCheckErrorScenarios } from '@suite-common/firmware-authenticity';
+import {
+    isHardRevisionCheckError,
+    isSkippedRevisionCheckError,
+    revisionCheckErrorScenarios,
+} from '@suite-common/firmware-authenticity';
 import {
     Feature,
     MessageSystemRootState,
     selectIsFeatureEnabled,
 } from '@suite-common/message-system';
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
-import { isDeviceAcquired } from '@suite-common/suite-utils';
 import {
     AccountsRootState,
     DeviceRootState,
@@ -25,6 +28,7 @@ import {
     selectDeviceInstances,
     selectDeviceModel,
     selectDevices,
+    selectFirmwareRevisionCheckError,
     selectHasDeviceFirmwareInstalled,
     selectIsConnectedDeviceUninitialized,
     selectIsDeviceConnectedAndAuthorized,
@@ -168,20 +172,6 @@ export const selectHasNoDeviceWithEmptyPassphrase = createMemoizedSelector(
     deviceInstances => A.isEmpty(deviceInstances.filter(d => d.useEmptyPassphrase)),
 );
 
-/**
- * Get firmware revision check error, or null if check was successful / skipped.
- */
-export const selectFirmwareRevisionCheckError = (state: DeviceRootState) => {
-    const device = selectSelectedDevice(state);
-    if (!isDeviceAcquired(device) || !device.authenticityChecks) return null;
-    const checkResult = device.authenticityChecks.firmwareRevision;
-
-    // null means not performed, then don't consider it failed
-    if (!checkResult || checkResult.success) return null;
-
-    return checkResult.error;
-};
-
 type FwAuthenticityCheckState = NativeDeviceRootState &
     FeatureFlagsRootState &
     MessageSystemRootState;
@@ -209,7 +199,7 @@ export const selectFirmwareRevisionCheckErrorIfEnabled = (state: FwAuthenticityC
 export const selectIsSkippedRevisionCheckError = (state: FwAuthenticityCheckState): boolean => {
     const revisionCheckError = selectFirmwareRevisionCheckErrorIfEnabled(state);
     if (revisionCheckError === null) return false;
-    if (revisionCheckErrorScenarios[revisionCheckError].type === 'skipped') return true;
+    if (isSkippedRevisionCheckError(revisionCheckError)) return true;
 
     // Special handling for offline error, which is handled as softWarning (top-screen banner),
     // but the banner is rendered separately in useIsOfflineBannerVisible.
@@ -226,15 +216,7 @@ export const selectIsSkippedRevisionCheckError = (state: FwAuthenticityCheckStat
  */
 export const selectHasFirmwareAuthenticityCheckHardFailed = createMemoizedSelector(
     [selectFirmwareRevisionCheckErrorIfEnabled],
-    revisionError => {
-        const isRevisionHardError =
-            revisionError !== null &&
-            revisionCheckErrorScenarios[revisionError].type === 'hardModal';
-
-        // FW hash check to be implemented
-
-        return isRevisionHardError;
-    },
+    revisionError => isHardRevisionCheckError(revisionError), // FW hash check to be implemented
 );
 
 export const selectIsEntropyCheckEnabledAndFailed = createMemoizedSelector(


### PR DESCRIPTION
## Description

Small code unification of firmware authenticity check selectors, introduction of small helpers.

## Related Issue

Resolve #20506

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/unify-fw-auth-check-selectors&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/unify-fw-auth-check-selectors&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/unify-fw-auth-check-selectors&lookback=7)