### PR TITLE
fix(suite): show only connected selected devices

### DIFF
--- a/packages/suite/src/components/connection/BluetoothConnectionModal.tsx
+++ b/packages/suite/src/components/connection/BluetoothConnectionModal.tsx
@@ -18,7 +18,10 @@ type BluetoothConnectionModalProps = {
     onRescanClick: () => void;
     onConnect: (deviceId: string) => Promise<void>;
     onCancel: () => void;
+    onClose: () => void;
 };
+
+const selectedDeviceConnectionTypes = ['connecting', 'pairing'];
 
 export const BluetoothConnectionModal = ({
     devices,
@@ -29,6 +32,7 @@ export const BluetoothConnectionModal = ({
     onRescanClick,
     onConnect,
     onCancel,
+    onClose,
 }: BluetoothConnectionModalProps) => {
     if (
         selectedDevice !== undefined &&
@@ -50,10 +54,13 @@ export const BluetoothConnectionModal = ({
         );
     }
 
-    if (selectedDevice !== undefined) {
+    if (
+        selectedDevice !== undefined &&
+        selectedDeviceConnectionTypes.includes(selectedDevice.connectionStatus.type)
+    ) {
         return (
             <Modal
-                onCancel={onCancel}
+                onCancel={onClose}
                 heading={<Translation id="TR_CONNECT_YOUR_TREZOR" />}
                 description={<Translation id="TR_CONNECT_YOUR_TREZOR_DESCRIPTION" />}
                 size="small"
@@ -67,7 +74,7 @@ export const BluetoothConnectionModal = ({
     if (devices.length > 0 && !selectedDevice && nearbyDevices && nearbyDevices.length > 0) {
         return (
             <Modal
-                onCancel={onCancel}
+                onCancel={onClose}
                 heading={<Translation id="TR_CONNECT_YOUR_TREZOR" />}
                 description={<Translation id="TR_CONNECT_YOUR_TREZOR_DESCRIPTION" />}
                 size="small"

--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -204,6 +204,7 @@ export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void })
                 onRescanClick={onReScanClick}
                 onConnect={onConnect}
                 onCancel={handleBluetoothConnectionCancel}
+                onClose={onCancel}
             />
         );
     }


### PR DESCRIPTION
For selected device connect modal - show only not connected or connecting devices.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21297

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connected-device-do-not-show&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connected-device-do-not-show&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connected-device-do-not-show&lookback=7)