### PR TITLE
feat(e2e): Added script for easy git bisect

### DIFF
--- a/docs/tests/e2e-playwright-suite.md
+++ b/docs/tests/e2e-playwright-suite.md
@@ -75,6 +75,8 @@ _(in case of Linux with X11 support, skip to step 6.)_
 
 1. **To run with x-main firmware** instead of x-latest you can use CANARY_FIRMWARE env variable like this: `CANARY_FIRMWARE=true yarn workspace @trezor/suite-desktop-core test:e2e:web` or `CANARY_FIRMWARE=true yarn workspace @trezor/suite-desktop-core test:e2e:desktop`
 
+1. **To find a breaking commit in develop** you can checkout latest develop and run `yarn workspace @trezor/suite-desktop git:bisect <last_good_commit> <desktop|web> <test_file>`
+
 ## Contribution
 
 Please follow our general [Playwright contribution guide](e2e-playwright-contribution-guide.md)

--- a/packages/suite-desktop-core/e2e/bisect-commits.sh
+++ b/packages/suite-desktop-core/e2e/bisect-commits.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- usage ---
+if [ "$#" -lt 3 ]; then
+  echo "Usage: $0 <last_good_commit> <desktop|web> <test_file>"
+  echo "Example: $0 abc123 desktop general/wallet-discovery.test.ts"
+  exit 1
+fi
+
+LAST_GOOD_COMMIT="$1"
+TARGET="$2" # desktop or web
+TEST_FILE="$3"
+
+
+# --- create runner script for git bisect ---
+RUNNER="$(mktemp)"
+chmod +x "$RUNNER"
+
+cat >"$RUNNER" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+wait_for_web_server() {
+  echo "⏳ Waiting for web server to be ready..."
+  for i in {1..30}; do
+    if curl -sSf http://localhost:8000 >/dev/null; then
+      return 0
+    fi
+    sleep 5
+  done
+  return 1
+}
+
+TARGET="$TARGET"
+TEST_FILE="$TEST_FILE"
+
+echo "[bisect] Building at commit \$(git rev-parse --short HEAD)"
+
+if [ "\$TARGET" = "desktop" ]; then
+  yarn install
+  yarn workspace @trezor/suite-desktop build:ui
+  yarn workspace @trezor/suite-desktop build:app
+
+  yarn workspace @trezor/suite-desktop-core test:e2e:desktop "\$TEST_FILE"
+  RESULT=\$?
+
+elif [ "\$TARGET" = "web" ]; then
+  yarn install
+
+  yarn suite:dev & SERVER_PID=\$!
+
+  wait_for_web_server || { kill "\$SERVER_PID" || true; exit 125; }
+
+  yarn workspace @trezor/suite-desktop-core test:e2e:web "\$TEST_FILE"
+  RESULT=\$?
+
+  kill "\$SERVER_PID" || true
+  wait "\$SERVER_PID" 2>/dev/null || true
+
+else
+  echo "Unknown TARGET: \$TARGET" >&2
+  exit 125
+fi
+
+if [ \$RESULT -eq 0 ]; then
+  echo "[bisect] Test passed (good)"
+  exit 0
+else
+  echo "[bisect] Test failed (bad)"
+  exit 1
+fi
+EOF
+
+# --- run the bisect ---
+git bisect start HEAD "$LAST_GOOD_COMMIT"
+git bisect run "$RUNNER"
+
+git bisect reset
+rm "$RUNNER"

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -17,7 +17,8 @@
         "test:orchestrated:e2e:desktop": "NODE_OPTIONS='--no-warnings=DEP0040' yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=desktop",
         "test:orchestrated:e2e:web": "NODE_OPTIONS='--no-warnings=DEP0040' yarn xvfb-maybe -- pwc-p --config=./e2e/playwright.config.ts --project=web",
         "github:report:manual": "NODE_OPTIONS='--no-warnings=DEP0040' yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts --project=manual --reporter=./e2e/support/reporters/gitHubReporter.ts",
-        "github:create:project": "tsx ./e2e/support/reporters/scriptCreateProject.ts"
+        "github:create:project": "tsx ./e2e/support/reporters/scriptCreateProject.ts",
+        "git:bisect": "./e2e/bisect-commits.sh"
     },
     "dependencies": {
         "@sentry/electron": "^5.12.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a script that can be used to find a commit breaking a specific E2E test.
`yarn workspace @trezor/suite-desktop git:bisect fe824666bb336058a6700ac2bfdeda68a2fed27e web general/wallet-discovery.test.ts` this will run web build and the specified test, where the commit hash is the last known working commit.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-test-commit-script&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-test-commit-script&lookback=7)