### PR TITLE
Mobile Swap close legal sheet on provider change

### DIFF
--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyFlow.test.ts
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import { BuyTrade } from 'invity-api';
 
 import {
@@ -13,7 +11,7 @@ import {
 import { getBtcAccount } from '../../../__fixtures__/account';
 import quotes from '../../../__fixtures__/buyQuotes.json';
 import { getInitializedTradingStateWithQuotes } from '../../../__fixtures__/tradingState';
-import { BuyFormValues } from '../../../types/buy';
+import { BuyFormType } from '../../../types/buy';
 import { useBuyFlow } from '../useBuyFlow';
 import { useBuyForm } from '../useBuyForm';
 
@@ -32,6 +30,9 @@ jest.mock('@suite-common/trading', () => ({
 }));
 
 describe('useBuyFlow', () => {
+    let buyForm: BuyFormType;
+    let store: TestStore;
+
     const getInitializedStore = async ({ isLoading }: { isLoading?: boolean }) => {
         const preloadedState: PreloadedState = {
             wallet: { tradingNew: getInitializedTradingStateWithQuotes() },
@@ -43,112 +44,109 @@ describe('useBuyFlow', () => {
         return await initStore(preloadedState);
     };
 
-    const renderUseTradingBuyFlow = ({
-        store,
-        ...formValues
-    }: Partial<BuyFormValues> & { store: TestStore }) =>
-        renderHookWithStoreProviderAsync(
-            () => {
-                const form = useBuyForm();
-                const { setValue } = form;
+    const renderBuyForm = () => renderHookWithStoreProviderAsync(() => useBuyForm(), { store });
 
-                useEffect(() => {
-                    // Set all provided form values
-                    (async () => {
-                        await act(() => {
-                            Object.entries(formValues).forEach(([key, value]) => {
-                                setValue(key as keyof BuyFormValues, value);
-                            });
+    const renderUseTradingBuyFlow = () =>
+        renderHookWithStoreProviderAsync(() => useBuyFlow(buyForm), { store });
 
-                            return Promise.resolve();
-                        });
-                    })();
-                }, [setValue]);
+    describe('while loading quotes', () => {
+        beforeEach(async () => {
+            store = await getInitializedStore({ isLoading: true });
 
-                return useBuyFlow(form);
-            },
-            { store },
-        );
+            const { result } = await renderBuyForm();
+            buyForm = result.current;
+        });
 
-    it('should canProceed be false when loading', async () => {
-        const store = await getInitializedStore({ isLoading: true });
-
-        const { result } = await renderUseTradingBuyFlow({ store });
-        expect(result.current.canProceed).toBe(false);
+        it('should canProceed be false when loading', async () => {
+            const { result } = await renderUseTradingBuyFlow();
+            expect(result.current.canProceed).toBe(false);
+        });
     });
 
-    it('should canProceed be true when not loading and orderId filters one in quotes', async () => {
-        const store = await getInitializedStore({ isLoading: false });
+    describe('with quote loaded and selected', () => {
+        beforeEach(async () => {
+            store = await getInitializedStore({ isLoading: false });
 
-        const { result } = await renderUseTradingBuyFlow({
-            store,
-            quote: quotes[1] as BuyTrade,
+            const { result } = await renderBuyForm();
+            buyForm = result.current;
+
+            act(() => {
+                buyForm.setValue('quote', quotes[2] as BuyTrade);
+            });
         });
 
-        expect(result.current.canProceed).toBe(true);
-    });
+        it('should canProceed be true when not loading and orderId filters one in quotes', async () => {
+            const { result } = await renderUseTradingBuyFlow();
 
-    it('should handle user consent flow', async () => {
-        const store = await getInitializedStore({ isLoading: false });
-        const btcAccount = getBtcAccount();
-        const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-        const { result } = await renderUseTradingBuyFlow({
-            store,
-            quote: quotes[2] as BuyTrade,
-            receiveAccount: { account: btcAccount, address: btcAccount.addresses?.used?.[0] },
+            expect(result.current.canProceed).toBe(true);
         });
 
-        act(() => {
-            result.current.selectQuote();
+        it('should handle user consent flow', async () => {
+            const btcAccount = getBtcAccount();
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+            act(() => {
+                buyForm.setValue('receiveAccount', {
+                    account: btcAccount,
+                    address: btcAccount.addresses?.used?.[0],
+                });
+            });
+            const { result } = await renderUseTradingBuyFlow();
+
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            const dispatchCall = dispatchSpy.mock.calls[0][0];
+            const { userConsent } = dispatchCall.payload;
+
+            act(() => {
+                userConsent('provider', 'BTC');
+            });
+
+            expect(result.current.isConsentRequested).toBe(true);
+
+            act(() => {
+                result.current.giveConsent();
+            });
+
+            expect(result.current.isConsentRequested).toBe(false);
         });
 
-        const dispatchCall = dispatchSpy.mock.calls[0][0];
-        const { userConsent } = dispatchCall.payload;
+        it('should call nextStep callback with correct address', async () => {
+            const btcAccount = getBtcAccount();
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const expectedAddress =
+                btcAccount.addresses?.used?.[0]?.address ?? btcAccount.descriptor;
 
-        act(() => {
-            userConsent('provider', 'BTC');
-        });
+            act(() => {
+                buyForm.setValue('receiveAccount', {
+                    account: btcAccount,
+                    address: btcAccount.addresses?.used?.[0],
+                });
+            });
 
-        expect(result.current.isConsentRequested).toBe(true);
+            const { result } = await renderUseTradingBuyFlow();
 
-        act(() => {
-            result.current.giveConsent();
-        });
+            act(() => {
+                result.current.selectQuote();
+            });
 
-        expect(result.current.isConsentRequested).toBe(false);
-    });
+            const dispatchCall = dispatchSpy.mock.calls[0][0];
+            const { nextStep } = dispatchCall.payload;
 
-    it('should call nextStep callback with correct address', async () => {
-        const store = await getInitializedStore({ isLoading: false });
-        const btcAccount = getBtcAccount();
-        const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const expectedAddress = btcAccount.addresses?.used?.[0]?.address ?? btcAccount.descriptor;
+            act(() => {
+                nextStep();
+            });
 
-        const { result } = await renderUseTradingBuyFlow({
-            store,
-            quote: quotes[2] as BuyTrade,
-            receiveAccount: { account: btcAccount, address: btcAccount.addresses?.used?.[0] },
-        });
-
-        act(() => {
-            result.current.selectQuote();
-        });
-
-        const dispatchCall = dispatchSpy.mock.calls[0][0];
-        const { nextStep } = dispatchCall.payload;
-
-        act(() => {
-            nextStep();
-        });
-
-        expect(store.dispatch).toHaveBeenCalledWith(
-            expect.objectContaining({
-                type: 'confirmTradeThunkMock',
-                payload: expect.objectContaining({
-                    address: expectedAddress,
+            expect(store.dispatch).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'confirmTradeThunkMock',
+                    payload: expect.objectContaining({
+                        address: expectedAddress,
+                    }),
                 }),
-            }),
-        );
+            );
+        });
     });
 });

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyFlow.test.ts
@@ -81,72 +81,97 @@ describe('useBuyFlow', () => {
             expect(result.current.canProceed).toBe(true);
         });
 
-        it('should handle user consent flow', async () => {
-            const btcAccount = getBtcAccount();
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-            act(() => {
-                buyForm.setValue('receiveAccount', {
-                    account: btcAccount,
-                    address: btcAccount.addresses?.used?.[0],
-                });
-            });
-            const { result } = await renderUseTradingBuyFlow();
-
-            act(() => {
-                result.current.selectQuote();
-            });
-
-            const dispatchCall = dispatchSpy.mock.calls[0][0];
-            const { userConsent } = dispatchCall.payload;
-
-            act(() => {
-                userConsent('provider', 'BTC');
-            });
-
-            expect(result.current.isConsentRequested).toBe(true);
-
-            act(() => {
-                result.current.giveConsent();
-            });
-
-            expect(result.current.isConsentRequested).toBe(false);
-        });
-
-        it('should call nextStep callback with correct address', async () => {
-            const btcAccount = getBtcAccount();
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const expectedAddress =
-                btcAccount.addresses?.used?.[0]?.address ?? btcAccount.descriptor;
-
-            act(() => {
-                buyForm.setValue('receiveAccount', {
-                    account: btcAccount,
-                    address: btcAccount.addresses?.used?.[0],
+        describe('and receive account selected', () => {
+            beforeEach(() => {
+                const btcAccount = getBtcAccount();
+                act(() => {
+                    buyForm.setValue('receiveAccount', {
+                        account: btcAccount,
+                        address: btcAccount.addresses?.used?.[0],
+                    });
                 });
             });
 
-            const { result } = await renderUseTradingBuyFlow();
+            it('should handle user consent flow', async () => {
+                const dispatchSpy = jest.spyOn(store, 'dispatch');
+                const { result } = await renderUseTradingBuyFlow();
 
-            act(() => {
-                result.current.selectQuote();
+                act(() => {
+                    result.current.selectQuote();
+                });
+
+                const dispatchCall = dispatchSpy.mock.calls[0][0];
+                const { userConsent } = dispatchCall.payload;
+
+                act(() => {
+                    userConsent('provider', 'BTC');
+                });
+
+                expect(result.current.isConsentRequested).toBe(true);
+
+                act(() => {
+                    result.current.giveConsent();
+                });
+
+                expect(result.current.isConsentRequested).toBe(false);
             });
 
-            const dispatchCall = dispatchSpy.mock.calls[0][0];
-            const { nextStep } = dispatchCall.payload;
+            it('should call nextStep callback with correct address', async () => {
+                const btcAccount = getBtcAccount();
+                const dispatchSpy = jest.spyOn(store, 'dispatch');
+                const expectedAddress =
+                    btcAccount.addresses?.used?.[0]?.address ?? btcAccount.descriptor;
 
-            act(() => {
-                nextStep();
-            });
+                const { result } = await renderUseTradingBuyFlow();
 
-            expect(store.dispatch).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    type: 'confirmTradeThunkMock',
-                    payload: expect.objectContaining({
-                        address: expectedAddress,
+                act(() => {
+                    result.current.selectQuote();
+                });
+
+                const dispatchCall = dispatchSpy.mock.calls[0][0];
+                const { nextStep } = dispatchCall.payload;
+
+                act(() => {
+                    nextStep();
+                });
+
+                expect(store.dispatch).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        type: 'confirmTradeThunkMock',
+                        payload: expect.objectContaining({
+                            address: expectedAddress,
+                        }),
                     }),
-                }),
-            );
+                );
+            });
+
+            it('should call cancelConsent when quote provider changes', async () => {
+                const dispatchSpy = jest.spyOn(store, 'dispatch');
+                const { result, rerender } = await renderUseTradingBuyFlow();
+
+                act(() => {
+                    result.current.selectQuote();
+                });
+
+                const dispatchCall = dispatchSpy.mock.calls[0][0];
+                // simulate userConsent call (as we mock the thunk)
+                const { userConsent } = dispatchCall.payload;
+                act(() => {
+                    userConsent();
+                });
+                expect(result.current.isConsentRequested).toBe(true);
+
+                // change selected quote to quote with different provider
+                act(() => {
+                    buyForm.setValue('quote', { ...quotes[2], exchange: 'invity-buy' } as BuyTrade);
+                });
+
+                // we need to manually rerender tested hook
+                rerender({});
+
+                // consent should not be requested anymore
+                expect(result.current.isConsentRequested).toBe(false);
+            });
         });
     });
 });

--- a/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
@@ -31,6 +31,7 @@ import {
 } from '../../utils/general/formUtils';
 import { getSymbolFromTradeableAsset } from '../../utils/general/tradeableAssetUtils';
 import { useConsent } from '../general/useConsent';
+import { useConsentDenier } from '../general/useConsentDenier';
 
 type NavigationProps = StackToStackCompositeNavigationProps<
     TradingStackParamList,
@@ -50,6 +51,11 @@ const reportTradeConfirmation = () => {
 export const useBuyFlow = (form: BuyFormType) => {
     const dispatch = useDispatch();
     const isLoading = useSelector(selectTradingBuyIsLoading);
+    const [asset, candidateQuote, receiveAccount] = form.watch([
+        'asset',
+        'quote',
+        'receiveAccount',
+    ]);
 
     const timer = useTimer();
     const navigation = useNavigation<NavigationProps>();
@@ -57,12 +63,8 @@ export const useBuyFlow = (form: BuyFormType) => {
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes>>();
 
     const { isConsentRequested, waitForConsent, resolveConsent } = useConsent();
+    useConsentDenier(candidateQuote?.exchange, resolveConsent);
 
-    const [asset, candidateQuote, receiveAccount] = form.watch([
-        'asset',
-        'quote',
-        'receiveAccount',
-    ]);
     const coinInfo = useSelector((state: TradingRootState) =>
         selectTradingCoinInfoByCryptoId(state, candidateQuote?.receiveCurrency),
     );

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import {
     PreloadedState,
     TestStore,
@@ -11,7 +9,7 @@ import {
 import { getBtcAccount, getEthAccount } from '../../../__fixtures__/account';
 import { exchangeQuotes } from '../../../__fixtures__/exchangeQuotes';
 import { getInitializedTradingStateWithQuotes } from '../../../__fixtures__/tradingState';
-import { ExchangeFormValues } from '../../../types/exchange';
+import { ExchangeFormType } from '../../../types/exchange';
 import { useExchangeForm } from '../useExchangeForm';
 import { useExchangeSelectQuote } from '../useExchangeSelectQuote';
 
@@ -46,6 +44,9 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 describe('useExchangeSelectQuote', () => {
+    let exchangeForm: ExchangeFormType;
+    let store: TestStore;
+
     const getInitializedStore = async ({ isLoading }: { isLoading?: boolean }) => {
         const btcAccount = getBtcAccount('btc-account-key');
         const ethAccount = getEthAccount('eth-account-key');
@@ -66,131 +67,113 @@ describe('useExchangeSelectQuote', () => {
         return await initStore(preloadedState);
     };
 
-    const renderUseExchangeSelectQuote = ({
-        store,
-        ...formValues
-    }: Partial<ExchangeFormValues> & { store: TestStore }) =>
-        renderHookWithStoreProviderAsync(
-            () => {
-                const form = useExchangeForm();
-                const { setValue } = form;
+    const renderExchangeForm = () =>
+        renderHookWithStoreProviderAsync(() => useExchangeForm(), { store });
 
-                useEffect(() => {
-                    // Set all provided form values
-                    (async () => {
-                        await act(() => {
-                            Object.entries(formValues).forEach(([key, value]) => {
-                                setValue(key as keyof ExchangeFormValues, value);
-                            });
-
-                            return Promise.resolve();
-                        });
-                    })();
-                }, [setValue]);
-
-                return useExchangeSelectQuote(form);
-            },
-            { store },
-        );
+    const renderUseExchangeSelectQuote = () =>
+        renderHookWithStoreProviderAsync(() => useExchangeSelectQuote(exchangeForm), { store });
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it('should canProceed be false when loading', async () => {
-        const store = await getInitializedStore({ isLoading: true });
+    describe('while loading quotes', () => {
+        beforeEach(async () => {
+            store = await getInitializedStore({ isLoading: true });
 
-        const { result } = await renderUseExchangeSelectQuote({ store });
-        expect(result.current.canProceed).toBe(false);
+            const { result } = await renderExchangeForm();
+            exchangeForm = result.current;
+        });
+
+        it('should canProceed be false when loading', async () => {
+            const { result } = await renderUseExchangeSelectQuote();
+            expect(result.current.canProceed).toBe(false);
+        });
     });
 
-    it('should canProceed be true when not loading and quote exists', async () => {
-        const store = await getInitializedStore({ isLoading: false });
+    describe('with quote loaded and selected', () => {
+        beforeEach(async () => {
+            store = await getInitializedStore({ isLoading: false });
 
-        const { result } = await renderUseExchangeSelectQuote({
-            store,
-            quote: exchangeQuotes[1],
+            const { result } = await renderExchangeForm();
+            exchangeForm = result.current;
+
+            act(() => {
+                exchangeForm.setValue('quote', exchangeQuotes[1]);
+            });
         });
 
-        await act(() => Promise.resolve());
+        it('should canProceed be true when not loading and quote exists', async () => {
+            const { result } = await renderUseExchangeSelectQuote();
 
-        expect(result.current.canProceed).toBe(true);
-    });
+            await act(() => Promise.resolve());
 
-    it('should handle user consent flow', async () => {
-        const store = await getInitializedStore({ isLoading: false });
-        const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-        const { result } = await renderUseExchangeSelectQuote({
-            store,
-            quote: exchangeQuotes[2],
+            expect(result.current.canProceed).toBe(true);
         });
 
-        act(() => {
-            result.current.selectQuote();
+        it('should handle user consent flow', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+            const { result } = await renderUseExchangeSelectQuote();
+
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            const dispatchCall = dispatchSpy.mock.calls[0][0];
+            const { userConsent } = (dispatchCall as any).payload;
+
+            act(() => {
+                userConsent('provider', 'BTC', 'ETH');
+            });
+
+            expect(result.current.isConsentRequested).toBe(true);
+
+            act(() => {
+                result.current.giveConsent();
+            });
+
+            expect(result.current.isConsentRequested).toBe(false);
         });
 
-        const dispatchCall = dispatchSpy.mock.calls[0][0];
-        const { userConsent } = (dispatchCall as any).payload;
+        it('should call selectQuoteThunk when selectQuote is called', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
 
-        act(() => {
-            userConsent('provider', 'BTC', 'ETH');
-        });
+            const { result } = await renderUseExchangeSelectQuote();
 
-        expect(result.current.isConsentRequested).toBe(true);
+            act(() => {
+                result.current.selectQuote();
+            });
 
-        act(() => {
-            result.current.giveConsent();
-        });
-
-        expect(result.current.isConsentRequested).toBe(false);
-    });
-
-    it('should call selectQuoteThunk when selectQuote is called', async () => {
-        const store = await getInitializedStore({ isLoading: false });
-        const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-        const { result } = await renderUseExchangeSelectQuote({
-            store,
-            quote: exchangeQuotes[1],
-        });
-
-        act(() => {
-            result.current.selectQuote();
-        });
-
-        expect(dispatchSpy).toHaveBeenCalledWith(
-            expect.objectContaining({
-                type: 'selectQuoteThunkMock',
-                payload: expect.objectContaining({
-                    quote: exchangeQuotes[1],
-                    timer: mockTimerReturn,
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'selectQuoteThunkMock',
+                    payload: expect.objectContaining({
+                        quote: exchangeQuotes[1],
+                        timer: mockTimerReturn,
+                    }),
                 }),
-            }),
-        );
-    });
-
-    it('should navigate to TradingExchangePreview when nextStep callback is executed', async () => {
-        const store = await getInitializedStore({ isLoading: false });
-        const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-        const { result } = await renderUseExchangeSelectQuote({
-            store,
-            quote: exchangeQuotes[1],
+            );
         });
 
-        act(() => {
-            result.current.selectQuote();
+        it('should navigate to TradingExchangePreview when nextStep callback is executed', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+            const { result } = await renderUseExchangeSelectQuote();
+
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            const dispatchCall = dispatchSpy.mock.calls[0][0];
+            const { nextStep } = (dispatchCall as any).payload;
+
+            // Execute the nextStep callback to simulate successful quote selection
+            act(() => {
+                nextStep();
+            });
+
+            expect(mockNavigation.navigate).toHaveBeenCalledWith('TradingExchangePreview');
         });
-
-        const dispatchCall = dispatchSpy.mock.calls[0][0];
-        const { nextStep } = (dispatchCall as any).payload;
-
-        // Execute the nextStep callback to simulate successful quote selection
-        act(() => {
-            nextStep();
-        });
-
-        expect(mockNavigation.navigate).toHaveBeenCalledWith('TradingExchangePreview');
     });
 });

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -175,5 +175,34 @@ describe('useExchangeSelectQuote', () => {
 
             expect(mockNavigation.navigate).toHaveBeenCalledWith('TradingExchangePreview');
         });
+
+        it('should call cancelConsent when quote provider changes', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+            const { result, rerender } = await renderUseExchangeSelectQuote();
+
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            const dispatchCall = dispatchSpy.mock.calls[0][0];
+            // simulate userConsent call (as we mock the thunk)
+            const { userConsent } = (dispatchCall as any).payload;
+            act(() => {
+                userConsent();
+            });
+            expect(result.current.isConsentRequested).toBe(true);
+
+            // change selected quote to quote with different provider
+            act(() => {
+                exchangeForm.setValue('quote', { ...exchangeQuotes[1], exchange: 'invity' });
+            });
+
+            // we need to manually rerender tested hook
+            rerender({});
+
+            // consent should not be requested anymore
+            expect(result.current.isConsentRequested).toBe(false);
+        });
     });
 });

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
@@ -20,6 +20,7 @@ import {
 import { ExchangeFormType } from '../../types/exchange';
 import { getSymbolFromTradeableAsset } from '../../utils/general/tradeableAssetUtils';
 import { useConsent } from '../general/useConsent';
+import { useConsentDenier } from '../general/useConsentDenier';
 
 type NavigationProps = StackToStackCompositeNavigationProps<
     TradingStackParamList,
@@ -41,6 +42,7 @@ export const useExchangeSelectQuote = (form: ExchangeFormType) => {
     const [candidateQuote, receiveAsset] = form.watch(['quote', 'receiveAsset']);
 
     const { isConsentRequested, waitForConsent, resolveConsent } = useConsent();
+    useConsentDenier(candidateQuote?.exchange, resolveConsent);
 
     const canProceed = !isLoading && !!candidateQuote && !!sendAccount;
 

--- a/suite-native/module-trading/src/hooks/general/__tests__/useConsentDenier.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useConsentDenier.test.ts
@@ -1,0 +1,44 @@
+import { renderHook } from '@suite-native/test-utils';
+
+import { useConsentDenier } from '../useConsentDenier';
+
+describe('useConsentDenier', () => {
+    const renderConsentDenierHook = <T>(
+        initialValue: T,
+        initialResolveConsent: (approved: false) => void,
+    ) =>
+        renderHook(
+            ({ watchedValue, resolveConsent }) => useConsentDenier<T>(watchedValue, resolveConsent),
+            {
+                initialProps: {
+                    watchedValue: initialValue,
+                    resolveConsent: initialResolveConsent,
+                },
+            },
+        );
+
+    it('should not call resolve callback on initial render', () => {
+        const resolveConsentMock = jest.fn();
+        renderConsentDenierHook(1, resolveConsentMock);
+
+        expect(resolveConsentMock).not.toHaveBeenCalled();
+    });
+
+    it('should call resolveConsent with false when watchedValue changes', () => {
+        const resolveConsentMock = jest.fn();
+        const { rerender } = renderConsentDenierHook(1, resolveConsentMock);
+
+        rerender({ watchedValue: 2, resolveConsent: resolveConsentMock });
+
+        expect(resolveConsentMock).toHaveBeenCalledWith(false);
+    });
+
+    it('should not call resolveConsent when watchedValue remains the same', () => {
+        const resolveConsentMock = jest.fn();
+        const { rerender } = renderConsentDenierHook(1, resolveConsentMock);
+
+        rerender({ watchedValue: 1, resolveConsent: resolveConsentMock });
+
+        expect(resolveConsentMock).not.toHaveBeenCalled();
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/useConsentDenier.ts
+++ b/suite-native/module-trading/src/hooks/general/useConsentDenier.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from 'react';
+
+export const useConsentDenier = <T>(
+    watchedValue: T,
+    resolveConsent: (approved: false) => void,
+): void => {
+    const previousValueRef = useRef<T>(watchedValue);
+
+    useEffect(() => {
+        if (previousValueRef.current !== watchedValue) {
+            resolveConsent(false);
+        }
+        previousValueRef.current = watchedValue;
+    }, [watchedValue, resolveConsent]);
+};

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
@@ -123,5 +123,19 @@ describe('useSellFlow', () => {
 
             expect(result.current.isConsentRequested).toEqual(false);
         });
+
+        it('should reset consent when quote provider changes', async () => {
+            const { result, rerender } = await renderUseSellFlow();
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            act(() => {
+                sellForm.setValue('quote', { ...sellQuotes, exchange: 'invity-sell' });
+            });
+            rerender({});
+
+            expect(result.current.isConsentRequested).toEqual(false);
+        });
     });
 });

--- a/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
@@ -5,6 +5,7 @@ import { selectTradingSellIsLoading } from '@suite-common/trading';
 
 import { SellFormType } from '../../types/sell';
 import { useConsent } from '../general/useConsent';
+import { useConsentDenier } from '../general/useConsentDenier';
 
 type SellFlowReturn = {
     canProceed: boolean;
@@ -15,10 +16,10 @@ type SellFlowReturn = {
 };
 
 export const useSellFlow = ({ watch }: SellFormType): SellFlowReturn => {
+    const candidateQuote = watch('quote');
     const isLoading = useSelector(selectTradingSellIsLoading);
     const { isConsentRequested, waitForConsent, resolveConsent } = useConsent();
-
-    const candidateQuote = watch('quote');
+    useConsentDenier(candidateQuote?.exchange, resolveConsent);
 
     const canProceed = !!candidateQuote && !isLoading;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

add check, that if selected provider changes we close the legal sheet.

## Related Issue

Resolve #20528

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=20528-mobile-swap-close-legal-sheet-on-provider-change&lookback=7)