### PR TITLE
fix(suite): close connection modal rather than toggle

### DIFF
--- a/packages/suite/src/components/connection/ConnectionGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectionGlobalModal.tsx
@@ -3,7 +3,7 @@ import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { exhaustive } from '@trezor/type-utils';
 
 import { selectIsConnectionModalOpen } from 'src/actions/device/deviceSelectors';
-import { toggleConnectionModal as toggleConnectionModalAction } from 'src/actions/device/deviceSlice';
+import { setConnectionModal } from 'src/actions/device/deviceSlice';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { ConnectDeviceGlobalModal } from './ConnectDeviceGlobalModal';
@@ -19,8 +19,8 @@ export const ConnectionGlobalModal = () => {
     const device = useSelector(selectSelectedDevice);
     const thpStep = useSelector(selectThpStep);
 
-    const toggleConnectionModal = () => {
-        dispatch(toggleConnectionModalAction());
+    const closeConnectionModal = () => {
+        dispatch(setConnectionModal(false));
     };
 
     // handle THP modals first if we have a device and thpStep
@@ -47,5 +47,5 @@ export const ConnectionGlobalModal = () => {
 
     if (!isConnectDeviceModalOpen) return null;
 
-    return <ConnectDeviceGlobalModal onCancel={toggleConnectionModal} />;
+    return <ConnectDeviceGlobalModal onCancel={closeConnectionModal} />;
 };


### PR DESCRIPTION
Close connection modal instead of toggle.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21295


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bluetooth-list-reopening-when-it-should-not&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bluetooth-list-reopening-when-it-should-not&lookback=7)