### PR TITLE
chore: enforce exactOptionalPropertyTypes for whole codebase

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -27,7 +27,8 @@
         "declarationMap": true,
         "incremental": true,
         "noEmitOnError": true,
-        "emitDeclarationOnly": true
+        "emitDeclarationOnly": true,
+        "exactOptionalPropertyTypes": true
     },
     "exclude": [
         "**/node_modules",


### PR DESCRIPTION
This is required by Evolu

<img width="1357" height="335" alt="image" src="https://github.com/user-attachments/assets/fe9fbf0b-de38-443c-b1e9-caa9dc9dbdf1" />

-https://www.evolu.dev/docs/quickstart
- https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=exactOptionalPropertyTypes&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=exactOptionalPropertyTypes&lookback=7)