### PR TITLE
feat(suite-native): Mobile Swap: set swapSlippage on quoteSelect

### DIFF
--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -1,3 +1,4 @@
+import { tradingSettingsActions } from '@suite-common/trading';
 import {
     PreloadedState,
     TestStore,
@@ -149,7 +150,29 @@ describe('useExchangeSelectQuote', () => {
                 expect.objectContaining({
                     type: 'selectQuoteThunkMock',
                     payload: expect.objectContaining({
-                        quote: exchangeQuotes[1],
+                        quote: expect.objectContaining({ quoteId: exchangeQuotes[1]?.quoteId }),
+                        timer: mockTimerReturn,
+                    }),
+                }),
+            );
+        });
+
+        it('should call selectQuoteThunk  with correct maxSlippage value', async () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            act(() => {
+                store.dispatch(tradingSettingsActions.setMaxSlippagePercentage('1.5'));
+            });
+            const { result } = await renderUseExchangeSelectQuote();
+
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'selectQuoteThunkMock',
+                    payload: expect.objectContaining({
+                        quote: expect.objectContaining({ swapSlippage: '1.5' }),
                         timer: mockTimerReturn,
                     }),
                 }),

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
@@ -3,7 +3,11 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { exchangeThunks, selectTradingExchangeIsLoading } from '@suite-common/trading';
+import {
+    exchangeThunks,
+    selectTradingExchangeIsLoading,
+    selectTradingMaxSlippagePercentage,
+} from '@suite-common/trading';
 import {
     RootStackParamList,
     StackToStackCompositeNavigationProps,
@@ -33,9 +37,9 @@ export const useExchangeSelectQuote = (form: ExchangeFormType) => {
     const timer = useTimer();
 
     const isLoading = useSelector(selectTradingExchangeIsLoading);
-
     const sendAccount = useSelector(selectExchangeSelectedSendAccount);
     const receiveAccount = useSelector(selectExchangeSelectedReceiveAccount);
+    const swapSlippage = useSelector(selectTradingMaxSlippagePercentage);
 
     const navigation = useNavigation<NavigationProps>();
 
@@ -78,7 +82,7 @@ export const useExchangeSelectQuote = (form: ExchangeFormType) => {
 
         await dispatch(
             exchangeThunks.selectQuoteThunk({
-                quote: candidateQuote,
+                quote: { ...candidateQuote, swapSlippage },
                 timer,
                 userConsent: handleConsent.request,
                 nextStep: () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use slippage for selected trade:

- when selecting quote in `useExchangeSelectQuote` set `swapSlippage` to what is saved in settings

## Related Issue

Resolve #20838


## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=20838-Mobile-Swap-Wire-slippage-settings-to-swap-trade&lookback=7)