### PR TITLE
fix(suite): runaway cycle of THP acquire errors

### DIFF
--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceTrezorHostProtocolPair.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceTrezorHostProtocolPair.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler, useEffect } from 'react';
+import { MouseEventHandler } from 'react';
 
 import { acquireDevice } from '@suite-common/wallet-core';
 import { Button } from '@trezor/components';
@@ -31,13 +31,6 @@ export const DeviceTrezorHostProtocolPair = () => {
     );
 
     const tips = [TROUBLESHOOTING_TIP_CLOSE_ALL_TABS, TROUBLESHOOTING_TIP_RECONNECT];
-
-    // if possible, prompt for THP pairing right away
-    useEffect(() => {
-        if (!isDeviceLocked) {
-            dispatch(acquireDevice({ requestedDevice: device }));
-        }
-    });
 
     return (
         <TroubleshootingTips


### PR DESCRIPTION
## Description

Fixes an endless loop of acquire errors caused by missing dependency list in `useEffect`. 

## Related Issue

Resolve #21303

## Screenshots:

Replicating the steps I described [in the issue coment](https://github.com/trezor/trezor-suite/issues/21303#issuecomment-3258622306), and now there is only one error toast as it should:

[AFTER.webm](https://github.com/user-attachments/assets/ff565459-6c8b-46c0-8fda-34324a2cf9ad)


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/runaway-device-acquire-errors&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/runaway-device-acquire-errors&lookback=7)