### PR TITLE
Fix/entropy check desktop

### DIFF
--- a/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
+++ b/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
@@ -3,7 +3,12 @@ import assert from 'assert';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { testMocks } from '@suite-common/test-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { deviceActions, prepareDeviceReducer, wipeDeviceThunk } from '@suite-common/wallet-core';
+import {
+    deviceActions,
+    deviceInitialState,
+    prepareDeviceReducer,
+    wipeDeviceThunk,
+} from '@suite-common/wallet-core';
 import { Response } from '@trezor/connect';
 
 import suiteReducer from 'src/reducers/suite/suiteReducer';
@@ -90,6 +95,7 @@ const fixture: Feature[] = [
         description: 'Wipe device with multiple device instances',
         initialState: {
             device: {
+                ...deviceInitialState,
                 devices: [
                     getSuiteDevice({
                         path: '1',
@@ -108,8 +114,6 @@ const fixture: Feature[] = [
                         state: '1stTestnetAddress@device_2_id:0',
                     }),
                 ],
-                isDeviceAutoEjectEnabled: false,
-                persistentDeviceData: [],
             },
         },
         action: () => wipeDeviceThunk(),
@@ -307,6 +311,65 @@ const fixture: Feature[] = [
             ],
         },
         initialState: {},
+    },
+    {
+        description: 'Reset device - Cancel - Entropy check not triggered',
+        action: () => deviceSettingsActions.resetDevice(),
+        mocks: { success: false, payload: { error: 'Canceled', code: 'Method_Cancel' } },
+        result: {
+            actions: [
+                {
+                    type: notificationsActions.addToast.type,
+                    payload: {
+                        type: 'error',
+                        error: 'Canceled',
+                        context: 'toast',
+                        id: expect.any(Number),
+                    },
+                } satisfies ReturnType<typeof notificationsActions.addToast>,
+            ],
+        },
+        initialState: {
+            device: {
+                ...deviceInitialState,
+                selectedDevice: getSuiteDevice({
+                    mode: 'initialize',
+                }),
+            },
+        },
+    },
+    {
+        description: 'Reset device - Entropy check fail - show Device compromised',
+        action: () => deviceSettingsActions.resetDevice(),
+        mocks: {
+            success: false,
+            payload: { error: 'Entropy check failed', code: 'Failure_EntropyCheck' },
+        },
+        result: {
+            actions: [
+                {
+                    type: notificationsActions.addToast.type,
+                    payload: {
+                        type: 'error',
+                        error: 'Entropy check failed',
+                        context: 'toast',
+                        id: expect.any(Number),
+                    },
+                } satisfies ReturnType<typeof notificationsActions.addToast>,
+                {
+                    type: deviceActions.setEntropyCheckFail.type,
+                    payload: 'device-id',
+                } satisfies ReturnType<typeof deviceActions.setEntropyCheckFail>,
+            ],
+        },
+        initialState: {
+            device: {
+                ...deviceInitialState,
+                selectedDevice: getSuiteDevice({
+                    mode: 'initialize',
+                }),
+            },
+        },
     },
 ];
 

--- a/packages/suite/src/actions/settings/__tests__/deviceSettingsActions.test.ts
+++ b/packages/suite/src/actions/settings/__tests__/deviceSettingsActions.test.ts
@@ -22,12 +22,13 @@ const getInitialState = (state: Partial<DeviceSettingsFixtureState> = {}) => ({
     },
     device: {
         devices: state.device?.devices ?? [DEVICE],
-        selectedDevice: DEVICE,
+        selectedDevice: state.device?.selectedDevice ?? DEVICE,
         isDeviceAutoEjectEnabled: false,
         persistentDeviceData: [],
         isConnectionModalOpen: false,
     },
     router: {},
+    messageSystem: { validMessages: { feature: [] } },
 });
 
 const mockStore = configureStore<DeviceSettingsFixtureState, any>();
@@ -65,6 +66,7 @@ describe('DeviceSettings Actions', () => {
             jest.spyOn(TrezorConnect, 'applySettings').mockImplementation(mock);
             jest.spyOn(TrezorConnect, 'wipeDevice').mockImplementation(mock);
             jest.spyOn(TrezorConnect, 'changePin').mockImplementation(mock);
+            jest.spyOn(TrezorConnect, 'resetDevice').mockImplementation(mock);
 
             await store.dispatch(f.action());
 

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -99,7 +99,6 @@ export const resetDevice =
             Feature.entropyCheck,
         );
 
-        // todo: this should be handled most likely in a component somewhere above
         if (device?.status === 'used' || device?.status === 'occupied') {
             const features = await TrezorConnect.getFeatures({ device: { path: device.path } });
             if (!features.success) {
@@ -113,8 +112,7 @@ export const resetDevice =
                 return;
             }
             if (features.payload.initialized) {
-                // todo: decide what should happen next UX wise. At the moment, user only gets an error toast
-                // and stays stuck on the 'create new wallet' screen;
+                // Note that user gets stuck on this page. It's a rare edge case; a solution would have its own drawbacks.
                 dispatch(
                     notificationsActions.addToast({
                         type: 'error',
@@ -129,7 +127,12 @@ export const resetDevice =
         if (!device || !device.features) return;
 
         if (device.mode !== 'initialize') {
-            console.error('resetDevice: device in invalid mode', device.mode);
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'error',
+                    error: 'Device is not in initialization mode.',
+                }),
+            );
 
             return;
         }

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -151,7 +151,9 @@ export const resetDevice =
 
         if (!result.success) {
             dispatch(notificationsActions.addToast({ type: 'error', error: result.payload.error }));
-            dispatch(failEntropyCheckThunk({ device, error: result.payload }));
+            if (result.payload.code === 'Failure_EntropyCheck') {
+                dispatch(failEntropyCheckThunk({ device, error: result.payload }));
+            }
         }
 
         return result;

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -554,10 +554,6 @@ type FailEntropyCheckParams = {
 export const failEntropyCheckThunk = createThunk(
     `${DEVICE_MODULE_PREFIX}/failEntropyCheckThunk`,
     ({ device, error }: FailEntropyCheckParams, { dispatch, extra }) => {
-        if (error.code === 'Method_Cancel') {
-            // resetDevice call was cancelled by user
-            return;
-        }
         const contextData = {
             model: device?.features?.internal_model,
             revision: device?.features?.revision,


### PR DESCRIPTION
[fix(suite): do not show entropy check failure when error is unrelated](https://github.com/trezor/trezor-suite/commit/e399670d9a37716ee936cbb688a69ee2f1e3425a) - fixes a critical bug I made [here](https://github.com/trezor/trezor-suite/commit/b4fa5d25474e6c2d2763d16bb546a98e283b71f6#diff-421f56f82059fd0dc10d368d8293426a09663e215aab21f89bd843d245b1137cL123) and adds a test to avoid the same mistake in future; the bug caused entropy check failure to be triggered when an unrelated error happened during wallet creation, e.g. cancellation on Trezor
[Revert "fix(suite): do not fail entropy check when cancelled by user"](https://github.com/trezor/trezor-suite/commit/0582cdcbbaa20373957b610d57466dc23883d0b7) - no longer needed
[chore(message-system): remove old message](https://github.com/trezor/trezor-
[feat(suite): add error toast when trying to initialize an initialized…](https://github.com/trezor/trezor-suite/commit/7dc11d8727002bdc126b04079b073364fe50540a) - I salvaged what I think is relevant from https://github.com/trezor/trezor-suite/pull/21232

**QA:** To reproduce the bug, create wallet in onboarding, but cancel on Trezor -> entropy check failed :(

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/entropy-check-desktop&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/entropy-check-desktop&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/entropy-check-desktop&lookback=7)