### PR TITLE
chore(suite-common): use less blocking verification

### DIFF
--- a/suite-common/message-system/eslint.config.mjs
+++ b/suite-common/message-system/eslint.config.mjs
@@ -1,0 +1,18 @@
+import { eslint, globalNoExtraneousDependenciesDevDependencies } from '@trezor/eslint';
+
+export default [
+    ...eslint,
+    {
+        rules: {
+            'import/no-extraneous-dependencies': [
+                'error',
+                {
+                    devDependencies: [
+                        ...globalNoExtraneousDependenciesDevDependencies,
+                        '**/scripts/**',
+                    ],
+                },
+            ],
+        },
+    },
+];

--- a/suite-common/message-system/package.json
+++ b/suite-common/message-system/package.json
@@ -27,7 +27,6 @@
         "@types/semver": "^7.7.0",
         "fs-extra": "^11.3.1",
         "json-schema-to-typescript": "^15.0.4",
-        "jws": "^4.0.0",
         "react": "19.0.0",
         "react-redux": "9.2.0",
         "semver": "^7.7.1",
@@ -35,7 +34,9 @@
     },
     "devDependencies": {
         "@suite-common/test-utils": "workspace:*",
+        "@trezor/eslint": "workspace:*",
         "@types/fs-extra": "^11.0.4",
+        "jws": "^4.0.0",
         "tsx": "^4.20.3"
     },
     "nx": {

--- a/suite-common/message-system/src/messageSystemThunks.ts
+++ b/suite-common/message-system/src/messageSystemThunks.ts
@@ -1,9 +1,7 @@
-import { decode, verify } from 'jws';
-
 import { createThunk } from '@suite-common/redux-utils';
 import { MessageSystem } from '@suite-common/suite-types';
-import { PollingController } from '@suite-common/suite-utils';
-import { getJWSPublicKey, isCodesignBuild, isNative } from '@trezor/env-utils';
+import { PollingController, decodeJws, verifyJws } from '@suite-common/suite-utils';
+import { isCodesignBuild, isNative } from '@trezor/env-utils';
 import { scheduleAction } from '@trezor/utils';
 
 import { ACTION_PREFIX, messageSystemActions } from './messageSystemActions';
@@ -84,7 +82,7 @@ export const fetchConfigThunk = createThunk(
             try {
                 const { configJws, isRemote } = await getConfigJws(useLocalConfig);
 
-                const decodedJws = decode(configJws);
+                const decodedJws = decodeJws(configJws);
 
                 if (!decodedJws) {
                     throw Error('Decoding of config failed');
@@ -95,17 +93,7 @@ export const fetchConfigThunk = createThunk(
                     throw Error(`Wrong algorithm in JWS config header: ${algorithmInHeader}`);
                 }
 
-                const authenticityPublicKey = getJWSPublicKey();
-
-                if (!authenticityPublicKey) {
-                    throw Error('JWS public key is not defined!');
-                }
-
-                const isAuthenticityValid = verify(
-                    configJws,
-                    JWS_SIGN_ALGORITHM,
-                    authenticityPublicKey,
-                );
+                const isAuthenticityValid = await verifyJws(configJws, JWS_SIGN_ALGORITHM);
 
                 if (!isAuthenticityValid) {
                     throw Error('Config authenticity is invalid');

--- a/suite-common/message-system/tsconfig.json
+++ b/suite-common/message-system/tsconfig.json
@@ -11,6 +11,7 @@
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/env-utils" },
         { "path": "../../packages/utils" },
-        { "path": "../test-utils" }
+        { "path": "../test-utils" },
+        { "path": "../../packages/eslint" }
     ]
 }

--- a/suite-common/suite-utils/package.json
+++ b/suite-common/suite-utils/package.json
@@ -18,9 +18,11 @@
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/env-utils": "workspace:*",
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "date-fns": "^4.1.0"
+        "date-fns": "^4.1.0",
+        "jws": "^4.0.0"
     },
     "devDependencies": {
         "@trezor/device-utils": "workspace:^"

--- a/suite-common/suite-utils/src/index.ts
+++ b/suite-common/suite-utils/src/index.ts
@@ -7,4 +7,5 @@ export * from './txsPerPage';
 export * from './parseFirmwareChangelog';
 export * from './protocol';
 export * from './invariant';
+export * from './jws';
 export * from './pollingController';

--- a/suite-common/suite-utils/src/jws.ts
+++ b/suite-common/suite-utils/src/jws.ts
@@ -1,0 +1,26 @@
+import { Algorithm, createVerify, decode } from 'jws';
+
+import { getJWSPublicKey } from '@trezor/env-utils';
+
+const authenticityPublicKey = getJWSPublicKey();
+
+export const verifyJws = (jws: string, algorithm: Algorithm) =>
+    new Promise<boolean>((resolve, reject) => {
+        if (!authenticityPublicKey) {
+            throw Error('JWS public key is not defined!');
+        }
+
+        try {
+            const verifier = createVerify({
+                algorithm,
+                publicKey: authenticityPublicKey,
+                signature: jws,
+            });
+            verifier.on('done', (valid: boolean) => resolve(valid));
+            verifier.on('error', reject);
+        } catch (e) {
+            reject(e);
+        }
+    });
+
+export const decodeJws = decode;

--- a/suite-common/suite-utils/tsconfig.json
+++ b/suite-common/suite-utils/tsconfig.json
@@ -8,6 +8,7 @@
         { "path": "../wallet-config" },
         { "path": "../wallet-types" },
         { "path": "../../packages/connect" },
+        { "path": "../../packages/env-utils" },
         { "path": "../../packages/urls" },
         { "path": "../../packages/utils" },
         { "path": "../../packages/device-utils" }

--- a/suite-common/token-definitions/eslint.config.mjs
+++ b/suite-common/token-definitions/eslint.config.mjs
@@ -1,0 +1,18 @@
+import { eslint, globalNoExtraneousDependenciesDevDependencies } from '@trezor/eslint';
+
+export default [
+    ...eslint,
+    {
+        rules: {
+            'import/no-extraneous-dependencies': [
+                'error',
+                {
+                    devDependencies: [
+                        ...globalNoExtraneousDependenciesDevDependencies,
+                        '**/scripts/**',
+                    ],
+                },
+            ],
+        },
+    },
+];

--- a/suite-common/token-definitions/package.json
+++ b/suite-common/token-definitions/package.json
@@ -25,10 +25,11 @@
         "@trezor/connect": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*",
-        "@trezor/utils": "workspace:*",
-        "jws": "^4.0.0"
+        "@trezor/utils": "workspace:*"
     },
     "devDependencies": {
-        "ajv": "^8.17.1"
+        "@trezor/eslint": "workspace:*",
+        "ajv": "^8.17.1",
+        "jws": "^4.0.0"
     }
 }

--- a/suite-common/token-definitions/scripts/utils/validate.ts
+++ b/suite-common/token-definitions/scripts/utils/validate.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-// eslint-disable-next-line import/no-extraneous-dependencies
 import Ajv from 'ajv';
 import * as fs from 'fs';
 import { join } from 'path';

--- a/suite-common/token-definitions/src/tokenDefinitionsUtils.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsUtils.ts
@@ -1,10 +1,8 @@
-import { G } from '@mobily/ts-belt';
-import { decode, verify } from 'jws';
-
+import { decodeJws, verifyJws } from '@suite-common/suite-utils';
 import { NetworkSymbol, getCoingeckoId, getNetworkFeatures } from '@suite-common/wallet-config';
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { TokenInfo } from '@trezor/connect';
-import { getJWSPublicKey, isCodesignBuild } from '@trezor/env-utils';
+import { isCodesignBuild } from '@trezor/env-utils';
 
 import {
     JWS_SIGN_ALGORITHM,
@@ -132,7 +130,7 @@ export const fetchTokenDefinitions = async (
 
     const jws = await response.text();
 
-    const decodedJws = decode(jws);
+    const decodedJws = decodeJws(jws);
 
     if (!decodedJws) {
         throw Error('Decoding of config failed');
@@ -143,13 +141,7 @@ export const fetchTokenDefinitions = async (
         throw Error(`Wrong algorithm in JWS config header: ${algorithmInHeader}`);
     }
 
-    const authenticityPublicKey = getJWSPublicKey();
-
-    if (G.isNullable(authenticityPublicKey)) {
-        throw Error('Public key check token definitions authenticity was not found.');
-    }
-
-    const isAuthenticityValid = verify(jws, JWS_SIGN_ALGORITHM, authenticityPublicKey);
+    const isAuthenticityValid = await verifyJws(jws, JWS_SIGN_ALGORITHM);
 
     if (!isAuthenticityValid) {
         throw Error('Config authenticity is invalid');

--- a/suite-common/token-definitions/tsconfig.json
+++ b/suite-common/token-definitions/tsconfig.json
@@ -18,6 +18,7 @@
         { "path": "../../packages/connect" },
         { "path": "../../packages/env-utils" },
         { "path": "../../packages/type-utils" },
-        { "path": "../../packages/utils" }
+        { "path": "../../packages/utils" },
+        { "path": "../../packages/eslint" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9604,6 +9604,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"
+    "@trezor/eslint": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/fs-extra": "npm:^11.0.4"
     "@types/semver": "npm:^7.7.0"
@@ -9723,9 +9724,11 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:^"
+    "@trezor/env-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     date-fns: "npm:^4.1.0"
+    jws: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -9789,6 +9792,7 @@ __metadata:
     "@trezor/blockchain-link-utils": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/env-utils": "workspace:*"
+    "@trezor/eslint": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     ajv: "npm:^8.17.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use async verifier stream instead of sync `jws.verify` to make the slow verification less blocking.

Tested by repeating verification 10 times and checking how responsive is the app during that process. It is almost fully blocked using `jws.verify` but using `jws.createVerify` I can switch tabs in mobile app during the verification.

I would like to apply the same in `packages/connect/src/utils/firmwareReleaseConfigUtils.ts`, but I didn't find a nice common place where to put it as a shared util with Connect and also error handling had some weird behaviour there and It needs more investigation. At the same time we agreed with @karliatto that he will slightly change the firmwareReleaseConfigUtils to use local config as simple JSON instead of JWS file to help us with the performance issue during startup and I don't want to create unnecessary conflicts there.

## Related Issue

Resolve partially https://github.com/trezor/trezor-suite/issues/20950


## Notes for @trezor/qa 
Please make sure that message-system and token definitions still work as expected.
 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/jws-less-blocking&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/jws-less-blocking&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/jws-less-blocking&lookback=7)