### PR TITLE
Refactor: suite prerequisite logic

### DIFF
--- a/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
+++ b/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
@@ -74,7 +74,7 @@ type GetMessageIdParams = {
     connected: boolean;
     deviceStatus: ConnectedDeviceStatus | null;
     showWarning: boolean;
-    prerequisite?: PrerequisiteType;
+    prerequisite: PrerequisiteType | null;
 };
 
 const getMessageId = ({
@@ -104,7 +104,7 @@ const getMessageId = ({
 
     const defaultKey = getDefaultKey();
 
-    if (prerequisite === undefined) {
+    if (prerequisite === null) {
         return defaultKey;
     }
 
@@ -151,7 +151,7 @@ interface ConnectDevicePromptProps {
     showWarning?: boolean;
     showWarningIcon: boolean;
     allowSwitchDevice?: boolean;
-    prerequisite?: PrerequisiteType;
+    prerequisite: PrerequisiteType | null;
     deviceStatus: ConnectedDeviceStatus | null;
 }
 

--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -110,7 +110,7 @@ export const Preloader = ({ children }: PropsWithChildren) => {
 
     // display prerequisite for regular application as page view
     // Fullscreen Apps should handle prerequisites by themselves!!!
-    if (prerequisite) {
+    if (prerequisite !== null) {
         return (
             <WelcomeLayout>
                 <Card paddingType="large">

--- a/packages/suite/src/selectors/suite/suiteSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteSelectors.ts
@@ -8,7 +8,7 @@ import { ExperimentalFeature } from 'src/constants/suite/experimental';
 import { RouterRootState, selectRouter } from 'src/reducers/suite/routerReducer';
 import { SuiteRootState } from 'src/reducers/suite/suiteReducer';
 import { AppState, PrerequisiteType, TorStatus, TrezorDevice } from 'src/types/suite';
-import { getExcludedPrerequisites, getPrerequisiteName } from 'src/utils/suite/prerequisites';
+import { getPrerequisiteName, isPrerequisiteGloballyExcluded } from 'src/utils/suite/prerequisites';
 import { getIsTorEnabled, getIsTorLoading } from 'src/utils/suite/tor';
 
 export const selectTorState = (state: SuiteRootState) => {
@@ -65,10 +65,10 @@ export const selectPrerequisite = (
     const device = selectSelectedDevice(state);
     const router = selectRouter(state);
 
-    const excluded = getExcludedPrerequisites(router);
     const prerequisite = getPrerequisiteName({ router, device, transport });
+    const isExcluded = isPrerequisiteGloballyExcluded({ router, prerequisite });
 
-    if (prerequisite === null || excluded.includes(prerequisite)) {
+    if (prerequisite === null || isExcluded) {
         return null;
     }
 

--- a/packages/suite/src/selectors/suite/suiteSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteSelectors.ts
@@ -7,7 +7,7 @@ import { SUITE } from 'src/actions/suite/constants';
 import { ExperimentalFeature } from 'src/constants/suite/experimental';
 import { RouterRootState, selectRouter } from 'src/reducers/suite/routerReducer';
 import { SuiteRootState } from 'src/reducers/suite/suiteReducer';
-import { AppState, TorStatus, TrezorDevice } from 'src/types/suite';
+import { AppState, PrerequisiteType, TorStatus, TrezorDevice } from 'src/types/suite';
 import { getExcludedPrerequisites, getPrerequisiteName } from 'src/utils/suite/prerequisites';
 import { getIsTorEnabled, getIsTorLoading } from 'src/utils/suite/tor';
 
@@ -58,7 +58,9 @@ export const selectIsActionAbortable = (state: SuiteRootState) => {
     return !bridge || versionUtils.isNewerOrEqual(bridge.version as string, '2.0.31');
 };
 
-export const selectPrerequisite = (state: SuiteRootState & RouterRootState & DeviceRootState) => {
+export const selectPrerequisite = (
+    state: SuiteRootState & RouterRootState & DeviceRootState,
+): PrerequisiteType | null => {
     const { transport } = state.suite;
     const device = selectSelectedDevice(state);
     const router = selectRouter(state);
@@ -66,10 +68,8 @@ export const selectPrerequisite = (state: SuiteRootState & RouterRootState & Dev
     const excluded = getExcludedPrerequisites(router);
     const prerequisite = getPrerequisiteName({ router, device, transport });
 
-    if (prerequisite === undefined) return;
-
-    if (excluded.includes(prerequisite)) {
-        return;
+    if (prerequisite === null || excluded.includes(prerequisite)) {
+        return null;
     }
 
     return prerequisite;

--- a/packages/suite/src/utils/suite/prerequisites.ts
+++ b/packages/suite/src/utils/suite/prerequisites.ts
@@ -93,25 +93,26 @@ export const getPrerequisiteName = ({
     return null;
 };
 
-export const getExcludedPrerequisites = (router: RouterState): PrerequisiteType[] => {
+const settingsAppActivePrerequisites: PrerequisiteType[] = ['device-disconnect-required'];
+
+type IsPrerequisiteExcluded = {
+    router: RouterState;
+    prerequisite: PrerequisiteType | null;
+};
+
+/**
+ * Check if the prerequisite should be ignored in whole suite.
+ * Note that fullscreen apps may ignore another prerequisites, e.g. 'start'.
+ * TODO: remove the fullscreenApp logic, see Preloader
+ */
+export const isPrerequisiteGloballyExcluded = ({
+    router,
+    prerequisite,
+}: IsPrerequisiteExcluded): boolean => {
+    if (prerequisite === null) return true;
     if (router.app === 'settings') {
-        return [
-            'no-transport',
-            'device-disconnected',
-            'device-unacquired',
-            'device-unacquired-requires-thp',
-            'device-used-elsewhere',
-            'device-unreadable',
-            'device-unknown',
-            'device-seedless',
-            'device-recovery-mode',
-            'device-initialize',
-            'device-bootloader',
-            'firmware-missing',
-            'firmware-required',
-            'multi-share-backup-in-progress',
-        ];
+        return !settingsAppActivePrerequisites.includes(prerequisite);
     }
 
-    return [];
+    return false;
 };

--- a/packages/suite/src/utils/suite/prerequisites.ts
+++ b/packages/suite/src/utils/suite/prerequisites.ts
@@ -1,5 +1,3 @@
-import { DefinedUnionMember } from '@trezor/type-utils';
-
 import { RouterState } from 'src/reducers/suite/routerReducer';
 import type { TransportState } from 'src/reducers/suite/suiteReducer';
 import type { AppState, TrezorDevice } from 'src/types/suite';
@@ -15,8 +13,29 @@ type GetPrerequisiteNameParams = {
     transport?: TransportState;
 };
 
-export const getPrerequisiteName = ({ router, device, transport }: GetPrerequisiteNameParams) => {
-    if (!router || router.app === 'unknown') return;
+export type PrerequisiteType =
+    | 'no-transport'
+    | 'device-disconnected'
+    | 'device-disconnect-required'
+    | 'device-used-elsewhere'
+    | 'device-unacquired-requires-thp'
+    | 'device-unacquired'
+    | 'device-unreadable'
+    | 'device-unknown'
+    | 'device-seedless'
+    | 'device-recovery-mode'
+    | 'multi-share-backup-in-progress'
+    | 'device-initialize'
+    | 'device-bootloader'
+    | 'firmware-missing'
+    | 'firmware-required';
+
+export const getPrerequisiteName = ({
+    router,
+    device,
+    transport,
+}: GetPrerequisiteNameParams): PrerequisiteType | null => {
+    if (!router || router.app === 'unknown') return null;
 
     // no transport available
     if (transport && !transport.transports.length) return 'no-transport';
@@ -70,6 +89,8 @@ export const getPrerequisiteName = ({ router, device, transport }: GetPrerequisi
 
     // device firmware update required
     if (device.firmware === 'required') return 'firmware-required';
+
+    return null;
 };
 
 export const getExcludedPrerequisites = (router: RouterState): PrerequisiteType[] => {
@@ -94,5 +115,3 @@ export const getExcludedPrerequisites = (router: RouterState): PrerequisiteType[
 
     return [];
 };
-
-export type PrerequisiteType = DefinedUnionMember<ReturnType<typeof getPrerequisiteName>>;

--- a/packages/suite/src/views/start/StartContent.tsx
+++ b/packages/suite/src/views/start/StartContent.tsx
@@ -3,17 +3,21 @@ import { Card } from '@trezor/components';
 import { PrerequisitesGuide } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { selectPrerequisite } from 'src/selectors/suite/suiteSelectors';
+import { PrerequisiteType } from 'src/utils/suite/prerequisites';
 
 import { ModalSwitcher } from '../../components/suite/modals/ModalSwitcher/ModalSwitcher';
 import { SecurityCheck } from '../onboarding/steps/SecurityCheck/SecurityCheck';
 
+const startAppExcludedPrerequisites: PrerequisiteType[] = [
+    'device-initialize',
+    'firmware-missing',
+    'device-recovery-mode',
+];
+
 export const StartContent = () => {
     const prerequisite = useSelector(selectPrerequisite);
 
-    if (
-        prerequisite !== null &&
-        !['device-initialize', 'firmware-missing', 'device-recovery-mode'].includes(prerequisite)
-    ) {
+    if (prerequisite !== null && !startAppExcludedPrerequisites.includes(prerequisite)) {
         return (
             <Card>
                 <ModalSwitcher />

--- a/packages/suite/src/views/start/StartContent.tsx
+++ b/packages/suite/src/views/start/StartContent.tsx
@@ -11,7 +11,7 @@ export const StartContent = () => {
     const prerequisite = useSelector(selectPrerequisite);
 
     if (
-        prerequisite &&
+        prerequisite !== null &&
         !['device-initialize', 'firmware-missing', 'device-recovery-mode'].includes(prerequisite)
     ) {
         return (


### PR DESCRIPTION
## Description

Followup to https://github.com/trezor/trezor-suite/pull/21336 to make things clearer for future :crossed_fingers: 

- explicitely type prerequisite instead of inferred
  - so there is single source of truth on the set of all possible prerequisites
- invert the condition for excluded prerequisites in the settings app → active prerequisites
  - because everything is excluded in settings except one, so it'll be more reliable to define it as active prerequisites
  - this is still a mess because each fullscreen app handles it on their own but that's for another day

## QA

Together with https://github.com/trezor/trezor-suite/issues/21335
plus a lot of it is covered by preloader tests or E2E tests :slightly_smiling_face: 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/suite-prerequisite-logic&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/suite-prerequisite-logic&lookback=7)