### PR TITLE
fix(connect): current release for only remote fws

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -19,7 +19,12 @@ import { checkFirmwareRevision } from './checkFirmwareRevision';
 import { abortThpWorkflow, getThpChannel } from './thp';
 import { checkFirmwareHashWithRetries } from './workflow/checkFirmwareHashWithRetries';
 import { getAllNetworks } from '../data/coinInfo';
-import { getFirmwareReleaseConfigInfo, getFirmwareStatus, getLanguage } from '../data/firmwareInfo';
+import {
+    getFirmwareReleaseConfigInfo,
+    getFirmwareStatus,
+    getLanguage,
+    getReleaseByVersion,
+} from '../data/firmwareInfo';
 import {
     DEVICE,
     DeviceButtonRequestPayload,
@@ -646,6 +651,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
             payload,
         );
         this._updateFeatures(message);
+        this._updateCurrentRelease(message);
         this.setState({ deriveCardano: payload?.derive_cardano });
     }
 
@@ -657,6 +663,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     async getFeatures() {
         const { message } = await this.getCurrentSession().typedCall('GetFeatures', 'Features', {});
         this._updateFeatures(message);
+        this._updateCurrentRelease(message);
     }
 
     getAuthenticityChecks() {
@@ -780,6 +787,27 @@ export class Device extends TypedEmitter<DeviceEvents> {
         return response.message;
     }
 
+    private async _updateCurrentRelease(feat: Features) {
+        const newVersion = [
+            feat.major_version,
+            feat.minor_version,
+            feat.patch_version,
+        ] satisfies VersionArray;
+        const newFirmwareType = getFirmwareType(feat);
+
+        if (
+            this._currentRelease &&
+            newFirmwareType === this.firmwareType &&
+            versionUtils.isEqual(this._currentRelease.version, newVersion)
+        ) {
+            return;
+        }
+
+        const release = await getReleaseByVersion(feat, newVersion, newFirmwareType);
+        this._currentRelease = release;
+        this.availableTranslations = this._currentRelease?.translations ?? {};
+    }
+
     private _updateFeatures(feat: Features) {
         const capabilities = parseCapabilities(feat);
         feat.capabilities = capabilities;
@@ -819,15 +847,17 @@ export class Device extends TypedEmitter<DeviceEvents> {
                     device: this.toMessageObject(),
                 });
             }
-            this._currentRelease = getReleaseAsset(
-                feat.internal_model,
-                newVersion,
-                getFirmwareType(feat),
-            );
             this._unavailableCapabilities = getUnavailableCapabilities(feat, getAllNetworks());
             this._firmwareStatus = getFirmwareStatus(feat, getFirmwareType(feat));
             this._firmwareReleaseConfigInfo = getFirmwareReleaseConfigInfo(
                 feat,
+                getFirmwareType(feat),
+            );
+            // Here we update `currentRelease` in case of a release JSON that was bundled.
+            // In case it was not bundled it will be fetched after `_updateFeatures` by `_updateCurrentRelease`.
+            this._currentRelease = getReleaseAsset(
+                feat.internal_model,
+                newVersion,
                 getFirmwareType(feat),
             );
             this.availableTranslations = this._currentRelease?.translations ?? {};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We were getting current release in Device only from bundled ones and we need it also for FWs that are only remote for example in case that you want to change language of current FW we need the information of the available languages and the path to obtain them.

## Related Issue

Resolve <!--- link the issue here -->

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/current-release-for-only-remote-fws&lookback=7)