### PR TITLE
ci(suite-native): fix e2e fail notification

### DIFF
--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Set failure flag for Slack webhook
         id: aggregate-result
         if: ${{ failure() && github.event_name == 'schedule' }}
-        run: echo "is_failure=true" >> $GITHUB_ENV
+        run: echo "is_failure=true" >> $GITHUB_OUTPUT
 
   notify_scheduled_failure_to_slack:
     if: ${{ needs.run_android_e2e_tests.outputs.is_failure == 'true' }}


### PR DESCRIPTION
The notification is not working, there is output of the job incorrectly set. Fixed by following: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/pass-job-outputs.



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ci/native/fix-e2e-fail-notification&lookback=7)