### PR TITLE
fix(connect): isCompatible should be true when same version

### DIFF
--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -303,12 +303,12 @@ export const getLanguage = (languageBinPath: string) => {
     return httpRequest(url, 'binary');
 };
 
-const getCurrentVersion = (
-    features: Features,
-): {
+export type CurrentVersion = {
     bootloaderVersion: VersionArray | null;
-    firmwareVersion: VersionArray;
-} => {
+    firmwareVersion: VersionArray | null;
+};
+
+const getCurrentVersion = (features: Features): CurrentVersion => {
     if (!isStrictFeatures(features)) {
         throw new Error('Features of unexpected shape provided.');
     }
@@ -332,7 +332,7 @@ const getCurrentVersion = (
 
     // `fw_version` is the firmware version when in bootloader mode, in firmware mode it will be [null, null, null]
     // when device is factory reset will always be in bootloader mode.
-    const fw_version = [fw_major, fw_minor, fw_patch] as VersionArray;
+    const fw_version = [fw_major, fw_minor, fw_patch];
     // `version` is bootloader version when in bootloader mode, in firmware mode it is firmware version.
     const version = [major_version, minor_version, patch_version] as VersionArray;
 
@@ -342,11 +342,11 @@ const getCurrentVersion = (
     // Some old version of T1B1 do not report FW version in bootloader mode,
     // so it is not 100% true that in bootloader mode we will know the firmware version,
     // but we are handling it `getReleaseInfo` when device is T1B1 we use bootloader version.
-    const firmwareVersion = bootloader_mode ? fw_version : version;
+    const fwVersion = bootloader_mode ? fw_version : version;
 
     return {
         bootloaderVersion,
-        firmwareVersion,
+        firmwareVersion: fwVersion.includes(null) ? null : (fwVersion as VersionArray),
     };
 };
 
@@ -374,9 +374,11 @@ const getIntermediaryMessageRelease = (features: Features) => {
         );
     } else {
         const { firmwareVersion } = getCurrentVersion(features);
-        intermediary = deviceIntermediaryReleases.find(inter =>
-            versionUtils.isNewer(inter.min_firmware_version, firmwareVersion),
-        );
+        intermediary = firmwareVersion
+            ? deviceIntermediaryReleases.find(inter =>
+                  versionUtils.isNewer(inter.min_firmware_version, firmwareVersion),
+              )
+            : undefined;
     }
 
     return intermediary || undefined;
@@ -511,13 +513,14 @@ export const getFirmwareReleaseConfigInfo = (features: Features, firmwareType: F
         : currentVersion.firmwareVersion;
     const minVersionKey = inBootloaderMode ? 'min_bootloader_version' : 'min_firmware_version';
 
-    const isCompatible = versionUtils.isNewerOrEqual(versionToCheck, release[minVersionKey]);
+    const isCompatible =
+        versionToCheck && versionUtils.isNewerOrEqual(versionToCheck, release[minVersionKey]);
 
     const compatibleRelease = isCompatible
         ? release
         : findBestCompatibleRelease(
               getReleasesAssetByDeviceModelAndFirmwareType(features.internal_model, firmwareType),
-              currentVersion.firmwareVersion,
+              currentVersion,
               minVersionKey,
           );
 

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -511,7 +511,7 @@ export const getFirmwareReleaseConfigInfo = (features: Features, firmwareType: F
         : currentVersion.firmwareVersion;
     const minVersionKey = inBootloaderMode ? 'min_bootloader_version' : 'min_firmware_version';
 
-    const isCompatible = versionUtils.isNewer(versionToCheck, release[minVersionKey]);
+    const isCompatible = versionUtils.isNewerOrEqual(versionToCheck, release[minVersionKey]);
 
     const compatibleRelease = isCompatible
         ? release

--- a/packages/connect/src/utils/__tests__/firmwareUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/firmwareUtils.test.ts
@@ -15,7 +15,11 @@ describe('firmwareUtils', () => {
         describe('handling invalid input', () => {
             it('should return undefined for an empty data object', () => {
                 expect(
-                    findBestCompatibleRelease({}, [1, 0, 0], 'min_firmware_version'),
+                    findBestCompatibleRelease(
+                        {},
+                        { bootloaderVersion: null, firmwareVersion: [1, 0, 0] },
+                        'min_firmware_version',
+                    ),
                 ).toBeUndefined();
             });
         });
@@ -24,7 +28,7 @@ describe('firmwareUtils', () => {
             it('should return the newest compatible release', () => {
                 const compatibleRelease = findBestCompatibleRelease(
                     firmwareAssets.t2t1.universal,
-                    [2, 0, 7],
+                    { bootloaderVersion: null, firmwareVersion: [2, 0, 7] },
                     'min_firmware_version',
                 );
                 expect(compatibleRelease?.version).toEqual([2, 1, 1]);
@@ -34,7 +38,7 @@ describe('firmwareUtils', () => {
                 expect(
                     findBestCompatibleRelease(
                         firmwareAssets.t1b1.universal,
-                        [0, 8, 5],
+                        { bootloaderVersion: null, firmwareVersion: [0, 8, 5] },
                         'min_firmware_version',
                     ),
                 ).toBeUndefined();
@@ -44,13 +48,17 @@ describe('firmwareUtils', () => {
         describe('with checkProperty = "min_bootloader_version"', () => {
             it('should return undefined for an empty data object', () => {
                 expect(
-                    findBestCompatibleRelease({}, [1, 0, 0], 'min_bootloader_version'),
+                    findBestCompatibleRelease(
+                        {},
+                        { bootloaderVersion: null, firmwareVersion: [1, 0, 0] },
+                        'min_bootloader_version',
+                    ),
                 ).toBeUndefined();
             });
             it('should return the correct release based on bootloader version', () => {
                 const compatibleRelease = findBestCompatibleRelease(
                     firmwareAssets.t1b1.universal,
-                    [1, 6, 3],
+                    { bootloaderVersion: null, firmwareVersion: [1, 6, 3] },
                     'min_bootloader_version',
                 );
                 expect(compatibleRelease?.version).toEqual([1, 11, 2]);
@@ -60,7 +68,7 @@ describe('firmwareUtils', () => {
                 expect(
                     findBestCompatibleRelease(
                         firmwareAssets.t1b1.universal,
-                        [0, 8, 5],
+                        { bootloaderVersion: null, firmwareVersion: [0, 8, 5] },
                         'min_bootloader_version',
                     ),
                 ).toBeUndefined();

--- a/packages/connect/src/utils/firmwareUtils.ts
+++ b/packages/connect/src/utils/firmwareUtils.ts
@@ -1,6 +1,7 @@
 import type { DeviceModelInternal, FirmwareRelease } from '@trezor/device-utils';
 import { versionUtils } from '@trezor/utils';
 
+import { CurrentVersion } from '../data/firmwareInfo';
 import { Features, FirmwareType, StrictFeatures, VersionArray } from '../types';
 
 export const isStrictFeatures = (extFeatures: Features): extFeatures is StrictFeatures =>
@@ -15,7 +16,7 @@ type VersionCheckProperty = 'min_firmware_version' | 'min_bootloader_version';
 //  that meets the minimum version requirement for a given device property.
 export const findBestCompatibleRelease = (
     releasesOfDevice: Record<string, FirmwareRelease>,
-    currentDeviceFirmwareVersion: VersionArray,
+    currentVesion: CurrentVersion,
     checkProperty: VersionCheckProperty,
 ): FirmwareRelease | undefined => {
     if (!releasesOfDevice || Object.keys(releasesOfDevice).length === 0) {
@@ -23,17 +24,30 @@ export const findBestCompatibleRelease = (
     }
 
     const availableFirmwares = Object.values(releasesOfDevice);
-    let versionToCompare = currentDeviceFirmwareVersion;
-    if (checkProperty === 'min_bootloader_version') {
-        // If the checkPropery is bootloader version we have to check with bootloader version of current firmware version.
+
+    const currentFirmwareVersion = currentVesion.firmwareVersion;
+    const currentBootloaderVersion = currentVesion.bootloaderVersion;
+
+    let versionToCompare = currentFirmwareVersion;
+
+    if (checkProperty === 'min_bootloader_version' && currentBootloaderVersion) {
+        versionToCompare = currentBootloaderVersion;
+    } else if (checkProperty === 'min_bootloader_version' && currentFirmwareVersion) {
+        // If we do not get current bootloader version from Device but ww have current FW version,
+        // we can use the current FW version to get the bootloader version based on releases information.
         const currentRelease = availableFirmwares.find(fw =>
-            versionUtils.isEqual(currentDeviceFirmwareVersion, fw.version),
+            versionUtils.isEqual(currentFirmwareVersion, fw.version),
         );
+
         if (!currentRelease?.bootloader_version) {
-            // Not found bootloader version of this release.
+            // Not found bootloader version for this release, or no release was found.
             return;
         }
-        versionToCompare = currentRelease?.bootloader_version;
+    }
+
+    if (!versionToCompare) {
+        // There is no version to compare.
+        return;
     }
 
     const sortedFirmwares = availableFirmwares.sort((a, b) =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The check that compares versions to be compatible `isCompatible` should be valid if they are newer or equal not only newer.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/is-compatible-release-should-accept-compatible-as-equal&lookback=7)