### PR TITLE
chore(suite): add active experiment variants to suite-ready analytics event

### DIFF
--- a/packages/suite/src/utils/suite/analytics.ts
+++ b/packages/suite/src/utils/suite/analytics.ts
@@ -1,3 +1,4 @@
+import { selectActiveExperimentsWithVariants } from '@suite-common/message-system';
 import { UNIT_ABBREVIATIONS } from '@suite-common/suite-constants';
 import {
     selectRememberedHiddenWalletsCount,
@@ -39,6 +40,7 @@ export const redactRouterUrl = (url: string) => url.replace(/coinjoin/g, 'taproo
 export const getSuiteReadyPayload = async (
     state: AppState,
 ): Promise<SuiteAnalyticsEventSuiteReady['payload']> => {
+    const experimentVariants = selectActiveExperimentsWithVariants(state);
     const [osVersion, osCpuArch] = await Promise.all([getOsVersion(), getCpuArch()]);
 
     return {
@@ -78,6 +80,8 @@ export const getSuiteReadyPayload = async (
         autodetectTheme: state.suite.settings.autodetect.theme,
 
         isAutomaticUpdateEnabled: state.desktopUpdate.isAutomaticUpdateEnabled,
+
+        experimentVariants: experimentVariants.map(({ name, variant }) => `${name}:${variant}`),
     };
 };
 

--- a/suite-common/analytics/src/events/suite/types.ts
+++ b/suite-common/analytics/src/events/suite/types.ts
@@ -36,6 +36,7 @@ export type SuiteAnalyticsEventSuiteReady = {
         desktopOsName?: string;
         desktopOsArchitecture?: string;
         isAutomaticUpdateEnabled: boolean;
+        experimentVariants: string[];
     };
 };
 

--- a/suite-common/message-system/src/__tests__/experimentUtils.test.ts
+++ b/suite-common/message-system/src/__tests__/experimentUtils.test.ts
@@ -2,9 +2,9 @@ import { getWeakRandomId } from '@trezor/utils';
 
 import { experimentTest, getArrayOfInstanceIds } from '../__fixtures__/experimentUtils';
 import {
+    getActiveExperimentGroup,
     getExperimentGroupByInclusion,
     getInclusionFromInstanceId,
-    selectActiveExperimentGroup,
 } from '../experimentUtils';
 import { ExperimentId } from '../messageSystemTypes';
 
@@ -48,7 +48,7 @@ describe('testing experiment utils', () => {
         );
     };
 
-    it('test selectActiveExperimentGroup share of variant inclusion', () => {
+    it('test getActiveExperimentGroup share of variant inclusion', () => {
         const sampleSize = 1000;
         let groupACount = 0;
         let groupBCount = 0;
@@ -65,7 +65,7 @@ describe('testing experiment utils', () => {
         const arrayOfIds = [...arrayOfIdsAGroup, ...arrayOfIdsBGroup];
 
         arrayOfIds.forEach(id => {
-            const selectedGroup = selectActiveExperimentGroup({
+            const selectedGroup = getActiveExperimentGroup({
                 experiment: experimentTest,
                 instanceId: id,
             });

--- a/suite-common/message-system/src/experimentUtils.ts
+++ b/suite-common/message-system/src/experimentUtils.ts
@@ -1,6 +1,6 @@
 import { getIntegerInRangeFromString } from '@trezor/utils';
 
-import { ExperimentId, ExperimentsItemType } from './messageSystemTypes';
+import { Experiment, ExperimentId, ExperimentKey, ExperimentsItemType } from './messageSystemTypes';
 
 type ExperimentCategoriesProps = {
     experiment: ExperimentsItemType | undefined;
@@ -46,7 +46,7 @@ export const getExperimentGroupByInclusion = ({
     )?.group;
 };
 
-export const selectActiveExperimentGroup = ({
+export const getActiveExperimentGroup = ({
     experiment,
     instanceId,
 }: ExperimentCategoriesProps): ExperimentsGroupType | undefined => {
@@ -61,4 +61,10 @@ export const selectActiveExperimentGroup = ({
     });
 
     return experimentRange;
+};
+
+export const getExperimentNameById = (id: ExperimentId) => {
+    if (!id) return null;
+
+    return (Object.keys(Experiment) as ExperimentKey[]).find(key => Experiment[key] === id);
 };

--- a/suite-common/message-system/src/messageSystemSelectors.ts
+++ b/suite-common/message-system/src/messageSystemSelectors.ts
@@ -1,15 +1,20 @@
-import { ExperimentId, resolveMessageContent } from '@suite-common/message-system';
+import { createSelector } from '@reduxjs/toolkit';
+
+import { selectAnalyticsInstanceId } from '@suite-common/analytics';
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { Category, Message } from '@suite-common/suite-types';
 
+import { getActiveExperimentGroup, getExperimentNameById } from './experimentUtils';
 import {
     ContextDomain,
     Experiment,
+    ExperimentId,
     ExperimentKey,
     ExperimentsItemType,
     FeatureDomain,
     MessageSystemRootState,
 } from './messageSystemTypes';
+import { resolveMessageContent } from './messageSystemUtils';
 
 // Create app-specific selectors with correct types
 export const createMemoizedSelector = createWeakMapSelector.withTypes<MessageSystemRootState>();
@@ -186,3 +191,23 @@ export const selectExperimentByKey = (key: ExperimentKey) =>
             (experiment): experiment is ExperimentsItemType => experiment.id === Experiment[key],
         ),
     );
+
+export const selectActiveExperimentsWithVariants = createSelector(
+    [selectAnalyticsInstanceId, selectAllValidExperiments],
+    (instanceId, experiments) =>
+        returnStableArrayIfEmpty(
+            experiments.flatMap(experiment => {
+                const id = experiment.id as ExperimentId;
+                const name = getExperimentNameById(id);
+                const activeGroup = getActiveExperimentGroup({
+                    instanceId,
+                    experiment: {
+                        ...experiment,
+                        id,
+                    },
+                });
+
+                return activeGroup ? [{ name, variant: activeGroup.variant }] : [];
+            }),
+        ),
+);

--- a/suite-common/message-system/src/useExperiment.ts
+++ b/suite-common/message-system/src/useExperiment.ts
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { selectAnalyticsInstanceId } from '@suite-common/analytics';
 
-import { selectActiveExperimentGroup } from './experimentUtils';
+import { getActiveExperimentGroup } from './experimentUtils';
 import { selectExperimentByKey } from './messageSystemSelectors';
 import { ExperimentKey } from './messageSystemTypes';
 
@@ -11,7 +11,7 @@ export const useExperiment = (experimentKey: ExperimentKey) => {
     const instanceId = useSelector(selectAnalyticsInstanceId);
     const experiment = useSelector(selectExperimentByKey(experimentKey));
     const activeExperimentVariant = useMemo(
-        () => selectActiveExperimentGroup({ instanceId, experiment }),
+        () => getActiveExperimentGroup({ instanceId, experiment }),
         [instanceId, experiment],
     );
 


### PR DESCRIPTION
## Description

This PR adds active experiment groups to the `suite-ready` analytics event payload.

`experimentVariants` are constructed by joining the experiment name and its active group variant together: `${experimentName}:${activeVariant}`.

Additionally, I renamed `selectActiveExperimentGroup` to `getActiveExperimentGroup`. Previous name was confusing as it is just an util function, not a selector.
## Related Issue

Resolve #20947

## Screenshots:
Query params being sent, now including `experimentVariants` at the end:
<img width="599" height="894" alt="image" src="https://github.com/user-attachments/assets/d26129d8-e4a9-4da1-a929-a3efb192229f" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/experiment-group-in-suite-ready-event&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/experiment-group-in-suite-ready-event&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/experiment-group-in-suite-ready-event&lookback=7)