### PR TITLE
Bump foundation deps 2025.09

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
         "@types/node": "22.13.10",
         "babel-jest": "30.0.0",
         "depcheck": "^1.4.7",
-        "eslint": "^9.33.0",
+        "eslint": "^9.34.0",
         "husky": "^9.1.7",
         "jest": "29.7.0",
         "jest-expo": "53.0.9",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
         "type-fest": "4.24.0",
         "bcrypto": "5.4.0",
         "react": "19.0.0",
-        "electron": "37.2.6",
+        "electron": "38.0.0",
         "@types/node": "22.13.10",
         "bn.js": "5.2.2",
         "node-addon-api": "8.5.0",

--- a/packages/connect-examples/electron-main-process/package.json
+++ b/packages/connect-examples/electron-main-process/package.json
@@ -56,7 +56,7 @@
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
-        "electron": "37.2.6",
+        "electron": "38.0.0",
         "electron-builder": "26.0.3"
     }
 }

--- a/packages/connect-examples/electron-renderer-with-popup/package.json
+++ b/packages/connect-examples/electron-renderer-with-popup/package.json
@@ -53,7 +53,7 @@
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
-        "electron": "37.2.6",
+        "electron": "38.0.0",
         "electron-builder": "26.0.3"
     }
 }

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -10,8 +10,8 @@
         "type-check": "yarn g:tsc --build"
     },
     "devDependencies": {
-        "@eslint/js": "^9.33.0",
-        "eslint": "^9.33.0",
+        "@eslint/js": "^9.34.0",
+        "eslint": "^9.34.0",
         "eslint-plugin-chai-friendly": "^1.1.0",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jest": "^29.0.1",
@@ -21,6 +21,6 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
         "globals": "^16.3.0",
-        "typescript-eslint": "^8.39.0"
+        "typescript-eslint": "^8.42.0"
     }
 }

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -1,5 +1,6 @@
 import tseslint from 'typescript-eslint';
 
+/** @type {import('typescript-eslint').ConfigArray} */
 export const typescriptConfig = [
     ...tseslint.configs.recommended,
     {

--- a/packages/suite-build/configs/desktop.webpack.config.ts
+++ b/packages/suite-build/configs/desktop.webpack.config.ts
@@ -22,9 +22,9 @@ const baseDir = getPathForProject('desktop');
 const BLUETOOTH_BIN_FILTER = !isDev && !process.env.BLUETOOTH ? [/bin\/bluetooth\//] : [];
 
 const config: webpack.Configuration = {
-    // Electron 37 runs on Chromium 138 https://www.electronjs.org/blog/electron-37-0#stack-changes
-    // but we are limited to 137 (supported by latest browserslist, as included by latest webpack)
-    target: 'browserslist:Chrome >= 137',
+    // Electron 38 runs on Chromium 140 https://github.com/electron/electron/releases/tag/v38.0.0
+    // but we are limited to 138 (supported by latest browserslist, as included by latest webpack)
+    target: 'browserslist:Chrome >= 138',
     entry: [path.join(baseDirUI, 'src', 'index.tsx')],
     output: {
         path: path.join(baseDir, 'build'),

--- a/packages/suite-desktop-api/package.json
+++ b/packages/suite-desktop-api/package.json
@@ -18,6 +18,6 @@
         "type-check": "yarn g:tsc --build tsconfig.json"
     },
     "dependencies": {
-        "electron": "37.2.6"
+        "electron": "38.0.0"
     }
 }

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -55,7 +55,7 @@
     "devDependencies": {
         "@currents/playwright": "^1.13.4",
         "@electron/fuses": "^2.0.0",
-        "@electron/notarize": "3.0.2",
+        "@electron/notarize": "3.1.0",
         "@octokit/rest": "^21.1.1",
         "@playwright/browser-chromium": "^1.52.0",
         "@playwright/browser-firefox": "^1.52.0",

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -72,7 +72,7 @@
         "@types/ws": "^8.5.13",
         "app-builder-lib": "^26.0.12",
         "dotenv": "^16.4.7",
-        "electron": "37.2.6",
+        "electron": "38.0.0",
         "fs-extra": "^11.3.1",
         "glob": "^11.0.3",
         "jest-diff": "^29.7.0",

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -49,7 +49,7 @@
         "electron-localshortcut": "^3.2.1",
         "electron-store": "8.2.0",
         "electron-updater": "6.6.4",
-        "openpgp": "^6.2.0",
+        "openpgp": "^6.2.2",
         "ws": "^8.18.0"
     },
     "devDependencies": {

--- a/packages/suite-desktop-ui/package.json
+++ b/packages/suite-desktop-ui/package.json
@@ -28,7 +28,7 @@
         "react-dom": "19.0.0",
         "react-helmet-async": "^2.0.5",
         "react-redux": "9.2.0",
-        "react-router": "^7.8.0",
+        "react-router": "^7.8.2",
         "styled-components": "^6.1.19"
     },
     "devDependencies": {

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "blake-hash": "^2.0.0",
-        "openpgp": "^6.2.0",
+        "openpgp": "^6.2.2",
         "usb": "^2.15.0"
     },
     "devDependencies": {

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -28,7 +28,7 @@
         "usb": "^2.15.0"
     },
     "devDependencies": {
-        "electron": "37.2.6",
+        "electron": "38.0.0",
         "electron-builder": "26.0.3"
     }
 }

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -23,7 +23,7 @@
         "react-dom": "19.0.0",
         "react-helmet-async": "^2.0.5",
         "react-redux": "9.2.0",
-        "react-router": "^7.8.0"
+        "react-router": "^7.8.2"
     },
     "devDependencies": {
         "@suite-common/test-utils": "workspace:*",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -112,7 +112,7 @@
         "react-hook-form": "^7.62.0",
         "react-intl": "^7.1.11",
         "react-redux": "9.2.0",
-        "react-router": "^7.8.0",
+        "react-router": "^7.8.2",
         "react-select": "^5.10.2",
         "react-svg": "16.3.0",
         "react-toastify": "^10.0.4",

--- a/suite-common/test-utils/package.json
+++ b/suite-common/test-utils/package.json
@@ -18,8 +18,8 @@
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "core-js": "^3.45.0",
-        "fake-indexeddb": "^6.1.0",
+        "core-js": "^3.45.1",
+        "fake-indexeddb": "^6.2.2",
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12662,7 +12662,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/suite-desktop-api@workspace:packages/suite-desktop-api"
   dependencies:
-    electron: "npm:37.2.6"
+    electron: "npm:38.0.0"
   languageName: unknown
   linkType: soft
 
@@ -12715,7 +12715,7 @@ __metadata:
     app-builder-lib: "npm:^26.0.12"
     chalk: "npm:^4.1.2"
     dotenv: "npm:^16.4.7"
-    electron: "npm:37.2.6"
+    electron: "npm:38.0.0"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:8.2.0"
     electron-updater: "npm:6.6.4"
@@ -12778,7 +12778,7 @@ __metadata:
   resolution: "@trezor/suite-desktop@workspace:packages/suite-desktop"
   dependencies:
     blake-hash: "npm:^2.0.0"
-    electron: "npm:37.2.6"
+    electron: "npm:38.0.0"
     electron-builder: "npm:26.0.3"
     openpgp: "npm:^6.2.0"
     usb: "npm:^2.15.0"
@@ -18752,7 +18752,7 @@ __metadata:
   dependencies:
     "@trezor/connect": "workspace:*"
     "@trezor/eslint": "workspace:*"
-    electron: "npm:37.2.6"
+    electron: "npm:38.0.0"
     electron-builder: "npm:26.0.3"
   languageName: unknown
   linkType: soft
@@ -18762,7 +18762,7 @@ __metadata:
   resolution: "connect-example-electron-renderer-popup@workspace:packages/connect-examples/electron-renderer-with-popup"
   dependencies:
     "@trezor/eslint": "workspace:*"
-    electron: "npm:37.2.6"
+    electron: "npm:38.0.0"
     electron-builder: "npm:26.0.3"
   languageName: unknown
   linkType: soft
@@ -21154,16 +21154,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:37.2.6":
-  version: 37.2.6
-  resolution: "electron@npm:37.2.6"
+"electron@npm:38.0.0":
+  version: 38.0.0
+  resolution: "electron@npm:38.0.0"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/b70ff62e22b13f9e7a0677d455da1e43e55db4fa7b7dca14ff3f0e5f0b653370d8008bc91881ffa67161528c8ec77e9b067bc155091e2fd4eca810010df97b6e
+  checksum: 10/a245bf63fae60d1db85acddbe5787750e4d07acb273a1a5058163aee427fe07e52100b0d5a1e6b41efbdc1b398b6e7ec0fb3df75672e9148e95b31309d0c8f3a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9741,8 +9741,8 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/utils": "workspace:*"
-    core-js: "npm:^3.45.0"
-    fake-indexeddb: "npm:^6.1.0"
+    core-js: "npm:^3.45.1"
+    fake-indexeddb: "npm:^6.2.2"
     redux: "npm:^5.0.1"
     redux-thunk: "npm:^3.1.0"
   languageName: unknown
@@ -18970,10 +18970,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:^3.30.2, core-js@npm:^3.45.0":
-  version: 3.45.0
-  resolution: "core-js@npm:3.45.0"
-  checksum: 10/162cd63b4d4cb2fed7a8635e69b760f4247e5d39ea99348e0b66af8e8899395a34de1b93504eb8db2adf4c47a0756475545c3da9c24875c7c33396fa8dc061c1
+"core-js@npm:^3.30.2, core-js@npm:^3.45.1":
+  version: 3.45.1
+  resolution: "core-js@npm:3.45.1"
+  checksum: 10/b9dca79b1af8bb4f0d4af0752ea98d694fe157abaf55513fd4084df32dfd4398f0fc57898b32cdb643c1cecb87b9231c2a2ce535797c80ae328eac6d6078ee61
   languageName: node
   linkType: hard
 
@@ -23437,10 +23437,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fake-indexeddb@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "fake-indexeddb@npm:6.1.0"
-  checksum: 10/89064dcf823179db27e4ecd680fc52aa791af093f40c4065a8cc1e2393663403de19a0e261d185727a9b7b3ce2dff38a245f0bb8c0db57c098e2205d486a4cad
+"fake-indexeddb@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "fake-indexeddb@npm:6.2.2"
+  checksum: 10/b2dd94419ebc836bf8b68badf653fbba878a73ea775f4c0fbcc55ee1a5d67fbf4be469388fd8044c80e11e8c5be37bc697131ec2747191e3d4569e009e0bb403
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2198,13 +2198,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@electron/notarize@npm:3.0.2":
-  version: 3.0.2
-  resolution: "@electron/notarize@npm:3.0.2"
+"@electron/notarize@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@electron/notarize@npm:3.1.0"
   dependencies:
     debug: "npm:^4.4.0"
     promise-retry: "npm:^2.0.1"
-  checksum: 10/224ccbd79eaff416070ec4d86fc87d4731911e19c2221bf322d04210faa4b122bd91c3eb1dc151d76a25bb8cad42a16e8c8d6274c853662b63168b6dc1799442
+  checksum: 10/9534fc7fd298c82abd79d0d3af34c432e84790703ace2fcbf296e0e64802ce352a309ecb920c54ac7baacd33bea4150c81512d0c8827e4cbab1519784cbc6527
   languageName: node
   linkType: hard
 
@@ -12672,7 +12672,7 @@ __metadata:
   dependencies:
     "@currents/playwright": "npm:^1.13.4"
     "@electron/fuses": "npm:^2.0.0"
-    "@electron/notarize": "npm:3.0.2"
+    "@electron/notarize": "npm:3.1.0"
     "@octokit/rest": "npm:^21.1.1"
     "@playwright/browser-chromium": "npm:^1.52.0"
     "@playwright/browser-firefox": "npm:^1.52.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12765,7 +12765,7 @@ __metadata:
     react-dom: "npm:19.0.0"
     react-helmet-async: "npm:^2.0.5"
     react-redux: "npm:9.2.0"
-    react-router: "npm:^7.8.0"
+    react-router: "npm:^7.8.2"
     styled-components: "npm:^6.1.19"
     stylelint: "npm:^16.14.1"
     stylelint-config-standard: "npm:^38.0.0"
@@ -12822,7 +12822,7 @@ __metadata:
     react-dom: "npm:19.0.0"
     react-helmet-async: "npm:^2.0.5"
     react-redux: "npm:9.2.0"
-    react-router: "npm:^7.8.0"
+    react-router: "npm:^7.8.2"
     rimraf: "npm:^6.0.1"
     stylelint: "npm:^16.17.0"
     tsx: "npm:^4.20.3"
@@ -12943,7 +12943,7 @@ __metadata:
     react-hook-form: "npm:^7.62.0"
     react-intl: "npm:^7.1.11"
     react-redux: "npm:9.2.0"
-    react-router: "npm:^7.8.0"
+    react-router: "npm:^7.8.2"
     react-select: "npm:^5.10.2"
     react-svg: "npm:16.3.0"
     react-toastify: "npm:^10.0.4"
@@ -35824,9 +35824,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:^7.8.0":
-  version: 7.8.0
-  resolution: "react-router@npm:7.8.0"
+"react-router@npm:^7.8.2":
+  version: 7.8.2
+  resolution: "react-router@npm:7.8.2"
   dependencies:
     cookie: "npm:^1.0.1"
     set-cookie-parser: "npm:^2.6.0"
@@ -35836,7 +35836,7 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10/bb46458bd15f73749a82d8ba0818d9ea98088378d569fd500aa4477cd08c1e359241b97de579f29e8bc78f8b81c76f660255b27a6249c305e4c66399f073e4df
+  checksum: 10/d1af3980cdfe8b915f6a8b219d57f18f9e3c4c062fa33bbb0946d4ff18c4c09fbf2f5c3616f5953f576c1d3be31616e4578773794cbb6eacf7812050997e04a2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12723,7 +12723,7 @@ __metadata:
     glob: "npm:^11.0.3"
     jest-diff: "npm:^29.7.0"
     lodash: "npm:^4.17.21"
-    openpgp: "npm:^6.2.0"
+    openpgp: "npm:^6.2.2"
     terser-webpack-plugin: "npm:^5.3.14"
     tsx: "npm:^4.20.3"
     webpack: "npm:5.100.0"
@@ -12780,7 +12780,7 @@ __metadata:
     blake-hash: "npm:^2.0.0"
     electron: "npm:38.0.0"
     electron-builder: "npm:26.0.3"
-    openpgp: "npm:^6.2.0"
+    openpgp: "npm:^6.2.2"
     usb: "npm:^2.15.0"
   languageName: unknown
   linkType: soft
@@ -32943,10 +32943,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openpgp@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "openpgp@npm:6.2.0"
-  checksum: 10/01b7524ff1fafa5f9c80533ca00e72f3a1fd3f2daa0406e491289b5d9b8b96c1e977e68792324b78f4c78da3204fc2f343e06515775e14ab04d5fc35dfd828d2
+"openpgp@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "openpgp@npm:6.2.2"
+  checksum: 10/de563997f1063ecdfd62571cd0b54b1d4050f90a82b4b7328bbe7d09769c83dc1180cacbec13cb4d9ab185ead72cd568a676226b1d6071bf1e2deb9982a9a380
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2754,10 +2754,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.33.0, @eslint/js@npm:^9.33.0":
-  version: 9.33.0
-  resolution: "@eslint/js@npm:9.33.0"
-  checksum: 10/415031162eeee4ed67457585f3a3f3442521e75dd352932582683452c393d837da81cf9726a2cf097b444119ae2e405951e6b5d84546f67b6370fc36f27d8321
+"@eslint/js@npm:9.34.0, @eslint/js@npm:^9.34.0":
+  version: 9.34.0
+  resolution: "@eslint/js@npm:9.34.0"
+  checksum: 10/3bbe8423e2d11e0eeb70a79f5cd25b89a8920cade36e479e4288d1e01043b48a0d737f46d8e5dc91c53afad5bc0edc882cc5a5a024ac1ac31b0b7b4d4a9f16c0
   languageName: node
   linkType: hard
 
@@ -12397,8 +12397,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/eslint@workspace:packages/eslint"
   dependencies:
-    "@eslint/js": "npm:^9.33.0"
-    eslint: "npm:^9.33.0"
+    "@eslint/js": "npm:^9.34.0"
+    eslint: "npm:^9.34.0"
     eslint-plugin-chai-friendly: "npm:^1.1.0"
     eslint-plugin-import: "npm:^2.32.0"
     eslint-plugin-jest: "npm:^29.0.1"
@@ -12408,7 +12408,7 @@ __metadata:
     eslint-plugin-react: "npm:^7.37.5"
     eslint-plugin-react-hooks: "npm:^5.2.0"
     globals: "npm:^16.3.0"
-    typescript-eslint: "npm:^8.39.0"
+    typescript-eslint: "npm:^8.42.0"
   languageName: unknown
   linkType: soft
 
@@ -14492,106 +14492,106 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.39.0":
-  version: 8.39.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.39.0"
+"@typescript-eslint/eslint-plugin@npm:8.42.0":
+  version: 8.42.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.42.0"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.39.0"
-    "@typescript-eslint/type-utils": "npm:8.39.0"
-    "@typescript-eslint/utils": "npm:8.39.0"
-    "@typescript-eslint/visitor-keys": "npm:8.39.0"
+    "@typescript-eslint/scope-manager": "npm:8.42.0"
+    "@typescript-eslint/type-utils": "npm:8.42.0"
+    "@typescript-eslint/utils": "npm:8.42.0"
+    "@typescript-eslint/visitor-keys": "npm:8.42.0"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^7.0.0"
     natural-compare: "npm:^1.4.0"
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
-    "@typescript-eslint/parser": ^8.39.0
+    "@typescript-eslint/parser": ^8.42.0
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10/31f879990aaedbd0eaf4ccb670c0b8d0686db8ced8fe5b58fabe509e38cd46e385b38a89a192ffb9d8486bce0ae5bf0032623149e07f07fab1b6548cbe52c373
+  checksum: 10/fb5b0e0785f9fa9d5ef88e78ff189334b2d1c558efd7b5063508d50275224a8aa38d4af0478228b90d6be6620289384a8d814f05e0af8c952c204515c0f3514e
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.39.0":
-  version: 8.39.0
-  resolution: "@typescript-eslint/parser@npm:8.39.0"
+"@typescript-eslint/parser@npm:8.42.0":
+  version: 8.42.0
+  resolution: "@typescript-eslint/parser@npm:8.42.0"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.39.0"
-    "@typescript-eslint/types": "npm:8.39.0"
-    "@typescript-eslint/typescript-estree": "npm:8.39.0"
-    "@typescript-eslint/visitor-keys": "npm:8.39.0"
+    "@typescript-eslint/scope-manager": "npm:8.42.0"
+    "@typescript-eslint/types": "npm:8.42.0"
+    "@typescript-eslint/typescript-estree": "npm:8.42.0"
+    "@typescript-eslint/visitor-keys": "npm:8.42.0"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10/9785994ff0cacaa168b460120177e4a78570dfbe105bfc9d27e8f58545ea07071cc8989910e72e3ae881945ad33986e004d14570824803016cc29408e9ec08b0
+  checksum: 10/25eb2d08c118742dc01c2aa279ea4ba2d277e2d9a042ffd4f9bda9e94d7ff2aa90b63aad1204a82617a5c63ddd3dd553d927944cd9c8345826484d0d523cf7ad
   languageName: node
   linkType: hard
 
-"@typescript-eslint/project-service@npm:8.39.0":
-  version: 8.39.0
-  resolution: "@typescript-eslint/project-service@npm:8.39.0"
+"@typescript-eslint/project-service@npm:8.42.0":
+  version: 8.42.0
+  resolution: "@typescript-eslint/project-service@npm:8.42.0"
   dependencies:
-    "@typescript-eslint/tsconfig-utils": "npm:^8.39.0"
-    "@typescript-eslint/types": "npm:^8.39.0"
+    "@typescript-eslint/tsconfig-utils": "npm:^8.42.0"
+    "@typescript-eslint/types": "npm:^8.42.0"
     debug: "npm:^4.3.4"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10/990ae23308993ac5fede1e2544fb3f3938424539d40adf810574d17283211533ebdddc42eb99c463ee493208a6700283401cede50f175cce0f2159bc61de96f7
+  checksum: 10/3e91fd4b4d60edd6fe3e108e8e75947de8aa060aab1de63c23017e8afeca72ef405faa6fcdd17e8aa0023261a81135d095072dc31343c57395e50450258d9fa5
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.39.0":
-  version: 8.39.0
-  resolution: "@typescript-eslint/scope-manager@npm:8.39.0"
+"@typescript-eslint/scope-manager@npm:8.42.0":
+  version: 8.42.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.42.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.39.0"
-    "@typescript-eslint/visitor-keys": "npm:8.39.0"
-  checksum: 10/c2b232a172221fc787eaef12e8ac59bbe211b7273c44c7f426c5b85dabb7470df899184a61ae35eded7d8de503d6c515856e4e5c2a616e7cf7f0ccd6a43ee255
+    "@typescript-eslint/types": "npm:8.42.0"
+    "@typescript-eslint/visitor-keys": "npm:8.42.0"
+  checksum: 10/81be2d908a9d2d83bc9fe5e9219b04277b9fa466bfa7faf45dc076e4b33b39db2fb99b34b8832e329c7db48ddfdc7b78f6c92b564cd6eec99e124d3feaad8645
   languageName: node
   linkType: hard
 
-"@typescript-eslint/tsconfig-utils@npm:8.39.0, @typescript-eslint/tsconfig-utils@npm:^8.39.0":
-  version: 8.39.0
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.39.0"
+"@typescript-eslint/tsconfig-utils@npm:8.42.0, @typescript-eslint/tsconfig-utils@npm:^8.42.0":
+  version: 8.42.0
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.42.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10/3457da49e7292bd07b1bd41f19661ea79481f3b6f6593fb1ecf6557c38c0f5fd77df397bc096d0bad400c4142d939d5fbaf060a524f9272c749cc02c53a65852
+  checksum: 10/927aa127983a62ddcbfbcd18806fd278e0bf18fade3cca658946f9ff4915e6a5c5cc85926afaa490512c88dd2950b2059f22b50b6d1f4461c9dbd755a4c71c1c
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.39.0":
-  version: 8.39.0
-  resolution: "@typescript-eslint/type-utils@npm:8.39.0"
+"@typescript-eslint/type-utils@npm:8.42.0":
+  version: 8.42.0
+  resolution: "@typescript-eslint/type-utils@npm:8.42.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.39.0"
-    "@typescript-eslint/typescript-estree": "npm:8.39.0"
-    "@typescript-eslint/utils": "npm:8.39.0"
+    "@typescript-eslint/types": "npm:8.42.0"
+    "@typescript-eslint/typescript-estree": "npm:8.42.0"
+    "@typescript-eslint/utils": "npm:8.42.0"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10/3efe4001b6b89bc8a32245fffc16b6aa6f1a5d571d7a103991fdb9f41afb1e7a3319ff3876182658a4296032a1475f8aa7853f6ad489e1491a1dda1d5c1da95e
+  checksum: 10/8d876bbd23c956b604d973c49720060c251f4d8cab255f1fd04826a9a1e3ab7c1310400d49d9ec6cdac3288d7a23cd9fb48d42777651ba53c02b5e1a34efd6e9
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.39.0, @typescript-eslint/types@npm:^8.39.0":
-  version: 8.39.0
-  resolution: "@typescript-eslint/types@npm:8.39.0"
-  checksum: 10/b08a42e8b5cc57f9b950150433386ac5da03d7f5e24b743fa0cb55f5672f314b5defa3cf9b1ed82af8e4de1265c9c79deab304910104091a24d41c70f2d98ff9
+"@typescript-eslint/types@npm:8.42.0, @typescript-eslint/types@npm:^8.42.0":
+  version: 8.42.0
+  resolution: "@typescript-eslint/types@npm:8.42.0"
+  checksum: 10/7c39a35e5bb7083070872edc797ea60a3d6ceff0e3bdf85701919b71da83a51963562053a4b35c9e2a2b08c138fb595e14bc0b5c450e671a26059b58f8d8b4f4
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.39.0":
-  version: 8.39.0
-  resolution: "@typescript-eslint/typescript-estree@npm:8.39.0"
+"@typescript-eslint/typescript-estree@npm:8.42.0":
+  version: 8.42.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.42.0"
   dependencies:
-    "@typescript-eslint/project-service": "npm:8.39.0"
-    "@typescript-eslint/tsconfig-utils": "npm:8.39.0"
-    "@typescript-eslint/types": "npm:8.39.0"
-    "@typescript-eslint/visitor-keys": "npm:8.39.0"
+    "@typescript-eslint/project-service": "npm:8.42.0"
+    "@typescript-eslint/tsconfig-utils": "npm:8.42.0"
+    "@typescript-eslint/types": "npm:8.42.0"
+    "@typescript-eslint/visitor-keys": "npm:8.42.0"
     debug: "npm:^4.3.4"
     fast-glob: "npm:^3.3.2"
     is-glob: "npm:^4.0.3"
@@ -14600,32 +14600,32 @@ __metadata:
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10/7e9dc461fe692a1b3a17fe0f8f3d9a361f3af0df115c2e3f72c82ee271d37107c1cddeeb976707d6fc3e24e87431c381d6045de5c187aff92c71847a22118ee8
+  checksum: 10/9bb5df97a2ac31e6e3ee6941e10702498a76d23235ba28a23d93e09aa75a2cbcd40dc74935d86706c8e2e55e1a8b6a34bb9fb234461920ed3d8a5abed68ba36b
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.39.0, @typescript-eslint/utils@npm:^8.0.0":
-  version: 8.39.0
-  resolution: "@typescript-eslint/utils@npm:8.39.0"
+"@typescript-eslint/utils@npm:8.42.0, @typescript-eslint/utils@npm:^8.0.0":
+  version: 8.42.0
+  resolution: "@typescript-eslint/utils@npm:8.42.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.7.0"
-    "@typescript-eslint/scope-manager": "npm:8.39.0"
-    "@typescript-eslint/types": "npm:8.39.0"
-    "@typescript-eslint/typescript-estree": "npm:8.39.0"
+    "@typescript-eslint/scope-manager": "npm:8.42.0"
+    "@typescript-eslint/types": "npm:8.42.0"
+    "@typescript-eslint/typescript-estree": "npm:8.42.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10/ed340f36fa0788fbc2ca1be6676e05be8f3f91497617701f0a77b61b94622f6ea3606fff4871623dfde261811cccc30e4dbe567f9400d056185a7f47054d903c
+  checksum: 10/41c6c0d01c414c94d7109e21deee73b416547b3be26240d0237a3004c6198f146afefc75feee5333bc957ece6a0856518750655e794fd68c96feec1001edbfe8
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.39.0":
-  version: 8.39.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.39.0"
+"@typescript-eslint/visitor-keys@npm:8.42.0":
+  version: 8.42.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.42.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.39.0"
+    "@typescript-eslint/types": "npm:8.42.0"
     eslint-visitor-keys: "npm:^4.2.1"
-  checksum: 10/2eb89b9e4d531d52de414591869bc208b45dd71b5f758302f176ef92bc3b922e60be5a046a2788cc0e16724631b2dc95aad849b866716a9c7a6361f994c97379
+  checksum: 10/ef3aeabf7b01eb72e176053a4fe7a4c4f0769a9f58d1f7a920c97d365305b950c402ad34227209781996ae187652ccf0f47c31015f992c502b5fa898a9d44bd5
   languageName: node
   linkType: hard
 
@@ -22269,9 +22269,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.33.0":
-  version: 9.33.0
-  resolution: "eslint@npm:9.33.0"
+"eslint@npm:^9.34.0":
+  version: 9.34.0
+  resolution: "eslint@npm:9.34.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.2.0"
     "@eslint-community/regexpp": "npm:^4.12.1"
@@ -22279,7 +22279,7 @@ __metadata:
     "@eslint/config-helpers": "npm:^0.3.1"
     "@eslint/core": "npm:^0.15.2"
     "@eslint/eslintrc": "npm:^3.3.1"
-    "@eslint/js": "npm:9.33.0"
+    "@eslint/js": "npm:9.34.0"
     "@eslint/plugin-kit": "npm:^0.3.5"
     "@humanfs/node": "npm:^0.16.6"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
@@ -22315,7 +22315,7 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10/3857f17460c8a245e3dd2d23b892ce844dc7d337db3fbdeb39f488d6405ae6e71f2142cc4514316d0042c85a77d9503e7dfd4637665eb389473145ad31bd8306
+  checksum: 10/edcd2e055521784cc941d26ea326fe488f749f6d9c18b5c10ea7ed779a502d3d6906b0cc49f68d208416f7b2cb82a21cb96d3031c2e02457f03dbf0c5be0992c
   languageName: node
   linkType: hard
 
@@ -39932,7 +39932,7 @@ __metadata:
     "@types/node": "npm:22.13.10"
     babel-jest: "npm:30.0.0"
     depcheck: "npm:^1.4.7"
-    eslint: "npm:^9.33.0"
+    eslint: "npm:^9.34.0"
     husky: "npm:^9.1.7"
     jest: "npm:29.7.0"
     jest-expo: "npm:53.0.9"
@@ -40396,18 +40396,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^8.39.0":
-  version: 8.39.0
-  resolution: "typescript-eslint@npm:8.39.0"
+"typescript-eslint@npm:^8.42.0":
+  version: 8.42.0
+  resolution: "typescript-eslint@npm:8.42.0"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.39.0"
-    "@typescript-eslint/parser": "npm:8.39.0"
-    "@typescript-eslint/typescript-estree": "npm:8.39.0"
-    "@typescript-eslint/utils": "npm:8.39.0"
+    "@typescript-eslint/eslint-plugin": "npm:8.42.0"
+    "@typescript-eslint/parser": "npm:8.42.0"
+    "@typescript-eslint/typescript-estree": "npm:8.42.0"
+    "@typescript-eslint/utils": "npm:8.42.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10/cdd28f429c10899e2b9777f63db00118dc7b1dae5cd0d79950ee6b46e0faf19119afef67b27bf14ff88a8ee8e3d0c2cd700c0fe2d59ce5b22b2112d92135553f
+  checksum: 10/7f71501823b2c1e87e89ff00d6d8eb40c7514630dbb6b7b44c4dd830c95709357270763df2d711a8ea7bb0b58bd69534f15b01db4550dc6e745df8fec8f6a3ae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Update most Foundation-related dependencies.

**major version:**
- `electron`

**minor version:**
- `react-router`
- `@electron/notarize`
- `@eslint/js`
- `eslint`
- `typescript-eslint`
- `fake-indexeddb`

**patch version:**
- `openpgp`
- `core-js`

**not updated:**
- `tiny-secp256k1` TODO in [#12261](https://github.com/trezor/trezor-suite/pull/12261)
- `electron-store + chalk` TODO in [#14482](https://github.com/trezor/trezor-suite/issues/14482)
  - **new**: `@noble/hashes` new major version is ESM only, adding to this list. But even if it wasn't, not worth upgrading: direct code usage in trezor-suite is minimal, mostly it's a subdep of other deps, and those still pin `1.8.0`. In such a case I think it's best to use the same version as required by our deps.
- `nx` TODO in [#18812](https://github.com/trezor/trezor-suite/issues/18812)
- `electron-builder` TODO in [#18919](https://github.com/trezor/trezor-suite/issues/18919)

:information_source: For reference, last bump foundation deps PR was #20688
:eye: I skimmed through all code changes _except_ eslint-related packages and `electron` and `react-router`; found nothing suspicious ✅ 

## Related Issue

Resolve #21282

## Dev QA
:eye: Besides CI checks, I have tested locally:
- suide dev web
  - app builds & runs
- suite dev desktop
  - app builds & runs on:
    - windows
    - linux
  - tor works

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=bump_foundation_deps_2025.09&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=bump_foundation_deps_2025.09&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=bump_foundation_deps_2025.09&lookback=7)