### PR TITLE
feat: Local First Storage (Evolu) for desktop [5]

### DIFF
--- a/packages/suite-desktop-ui/src/MainDesktop.tsx
+++ b/packages/suite-desktop-ui/src/MainDesktop.tsx
@@ -43,6 +43,7 @@ import { TorLoadingScreen } from './support/screens/TorLoadingScreen';
 import { ResponsiveContextProvider } from 'src/support/suite/ResponsiveContext';
 import { BioAuthGuard } from '../../suite/src/components/suite/BioAuthGuard/BioAuthGuard';
 import { desktopComponents } from './support/desktopComponents';
+import { initSuiteLocalFirstStorageThunk } from '@trezor/suite-local-first-storage';
 
 const MainDesktop = () => {
     useTor();
@@ -149,6 +150,9 @@ export const init = async (container: HTMLElement) => {
 
     // init bluetooth module
     await store.dispatch(initBluetoothThunk());
+
+    // This needs to be initialized to subscribe to all Remembered Wallets
+    await store.dispatch(initSuiteLocalFirstStorageThunk());
 
     // finally render whole app
     root.render(

--- a/packages/suite-local-first-storage/package.json
+++ b/packages/suite-local-first-storage/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "@trezor/suite-local-first-storage",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@evolu/web": "^1.0.1-preview.5",
+        "@suite-common/local-first-storage": "workspace:*"
+    }
+}

--- a/packages/suite-local-first-storage/src/index.ts
+++ b/packages/suite-local-first-storage/src/index.ts
@@ -1,0 +1,5 @@
+import { evoluWebDeps } from '@evolu/web';
+
+import { initLocalFirstStorageThunkFactory } from '@suite-common/local-first-storage';
+
+export const initSuiteLocalFirstStorageThunk = initLocalFirstStorageThunkFactory(evoluWebDeps);

--- a/packages/suite-local-first-storage/tsconfig.json
+++ b/packages/suite-local-first-storage/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "./libDev",
+        "exactOptionalPropertyTypes": true
+    },
+    "include": [".", "**/*.json"],
+    "references": [
+        {
+            "path": "../../suite-common/local-first-storage"
+        }
+    ]
+}

--- a/packages/suite-web/src/MainWeb.tsx
+++ b/packages/suite-web/src/MainWeb.tsx
@@ -28,6 +28,7 @@ import { usePlaywright } from './support/usePlaywright';
 import { ResponsiveContextProvider } from 'src/support/suite/ResponsiveContext';
 import { Suspense } from 'react';
 import { webComponents } from './support/webComponents';
+import { initSuiteLocalFirstStorageThunk } from '@trezor/suite-local-first-storage';
 
 const MainWeb = () => {
     usePlaywright();
@@ -80,6 +81,9 @@ export const init = async (container: HTMLElement) => {
 
     const preloadAction = await preloadStore();
     const store = initStore(preloadAction);
+
+    // This needs to be initialized to subscribe to all Remembered Wallets
+    await store.dispatch(initSuiteLocalFirstStorageThunk());
 
     root.render(
         <ReduxProvider store={store}>

--- a/packages/suite/jest.setup.js
+++ b/packages/suite/jest.setup.js
@@ -14,6 +14,9 @@ Object.defineProperty(Uint8Array, Symbol.hasInstance, {
     },
 });
 
+// Todo: once we are on ESM this should not be needed + the WASM import will needs to be solved in jest
+jest.mock('@evolu/web', () => ({ evoluWebDeps: {} }));
+
 Object.defineProperty(window, 'matchMedia', {
     writable: true,
     value: jest.fn().mockImplementation(query => ({

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -87,6 +87,7 @@
         "@trezor/suite-analytics": "workspace:*",
         "@trezor/suite-data": "workspace:*",
         "@trezor/suite-desktop-api": "workspace:*",
+        "@trezor/suite-local-first-storage": "workspace:*",
         "@trezor/suite-storage": "workspace:*",
         "@trezor/theme": "workspace:*",
         "@trezor/transport-bluetooth": "workspace:*",

--- a/packages/suite/src/actions/settings/settingsActions.ts
+++ b/packages/suite/src/actions/settings/settingsActions.ts
@@ -1,0 +1,8 @@
+import { createAction } from '@reduxjs/toolkit';
+
+import { SUITE } from 'src/actions/suite/constants';
+
+export const setLocalFirstStorageRelayAction = createAction(
+    SUITE.SET_LOCAL_FIRST_STORAGE_RELAY,
+    ({ url }: { url: string }) => ({ payload: { url } }),
+);

--- a/packages/suite/src/actions/storage/constants.ts
+++ b/packages/suite/src/actions/storage/constants.ts
@@ -1,0 +1,1 @@
+export const LOCAL_FIRST_STORAGE_PREFIX = '@suite/local-first-storage';

--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -6,6 +6,7 @@ import { DEVICE, Device, TRANSPORT } from '@trezor/connect';
 import { SUITE } from 'src/actions/suite/constants';
 import { AppState, TorStatus } from 'src/types/suite';
 
+import { SuiteState } from '../../../reducers/suite/suiteReducer';
 import * as suiteActions from '../suiteActions';
 
 const { getSuiteDevice, getConnectDevice } = testMocks;
@@ -160,7 +161,7 @@ const reducerActions = [
     },
 ];
 
-const initialRun = [
+const initialRun: Array<{ description: string; state?: Partial<SuiteState> }> = [
     {
         description: `initialRunCompleted (initialRun = true)`,
     },
@@ -169,7 +170,6 @@ const initialRun = [
         state: {
             flags: {
                 initialRun: false,
-                initialWebRun: false,
                 discreetModeCompleted: false,
                 taprootBannerClosed: false,
                 firmwareTypeBannerClosed: false,
@@ -190,6 +190,8 @@ const initialRun = [
                 showBluetoothDebugInfo: false,
                 stellarLimitedHistoryBannerClosed: false,
                 solanaLimitedHistoryBannerClosed: false,
+                isLocalFirstStorageEnabled: false,
+                isLocalFirstStorageDebugEnabled: false,
                 hasSeenDisconnectTooltip: false,
             },
         },

--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -10,6 +10,7 @@ export const BIO_AUTH_WINDOW_BLUR = '@suite/bio-auth-window-blur';
 export const BIO_AUTH_WINDOW_FOCUS = '@suite/bio-auth-window-focus';
 export const TOGGLE_BIO_AUTH_VALIDATION_REQUESTED = '@suite/toggle-bio-auth-validation-requested';
 export const SET_LANGUAGE = '@suite/set-language';
+export const SET_LOCAL_FIRST_STORAGE_RELAY = '@suite/set-local-first-storage-relay';
 export const SET_DEBUG_MODE = '@suite/set-debug-mode';
 export const SET_FLAG = '@suite/set-flag';
 export const SET_RECENTLY_CONNECTED_DEVICE = '@suite/set-recently-connected-device';

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -18,6 +18,7 @@ import type { AppState, Dispatch, GetState, TorBootstrap } from 'src/types/suite
 import { isOnionUrl } from 'src/utils/suite/tor';
 
 import { SUITE } from './constants';
+import { setLocalFirstStorageRelayAction } from '../settings/settingsActions';
 
 export type SuiteAction =
     | { type: typeof SUITE.INIT }
@@ -29,6 +30,7 @@ export type SuiteAction =
           locale: Locale;
       }
     | { type: typeof SUITE.SET_DEBUG_MODE; payload: Partial<DebugModeOptions> }
+    | ReturnType<typeof setLocalFirstStorageRelayAction>
     | { type: typeof SUITE.ONLINE_STATUS; payload: boolean }
     | { type: typeof SUITE.TOR_STATUS; payload: TorStatus }
     | { type: typeof SUITE.TOR_BOOTSTRAP; payload: TorBootstrap | null }

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -1,6 +1,7 @@
 import { G } from '@mobily/ts-belt';
 import { isRejected } from '@reduxjs/toolkit';
 
+import { processMetadataMessageThunk } from '@suite-common/local-first-storage';
 import { MetadataAddPayload } from '@suite-common/metadata-types';
 import { createThunk } from '@suite-common/redux-utils';
 import {
@@ -36,6 +37,7 @@ import { RbfLabelsToBeUpdated } from 'src/types/wallet/sendForm';
 
 import { RBF_ERROR_ALREADY_MINED } from './replaceByFeeErrorThunk';
 import { MODULE_PREFIX } from './sendThunksConsts';
+import { selectSuiteFlags } from '../../../selectors/suite/suiteSelectors';
 import { findLabelsToBeMovedOrDeletedThunk } from '../moveLabelsForRbf/findLabelsToBeMovedOrDeletedThunk';
 import { moveLabelsForRbfThunk } from '../moveLabelsForRbf/moveLabelsForRbfThunk';
 
@@ -108,23 +110,25 @@ const updateRbfLabelsThunk = createThunk<void, UpdateRbfLabelsThunkParams, void>
     },
 );
 
-const applySendFormMetadataLabelsThunk = createThunk(
-    `${MODULE_PREFIX}/applyMetadataLabelsThunk`,
-    (
-        {
-            selectedAccount,
-            precomposedTransaction,
-            txid,
-        }: {
-            selectedAccount: Account;
-            precomposedTransaction: GeneralPrecomposedTransactionFinal;
-            txid: string;
-        },
-        { dispatch, getState },
-    ) => {
-        const metadata = selectMetadata(getState());
+type ApplySendFormMetadataLabelsThunkParams = {
+    selectedAccount: Account;
+    precomposedTransaction: GeneralPrecomposedTransactionFinal;
+    txid: string;
+};
 
-        if (!metadata.enabled) return;
+const applySendFormMetadataLabelsThunk = createThunk<
+    void,
+    ApplySendFormMetadataLabelsThunkParams,
+    void
+>(
+    `${MODULE_PREFIX}/applyMetadataLabelsThunk`,
+    ({ selectedAccount, precomposedTransaction, txid }, { dispatch, getState }) => {
+        const metadata = selectMetadata(getState());
+        const { isLocalFirstStorageEnabled } = selectSuiteFlags(getState());
+
+        if (!metadata.enabled && !isLocalFirstStorageEnabled) {
+            return;
+        }
 
         const precomposedForm = selectPrecomposedSendForm(getState());
         const outputsPermutation = isCardanoTx(selectedAccount, precomposedTransaction)
@@ -158,14 +162,24 @@ const applySendFormMetadataLabelsThunk = createThunk(
             .forEach((output, index, arr) => {
                 const isLast = index === arr.length - 1;
 
-                synchronize(() =>
-                    dispatch(
-                        metadataLabelingActions.addAccountMetadata({
-                            ...output,
-                            skipSave: !isLast,
-                        }),
-                    ),
-                );
+                synchronize(() => {
+                    if (isLocalFirstStorageEnabled) {
+                        return dispatch(
+                            processMetadataMessageThunk({
+                                payload: output,
+                                deviceStaticSessionId: selectedAccount.deviceState,
+                                value: output.value,
+                            }),
+                        );
+                    } else {
+                        return dispatch(
+                            metadataLabelingActions.addAccountMetadata({
+                                ...output,
+                                skipSave: !isLast,
+                            }),
+                        );
+                    }
+                });
             });
     },
 );

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { processMetadataMessageThunk } from '@suite-common/local-first-storage';
-import { Button, DropdownMenuItemProps, Row } from '@trezor/components';
+import { Button, DropdownMenuItemProps, Row, Text, Tooltip } from '@trezor/components';
 import { StaticSessionId } from '@trezor/connect';
 import { spacingsPx } from '@trezor/theme';
 import { TimerId } from '@trezor/type-utils';
@@ -407,13 +407,6 @@ export const MetadataLabeling = ({
         !showSuccess &&
         !editActive;
 
-    console.log('____???', {
-        showActionButton,
-        isLegacyLabelingEnabled,
-        isLegacyLabelingInitPossible,
-        isEvoluLabeling,
-    });
-
     const isVisible = pending || visible;
 
     // Metadata is still initiating, on hover, show only disabled button with spinner.
@@ -435,95 +428,106 @@ export const MetadataLabeling = ({
         showActionButton && (!payload.value || (payload.value && pending));
 
     return (
-        <LabelContainer
-            data-testid={labelContainerDataTest}
-            onClick={e => payload.value && !editActive && e.stopPropagation()}
+        <Tooltip
+            content={
+                !showActionButton &&
+                !isEvoluSupportedByDevice && (
+                    <Text variant="warning">
+                        <Translation id="FIRMWARE_NEEDS_UPGRADE_FOR_EVOLU" />
+                    </Text>
+                )
+            }
         >
-            {payload.type === 'outputLabel' ? (
-                <>
-                    <ButtonLikeLabelWithDropdown
-                        editActive={editActive}
-                        onSubmit={onSubmit || defaultOnSubmit}
-                        onBlur={handleBlur}
-                        data-testid={dataTestBase}
-                        payload={payload}
-                        defaultEditableValue={defaultEditableValue}
-                        defaultVisibleValue={defaultVisibleValue}
-                        dropdownOptions={dropdownItems}
-                        deviceStaticSessionId={deviceStaticSessionId}
-                    />
-                    {showOutputLabelActionButton && (
-                        <ActionButton
-                            data-testid={`${dataTestBase}/add-label-button`}
-                            variant="tertiary"
-                            icon={!actionButtonsDisabled ? 'tag' : undefined}
-                            isLoading={actionButtonsDisabled}
-                            isDisabled={actionButtonsDisabled}
-                            $isVisible={isVisible}
-                            size="tiny"
-                            onClick={e => {
-                                e.stopPropagation();
-                                // By clicking on add label button, metadata.editing field is set
-                                // to default value of whatever may be labeled (address, etc..)
-                                // this way we ensure that only one field may be active at time.
-                                activateEdit();
-                            }}
-                        >
-                            {l10nLabelling.add}
-                        </ActionButton>
-                    )}
-                </>
-            ) : (
-                <>
-                    <TextLikeLabel
-                        editActive={editActive}
-                        accountType={accountType}
-                        onSubmit={onSubmit || defaultOnSubmit}
-                        onBlur={handleBlur}
-                        data-testid={dataTestBase}
-                        payload={payload}
-                        networkType={networkType}
-                        path={path}
-                        defaultEditableValue={defaultEditableValue}
-                        defaultVisibleValue={defaultVisibleValue}
-                        updateFlag={updateFlag}
-                        deviceStaticSessionId={deviceStaticSessionId}
-                    />
+            <LabelContainer
+                data-testid={labelContainerDataTest}
+                onClick={e => payload.value && !editActive && e.stopPropagation()}
+            >
+                {payload.type === 'outputLabel' ? (
+                    <>
+                        <ButtonLikeLabelWithDropdown
+                            editActive={editActive}
+                            onSubmit={onSubmit || defaultOnSubmit}
+                            onBlur={handleBlur}
+                            data-testid={dataTestBase}
+                            payload={payload}
+                            defaultEditableValue={defaultEditableValue}
+                            defaultVisibleValue={defaultVisibleValue}
+                            dropdownOptions={dropdownItems}
+                            deviceStaticSessionId={deviceStaticSessionId}
+                        />
+                        {showOutputLabelActionButton && (
+                            <ActionButton
+                                data-testid={`${dataTestBase}/add-label-button`}
+                                variant="tertiary"
+                                icon={!actionButtonsDisabled ? 'tag' : undefined}
+                                isLoading={actionButtonsDisabled}
+                                isDisabled={actionButtonsDisabled}
+                                $isVisible={isVisible}
+                                size="tiny"
+                                onClick={e => {
+                                    e.stopPropagation();
+                                    // By clicking on add label button, metadata.editing field is set
+                                    // to default value of whatever may be labeled (address, etc..)
+                                    // this way we ensure that only one field may be active at time.
+                                    activateEdit();
+                                }}
+                            >
+                                {l10nLabelling.add}
+                            </ActionButton>
+                        )}
+                    </>
+                ) : (
+                    <>
+                        <TextLikeLabel
+                            editActive={editActive}
+                            accountType={accountType}
+                            onSubmit={onSubmit || defaultOnSubmit}
+                            onBlur={handleBlur}
+                            data-testid={dataTestBase}
+                            payload={payload}
+                            networkType={networkType}
+                            path={path}
+                            defaultEditableValue={defaultEditableValue}
+                            defaultVisibleValue={defaultVisibleValue}
+                            updateFlag={updateFlag}
+                            deviceStaticSessionId={deviceStaticSessionId}
+                        />
 
-                    {showActionButton && (
-                        <ActionButton
-                            data-testid={
-                                payload.value
-                                    ? `${dataTestBase}/edit-label-button`
-                                    : `${dataTestBase}/add-label-button`
-                            }
-                            variant="tertiary"
-                            icon={!actionButtonsDisabled ? 'tag' : undefined}
-                            isLoading={actionButtonsDisabled}
-                            isDisabled={actionButtonsDisabled}
-                            $isVisible={isVisible}
-                            size="tiny"
-                            onClick={e => {
-                                e.stopPropagation();
-                                activateEdit();
-                            }}
-                        >
-                            {payload.value ? l10nLabelling.edit : l10nLabelling.add}
-                        </ActionButton>
-                    )}
-                </>
-            )}
+                        {showActionButton && (
+                            <ActionButton
+                                data-testid={
+                                    payload.value
+                                        ? `${dataTestBase}/edit-label-button`
+                                        : `${dataTestBase}/add-label-button`
+                                }
+                                variant="tertiary"
+                                icon={!actionButtonsDisabled ? 'tag' : undefined}
+                                isLoading={actionButtonsDisabled}
+                                isDisabled={actionButtonsDisabled}
+                                $isVisible={isVisible}
+                                size="tiny"
+                                onClick={e => {
+                                    e.stopPropagation();
+                                    activateEdit();
+                                }}
+                            >
+                                {payload.value ? l10nLabelling.edit : l10nLabelling.add}
+                            </ActionButton>
+                        )}
+                    </>
+                )}
 
-            {showSuccess && !editActive && (
-                <SuccessButton
-                    variant="tertiary"
-                    data-testid={`${dataTestBase}/success`}
-                    icon="check"
-                    size="tiny"
-                >
-                    {l10nLabelling.edited}
-                </SuccessButton>
-            )}
-        </LabelContainer>
+                {showSuccess && !editActive && (
+                    <SuccessButton
+                        variant="tertiary"
+                        data-testid={`${dataTestBase}/success`}
+                        icon="check"
+                        size="tiny"
+                    >
+                        {l10nLabelling.edited}
+                    </SuccessButton>
+                )}
+            </LabelContainer>
+        </Tooltip>
     );
 };

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -296,8 +296,12 @@ export const MetadataLabeling = ({
     const actionButtonsDisabled = isDiscoveryRunning || pending;
     const isSubscribedToSubmitResult = useRef(payload.defaultValue);
 
-    const { isLocalFirstStorageEnabled, isEvoluSupportedByDevice, legacyMetadataState } =
-        useLabelingCombined({ deviceStaticSessionId });
+    const {
+        isLocalFirstStorageEnabled,
+        isEvoluSupportedByDevice,
+        legacyMetadataState,
+        hasDeviceLocalFirstStorageKeys,
+    } = useLabelingCombined({ deviceStaticSessionId });
 
     let timeout: TimerId | undefined;
     useEffect(() => {
@@ -398,7 +402,8 @@ export const MetadataLabeling = ({
 
     const labelContainerDataTest = `${dataTestBase}/hover-container`;
 
-    const isEvoluLabeling = isLocalFirstStorageEnabled && isEvoluSupportedByDevice;
+    const isEvoluLabeling =
+        isLocalFirstStorageEnabled && isEvoluSupportedByDevice && hasDeviceLocalFirstStorageKeys;
 
     // Should "add label"/"edit label" button be visible?
     const showActionButton =

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -15,12 +15,12 @@ import {
     selectIsLabelingAvailableForEntity,
     selectIsLabelingInitPossible,
 } from 'src/reducers/suite/metadataReducer';
-import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 import { MetadataAddPayload } from 'src/types/suite/metadata';
 
 import { ExtendedProps, Props } from './definitions';
 import { withDropdown } from './withDropdown';
 import { withEditable } from './withEditable';
+import { useLabelingCombined } from '../../../../hooks/suite/useLabelingCombined';
 import { AccountTypeBadge } from '../../AccountTypeBadge';
 
 const LabelValue = styled.div`
@@ -297,7 +297,7 @@ export const MetadataLabeling = ({
     const actionButtonsDisabled = isDiscoveryRunning || pending;
     const isSubscribedToSubmitResult = useRef(payload.defaultValue);
 
-    const { isLocalFirstStorageEnabled } = useSelector(selectSuiteFlags);
+    const { isLocalFirstStorageEnabled } = useLabelingCombined();
 
     let timeout: TimerId | undefined;
     useEffect(() => {

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -297,7 +297,7 @@ export const MetadataLabeling = ({
     const isSubscribedToSubmitResult = useRef(payload.defaultValue);
 
     const { isLocalFirstStorageEnabled, isEvoluSupportedByDevice, legacyMetadataState } =
-        useLabelingCombined();
+        useLabelingCombined({ deviceStaticSessionId });
 
     let timeout: TimerId | undefined;
     useEffect(() => {

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -430,7 +430,7 @@ export const MetadataLabeling = ({
     return (
         <Tooltip
             content={
-                !showActionButton &&
+                isLocalFirstStorageEnabled &&
                 !isEvoluSupportedByDevice && (
                     <Text variant="warning">
                         <Translation id="FIRMWARE_NEEDS_UPGRADE_FOR_EVOLU" />

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -2,10 +2,11 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import styled from 'styled-components';
 
+import { processMetadataMessageThunk } from '@suite-common/local-first-storage';
 import { Button, DropdownMenuItemProps, Row } from '@trezor/components';
 import { StaticSessionId } from '@trezor/connect';
 import { spacingsPx } from '@trezor/theme';
-import type { TimerId } from '@trezor/type-utils';
+import { TimerId } from '@trezor/type-utils';
 
 import { addMetadata, init, setEditing } from 'src/actions/suite/metadataLabelingActions';
 import { Translation } from 'src/components/suite';
@@ -14,6 +15,7 @@ import {
     selectIsLabelingAvailableForEntity,
     selectIsLabelingInitPossible,
 } from 'src/reducers/suite/metadataReducer';
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 import { MetadataAddPayload } from 'src/types/suite/metadata';
 
 import { ExtendedProps, Props } from './definitions';
@@ -282,6 +284,7 @@ export const MetadataLabeling = ({
     onSubmit,
     visible,
     updateFlag,
+    deviceStaticSessionId,
 }: Props) => {
     const metadata = useSelector(state => state.metadata);
     const dispatch = useDispatch();
@@ -293,6 +296,9 @@ export const MetadataLabeling = ({
     const dataTestBase = `@metadata/${payload.type}/${payload.defaultValue}`;
     const actionButtonsDisabled = isDiscoveryRunning || pending;
     const isSubscribedToSubmitResult = useRef(payload.defaultValue);
+
+    const { isLocalFirstStorageEnabled } = useSelector(selectSuiteFlags);
+
     let timeout: TimerId | undefined;
     useEffect(() => {
         setPending(false);
@@ -317,6 +323,7 @@ export const MetadataLabeling = ({
     const activateEdit = () => {
         // When clicking on inline input edit, ensure that everything needed is already ready.
         if (
+            !isLocalFirstStorageEnabled &&
             // Isn't initiation in progress?
             !metadata.initiating &&
             // Is there something that needs to be initiated?
@@ -355,22 +362,29 @@ export const MetadataLabeling = ({
     const defaultOnSubmit = async (value: string | undefined) => {
         isSubscribedToSubmitResult.current = payload.defaultValue;
         setPending(true);
-        const result = await dispatch(
-            addMetadata({
-                ...payload,
-                value: value || undefined,
-            }),
-        );
-        // payload.defaultValue might change during next render, this comparison
-        // ensures that success state does not appear if it is no longer relevant.
-        if (isSubscribedToSubmitResult.current === payload.defaultValue) {
-            setPending(false);
-            if (result) {
-                setShowSuccess(true);
-            }
+
+        if (isLocalFirstStorageEnabled) {
+            await dispatch(processMetadataMessageThunk({ payload, deviceStaticSessionId, value }));
+
+            setShowSuccess(true);
             timeout = setTimeout(() => {
                 setShowSuccess(false);
             }, 2000);
+            setPending(false);
+        } else {
+            const result = await dispatch(addMetadata({ ...payload, value: value || undefined }));
+
+            // payload.defaultValue might change during next render, this comparison
+            // ensures that success state does not appear if it is no longer relevant.
+            if (isSubscribedToSubmitResult.current === payload.defaultValue) {
+                setPending(false);
+                if (result) {
+                    setShowSuccess(true);
+                }
+                timeout = setTimeout(() => {
+                    setShowSuccess(false);
+                }, 2000);
+            }
         }
     };
 
@@ -387,7 +401,7 @@ export const MetadataLabeling = ({
     // Should "add label"/"edit label" button be visible?
     const showActionButton =
         !isDisabled &&
-        (isLabelingAvailable || isLabelingInitPossible) &&
+        (isLabelingAvailable || isLabelingInitPossible || isLocalFirstStorageEnabled) &&
         !showSuccess &&
         !editActive;
     const isVisible = pending || visible;
@@ -426,6 +440,7 @@ export const MetadataLabeling = ({
                         defaultEditableValue={defaultEditableValue}
                         defaultVisibleValue={defaultVisibleValue}
                         dropdownOptions={dropdownItems}
+                        deviceStaticSessionId={deviceStaticSessionId}
                     />
                     {showOutputLabelActionButton && (
                         <ActionButton
@@ -462,6 +477,7 @@ export const MetadataLabeling = ({
                         defaultEditableValue={defaultEditableValue}
                         defaultVisibleValue={defaultVisibleValue}
                         updateFlag={updateFlag}
+                        deviceStaticSessionId={deviceStaticSessionId}
                     />
 
                     {showActionButton && (

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -286,7 +286,6 @@ export const MetadataLabeling = ({
     updateFlag,
     deviceStaticSessionId,
 }: Props) => {
-    const metadata = useSelector(state => state.metadata);
     const dispatch = useDispatch();
     const { isDiscoveryRunning } = useDiscovery();
     const [showSuccess, setShowSuccess] = useState(false);
@@ -297,7 +296,8 @@ export const MetadataLabeling = ({
     const actionButtonsDisabled = isDiscoveryRunning || pending;
     const isSubscribedToSubmitResult = useRef(payload.defaultValue);
 
-    const { isLocalFirstStorageEnabled } = useLabelingCombined();
+    const { isLocalFirstStorageEnabled, isEvoluSupportedByDevice, legacyMetadataState } =
+        useLabelingCombined();
 
     let timeout: TimerId | undefined;
     useEffect(() => {
@@ -310,24 +310,24 @@ export const MetadataLabeling = ({
         };
     }, [payload.defaultValue, timeout]);
 
-    const isLabelingInitPossible = useSelector(selectIsLabelingInitPossible);
+    const isLegacyLabelingInitPossible = useSelector(selectIsLabelingInitPossible);
     const deviceState =
         payload.type === 'walletLabel' ? (payload.entityKey as StaticSessionId) : undefined;
-    const isLabelingAvailable = useSelector(state =>
+    const isLegacyLabelingEnabled = useSelector(state =>
         selectIsLabelingAvailableForEntity(state, payload.entityKey, deviceState),
     );
 
     // is this concrete instance being edited?
-    const editActive = metadata.editing === payload.defaultValue;
+    const editActive = legacyMetadataState.editing === payload.defaultValue;
 
     const activateEdit = () => {
         // When clicking on inline input edit, ensure that everything needed is already ready.
         if (
             !isLocalFirstStorageEnabled &&
             // Isn't initiation in progress?
-            !metadata.initiating &&
+            !legacyMetadataState.initiating &&
             // Is there something that needs to be initiated?
-            !isLabelingAvailable
+            !isLegacyLabelingEnabled
         ) {
             dispatch(
                 init(
@@ -354,7 +354,7 @@ export const MetadataLabeling = ({
     }
 
     const handleBlur = () => {
-        if (!metadata.initiating) {
+        if (!legacyMetadataState.initiating) {
             dispatch(setEditing(undefined));
         }
     };
@@ -398,16 +398,26 @@ export const MetadataLabeling = ({
 
     const labelContainerDataTest = `${dataTestBase}/hover-container`;
 
+    const isEvoluLabeling = isLocalFirstStorageEnabled && isEvoluSupportedByDevice;
+
     // Should "add label"/"edit label" button be visible?
     const showActionButton =
         !isDisabled &&
-        (isLabelingAvailable || isLabelingInitPossible || isLocalFirstStorageEnabled) &&
+        (isLegacyLabelingEnabled || isLegacyLabelingInitPossible || isEvoluLabeling) &&
         !showSuccess &&
         !editActive;
+
+    console.log('____???', {
+        showActionButton,
+        isLegacyLabelingEnabled,
+        isLegacyLabelingInitPossible,
+        isEvoluLabeling,
+    });
+
     const isVisible = pending || visible;
 
     // Metadata is still initiating, on hover, show only disabled button with spinner.
-    if (metadata.initiating)
+    if (legacyMetadataState.initiating)
         return (
             <LabelContainer data-testid={labelContainerDataTest}>
                 {defaultVisibleValue}

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/definitions.ts
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/definitions.ts
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 
 import { AccountType, Bip43Path, NetworkType } from '@suite-common/wallet-config';
 import { DropdownMenuItemProps } from '@trezor/components';
+import type { StaticSessionId } from '@trezor/connect';
 
 import { MetadataAddPayload } from 'src/types/suite/metadata';
 
@@ -20,6 +21,7 @@ export interface Props {
     visible?: boolean;
     placeholder?: string;
     updateFlag?: any;
+    deviceStaticSessionId: StaticSessionId;
 }
 
 export interface ExtendedProps extends Props {

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
@@ -2,8 +2,10 @@ import { useEffect, useState } from 'react';
 
 import styled, { keyframes } from 'styled-components';
 
+import { selectAccountLabel } from '@suite-common/local-first-storage';
 import { useDisplayBaseCurrency } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
+import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { H2 } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
 import { spacingsPx, typography, zIndices } from '@trezor/theme';
@@ -94,8 +96,22 @@ export const AccountDetails = ({ selectedAccount, isBalanceShown }: AccountDetai
     const [shouldAnimate, setShouldAnimate] = useState(false);
     const [hasMounted, setHasMounted] = useState(false);
     const selectedAccountLabels = useSelector(selectLabelingDataForSelectedAccount);
+
+    const { walletDescriptor } = parseDeviceStaticSessionId(selectedAccount.deviceState);
+
+    const localFirstAccountLabel = useSelector(state =>
+        selectAccountLabel({
+            state,
+            walletDescriptor,
+            accountKey: selectedAccount.key,
+        }),
+    );
+
+    const label = localFirstAccountLabel?.label ?? selectedAccountLabels.accountLabel;
+
     const { getDefaultAccountLabel } = useDefaultAccountLabel();
-    const { symbol, key, path, index, accountType, formattedBalance } = selectedAccount;
+    const { symbol, key, path, index, accountType, formattedBalance, deviceState } =
+        selectedAccount;
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(symbol);
 
     useEffect(() => {
@@ -122,7 +138,7 @@ export const AccountDetails = ({ selectedAccount, isBalanceShown }: AccountDetai
                             <AccountLabel
                                 account={{
                                     ...selectedAccount,
-                                    accountLabel: selectedAccountLabels.accountLabel,
+                                    accountLabel: label,
                                 }}
                                 showAccountTypeBadge
                             />
@@ -131,8 +147,9 @@ export const AccountDetails = ({ selectedAccount, isBalanceShown }: AccountDetai
                             type: 'accountLabel',
                             entityKey: key,
                             defaultValue: path,
-                            value: selectedAccountLabels.accountLabel,
+                            value: label,
                         }}
+                        deviceStaticSessionId={deviceState}
                         defaultEditableValue={getDefaultAccountLabel({
                             accountType,
                             symbol,

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TargetAddressLabel.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TargetAddressLabel.tsx
@@ -1,11 +1,15 @@
 import styled from 'styled-components';
 
+import { selectAddressLabels } from '@suite-common/local-first-storage';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
+import type { StaticSessionId } from '@trezor/connect';
 import { ArrayElement } from '@trezor/type-utils';
 
 import { AddressLabeling, Translation } from 'src/components/suite';
 import { AccountLabels } from 'src/types/suite/metadata';
 import { WalletAccountTransaction } from 'src/types/wallet';
+
+import { useSelector } from '../../../../hooks/suite';
 
 const TruncatedSpan = styled.span<{ $isBlurred?: boolean }>`
     overflow: hidden;
@@ -18,6 +22,7 @@ interface TargetAddressLabelProps {
     target: ArrayElement<WalletAccountTransaction['targets']>;
     type: WalletAccountTransaction['type'];
     accountMetadata?: AccountLabels;
+    deviceStaticSessionId: StaticSessionId;
 }
 
 export const TargetAddressLabel = ({
@@ -25,8 +30,13 @@ export const TargetAddressLabel = ({
     target,
     type,
     accountMetadata,
+    deviceStaticSessionId,
 }: TargetAddressLabelProps) => {
     const isLocalTarget = (type === 'sent' || type === 'self') && target.isAccountTarget;
+
+    const localFirstStorageAddressLabels = useSelector(state =>
+        selectAddressLabels({ state, deviceStaticSessionId }),
+    );
 
     if (isLocalTarget) {
         return (
@@ -38,17 +48,21 @@ export const TargetAddressLabel = ({
 
     return (
         <TruncatedSpan data-testid="@wallet/transaction/target-address">
-            {target.addresses?.map((a, i) =>
+            {target.addresses?.map((a, i) => {
+                const addressLabel =
+                    localFirstStorageAddressLabels.find(it => it.address === a)?.label ??
+                    accountMetadata?.addressLabels[a];
+
                 // either it may be AddressLabeling - sent to another account associated with this device, e.g: "Bitcoin #2"
                 // or it may show address metadata label added from receive tab e.g "My address for illegal things"
-                type === 'sent' ? (
+                return type === 'sent' ? (
                     // Using index as a key is safe as the array doesn't change (no filter/reordering, pushing new items)
 
                     <AddressLabeling key={i} address={a} symbol={symbol} />
                 ) : (
-                    <span key={i}>{accountMetadata?.addressLabels[a] || a}</span>
-                ),
-            )}
+                    <span key={i}>{addressLabel || a}</span>
+                );
+            })}
         </TruncatedSpan>
     );
 };

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 
+import { selectOutputLabels } from '@suite-common/local-first-storage';
 import { ToastPayload, notificationsActions } from '@suite-common/toast-notifications';
 import {
     selectBaseCurrency,
@@ -72,6 +73,9 @@ export const TransactionTarget = ({
         selectHistoricFiatRatesByTimestamp(state, fiatRateKey, transaction.blockTime as Timestamp),
     );
     const labelingValueBeingEdited = useSelector(selectLabelingValueBeingEdited);
+    const localFirstOutputLabels = useSelector(state =>
+        selectOutputLabels(state, transaction.deviceState),
+    );
     const isSolanaUnstakeTx = transaction?.solanaSpecific?.stakeOperation?.type === 'unstake';
 
     const amount = useMemo(() => {
@@ -142,7 +146,9 @@ export const TransactionTarget = ({
                 return exhaustive(type);
         }
     }, [type, payload]);
+
     const targetMetadata = accountMetadata?.outputLabels?.[transaction.txid]?.[metadataId];
+
     const defaultMetadataValue = `${transaction.txid}-${metadataId}`;
     const isBeingEdited = defaultMetadataValue === labelingValueBeingEdited;
 
@@ -176,6 +182,7 @@ export const TransactionTarget = ({
                         accountMetadata={accountMetadata}
                         target={payload}
                         type={transaction.type}
+                        deviceStaticSessionId={transaction.deviceState}
                     />
                 );
             case 'token':
@@ -200,6 +207,7 @@ export const TransactionTarget = ({
             useHiddenPlaceholder={!isBeingEdited}
             addressLabel={
                 <MetadataLabeling
+                    deviceStaticSessionId={transaction.deviceState}
                     isDisabled={isActionDisabled}
                     defaultVisibleValue={label}
                     dropdownOptions={[
@@ -215,7 +223,10 @@ export const TransactionTarget = ({
                         txid: transaction.txid,
                         outputIndex: metadataId,
                         defaultValue: defaultMetadataValue,
-                        value: targetMetadata,
+                        value:
+                            localFirstOutputLabels.find(
+                                it => it.txId === transaction.txid && it.outputIndex == metadataId,
+                            )?.label ?? targetMetadata,
                     }}
                 />
             }

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -1,13 +1,15 @@
+import { findAccountLabel, selectAccountLabels } from '@suite-common/local-first-storage';
 import { AccountType } from '@suite-common/wallet-config';
 import { selectAllAccountsToList, selectSelectedDevice } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
-import { accountSearchFn } from '@suite-common/wallet-utils';
+import { accountSearchFn, parseAccountKey } from '@suite-common/wallet-utils';
 import { Column } from '@trezor/components';
+import type { StaticSessionId } from '@trezor/connect';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
 import { useAccountSearch, useDefaultAccountLabel, useSelector } from 'src/hooks/suite';
-import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
+import { selectAccountLabels as selectAccountLabelsOld } from 'src/reducers/suite/metadataReducer';
 import { AccountItemType } from 'src/types/wallet';
 
 import { AccountGroup } from './AccountGroup';
@@ -34,6 +36,7 @@ type AccountsProps = {
     // NOTE: this is to disable completely default click behavior of the item
     forceOnlyItemClick?: boolean;
     onItemClick?: (account: Account, type: AccountItemType) => void;
+    deviceStaticSessionId: StaticSessionId;
 };
 
 const Accounts = ({
@@ -44,11 +47,16 @@ const Accounts = ({
     discoveryInProgress,
     type,
     onItemClick,
+    deviceStaticSessionId,
 }: AccountsProps) => {
-    const accountLabels = useSelector(selectAccountLabels);
+    const accountLabels = useSelector(selectAccountLabelsOld);
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const { params } = selectedAccount;
     const isSkeletonShown = discoveryInProgress || (type === 'coinjoin' && coinjoinIsPreloading);
+
+    const localFirstAccountLabels = useSelector(state =>
+        selectAccountLabels({ state, deviceStaticSessionId }),
+    );
 
     return (
         <>
@@ -61,6 +69,15 @@ const Accounts = ({
 
                 const selected = !!isSelected(account);
 
+                const { accountDescriptor, networkSymbol } = parseAccountKey(account.key);
+
+                const label =
+                    findAccountLabel({
+                        accountLabels: localFirstAccountLabels,
+                        accountDescriptor,
+                        networkSymbol,
+                    })?.label ?? accountLabels[account.key];
+
                 return (
                     <AccountSection
                         key={account.key}
@@ -68,7 +85,7 @@ const Accounts = ({
                         hideStaking={hideStaking}
                         account={{
                             ...account,
-                            accountLabel: accountLabels[account.key],
+                            accountLabel: label,
                         }}
                         selected={selected}
                         onItemClick={onItemClick}
@@ -89,7 +106,14 @@ export const AccountsList = ({
     const accounts = useSelector(selectAllAccountsToList);
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const coinjoinIsPreloading = useSelector(state => state.wallet.coinjoin.isPreloading);
-    const accountLabels = useSelector(selectAccountLabels);
+    const accountLabels = useSelector(selectAccountLabelsOld);
+
+    const localFirstAccountLabels = useSelector(state =>
+        device?.state?.staticSessionId !== undefined
+            ? selectAccountLabels({ state, deviceStaticSessionId: device?.state?.staticSessionId })
+            : [],
+    );
+
     const { getDefaultAccountLabel } = useDefaultAccountLabel();
     const isSidebarCollapsed = useIsSidebarCollapsed();
     const { coinFilter, searchString } = useAccountSearch();
@@ -104,9 +128,18 @@ export const AccountsList = ({
         searchString || coinFilter
             ? accounts.filter(account => {
                   const { key, accountType, symbol, index } = account;
-                  const accountLabel = Object.prototype.hasOwnProperty.call(accountLabels, key)
+                  const accountLabelOld = Object.prototype.hasOwnProperty.call(accountLabels, key)
                       ? accountLabels[key]
                       : getDefaultAccountLabel({ accountType, symbol, index });
+
+                  const { accountDescriptor, networkSymbol } = parseAccountKey(account.key);
+
+                  const accountLabel =
+                      findAccountLabel({
+                          accountLabels: localFirstAccountLabels,
+                          accountDescriptor,
+                          networkSymbol,
+                      })?.label ?? accountLabelOld;
 
                   return accountSearchFn(account, searchString, coinFilter, accountLabel);
               })
@@ -144,13 +177,19 @@ export const AccountsList = ({
             return;
         }
 
-        const accountProps = {
+        const deviceStaticSessionId = device.state?.staticSessionId;
+        if (deviceStaticSessionId === undefined) {
+            return;
+        }
+
+        const accountProps: AccountsProps = {
             forceOnlyItemClick,
             accounts,
             onItemClick,
             coinjoinIsPreloading,
             discoveryInProgress: false,
             type,
+            deviceStaticSessionId,
         };
 
         return (

--- a/packages/suite/src/hooks/suite/useLabelingCombined.ts
+++ b/packages/suite/src/hooks/suite/useLabelingCombined.ts
@@ -49,11 +49,14 @@ export const useLabelingCombined = ({ deviceStaticSessionId }: UseLabelingCombin
 
     const isEvoluSupportedByDevice = device?.unavailableCapabilities?.evolu === undefined;
 
+    const hasDeviceLocalFirstStorageKeys = device?.localFirstStorageSecret?.evoluKeys !== undefined;
+
     return {
         /** New Labeling: LocalFirstStorage (Evolu) */
         isLocalFirstStorageEnabled,
         isEvoluSupportedByDevice,
         isLocalFirstStorageDebugEnabled,
+        hasDeviceLocalFirstStorageKeys,
         localFirstEnable,
         localFirstDisable,
 

--- a/packages/suite/src/hooks/suite/useLabelingCombined.ts
+++ b/packages/suite/src/hooks/suite/useLabelingCombined.ts
@@ -12,6 +12,8 @@ import { selectSuiteFlags } from '../../selectors/suite/suiteSelectors';
 
 export const useLabelingCombined = () => {
     const dispatch = useDispatch();
+
+    // Todo: device needs to be passed as arg
     const device = useSelector(selectSelectedDevice);
 
     const { isLocalFirstStorageEnabled, isLocalFirstStorageDebugEnabled } =

--- a/packages/suite/src/hooks/suite/useLabelingCombined.ts
+++ b/packages/suite/src/hooks/suite/useLabelingCombined.ts
@@ -1,4 +1,5 @@
 import { disposeAllLocalFirstStorageThunk } from '@suite-common/local-first-storage';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { initSuiteLocalFirstStorageThunk } from '@trezor/suite-local-first-storage';
 
 import * as metadataActions from 'src/actions/suite/metadataActions';
@@ -11,6 +12,8 @@ import { selectSuiteFlags } from '../../selectors/suite/suiteSelectors';
 
 export const useLabelingCombined = () => {
     const dispatch = useDispatch();
+    const device = useSelector(selectSelectedDevice);
+
     const { isLocalFirstStorageEnabled, isLocalFirstStorageDebugEnabled } =
         useSelector(selectSuiteFlags);
     const legacyMetadataState = useSelector(state => state.metadata);
@@ -32,9 +35,12 @@ export const useLabelingCombined = () => {
         dispatch(metadataLabelingActions.init(true));
     };
 
+    const isEvoluSupportedByDevice = device?.unavailableCapabilities?.evolu === undefined;
+
     return {
         /** New Labeling: LocalFirstStorage (Evolu) */
         isLocalFirstStorageEnabled,
+        isEvoluSupportedByDevice,
         isLocalFirstStorageDebugEnabled,
         localFirstEnable,
         localFirstDisable,

--- a/packages/suite/src/hooks/suite/useLabelingCombined.ts
+++ b/packages/suite/src/hooks/suite/useLabelingCombined.ts
@@ -1,5 +1,6 @@
 import { disposeAllLocalFirstStorageThunk } from '@suite-common/local-first-storage';
-import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { selectDeviceByStaticSessionId } from '@suite-common/wallet-core';
+import type { StaticSessionId } from '@trezor/connect';
 import { initSuiteLocalFirstStorageThunk } from '@trezor/suite-local-first-storage';
 
 import * as metadataActions from 'src/actions/suite/metadataActions';
@@ -10,11 +11,20 @@ import { useSelector } from './useSelector';
 import { setFlag } from '../../actions/suite/suiteActions';
 import { selectSuiteFlags } from '../../selectors/suite/suiteSelectors';
 
-export const useLabelingCombined = () => {
+type UseLabelingCombinedParams = {
+    // This needs to be passed, as labeling can be attached to remembered wallets
+    // and different devices can have different states (FW versions)
+    deviceStaticSessionId: StaticSessionId | undefined;
+};
+
+export const useLabelingCombined = ({ deviceStaticSessionId }: UseLabelingCombinedParams) => {
     const dispatch = useDispatch();
 
-    // Todo: device needs to be passed as arg
-    const device = useSelector(selectSelectedDevice);
+    const device = useSelector(state =>
+        deviceStaticSessionId !== undefined
+            ? selectDeviceByStaticSessionId(state, deviceStaticSessionId)
+            : undefined,
+    );
 
     const { isLocalFirstStorageEnabled, isLocalFirstStorageDebugEnabled } =
         useSelector(selectSuiteFlags);

--- a/packages/suite/src/hooks/suite/useLabelingCombined.ts
+++ b/packages/suite/src/hooks/suite/useLabelingCombined.ts
@@ -1,0 +1,47 @@
+import { disposeAllLocalFirstStorageThunk } from '@suite-common/local-first-storage';
+import { initSuiteLocalFirstStorageThunk } from '@trezor/suite-local-first-storage';
+
+import * as metadataActions from 'src/actions/suite/metadataActions';
+import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
+
+import { useDispatch } from './useDispatch';
+import { useSelector } from './useSelector';
+import { setFlag } from '../../actions/suite/suiteActions';
+import { selectSuiteFlags } from '../../selectors/suite/suiteSelectors';
+
+export const useLabelingCombined = () => {
+    const dispatch = useDispatch();
+    const { isLocalFirstStorageEnabled, isLocalFirstStorageDebugEnabled } =
+        useSelector(selectSuiteFlags);
+    const legacyMetadataState = useSelector(state => state.metadata);
+
+    const legacyDisable = () => {
+        dispatch(metadataActions.disableMetadata());
+    };
+    const localFirstDisable = () => {
+        dispatch(setFlag('isLocalFirstStorageEnabled', false));
+        dispatch(disposeAllLocalFirstStorageThunk());
+    };
+    const localFirstEnable = () => {
+        legacyDisable(); // Enabling Evolu implicitly disables Legacy Labeling
+        dispatch(setFlag('isLocalFirstStorageEnabled', true));
+        dispatch(initSuiteLocalFirstStorageThunk());
+    };
+    const legacyEnable = () => {
+        localFirstDisable(); // Enabling Legacy Labeling implicitly disables Evolu
+        dispatch(metadataLabelingActions.init(true));
+    };
+
+    return {
+        /** New Labeling: LocalFirstStorage (Evolu) */
+        isLocalFirstStorageEnabled,
+        isLocalFirstStorageDebugEnabled,
+        localFirstEnable,
+        localFirstDisable,
+
+        /** Legacy Labeling */
+        legacyMetadataState,
+        legacyEnable,
+        legacyDisable,
+    };
+};

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -1,5 +1,6 @@
 import { combineReducers, createReducer } from '@reduxjs/toolkit';
 
+import { LabelingState } from '@suite-common/local-first-storage';
 import { testMocks } from '@suite-common/test-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { Network, getNetwork } from '@suite-common/wallet-config';
@@ -411,6 +412,7 @@ export const getRootReducer = (selectedAccount = BTC_ACCOUNT, fees = DEFAULT_FEE
         ),
         router: createReducer({}, () => ({})),
         modal: createReducer({}, () => ({})),
+        labeling: createReducer({ walletsLabels: {} } satisfies LabelingState, state => state),
     });
 
 const DEFAULT_DRAFT = {

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -29,6 +29,7 @@ const isActionDeviceRelated = (action: AnyAction): boolean => {
             deviceActions.forgetDevice,
             // ?
             deviceActions.setDeviceState,
+            deviceActions.setLocalFirstStorageSecret,
             deviceActions.setDiscovered,
         )(action)
     ) {

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -248,6 +248,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case WALLET_SETTINGS.SET_MEV_PROTECTION:
                 case WALLET_SETTINGS.AUTO_FORGET_DEVICE_DATA:
                     api.dispatch(storageActions.saveWalletSettings());
+
                     break;
                 case SUITE.SET_LANGUAGE:
                 case SUITE.SET_FLAG:
@@ -268,6 +269,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case SUITE.SET_IS_COINS_FILTER_VISIBLE:
                 case SUITE.DISMISSED_TRADING_TERMS:
                 case SUITE.SET_AUTO_EJECT:
+                case SUITE.SET_LOCAL_FIRST_STORAGE_RELAY:
                     api.dispatch(storageActions.saveSuiteSettings());
                     break;
                 case SUITE.COINJOIN_RECEIVE_WARNING: {

--- a/packages/suite/src/middlewares/wallet/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.ts
@@ -34,10 +34,10 @@ const walletMiddleware =
 
         if (deviceActions.forgetDevice.match(action)) {
             const deviceState = action.payload.device.state?.staticSessionId;
-            const accounts = api
+            const accountsToRemove = api
                 .getState()
                 .wallet.accounts.filter(a => a.deviceState === deviceState);
-            api.dispatch(forgetAccountsThunk({ accountsToRemove: accounts }));
+            api.dispatch(forgetAccountsThunk({ accountsToRemove }));
         }
 
         // propagate action to reducers, this needs to happen before addTransaction is dispatched because it needs to have account in redux already

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -16,6 +16,7 @@ import { mergeDeepObject } from '@trezor/utils';
 import { prepareTokenDefinitionsReducer } from '@suite-common/token-definitions';
 import { prepareFirmwareReducer } from '@suite-common/firmware';
 import { prepareThpReducer } from '@suite-common/thp';
+import { prepareLabelingReducer } from '@suite-common/local-first-storage';
 import { accountsActions } from '@suite-common/wallet-core';
 
 import suiteMiddlewares from 'src/middlewares/suite';
@@ -43,6 +44,7 @@ const firmwareReducer = prepareFirmwareReducer(extraDependencies);
 const tokenDefinitionsReducer = prepareTokenDefinitionsReducer(extraDependencies);
 const bluetoothReducer = bluetoothSlice.prepareReducer(extraDependencies);
 const thpReducer = prepareThpReducer(extraDependencies);
+const labelingReducer = prepareLabelingReducer(extraDependencies);
 
 const rootReducer = combineReducers({
     ...suiteReducers,
@@ -56,6 +58,7 @@ const rootReducer = combineReducers({
     tokenDefinitions: tokenDefinitionsReducer,
     bluetooth: bluetoothReducer,
     thp: thpReducer,
+    labeling: labelingReducer,
     geolocation: geolocationReducer,
 });
 

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -33,6 +33,7 @@ import {
 import { Account } from 'src/types/wallet';
 
 import { SuiteRootState } from './suiteReducer';
+import { selectSuiteFlags } from '../../selectors/suite/suiteSelectors';
 
 export const initialState: MetadataState = {
     // is Suite trying to load metadata (get master key -> sync cloud)?
@@ -284,10 +285,17 @@ export const selectIsLabelingAvailable = (state: MetadataRootState) => {
 };
 
 /**
- it is possible to initiate metadata
+ * @deprecated this is Legacy Labeling
+ *
+ * It is possible to initiate metadata (labeling)
  */
 export const selectIsLabelingInitPossible = (state: MetadataRootState) => {
     const device = selectSelectedDevice(state);
+    const { isLocalFirstStorageEnabled } = selectSuiteFlags(state);
+
+    if (isLocalFirstStorageEnabled) {
+        return false;
+    }
 
     return (
         // device already has keys or it is at least connected and authorized

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -293,6 +293,8 @@ export const selectIsLabelingInitPossible = (state: MetadataRootState) => {
     const device = selectSelectedDevice(state);
     const { isLocalFirstStorageEnabled } = selectSuiteFlags(state);
 
+    // If Evolu is enabled, we do not want to allow for enabling Legacy Labeling just by
+    // clicking on the stuff.
     if (isLocalFirstStorageEnabled) {
         return false;
     }

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -17,6 +17,8 @@ import { Action, TorBootstrap, TorStatus } from 'src/types/suite';
 import type { OAuthServerEnvironment } from 'src/types/suite/metadata';
 import { ensureLocale } from 'src/utils/suite/l10n';
 
+import { setLocalFirstStorageRelayAction } from '../../actions/settings/settingsActions';
+
 export interface SuiteRootState {
     suite: SuiteState;
 }
@@ -71,6 +73,8 @@ export interface Flags {
     showBluetoothDebugInfo: boolean;
     stellarLimitedHistoryBannerClosed: boolean; // banner in account view (Overview tab) presenting limited history for Stellar
     solanaLimitedHistoryBannerClosed: boolean; // banner in account view (Overview tab) presenting limited history for Solana
+    isLocalFirstStorageEnabled: boolean;
+    isLocalFirstStorageDebugEnabled: boolean;
     hasSeenDisconnectTooltip: boolean; // tooltip shown when device disconnects - show only once ever
 }
 
@@ -105,6 +109,7 @@ export interface SuiteSettings {
     experimental?: ExperimentalFeature[];
     sidebarWidth: number;
     isCoinsFilterVisible: boolean;
+    localFirstStorageRelayUrl: string | null;
     autoEject: boolean;
 }
 
@@ -166,6 +171,8 @@ const initialState: SuiteState = {
         showBluetoothDebugInfo: false,
         stellarLimitedHistoryBannerClosed: false,
         solanaLimitedHistoryBannerClosed: false,
+        isLocalFirstStorageEnabled: false,
+        isLocalFirstStorageDebugEnabled: false,
         hasSeenDisconnectTooltip: false,
     },
     evmSettings: {
@@ -207,6 +214,7 @@ const initialState: SuiteState = {
         defaultWalletLoading: WalletType.STANDARD,
         sidebarWidth: SIDEBAR_WIDTH_NUMERIC,
         isCoinsFilterVisible: false,
+        localFirstStorageRelayUrl: null,
         autoEject: false,
     },
     recentlyConnectedDeviceRef: null,
@@ -433,6 +441,9 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
             case SUITE.LOCK_ROUTER:
                 changeLock(draft, SUITE.LOCK_TYPE.ROUTER, action.payload);
                 break;
+
+            case setLocalFirstStorageRelayAction.type:
+                draft.settings.localFirstStorageRelayUrl = action.payload.url;
 
             // no default
         }

--- a/packages/suite/src/selectors/suite/suiteSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteSelectors.ts
@@ -26,6 +26,9 @@ export const selectTorState = (state: SuiteRootState) => {
     };
 };
 
+export const selectLocalFirstStorageRelayUrl = (state: SuiteRootState) =>
+    state.suite.settings.localFirstStorageRelayUrl;
+
 // TODO: use this selector in all places where we need to check if debug mode is active
 export const selectIsDebugModeActive = (state: SuiteRootState) =>
     state.suite.settings.debug.showDebugMenu;
@@ -89,8 +92,8 @@ export const selectIsLoggedOut = (state: SuiteRootState & DeviceRootState) =>
 export const selectSuiteFlags = (state: SuiteRootState) => state.suite.flags;
 export const selectSuiteSettings = (state: SuiteRootState) => ({
     defaultWalletLoading: state.suite.settings.defaultWalletLoading,
-    isLocalFirstStorageEnabled: false, // Todo: will be implemented in next PR
-    localFirstStorageRelayUrl: null, // Todo: will be implemented in next PR
+    isLocalFirstStorageEnabled: state.suite.flags.isLocalFirstStorageEnabled,
+    localFirstStorageRelayUrl: state.suite.settings.localFirstStorageRelayUrl,
 });
 export const selectHasExperimentalFeature =
     (feature: ExperimentalFeature) => (state: SuiteRootState) =>

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -2,6 +2,10 @@ import { PayloadAction } from '@reduxjs/toolkit';
 import { saveAs } from 'file-saver';
 
 import { FW_HASH_CHECK_DEFAULT_TIMEOUTS } from '@suite-common/firmware-authenticity';
+import {
+    subscribeLocalFirstStorageThunk,
+    unsubscribeAndDisposeLocalFirstStorageThunk,
+} from '@suite-common/local-first-storage';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import {
     TokenDefinitionsState,
@@ -57,8 +61,8 @@ export const extraDependencies: ExtraDependencies = {
         cardanoValidatePendingTxOnBlock: cardanoStakingActions.validatePendingTxOnBlock,
         cardanoFetchTrezorData: cardanoStakingActions.fetchTrezorData,
         initMetadata: metadataLabelingActions.init,
-        subscribeLocalFirstStorage: () => () => {}, // Todo: will be implemented in next PR
-        unsubscribeAndDisposeLocalFirstStorage: () => () => {}, // Todo: will be implemented in next PR
+        subscribeLocalFirstStorage: subscribeLocalFirstStorageThunk,
+        unsubscribeAndDisposeLocalFirstStorage: unsubscribeAndDisposeLocalFirstStorageThunk,
         fetchAndSaveMetadata: metadataLabelingActions.fetchAndSaveMetadata,
         addAccountMetadata: metadataLabelingActions.addAccountMetadata,
         forgetBluetoothDevice: forgetBluetoothDeviceThunk,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6330,6 +6330,15 @@ export default defineMessages({
         defaultMessage: 'Select how to sync your labels. Your data is encrypted by Trezor.',
         id: 'METADATA_MODAL_DESCRIPTION',
     },
+    FIRMWARE_NEEDS_UPGRADE_FOR_EVOLU: {
+        id: 'FIRMWARE_NEEDS_UPGRADE_FOR_EVOLU',
+        defaultMessage: 'Upgrade Firmware for Evolu Labeling.',
+    },
+    LEGACY_LABELING_TURNS_OFF_EVOLU_NOTICE: {
+        id: 'LEGACY_LABELING_TURNS_OFF_EVOLU_NOTICE',
+        defaultMessage:
+            'Local First Storage (Evolu) will be turned off by enabling this Legacy Labeling',
+    },
     TR_DISABLED_SWITCH_TOOLTIP: {
         id: 'TR_DISABLED_SWITCH_TOOLTIP',
         defaultMessage: 'Connect & unlock device to change',

--- a/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
+++ b/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
@@ -1,4 +1,5 @@
 import { FirmwareUpdateState } from '@suite-common/firmware';
+import { initialLabelingState } from '@suite-common/local-first-storage';
 import { messageSystemInitialState } from '@suite-common/message-system';
 import { MetadataState } from '@suite-common/metadata-types';
 import { NetworkSymbol } from '@suite-common/wallet-config';
@@ -31,6 +32,7 @@ export const initialAppState: AppState = {
         lastThpCode: undefined,
         credentials: [],
     },
+    labeling: initialLabelingState,
     window: {
         isVisible: true,
         isBelowMobile: false,

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -6,6 +6,7 @@ import { bluetoothActions } from '@suite-common/bluetooth';
 import { deviceAuthenticityActions } from '@suite-common/device-authenticity';
 import { firmwareActions } from '@suite-common/firmware';
 import { geolocationActions } from '@suite-common/geolocation';
+import { labelingActions } from '@suite-common/local-first-storage';
 import { addLog } from '@suite-common/logger';
 import { messageSystemActions } from '@suite-common/message-system';
 import type { Route } from '@suite-common/suite-types';
@@ -87,6 +88,7 @@ type DeviceActionDesktop = ReturnType<
     (typeof deviceSlice.actions)[keyof typeof deviceSlice.actions]
 >;
 type ThpAction = ReturnType<(typeof thpActions)[keyof typeof thpActions]>;
+type LabelingAction = ReturnType<(typeof labelingActions)[keyof typeof labelingActions]>;
 type GeolocationAction = ReturnType<(typeof geolocationActions)[keyof typeof geolocationActions]>;
 type FeeAction = ReturnType<(typeof feesActions)[keyof typeof feesActions]>;
 
@@ -119,6 +121,7 @@ export type Action =
     | BluetoothActionDesktop
     | DeviceActionDesktop
     | ThpAction
+    | LabelingAction
     | GeolocationAction
     | BioAuthAction
     | FeeAction;

--- a/packages/suite/src/views/settings/SettingsDebug/LocalFirstStorageDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/LocalFirstStorageDebug.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+
+import {
+    DEFAULT_LOCAL_FIRST_STORAGE_RELAY_URL,
+    disposeAllLocalFirstStorageThunk,
+} from '@suite-common/local-first-storage';
+import { Button, Checkbox, Code, Column, Input, Text } from '@trezor/components';
+import { initSuiteLocalFirstStorageThunk } from '@trezor/suite-local-first-storage';
+import { spacings } from '@trezor/theme';
+
+import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
+
+import { setLocalFirstStorageRelayAction } from '../../../actions/settings/settingsActions';
+import { setFlag } from '../../../actions/suite/suiteActions';
+import { SettingsSection } from '../../../components/settings';
+import { useDispatch, useSelector } from '../../../hooks/suite';
+import {
+    selectLocalFirstStorageRelayUrl,
+    selectSuiteFlags,
+} from '../../../selectors/suite/suiteSelectors';
+
+export const LocalFirstStorageDebug = () => {
+    const [isLoading, setIsLoading] = useState(false);
+
+    const { isLocalFirstStorageEnabled, isLocalFirstStorageDebugEnabled } =
+        useSelector(selectSuiteFlags);
+    const localFirstStorageRelayUrl = useSelector(selectLocalFirstStorageRelayUrl);
+
+    const [relayUrl, setRelayUrl] = useState(localFirstStorageRelayUrl ?? '');
+
+    const dispatch = useDispatch();
+
+    const handleToggleLocalFirstStorage = () => {
+        dispatch(setFlag('isLocalFirstStorageEnabled', !isLocalFirstStorageEnabled));
+        if (!isLocalFirstStorageEnabled) {
+            dispatch(initSuiteLocalFirstStorageThunk());
+        } else {
+            dispatch(disposeAllLocalFirstStorageThunk());
+        }
+    };
+
+    const handleToggleLocalFirstStorageDebug = () => {
+        dispatch(setFlag('isLocalFirstStorageDebugEnabled', !isLocalFirstStorageDebugEnabled));
+    };
+
+    const onRelayUrlSave = () => {
+        setIsLoading(true);
+        dispatch(setLocalFirstStorageRelayAction({ url: relayUrl }));
+
+        // We need to dispose of all Evolu instances and create new
+        // as they do not support the Relay URL change
+        dispatch(disposeAllLocalFirstStorageThunk());
+        dispatch(initSuiteLocalFirstStorageThunk());
+
+        // Fake it, to make some UI interaction for the user
+        setTimeout(() => {
+            setIsLoading(false);
+        }, 300);
+    };
+
+    return (
+        <SettingsSection title="Local First Storage">
+            <SectionItem>
+                <TextColumn title="Local First Storage (Evolu)" />
+                <ActionColumn>
+                    <Checkbox
+                        isChecked={isLocalFirstStorageEnabled}
+                        onClick={handleToggleLocalFirstStorage}
+                    />
+                </ActionColumn>
+            </SectionItem>
+            {isLocalFirstStorageEnabled && (
+                <>
+                    <SectionItem>
+                        <TextColumn title="Relay URL" />
+                        <ActionColumn>
+                            <Column gap={spacings.xxs}>
+                                <Input
+                                    isDisabled={isLoading}
+                                    value={relayUrl}
+                                    onChange={e => setRelayUrl(e.target.value)}
+                                    innerAddon={
+                                        <Button
+                                            isLoading={isLoading}
+                                            onClick={onRelayUrlSave}
+                                            size="small"
+                                        >
+                                            Save
+                                        </Button>
+                                    }
+                                />
+                                <Text typographyStyle="hint" variant="tertiary">
+                                    Default is: <Code>{DEFAULT_LOCAL_FIRST_STORAGE_RELAY_URL}</Code>
+                                </Text>
+                            </Column>
+                        </ActionColumn>
+                    </SectionItem>
+                    <SectionItem>
+                        <TextColumn title="Local First Storage (Evolu) Debug" />
+                        <ActionColumn>
+                            <Checkbox
+                                isChecked={isLocalFirstStorageDebugEnabled}
+                                onClick={handleToggleLocalFirstStorageDebug}
+                            />
+                        </ActionColumn>
+                    </SectionItem>
+                </>
+            )}
+        </SettingsSection>
+    );
+};

--- a/packages/suite/src/views/settings/SettingsDebug/LocalFirstStorageSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/LocalFirstStorageSettings.tsx
@@ -26,7 +26,10 @@ export const LocalFirstStorageSettings = () => {
         isLocalFirstStorageDebugEnabled,
         localFirstDisable,
         localFirstEnable,
-    } = useLabelingCombined();
+    } = useLabelingCombined({
+        // In debug, there may not be any device selected and it is in fact irrelevant
+        deviceStaticSessionId: undefined,
+    });
 
     const localFirstStorageRelayUrl = useSelector(selectLocalFirstStorageRelayUrl);
 

--- a/packages/suite/src/views/settings/SettingsDebug/LocalFirstStorageSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/LocalFirstStorageSettings.tsx
@@ -4,7 +4,7 @@ import {
     DEFAULT_LOCAL_FIRST_STORAGE_RELAY_URL,
     disposeAllLocalFirstStorageThunk,
 } from '@suite-common/local-first-storage';
-import { Button, Checkbox, Code, Column, Input, Text } from '@trezor/components';
+import { Banner, Button, Checkbox, Code, Column, Input, Text } from '@trezor/components';
 import { initSuiteLocalFirstStorageThunk } from '@trezor/suite-local-first-storage';
 import { spacings } from '@trezor/theme';
 
@@ -14,16 +14,20 @@ import { setLocalFirstStorageRelayAction } from '../../../actions/settings/setti
 import { setFlag } from '../../../actions/suite/suiteActions';
 import { SettingsSection } from '../../../components/settings';
 import { useDispatch, useSelector } from '../../../hooks/suite';
-import {
-    selectLocalFirstStorageRelayUrl,
-    selectSuiteFlags,
-} from '../../../selectors/suite/suiteSelectors';
+import { useLabelingCombined } from '../../../hooks/suite/useLabelingCombined';
+import { selectLocalFirstStorageRelayUrl } from '../../../selectors/suite/suiteSelectors';
 
-export const LocalFirstStorageDebug = () => {
+export const LocalFirstStorageSettings = () => {
     const [isLoading, setIsLoading] = useState(false);
 
-    const { isLocalFirstStorageEnabled, isLocalFirstStorageDebugEnabled } =
-        useSelector(selectSuiteFlags);
+    const {
+        legacyMetadataState,
+        isLocalFirstStorageEnabled,
+        isLocalFirstStorageDebugEnabled,
+        localFirstDisable,
+        localFirstEnable,
+    } = useLabelingCombined();
+
     const localFirstStorageRelayUrl = useSelector(selectLocalFirstStorageRelayUrl);
 
     const [relayUrl, setRelayUrl] = useState(localFirstStorageRelayUrl ?? '');
@@ -31,11 +35,10 @@ export const LocalFirstStorageDebug = () => {
     const dispatch = useDispatch();
 
     const handleToggleLocalFirstStorage = () => {
-        dispatch(setFlag('isLocalFirstStorageEnabled', !isLocalFirstStorageEnabled));
         if (!isLocalFirstStorageEnabled) {
-            dispatch(initSuiteLocalFirstStorageThunk());
+            localFirstEnable();
         } else {
-            dispatch(disposeAllLocalFirstStorageThunk());
+            localFirstDisable();
         }
     };
 
@@ -61,7 +64,17 @@ export const LocalFirstStorageDebug = () => {
     return (
         <SettingsSection title="Local First Storage">
             <SectionItem>
-                <TextColumn title="Local First Storage (Evolu)" />
+                <TextColumn
+                    title="Local First Storage (Evolu)"
+                    description={
+                        legacyMetadataState.enabled && (
+                            <Banner>
+                                Legacy Labeling will be turned off by enabling Local First Storage
+                                (Evolu)
+                            </Banner>
+                        )
+                    }
+                />
                 <ActionColumn>
                     <Checkbox
                         isChecked={isLocalFirstStorageEnabled}

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -18,7 +18,7 @@ import { FirmwareUpdate } from './FirmwareUpdate';
 import { ForgetAllDevicesButton } from './ForgetBluetoothDevices';
 import { GithubIssue } from './GithubIssue';
 import { InvityApi } from './InvityApi';
-import { LocalFirstStorageDebug } from './LocalFirstStorageDebug';
+import { LocalFirstStorageSettings } from './LocalFirstStorageSettings';
 import { MessageSystemConfigSourceSelect } from './MessageSystem/MessageSystemConfigSourceSelect';
 import { Metadata } from './Metadata';
 import { OAuthApi } from './OAuthApi';
@@ -106,7 +106,7 @@ export const SettingsDebug = () => {
             <SettingsSection title="Firmware update source">
                 <FirmwareUpdate />
             </SettingsSection>
-            <LocalFirstStorageDebug />
+            <LocalFirstStorageSettings />
         </SettingsLayout>
     );
 };

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -18,8 +18,8 @@ import { FirmwareUpdate } from './FirmwareUpdate';
 import { ForgetAllDevicesButton } from './ForgetBluetoothDevices';
 import { GithubIssue } from './GithubIssue';
 import { InvityApi } from './InvityApi';
+import { LocalFirstStorageDebug } from './LocalFirstStorageDebug';
 import { MessageSystemConfigSourceSelect } from './MessageSystem/MessageSystemConfigSourceSelect';
-import { MessageSystemDebugInfo } from './MessageSystem/MessageSystemDebugInfo';
 import { Metadata } from './Metadata';
 import { OAuthApi } from './OAuthApi';
 import { PreField } from './PreField';
@@ -88,7 +88,6 @@ export const SettingsDebug = () => {
             </SettingsSection>
             <SettingsSection title="Message system info">
                 <MessageSystemConfigSourceSelect />
-                <MessageSystemDebugInfo />
             </SettingsSection>
             {isDesktop() && (
                 <SettingsSection title={<Translation id="TR_BLUETOOTH" />}>
@@ -107,6 +106,7 @@ export const SettingsDebug = () => {
             <SettingsSection title="Firmware update source">
                 <FirmwareUpdate />
             </SettingsSection>
+            <LocalFirstStorageDebug />
         </SettingsLayout>
     );
 };

--- a/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
@@ -80,8 +80,7 @@ export const Labeling = () => {
                         <Translation id="TR_LABELING_FEATURE_ALLOWS" />
                         {isLocalFirstStorageEnabled && (
                             <Banner>
-                                Local First Storage (Evolu) will be turned off by enabling this
-                                Legacy Labeling
+                                <Translation id="LEGACY_LABELING_TURNS_OFF_EVOLU_NOTICE" />
                             </Banner>
                         )}
                     </>

--- a/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
@@ -1,33 +1,36 @@
 import { isDevicePerceivedAsNew } from '@suite-common/suite-utils';
-import { LoadingContent, Switch, Tooltip } from '@trezor/components';
+import { Banner, LoadingContent, Switch, Tooltip } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { HELP_CENTER_LABELING } from '@trezor/urls';
 
-import * as metadataActions from 'src/actions/suite/metadataActions';
-import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
 import { SettingsSectionItem } from 'src/components/settings';
 import { ActionColumn, TextColumn, Translation } from 'src/components/suite';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
-import { useDevice, useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
+import { useDevice, useDiscovery } from 'src/hooks/suite';
 
+import { useLabelingCombined } from '../../../hooks/suite/useLabelingCombined';
+
+/**
+ * @deprecated This will be replaced by LocalFistStorage (Evolu)
+ */
 export const Labeling = () => {
-    const metadata = useSelector(state => state.metadata);
+    const { legacyMetadataState, legacyEnable, legacyDisable, isLocalFirstStorageEnabled } =
+        useLabelingCombined();
 
     const { device, isLocked } = useDevice();
-    const dispatch = useDispatch();
     const { isDiscoveryRunning } = useDiscovery();
 
     const handleSwitchClick = () => {
-        if (metadata.enabled) {
-            dispatch(metadataActions.disableMetadata());
+        if (legacyMetadataState.enabled) {
+            legacyDisable();
         } else {
-            dispatch(metadataLabelingActions.init(true));
+            legacyEnable();
         }
 
         analytics.report({
             type: EventType.SettingsGeneralLabeling,
             payload: {
-                value: !metadata.enabled,
+                value: !legacyMetadataState.enabled,
             },
         });
     };
@@ -65,11 +68,24 @@ export const Labeling = () => {
         <SettingsSectionItem anchorId={SettingsAnchor.Labeling}>
             <TextColumn
                 title={
-                    <LoadingContent isLoading={metadata.initiating} isSuccessful={metadata.enabled}>
+                    <LoadingContent
+                        isLoading={legacyMetadataState.initiating}
+                        isSuccessful={legacyMetadataState.enabled}
+                    >
                         <Translation id="TR_LABELING_ENABLED" />
                     </LoadingContent>
                 }
-                description={<Translation id="TR_LABELING_FEATURE_ALLOWS" />}
+                description={
+                    <>
+                        <Translation id="TR_LABELING_FEATURE_ALLOWS" />
+                        {isLocalFirstStorageEnabled && (
+                            <Banner>
+                                Local First Storage (Evolu) will be turned off by enabling this
+                                Legacy Labeling
+                            </Banner>
+                        )}
+                    </>
+                }
                 buttonLink={HELP_CENTER_LABELING}
             />
             <ActionColumn>
@@ -81,9 +97,9 @@ export const Labeling = () => {
                     content={getTooltipContent()}
                 >
                     <Switch
-                        isDisabled={isDisabled || metadata.initiating}
+                        isDisabled={isDisabled || legacyMetadataState.initiating}
                         data-testid="@settings/metadata-switch"
-                        isChecked={metadata.enabled}
+                        isChecked={legacyMetadataState.enabled}
                         onChange={handleSwitchClick}
                     />
                 </Tooltip>

--- a/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
@@ -14,10 +14,10 @@ import { useLabelingCombined } from '../../../hooks/suite/useLabelingCombined';
  * @deprecated This will be replaced by LocalFistStorage (Evolu)
  */
 export const Labeling = () => {
-    const { legacyMetadataState, legacyEnable, legacyDisable, isLocalFirstStorageEnabled } =
-        useLabelingCombined();
-
     const { device, isLocked } = useDevice();
+    const { legacyMetadataState, legacyEnable, legacyDisable, isLocalFirstStorageEnabled } =
+        useLabelingCombined({ deviceStaticSessionId: device?.state?.staticSessionId });
+
     const { isDiscoveryRunning } = useDiscovery();
 
     const handleSwitchClick = () => {

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
@@ -1,5 +1,6 @@
 import React, { MouseEventHandler } from 'react';
 
+import { selectWalletLabel } from '@suite-common/local-first-storage';
 import { TrezorDevice } from '@suite-common/suite-types';
 import * as deviceUtils from '@suite-common/suite-utils';
 import { TOOLTIP_DELAY_LONG, TruncateWithTooltip } from '@trezor/components';
@@ -24,14 +25,21 @@ type DeviceStatusVisible = {
 };
 
 const DeviceStatusVisible = ({ device, connected, forceConnectionInfo }: DeviceStatusVisible) => {
-    const { walletLabel } = useSelector(state => selectLabelingDataForWallet(state, device.state));
+    const { walletLabel: walletLabelOld } = useSelector(state =>
+        selectLabelingDataForWallet(state, device.state),
+    );
 
     const { defaultAccountLabelString } = useWalletLabeling();
 
     const defaultWalletLabel =
         device !== undefined ? defaultAccountLabelString({ device }) : undefined;
-    const isWalletLabelEmpty = walletLabel === undefined || walletLabel.trim() === '';
 
+    const localFirstWalletLabel = useSelector(state =>
+        selectWalletLabel({ state, deviceStaticSessionId: device?.state?.staticSessionId }),
+    );
+
+    const walletLabel = localFirstWalletLabel ?? walletLabelOld;
+    const isWalletLabelEmpty = walletLabel === undefined || walletLabel.trim() === '';
     const walletText = isWalletLabelEmpty ? defaultWalletLabel : walletLabel;
 
     return (

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/LocalFirstStorageDebug.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/LocalFirstStorageDebug.tsx
@@ -1,20 +1,23 @@
 import { AcquiredDevice } from '@suite-common/suite-types';
-import { Banner, Code, Row, Text, Tooltip } from '@trezor/components';
+import { Code, Row, Text, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { useLabelingCombined } from '../../../../hooks/suite/useLabelingCombined';
 
 export const LocalFirstStorageDebug = ({ device }: { device: AcquiredDevice }) => {
-    const { legacyMetadataState, isLocalFirstStorageEnabled, isLocalFirstStorageDebugEnabled } =
-        useLabelingCombined();
+    const {
+        legacyMetadataState,
+        isLocalFirstStorageEnabled,
+        isLocalFirstStorageDebugEnabled,
+        isEvoluSupportedByDevice,
+    } = useLabelingCombined();
 
-    if (!isLocalFirstStorageDebugEnabled || !device.state?.staticSessionId) {
+    if (
+        !isLocalFirstStorageDebugEnabled ||
+        !isEvoluSupportedByDevice ||
+        !device.state?.staticSessionId
+    ) {
         return;
-    }
-
-    if (device.unavailableCapabilities.evolu) {
-        // Todo: better UX to cover this
-        return <Banner variant="warning">Upgrade Firmware for Evolu Labeling.</Banner>;
     }
 
     return isLocalFirstStorageEnabled ? (

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/LocalFirstStorageDebug.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/LocalFirstStorageDebug.tsx
@@ -10,7 +10,7 @@ export const LocalFirstStorageDebug = ({ device }: { device: AcquiredDevice }) =
         isLocalFirstStorageEnabled,
         isLocalFirstStorageDebugEnabled,
         isEvoluSupportedByDevice,
-    } = useLabelingCombined();
+    } = useLabelingCombined({ deviceStaticSessionId: device.state?.staticSessionId });
 
     if (
         !isLocalFirstStorageDebugEnabled ||

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/LocalFirstStorageDebug.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/LocalFirstStorageDebug.tsx
@@ -2,34 +2,48 @@ import { AcquiredDevice } from '@suite-common/suite-types';
 import { Banner, Code, Row, Text, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
-
-import { useSelector } from '../../../../hooks/suite';
+import { useLabelingCombined } from '../../../../hooks/suite/useLabelingCombined';
 
 export const LocalFirstStorageDebug = ({ device }: { device: AcquiredDevice }) => {
-    const { isLocalFirstStorageDebugEnabled } = useSelector(selectSuiteFlags);
+    const { legacyMetadataState, isLocalFirstStorageEnabled, isLocalFirstStorageDebugEnabled } =
+        useLabelingCombined();
+
+    if (!isLocalFirstStorageDebugEnabled || !device.state?.staticSessionId) {
+        return;
+    }
 
     if (device.unavailableCapabilities.evolu) {
         // Todo: better UX to cover this
         return <Banner variant="warning">Upgrade Firmware for Evolu Labeling.</Banner>;
     }
 
-    return isLocalFirstStorageDebugEnabled && device.state?.staticSessionId ? (
+    return isLocalFirstStorageEnabled ? (
         <Row gap={spacings.xxs}>
-            <Text typographyStyle="hint" variant="warning">
-                <Code>{device.state.staticSessionId.split('@')[0].slice(-8)}</Code>
-            </Text>
-            @
-            <Text typographyStyle="hint" variant="purple">
-                <Code>{device.state.staticSessionId.slice(-8)}</Code>
-            </Text>
-            <Tooltip
-                content={<Code>{JSON.stringify(device.localFirstStorageSecret, null, 2)}</Code>}
-            >
-                <Text typographyStyle="hint" variant="purple">
-                    E: <Code>{device.localFirstStorageSecret?.evoluKeys?.ownerId.slice(-8)}</Code>
-                </Text>
-            </Tooltip>
+            🐞
+            {legacyMetadataState.enabled && <Text variant="purple">[Legacy]</Text>}
+            {isLocalFirstStorageEnabled && (
+                <>
+                    <Text typographyStyle="hint" variant="warning">
+                        <Code>{device.state.staticSessionId.split('@')[0].slice(-8)}</Code>
+                    </Text>
+                    @
+                    <Text typographyStyle="hint" variant="purple">
+                        <Code>{device.state.staticSessionId.slice(-8)}</Code>
+                    </Text>
+                    <Tooltip
+                        content={
+                            <Code>{JSON.stringify(device.localFirstStorageSecret, null, 2)}</Code>
+                        }
+                    >
+                        <Text typographyStyle="hint" variant="purple">
+                            E:{' '}
+                            <Code>
+                                {device.localFirstStorageSecret?.evoluKeys?.ownerId.slice(-8)}
+                            </Code>
+                        </Text>
+                    </Tooltip>
+                </>
+            )}
         </Row>
     ) : null;
 };

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/LocalFirstStorageDebug.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/LocalFirstStorageDebug.tsx
@@ -1,0 +1,35 @@
+import { AcquiredDevice } from '@suite-common/suite-types';
+import { Banner, Code, Row, Text, Tooltip } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
+
+import { useSelector } from '../../../../hooks/suite';
+
+export const LocalFirstStorageDebug = ({ device }: { device: AcquiredDevice }) => {
+    const { isLocalFirstStorageDebugEnabled } = useSelector(selectSuiteFlags);
+
+    if (device.unavailableCapabilities.evolu) {
+        // Todo: better UX to cover this
+        return <Banner variant="warning">Upgrade Firmware for Evolu Labeling.</Banner>;
+    }
+
+    return isLocalFirstStorageDebugEnabled && device.state?.staticSessionId ? (
+        <Row gap={spacings.xxs}>
+            <Text typographyStyle="hint" variant="warning">
+                <Code>{device.state.staticSessionId.split('@')[0].slice(-8)}</Code>
+            </Text>
+            @
+            <Text typographyStyle="hint" variant="purple">
+                <Code>{device.state.staticSessionId.slice(-8)}</Code>
+            </Text>
+            <Tooltip
+                content={<Code>{JSON.stringify(device.localFirstStorageSecret, null, 2)}</Code>}
+            >
+                <Text typographyStyle="hint" variant="purple">
+                    E: <Code>{device.localFirstStorageSecret?.evoluKeys?.ownerId.slice(-8)}</Code>
+                </Text>
+            </Tooltip>
+        </Row>
+    ) : null;
+};

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { selectWalletLabel } from '@suite-common/local-first-storage';
 import {
     getAccountsByDeviceState,
     selectAllAccountsToList,
@@ -24,6 +25,7 @@ import { spacings } from '@trezor/theme';
 import { METADATA_LABELING } from 'src/actions/suite/constants';
 import { redirectAfterWalletSelectedThunk } from 'src/actions/wallet/addWalletThunk';
 import { MetadataLabeling, Translation, WalletLabeling } from 'src/components/suite';
+import { useWalletLabeling } from 'src/components/suite/labeling/WalletLabeling';
 import { FiatHeader } from 'src/components/wallet/FiatHeader';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useStore } from 'src/hooks/suite/useStore';
@@ -32,7 +34,7 @@ import { selectLabelingDataForWallet } from 'src/reducers/suite/metadataReducer'
 import { AcquiredDevice, ForegroundAppProps } from 'src/types/suite';
 
 import { EjectConfirmation } from './EjectConfirmation';
-import { useWalletLabeling } from '../../../../components/suite/labeling/WalletLabeling';
+import { LocalFirstStorageDebug } from './LocalFirstStorageDebug';
 
 type WalletInstanceProps = {
     instance: AcquiredDevice;
@@ -64,9 +66,16 @@ export const WalletInstance = ({
 
     const walletBalance = useTotalFiatBalance(deviceAccounts, baseCurrencyCode, currentFiatRates);
 
-    const { walletLabel } = useSelector(state =>
+    const { walletLabel: oldWalletLabel } = useSelector(state =>
         selectLabelingDataForWallet(state, instance.state),
     );
+
+    const localFirstWalletLabel = useSelector(state =>
+        selectWalletLabel({ state, deviceStaticSessionId: instance?.state?.staticSessionId }),
+    );
+
+    const walletLabel = localFirstWalletLabel ?? oldWalletLabel;
+
     const dataTestBase = `@switch-device/wallet-on-index/${index}`;
 
     const defaultWalletLabel = defaultAccountLabelString({ device: instance });
@@ -144,25 +153,31 @@ export const WalletInstance = ({
                                         </Tooltip>
                                     )}
                                     {instance.state?.staticSessionId ? (
-                                        <MetadataLabeling
-                                            defaultVisibleValue={
-                                                walletLabel === undefined ||
-                                                walletLabel.trim() === ''
-                                                    ? defaultWalletLabel
-                                                    : walletLabel
-                                            }
-                                            payload={{
-                                                type: 'walletLabel',
-                                                entityKey: instance.state.staticSessionId,
-                                                defaultValue: instance.state.staticSessionId,
-                                                value: instance?.metadata[
-                                                    METADATA_LABELING.ENCRYPTION_VERSION
-                                                ]
-                                                    ? walletLabel
-                                                    : '',
-                                            }}
-                                            defaultEditableValue={defaultWalletLabel}
-                                        />
+                                        <Column>
+                                            <MetadataLabeling
+                                                deviceStaticSessionId={
+                                                    instance.state.staticSessionId
+                                                }
+                                                defaultVisibleValue={
+                                                    walletLabel === undefined ||
+                                                    walletLabel.trim() === ''
+                                                        ? defaultWalletLabel
+                                                        : walletLabel
+                                                }
+                                                payload={{
+                                                    type: 'walletLabel',
+                                                    entityKey: instance.state.staticSessionId,
+                                                    defaultValue: instance.state.staticSessionId,
+                                                    value: instance?.metadata[
+                                                        METADATA_LABELING.ENCRYPTION_VERSION
+                                                    ]
+                                                        ? walletLabel
+                                                        : '',
+                                                }}
+                                                defaultEditableValue={defaultWalletLabel}
+                                            />
+                                            <LocalFirstStorageDebug device={instance} />
+                                        </Column>
                                     ) : (
                                         <WalletLabeling device={instance} />
                                     )}

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -22,7 +22,6 @@ import {
 } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { METADATA_LABELING } from 'src/actions/suite/constants';
 import { redirectAfterWalletSelectedThunk } from 'src/actions/wallet/addWalletThunk';
 import { MetadataLabeling, Translation, WalletLabeling } from 'src/components/suite';
 import { useWalletLabeling } from 'src/components/suite/labeling/WalletLabeling';
@@ -120,6 +119,9 @@ export const WalletInstance = ({
         }
     };
 
+    const valueLabel =
+        walletLabel === undefined || walletLabel.trim() === '' ? defaultWalletLabel : walletLabel;
+
     return (
         <Box position={{ type: 'relative' }} width="100%">
             <Card
@@ -158,23 +160,14 @@ export const WalletInstance = ({
                                                 deviceStaticSessionId={
                                                     instance.state.staticSessionId
                                                 }
-                                                defaultVisibleValue={
-                                                    walletLabel === undefined ||
-                                                    walletLabel.trim() === ''
-                                                        ? defaultWalletLabel
-                                                        : walletLabel
-                                                }
+                                                defaultVisibleValue={valueLabel}
                                                 payload={{
                                                     type: 'walletLabel',
                                                     entityKey: instance.state.staticSessionId,
                                                     defaultValue: instance.state.staticSessionId,
-                                                    value: instance?.metadata[
-                                                        METADATA_LABELING.ENCRYPTION_VERSION
-                                                    ]
-                                                        ? walletLabel
-                                                        : '',
+                                                    value: valueLabel,
                                                 }}
-                                                defaultEditableValue={defaultWalletLabel}
+                                                defaultEditableValue={valueLabel}
                                             />
                                             <LocalFirstStorageDebug device={instance} />
                                         </Column>

--- a/packages/suite/src/views/wallet/receive/Receive.tsx
+++ b/packages/suite/src/views/wallet/receive/Receive.tsx
@@ -58,12 +58,14 @@ export const Receive = () => {
                     pendingAddresses={pendingAddresses}
                     isDeviceConnected={isDeviceConnected}
                 />
-                <UsedAddresses
-                    account={account}
-                    addresses={receive}
-                    locked={isDeviceLocked}
-                    pendingAddresses={pendingAddresses}
-                />
+                {account && (
+                    <UsedAddresses
+                        account={account}
+                        addresses={receive}
+                        locked={isDeviceLocked}
+                        pendingAddresses={pendingAddresses}
+                    />
+                )}
             </Column>
 
             <ConfirmEvmExplanationModal account={account} route="wallet-receive" />

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -2,7 +2,9 @@ import { useState } from 'react';
 
 import styled from 'styled-components';
 
+import { selectAddressLabels } from '@suite-common/local-first-storage';
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { Account } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { Button, Card, Column, GradientOverlay, Row, Table, Text } from '@trezor/components';
 import { AccountAddress } from '@trezor/connect';
@@ -37,9 +39,10 @@ type ItemProps = {
     symbol: NetworkSymbol;
     metadataPayload: MetadataAddPayload;
     onClick: () => void;
+    account: Account;
 };
 
-const Item = ({ addr, locked, symbol, onClick, metadataPayload, index }: ItemProps) => {
+const Item = ({ account, addr, locked, symbol, onClick, metadataPayload, index }: ItemProps) => {
     const { isReceiveDisabled, ReceiveDisabledWrapper } = useReceiveDisabled();
     const [isHovered, setIsHovered] = useState(false);
 
@@ -53,6 +56,7 @@ const Item = ({ addr, locked, symbol, onClick, metadataPayload, index }: ItemPro
             <Table.Cell>
                 <Text typographyStyle="hint" data-testid={`@wallet/receive/used-address/${index}`}>
                     <MetadataLabeling
+                        deviceStaticSessionId={account.deviceState}
                         payload={{
                             ...metadataPayload,
                         }}
@@ -100,7 +104,7 @@ const Item = ({ addr, locked, symbol, onClick, metadataPayload, index }: ItemPro
 };
 
 interface UsedAddressesProps {
-    account: AppState['wallet']['selectedAccount']['account'];
+    account: Account;
     addresses: AppState['wallet']['receive'];
     locked: boolean;
     pendingAddresses: string[];
@@ -116,9 +120,9 @@ export const UsedAddresses = ({
     const dispatch = useDispatch();
     const { addressLabels } = useSelector(selectLabelingDataForSelectedAccount);
 
-    if (!account) {
-        return null;
-    }
+    const localFirstAddressLabels = useSelector(state =>
+        selectAddressLabels({ state, deviceStaticSessionId: account.deviceState }),
+    );
 
     if (
         (account.networkType !== 'bitcoin' && account.networkType !== 'cardano') ||
@@ -169,6 +173,7 @@ export const UsedAddresses = ({
                     <Table.Body>
                         {list.slice(0, limit).map((addr, index) => (
                             <Item
+                                account={account}
                                 index={index}
                                 key={addr.path}
                                 addr={addr}
@@ -178,7 +183,10 @@ export const UsedAddresses = ({
                                     type: 'addressLabel',
                                     entityKey: account.key,
                                     defaultValue: addr.address,
-                                    value: addressLabels[addr.address],
+                                    value:
+                                        localFirstAddressLabels.find(
+                                            it => it.address === addr.address,
+                                        )?.label ?? addressLabels[addr.address],
                                 }}
                                 onClick={() => dispatch(showAddress(addr.path, addr.address))}
                             />

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
@@ -2,6 +2,7 @@ import { MouseEventHandler, ReactNode } from 'react';
 
 import styled, { css, useTheme } from 'styled-components';
 
+import { selectAddressLabels, selectOutputLabels } from '@suite-common/local-first-storage';
 import { useDisplayBaseCurrency } from '@suite-common/wallet-core';
 import { formatNetworkAmount, isSameUtxo } from '@suite-common/wallet-utils';
 import { Checkbox, Row, Spinner, Text, TextButton, Tooltip } from '@trezor/components';
@@ -177,6 +178,13 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
     // selecting metadata from store rather than send form context which does not update on metadata change
     const { addressLabels, outputLabels } = useSelector(selectLabelingDataForSelectedAccount);
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(account.symbol);
+    const localFirstAddressLabels = useSelector(state =>
+        selectAddressLabels({ state, deviceStaticSessionId: account.deviceState }),
+    );
+    const localFirstOutputLabels = useSelector(state =>
+        selectOutputLabels(state, account.deviceState),
+    );
+
     const dispatch = useDispatch();
 
     const theme = useTheme();
@@ -259,11 +267,14 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
                     )}
                     <Text typographyStyle="hint">
                         <MetadataLabeling
+                            deviceStaticSessionId={account.deviceState}
                             payload={{
                                 type: 'addressLabel',
                                 entityKey: account.key,
                                 defaultValue: utxo.address,
-                                value: addressLabels[utxo.address],
+                                value:
+                                    localFirstAddressLabels.find(it => it.address === utxo.address)
+                                        ?.label ?? addressLabels[utxo.address],
                             }}
                             isDisabled
                             defaultVisibleValue={<Address>{utxo.address}</Address>}
@@ -299,6 +310,7 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
                         <LabelPart>
                             <span>•</span>
                             <MetadataLabeling
+                                deviceStaticSessionId={account.deviceState}
                                 visible
                                 payload={{
                                     type: 'outputLabel',
@@ -306,7 +318,12 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
                                     txid: utxo.txid,
                                     outputIndex: utxo.vout,
                                     defaultValue: `${utxo.txid}-${utxo.vout}`,
-                                    value: outputLabel,
+                                    value:
+                                        localFirstOutputLabels.find(
+                                            it =>
+                                                it.txId === utxo.txid &&
+                                                it.outputIndex == utxo.vout,
+                                        )?.label ?? outputLabel,
                                 }}
                             />
                         </LabelPart>

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -166,6 +166,10 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
         }
     }, [amountInputName, composeTransaction, dispatch, inputName, setValue, symbol]);
 
+    if (device?.state?.staticSessionId === undefined) {
+        return;
+    }
+
     const getInputErrorProps = (): {
         learnMoreUrl?: InputErrorProps['learnMoreUrl'];
         buttonProps?: InputErrorProps['buttonProps'];
@@ -452,6 +456,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                 metadataEnabled && broadcastEnabled ? (
                     <Box maxWidth={200}>
                         <MetadataLabeling
+                            deviceStaticSessionId={device.state.staticSessionId}
                             defaultVisibleValue=""
                             payload={{
                                 type: 'outputLabel',

--- a/packages/suite/src/views/wallet/send/index.tsx
+++ b/packages/suite/src/views/wallet/send/index.tsx
@@ -15,6 +15,7 @@ import {
     selectRegisteredUtxosByAccountKey,
     selectTargetAnonymityByAccountKey,
 } from 'src/reducers/wallet/coinjoinReducer';
+import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 import { Options } from './Options/Options';
 import { Outputs } from './Outputs/Outputs';
@@ -58,12 +59,15 @@ interface SendLoadedProps extends SendProps {
 // separated to call `useSendForm` hook at top level
 // children are only for test purposes, this prop is not available in regular build
 const SendLoaded = ({ children, selectedAccount }: SendLoadedProps) => {
+    const { isLocalFirstStorageEnabled } = useSelector(selectSuiteFlags);
+
     const props = useSelector(state => ({
         localCurrency: state.wallet.settings.localCurrency,
         fees: state.wallet.fees,
         online: state.suite.online,
         sendRaw: state.wallet.send.sendRaw,
-        metadataEnabled: state.metadata.enabled && !!state.metadata.providers[0],
+        metadataEnabled:
+            (state.metadata.enabled && !!state.metadata.providers[0]) || isLocalFirstStorageEnabled,
         targetAnonymity: selectTargetAnonymityByAccountKey(state, selectedAccount.account.key),
         prison: selectRegisteredUtxosByAccountKey(state, selectedAccount.account.key),
     }));

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -129,6 +129,9 @@
         { "path": "../suite-analytics" },
         { "path": "../suite-data" },
         { "path": "../suite-desktop-api" },
+        {
+            "path": "../suite-local-first-storage"
+        },
         { "path": "../suite-storage" },
         { "path": "../theme" },
         { "path": "../transport-bluetooth" },

--- a/scripts/list-outdated-dependencies/foundation-dependencies.txt
+++ b/scripts/list-outdated-dependencies/foundation-dependencies.txt
@@ -3,6 +3,7 @@
 @electron/notarize
 @eslint/js
 @evolu/common
+@evolu/web
 @hookform/resolvers
 @noble/hashes
 @types/bn.js

--- a/suite-common/local-first-storage/src/index.ts
+++ b/suite-common/local-first-storage/src/index.ts
@@ -25,4 +25,5 @@ export {
 export type { WithLabelingState } from './labeling/labelingSelectors';
 export { labelingActions } from './labeling/labelingActions';
 export { prepareLabelingReducer, initialLabelingState } from './labeling/labelingReducer';
+export type { LabelingState } from './labeling/labelingReducer';
 export { processMetadataMessageThunk } from './labeling/processMetadataMessageThunk';

--- a/suite-common/local-first-storage/src/labeling/evolu/accountLabels.ts
+++ b/suite-common/local-first-storage/src/labeling/evolu/accountLabels.ts
@@ -12,6 +12,7 @@ import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { AccountDescriptor } from '@suite-common/wallet-types';
 
 import { UnwrapQuery } from '../../evoluUtils';
+import { normalizeLabel } from '../normalizeLabel';
 
 export const AccountLabelId = id('AccountLabelId');
 export type AccountLabelId = typeof AccountLabelId.Type;
@@ -52,7 +53,7 @@ export class AccountLabels {
             id: idResult.value,
             accountDescriptor,
             networkSymbol,
-            label,
+            label: normalizeLabel(label),
         });
 
         if (!result.ok) {

--- a/suite-common/local-first-storage/src/labeling/evolu/addressLabels.ts
+++ b/suite-common/local-first-storage/src/labeling/evolu/addressLabels.ts
@@ -8,6 +8,7 @@ import {
 } from '@evolu/common';
 
 import { UnwrapQuery } from '../../evoluUtils';
+import { normalizeLabel } from '../normalizeLabel';
 
 export const AddressLabelId = id('AddressLabelId');
 export type AddressLabelId = typeof AddressLabelId.Type;
@@ -43,7 +44,7 @@ export class AddressLabels {
         const result = this.evolu.upsert('addressLabel', {
             id: idResult.value,
             address,
-            label,
+            label: normalizeLabel(label),
         });
 
         if (!result.ok) {

--- a/suite-common/local-first-storage/src/labeling/evolu/outputLabels.ts
+++ b/suite-common/local-first-storage/src/labeling/evolu/outputLabels.ts
@@ -9,6 +9,7 @@ import {
 } from '@evolu/common';
 
 import { UnwrapQuery } from '../../evoluUtils';
+import { normalizeLabel } from '../normalizeLabel';
 
 export const OutputLabelId = id('OutputLabelId');
 export type OutputLabelId = typeof OutputLabelId.Type;
@@ -47,7 +48,7 @@ export class OutputLabels {
             id: idResult.value,
             txId,
             outputIndex,
-            label,
+            label: normalizeLabel(label),
         });
 
         if (!result.ok) {

--- a/suite-common/local-first-storage/src/labeling/evolu/walletLabels.ts
+++ b/suite-common/local-first-storage/src/labeling/evolu/walletLabels.ts
@@ -10,6 +10,7 @@ import {
 import type { WalletDescriptor } from '@suite-common/wallet-types';
 
 import { UnwrapQuery } from '../../evoluUtils';
+import { normalizeLabel } from '../normalizeLabel';
 
 export const WalletLabelId = id('WalletLabelId');
 export type WalletLabelId = typeof WalletLabelId.Type;
@@ -49,7 +50,7 @@ export class WalletLabels {
         const result = this.evolu.upsert('walletLabel', {
             id: idResult.value,
             walletDescriptor,
-            label,
+            label: normalizeLabel(label),
         });
 
         if (!result.ok) {

--- a/suite-common/local-first-storage/src/labeling/normalizeLabel.ts
+++ b/suite-common/local-first-storage/src/labeling/normalizeLabel.ts
@@ -1,0 +1,4 @@
+export const normalizeLabel = (label: string | null) =>
+    // No-label is represented as NULL. In current logic we do not allow for "" labels as
+    // we want to always display something (default placeholder)
+    label === null || label.trim() === '' ? null : label;

--- a/suite-common/local-first-storage/src/storage/LocalFirstStorageProvider.ts
+++ b/suite-common/local-first-storage/src/storage/LocalFirstStorageProvider.ts
@@ -79,7 +79,10 @@ export class LocalFirstStorageProvider {
 
         if (storage === undefined) {
             const evolu = createEvoluInstance({
-                relayUrl: this.relayUrl ?? DEFAULT_LOCAL_FIRST_STORAGE_RELAY_URL,
+                relayUrl:
+                    this.relayUrl === null || this.relayUrl.trim() === ''
+                        ? DEFAULT_LOCAL_FIRST_STORAGE_RELAY_URL
+                        : this.relayUrl,
                 evoluKeys,
                 evoluDeps: this.evoluDeps,
             });

--- a/suite-common/local-first-storage/src/storage/LocalFirstStorageProvider.ts
+++ b/suite-common/local-first-storage/src/storage/LocalFirstStorageProvider.ts
@@ -63,7 +63,8 @@ const createEvoluInstance = ({ relayUrl, evoluKeys, evoluDeps }: CreateEvoluInst
 
 type SuiteOwnerId = string;
 
-export const DEFAULT_LOCAL_FIRST_STORAGE_RELAY_URL = 'https://free.evoluhq.com';
+// The `https://evolu.suite.sldev.cz/evolu/` MUST have the last `/` in the URL.
+export const DEFAULT_LOCAL_FIRST_STORAGE_RELAY_URL = 'https://evolu.suite.sldev.cz/evolu/';
 
 export class LocalFirstStorageProvider {
     private storages = new Map<SuiteOwnerId, LocalFirstStorage>();

--- a/suite-common/local-first-storage/src/storage/initLocalFirstStorageThunk.ts
+++ b/suite-common/local-first-storage/src/storage/initLocalFirstStorageThunk.ts
@@ -1,17 +1,15 @@
 import { EvoluDeps } from '@evolu/common';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { selectDevices } from '@suite-common/wallet-core';
 
 import { LocalFirstStorageProvider } from './LocalFirstStorageProvider';
 import { LOCAL_FIRST_STORAGE_PREFIX } from './constants';
 import { setLocalFirstStorageProvider } from './sharedObjects';
-import { subscribeLocalFirstStorageThunk } from './subscribeLocalFirstStorageThunk';
 
 export const initLocalFirstStorageThunkFactory = (evoluDeps: EvoluDeps) =>
     createThunk<void, void, void>(
         `${LOCAL_FIRST_STORAGE_PREFIX}/initLocalFirstStorageThunk`,
-        (_, { getState, dispatch, extra }) => {
+        (_, { getState, extra }) => {
             const { isLocalFirstStorageEnabled } = extra.selectors.selectSuiteSettings(getState());
 
             if (!isLocalFirstStorageEnabled) {
@@ -22,11 +20,5 @@ export const initLocalFirstStorageThunkFactory = (evoluDeps: EvoluDeps) =>
                 extra.selectors.selectSuiteSettings(getState()).localFirstStorageRelayUrl;
 
             setLocalFirstStorageProvider(new LocalFirstStorageProvider(relayUrl, evoluDeps));
-
-            const devices = selectDevices(getState());
-
-            for (const device of devices) {
-                dispatch(subscribeLocalFirstStorageThunk({ device }));
-            }
         },
     );

--- a/suite-common/local-first-storage/src/storage/subscribeLocalFirstStorageThunk.ts
+++ b/suite-common/local-first-storage/src/storage/subscribeLocalFirstStorageThunk.ts
@@ -4,7 +4,6 @@ import { initEvoluKeysThunk, selectDevices } from '@suite-common/wallet-core';
 import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 
 import { LOCAL_FIRST_STORAGE_PREFIX } from './constants';
-import { subscriptionStorage } from './sharedObjects';
 import { subscribeLabelingUpdatesThunk } from '../labeling/subscribeLabelingUpdatesThunk';
 
 type SubscribeLocalFirstStorageThunkParams = {
@@ -26,15 +25,7 @@ export const subscribeLocalFirstStorageThunk = createThunk<
 
         const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticSessionId);
 
-        if (subscriptionStorage[walletDescriptor]) {
-            console.error(
-                `____${deviceStaticSessionId} was already subscribed! This shall NOT happen.`,
-            );
-
-            return;
-        }
-
-        if (device.localFirstStorageSecret === undefined) {
+        if (device.localFirstStorageSecret?.evoluKeys === undefined) {
             await dispatch(initEvoluKeysThunk({ device }));
         }
 

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -50,7 +50,10 @@ export interface ExtendedDevice {
     firstConnectedTimestamp: number;
     buttonRequests: ButtonRequest[];
     metadata: DeviceMetadata;
-    localFirstStorageSecret?: { evoluKeys?: EvoluKeys };
+    localFirstStorageSecret?: {
+        isRetrieving: boolean; // To prevent consequential call of the TrezorConnect.evoluGetNode(...)
+        evoluKeys: EvoluKeys | undefined;
+    };
     walletNumber?: number; // number of passphrase wallet intended to be used in UI
     passwords: DeviceMetadata;
     reconnectRequested?: boolean; // currently only after wipeDevice

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -133,6 +133,13 @@ const setLocalFirstStorageSecret = createAction(
     }),
 );
 
+const setLocalFirstStorageSecretRetrieving = createAction(
+    `${DEVICE_MODULE_PREFIX}/setLocalFirstStorageSecretRetrieving`,
+    ({ device, isRetrieving }: { device: TrezorDevice; isRetrieving: boolean }) => ({
+        payload: { device, isRetrieving },
+    }),
+);
+
 const toggleIsDeviceAutoEjectEnabled = createAction(
     `${DEVICE_MODULE_PREFIX}/toggleAutoEjectDevices`,
 );
@@ -166,6 +173,7 @@ export const deviceActions = {
     setEntropyCheckFail,
     setThpCredentials,
     setLocalFirstStorageSecret,
+    setLocalFirstStorageSecretRetrieving,
     toggleIsDeviceAutoEjectEnabled,
     setDiscovered,
 };

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -693,7 +693,22 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(
                     if (!device.features) return;
                     const index = deviceUtils.findInstanceIndex(state.devices, device);
                     if (!state.devices[index]) return;
-                    state.devices[index].localFirstStorageSecret = { evoluKeys };
+                    state.devices[index].localFirstStorageSecret = {
+                        evoluKeys,
+                        isRetrieving: false,
+                    };
+                },
+            )
+            .addCase(
+                deviceActions.setLocalFirstStorageSecretRetrieving,
+                (state, { payload: { device, isRetrieving } }) => {
+                    if (!device.features) return;
+                    const index = deviceUtils.findInstanceIndex(state.devices, device);
+                    if (!state.devices[index]) return;
+                    state.devices[index].localFirstStorageSecret = {
+                        isRetrieving,
+                        evoluKeys: undefined,
+                    };
                 },
             )
             .addCase(deviceActions.toggleIsDeviceAutoEjectEnabled, state => {

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -56,7 +56,7 @@ type SelectDeviceThunkParams = {
  */
 export const selectDeviceThunk = createThunk<void, SelectDeviceThunkParams, void>(
     `${DEVICE_MODULE_PREFIX}/selectDevice`,
-    ({ device }, { dispatch, getState }) => {
+    ({ device }, { dispatch, getState, extra }) => {
         let trezorDevice: TrezorDevice | typeof undefined;
         const devices = selectDevices(getState());
 
@@ -76,6 +76,9 @@ export const selectDeviceThunk = createThunk<void, SelectDeviceThunkParams, void
         }
 
         dispatch(deviceActions.selectDevice(trezorDevice));
+        if (trezorDevice?.state?.staticSessionId !== undefined) {
+            dispatch(extra.thunks.subscribeLocalFirstStorage({ device: trezorDevice }));
+        }
     },
 );
 

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -76,7 +76,10 @@ export const selectDeviceThunk = createThunk<void, SelectDeviceThunkParams, void
         }
 
         dispatch(deviceActions.selectDevice(trezorDevice));
-        if (trezorDevice?.state?.staticSessionId !== undefined) {
+        if (
+            trezorDevice?.state?.staticSessionId !== undefined &&
+            extra.selectors.selectSuiteSettings(getState()).isLocalFirstStorageEnabled
+        ) {
             dispatch(extra.thunks.subscribeLocalFirstStorage({ device: trezorDevice }));
         }
     },

--- a/suite-common/wallet-core/src/device/initEvoluKeysThunk.ts
+++ b/suite-common/wallet-core/src/device/initEvoluKeysThunk.ts
@@ -24,9 +24,20 @@ export const initEvoluKeysThunk = createThunk<void, InitCipherKeyThunkParams, vo
             it => it.state?.staticSessionId === originalDevice.state?.staticSessionId,
         );
 
-        if (device === undefined || device.localFirstStorageSecret !== undefined) {
+        if (
+            device === undefined ||
+            device.localFirstStorageSecret?.evoluKeys !== undefined ||
+            // We are already getting the keys in different "await"
+            // This may happen if selectedDeviceThunk is called concurrently.
+            // Todo: This probably shall not happen, but it happens currently.
+            device.localFirstStorageSecret?.isRetrieving
+        ) {
             return;
         }
+
+        dispatch(
+            deviceActions.setLocalFirstStorageSecretRetrieving({ device, isRetrieving: true }),
+        );
 
         const result = await TrezorConnect.evoluGetNode({
             device: {
@@ -53,9 +64,12 @@ export const initEvoluKeysThunk = createThunk<void, InitCipherKeyThunkParams, vo
                 ),
             };
 
+            // This also sets the `isRetrieving` flag to `false`
             dispatch(deviceActions.setLocalFirstStorageSecret({ device, evoluKeys }));
         } else {
-            console.error('Error:', result.payload);
+            dispatch(
+                deviceActions.setLocalFirstStorageSecretRetrieving({ device, isRetrieving: false }),
+            );
 
             return rejectWithValue(result.payload);
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3553,6 +3553,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@evolu/web@npm:^1.0.1-preview.5":
+  version: 1.0.1-preview.5
+  resolution: "@evolu/web@npm:1.0.1-preview.5"
+  dependencies:
+    "@sqlite.org/sqlite-wasm": "npm:3.50.4-build1"
+  peerDependencies:
+    "@evolu/common": ^6.0.1-preview.18
+  checksum: 10/0de67ce2df9f5ca5c6c99ff58387de7f609d8b8a0f952f9bb23d6d4b8a1bf44f5dbf160680bd2f3ff8e0fc42f7a54c2108ae670abdd6deff5a7ceaddfebe66f9
+  languageName: node
+  linkType: hard
+
 "@exodus/patch-broken-hermes-typed-arrays@npm:^1.0.0-alpha.1":
   version: 1.0.0-alpha.1
   resolution: "@exodus/patch-broken-hermes-typed-arrays@npm:1.0.0-alpha.1"
@@ -9095,6 +9106,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sqlite.org/sqlite-wasm@npm:3.50.4-build1":
+  version: 3.50.4-build1
+  resolution: "@sqlite.org/sqlite-wasm@npm:3.50.4-build1"
+  bin:
+    sqlite-wasm: bin/index.js
+  checksum: 10/5c486213552029065d8b90de823186465972d9a71b921e2303a6834d271e66fd5c2181c63c4452c2847e0745e8fde4b25b5f6baacf53f377093b16e27bacb2a6
+  languageName: node
+  linkType: hard
+
 "@standard-schema/spec@npm:^1.0.0":
   version: 1.0.0
   resolution: "@standard-schema/spec@npm:1.0.0"
@@ -9559,7 +9579,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@suite-common/local-first-storage@workspace:suite-common/local-first-storage":
+"@suite-common/local-first-storage@workspace:*, @suite-common/local-first-storage@workspace:suite-common/local-first-storage":
   version: 0.0.0-use.local
   resolution: "@suite-common/local-first-storage@workspace:suite-common/local-first-storage"
   dependencies:
@@ -12795,6 +12815,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@trezor/suite-local-first-storage@workspace:*, @trezor/suite-local-first-storage@workspace:packages/suite-local-first-storage":
+  version: 0.0.0-use.local
+  resolution: "@trezor/suite-local-first-storage@workspace:packages/suite-local-first-storage"
+  dependencies:
+    "@evolu/web": "npm:^1.0.1-preview.5"
+    "@suite-common/local-first-storage": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
 "@trezor/suite-storage@workspace:*, @trezor/suite-storage@workspace:packages/suite-storage":
   version: 0.0.0-use.local
   resolution: "@trezor/suite-storage@workspace:packages/suite-storage"
@@ -12916,6 +12945,7 @@ __metadata:
     "@trezor/suite-analytics": "workspace:*"
     "@trezor/suite-data": "workspace:*"
     "@trezor/suite-desktop-api": "workspace:*"
+    "@trezor/suite-local-first-storage": "workspace:*"
     "@trezor/suite-storage": "workspace:*"
     "@trezor/theme": "workspace:*"
     "@trezor/transport-bluetooth": "workspace:*"


### PR DESCRIPTION
Part of: https://github.com/trezor/trezor-suite/issues/19262

Implement Evolu labeling into Desktop Suite.


# Testing

1. Legacy Labeling logic needs to be tested
    - wallet, account, tx and address.
    - edit, remove, disable, enable, ..
    
2. Enable Evolu in debug settings 
    <img width="1843" height="410" alt="image" src="https://github.com/user-attachments/assets/2120ecd9-ad69-4d91-99d6-ea6b9e239cec" />
    - all from above needs to be tested
    - connecting two devices with same seed shall make them sync labels (locally)
    - connecting two devices with same seed to different computers shall make them sync labels (over Relay)
    - device without new FW (not supporting Evolu) shall work as well in a way, that labeling is disabled and there is an tooltip 
      <img width="610" height="268" alt="image" src="https://github.com/user-attachments/assets/cd8a591d-0a22-4b6e-8a14-c9839c157eb7" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=evolu_desktop&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=evolu_desktop&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=evolu_desktop&lookback=7)