### PR TITLE
feat(suite-native): hide Cardano accounts from MyAssetSheet

### DIFF
--- a/suite-native/module-trading/src/__fixtures__/account.ts
+++ b/suite-native/module-trading/src/__fixtures__/account.ts
@@ -133,3 +133,18 @@ export const getBaseAccount = (key = 'base-account-1') =>
             total: 1,
         },
     }) as unknown as Account;
+
+export const getCardanoAccount = (key = 'ada-account-1') =>
+    ({
+        key,
+        symbol: 'ada',
+        accountType: 'normal',
+        accountLabel: 'Cardano Account #1',
+        descriptor: 'descriptor-' + key,
+        balance: '1000000',
+        availableBalance: '1000000',
+        formattedBalance: '1',
+        networkType: 'cardano',
+        visible: true,
+        deviceState: 'test-device',
+    }) as unknown as Account;

--- a/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
@@ -1,10 +1,10 @@
 import { Action, Feature, Message } from '@suite-common/suite-types';
 import { InvityServerEnvironment } from '@suite-common/trading';
 import { AccountsRootState } from '@suite-common/wallet-core';
-import { featureFlagsInitialState } from '@suite-native/feature-flags';
+import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
 import { BigNumber } from '@trezor/utils';
 
-import { getBtcAccount, getEthAccount } from '../../__fixtures__/account';
+import { getBtcAccount, getCardanoAccount, getEthAccount } from '../../__fixtures__/account';
 import { btcAsset } from '../../__fixtures__/tradeableAssets';
 import { getInitializedTradingState } from '../../__fixtures__/tradingState';
 import { getWalletState } from '../../__fixtures__/walletState';
@@ -319,6 +319,7 @@ describe('commonSelectors', () => {
             const stateWithDevice = {
                 ...state,
                 device: { selectedDevice: null },
+                featureFlags: featureFlagsInitialState,
             } as any;
 
             expect(
@@ -345,6 +346,7 @@ describe('commonSelectors', () => {
                 device: { selectedDevice: { state: { staticSessionId: testDeviceState } } },
                 tokenDefinitions: {},
                 fiat: { rates: {}, current: 'usd' },
+                featureFlags: featureFlagsInitialState,
             } as any;
 
             const result = selectAccountsWithTokensToSellSectionListByTradingType(
@@ -383,6 +385,7 @@ describe('commonSelectors', () => {
                 device: { selectedDevice: { state: { staticSessionId: testDeviceState } } },
                 tokenDefinitions: {},
                 fiat: { rates: {}, current: 'usd' },
+                featureFlags: featureFlagsInitialState,
             } as any;
 
             expect(
@@ -424,6 +427,7 @@ describe('commonSelectors', () => {
             const cleanState = getInitializedTradingState('exchange');
 
             const stateWithDevice = {
+                featureFlags: featureFlagsInitialState,
                 wallet: {
                     trading: cleanState,
                     accounts: [ethAccount],
@@ -483,6 +487,7 @@ describe('commonSelectors', () => {
             const cleanState = getInitializedTradingState('exchange');
 
             const stateWithDevice = {
+                featureFlags: featureFlagsInitialState,
                 wallet: {
                     trading: cleanState,
                     accounts: [ethAccount],
@@ -538,6 +543,7 @@ describe('commonSelectors', () => {
             const cleanState = getInitializedTradingState('exchange');
 
             const stateWithDevice = {
+                featureFlags: featureFlagsInitialState,
                 wallet: {
                     trading: cleanState,
                     accounts: [ethAccount],
@@ -591,6 +597,7 @@ describe('commonSelectors', () => {
             const cleanState = getInitializedTradingState('exchange');
 
             const stateWithDevice = {
+                featureFlags: featureFlagsInitialState,
                 wallet: {
                     trading: cleanState,
                     accounts: [ethAccount],
@@ -624,6 +631,7 @@ describe('commonSelectors', () => {
             const cleanState = getInitializedTradingState('buy');
 
             const stateWithDevice = {
+                featureFlags: featureFlagsInitialState,
                 wallet: {
                     trading: cleanState,
                     accounts: [btcAccount],
@@ -655,6 +663,7 @@ describe('commonSelectors', () => {
             const cleanState = getInitializedTradingState('sell');
 
             const stateWithDevice = {
+                featureFlags: featureFlagsInitialState,
                 wallet: {
                     trading: cleanState,
                     accounts: [btcAccount],
@@ -687,6 +696,7 @@ describe('commonSelectors', () => {
             const testDeviceState = 'test-device';
 
             const stateWithDevice = {
+                featureFlags: featureFlagsInitialState,
                 wallet: getWalletState({ tradeType: 'exchange', deviceState: testDeviceState }),
                 device: { selectedDevice: { state: { staticSessionId: testDeviceState } } },
                 tokenDefinitions: {},
@@ -701,6 +711,86 @@ describe('commonSelectors', () => {
             const accountAsset = result[1].data[0];
             expect(accountAsset.symbol).toBe('base');
             expect(accountAsset.name).toBe('Base Ethereum');
+        });
+
+        it('should filter out Cardano accounts when IsCardanoSendEnabled feature flag is disabled', () => {
+            const testDeviceState = 'test-device';
+            const cardanoAccount = {
+                ...getCardanoAccount(),
+                visible: true,
+                deviceState: testDeviceState,
+            };
+            const btcAccount = {
+                ...getBtcAccount(),
+                visible: true,
+                deviceState: testDeviceState,
+            };
+            const cleanState = getInitializedTradingState('exchange');
+
+            const stateWithDevice = {
+                wallet: {
+                    trading: cleanState,
+                    accounts: [cardanoAccount, btcAccount],
+                    settings: { localCurrency: 'usd', enabledNetworks: ['ada', 'btc'] },
+                    transactions: { transactions: {} },
+                },
+                device: { selectedDevice: { state: { staticSessionId: testDeviceState } } },
+                tokenDefinitions: {},
+                fiat: { rates: {}, current: 'usd' },
+                featureFlags: {
+                    ...featureFlagsInitialState,
+                    [FeatureFlag.IsCardanoSendEnabled]: false,
+                },
+            } as any;
+
+            const result = selectAccountsWithTokensToSellSectionListByTradingType(
+                stateWithDevice,
+                'exchange',
+            );
+
+            expect(result.length).toBe(1);
+            expect(result[0].sectionData.symbol).toBe('btc');
+        });
+
+        it('should include Cardano accounts when IsCardanoSendEnabled feature flag is enabled', () => {
+            const testDeviceState = 'test-device';
+            const cardanoAccount = {
+                ...getCardanoAccount(),
+                visible: true,
+                deviceState: testDeviceState,
+            };
+            const btcAccount = {
+                ...getBtcAccount(),
+                visible: true,
+                deviceState: testDeviceState,
+            };
+            const cleanState = getInitializedTradingState('exchange');
+
+            const stateWithDevice = {
+                wallet: {
+                    trading: cleanState,
+                    accounts: [cardanoAccount, btcAccount],
+                    settings: { localCurrency: 'usd', enabledNetworks: ['ada', 'btc'] },
+                    transactions: { transactions: {} },
+                },
+                device: { selectedDevice: { state: { staticSessionId: testDeviceState } } },
+                tokenDefinitions: {},
+                fiat: { rates: {}, current: 'usd' },
+                featureFlags: {
+                    ...featureFlagsInitialState,
+                    [FeatureFlag.IsCardanoSendEnabled]: true,
+                },
+            } as any;
+
+            const result = selectAccountsWithTokensToSellSectionListByTradingType(
+                stateWithDevice,
+                'exchange',
+            );
+
+            expect(result.length).toBe(2);
+            const symbols = result.map(section => section.sectionData.symbol);
+            expect(symbols).toContain('btc');
+            expect(symbols).toContain('ada');
         });
     });
 });

--- a/suite-native/module-trading/src/selectors/commonSelectors.ts
+++ b/suite-native/module-trading/src/selectors/commonSelectors.ts
@@ -30,6 +30,7 @@ import {
 } from '@suite-common/wallet-core';
 import { Account, TokenAddress, TokenSymbol } from '@suite-common/wallet-types';
 import { getAccountFiatBalance, getFiatRateKey, toFiatCurrency } from '@suite-common/wallet-utils';
+import { sortAccountsByNetworksAndAccountTypes } from '@suite-native/accounts/src/utils';
 import {
     FeatureFlag,
     FeatureFlagsRootState,
@@ -171,7 +172,9 @@ export const selectAccountsWithTokensToSellSectionListByTradingType =
             const sellCryptoIds =
                 tradingType === 'sell' ? sellSellCryptoIds : exchangeSellCryptoIds;
 
-            return accounts
+            const sortedAccounts = sortAccountsByNetworksAndAccountTypes(accounts);
+
+            return sortedAccounts
                 .map<SectionListData<MyAsset, Account>[number]>((account: Account) => {
                     const networkTokenDefinitions = getSimpleCoinDefinitionsByNetwork(
                         tokenDefinitions,

--- a/suite-native/module-trading/src/selectors/commonSelectors.ts
+++ b/suite-native/module-trading/src/selectors/commonSelectors.ts
@@ -18,7 +18,11 @@ import {
     selectTradingSellSellCryptoIds,
     toTokenCryptoId,
 } from '@suite-common/trading';
-import { getNetwork, getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
+import {
+    getNetwork,
+    getNetworkDisplaySymbolName,
+    getNetworkType,
+} from '@suite-common/wallet-config';
 import {
     AccountsRootState,
     DeviceRootState,
@@ -49,7 +53,8 @@ export type CombinedSelectorsRootState = TradingRootState &
     TokenDefinitionsRootState &
     FiatRatesRootState &
     WalletSettingsRootState &
-    TokensRootState;
+    TokensRootState &
+    FeatureFlagsRootState;
 
 const createCombinedMemoizedSelector =
     createWeakMapSelector.withTypes<CombinedSelectorsRootState>();
@@ -154,6 +159,8 @@ export const selectAccountsWithTokensToSellSectionListByTradingType =
             selectBaseCurrency,
             selectTradingSellSellCryptoIds,
             selectTradingExchangeSellCryptoIds,
+            (state: CombinedSelectorsRootState) =>
+                selectIsFeatureFlagEnabled(state, FeatureFlag.IsCardanoSendEnabled),
             (_state, tradingType: TradingType) => tradingType,
         ],
         (
@@ -163,6 +170,7 @@ export const selectAccountsWithTokensToSellSectionListByTradingType =
             localCurrency,
             sellSellCryptoIds,
             exchangeSellCryptoIds,
+            isCardanoSendEnabled,
             tradingType,
         ) => {
             if (tradingType === 'buy') {
@@ -172,7 +180,15 @@ export const selectAccountsWithTokensToSellSectionListByTradingType =
             const sellCryptoIds =
                 tradingType === 'sell' ? sellSellCryptoIds : exchangeSellCryptoIds;
 
-            const sortedAccounts = sortAccountsByNetworksAndAccountTypes(accounts);
+            // TODO: Remove this filter when Cardano send is implemented (#15068)
+            // Currently filtering out Cardano accounts and tokens from trading until Cardano send is supported
+            const filteredAccounts = accounts.filter(account => {
+                const networkType = getNetworkType(account.symbol);
+
+                return networkType !== 'cardano' || isCardanoSendEnabled;
+            });
+
+            const sortedAccounts = sortAccountsByNetworksAndAccountTypes(filteredAccounts);
 
             return sortedAccounts
                 .map<SectionListData<MyAsset, Account>[number]>((account: Account) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve #21022
Resolve #20839 

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=21022-mobile-swap-cardano-assets-should-be-disabled-in-my-asset-picker&lookback=7)