### PR TITLE
feat(suite): move autostart settings under application section

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -103,16 +103,6 @@ export const SettingsGeneral = () => {
                 </SettingsSection>
             )}
 
-            <SettingsSection title={<Translation id="TR_APPLICATION" />} icon="appWindow">
-                <Theme />
-                <AddressDisplay />
-                <Analytics />
-                <ShowApplicationLog />
-                <ClearStorage />
-                <AutomaticUpdate />
-                <VersionWithUpdate />
-            </SettingsSection>
-
             <SettingsSection title={<Translation id="TR_PRIVACY" />} icon="lock">
                 <AutoEject />
                 {isDesktop() && !isLinux() && <BioAuthSettings />}
@@ -124,12 +114,21 @@ export const SettingsGeneral = () => {
                 </SettingsSection>
             )}
 
-            {isDesktop() && (
-                <SettingsSection title={<Translation id="TR_TREZOR_CONNECT" />} icon="plugs">
-                    <AutoStart />
-                    <ShowOnTray />
-                </SettingsSection>
-            )}
+            <SettingsSection title={<Translation id="TR_APPLICATION" />} icon="appWindow">
+                <Theme />
+                <AddressDisplay />
+                {isDesktop() && (
+                    <>
+                        <AutoStart />
+                        <ShowOnTray />
+                    </>
+                )}
+                <Analytics />
+                <ShowApplicationLog />
+                <ClearStorage />
+                <AutomaticUpdate />
+                <VersionWithUpdate />
+            </SettingsSection>
 
             <SettingsSection title={<Translation id="TR_EXPERIMENTAL_FEATURES" />} icon="atom">
                 {desktopUpdate.enabled && <EarlyAccess />}


### PR DESCRIPTION
## Description

Merged Trezor Connect settings section (containing autostart) with Application. 
Moved Application section down after Privacy, Security. 

## Screenshots:

<img width="1138" height="759" alt="Screenshot 2025-09-02 at 14 54 41" src="https://github.com/user-attachments/assets/8c55a4c6-fdd4-4ef0-87bb-b87d4ce5b429" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/move-autostart-under-app-settings&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/move-autostart-under-app-settings&lookback=7)