### PR TITLE
fix(suite): don't offer autoconnect when not initialized

### DIFF
--- a/suite-common/thp/src/connectThpDeviceThunk.ts
+++ b/suite-common/thp/src/connectThpDeviceThunk.ts
@@ -8,7 +8,7 @@ import { selectThpCredentials } from './thpSelectors';
 const NUMBER_OF_CONNECTIONS_TO_ASK_FOR_AUTOCONNECT = 3;
 
 type ConnectThpDeviceThinkParams = {
-    device: Pick<Device, 'thp'>;
+    device: Pick<Device, 'thp' | 'features'>;
 };
 
 export const connectThpDeviceThunk = createThunk<void, ConnectThpDeviceThinkParams, void>(
@@ -27,7 +27,8 @@ export const connectThpDeviceThunk = createThunk<void, ConnectThpDeviceThinkPara
         if (credential !== undefined) {
             // We do not want to offer Autoconnect after reconnection dues to Firmware installation.
             // Autoconnect will be offered on the next reconnection.
-            if (!isFwInstall) {
+            // Also, do not offer Autoconnect if reconnecting a device with Firmware, but not yet a wallet.
+            if (!isFwInstall && device.features?.initialized === true) {
                 dispatch(thpActions.incrementCredentialConnectionCounter({ credential }));
             }
 

--- a/suite-common/thp/tests/connectThpDeviceThunk.test.ts
+++ b/suite-common/thp/tests/connectThpDeviceThunk.test.ts
@@ -2,7 +2,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 
 import { FirmwareUpdateState, prepareFirmwareReducer } from '@suite-common/firmware';
 import { ThpSuiteCredentials } from '@suite-common/suite-types';
-import { configureMockStore, extraDependenciesMock } from '@suite-common/test-utils';
+import { configureMockStore, extraDependenciesMock, testMocks } from '@suite-common/test-utils';
 import { Device } from '@trezor/connect';
 
 import { connectThpDeviceThunk } from '../src/connectThpDeviceThunk';
@@ -41,7 +41,7 @@ const initialFirmwareState: FirmwareUpdateState = {
     firmwareUpdateSource: 'production',
 };
 
-const device: Pick<Device, 'thp'> = {
+const device: Pick<Device, 'thp' | 'features'> = {
     thp: {
         credentials: [thpCredential1],
         properties: {
@@ -58,6 +58,7 @@ const device: Pick<Device, 'thp'> = {
         recvNonce: 0,
         expectedResponses: [],
     },
+    features: testMocks.getDeviceFeatures(),
 };
 
 describe(connectThpDeviceThunk.name, () => {
@@ -100,6 +101,24 @@ describe(connectThpDeviceThunk.name, () => {
         });
 
         store.dispatch(connectThpDeviceThunk({ device }));
+        expect(store.getState().thp.credentials[0].connectionCounter).toEqual(0);
+        expect(store.getState().thp.credentials[1].connectionCounter).toEqual(0);
+        expect(store.getState().thp.step).toEqual(null);
+    });
+
+    it("won't update the connection counter for credential when not initialized", () => {
+        const store = configureMockStore({
+            extra: {},
+            reducer: combineReducers({ thp: thpReduce, firmware: firmwareReduce }),
+            preloadedState: { thp: initialThpState, firmware: initialFirmwareState },
+        });
+
+        const nonInitializedDevice = {
+            ...device,
+            features: { ...testMocks.getDeviceFeatures(), initialized: false },
+        };
+
+        store.dispatch(connectThpDeviceThunk({ device: nonInitializedDevice }));
         expect(store.getState().thp.credentials[0].connectionCounter).toEqual(0);
         expect(store.getState().thp.credentials[1].connectionCounter).toEqual(0);
         expect(store.getState().thp.step).toEqual(null);


### PR DESCRIPTION
## Description

I couldn't reproduce it, but it should fix the issue for anyone who can.

## Related Issue

Resolve #21307

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/dont-offer-autoconnect-when-not-initialized&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/dont-offer-autoconnect-when-not-initialized&lookback=7)