### PR TITLE
fix(connect): thpCall error handling

### DIFF
--- a/packages/connect/src/constants/errors.ts
+++ b/packages/connect/src/constants/errors.ts
@@ -1,3 +1,6 @@
+import { Messages } from '@trezor/protobuf';
+import { thp } from '@trezor/protocol';
+
 export const ERROR_CODES = {
     Init_NotInitialized: 'TrezorConnect not initialized', // race condition: call on not initialized Core (usually hot-reloading)
     Init_AlreadyInitialized: 'TrezorConnect has been already initialized', // thrown by .init called multiple times
@@ -48,21 +51,15 @@ export const ERROR_CODES = {
     Device_ThpStateMissing: 'ThpState missing', // thrown by thp related actions
     Device_ThpPairingMethodsException: 'No common pairing methods', // device doesn't support requested pairing method(s)
 
-    Failure_ActionCancelled: 'Action canceled by user',
-    Failure_FirmwareError: 'Firmware installation failed',
-    Failure_Busy: 'Device busy',
     Failure_UnknownCode: 'Unknown error',
-    Failure_PinCancelled: 'PIN canceled',
-    Failure_PinInvalid: 'PIN invalid',
-    Failure_PinMismatch: 'PIN mismatch',
-    Failure_WipeCodeMismatch: 'Wipe code mismatch',
-    Failure_ProcessError: 'Process failed',
     Failure_EntropyCheck: '', // message from verifyEntropy process
 
     Deeplink_VersionMismatch: 'Not compatible with current version of the app',
 } as const;
 
-export type ErrorCode = keyof typeof ERROR_CODES;
+type TypedErrorCode = keyof typeof ERROR_CODES;
+
+export type ErrorCode = TypedErrorCode | Messages.FailureType | thp.ThpError['code'];
 
 export class TrezorError extends Error {
     code: ErrorCode;
@@ -89,7 +86,7 @@ export const nestError = (cause: Error) =>
 export class TransportError extends Error {}
 
 export const TypedError = (id: ErrorCode, message?: string) =>
-    new TrezorError(id, message || ERROR_CODES[id]);
+    new TrezorError(id, message || ERROR_CODES[id as TypedErrorCode] || id);
 
 // serialize Error/TypeError object into payload error type (Error object/class is converted to string while sent via postMessage)
 export const serializeError = (payload: any) => {

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -242,9 +242,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
                         'Failure_UnknownMessage';
 
                     // pass code and message from firmware error
-                    return error(
-                        new ERRORS.TrezorError((code as any) || 'Failure_UnknownCode', err),
-                    );
+                    return error(new ERRORS.TrezorError(code || 'Failure_UnknownCode', err));
                 }
                 case 'ButtonRequest': {
                     if (res.message.code === 'ButtonRequest_PassphraseEntry') {

--- a/packages/connect/src/device/thp/thpCall.ts
+++ b/packages/connect/src/device/thp/thpCall.ts
@@ -1,6 +1,6 @@
 import { thp as protocolThp } from '@trezor/protocol';
 
-import { ERRORS } from '../../constants';
+import { TypedError } from '../../constants/errors';
 import { DEVICE } from '../../events';
 import type { Device } from '../Device';
 
@@ -53,12 +53,12 @@ export const thpCall = async <T extends MessageKey>(
 ): Promise<ThpCallResponse[T]> => {
     const thpState = device.getThpState();
     if (!thpState) {
-        throw ERRORS.TypedError('Device_ThpStateMissing');
+        throw TypedError('Device_ThpStateMissing');
     }
 
     const result = await device.getCurrentSession().call(name, data);
     if (!result.success) {
-        throw ERRORS.serializeError({ code: result.error, message: result.error.message });
+        throw result.error;
     }
 
     thpState.setCancelablePromise(false);
@@ -76,11 +76,13 @@ export const thpCall = async <T extends MessageKey>(
     }
 
     if (result.payload.type === 'Failure') {
-        throw ERRORS.serializeError(result.payload.message);
+        const { code, message } = result.payload.message;
+        throw TypedError(code || 'Failure_UnknownCode', message);
     }
 
     if (result.payload.type === 'ThpError') {
-        throw ERRORS.serializeError(result.payload.message);
+        const { code, message } = result.payload.message;
+        throw TypedError(code, message);
     }
 
     return result.payload as ThpCallResponse[T];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix:  https://github.com/trezor/trezor-suite/issues/20954

thpCall is throwing an object instead of Error

additionally remove partial changes of https://github.com/trezor/trezor-suite/commit/57815188d16e0ef8d438cecb1a264afb85fea815

TypedError/TrezorError code should be either defined in `ERROR_CODES` **or** protobuf `FailureType` (partially was added/duplicated manually) **or** protocol `ThpError.code`



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/thpcall-errors&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thpcall-errors&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thpcall-errors&lookback=7)