### PR TITLE
fix(suite): prevent passphrase prompt on standard wallets when adding empty accounts

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -192,6 +192,7 @@ export const AddAccountModal = ({
                 selectedAccount,
                 accountTypes,
                 deviceState: device.state?.staticSessionId,
+                useEmptyPassphrase: device.useEmptyPassphrase,
             });
 
             if (newAccount instanceof Error) {
@@ -239,6 +240,7 @@ export const AddAccountModal = ({
                     selectedAccount,
                     accountTypes,
                     deviceState: device.state?.staticSessionId,
+                    useEmptyPassphrase: device.useEmptyPassphrase,
                 });
 
                 if (newAccount instanceof Error) {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -1241,6 +1241,7 @@ export const prepareNewAccountPayload = async ({
     selectedAccount,
     accountTypes,
     deviceState,
+    useEmptyPassphrase = true,
 }: {
     accountType: AccountType;
     networkSymbol: NetworkSymbol;
@@ -1249,6 +1250,7 @@ export const prepareNewAccountPayload = async ({
     selectedAccount?: NetworkAccount;
     accountTypes?: NetworkAccount[];
     deviceState?: StaticSessionId;
+    useEmptyPassphrase?: boolean;
 }) => {
     const networkAccount =
         selectedAccount ?? accountTypes?.find(v => v.accountType === accountType);
@@ -1260,6 +1262,7 @@ export const prepareNewAccountPayload = async ({
     const res = await TrezorConnect.getAccountInfo({
         path: newPath,
         coin: networkSymbol,
+        useEmptyPassphrase,
     });
 
     if (!res.success) return new Error(res.payload.error);


### PR DESCRIPTION
## Description

Adding multiple empty accounts in a standard wallet incorrectly triggered a passphrase prompt. The passphrase prompt is now only displayed when the device is in passphrase mode.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/5659


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/add-multiple-accounts-passphrase&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/add-multiple-accounts-passphrase&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/add-multiple-accounts-passphrase&lookback=7)