### PR TITLE
fix(suite): bluetooth scanning stops when not intended

### DIFF
--- a/packages/suite/src/actions/bluetooth/bluetoothStopScanningThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothStopScanningThunk.ts
@@ -2,11 +2,24 @@ import { BLUETOOTH_PREFIX, bluetoothActions } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
+import {
+    selectDeviceDefaultConnectionMode,
+    selectIsConnectionModalOpen,
+} from '../device/deviceSelectors';
+
 export const bluetoothStopScanningThunk = createThunk<void, void, void>(
     `${BLUETOOTH_PREFIX}/bluetoothStopScanningThunk`,
-    (_, { dispatch }) => {
+    (_, { dispatch, getState }) => {
+        const defaultConnectionMode = selectDeviceDefaultConnectionMode(getState());
+        const isModalOpen = selectIsConnectionModalOpen(getState());
+        if (defaultConnectionMode === 'bluetooth' && isModalOpen) {
+            // Don't actually stop scanning
+            return;
+        }
+
         dispatch(bluetoothActions.scanStatusAction({ status: 'idle' }));
         // This can fail, but there is nothing we can do about it
+        console.log('_____BT: scanning - STOP');
         bluetoothIpc.stopScan();
     },
 );


### PR DESCRIPTION
## Description

Since adding the new connection modals, `bluetoothStopScanningThunk` is called on cleanup of a `useEffect` in `ConnectDeviceGlobalModal`, but it's called more often than we'd want to, causing issues with scanning. 

This PR adds a check to `bluetoothStopScanningThunk` if the conditions to stop scanning are actually met. 

Maybe we can refactor this whole thing in a more elegant way later, but currently I just need to get it working again. 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bt-scanning-stops&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bt-scanning-stops&lookback=7)