### PR TITLE
Fix: reset device edge cases

### DIFF
--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -8,7 +8,7 @@ import TrezorConnect, { ERRORS } from '@trezor/connect';
 import * as modalActions from 'src/actions/suite/modalActions';
 import * as DEVICE from 'src/constants/suite/device';
 import { selectIsEntropyCheckEnabled } from 'src/selectors/suite/suiteSelectors';
-import { Dispatch, GetState } from 'src/types/suite';
+import { AcquiredDevice, Dispatch, GetState } from 'src/types/suite';
 
 export const applySettings =
     (params: Parameters<typeof TrezorConnect.applySettings>[0]) =>
@@ -89,50 +89,21 @@ export const changeWipeCode =
         }
     };
 
+export type ResetDeviceParams = Parameters<typeof TrezorConnect.resetDevice>[0];
+
+type ResetDeviceProps = {
+    params: ResetDeviceParams;
+    device: AcquiredDevice;
+};
+
 export const resetDevice =
-    (params: Parameters<typeof TrezorConnect.resetDevice>[0] = {}) =>
+    ({ params, device }: ResetDeviceProps) =>
     async (dispatch: Dispatch, getState: GetState) => {
-        const device = selectSelectedDevice(getState());
         const isEntropyCheckEnabled = selectIsEntropyCheckEnabled(getState());
         const isEntropyCheckDisabledByMessageSystem = selectIsFeatureDisabled(
             getState(),
             Feature.entropyCheck,
         );
-
-        // todo: this should be handled most likely in a component somewhere above
-        if (device?.status === 'used' || device?.status === 'occupied') {
-            const features = await TrezorConnect.getFeatures({ device: { path: device.path } });
-            if (!features.success) {
-                dispatch(
-                    notificationsActions.addToast({
-                        type: 'error',
-                        error: 'Device is unreadable',
-                    }),
-                );
-
-                return;
-            }
-            if (features.payload.initialized) {
-                // todo: decide what should happen next UX wise. At the moment, user only gets an error toast
-                // and stays stuck on the 'create new wallet' screen;
-                dispatch(
-                    notificationsActions.addToast({
-                        type: 'error',
-                        error: 'This device has already been initialized',
-                    }),
-                );
-
-                return;
-            }
-        }
-
-        if (!device || !device.features) return;
-
-        if (device.mode !== 'initialize') {
-            console.error('resetDevice: device in invalid mode', device.mode);
-
-            return;
-        }
 
         const defaults = {
             strength: DEVICE.DEFAULT_STRENGTH[device.features.internal_model],
@@ -155,6 +126,57 @@ export const resetDevice =
         }
 
         return result;
+    };
+
+type ResetDeviceOrSkipProps = {
+    params: ResetDeviceParams;
+};
+
+export const resetDeviceOrSkip =
+    ({ params }: ResetDeviceOrSkipProps) =>
+    async (dispatch: Dispatch, getState: GetState) => {
+        const device = selectSelectedDevice(getState());
+
+        if (device?.status === 'used' || device?.status === 'occupied') {
+            const response = await TrezorConnect.getFeatures({ device: { path: device.path } });
+            if (!response.success) {
+                dispatch(
+                    notificationsActions.addToast({ type: 'error', error: 'Device is unreadable' }),
+                );
+
+                return;
+            }
+            if (response.payload.initialized) {
+                // Note that user gets stuck on this page. It's a rare edge case; a solution would have its own drawbacks.
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'error',
+                        error: 'This device has already been initialized',
+                    }),
+                );
+
+                return;
+            }
+        }
+
+        // This should never occurr because it is handled by prerequisites:
+        // Onboarding renders the proper UI instead of rendering ResetDevice UI
+        if (!device || !device.features) return;
+
+        if (device.mode !== 'initialize') {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'error',
+                    error: 'Device is not in initialization mode.',
+                }),
+            );
+            // Unlike previous cases, this cannot happen by a user action, so let's log it.
+            console.error('resetDevice: device in invalid mode', device.mode);
+
+            return;
+        }
+
+        return dispatch(resetDevice({ params, device }));
     };
 
 export const changeLanguage = createThunk(

--- a/packages/suite/src/views/onboarding/steps/ResetDevice.tsx
+++ b/packages/suite/src/views/onboarding/steps/ResetDevice.tsx
@@ -7,7 +7,7 @@ import { selectDeviceDefaultBackupType, selectSelectedDevice } from '@suite-comm
 import { Button, Divider, Text, Tooltip } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { resetDevice } from 'src/actions/settings/deviceSettingsActions';
+import { ResetDeviceParams, resetDeviceOrSkip } from 'src/actions/settings/deviceSettingsActions';
 import { OnboardingButtonBack, OnboardingStepBox, OptionsWrapper } from 'src/components/onboarding';
 import { Translation } from 'src/components/suite';
 import * as STEP from 'src/constants/onboarding/steps';
@@ -53,10 +53,10 @@ export const ResetDeviceStep = () => {
     const isDeviceLocked = isLocked();
 
     const onResetDevice = useCallback(
-        async (params?: Parameters<typeof resetDevice>[0]) => {
+        async (params: ResetDeviceParams) => {
             setSubmitted(false);
 
-            const result = await dispatch(resetDevice(params));
+            const result = await dispatch(resetDeviceOrSkip({ params }));
 
             setSubmitted(true);
 

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -527,6 +527,7 @@ export const failEntropyCheckThunk = createThunk(
             'A transfer error has occurred',
             // This one was not in Sentry but can be triggered by manually disconnecting the device. Investigate. https://github.com/trezor/trezor-suite-private/issues/135
             'device disconnected during action',
+            'Device is used in another window',
         ];
         if (!temporarilySkippedErrorsToBeInvestigated.includes(error.error)) {
             dispatch(deviceActions.setEntropyCheckFail(device.id));


### PR DESCRIPTION
## Description

- ignore entropy check failure case `'Device is used in another window'`
  - that can only come from transport AFAIK
- cleanup interface of resetDevice, split into two thunks, proper notifications, commentary 

## QA instructions

Try going through device onboarding with two sessions at once: see the situations described in Screenshots.
If you find a new situation that's not handled well please create a new issue :pray: 

## Screenshots:

Case A:
- In session "left", go through onboarding up to creating a wallet but don't do it.
- In session "right", create a wallet.
 - Now try to continue with creating wallet in session "left":
- [Before and after](https://github.com/user-attachments/assets/46c27e56-4e5a-48c7-88fa-b7f59e3101ab) (unchanged behavior)

Case B:

- In session "left", start creating a wallet but don't confirm in device.
- In session "right", start creating a wallet (cannot, device is occupied).
- In session "left", the creation of wallet has failed, but entropy check has not failed!
- **Before**: [entropy check fail](https://github.com/user-attachments/assets/27e88d26-029f-4148-94e3-cf37276897a3) when interrupting resetDevice on-device confirmation with another request
- **After**: [no entropy check fail](https://github.com/user-attachments/assets/a317de37-3348-4587-be79-e180d3d2c573).


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/resetDevice-edge-cases&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/resetDevice-edge-cases&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/resetDevice-edge-cases&lookback=7)