### PR TITLE
chore(suite-native): mmkv - enable flexible page size support

### DIFF
--- a/patches/react-native-mmkv + 2.12.2.patch
+++ b/patches/react-native-mmkv + 2.12.2.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-native-mmkv/android/build.gradle b/node_modules/react-native-mmkv/android/build.gradle
+index d912387..62e8aa2 100644
+--- a/node_modules/react-native-mmkv/android/build.gradle
++++ b/node_modules/react-native-mmkv/android/build.gradle
+@@ -91,7 +91,7 @@ android {
+     externalNativeBuild {
+       cmake {
+         cppFlags "-O2 -frtti -fexceptions -Wall -Wno-unused-variable -fstack-protector-all"
+-        arguments "-DANDROID_STL=c++_shared"
++        arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
+         abiFilters (*reactNativeArchitectures())
+       }
+     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

To support Android devices using a 16KB page size without migrating to the new architecture, we temporarily patch `react-native-mmkv` to enable flexible page size support

https://github.com/mrousavy/react-native-mmkv/issues/836#issuecomment-3064922593

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/mmkv-patch&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/mmkv-patch&lookback=7)