### PR TITLE
feat(suite): Unify & Beautify base currency selection

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/BaseCurrency.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/BaseCurrency.tsx
@@ -1,30 +1,24 @@
 import { useMemo } from 'react';
 
 import { selectBaseCurrency, setBaseCurrency } from '@suite-common/wallet-core';
-import {
-    BaseCurrencyCode,
-    fiatBaseCurrencies,
-    valuablesBaseCurrencies,
-} from '@trezor/blockchain-link-types';
+import { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { EventType, analytics } from '@trezor/suite-analytics';
-import { typedObjectKeys } from '@trezor/utils';
 
 import { SettingsSectionItem } from 'src/components/settings';
 import { ActionColumn, ActionSelect, TextColumn, Translation } from 'src/components/suite';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
-
-const buildCurrencyOption = (currency: BaseCurrencyCode) => ({
-    value: currency,
-    label: currency.toUpperCase(),
-});
+import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
+import {
+    buildCurrencyOptions,
+    buildShortCurrencyOption,
+} from 'src/views/wallet/send/Outputs/Amount/BaseCurrencyOptions';
 
 export const BaseCurrency = () => {
-    const { translationString } = useTranslation();
     const baseCurrencyCode = useSelector(selectBaseCurrency);
+    const { areSatsDisplayed } = useBitcoinAmountUnit();
+    const { translationString } = useTranslation();
     const dispatch = useDispatch();
-
-    const value = buildCurrencyOption(baseCurrencyCode);
 
     const handleChange = (option: { value: BaseCurrencyCode; label: string }) => {
         dispatch(setBaseCurrency(option.value));
@@ -37,17 +31,8 @@ export const BaseCurrency = () => {
     };
 
     const options = useMemo(
-        () => [
-            {
-                label: translationString('TR_BASE_CURRENCY_FIAT'),
-                options: typedObjectKeys(fiatBaseCurrencies).map(buildCurrencyOption),
-            },
-            {
-                label: translationString('TR_BASE_CURRENCY_VALUABLES'),
-                options: typedObjectKeys(valuablesBaseCurrencies).map(buildCurrencyOption),
-            },
-        ],
-        [translationString],
+        () => buildCurrencyOptions({ translationString, areSatsDisplayed }),
+        [translationString, areSatsDisplayed],
     );
 
     return (
@@ -57,7 +42,10 @@ export const BaseCurrency = () => {
                 <ActionSelect
                     useKeyPressScroll
                     onChange={handleChange}
-                    value={value}
+                    value={buildShortCurrencyOption({
+                        currency: baseCurrencyCode,
+                        areSatsDisplayed,
+                    })}
                     options={options}
                     data-testid="@settings/fiat-select"
                 />

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { Controller } from 'react-hook-form';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -11,8 +12,6 @@ import {
     TokenAddress,
 } from '@suite-common/wallet-types';
 import {
-    buildCurrencyOption,
-    buildCurrencyOptions,
     findToken,
     getDecimalsForBaseCurrency,
     getInputState,
@@ -29,6 +28,8 @@ import { useSendFormContext } from 'src/hooks/wallet';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 import { validateDecimals } from 'src/utils/suite/validation';
+
+import { buildCurrencyOptions, buildShortCurrencyOption } from './BaseCurrencyOptions';
 
 type FiatInputProps = {
     output: Partial<Output>;
@@ -134,15 +135,17 @@ export const BaseCurrencyInput = ({
         };
     }
 
+    const options = useMemo(
+        () => buildCurrencyOptions({ translationString, areSatsDisplayed }),
+        [translationString, areSatsDisplayed],
+    );
+
     const renderCurrencySelect = ({
         field: { onChange, value: selectedOption },
     }: CallbackParams) => (
         <Select
-            options={buildCurrencyOptions({ selected: selectedOption, areSatsDisplayed })}
-            value={buildCurrencyOption({
-                currency: selectedOption.value,
-                areSatsDisplayed,
-            })}
+            options={options}
+            value={buildShortCurrencyOption({ currency: selectedOption.value, areSatsDisplayed })}
             isClearable={false}
             isSearchable
             minValueWidth="58px"

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyOptions.tsx
@@ -1,0 +1,69 @@
+import { isBaseCurrencyWithSats } from '@suite-common/wallet-utils';
+import {
+    BaseCurrencyCode,
+    baseCurrencies,
+    fiatBaseCurrencies,
+    valuablesBaseCurrencies,
+} from '@trezor/blockchain-link-types';
+import { typedObjectKeys } from '@trezor/utils';
+
+const CURRENCY_SEPARATOR = ' · ';
+
+type BuildCurrencyOptionParams = {
+    currency: BaseCurrencyCode | '';
+    areSatsDisplayed: boolean;
+};
+
+export const buildFullCurrencyOption = ({
+    currency,
+    areSatsDisplayed,
+}: BuildCurrencyOptionParams) => {
+    if (currency === '')
+        return {
+            value: '',
+            label: '',
+        };
+    else
+        return {
+            value: currency,
+            label:
+                isBaseCurrencyWithSats(currency) && areSatsDisplayed
+                    ? `SATS${CURRENCY_SEPARATOR}Satoshis`
+                    : `${currency.toUpperCase()}${CURRENCY_SEPARATOR}${baseCurrencies[currency].label}`,
+        };
+};
+
+export const buildShortCurrencyOption = ({
+    currency,
+    areSatsDisplayed,
+}: BuildCurrencyOptionParams) => {
+    const option = buildFullCurrencyOption({ currency, areSatsDisplayed });
+
+    return {
+        value: option.value,
+        label: option.label.split(CURRENCY_SEPARATOR)[0],
+    };
+};
+
+type BuildCurrencyOptionsParams = {
+    translationString: any;
+    areSatsDisplayed: boolean;
+};
+
+export const buildCurrencyOptions = ({
+    translationString,
+    areSatsDisplayed,
+}: BuildCurrencyOptionsParams) => [
+    {
+        label: translationString('TR_BASE_CURRENCY_FIAT'),
+        options: typedObjectKeys(fiatBaseCurrencies).map(currency =>
+            buildFullCurrencyOption({ currency, areSatsDisplayed }),
+        ),
+    },
+    {
+        label: translationString('TR_BASE_CURRENCY_VALUABLES'),
+        options: typedObjectKeys(valuablesBaseCurrencies).map(currency =>
+            buildFullCurrencyOption({ currency, areSatsDisplayed }),
+        ),
+    },
+];

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency.tsx
@@ -7,10 +7,11 @@ import {
     TRADING_FORM_OUTPUT_CURRENCY,
     TradingFiatCurrencyOption,
 } from '@suite-common/trading';
-import { buildCurrencyOptions } from '@suite-common/wallet-utils';
 import { Select } from '@trezor/components';
 
+import { useTranslation } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { TradingAllFormProps, TradingFormInputCurrencyProps } from 'src/types/trading/tradingForm';
 import {
     getFiatCurrenciesProps,
@@ -20,8 +21,7 @@ import {
     isTradingSellContext,
 } from 'src/utils/wallet/trading/tradingTypingUtils';
 import { buildTradingFiatOption } from 'src/utils/wallet/trading/tradingUtils';
-
-import { useBitcoinAmountUnit } from '../../../../../../hooks/wallet/useBitcoinAmountUnit';
+import { buildCurrencyOptions } from 'src/views/wallet/send/Outputs/Amount/BaseCurrencyOptions';
 
 export const TradingFormInputCurrency = ({
     isClean = true,
@@ -36,6 +36,7 @@ export const TradingFormInputCurrency = ({
     const fiatCurrencies = getFiatCurrenciesProps(context);
     const currencies = fiatCurrencies?.supportedFiatCurrencies ?? null;
     const { areSatsDisplayed } = useBitcoinAmountUnit(context.network.symbol);
+    const { translationString } = useTranslation();
 
     const options = useMemo(
         () =>
@@ -43,8 +44,8 @@ export const TradingFormInputCurrency = ({
                 ? [...currencies]
                       .map(currency => buildTradingFiatOption(currency))
                       .filter(currency => currency.value !== currentCurrency.value)
-                : buildCurrencyOptions({ selected: currentCurrency, areSatsDisplayed }),
-        [currencies, currentCurrency, areSatsDisplayed],
+                : buildCurrencyOptions({ translationString, areSatsDisplayed }),
+        [areSatsDisplayed, currencies, currentCurrency, translationString],
     );
 
     const onChangeAdditional = (option: TradingFiatCurrencyOption) => {

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -19,7 +19,6 @@ import {
 import type {
     Account,
     AccountKey,
-    BaseCurrencyOption,
     EthTransactionData,
     ExcludedUtxos,
     ExternalOutput,
@@ -31,8 +30,6 @@ import type {
     SendFormDraftKey,
     TokenAddress,
 } from '@suite-common/wallet-types';
-import { isBaseCurrencyWithSats } from '@suite-common/wallet-utils';
-import { BaseCurrencyCode, baseCurrencies } from '@trezor/blockchain-link-types';
 import {
     ComposeOutput,
     EthereumTransaction,
@@ -41,7 +38,6 @@ import {
     PROTO,
     TokenInfo,
 } from '@trezor/connect';
-import { typedObjectKeys } from '@trezor/utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import {
@@ -529,44 +525,6 @@ export const getDefaultValues = (currency: Output['currency']): FormState => ({
     outputs: [{ ...DEFAULT_PAYMENT, currency }],
     selectedUtxos: [],
 });
-
-type BuildCurrencyOptionParams = {
-    currency: BaseCurrencyCode | '';
-    areSatsDisplayed: boolean;
-};
-
-export const buildCurrencyOption = ({
-    currency,
-    areSatsDisplayed,
-}: BuildCurrencyOptionParams): BaseCurrencyOption => ({
-    value: currency,
-    label:
-        currency !== '' && isBaseCurrencyWithSats(currency) && areSatsDisplayed
-            ? 'Sats'
-            : currency.toUpperCase(),
-});
-
-type BuildCurrencyOptionsParams = {
-    selected: BaseCurrencyOption;
-    areSatsDisplayed: boolean;
-};
-
-export const buildCurrencyOptions = ({
-    selected,
-    areSatsDisplayed,
-}: BuildCurrencyOptionsParams): BaseCurrencyOption[] => {
-    const result: BaseCurrencyOption[] = [];
-
-    typedObjectKeys(baseCurrencies).forEach(currency => {
-        if (selected.value === currency) {
-            return;
-        }
-
-        result.push(buildCurrencyOption({ currency, areSatsDisplayed }));
-    });
-
-    return result;
-};
 
 export interface GetExcludedUtxosProps {
     utxos?: Account['utxo'];


### PR DESCRIPTION
Unified base currency options for `Select`s and added long names.

## Related Issue

Resolve #21021 

## Screenshots:
Before / after:

<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/1ae20f13-56f2-44ed-960d-5ce714581dff" />
<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/cdbba69f-8d4e-4207-9ce7-2c3ccd913c0d" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/unify-base-currency-selection&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/unify-base-currency-selection&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/unify-base-currency-selection&lookback=7)