### PR TITLE
chore(suite): prevent loading skeleton for zero-balance tokens in BaseCurrencyValue

### DIFF
--- a/packages/suite/src/components/suite/BaseCurrencyValue.tsx
+++ b/packages/suite/src/components/suite/BaseCurrencyValue.tsx
@@ -96,12 +96,16 @@ export const BaseCurrencyValue = ({
         selectIsSpecificCoinDefinitionKnown(state, symbol, tokenAddress || ('' as TokenAddress)),
     );
 
-    if (
-        (!rate || !value || !currentRate?.lastTickerTimestamp || isLoading) &&
+    const isZeroAmount = new BigNumber(amount ?? 0).isZero();
+
+    const isLoadingSkeletonVisible =
         showLoadingSkeleton &&
+        isTokenKnown &&
+        !isZeroAmount &&
         !currentRate?.error &&
-        isTokenKnown
-    ) {
+        (currentRate?.isLoading || isLoading);
+
+    if (isLoadingSkeletonVisible) {
         return <SkeletonRectangle animate={shouldAnimate} />;
     }
 


### PR DESCRIPTION
## Description

Not fetching fiat rates for tokens with a 0 balance (#21063) caused the `BaseCurrencyValue` component to remain stuck on the skeleton screen when `currentRate` was unavailable. This PR fixes that behavior and adds explicit handling for 0 amounts.

## Screenshots:

### Before
<img width="877" height="317" alt="before" src="https://github.com/user-attachments/assets/4a2effd2-51e7-45cf-8970-413fa71e190e" />

### After
<img width="877" height="312" alt="after" src="https://github.com/user-attachments/assets/e32a7374-f40c-4688-9b0b-8f7baf298a0b" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/base-currency-loading-update&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/base-currency-loading-update&lookback=7)