### PR TITLE
fix(suite): make sure that text alignment is center on bio auth guard…

### DIFF
--- a/packages/suite/src/components/suite/BioAuthGuard/BioAuthGuard.tsx
+++ b/packages/suite/src/components/suite/BioAuthGuard/BioAuthGuard.tsx
@@ -83,10 +83,10 @@ const BioAuthOverlay = ({
                                 {isBioAuthValidationRequired ? (
                                     <Container $elevation={elevation}>
                                         <Icon name="lockFilled" />
-                                        <Paragraph typographyStyle="titleSmall">
+                                        <Paragraph align="center" typographyStyle="titleSmall">
                                             <Translation id="TR_BIO_AUTH_LOCKED_HEADING" />
                                         </Paragraph>
-                                        <Paragraph typographyStyle="body">
+                                        <Paragraph align="center" typographyStyle="body">
                                             {isMacOs() ? (
                                                 <Translation id="TR_BIO_AUTH_LOCKED_TEXT_MAC" />
                                             ) : (


### PR DESCRIPTION
…  unlock screen

<!--- Provide a general summary of your changes in the Title above -->

## Description

When the text was longer than a align, suddenly text aligned itself to the left, dunno why

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
<img width="1048" height="926" alt="Snímek obrazovky 2025-09-04 v 19 34 22" src="https://github.com/user-attachments/assets/ad93f214-547a-476b-a150-7aefeb19319f" />



<img width="507" height="327" alt="Screenshot 2025-09-08 at 1 51 41 PM" src="https://github.com/user-attachments/assets/c3bc11fe-5b2e-494d-8223-5bd7c7406724" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-alignment-bio-auth&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-alignment-bio-auth&lookback=7)