### PR TITLE
fix(suite): misaligned texts on welcome screen

### DIFF
--- a/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
+++ b/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
@@ -232,7 +232,7 @@ export const ConnectDevicePrompt = ({
             transition={{ delay: 0.2, duration: 0.6, ease: motionEasing.enter }}
             data-testid="@connect-device-prompt"
         >
-            <Column gap={spacings.sm}>
+            <Column alignItems="center" gap={spacings.sm}>
                 <Column alignItems="center" gap={spacings.xxl}>
                     <ElevationUp>
                         <ConnectImage


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
<img width="1204" height="395" alt="image" src="https://github.com/user-attachments/assets/d94ebe67-623d-4b04-94c3-d40c32cca71e" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-text-not-centered&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-text-not-centered&lookback=7)