### PR TITLE
fix(suite): Show base currency amount even for bitcoin base currency

### DIFF
--- a/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
@@ -1,6 +1,5 @@
 import { formInputsMaxLength } from '@suite-common/validators';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
-import { useDisplayBaseCurrency } from '@suite-common/wallet-core';
 import { Output, TokenAddress } from '@suite-common/wallet-types';
 import {
     convertAmountUnitsToSubunits,
@@ -49,20 +48,23 @@ export const Amount = ({ output, outputId }: AmountProps) => {
         setMax,
         composeTransaction,
         getCurrentFiatRate,
+        watch,
     } = useSendFormContext();
     const { symbol, tokens } = account;
     const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
     const { isBelowLaptop } = useLayoutSize();
-    const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(symbol);
 
     const locale = useSelector(selectLanguage);
 
     const amountName = `outputs.${outputId}.amount` as const;
     const tokenInputName = `outputs.${outputId}.token`;
+    const currencyInputName = `outputs.${outputId}.currency` as const;
     const maxOutputId = getDefaultValue('setMaxOutputId');
     const isSendMaxActive = maxOutputId === outputId;
     const outputError = errors.outputs ? errors.outputs[outputId] : undefined;
     const error = outputError ? outputError.amount : undefined;
+
+    const selectedBaseCurrency = watch(currencyInputName);
 
     // corner-case: do not display "setMax" button if FormState got ANY error (setMax probably cannot be calculated)
     const isSendMaxVisible = isSendMaxActive && !error && !Object.keys(errors).length;
@@ -77,8 +79,8 @@ export const Amount = ({ output, outputId }: AmountProps) => {
         currencyCode: (output.currency?.value ?? '') as BaseCurrencyCode,
     });
 
-    const isWithBaseCurrency =
-        shallDisplayBaseCurrency && (!!currentRate?.rate || !!currentRate?.isLoading);
+    const showBaseCurrency = !!currentRate?.rate || !!currentRate?.isLoading;
+    const showTokenCurrency = selectedBaseCurrency.value !== symbol || !showBaseCurrency; // Show always at least one currency
 
     let decimals: number;
     if (token) {
@@ -155,46 +157,56 @@ export const Amount = ({ output, outputId }: AmountProps) => {
                 alignItems={isBelowLaptop ? 'center' : 'normal'}
                 gap={spacings.sm}
             >
-                <NumberInput
-                    inputState={inputState}
-                    locale={locale}
-                    labelHoverRight={
-                        !isSendMaxVisible && (!isWithBaseCurrency || isBelowLaptop) && sendMaxSwitch
-                    }
-                    labelRight={
-                        isSendMaxVisible && (!isWithBaseCurrency || isBelowLaptop) && sendMaxSwitch
-                    }
-                    labelLeft={
-                        <Row>
-                            <Translation id="AMOUNT" />
-                        </Row>
-                    }
-                    bottomText={bottomText || null}
-                    onChange={handleInputChange}
-                    name={amountName}
-                    data-testid={amountName}
-                    defaultValue={amountValue}
-                    maxLength={formInputsMaxLength.amount}
-                    rules={cryptoAmountRules}
-                    control={control}
-                    innerAddon={
-                        <Text variant="tertiary">
-                            {withTokens && token ? token?.symbol?.toUpperCase() : displayTicker}
-                        </Text>
-                    }
-                />
+                {showTokenCurrency && (
+                    <NumberInput
+                        inputState={inputState}
+                        locale={locale}
+                        labelHoverRight={
+                            !isSendMaxVisible &&
+                            (!showBaseCurrency || isBelowLaptop) &&
+                            sendMaxSwitch
+                        }
+                        labelRight={
+                            isSendMaxVisible &&
+                            (!showBaseCurrency || isBelowLaptop) &&
+                            sendMaxSwitch
+                        }
+                        labelLeft={
+                            <Row>
+                                <Translation id="AMOUNT" />
+                            </Row>
+                        }
+                        bottomText={bottomText || null}
+                        onChange={handleInputChange}
+                        name={amountName}
+                        data-testid={amountName}
+                        defaultValue={amountValue}
+                        maxLength={formInputsMaxLength.amount}
+                        rules={cryptoAmountRules}
+                        control={control}
+                        innerAddon={
+                            <Text variant="tertiary">
+                                {withTokens && token ? token?.symbol?.toUpperCase() : displayTicker}
+                            </Text>
+                        }
+                    />
+                )}
 
-                {isWithBaseCurrency && (
+                {showBaseCurrency && (
                     <BaseCurrencyValue amount="1" symbol={symbol}>
                         {({ rate }) =>
                             rate && (
                                 <>
-                                    <Icon
-                                        name={isBelowLaptop ? 'arrowsDownUp' : 'arrowsLeftRight'}
-                                        size={20}
-                                        variant="tertiary"
-                                        margin={{ top: isBelowLaptop ? 0 : spacings.xxxxl }}
-                                    />
+                                    {showTokenCurrency && (
+                                        <Icon
+                                            name={
+                                                isBelowLaptop ? 'arrowsDownUp' : 'arrowsLeftRight'
+                                            }
+                                            size={20}
+                                            variant="tertiary"
+                                            margin={{ top: isBelowLaptop ? 0 : spacings.xxxxl }}
+                                        />
+                                    )}
                                     <BaseCurrencyInput
                                         output={output}
                                         outputId={outputId}


### PR DESCRIPTION
Display base currecny amount even when current currency == base curency. This allows users to see value in fiat/other valuables if they want to.

## Related Issue

Resolve #21288 

## Screenshots:

Before:

<img width="1005" height="413" alt="Image" src="https://github.com/user-attachments/assets/9106839d-e1ef-416c-9882-f20b1425d3e8" />

After:
<img width="1016" height="338" alt="image" src="https://github.com/user-attachments/assets/a9f1da6b-7ac7-4692-83ba-546adca8f33e" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bitcoin-show-base-currency&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bitcoin-show-base-currency&lookback=7)