### PR TITLE
fix(e2e-reporter): fixes reporter conditional start

### DIFF
--- a/.github/workflows/test-suite-desktop-e2e-release.yml
+++ b/.github/workflows/test-suite-desktop-e2e-release.yml
@@ -17,7 +17,14 @@ on:
         description: "(optional) Publish test report to GitHub Project"
         required: false
         default: false
+        type: boolean
   workflow_call:
+    inputs:
+      publishResultsToGitHub:
+        description: "(optional) Publish test report to GitHub Project"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: desktop-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -90,4 +97,4 @@ jobs:
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}
           github-token: ${{ steps.trezor-bot-token.outputs.token }}
           release-build: ${{ env.release_build }}
-          run-reporter: ${{ inputs.publishResultsToGitHub == 'true' || github.event_name == 'workflow_call' }}
+          run-reporter: ${{ inputs.publishResultsToGitHub }}

--- a/.github/workflows/test-suite-native-e2e-android-t3w1.yml
+++ b/.github/workflows/test-suite-native-e2e-android-t3w1.yml
@@ -24,6 +24,7 @@ on:
         description: "(optional) Publish test report to GitHub Project"
         required: false
         default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -41,6 +42,7 @@ jobs:
       emulator_model: "T3W1"
       detox_extra_args: "--testNamePattern '^(?!.*@specificModel)'"
     secrets:
+      PUBLISH_RESULTS_TO_GITHUB: ${{ inputs.publishResultsToGitHub }}
       TREZOR_BOT_APP_ID: ${{ secrets.TREZOR_BOT_APP_ID }}
       TREZOR_BOT_PRIVATE_KEY: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
       CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}

--- a/.github/workflows/test-suite-native-e2e-android.yml
+++ b/.github/workflows/test-suite-native-e2e-android.yml
@@ -24,6 +24,7 @@ on:
         description: "(optional) Publish test report to GitHub Project"
         required: false
         default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -40,6 +41,7 @@ jobs:
     with:
       emulator_model: "T3T1"
     secrets:
+      PUBLISH_RESULTS_TO_GITHUB: ${{ inputs.publishResultsToGitHub }}
       TREZOR_BOT_APP_ID: ${{ secrets.TREZOR_BOT_APP_ID }}
       TREZOR_BOT_PRIVATE_KEY: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
       CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}

--- a/.github/workflows/test-suite-release-e2e-report-orchestration.yml
+++ b/.github/workflows/test-suite-release-e2e-report-orchestration.yml
@@ -17,7 +17,11 @@ jobs:
   call-test-suite-desktop-e2e-release:
     uses: ./.github/workflows/test-suite-desktop-e2e-release.yml
     secrets: inherit
+    with:
+      publishResultsToGitHub: true
 
   call-test-suite-web-e2e-release:
     uses: ./.github/workflows/test-suite-web-e2e-release.yml
     secrets: inherit
+    with:
+      publishResultsToGitHub: true

--- a/.github/workflows/test-suite-web-e2e-release.yml
+++ b/.github/workflows/test-suite-web-e2e-release.yml
@@ -17,7 +17,14 @@ on:
         description: "(optional) Publish test report to GitHub Project"
         required: false
         default: false
+        type: boolean
   workflow_call:
+    inputs:
+      publishResultsToGitHub:
+        description: "(optional) Publish test report to GitHub Project"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: web-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -82,4 +89,4 @@ jobs:
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}
           github-token: ${{ steps.trezor-bot-token.outputs.token }}
           release-build: ${{ env.release_build }}
-          run-reporter: ${{ inputs.publishResultsToGitHub == 'true' || github.event_name == 'workflow_call' }}
+          run-reporter: ${{ inputs.publishResultsToGitHub }}

--- a/docs/tests/e2e-github-reporter.md
+++ b/docs/tests/e2e-github-reporter.md
@@ -207,5 +207,3 @@ The reporter is integrated into release branch CI workflows:
 
 Each workflow passes the `RELEASE_BUILD` and `GITHUB_TOKEN` environment variables to enable test reporting.
 On the Web, Desktop, Android and iOS workflows, reporter is enabled only when workflow is run manually with param `publishResultsToGitHub` se to `true`. Otherwise only test are run. That way we have full control on the generation of issues in GitHub. We had a problem of duplicate and unwanted triggers when it was based on push to release branch.
-Implemented by this condition in Suite workflows: `run-reporter: ${{ inputs.publishResultsToGitHub == 'true' || github.event_name == 'workflow_call' }}`
-Implemented by env var in Suite native workflow, condition is in jest.config.js


### PR DESCRIPTION
The condition was wrong from the start but my recent changes made it to profess this problem and report was not published when report orchestrator was run. This fix simplifies the logic and fixes the problem

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-release-report-orchestration&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-release-report-orchestration&lookback=7)