### PR TITLE
fix(e2e-suite): Incrase assert timeout for continueThroughFirmware

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/firmwareSection.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/firmwareSection.ts
@@ -25,7 +25,7 @@ export class FirmwareSection {
 
     @step()
     async continueThroughFirmware() {
-        await expect(this.onboardingLayout).toBeVisible();
+        await expect(this.onboardingLayout).toBeVisible({ timeout: 15_000 });
         // Test using this method do not care if we have current firmware or not
         // that is way we are using Promise.race to get through firmware check either way
         await Promise.race([this.continueButton.click(), this.skip()]);


### PR DESCRIPTION
To resolve failing test. Product performance got worse by ~0.8s

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-tests&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-tests&lookback=7)