### PR TITLE
chore(suite-native): Mobile Trade: do not log missing currency name

### DIFF
--- a/suite-native/module-trading/src/utils/general/__tests__/currencyUtils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/currencyUtils.test.ts
@@ -2,23 +2,8 @@ import { getCurrencyLabel } from '../currencyUtils';
 
 describe('currencyUtils', () => {
     describe('getCurrencyLabel', () => {
-        let consoleErrorSpy: jest.SpyInstance;
-
-        beforeAll(() => {
-            consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-        });
-
-        beforeEach(() => {
-            consoleErrorSpy.mockClear();
-        });
-
-        afterAll(() => {
-            consoleErrorSpy.mockRestore();
-        });
-
         it('should return label from supported currencies map', () => {
             expect(getCurrencyLabel('czk')).toBe('Czech Koruna');
-            expect(consoleErrorSpy).not.toHaveBeenCalled();
         });
 
         it('should return label from other currencies map', () => {
@@ -28,17 +13,5 @@ describe('currencyUtils', () => {
         it('should be uppercase code otherwise', () => {
             expect(getCurrencyLabel('xyz')).toBe('XYZ');
         });
-
-        it.each(['xof', 'xyz'])(
-            'should log warning when currency is not supported, case %#',
-            fiatCurrency => {
-                getCurrencyLabel(fiatCurrency);
-
-                expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-                expect(consoleErrorSpy).toHaveBeenCalledWith(
-                    `Trading: Currency [${fiatCurrency}] is not in supportedFiatCurrenciesMap`,
-                );
-            },
-        );
     });
 });

--- a/suite-native/module-trading/src/utils/general/currencyUtils.ts
+++ b/suite-native/module-trading/src/utils/general/currencyUtils.ts
@@ -11,8 +11,6 @@ export const getCurrencyLabel = (currencyCode: FiatCurrencyCode | string) => {
         return supportedCurrencyLabel;
     }
 
-    console.error(`Trading: Currency [${currencyCode}] is not in supportedFiatCurrenciesMap`);
-
     const otherCurrencyLabel = otherCurrenciesMap[currencyCode as Lowercase<string>];
     if (otherCurrencyLabel) {
         return otherCurrencyLabel;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove error log in `getCurrencyLabel` as there are currently no plans to fix this behavior anytime soon.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=remove-getCurrencyLabel-error-log&lookback=7)