### PR TITLE
fix(suite-native): trading card title line break

### DIFF
--- a/suite-native/module-trading/src/components/general/CardTitle.tsx
+++ b/suite-native/module-trading/src/components/general/CardTitle.tsx
@@ -7,7 +7,7 @@ export type CardTitleProps = {
 };
 
 export const CardTitle = ({ children }: CardTitleProps) => (
-    <Box paddingHorizontal="sp8">
+    <Box paddingHorizontal="sp8" flex={1}>
         <Text variant="body" color="textDefault">
             {children}
         </Text>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve #21034 

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=21034-bad-linebreak-in-buy&lookback=7)