### PR TITLE
fix(suite): only extend the styles of the select item to keep the the…

### DIFF
--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -394,7 +394,6 @@ export const Select = ({
                     closeMenuOnScroll={closeMenuOnScroll}
                     menuPosition="fixed" // Required for closeMenuOnScroll to work properly when near page bottom
                     menuPortalTarget={menuPortalTarget}
-                    styles={createSelectStyle(theme, isRenderedInModal)}
                     onChange={handleOnChange}
                     isSearchable={isSearchable}
                     menuIsOpen={isMenuOpen}
@@ -402,6 +401,10 @@ export const Select = ({
                     menuPlacement="auto"
                     placeholder={placeholder || ''}
                     {...rest}
+                    styles={{
+                        ...createSelectStyle(theme, isRenderedInModal),
+                        ...(rest.styles || {}),
+                    }}
                     components={memoizedComponents}
                 />
 

--- a/packages/suite/src/components/suite/WordInput.tsx
+++ b/packages/suite/src/components/suite/WordInput.tsx
@@ -50,3 +50,5 @@ export const WordInput = memo(() => {
         />
     );
 });
+
+WordInput.displayName = 'WordInput';


### PR DESCRIPTION
…mes and stuff, not replace them



## Description

The problem was the the default select styles were completely overridden. Maybe that's wrong usage of "base" and we should pass it from the select itself.

Anyways, I fixed it so that we only extend the current styles, we do not replace the defaults

## REPRO:
It is T1B1 recovery process in onboarding

## Related Issue
https://github.com/trezor/trezor-suite/issues/21283
Resolves https://github.com/trezor/trezor-suite/issues/21283

## Screenshots:
<img width="1906" height="1002" alt="485525265-574fac71-7118-4711-ab8b-bd4280710483" src="https://github.com/user-attachments/assets/bdee880c-5326-4f92-8610-0cb9e0a73c47" />


<img width="1258" height="683" alt="Screenshot 2025-09-08 at 10 32 37 AM" src="https://github.com/user-attachments/assets/b66175ef-18fb-45c4-8195-945051b38ac9" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=21283-fix-the-select-items-stylings&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=21283-fix-the-select-items-stylings&lookback=7)