### PR TITLE
chore(suite-native): useOverrideBackNavigation refactor

### DIFF
--- a/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
+++ b/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
@@ -19,7 +19,7 @@ import {
     Screen,
     ScreenFooterGradient,
     StackToStackCompositeNavigationProps,
-    useHandleHardwareBackNavigation,
+    useOverrideBackNavigation,
 } from '@suite-native/navigation';
 import { setIsCoinEnablingInitFinished } from '@suite-native/settings';
 
@@ -35,7 +35,7 @@ type NavigationProps = StackToStackCompositeNavigationProps<
 export const CoinEnablingInitScreen = () => {
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
-    useHandleHardwareBackNavigation();
+    useOverrideBackNavigation();
 
     const networkSymbols = useSelector(selectDiscoveryNetworkSymbols);
 

--- a/suite-native/device/src/components/BootloaderModeScreen.tsx
+++ b/suite-native/device/src/components/BootloaderModeScreen.tsx
@@ -16,6 +16,7 @@ import {
     WipeDeviceStackParamList,
     WipeDeviceStackRoutes,
     useNavigateToInitialScreen,
+    useOverrideBackNavigation,
 } from '@suite-native/navigation';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
@@ -46,6 +47,8 @@ export const BootloaderModeScreen = () => {
     const shouldFactoryResetBeVisible = useSelector(selectShouldFactoryResetBeVisible);
     const navigateToInitialScreen = useNavigateToInitialScreen();
 
+    useOverrideBackNavigation();
+
     const handleRedirectToFactoryReset = () => {
         navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
             screen: DeviceSettingsStackRoutes.WipeDeviceStack,
@@ -61,17 +64,6 @@ export const BootloaderModeScreen = () => {
             navigateToInitialScreen();
         }
     }, [shouldFactoryResetBeVisible, navigateToInitialScreen, navigation]);
-
-    useEffect(() => {
-        // Navigating back from the bootloader screen would get the user back to homescreen in incorrect state, so we'll avoid it by this.
-        const unsubscribe = navigation.addListener('beforeRemove', e => {
-            if (e.data.action.type === 'GO_BACK') {
-                e.preventDefault();
-            }
-        });
-
-        return unsubscribe;
-    }, [navigation]);
 
     return (
         <Screen header={<DeviceManagerScreenHeader />}>

--- a/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
@@ -9,7 +9,7 @@ import {
     RootStackParamList,
     Screen,
     StackToStackCompositeScreenProps,
-    useHandleHardwareBackNavigation,
+    useOverrideBackNavigation,
 } from '@suite-native/navigation';
 import { AccountInfo } from '@trezor/connect';
 
@@ -36,7 +36,7 @@ export const AccountImportLoadingScreen = ({
     const [accountInfoFetchResult, setAccountInfoFetchResult] =
         useState<SpinnerLoadingState>('idle');
 
-    useHandleHardwareBackNavigation();
+    useOverrideBackNavigation();
 
     const fetchAccountInfo = useCallback(async () => {
         try {

--- a/suite-native/module-accounts-import/src/screens/AccountImportSummaryScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/AccountImportSummaryScreen.tsx
@@ -13,7 +13,7 @@ import {
     AccountsImportStackRoutes,
     RootStackParamList,
     StackToTabCompositeScreenProps,
-    useHandleHardwareBackNavigation,
+    useOverrideBackNavigation,
 } from '@suite-native/navigation';
 
 import { AccountAlreadyImportedScreen } from '../components/AccountAlreadyImportedScreen';
@@ -28,7 +28,7 @@ export const AccountImportSummaryScreen = ({
 >) => {
     const { accountInfo, networkSymbol } = route.params;
 
-    useHandleHardwareBackNavigation();
+    useOverrideBackNavigation();
 
     const account = useSelector((state: AccountsRootState & DeviceRootState) =>
         selectDeviceAccountByDescriptorAndNetworkSymbol(

--- a/suite-native/module-authenticity-checks/src/components/EntropyCheckFailModalContent.tsx
+++ b/suite-native/module-authenticity-checks/src/components/EntropyCheckFailModalContent.tsx
@@ -1,26 +1,11 @@
-import { useEffect } from 'react';
-
-import { useNavigation } from '@react-navigation/core';
-
 import { Translation } from '@suite-native/intl';
-import { ScreenHeader } from '@suite-native/navigation';
+import { ScreenHeader, useOverrideBackNavigation } from '@suite-native/navigation';
 import { HELP_CENTER_ENTROPY_CHECK_URL } from '@trezor/urls';
 
 import { DeviceCompromisedModalContent } from './DeviceCompromisedModalContent';
 
 export const EntropyCheckFailModalContent = () => {
-    const navigation = useNavigation();
-
-    useEffect(() => {
-        // Prevent navigation GO_BACK action; this modal will be shown as long as the device is connected
-        const unsubscribe = navigation.addListener('beforeRemove', e => {
-            if (e.data.action.type === 'GO_BACK') {
-                e.preventDefault();
-            }
-        });
-
-        return unsubscribe;
-    }, [navigation]);
+    useOverrideBackNavigation();
 
     return (
         <DeviceCompromisedModalContent

--- a/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreenHeader.tsx
+++ b/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreenHeader.tsx
@@ -17,7 +17,7 @@ import {
     NavigateParameters,
     RootStackParamList,
     StackToStackCompositeNavigationProps,
-    useHandleHardwareBackNavigation,
+    useOverrideBackNavigation,
 } from '@suite-native/navigation';
 import TrezorConnect from '@trezor/connect';
 
@@ -91,7 +91,7 @@ export const ConnectDeviceScreenHeader = ({
         navigation,
     ]);
 
-    useHandleHardwareBackNavigation(handleCancel);
+    useOverrideBackNavigation({ onNavigateBack: handleCancel });
 
     // Hide alert when navigating away from the PIN entry screen (PIN entered or canceled on device)
     // eslint-disable-next-line arrow-body-style

--- a/suite-native/module-authorize-device/src/screens/connect/ConnectingDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/ConnectingDeviceScreen.tsx
@@ -3,7 +3,7 @@ import { ActivityIndicator } from 'react-native';
 import { Box, Text, VStack, resetLetterSpacingOnAndroidStyle } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import { useHandleHardwareBackNavigation } from '@suite-native/navigation';
+import { useOverrideBackNavigation } from '@suite-native/navigation';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { ConnectDeviceScreenView } from '../../components/connect/ConnectDeviceScreenView';
@@ -17,7 +17,7 @@ const screenStyle = prepareNativeStyle(() => ({
 
 export const ConnectingDeviceScreen = () => {
     useOnDeviceReadyNavigation();
-    useHandleHardwareBackNavigation();
+    useOverrideBackNavigation();
 
     const { applyStyle } = useNativeStyles();
 

--- a/suite-native/module-device-onboarding/src/components/DeviceOnboardingScreenWithExitButton.tsx
+++ b/suite-native/module-device-onboarding/src/components/DeviceOnboardingScreenWithExitButton.tsx
@@ -1,26 +1,15 @@
-import React, { ReactNode, useEffect } from 'react';
-
-import { useNavigation } from '@react-navigation/core';
+import React, { ReactNode } from 'react';
 
 import { Box } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
-    DeviceOnboardingStackParamList,
-    DeviceOnboardingStackRoutes,
     DynamicScreenHeader,
-    RootStackParamList,
     Screen,
     ScreenProps,
-    StackToStackCompositeNavigationProps,
+    useOverrideBackNavigation,
 } from '@suite-native/navigation';
 
 import { useExitAlert } from '../hooks/useExitAlert';
-
-type NavigationProps = StackToStackCompositeNavigationProps<
-    DeviceOnboardingStackParamList,
-    DeviceOnboardingStackRoutes,
-    RootStackParamList
->;
 
 type DeviceOnboardingExitButtonScreenHeaderProps = {
     screenHeaderRightIcon?: ReactNode;
@@ -31,20 +20,8 @@ export const DeviceOnboardingExitButtonScreenHeader = ({
     screenHeaderRightIcon,
     onAlertContinueButtonPress,
 }: DeviceOnboardingExitButtonScreenHeaderProps) => {
-    const navigation = useNavigation<NavigationProps>();
     const { handleExitButtonPress } = useExitAlert(onAlertContinueButtonPress);
-
-    useEffect(() => {
-        // Override default navigation GO_BACK action to align it with the exit button behavior.
-        const unsubscribe = navigation.addListener('beforeRemove', e => {
-            if (e.data.action.type === 'GO_BACK') {
-                e.preventDefault();
-                handleExitButtonPress();
-            }
-        });
-
-        return unsubscribe;
-    }, [handleExitButtonPress, navigation]);
+    useOverrideBackNavigation({ onNavigateBack: handleExitButtonPress });
 
     return (
         <DynamicScreenHeader

--- a/suite-native/module-device-onboarding/src/screens/DeviceDisconnectedScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/DeviceDisconnectedScreen.tsx
@@ -18,6 +18,7 @@ import {
     Screen,
     ScreenHeader,
     StackToStackCompositeScreenProps,
+    useOverrideBackNavigation,
 } from '@suite-native/navigation';
 
 export const DeviceDisconnectedScreen = ({
@@ -35,6 +36,7 @@ export const DeviceDisconnectedScreen = ({
     const { translate } = useTranslate();
 
     const [isAlertDismissed, setIsAlertDismissed] = useState(false);
+    useOverrideBackNavigation();
 
     const navigateToHome = () =>
         navigation.popTo(RootStackRoutes.AppTabs, {
@@ -67,17 +69,6 @@ export const DeviceDisconnectedScreen = ({
         // This effect should be called only once during the first render.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
-
-    useEffect(() => {
-        const unsubscribe = navigation.addListener('beforeRemove', e => {
-            if (e.data.action.type === 'GO_BACK') {
-                // Prevent going back to device onboarding without device connected.
-                e.preventDefault();
-            }
-        });
-
-        return unsubscribe;
-    }, [navigation]);
 
     return (
         <Screen

--- a/suite-native/module-device-settings/src/screens/WipeDeviceContinueOnTrezorScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/WipeDeviceContinueOnTrezorScreen.tsx
@@ -16,8 +16,7 @@ export const WipeDeviceContinueOnTrezorScreen = () => {
     const shouldFactoryResetBeVisible = useSelector(selectShouldFactoryResetBeVisible);
 
     useDeviceConnectionGuard();
-
-    useHandleHardwareBackNavigation(() => TrezorConnect.cancel());
+    useHandleHardwareBackNavigation(TrezorConnect.cancel);
 
     const device = useSelector(selectSelectedDevice);
 

--- a/suite-native/module-send/src/hooks/useShowReviewCancellationAlert.tsx
+++ b/suite-native/module-send/src/hooks/useShowReviewCancellationAlert.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { cancelSignSendFormTransactionThunk } from '@suite-common/wallet-core';
@@ -10,24 +11,27 @@ export const useShowReviewCancellationAlert = () => {
     const { showAlert } = useAlert();
     const dispatch = useDispatch();
 
-    const showReviewCancellationAlert = () =>
-        new Promise<AlertResolveValue>(resolve =>
-            showAlert({
-                title: <Translation id="moduleSend.review.cancelAlert.title" />,
-                primaryButtonTitle: <Translation id="generic.buttons.cancel" />,
-                primaryButtonVariant: 'redBold',
-                secondaryButtonVariant: 'redElevation0',
-                secondaryButtonTitle: (
-                    <Translation id="moduleSend.review.cancelAlert.continueButton" />
-                ),
-                onPressPrimaryButton: () => {
-                    dispatch(cancelSignSendFormTransactionThunk());
+    const showReviewCancellationAlert = useCallback(
+        () =>
+            new Promise<AlertResolveValue>(resolve =>
+                showAlert({
+                    title: <Translation id="moduleSend.review.cancelAlert.title" />,
+                    primaryButtonTitle: <Translation id="generic.buttons.cancel" />,
+                    primaryButtonVariant: 'redBold',
+                    secondaryButtonVariant: 'redElevation0',
+                    secondaryButtonTitle: (
+                        <Translation id="moduleSend.review.cancelAlert.continueButton" />
+                    ),
+                    onPressPrimaryButton: () => {
+                        dispatch(cancelSignSendFormTransactionThunk());
 
-                    return resolve({ wasReviewCanceled: true });
-                },
-                onPressSecondaryButton: () => resolve({ wasReviewCanceled: false }),
-            }),
-        );
+                        return resolve({ wasReviewCanceled: true });
+                    },
+                    onPressSecondaryButton: () => resolve({ wasReviewCanceled: false }),
+                }),
+            ),
+        [dispatch, showAlert],
+    );
 
     return showReviewCancellationAlert;
 };

--- a/suite-native/module-send/src/screens/SendOutputsReviewScreen.tsx
+++ b/suite-native/module-send/src/screens/SendOutputsReviewScreen.tsx
@@ -1,7 +1,5 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-
-import { useNavigation } from '@react-navigation/native';
 
 import {
     AccountsRootState,
@@ -12,13 +10,12 @@ import { Box, VStack } from '@suite-native/atoms';
 import { ConfirmOnTrezorWrapper, useConfirmOnTrezorController } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 import {
-    RootStackParamList,
     ScreenHeader,
     SendStackParamList,
     SendStackRoutes,
     StackProps,
-    StackToStackCompositeNavigationProps,
     useNavigateToInitialScreen,
+    useOverrideBackNavigation,
 } from '@suite-native/navigation';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
@@ -27,11 +24,6 @@ import { ReviewOutputItemList } from '../components/ReviewOutputItemList';
 import { useShowReviewCancellationAlert } from '../hooks/useShowReviewCancellationAlert';
 import { selectIsTransactionAlreadySigned } from '../selectors';
 
-type NavigationProps = StackToStackCompositeNavigationProps<
-    SendStackParamList,
-    SendStackRoutes.SendOutputsReview,
-    RootStackParamList
->;
 const spacerStyle = prepareNativeStyle(_ => ({
     height: 150,
 }));
@@ -40,7 +32,6 @@ export const SendOutputsReviewScreen = ({
     route,
 }: StackProps<SendStackParamList, SendStackRoutes.SendOutputsReview>) => {
     const { accountKey, tokenContract } = route.params;
-    const navigation = useNavigation<NavigationProps>();
     const showReviewCancellationAlert = useShowReviewCancellationAlert();
     const navigateToInitialScreen = useNavigateToInitialScreen();
 
@@ -57,24 +48,16 @@ export const SendOutputsReviewScreen = ({
 
     const showOutputsReviewFooter = isTransactionAlreadySigned && account;
 
-    useEffect(() => {
-        const unsubscribe = navigation.addListener('beforeRemove', async e => {
-            // We want to modify only behavior of back button actions.
+    const onNavigateBack = useCallback(async () => {
+        const { wasReviewCanceled } = await showReviewCancellationAlert();
 
-            if (e.data.action.type !== 'GO_BACK') return;
+        if (wasReviewCanceled) {
+            dispatch(cancelSignSendFormTransactionThunk());
+            navigateToInitialScreen();
+        }
+    }, [dispatch, navigateToInitialScreen, showReviewCancellationAlert]);
 
-            e.preventDefault();
-
-            const { wasReviewCanceled } = await showReviewCancellationAlert();
-
-            if (wasReviewCanceled) {
-                dispatch(cancelSignSendFormTransactionThunk());
-                navigateToInitialScreen();
-            }
-        });
-
-        return unsubscribe;
-    });
+    useOverrideBackNavigation({ onNavigateBack });
 
     useEffect(() => {
         if (showOutputsReviewFooter) {

--- a/suite-native/navigation/src/hooks/useOverrideBackNavigation.tsx
+++ b/suite-native/navigation/src/hooks/useOverrideBackNavigation.tsx
@@ -1,18 +1,29 @@
-import { useEffect } from 'react';
+import { useCallback } from 'react';
 
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 
-export const useOverrideBackNavigation = ({ onNavigateBack }: { onNavigateBack?: () => void }) => {
+export const useOverrideBackNavigation = ({
+    onNavigateBack,
+    gestureEnabled = false,
+}: { onNavigateBack?: () => void; gestureEnabled?: boolean } = {}) => {
     const navigation = useNavigation();
 
-    useEffect(() => {
-        const unsubscribe = navigation.addListener('beforeRemove', e => {
-            if (e.data.action.type === 'GO_BACK') {
-                e.preventDefault();
-                onNavigateBack?.();
-            }
-        });
+    useFocusEffect(
+        useCallback(() => {
+            // iOS only - disable swipe back gesture
+            navigation.getParent()?.setOptions({ gestureEnabled });
 
-        return unsubscribe;
-    }, [onNavigateBack, navigation]);
+            const unsubscribe = navigation.addListener('beforeRemove', e => {
+                if (e.data.action.type === 'GO_BACK') {
+                    e.preventDefault();
+                    onNavigateBack?.();
+                }
+            });
+
+            return () => {
+                navigation.getParent()?.setOptions({ gestureEnabled: true });
+                unsubscribe();
+            };
+        }, [navigation, onNavigateBack, gestureEnabled]),
+    );
 };

--- a/suite-native/navigation/src/useHandleHardwareBackNavigation.ts
+++ b/suite-native/navigation/src/useHandleHardwareBackNavigation.ts
@@ -1,9 +1,11 @@
 import { useCallback } from 'react';
 import { BackHandler } from 'react-native';
 
-import { useFocusEffect } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 
 export const useHandleHardwareBackNavigation = (onPress?: () => void) => {
+    const navigation = useNavigation();
+
     useFocusEffect(
         useCallback(() => {
             // do nothing unless onPress has some custom handling
@@ -13,7 +15,10 @@ export const useHandleHardwareBackNavigation = (onPress?: () => void) => {
                 return true;
             });
 
-            return () => subscription.remove();
-        }, [onPress]),
+            return () => {
+                navigation.getParent()?.setOptions({ gestureEnabled: true });
+                subscription.remove();
+            };
+        }, [navigation, onPress]),
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

_note: I omitted https://github.com/trezor/trezor-suite/blob/661a8df9fdc3eed03c56790adeb5a6849a391e56/suite-native/module-send/src/hooks/useHandleOnDeviceTransactionReview.tsx#L61 because the logic is a bit advanced, and I didn’t want to complicate the hook for just one use case._

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19838

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/override-back-navigation&lookback=7)