### PR TITLE
Fix: intermediary and compatible

### DIFF
--- a/packages/connect/src/api/firmware/getBinary.ts
+++ b/packages/connect/src/api/firmware/getBinary.ts
@@ -3,7 +3,10 @@ import { removeTrailingSlashes } from '@trezor/utils';
 
 import { parseFirmwareHeaders } from './parseFirmwareHeaders';
 import { ERRORS } from '../../constants';
+import { BinaryInfo } from '../../types';
 import { httpRequest } from '../../utils/assets';
+
+const MIN_FIRMWARE_SIZE_BYTES = 200;
 
 interface GetBinaryParams {
     baseUrl: string;
@@ -11,20 +14,27 @@ interface GetBinaryParams {
     version: VersionArray;
 }
 
-export const getBinary = async ({ baseUrl, path, version }: GetBinaryParams) => {
+export const getBinary = async ({
+    baseUrl,
+    path,
+    version,
+}: GetBinaryParams): Promise<BinaryInfo> => {
     const sanitizedBaseUrl = removeTrailingSlashes(baseUrl);
     const url = `${sanitizedBaseUrl}/${path}`;
 
-    const res = await httpRequest(url, 'binary');
+    const binaryArrayBuffer = (await httpRequest(url, 'binary')) as ArrayBuffer;
     // suspiciously small binary. this typically happens when build does not have git lfs enabled and all
     // you download here are some pointers to lfs objects which are around ~132 byteLength
-    if (res.byteLength < 200) {
+    if (binaryArrayBuffer.byteLength < MIN_FIRMWARE_SIZE_BYTES) {
         throw ERRORS.TypedError('Runtime', 'Firmware binary is too small');
     }
 
+    const firmwareBuffer = Buffer.from(binaryArrayBuffer);
+    const { version: binaryVersion } = parseFirmwareHeaders(firmwareBuffer);
+
     return {
-        binary: res,
-        binaryVersion: parseFirmwareHeaders(Buffer.from(res)).version,
+        binary: binaryArrayBuffer,
+        binaryVersion,
         releaseVersion: version,
     };
 };

--- a/packages/connect/src/data/__tests__/firmwareInfo.test.ts
+++ b/packages/connect/src/data/__tests__/firmwareInfo.test.ts
@@ -1,5 +1,7 @@
+import { firmwareAssets } from '@trezor/connect-common/files/firmware';
 import { FirmwareType } from '@trezor/device-utils';
 import { DeviceModelInternal } from '@trezor/protobuf/src/messages-schema';
+import { versionUtils } from '@trezor/utils';
 
 import { getDeviceFeatures } from '../../../setupJest';
 import { DataManager } from '../DataManager';
@@ -43,6 +45,25 @@ describe('data/firmwareInfo', () => {
                 FirmwareType.Universal,
             );
             expect(firmwareReleaseConfigInfo?.release.version).toEqual([2, 1, 1]);
+        });
+
+        it('should offer lastest release and intermediary v2 for T1B1 <  1.12.0', () => {
+            const [latestRelase] = Object.values(firmwareAssets.t1b1.universal).sort((a, b) =>
+                versionUtils.isNewer(b.version, a.version) ? 1 : -1,
+            );
+            const features = getDeviceFeatures({
+                bootloader_mode: null,
+                major_version: 1,
+                minor_version: 11,
+                patch_version: 2,
+                internal_model: DeviceModelInternal.T1B1,
+            });
+            const firmwareReleaseConfigInfo = getFirmwareReleaseConfigInfo(
+                features,
+                FirmwareType.Universal,
+            );
+            expect(firmwareReleaseConfigInfo?.intermediary).toBeTruthy();
+            expect(firmwareReleaseConfigInfo?.release.version).toEqual(latestRelase.version);
         });
     });
 });

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -351,37 +351,32 @@ const getCurrentVersion = (features: Features): CurrentVersion => {
 };
 
 const getIntermediaryMessageRelease = (features: Features) => {
-    const { internal_model } = features;
-    const firmwareIntermediaryReleasesConfig = DataManager.getFirmwareIntermediaryReleaseConfig();
-
-    if (!firmwareIntermediaryReleasesConfig) {
+    const config = DataManager.getFirmwareIntermediaryReleaseConfig();
+    if (!config) {
         throw new Error('Firmware release config not loaded.');
     }
 
-    const deviceIntermediaryReleases = firmwareIntermediaryReleasesConfig[internal_model];
-    if (!deviceIntermediaryReleases) {
-        // There are not intermediary releases for this model.
+    const deviceIntermediaryReleases = config[features.internal_model];
+    if (!deviceIntermediaryReleases || deviceIntermediaryReleases.length === 0) {
+        // No intermediary releases are defined for this model.
+        return;
+    }
+
+    const { bootloaderVersion, firmwareVersion } = getCurrentVersion(features);
+
+    const currentVersion = features.bootloader_mode ? bootloaderVersion : firmwareVersion;
+    const minVersionKey = features.bootloader_mode
+        ? 'min_bootloader_version'
+        : 'min_firmware_version';
+
+    if (!currentVersion) {
         return undefined;
     }
-    let intermediary;
 
-    if (features.bootloader_mode) {
-        const { bootloaderVersion } = getCurrentVersion(features);
-        intermediary = deviceIntermediaryReleases.find(
-            inter =>
-                bootloaderVersion &&
-                versionUtils.isNewer(inter.min_bootloader_version, bootloaderVersion),
-        );
-    } else {
-        const { firmwareVersion } = getCurrentVersion(features);
-        intermediary = firmwareVersion
-            ? deviceIntermediaryReleases.find(inter =>
-                  versionUtils.isNewer(inter.min_firmware_version, firmwareVersion),
-              )
-            : undefined;
-    }
-
-    return intermediary || undefined;
+    // Find the first intermediary release that requires a newer version than the current one.
+    return deviceIntermediaryReleases.find(release =>
+        versionUtils.isNewer(release[minVersionKey], currentVersion),
+    );
 };
 
 const getIsBitcoinOnlyAvailable = (features: Features) => {
@@ -480,6 +475,10 @@ export const getReleaseInfo = ({
     const { rollout_probability } = conditions;
     const shouldBeOffered = calculateShouldOfferRelease(rollout_probability, features.device_id);
 
+    if (requiresIntermediary && intermediary) {
+        isNewer = true;
+    }
+
     return {
         firmwareType,
         isBitcoinOnlyAvailable,
@@ -497,40 +496,49 @@ export const getReleaseInfo = ({
 
 export const getFirmwareReleaseConfigInfo = (features: Features, firmwareType: FirmwareType) => {
     const deviceMessageRelease = getReleaseConfig(features, firmwareType);
-    if (!deviceMessageRelease) {
+    if (!deviceMessageRelease?.release) {
         return;
     }
-
     const { release, conditions, firmware_type } = deviceMessageRelease;
-    if (!release) {
-        return;
-    }
 
     const currentVersion = getCurrentVersion(features);
     const inBootloaderMode = features.bootloader_mode && !!currentVersion.bootloaderVersion;
-    const versionToCheck = inBootloaderMode
-        ? currentVersion.bootloaderVersion!
-        : currentVersion.firmwareVersion;
-    const minVersionKey = inBootloaderMode ? 'min_bootloader_version' : 'min_firmware_version';
+
+    const versionContext = inBootloaderMode
+        ? {
+              version: currentVersion.bootloaderVersion!,
+              minVersionKey: 'min_bootloader_version' as const,
+          }
+        : {
+              version: currentVersion.firmwareVersion,
+              minVersionKey: 'min_firmware_version' as const,
+          };
 
     const isCompatible =
-        versionToCheck && versionUtils.isNewerOrEqual(versionToCheck, release[minVersionKey]);
+        versionContext.version &&
+        versionUtils.isNewerOrEqual(versionContext.version, release[versionContext.minVersionKey]);
 
-    const compatibleRelease = isCompatible
-        ? release
-        : findBestCompatibleRelease(
-              getReleasesAssetByDeviceModelAndFirmwareType(features.internal_model, firmwareType),
-              currentVersion,
-              minVersionKey,
-          );
+    let suitableRelease = release;
+    if (!isCompatible) {
+        // If the target isn't compatible, search for the best alternative.
+        const alternativeRelease = findBestCompatibleRelease(
+            getReleasesAssetByDeviceModelAndFirmwareType(features.internal_model, firmwareType),
+            currentVersion,
+            versionContext.minVersionKey,
+        );
+        // If an alternative is found, use it. Otherwise, we proceed with the original.
+        if (alternativeRelease) {
+            suitableRelease = alternativeRelease;
+        }
+    }
 
     const intermediary = getIntermediaryMessageRelease(features);
-    const isBitcoinOnlyAvailable = getIsBitcoinOnlyAvailable(features);
+    const finalTargetRelease = intermediary ? release : suitableRelease;
 
     return getReleaseInfo({
-        isBitcoinOnlyAvailable,
+        isBitcoinOnlyAvailable: getIsBitcoinOnlyAvailable(features),
         features,
-        release: compatibleRelease || release,
+        release: finalTargetRelease,
         conditions,
         intermediary,
         firmwareType: firmware_type,
@@ -579,9 +587,7 @@ export const getFirmwareLocation = ({
         ? buildIntermediaryFirmwareFileName(deviceModel, intermediaryVersion)
         : buildLocalFirmwareFileName(firmwareType, deviceModel, firmwareVersion);
 
-    const versionString = intermediaryVersion
-        ? String(intermediaryVersion)
-        : firmwareVersion.join('.');
+    const versionString = firmwareVersion.join('.');
 
     const bundledBaseUrl = removeTrailingSlashes(DataManager.getSettings('binFilesBaseUrl'));
     // Here we care just to know if the binaries are bundled, in order to use them locally instead of fetching them
@@ -589,7 +595,11 @@ export const getFirmwareLocation = ({
     const isRealBundled = !bundledBaseUrl.includes('data.trezor.io');
     const bundledVersion = getBundledFirmwareVersion(deviceModel, firmwareType);
 
-    if (bundledBaseUrl && isRealBundled && bundledVersion === versionString) {
+    const isIntermediary = bundledBaseUrl && intermediaryVersion;
+    const isMatchingBundledVersion =
+        bundledBaseUrl && isRealBundled && bundledVersion === versionString;
+
+    if (isIntermediary || isMatchingBundledVersion) {
         return {
             baseUrl: bundledBaseUrl,
             path: `firmware/${deviceModel.toLowerCase()}/${firmwareName}`,

--- a/packages/connect/src/utils/__tests__/firmwareUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/firmwareUtils.test.ts
@@ -1,4 +1,5 @@
 import { firmwareAssets } from '@trezor/connect-common/files/firmware';
+import { versionUtils } from '@trezor/utils';
 
 import { findBestCompatibleRelease, isStrictFeatures } from '../firmwareUtils';
 
@@ -72,6 +73,36 @@ describe('firmwareUtils', () => {
                         'min_bootloader_version',
                     ),
                 ).toBeUndefined();
+            });
+
+            it('first release with bootloader equal to min_bootloader in lastest release should return latest release as compatible', () => {
+                const [latestRelase] = Object.values(firmwareAssets.t3t1.universal).sort((a, b) =>
+                    versionUtils.isNewer(b.version, a.version) ? 1 : -1,
+                );
+
+                const releasesAscendentOrder = Object.values(firmwareAssets.t3t1.universal).sort(
+                    (a, b) => (versionUtils.isNewer(a.version, b.version) ? 1 : -1),
+                );
+
+                const latestReleaseMinBootloaderVersion = latestRelase.min_bootloader_version;
+
+                const firstReleaseWithBootloaderCompatibleWithLatest = releasesAscendentOrder.find(
+                    fw =>
+                        versionUtils.isEqual(
+                            fw.bootloader_version,
+                            latestReleaseMinBootloaderVersion,
+                        ),
+                );
+                const comptabibleRelease = findBestCompatibleRelease(
+                    firmwareAssets.t3t1.universal,
+                    {
+                        bootloaderVersion:
+                            firstReleaseWithBootloaderCompatibleWithLatest.bootloader_version,
+                        firmwareVersion: null,
+                    },
+                    'min_bootloader_version',
+                );
+                expect(comptabibleRelease?.version).toEqual(latestRelase.version);
             });
         });
     });

--- a/packages/connect/src/utils/firmwareUtils.ts
+++ b/packages/connect/src/utils/firmwareUtils.ts
@@ -55,7 +55,7 @@ export const findBestCompatibleRelease = (
     );
 
     const compatibleFirmware = sortedFirmwares.find(fw =>
-        versionUtils.isNewer(versionToCompare, fw[checkProperty]),
+        versionUtils.isNewerOrEqual(versionToCompare, fw[checkProperty]),
     );
 
     return compatibleFirmware;
@@ -74,7 +74,7 @@ export const buildLocalFirmwareFileName = (
 export const buildIntermediaryFirmwareFileName = (
     internalModel: DeviceModelInternal,
     version: number,
-) => `trezor-${internalModel}-inter-v${version}.bin`;
+) => `trezor-${internalModel.toLowerCase()}-inter-v${version}.bin`;
 
 export const getFirmwareMode = (features: Features) => {
     if (features.bootloader_mode) return 'bootloader';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It should properly select intermediaries and it should offer to update to T1B1 devices with FW version that requires intermediary.

I also add some test cases to make sure this stays solid and refactor it a bit for better readability.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21267

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/intermediary-and-compatible&lookback=7)