### PR TITLE
fix(suite): Reuse max-width container for welcome screen content

### DIFF
--- a/packages/suite/src/components/suite/layouts/ContentContainer.tsx
+++ b/packages/suite/src/components/suite/layouts/ContentContainer.tsx
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+import { variables } from '@trezor/components';
+import { spacingsPx } from '@trezor/theme';
+
+import { HORIZONTAL_LAYOUT_PADDINGS, MAX_CONTENT_WIDTH } from '../../../constants/suite/layout';
+
+export const ContentContainer = styled.div`
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    width: 100%;
+    max-width: ${MAX_CONTENT_WIDTH};
+    padding: ${spacingsPx.xxl} ${HORIZONTAL_LAYOUT_PADDINGS} 134px ${HORIZONTAL_LAYOUT_PADDINGS};
+
+    ${variables.SCREEN_QUERY.MOBILE} {
+        padding-bottom: 90px;
+    }
+`;

--- a/packages/suite/src/components/suite/layouts/LoggedOutLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/LoggedOutLayout.tsx
@@ -9,17 +9,11 @@ import { useResetScrollOnUrl } from 'src/hooks/suite/useResetScrollOnUrl';
 import { LayoutContext, LayoutContextPayload } from 'src/support/suite/LayoutContext';
 
 import { Metadata } from '../Metadata';
+import { ContentContainer } from './ContentContainer';
 import { LoggedOutSidebar } from './LoggedOutSidebar';
 import { SuiteBanners } from '../banners';
 import { DebugLegend } from './SuiteLayout/DebugLegend';
-import {
-    AppWrapper,
-    Body,
-    Columns,
-    ContentWrapper,
-    PageWrapper,
-    Wrapper,
-} from './SuiteLayout/SuiteLayout';
+import { AppWrapper, Body, Columns, PageWrapper, Wrapper } from './SuiteLayout/SuiteLayout';
 import { ModalSwitcher } from '../modals/ModalSwitcher/ModalSwitcher';
 
 interface LoggedOutLayout {
@@ -59,7 +53,7 @@ export const LoggedOutLayout = ({ children }: LoggedOutLayout) => {
                                         >
                                             {layoutHeader}
                                             <ElevationUp>
-                                                <ContentWrapper>{children}</ContentWrapper>
+                                                <ContentContainer>{children}</ContentContainer>
                                             </ElevationUp>
                                         </AppWrapper>
                                     </Column>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
@@ -4,14 +4,12 @@ import styled from 'styled-components';
 
 import { ElevationContext, ElevationDown, ElevationUp, Modal, variables } from '@trezor/components';
 import { useDebounce } from '@trezor/react-utils';
-import { spacingsPx } from '@trezor/theme';
 
 import { GuideButton, GuideRouter } from 'src/components/guide';
 import { Metadata } from 'src/components/suite';
 import { SuiteBanners } from 'src/components/suite/banners';
 import { DiscoveryProgress } from 'src/components/wallet';
 import { MobileAccountsMenu } from 'src/components/wallet/WalletLayout/AccountsMenu/MobileAccountsMenu';
-import { HORIZONTAL_LAYOUT_PADDINGS, MAX_CONTENT_WIDTH } from 'src/constants/suite/layout';
 import { useLayoutSize, useSelector } from 'src/hooks/suite';
 import { useClearAnchorHighlightOnClick } from 'src/hooks/suite/useClearAnchorHighlightOnClick';
 import { useResetScrollOnUrl } from 'src/hooks/suite/useResetScrollOnUrl';
@@ -26,6 +24,7 @@ import { MobileMenu } from './MobileMenu/MobileMenu';
 import { PassphraseFlow } from './PassphraseFlow';
 import { Sidebar } from './Sidebar/Sidebar';
 import { ModalSwitcher } from '../../modals/ModalSwitcher/ModalSwitcher';
+import { ContentContainer } from '../ContentContainer';
 
 export const ScrollContext = createContext<React.RefObject<HTMLDivElement | null>>({
     current: null,
@@ -75,20 +74,6 @@ export const AppWrapper = styled.div`
 
     ${variables.SCREEN_QUERY.BELOW_LAPTOP} {
         overflow-x: hidden;
-    }
-`;
-
-export const ContentWrapper = styled.div`
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    width: 100%;
-    max-width: ${MAX_CONTENT_WIDTH};
-    padding: ${spacingsPx.xxl} ${HORIZONTAL_LAYOUT_PADDINGS} 134px ${HORIZONTAL_LAYOUT_PADDINGS};
-
-    ${variables.SCREEN_QUERY.MOBILE} {
-        padding-bottom: 90px;
     }
 `;
 
@@ -187,7 +172,7 @@ export const SuiteLayout = ({ children }: SuiteLayoutProps) => {
                                                     )}
                                                     {layoutHeader}
 
-                                                    <ContentWrapper>{children}</ContentWrapper>
+                                                    <ContentContainer>{children}</ContentContainer>
                                                 </ElevationUp>
                                             </AppWrapper>
                                         </MainContent>

--- a/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayoutWithoutModalSwitcher.tsx
+++ b/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayoutWithoutModalSwitcher.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 import styled from 'styled-components';
 
 import {
+    Card,
     Column,
     Divider,
     ElevationDown,
@@ -12,7 +13,7 @@ import {
     useElevation,
     variables,
 } from '@trezor/components';
-import { Elevation, borders, spacingsPx } from '@trezor/theme';
+import { Elevation, spacingsPx } from '@trezor/theme';
 
 import { GuideButton, GuideRouter } from 'src/components/guide';
 // importing directly, otherwise unit tests fail, seems to be a styled-components issue
@@ -20,6 +21,7 @@ import { SuiteBanners } from 'src/components/suite/banners';
 import { useSelector } from 'src/hooks/suite';
 import { ResponsiveContextProvider } from 'src/support/suite/ResponsiveContext';
 
+import { ContentContainer } from '../ContentContainer';
 import { LoggedOutSidebar } from '../LoggedOutSidebar';
 import { DebugLegend } from '../SuiteLayout/DebugLegend';
 import { BasicName } from '../SuiteLayout/PageHeader/PageNames/BasicName';
@@ -49,19 +51,6 @@ const PureChildrenWrapper = styled.div`
     align-items: center;
     justify-content: center;
     width: 100%;
-`;
-
-const ChildrenWrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    gap: ${spacingsPx.md};
-    padding: ${spacingsPx.xxl};
-    border-radius: ${borders.radii.md};
-    border: ${borders.widths.small} solid ${({ theme }) => theme.borderElevation1};
-    background-color: ${({ theme }) => theme.backgroundSurfaceElevation1};
 `;
 
 const WelcomePageHeaderWrapper = styled.div`
@@ -105,9 +94,11 @@ const RightSideContent = ({ bannerSlot, showPureChildren, children }: RightConte
                     <BasicName nameId="TR_DASHBOARD" />
                     <Divider />
                 </WelcomePageHeaderWrapper>
-                <ChildrenWrapper>
-                    <ElevationUp>{children}</ElevationUp>
-                </ChildrenWrapper>
+                <ContentContainer>
+                    <ElevationUp>
+                        <Card>{children}</Card>
+                    </ElevationUp>
+                </ContentContainer>
             </Content>
         </ResponsiveContextProvider>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<img width="2393" height="805" alt="image" src="https://github.com/user-attachments/assets/7c72fe85-b5aa-479e-a27c-58f97bef0e93" />


## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=max-width-container&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=max-width-container&lookback=7)