### PR TITLE
test(suite): fix act warning because of unnecessary act() wrappers

### DIFF
--- a/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { DeepPartial } from 'react-hook-form';
 
-import { act, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 
 import { configureMockStore, initPreloadedState, testMocks } from '@suite-common/test-utils';
 import { FormState } from '@suite-common/wallet-types';
@@ -230,13 +230,11 @@ describe('useSendForm hook', () => {
             async () => {
                 const store = initStore(f.store);
                 const callback: TestCallback = {};
-                const { unmount } = await act(() =>
-                    renderWithProviders(
-                        store,
-                        <SendIndex>
-                            <Component callback={callback} />
-                        </SendIndex>,
-                    ),
+                const { unmount } = renderWithProviders(
+                    store,
+                    <SendIndex>
+                        <Component callback={callback} />
+                    </SendIndex>,
                 );
                 // wait for first render
                 await waitForLoader();
@@ -328,13 +326,11 @@ describe('useSendForm hook', () => {
                 testMocks.setTrezorConnectFixtures(f.connect);
                 const store = initStore(f.store);
                 const callback: TestCallback = {};
-                const { unmount } = await act(() =>
-                    renderWithProviders(
-                        store,
-                        <SendIndex>
-                            <Component callback={callback} />
-                        </SendIndex>,
-                    ),
+                const { unmount } = renderWithProviders(
+                    store,
+                    <SendIndex>
+                        <Component callback={callback} />
+                    </SendIndex>,
                 );
 
                 // wait for first render

--- a/packages/suite/src/support/tests/hooksHelper.tsx
+++ b/packages/suite/src/support/tests/hooksHelper.tsx
@@ -18,8 +18,8 @@ import { ConnectedThemeProvider } from 'src/support/suite/ConnectedThemeProvider
 import { ResponsiveContextProvider } from '../suite/ResponsiveContext';
 
 // used in hooks tests
-export const renderWithProviders = (store: any, children: ReactNode): RenderResult => {
-    const renderMethods = render(
+export const renderWithProviders = (store: any, children: ReactNode): RenderResult =>
+    render(
         <Provider store={store}>
             <ConnectedThemeProvider>
                 <ResponsiveContextProvider>
@@ -30,9 +30,6 @@ export const renderWithProviders = (store: any, children: ReactNode): RenderResu
             </ConnectedThemeProvider>
         </Provider>,
     );
-
-    return renderMethods;
-};
 
 export const waitForLoader = (text = /Loading/i) => {
     try {
@@ -88,7 +85,7 @@ export const actionSequence = <A extends UserAction[]>(
             p.then(async () => {
                 const element = findByTestId(action.element);
                 if (action.type === 'hover') {
-                    await act(() => user.hover(element));
+                    await user.hover(element);
                 }
                 if (action.type === 'click') {
                     const isDisabled = element.getAttributeNames().includes('disabled');
@@ -96,20 +93,20 @@ export const actionSequence = <A extends UserAction[]>(
                         throw new Error('Unable to perform pointer interaction');
                     }
 
-                    await act(() => user.click(element));
+                    await user.click(element);
                 } else if (action.type === 'input') {
                     const { value } = action;
                     const typeUser = userEvent.setup(
                         action.delay ? { delay: action.delay } : undefined,
                     );
                     if (!value) {
-                        await act(() => typeUser.clear(element));
+                        await typeUser.clear(element);
                     } else {
-                        await act(() => typeUser.type(element, value));
+                        await typeUser.type(element, value);
                     }
 
                     // NOTE: typing or clearing inputs requires extra user action for proper render
-                    await act(() => user.click(element));
+                    await user.click(element);
                 }
 
                 // wait for compose


### PR DESCRIPTION
## Description

Since jest 28 or something, the act() wrappers are no longer necessary because the `@testing-library` functions wrap it themselves. The unnecessary wrapper actualy causes this bug where stdoutput is absolutely flooded with :
```
 console.error: The current testing environment is not configured to support act(...)
```

Now the [logs are nice and clean](https://github.com/trezor/trezor-suite/actions/runs/17369786723/job/49303174574?pr=21201) :sparkles: 

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/fix-act-in-useSendForm.test&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/fix-act-in-useSendForm.test&lookback=7)