### PR TITLE
Suite - Rename `tradingNew` to `trading`

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/trading/swap-fees-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-fees-bitcoin.test.ts
@@ -44,7 +44,7 @@ test.describe('Trading - Swap fees Bitcoin', { tag: ['@group=trading', '@webOnly
             await tradingPage.swapBestOfferButton.click();
             await tradingPage.confirmTrade('Ethereum #1');
             await tradingPage.finishTransactionButton.click();
-            await page.expectReduxObjectNotToBeEmpty('wallet.tradingNew.composedTransactionInfo');
+            await page.expectReduxObjectNotToBeEmpty('wallet.trading.composedTransactionInfo');
             await tradingPage.openConfirmAndSendModal();
             await expect(devicePrompt.headerParagraph).toContainText('Bitcoin #1');
             await devicePrompt.waitForPromptAndClick();

--- a/packages/suite-desktop-core/e2e/tests/trading/swap-fees-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/swap-fees-ethereum.test.ts
@@ -55,7 +55,7 @@ test.describe('Trading - Swap fees', { tag: ['@group=trading', '@webOnly'] }, ()
             await tradingPage.swapBestOfferButton.click();
             await tradingPage.confirmTrade('Bitcoin #1');
             await tradingPage.finishTransactionButton.click();
-            await page.expectReduxObjectNotToBeEmpty('wallet.tradingNew.composedTransactionInfo');
+            await page.expectReduxObjectNotToBeEmpty('wallet.trading.composedTransactionInfo');
             await tradingPage.openConfirmAndSendModal();
             await expect(devicePrompt.headerParagraph).toContainText('Ethereum #1');
             await devicePrompt.waitForPromptAndClick();

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
@@ -32,7 +32,7 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
     const device = useSelector(selectSelectedDevice);
     const account = useSelector(selectAccountIncludingChosenInTrading);
     const isTradingFlow = useSelector(selectTradingModalAccountKey);
-    const { modalCryptoId } = useSelector(state => state.wallet.tradingNew);
+    const { modalCryptoId } = useSelector(state => state.wallet.trading);
     const { cryptoIdToSymbolAndContractAddress } = useTradingInfo();
     const isConnectPopup = useSelector(
         state => selectConnectPopupCall(state)?.state === 'address-confirmation',

--- a/packages/suite/src/hooks/wallet/trading/useTradingDetail.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingDetail.ts
@@ -50,14 +50,14 @@ const getTypedTrade = <T extends TradingType>({
 };
 
 const getTradingDetailData = <T extends TradingType>({
-    tradingNew,
+    trading,
     tradeType,
     infos,
 }: TradingGetDetailDataProps): TradingGetDetailDataOutputProps<T> => {
     const info = infos[tradeType] as TradingTradeInfoMapProps[T];
 
-    const { trades } = tradingNew;
-    const { transactionId } = tradingNew[tradeType];
+    const { trades } = trading;
+    const { transactionId } = trading[tradeType];
 
     const trade = getTypedTrade<T>({
         trades,
@@ -76,13 +76,13 @@ export const useTradingDetail = <T extends TradingType>({
     selectedAccount,
     tradeType,
 }: TradingUseDetailProps): TradingUseDetailOutputProps<T> => {
-    const tradingNew = useSelector(selectTrading);
+    const trading = useSelector(selectTrading);
     const { account } = selectedAccount;
     const buyInfo = useSelector(selectTradingBuyInfo);
     const sellInfo = useSelector(selectTradingSellInfo);
     const exchangeInfo = useSelector(selectTradingExchangeInfo);
     const { info, transactionId, trade } = getTradingDetailData<T>({
-        tradingNew,
+        trading,
         tradeType,
         infos: {
             buy: buyInfo,

--- a/packages/suite/src/middlewares/wallet/__tests__/tradingMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/tradingMiddleware.test.ts
@@ -36,21 +36,21 @@ jest.mock('@suite-common/trading', () => {
     };
 });
 
-const tradingNewReducer = prepareTradingReducer(extraDependenciesMock);
+const tradingReducer = prepareTradingReducer(extraDependenciesMock);
 const accountsReducer = prepareAccountsReducer(extraDependenciesMock);
 
 interface Args {
-    tradingNew?: TradingState;
+    trading?: TradingState;
     selectedAccount?: SelectedAccountStatus;
     settings?: SuiteState;
     router?: RouterState;
     modal?: ModalState;
 }
 
-const getInitialState = ({ tradingNew, selectedAccount, router }: Args = {}) => ({
+const getInitialState = ({ trading, selectedAccount, router }: Args = {}) => ({
     wallet: {
-        tradingNew:
-            tradingNew ??
+        trading:
+            trading ??
             ({
                 isLoading: false,
                 lastLoadedTimestamp: 0,
@@ -78,13 +78,13 @@ type State = ReturnType<typeof getInitialState>;
 
 const initStore = (state: State) => {
     const { settings } = state.suite;
-    const { tradingNew, selectedAccount } = state.wallet;
+    const { trading, selectedAccount } = state.wallet;
 
     const store = configureMockStore({
         extra: {},
         reducer: combineReducers({
             wallet: combineReducers({
-                tradingNew: tradingNewReducer,
+                trading: tradingReducer,
                 selectedAccount: selectedAccountReducer,
                 accounts: accountsReducer,
             }),
@@ -94,9 +94,9 @@ const initStore = (state: State) => {
         }),
         preloadedState: {
             wallet: {
-                tradingNew: {
+                trading: {
                     ...initialState,
-                    ...tradingNew,
+                    ...trading,
                 },
                 selectedAccount,
                 accounts,
@@ -138,7 +138,7 @@ describe('tradingMiddleware', () => {
     ])('%s', (_, result, routeChange) => {
         const store = initStore(
             getInitialState({
-                tradingNew: {
+                trading: {
                     ...initialState,
                     modalAccountKey: 'mocked-key',
                     modalCryptoId: 'mocked-key' as CryptoId,
@@ -155,8 +155,8 @@ describe('tradingMiddleware', () => {
             },
         });
 
-        expect(store.getState().wallet.tradingNew.modalCryptoId).toEqual(result);
-        expect(store.getState().wallet.tradingNew.modalAccountKey).toEqual(result);
+        expect(store.getState().wallet.trading.modalCryptoId).toEqual(result);
+        expect(store.getState().wallet.trading.modalAccountKey).toEqual(result);
     });
 
     it.each([
@@ -199,7 +199,7 @@ describe('tradingMiddleware', () => {
     ])('%s', (_, result, routeDefault, routeChange) => {
         const store = initStore(
             getInitialState({
-                tradingNew: {
+                trading: {
                     ...initialState,
                     prefilledFromAccount: {
                         cryptoId: 'bitcoin' as CryptoId,
@@ -217,7 +217,7 @@ describe('tradingMiddleware', () => {
             },
         });
 
-        expect(store.getState().wallet.tradingNew.prefilledFromAccount).toEqual(result);
+        expect(store.getState().wallet.trading.prefilledFromAccount).toEqual(result);
     });
 
     it.each([
@@ -229,7 +229,7 @@ describe('tradingMiddleware', () => {
         (section, route) => {
             const store = initStore(
                 getInitialState({
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                     },
                     router: {
@@ -246,8 +246,8 @@ describe('tradingMiddleware', () => {
                 },
             });
 
-            expect(store.getState().wallet.tradingNew.activeSection).toEqual(section);
-            expect(store.getState().wallet.tradingNew[section].transactionId).toBeUndefined();
+            expect(store.getState().wallet.trading.activeSection).toEqual(section);
+            expect(store.getState().wallet.trading[section].transactionId).toBeUndefined();
         },
     );
 
@@ -257,7 +257,7 @@ describe('tradingMiddleware', () => {
     ])('should create new invity API key when action %s is called', (action, section) => {
         const store = initStore(
             getInitialState({
-                tradingNew: {
+                trading: {
                     ...initialState,
                 },
                 router: {
@@ -273,7 +273,7 @@ describe('tradingMiddleware', () => {
         });
 
         expect(invityAPI.createInvityAPIKey).toHaveBeenCalledTimes(1);
-        expect(store.getState().wallet.tradingNew[section].tradingAccountKey).toEqual(
+        expect(store.getState().wallet.trading[section].tradingAccountKey).toEqual(
             'btc-descriptor',
         );
     });

--- a/packages/suite/src/reducers/wallet/index.ts
+++ b/packages/suite/src/reducers/wallet/index.ts
@@ -32,7 +32,7 @@ export const fiatRatesReducer = prepareFiatRatesReducer(extraDependencies);
 export const discoveryReducer = prepareDiscoveryReducer(extraDependencies);
 export const stakeReducer = prepareStakeReducer(extraDependencies);
 export const sendFormReducer = prepareSendFormReducer(extraDependencies);
-export const tradingNewReducer = prepareTradingReducer(extraDependencies);
+export const tradingReducer = prepareTradingReducer(extraDependencies);
 export const walletSettingsReducer = prepareWalletSettingsReducer(extraDependencies);
 
 const WalletReducers = combineReducers({
@@ -46,7 +46,7 @@ const WalletReducers = combineReducers({
     fees: feesReducer,
     blockchain: blockchainReducer,
     explorer: explorerReducer,
-    tradingNew: tradingNewReducer, // TODO: trading - tradingNew is temporary
+    trading: tradingReducer,
     send: sendFormReducer,
     accountSearch: accountSearchReducer,
     formDrafts: formDraftReducer,

--- a/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
+++ b/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
@@ -1,5 +1,5 @@
 import { ConnectPopupState } from '@suite-common/connect-popup';
-import { TradingState as TradingNewState } from '@suite-common/trading';
+import { TradingState } from '@suite-common/trading';
 import { AccountsRootState, accountsActions, selectAccountByKey } from '@suite-common/wallet-core';
 import type { SelectedAccountStatus } from '@suite-common/wallet-types';
 
@@ -15,7 +15,7 @@ export type SelectedAccountRootState = {
 
 export type SelectedAccountRootStateWithTrading = SelectedAccountRootState & {
     wallet: {
-        tradingNew: TradingNewState;
+        trading: TradingState;
     };
     connectPopup: ConnectPopupState;
 };
@@ -53,7 +53,7 @@ export const selectIsSelectedAccountLoaded = (state: SelectedAccountRootState) =
 export const selectAccountIncludingChosenInTrading = (
     state: SelectedAccountRootStateWithTrading,
 ) => {
-    const { modalAccountKey } = state.wallet.tradingNew;
+    const { modalAccountKey } = state.wallet.trading;
 
     if (modalAccountKey) {
         return selectAccountByKey(state, modalAccountKey) ?? undefined;

--- a/packages/suite/src/types/trading/trading.ts
+++ b/packages/suite/src/types/trading/trading.ts
@@ -84,7 +84,7 @@ export interface TradingGetTypedTradeProps {
 }
 
 export interface TradingGetDetailDataProps {
-    tradingNew: TradingStateSelector;
+    trading: TradingStateSelector;
     tradeType: TradingType;
     infos: {
         buy: TradingBuyInfoSelector | undefined;

--- a/suite-common/trading/src/reducers/__tests__/buyReducer.test.ts
+++ b/suite-common/trading/src/reducers/__tests__/buyReducer.test.ts
@@ -12,14 +12,14 @@ describe('tradingBuyReducer', () => {
                 extra: {},
                 reducer: combineReducers({
                     wallet: combineReducers({
-                        tradingNew: combineReducers({
+                        trading: combineReducers({
                             buy: tradingBuyReducer,
                         }),
                     }),
                 }),
                 preloadedState: {
                     wallet: {
-                        tradingNew: {
+                        trading: {
                             buy: f.initialState,
                         },
                     },
@@ -28,7 +28,7 @@ describe('tradingBuyReducer', () => {
             f.actions.forEach(action => {
                 store.dispatch(action);
             });
-            expect(store.getState().wallet.tradingNew.buy).toEqual(f.result);
+            expect(store.getState().wallet.trading.buy).toEqual(f.result);
         });
     });
 });

--- a/suite-common/trading/src/reducers/__tests__/exchangeReducer.test.ts
+++ b/suite-common/trading/src/reducers/__tests__/exchangeReducer.test.ts
@@ -12,14 +12,14 @@ describe('tradingExchangeReducer', () => {
                 extra: {},
                 reducer: combineReducers({
                     wallet: combineReducers({
-                        tradingNew: combineReducers({
+                        trading: combineReducers({
                             exchange: tradingExchangeReducer,
                         }),
                     }),
                 }),
                 preloadedState: {
                     wallet: {
-                        tradingNew: {
+                        trading: {
                             exchange: fixture.initialState,
                         },
                     },
@@ -28,7 +28,7 @@ describe('tradingExchangeReducer', () => {
             fixture.actions.forEach(action => {
                 store.dispatch(action);
             });
-            expect(store.getState().wallet.tradingNew.exchange).toEqual(fixture.result);
+            expect(store.getState().wallet.trading.exchange).toEqual(fixture.result);
         });
     });
 });

--- a/suite-common/trading/src/reducers/__tests__/sellReducer.test.ts
+++ b/suite-common/trading/src/reducers/__tests__/sellReducer.test.ts
@@ -12,14 +12,14 @@ describe('tradingSellReducer', () => {
                 extra: {},
                 reducer: combineReducers({
                     wallet: combineReducers({
-                        tradingNew: combineReducers({
+                        trading: combineReducers({
                             sell: tradingSellReducer,
                         }),
                     }),
                 }),
                 preloadedState: {
                     wallet: {
-                        tradingNew: {
+                        trading: {
                             sell: fixture.initialState,
                         },
                     },
@@ -28,7 +28,7 @@ describe('tradingSellReducer', () => {
             fixture.actions.forEach(action => {
                 store.dispatch(action);
             });
-            expect(store.getState().wallet.tradingNew.sell).toEqual(fixture.result);
+            expect(store.getState().wallet.trading.sell).toEqual(fixture.result);
         });
     });
 });

--- a/suite-common/trading/src/reducers/__tests__/tradingReducer.test.ts
+++ b/suite-common/trading/src/reducers/__tests__/tradingReducer.test.ts
@@ -17,15 +17,15 @@ describe('Testing trading reducer', () => {
                 extra: {},
                 reducer: combineReducers({
                     wallet: combineReducers({
-                        tradingNew: tradingReducer,
+                        trading: tradingReducer,
                     }),
                 }),
-                preloadedState: { wallet: { tradingNew: f.initialState } },
+                preloadedState: { wallet: { trading: f.initialState } },
             });
             f.actions.forEach(action => {
                 store.dispatch(action);
             });
-            expect(store.getState().wallet.tradingNew).toEqual(f.result);
+            expect(store.getState().wallet.trading).toEqual(f.result);
         });
     });
 
@@ -34,12 +34,12 @@ describe('Testing trading reducer', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         isLoading: true,
                         info: { paymentMethods: [{ value: 'creditCard', label: 'Credit Card' }] },
@@ -55,7 +55,7 @@ describe('Testing trading reducer', () => {
 
         store.dispatch({ type: buyThunks.handleRequestThunk.rejected.type });
 
-        expect(store.getState().wallet.tradingNew.buy).toEqual(
+        expect(store.getState().wallet.trading.buy).toEqual(
             expect.objectContaining({
                 isLoading: false,
                 quotesRequest: undefined,
@@ -63,7 +63,7 @@ describe('Testing trading reducer', () => {
                 amountLimits: undefined,
             }),
         );
-        expect(store.getState().wallet.tradingNew.info).toEqual(
+        expect(store.getState().wallet.trading.info).toEqual(
             expect.objectContaining({ paymentMethods: [] }),
         );
     });
@@ -73,12 +73,12 @@ describe('Testing trading reducer', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         isLoading: true,
                         info: { paymentMethods: [{ value: 'creditCard', label: 'Credit Card' }] },
@@ -94,7 +94,7 @@ describe('Testing trading reducer', () => {
 
         store.dispatch({ type: sellThunks.handleRequestThunk.rejected.type });
 
-        expect(store.getState().wallet.tradingNew.sell).toEqual(
+        expect(store.getState().wallet.trading.sell).toEqual(
             expect.objectContaining({
                 isLoading: false,
                 quotesRequest: undefined,
@@ -102,7 +102,7 @@ describe('Testing trading reducer', () => {
                 amountLimits: undefined,
             }),
         );
-        expect(store.getState().wallet.tradingNew.info).toEqual(
+        expect(store.getState().wallet.trading.info).toEqual(
             expect.objectContaining({ paymentMethods: [] }),
         );
     });
@@ -113,12 +113,12 @@ describe('Testing trading reducer', () => {
                 extra: {},
                 reducer: combineReducers({
                     wallet: combineReducers({
-                        tradingNew: tradingReducer,
+                        trading: tradingReducer,
                     }),
                 }),
             });
 
-            expect(store.getState().wallet.tradingNew.settings).toEqual(settingsInitialState);
+            expect(store.getState().wallet.trading.settings).toEqual(settingsInitialState);
         });
 
         it('should delegate settings actions to settings slice', () => {
@@ -126,7 +126,7 @@ describe('Testing trading reducer', () => {
                 extra: {},
                 reducer: combineReducers({
                     wallet: combineReducers({
-                        tradingNew: tradingReducer,
+                        trading: tradingReducer,
                     }),
                 }),
             });

--- a/suite-common/trading/src/selectors/__tests__/settingsSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/settingsSelectors.test.ts
@@ -5,7 +5,7 @@ import { selectTradingMaxSlippagePercentage } from '../settingsSelectors';
 describe('settingsSelectors', () => {
     const getInitialState = (): TradingRootState => ({
         wallet: {
-            tradingNew: {
+            trading: {
                 ...initialState,
             },
         },
@@ -19,7 +19,7 @@ describe('settingsSelectors', () => {
         it('should return "1" even when state is undefined', () => {
             const state = getInitialState();
             // @ts-expect-error - undefined state (can happen e.g. after upgrade from old version)
-            state.wallet.tradingNew.settings.maxSlippagePercentage = undefined;
+            state.wallet.trading.settings.maxSlippagePercentage = undefined;
 
             expect(selectTradingMaxSlippagePercentage(getInitialState())).toEqual('1');
         });

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -230,7 +230,7 @@ describe('tradingSelectors', () => {
     const getState = () =>
         ({
             wallet: {
-                tradingNew: {
+                trading: {
                     ...initialState,
                     buy: getBuyState(),
                     info: {
@@ -378,7 +378,7 @@ describe('tradingSelectors', () => {
         it('should return correct data', () => {
             const stateBuy = {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         buy: {
                             buyInfo: {
                                 buyInfo: {},
@@ -403,7 +403,7 @@ describe('tradingSelectors', () => {
 
         const stateBuyWithUndefinedInfo = {
             wallet: {
-                tradingNew: {
+                trading: {
                     buy: {},
                 },
             },
@@ -436,7 +436,7 @@ describe('tradingSelectors', () => {
 
         const stateExchangeWithUndefinedInfo = {
             wallet: {
-                tradingNew: {
+                trading: {
                     exchange: {},
                 },
             },
@@ -457,7 +457,7 @@ describe('tradingSelectors', () => {
         it('should return correct data', () => {
             const stateExchange = {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         sell: {
                             sellInfo: {
                                 providerInfos: {},
@@ -478,7 +478,7 @@ describe('tradingSelectors', () => {
 
         const stateSellWithUndefinedInfo = {
             wallet: {
-                tradingNew: {
+                trading: {
                     sell: {},
                 },
             },
@@ -498,10 +498,10 @@ describe('tradingSelectors', () => {
     describe('selectTrading', () => {
         it('should return correct data', () => {
             const {
-                wallet: { tradingNew },
+                wallet: { trading },
             } = getState() as Record<string, any>;
 
-            tradingNew.buy.buyInfo.supportedCryptoCurrencies = new Set([
+            trading.buy.buyInfo.supportedCryptoCurrencies = new Set([
                 'eos',
                 'bitcoin',
                 'ethereum',
@@ -509,13 +509,13 @@ describe('tradingSelectors', () => {
                 'base--0x0000000000000000000000000000000000000000',
                 'ethereum--0xWithoutObjectInCoinsInfo',
             ]);
-            tradingNew.buy.buyInfo.supportedFiatCurrencies = new Set(['usd', 'eur', 'czk']);
-            tradingNew.buy.buyInfo.buyInfo.defaultAmountsOfFiatCurrencies = new Map([
+            trading.buy.buyInfo.supportedFiatCurrencies = new Set(['usd', 'eur', 'czk']);
+            trading.buy.buyInfo.buyInfo.defaultAmountsOfFiatCurrencies = new Map([
                 ['usd', '150'],
                 ['eur', '100'],
             ]);
-            tradingNew.exchange.exchangeInfo.buyCryptoIds = new Set(['bitcoin']);
-            tradingNew.exchange.exchangeInfo.sellCryptoIds = new Set([
+            trading.exchange.exchangeInfo.buyCryptoIds = new Set(['bitcoin']);
+            trading.exchange.exchangeInfo.sellCryptoIds = new Set([
                 'eos',
                 'bitcoin',
                 'ethereum',
@@ -523,9 +523,9 @@ describe('tradingSelectors', () => {
                 'base--0x0000000000000000000000000000000000000000',
                 'ethereum--0xWithoutObjectInCoinsInfo',
             ]);
-            tradingNew.exchange.tradingAccountKey = 'eth-descriptor-eth';
+            trading.exchange.tradingAccountKey = 'eth-descriptor-eth';
 
-            expect(selectTrading(state)).toEqual(tradingNew);
+            expect(selectTrading(state)).toEqual(trading);
         });
 
         it('should be stable', () => {
@@ -536,7 +536,7 @@ describe('tradingSelectors', () => {
     describe('selectTradingBuyProviders', () => {
         it('should return correct data', () => {
             expect(selectTradingBuyProviders(state)).toEqual(
-                state.wallet.tradingNew.buy.buyInfo?.providerInfos,
+                state.wallet.trading.buy.buyInfo?.providerInfos,
             );
         });
 
@@ -548,7 +548,7 @@ describe('tradingSelectors', () => {
     describe('selectTradingExchangeProviders', () => {
         it('should return correct data', () => {
             expect(selectTradingExchangeProviders(state)).toEqual(
-                state.wallet.tradingNew.exchange.exchangeInfo?.providerInfos,
+                state.wallet.trading.exchange.exchangeInfo?.providerInfos,
             );
         });
 
@@ -562,7 +562,7 @@ describe('tradingSelectors', () => {
     describe('selectTradingSellProviders', () => {
         it('should return correct data', () => {
             expect(selectTradingSellProviders(state)).toEqual(
-                state.wallet.tradingNew.sell.sellInfo?.providerInfos,
+                state.wallet.trading.sell.sellInfo?.providerInfos,
             );
         });
 
@@ -572,49 +572,39 @@ describe('tradingSelectors', () => {
     });
 
     it('selectTradingBuyQuotesRequest should return correct data', () => {
-        expect(selectTradingBuyQuotesRequest(state)).toBe(
-            state.wallet.tradingNew.buy.quotesRequest,
-        );
+        expect(selectTradingBuyQuotesRequest(state)).toBe(state.wallet.trading.buy.quotesRequest);
     });
 
     it('selectTradingExchangeQuotesRequest should return correct data', () => {
         expect(selectTradingExchangeQuotesRequest(state)).toBe(
-            state.wallet.tradingNew.exchange.quotesRequest,
+            state.wallet.trading.exchange.quotesRequest,
         );
     });
 
     it('selectTradingSellQuotesRequest should return correct data', () => {
-        expect(selectTradingSellQuotesRequest(state)).toBe(
-            state.wallet.tradingNew.sell.quotesRequest,
-        );
+        expect(selectTradingSellQuotesRequest(state)).toBe(state.wallet.trading.sell.quotesRequest);
     });
 
     it('selectTradingBuySelectedQuote should return correct data', () => {
-        expect(selectTradingBuySelectedQuote(state)).toBe(
-            state.wallet.tradingNew.buy.selectedQuote,
-        );
+        expect(selectTradingBuySelectedQuote(state)).toBe(state.wallet.trading.buy.selectedQuote);
     });
 
     it('selectTradingExchangeSelectedQuote should return correct data', () => {
         expect(selectTradingExchangeSelectedQuote(state)).toBe(
-            state.wallet.tradingNew.exchange.selectedQuote,
+            state.wallet.trading.exchange.selectedQuote,
         );
     });
 
     it('selectTradingSellSelectedQuote should return correct data', () => {
-        expect(selectTradingSellSelectedQuote(state)).toBe(
-            state.wallet.tradingNew.sell.selectedQuote,
-        );
+        expect(selectTradingSellSelectedQuote(state)).toBe(state.wallet.trading.sell.selectedQuote);
     });
 
     it('selectTradingPaymentMethods should return correct data', () => {
-        expect(selectTradingPaymentMethods(state)).toBe(
-            state.wallet.tradingNew.info.paymentMethods,
-        );
+        expect(selectTradingPaymentMethods(state)).toBe(state.wallet.trading.info.paymentMethods);
     });
 
     it('selectTradingTrades should return correct data', () => {
-        expect(selectTradingTrades(state)).toBe(state.wallet.tradingNew.trades);
+        expect(selectTradingTrades(state)).toBe(state.wallet.trading.trades);
     });
 
     describe('selectDeviceTradingTradesOrderedByDate', () => {
@@ -741,19 +731,19 @@ describe('tradingSelectors', () => {
         });
 
         it('should be empty array when platforms are not set', () => {
-            state.wallet.tradingNew.info.platforms = undefined;
+            state.wallet.trading.info.platforms = undefined;
 
             expect(selectTradingBuySupportedCryptoIds(state)).toEqual([]);
         });
 
         it('should be empty array when coins are not set', () => {
-            state.wallet.tradingNew.info.coins = undefined;
+            state.wallet.trading.info.coins = undefined;
 
             expect(selectTradingBuySupportedCryptoIds(state)).toEqual([]);
         });
 
         it('should be empty array when supportedCryptoCurrencies are not set', () => {
-            state.wallet.tradingNew.buy.buyInfo = undefined;
+            state.wallet.trading.buy.buyInfo = undefined;
 
             expect(selectTradingBuySupportedCryptoIds(state)).toEqual([]);
         });
@@ -777,19 +767,19 @@ describe('tradingSelectors', () => {
         });
 
         it('should be empty array when platforms are not set', () => {
-            state.wallet.tradingNew.info.platforms = undefined;
+            state.wallet.trading.info.platforms = undefined;
 
             expect(selectTradingSellSupportedCryptoIds(state)).toEqual([]);
         });
 
         it('should be empty array when coins are not set', () => {
-            state.wallet.tradingNew.info.coins = undefined;
+            state.wallet.trading.info.coins = undefined;
 
             expect(selectTradingSellSupportedCryptoIds(state)).toEqual([]);
         });
 
         it('should be empty array when supportedCryptoCurrencies are not set', () => {
-            state.wallet.tradingNew.sell.sellInfo = undefined;
+            state.wallet.trading.sell.sellInfo = undefined;
 
             expect(selectTradingSellSupportedCryptoIds(state)).toEqual([]);
         });
@@ -813,19 +803,19 @@ describe('tradingSelectors', () => {
         });
 
         it('should be empty array when platforms are not set', () => {
-            state.wallet.tradingNew.info.platforms = undefined;
+            state.wallet.trading.info.platforms = undefined;
 
             expect(selectTradingSellSellCryptoIds(state)).toEqual([]);
         });
 
         it('should be empty array when coins are not set', () => {
-            state.wallet.tradingNew.info.coins = undefined;
+            state.wallet.trading.info.coins = undefined;
 
             expect(selectTradingSellSellCryptoIds(state)).toEqual([]);
         });
 
         it('should be empty array when supportedCryptoCurrencies are not set', () => {
-            state.wallet.tradingNew.sell.sellInfo = undefined;
+            state.wallet.trading.sell.sellInfo = undefined;
 
             expect(selectTradingSellSellCryptoIds(state)).toEqual([]);
         });
@@ -849,19 +839,19 @@ describe('tradingSelectors', () => {
         });
 
         it('should be empty array when platforms are not set', () => {
-            state.wallet.tradingNew.info.platforms = undefined;
+            state.wallet.trading.info.platforms = undefined;
 
             expect(selectTradingExchangeSellCryptoIds(state)).toEqual([]);
         });
 
         it('should be empty array when coins are not set', () => {
-            state.wallet.tradingNew.info.coins = undefined;
+            state.wallet.trading.info.coins = undefined;
 
             expect(selectTradingExchangeSellCryptoIds(state)).toEqual([]);
         });
 
         it('should be empty array when sellCryptoIds are not set', () => {
-            state.wallet.tradingNew.exchange.exchangeInfo = undefined;
+            state.wallet.trading.exchange.exchangeInfo = undefined;
 
             expect(selectTradingExchangeSellCryptoIds(state)).toEqual([]);
         });
@@ -880,19 +870,19 @@ describe('tradingSelectors', () => {
         });
 
         it('should be empty array when platforms are not set', () => {
-            state.wallet.tradingNew.info.platforms = undefined;
+            state.wallet.trading.info.platforms = undefined;
 
             expect(selectTradingExchangeBuyCryptoIds(state)).toEqual([]);
         });
 
         it('should be empty array when coins are not set', () => {
-            state.wallet.tradingNew.info.coins = undefined;
+            state.wallet.trading.info.coins = undefined;
 
             expect(selectTradingExchangeBuyCryptoIds(state)).toEqual([]);
         });
 
         it('should be empty array when buyCryptoIds are not set', () => {
-            state.wallet.tradingNew.exchange.exchangeInfo = undefined;
+            state.wallet.trading.exchange.exchangeInfo = undefined;
 
             expect(selectTradingExchangeBuyCryptoIds(state)).toEqual([]);
         });
@@ -904,7 +894,7 @@ describe('tradingSelectors', () => {
         });
 
         it('should be true when trading is loading', () => {
-            state.wallet.tradingNew.buy.isLoading = true;
+            state.wallet.trading.buy.isLoading = true;
 
             expect(selectTradingBuyIsLoading(state)).toBe(true);
         });
@@ -912,7 +902,7 @@ describe('tradingSelectors', () => {
 
     describe('selectTradingBuyQuotes', () => {
         it('should return quotes', () => {
-            expect(selectTradingBuyQuotes(state)).toBe(state.wallet.tradingNew.buy.quotes);
+            expect(selectTradingBuyQuotes(state)).toBe(state.wallet.trading.buy.quotes);
         });
     });
 
@@ -931,7 +921,7 @@ describe('tradingSelectors', () => {
         });
 
         it('should be undefined when no quotes are loaded', () => {
-            state.wallet.tradingNew.buy.quotes = [];
+            state.wallet.trading.buy.quotes = [];
 
             expect(selectBestBuyQuoteByPaymentMethod(state, 'eps')).toBeUndefined();
         });
@@ -983,7 +973,7 @@ describe('tradingSelectors', () => {
         });
 
         it('should be true when trading is loading', () => {
-            state.wallet.tradingNew.exchange.isLoading = true;
+            state.wallet.trading.exchange.isLoading = true;
 
             expect(selectTradingExchangeIsLoading(state)).toBe(true);
         });
@@ -1033,7 +1023,7 @@ describe('tradingSelectors', () => {
                 ),
             ).toEqual(
                 state.wallet.accounts.find(
-                    account => account.key === state.wallet.tradingNew.buy.tradingAccountKey,
+                    account => account.key === state.wallet.trading.buy.tradingAccountKey,
                 ),
             );
         });
@@ -1047,7 +1037,7 @@ describe('tradingSelectors', () => {
                 ),
             ).toEqual(
                 state.wallet.accounts.find(
-                    account => account.key === state.wallet.tradingNew.exchange.tradingAccountKey,
+                    account => account.key === state.wallet.trading.exchange.tradingAccountKey,
                 ),
             );
         });
@@ -1061,7 +1051,7 @@ describe('tradingSelectors', () => {
                 ),
             ).toEqual(
                 state.wallet.accounts.find(
-                    account => account.key === state.wallet.tradingNew.sell.tradingAccountKey,
+                    account => account.key === state.wallet.trading.sell.tradingAccountKey,
                 ),
             );
         });
@@ -1069,7 +1059,7 @@ describe('tradingSelectors', () => {
 
     describe('selectValidTradingBuyQuotes', () => {
         beforeEach(() => {
-            state.wallet.tradingNew.buy.quotes = [
+            state.wallet.trading.buy.quotes = [
                 {
                     fiatStringAmount: '10',
                     fiatCurrency: 'EUR',
@@ -1102,7 +1092,7 @@ describe('tradingSelectors', () => {
         it('should return only quotes with non-zero rate', () => {
             const validQuotes = selectValidTradingBuyQuotes(state);
 
-            expect(validQuotes).toEqual([state.wallet.tradingNew.buy.quotes[0]]);
+            expect(validQuotes).toEqual([state.wallet.trading.buy.quotes[0]]);
         });
 
         it('should be stable', () => {
@@ -1112,9 +1102,9 @@ describe('tradingSelectors', () => {
 
     describe('selectValidTradingSellQuotes', () => {
         beforeEach(() => {
-            const quoteDraft = state.wallet.tradingNew.sell.quotes[0];
+            const quoteDraft = state.wallet.trading.sell.quotes[0];
 
-            state.wallet.tradingNew.sell.quotes = [
+            state.wallet.trading.sell.quotes = [
                 {
                     ...quoteDraft,
                     rate: 20000,
@@ -1136,7 +1126,7 @@ describe('tradingSelectors', () => {
         it('should return only quotes with non-zero rate', () => {
             const validQuotes = selectValidTradingSellQuotes(state);
 
-            expect(validQuotes).toEqual([state.wallet.tradingNew.sell.quotes[0]]);
+            expect(validQuotes).toEqual([state.wallet.trading.sell.quotes[0]]);
         });
 
         it('should be stable', () => {
@@ -1148,24 +1138,21 @@ describe('tradingSelectors', () => {
         it.each<[boolean, number]>([
             [true, 0],
             [false, 123456789],
-        ])(
-            'should return values from tradingNew state, case %#',
-            (isLoading, lastLoadedTimestamp) => {
-                state.wallet.tradingNew.isLoading = isLoading;
-                state.wallet.tradingNew.lastLoadedTimestamp = lastLoadedTimestamp;
+        ])('should return values from trading state, case %#', (isLoading, lastLoadedTimestamp) => {
+            state.wallet.trading.isLoading = isLoading;
+            state.wallet.trading.lastLoadedTimestamp = lastLoadedTimestamp;
 
-                expect(selectTradingBuyLoadingTimestampAndStatus(state)).toEqual(
-                    expect.objectContaining({
-                        isLoading,
-                        lastLoadedTimestamp,
-                    }),
-                );
-            },
-        );
+            expect(selectTradingBuyLoadingTimestampAndStatus(state)).toEqual(
+                expect.objectContaining({
+                    isLoading,
+                    lastLoadedTimestamp,
+                }),
+            );
+        });
 
         describe('isFullyLoaded', () => {
             it('should be false when trading info is empty', () => {
-                state.wallet.tradingNew.info = {
+                state.wallet.trading.info = {
                     paymentMethods: [],
                 };
 
@@ -1173,14 +1160,14 @@ describe('tradingSelectors', () => {
             });
 
             it('should be false when trading buyInfo is empty', () => {
-                state.wallet.tradingNew.buy.buyInfo = undefined;
+                state.wallet.trading.buy.buyInfo = undefined;
 
                 expect(selectTradingBuyLoadingTimestampAndStatus(state).isFullyLoaded).toBe(false);
             });
 
             it('should be false when providers info is empty', () => {
-                state.wallet.tradingNew.buy.buyInfo!.providerInfos = {};
-                state.wallet.tradingNew.buy.buyInfo!.buyInfo.providers = [];
+                state.wallet.trading.buy.buyInfo!.providerInfos = {};
+                state.wallet.trading.buy.buyInfo!.buyInfo.providers = [];
 
                 expect(selectTradingBuyLoadingTimestampAndStatus(state).isFullyLoaded).toBe(false);
             });
@@ -1195,24 +1182,21 @@ describe('tradingSelectors', () => {
         it.each<[boolean, number]>([
             [true, 0],
             [false, 123456789],
-        ])(
-            'should return values from tradingNew state, case %#',
-            (isLoading, lastLoadedTimestamp) => {
-                state.wallet.tradingNew.isLoading = isLoading;
-                state.wallet.tradingNew.lastLoadedTimestamp = lastLoadedTimestamp;
+        ])('should return values from trading state, case %#', (isLoading, lastLoadedTimestamp) => {
+            state.wallet.trading.isLoading = isLoading;
+            state.wallet.trading.lastLoadedTimestamp = lastLoadedTimestamp;
 
-                expect(selectTradingExchangeLoadingTimestampAndStatus(state)).toEqual(
-                    expect.objectContaining({
-                        isLoading,
-                        lastLoadedTimestamp,
-                    }),
-                );
-            },
-        );
+            expect(selectTradingExchangeLoadingTimestampAndStatus(state)).toEqual(
+                expect.objectContaining({
+                    isLoading,
+                    lastLoadedTimestamp,
+                }),
+            );
+        });
 
         describe('isFullyLoaded', () => {
             it('should be false when trading info is empty', () => {
-                state.wallet.tradingNew.exchange = {
+                state.wallet.trading.exchange = {
                     ...initialState.exchange,
                     exchangeInfo: {
                         providerInfos: {},
@@ -1227,7 +1211,7 @@ describe('tradingSelectors', () => {
             });
 
             it('should be false when trading exchangeInfo is empty', () => {
-                state.wallet.tradingNew.exchange.exchangeInfo = undefined;
+                state.wallet.trading.exchange.exchangeInfo = undefined;
 
                 expect(selectTradingExchangeLoadingTimestampAndStatus(state).isFullyLoaded).toBe(
                     false,
@@ -1235,7 +1219,7 @@ describe('tradingSelectors', () => {
             });
 
             it('should be false when providers info is empty', () => {
-                state.wallet.tradingNew.exchange.exchangeInfo!.providerInfos = {};
+                state.wallet.trading.exchange.exchangeInfo!.providerInfos = {};
 
                 expect(selectTradingExchangeLoadingTimestampAndStatus(state).isFullyLoaded).toBe(
                     false,
@@ -1254,24 +1238,21 @@ describe('tradingSelectors', () => {
         it.each<[boolean, number]>([
             [true, 0],
             [false, 123456789],
-        ])(
-            'should return values from tradingNew state, case %#',
-            (isLoading, lastLoadedTimestamp) => {
-                state.wallet.tradingNew.isLoading = isLoading;
-                state.wallet.tradingNew.lastLoadedTimestamp = lastLoadedTimestamp;
+        ])('should return values from trading state, case %#', (isLoading, lastLoadedTimestamp) => {
+            state.wallet.trading.isLoading = isLoading;
+            state.wallet.trading.lastLoadedTimestamp = lastLoadedTimestamp;
 
-                expect(selectTradingSellLoadingTimestampAndStatus(state)).toEqual(
-                    expect.objectContaining({
-                        isLoading,
-                        lastLoadedTimestamp,
-                    }),
-                );
-            },
-        );
+            expect(selectTradingSellLoadingTimestampAndStatus(state)).toEqual(
+                expect.objectContaining({
+                    isLoading,
+                    lastLoadedTimestamp,
+                }),
+            );
+        });
 
         describe('isFullyLoaded', () => {
             it('should be false when trading info is empty', () => {
-                state.wallet.tradingNew.info = {
+                state.wallet.trading.info = {
                     paymentMethods: [],
                 };
 
@@ -1279,13 +1260,13 @@ describe('tradingSelectors', () => {
             });
 
             it('should be false when trading sellInfo is empty', () => {
-                state.wallet.tradingNew.sell.sellInfo = undefined;
+                state.wallet.trading.sell.sellInfo = undefined;
 
                 expect(selectTradingSellLoadingTimestampAndStatus(state).isFullyLoaded).toBe(false);
             });
 
             it('should be false when providers info is empty', () => {
-                state.wallet.tradingNew.sell.sellInfo!.providerInfos = {};
+                state.wallet.trading.sell.sellInfo!.providerInfos = {};
 
                 expect(selectTradingSellLoadingTimestampAndStatus(state).isFullyLoaded).toBe(false);
             });
@@ -1298,15 +1279,15 @@ describe('tradingSelectors', () => {
 
     describe('selectTradingSellQuotes', () => {
         it('should return quotes from trading sell state', () => {
-            expect(selectTradingSellQuotes(state)).toBe(state.wallet.tradingNew.sell.quotes);
+            expect(selectTradingSellQuotes(state)).toBe(state.wallet.trading.sell.quotes);
         });
     });
 
     describe('selectTradingProviderByNameAndTradeType', () => {
         it('should return the correct provider for buy trade type', () => {
             const providerName = 'provider1';
-            state.wallet.tradingNew.buy.buyInfo = {
-                ...state.wallet.tradingNew.buy.buyInfo,
+            state.wallet.trading.buy.buyInfo = {
+                ...state.wallet.trading.buy.buyInfo,
                 providerInfos: {
                     [providerName]: { name: providerName },
                 },
@@ -1318,8 +1299,8 @@ describe('tradingSelectors', () => {
 
         it('should return the correct provider for exchange trade type', () => {
             const providerName = 'provider2';
-            state.wallet.tradingNew.exchange.exchangeInfo = {
-                ...state.wallet.tradingNew.exchange.exchangeInfo,
+            state.wallet.trading.exchange.exchangeInfo = {
+                ...state.wallet.trading.exchange.exchangeInfo,
                 providerInfos: {
                     [providerName]: { name: providerName },
                 },
@@ -1331,8 +1312,8 @@ describe('tradingSelectors', () => {
 
         it('should return the correct provider for sell trade type', () => {
             const providerName = 'provider3';
-            state.wallet.tradingNew.sell.sellInfo = {
-                ...state.wallet.tradingNew.sell.sellInfo,
+            state.wallet.trading.sell.sellInfo = {
+                ...state.wallet.trading.sell.sellInfo,
                 providerInfos: {
                     [providerName]: { name: providerName },
                 },
@@ -1370,7 +1351,7 @@ describe('tradingSelectors', () => {
                         { key: 'key1', deviceState: 'device1' },
                         { key: 'key2', deviceState: 'device2' },
                     ],
-                    tradingNew: {
+                    trading: {
                         trades: [
                             { selectedAccountKey: 'key1', tradeType: 'buy' },
                             { sendAccountKey: 'key2', tradeType: 'sell' },
@@ -1394,7 +1375,7 @@ describe('tradingSelectors', () => {
                         { key: 'key1', deviceState: 'device1' },
                         { key: 'key2', deviceState: 'device2' },
                     ],
-                    tradingNew: {
+                    trading: {
                         trades: [{ tradeType: 'buy' }, { tradeType: 'sell' }],
                     },
                 },
@@ -1415,7 +1396,7 @@ describe('tradingSelectors', () => {
                         { key: 'key1', deviceState: 'device1' },
                         { key: 'key2', deviceState: 'device2' },
                     ],
-                    tradingNew: {
+                    trading: {
                         trades: [],
                     },
                 },

--- a/suite-common/trading/src/selectors/settingsSelectors.ts
+++ b/suite-common/trading/src/selectors/settingsSelectors.ts
@@ -2,5 +2,5 @@ import { TRADING_SETTINGS_MAX_SLIPPAGE_PERCENTAGE_DEFAULT } from '../constants';
 import { TradingRootState } from '../types';
 
 export const selectTradingMaxSlippagePercentage = (state: TradingRootState) =>
-    state.wallet.tradingNew.settings.maxSlippagePercentage ??
+    state.wallet.trading.settings.maxSlippagePercentage ??
     TRADING_SETTINGS_MAX_SLIPPAGE_PERCENTAGE_DEFAULT;

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -86,8 +86,8 @@ const createMemoizedSelectorWithDeviceAndAccounts =
 
 export const selectTradingLoadingAndTimestamp = createMemoizedSelector(
     [
-        (state: TradingRootState) => state.wallet.tradingNew.isLoading,
-        (state: TradingRootState) => state.wallet.tradingNew.lastLoadedTimestamp,
+        (state: TradingRootState) => state.wallet.trading.isLoading,
+        (state: TradingRootState) => state.wallet.trading.lastLoadedTimestamp,
     ],
     (isLoading, lastLoadedTimestamp) => ({
         isLoading,
@@ -98,8 +98,8 @@ export const selectTradingLoadingAndTimestamp = createMemoizedSelector(
 export const selectTradingBuyLoadingTimestampAndStatus = createMemoizedSelector(
     [
         selectTradingLoadingAndTimestamp,
-        (state: TradingRootState) => state.wallet.tradingNew.info,
-        (state: TradingRootState) => state.wallet.tradingNew.buy.buyInfo,
+        (state: TradingRootState) => state.wallet.trading.info,
+        (state: TradingRootState) => state.wallet.trading.buy.buyInfo,
     ],
     (loadingAndTimestamp, info, buyInfo) => ({
         isLoading: loadingAndTimestamp.isLoading,
@@ -109,10 +109,10 @@ export const selectTradingBuyLoadingTimestampAndStatus = createMemoizedSelector(
     }),
 );
 
-export const selectTradingInfo = (state: TradingRootState) => state.wallet?.tradingNew?.info;
+export const selectTradingInfo = (state: TradingRootState) => state.wallet?.trading?.info;
 
 export const selectTradingBuyInfo = createMemoizedSelector(
-    [state => state.wallet.tradingNew.buy.buyInfo],
+    [state => state.wallet.trading.buy.buyInfo],
     (buyInfo): TradingBuyInfoSelector | undefined => {
         if (!buyInfo) return;
 
@@ -139,7 +139,7 @@ export const selectTradingBuyInfo = createMemoizedSelector(
 );
 
 export const selectTradingExchangeInfo = createMemoizedSelector(
-    [state => state.wallet.tradingNew.exchange.exchangeInfo],
+    [state => state.wallet.trading.exchange.exchangeInfo],
     (exchangeInfo): TradingExchangeInfoSelector | undefined => {
         if (!exchangeInfo) return;
 
@@ -152,7 +152,7 @@ export const selectTradingExchangeInfo = createMemoizedSelector(
 );
 
 export const selectTradingSellInfo = createMemoizedSelector(
-    [state => state.wallet.tradingNew.sell.sellInfo],
+    [state => state.wallet.trading.sell.sellInfo],
     (sellInfo): TradingSellInfoSelector | undefined => {
         if (!sellInfo) return;
 
@@ -167,7 +167,7 @@ export const selectTradingSellInfo = createMemoizedSelector(
 );
 
 export const selectTradingBuy = createMemoizedSelector(
-    [state => state.wallet.tradingNew.buy, selectTradingBuyInfo],
+    [state => state.wallet.trading.buy, selectTradingBuyInfo],
     (buy, buyInfo) => ({
         ...buy,
         buyInfo,
@@ -175,7 +175,7 @@ export const selectTradingBuy = createMemoizedSelector(
 );
 
 export const selectTradingExchange = createMemoizedSelector(
-    [state => state.wallet.tradingNew.exchange, selectTradingExchangeInfo],
+    [state => state.wallet.trading.exchange, selectTradingExchangeInfo],
     (exchange, exchangeInfo) => ({
         ...exchange,
         exchangeInfo,
@@ -183,7 +183,7 @@ export const selectTradingExchange = createMemoizedSelector(
 );
 
 export const selectTradingSell = createMemoizedSelector(
-    [state => state.wallet.tradingNew.sell, selectTradingSellInfo],
+    [state => state.wallet.trading.sell, selectTradingSellInfo],
     (sell, sellInfo) => ({
         ...sell,
         sellInfo,
@@ -191,9 +191,9 @@ export const selectTradingSell = createMemoizedSelector(
 );
 
 export const selectTrading = createMemoizedSelector(
-    [state => state.wallet.tradingNew, selectTradingBuy, selectTradingExchange],
-    (tradingNew, buy, exchange): TradingStateSelector => ({
-        ...tradingNew,
+    [state => state.wallet.trading, selectTradingBuy, selectTradingExchange],
+    (trading, buy, exchange): TradingStateSelector => ({
+        ...trading,
         buy,
         exchange,
     }),
@@ -202,7 +202,7 @@ export const selectTrading = createMemoizedSelector(
 export const selectTradingExchangeLoadingTimestampAndStatus = createMemoizedSelector(
     [
         selectTradingLoadingAndTimestamp,
-        (state: TradingRootState) => state.wallet.tradingNew.info,
+        (state: TradingRootState) => state.wallet.trading.info,
         selectTradingExchangeInfo,
     ],
     (loadingAndTimestamp, info, exchangeInfo) => ({
@@ -217,7 +217,7 @@ export const selectTradingExchangeLoadingTimestampAndStatus = createMemoizedSele
 export const selectTradingSellLoadingTimestampAndStatus = createMemoizedSelector(
     [
         selectTradingLoadingAndTimestamp,
-        (state: TradingRootState) => state.wallet.tradingNew.info,
+        (state: TradingRootState) => state.wallet.trading.info,
         selectTradingSellInfo,
     ],
     (loadingAndTimestamp, info, sellInfo) => ({
@@ -276,31 +276,31 @@ export const selectTradingProviderKycPolicy = (
 };
 
 export const selectTradingBuyQuotesRequest = (state: TradingRootState) =>
-    state.wallet.tradingNew.buy.quotesRequest;
+    state.wallet.trading.buy.quotesRequest;
 
 export const selectTradingExchangeQuotesRequest = (state: TradingRootState) =>
-    state.wallet.tradingNew.exchange.quotesRequest;
+    state.wallet.trading.exchange.quotesRequest;
 
 export const selectTradingSellQuotesRequest = (state: TradingRootState) =>
-    state.wallet.tradingNew.sell.quotesRequest;
+    state.wallet.trading.sell.quotesRequest;
 
 export const selectTradingBuySelectedQuote = (state: TradingRootState) =>
-    state.wallet.tradingNew.buy.selectedQuote;
+    state.wallet.trading.buy.selectedQuote;
 
 export const selectTradingExchangeSelectedQuote = (state: TradingRootState) =>
-    state.wallet.tradingNew.exchange.selectedQuote;
+    state.wallet.trading.exchange.selectedQuote;
 
 export const selectTradingExchangePreselectedQuote = (state: TradingRootState) =>
-    state.wallet.tradingNew.exchange.preselectedQuote;
+    state.wallet.trading.exchange.preselectedQuote;
 
 export const selectTradingSellSelectedQuote = (state: TradingRootState) =>
-    state.wallet.tradingNew.sell.selectedQuote;
+    state.wallet.trading.sell.selectedQuote;
 
 export const selectTradingPaymentMethods = (state: TradingRootState) =>
-    state.wallet.tradingNew.info.paymentMethods;
+    state.wallet.trading.info.paymentMethods;
 
 export const selectTradingTrades = (state: TradingRootState) =>
-    returnStableArrayIfEmpty(state.wallet.tradingNew.trades);
+    returnStableArrayIfEmpty(state.wallet.trading.trades);
 
 export const selectTradingTradesForSelectedDevice = createMemoizedSelectorWithDeviceAndAccounts(
     [selectAccounts, state => state.wallet.selectedAccount, selectTradingTrades],
@@ -355,7 +355,7 @@ export const selectTradingCoinInfoByCryptoId = (
     if (!cryptoId) {
         return undefined;
     }
-    const { coins = {} } = state.wallet.tradingNew.info;
+    const { coins = {} } = state.wallet.trading.info;
 
     return getTradingCoinInfoByCryptoId(coins, cryptoId);
 };
@@ -367,13 +367,13 @@ export const selectTradingCoinSymbolByCryptoId = (
     if (cryptoId === undefined) {
         return undefined;
     }
-    const { coins = {} } = state.wallet.tradingNew.info;
+    const { coins = {} } = state.wallet.trading.info;
 
     return getTradingCoinSymbolByCryptoId(coins, cryptoId);
 };
 
 export const selectTradingPlatformByCryptoId = (state: TradingRootState, cryptoId: CryptoId) => {
-    const { platforms = {} } = state.wallet.tradingNew.info;
+    const { platforms = {} } = state.wallet.trading.info;
 
     return getTradingPlatformsInfoByCryptoId(platforms, cryptoId);
 };
@@ -382,7 +382,7 @@ export const selectTradingNativeCoinSymbolByCryptoId = (
     state: TradingRootState,
     cryptoId: CryptoId,
 ) => {
-    const { coins = {}, platforms = {} } = state.wallet.tradingNew.info;
+    const { coins = {}, platforms = {} } = state.wallet.trading.info;
 
     return getTradingNativeCoinSymbolByCryptoId(platforms, coins, cryptoId);
 };
@@ -395,8 +395,7 @@ export const selectTradingSymbolAndContractAddressByCryptoId: (
     contractAddress: string | undefined;
 } = createMemoizedSelector(
     [
-        ({ wallet }: TradingRootState, _: CryptoId): Coins | undefined =>
-            wallet.tradingNew.info.coins,
+        ({ wallet }: TradingRootState, _: CryptoId): Coins | undefined => wallet.trading.info.coins,
         (_: TradingRootState, cryptoId: CryptoId): CryptoId => cryptoId,
     ],
     getTradingSymbolAndContractAddressByCryptoId,
@@ -432,11 +431,11 @@ const getFilteredCryptoIds = (
 
 export const selectTradingBuySupportedCryptoIds = createMemoizedSelector(
     [
-        ({ wallet }) => wallet.tradingNew.info.coins,
-        ({ wallet }) => wallet.tradingNew.info.platforms,
+        ({ wallet }) => wallet.trading.info.coins,
+        ({ wallet }) => wallet.trading.info.platforms,
         ({ wallet }) =>
             returnStableArrayIfEmpty<CryptoId>(
-                wallet.tradingNew.buy.buyInfo?.supportedCryptoCurrencies,
+                wallet.trading.buy.buyInfo?.supportedCryptoCurrencies,
             ),
     ],
     (coins, platforms, supportedCryptoIds) =>
@@ -445,11 +444,11 @@ export const selectTradingBuySupportedCryptoIds = createMemoizedSelector(
 
 export const selectTradingSellSupportedCryptoIds = createMemoizedSelector(
     [
-        ({ wallet }) => wallet.tradingNew.info.coins,
-        ({ wallet }) => wallet.tradingNew.info.platforms,
+        ({ wallet }) => wallet.trading.info.coins,
+        ({ wallet }) => wallet.trading.info.platforms,
         ({ wallet }) =>
             returnStableArrayIfEmpty<CryptoId>(
-                wallet.tradingNew.sell.sellInfo?.supportedCryptoCurrencies,
+                wallet.trading.sell.sellInfo?.supportedCryptoCurrencies,
             ),
     ],
     (coins, platforms, supportedCryptoIds) =>
@@ -459,10 +458,10 @@ export const selectTradingSellSupportedCryptoIds = createMemoizedSelector(
 const createExchangeCryptoIdsSelector = (key: 'buyCryptoIds' | 'sellCryptoIds') =>
     createMemoizedSelector(
         [
-            ({ wallet }) => wallet.tradingNew.info.coins,
-            ({ wallet }) => wallet.tradingNew.info.platforms,
+            ({ wallet }) => wallet.trading.info.coins,
+            ({ wallet }) => wallet.trading.info.platforms,
             ({ wallet }) =>
-                returnStableArrayIfEmpty<CryptoId>(wallet.tradingNew.exchange.exchangeInfo?.[key]),
+                returnStableArrayIfEmpty<CryptoId>(wallet.trading.exchange.exchangeInfo?.[key]),
         ],
         (coins, platforms, cryptoIds) => getFilteredCryptoIds(cryptoIds, coins, platforms),
     );
@@ -472,9 +471,9 @@ export const selectTradingExchangeBuyCryptoIds = createExchangeCryptoIdsSelector
 
 export const selectTradingSellSellCryptoIds = createMemoizedSelector(
     [
-        ({ wallet }) => wallet.tradingNew.info.coins,
-        ({ wallet }) => wallet.tradingNew.info.platforms,
-        ({ wallet }) => wallet.tradingNew.sell.sellInfo?.supportedCryptoCurrencies,
+        ({ wallet }) => wallet.trading.info.coins,
+        ({ wallet }) => wallet.trading.info.platforms,
+        ({ wallet }) => wallet.trading.sell.sellInfo?.supportedCryptoCurrencies,
     ],
     (coins, platforms, supportedCryptoIds) =>
         getFilteredCryptoIds(
@@ -485,15 +484,14 @@ export const selectTradingSellSellCryptoIds = createMemoizedSelector(
 );
 
 export const selectTradingBuyIsLoading = (state: TradingRootState) =>
-    state.wallet.tradingNew.buy.isLoading;
+    state.wallet.trading.buy.isLoading;
 
-export const selectTradingBuyQuotes = (state: TradingRootState) =>
-    state.wallet.tradingNew.buy.quotes;
+export const selectTradingBuyQuotes = (state: TradingRootState) => state.wallet.trading.buy.quotes;
 
 export const selectTradingBuyQuoteByOrderId = (
     state: TradingRootState,
     orderId: string | undefined,
-) => (orderId ? state.wallet.tradingNew.buy.quotes.find(q => q.orderId === orderId) : undefined);
+) => (orderId ? state.wallet.trading.buy.quotes.find(q => q.orderId === orderId) : undefined);
 
 export const selectBuyQuotesByPaymentMethod = createMemoizedSelector(
     [
@@ -515,22 +513,22 @@ export const selectBestBuyQuoteByPaymentMethod = createMemoizedSelector(
 );
 
 export const selectTradingExchangeIsLoading = (state: TradingRootState) =>
-    state.wallet.tradingNew.exchange.isLoading;
+    state.wallet.trading.exchange.isLoading;
 
 export const selectTradingSellIsLoading = (state: TradingRootState) =>
-    state.wallet.tradingNew.sell.isLoading;
+    state.wallet.trading.sell.isLoading;
 
 export const selectTradingSellQuotes = (state: TradingRootState) =>
-    state.wallet.tradingNew.sell.quotes;
+    state.wallet.trading.sell.quotes;
 
 export const selectTradingExchangeFormStep = (state: TradingRootState) =>
-    state.wallet.tradingNew.exchange.formStep;
+    state.wallet.trading.exchange.formStep;
 
 export const selectTradingSellFormStep = (state: TradingRootState) =>
-    state.wallet.tradingNew.sell.formStep;
+    state.wallet.trading.sell.formStep;
 
 export const selectTradingComposedTransactionInfo = (state: TradingRootState) =>
-    state.wallet.tradingNew.composedTransactionInfo;
+    state.wallet.trading.composedTransactionInfo;
 
 export const selectTradingAccountAccordingActiveSection =
     createMemoizedSelectorWithDeviceAndAccounts(
@@ -579,22 +577,22 @@ export const selectValidTradingSellQuotes = createMemoizedSelector(
 );
 
 export const selectTradingBuyReceiveAccountKey = (state: TradingRootState) =>
-    state.wallet.tradingNew.buy.tradingAccountKey;
+    state.wallet.trading.buy.tradingAccountKey;
 
 export const selectTradingExchangeAccountKey = (state: TradingRootState) =>
-    state.wallet.tradingNew.exchange.tradingAccountKey;
+    state.wallet.trading.exchange.tradingAccountKey;
 
 export const selectTradingExchangeReceiveAccountKey = (state: TradingRootState) =>
-    state.wallet.tradingNew.exchange.receiveAccountKey;
+    state.wallet.trading.exchange.receiveAccountKey;
 
 export const selectTradingModalAccountKey = (state: TradingRootState) =>
-    state.wallet.tradingNew.modalAccountKey;
+    state.wallet.trading.modalAccountKey;
 
 export const selectTradingPrefilledFromAccount = (state: TradingRootState) =>
-    state.wallet.tradingNew.prefilledFromAccount;
+    state.wallet.trading.prefilledFromAccount;
 
 export const selectTradingActiveSection = (state: TradingRootState) =>
-    state.wallet.tradingNew.activeSection;
+    state.wallet.trading.activeSection;
 
 export const selectTradingSupportedSymbols = createMemoizedSelector(
     [
@@ -618,13 +616,13 @@ export const selectTradingSupportedSymbols = createMemoizedSelector(
 );
 
 export const selectTradingExchangeTransactionId = (state: TradingRootState) =>
-    state.wallet.tradingNew.exchange.transactionId;
+    state.wallet.trading.exchange.transactionId;
 
 export const selectTradingSellTransactionId = (state: TradingRootState) =>
-    state.wallet.tradingNew.sell.transactionId;
+    state.wallet.trading.sell.transactionId;
 
 export const selectTradingVerifiedAddress = (state: TradingRootState) =>
-    state.wallet.tradingNew.verifiedAddress;
+    state.wallet.trading.verifiedAddress;
 
 export const selectTradingIsSlip24Allowed = createMemoizedSelectorWithDeviceAndAccounts(
     [

--- a/suite-common/trading/src/thunks/buy/__tests__/confirmBuyTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/__tests__/confirmBuyTradeThunk.test.ts
@@ -27,12 +27,12 @@ describe('confirmBuyTradeThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         buy: {
                             ...initialState.buy,
@@ -90,7 +90,7 @@ describe('confirmBuyTradeThunk', () => {
         expect(store.getActions().length).toEqual(2);
         expect(mockProcessResponseData).toHaveBeenCalledTimes(0);
         expect(mocktriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(0);
-        expect(store.getState().wallet.tradingNew.buy.isLoading).toBeFalsy();
+        expect(store.getState().wallet.trading.buy.isLoading).toBeFalsy();
     });
 
     describe('should show error toast', () => {
@@ -123,7 +123,7 @@ describe('confirmBuyTradeThunk', () => {
             expect(toastAction?.payload.type).toEqual('error');
             expect(toastAction?.payload.error).toEqual('No response from the server');
             expect(mockProcessResponseData).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.buy.isLoading).toBeFalsy();
+            expect(store.getState().wallet.trading.buy.isLoading).toBeFalsy();
         });
 
         it('if there is no trade in response', async () => {
@@ -155,7 +155,7 @@ describe('confirmBuyTradeThunk', () => {
             expect(toastAction?.payload.type).toEqual('error');
             expect(toastAction?.payload.error).toEqual('No response from the server');
             expect(mockProcessResponseData).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.buy.isLoading).toBeFalsy();
+            expect(store.getState().wallet.trading.buy.isLoading).toBeFalsy();
         });
 
         it('if there is no response trade payment id', async () => {
@@ -193,7 +193,7 @@ describe('confirmBuyTradeThunk', () => {
             expect(toastAction?.payload.type).toEqual('error');
             expect(toastAction?.payload.error).toEqual('No response from the server');
             expect(mockProcessResponseData).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.buy.isLoading).toBeFalsy();
+            expect(store.getState().wallet.trading.buy.isLoading).toBeFalsy();
         });
 
         it('if there is trade error', async () => {
@@ -231,7 +231,7 @@ describe('confirmBuyTradeThunk', () => {
             expect(toastAction?.payload.type).toEqual('error');
             expect(toastAction?.payload.error).toEqual(error);
             expect(mockProcessResponseData).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.buy.isLoading).toBeFalsy();
+            expect(store.getState().wallet.trading.buy.isLoading).toBeFalsy();
         });
     });
 
@@ -261,7 +261,7 @@ describe('confirmBuyTradeThunk', () => {
             }),
         );
 
-        const { trades } = store.getState().wallet.tradingNew;
+        const { trades } = store.getState().wallet.trading;
 
         expect(mocktriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
         expect(mockProcessResponseData).toHaveBeenCalledTimes(1);
@@ -273,6 +273,6 @@ describe('confirmBuyTradeThunk', () => {
             key: MIN_MAX_QUOTES_OK[1].paymentId,
             selectedAccountKey: 'yyy',
         });
-        expect(store.getState().wallet.tradingNew.buy.isLoading).toBeFalsy();
+        expect(store.getState().wallet.trading.buy.isLoading).toBeFalsy();
     });
 });

--- a/suite-common/trading/src/thunks/buy/__tests__/handleBuyRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/__tests__/handleBuyRequestThunk.test.ts
@@ -32,12 +32,12 @@ describe('handleBuyRequestThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         info: {
                             ...initialState.info,
@@ -116,7 +116,7 @@ describe('handleBuyRequestThunk', () => {
 
         const quotesResponse = await store.dispatch(buyThunks.handleRequestThunk(input)).unwrap();
 
-        const state = store.getState().wallet.tradingNew;
+        const state = store.getState().wallet.trading;
 
         expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(state.buy.amountLimits).toBeUndefined();
@@ -162,7 +162,7 @@ describe('handleBuyRequestThunk', () => {
         const promise = store.dispatch(buyThunks.handleRequestThunk(inputWithIncorrectData));
         await promise;
 
-        const state = store.getState().wallet.tradingNew;
+        const state = store.getState().wallet.trading;
 
         expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(mockTimerStop).toHaveBeenCalledTimes(1);
@@ -179,7 +179,7 @@ describe('handleBuyRequestThunk', () => {
 
         const quotesResponse = await store.dispatch(buyThunks.handleRequestThunk(input)).unwrap();
 
-        const state = store.getState().wallet.tradingNew;
+        const state = store.getState().wallet.trading;
 
         expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(mockTimerStop).toHaveBeenCalledTimes(1);
@@ -206,7 +206,7 @@ describe('handleBuyRequestThunk', () => {
         promise.abort();
         await promise;
 
-        const state = store.getState().wallet.tradingNew;
+        const state = store.getState().wallet.trading;
 
         expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(mockTimerReset).toHaveBeenCalledTimes(1);

--- a/suite-common/trading/src/thunks/buy/__tests__/loadBuyInfoThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/__tests__/loadBuyInfoThunk.test.ts
@@ -18,14 +18,14 @@ describe('loadBuyInfoThunk', () => {
         extra: {},
         reducer: combineReducers({
             wallet: combineReducers({
-                tradingNew: combineReducers({
+                trading: combineReducers({
                     buy: tradingBuyReducer,
                 }),
             }),
         }),
         preloadedState: {
             wallet: {
-                tradingNew: {
+                trading: {
                     buy: buyInitialState,
                 },
             },

--- a/suite-common/trading/src/thunks/buy/__tests__/selectBuyQuoteThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/__tests__/selectBuyQuoteThunk.test.ts
@@ -99,12 +99,12 @@ describe('selectBuyQuoteThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         buy: {
                             ...initialState.buy,
@@ -159,7 +159,7 @@ describe('selectBuyQuoteThunk', () => {
         expect(mockUserConsent).toHaveBeenCalledTimes(1);
         expect(mockNextStep).toHaveBeenCalledTimes(1);
         expect(mockTimerStop).toHaveBeenCalledTimes(1);
-        expect(store.getState().wallet.tradingNew.buy.selectedQuote).toEqual(quote);
+        expect(store.getState().wallet.trading.buy.selectedQuote).toEqual(quote);
     });
 
     it('should call onCancel on cancelling the user consent', async () => {
@@ -192,7 +192,7 @@ describe('selectBuyQuoteThunk', () => {
         expect(mockNextStep).toHaveBeenCalledTimes(0);
         expect(mockOnCancel).toHaveBeenCalledTimes(1);
         expect(mockTimerStop).toHaveBeenCalledTimes(0);
-        expect(store.getState().wallet.tradingNew.buy.selectedQuote).not.toEqual(quote);
+        expect(store.getState().wallet.trading.buy.selectedQuote).not.toEqual(quote);
     });
 
     describe('should not be possible to save selected quote', () => {
@@ -221,7 +221,7 @@ describe('selectBuyQuoteThunk', () => {
             expect(mockUserConsent).toHaveBeenCalledTimes(0);
             expect(mockNextStep).toHaveBeenCalledTimes(0);
             expect(mockTimerStop).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.buy.selectedQuote).toEqual(undefined);
+            expect(store.getState().wallet.trading.buy.selectedQuote).toEqual(undefined);
         });
 
         it('when quotesRequest is undefined', async () => {
@@ -249,7 +249,7 @@ describe('selectBuyQuoteThunk', () => {
             expect(mockUserConsent).toHaveBeenCalledTimes(0);
             expect(mockNextStep).toHaveBeenCalledTimes(0);
             expect(mockTimerStop).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.buy.selectedQuote).toEqual(undefined);
+            expect(store.getState().wallet.trading.buy.selectedQuote).toEqual(undefined);
         });
 
         it('when exchange is not found in providerInfos', async () => {
@@ -278,7 +278,7 @@ describe('selectBuyQuoteThunk', () => {
             expect(mockUserConsent).toHaveBeenCalledTimes(0);
             expect(mockNextStep).toHaveBeenCalledTimes(0);
             expect(mockTimerStop).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.buy.selectedQuote).toEqual(undefined);
+            expect(store.getState().wallet.trading.buy.selectedQuote).toEqual(undefined);
         });
 
         it('when quote receiveCurrency is undefined', async () => {
@@ -307,7 +307,7 @@ describe('selectBuyQuoteThunk', () => {
             expect(mockUserConsent).toHaveBeenCalledTimes(0);
             expect(mockNextStep).toHaveBeenCalledTimes(0);
             expect(mockTimerStop).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.buy.selectedQuote).toEqual(undefined);
+            expect(store.getState().wallet.trading.buy.selectedQuote).toEqual(undefined);
         });
 
         it('when user cancels consent', async () => {
@@ -333,7 +333,7 @@ describe('selectBuyQuoteThunk', () => {
             expect(mockUserConsent).toHaveBeenCalledTimes(1);
             expect(mockNextStep).toHaveBeenCalledTimes(0);
             expect(mockTimerStop).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.buy.selectedQuote).toEqual(undefined);
+            expect(store.getState().wallet.trading.buy.selectedQuote).toEqual(undefined);
         });
     });
 
@@ -379,7 +379,7 @@ describe('selectBuyQuoteThunk', () => {
             expect(mockLoginRequest).toHaveBeenCalledTimes(1);
             expect(mockNextStep).toHaveBeenCalledTimes(0);
             expect(mockTimerStop).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.buy.selectedQuote).toEqual(undefined);
+            expect(store.getState().wallet.trading.buy.selectedQuote).toEqual(undefined);
         });
 
         it('when login response has not tradeForm', async () => {
@@ -414,7 +414,7 @@ describe('selectBuyQuoteThunk', () => {
 
             expect(mockUserConsent).toHaveBeenCalledTimes(1);
             expect(mockLoginRequest).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.buy.selectedQuote).toEqual(undefined);
+            expect(store.getState().wallet.trading.buy.selectedQuote).toEqual(undefined);
         });
 
         it('when login response has incorrect status', async () => {
@@ -450,7 +450,7 @@ describe('selectBuyQuoteThunk', () => {
 
             expect(mockUserConsent).toHaveBeenCalledTimes(1);
             expect(mockLoginRequest).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.buy.selectedQuote).toEqual(undefined);
+            expect(store.getState().wallet.trading.buy.selectedQuote).toEqual(undefined);
         });
 
         it('when login response is undefined', async () => {
@@ -482,7 +482,7 @@ describe('selectBuyQuoteThunk', () => {
 
             expect(mockUserConsent).toHaveBeenCalledTimes(1);
             expect(mockLoginRequest).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.buy.selectedQuote).toEqual(undefined);
+            expect(store.getState().wallet.trading.buy.selectedQuote).toEqual(undefined);
             expect(actionToast?.payload?.type).toEqual('error');
             expect(actionToast?.payload?.error).toEqual('No response from the server');
         });

--- a/suite-common/trading/src/thunks/common/__tests__/createPaymentRequestsThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/createPaymentRequestsThunk.test.ts
@@ -188,12 +188,12 @@ describe('createPaymentRequestsThunk', () => {
             extra: extraDependenciesMock,
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         info: {
                             coins: {

--- a/suite-common/trading/src/thunks/common/__tests__/getNonce.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/getNonce.test.ts
@@ -41,12 +41,12 @@ describe('getNonce thunk', () => {
             extra: extraDependenciesMock,
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         ...preloadedState,
                     },

--- a/suite-common/trading/src/thunks/common/__tests__/getRefundAddress.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/getRefundAddress.test.ts
@@ -52,12 +52,12 @@ describe('getRefundAddress thunk', () => {
             },
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         ...preloadedState,
                     },
@@ -119,12 +119,12 @@ describe('getRefundAddress thunk', () => {
                 },
                 reducer: combineReducers({
                     wallet: combineReducers({
-                        tradingNew: tradingReducer,
+                        trading: tradingReducer,
                     }),
                 }),
                 preloadedState: {
                     wallet: {
-                        tradingNew: initialState,
+                        trading: initialState,
                     },
                 },
             });

--- a/suite-common/trading/src/thunks/common/__tests__/loadInitialDataThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/loadInitialDataThunk.test.ts
@@ -60,7 +60,7 @@ const initStore = (localInitialState?: Partial<TradingState>) =>
         },
         reducer: combineReducers({
             wallet: combineReducers({
-                tradingNew: tradingReducer,
+                trading: tradingReducer,
                 selectedAccount: mockedSelectedAccountReducer,
                 accounts: mockedAccountReducer,
             }),
@@ -68,7 +68,7 @@ const initStore = (localInitialState?: Partial<TradingState>) =>
         }),
         preloadedState: {
             wallet: {
-                tradingNew: {
+                trading: {
                     ...initialState,
                     ...localInitialState,
                 },
@@ -269,6 +269,6 @@ describe('loadInitialDataThunk', () => {
 
         await store.dispatch(loadInitialDataThunk({ activeSection: 'exchange' })).unwrap();
 
-        expect(store.getState().wallet.tradingNew.activeSection).toBe('exchange');
+        expect(store.getState().wallet.trading.activeSection).toBe('exchange');
     });
 });

--- a/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
@@ -115,14 +115,14 @@ describe('recomposeAndSignTxThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                     fees: mockedSuiteReducer,
                 }),
                 device: deviceReducer,
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         composedTransactionInfo: {
                             ...mockComposedTransactionInfo,

--- a/suite-common/trading/src/thunks/common/__tests__/verifyAddressThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/verifyAddressThunk.test.ts
@@ -35,13 +35,13 @@ describe('verifyAddressThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
                 suite: mockedSuiteReducer(extraDependenciesMock),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: initialState,
+                    trading: initialState,
                 },
             },
         });
@@ -76,7 +76,7 @@ describe('verifyAddressThunk', () => {
         );
 
         expect(store.getActions().length).toEqual(7);
-        expect(store.getState().wallet.tradingNew.verifiedAddress).toEqual(verifiedAddress);
+        expect(store.getState().wallet.trading.verifiedAddress).toEqual(verifiedAddress);
     });
 
     it('should not update verified address device not found', async () => {
@@ -84,13 +84,13 @@ describe('verifyAddressThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
                 suite: mockedSuiteReducer(extraDependenciesMock),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: initialState,
+                    trading: initialState,
                 },
             },
         });
@@ -109,7 +109,7 @@ describe('verifyAddressThunk', () => {
         );
 
         expect(store.getActions().length).toEqual(2);
-        expect(store.getState().wallet.tradingNew.verifiedAddress).toEqual(undefined);
+        expect(store.getState().wallet.trading.verifiedAddress).toEqual(undefined);
     });
 
     it('should not update verified address when path or address are not defined', async () => {
@@ -117,13 +117,13 @@ describe('verifyAddressThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
                 suite: mockedSuiteReducer(extraDependenciesMock),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: initialState,
+                    trading: initialState,
                 },
             },
         });
@@ -151,7 +151,7 @@ describe('verifyAddressThunk', () => {
         );
 
         expect(store.getActions().length).toEqual(2);
-        expect(store.getState().wallet.tradingNew.verifiedAddress).toEqual(undefined);
+        expect(store.getState().wallet.trading.verifiedAddress).toEqual(undefined);
     });
 
     it('should not update verified address, but trigger toast when device is not available', async () => {
@@ -159,13 +159,13 @@ describe('verifyAddressThunk', () => {
             extra: extraDependenciesMock,
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
                 suite: mockedSuiteReducer(extraDependenciesMock),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: initialState,
+                    trading: initialState,
                 },
             },
         });
@@ -198,7 +198,7 @@ describe('verifyAddressThunk', () => {
                 value: addressData?.address,
             },
         });
-        expect(store.getState().wallet.tradingNew.verifiedAddress).toEqual(undefined);
+        expect(store.getState().wallet.trading.verifiedAddress).toEqual(undefined);
     });
 
     it('should not update verified address, but trigger toast when device is not connected', async () => {
@@ -206,13 +206,13 @@ describe('verifyAddressThunk', () => {
             extra: extraDependenciesMock,
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
                 suite: mockedSuiteReducer(extraDependenciesMock),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: initialState,
+                    trading: initialState,
                 },
             },
         });
@@ -245,7 +245,7 @@ describe('verifyAddressThunk', () => {
                 value: addressData?.address,
             },
         });
-        expect(store.getState().wallet.tradingNew.verifiedAddress).toEqual(undefined);
+        expect(store.getState().wallet.trading.verifiedAddress).toEqual(undefined);
     });
 
     it('should not update verified address when a confirmation of address on device is not successful (no permission)', async () => {
@@ -253,13 +253,13 @@ describe('verifyAddressThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
                 suite: mockedSuiteReducer(extraDependenciesMock),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: initialState,
+                    trading: initialState,
                 },
             },
         });
@@ -290,7 +290,7 @@ describe('verifyAddressThunk', () => {
             }),
         );
 
-        expect(store.getState().wallet.tradingNew.verifiedAddress).toEqual(undefined);
+        expect(store.getState().wallet.trading.verifiedAddress).toEqual(undefined);
     });
 
     it('should not update verified address when a confirmation of address on device is not successful', async () => {
@@ -298,13 +298,13 @@ describe('verifyAddressThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
                 suite: mockedSuiteReducer(extraDependenciesMock),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: initialState,
+                    trading: initialState,
                 },
             },
         });
@@ -345,6 +345,6 @@ describe('verifyAddressThunk', () => {
         expect(actionToast?.payload?.type).toEqual('verify-address-error');
         expect(actionToast?.payload?.error).toEqual(error);
 
-        expect(store.getState().wallet.tradingNew.verifiedAddress).toEqual(undefined);
+        expect(store.getState().wallet.trading.verifiedAddress).toEqual(undefined);
     });
 });

--- a/suite-common/trading/src/thunks/common/__tests__/watchTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/watchTradeThunk.test.ts
@@ -30,12 +30,12 @@ describe('watchTradeThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         ...updatedState,
                     },

--- a/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
@@ -35,12 +35,12 @@ describe('confirmExchangeTradeThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         exchange: {
                             ...initialState.exchange,
@@ -106,7 +106,7 @@ describe('confirmExchangeTradeThunk', () => {
             )
             .unwrap();
 
-        const { exchange } = store.getState().wallet.tradingNew;
+        const { exchange } = store.getState().wallet.trading;
 
         expect(exchange.quotesRequest).toBeUndefined();
         expect(store.getActions().length).toEqual(2); // loadings
@@ -142,7 +142,7 @@ describe('confirmExchangeTradeThunk', () => {
             )
             .unwrap();
 
-        const { exchange } = store.getState().wallet.tradingNew;
+        const { exchange } = store.getState().wallet.trading;
 
         expect(store.getActions().length).toEqual(2); // loadings
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
@@ -174,7 +174,7 @@ describe('confirmExchangeTradeThunk', () => {
             )
             .unwrap();
 
-        const { exchange } = store.getState().wallet.tradingNew;
+        const { exchange } = store.getState().wallet.trading;
 
         expect(store.getActions().length).toEqual(2); // loadings
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
@@ -207,7 +207,7 @@ describe('confirmExchangeTradeThunk', () => {
             )
             .unwrap();
 
-        const { exchange } = store.getState().wallet.tradingNew;
+        const { exchange } = store.getState().wallet.trading;
 
         expect(store.getActions().length).toEqual(2); // loadings
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
@@ -243,7 +243,7 @@ describe('confirmExchangeTradeThunk', () => {
             )
             .unwrap();
 
-        const { exchange } = store.getState().wallet.tradingNew;
+        const { exchange } = store.getState().wallet.trading;
         const actionToast = store
             .getActions()
             .find(action => action.type === '@common/in-app-notifications/addToast');
@@ -313,7 +313,7 @@ describe('confirmExchangeTradeThunk', () => {
                 )
                 .unwrap();
 
-            const { exchange } = store.getState().wallet.tradingNew;
+            const { exchange } = store.getState().wallet.trading;
             const actionToast = store
                 .getActions()
                 .find(action => action.type === '@common/in-app-notifications/addToast');
@@ -373,7 +373,7 @@ describe('confirmExchangeTradeThunk', () => {
                 )
                 .unwrap();
 
-            const { exchange } = store.getState().wallet.tradingNew;
+            const { exchange } = store.getState().wallet.trading;
 
             expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
             expect(store.getActions().length).toEqual(5);
@@ -421,7 +421,7 @@ describe('confirmExchangeTradeThunk', () => {
             )
             .unwrap();
 
-        const { exchange } = store.getState().wallet.tradingNew;
+        const { exchange } = store.getState().wallet.trading;
 
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
         expect(store.getActions().length).toEqual(5);
@@ -469,7 +469,7 @@ describe('confirmExchangeTradeThunk', () => {
                 )
                 .unwrap();
 
-            const { exchange } = store.getState().wallet.tradingNew;
+            const { exchange } = store.getState().wallet.trading;
 
             expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
             expect(store.getActions().length).toEqual(5);
@@ -517,7 +517,7 @@ describe('confirmExchangeTradeThunk', () => {
             )
             .unwrap();
 
-        const { exchange } = store.getState().wallet.tradingNew;
+        const { exchange } = store.getState().wallet.trading;
 
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
         expect(store.getActions().length).toEqual(5);
@@ -566,8 +566,8 @@ describe('confirmExchangeTradeThunk', () => {
             )
             .unwrap();
 
-        const { tradingNew } = store.getState().wallet;
-        const { exchange } = tradingNew;
+        const { trading } = store.getState().wallet;
+        const { exchange } = trading;
 
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
         expect(store.getActions().length).toEqual(5);
@@ -575,7 +575,7 @@ describe('confirmExchangeTradeThunk', () => {
         expect(exchange.isLoading).toBeFalsy();
         expect(exchange.selectedQuote).toEqual(exchange.selectedQuote);
         expect(mockNextStep).toHaveBeenCalledTimes(1);
-        expect(tradingNew.trades[0]).toEqual({
+        expect(trading.trades[0]).toEqual({
             tradeType: 'exchange',
             date: dateString,
             data: tradeResponse,
@@ -629,8 +629,8 @@ describe('confirmExchangeTradeThunk', () => {
             )
             .unwrap();
 
-        const { tradingNew } = store.getState().wallet;
-        const { exchange } = tradingNew;
+        const { trading } = store.getState().wallet;
+        const { exchange } = trading;
 
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
         expect(store.getActions().length).toEqual(5);
@@ -638,7 +638,7 @@ describe('confirmExchangeTradeThunk', () => {
         expect(exchange.isLoading).toBeFalsy();
         expect(exchange.selectedQuote).toEqual(exchange.selectedQuote);
         expect(mockNextStep).toHaveBeenCalledTimes(1);
-        expect(tradingNew.trades[0]).toEqual({
+        expect(trading.trades[0]).toEqual({
             tradeType: 'exchange',
             date: dateString,
             data: tradeResponse,
@@ -696,15 +696,15 @@ describe('confirmExchangeTradeThunk', () => {
             )
             .unwrap();
 
-        const { tradingNew } = store.getState().wallet;
-        const { exchange } = tradingNew;
+        const { trading } = store.getState().wallet;
+        const { exchange } = trading;
 
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
         expect(store.getActions().length).toEqual(5);
         expect(exchange.transactionId).toBe(mockResponse.orderId);
         expect(exchange.isLoading).toBeFalsy();
         expect(exchange.selectedQuote).toEqual(exchange.selectedQuote);
-        expect(tradingNew.trades[0]).toEqual({
+        expect(trading.trades[0]).toEqual({
             tradeType: 'exchange',
             date: dateString,
             data: tradeResponse,
@@ -753,15 +753,15 @@ describe('confirmExchangeTradeThunk', () => {
             )
             .unwrap();
 
-        const { tradingNew } = store.getState().wallet;
-        const { exchange } = tradingNew;
+        const { trading } = store.getState().wallet;
+        const { exchange } = trading;
 
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
         expect(store.getActions().length).toEqual(6);
         expect(exchange.transactionId).toBe(mockResponse.orderId);
         expect(exchange.isLoading).toBeFalsy();
         expect(exchange.selectedQuote).toEqual(exchange.selectedQuote);
-        expect(tradingNew.trades[0]).toEqual({
+        expect(trading.trades[0]).toEqual({
             tradeType: 'exchange',
             date: dateString,
             data: tradeResponse,

--- a/suite-common/trading/src/thunks/exchange/__tests__/handleExchangeRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/handleExchangeRequestThunk.test.ts
@@ -27,12 +27,12 @@ describe('handleExchangeRequestThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         info: {
                             ...initialState.info,
@@ -141,7 +141,7 @@ describe('handleExchangeRequestThunk', () => {
             .dispatch(exchangeThunks.handleRequestThunk(input))
             .unwrap();
 
-        const state = store.getState().wallet.tradingNew;
+        const state = store.getState().wallet.trading;
 
         expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(state.exchange.amountLimits).toBeUndefined();
@@ -182,7 +182,7 @@ describe('handleExchangeRequestThunk', () => {
             )
             .unwrap();
 
-        const state = store.getState().wallet.tradingNew;
+        const state = store.getState().wallet.trading;
 
         expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(state.exchange.amountLimits).toBeUndefined();
@@ -236,7 +236,7 @@ describe('handleExchangeRequestThunk', () => {
 
             await promise;
 
-            const state = store.getState().wallet.tradingNew;
+            const state = store.getState().wallet.trading;
 
             expect(mockTimerLoading).toHaveBeenCalledTimes(1);
             expect(mockTimerStop).toHaveBeenCalledTimes(1);
@@ -258,7 +258,7 @@ describe('handleExchangeRequestThunk', () => {
 
         await promise;
 
-        const state = store.getState().wallet.tradingNew;
+        const state = store.getState().wallet.trading;
 
         expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(mockTimerReset).toHaveBeenCalledTimes(1);
@@ -276,7 +276,7 @@ describe('handleExchangeRequestThunk', () => {
             .dispatch(exchangeThunks.handleRequestThunk(input))
             .unwrap();
 
-        const state = store.getState().wallet.tradingNew;
+        const state = store.getState().wallet.trading;
 
         expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(mockTimerStop).toHaveBeenCalledTimes(1);

--- a/suite-common/trading/src/thunks/exchange/__tests__/loadExchangeInfoThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/loadExchangeInfoThunk.test.ts
@@ -18,14 +18,14 @@ describe('loadExchangeInfoThunk', () => {
         extra: {},
         reducer: combineReducers({
             wallet: combineReducers({
-                tradingNew: combineReducers({
+                trading: combineReducers({
                     exchange: tradingExchangeReducer,
                 }),
             }),
         }),
         preloadedState: {
             wallet: {
-                tradingNew: {
+                trading: {
                     exchange: exchangeInitialState,
                 },
             },

--- a/suite-common/trading/src/thunks/exchange/__tests__/selectExchangeQuoteThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/selectExchangeQuoteThunk.test.ts
@@ -77,12 +77,12 @@ describe('selectExchangeQuoteThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         exchange: {
                             ...initialState.exchange,
@@ -132,7 +132,7 @@ describe('selectExchangeQuoteThunk', () => {
         expect(mockUserConsent).toHaveBeenCalledTimes(1);
         expect(mockNextStep).toHaveBeenCalledTimes(1);
         expect(mockTimerStop).toHaveBeenCalledTimes(1);
-        expect(store.getState().wallet.tradingNew.exchange.selectedQuote).toEqual(quote);
+        expect(store.getState().wallet.trading.exchange.selectedQuote).toEqual(quote);
     });
 
     it('should call onCancel on cancelling the user consent', async () => {
@@ -162,7 +162,7 @@ describe('selectExchangeQuoteThunk', () => {
         expect(mockNextStep).toHaveBeenCalledTimes(0);
         expect(mockOnCancel).toHaveBeenCalledTimes(1);
         expect(mockTimerStop).toHaveBeenCalledTimes(0);
-        expect(store.getState().wallet.tradingNew.exchange.selectedQuote).not.toEqual(quote);
+        expect(store.getState().wallet.trading.exchange.selectedQuote).not.toEqual(quote);
     });
 
     describe('should not be possible to save selected quote', () => {
@@ -187,7 +187,7 @@ describe('selectExchangeQuoteThunk', () => {
             expect(mockUserConsent).toHaveBeenCalledTimes(0);
             expect(mockNextStep).toHaveBeenCalledTimes(0);
             expect(mockTimerStop).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.exchange.selectedQuote).toEqual(undefined);
+            expect(store.getState().wallet.trading.exchange.selectedQuote).toEqual(undefined);
         });
 
         it('when quote send is undefined', async () => {
@@ -212,7 +212,7 @@ describe('selectExchangeQuoteThunk', () => {
             expect(mockUserConsent).toHaveBeenCalledTimes(0);
             expect(mockNextStep).toHaveBeenCalledTimes(0);
             expect(mockTimerStop).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.exchange.selectedQuote).toEqual(undefined);
+            expect(store.getState().wallet.trading.exchange.selectedQuote).toEqual(undefined);
         });
 
         it('when quote receive is undefined', async () => {
@@ -237,7 +237,7 @@ describe('selectExchangeQuoteThunk', () => {
             expect(mockUserConsent).toHaveBeenCalledTimes(0);
             expect(mockNextStep).toHaveBeenCalledTimes(0);
             expect(mockTimerStop).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.exchange.selectedQuote).toEqual(undefined);
+            expect(store.getState().wallet.trading.exchange.selectedQuote).toEqual(undefined);
         });
 
         it('when user cancels consent', async () => {
@@ -260,7 +260,7 @@ describe('selectExchangeQuoteThunk', () => {
             expect(mockUserConsent).toHaveBeenCalledTimes(1);
             expect(mockNextStep).toHaveBeenCalledTimes(0);
             expect(mockTimerStop).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.exchange.selectedQuote).toEqual(undefined);
+            expect(store.getState().wallet.trading.exchange.selectedQuote).toEqual(undefined);
         });
     });
 });

--- a/suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts
@@ -44,12 +44,12 @@ describe('sendDexTransactionThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         exchange: {
                             ...initialState.exchange,
@@ -179,7 +179,7 @@ describe('sendDexTransactionThunk', () => {
 
         expect(result.meta.requestStatus).toEqual('fulfilled');
         expect(tradingThunks.recomposeAndSignTxThunk).toHaveBeenCalledTimes(1);
-        expect(store.getState().wallet.tradingNew.trades).toEqual([]);
+        expect(store.getState().wallet.trading.trades).toEqual([]);
         expect(exchangeThunks.confirmTradeThunk).toHaveBeenCalledTimes(1);
         expect(confirmTradeThunkArgs.trade.approvalSendTxHash).toEqual('txid');
         expect(confirmTradeThunkArgs.trade.status).toEqual('APPROVAL_PENDING');
@@ -228,7 +228,7 @@ describe('sendDexTransactionThunk', () => {
 
         expect(result.meta.requestStatus).toEqual('fulfilled');
         expect(tradingThunks.recomposeAndSignTxThunk).toHaveBeenCalledTimes(1);
-        expect(store.getState().wallet.tradingNew.trades).toEqual([
+        expect(store.getState().wallet.trading.trades).toEqual([
             {
                 tradeType: 'exchange',
                 date: dateString,

--- a/suite-common/trading/src/thunks/exchange/__tests__/sendTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/sendTransactionThunk.test.ts
@@ -61,12 +61,12 @@ describe('sendTransactionThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         exchange: {
                             ...initialState.exchange,
@@ -132,7 +132,7 @@ describe('sendTransactionThunk', () => {
             )
             .unwrap();
 
-        expect(store.getState().wallet.tradingNew.modalAccountKey).toBe(account.key);
+        expect(store.getState().wallet.trading.modalAccountKey).toBe(account.key);
         expect(exchangeThunks.sendDexTransactionThunk).toHaveBeenCalledTimes(1);
         expect(tradingThunks.recomposeAndSignTxThunk).toHaveBeenCalledTimes(0);
         expect(result).toBeUndefined();
@@ -174,7 +174,7 @@ describe('sendTransactionThunk', () => {
             }),
         );
 
-        expect(store.getState().wallet.tradingNew.modalAccountKey).toBe(account.key);
+        expect(store.getState().wallet.trading.modalAccountKey).toBe(account.key);
         expect(exchangeThunks.sendDexTransactionThunk).toHaveBeenCalledTimes(1);
         expect(tradingThunks.recomposeAndSignTxThunk).toHaveBeenCalledTimes(0);
         expect(result.meta.requestStatus).toBe('rejected');
@@ -209,7 +209,7 @@ describe('sendTransactionThunk', () => {
                 }),
             );
 
-            expect(store.getState().wallet.tradingNew.modalAccountKey).toBe(account.key);
+            expect(store.getState().wallet.trading.modalAccountKey).toBe(account.key);
             expect(exchangeThunks.sendDexTransactionThunk).toHaveBeenCalledTimes(0);
             expect(tradingThunks.recomposeAndSignTxThunk).toHaveBeenCalledTimes(0);
             expect(result.meta.requestStatus).toEqual('rejected');
@@ -252,7 +252,7 @@ describe('sendTransactionThunk', () => {
                 }),
             );
 
-            expect(store.getState().wallet.tradingNew.modalAccountKey).toBe(account.key);
+            expect(store.getState().wallet.trading.modalAccountKey).toBe(account.key);
             expect(exchangeThunks.sendDexTransactionThunk).toHaveBeenCalledTimes(0);
             expect(tradingThunks.recomposeAndSignTxThunk).toHaveBeenCalledTimes(1);
             expect(result.meta.requestStatus).toEqual('rejected');
@@ -298,10 +298,10 @@ describe('sendTransactionThunk', () => {
             }),
         );
 
-        expect(store.getState().wallet.tradingNew.modalAccountKey).toBe(account.key);
+        expect(store.getState().wallet.trading.modalAccountKey).toBe(account.key);
         expect(exchangeThunks.sendDexTransactionThunk).toHaveBeenCalledTimes(0);
         expect(tradingThunks.recomposeAndSignTxThunk).toHaveBeenCalledTimes(1);
-        expect(store.getState().wallet.tradingNew.trades).toEqual([
+        expect(store.getState().wallet.trading.trades).toEqual([
             {
                 tradeType: 'exchange',
                 date: dateString,
@@ -313,7 +313,7 @@ describe('sendTransactionThunk', () => {
                 key: trade.data.orderId,
             },
         ]);
-        expect(store.getState().wallet.tradingNew.exchange.transactionId).toBe(trade.data.orderId);
+        expect(store.getState().wallet.trading.exchange.transactionId).toBe(trade.data.orderId);
         expect(mockNextStep).toHaveBeenCalledTimes(1);
         expect(result.meta.requestStatus).toEqual('fulfilled');
     });

--- a/suite-common/trading/src/thunks/exchange/__tests__/signDataAndConfirmThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/signDataAndConfirmThunk.test.ts
@@ -44,12 +44,12 @@ describe('signDataAndConfirmThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         exchange: {
                             ...initialState.exchange,
@@ -228,13 +228,13 @@ describe('signDataAndConfirmThunk', () => {
             }),
         );
 
-        const { tradingNew } = store.getState().wallet;
+        const { trading } = store.getState().wallet;
         const actionToast = store
             .getActions()
             .find(action => action.type === '@common/in-app-notifications/addToast');
 
         expect(store.getActions().length).toEqual(4);
-        expect(tradingNew.modalAccountKey).toEqual(account.key);
+        expect(trading.modalAccountKey).toEqual(account.key);
         expect(actionToast?.payload?.type).toEqual('sign-message-error');
         expect(actionToast?.payload?.error).toEqual('Data is not correct');
     });
@@ -280,11 +280,11 @@ describe('signDataAndConfirmThunk', () => {
             }),
         );
 
-        const { tradingNew } = store.getState().wallet;
+        const { trading } = store.getState().wallet;
 
         expect(store.getActions().length).toEqual(3);
-        expect(tradingNew.modalAccountKey).toEqual(account.key);
-        expect(tradingNew.trades).toEqual([]);
+        expect(trading.modalAccountKey).toEqual(account.key);
+        expect(trading.trades).toEqual([]);
         expect(exchangeThunks.confirmTradeThunk).not.toHaveBeenCalled();
     });
 
@@ -327,8 +327,8 @@ describe('signDataAndConfirmThunk', () => {
             }),
         );
 
-        const { tradingNew } = store.getState().wallet;
-        const { selectedQuote } = tradingNew.exchange;
+        const { trading } = store.getState().wallet;
+        const { selectedQuote } = trading.exchange;
         const trade = {
             ...selectedQuote,
             signature: 'signature',
@@ -340,8 +340,8 @@ describe('signDataAndConfirmThunk', () => {
             .mockImplementation(createThunk('@trading-exchange/thunk/confirmTrade', () => true));
 
         expect(store.getActions().length).toEqual(6);
-        expect(tradingNew.modalAccountKey).toEqual(account.key);
-        expect(tradingNew.trades[0]).toEqual({
+        expect(trading.modalAccountKey).toEqual(account.key);
+        expect(trading.trades[0]).toEqual({
             tradeType: 'exchange',
             date: dateString,
             data: trade,

--- a/suite-common/trading/src/thunks/sell/__tests__/confirmSellTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/confirmSellTradeThunk.test.ts
@@ -29,12 +29,12 @@ describe('confirmSellTradeThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         sell: {
                             ...initialState.sell,
@@ -99,7 +99,7 @@ describe('confirmSellTradeThunk', () => {
             )
             .unwrap();
 
-        const sellState = store.getState().wallet.tradingNew.sell;
+        const sellState = store.getState().wallet.trading.sell;
 
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
         expect(sellThunks.handleTradeThunk).toHaveBeenCalledTimes(1);
@@ -142,7 +142,7 @@ describe('confirmSellTradeThunk', () => {
             )
             .unwrap();
 
-        const sellState = store.getState().wallet.tradingNew.sell;
+        const sellState = store.getState().wallet.trading.sell;
 
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(0);
         expect(sellThunks.handleTradeThunk).toHaveBeenCalledTimes(0);
@@ -178,7 +178,7 @@ describe('confirmSellTradeThunk', () => {
             )
             .unwrap();
 
-        const sellState = store.getState().wallet.tradingNew.sell;
+        const sellState = store.getState().wallet.trading.sell;
 
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
         expect(sellThunks.handleTradeThunk).toHaveBeenCalledTimes(1);

--- a/suite-common/trading/src/thunks/sell/__tests__/handleSellRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/handleSellRequestThunk.test.ts
@@ -32,12 +32,12 @@ describe('handleSellRequestThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         info: {
                             ...initialState.info,
@@ -133,7 +133,7 @@ describe('handleSellRequestThunk', () => {
 
         const quotesResponse = await store.dispatch(sellThunks.handleRequestThunk(input)).unwrap();
 
-        const state = store.getState().wallet.tradingNew;
+        const state = store.getState().wallet.trading;
 
         expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(state.sell.amountLimits).toBeUndefined();
@@ -178,7 +178,7 @@ describe('handleSellRequestThunk', () => {
             )
             .unwrap();
 
-        const state = store.getState().wallet.tradingNew;
+        const state = store.getState().wallet.trading;
 
         expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(state.sell.amountLimits).toBeUndefined();
@@ -232,7 +232,7 @@ describe('handleSellRequestThunk', () => {
             )
             .unwrap();
 
-        const state = store.getState().wallet.tradingNew;
+        const state = store.getState().wallet.trading;
 
         expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(state.sell.amountLimits).toBeUndefined();
@@ -263,7 +263,7 @@ describe('handleSellRequestThunk', () => {
 
         await promise;
 
-        const state = store.getState().wallet.tradingNew;
+        const state = store.getState().wallet.trading;
 
         expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(mockTimerReset).toHaveBeenCalledTimes(1);
@@ -291,7 +291,7 @@ describe('handleSellRequestThunk', () => {
         const promise = store.dispatch(sellThunks.handleRequestThunk(incorrectData));
         await promise;
 
-        const state = store.getState().wallet.tradingNew;
+        const state = store.getState().wallet.trading;
 
         expect(invityAPI.getSellQuotes).not.toHaveBeenCalled();
         expect(mockTimerLoading).toHaveBeenCalledTimes(1);
@@ -322,7 +322,7 @@ describe('handleSellRequestThunk', () => {
         const promise = store.dispatch(sellThunks.handleRequestThunk(modifiedInput));
         await promise;
 
-        const state = store.getState().wallet.tradingNew;
+        const state = store.getState().wallet.trading;
 
         expect(mockTimerStop).toHaveBeenCalledTimes(1);
         expect(state.sell.quotes.length).toEqual(0);
@@ -338,7 +338,7 @@ describe('handleSellRequestThunk', () => {
 
         const quotesResponse = await store.dispatch(sellThunks.handleRequestThunk(input)).unwrap();
 
-        const state = store.getState().wallet.tradingNew;
+        const state = store.getState().wallet.trading;
 
         expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(mockTimerStop).toHaveBeenCalledTimes(1);
@@ -369,7 +369,7 @@ describe('handleSellRequestThunk', () => {
             .dispatch(sellThunks.handleRequestThunk(modifiedInput))
             .unwrap();
 
-        const state = store.getState().wallet.tradingNew;
+        const state = store.getState().wallet.trading;
 
         expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(state.sell.quotes.length).toEqual(1);

--- a/suite-common/trading/src/thunks/sell/__tests__/handleSellTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/handleSellTradeThunk.test.ts
@@ -35,12 +35,12 @@ describe('handleSellTradeThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         sell: {
                             ...initialState.sell,
@@ -117,7 +117,7 @@ describe('handleSellTradeThunk', () => {
                 )
                 .unwrap();
 
-            const tradingState = store.getState().wallet.tradingNew;
+            const tradingState = store.getState().wallet.trading;
 
             expect(invityAPI.doSellTrade).not.toHaveBeenCalled();
             expect(result).toBeUndefined();
@@ -147,7 +147,7 @@ describe('handleSellTradeThunk', () => {
         const actionToast = store
             .getActions()
             .find(action => action.type === '@common/in-app-notifications/addToast');
-        const tradingState = store.getState().wallet.tradingNew;
+        const tradingState = store.getState().wallet.trading;
 
         expect(actionToast?.payload?.type).toEqual('error');
         expect(actionToast?.payload?.error).toEqual('No response from the server');
@@ -180,7 +180,7 @@ describe('handleSellTradeThunk', () => {
         const actionToast = store
             .getActions()
             .find(action => action.type === '@common/in-app-notifications/addToast');
-        const tradingState = store.getState().wallet.tradingNew;
+        const tradingState = store.getState().wallet.trading;
 
         expect(actionToast?.payload?.type).toEqual('error');
         expect(actionToast?.payload?.error).toEqual('Trade error');
@@ -210,7 +210,7 @@ describe('handleSellTradeThunk', () => {
                 }),
             )
             .unwrap();
-        const tradingState = store.getState().wallet.tradingNew;
+        const tradingState = store.getState().wallet.trading;
 
         expect(result).toEqual(quoteData);
         expect(tradingState.sell.transactionId).toBeUndefined();
@@ -242,7 +242,7 @@ describe('handleSellTradeThunk', () => {
             )
             .unwrap();
 
-        const tradingState = store.getState().wallet.tradingNew;
+        const tradingState = store.getState().wallet.trading;
 
         expect(result).toBeUndefined();
         expect(tradingState.sell.transactionId).toBe(mockResponse.trade.orderId);
@@ -290,7 +290,7 @@ describe('handleSellTradeThunk', () => {
             )
             .unwrap();
 
-        const tradingState = store.getState().wallet.tradingNew;
+        const tradingState = store.getState().wallet.trading;
 
         expect(result).toBeUndefined();
         expect(tradingState.sell.transactionId).toBe(mockResponse.trade.orderId);
@@ -351,7 +351,7 @@ describe('handleSellTradeThunk', () => {
             )
             .unwrap();
 
-        const tradingState = store.getState().wallet.tradingNew;
+        const tradingState = store.getState().wallet.trading;
 
         expect(result).toBeUndefined();
         expect(tradingState.sell.transactionId).toBeUndefined();

--- a/suite-common/trading/src/thunks/sell/__tests__/loadSellInfoThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/loadSellInfoThunk.test.ts
@@ -31,14 +31,14 @@ describe('loadSellInfoThunk', () => {
         extra: {},
         reducer: combineReducers({
             wallet: combineReducers({
-                tradingNew: combineReducers({
+                trading: combineReducers({
                     sell: tradingSellReducer,
                 }),
             }),
         }),
         preloadedState: {
             wallet: {
-                tradingNew: {
+                trading: {
                     sell: sellInitialState,
                 },
             },

--- a/suite-common/trading/src/thunks/sell/__tests__/selectSellQuoteThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/selectSellQuoteThunk.test.ts
@@ -71,12 +71,12 @@ describe('selectSellQuoteThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         sell: {
                             ...initialState.sell,
@@ -127,7 +127,7 @@ describe('selectSellQuoteThunk', () => {
         expect(mockNextStep).toHaveBeenCalledTimes(1);
         expect(mockTimerStop).toHaveBeenCalledTimes(1);
         expect(mockOnCancel).toHaveBeenCalledTimes(0);
-        expect(store.getState().wallet.tradingNew.sell.selectedQuote).toEqual(quote);
+        expect(store.getState().wallet.trading.sell.selectedQuote).toEqual(quote);
     });
 
     describe('should not be possible to save selected quote', () => {
@@ -155,7 +155,7 @@ describe('selectSellQuoteThunk', () => {
             expect(mockNextStep).toHaveBeenCalledTimes(0);
             expect(mockTimerStop).toHaveBeenCalledTimes(0);
             expect(mockOnCancel).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.sell.selectedQuote).toEqual(undefined);
+            expect(store.getState().wallet.trading.sell.selectedQuote).toEqual(undefined);
         });
 
         it('when quote exchange is undefined', async () => {
@@ -185,7 +185,7 @@ describe('selectSellQuoteThunk', () => {
             expect(mockNextStep).toHaveBeenCalledTimes(0);
             expect(mockTimerStop).toHaveBeenCalledTimes(0);
             expect(mockOnCancel).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.sell.selectedQuote).toEqual(undefined);
+            expect(store.getState().wallet.trading.sell.selectedQuote).toEqual(undefined);
         });
 
         it('when quoteRequest is undefined', async () => {
@@ -212,7 +212,7 @@ describe('selectSellQuoteThunk', () => {
             expect(mockNextStep).toHaveBeenCalledTimes(0);
             expect(mockTimerStop).toHaveBeenCalledTimes(0);
             expect(mockOnCancel).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.sell.selectedQuote).toEqual(undefined);
+            expect(store.getState().wallet.trading.sell.selectedQuote).toEqual(undefined);
         });
 
         it('when quote cryptoCurrency is undefined', async () => {
@@ -239,7 +239,7 @@ describe('selectSellQuoteThunk', () => {
             expect(mockNextStep).toHaveBeenCalledTimes(0);
             expect(mockTimerStop).toHaveBeenCalledTimes(0);
             expect(mockOnCancel).toHaveBeenCalledTimes(0);
-            expect(store.getState().wallet.tradingNew.sell.selectedQuote).toEqual(undefined);
+            expect(store.getState().wallet.trading.sell.selectedQuote).toEqual(undefined);
         });
 
         it('when user cancels consent', async () => {
@@ -264,7 +264,7 @@ describe('selectSellQuoteThunk', () => {
             expect(mockNextStep).toHaveBeenCalledTimes(0);
             expect(mockTimerStop).toHaveBeenCalledTimes(0);
             expect(mockOnCancel).toHaveBeenCalledTimes(1);
-            expect(store.getState().wallet.tradingNew.sell.selectedQuote).toEqual(undefined);
+            expect(store.getState().wallet.trading.sell.selectedQuote).toEqual(undefined);
         });
     });
 });

--- a/suite-common/trading/src/thunks/sell/__tests__/sendSellTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/sendSellTransactionThunk.test.ts
@@ -56,12 +56,12 @@ describe('sendSellTransactionThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    tradingNew: tradingReducer,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         sell: {
                             ...sellInitialState,
@@ -117,7 +117,7 @@ describe('sendSellTransactionThunk', () => {
                 }),
             );
 
-            const tradingState = store.getState().wallet.tradingNew;
+            const tradingState = store.getState().wallet.trading;
 
             expect(tradingState.modalAccountKey).toBe(account.key);
             expect(tradingThunks.recomposeAndSignTxThunk).toHaveBeenCalledTimes(0);
@@ -164,7 +164,7 @@ describe('sendSellTransactionThunk', () => {
                     signAndPushSendFormTransaction: jest.fn(),
                 }),
             );
-            const tradingState = store.getState().wallet.tradingNew;
+            const tradingState = store.getState().wallet.trading;
 
             expect(tradingState.modalAccountKey).toBe(account.key);
             expect(tradingThunks.recomposeAndSignTxThunk).toHaveBeenCalledTimes(1);
@@ -220,7 +220,7 @@ describe('sendSellTransactionThunk', () => {
                     signAndPushSendFormTransaction: jest.fn(),
                 }),
             );
-            const tradingState = store.getState().wallet.tradingNew;
+            const tradingState = store.getState().wallet.trading;
 
             expect(tradingState.modalAccountKey).toBe(account.key);
             expect(tradingThunks.recomposeAndSignTxThunk).toHaveBeenCalledTimes(1);
@@ -259,7 +259,7 @@ describe('sendSellTransactionThunk', () => {
                 signAndPushSendFormTransaction: jest.fn(),
             }),
         );
-        const tradingState = store.getState().wallet.tradingNew;
+        const tradingState = store.getState().wallet.trading;
 
         expect(tradingState.modalAccountKey).toBe(account.key);
         expect(tradingThunks.recomposeAndSignTxThunk).toHaveBeenCalledTimes(1);
@@ -301,7 +301,7 @@ describe('sendSellTransactionThunk', () => {
                 signAndPushSendFormTransaction: jest.fn(),
             }),
         );
-        const tradingState = store.getState().wallet.tradingNew;
+        const tradingState = store.getState().wallet.trading;
         const mockedRecomposeAndSignTxThunk =
             tradingThunks.recomposeAndSignTxThunk as unknown as jest.Mock;
 
@@ -360,7 +360,7 @@ describe('sendSellTransactionThunk', () => {
                 signAndPushSendFormTransaction: jest.fn(),
             }),
         );
-        const tradingState = store.getState().wallet.tradingNew;
+        const tradingState = store.getState().wallet.trading;
         const mockedRecomposeAndSignTxThunk =
             tradingThunks.recomposeAndSignTxThunk as unknown as jest.Mock;
 
@@ -415,7 +415,7 @@ describe('sendSellTransactionThunk', () => {
                 signAndPushSendFormTransaction: jest.fn(),
             }),
         );
-        const tradingState = store.getState().wallet.tradingNew;
+        const tradingState = store.getState().wallet.trading;
         const mockedRecomposeAndSignTxThunk =
             tradingThunks.recomposeAndSignTxThunk as unknown as jest.Mock;
 

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -334,7 +334,7 @@ export type TradingVerifiedAddress =
 
 export type TradingRootState = {
     wallet: {
-        tradingNew: TradingState; // TODO: trading - tradingNew is temporary
+        trading: TradingState;
     };
 };
 

--- a/suite-native/module-trading/src/__fixtures__/walletState.ts
+++ b/suite-native/module-trading/src/__fixtures__/walletState.ts
@@ -17,7 +17,7 @@ export const getWalletState = ({
     tradeType = 'buy',
     deviceState,
 }: GetWalletStateParams = {}) => ({
-    tradingNew: getInitializedTradingState(tradeType),
+    trading: getInitializedTradingState(tradeType),
     settings: {
         localCurrency: 'usd',
         bitcoinAmountUnit,

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyConfirmation.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyConfirmation.comp.test.tsx
@@ -18,7 +18,7 @@ describe('BuyConfirmation', () => {
 
     const renderConfirmation = () =>
         renderWithStoreProviderAsync(<BuyConfirmation />, {
-            preloadedState: { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } },
+            preloadedState: { wallet: { trading: getInitializedTradingStateWithQuotes() } },
         });
 
     it('should render continue button when canProceed is true', async () => {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyCryptoAmountInput.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyCryptoAmountInput.comp.test.tsx
@@ -123,8 +123,8 @@ describe('BuyCryptoAmountInput', () => {
     });
 
     it('should display loading skeleton while amountInCrypto is false and buyInfo is loading', async () => {
-        const preloadedState = { wallet: { tradingNew: getInitializedTradingState() } };
-        preloadedState.wallet.tradingNew.buy.isLoading = true;
+        const preloadedState = { wallet: { trading: getInitializedTradingState() } };
+        preloadedState.wallet.trading.buy.isLoading = true;
         const form = await renderUseTradingBuyForm();
 
         const { getByLabelText } = await renderCryptoAmountInput({}, form, preloadedState);
@@ -133,8 +133,8 @@ describe('BuyCryptoAmountInput', () => {
     });
 
     it('should not display loading skeleton while amountInCrypto is true and buyInfo is loading', async () => {
-        const preloadedState = { wallet: { tradingNew: getInitializedTradingState() } };
-        preloadedState.wallet.tradingNew.buy.isLoading = true;
+        const preloadedState = { wallet: { trading: getInitializedTradingState() } };
+        preloadedState.wallet.trading.buy.isLoading = true;
         const form = await renderUseTradingBuyForm();
         act(() => {
             form.setValue('amountInCrypto', true);

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFiatAmountInput.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFiatAmountInput.comp.test.tsx
@@ -59,8 +59,8 @@ describe('BuyFiatAmountInput', () => {
     });
 
     it('should display loading skeleton while amountInCrypto is true and buyInfo is loading', async () => {
-        const preloadedState = { wallet: { tradingNew: getInitializedTradingState() } };
-        preloadedState.wallet.tradingNew.buy.isLoading = true;
+        const preloadedState = { wallet: { trading: getInitializedTradingState() } };
+        preloadedState.wallet.trading.buy.isLoading = true;
         const form = await renderUseTradingBuyForm();
         act(() => {
             form.setValue('amountInCrypto', true);
@@ -72,8 +72,8 @@ describe('BuyFiatAmountInput', () => {
     });
 
     it('should not display loading skeleton while amountInCrypto is false and buyInfo is loading', async () => {
-        const preloadedState = { wallet: { tradingNew: getInitializedTradingState() } };
-        preloadedState.wallet.tradingNew.buy.isLoading = true;
+        const preloadedState = { wallet: { trading: getInitializedTradingState() } };
+        preloadedState.wallet.trading.buy.isLoading = true;
         const form = await renderUseTradingBuyForm();
 
         const { queryByLabelText } = await renderFiatAmountInput(form, preloadedState);

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencyPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencyPicker.comp.test.tsx
@@ -27,7 +27,7 @@ describe('BuyFiatCurrencyPicker', () => {
     });
 
     const renderFiatCurrencyPicker = async () => {
-        const preloadedState = { wallet: { tradingNew: getInitializedTradingState() } };
+        const preloadedState = { wallet: { trading: getInitializedTradingState() } };
         const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm(), {
             preloadedState,
         });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyForm.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyForm.comp.test.tsx
@@ -43,7 +43,7 @@ describe('BuyForm', () => {
 
     describe('with preloaded buy data', () => {
         let form: BuyFormType;
-        const preloadedState = { wallet: { tradingNew: getInitializedTradingState() } };
+        const preloadedState = { wallet: { trading: getInitializedTradingState() } };
 
         beforeEach(async () => {
             const { result } = await renderFormHook(preloadedState);

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFormFieldErrorBadge.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFormFieldErrorBadge.comp.test.tsx
@@ -144,9 +144,9 @@ describe('BuyFormFieldErrorBadge', () => {
                 tradingForm.setValue('cryptoValue', '0.0006');
             });
             const preloadedState = {
-                wallet: { tradingNew: getInitializedTradingStateWithQuotes() },
+                wallet: { trading: getInitializedTradingStateWithQuotes() },
             };
-            preloadedState!.wallet!.tradingNew!.buy!.isLoading = true;
+            preloadedState!.wallet!.trading!.buy!.isLoading = true;
 
             const { toJSON } = await renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyLegalSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyLegalSheet.comp.test.tsx
@@ -22,7 +22,7 @@ describe('BuyLegalSheet', () => {
                 tradeProvider="invity"
                 {...props}
             />,
-            { preloadedState: { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } } },
+            { preloadedState: { wallet: { trading: getInitializedTradingStateWithQuotes() } } },
         );
 
     it('should render text info with given tradeProviderName', async () => {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
@@ -45,7 +45,7 @@ describe('BuyPaymentMethodPicker', () => {
 
     it('should display loader when loading initial quotes', async () => {
         const preloadedState: PreloadedState = {
-            wallet: { tradingNew: { buy: { isLoading: true, quotes: [] } } },
+            wallet: { trading: { buy: { isLoading: true, quotes: [] } } },
         };
 
         const { getByLabelText } = await renderPaymentMethodPicker(preloadedState);
@@ -57,7 +57,7 @@ describe('BuyPaymentMethodPicker', () => {
         let preloadedState: PreloadedState;
 
         beforeEach(() => {
-            preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
+            preloadedState = { wallet: { trading: getInitializedTradingStateWithQuotes() } };
         });
 
         it('should display "Not selected" when no method is selected in form', async () => {
@@ -75,7 +75,7 @@ describe('BuyPaymentMethodPicker', () => {
         });
 
         it('should display loader while quotes are fetched', async () => {
-            preloadedState!.wallet!.tradingNew!.buy!.isLoading = true;
+            preloadedState!.wallet!.trading!.buy!.isLoading = true;
             const { getByLabelText } = await renderPaymentMethodPicker(preloadedState);
 
             expect(getByLabelText('Fetching offers...')).toBeOnTheScreen();

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.comp.test.tsx
@@ -46,7 +46,7 @@ describe('BuyProviderPicker', () => {
 
     it('should display loader while quotes are fetched', async () => {
         const preloadedState: PreloadedState = {
-            wallet: { tradingNew: { buy: { isLoading: true, quotes: [] } } },
+            wallet: { trading: { buy: { isLoading: true, quotes: [] } } },
         };
         await renderUseTradingBuyForm();
         const { getByLabelText } = await renderTradingProviderPicker(preloadedState);
@@ -62,8 +62,8 @@ describe('BuyProviderPicker', () => {
                 form.setValue('quote', quotes[1] as BuyTrade);
             });
 
-            preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
-            preloadedState.wallet!.tradingNew!.buy!.buyInfo!.providerInfos = {
+            preloadedState = { wallet: { trading: getInitializedTradingStateWithQuotes() } };
+            preloadedState.wallet!.trading!.buy!.buyInfo!.providerInfos = {
                 invity: buyInvity,
                 mercuryo: buyMercuryo,
                 cexdirect: buyCexdirect,
@@ -80,14 +80,14 @@ describe('BuyProviderPicker', () => {
         });
 
         it('should display loader while quotes are re-fetched', async () => {
-            preloadedState!.wallet!.tradingNew!.buy!.isLoading = true;
+            preloadedState!.wallet!.trading!.buy!.isLoading = true;
             const { getByLabelText } = await renderTradingProviderPicker(preloadedState);
 
             expect(getByLabelText('Fetching offers...')).toBeOnTheScreen();
         });
 
         it('should display sheet even while quotes are fetched', async () => {
-            preloadedState!.wallet!.tradingNew!.buy!.isLoading = true;
+            preloadedState!.wallet!.trading!.buy!.isLoading = true;
             const { getByText } = await renderTradingProviderPicker(preloadedState);
 
             fireEvent.press(getByText('Provider'));
@@ -102,7 +102,7 @@ describe('BuyProviderPicker', () => {
         });
 
         it('should not display kyc warning when loading', async () => {
-            preloadedState!.wallet!.tradingNew!.buy!.isLoading = true;
+            preloadedState!.wallet!.trading!.buy!.isLoading = true;
             const { queryByText } = await renderTradingProviderPicker(preloadedState);
             expect(
                 queryByText('This provider requires to know your identity.'),
@@ -169,7 +169,7 @@ describe('BuyProviderPicker', () => {
             });
 
             it('should not call analytics when user tries to open sheet while quotes are loading', async () => {
-                preloadedState!.wallet!.tradingNew!.buy!.isLoading = true;
+                preloadedState!.wallet!.trading!.buy!.isLoading = true;
                 const { getByText } = await renderTradingProviderPicker(preloadedState);
 
                 fireEvent.press(getByText('Provider'));

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountPicker.comp.test.tsx
@@ -28,7 +28,7 @@ jest.mock('@react-navigation/native', () => ({
 
 const getTradingState = (selectedReceiveAccount: ReceiveAccount | undefined) => ({
     wallet: {
-        tradingNew: {
+        trading: {
             ...initialState,
             buy: {
                 ...initialState.buy,

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyTradeableAssetPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyTradeableAssetPicker.comp.test.tsx
@@ -21,7 +21,7 @@ describe('BuyTradeableAssetPicker', () => {
     const initPreloadedStore = (firmwareType: FirmwareType) =>
         initStore({
             device: { selectedDevice: { firmwareType } },
-            wallet: { tradingNew: getInitializedTradingState() },
+            wallet: { trading: getInitializedTradingState() },
         });
 
     const renderFormHook = async () => {

--- a/suite-native/module-trading/src/components/exchange/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitSheet.comp.test.tsx
@@ -10,7 +10,7 @@ const testQuote = exchangeQuotes[0];
 
 const getPreloadedState = (): PreloadedState => ({
     wallet: {
-        tradingNew: {
+        trading: {
             ...getInitializedTradingState('exchange'),
             exchange: {
                 ...getInitializedTradingState('exchange').exchange,
@@ -22,7 +22,7 @@ const getPreloadedState = (): PreloadedState => ({
 
 const getPreloadedStateWithoutQuote = (): PreloadedState => ({
     wallet: {
-        tradingNew: {
+        trading: {
             ...getInitializedTradingState('exchange'),
             exchange: {
                 ...getInitializedTradingState('exchange').exchange,

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeConfirmation.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeConfirmation.comp.test.tsx
@@ -27,7 +27,7 @@ describe('ExchangeConfirmation', () => {
 
     const renderConfirmation = () =>
         renderWithStoreProviderAsync(<ExchangeConfirmation />, {
-            preloadedState: { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } },
+            preloadedState: { wallet: { trading: getInitializedTradingStateWithQuotes() } },
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeForm.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeForm.comp.test.tsx
@@ -25,7 +25,7 @@ describe('ExchangeForm', () => {
         renderWithStoreProviderAsync(<ExchangeForm />, {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
             preloadedState: {
-                wallet: { tradingNew: getInitializedTradingState() },
+                wallet: { trading: getInitializedTradingState() },
             },
         });
 

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeLegalSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeLegalSheet.comp.test.tsx
@@ -35,7 +35,7 @@ describe('ExchangeLegalSheet', () => {
                 isDex={false}
                 {...props}
             />,
-            { preloadedState: { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } } },
+            { preloadedState: { wallet: { trading: getInitializedTradingStateWithQuotes() } } },
         );
 
     it('should render text info with given provider name for CEX', async () => {

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeRateAndProviderPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeRateAndProviderPicker.comp.test.tsx
@@ -38,7 +38,7 @@ describe('ExchangeRateAndProviderPicker', () => {
     });
 
     it('should render provider and rate pickers when no quote is selected and quotes are loading', async () => {
-        preloadedState!.wallet!.tradingNew!.exchange!.isLoading = true;
+        preloadedState!.wallet!.trading!.exchange!.isLoading = true;
 
         const { getByText } = await renderExchangeRateAndProviderPicker();
 

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountPicker.comp.test.tsx
@@ -28,7 +28,7 @@ jest.mock('@react-navigation/native', () => ({
 
 const getExchangeState = (selectedReceiveAccount: ReceiveAccount | undefined) => ({
     wallet: {
-        tradingNew: {
+        trading: {
             ...initialState,
             exchange: {
                 ...initialState.exchange,

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAmountInput.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAmountInput.comp.test.tsx
@@ -59,8 +59,8 @@ describe('ExchangeReceiveAmountInput', () => {
     });
 
     it('should display loading skeleton when quotes are being fetched', async () => {
-        const preloadedState = { wallet: { tradingNew: getInitializedTradingState() } };
-        preloadedState.wallet.tradingNew.exchange.isLoading = true;
+        const preloadedState = { wallet: { trading: getInitializedTradingState() } };
+        preloadedState.wallet.trading.exchange.isLoading = true;
 
         const { getByLabelText } = await renderExchangeReceiveAmountInput({}, preloadedState);
 

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeTradeableAssetPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeTradeableAssetPicker.comp.test.tsx
@@ -20,7 +20,7 @@ describe('ExchangeTradeableAssetPicker', () => {
     const initPreloadedStore = (firmwareType: FirmwareType) =>
         initStore({
             device: { selectedDevice: { firmwareType } },
-            wallet: { tradingNew: getInitializedTradingState() },
+            wallet: { trading: getInitializedTradingState() },
         });
 
     const renderFormHook = async () => {

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountBadge.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountBadge.comp.test.tsx
@@ -96,7 +96,7 @@ describe('ExchangeSendAmountBadge', () => {
                 form.setValue('sendCryptoAmount', '1000');
             });
             const preloadedState = getPreloadedState();
-            preloadedState!.wallet!.tradingNew!.exchange!.isLoading = true;
+            preloadedState!.wallet!.trading!.exchange!.isLoading = true;
 
             const { getByText, queryByText } = await renderExchangeSendAmountBadge(preloadedState);
 

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAssetPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAssetPicker.comp.test.tsx
@@ -59,7 +59,7 @@ describe('ExchangeSendAssetPicker', () => {
 
     const getPreloadedState = () => ({
         wallet: {
-            tradingNew: getInitializedTradingState(),
+            trading: getInitializedTradingState(),
             accounts: [btcAccount, ethAccount],
         },
     });
@@ -103,7 +103,7 @@ describe('ExchangeSendAssetPicker', () => {
         await userEvent.press(getByText('BTC'));
 
         const accountForm = form.getValues('sendAccount');
-        const accountKeyStore = store.getState().wallet.tradingNew.exchange.tradingAccountKey;
+        const accountKeyStore = store.getState().wallet.trading.exchange.tradingAccountKey;
 
         expect(accountForm).toEqual(btcAccount);
         expect(accountKeyStore).toBe(btcAccount.key);

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountList.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountList.comp.test.tsx
@@ -36,7 +36,7 @@ const getStateMockupBuy = (selectedAccount: ReceiveAccount) => ({
     ...defaultPreloadedState,
     wallet: {
         accounts: defaultPreloadedState.wallet.accounts,
-        tradingNew: {
+        trading: {
             ...initialState,
             buy: {
                 ...initialState.buy,
@@ -51,7 +51,7 @@ const getStateMockupExchange = (selectedAccount: ReceiveAccount) => ({
     ...defaultPreloadedState,
     wallet: {
         accounts: defaultPreloadedState.wallet.accounts,
-        tradingNew: {
+        trading: {
             ...initialState,
             exchange: {
                 ...initialState.exchange,

--- a/suite-native/module-trading/src/components/general/Header/__tests__/Header.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/Header/__tests__/Header.comp.test.tsx
@@ -153,7 +153,7 @@ describe('Header', () => {
             buyEnabled: true,
             tradingPreloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         isAmountInputActive: true,
                     } as any,
                 },
@@ -174,7 +174,7 @@ describe('Header', () => {
 
         fireEvent.press(getByText('Swap'));
 
-        expect(store.getState().wallet.tradingNew.activeTradingType).toBe('exchange');
+        expect(store.getState().wallet.trading.activeTradingType).toBe('exchange');
     });
 
     it('should display trade settings button', async () => {

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetListItem.comp.test.tsx
@@ -43,7 +43,7 @@ describe('MyAssetListItem', () => {
     const getPreloadedState = () => ({
         wallet: {
             accounts: [getBtcAccount(), getEthAccount()],
-            tradingNew: {
+            trading: {
                 info: {
                     coins: {
                         bitcoin: { symbol: 'btc', name: 'Bitcoin', cryptoId: 'bitcoin' },
@@ -233,7 +233,7 @@ describe('MyAssetListItem', () => {
             const preloadedStateWithoutCoinInfo = {
                 wallet: {
                     accounts: [getBtcAccount(), getEthAccount()],
-                    tradingNew: {
+                    trading: {
                         info: {
                             coins: {}, // Empty coins object
                         },

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheet.comp.test.tsx
@@ -54,7 +54,7 @@ describe('MyAssetSheet', () => {
 
     const getPreloadedState = () => ({
         wallet: {
-            tradingNew: getInitializedTradingState(),
+            trading: getInitializedTradingState(),
             accounts: [btcAccount, ethAccount],
         },
     });

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.comp.test.tsx
@@ -22,8 +22,8 @@ describe('ProviderListItem', () => {
         );
 
     it('should render provider information correctly', async () => {
-        const preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
-        const quote = preloadedState.wallet.tradingNew.buy.quotes[0];
+        const preloadedState = { wallet: { trading: getInitializedTradingStateWithQuotes() } };
+        const quote = preloadedState.wallet.trading.buy.quotes[0];
 
         const { queryByText } = await renderProviderListItem(quote, preloadedState, {});
 
@@ -31,8 +31,8 @@ describe('ProviderListItem', () => {
     });
 
     it('should render trading information with formatted strings', async () => {
-        const preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
-        const quote = preloadedState.wallet.tradingNew.buy.quotes[0];
+        const preloadedState = { wallet: { trading: getInitializedTradingStateWithQuotes() } };
+        const quote = preloadedState.wallet.trading.buy.quotes[0];
 
         const { queryByText } = await renderProviderListItem(quote, preloadedState, {});
 
@@ -41,8 +41,8 @@ describe('ProviderListItem', () => {
     });
 
     it('should render KYC information when provider has KYC policy', async () => {
-        const preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
-        const quote = preloadedState.wallet.tradingNew.exchange.quotes[2];
+        const preloadedState = { wallet: { trading: getInitializedTradingStateWithQuotes() } };
+        const quote = preloadedState.wallet.trading.exchange.quotes[2];
 
         const { queryByText } = await renderProviderListItem(quote, preloadedState, {
             tradingType: 'exchange',
@@ -52,8 +52,8 @@ describe('ProviderListItem', () => {
     });
 
     it('should render anonymous information for DEX providers', async () => {
-        const preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
-        const quote = preloadedState.wallet.tradingNew.exchange.quotes[3];
+        const preloadedState = { wallet: { trading: getInitializedTradingStateWithQuotes() } };
+        const quote = preloadedState.wallet.trading.exchange.quotes[3];
 
         const { queryByText } = await renderProviderListItem(quote, preloadedState, {
             tradingType: 'exchange',
@@ -64,8 +64,8 @@ describe('ProviderListItem', () => {
     });
 
     it('should not render when quote has no orderId', async () => {
-        const preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
-        const baseQuote = preloadedState.wallet.tradingNew.buy.quotes[0];
+        const preloadedState = { wallet: { trading: getInitializedTradingStateWithQuotes() } };
+        const baseQuote = preloadedState.wallet.trading.buy.quotes[0];
         const { orderId, ...quoteWithoutOrderId } = baseQuote;
         const quote = quoteWithoutOrderId as TradingTradeType;
 
@@ -75,8 +75,8 @@ describe('ProviderListItem', () => {
     });
 
     it('should render KYC warning for buy quote', async () => {
-        const preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
-        const quote = preloadedState.wallet.tradingNew.buy.quotes[0];
+        const preloadedState = { wallet: { trading: getInitializedTradingStateWithQuotes() } };
+        const quote = preloadedState.wallet.trading.buy.quotes[0];
 
         const { queryByText } = await renderProviderListItem(quote, preloadedState, {});
 
@@ -84,8 +84,8 @@ describe('ProviderListItem', () => {
     });
 
     it('should render KYC warning for sell quote', async () => {
-        const preloadedState = { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } };
-        const quote = preloadedState.wallet.tradingNew.sell.quotes[0];
+        const preloadedState = { wallet: { trading: getInitializedTradingStateWithQuotes() } };
+        const quote = preloadedState.wallet.trading.sell.quotes[0];
 
         const { queryByText } = await renderProviderListItem(quote, preloadedState, {
             tradingType: 'sell',

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheetHandle.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheetHandle.comp.test.tsx
@@ -80,7 +80,7 @@ describe('ProviderSheetHandle', () => {
             {},
             {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         activeTradingType: 'exchange',
                     },
                 },

--- a/suite-native/module-trading/src/components/general/__tests__/ActiveTab.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/ActiveTab.comp.test.tsx
@@ -21,7 +21,7 @@ describe('ActiveTab', () => {
         ['sell', 'Sell disabled'],
     ])('should display correct trading type tab for %s', async (tradingType, expectedTitle) => {
         const { getByText } = await renderActiveTab({
-            wallet: { tradingNew: { activeTradingType: tradingType } },
+            wallet: { trading: { activeTradingType: tradingType } },
         });
 
         expect(getByText(expectedTitle)).toBeOnTheScreen();
@@ -29,7 +29,7 @@ describe('ActiveTab', () => {
 
     it('should render nothing when no active tab is specified', async () => {
         const { toJSON } = await renderActiveTab({
-            wallet: { tradingNew: { activeTradingType: undefined } },
+            wallet: { trading: { activeTradingType: undefined } },
         });
 
         expect(toJSON()).toBeNull();

--- a/suite-native/module-trading/src/components/general/__tests__/Footer.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/Footer.comp.test.tsx
@@ -27,7 +27,7 @@ describe('Footer', () => {
     it('should render nothing when isAmountInputActive is true', async () => {
         const { toJSON } = await renderWithStoreProviderAsync(<Footer />, {
             preloadedState: {
-                wallet: { tradingNew: { isAmountInputActive: true } },
+                wallet: { trading: { isAmountInputActive: true } },
             },
         });
 

--- a/suite-native/module-trading/src/components/general/__tests__/HistoryButton.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/HistoryButton.comp.test.tsx
@@ -47,7 +47,7 @@ describe('HistoryButton', () => {
         it('should render nothing when isAmountInputActive is true', async () => {
             const { toJSON } = await renderHistoryButton({
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         isAmountInputActive: true,
                     },
                 },

--- a/suite-native/module-trading/src/components/general/__tests__/NetworkBadge.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/NetworkBadge.comp.test.tsx
@@ -9,7 +9,7 @@ describe('NetworkBadge', () => {
     const renderPlatformBadge = (symbol: NetworkSymbol) =>
         renderWithStoreProviderAsync(<NetworkBadge symbol={symbol} />, {
             preloadedState: {
-                wallet: { tradingNew: { info: { coins, platforms } } },
+                wallet: { trading: { info: { coins, platforms } } },
             },
         });
 

--- a/suite-native/module-trading/src/components/general/__tests__/TradingTabContent.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingTabContent.comp.test.tsx
@@ -24,7 +24,7 @@ describe('TradingTabContent', () => {
         renderWithStoreProviderAsync(<TradingTabContent />, {
             preloadedState: {
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         ...initialState,
                         activeTradingType: 'buy',
                     },

--- a/suite-native/module-trading/src/components/general/__tests__/TradingTypeAwareContextMessage.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingTypeAwareContextMessage.comp.test.tsx
@@ -25,7 +25,7 @@ jest.mock('@suite-common/message-system', () => {
 describe('TradingTypeAwareContextMessage', () => {
     const getPreloadedState = (activeTradingType: TradingType | undefined): PreloadedState => ({
         wallet: {
-            tradingNew: {
+            trading: {
                 activeTradingType,
             },
         },

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailErrorAlert.comp.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailErrorAlert.comp.test.tsx
@@ -18,7 +18,7 @@ jest.mock('@suite-native/link', () => ({
 describe('TradeDetailErrorAlert', () => {
     const getPreloadedState = (supportUrl: string | undefined): PreloadedState => ({
         wallet: {
-            tradingNew: {
+            trading: {
                 ...getInitializedTradingStateWithQuotes(),
                 trades: [getBuyTrade({ status: 'ERROR' })],
                 buy: {

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailFooter.comp.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailFooter.comp.test.tsx
@@ -13,7 +13,7 @@ jest.mock('@suite-native/helpers', () => ({
 
 const getPreloadedState = (trades: TradingTransaction[]) => ({
     wallet: {
-        tradingNew: {
+        trading: {
             ...getInitializedTradingState(),
             trades,
         },

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailHeader.comp.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailHeader.comp.test.tsx
@@ -7,7 +7,7 @@ import { TradeDetailHeader } from '../TradeDetailHeader';
 
 const getPreloadedState = (trades: TradingTransaction[]) => ({
     wallet: {
-        tradingNew: {
+        trading: {
             ...getInitializedTradingState(),
             trades,
         },

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailInfo.comp.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailInfo.comp.test.tsx
@@ -7,7 +7,7 @@ import { TradeDetailInfo } from '../TradeDetailInfo';
 
 const getPreloadedState = (trades: TradingTransaction[]) => ({
     wallet: {
-        tradingNew: {
+        trading: {
             ...getInitializedTradingState(),
             trades,
         },

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailTransactionInfo.comp.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailTransactionInfo.comp.test.tsx
@@ -25,7 +25,7 @@ const getPreloadedState = (trades: TradingTransaction[]): PreloadedState => ({
     },
     wallet: {
         accounts,
-        tradingNew: {
+        trading: {
             ...getInitializedTradingState(),
             trades,
         },

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailWaitingAlert.comp.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailWaitingAlert.comp.test.tsx
@@ -7,7 +7,7 @@ import { TradeDetailWaitingAlert } from '../TradeDetailWaitingAlert';
 
 const getPreloadedState = (trades: TradingTransaction[]) => ({
     wallet: {
-        tradingNew: {
+        trading: {
             ...getInitializedTradingState(),
             trades,
         },

--- a/suite-native/module-trading/src/components/history/TradeHistoryListItem/__tests__/TradeHistoryListItem.comp.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeHistoryListItem/__tests__/TradeHistoryListItem.comp.test.tsx
@@ -9,7 +9,7 @@ describe('TradeHistoryListItem', () => {
     const renderTradeHistoryListItem = (transaction: TradingTransaction) =>
         renderWithStoreProviderAsync(
             <TradeHistoryListItem transaction={transaction} onPress={jest.fn()} />,
-            { preloadedState: { wallet: { tradingNew: getInitializedTradingState() } } },
+            { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
         );
 
     it('should render trade correctly', async () => {

--- a/suite-native/module-trading/src/components/sell/__tests__/SellCard.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellCard.comp.test.tsx
@@ -19,7 +19,7 @@ describe('SellCard', () => {
 
     const renderSellCard = (isAmountInputActive: boolean) => {
         const preloadedState = { wallet: getWalletState({ tradeType: 'sell' }) };
-        preloadedState.wallet!.tradingNew!.sell!.quotes = sellQuotes;
+        preloadedState.wallet!.trading!.sell!.quotes = sellQuotes;
 
         return renderWithStoreProviderAsync(
             <SellCard isAmountInputActive={isAmountInputActive} />,

--- a/suite-native/module-trading/src/components/sell/__tests__/SellConfirmation.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellConfirmation.comp.test.tsx
@@ -18,7 +18,7 @@ describe('SellConfirmation', () => {
 
     const renderConfirmation = () =>
         renderWithStoreProviderAsync(<SellConfirmation />, {
-            preloadedState: { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } },
+            preloadedState: { wallet: { trading: getInitializedTradingStateWithQuotes() } },
         });
 
     it('should render continue button when canProceed is true', async () => {

--- a/suite-native/module-trading/src/components/sell/__tests__/SellForm.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellForm.comp.test.tsx
@@ -42,8 +42,8 @@ describe('SellForm', () => {
         let preloadedState: PreloadedState;
 
         beforeEach(async () => {
-            preloadedState = { wallet: { tradingNew: getInitializedTradingState() } };
-            preloadedState.wallet!.tradingNew!.sell!.quotes = sellQuotes;
+            preloadedState = { wallet: { trading: getInitializedTradingState() } };
+            preloadedState.wallet!.trading!.sell!.quotes = sellQuotes;
 
             const { result } = await renderFormHook(preloadedState);
             form = result.current;

--- a/suite-native/module-trading/src/components/sell/__tests__/SellFormFieldErrorBadge.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellFormFieldErrorBadge.comp.test.tsx
@@ -152,7 +152,7 @@ describe('SellFormFieldErrorBadge', () => {
                 const preloadedState = {
                     wallet: getWalletState({ tradeType: 'sell' }),
                 };
-                preloadedState!.wallet!.tradingNew!.sell!.isLoading = true;
+                preloadedState!.wallet!.trading!.sell!.isLoading = true;
 
                 const { getByText, queryByText } = await renderSellFormFieldErrorBadge(
                     { fieldName: 'cryptoStringAmount' },
@@ -244,7 +244,7 @@ describe('SellFormFieldErrorBadge', () => {
                 tradingForm.setValue('cryptoStringAmount', '0.0006');
             });
             const preloadedState = getPreloadedState();
-            preloadedState!.wallet!.tradingNew!.sell!.isLoading = true;
+            preloadedState!.wallet!.trading!.sell!.isLoading = true;
 
             const { getByText } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },

--- a/suite-native/module-trading/src/components/sell/__tests__/SellLegalSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellLegalSheet.comp.test.tsx
@@ -14,7 +14,7 @@ describe('SellLegalSheet', () => {
                 sendSymbol="usdc"
                 {...props}
             />,
-            { preloadedState: { wallet: { tradingNew: getInitializedTradingStateWithQuotes() } } },
+            { preloadedState: { wallet: { trading: getInitializedTradingStateWithQuotes() } } },
         );
 
     it('should render text info with given tradeProviderName', async () => {

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.comp.test.tsx
@@ -40,7 +40,7 @@ describe('SellReceiveMethodPicker', () => {
     });
 
     it('should render loading skeleton when no quotes are loaded and new quotes are loading', async () => {
-        preloadedState!.wallet!.tradingNew!.sell!.isLoading = true;
+        preloadedState!.wallet!.trading!.sell!.isLoading = true;
 
         const { getByLabelText } = await renderSellReceiveMethodPicker();
 
@@ -48,7 +48,7 @@ describe('SellReceiveMethodPicker', () => {
     });
 
     it('should render "Not selected" when no quote is selected', async () => {
-        preloadedState!.wallet!.tradingNew!.sell!.quotes = sellQuotes;
+        preloadedState!.wallet!.trading!.sell!.quotes = sellQuotes;
 
         const { getByLabelText } = await renderSellReceiveMethodPicker();
 
@@ -57,7 +57,7 @@ describe('SellReceiveMethodPicker', () => {
 
     describe('with quotes loaded', () => {
         beforeEach(() => {
-            preloadedState!.wallet!.tradingNew!.sell!.quotes = sellQuotes;
+            preloadedState!.wallet!.trading!.sell!.quotes = sellQuotes;
             act(() => {
                 form.setValue('quote', sellQuotes[1]);
             });
@@ -70,7 +70,7 @@ describe('SellReceiveMethodPicker', () => {
         });
 
         it('should render loading skeleton when quotes are loaded and new quotes are loading', async () => {
-            preloadedState!.wallet!.tradingNew!.sell!.isLoading = true;
+            preloadedState!.wallet!.trading!.sell!.isLoading = true;
 
             const { getByLabelText } = await renderSellReceiveMethodPicker();
 

--- a/suite-native/module-trading/src/components/sell/payment/__tests__/SellProviderPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/payment/__tests__/SellProviderPicker.comp.test.tsx
@@ -40,7 +40,7 @@ describe('SellProviderPicker', () => {
     });
 
     it('should render loading skeleton when no quotes are loaded and new quotes are loading', async () => {
-        preloadedState!.wallet!.tradingNew!.sell!.isLoading = true;
+        preloadedState!.wallet!.trading!.sell!.isLoading = true;
 
         const { getByLabelText } = await renderSellProviderPicker();
 
@@ -49,14 +49,14 @@ describe('SellProviderPicker', () => {
 
     describe('with quotes loaded', () => {
         beforeEach(() => {
-            preloadedState!.wallet!.tradingNew!.sell!.quotes = sellQuotes;
+            preloadedState!.wallet!.trading!.sell!.quotes = sellQuotes;
             act(() => {
                 form.setValue('quote', sellQuotes[0]);
             });
         });
 
         it('should render loading skeleton when quotes are loaded and new quotes are loading', async () => {
-            preloadedState!.wallet!.tradingNew!.sell!.isLoading = true;
+            preloadedState!.wallet!.trading!.sell!.isLoading = true;
 
             const { getByLabelText } = await renderSellProviderPicker();
 
@@ -76,7 +76,7 @@ describe('SellProviderPicker', () => {
         });
 
         it('should not display kyc warning when loading', async () => {
-            preloadedState!.wallet!.tradingNew!.sell!.isLoading = true;
+            preloadedState!.wallet!.trading!.sell!.isLoading = true;
             const { queryByText } = await renderSellProviderPicker();
 
             expect(
@@ -142,7 +142,7 @@ describe('SellProviderPicker', () => {
             });
 
             it('should not call analytics when user tries to open sheet while quotes are loading', async () => {
-                preloadedState!.wallet!.tradingNew!.sell!.isLoading = true;
+                preloadedState!.wallet!.trading!.sell!.isLoading = true;
                 const { getByText } = await renderSellProviderPicker();
 
                 fireEvent.press(getByText('Provider'));

--- a/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAmountInput.test.tsx
@@ -159,7 +159,7 @@ describe('SellSendAmountInput', () => {
 
     it('should display loading skeleton while amountInCrypto is false and quotes are loading', async () => {
         const preloadedState = { wallet: getWalletState({ tradeType: 'sell' }) };
-        preloadedState.wallet!.tradingNew!.sell!.isLoading = true;
+        preloadedState.wallet!.trading!.sell!.isLoading = true;
         const form = await renderUseTradingSellForm(preloadedState);
 
         act(() => {
@@ -173,7 +173,7 @@ describe('SellSendAmountInput', () => {
 
     it('should not display loading skeleton when amountInCrypto is true', async () => {
         const preloadedState = { wallet: getWalletState({ tradeType: 'sell' }) };
-        preloadedState.wallet!.tradingNew!.sell!.isLoading = true;
+        preloadedState.wallet!.trading!.sell!.isLoading = true;
         const form = await renderUseTradingSellForm(preloadedState);
 
         act(() => {

--- a/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAssetPicker.test.tsx
@@ -59,7 +59,7 @@ describe('SellSendAssetPicker', () => {
 
     const getPreloadedState = () => ({
         wallet: {
-            tradingNew: getInitializedTradingState(),
+            trading: getInitializedTradingState(),
             accounts: [btcAccount, ethAccount],
         },
     });
@@ -101,7 +101,7 @@ describe('SellSendAssetPicker', () => {
 
         await userEvent.press(getByText('BTC'));
 
-        const accountKeyStore = store.getState().wallet.tradingNew.sell.tradingAccountKey;
+        const accountKeyStore = store.getState().wallet.trading.sell.tradingAccountKey;
         expect(accountKeyStore).toBe(btcAccount.key);
     });
 });

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyData.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyData.test.tsx
@@ -20,7 +20,7 @@ describe('useBuyData', () => {
     const getInitializedStore = async (tradingAccountKey: string | undefined) => {
         const preloadedState: PreloadedState = {
             wallet: {
-                tradingNew: getInitializedTradingState(),
+                trading: getInitializedTradingState(),
                 accounts: [
                     getBtcAccount('btc-account-1'),
                     getBtcAccount('btc-account-2'),
@@ -28,7 +28,7 @@ describe('useBuyData', () => {
                 ],
             },
         };
-        preloadedState.wallet!.tradingNew!.buy!.tradingAccountKey = tradingAccountKey;
+        preloadedState.wallet!.trading!.buy!.tradingAccountKey = tradingAccountKey;
 
         return await initStore(preloadedState);
     };

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyFlow.test.ts
@@ -34,10 +34,10 @@ jest.mock('@suite-common/trading', () => ({
 describe('useBuyFlow', () => {
     const getInitializedStore = async ({ isLoading }: { isLoading?: boolean }) => {
         const preloadedState: PreloadedState = {
-            wallet: { tradingNew: getInitializedTradingStateWithQuotes() },
+            wallet: { trading: getInitializedTradingStateWithQuotes() },
         };
         if (isLoading !== undefined) {
-            preloadedState.wallet!.tradingNew!.buy!.isLoading = isLoading;
+            preloadedState.wallet!.trading!.buy!.isLoading = isLoading;
         }
 
         return await initStore(preloadedState);

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
@@ -40,7 +40,7 @@ describe('useBuyForm', () => {
     const getInitializedStore = async (amountInSats = false) => {
         const preloadedState: PreloadedState = {
             wallet: {
-                tradingNew: getInitializedTradingState(),
+                trading: getInitializedTradingState(),
                 settings: {
                     bitcoinAmountUnit: amountInSats
                         ? PROTO.AmountUnit.SATOSHI
@@ -53,7 +53,7 @@ describe('useBuyForm', () => {
                 ],
             },
         };
-        preloadedState.wallet!.tradingNew!.buy!.tradingAccountKey = 'btc-account-1';
+        preloadedState.wallet!.trading!.buy!.tradingAccountKey = 'btc-account-1';
 
         return await initStore(preloadedState);
     };

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
@@ -46,9 +46,9 @@ jest.mock('@suite-common/trading', () => ({
 describe('useBuyQuotes', () => {
     const getInitializedStore = async () => {
         const preloadedState: PreloadedState = {
-            wallet: { tradingNew: getInitializedTradingState(), accounts: [getBtcAccount()] },
+            wallet: { trading: getInitializedTradingState(), accounts: [getBtcAccount()] },
         };
-        preloadedState.wallet!.tradingNew!.buy!.tradingAccountKey = 'btc-account-1';
+        preloadedState.wallet!.trading!.buy!.tradingAccountKey = 'btc-account-1';
 
         return await initStore(preloadedState);
     };
@@ -268,6 +268,6 @@ describe('useBuyQuotes', () => {
             payload: undefined,
             type: 'tradingBuy/clearQuotesAndQuotesRequest',
         });
-        expect(store.getState().wallet.tradingNew.buy.quotes).toEqual([]);
+        expect(store.getState().wallet.trading.buy.quotes).toEqual([]);
     });
 });

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeData.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeData.test.ts
@@ -20,7 +20,7 @@ describe('useExchangeData', () => {
     const getInitializedStore = async (tradingAccountKey: string | undefined) => {
         const preloadedState: PreloadedState = {
             wallet: {
-                tradingNew: getInitializedTradingState('exchange'),
+                trading: getInitializedTradingState('exchange'),
                 accounts: [
                     getBtcAccount('btc-account-1'),
                     getBtcAccount('btc-account-2'),
@@ -28,7 +28,7 @@ describe('useExchangeData', () => {
                 ],
             },
         };
-        preloadedState.wallet!.tradingNew!.exchange!.tradingAccountKey = tradingAccountKey;
+        preloadedState.wallet!.trading!.exchange!.tradingAccountKey = tradingAccountKey;
 
         return await initStore(preloadedState);
     };

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
@@ -70,7 +70,7 @@ describe('useExchangeFlow', () => {
 
         const preloadedState: PreloadedState = {
             wallet: {
-                tradingNew: tradingState,
+                trading: tradingState,
                 accounts: getMockAccounts(),
             },
         };
@@ -294,7 +294,7 @@ describe('useExchangeFlow', () => {
         it('should return undefined when no trade is provided and no selectedQuote', async () => {
             // Mock the selector to return undefined for selectedQuote
             const modifiedStore = await getInitializedStore();
-            modifiedStore.getState().wallet.tradingNew.exchange.selectedQuote = undefined;
+            modifiedStore.getState().wallet.trading.exchange.selectedQuote = undefined;
 
             const { result: modifiedResult } = await renderUseExchangeFlow({
                 store: modifiedStore,

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeQuotes.test.ts
@@ -48,7 +48,7 @@ describe('useExchangeQuotes', () => {
     const getInitializedStore = async (bitcoinAmountUnit = PROTO.AmountUnit.BITCOIN) => {
         const preloadedState: PreloadedState = {
             wallet: {
-                tradingNew: getInitializedTradingState(),
+                trading: getInitializedTradingState(),
                 accounts: [getBtcAccount(), getEthAccount()],
                 settings: {
                     bitcoinAmountUnit,
@@ -307,6 +307,6 @@ describe('useExchangeQuotes', () => {
             payload: undefined,
             type: 'tradingExchange/clearQuotesAndQuotesRequest',
         });
-        expect(store.getState().wallet.tradingNew.exchange.quotes).toEqual([]);
+        expect(store.getState().wallet.trading.exchange.quotes).toEqual([]);
     });
 });

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -52,16 +52,16 @@ describe('useExchangeSelectQuote', () => {
 
         const preloadedState: PreloadedState = {
             wallet: {
-                tradingNew: getInitializedTradingStateWithQuotes(),
+                trading: getInitializedTradingStateWithQuotes(),
                 accounts: [btcAccount, ethAccount],
             },
         };
         if (isLoading !== undefined) {
-            preloadedState.wallet!.tradingNew!.exchange!.isLoading = isLoading;
+            preloadedState.wallet!.trading!.exchange!.isLoading = isLoading;
         }
         // Ensure required keys are present so the hook can proceed
-        preloadedState.wallet!.tradingNew!.exchange!.tradingAccountKey = 'btc-account-key';
-        preloadedState.wallet!.tradingNew!.exchange!.receiveAccountKey = 'eth-account-key';
+        preloadedState.wallet!.trading!.exchange!.tradingAccountKey = 'btc-account-key';
+        preloadedState.wallet!.trading!.exchange!.receiveAccountKey = 'eth-account-key';
 
         return await initStore(preloadedState);
     };

--- a/suite-native/module-trading/src/hooks/general/__tests__/useAllTradesReloadTimer.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useAllTradesReloadTimer.test.ts
@@ -38,7 +38,7 @@ describe('useAllTradesReloadTimer', () => {
     const getInitializedStore = async ({ trades = [] }: { trades?: any[] } = {}) => {
         const preloadedState: PreloadedState = {
             wallet: {
-                tradingNew: {
+                trading: {
                     ...getInitializedTradingState(),
                     trades,
                 },

--- a/suite-native/module-trading/src/hooks/general/__tests__/useFavouriteAssetsSectionList.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useFavouriteAssetsSectionList.test.tsx
@@ -23,7 +23,7 @@ describe('useFavouriteAssetsSectionList', () => {
     ) => {
         const preloadedState: Partial<PreloadedState> = {
             wallet: {
-                tradingNew: {
+                trading: {
                     favouriteAssets,
                 },
             },

--- a/suite-native/module-trading/src/hooks/general/__tests__/useWatchAllTrades.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useWatchAllTrades.test.ts
@@ -46,7 +46,7 @@ describe('useWatchAllTrades', () => {
     const getInitializedStore = async ({ trades = [] }: { trades?: any[] } = {}) => {
         const preloadedState: PreloadedState = {
             wallet: {
-                tradingNew: {
+                trading: {
                     ...getInitializedTradingState(),
                     trades,
                 },

--- a/suite-native/module-trading/src/hooks/history/__tests__/useChangeStringsExtractor.test.ts
+++ b/suite-native/module-trading/src/hooks/history/__tests__/useChangeStringsExtractor.test.ts
@@ -9,7 +9,7 @@ describe('useChangeStringsExtractor', () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
         const { result } = await renderHookWithStoreProviderAsync(
             () => useChangeStringsExtractor(buyTrade.data),
-            { preloadedState: { wallet: { tradingNew: getInitializedTradingState() } } },
+            { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
         );
 
         expect(result.current).toEqual({
@@ -29,7 +29,7 @@ describe('useChangeStringsExtractor', () => {
         const sellTrade = getSellTrade({ status: 'SUBMITTED' });
         const { result } = await renderHookWithStoreProviderAsync(
             () => useChangeStringsExtractor(sellTrade.data),
-            { preloadedState: { wallet: { tradingNew: getInitializedTradingState() } } },
+            { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
         );
 
         expect(result.current).toEqual({
@@ -49,7 +49,7 @@ describe('useChangeStringsExtractor', () => {
         const exchangeTrade = getExchangeTrade({ status: 'CONFIRM' });
         const { result } = await renderHookWithStoreProviderAsync(
             () => useChangeStringsExtractor(exchangeTrade.data),
-            { preloadedState: { wallet: { tradingNew: getInitializedTradingState() } } },
+            { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
         );
 
         expect(result.current).toEqual({
@@ -68,7 +68,7 @@ describe('useChangeStringsExtractor', () => {
     it('should handle undefined trade', async () => {
         const { result } = await renderHookWithStoreProviderAsync(
             () => useChangeStringsExtractor(undefined),
-            { preloadedState: { wallet: { tradingNew: getInitializedTradingState() } } },
+            { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
         );
 
         expect(result.current).toEqual({
@@ -94,7 +94,7 @@ describe('useChangeStringsExtractor', () => {
 
         const { result } = await renderHookWithStoreProviderAsync(
             () => useChangeStringsExtractor(tradeWithMissingValues),
-            { preloadedState: { wallet: { tradingNew: getInitializedTradingState() } } },
+            { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
         );
 
         expect(result.current).toEqual({

--- a/suite-native/module-trading/src/hooks/history/__tests__/useSymbolExtractor.test.ts
+++ b/suite-native/module-trading/src/hooks/history/__tests__/useSymbolExtractor.test.ts
@@ -9,7 +9,7 @@ describe('useSymbolExtractor', () => {
     it('should return symbol for known cryptoId', async () => {
         const { result } = await renderHookWithStoreProviderAsync(
             () => useSymbolExtractor('bitcoin' as CryptoId),
-            { preloadedState: { wallet: { tradingNew: getInitializedTradingState() } } },
+            { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
         );
 
         expect(result.current).toBe('BTC');
@@ -18,7 +18,7 @@ describe('useSymbolExtractor', () => {
     it('should return original cryptoId for unknown cryptoId', async () => {
         const { result } = await renderHookWithStoreProviderAsync(
             () => useSymbolExtractor('unknown-crypto' as CryptoId),
-            { preloadedState: { wallet: { tradingNew: getInitializedTradingState() } } },
+            { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
         );
 
         expect(result.current).toBe('unknown-crypto');
@@ -27,7 +27,7 @@ describe('useSymbolExtractor', () => {
     it('should handle undefined cryptoId', async () => {
         const { result } = await renderHookWithStoreProviderAsync(
             () => useSymbolExtractor(undefined),
-            { preloadedState: { wallet: { tradingNew: getInitializedTradingState() } } },
+            { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
         );
 
         expect(result.current).toBeUndefined();

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellData.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellData.test.tsx
@@ -20,7 +20,7 @@ describe('useSellData', () => {
     const getInitializedStore = async (tradingAccountKey: string | undefined) => {
         const preloadedState: PreloadedState = {
             wallet: {
-                tradingNew: getInitializedTradingState('sell'),
+                trading: getInitializedTradingState('sell'),
                 accounts: [
                     getBtcAccount('btc-account-1'),
                     getBtcAccount('btc-account-2'),
@@ -28,7 +28,7 @@ describe('useSellData', () => {
                 ],
             },
         };
-        preloadedState.wallet!.tradingNew!.sell!.tradingAccountKey = tradingAccountKey;
+        preloadedState.wallet!.trading!.sell!.tradingAccountKey = tradingAccountKey;
 
         return await initStore(preloadedState);
     };

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellQuotes.test.ts
@@ -47,7 +47,7 @@ describe('useSellQuotes', () => {
                 tradeType: 'sell',
             }),
         };
-        preloadedState.wallet!.tradingNew!.sell!.tradingAccountKey = 'btc-account-1';
+        preloadedState.wallet!.trading!.sell!.tradingAccountKey = 'btc-account-1';
 
         return await initStore(preloadedState);
     };
@@ -245,7 +245,7 @@ describe('useSellQuotes', () => {
             payload: undefined,
             type: 'tradingSell/clearQuotesAndQuotesRequest',
         });
-        expect(store.getState().wallet.tradingNew.sell.quotes).toEqual([]);
+        expect(store.getState().wallet.trading.sell.quotes).toEqual([]);
     });
 
     it('should not query quotes when form contains error', async () => {

--- a/suite-native/module-trading/src/reducers/tradingSlice.ts
+++ b/suite-native/module-trading/src/reducers/tradingSlice.ts
@@ -40,7 +40,7 @@ export interface TradingState extends CommonTradingState {
 
 export type TradingRootState = {
     wallet: {
-        tradingNew: TradingState;
+        trading: TradingState;
     };
 };
 

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.comp.test.tsx
@@ -33,7 +33,7 @@ const testQuote = exchangeQuotes[0];
 
 const preloadedState = {
     wallet: {
-        tradingNew: {
+        trading: {
             ...getInitializedTradingState('exchange'),
             exchange: {
                 ...getInitializedTradingState('exchange').exchange,

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangeRevokeScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangeRevokeScreen.comp.test.tsx
@@ -22,7 +22,7 @@ const testQuote = exchangeQuotes[0];
 
 const preloadedState = {
     wallet: {
-        tradingNew: {
+        trading: {
             ...getInitializedTradingState('exchange'),
             exchange: {
                 ...getInitializedTradingState('exchange').exchange,

--- a/suite-native/module-trading/src/screens/__tests__/TradingHistoryScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingHistoryScreen.comp.test.tsx
@@ -40,7 +40,7 @@ jest.mock('@suite-common/trading', () => {
 
 const getPreloadedState = (): PreloadedState => ({
     wallet: {
-        tradingNew: {
+        trading: {
             ...getInitializedTradingState(),
             trades: [getBuyTrade({ status: 'SUBMITTED' })],
         },

--- a/suite-native/module-trading/src/screens/__tests__/TradingReceiveAccountsPickerScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingReceiveAccountsPickerScreen.comp.test.tsx
@@ -38,7 +38,7 @@ const getPreloadedState = (preloadedAccounts: Account[]): PreloadedState => ({
     },
     wallet: {
         accounts: preloadedAccounts,
-        tradingNew: {
+        trading: {
             ...getInitializedTradingState(),
         },
     },

--- a/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/buySelectors.test.ts
@@ -37,7 +37,7 @@ describe('buySelectors', () => {
     });
 
     it('selectTradingBuy should select trading buy state', () => {
-        expect(selectTradingBuy(state)).toEqual(state.wallet.tradingNew.buy);
+        expect(selectTradingBuy(state)).toEqual(state.wallet.trading.buy);
     });
 
     describe('selectBuySelectedReceiveAccount', () => {
@@ -45,12 +45,12 @@ describe('buySelectors', () => {
 
         beforeEach(() => {
             account = getBtcAccount();
-            state.wallet.tradingNew.buy.tradingAccountKey = account.key;
-            state.wallet.tradingNew.buy.receiveAddress = account.addresses?.used[0];
+            state.wallet.trading.buy.tradingAccountKey = account.key;
+            state.wallet.trading.buy.receiveAddress = account.addresses?.used[0];
         });
 
         it('should be undefined when no tradingAccountKey is defined', () => {
-            state.wallet.tradingNew.buy.tradingAccountKey = undefined;
+            state.wallet.trading.buy.tradingAccountKey = undefined;
 
             expect(selectBuySelectedReceiveAccount(state)).toBeUndefined();
         });
@@ -69,7 +69,7 @@ describe('buySelectors', () => {
         });
 
         it('should throw when no account with given key exists', () => {
-            state.wallet.tradingNew.buy.tradingAccountKey = 'unknown_account_key';
+            state.wallet.trading.buy.tradingAccountKey = 'unknown_account_key';
 
             expect(() => selectBuySelectedReceiveAccount(state)).toThrow(
                 'Unknown tradingAccountKey: [unknown_account_key]',
@@ -92,7 +92,7 @@ describe('buySelectors', () => {
         });
 
         it('should sort coins', () => {
-            state.wallet.tradingNew.buy.buyInfo!.supportedCryptoCurrencies = [
+            state.wallet.trading.buy.buyInfo!.supportedCryptoCurrencies = [
                 'bitcoin',
                 'ethereum',
                 'eos',
@@ -121,7 +121,7 @@ describe('buySelectors', () => {
         });
 
         it('should be empty array when coins are not set', () => {
-            state.wallet.tradingNew.info.coins = undefined;
+            state.wallet.trading.info.coins = undefined;
 
             expect(selectBuyTradeableAssetsSorted(state)).toEqual([]);
         });
@@ -129,7 +129,7 @@ describe('buySelectors', () => {
 
     describe('selectBuyFormDefaultValues', () => {
         it('should return object with empty values when buy info is not initialized ', () => {
-            state.wallet.tradingNew.buy.buyInfo = undefined;
+            state.wallet.trading.buy.buyInfo = undefined;
 
             expect(selectBuyFormDefaultValues(state)).toEqual({});
         });
@@ -146,7 +146,7 @@ describe('buySelectors', () => {
         });
 
         it('should use default value for fiat currency if no fiat is suggested', () => {
-            state.wallet.tradingNew.buy.buyInfo!.buyInfo.suggestedFiatCurrency = undefined;
+            state.wallet.trading.buy.buyInfo!.buyInfo.suggestedFiatCurrency = undefined;
 
             expect(selectBuyFormDefaultValues(state)).toEqual(
                 expect.objectContaining({
@@ -156,7 +156,7 @@ describe('buySelectors', () => {
         });
 
         it('should not specify country if country is not in the list', () => {
-            state.wallet.tradingNew.buy.buyInfo!.buyInfo.country = 'XX';
+            state.wallet.trading.buy.buyInfo!.buyInfo.country = 'XX';
 
             expect(selectBuyFormDefaultValues(state)).toEqual(
                 expect.objectContaining({
@@ -172,7 +172,7 @@ describe('buySelectors', () => {
         });
 
         it('should return stable empty array when supportedFiatCurrencies are not set', () => {
-            state.wallet.tradingNew.buy.buyInfo = undefined;
+            state.wallet.trading.buy.buyInfo = undefined;
 
             const result = selectBuySupportedFiatCurrencies(state);
             expect(result).toEqual([]);
@@ -208,7 +208,7 @@ describe('buySelectors', () => {
         });
 
         it('should deduplicate values', () => {
-            state.wallet.tradingNew.buy.buyInfo!.supportedFiatCurrencies = [
+            state.wallet.trading.buy.buyInfo!.supportedFiatCurrencies = [
                 'usd',
                 'usd',
                 'eur',
@@ -236,7 +236,7 @@ describe('buySelectors', () => {
 
     describe('selectValidMobileTradingBuyQuotes', () => {
         beforeEach(() => {
-            state.wallet.tradingNew.buy.quotes = [
+            state.wallet.trading.buy.quotes = [
                 ...quotes,
                 { ...quotes[0], exchange: 'simplex', orderId: 'order_id_4' },
             ] as BuyTrade[];
@@ -284,7 +284,7 @@ describe('buySelectors', () => {
 
     describe('selectBuyBestQuotesForAvailablePaymentMethods', () => {
         beforeEach(() => {
-            state.wallet.tradingNew.buy.quotes = quotes as BuyTrade[];
+            state.wallet.trading.buy.quotes = quotes as BuyTrade[];
         });
 
         it('should return only best quote for each payment method', () => {
@@ -316,7 +316,7 @@ describe('buySelectors', () => {
                 paymentMethod: undefined,
             } as unknown as BuyTrade;
 
-            state.wallet.tradingNew.buy.quotes = [quote];
+            state.wallet.trading.buy.quotes = [quote];
 
             expect(selectBuyBestQuotesForAvailablePaymentMethods(state)).toEqual([]);
         });
@@ -327,7 +327,7 @@ describe('buySelectors', () => {
                 paymentMethodName: undefined,
             } as unknown as BuyTrade;
 
-            state.wallet.tradingNew.buy.quotes = [quote];
+            state.wallet.trading.buy.quotes = [quote];
 
             expect(selectBuyBestQuotesForAvailablePaymentMethods(state)).toEqual([]);
         });
@@ -335,7 +335,7 @@ describe('buySelectors', () => {
 
     describe('selectMobileBuyQuotesByPaymentMethod', () => {
         beforeEach(() => {
-            state.wallet.tradingNew.buy.quotes = [
+            state.wallet.trading.buy.quotes = [
                 ...quotes,
                 { ...quotes[0], exchange: 'simplex', orderId: 'order_id_4' },
             ] as BuyTrade[];

--- a/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/commonSelectors.test.ts
@@ -124,7 +124,7 @@ describe('commonSelectors', () => {
                 tradingEnvironment: 'staging' as InvityServerEnvironment,
             };
 
-            expect(selectTradingEnvironment({ wallet: { tradingNew: state } })).toBe('staging');
+            expect(selectTradingEnvironment({ wallet: { trading: state } })).toBe('staging');
         });
     });
 
@@ -182,7 +182,7 @@ describe('commonSelectors', () => {
         const getMockStateForTradeToBeOpened = (orderId: string | undefined) =>
             ({
                 wallet: {
-                    tradingNew: {
+                    trading: {
                         tradeOrderIdToBeOpened: orderId,
                         trades: [{ data: { orderId: 'order1' } }, { data: { orderId: 'order2' } }],
                     },
@@ -212,7 +212,7 @@ describe('commonSelectors', () => {
         it('should correctly select trading.isAmountInputActive state', () => {
             expect(
                 selectIsAmountInputActive({
-                    wallet: { tradingNew: { isAmountInputActive: true } as any },
+                    wallet: { trading: { isAmountInputActive: true } as any },
                 }),
             ).toBe(true);
         });
@@ -222,7 +222,7 @@ describe('commonSelectors', () => {
         it('should correctly select trading.activeTradingType state', () => {
             expect(
                 selectActiveTradingType({
-                    wallet: { tradingNew: { activeTradingType: 'exchange' } as any },
+                    wallet: { trading: { activeTradingType: 'exchange' } as any },
                 }),
             ).toBe('exchange');
         });
@@ -337,7 +337,7 @@ describe('commonSelectors', () => {
 
             const stateWithDevice = {
                 wallet: {
-                    tradingNew: cleanState,
+                    trading: cleanState,
                     accounts: [btcAccount],
                     settings: { localCurrency: 'usd', enabledNetworks: ['btc'] },
                     transactions: { transactions: {} },
@@ -376,7 +376,7 @@ describe('commonSelectors', () => {
 
             const stateWithDevice = {
                 wallet: {
-                    tradingNew: cleanState,
+                    trading: cleanState,
                     accounts: [zeroBalanceAccount],
                     settings: { localCurrency: 'usd', enabledNetworks: ['btc'] },
                 },
@@ -425,7 +425,7 @@ describe('commonSelectors', () => {
 
             const stateWithDevice = {
                 wallet: {
-                    tradingNew: cleanState,
+                    trading: cleanState,
                     accounts: [ethAccount],
                     settings: { localCurrency: 'usd', enabledNetworks: ['eth'] },
                     transactions: { transactions: {} },
@@ -484,7 +484,7 @@ describe('commonSelectors', () => {
 
             const stateWithDevice = {
                 wallet: {
-                    tradingNew: cleanState,
+                    trading: cleanState,
                     accounts: [ethAccount],
                     settings: { localCurrency: 'usd', enabledNetworks: ['eth'] },
                     transactions: { transactions: {} },
@@ -539,7 +539,7 @@ describe('commonSelectors', () => {
 
             const stateWithDevice = {
                 wallet: {
-                    tradingNew: cleanState,
+                    trading: cleanState,
                     accounts: [ethAccount],
                     settings: { localCurrency: 'usd', enabledNetworks: ['eth'] },
                     transactions: { transactions: {} },
@@ -592,7 +592,7 @@ describe('commonSelectors', () => {
 
             const stateWithDevice = {
                 wallet: {
-                    tradingNew: cleanState,
+                    trading: cleanState,
                     accounts: [ethAccount],
                     settings: { localCurrency: 'usd', enabledNetworks: ['eth'] },
                     transactions: { transactions: {} },
@@ -625,7 +625,7 @@ describe('commonSelectors', () => {
 
             const stateWithDevice = {
                 wallet: {
-                    tradingNew: cleanState,
+                    trading: cleanState,
                     accounts: [btcAccount],
                     settings: { localCurrency: 'usd', enabledNetworks: ['btc'] },
                     transactions: { transactions: {} },
@@ -656,7 +656,7 @@ describe('commonSelectors', () => {
 
             const stateWithDevice = {
                 wallet: {
-                    tradingNew: cleanState,
+                    trading: cleanState,
                     accounts: [btcAccount],
                     settings: { localCurrency: 'usd', enabledNetworks: ['btc'] },
                     transactions: { transactions: {} },

--- a/suite-native/module-trading/src/selectors/__tests__/exchangeSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/exchangeSelectors.test.ts
@@ -27,7 +27,7 @@ describe('exchangeSelectors', () => {
     });
 
     it('selectTradingExchange should select trading exchange state', () => {
-        expect(selectTradingExchange(state)).toEqual(state.wallet.tradingNew.exchange);
+        expect(selectTradingExchange(state)).toEqual(state.wallet.trading.exchange);
     });
 
     describe('selectExchangeSelectedSendAccount', () => {
@@ -35,11 +35,11 @@ describe('exchangeSelectors', () => {
 
         beforeEach(() => {
             account = getBtcAccount();
-            state.wallet.tradingNew.exchange.tradingAccountKey = account.key;
+            state.wallet.trading.exchange.tradingAccountKey = account.key;
         });
 
         it('should be undefined when no tradingAccountKey is defined', () => {
-            state.wallet.tradingNew.exchange.tradingAccountKey = undefined;
+            state.wallet.trading.exchange.tradingAccountKey = undefined;
 
             expect(selectExchangeSelectedSendAccount(state)).toBeUndefined();
         });
@@ -55,7 +55,7 @@ describe('exchangeSelectors', () => {
         });
 
         it('should return undefined when no account with given key exists', () => {
-            state.wallet.tradingNew.exchange.tradingAccountKey = 'unknown_account_key';
+            state.wallet.trading.exchange.tradingAccountKey = 'unknown_account_key';
 
             expect(selectExchangeSelectedSendAccount(state)).toBeUndefined();
         });
@@ -66,12 +66,12 @@ describe('exchangeSelectors', () => {
 
         beforeEach(() => {
             account = getBtcAccount();
-            state.wallet.tradingNew.exchange.receiveAccountKey = account.key;
-            state.wallet.tradingNew.exchange.receiveAddress = account.addresses?.used[0];
+            state.wallet.trading.exchange.receiveAccountKey = account.key;
+            state.wallet.trading.exchange.receiveAddress = account.addresses?.used[0];
         });
 
         it('should be undefined when no receiveAccountKey is defined', () => {
-            state.wallet.tradingNew.exchange.receiveAccountKey = undefined;
+            state.wallet.trading.exchange.receiveAccountKey = undefined;
 
             expect(selectExchangeSelectedReceiveAccount(state)).toBeUndefined();
         });
@@ -90,7 +90,7 @@ describe('exchangeSelectors', () => {
         });
 
         it('should return undefined no account with given key exists', () => {
-            state.wallet.tradingNew.exchange.receiveAccountKey = 'unknown_account_key';
+            state.wallet.trading.exchange.receiveAccountKey = 'unknown_account_key';
 
             expect(selectExchangeSelectedReceiveAccount(state)).toBeUndefined();
         });
@@ -108,7 +108,7 @@ describe('exchangeSelectors', () => {
         });
 
         it('should sort coins', () => {
-            state.wallet.tradingNew.exchange.exchangeInfo!.buyCryptoIds = [
+            state.wallet.trading.exchange.exchangeInfo!.buyCryptoIds = [
                 'bitcoin',
                 'ethereum',
                 'eos',
@@ -137,7 +137,7 @@ describe('exchangeSelectors', () => {
         });
 
         it('should be empty array when coins are not set', () => {
-            state.wallet.tradingNew.info.coins = undefined;
+            state.wallet.trading.info.coins = undefined;
 
             expect(selectExchangeBuyTradeableAssetsSorted(state)).toEqual([]);
         });
@@ -145,7 +145,7 @@ describe('exchangeSelectors', () => {
 
     describe('selectExchangeQuotes', () => {
         it('should return exchange.quotes', () => {
-            state.wallet.tradingNew.exchange.quotes = exchangeQuotes;
+            state.wallet.trading.exchange.quotes = exchangeQuotes;
 
             expect(selectExchangeQuotes(state)).toEqual(exchangeQuotes);
         });
@@ -161,7 +161,7 @@ describe('exchangeSelectors', () => {
         });
 
         it('should group quotes by fixed/float/dex', () => {
-            state.wallet.tradingNew.exchange.quotes = exchangeQuotes;
+            state.wallet.trading.exchange.quotes = exchangeQuotes;
 
             const groupedQuotes = selectGroupedExchangeQuotes(state);
 
@@ -191,7 +191,7 @@ describe('exchangeSelectors', () => {
         });
 
         it('should be stable', () => {
-            state.wallet.tradingNew.exchange.quotes = exchangeQuotes;
+            state.wallet.trading.exchange.quotes = exchangeQuotes;
 
             expect(selectGroupedExchangeQuotes(state)).toBe(selectGroupedExchangeQuotes(state));
         });

--- a/suite-native/module-trading/src/selectors/__tests__/favouritesSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/favouritesSelectors.test.ts
@@ -25,7 +25,7 @@ describe('favouritesSelectors', () => {
 
     it('selectTradingFavouriteAssets should return favourites assets map', () => {
         const favouritesArray = selectTradingFavouriteAssets({
-            wallet: { tradingNew: state },
+            wallet: { trading: state },
         });
 
         expect(favouritesArray).toEqual({ bitcoin: true });
@@ -33,11 +33,11 @@ describe('favouritesSelectors', () => {
 
     it('selectTradingFavouriteAssetsArray should return memoized array', () => {
         const favouritesArray = selectTradingFavouriteAssetsArray({
-            wallet: { tradingNew: state },
+            wallet: { trading: state },
         });
 
         expect(favouritesArray).toEqual(['bitcoin']);
-        expect(selectTradingFavouriteAssetsArray({ wallet: { tradingNew: state } })).toBe(
+        expect(selectTradingFavouriteAssetsArray({ wallet: { trading: state } })).toBe(
             favouritesArray,
         );
     });
@@ -51,7 +51,7 @@ describe('favouritesSelectors', () => {
         (expectedValue, cryptoId) => {
             const asset = { cryptoId } as unknown as TradeableAsset;
 
-            expect(selectIsTradingFavouriteAsset({ wallet: { tradingNew: state } }, asset)).toBe(
+            expect(selectIsTradingFavouriteAsset({ wallet: { trading: state } }, asset)).toBe(
                 expectedValue,
             );
         },

--- a/suite-native/module-trading/src/selectors/__tests__/sellSelectors.test.ts
+++ b/suite-native/module-trading/src/selectors/__tests__/sellSelectors.test.ts
@@ -26,13 +26,13 @@ describe('sellSelectors', () => {
     });
 
     it('selectTradingSell should select trading sell state', () => {
-        expect(selectTradingSell(state)).toEqual(state.wallet.tradingNew.sell);
+        expect(selectTradingSell(state)).toEqual(state.wallet.trading.sell);
     });
 
     describe('selectSellSupportedFiatCurrencies', () => {
         it('should select supportedFiatCurrencies', () => {
             // Mock the sell info with supported currencies
-            state.wallet.tradingNew.sell.sellInfo = {
+            state.wallet.trading.sell.sellInfo = {
                 supportedFiatCurrencies: ['usd', 'eur', 'czk'],
                 supportedCryptoCurrencies: [],
                 providerInfos: {},
@@ -43,7 +43,7 @@ describe('sellSelectors', () => {
         });
 
         it('should return stable empty array when supportedFiatCurrencies are not set', () => {
-            state.wallet.tradingNew.sell.sellInfo = undefined;
+            state.wallet.trading.sell.sellInfo = undefined;
 
             const result = selectSellSupportedFiatCurrencies(state);
             expect(result).toEqual([]);
@@ -51,7 +51,7 @@ describe('sellSelectors', () => {
         });
 
         it('should return stable empty array when sellInfo is not set', () => {
-            state.wallet.tradingNew.sell.sellInfo = undefined;
+            state.wallet.trading.sell.sellInfo = undefined;
 
             const result = selectSellSupportedFiatCurrencies(state);
             expect(result).toEqual([]);
@@ -61,7 +61,7 @@ describe('sellSelectors', () => {
 
     describe('selectSellSupportedFiatCurrenciesList', () => {
         beforeEach(() => {
-            state.wallet.tradingNew.sell.sellInfo = {
+            state.wallet.trading.sell.sellInfo = {
                 supportedFiatCurrencies: ['usd', 'eur', 'czk'],
                 supportedCryptoCurrencies: [],
                 providerInfos: {},
@@ -96,7 +96,7 @@ describe('sellSelectors', () => {
         });
 
         it('should handle unknown currency codes', () => {
-            state.wallet.tradingNew.sell.sellInfo!.supportedFiatCurrencies = ['unknown', 'usd'];
+            state.wallet.trading.sell.sellInfo!.supportedFiatCurrencies = ['unknown', 'usd'];
 
             expect(selectSellSupportedFiatCurrenciesList(state)).toEqual([
                 {
@@ -115,7 +115,7 @@ describe('sellSelectors', () => {
 
     describe('selectSellAmountLimits', () => {
         it('should return amount limits', () => {
-            state.wallet.tradingNew.sell.amountLimits = {
+            state.wallet.trading.sell.amountLimits = {
                 currency: 'BTC',
                 maxCrypto: '50',
                 minCrypto: '0.0001',
@@ -129,7 +129,7 @@ describe('sellSelectors', () => {
         });
 
         it('should return undefined when amount limits are not set', () => {
-            state.wallet.tradingNew.sell.amountLimits = undefined;
+            state.wallet.trading.sell.amountLimits = undefined;
 
             expect(selectSellAmountLimits(state)).toBeUndefined();
         });
@@ -138,7 +138,7 @@ describe('sellSelectors', () => {
     describe('selectSellFormDefaultValues', () => {
         beforeEach(() => {
             // Mock the trading sell info
-            state.wallet.tradingNew.sell.sellInfo = {
+            state.wallet.trading.sell.sellInfo = {
                 supportedFiatCurrencies: ['usd', 'eur'],
                 supportedCryptoCurrencies: [],
                 providerInfos: {},
@@ -146,7 +146,7 @@ describe('sellSelectors', () => {
             };
 
             // Mock the coins info
-            state.wallet.tradingNew.info.coins = {
+            state.wallet.trading.info.coins = {
                 bitcoin: {
                     symbol: 'btc',
                     name: 'Bitcoin',
@@ -172,19 +172,19 @@ describe('sellSelectors', () => {
         });
 
         it('should return empty object when sell info is not initialized', () => {
-            state.wallet.tradingNew.sell.sellInfo = undefined;
+            state.wallet.trading.sell.sellInfo = undefined;
 
             expect(selectSellFormDefaultValues(state)).toEqual({});
         });
 
         it('should return empty object when coins are not set', () => {
-            state.wallet.tradingNew.info.coins = undefined;
+            state.wallet.trading.info.coins = undefined;
 
             expect(selectSellFormDefaultValues(state)).toEqual({});
         });
 
         it('should not specify country if country is not in the list', () => {
-            state.wallet.tradingNew.sell.sellInfo!.country = 'XX';
+            state.wallet.trading.sell.sellInfo!.country = 'XX';
 
             expect(selectSellFormDefaultValues(state)).toEqual(
                 expect.objectContaining({
@@ -219,11 +219,11 @@ describe('sellSelectors', () => {
 
         beforeEach(() => {
             account = getBtcAccount();
-            state.wallet.tradingNew.sell.tradingAccountKey = account.key;
+            state.wallet.trading.sell.tradingAccountKey = account.key;
         });
 
         it('should be undefined when no tradingAccountKey is defined', () => {
-            state.wallet.tradingNew.sell.tradingAccountKey = undefined;
+            state.wallet.trading.sell.tradingAccountKey = undefined;
 
             expect(selectSellSelectedSendAccount(state)).toBeUndefined();
         });
@@ -237,7 +237,7 @@ describe('sellSelectors', () => {
         });
 
         it('should return undefined when no account with given key exists', () => {
-            state.wallet.tradingNew.sell.tradingAccountKey = 'unknown_account_key';
+            state.wallet.trading.sell.tradingAccountKey = 'unknown_account_key';
 
             expect(selectSellSelectedSendAccount(state)).toBeUndefined();
         });
@@ -245,7 +245,7 @@ describe('sellSelectors', () => {
 
     describe('selectSellBestQuotesForAvailablePaymentMethods', () => {
         beforeEach(() => {
-            state.wallet.tradingNew.sell.quotes = sellQuotes;
+            state.wallet.trading.sell.quotes = sellQuotes;
         });
 
         it('should return only best quote for each payment method', () => {
@@ -273,7 +273,7 @@ describe('sellSelectors', () => {
                 paymentMethod: undefined,
             } as unknown as SellFiatTrade;
 
-            state.wallet.tradingNew.sell.quotes = [quote];
+            state.wallet.trading.sell.quotes = [quote];
 
             expect(selectSellBestQuotesForAvailablePaymentMethods(state)).toEqual([]);
         });
@@ -284,7 +284,7 @@ describe('sellSelectors', () => {
                 paymentMethodName: undefined,
             } as unknown as SellFiatTrade;
 
-            state.wallet.tradingNew.sell.quotes = [quote];
+            state.wallet.trading.sell.quotes = [quote];
 
             expect(selectSellBestQuotesForAvailablePaymentMethods(state)).toEqual([]);
         });
@@ -292,7 +292,7 @@ describe('sellSelectors', () => {
 
     describe('selectSellQuotesByPaymentMethod', () => {
         beforeEach(() => {
-            state.wallet.tradingNew.sell.quotes = sellQuotes;
+            state.wallet.trading.sell.quotes = sellQuotes;
         });
 
         it('should select valid quotes', () => {

--- a/suite-native/module-trading/src/selectors/buySelectors.ts
+++ b/suite-native/module-trading/src/selectors/buySelectors.ts
@@ -31,7 +31,7 @@ import {
 
 const DEFAULT_FIAT_CURRENCY_FALLBACK = 'USD';
 
-export const selectTradingBuy = (state: TradingRootState) => state.wallet.tradingNew.buy;
+export const selectTradingBuy = (state: TradingRootState) => state.wallet.trading.buy;
 
 export const selectBuySelectedReceiveAccount = createMemoizedSelectorWithAccounts(
     [state => state, selectTradingBuy],
@@ -55,7 +55,7 @@ export const selectBuyTradeableAssetsSorted = createMemoizedSelector(
         selectTradingBuySupportedCryptoIds as unknown as (
             state: TradingRootState,
         ) => ReturnType<typeof selectTradingBuySupportedCryptoIds>,
-        ({ wallet }) => wallet.tradingNew.info.coins,
+        ({ wallet }) => wallet.trading.info.coins,
     ],
     (cryptoIds, coins) => {
         if (!coins || !cryptoIds) {
@@ -73,7 +73,7 @@ export const selectBuyFormDefaultValues = createMemoizedSelector(
         selectTradingBuyInfo as unknown as (
             state: TradingRootState,
         ) => ReturnType<typeof selectTradingBuyInfo>,
-        ({ wallet }) => wallet.tradingNew.info.coins,
+        ({ wallet }) => wallet.trading.info.coins,
     ],
     (buyInfo, coins) => {
         if (!buyInfo || !coins) {

--- a/suite-native/module-trading/src/selectors/commonSelectors.ts
+++ b/suite-native/module-trading/src/selectors/commonSelectors.ts
@@ -62,7 +62,7 @@ const createFiatRatesMemoizedSelector = createWeakMapSelector.withTypes<
 >();
 
 export const selectTradingEnvironment = (state: TradingRootState) =>
-    state.wallet.tradingNew.tradingEnvironment;
+    state.wallet.trading.tradingEnvironment;
 
 export const selectIsTradingBuyEnabled = (state: MessageSystemRootState & FeatureFlagsRootState) =>
     selectIsFeatureFlagEnabled(state, FeatureFlag.IsTradingBuyEnabled) ||
@@ -107,17 +107,17 @@ export const selectIsTradingBlacklisted = (state: MessageSystemRootState) =>
 
 // trade for opening in detail
 export const selectTradeToBeOpened = (state: TradingRootState) => {
-    const orderId = state.wallet.tradingNew.tradeOrderIdToBeOpened;
+    const orderId = state.wallet.trading.tradeOrderIdToBeOpened;
     if (!orderId) return undefined;
 
-    return state.wallet.tradingNew.trades.find(trade => trade.data.orderId === orderId);
+    return state.wallet.trading.trades.find(trade => trade.data.orderId === orderId);
 };
 
 export const selectIsAmountInputActive = (state: TradingRootState) =>
-    state.wallet.tradingNew.isAmountInputActive;
+    state.wallet.trading.isAmountInputActive;
 
 export const selectActiveTradingType = (state: TradingRootState) =>
-    state.wallet.tradingNew.activeTradingType;
+    state.wallet.trading.activeTradingType;
 
 export const selectAmountInBaseFiatCurrency = createFiatRatesMemoizedSelector(
     [

--- a/suite-native/module-trading/src/selectors/exchangeSelectors.ts
+++ b/suite-native/module-trading/src/selectors/exchangeSelectors.ts
@@ -17,7 +17,7 @@ import {
     tradeableAssetSortingComparator,
 } from '../utils/general/tradeableAssetUtils';
 
-export const selectTradingExchange = (state: TradingRootState) => state.wallet.tradingNew.exchange;
+export const selectTradingExchange = (state: TradingRootState) => state.wallet.trading.exchange;
 
 export const selectExchangeSelectedSendAccount = createMemoizedSelectorWithAccounts(
     [state => state, selectTradingExchange],
@@ -38,7 +38,7 @@ export const selectExchangeBuyTradeableAssetsSorted = createMemoizedSelector(
         selectTradingExchangeBuyCryptoIds as unknown as (
             state: TradingRootState,
         ) => ReturnType<typeof selectTradingExchangeBuyCryptoIds>,
-        ({ wallet }) => wallet.tradingNew.info.coins,
+        ({ wallet }) => wallet.trading.info.coins,
     ],
     (cryptoIds, coins) => {
         if (!coins || !cryptoIds) {
@@ -52,7 +52,7 @@ export const selectExchangeBuyTradeableAssetsSorted = createMemoizedSelector(
 );
 
 export const selectExchangeQuotes = (state: TradingRootState) =>
-    state.wallet.tradingNew.exchange.quotes;
+    state.wallet.trading.exchange.quotes;
 
 const ratingSortingComparator = (
     a: { rate?: number | undefined },

--- a/suite-native/module-trading/src/selectors/favouritesSelectors.ts
+++ b/suite-native/module-trading/src/selectors/favouritesSelectors.ts
@@ -2,7 +2,7 @@ import { TradingRootState, createMemoizedSelector } from '../reducers';
 import { TradeableAsset } from '../types/general';
 
 export const selectTradingFavouriteAssets = (state: TradingRootState) =>
-    state.wallet.tradingNew.favouriteAssets;
+    state.wallet.trading.favouriteAssets;
 
 export const selectTradingFavouriteAssetsArray = createMemoizedSelector(
     [selectTradingFavouriteAssets],

--- a/suite-native/module-trading/src/selectors/sellSelectors.ts
+++ b/suite-native/module-trading/src/selectors/sellSelectors.ts
@@ -22,7 +22,7 @@ import { FiatCurrencyItem } from '../types/general';
 import { SellFormValues } from '../types/sell';
 
 const DEFAULT_FIAT_CURRENCY_FALLBACK = 'USD';
-export const selectTradingSell = (state: TradingRootState) => state.wallet.tradingNew.sell;
+export const selectTradingSell = (state: TradingRootState) => state.wallet.trading.sell;
 
 export const selectSellSupportedFiatCurrencies = (state: TradingRootState) =>
     returnStableArrayIfEmpty(
@@ -47,7 +47,7 @@ export const selectSellFormDefaultValues = createMemoizedSelector(
         selectTradingSellInfo as unknown as (
             state: TradingRootState,
         ) => ReturnType<typeof selectTradingSellInfo>,
-        ({ wallet }) => wallet.tradingNew.info.coins,
+        ({ wallet }) => wallet.trading.info.coins,
     ],
     (sellInfo, coins) => {
         if (!sellInfo || !coins) {

--- a/suite-native/module-trading/src/utils/buy/__tests__/quotesUtils.test.ts
+++ b/suite-native/module-trading/src/utils/buy/__tests__/quotesUtils.test.ts
@@ -15,7 +15,7 @@ describe('quotesUtils', () => {
 
     const renderUseTradingBuyForm = () =>
         renderHookWithStoreProviderAsync(() => useBuyForm(), {
-            preloadedState: { wallet: { tradingNew: getInitializedTradingState() } },
+            preloadedState: { wallet: { trading: getInitializedTradingState() } },
         });
 
     beforeEach(async () => {

--- a/suite-native/module-trading/src/utils/exchange/__tests__/quotesUtils.test.ts
+++ b/suite-native/module-trading/src/utils/exchange/__tests__/quotesUtils.test.ts
@@ -13,7 +13,7 @@ describe('quotesUtils', () => {
 
     const renderUseTradingBuyForm = () =>
         renderHookWithStoreProviderAsync(() => useExchangeForm(), {
-            preloadedState: { wallet: { tradingNew: getInitializedTradingState() } },
+            preloadedState: { wallet: { trading: getInitializedTradingState() } },
         });
 
     beforeEach(async () => {

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -145,7 +145,7 @@ export const prepareRootReducers = async () => {
         send: sendFormReducer,
         fees: feesReducer,
         stake: stakeReducer,
-        tradingNew: tradingPersistedReducer,
+        trading: tradingPersistedReducer,
         settings: walletSettingsPersistedReducer,
     });
 


### PR DESCRIPTION
## Description

Rename `tradingNew` to `trading`.

## Related Issue

Resolve #20995 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/rename-trading-new&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/rename-trading-new&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/rename-trading-new&lookback=7)