### PR TITLE
fix(suite-desktop-core): getComputerName fallback

### DIFF
--- a/packages/suite-desktop-core/src/libs/info.ts
+++ b/packages/suite-desktop-core/src/libs/info.ts
@@ -3,7 +3,7 @@ import { app } from 'electron';
 import os from 'os';
 
 import { isDevEnv } from '@suite-common/suite-utils';
-import { bytesToHumanReadable } from '@trezor/utils';
+import { bytesToHumanReadable, capitalizeFirstLetter } from '@trezor/utils';
 
 import { b2t } from './utils';
 
@@ -53,18 +53,23 @@ export const getComputerInfo = () => {
 };
 
 export const getComputerName = () => {
-    let name;
-    switch (process.platform) {
-        case 'win32':
-            name = process.env.COMPUTERNAME;
-            break;
-        case 'darwin':
-            name = execSync('scutil --get ComputerName').toString().trim();
-            break;
-        case 'linux':
-            name = execSync('hostnamectl --pretty').toString().trim();
-            break;
-    }
+    try {
+        let name;
+        switch (process.platform) {
+            case 'win32':
+                name = process.env.COMPUTERNAME;
+                break;
+            case 'darwin':
+                name = execSync('scutil --get ComputerName').toString().trim();
+                break;
+            case 'linux':
+                name = execSync('hostnamectl --pretty').toString().trim();
+                break;
+        }
 
-    return name || os.hostname();
+        return name || os.hostname();
+    } catch {
+        // Fallback - executed binaries might not be available
+        return os.hostname() || capitalizeFirstLetter(process.platform);
+    }
 };


### PR DESCRIPTION
## Description

@Ondra-Zik-SL found that `hostnamectl` called from `getComputerName` might not be available on all Linux distros. 
We need to catch the error and provide a fallback. 


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/getcomputername-fallback&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/getcomputername-fallback&lookback=7)