### PR TITLE
fix(connect-mobile): properly format deeplink url

### DIFF
--- a/packages/connect-explorer/src/pages/details/deeplinking.mdx
+++ b/packages/connect-explorer/src/pages/details/deeplinking.mdx
@@ -18,11 +18,11 @@ To support connecting to Trezor devices from 3rd party apps on mobile devices, T
 The base URL for deep linking is different depending on the environment.
 Last segment of the URL tracks the version of the deeplinking API.
 
-| Environment | Base URL                                                 |
-| ----------- | -------------------------------------------------------- |
-| Production  | currently unavailable                                    |
-| Development | `https://dev.suite.sldev.cz/connect/develop/deeplink/1/` |
-| Local       | `trezorsuitelite://connect/1/`                           |
+| Environment       | Base URL                                                 |
+| ----------------- | -------------------------------------------------------- |
+| Production build  | `https://connect.trezor.io/9/deeplink/1/`                |
+| Development build | `https://dev.suite.sldev.cz/connect/develop/deeplink/1/` |
+| Local (emulator)  | `trezorsuitelite://connect/1/`                           |
 
 ## Query parameters
 

--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -2,7 +2,7 @@ import EventEmitter from 'events';
 
 import * as ERRORS from '@trezor/connect/src/constants/errors';
 import { corsValidator, parseConnectSettings } from '@trezor/connect/src/data/connectSettings';
-import { DEEPLINK_VERSION } from '@trezor/connect/src/data/version';
+import { DEEPLINK_VERSION, DEFAULT_DOMAIN_MAJOR_VER } from '@trezor/connect/src/data/version';
 import type { CallMethodPayload } from '@trezor/connect/src/events/call';
 import { ConnectFactoryDependencies, factory } from '@trezor/connect/src/factory';
 import type {
@@ -13,7 +13,7 @@ import type {
 } from '@trezor/connect/src/types';
 import { InitFullSettings } from '@trezor/connect/src/types/api/init';
 import { Login } from '@trezor/connect/src/types/api/requestLogin';
-import { Deferred, createDeferred } from '@trezor/utils';
+import { Deferred, createDeferred, removeTrailingSlashes } from '@trezor/utils';
 
 export class TrezorConnectDeeplink implements ConnectFactoryDependencies<ConnectSettingsMobile> {
     public eventEmitter = new EventEmitter();
@@ -46,6 +46,7 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies<Connect
     }
 
     private validateConnectSrc(connectSrc?: string) {
+        if (!connectSrc) return DEFAULT_DOMAIN_MAJOR_VER;
         if (connectSrc === 'trezorsuitelite://connect') return connectSrc;
 
         return corsValidator(connectSrc);
@@ -59,8 +60,8 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies<Connect
 
         this._settings = {
             ...parseConnectSettings({ ...this._settings, ...settings }),
-            connectSrc: this.validateConnectSrc(settings.connectSrc),
-            deeplinkUrl: `${connectSrc}deeplink/${DEEPLINK_VERSION}/`,
+            connectSrc,
+            deeplinkUrl: `${removeTrailingSlashes(connectSrc)}/deeplink/${DEEPLINK_VERSION}/`,
             deeplinkOpen: settings.deeplinkOpen,
             deeplinkCallbackUrl: settings.deeplinkCallbackUrl,
         };

--- a/packages/connect/src/data/version.ts
+++ b/packages/connect/src/data/version.ts
@@ -4,9 +4,11 @@ const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 
 const isBeta = VERSION.includes('beta');
 
+export const DEFAULT_DOMAIN_MAJOR_VER = `https://connect.trezor.io/${versionN[0]}/`;
+
 export const DEFAULT_DOMAIN = isBeta
     ? `https://connect.trezor.io/${VERSION}/`
-    : `https://connect.trezor.io/${versionN[0]}/`;
+    : DEFAULT_DOMAIN_MAJOR_VER;
 
 // Increment with content script changes
 export const CONTENT_SCRIPT_VERSION = 1;


### PR DESCRIPTION
## Description

This PR fixes incorrect `connectSrc` handling in connect-mobile.

1. Default value handling: When `connectSrc` was undefined, the default value was not set correctly, which caused malformed deeplink URLs.

2. Trailing slashes: The concatenation did not account for trailing slashes, leading to incorrect URLs such as `trezorsuitelite://connectdeeplink/...`

Documentation is also updated to include the production URL. 

## Related Issue

Resolve #21228


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-mobile-src&lookback=7)