### PR TITLE
fix(suite): allow navigation to settings when device-used-elsewhere

### DIFF
--- a/packages/suite/src/utils/suite/prerequisites.ts
+++ b/packages/suite/src/utils/suite/prerequisites.ts
@@ -79,6 +79,7 @@ export const getExcludedPrerequisites = (router: RouterState): PrerequisiteType[
             'device-disconnected',
             'device-unacquired',
             'device-unacquired-requires-thp',
+            'device-used-elsewhere',
             'device-unreadable',
             'device-unknown',
             'device-seedless',


### PR DESCRIPTION
## Description

:thought_balloon: The prerequisite logic is a mess, I want to declaratively type prerequistie (rather than inferred type) and invert the condition for excluded. But that cannot go into cherrypick so there'll be next PR.

## Related Issue

Resolve #21335


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/prerequisite-screen-settings&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/prerequisite-screen-settings&lookback=7)