### PR TITLE
fix(suite-native): no bottom padding/insets on THP confirmation screens

### DIFF
--- a/suite-native/module-authorize-device/src/screens/thp/ThpConfirmationScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/thp/ThpConfirmationScreen.tsx
@@ -44,7 +44,12 @@ export const ThpConfirmationScreen = ({
     ]);
 
     return (
-        <Screen header={<ThpScreenHeader />}>
+        <Screen
+            header={<ThpScreenHeader />}
+            isScrollable={false}
+            noBottomPadding={true}
+            hasBottomInset={false}
+        >
             <ContinueOnTrezorScreenContent />
         </Screen>
     );

--- a/suite-native/module-device-onboarding/src/screens/ThpConfirmationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/ThpConfirmationScreen.tsx
@@ -27,7 +27,11 @@ export const ThpConfirmationScreen = ({
     }, [thpStep, navigation]);
 
     return (
-        <DeviceOnboardingScreenWithExitButton>
+        <DeviceOnboardingScreenWithExitButton
+            isScrollable={false}
+            noBottomPadding={true}
+            hasBottomInset={false}
+        >
             <ContinueOnTrezorScreenContent />
         </DeviceOnboardingScreenWithExitButton>
     );

--- a/suite-native/module-device-settings/src/screens/ThpConfirmationScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/ThpConfirmationScreen.tsx
@@ -37,8 +37,8 @@ export const ThpConfirmationScreen = () => {
     }, [thpStep, navigation, dispatch, navigateToInitialScreen]);
 
     return (
-        <Screen>
-            <Box marginTop="sp64">
+        <Screen isScrollable={false} noBottomPadding={true} hasBottomInset={false}>
+            <Box marginTop="sp64" flex={1}>
                 <ContinueOnTrezorScreenContent />
             </Box>
         </Screen>


### PR DESCRIPTION


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/thp-confirmation-screen&lookback=7)