### PR TITLE
fix(suite-native): fix useHandleHardwareBackNavigation

### DIFF
--- a/suite-native/navigation/src/useHandleHardwareBackNavigation.ts
+++ b/suite-native/navigation/src/useHandleHardwareBackNavigation.ts
@@ -1,15 +1,19 @@
-import { useEffect } from 'react';
+import { useCallback } from 'react';
 import { BackHandler } from 'react-native';
 
+import { useFocusEffect } from '@react-navigation/native';
+
 export const useHandleHardwareBackNavigation = (onPress?: () => void) => {
-    useEffect(() => {
-        // do nothing unless onPress has some custom handling
-        const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
-            onPress?.();
+    useFocusEffect(
+        useCallback(() => {
+            // do nothing unless onPress has some custom handling
+            const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+                onPress?.();
 
-            return true;
-        });
+                return true;
+            });
 
-        return () => subscription.remove();
-    }, [onPress]);
+            return () => subscription.remove();
+        }, [onPress]),
+    );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- `useHandleHardwareBackNavigation` remains active after first mount and it keeps being used accross multiple screens. It's unwanted behavior and it should only remain active on the screen it was mounted on.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/hardware-back-handler-tweak&lookback=7)