### PR TITLE
refactor(suite-native): implicit FF reading for e2e tests

### DIFF
--- a/suite-native/app/e2e/utils.ts
+++ b/suite-native/app/e2e/utils.ts
@@ -20,10 +20,13 @@ const INITIAL_LAUNCH_ARGS: LaunchArgumentsWithPreloadedState = {
     // Main loop synchronization is infinitely blocking iOS tests while is the graph displayed, so we need to disable it.
     // Not sure about the cause of it yet.
     DTXDisableMainRunLoopSync: platform === 'ios',
-    isConnectPopupEnabled_v2: true,
-    isDebugKeysAllowed: true,
-    isTradingBuyEnabled: true,
-    areDebugOnlyNetworksEnabled: true,
+
+    featureFlags: {
+        isConnectPopupEnabled_v2: true,
+        isDebugKeysAllowed: true,
+        isTradingBuyEnabled: true,
+        areDebugOnlyNetworksEnabled: true,
+    },
 };
 
 const TREZOR_E2E_DEVICE_LABEL = 'Trezor T - Tester';
@@ -84,10 +87,7 @@ export const openApp = async ({
     newInstance: boolean;
     args?: LaunchArgumentsWithPreloadedState;
 }) => {
-    const launchArgs = {
-        ...INITIAL_LAUNCH_ARGS,
-        ...args,
-    };
+    const launchArgs = mergeDeepObject(INITIAL_LAUNCH_ARGS, args);
 
     if (await isDebugTestBuild()) {
         await openExpoDevClientApp({ newInstance, launchArgs });

--- a/suite-native/config/package.json
+++ b/suite-native/config/package.json
@@ -13,6 +13,7 @@
         "@mobily/ts-belt": "^3.13.1",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
+        "@suite-native/feature-flags": "workspace:*",
         "react-native-launch-arguments": "^4.1.0"
     }
 }

--- a/suite-native/config/src/launch-arguments.ts
+++ b/suite-native/config/src/launch-arguments.ts
@@ -1,23 +1,17 @@
 import { LaunchArguments } from 'react-native-launch-arguments';
 
+import { FeatureFlag } from '@suite-native/feature-flags';
+
+type FeatureFlagLaunchArguments = {
+    [key in FeatureFlag]?: boolean;
+};
+
 export type LaunchArguments = {
     detoxURLBlacklistRegex?: string;
     DTXDisableMainRunLoopSync?: boolean;
-    isBluetoothEnabled?: boolean;
-    isCardanoSendEnabled?: boolean;
-    isConnectPopupEnabled_v2?: boolean;
-    isDebugKeysAllowed?: boolean;
-    isWalletConnectEnabled_v2?: boolean;
-    isTradingBuyEnabled?: boolean;
-    isTradingExchangeEnabled?: boolean;
-    isTradingSellEnabled?: boolean;
-    isDeviceConnectEnabled?: boolean;
-    areDebugOnlyNetworksEnabled?: boolean;
-    preloadedState?: Record<string, unknown>;
     isFirmwareUpdateEnabled?: boolean;
-    isLocalizationEnabled?: boolean;
-    isLocalFirstStorageEnabled?: boolean;
-    areTradingExchangeDexesEnabled?: boolean;
+    preloadedState?: Record<string, unknown>;
+    featureFlags?: FeatureFlagLaunchArguments;
 };
 
 export const launchArguments = LaunchArguments.value<LaunchArguments>();

--- a/suite-native/config/tsconfig.json
+++ b/suite-native/config/tsconfig.json
@@ -7,6 +7,7 @@
         },
         {
             "path": "../../suite-common/wallet-utils"
-        }
+        },
+        { "path": "../feature-flags" }
     ]
 }

--- a/suite-native/feature-flags/src/featureFlagsSelectors.e2e.ts
+++ b/suite-native/feature-flags/src/featureFlagsSelectors.e2e.ts
@@ -3,4 +3,4 @@ import { launchArguments } from '@suite-native/config';
 import { FeatureFlag, FeatureFlagsRootState } from './featureFlagsSlice';
 
 export const selectIsFeatureFlagEnabled = (state: FeatureFlagsRootState, key: FeatureFlag) =>
-    launchArguments[key] ?? state.featureFlags[key];
+    launchArguments['featureFlags']?.[key] ?? state.featureFlags[key];

--- a/yarn.lock
+++ b/yarn.lock
@@ -11226,6 +11226,7 @@ __metadata:
     "@mobily/ts-belt": "npm:^3.13.1"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
+    "@suite-native/feature-flags": "workspace:*"
     react-native-launch-arguments: "npm:^4.1.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description
- only refactor, no new functionality
- improving E2E test launch arguments, TypeScript typing to implicitly read all the possible feature flags
- It is not needed to manually add a new feature flag to the launch arguments type whenever a new flag is added


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native/implicit-ff-evaluation-for-e2e&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/native/implicit-ff-evaluation-for-e2e&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/native/implicit-ff-evaluation-for-e2e&lookback=7)