### PR TITLE
Suite - Unify stake/unstake/claim texts

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
@@ -200,6 +200,7 @@ export const TransactionReviewModalBodyInner = ({
 
     const actionTranslation = (source: 'heading' | 'button') =>
         getTransactionReviewModalActionTranslation({
+            symbol,
             stakeType,
             precomposedForm,
             tradingToken,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
@@ -115,7 +115,7 @@ const ClaimModalLoaded = ({ onCancel, selectedAccount }: ClaimModalModalProps) =
                             onClick={onClaimClick}
                             icon={isClaimingDisabled ? 'info' : undefined}
                         >
-                            <Translation id="TR_STAKE_CLAIM" />
+                            <Translation id="TR_CONTINUE" />
                         </Modal.Button>
                     </Tooltip>
                     <Modal.Button variant="tertiary" onClick={onCancelClick}>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
@@ -91,7 +91,12 @@ const ClaimModalLoaded = ({ onCancel, selectedAccount }: ClaimModalModalProps) =
     return (
         <Modal
             data-testid="@staking/claim-modal"
-            heading={<Translation id="TR_STAKE_CLAIM" />}
+            heading={
+                <Translation
+                    id="TR_STAKE_CLAIM_TOKEN"
+                    values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
+                />
+            }
             description={
                 <Translation
                     id="TR_STAKE_CLAIMED_AMOUNT_TRANSFERRED"

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeModal.tsx
@@ -42,7 +42,7 @@ export const StakeModalLoaded = ({ onCancel, selectedAccount }: StakeModalModalP
                 size="huge"
                 heading={
                     <Translation
-                        id="TR_STAKE_NETWORK"
+                        id="TR_STAKE_STAKE_TOKEN"
                         values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
                     />
                 }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/EverstakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/EverstakeModal.tsx
@@ -89,7 +89,7 @@ export const EverstakeModal = ({ onCancel }: EverstakeModalProps) => {
 
     return (
         <Modal
-            heading={<Translation id="TR_STAKE_NETWORK" values={{ symbol: displaySymbol }} />}
+            heading={<Translation id="TR_STAKE_STAKE_TOKEN" values={{ symbol: displaySymbol }} />}
             description={
                 <Translation
                     id="TR_STAKE_YOUR_FUNDS_MAINTAINED"

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeButton.tsx
@@ -1,6 +1,6 @@
 import { selectAreFeesLoading, selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
-import { Button, Tooltip } from '@trezor/components';
+import { Modal, Tooltip } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { Translation } from 'src/components/suite';
@@ -56,15 +56,14 @@ export const UnstakeButton = () => {
 
     return (
         <Tooltip content={unstakingMessageContent}>
-            <Button
-                type="submit"
+            <Modal.Button
                 isDisabled={isDisabled || isUnstakingDisabled}
                 isLoading={isLoading}
                 onClick={onUnstakeClick}
                 icon={isUnstakingDisabled ? 'info' : undefined}
             >
-                <Translation id="TR_STAKE_UNSTAKE" />
-            </Button>
+                <Translation id="TR_CONTINUE" />
+            </Modal.Button>
         </Tooltip>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeModal.tsx
@@ -1,3 +1,4 @@
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { CollapsibleBox, Column, Grid, H3, Modal } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
@@ -39,7 +40,12 @@ export const UnstakeModalLoaded = ({ onCancel, selectedAccount }: UnstakeModalMo
         <UnstakeFormContext.Provider value={unstakeContextValues}>
             <Modal
                 size="huge"
-                heading={<Translation id="TR_STAKE_UNSTAKE" />}
+                heading={
+                    <Translation
+                        id="TR_STAKE_UNSTAKE_TOKEN"
+                        values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
+                    />
+                }
                 description={<Translation id="TR_STAKE_CLAIM_AFTER_UNSTAKING" />}
                 onCancel={onCancelClick}
                 bottomContent={<UnstakeButton />}

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9412,10 +9412,6 @@ export default defineMessages({
         id: 'TR_STAKING_CARD_RESTAKE_TEXT',
         defaultMessage: 'Your rewards are restaked automatically—so your balance grows faster.',
     },
-    TR_STAKE_NETWORK: {
-        id: 'TR_STAKE_NETWORK',
-        defaultMessage: 'Stake {symbol}',
-    },
     TR_STAKE_RESTAKED_BADGE: {
         id: 'TR_STAKE_RESTAKED_BADGE',
         defaultMessage: 'Restaked',
@@ -9732,6 +9728,18 @@ export default defineMessages({
     TR_STAKE_CLAIM: {
         id: 'TR_STAKE_CLAIM',
         defaultMessage: 'Claim',
+    },
+    TR_STAKE_STAKE_TOKEN: {
+        id: 'TR_STAKE_STAKE_TOKEN',
+        defaultMessage: 'Stake {symbol}',
+    },
+    TR_STAKE_UNSTAKE_TOKEN: {
+        id: 'TR_STAKE_UNSTAKE_TOKEN',
+        defaultMessage: 'Unstake {symbol}',
+    },
+    TR_STAKE_CLAIM_TOKEN: {
+        id: 'TR_STAKE_CLAIM_TOKEN',
+        defaultMessage: 'Claim {symbol}',
     },
     TR_STAKE_STAKED_AMOUNT: {
         id: 'TR_STAKE_STAKED_AMOUNT',

--- a/packages/suite/src/utils/suite/transactionReview.ts
+++ b/packages/suite/src/utils/suite/transactionReview.ts
@@ -1,9 +1,11 @@
 import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
+import { NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { FormState, StakeFormState } from '@suite-common/wallet-types';
 import { getEvmTransactionTextSignature } from '@suite-common/wallet-utils';
 import { TokenInfo } from '@trezor/blockchain-link-types';
 
 interface GetTransactionReviewModalActionTranslationParams {
+    symbol: NetworkSymbol;
     stakeType: StakeFormState['stakeType'] | null;
     precomposedForm: FormState | StakeFormState;
     tradingToken: TokenInfo | undefined;
@@ -14,6 +16,7 @@ interface GetTransactionReviewModalActionTranslationParams {
 }
 
 export const getTransactionReviewModalActionTranslation = ({
+    symbol,
     stakeType,
     precomposedForm,
     tradingToken,
@@ -24,11 +27,20 @@ export const getTransactionReviewModalActionTranslation = ({
 }: GetTransactionReviewModalActionTranslationParams): ExtendedMessageDescriptor => {
     switch (stakeType) {
         case 'stake':
-            return { id: 'TR_STAKE_STAKE' };
+            return {
+                id: source === 'heading' ? 'TR_STAKE_STAKE_TOKEN' : 'TR_STAKE_STAKE',
+                values: { symbol: getNetworkDisplaySymbol(symbol) },
+            };
         case 'unstake':
-            return { id: 'TR_STAKE_UNSTAKE' };
+            return {
+                id: source === 'heading' ? 'TR_STAKE_UNSTAKE_TOKEN' : 'TR_STAKE_UNSTAKE',
+                values: { symbol: getNetworkDisplaySymbol(symbol) },
+            };
         case 'claim':
-            return { id: 'TR_STAKE_CLAIM' };
+            return {
+                id: source === 'heading' ? 'TR_STAKE_CLAIM_TOKEN' : 'TR_STAKE_CLAIM',
+                values: { symbol: getNetworkDisplaySymbol(symbol) },
+            };
         // no default
     }
 

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/EthStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/EthStakingDashboard.tsx
@@ -87,7 +87,7 @@ export const EthStakingDashboard = ({ selectedAccount }: EthStakingDashboardProp
                         <DashboardSection
                             heading={
                                 <Translation
-                                    id="TR_STAKE_NETWORK"
+                                    id="TR_STAKE_STAKE_TOKEN"
                                     values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
                                 />
                             }

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
@@ -54,7 +54,7 @@ export const SolStakingDashboard = ({ selectedAccount }: SolStakingDashboardProp
                         <DashboardSection
                             heading={
                                 <Translation
-                                    id="TR_STAKE_NETWORK"
+                                    id="TR_STAKE_STAKE_TOKEN"
                                     values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
                                 />
                             }

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/StakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/StakingDashboard.tsx
@@ -15,7 +15,7 @@ export const StakingDashboard = ({ selectedAccount, dashboard }: StakingDashboar
 
     return (
         <WalletLayout
-            title="TR_STAKE_NETWORK"
+            title="TR_STAKE_STAKE_TOKEN"
             titleValues={{ symbol: getNetworkDisplaySymbol(selectedAccount.account.symbol) }}
             account={selectedAccount}
         >

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
@@ -150,7 +150,7 @@ export const EmptyStakingCard = () => {
     return (
         <DashboardSection
             data-testid="@wallet/staking/empty-card"
-            heading={<Translation id="TR_STAKE_NETWORK" values={{ symbol: displaySymbol }} />}
+            heading={<Translation id="TR_STAKE_STAKE_TOKEN" values={{ symbol: displaySymbol }} />}
         >
             {!isDeviceConnected && <ConnectDeviceGenericPromo />}
             {isDiscoveryRunning && <DiscoveryWarning />}


### PR DESCRIPTION
## Description

Unify texts for stake/unstake/claim modals.

- changed all tx review modal headlines to `Stake ETH`/`Unstake ETH`/`Claim ETH`
- changed all tx review modal buttons to `Stake`/`Unstake`/`Claim`
- changed all other previous stake/unstake/claim modal buttons to `Continue`

## Related Issue

Resolve #21095 

## Screenshots:

<img width="100%" alt="Screenshot 2025-09-04 at 09 55 44" src="https://github.com/user-attachments/assets/f32654b6-6351-401d-8765-ca6eba785f50" />

<img width="100%" alt="Screenshot 2025-09-04 at 09 56 09" src="https://github.com/user-attachments/assets/277f68d2-1edb-4718-a2ed-86f353feb083" />

<img width="100%" alt="Screenshot 2025-09-04 at 10 02 39" src="https://github.com/user-attachments/assets/3dda5ca1-857d-4292-987b-3f93f276ff3a" />

<img width="100%" alt="Screenshot 2025-09-04 at 09 56 25" src="https://github.com/user-attachments/assets/49fb5f0f-5060-4032-9306-f8892607d761" />

<img width="100%" alt="Screenshot 2025-09-04 at 09 56 33" src="https://github.com/user-attachments/assets/1d3678e3-a6b2-42bc-8e97-3a3e0ce65ca9" />

<img width="100%" alt="Screenshot 2025-09-04 at 09 56 42" src="https://github.com/user-attachments/assets/fa9344fc-1e4e-4238-8fc3-4f351d4f9fdb" />

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/staking-headlines&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/staking-headlines&lookback=7)