### PR TITLE
fix(suite): handle some missing onboarding prerequisites

### DIFF
--- a/packages/suite/src/config/onboarding/steps.ts
+++ b/packages/suite/src/config/onboarding/steps.ts
@@ -8,6 +8,8 @@ const commonPrerequisites: Step['prerequisites'] = [
     'device-bootloader',
     'device-seedless',
     'device-unacquired',
+    'device-unacquired-requires-thp',
+    'device-used-elsewhere',
     'device-unknown',
     'device-unreadable',
     'device-disconnected',


### PR DESCRIPTION
## Description

Two random fixes: missing prerequisites that are currently suppressed in onboarding, instead let `UnexpectedState` handle them by rendereing the respective troubleshooting component.
 - THP pairing needed (unacquired)
   - this is especially severe: I observed a few times that the onboarding is stuck at blank screen because of [conditions such as this one](https://github.com/trezor/trezor-suite/blob/d2e036284e9cbc1c8ae4994346a177665b673f74/packages/suite/src/views/onboarding/steps/ResetDevice.tsx#L106-L107)
- device used elsewhere
  - ~idk how to get this error in onboarding, maybe not possible but why not?~
  - :warning:  **EDIT:** The prerequisite itself is broken, it does not occur when it should. So while this PR is correct step, it will only be effective when the prerequiste `'device-used-elsewhere'` is fixed 

## QA instructions

N/A, because THP is still WIP and `'device-used-elsewhere'` is not effectie yet. 

## Screenshots:

Simulated code, that's why the buttons don't do anything...

THP

[THP pairing in onboarding.webm](https://github.com/user-attachments/assets/4c353a55-0661-47a5-86a5-afefa23c00ee)


used elsehwer

[Elsewhere in onboarding.webm](https://github.com/user-attachments/assets/3b69c090-05d7-4876-96ab-144b0f2109b8)


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/missing-onboarding-prereqs&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/missing-onboarding-prereqs&lookback=7)