### PR TITLE
feat(suite): Add full currency names to selection

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/BaseCurrency.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/BaseCurrency.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import { selectBaseCurrency, setBaseCurrency } from '@suite-common/wallet-core';
+import { buildCurrencyLongOption, buildCurrencyShortOption } from '@suite-common/wallet-utils';
 import {
     BaseCurrencyCode,
     fiatBaseCurrencies,
@@ -14,17 +15,12 @@ import { ActionColumn, ActionSelect, TextColumn, Translation } from 'src/compone
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 
-const buildCurrencyOption = (currency: BaseCurrencyCode) => ({
-    value: currency,
-    label: currency.toUpperCase(),
-});
-
 export const BaseCurrency = () => {
     const { translationString } = useTranslation();
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const dispatch = useDispatch();
 
-    const value = buildCurrencyOption(baseCurrencyCode);
+    const value = buildCurrencyShortOption({ currency: baseCurrencyCode, areSatsDisplayed: false });
 
     const handleChange = (option: { value: BaseCurrencyCode; label: string }) => {
         dispatch(setBaseCurrency(option.value));
@@ -40,11 +36,15 @@ export const BaseCurrency = () => {
         () => [
             {
                 label: translationString('TR_BASE_CURRENCY_FIAT'),
-                options: typedObjectKeys(fiatBaseCurrencies).map(buildCurrencyOption),
+                options: typedObjectKeys(fiatBaseCurrencies).map(currency =>
+                    buildCurrencyLongOption({ currency, areSatsDisplayed: false }),
+                ),
             },
             {
                 label: translationString('TR_BASE_CURRENCY_VALUABLES'),
-                options: typedObjectKeys(valuablesBaseCurrencies).map(buildCurrencyOption),
+                options: typedObjectKeys(valuablesBaseCurrencies).map(currency =>
+                    buildCurrencyLongOption({ currency, areSatsDisplayed: false }),
+                ),
             },
         ],
         [translationString],
@@ -55,7 +55,7 @@ export const BaseCurrency = () => {
             <TextColumn title={<Translation id="TR_BASE_CURRENCY" />} />
             <ActionColumn>
                 <ActionSelect
-                    useKeyPressScroll
+                    isSearchable
                     onChange={handleChange}
                     value={value}
                     options={options}

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { Controller } from 'react-hook-form';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -11,17 +12,22 @@ import {
     TokenAddress,
 } from '@suite-common/wallet-types';
 import {
-    buildCurrencyOption,
-    buildCurrencyOptions,
+    buildCurrencyLongOption,
+    buildCurrencyShortOption,
     findToken,
     getDecimalsForBaseCurrency,
     getInputState,
     isLowAnonymityWarning,
     parseCryptoToFormattedBaseCurrency,
 } from '@suite-common/wallet-utils';
-import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
+import {
+    type BaseCurrencyCode,
+    fiatBaseCurrencies,
+    valuablesBaseCurrencies,
+} from '@trezor/blockchain-link-types';
 import { Select } from '@trezor/components';
 import { NumberInput } from '@trezor/product-components';
+import { typedObjectKeys } from '@trezor/utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { useTranslation } from 'src/hooks/suite';
@@ -134,12 +140,30 @@ export const BaseCurrencyInput = ({
         };
     }
 
+    const options = useMemo(
+        () => [
+            {
+                label: translationString('TR_BASE_CURRENCY_FIAT'),
+                options: typedObjectKeys(fiatBaseCurrencies).map(currency =>
+                    buildCurrencyLongOption({ currency, areSatsDisplayed }),
+                ),
+            },
+            {
+                label: translationString('TR_BASE_CURRENCY_VALUABLES'),
+                options: typedObjectKeys(valuablesBaseCurrencies).map(currency =>
+                    buildCurrencyLongOption({ currency, areSatsDisplayed }),
+                ),
+            },
+        ],
+        [translationString, areSatsDisplayed],
+    );
+
     const renderCurrencySelect = ({
         field: { onChange, value: selectedOption },
     }: CallbackParams) => (
         <Select
-            options={buildCurrencyOptions({ selected: selectedOption, areSatsDisplayed })}
-            value={buildCurrencyOption({
+            options={options}
+            value={buildCurrencyShortOption({
                 currency: selectedOption.value,
                 areSatsDisplayed,
             })}

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -535,16 +535,38 @@ type BuildCurrencyOptionParams = {
     areSatsDisplayed: boolean;
 };
 
-export const buildCurrencyOption = ({
+export const buildCurrencyShortOption = ({
     currency,
     areSatsDisplayed,
-}: BuildCurrencyOptionParams): BaseCurrencyOption => ({
-    value: currency,
-    label:
-        currency !== '' && isBaseCurrencyWithSats(currency) && areSatsDisplayed
-            ? 'Sats'
-            : currency.toUpperCase(),
-});
+}: BuildCurrencyOptionParams): BaseCurrencyOption => {
+    if (currency === '') return { value: '', label: '' };
+
+    return {
+        value: currency,
+        label:
+            isBaseCurrencyWithSats(currency) && areSatsDisplayed ? 'sat' : currency.toUpperCase(),
+    };
+};
+
+export const buildCurrencyLongOption = ({
+    currency,
+    areSatsDisplayed,
+}: BuildCurrencyOptionParams): BaseCurrencyOption => {
+    const shortOption = buildCurrencyShortOption({ currency, areSatsDisplayed });
+
+    if (currency === '') return shortOption;
+    else {
+        return {
+            value: shortOption.value,
+            label:
+                shortOption.label +
+                ' · ' +
+                (isBaseCurrencyWithSats(currency) && areSatsDisplayed
+                    ? 'Satoshis'
+                    : baseCurrencies[currency].label),
+        };
+    }
+};
 
 type BuildCurrencyOptionsParams = {
     selected: BaseCurrencyOption;
@@ -562,7 +584,7 @@ export const buildCurrencyOptions = ({
             return;
         }
 
-        result.push(buildCurrencyOption({ currency, areSatsDisplayed }));
+        result.push(buildCurrencyLongOption({ currency, areSatsDisplayed }));
     });
 
     return result;


### PR DESCRIPTION
Adds full currency names to our Select components as well as categories (fiat / valuables).

## Description

I very much do not like the two implementations, but given the fact that they should display different options... 

## Related Issue

Resolve #21021

## Screenshots:
Before / after:

<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/1ae20f13-56f2-44ed-960d-5ce714581dff" />
<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/cdbba69f-8d4e-4207-9ce7-2c3ccd913c0d" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/add-full-currency-names&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/add-full-currency-names&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/add-full-currency-names&lookback=7)