### PR TITLE
Replace hard-coded model name

### DIFF
--- a/packages/suite/src/components/suite/bluetooth/BluetoothDeviceComponent.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDeviceComponent.tsx
@@ -16,17 +16,18 @@ type BluetoothDeviceProps = {
 };
 
 export const BluetoothDeviceComponent = ({ device, flex, margin }: BluetoothDeviceProps) => {
-    const model = device.manufacturerData.deviceModel;
-    const modelName = models[model].name;
+    const internalModel = device.manufacturerData.deviceModel;
+    const modelConfig = models[internalModel];
+    const modelName = modelConfig.name;
     const color = device.manufacturerData.deviceColor;
-    const colorName = models[model]?.colors[color.toString()];
+    const colorName = modelConfig.colors[color.toString()];
 
     const { showBluetoothDebugInfo } = useSelector(selectSuiteFlags);
 
     return (
         <Row gap={spacings.md} alignItems="stretch" flex={flex} margin={margin}>
             <RotateDeviceImage
-                deviceModel={model}
+                deviceModel={internalModel}
                 deviceColor={color}
                 animationHeight="44px"
                 animationWidth="44px"

--- a/packages/suite/src/components/suite/bluetooth/BluetoothDeviceComponent.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDeviceComponent.tsx
@@ -17,6 +17,7 @@ type BluetoothDeviceProps = {
 
 export const BluetoothDeviceComponent = ({ device, flex, margin }: BluetoothDeviceProps) => {
     const model = device.manufacturerData.deviceModel;
+    const modelName = models[model].name;
     const color = device.manufacturerData.deviceColor;
     const colorName = models[model]?.colors[color.toString()];
 
@@ -32,7 +33,7 @@ export const BluetoothDeviceComponent = ({ device, flex, margin }: BluetoothDevi
             />
 
             <Column justifyContent="start" alignItems="start" flex="1">
-                <Text typographyStyle="body">Trezor Safe 7</Text>
+                <Text typographyStyle="body">{modelName}</Text>
                 {showBluetoothDebugInfo && <BluetoothDebugInfo device={device} />}
 
                 <InfoSegments>


### PR DESCRIPTION
No visible change, the top heading should always be Trezor Safe 7.

<img width="708" height="199" alt="Screenshot 2025-09-04 at 15 44 25" src="https://github.com/user-attachments/assets/81a9900f-f38d-46e3-b068-ab1faa22cc0d" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/model-name&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/model-name&lookback=7)