### PR TITLE
fix(suite): early-return PowerMonitor on web

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PowerMonitor/PowerMonitor.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PowerMonitor/PowerMonitor.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 
 import { selectKnownDevices } from '@suite-common/bluetooth';
-import { isDesktop } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { bluetoothDisconnectDeviceThunk } from 'src/actions/bluetooth/bluetoothDisconnectDeviceThunk';
@@ -10,11 +9,10 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 export const PowerMonitorManager = () => {
     const dispatch = useDispatch();
     const knownDevices = useSelector(selectKnownDevices);
+    const isDesktopApiAvailable = desktopApi?.available === true;
 
     useEffect(() => {
-        if (typeof window === 'undefined' || !isDesktop) {
-            return;
-        }
+        if (!isDesktopApiAvailable) return;
 
         const disconnectAllDevices = () => {
             knownDevices.forEach(device => {
@@ -26,7 +24,7 @@ export const PowerMonitorManager = () => {
         return () => {
             desktopApi.removeAllListeners('power-monitor/screen-locked');
         };
-    }, [dispatch, knownDevices]);
+    }, [dispatch, knownDevices, isDesktopApiAvailable]);
 
     return null;
 };


### PR DESCRIPTION
Followup to #21260 to fix this console error:

<img width="574" height="264" alt="image" src="https://github.com/user-attachments/assets/085badea-96ae-40d6-9a28-b289094be512" />

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/web-PowerMonitor&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/web-PowerMonitor&lookback=7)