### PR TITLE
Feat/disconnect device when computer goes to sleep

### DIFF
--- a/packages/suite-desktop-api/README.md
+++ b/packages/suite-desktop-api/README.md
@@ -36,6 +36,7 @@ export const desktopApi: DesktopApi;
 To invoke a method on the `main` process and return an asynchronous result to the `renderer` process
 
 - add a channel to `./src/api.ts InvokeChannels`
+- add a channel to validChannels in `./src/validation.ts`
 - add a method to `./src/api.ts DesktopApi` as `DesktopApiInvoke<'your-new-channel'>`
 - process incoming request in `@trezor/suite-desktop/src/modules/*` using `ipcMain.handle('your-new-channel', (arg?: string) => { return 1; })`
 - trigger it from `@trezor/suite` using `const r = await desktopApi.yourNewFunction()`
@@ -43,12 +44,14 @@ To invoke a method on the `main` process and return an asynchronous result to th
 To receive an asynchronous event in `renderer` process
 
 - add a channel to `./src/api.ts RendererChannels`
+- add a channel to validChannels in `./src/validation.ts`
 - set a listener in `@trezor/suite` using `await desktopApi.on('your-new-channel', (payload) => {})`
 - trigger an event from `@trezor/suite-desktop/src/modules/*` using `mainWindow.webContents.send('your-new-channel', { foo: 'bar' })`
 
 To receive an asynchronous event in `main` process
 
 - add a channel to `./src/api.ts MainChannels`
+- add a channel to validChannels in `./src/validation.ts`
 - add a method to `./src/api.ts DesktopApi` as `DesktopApiSend<'your-new-channel'>`
 - set a listener in `@trezor/suite-desktop/src/modules/*` using `ipcMain.on('your-new-channel', (_, { foo }) => {})`
 - trigger an event from `@trezor/suite` using `desktopApi.yourNewFunction({ foo: 'bar' })`

--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -99,6 +99,7 @@ export interface RendererChannels {
               message: string;
           };
     'bio-auth/is-available': boolean;
+    'power-monitor/screen-locked': void;
 }
 
 // Invocation from renderer process

--- a/packages/suite-desktop-api/src/validation.ts
+++ b/packages/suite-desktop-api/src/validation.ts
@@ -47,5 +47,6 @@ const validChannels: Array<keyof RendererChannels> = [
     'connect-popup/call',
     'connect-popup/cancel',
     'app/auto-start/popup-request',
+    'power-monitor/screen-locked',
 ];
 export const isValidChannel = (channel: any) => validChannels.includes(channel);

--- a/packages/suite-desktop-core/src/modules/index.ts
+++ b/packages/suite-desktop-core/src/modules/index.ts
@@ -27,6 +27,7 @@ import * as firmware from './firmware';
 import * as httpReceiverModule from './http-receiver';
 import * as menu from './menu';
 import * as metadata from './metadata';
+import * as powerMonitor from './power-monitor';
 import * as requestFilter from './request-filter';
 import * as requestInterceptor from './request-interceptor';
 import * as shortcuts from './shortcuts';
@@ -67,6 +68,7 @@ const MODULES: Module[] = [
     systemSettings,
     bluetooth,
     firmware,
+    powerMonitor,
     // Modules used only in dev/prod mode
     ...(isDevEnv ? [] : [csp, fileProtocol]),
 ];

--- a/packages/suite-desktop-core/src/modules/power-monitor.ts
+++ b/packages/suite-desktop-core/src/modules/power-monitor.ts
@@ -1,0 +1,14 @@
+import { powerMonitor } from 'electron';
+
+import type { ModuleInit } from './index';
+
+export const SERVICE_NAME = 'power-monitor';
+
+export const init: ModuleInit = ({ mainWindowProxy }) => {
+    mainWindowProxy.on('init', mainWindow => {
+        powerMonitor.on('lock-screen', () => {
+            logger.info('power-monitor', 'Lock screen event detected');
+            mainWindow.webContents.send('power-monitor/screen-locked');
+        });
+    });
+};

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PowerMonitor/PowerMonitor.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PowerMonitor/PowerMonitor.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+
+import { selectKnownDevices } from '@suite-common/bluetooth';
+import { isDesktop } from '@trezor/env-utils';
+import { desktopApi } from '@trezor/suite-desktop-api';
+
+import { bluetoothDisconnectDeviceThunk } from 'src/actions/bluetooth/bluetoothDisconnectDeviceThunk';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+export const PowerMonitorManager = () => {
+    const dispatch = useDispatch();
+    const knownDevices = useSelector(selectKnownDevices);
+
+    useEffect(() => {
+        if (typeof window === 'undefined' || !isDesktop) {
+            return;
+        }
+
+        const disconnectAllDevices = () => {
+            knownDevices.forEach(device => {
+                if (device.connected) dispatch(bluetoothDisconnectDeviceThunk({ id: device.id }));
+            });
+        };
+        desktopApi.on('power-monitor/screen-locked', disconnectAllDevices);
+
+        return () => {
+            desktopApi.removeAllListeners('power-monitor/screen-locked');
+        };
+    }, [dispatch, knownDevices]);
+
+    return null;
+};

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
@@ -22,6 +22,7 @@ import { CoinjoinBars } from './CoinjoinBars/CoinjoinBars';
 import { DebugLegend } from './DebugLegend';
 import { MobileMenu } from './MobileMenu/MobileMenu';
 import { PassphraseFlow } from './PassphraseFlow';
+import { PowerMonitorManager } from './PowerMonitor/PowerMonitor';
 import { Sidebar } from './Sidebar/Sidebar';
 import { ModalSwitcher } from '../../modals/ModalSwitcher/ModalSwitcher';
 import { ContentContainer } from '../ContentContainer';
@@ -147,6 +148,8 @@ export const SuiteLayout = ({ children }: SuiteLayoutProps) => {
                             <ModalSwitcher />
                             <PassphraseFlow />
                             <AppShortcuts />
+
+                            <PowerMonitorManager />
 
                             {isBelowTablet && <CoinjoinBars />}
 


### PR DESCRIPTION
Disconnects all connected devices when computer goes to sleep or after is locked.
This fixes reconnect issue after computer used again.

**changes**:
- propagate `lock-screen` event from powerMonitor to renderer process
- created and implement `PowerMonitorManager.tsx`
- fixed `README.md` as there was one point missing for adding a new channel 

🤔 maybe we should add toast messages w/ info about device disconnect in unexpected cases.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21212


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/disconnect-device-when-computer-goes-to-sleep-or-shutdown&lookback=7)