### PR TITLE
fix(suite-native): use navigation popTo method to disallow navigating back

### DIFF
--- a/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
+++ b/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
@@ -55,7 +55,7 @@ export const CoinEnablingInitScreen = () => {
             payload: { enabledNetworks: values.enabledCoins },
         });
 
-        navigation.navigate(RootStackRoutes.AppTabs, {
+        navigation.popTo(RootStackRoutes.AppTabs, {
             screen: AppTabsRoutes.HomeStack,
             params: {
                 screen: HomeStackRoutes.Home,

--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -107,13 +107,13 @@ export const useHandleDeviceConnection = () => {
             !isDeviceCompromised
         ) {
             if (!wasDeviceOnboardingCancelled) {
-                navigation.navigate(RootStackRoutes.DeviceOnboardingStack, {
+                navigation.popTo(RootStackRoutes.DeviceOnboardingStack, {
                     screen: DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
                 });
             } else if (isAuthorizeDeviceStackFocused) {
                 // This ensures that THP-related screens are dismissed after a THP connection.
                 // Dismissing them any other way caused navigation glitches.
-                navigation.navigate(RootStackRoutes.AppTabs, {
+                navigation.popTo(RootStackRoutes.AppTabs, {
                     screen: AppTabsRoutes.HomeStack,
                     params: {
                         screen: HomeStackRoutes.Home,

--- a/suite-native/module-device-onboarding/src/screens/CreatePinScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/CreatePinScreen.tsx
@@ -42,6 +42,7 @@ type NavigationProps = StackToStackCompositeNavigationProps<
     DeviceOnboardingStackRoutes.CreatePin,
     RootStackParamList
 >;
+
 export const CreatePinScreen = () => {
     const navigation = useNavigation<NavigationProps>();
     const deviceModel = useSelector(selectDeviceModel);
@@ -53,16 +54,15 @@ export const CreatePinScreen = () => {
 
     const handlePinCreated = useCallback(() => {
         if (hasBitcoinOnlyFirmware || isCoinEnablingInitFinished) {
-            navigation.navigate(RootStackRoutes.AppTabs, {
+            navigation.popTo(RootStackRoutes.AppTabs, {
                 screen: AppTabsRoutes.HomeStack,
                 params: {
                     screen: HomeStackRoutes.Home,
                 },
             });
         } else {
-            navigation.navigate(RootStackRoutes.CoinEnablingInit);
+            navigation.popTo(RootStackRoutes.CoinEnablingInit);
         }
-
         reportOnboardingSuccessAnalytics();
     }, [
         hasBitcoinOnlyFirmware,

--- a/suite-native/module-device-settings/src/screens/WipeDeviceLoadingScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/WipeDeviceLoadingScreen.tsx
@@ -26,7 +26,7 @@ export const WipeDeviceLoadingScreen = () => {
     const isDeviceInBootloader = useSelector(selectIsDeviceInBootloader);
 
     const handleFinish = () => {
-        navigation.navigate(RootStackRoutes.AppTabs, {
+        navigation.popTo(RootStackRoutes.AppTabs, {
             screen: AppTabsRoutes.HomeStack,
             params: {
                 screen: HomeStackRoutes.Home,


### PR DESCRIPTION
Disallow navigating back from:
- uninitialized device landing screen
- coin enabling init screen
- home screen

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/navigation-pop-to&lookback=7)