### PR TITLE
Entropy check check

### DIFF
--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -98,7 +98,41 @@ export const resetDevice =
             getState(),
             Feature.entropyCheck,
         );
+
+        // todo: this should be handled most likely in a component somewhere above
+        if (device?.status === 'used' || device?.status === 'occupied') {
+            const features = await TrezorConnect.getFeatures({ device: { path: device.path } });
+            if (!features.success) {
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'error',
+                        error: 'Device is unreadable',
+                    }),
+                );
+
+                return;
+            }
+            if (features.payload.initialized) {
+                // todo: decide what should happen next UX wise. At the moment, user only gets an error toast
+                // and stays stuck on the 'create new wallet' screen;
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'error',
+                        error: 'This device has already been initialized',
+                    }),
+                );
+
+                return;
+            }
+        }
+
         if (!device || !device.features) return;
+
+        if (device.mode !== 'initialize') {
+            console.error('resetDevice: device in invalid mode', device.mode);
+
+            return;
+        }
 
         const defaults = {
             strength: DEVICE.DEFAULT_STRENGTH[device.features.internal_model],

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -107,11 +107,11 @@ export const resetDevice =
         };
 
         const result = await TrezorConnect.resetDevice({
+            ...defaults,
+            ...params,
             device: {
                 path: device.path,
             },
-            ...defaults,
-            ...params,
             entropy_check: isEntropyCheckEnabled && !isEntropyCheckDisabledByMessageSystem,
         });
 

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -117,7 +117,7 @@ export const resetDevice =
 
         if (!result.success) {
             dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
-            dispatch(failEntropyCheckThunk({ device, error: result.payload.error }));
+            dispatch(failEntropyCheckThunk({ device, error: result.payload }));
         }
 
         return result;

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -503,6 +503,10 @@ type FailEntropyCheckParams = {
 export const failEntropyCheckThunk = createThunk(
     `${DEVICE_MODULE_PREFIX}/failEntropyCheckThunk`,
     ({ device, error }: FailEntropyCheckParams, { dispatch, extra }) => {
+        if (error.code === 'Method_Cancel') {
+            // resetDevice call was cancelled by user
+            return;
+        }
         const contextData = {
             model: device?.features?.internal_model,
             revision: device?.features?.revision,

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -497,7 +497,7 @@ export const toggleAutoEjectThunk = createThunk(
 
 type FailEntropyCheckParams = {
     device: AcquiredDevice;
-    error: string;
+    error: { code?: string; error: string };
 };
 
 export const failEntropyCheckThunk = createThunk(
@@ -524,7 +524,7 @@ export const failEntropyCheckThunk = createThunk(
             // This one was not in Sentry but can be triggered by manually disconnecting the device. Investigate. https://github.com/trezor/trezor-suite-private/issues/135
             'device disconnected during action',
         ];
-        if (!temporarilySkippedErrorsToBeInvestigated.includes(error)) {
+        if (!temporarilySkippedErrorsToBeInvestigated.includes(error.error)) {
             dispatch(deviceActions.setEntropyCheckFail(device.id));
         }
     },

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -124,7 +124,7 @@ export const createAndBackupWalletThunk = createThunk(
 
         const result = deviceResponse.payload;
         if (!result.success && result.payload.code === 'Failure_EntropyCheck') {
-            dispatch(failEntropyCheckThunk({ device, error: result.payload.error }));
+            dispatch(failEntropyCheckThunk({ device, error: result.payload }));
         }
 
         return result;


### PR DESCRIPTION
problems solved

- `device already initialised` - conflict between 2 tabs - in general, the problem is that onboarding does not handle unacquired/occupied device at all. 
- `ui-device_bootloader_mode` - this is probably solved, needs some testing, I would suspect again the same cuplrit using suite in 2 tabs.
- `cancelled`, `cancelado` etc. - imho we simply need to filter out this kind of expected error (when cancelled by user)

problems remaining 

-  `device disconnected during action` - could be caused by conflict of 2 tabs, tab A started reset device flow but hasn't finished it. Tab B fired a call to device. 
- `unexpected error` 
- `Malformed protocol format`

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=entropy-check-check&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=entropy-check-check&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=entropy-check-check&lookback=7)