### PR TITLE
Native connect calls race

### DIFF
--- a/suite-native/device/src/hooks/useRetryFwAuthenticityChecks.ts
+++ b/suite-native/device/src/hooks/useRetryFwAuthenticityChecks.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
+import { requestDeviceAccess } from '@suite-native/device-mutex';
 import TrezorConnect, { FIRMWARE } from '@trezor/connect';
 import { TimerId } from '@trezor/type-utils';
 import { isArrayMember } from '@trezor/utils';
@@ -22,7 +23,9 @@ export const useRetryFwAuthenticityChecks = () => {
             if (isRetriableError) {
                 // any device call will cause the tests to be rerun, so getFeatures is used as the most basic one
                 // it'd be useless to await the result; what interests us is the Device state that updates, and gets propagated into redux
-                TrezorConnect.getFeatures({ useEmptyPassphrase: true });
+                requestDeviceAccess({
+                    deviceCallback: () => TrezorConnect.getFeatures({ useEmptyPassphrase: true }),
+                });
                 timeoutHandle = setTimeout(recheckFwRevision, REFRESH_INTERVAL);
             }
         };

--- a/suite-native/device/src/hooks/useRetryFwAuthenticityChecks.ts
+++ b/suite-native/device/src/hooks/useRetryFwAuthenticityChecks.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
 import { requestDeviceAccess } from '@suite-native/device-mutex';
+import { deviceAccessMutex } from '@suite-native/device-mutex/src/DeviceAccessMutex';
 import TrezorConnect, { FIRMWARE } from '@trezor/connect';
 import { TimerId } from '@trezor/type-utils';
 import { isArrayMember } from '@trezor/utils';
@@ -21,11 +22,15 @@ export const useRetryFwAuthenticityChecks = () => {
         let timeoutHandle: TimerId;
         const recheckFwRevision = () => {
             if (isRetriableError) {
-                // any device call will cause the tests to be rerun, so getFeatures is used as the most basic one
-                // it'd be useless to await the result; what interests us is the Device state that updates, and gets propagated into redux
-                requestDeviceAccess({
-                    deviceCallback: () => TrezorConnect.getFeatures({ useEmptyPassphrase: true }),
-                });
+                // refrain from scheduling multiple tasks (since this runs in a loop)
+                if (deviceAccessMutex.taskQueue.length === 0) {
+                    // any device call will cause the tests to be rerun, so getFeatures is used as the most basic one
+                    // it'd be useless to await the result; what interests us is the Device state that updates, and gets propagated into redux
+                    requestDeviceAccess({
+                        deviceCallback: () =>
+                            TrezorConnect.getFeatures({ useEmptyPassphrase: true }),
+                    });
+                }
                 timeoutHandle = setTimeout(recheckFwRevision, REFRESH_INTERVAL);
             }
         };


### PR DESCRIPTION
connect calls fired from here https://github.com/trezor/trezor-suite/blob/develop/suite-native/device/src/hooks/useRetryFwAuthenticityChecks.ts#L12
could unexpectedly interfere with app by removing button requests here http://github.com/trezor/trezor-suite/blob/develop/suite-common/connect-init/src/connectInitThunks.ts#L155
and possibly also elsewhere. what is the point of using mutex if not used for all connect calls? 🤔 

I think I got hit by this in https://github.com/trezor/trezor-suite/pull/21191 where I am trying to unify some logic between suite ant native

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=native-connect-calls-race&lookback=7)