### PR TITLE
fix(e2e): corrects publish_results_to_github parameter in test workflows

### DIFF
--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: ""
         type: string
+      publish_results_to_github:
+        description: "Publish test report to GitHub Project"
+        required: false
+        default: false
+        type: boolean
     secrets:
       TREZOR_BOT_APP_ID:
         required: true
@@ -107,6 +112,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
           RELEASE_BUILD: ${{ env.release_build }}
           EMULATOR_MODEL: ${{ inputs.emulator_model }}
+          PUBLISH_RESULTS_TO_GITHUB: ${{ inputs.publish_results_to_github == true }}
         with:
           api-level: 31
           profile: pixel_3a

--- a/.github/workflows/test-suite-desktop-e2e-release.yml
+++ b/.github/workflows/test-suite-desktop-e2e-release.yml
@@ -13,15 +13,15 @@ on:
       - release/2*
   workflow_dispatch:
     inputs:
-      publishResultsToGitHub:
-        description: "(optional) Publish test report to GitHub Project"
+      publish_results_to_github:
+        description: "Publish test report to GitHub Project"
         required: false
         default: false
         type: boolean
   workflow_call:
     inputs:
-      publishResultsToGitHub:
-        description: "(optional) Publish test report to GitHub Project"
+      publish_results_to_github:
+        description: "Publish test report to GitHub Project"
         required: false
         default: false
         type: boolean
@@ -97,4 +97,4 @@ jobs:
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}
           github-token: ${{ steps.trezor-bot-token.outputs.token }}
           release-build: ${{ env.release_build }}
-          run-reporter: ${{ inputs.publishResultsToGitHub }}
+          run-reporter: ${{ inputs.publish_results_to_github == true }}

--- a/.github/workflows/test-suite-native-e2e-android-t3w1.yml
+++ b/.github/workflows/test-suite-native-e2e-android-t3w1.yml
@@ -20,8 +20,8 @@ on:
   #     - release-native/*
   workflow_dispatch:
     inputs:
-      publishResultsToGitHub:
-        description: "(optional) Publish test report to GitHub Project"
+      publish_results_to_github:
+        description: "Publish test report to GitHub Project"
         required: false
         default: false
         type: boolean
@@ -41,8 +41,8 @@ jobs:
     with:
       emulator_model: "T3W1"
       detox_extra_args: "--testNamePattern '^(?!.*@specificModel)'"
+      publish_results_to_github: ${{ inputs.publish_results_to_github == true }}
     secrets:
-      PUBLISH_RESULTS_TO_GITHUB: ${{ inputs.publishResultsToGitHub }}
       TREZOR_BOT_APP_ID: ${{ secrets.TREZOR_BOT_APP_ID }}
       TREZOR_BOT_PRIVATE_KEY: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
       CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}

--- a/.github/workflows/test-suite-native-e2e-android.yml
+++ b/.github/workflows/test-suite-native-e2e-android.yml
@@ -20,8 +20,8 @@ on:
       - release-native/*
   workflow_dispatch:
     inputs:
-      publishResultsToGitHub:
-        description: "(optional) Publish test report to GitHub Project"
+      publish_results_to_github:
+        description: "Publish test report to GitHub Project"
         required: false
         default: false
         type: boolean
@@ -40,8 +40,8 @@ jobs:
     needs: prepare_android_test_app
     with:
       emulator_model: "T3T1"
+      publish_results_to_github: ${{ inputs.publish_results_to_github == true }}
     secrets:
-      PUBLISH_RESULTS_TO_GITHUB: ${{ inputs.publishResultsToGitHub }}
       TREZOR_BOT_APP_ID: ${{ secrets.TREZOR_BOT_APP_ID }}
       TREZOR_BOT_PRIVATE_KEY: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
       CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}

--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -9,10 +9,11 @@ on:
   #     - release-native/*
   workflow_dispatch:
     inputs:
-      publishResultsToGitHub:
-        description: "(optional) Publish test report to GitHub Project"
+      publish_results_to_github:
+        description: "Publish test report to GitHub Project"
         required: false
         default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -138,7 +139,7 @@ jobs:
       - name: Run Detox E2E iOS tests
         working-directory: ./suite-native/app
         env:
-          PUBLISH_RESULTS_TO_GITHUB: ${{ inputs.publishResultsToGitHub }}
+          PUBLISH_RESULTS_TO_GITHUB: ${{ inputs.publish_results_to_github == true }}
           GITHUB_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
           GITHUB_REPORTER_VERBOSE: false
           RELEASE_BUILD: ${{ env.release_build }}

--- a/.github/workflows/test-suite-release-e2e-report-orchestration.yml
+++ b/.github/workflows/test-suite-release-e2e-report-orchestration.yml
@@ -18,10 +18,10 @@ jobs:
     uses: ./.github/workflows/test-suite-desktop-e2e-release.yml
     secrets: inherit
     with:
-      publishResultsToGitHub: true
+      publish_results_to_github: true
 
   call-test-suite-web-e2e-release:
     uses: ./.github/workflows/test-suite-web-e2e-release.yml
     secrets: inherit
     with:
-      publishResultsToGitHub: true
+      publish_results_to_github: true

--- a/.github/workflows/test-suite-web-e2e-release.yml
+++ b/.github/workflows/test-suite-web-e2e-release.yml
@@ -13,15 +13,15 @@ on:
       - release/2*
   workflow_dispatch:
     inputs:
-      publishResultsToGitHub:
-        description: "(optional) Publish test report to GitHub Project"
+      publish_results_to_github:
+        description: "Publish test report to GitHub Project"
         required: false
         default: false
         type: boolean
   workflow_call:
     inputs:
-      publishResultsToGitHub:
-        description: "(optional) Publish test report to GitHub Project"
+      publish_results_to_github:
+        description: "Publish test report to GitHub Project"
         required: false
         default: false
         type: boolean
@@ -89,4 +89,4 @@ jobs:
           e2e-passphrase: ${{ secrets.E2E_TEST_PASSPHRASE }}
           github-token: ${{ steps.trezor-bot-token.outputs.token }}
           release-build: ${{ env.release_build }}
-          run-reporter: ${{ inputs.publishResultsToGitHub }}
+          run-reporter: ${{ inputs.publish_results_to_github == true }}

--- a/docs/tests/e2e-github-reporter.md
+++ b/docs/tests/e2e-github-reporter.md
@@ -16,7 +16,7 @@ When executed during release builds, the reporter adds new draft issues to a Git
 ## How to run
 
 Reporter no longer has automatic trigger. It needs to be triggered manually by running its orchestration workflow **[Test] Release Suite Report orchestration** which will run 3 relevant workflows (Web, Desktop and Manual). All automated tests will be run on the release again, their results reported to GitHub project and issues for manual regression will be generated as well.
-You can also run the specific workflow one by one. Web and Desktop workflows needs to be run with parameter publishResultsToGitHub set to `true`.
+You can also run the specific workflow one by one. Web and Desktop workflows needs to be run with parameter `publish_results_to_github set` to `true`.
 
 ## What to do when workflow fails
 
@@ -206,4 +206,4 @@ The reporter is integrated into release branch CI workflows:
 - `test-suite-native-e2e-ios.yml` for Suite native iOS tests (wf is broken ATM so we cannot guarantee reporter is working)
 
 Each workflow passes the `RELEASE_BUILD` and `GITHUB_TOKEN` environment variables to enable test reporting.
-On the Web, Desktop, Android and iOS workflows, reporter is enabled only when workflow is run manually with param `publishResultsToGitHub` se to `true`. Otherwise only test are run. That way we have full control on the generation of issues in GitHub. We had a problem of duplicate and unwanted triggers when it was based on push to release branch.
+On the Web, Desktop, Android and iOS workflows, reporter is enabled only when workflow is run manually with param `publish_results_to_github` se to `true`. Otherwise only test are run. That way we have full control on the generation of issues in GitHub. We had a problem of duplicate and unwanted triggers when it was based on push to release branch.


### PR DESCRIPTION
Fixes incorrectly passed parameter publish_results_to_github 

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-release-report-orchestration&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-release-report-orchestration&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-release-report-orchestration&lookback=7)