### PR TITLE
fix(suite): move the bio auth settings to the privacy section of the …

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -110,13 +110,8 @@ export const SettingsGeneral = () => {
 
             <SettingsSection title={<Translation id="TR_PRIVACY" />} icon="shield">
                 <AutoEject />
+                {isDesktop() && !isLinux() && <BioAuthSettings />}
             </SettingsSection>
-
-            {isDesktop() && !isLinux() && (
-                <SettingsSection title={<Translation id="TR_BIO_AUTH" />}>
-                    <BioAuthSettings />
-                </SettingsSection>
-            )}
 
             {isDesktop() && (
                 <SettingsSection title={<Translation id="TR_TREZOR_CONNECT" />} icon="plugs">


### PR DESCRIPTION
…settings

<!--- Provide a general summary of your changes in the Title above -->

## Description

Tomas wisely requested to move the biometric auth to privacy section as there will be more sections being added and this should be under privacy.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="1212" height="501" alt="Screenshot 2025-09-01 at 11 02 59 AM" src="https://github.com/user-attachments/assets/ece998ef-796d-4a24-8701-905125a8d970" />


AFTR
<img width="1238" height="616" alt="Screenshot 2025-09-01 at 11 02 12 AM" src="https://github.com/user-attachments/assets/14bfb21b-71c1-4ef8-a6f9-235978e6e63e" />




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=bioauth-to-privaccy&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=bioauth-to-privaccy&lookback=7)