### PR TITLE
fix(suite): do not show staking banner in acc when staking is active

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -6,12 +6,11 @@ import {
     MIN_ETH_AMOUNT_FOR_STAKING,
     MIN_SOL_AMOUNT_FOR_STAKING,
 } from '@suite-common/wallet-constants';
-import { selectPoolStatsApyData } from '@suite-common/wallet-core';
+import { selectAccountIsStakingActive, selectPoolStatsApyData } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import {
     getStakingDataForNetwork,
-    isSupportedEthStakingNetworkSymbol,
-    isSupportedSolStakingNetworkSymbol,
+    getStakingLimitsByNetworkSymbol,
 } from '@suite-common/wallet-utils';
 import {
     Button,
@@ -45,14 +44,14 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
     const { stakeEthBannerClosed, stakeSolBannerClosed } = useSelector(selectSuiteFlags);
     const { route } = useSelector(state => state.router);
     const apy = useSelector(state => selectPoolStatsApyData(state, account.symbol));
+    const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
+    const stakingLimits = getStakingLimitsByNetworkSymbol(account.symbol);
 
     const displaySymbol = getDisplaySymbol(account.symbol);
     const stakingData = getStakingDataForNetwork(account);
 
     const accountBalance = account.formattedBalance;
     const stakingBalance = stakingData?.depositedBalance ?? '0';
-
-    const isAccountEmpty = new BigNumber(accountBalance).eq(0);
 
     const potentialRewards = useMemo(() => {
         const totalBalance = new BigNumber(stakingBalance).plus(accountBalance).toString();
@@ -106,38 +105,35 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
                 return {
                     isStakingBannerClosed: stakeEthBannerClosed,
                     minStakingAmount: MIN_ETH_AMOUNT_FOR_STAKING,
-                    isSupportedStakingNetworkSymbol: isSupportedEthStakingNetworkSymbol(
-                        account.symbol,
-                    ),
                 };
             case 'solana':
                 return {
                     isStakingBannerClosed: stakeSolBannerClosed,
                     minStakingAmount: MIN_SOL_AMOUNT_FOR_STAKING,
-                    isSupportedStakingNetworkSymbol: isSupportedSolStakingNetworkSymbol(
-                        account.symbol,
-                    ),
                 };
             default:
                 return {
                     isStakingBannerClosed: true,
                     minStakingAmount: undefined,
-                    isSupportedStakingNetworkSymbol: false,
                 };
         }
     };
 
-    const { isStakingBannerClosed, isSupportedStakingNetworkSymbol } =
-        getNetworkDetails(account.networkType) ?? {};
+    const { isStakingBannerClosed } = getNetworkDetails(account.networkType) ?? {};
 
     if (
         route?.name !== 'wallet-index' ||
         isStakingBannerClosed ||
         !account ||
-        !isSupportedStakingNetworkSymbol
+        isStakingActive ||
+        !stakingLimits
     ) {
         return null;
     }
+
+    const hasEnoughBalanceForStaking = new BigNumber(accountBalance).gte(
+        stakingLimits.MIN_AMOUNT_FOR_STAKING,
+    );
 
     return (
         <Card>
@@ -155,7 +151,7 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
                         </H4>
 
                         <Paragraph variant="tertiary" typographyStyle="hint">
-                            {isAccountEmpty ? (
+                            {!hasEnoughBalanceForStaking ? (
                                 <Translation
                                     id="TR_STAKING_BANNER_DETAIL_TEXT_EMPTY"
                                     values={{ displaySymbol }}

--- a/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboard.tsx
+++ b/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboard.tsx
@@ -76,9 +76,14 @@ export const StakingDashboard = () => {
     const [accountsSufficientFunds, accountsInsufficientFunds] = arrayPartition(
         accountsStakingNotActive,
         (account: Account) => {
-            const { MIN_AMOUNT_FOR_STAKING } = getStakingLimitsByNetworkSymbol(account.symbol);
+            const minStakingAmount = getStakingLimitsByNetworkSymbol(
+                account.symbol,
+            )?.MIN_AMOUNT_FOR_STAKING;
 
-            return new BigNumber(account.formattedBalance).gte(MIN_AMOUNT_FOR_STAKING);
+            return (
+                minStakingAmount !== undefined &&
+                new BigNumber(account.formattedBalance).gte(minStakingAmount)
+            );
         },
     );
 

--- a/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardAccountRow.tsx
+++ b/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardAccountRow.tsx
@@ -26,7 +26,9 @@ export const StakingDashboardAccountRow = ({ account }: { account: Account }) =>
     const apy = useSelector(state => selectPoolStatsApyData(state, account.symbol));
     const displaySymbol = getDisplaySymbol(account.symbol);
 
-    const { MIN_AMOUNT_FOR_STAKING } = getStakingLimitsByNetworkSymbol(account.symbol);
+    const minStakingAmount = getStakingLimitsByNetworkSymbol(
+        account.symbol,
+    )?.MIN_AMOUNT_FOR_STAKING;
 
     const accountBalance = account.formattedBalance;
     const stakingBalance = getAccountTotalStakingBalance(account) ?? '0';
@@ -94,9 +96,8 @@ export const StakingDashboardAccountRow = ({ account }: { account: Account }) =>
             return 'staking-max';
         }
 
-        const hasEnoughBalanceForStaking = new BigNumber(accountBalance).gte(
-            MIN_AMOUNT_FOR_STAKING,
-        );
+        const hasEnoughBalanceForStaking =
+            minStakingAmount && new BigNumber(accountBalance).gte(minStakingAmount);
 
         if (stakingBalance !== '0') {
             if (!hasEnoughBalanceForStaking) {
@@ -111,7 +112,7 @@ export const StakingDashboardAccountRow = ({ account }: { account: Account }) =>
         }
 
         return 'staking-inactive';
-    }, [accountBalance, stakingBalance, MIN_AMOUNT_FOR_STAKING]);
+    }, [accountBalance, stakingBalance, minStakingAmount]);
 
     const CurrentRewardsCell = () => {
         const isStakingActive = stakingBalance !== '0';
@@ -180,7 +181,7 @@ export const StakingDashboardAccountRow = ({ account }: { account: Account }) =>
                             <Translation
                                 id="TR_STAKING_DASHBOARD_MINIMUM_STAKE"
                                 values={{
-                                    amount: MIN_AMOUNT_FOR_STAKING.toString(),
+                                    amount: minStakingAmount?.toString(),
                                     displaySymbol,
                                 }}
                             />

--- a/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardActivateRow.tsx
+++ b/packages/suite/src/views/dashboard/StakingDashboard/StakingDashboardActivateRow.tsx
@@ -16,7 +16,7 @@ export const StakingDashboardActivateRow = ({ symbol }: { symbol: NetworkSymbol 
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     const { displaySymbol, name } = getNetwork(symbol);
-    const { MIN_AMOUNT_FOR_STAKING } = getStakingLimitsByNetworkSymbol(symbol);
+    const minStakingAmount = getStakingLimitsByNetworkSymbol(symbol)?.MIN_AMOUNT_FOR_STAKING;
 
     const startNetworkDiscovery = () => {
         if (!device) return;
@@ -46,7 +46,7 @@ export const StakingDashboardActivateRow = ({ symbol }: { symbol: NetworkSymbol 
                     <Translation
                         id="TR_STAKING_DASHBOARD_MINIMUM_STAKE"
                         values={{
-                            amount: MIN_AMOUNT_FOR_STAKING.toString(),
+                            amount: minStakingAmount?.toString(),
                             displaySymbol,
                         }}
                     />

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
@@ -4,7 +4,10 @@ import { useFormatters } from '@suite-common/formatters';
 import { Context } from '@suite-common/message-system';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { selectHasRunningDiscovery, selectPoolStatsApyData } from '@suite-common/wallet-core';
-import { getStakingDataForNetwork } from '@suite-common/wallet-utils';
+import {
+    getStakingDataForNetwork,
+    getStakingLimitsByNetworkSymbol,
+} from '@suite-common/wallet-utils';
 import {
     Button,
     Card,
@@ -51,7 +54,9 @@ export const EmptyStakingCard = () => {
     const accountBalance = account?.formattedBalance ?? '0';
     const stakingBalance = stakingData?.depositedBalance ?? '0';
 
-    const isAccountEmpty = new BigNumber(accountBalance).eq(0);
+    const stakingLimits = getStakingLimitsByNetworkSymbol(account?.symbol);
+    const hasEnoughBalanceForStaking =
+        stakingLimits && new BigNumber(accountBalance).gte(stakingLimits.MIN_AMOUNT_FOR_STAKING);
 
     const potentialRewards = useMemo(() => {
         const totalBalance = new BigNumber(stakingBalance).plus(accountBalance).toString();
@@ -164,7 +169,7 @@ export const EmptyStakingCard = () => {
                             />
                         </H3>
                         <Paragraph variant="tertiary" maxWidth={700}>
-                            {isAccountEmpty ? (
+                            {!hasEnoughBalanceForStaking ? (
                                 <Translation
                                     id="TR_STAKING_CARD_TEXT_EMPTY"
                                     values={{ displaySymbol }}

--- a/suite-common/wallet-utils/src/stakingUtils.ts
+++ b/suite-common/wallet-utils/src/stakingUtils.ts
@@ -47,7 +47,7 @@ export const getAccountTotalStakingBalance = (account: Account) => {
 export const isSupportedStakingNetworkSymbol = (symbol: NetworkSymbol) =>
     isSupportedEthStakingNetworkSymbol(symbol) || isSupportedSolStakingNetworkSymbol(symbol);
 
-export const getStakingLimitsByNetworkSymbol = (symbol: NetworkSymbol) => {
+export const getStakingLimitsByNetworkSymbol = (symbol: NetworkSymbol | undefined) => {
     switch (symbol) {
         case 'eth':
             return {
@@ -56,16 +56,17 @@ export const getStakingLimitsByNetworkSymbol = (symbol: NetworkSymbol) => {
                 MIN_FOR_WITHDRAWALS: MIN_ETH_FOR_WITHDRAWALS,
                 MIN_BALANCE_FOR_STAKING: MIN_ETH_BALANCE_FOR_STAKING,
             };
-        case 'sol': {
+        case 'sol':
             return {
                 MIN_AMOUNT_FOR_STAKING: MIN_SOL_AMOUNT_FOR_STAKING,
                 MAX_AMOUNT_FOR_STAKING: MAX_SOL_AMOUNT_FOR_STAKING,
                 MIN_FOR_WITHDRAWALS: MIN_SOL_FOR_WITHDRAWALS,
                 MIN_BALANCE_FOR_STAKING: MIN_SOL_BALANCE_FOR_STAKING,
             };
-        }
         default:
-            throw new Error(`Unsupported network symbol: ${symbol}`);
+            console.warn(`Unsupported or missing network symbol: ${symbol}`);
+
+            return null;
     }
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- promo to stake is not shown in case user already stakes
- promo to stake shows correct text based on user's balance


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/21333

## Screenshots:
Already staked
<img width="883" height="506" alt="Screenshot 2025-09-08 at 9 40 13" src="https://github.com/user-attachments/assets/3ac2b72f-69a5-4a5c-88f0-6ff1336a0c30" />
Not staked, enough balance
<img width="1033" height="619" alt="Screenshot 2025-09-08 at 9 40 18" src="https://github.com/user-attachments/assets/8e060d32-3718-41f2-b4c5-c6cbc88605ee" />
Not staked, not enough balance
<img width="1062" height="738" alt="Screenshot 2025-09-08 at 9 40 23" src="https://github.com/user-attachments/assets/7ab926ef-dc9e-464a-a7ab-1ae11c02e249" />
No balance
<img width="970" height="834" alt="Screenshot 2025-09-08 at 9 40 28" src="https://github.com/user-attachments/assets/1131d38f-5dd4-49e7-9455-7893037dc2c7" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/banner-staking&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/banner-staking&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/banner-staking&lookback=7)