### PR TITLE
fix suite-native unexpected state changes due to retried checks

### DIFF
--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -145,8 +145,17 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
                 // typescript complains about params and return type, need to be "any"
                 const original: any = TrezorConnect[key as ConnectKey];
                 if (!original) return;
-                (TrezorConnect[key as ConnectKey] as any) = async (params: any) => {
-                    dispatch(lockDevice(true));
+                (TrezorConnect[key as ConnectKey] as any) = async (
+                    params: any,
+                    // this is a temporary solution to prevent unwanted state changes in suite-native that are caused by calling connect
+                    // in a loop from useRetryFwAuthenticityChecks. This mechanism here is not designed to support concurrency in trezor-connect
+                    // calls but suite-native does use it like this which leads to clearing device.buttonRequests whenever the 'getFeatures' call
+                    // from useRetryFwAuthenticityChecks is made.
+                    enhancedCall = true,
+                ) => {
+                    if (enhancedCall) {
+                        dispatch(lockDevice(true));
+                    }
 
                     // cardano patch
                     const enabledNetworks = getEnabledNetworks();
@@ -158,14 +167,16 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
                         original({ ...params, useCardanoDerivation: cardanoEnabled }),
                     );
 
-                    dispatch(lockDevice(false));
-                    dispatch(
-                        deviceActions.removeButtonRequests({
-                            // todo: device not 'thread safe' - meaning that device to which button requests have been added to might not
-                            // be the same re-selected device from this line. We should reuse device from params.
-                            device: selectSelectedDevice(getState()),
-                        }),
-                    );
+                    if (enhancedCall) {
+                        dispatch(lockDevice(false));
+                        dispatch(
+                            deviceActions.removeButtonRequests({
+                                // todo: device not 'thread safe' - meaning that device to which button requests have been added to might not
+                                // be the same re-selected device from this line. We should reuse device from params.
+                                device: selectSelectedDevice(getState()),
+                            }),
+                        );
+                    }
 
                     return result;
                 };

--- a/suite-native/device/src/hooks/useRetryFwAuthenticityChecks.ts
+++ b/suite-native/device/src/hooks/useRetryFwAuthenticityChecks.ts
@@ -28,7 +28,11 @@ export const useRetryFwAuthenticityChecks = () => {
                     // it'd be useless to await the result; what interests us is the Device state that updates, and gets propagated into redux
                     requestDeviceAccess({
                         deviceCallback: () =>
-                            TrezorConnect.getFeatures({ useEmptyPassphrase: true }),
+                            TrezorConnect.getFeatures(
+                                { useEmptyPassphrase: true },
+                                // @ts-expect-error see comment in connectInitThunk
+                                false,
+                            ),
                     });
                 }
                 timeoutHandle = setTimeout(recheckFwRevision, REFRESH_INTERVAL);


### PR DESCRIPTION
following up after #21204, prerequisite for #21191

suite-native already depends on device.buttonRequests, [for example here](https://github.com/trezor/trezor-suite/blob/develop/suite-native/receive/src/hooks/receiveSelectors.ts#L6), but they might [get unexpectedly nuked.](https://github.com/trezor/trezor-suite/blob/develop/suite-common/connect-init/src/connectInitThunks.ts#L163)
Adding a temporary workaround before we proceed with some more well thought through unification

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=native-unexpected-state-changes&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=native-unexpected-state-changes&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=native-unexpected-state-changes&lookback=7)