### PR TITLE
chore(suite-desktop): enable log from transport-bluetooth

### DIFF
--- a/packages/suite-desktop-core/src/libs/processes/BaseProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/BaseProcess.ts
@@ -1,4 +1,4 @@
-import { ChildProcess, spawn } from 'child_process';
+import { ChildProcess, IOType, spawn } from 'child_process';
 import { app } from 'electron';
 import path from 'path';
 
@@ -15,12 +15,15 @@ export type Status = {
  * [startupCooldown] Cooldown before being able to run start again (seconds).
  * [stopKillWait] How long to wait before killing the process on stop (seconds).
  * [autoRestart] Seconds to wait before auto-restarting the process (seconds). 0 = off.
+ * [env] additional env variables.
+ * [stdio] inherit process stdio. doesn't work on windows, "inherit" works on linux/macos
  */
 export type Options = {
     startupCooldown?: number;
     stopKillWait?: number;
     autoRestart?: number;
     env?: Record<string, string | undefined>;
+    stdio?: IOType;
 };
 
 const defaultOptions: Options = {
@@ -142,7 +145,7 @@ export abstract class BaseProcess {
             this.process = spawn(processPath, params, {
                 cwd: processDir,
                 env: processEnv,
-                stdio: ['ignore', 'ignore', 'ignore'],
+                stdio: this.options.stdio || ['ignore', 'ignore', 'ignore'],
             });
             this.process.on('error', err => this.onError(err));
             this.process.on('close', code => this.onExit(code));

--- a/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
@@ -1,15 +1,18 @@
 import path from 'path';
 
 import { isDevEnv } from '@suite-common/suite-utils';
-import { isMacOs } from '@trezor/env-utils';
+import { isMacOs, isWindows } from '@trezor/env-utils';
 
 import { BaseProcess, Status } from './BaseProcess';
 import { getSwitchValue } from '../process-switches';
 
 export class BluetoothProcess extends BaseProcess {
     private readonly port;
+    private readonly debug;
 
     constructor(port = 21327) {
+        const debug = isDevEnv || getSwitchValue('log-level') === 'debug';
+
         super('bluetooth', 'trezor-bluetooth', {
             autoRestart: 0,
             env: {
@@ -18,8 +21,11 @@ export class BluetoothProcess extends BaseProcess {
                 XDG_CURRENT_DESKTOP:
                     process.env.ORIGINAL_XDG_CURRENT_DESKTOP || process.env.XDG_CURRENT_DESKTOP,
             },
+            stdio: debug && !isWindows() ? 'inherit' : undefined,
         });
+
         this.port = port;
+        this.debug = debug;
     }
 
     getUrl() {
@@ -65,7 +71,7 @@ export class BluetoothProcess extends BaseProcess {
     }
 
     async start() {
-        if (isDevEnv || getSwitchValue('log-level') === 'debug') {
+        if (this.debug) {
             process.env.RUST_LOG = 'debug';
             process.env.RUST_BACKTRACE = '1';
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
conditionally enabling `stdio` from the `transport-bluetooth` process.

we are enabling it [back and forth](https://github.com/trezor/trezor-suite/pull/7429)  as there is some problem with windows. https://github.com/trezor/trezor-suite/issues/7427
this time its enabled only in debug builds excluding windows

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bt-process-log&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bt-process-log&lookback=7)