### PR TITLE
feat(suite): move autostart setting out of experimental

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -63,7 +63,6 @@ export const SettingsGeneral = () => {
 
     const isMetadataEnabled = metadata.enabled && !metadata.initiating;
     const isProviderConnected = useSelector(selectSelectedProviderForLabels);
-    const isExperimentalEnabled = useSelector(state => state.suite.settings.experimental);
 
     return (
         <SettingsLayout data-testid="@settings/index">
@@ -119,16 +118,17 @@ export const SettingsGeneral = () => {
                 </SettingsSection>
             )}
 
-            <SettingsSection title={<Translation id="TR_EXPERIMENTAL_FEATURES" />} icon="atom">
-                {desktopUpdate.enabled && <EarlyAccess />}
-                <Experimental />
-            </SettingsSection>
-            {isDesktop() && isExperimentalEnabled !== undefined && (
+            {isDesktop() && (
                 <SettingsSection title={<Translation id="TR_TREZOR_CONNECT" />} icon="plugs">
                     <AutoStart />
                     <ShowOnTray />
                 </SettingsSection>
             )}
+
+            <SettingsSection title={<Translation id="TR_EXPERIMENTAL_FEATURES" />} icon="atom">
+                {desktopUpdate.enabled && <EarlyAccess />}
+                <Experimental />
+            </SettingsSection>
         </SettingsLayout>
     );
 };


### PR DESCRIPTION
## Description

We already started showing the autostart modal with the release of Connect, but we didn't start showing the settings section, which still needed experimental features to be enabled. 
This PR enables it for everybody. 

## Screenshots:

<img width="1215" height="605" alt="Screenshot 2025-09-01 at 10 00 25" src="https://github.com/user-attachments/assets/cdd5d099-f03b-405c-ad8e-672c5352ba33" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/autostart-move-from-experimental&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/autostart-move-from-experimental&lookback=7)