### PR TITLE
feat(suite-native): display discovery interrupted warning

### DIFF
--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -34,7 +34,7 @@ This file is for selectors that reach into more than one wallet-core reduce
 to prevent circular dependencies between reducers
 */
 
-type CompoundRootState = AccountsRootState &
+export type CompoundRootState = AccountsRootState &
     DeviceRootState &
     DiscoveryRootState &
     WalletSettingsRootState;

--- a/suite-native/assets/src/components/Assets.tsx
+++ b/suite-native/assets/src/components/Assets.tsx
@@ -17,6 +17,7 @@ import {
     TabToStackCompositeNavigationProp,
 } from '@suite-native/navigation';
 
+import { RediscoveryNeededWarning } from './RediscoveryNeededWarning';
 import { selectDeviceNetworksWithAssets } from '../assetsSelectors';
 import { AssetItem } from './AssetItem';
 import { DiscoveryAssetsLoader } from './DiscoveryAssetsLoader';
@@ -64,6 +65,7 @@ export const Assets = () => {
     return (
         <>
             <AnimatedCard noPadding layout={LinearTransition}>
+                <RediscoveryNeededWarning hasPadding />
                 {deviceNetworks.map(symbol => (
                     <Animated.View
                         entering={isLoading ? FadeInDown : undefined}

--- a/suite-native/assets/src/components/RediscoveryNeededWarning.tsx
+++ b/suite-native/assets/src/components/RediscoveryNeededWarning.tsx
@@ -1,0 +1,37 @@
+import Animated from 'react-native-reanimated';
+import { useSelector } from 'react-redux';
+
+import {
+    CompoundRootState,
+    selectSelectedDevice,
+    selectShouldRediscover,
+} from '@suite-common/wallet-core';
+import { Box, InlineAlertBox } from '@suite-native/atoms';
+import { DeviceItemIcon } from '@suite-native/device';
+import { Translation } from '@suite-native/intl';
+
+type RediscoveryNeededWarningProps = {
+    hasPadding?: boolean;
+};
+
+export const RediscoveryNeededWarning = ({ hasPadding = false }: RediscoveryNeededWarningProps) => {
+    const device = useSelector(selectSelectedDevice);
+
+    const shouldRediscover = useSelector((state: CompoundRootState) =>
+        selectShouldRediscover(state, device),
+    );
+
+    if (!shouldRediscover) return null;
+
+    return (
+        <Animated.View>
+            <Box padding={hasPadding ? 'sp8' : undefined}>
+                <InlineAlertBox
+                    title={<Translation id="assets.rediscoveryNeeded" />}
+                    variant="warning"
+                    customIcon={<DeviceItemIcon deviceId={device?.id} iconSize="mediumLarge" />}
+                />
+            </Box>
+        </Animated.View>
+    );
+};

--- a/suite-native/assets/src/index.ts
+++ b/suite-native/assets/src/index.ts
@@ -1,1 +1,2 @@
 export * from './components/Assets';
+export * from './components/RediscoveryNeededWarning';

--- a/suite-native/atoms/src/InlineAlertBox/InlineAlertBox.tsx
+++ b/suite-native/atoms/src/InlineAlertBox/InlineAlertBox.tsx
@@ -38,6 +38,7 @@ export type InlineAlertBoxProps = Omit<BoxProps, 'style'> & {
     buttonLabel?: ReactNode;
     onButtonPress?: () => void;
     iconName?: IconName;
+    customIcon?: ReactNode;
     buttonProps?: Partial<ButtonProps>;
 };
 
@@ -47,6 +48,7 @@ export const InlineAlertBox = ({
     onButtonPress,
     iconName,
     buttonProps,
+    customIcon,
     variant = 'neutral',
     ...props
 }: InlineAlertBoxProps) => {
@@ -62,7 +64,11 @@ export const InlineAlertBox = ({
             })}
             {...props}
         >
-            <Icon name={iconName || variantToIconName[variant]} size="mediumLarge" />
+            {customIcon ? (
+                customIcon
+            ) : (
+                <Icon name={iconName || variantToIconName[variant]} size="mediumLarge" />
+            )}
             <Text variant="hint" style={applyStyle(textStyle)}>
                 {title}
             </Text>

--- a/suite-native/device-manager/src/components/BootloaderModeItemContent.tsx
+++ b/suite-native/device-manager/src/components/BootloaderModeItemContent.tsx
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Box, HStack, Text } from '@suite-native/atoms';
+import { DeviceItemIcon } from '@suite-native/device';
 import { useNativeStyles } from '@trezor/styles';
 
 import { DeviceConnectionStatus } from './DeviceItem/DeviceConnectionStatus';
@@ -10,7 +11,6 @@ import {
     contentWrapperStyle,
     itemStyle,
 } from './DeviceItem/DeviceItemContent';
-import { DeviceItemIcon } from './DeviceItem/DeviceItemIcon';
 import { headerStyle } from './DeviceItem/SimpleDeviceItemContent';
 
 export const BootloaderModeItemContent = () => {

--- a/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
@@ -12,13 +12,12 @@ import {
     selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { ACCESSIBILITY_FONTSIZE_MULTIPLIER, Box, HStack } from '@suite-native/atoms';
-import { selectShouldFactoryResetBeVisible } from '@suite-native/device';
+import { DeviceItemIcon, selectShouldFactoryResetBeVisible } from '@suite-native/device';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { WalletLabel } from '@suite-native/labeling';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { NativeTypographyStyle } from '@trezor/theme';
 
-import { DeviceItemIcon } from './DeviceItemIcon';
 import { SimpleDeviceItemContent } from './SimpleDeviceItemContent';
 import { WalletDetailDeviceItemContent } from './WalletDetailDeviceItemContent';
 

--- a/suite-native/device/src/components/DeviceItemIcon.tsx
+++ b/suite-native/device/src/components/DeviceItemIcon.tsx
@@ -6,25 +6,26 @@ import {
     PORTFOLIO_TRACKER_DEVICE_ID,
     selectDeviceModelById,
 } from '@suite-common/wallet-core';
-import { DeviceModelIcon, Icon } from '@suite-native/icons';
+import { DeviceModelIcon, Icon, IconSize } from '@suite-native/icons';
 
 type DeviceItemIconProps = {
     deviceId: TrezorDevice['id'];
+    iconSize?: IconSize | number;
 };
 
 const ICON_SIZE = 28;
 
-export const DeviceItemIcon = ({ deviceId }: DeviceItemIconProps) => {
+export const DeviceItemIcon = ({ deviceId, iconSize = ICON_SIZE }: DeviceItemIconProps) => {
     const deviceModel = useSelector((state: DeviceRootState) =>
         selectDeviceModelById(state, deviceId),
     );
 
     if (deviceId === PORTFOLIO_TRACKER_DEVICE_ID) {
-        return <Icon name="database" color="iconDefault" size={ICON_SIZE} />;
+        return <Icon name="database" color="iconDefault" size={iconSize} />;
     }
     if (deviceModel !== null) {
-        return <DeviceModelIcon deviceModel={deviceModel} size={ICON_SIZE} />;
+        return <DeviceModelIcon deviceModel={deviceModel} size={iconSize} />;
     }
 
-    return <Icon name="trezorLogo" color="iconDefault" size={ICON_SIZE} />;
+    return <Icon name="trezorLogo" color="iconDefault" size={iconSize} />;
 };

--- a/suite-native/device/src/index.ts
+++ b/suite-native/device/src/index.ts
@@ -13,6 +13,7 @@ export * from './components/ConnectDeviceAnimation';
 export * from './components/ConfirmOnTrezorImage';
 export * from './components/ConnectorImage';
 export * from './components/DeviceImage';
+export * from './components/DeviceItemIcon';
 export * from './components/BootloaderModeScreen';
 export * from './components/ContinueOnTrezorScreenContent';
 export * from './components/ConnectAndUnlockDeviceScreenContent';

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -27,6 +27,7 @@ const isActionDeviceRelated = (action: AnyAction): boolean => {
             deviceActions.removeButtonRequests,
             deviceActions.rememberDevice,
             deviceActions.forgetDevice,
+            deviceActions.setDiscovered,
         )(action)
     ) {
         return true;

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -151,6 +151,7 @@ export const messages = {
         stakingDisabled: 'Staking is not available in this context.',
     },
     assets: {
+        rediscoveryNeeded: 'Reconnect your trezor to load all assets.',
         dashboard: {
             discoveryProgress: {
                 loading: 'Loading...',

--- a/suite-native/module-accounts-management/src/screens/AccountsScreen/AccountsScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountsScreen/AccountsScreen.tsx
@@ -7,6 +7,7 @@ import {
     OnSelectAccount,
     SearchableAccountsListHeader,
 } from '@suite-native/accounts';
+import { RediscoveryNeededWarning } from '@suite-native/assets';
 import { DeviceManagerScreenHeader } from '@suite-native/device-manager';
 import { Translation } from '@suite-native/intl';
 import {
@@ -48,6 +49,7 @@ export const AccountsScreen = () => {
                 onSearchInputChange={handleFilterChange}
                 flowType="accounts"
             />
+            <RediscoveryNeededWarning />
             <AccountsList
                 onSelectAccount={handleSelectAccount}
                 filterValue={accountsFilterValue}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/rediscover-banner-message&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/rediscover-banner-message&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/rediscover-banner-message&lookback=7)