### PR TITLE
refactor(e2e-suite): switch staking test's locators to testIds only

### DIFF
--- a/packages/components/src/components/Modal/ModalButton.tsx
+++ b/packages/components/src/components/Modal/ModalButton.tsx
@@ -1,7 +1,7 @@
 import { ModalContext, useModalContext } from './ModalContext';
 import { Button, ButtonProps } from '../buttons/Button/Button';
 
-export const ModalButton = ({ children, ...rest }: ButtonProps) => {
+export const ModalButton = ({ children, 'data-testid': dataTestId, ...rest }: ButtonProps) => {
     const { variant } = useModalContext();
     const value = { variant };
 
@@ -12,6 +12,7 @@ export const ModalButton = ({ children, ...rest }: ButtonProps) => {
                 variant={rest.variant ?? variant}
                 size={rest.size ?? 'large'}
                 minWidth={150}
+                data-testid={dataTestId}
             >
                 {children}
             </Button>

--- a/packages/suite-desktop-core/e2e/support/pageObjects/stakingSection.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/stakingSection.ts
@@ -57,26 +57,28 @@ export class StakingSection {
         this.stakedAmount = this.page.getByTestId('@account/staking/staked');
         this.rewardsAmount = this.page.getByTestId('@account/staking/rewards');
         this.unstakingAmount = this.page.getByTestId('@account/staking/unstaking');
-        this.unstakeToClaimButton = this.page.getByRole('button', { name: 'Unstake to claim' });
+        this.unstakeToClaimButton = this.page.getByTestId('@account/staking/unstake-button');
         this.availableBalanceWithSymbol = this.page.getByTestId(
             '@staking/available-balance-with-symbol',
         );
         this.cryptoInput = this.page.getByTestId('@staking/form/crypto-input');
         this.fiatInput = this.page.getByTestId('@staking/form/fiat-input');
-        this.unstakeButton = this.page
-            .getByTestId('@modal')
-            .getByRole('button', { name: 'Unstake' });
-        this.speedUpButton = this.page.getByRole('button', { name: 'Speed up' });
+        this.unstakeButton = this.page.getByTestId('@modal/staking/unstake-button');
+        this.speedUpButton = this.page.getByTestId('@transaction-item/bump-fee-button');
         this.pendingTransactionText = this.page.getByText('Pending transaction•1');
-        this.stakeMoreButton = this.page.getByRole('button', { name: 'Stake more' });
-        this.startStakingButton = this.page.getByRole('button', { name: 'Start staking' });
-        this.continueButton = this.page.getByRole('button', { name: 'Continue' });
-        this.confirmButton = this.page.getByRole('button', { name: 'Confirm' });
+        this.stakeMoreButton = this.page.getByTestId('@account/staking/stake-more-button');
+        this.startStakingButton = this.page.getByTestId(
+            '@wallet/staking/empty-card/start-staking-button',
+        );
+        this.continueButton = this.page.getByTestId('@modal/staking/continue-button');
+        this.confirmButton = this.page.getByTestId('@modal/staking/confirm-button');
         this.acknowledgeCheckbox = this.page.getByTestId('@staking/acknowledge-checkbox');
         this.everstakeAcknowledgeCheckbox = this.page.getByTestId(
             '@staking/everstake-acknowledge-checkbox',
         );
-        this.confirmAndStakeButton = this.page.getByRole('button', { name: 'Confirm & stake' });
+        this.confirmAndStakeButton = this.page.getByTestId(
+            '@modal/staking/confirm-and-stake-button',
+        );
         this.progressLabels = this.page.getByTestId('@staking/progress-labels');
         this.transactionStatus = this.page.getByTestId('@staking/transaction-status');
         this.transactionStatusContainer = this.page.getByTestId(
@@ -96,11 +98,9 @@ export class StakingSection {
         );
         this.claimCard = this.page.getByTestId('@staking/can-claim-card');
         this.claimBalanceWithSymbol = this.page.getByTestId('@staking/can-claim-with-symbol');
-        this.claimButton = this.page.getByRole('button', { name: 'Claim', exact: true });
+        this.claimButton = this.page.getByTestId('@account/staking/claim-button');
         this.claimModalAmount = this.page.getByTestId('@staking/claim-modal/amount-with-symbol');
-        this.claimModalButton = this.page
-            .getByTestId('@staking/claim-modal')
-            .getByRole('button', { name: 'Claim', exact: true });
+        this.claimModalButton = this.page.getByTestId('@staking/claim-modal/continue-button');
         this.cryptoInputBottomText = this.page.getByTestId(
             '@staking/form/crypto-input/bottom-text',
         );

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
@@ -114,6 +114,7 @@ const ClaimModalLoaded = ({ onCancel, selectedAccount }: ClaimModalModalProps) =
                             isLoading={isLoading}
                             onClick={onClaimClick}
                             icon={isClaimingDisabled ? 'info' : undefined}
+                            data-testid="@staking/claim-modal/continue-button"
                         >
                             <Translation id="TR_CONTINUE" />
                         </Modal.Button>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeInANutshellModal/StakeInANutshellModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeInANutshellModal/StakeInANutshellModal.tsx
@@ -149,7 +149,10 @@ export const StakeInANutshellModal = ({ onCancel }: StakeInANutshellModalProps) 
             size="tiny"
             onCancel={onCancelClick}
             bottomContent={
-                <Modal.Button onClick={proceedToEverstakeModal}>
+                <Modal.Button
+                    onClick={proceedToEverstakeModal}
+                    data-testid="@modal/staking/continue-button"
+                >
                     <Translation id="TR_CONTINUE" />
                 </Modal.Button>
             }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/ConfirmStakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/ConfirmStakeModal.tsx
@@ -85,7 +85,11 @@ export const ConfirmStakeModal = ({ isLoading, onConfirm, onCancel }: ConfirmSta
             variant="warning"
             bottomContent={
                 <>
-                    <Modal.Button isDisabled={isDisabled} onClick={onClick}>
+                    <Modal.Button
+                        isDisabled={isDisabled}
+                        onClick={onClick}
+                        data-testid="@modal/staking/confirm-and-stake-button"
+                    >
                         <Translation id="TR_STAKE_CONFIRM_AND_STAKE" />
                     </Modal.Button>
                     <Modal.Button variant="tertiary" onClick={handleOnCancel}>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeForm/StakeButton.tsx
@@ -59,6 +59,7 @@ export const StakeButton = () => {
                 isLoading={isLoading}
                 onClick={onStakeClick}
                 icon={isStakingDisabled ? 'info' : undefined}
+                data-testid="@modal/staking/continue-button"
             >
                 <Translation id="TR_CONTINUE" />
             </Modal.Button>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/EverstakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/EverstakeModal.tsx
@@ -100,7 +100,11 @@ export const EverstakeModal = ({ onCancel }: EverstakeModalProps) => {
             size="small"
             bottomContent={
                 <>
-                    <Modal.Button isDisabled={!hasAgreed} onClick={proceedToStaking}>
+                    <Modal.Button
+                        isDisabled={!hasAgreed}
+                        onClick={proceedToStaking}
+                        data-testid="@modal/staking/confirm-button"
+                    >
                         <Translation id="TR_CONFIRM" />
                     </Modal.Button>
                     <Modal.Button variant="tertiary" onClick={onCancelClick}>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeForm/UnstakeButton.tsx
@@ -61,6 +61,7 @@ export const UnstakeButton = () => {
                 isLoading={isLoading}
                 onClick={onUnstakeClick}
                 icon={isUnstakingDisabled ? 'info' : undefined}
+                data-testid="@modal/staking/unstake-button"
             >
                 <Translation id="TR_CONTINUE" />
             </Modal.Button>

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -175,6 +175,7 @@ export const TransactionItem = memo(
                 icon="gauge"
                 onClick={() => openTxDetailsModal({ flow: 'bump-fee' })}
                 isDisabled={isDisabled}
+                data-testid="@transaction-item/bump-fee-button"
             >
                 <Translation id="TR_BUMP_FEE" />
             </Button>

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ClaimCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ClaimCard.tsx
@@ -112,6 +112,7 @@ export const ClaimCard = () => {
                         onClick={openClaimModal}
                         isDisabled={isClaimingDisabled}
                         icon={isClaimingDisabled ? 'info' : undefined}
+                        data-testid="@account/staking/claim-button"
                     >
                         <Translation id="TR_STAKE_CLAIM" />
                     </Button>

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
@@ -202,6 +202,7 @@ export const EmptyStakingCard = () => {
                             onClick={openStakeInANutshellModal}
                             isDisabled={isStakingDisabled}
                             icon={isStakingDisabled ? 'info' : undefined}
+                            data-testid="@wallet/staking/empty-card/start-staking-button"
                         >
                             <Translation id="TR_STAKING_CARD_START_STAKING" />
                         </Button>

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
@@ -291,6 +291,7 @@ export const StakingCard = ({
                             isDisabled={isStakingDisabled}
                             icon={isStakingDisabled ? 'info' : undefined}
                             variant="tertiary"
+                            data-testid="@account/staking/stake-more-button"
                         >
                             <Translation id="TR_STAKE_STAKE_MORE" />
                         </Button>
@@ -301,6 +302,7 @@ export const StakingCard = ({
                             onClick={openUnstakeModal}
                             icon={isUnstakingDisabled ? 'info' : undefined}
                             variant="tertiary"
+                            data-testid="@account/staking/unstake-button"
                         >
                             <Translation id="TR_STAKE_UNSTAKE_TO_CLAIM" />
                         </Button>


### PR DESCRIPTION
Changing original locators that relied on button texts to data-testId only for stability reasons

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-strings-in-tests&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-strings-in-tests&lookback=7)