### PR TITLE
(Re)set device state only for standard wallet

### DIFF
--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -654,13 +654,15 @@ export const runAdditionalDiscoveryThunk = createThunk(
 
         assertStaticSessionId(deviceStateResponse.payload._state);
 
-        dispatch(
-            deviceActions.setDeviceState({
-                device,
-                state: deviceStateResponse.payload._state,
-                useEmptyPassphrase: device.useEmptyPassphrase,
-            }),
-        );
+        if (device.useEmptyPassphrase) {
+            dispatch(
+                deviceActions.setDeviceState({
+                    device,
+                    state: deviceStateResponse.payload._state,
+                    useEmptyPassphrase: device.useEmptyPassphrase,
+                }),
+            );
+        }
 
         // NOTE: keep here the previous device as default to prevent TS from screaming
         const updatedDevice = selectDeviceByStaticSessionId(getState(), staticSessionId) ?? device;


### PR DESCRIPTION
## Description

Should resolve #21058 issue where passphrase wallet number is increased on every rediscover.

Lore mainly for @mroz22:
- in https://github.com/trezor/trezor-suite/commit/a8b7030e4f26db2c19fcf02ae031401b330451af you started to call `getDeviceState` and store it by `applyDeviceStatesThunk`, in order to show the passphrase screen sooner IIRC
- it sometimes causes multiple standard wallets during rediscover, because of `addAuthorizedDevice` inside `applyDeviceStatesThunk`, so in #20737 I replaced it directly by `setDeviceState` from `applyDeviceStatesThunk` (which should be enough for rediscover)
- in #21058 it was found out that my fix causes still-increasing passphrase wallet number when rediscovering, so I put together my fix (replacing `applyDeviceStatesThunk` directly by `setDeviceState`) with missing condition from previous code (`applyDeviceStatesThunk` did nothing when adding hidden wallet and the device already existed)
- I have no idea what I'm doing but it somehow seems to work, let's discuss it later

## QA
https://dev.suite.sldev.cz/suite-web/fix/stable-passphrase-number/web/ (Cc: @STew790)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/stable-passphrase-number&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/stable-passphrase-number&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/stable-passphrase-number&lookback=7)