### PR TITLE
fix(suite): Fix DeviceSelector vertical alignment when sidebar is shrinked

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
@@ -51,7 +51,7 @@ export const DeviceStatus = ({
     );
 
     return (
-        <Row flex="1" gap={spacings.sm}>
+        <Row flex="1" gap={spacings.sm} justifyContent="center">
             {isDeviceDetailVisible ? (
                 <>
                     {image}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

before
<img width="191" height="254" alt="image" src="https://github.com/user-attachments/assets/27646c0b-e452-4388-88ec-1711a10f2749" />

after
<img width="196" height="230" alt="image" src="https://github.com/user-attachments/assets/bfde6231-e975-490c-bdfe-d17835d40349" />


## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-device-selector-alignment&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-device-selector-alignment&lookback=7)