### PR TITLE
chore(transport-bluetooth): disable write throttling

### DIFF
--- a/packages/suite-desktop-core/src/modules/bluetooth.ts
+++ b/packages/suite-desktop-core/src/modules/bluetooth.ts
@@ -1,6 +1,5 @@
 import { ipcMain } from 'electron';
 
-import { isMacOs, isWindows } from '@trezor/env-utils';
 import { IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
 import { getFreePort } from '@trezor/node-utils';
 import { BluetoothIpc, BluetoothIpcApi, BluetoothTransport } from '@trezor/transport-bluetooth';
@@ -67,8 +66,8 @@ export const init: ModuleInit = () => {
                   url: bluetoothProcess.getUrl(),
                   logger: desktopLogger,
                   messages: {}, // will be added by @trezor/connect transport initialization
-                  writeWithResponse: isMacOs(),
-                  writeWithDelay: isWindows(),
+                  // writeWithResponse: isMacOs(),
+                  // writeWithDelay: isWindows(),
               })
             : undefined;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
With [recent FW fixes](https://github.com/trezor/trezor-firmware/pull/5654) seems like its not required anymore.
i'm not removing the code completely  as it might be needed in the future, bootloader mode is faster than firmware mode.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/disable-bt-throttling&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/disable-bt-throttling&lookback=7)