### PR TITLE
fix: simplify import, use bytesToHex and hexToBytes from evolu directly, to avin unneceary import from noble/ciphers

### DIFF
--- a/scripts/list-outdated-dependencies/foundation-dependencies.txt
+++ b/scripts/list-outdated-dependencies/foundation-dependencies.txt
@@ -4,7 +4,6 @@
 @eslint/js
 @evolu/common
 @hookform/resolvers
-@noble/ciphers
 @noble/hashes
 @types/bn.js
 @types/create-hmac

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -13,7 +13,6 @@
     "dependencies": {
         "@evolu/common": "^6.0.1-preview.19",
         "@mobily/ts-belt": "^3.13.1",
-        "@noble/ciphers": "^2.0.0",
         "@reduxjs/toolkit": "2.8.2",
         "@suite-common/bluetooth": "workspace:*",
         "@suite-common/device-authenticity": "workspace:*",

--- a/suite-common/wallet-core/src/device/initEvoluKeysThunk.ts
+++ b/suite-common/wallet-core/src/device/initEvoluKeysThunk.ts
@@ -2,10 +2,6 @@
 //       For running the e2e tests in Playwright
 const loadEvoluCommon = async () => await import('@evolu/common');
 
-// Todo: This is here so "solve" the "Error: No "exports" main defined in /home/user/workspace/trezor/trezor-suite/node_modules/@evolu/common/package.json"
-//       For running the e2e tests in Playwright
-const loadNobleCyphersUtils = async () => await import('@noble/ciphers/utils');
-
 import { createThunk } from '@suite-common/redux-utils';
 import { EvoluKeys, TrezorDevice, asDeviceEvoluOwnerId } from '@suite-common/suite-types';
 import TrezorConnect from '@trezor/connect';
@@ -42,8 +38,7 @@ export const initEvoluKeysThunk = createThunk<void, InitCipherKeyThunkParams, vo
         });
 
         if (result.success) {
-            const { deriveSlip21Node } = await loadEvoluCommon();
-            const { bytesToHex, hexToBytes } = await loadNobleCyphersUtils();
+            const { deriveSlip21Node, bytesToHex, hexToBytes } = await loadEvoluCommon();
 
             // Slip21 path from Trezor Device: ["TREZOR", "Evolu"]
             const evoluNode = hexToBytes(result.payload.data);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5616,13 +5616,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/ciphers@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@noble/ciphers@npm:2.0.0"
-  checksum: 10/3346baa09ac25e8e0587c87613f97590634cdc0fdb95dd68e2406791d108b3173552413092361c771ff23533129a1d37811b3f1a5c9bfcf42f9bf9239a76ca16
-  languageName: node
-  linkType: hard
-
 "@noble/curves@npm:1.4.2, @noble/curves@npm:~1.4.0":
   version: 1.4.2
   resolution: "@noble/curves@npm:1.4.2"
@@ -9870,7 +9863,6 @@ __metadata:
   dependencies:
     "@evolu/common": "npm:^6.0.1-preview.19"
     "@mobily/ts-belt": "npm:^3.13.1"
-    "@noble/ciphers": "npm:^2.0.0"
     "@reduxjs/toolkit": "npm:2.8.2"
     "@suite-common/bluetooth": "workspace:*"
     "@suite-common/device-authenticity": "workspace:*"


### PR DESCRIPTION


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=evolu_simplify_hex2bytes&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=evolu_simplify_hex2bytes&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=evolu_simplify_hex2bytes&lookback=7)