### PR TITLE
feat(transport-bluetooth): server forget_device method

### DIFF
--- a/packages/transport-bluetooth/src/server/message_handler.rs
+++ b/packages/transport-bluetooth/src/server/message_handler.rs
@@ -76,6 +76,7 @@ pub async fn handle_message(
         WsRequestMethod::DisconnectDevice(id) => {
             methods::disconnect_device(manager, broadcast, id).await
         }
+        WsRequestMethod::ForgetDevice(id) => methods::forget_device(manager, broadcast, id).await,
     };
 
     match payload {

--- a/packages/transport-bluetooth/src/server/methods/forget_device.rs
+++ b/packages/transport-bluetooth/src/server/methods/forget_device.rs
@@ -1,0 +1,21 @@
+use log::info;
+
+use crate::server::{
+    adapter_manager::AdapterManager,
+    platform::{BluetoothDevice, PlatformDevice},
+    types::{MethodError, MethodResult, WsResponsePayload},
+    ConnectionBroadcast,
+};
+
+pub async fn forget_device(
+    _manager: AdapterManager,
+    _sender: ConnectionBroadcast,
+    id: String,
+) -> MethodResult {
+    info!("forget_device");
+
+    match BluetoothDevice::forget(id).await {
+        Ok(()) => Ok(WsResponsePayload::Success(true)),
+        Err(err) => Err(MethodError::PlatformError(err)),
+    }
+}

--- a/packages/transport-bluetooth/src/server/methods/mod.rs
+++ b/packages/transport-bluetooth/src/server/methods/mod.rs
@@ -1,6 +1,7 @@
 pub mod connect_device;
 pub mod disconnect_device;
 pub mod enumerate;
+pub mod forget_device;
 pub mod get_info;
 pub mod set_state;
 pub mod start_scan;
@@ -9,6 +10,7 @@ pub mod stop_scan;
 pub use self::connect_device::connect_device;
 pub use self::disconnect_device::disconnect_device;
 pub use self::enumerate::enumerate;
+pub use self::forget_device::forget_device;
 pub use self::get_info::get_info;
 pub use self::set_state::set_state;
 pub use self::start_scan::start_scan;

--- a/packages/transport-bluetooth/src/server/platform/linux.rs
+++ b/packages/transport-bluetooth/src/server/platform/linux.rs
@@ -43,6 +43,30 @@ impl PlatformDevice for LinuxDevice {
         discover_services(&ctx).await?;
         verify_connection(&ctx).await
     }
+
+    async fn forget(_id: String) -> Result<(), PlatformError> {
+        // use dbus::arg::{RefArg, Variant};
+        // use tokio::time::Duration;
+        // let device = manager.get_device_or_die(id).await?;
+        // let adapter_proxy = platform::get_device_proxy(device.get_id().clone(), 5 * 1000);
+
+        // this will throw: Forget error D-Bus error: Does Not Exist (org.bluez.Error.DoesNotExist)
+        // the device will be unpaired but only partially and it causes problems after future reconnection
+        // next pairing will most likely throw "le-connection-abort-by-local"
+
+        // let res: Result<(), dbus::Error> = adapter_proxy.method_call("org.bluez.Device1", "CancelPairing", ()).await;
+        // match res {
+        //     Ok(()) => {
+        //         Ok(WsResponsePayload::Success(true))
+        //     }
+        //     Err(err) => {
+        //         println!("Forget error {:?}", err);
+        //         Ok(WsResponsePayload::Success(false))
+        //     }
+        // }
+
+        Err("forget_device is not implemented".into())
+    }
 }
 
 /// get bluez device (proxy) reference

--- a/packages/transport-bluetooth/src/server/platform/macos.rs
+++ b/packages/transport-bluetooth/src/server/platform/macos.rs
@@ -33,6 +33,10 @@ impl PlatformDevice for MacosDevice {
         try_to_subscribe(&ctx).await?;
         verify_connection(&ctx).await
     }
+
+    async fn forget(_id: String) -> Result<(), PlatformError> {
+        Err("forget_device is not implemented".into())
+    }
 }
 
 pub async fn try_to_subscribe(ctx: &ConnectDeviceContext) -> Result<(), PlatformError> {

--- a/packages/transport-bluetooth/src/server/platform/mod.rs
+++ b/packages/transport-bluetooth/src/server/platform/mod.rs
@@ -19,6 +19,8 @@ pub trait PlatformDevice {
     fn get_address(peripheral: Peripheral) -> String;
 
     async fn connect(ctx: ConnectDeviceContext) -> Result<(), PlatformError>;
+
+    async fn forget(id: String) -> Result<(), PlatformError>;
 }
 
 #[cfg(target_os = "linux")]

--- a/packages/transport-bluetooth/src/server/platform/windows.rs
+++ b/packages/transport-bluetooth/src/server/platform/windows.rs
@@ -12,7 +12,7 @@ use windows::{
     core::Ref,
     Devices::Bluetooth::BluetoothLEDevice,
     Devices::Enumeration::{
-        DeviceInformationCustomPairing, DevicePairingKinds, DevicePairingRequestedEventArgs,
+        DeviceInformationCustomPairing, DevicePairingKinds, DevicePairingRequestedEventArgs, DeviceUnpairingResultStatus,
         DevicePairingResultStatus,
     },
     Foundation::TypedEventHandler,
@@ -34,6 +34,21 @@ impl PlatformDevice for WindowsDevice {
         try_to_pair(&ctx).await?;
         discover_services(&ctx).await?;
         verify_connection(&ctx).await
+    }
+
+    async fn forget(id: String) -> Result<(), PlatformError> {
+        let address = BDAddr::from_str_delim(&id)?;
+        let device = BluetoothLEDevice::FromBluetoothAddressAsync(address.into())?.await?;
+        let pairing = device.DeviceInformation()?.Pairing()?;
+
+        let result = pairing.UnpairAsync()?.await?;
+        let status = result.Status()?;
+        if status != DeviceUnpairingResultStatus::Unpaired {
+            Err(format!("Unpair failed: {:?}", status).into())
+        } else {
+            let _ = device.Close();
+            Ok(())
+        }
     }
 }
 

--- a/packages/transport-bluetooth/src/server/types.rs
+++ b/packages/transport-bluetooth/src/server/types.rs
@@ -51,6 +51,7 @@ pub enum WsRequestMethod {
     SetState(SetStateParams),
     ConnectDevice(ConnectDeviceParams),
     DisconnectDevice(String),
+    ForgetDevice(String),
 }
 
 #[derive(serde::Deserialize, Debug)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
cherry picked from https://github.com/trezor/trezor-suite/pull/20998 


`forget_device` method - works only on windows

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/bt-server-forget_device&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/bt-server-forget_device&lookback=7)