### PR TITLE
fix(suite): send analytics from AddAccountButton instead of common utils

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { Network, NetworkAccount } from '@suite-common/wallet-config';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { UnavailableCapability } from '@trezor/connect';
+import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { Translation } from 'src/components/suite';
 import { useAccountSearch, useSelector } from 'src/hooks/suite';
@@ -81,6 +82,15 @@ const AddDefaultAccountButton = ({
                 // if coinFilter is active then reset it only if added account doesn't belong to selected/filtered coin
                 setCoinFilter(undefined);
             }
+
+            analytics.report({
+                type: EventType.AccountsNewAccount,
+                payload: {
+                    type: defaultAccount.accountType,
+                    path: defaultAccount.path,
+                    symbol: defaultAccount.symbol,
+                },
+            });
         } else {
             onAddNewAccount();
         }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -240,6 +240,7 @@ export const AddAccountModal = ({
                     accountTypes,
                     deviceState: device.state?.staticSessionId,
                 });
+
                 if (newAccount instanceof Error) {
                     dispatch(
                         notificationsActions.addToast({

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -40,7 +40,6 @@ import TrezorConnect, {
     TokenInfo,
     TokenTransfer,
 } from '@trezor/connect';
-import { EventType, analytics } from '@trezor/suite-analytics';
 import { exhaustive } from '@trezor/type-utils';
 import { HELP_CENTER_ADDRESSES_URL, HELP_CENTER_TAPROOT_URL } from '@trezor/urls';
 import { arrayDistinct, bufferUtils } from '@trezor/utils';
@@ -1264,16 +1263,6 @@ export const prepareNewAccountPayload = async ({
     });
 
     if (!res.success) return new Error(res.payload.error);
-
-    // just to log that account was added manually.
-    analytics.report({
-        type: EventType.AccountsNewAccount,
-        payload: {
-            type: accountType,
-            path: newPath,
-            symbol: networkSymbol,
-        },
-    });
 
     return {
         accountInfo: res.payload,


### PR DESCRIPTION
## Description

Removed desktop-only analytics import from `suite-common` (`accountUtils`), which caused issues in mobile.
Analytics event is now sent directly from `AddAccountButton`.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15417

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/analytics-addAccountModal&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/analytics-addAccountModal&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/analytics-addAccountModal&lookback=7)