### PR TITLE
Dev util to select message system config source also on mobile

### DIFF
--- a/suite-common/message-system/src/messageSystemReducer.ts
+++ b/suite-common/message-system/src/messageSystemReducer.ts
@@ -33,6 +33,7 @@ export const messageSystemPersistedWhitelist: Array<keyof MessageSystemState> = 
     'config',
     'currentSequence',
     'dismissedMessages',
+    'configSource',
 ];
 
 const getMessageStateById = (draft: MessageSystemState, id: string): MessageState => {

--- a/suite-common/message-system/src/messageSystemReducer.ts
+++ b/suite-common/message-system/src/messageSystemReducer.ts
@@ -111,9 +111,10 @@ export const prepareMessageSystemReducer = createReducerWithExtraDeps(
             .addCase(messageSystemActions.updateValidExperiments, (state, { payload }) => {
                 state.validExperiments = payload;
             })
-            .addCase(messageSystemActions.setConfigSource, (state, { payload }) => {
-                state.configSource = payload;
-            })
+            .addCase(messageSystemActions.setConfigSource, (_state, { payload }) => ({
+                ...initialState,
+                configSource: payload,
+            }))
             .addCase(messageSystemActions.addMessage, (state, { payload }) => {
                 if (state.config) {
                     state.config.actions = [payload, ...state.config.actions];

--- a/suite-native/module-dev-utils/src/components/MessageSystemConfigSourceSelect.tsx
+++ b/suite-native/module-dev-utils/src/components/MessageSystemConfigSourceSelect.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import {
+    MessageSystemConfigSource,
+    initMessageSystemThunk,
+    messageSystemActions,
+    selectMessageSystemConfigSource,
+} from '@suite-common/message-system';
+import { Select, SelectItemType } from '@suite-native/atoms';
+
+const options: SelectItemType<MessageSystemConfigSource>[] = [
+    { label: 'Remote', value: 'remote' },
+    { label: 'Local', value: 'local' },
+];
+
+export const MessageSystemConfigSourceSelect = () => {
+    const dispatch = useDispatch();
+
+    const messageSystemConfigSource = useSelector(selectMessageSystemConfigSource);
+
+    const handleSelect = (configSource: MessageSystemConfigSource) => {
+        dispatch(messageSystemActions.setConfigSource(configSource));
+        dispatch(initMessageSystemThunk());
+    };
+
+    return (
+        <Select<MessageSystemConfigSource>
+            items={options}
+            selectLabel="Environment"
+            selectValue={messageSystemConfigSource}
+            onSelectItem={handleSelect}
+        />
+    );
+};

--- a/suite-native/module-dev-utils/src/components/MessageSystemInfo.tsx
+++ b/suite-native/module-dev-utils/src/components/MessageSystemInfo.tsx
@@ -11,6 +11,8 @@ import { Button, Card, Divider, Text, VStack } from '@suite-native/atoms';
 import { useCopyToClipboard } from '@suite-native/helpers';
 import { isCodesignBuild } from '@trezor/env-utils';
 
+import { MessageSystemConfigSourceSelect } from './MessageSystemConfigSourceSelect';
+
 export const MessageSystemInfo = () => {
     const config = useSelector(selectMessageSystemConfig);
     const allValidMessages = useSelector(selectAllValidMessages);
@@ -26,6 +28,7 @@ export const MessageSystemInfo = () => {
         <Card>
             <VStack paddingTop="sp16">
                 <Text variant="highlight">Message system</Text>
+                <MessageSystemConfigSourceSelect />
                 <VStack spacing="sp8" paddingBottom="sp16">
                     <Text variant="label">Codesign Build: {isCodesigned.toString()}</Text>
                     <Text variant="label">ConfigUrl: {remoteConfigUrl}</Text>


### PR DESCRIPTION


## Description

First commit adds a reset of the message system state during config source switch, so you don't need to wipe the whole storage to get back to the remote config with the lower sequence number.

Second commit adds the option to select configSource for mobile in DEV settings.

## Related Issue

Follow-up for https://github.com/trezor/trezor-suite/pull/20457

## Screenshots:
<img width="372" height="855" alt="image" src="https://github.com/user-attachments/assets/ce502816-71d8-484b-a318-ce55237a73b5" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/change-message-system-config-source&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/change-message-system-config-source&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/change-message-system-config-source&lookback=7)